### PR TITLE
feat(host): compress workflow documents in beads metadata

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1489,7 +1489,9 @@ name = "host-infra-beads"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
+ "flate2",
  "host-domain",
  "host-infra-system",
  "serde",

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp.rs
@@ -157,4 +157,39 @@ mod tests {
         assert_eq!(qa.updated_at, None);
         assert_eq!(qa.verdict, host_domain::QaWorkflowVerdict::NotReviewed);
     }
+
+    #[test]
+    fn odt_read_task_documents_preserves_qa_decode_errors() {
+        let (service, task_state, _) =
+            build_service_with_state(vec![task("fairnest-4y3", "Fairnest")]);
+        {
+            let mut state = task_state.lock().expect("task state lock poisoned");
+            state.latest_qa_report = Some(host_domain::QaReportDocument {
+                markdown: String::new(),
+                verdict: host_domain::QaWorkflowVerdict::Approved,
+                updated_at: Some("2026-02-20T12:00:00Z".to_string()),
+                revision: Some(2),
+                error: Some(
+                    "Failed to decode openducktor.documents.qaReports[0]: invalid base64 payload"
+                        .to_string(),
+                ),
+            });
+        }
+
+        let result = service
+            .odt_read_task_documents("/repo", "fairnest-4y3", false, false, true)
+            .expect("read task documents should succeed");
+
+        let qa = result
+            .documents
+            .latest_qa_report
+            .expect("qa report should be present when requested");
+        assert_eq!(qa.markdown, "");
+        assert_eq!(qa.updated_at.as_deref(), Some("2026-02-20T12:00:00Z"));
+        assert_eq!(qa.verdict, host_domain::QaWorkflowVerdict::Approved);
+        assert_eq!(
+            qa.error.as_deref(),
+            Some("Failed to decode openducktor.documents.qaReports[0]: invalid base64 payload"),
+        );
+    }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp.rs
@@ -192,4 +192,57 @@ mod tests {
             Some("Failed to decode openducktor.documents.qaReports[0]: invalid base64 payload"),
         );
     }
+
+    #[test]
+    fn odt_read_task_documents_preserves_spec_and_plan_decode_errors() {
+        let (service, task_state, _) =
+            build_service_with_state(vec![task("fairnest-4y3", "Fairnest")]);
+        {
+            let mut state = task_state.lock().expect("task state lock poisoned");
+            state.metadata_spec = Some(host_domain::SpecDocument {
+                markdown: String::new(),
+                updated_at: Some("2026-02-20T10:00:00Z".to_string()),
+                revision: Some(1),
+                error: Some(
+                    "Failed to decode openducktor.documents.spec[0]: invalid base64 payload"
+                        .to_string(),
+                ),
+            });
+            state.metadata_plan = Some(host_domain::SpecDocument {
+                markdown: String::new(),
+                updated_at: Some("2026-02-20T11:00:00Z".to_string()),
+                revision: Some(2),
+                error: Some(
+                    "Failed to decode openducktor.documents.implementationPlan[0]: invalid gzip payload"
+                        .to_string(),
+                ),
+            });
+        }
+
+        let result = service
+            .odt_read_task_documents("/repo", "fairnest-4y3", true, true, false)
+            .expect("read task documents should succeed");
+
+        let spec = result
+            .documents
+            .spec
+            .expect("spec should be present when requested");
+        assert!(spec.markdown.is_empty());
+        assert_eq!(spec.updated_at.as_deref(), Some("2026-02-20T10:00:00Z"));
+        assert_eq!(
+            spec.error.as_deref(),
+            Some("Failed to decode openducktor.documents.spec[0]: invalid base64 payload"),
+        );
+
+        let plan = result
+            .documents
+            .implementation_plan
+            .expect("plan should be present when requested");
+        assert!(plan.markdown.is_empty());
+        assert_eq!(plan.updated_at.as_deref(), Some("2026-02-20T11:00:00Z"));
+        assert_eq!(
+            plan.error.as_deref(),
+            Some("Failed to decode openducktor.documents.implementationPlan[0]: invalid gzip payload"),
+        );
+    }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp/mapping.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp/mapping.rs
@@ -5,8 +5,7 @@ use super::types::{
 };
 use anyhow::{anyhow, Result};
 use host_domain::{
-    QaReportDocument, QaVerdict, QaWorkflowVerdict, SpecDocument, TaskCard, TaskMetadata,
-    TaskStatus,
+    QaReportDocument, QaWorkflowVerdict, SpecDocument, TaskCard, TaskMetadata, TaskStatus,
 };
 use std::collections::HashSet;
 
@@ -47,6 +46,7 @@ fn map_markdown_document(document: SpecDocument) -> OdtMarkdownDocument {
     OdtMarkdownDocument {
         markdown: document.markdown,
         updated_at: document.updated_at,
+        error: document.error,
     }
 }
 
@@ -54,16 +54,15 @@ fn map_qa_report_document(report: Option<QaReportDocument>) -> OdtQaReportDocume
     match report {
         Some(report) => OdtQaReportDocument {
             markdown: report.markdown,
-            updated_at: Some(report.updated_at),
-            verdict: match report.verdict {
-                QaVerdict::Approved => QaWorkflowVerdict::Approved,
-                QaVerdict::Rejected => QaWorkflowVerdict::Rejected,
-            },
+            updated_at: report.updated_at,
+            verdict: report.verdict,
+            error: report.error,
         },
         None => OdtQaReportDocument {
             markdown: String::new(),
             updated_at: None,
             verdict: QaWorkflowVerdict::NotReviewed,
+            error: None,
         },
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp/types.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp/types.rs
@@ -65,6 +65,8 @@ pub struct OdtTaskDocumentsRead {
 pub struct OdtMarkdownDocument {
     pub markdown: String,
     pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,6 +75,8 @@ pub struct OdtQaReportDocument {
     pub markdown: String,
     pub updated_at: Option<String>,
     pub verdict: QaWorkflowVerdict,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/qa_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/qa_service.rs
@@ -10,13 +10,15 @@ impl AppService {
             .qa_report
             .map(|entry| SpecDocument {
                 markdown: entry.markdown,
-                updated_at: Some(entry.updated_at),
-                revision: Some(entry.revision),
+                updated_at: entry.updated_at,
+                revision: entry.revision,
+                error: entry.error,
             })
             .unwrap_or_else(|| SpecDocument {
                 markdown: String::new(),
                 updated_at: None,
                 revision: None,
+                error: None,
             });
         Ok(report)
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -237,6 +237,7 @@ impl TaskStore for FakeTaskStore {
             markdown: String::new(),
             updated_at: None,
             revision: None,
+            error: None,
         })
     }
 
@@ -249,6 +250,7 @@ impl TaskStore for FakeTaskStore {
             markdown: markdown.to_string(),
             updated_at: Some("2026-01-01T00:00:00Z".to_string()),
             revision: Some(1),
+            error: None,
         })
     }
 
@@ -259,6 +261,7 @@ impl TaskStore for FakeTaskStore {
             markdown: String::new(),
             updated_at: None,
             revision: None,
+            error: None,
         })
     }
 
@@ -271,6 +274,7 @@ impl TaskStore for FakeTaskStore {
             markdown: markdown.to_string(),
             updated_at: Some("2026-01-01T00:00:00Z".to_string()),
             revision: Some(1),
+            error: None,
         })
     }
 
@@ -296,9 +300,13 @@ impl TaskStore for FakeTaskStore {
             .push((_task_id.to_string(), markdown.to_string(), verdict.clone()));
         Ok(QaReportDocument {
             markdown: markdown.to_string(),
-            verdict,
-            updated_at: "2026-01-01T00:00:00Z".to_string(),
-            revision: 1,
+            verdict: match verdict {
+                QaVerdict::Approved => QaWorkflowVerdict::Approved,
+                QaVerdict::Rejected => QaWorkflowVerdict::Rejected,
+            },
+            updated_at: Some("2026-01-01T00:00:00Z".to_string()),
+            revision: Some(1),
+            error: None,
         })
     }
 
@@ -319,9 +327,13 @@ impl TaskStore for FakeTaskStore {
         ));
         state.latest_qa_report = Some(QaReportDocument {
             markdown: markdown.to_string(),
-            verdict: verdict.clone(),
-            updated_at: "2026-01-01T00:00:00Z".to_string(),
-            revision: 1,
+            verdict: match verdict.clone() {
+                QaVerdict::Approved => QaWorkflowVerdict::Approved,
+                QaVerdict::Rejected => QaWorkflowVerdict::Rejected,
+            },
+            updated_at: Some("2026-01-01T00:00:00Z".to_string()),
+            revision: Some(1),
+            error: None,
         });
 
         let index = state
@@ -502,11 +514,13 @@ impl TaskStore for FakeTaskStore {
                 markdown: String::new(),
                 updated_at: None,
                 revision: None,
+                error: None,
             },
             plan: SpecDocument {
                 markdown: String::new(),
                 updated_at: None,
                 revision: None,
+                error: None,
             },
             qa_report,
             pull_request: state.pull_requests.get(_task_id).cloned(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -98,6 +98,8 @@ pub(crate) struct TaskStoreState {
     pub(crate) plan_get_calls: Vec<String>,
     pub(crate) plan_set_calls: Vec<(String, String)>,
     pub(crate) metadata_get_calls: Vec<String>,
+    pub(crate) metadata_spec: Option<SpecDocument>,
+    pub(crate) metadata_plan: Option<SpecDocument>,
     pub(crate) qa_append_calls: Vec<(String, String, QaVerdict)>,
     pub(crate) qa_outcome_calls: Vec<(String, TaskStatus, String, QaVerdict)>,
     pub(crate) latest_qa_report: Option<QaReportDocument>,
@@ -507,21 +509,23 @@ impl TaskStore for FakeTaskStore {
     fn get_task_metadata(&self, _repo_path: &Path, _task_id: &str) -> Result<TaskMetadata> {
         let mut state = self.state.lock().expect("task store lock poisoned");
         state.metadata_get_calls.push(_task_id.to_string());
+        let spec = state.metadata_spec.clone().unwrap_or(SpecDocument {
+            markdown: String::new(),
+            updated_at: None,
+            revision: None,
+            error: None,
+        });
+        let plan = state.metadata_plan.clone().unwrap_or(SpecDocument {
+            markdown: String::new(),
+            updated_at: None,
+            revision: None,
+            error: None,
+        });
         let qa_report = state.latest_qa_report.clone();
         let agent_sessions = state.agent_sessions.clone();
         Ok(TaskMetadata {
-            spec: SpecDocument {
-                markdown: String::new(),
-                updated_at: None,
-                revision: None,
-                error: None,
-            },
-            plan: SpecDocument {
-                markdown: String::new(),
-                updated_at: None,
-                revision: None,
-                error: None,
-            },
+            spec,
+            plan,
             qa_report,
             pull_request: state.pull_requests.get(_task_id).cloned(),
             direct_merge: state.direct_merge_records.get(_task_id).cloned(),
@@ -1081,6 +1085,8 @@ pub(crate) fn build_service_with_git_state_enforced(
         plan_get_calls: Vec::new(),
         plan_set_calls: Vec::new(),
         metadata_get_calls: Vec::new(),
+        metadata_spec: None,
+        metadata_plan: None,
         qa_append_calls: Vec::new(),
         qa_outcome_calls: Vec::new(),
         latest_qa_report: None,
@@ -1170,6 +1176,8 @@ pub(crate) fn build_service_with_git_state(
         plan_get_calls: Vec::new(),
         plan_set_calls: Vec::new(),
         metadata_get_calls: Vec::new(),
+        metadata_spec: None,
+        metadata_plan: None,
         qa_append_calls: Vec::new(),
         qa_outcome_calls: Vec::new(),
         latest_qa_report: None,
@@ -1722,6 +1730,8 @@ pub(crate) fn build_service_with_store(
         plan_get_calls: Vec::new(),
         plan_set_calls: Vec::new(),
         metadata_get_calls: Vec::new(),
+        metadata_spec: None,
+        metadata_plan: None,
         qa_append_calls: Vec::new(),
         qa_outcome_calls: Vec::new(),
         latest_qa_report: None,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -412,6 +412,8 @@ impl TaskStore for FakeTaskStore {
         if let Some(task) = state.tasks.iter_mut().find(|task| task.id == task_id) {
             task.document_summary = TaskDocumentSummary::default();
         }
+        state.metadata_spec = None;
+        state.metadata_plan = None;
         state.latest_qa_report = None;
         Ok(())
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1783,9 +1783,10 @@ fn qa_get_report_returns_latest_markdown_when_present() -> Result<()> {
         let mut state = task_state.lock().expect("task lock poisoned");
         state.latest_qa_report = Some(QaReportDocument {
             markdown: "QA body".to_string(),
-            verdict: QaVerdict::Approved,
-            updated_at: "2026-02-20T12:00:00Z".to_string(),
-            revision: 2,
+            verdict: QaWorkflowVerdict::Approved,
+            updated_at: Some("2026-02-20T12:00:00Z".to_string()),
+            revision: Some(2),
+            error: None,
         });
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1853,6 +1853,60 @@ fn qa_get_report_preserves_document_level_decode_errors() -> Result<()> {
 }
 
 #[test]
+fn spec_get_and_plan_get_preserve_document_level_decode_errors() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-doc-errors";
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    {
+        let mut state = task_state.lock().expect("task lock poisoned");
+        state.metadata_spec = Some(host_domain::SpecDocument {
+            markdown: String::new(),
+            updated_at: Some("2026-02-20T10:00:00Z".to_string()),
+            revision: Some(1),
+            error: Some(
+                "Failed to decode openducktor.documents.spec[0]: invalid base64 payload"
+                    .to_string(),
+            ),
+        });
+        state.metadata_plan = Some(host_domain::SpecDocument {
+            markdown: String::new(),
+            updated_at: Some("2026-02-20T11:00:00Z".to_string()),
+            revision: Some(2),
+            error: Some(
+                "Failed to decode openducktor.documents.implementationPlan[0]: invalid gzip payload"
+                    .to_string(),
+            ),
+        });
+    }
+
+    let spec = service.spec_get(repo_path, "task-1")?;
+    assert!(spec.markdown.is_empty());
+    assert_eq!(spec.updated_at.as_deref(), Some("2026-02-20T10:00:00Z"));
+    assert_eq!(spec.revision, Some(1));
+    assert_eq!(
+        spec.error.as_deref(),
+        Some("Failed to decode openducktor.documents.spec[0]: invalid base64 payload"),
+    );
+
+    let plan = service.plan_get(repo_path, "task-1")?;
+    assert!(plan.markdown.is_empty());
+    assert_eq!(plan.updated_at.as_deref(), Some("2026-02-20T11:00:00Z"));
+    assert_eq!(plan.revision, Some(2));
+    assert_eq!(
+        plan.error.as_deref(),
+        Some("Failed to decode openducktor.documents.implementationPlan[0]: invalid gzip payload"),
+    );
+    Ok(())
+}
+
+#[test]
 fn spec_get_and_plan_get_use_consolidated_metadata_lookup() -> Result<()> {
     let repo_path = "/tmp/odt-repo-docs-read";
     let (service, task_state, _git_state) = build_service_with_git_state(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1816,6 +1816,43 @@ fn qa_get_report_returns_empty_when_not_present() -> Result<()> {
 }
 
 #[test]
+fn qa_get_report_preserves_document_level_decode_errors() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-qa-error";
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    {
+        let mut state = task_state.lock().expect("task lock poisoned");
+        state.latest_qa_report = Some(QaReportDocument {
+            markdown: String::new(),
+            verdict: QaWorkflowVerdict::Approved,
+            updated_at: Some("2026-02-20T12:00:00Z".to_string()),
+            revision: Some(2),
+            error: Some(
+                "Failed to decode openducktor.documents.qaReports[0]: invalid base64 payload"
+                    .to_string(),
+            ),
+        });
+    }
+
+    let report = service.qa_get_report(repo_path, "task-1")?;
+    assert!(report.markdown.is_empty());
+    assert_eq!(report.updated_at.as_deref(), Some("2026-02-20T12:00:00Z"));
+    assert_eq!(report.revision, Some(2));
+    assert_eq!(
+        report.error.as_deref(),
+        Some("Failed to decode openducktor.documents.qaReports[0]: invalid base64 payload"),
+    );
+    Ok(())
+}
+
+#[test]
 fn spec_get_and_plan_get_use_consolidated_metadata_lookup() -> Result<()> {
     let repo_path = "/tmp/odt-repo-docs-read";
     let (service, task_state, _git_state) = build_service_with_git_state(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -950,6 +950,8 @@ fn task_reset_clears_workflow_artifacts_and_sets_status_to_open() -> Result<()> 
     assert_eq!(reset.status, TaskStatus::Open);
     let state = task_state.lock().expect("task store lock poisoned");
     assert_eq!(state.cleared_workflow_documents, vec!["task-1".to_string()]);
+    assert!(state.metadata_spec.is_none());
+    assert!(state.metadata_plan.is_none());
     assert_eq!(
         state.cleared_session_roles,
         vec![(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -95,6 +95,8 @@ fn app_service_new_constructor_is_callable() -> Result<()> {
             plan_get_calls: Vec::new(),
             plan_set_calls: Vec::new(),
             metadata_get_calls: Vec::new(),
+            metadata_spec: None,
+            metadata_plan: None,
             qa_append_calls: Vec::new(),
             qa_outcome_calls: Vec::new(),
             latest_qa_report: None,

--- a/apps/desktop/src-tauri/crates/host-domain/src/document.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/document.rs
@@ -100,6 +100,8 @@ pub struct SpecDocument {
     pub updated_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -113,9 +115,12 @@ pub enum QaVerdict {
 #[serde(rename_all = "camelCase")]
 pub struct QaReportDocument {
     pub markdown: String,
-    pub verdict: QaVerdict,
-    pub updated_at: String,
-    pub revision: u32,
+    pub verdict: QaWorkflowVerdict,
+    pub updated_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/Cargo.toml
@@ -5,7 +5,9 @@ edition.workspace = true
 
 [dependencies]
 anyhow = "1"
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
+flate2 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
@@ -1,0 +1,374 @@
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use host_domain::{QaReportDocument, QaWorkflowVerdict, SpecDocument};
+#[cfg(test)]
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use std::io::{Read, Write};
+
+#[cfg(test)]
+use crate::model::{MarkdownEntry, QaEntry};
+
+pub(crate) const DOCUMENT_ENCODING_GZIP_BASE64_V1: &str = "gzip-base64-v1";
+
+pub(crate) fn encode_markdown_for_storage(markdown: &str) -> Result<String> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(markdown.as_bytes())?;
+    let compressed = encoder.finish()?;
+    Ok(STANDARD.encode(compressed))
+}
+
+fn decode_markdown_payload(payload: &str, encoding: &str, path: &str) -> Result<String> {
+    match encoding {
+        DOCUMENT_ENCODING_GZIP_BASE64_V1 => {
+            let compressed = STANDARD.decode(payload).map_err(|error| {
+                anyhow!("Failed to decode {path}: invalid base64 payload: {error}")
+            })?;
+            let mut decoder = GzDecoder::new(compressed.as_slice());
+            let mut markdown = String::new();
+            decoder.read_to_string(&mut markdown).map_err(|error| {
+                anyhow!("Failed to decode {path}: invalid gzip payload: {error}")
+            })?;
+            Ok(markdown)
+        }
+        other => Err(anyhow!(
+            "Failed to decode {path}: unsupported encoding {other}"
+        )),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn parse_markdown_entries(value: &Value) -> Option<Vec<MarkdownEntry>> {
+    value
+        .as_array()?
+        .iter()
+        .map(|entry| MarkdownEntry::deserialize(entry).ok())
+        .collect::<Option<Vec<_>>>()
+}
+
+#[cfg(test)]
+pub(crate) fn parse_qa_entries(value: &Value) -> Option<Vec<QaEntry>> {
+    value
+        .as_array()?
+        .iter()
+        .map(|entry| QaEntry::deserialize(entry).ok())
+        .collect::<Option<Vec<_>>>()
+}
+
+pub(crate) fn next_document_revision(value: Option<&Value>, path: &str) -> Result<u32> {
+    match value {
+        None => Ok(1),
+        Some(Value::Array(entries)) => {
+            let mut max_revision = 0u32;
+            for (index, entry) in entries.iter().enumerate() {
+                let object = entry.as_object().ok_or_else(|| {
+                    anyhow!("Invalid existing {path} metadata at index {index}: expected an object")
+                })?;
+                let revision = parse_required_u32_field(object, "revision", path, index)?;
+                max_revision = max_revision.max(revision);
+            }
+            Ok(max_revision + 1)
+        }
+        Some(_) => Err(anyhow!(
+            "Invalid existing {path} metadata: expected an array"
+        )),
+    }
+}
+
+pub(crate) fn read_latest_markdown_document(value: Option<&Value>, path: &str) -> SpecDocument {
+    let Some(value) = value else {
+        return SpecDocument {
+            markdown: String::new(),
+            updated_at: None,
+            revision: None,
+            error: None,
+        };
+    };
+
+    let Some((entry, index)) = latest_entry(value) else {
+        return SpecDocument {
+            markdown: String::new(),
+            updated_at: None,
+            revision: None,
+            error: malformed_collection_error(path, value),
+        };
+    };
+
+    read_markdown_entry(entry, &format!("{path}[{index}]"))
+}
+
+pub(crate) fn read_latest_qa_document(
+    value: Option<&Value>,
+    path: &str,
+) -> Option<QaReportDocument> {
+    let value = value?;
+
+    let Some((entry, index)) = latest_entry(value) else {
+        return Some(QaReportDocument {
+            markdown: String::new(),
+            verdict: QaWorkflowVerdict::NotReviewed,
+            updated_at: None,
+            revision: None,
+            error: malformed_collection_error(path, value),
+        });
+    };
+
+    Some(read_qa_entry(entry, &format!("{path}[{index}]")))
+}
+
+pub(crate) fn document_presence(value: Option<&Value>) -> bool {
+    match value {
+        Some(Value::Array(entries)) => {
+            let Some(entry) = entries.last() else {
+                return false;
+            };
+            match entry.as_object() {
+                Some(object) => match object.get("markdown").and_then(Value::as_str) {
+                    Some(markdown) => !markdown.trim().is_empty(),
+                    None => true,
+                },
+                None => true,
+            }
+        }
+        Some(_) => true,
+        None => false,
+    }
+}
+
+pub(crate) fn latest_updated_at(value: Option<&Value>) -> Option<String> {
+    latest_entry(value?).and_then(|(entry, _)| {
+        entry.as_object().and_then(|object| {
+            object
+                .get("updatedAt")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+    })
+}
+
+pub(crate) fn latest_qa_verdict(value: Option<&Value>) -> QaWorkflowVerdict {
+    let Some(value) = value else {
+        return QaWorkflowVerdict::NotReviewed;
+    };
+    let Some((entry, _)) = latest_entry(value) else {
+        return QaWorkflowVerdict::NotReviewed;
+    };
+    let Some(object) = entry.as_object() else {
+        return QaWorkflowVerdict::NotReviewed;
+    };
+    parse_workflow_verdict(object.get("verdict")).unwrap_or(QaWorkflowVerdict::NotReviewed)
+}
+
+fn latest_entry<'a>(value: &'a Value) -> Option<(&'a Value, usize)> {
+    let entries = value.as_array()?;
+    let index = entries.len().checked_sub(1)?;
+    entries.get(index).map(|entry| (entry, index))
+}
+
+fn malformed_collection_error(path: &str, value: &Value) -> Option<String> {
+    if value.is_array() {
+        return None;
+    }
+    Some(format!("Failed to read {path}: expected an array"))
+}
+
+fn read_markdown_entry(entry: &Value, path: &str) -> SpecDocument {
+    let Some(object) = entry.as_object() else {
+        return SpecDocument {
+            markdown: String::new(),
+            updated_at: None,
+            revision: None,
+            error: Some(format!("Failed to read {path}: expected an object")),
+        };
+    };
+
+    let updated_at = optional_string_field(object, "updatedAt");
+    let revision = optional_u32_field(object, "revision");
+    let payload = required_string_field(object, "markdown");
+    let encoding = encoding_field(object);
+    let mut errors = field_errors(object, path, &["updatedAt", "revision"]);
+
+    if payload.is_none() {
+        errors.push(format!("{path}.markdown must be a string"));
+    }
+    if let Some(error) = encoding.as_ref().err() {
+        errors.push(error.clone());
+    }
+
+    if !errors.is_empty() {
+        return SpecDocument {
+            markdown: String::new(),
+            updated_at,
+            revision,
+            error: Some(format!("Failed to read {path}: {}", errors.join("; "))),
+        };
+    }
+
+    let payload = payload.expect("payload checked above");
+    let markdown = match encoding {
+        Ok(Some(value)) => match decode_markdown_payload(payload, &value, path) {
+            Ok(markdown) => markdown,
+            Err(error) => {
+                return SpecDocument {
+                    markdown: String::new(),
+                    updated_at,
+                    revision,
+                    error: Some(error.to_string()),
+                };
+            }
+        },
+        Ok(None) => payload.to_string(),
+        Err(_) => unreachable!("encoding error handled above"),
+    };
+
+    SpecDocument {
+        markdown,
+        updated_at,
+        revision,
+        error: None,
+    }
+}
+
+fn read_qa_entry(entry: &Value, path: &str) -> QaReportDocument {
+    let Some(object) = entry.as_object() else {
+        return QaReportDocument {
+            markdown: String::new(),
+            verdict: QaWorkflowVerdict::NotReviewed,
+            updated_at: None,
+            revision: None,
+            error: Some(format!("Failed to read {path}: expected an object")),
+        };
+    };
+
+    let updated_at = optional_string_field(object, "updatedAt");
+    let revision = optional_u32_field(object, "revision");
+    let payload = required_string_field(object, "markdown");
+    let encoding = encoding_field(object);
+    let verdict = parse_workflow_verdict(object.get("verdict"));
+    let mut errors = field_errors(object, path, &["updatedAt", "revision"]);
+
+    if payload.is_none() {
+        errors.push(format!("{path}.markdown must be a string"));
+    }
+    if let Some(error) = encoding.as_ref().err() {
+        errors.push(error.clone());
+    }
+    if verdict.is_none() {
+        errors.push(format!(
+            "{path}.verdict must be one of approved or rejected"
+        ));
+    }
+
+    if !errors.is_empty() {
+        return QaReportDocument {
+            markdown: String::new(),
+            verdict: verdict.unwrap_or(QaWorkflowVerdict::NotReviewed),
+            updated_at,
+            revision,
+            error: Some(format!("Failed to read {path}: {}", errors.join("; "))),
+        };
+    }
+
+    let payload = payload.expect("payload checked above");
+    let markdown = match encoding {
+        Ok(Some(value)) => match decode_markdown_payload(payload, &value, path) {
+            Ok(markdown) => markdown,
+            Err(error) => {
+                return QaReportDocument {
+                    markdown: String::new(),
+                    verdict: verdict.expect("verdict checked above"),
+                    updated_at,
+                    revision,
+                    error: Some(error.to_string()),
+                };
+            }
+        },
+        Ok(None) => payload.to_string(),
+        Err(_) => unreachable!("encoding error handled above"),
+    };
+
+    QaReportDocument {
+        markdown,
+        verdict: verdict.expect("verdict checked above"),
+        updated_at,
+        revision,
+        error: None,
+    }
+}
+
+fn parse_required_u32_field(
+    object: &Map<String, Value>,
+    field: &str,
+    path: &str,
+    index: usize,
+) -> Result<u32> {
+    let value = object.get(field).and_then(Value::as_u64).ok_or_else(|| {
+        anyhow!(
+            "Invalid existing {path} metadata at index {index}: {field} must be a positive integer"
+        )
+    })?;
+    u32::try_from(value).map_err(|_| {
+        anyhow!("Invalid existing {path} metadata at index {index}: {field} exceeds u32")
+    })
+}
+
+fn optional_u32_field(object: &Map<String, Value>, field: &str) -> Option<u32> {
+    object
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+}
+
+fn optional_string_field(object: &Map<String, Value>, field: &str) -> Option<String> {
+    object
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn required_string_field<'a>(object: &'a Map<String, Value>, field: &str) -> Option<&'a str> {
+    object.get(field).and_then(Value::as_str)
+}
+
+fn encoding_field(object: &Map<String, Value>) -> std::result::Result<Option<String>, String> {
+    if !object.contains_key("encoding") {
+        return Ok(None);
+    }
+
+    match object.get("encoding").and_then(Value::as_str) {
+        Some(value) => Ok(Some(value.to_string())),
+        None => Err("encoding must be a string when present".to_string()),
+    }
+}
+
+fn parse_workflow_verdict(value: Option<&Value>) -> Option<QaWorkflowVerdict> {
+    match value.and_then(Value::as_str) {
+        Some("approved") => Some(QaWorkflowVerdict::Approved),
+        Some("rejected") => Some(QaWorkflowVerdict::Rejected),
+        _ => None,
+    }
+}
+
+fn field_errors(object: &Map<String, Value>, path: &str, fields: &[&str]) -> Vec<String> {
+    let mut errors = Vec::new();
+    for &field in fields {
+        let invalid = match field {
+            "updatedAt" => {
+                object.contains_key(field) && object.get(field).and_then(Value::as_str).is_none()
+            }
+            "revision" => object.contains_key(field) && optional_u32_field(object, field).is_none(),
+            _ => false,
+        };
+
+        if invalid {
+            let description = match field {
+                "updatedAt" => "must be a string",
+                "revision" => "must be a positive integer",
+                _ => "is invalid",
+            };
+            errors.push(format!("{path}.{field} {description}"));
+        }
+    }
+    errors
+}

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
@@ -11,6 +11,7 @@ use std::io::{Read, Write};
 use crate::model::{MarkdownEntry, QaEntry};
 
 pub(crate) const DOCUMENT_ENCODING_GZIP_BASE64_V1: &str = "gzip-base64-v1";
+pub(crate) const MAX_DECODED_MARKDOWN_BYTES: u64 = 2 * 1024 * 1024;
 
 pub(crate) fn encode_markdown_for_storage(markdown: &str) -> Result<String> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
@@ -25,12 +26,21 @@ fn decode_markdown_payload(payload: &str, encoding: &str, path: &str) -> Result<
             let compressed = STANDARD.decode(payload).map_err(|error| {
                 anyhow!("Failed to decode {path}: invalid base64 payload: {error}")
             })?;
-            let mut decoder = GzDecoder::new(compressed.as_slice());
-            let mut markdown = String::new();
-            decoder.read_to_string(&mut markdown).map_err(|error| {
-                anyhow!("Failed to decode {path}: invalid gzip payload: {error}")
-            })?;
-            Ok(markdown)
+            let decoder = GzDecoder::new(compressed.as_slice());
+            let mut bytes = Vec::new();
+            decoder
+                .take(MAX_DECODED_MARKDOWN_BYTES + 1)
+                .read_to_end(&mut bytes)
+                .map_err(|error| {
+                    anyhow!("Failed to decode {path}: invalid gzip payload: {error}")
+                })?;
+            if (bytes.len() as u64) > MAX_DECODED_MARKDOWN_BYTES {
+                return Err(anyhow!(
+                    "Failed to decode {path}: decoded payload exceeds size limit"
+                ));
+            }
+            String::from_utf8(bytes)
+                .map_err(|error| anyhow!("Failed to decode {path}: invalid utf-8 payload: {error}"))
         }
         other => Err(anyhow!(
             "Failed to decode {path}: unsupported encoding {other}"

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
@@ -105,6 +105,9 @@ pub(crate) fn read_latest_qa_document(
     path: &str,
 ) -> Option<QaReportDocument> {
     let value = value?;
+    if matches!(value, Value::Array(entries) if entries.is_empty()) {
+        return None;
+    }
 
     let Some((entry, index)) = latest_entry(value) else {
         return Some(QaReportDocument {
@@ -328,6 +331,11 @@ fn parse_required_u32_field(
             "Invalid existing {path} metadata at index {index}: {field} must be a positive integer"
         )
     })?;
+    if value == 0 {
+        return Err(anyhow!(
+            "Invalid existing {path} metadata at index {index}: {field} must be a positive integer"
+        ));
+    }
     u32::try_from(value).map_err(|_| {
         anyhow!("Invalid existing {path} metadata at index {index}: {field} exceeds u32")
     })
@@ -337,6 +345,7 @@ fn optional_u32_field(object: &Map<String, Value>, field: &str) -> Option<u32> {
     object
         .get(field)
         .and_then(Value::as_u64)
+        .and_then(|value| (value > 0).then_some(value))
         .and_then(|value| u32::try_from(value).ok())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
@@ -68,7 +68,9 @@ pub(crate) fn next_document_revision(value: Option<&Value>, path: &str) -> Resul
                 let revision = parse_required_u32_field(object, "revision", path, index)?;
                 max_revision = max_revision.max(revision);
             }
-            Ok(max_revision + 1)
+            max_revision.checked_add(1).ok_or_else(|| {
+                anyhow!("Invalid existing {path} metadata: revision exceeds supported range")
+            })
         }
         Some(_) => Err(anyhow!(
             "Invalid existing {path} metadata: expected an array"
@@ -171,7 +173,7 @@ pub(crate) fn latest_qa_verdict(value: Option<&Value>) -> QaWorkflowVerdict {
     parse_workflow_verdict(object.get("verdict")).unwrap_or(QaWorkflowVerdict::NotReviewed)
 }
 
-fn latest_entry<'a>(value: &'a Value) -> Option<(&'a Value, usize)> {
+fn latest_entry(value: &Value) -> Option<(&Value, usize)> {
     let entries = value.as_array()?;
     let index = entries.len().checked_sub(1)?;
     entries.get(index).map(|entry| (entry, index))

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
@@ -124,10 +124,21 @@ pub(crate) fn document_presence(value: Option<&Value>) -> bool {
                 return false;
             };
             match entry.as_object() {
-                Some(object) => match object.get("markdown").and_then(Value::as_str) {
-                    Some(markdown) => !markdown.trim().is_empty(),
-                    None => true,
-                },
+                Some(object) => {
+                    let Some(payload) = object.get("markdown").and_then(Value::as_str) else {
+                        return true;
+                    };
+
+                    match object.get("encoding").and_then(Value::as_str) {
+                        Some(encoding) => {
+                            decode_markdown_payload(payload, encoding, "document presence")
+                                .map(|markdown| !markdown.trim().is_empty())
+                                .unwrap_or(true)
+                        }
+                        None if object.contains_key("encoding") => true,
+                        None => !payload.trim().is_empty(),
+                    }
+                }
                 None => true,
             }
         }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/document_storage.rs
@@ -173,6 +173,61 @@ fn malformed_collection_error(path: &str, value: &Value) -> Option<String> {
     Some(format!("Failed to read {path}: expected an array"))
 }
 
+struct BaseDocumentFields<'a> {
+    updated_at: Option<String>,
+    revision: Option<u32>,
+    payload: Option<&'a str>,
+    encoding: std::result::Result<Option<String>, String>,
+    errors: Vec<String>,
+}
+
+impl<'a> BaseDocumentFields<'a> {
+    fn from_object(object: &'a Map<String, Value>, path: &str) -> Self {
+        let updated_at = optional_string_field(object, "updatedAt");
+        let revision = optional_u32_field(object, "revision");
+        let payload = required_string_field(object, "markdown");
+        let encoding = encoding_field(object);
+        let mut errors = field_errors(object, path, &["updatedAt", "revision"]);
+
+        if payload.is_none() {
+            errors.push(format!("{path}.markdown must be a string"));
+        }
+        if let Some(error) = encoding.as_ref().err() {
+            errors.push(error.clone());
+        }
+
+        Self {
+            updated_at,
+            revision,
+            payload,
+            encoding,
+            errors,
+        }
+    }
+
+    fn with_additional_error(mut self, error: Option<String>) -> Self {
+        if let Some(error) = error {
+            self.errors.push(error);
+        }
+        self
+    }
+
+    fn decode_markdown(&self, path: &str) -> std::result::Result<String, String> {
+        if !self.errors.is_empty() {
+            return Err(format!("Failed to read {path}: {}", self.errors.join("; ")));
+        }
+
+        let payload = self.payload.expect("payload checked above");
+        match &self.encoding {
+            Ok(Some(encoding)) => {
+                decode_markdown_payload(payload, encoding, path).map_err(|error| error.to_string())
+            }
+            Ok(None) => Ok(payload.to_string()),
+            Err(_) => unreachable!("encoding error handled above"),
+        }
+    }
+}
+
 fn read_markdown_entry(entry: &Value, path: &str) -> SpecDocument {
     let Some(object) = entry.as_object() else {
         return SpecDocument {
@@ -183,43 +238,20 @@ fn read_markdown_entry(entry: &Value, path: &str) -> SpecDocument {
         };
     };
 
-    let updated_at = optional_string_field(object, "updatedAt");
-    let revision = optional_u32_field(object, "revision");
-    let payload = required_string_field(object, "markdown");
-    let encoding = encoding_field(object);
-    let mut errors = field_errors(object, path, &["updatedAt", "revision"]);
+    let fields = BaseDocumentFields::from_object(object, path);
+    let updated_at = fields.updated_at.clone();
+    let revision = fields.revision;
 
-    if payload.is_none() {
-        errors.push(format!("{path}.markdown must be a string"));
-    }
-    if let Some(error) = encoding.as_ref().err() {
-        errors.push(error.clone());
-    }
-
-    if !errors.is_empty() {
-        return SpecDocument {
-            markdown: String::new(),
-            updated_at,
-            revision,
-            error: Some(format!("Failed to read {path}: {}", errors.join("; "))),
-        };
-    }
-
-    let payload = payload.expect("payload checked above");
-    let markdown = match encoding {
-        Ok(Some(value)) => match decode_markdown_payload(payload, &value, path) {
-            Ok(markdown) => markdown,
-            Err(error) => {
-                return SpecDocument {
-                    markdown: String::new(),
-                    updated_at,
-                    revision,
-                    error: Some(error.to_string()),
-                };
-            }
-        },
-        Ok(None) => payload.to_string(),
-        Err(_) => unreachable!("encoding error handled above"),
+    let markdown = match fields.decode_markdown(path) {
+        Ok(markdown) => markdown,
+        Err(error) => {
+            return SpecDocument {
+                markdown: String::new(),
+                updated_at,
+                revision,
+                error: Some(error),
+            };
+        }
     };
 
     SpecDocument {
@@ -241,51 +273,26 @@ fn read_qa_entry(entry: &Value, path: &str) -> QaReportDocument {
         };
     };
 
-    let updated_at = optional_string_field(object, "updatedAt");
-    let revision = optional_u32_field(object, "revision");
-    let payload = required_string_field(object, "markdown");
-    let encoding = encoding_field(object);
     let verdict = parse_workflow_verdict(object.get("verdict"));
-    let mut errors = field_errors(object, path, &["updatedAt", "revision"]);
+    let fields = BaseDocumentFields::from_object(object, path).with_additional_error(
+        verdict
+            .is_none()
+            .then(|| format!("{path}.verdict must be one of approved or rejected")),
+    );
+    let updated_at = fields.updated_at.clone();
+    let revision = fields.revision;
 
-    if payload.is_none() {
-        errors.push(format!("{path}.markdown must be a string"));
-    }
-    if let Some(error) = encoding.as_ref().err() {
-        errors.push(error.clone());
-    }
-    if verdict.is_none() {
-        errors.push(format!(
-            "{path}.verdict must be one of approved or rejected"
-        ));
-    }
-
-    if !errors.is_empty() {
-        return QaReportDocument {
-            markdown: String::new(),
-            verdict: verdict.unwrap_or(QaWorkflowVerdict::NotReviewed),
-            updated_at,
-            revision,
-            error: Some(format!("Failed to read {path}: {}", errors.join("; "))),
-        };
-    }
-
-    let payload = payload.expect("payload checked above");
-    let markdown = match encoding {
-        Ok(Some(value)) => match decode_markdown_payload(payload, &value, path) {
-            Ok(markdown) => markdown,
-            Err(error) => {
-                return QaReportDocument {
-                    markdown: String::new(),
-                    verdict: verdict.expect("verdict checked above"),
-                    updated_at,
-                    revision,
-                    error: Some(error.to_string()),
-                };
-            }
-        },
-        Ok(None) => payload.to_string(),
-        Err(_) => unreachable!("encoding error handled above"),
+    let markdown = match fields.decode_markdown(path) {
+        Ok(markdown) => markdown,
+        Err(error) => {
+            return QaReportDocument {
+                markdown: String::new(),
+                verdict: verdict.unwrap_or(QaWorkflowVerdict::NotReviewed),
+                updated_at,
+                revision,
+                error: Some(error),
+            };
+        }
     };
 
     QaReportDocument {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
@@ -19,7 +19,7 @@ use constants::{CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS};
 #[cfg(test)]
 use document_storage::{
     encode_markdown_for_storage, next_document_revision, parse_markdown_entries, parse_qa_entries,
-    DOCUMENT_ENCODING_GZIP_BASE64_V1,
+    read_latest_markdown_document, DOCUMENT_ENCODING_GZIP_BASE64_V1,
 };
 #[cfg(test)]
 use metadata::{

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
@@ -19,7 +19,7 @@ use constants::{CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS};
 #[cfg(test)]
 use document_storage::{
     encode_markdown_for_storage, next_document_revision, parse_markdown_entries, parse_qa_entries,
-    read_latest_markdown_document, DOCUMENT_ENCODING_GZIP_BASE64_V1,
+    read_latest_markdown_document, DOCUMENT_ENCODING_GZIP_BASE64_V1, MAX_DECODED_MARKDOWN_BYTES,
 };
 #[cfg(test)]
 use metadata::{

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
@@ -18,7 +18,7 @@ use command_runner::{CommandRunner, ProcessCommandRunner};
 use constants::{CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS};
 #[cfg(test)]
 use document_storage::{
-    encode_markdown_for_storage, parse_markdown_entries, parse_qa_entries,
+    encode_markdown_for_storage, next_document_revision, parse_markdown_entries, parse_qa_entries,
     DOCUMENT_ENCODING_GZIP_BASE64_V1,
 };
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
@@ -1,5 +1,6 @@
 mod command_runner;
 mod constants;
+mod document_storage;
 mod execution;
 mod lifecycle;
 mod metadata;
@@ -16,9 +17,13 @@ use command_runner::{CommandRunner, ProcessCommandRunner};
 #[cfg(test)]
 use constants::{CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS};
 #[cfg(test)]
+use document_storage::{
+    encode_markdown_for_storage, parse_markdown_entries, parse_qa_entries,
+    DOCUMENT_ENCODING_GZIP_BASE64_V1,
+};
+#[cfg(test)]
 use metadata::{
-    metadata_bool_qa_required, metadata_namespace, parse_agent_sessions, parse_markdown_entries,
-    parse_metadata_root, parse_qa_entries,
+    metadata_bool_qa_required, metadata_namespace, parse_agent_sessions, parse_metadata_root,
 };
 #[cfg(test)]
 use normalize::{

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
@@ -1,11 +1,10 @@
 use host_domain::{
-    AgentSessionDocument, QaVerdict, QaWorkflowVerdict, TaskDocumentPresence, TaskDocumentSummary,
-    TaskQaDocumentPresence,
+    AgentSessionDocument, TaskDocumentPresence, TaskDocumentSummary, TaskQaDocumentPresence,
 };
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
-use crate::model::{MarkdownEntry, QaEntry};
+use crate::document_storage::{document_presence, latest_qa_verdict, latest_updated_at};
 
 const LEGACY_AGENT_SESSION_SCENARIO_ALIASES: &[(&str, &str)] = &[
     ("spec_revision", "spec_initial"),
@@ -30,41 +29,31 @@ pub(crate) fn metadata_bool_qa_required(namespace: &Map<String, Value>) -> Optio
     namespace.get("qaRequired").and_then(Value::as_bool)
 }
 
-pub(crate) fn markdown_document_presence(
-    entries: Option<Vec<MarkdownEntry>>,
-) -> TaskDocumentPresence {
-    let latest = entries.as_ref().and_then(|list| list.last());
-    match latest {
-        Some(entry) if !entry.markdown.trim().is_empty() => TaskDocumentPresence {
-            has: true,
-            updated_at: Some(entry.updated_at.clone()),
-        },
-        _ => TaskDocumentPresence::default(),
+pub(crate) fn markdown_document_presence(value: Option<&Value>) -> TaskDocumentPresence {
+    if !document_presence(value) {
+        return TaskDocumentPresence::default();
+    }
+
+    TaskDocumentPresence {
+        has: true,
+        updated_at: latest_updated_at(value),
     }
 }
 
-fn qa_workflow_verdict_from_entry(verdict: &QaVerdict) -> QaWorkflowVerdict {
-    match verdict {
-        QaVerdict::Approved => QaWorkflowVerdict::Approved,
-        QaVerdict::Rejected => QaWorkflowVerdict::Rejected,
-    }
-}
-
-pub(crate) fn qa_document_presence(entries: Option<Vec<QaEntry>>) -> TaskQaDocumentPresence {
-    let Some(latest) = entries.as_ref().and_then(|list| list.last()) else {
+pub(crate) fn qa_document_presence(value: Option<&Value>) -> TaskQaDocumentPresence {
+    let Some(value) = value else {
         return TaskQaDocumentPresence::default();
     };
-
-    let has_content = !latest.markdown.trim().is_empty();
+    let has = document_presence(Some(value));
 
     TaskQaDocumentPresence {
-        has: has_content,
-        updated_at: if has_content {
-            Some(latest.updated_at.clone())
+        has,
+        updated_at: if has {
+            latest_updated_at(Some(value))
         } else {
             None
         },
-        verdict: qa_workflow_verdict_from_entry(&latest.verdict),
+        verdict: latest_qa_verdict(Some(value)),
     }
 }
 
@@ -75,45 +64,16 @@ pub(crate) fn metadata_document_summary(
         .and_then(|entry| entry.get("documents"))
         .and_then(Value::as_object);
 
-    let spec = markdown_document_presence(
-        documents
-            .and_then(|docs| docs.get("spec"))
-            .and_then(parse_markdown_entries),
-    );
-    let plan = markdown_document_presence(
-        documents
-            .and_then(|docs| docs.get("implementationPlan"))
-            .and_then(parse_markdown_entries),
-    );
-    let qa_report = qa_document_presence(
-        documents
-            .and_then(|docs| docs.get("qaReports"))
-            .and_then(parse_qa_entries),
-    );
+    let spec = markdown_document_presence(documents.and_then(|docs| docs.get("spec")));
+    let plan =
+        markdown_document_presence(documents.and_then(|docs| docs.get("implementationPlan")));
+    let qa_report = qa_document_presence(documents.and_then(|docs| docs.get("qaReports")));
 
     TaskDocumentSummary {
         spec,
         plan,
         qa_report,
     }
-}
-
-pub(crate) fn parse_markdown_entries(value: &Value) -> Option<Vec<MarkdownEntry>> {
-    let entries = value
-        .as_array()?
-        .iter()
-        .filter_map(|entry| MarkdownEntry::deserialize(entry).ok())
-        .collect::<Vec<_>>();
-    Some(entries)
-}
-
-pub(crate) fn parse_qa_entries(value: &Value) -> Option<Vec<QaEntry>> {
-    let entries = value
-        .as_array()?
-        .iter()
-        .filter_map(|entry| QaEntry::deserialize(entry).ok())
-        .collect::<Vec<_>>();
-    Some(entries)
 }
 
 fn normalize_agent_session_entry(entry: &Value) -> Value {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/model.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/model.rs
@@ -43,6 +43,8 @@ pub(crate) struct RawDependency {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct MarkdownEntry {
     pub(crate) markdown: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) encoding: Option<String>,
     pub(crate) updated_at: String,
     pub(crate) updated_by: String,
     pub(crate) source_tool: String,
@@ -53,6 +55,8 @@ pub(crate) struct MarkdownEntry {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct QaEntry {
     pub(crate) markdown: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) encoding: Option<String>,
     pub(crate) verdict: QaVerdict,
     pub(crate) updated_at: String,
     pub(crate) updated_by: String,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     now_rfc3339, AgentSessionDocument, CreateTaskInput, DirectMergeRecord, PullRequestRecord,
-    QaReportDocument, QaVerdict, SpecDocument, TaskCard, TaskMetadata, TaskStatus, TaskStore,
-    UpdateTaskPatch, ODT_QA_APPROVED_SOURCE_TOOL, ODT_QA_REJECTED_SOURCE_TOOL,
-    ODT_SET_PLAN_SOURCE_TOOL, ODT_SET_SPEC_SOURCE_TOOL,
+    QaReportDocument, QaVerdict, QaWorkflowVerdict, SpecDocument, TaskCard, TaskMetadata,
+    TaskStatus, TaskStore, UpdateTaskPatch, ODT_QA_APPROVED_SOURCE_TOOL,
+    ODT_QA_REJECTED_SOURCE_TOOL, ODT_SET_PLAN_SOURCE_TOOL, ODT_SET_SPEC_SOURCE_TOOL,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -15,10 +15,7 @@ use std::time::{Duration, Instant};
 use crate::command_runner::{CommandRunner, ProcessCommandRunner};
 use crate::constants::{DEFAULT_METADATA_NAMESPACE, TASK_LIST_CACHE_TTL_MS};
 use crate::lifecycle::BeadsLifecycle;
-use crate::metadata::{
-    metadata_namespace, parse_agent_sessions, parse_markdown_entries, parse_metadata_root,
-    parse_qa_entries,
-};
+use crate::metadata::{metadata_namespace, parse_agent_sessions, parse_metadata_root};
 use crate::model::{MarkdownEntry, QaEntry, RawIssue};
 use crate::normalize::{normalize_labels, normalize_text_option};
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
@@ -4,10 +4,11 @@ fn write_latest_qa_report(
     documents_map: &mut serde_json::Map<String, Value>,
     markdown: &str,
     verdict: QaVerdict,
+    qa_reports_path: &str,
 ) -> Result<QaEntry> {
     let next_revision = crate::document_storage::next_document_revision(
         documents_map.get("qaReports"),
-        "openducktor.documents.qaReports",
+        qa_reports_path,
     )?;
     let encoded_markdown = crate::document_storage::encode_markdown_for_storage(markdown.trim())?;
 
@@ -38,11 +39,12 @@ impl BeadsTaskStore {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
+        let spec_path = format!("{namespace_key}.documents.spec");
         Ok(crate::document_storage::read_latest_markdown_document(
             metadata_namespace(&metadata_root, &namespace_key)
                 .and_then(|ns| ns.get("documents"))
                 .and_then(|docs| docs.get("spec")),
-            "openducktor.documents.spec",
+            &spec_path,
         ))
     }
 
@@ -54,16 +56,15 @@ impl BeadsTaskStore {
     ) -> Result<SpecDocument> {
         let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
+        let spec_path = format!("{namespace_key}.documents.spec");
         let mut documents_map = namespace_map
             .get("documents")
             .and_then(Value::as_object)
             .cloned()
             .unwrap_or_default();
 
-        let next_revision = crate::document_storage::next_document_revision(
-            documents_map.get("spec"),
-            "openducktor.documents.spec",
-        )?;
+        let next_revision =
+            crate::document_storage::next_document_revision(documents_map.get("spec"), &spec_path)?;
 
         let timestamp = now_rfc3339();
         let encoded_markdown =
@@ -97,11 +98,12 @@ impl BeadsTaskStore {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
+        let plan_path = format!("{namespace_key}.documents.implementationPlan");
         Ok(crate::document_storage::read_latest_markdown_document(
             metadata_namespace(&metadata_root, &namespace_key)
                 .and_then(|ns| ns.get("documents"))
                 .and_then(|docs| docs.get("implementationPlan")),
-            "openducktor.documents.implementationPlan",
+            &plan_path,
         ))
     }
 
@@ -113,6 +115,7 @@ impl BeadsTaskStore {
     ) -> Result<SpecDocument> {
         let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
+        let plan_path = format!("{namespace_key}.documents.implementationPlan");
         let mut documents_map = namespace_map
             .get("documents")
             .and_then(Value::as_object)
@@ -121,7 +124,7 @@ impl BeadsTaskStore {
 
         let next_revision = crate::document_storage::next_document_revision(
             documents_map.get("implementationPlan"),
-            "openducktor.documents.implementationPlan",
+            &plan_path,
         )?;
 
         let timestamp = now_rfc3339();
@@ -160,12 +163,13 @@ impl BeadsTaskStore {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
+        let qa_path = format!("{namespace_key}.documents.qaReports");
         let namespace = metadata_namespace(&metadata_root, &namespace_key);
         let report = crate::document_storage::read_latest_qa_document(
             namespace
                 .and_then(|ns| ns.get("documents"))
                 .and_then(|docs| docs.get("qaReports")),
-            "openducktor.documents.qaReports",
+            &qa_path,
         );
 
         Ok(report)
@@ -180,12 +184,13 @@ impl BeadsTaskStore {
     ) -> Result<QaReportDocument> {
         let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
+        let qa_path = format!("{namespace_key}.documents.qaReports");
         let mut documents_map = namespace_map
             .get("documents")
             .and_then(Value::as_object)
             .cloned()
             .unwrap_or_default();
-        let entry = write_latest_qa_report(&mut documents_map, markdown, verdict)?;
+        let entry = write_latest_qa_report(&mut documents_map, markdown, verdict, &qa_path)?;
         namespace_map.insert("documents".to_string(), Value::Object(documents_map));
 
         self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
@@ -211,12 +216,13 @@ impl BeadsTaskStore {
     ) -> Result<TaskCard> {
         let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
+        let qa_path = format!("{namespace_key}.documents.qaReports");
         let mut documents_map = namespace_map
             .get("documents")
             .and_then(Value::as_object)
             .cloned()
             .unwrap_or_default();
-        write_latest_qa_report(&mut documents_map, markdown, verdict)?;
+        write_latest_qa_report(&mut documents_map, markdown, verdict, &qa_path)?;
         namespace_map.insert("documents".to_string(), Value::Object(documents_map));
         root.insert(namespace_key, Value::Object(namespace_map));
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
@@ -5,39 +5,19 @@ fn write_latest_qa_report(
     markdown: &str,
     verdict: QaVerdict,
 ) -> Result<QaEntry> {
-    let next_revision = match documents_map.get("qaReports") {
-        None => 1,
-        Some(raw_reports) => {
-            let raw_entries = raw_reports.as_array().ok_or_else(|| {
-                anyhow::Error::msg("Invalid existing qaReports metadata: expected an array")
-            })?;
-            let entries = raw_entries
-                .iter()
-                .enumerate()
-                .map(|(index, entry)| {
-                    serde_json::from_value::<QaEntry>(entry.clone()).map_err(|error| {
-                        anyhow::Error::msg(format!(
-                            "Invalid existing qaReports metadata at index {index}: {error}"
-                        ))
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?;
-
-            entries
-                .iter()
-                .map(|entry| entry.revision)
-                .max()
-                .unwrap_or(0)
-                + 1
-        }
-    };
+    let next_revision = crate::document_storage::next_document_revision(
+        documents_map.get("qaReports"),
+        "openducktor.documents.qaReports",
+    )?;
+    let encoded_markdown = crate::document_storage::encode_markdown_for_storage(markdown.trim())?;
 
     let source_tool = match verdict {
         QaVerdict::Approved => ODT_QA_APPROVED_SOURCE_TOOL,
         QaVerdict::Rejected => ODT_QA_REJECTED_SOURCE_TOOL,
     };
     let entry = QaEntry {
-        markdown: markdown.trim().to_string(),
+        markdown: encoded_markdown,
+        encoding: Some(crate::document_storage::DOCUMENT_ENCODING_GZIP_BASE64_V1.to_string()),
         verdict,
         updated_at: now_rfc3339(),
         updated_by: "qa-agent".to_string(),
@@ -58,19 +38,12 @@ impl BeadsTaskStore {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
-        let entries = metadata_namespace(&metadata_root, &namespace_key)
-            .and_then(|ns| ns.get("documents"))
-            .and_then(|docs| docs.get("spec"))
-            .and_then(parse_markdown_entries);
-        let latest = entries.as_ref().and_then(|list| list.last());
-
-        Ok(SpecDocument {
-            markdown: latest
-                .map(|entry| entry.markdown.clone())
-                .unwrap_or_default(),
-            updated_at: latest.map(|entry| entry.updated_at.clone()),
-            revision: latest.map(|entry| entry.revision),
-        })
+        Ok(crate::document_storage::read_latest_markdown_document(
+            metadata_namespace(&metadata_root, &namespace_key)
+                .and_then(|ns| ns.get("documents"))
+                .and_then(|docs| docs.get("spec")),
+            "openducktor.documents.spec",
+        ))
     }
 
     pub(super) fn set_spec_impl(
@@ -87,15 +60,17 @@ impl BeadsTaskStore {
             .cloned()
             .unwrap_or_default();
 
-        let next_revision = documents_map
-            .get("spec")
-            .and_then(parse_markdown_entries)
-            .and_then(|entries| entries.last().map(|entry| entry.revision + 1))
-            .unwrap_or(1);
+        let next_revision = crate::document_storage::next_document_revision(
+            documents_map.get("spec"),
+            "openducktor.documents.spec",
+        )?;
 
         let timestamp = now_rfc3339();
+        let encoded_markdown =
+            crate::document_storage::encode_markdown_for_storage(markdown.trim())?;
         let entry = MarkdownEntry {
-            markdown: markdown.trim().to_string(),
+            markdown: encoded_markdown,
+            encoding: Some(crate::document_storage::DOCUMENT_ENCODING_GZIP_BASE64_V1.to_string()),
             updated_at: timestamp.clone(),
             updated_by: "planner-agent".to_string(),
             source_tool: ODT_SET_SPEC_SOURCE_TOOL.to_string(),
@@ -111,9 +86,10 @@ impl BeadsTaskStore {
         self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
 
         Ok(SpecDocument {
-            markdown: entry.markdown,
+            markdown: markdown.trim().to_string(),
             updated_at: Some(timestamp),
             revision: Some(entry.revision),
+            error: None,
         })
     }
 
@@ -121,19 +97,12 @@ impl BeadsTaskStore {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
-        let entries = metadata_namespace(&metadata_root, &namespace_key)
-            .and_then(|ns| ns.get("documents"))
-            .and_then(|docs| docs.get("implementationPlan"))
-            .and_then(parse_markdown_entries);
-        let latest = entries.as_ref().and_then(|list| list.last());
-
-        Ok(SpecDocument {
-            markdown: latest
-                .map(|entry| entry.markdown.clone())
-                .unwrap_or_default(),
-            updated_at: latest.map(|entry| entry.updated_at.clone()),
-            revision: latest.map(|entry| entry.revision),
-        })
+        Ok(crate::document_storage::read_latest_markdown_document(
+            metadata_namespace(&metadata_root, &namespace_key)
+                .and_then(|ns| ns.get("documents"))
+                .and_then(|docs| docs.get("implementationPlan")),
+            "openducktor.documents.implementationPlan",
+        ))
     }
 
     pub(super) fn set_plan_impl(
@@ -150,15 +119,17 @@ impl BeadsTaskStore {
             .cloned()
             .unwrap_or_default();
 
-        let next_revision = documents_map
-            .get("implementationPlan")
-            .and_then(parse_markdown_entries)
-            .and_then(|entries| entries.last().map(|entry| entry.revision + 1))
-            .unwrap_or(1);
+        let next_revision = crate::document_storage::next_document_revision(
+            documents_map.get("implementationPlan"),
+            "openducktor.documents.implementationPlan",
+        )?;
 
         let timestamp = now_rfc3339();
+        let encoded_markdown =
+            crate::document_storage::encode_markdown_for_storage(markdown.trim())?;
         let entry = MarkdownEntry {
-            markdown: markdown.trim().to_string(),
+            markdown: encoded_markdown,
+            encoding: Some(crate::document_storage::DOCUMENT_ENCODING_GZIP_BASE64_V1.to_string()),
             updated_at: timestamp.clone(),
             updated_by: "planner-agent".to_string(),
             source_tool: ODT_SET_PLAN_SOURCE_TOOL.to_string(),
@@ -174,9 +145,10 @@ impl BeadsTaskStore {
         self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
 
         Ok(SpecDocument {
-            markdown: entry.markdown,
+            markdown: markdown.trim().to_string(),
             updated_at: Some(timestamp),
             revision: Some(entry.revision),
+            error: None,
         })
     }
 
@@ -189,20 +161,14 @@ impl BeadsTaskStore {
         let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
         let namespace = metadata_namespace(&metadata_root, &namespace_key);
-        let Some(entries) = namespace
-            .and_then(|ns| ns.get("documents"))
-            .and_then(|docs| docs.get("qaReports"))
-            .and_then(parse_qa_entries)
-        else {
-            return Ok(None);
-        };
+        let report = crate::document_storage::read_latest_qa_document(
+            namespace
+                .and_then(|ns| ns.get("documents"))
+                .and_then(|docs| docs.get("qaReports")),
+            "openducktor.documents.qaReports",
+        );
 
-        Ok(entries.last().map(|entry| QaReportDocument {
-            markdown: entry.markdown.clone(),
-            verdict: entry.verdict.clone(),
-            updated_at: entry.updated_at.clone(),
-            revision: entry.revision,
-        }))
+        Ok(report)
     }
 
     pub(super) fn append_qa_report_impl(
@@ -224,10 +190,14 @@ impl BeadsTaskStore {
 
         self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
         Ok(QaReportDocument {
-            markdown: entry.markdown,
-            verdict: entry.verdict,
-            updated_at: entry.updated_at,
-            revision: entry.revision,
+            markdown: markdown.trim().to_string(),
+            verdict: match entry.verdict {
+                QaVerdict::Approved => QaWorkflowVerdict::Approved,
+                QaVerdict::Rejected => QaWorkflowVerdict::Rejected,
+            },
+            updated_at: Some(entry.updated_at),
+            revision: Some(entry.revision),
+            error: None,
         })
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -15,18 +15,21 @@ impl BeadsTaskStore {
         let namespace_key = self.current_metadata_namespace();
         let namespace = metadata_namespace(&metadata_root, &namespace_key);
         let documents = namespace.and_then(|ns| ns.get("documents"));
+        let spec_path = format!("{namespace_key}.documents.spec");
+        let plan_path = format!("{namespace_key}.documents.implementationPlan");
+        let qa_path = format!("{namespace_key}.documents.qaReports");
 
         let spec = crate::document_storage::read_latest_markdown_document(
             documents.and_then(|docs| docs.get("spec")),
-            "openducktor.documents.spec",
+            &spec_path,
         );
         let plan = crate::document_storage::read_latest_markdown_document(
             documents.and_then(|docs| docs.get("implementationPlan")),
-            "openducktor.documents.implementationPlan",
+            &plan_path,
         );
         let qa_report = crate::document_storage::read_latest_qa_document(
             documents.and_then(|docs| docs.get("qaReports")),
-            "openducktor.documents.qaReports",
+            &qa_path,
         );
 
         let mut agent_sessions = namespace

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -14,46 +14,20 @@ impl BeadsTaskStore {
         let metadata_root = parse_metadata_root(issue.metadata.clone());
         let namespace_key = self.current_metadata_namespace();
         let namespace = metadata_namespace(&metadata_root, &namespace_key);
+        let documents = namespace.and_then(|ns| ns.get("documents"));
 
-        let spec_entries = namespace
-            .and_then(|ns| ns.get("documents"))
-            .and_then(|docs| docs.get("spec"))
-            .and_then(parse_markdown_entries);
-        let spec_latest = spec_entries.as_ref().and_then(|list| list.last());
-        let spec = SpecDocument {
-            markdown: spec_latest
-                .map(|entry| entry.markdown.clone())
-                .unwrap_or_default(),
-            updated_at: spec_latest.map(|entry| entry.updated_at.clone()),
-            revision: spec_latest.map(|entry| entry.revision),
-        };
-
-        let plan_entries = namespace
-            .and_then(|ns| ns.get("documents"))
-            .and_then(|docs| docs.get("implementationPlan"))
-            .and_then(parse_markdown_entries);
-        let plan_latest = plan_entries.as_ref().and_then(|list| list.last());
-        let plan = SpecDocument {
-            markdown: plan_latest
-                .map(|entry| entry.markdown.clone())
-                .unwrap_or_default(),
-            updated_at: plan_latest.map(|entry| entry.updated_at.clone()),
-            revision: plan_latest.map(|entry| entry.revision),
-        };
-
-        let qa_entries = namespace
-            .and_then(|ns| ns.get("documents"))
-            .and_then(|docs| docs.get("qaReports"))
-            .and_then(parse_qa_entries);
-        let qa_report = qa_entries
-            .as_ref()
-            .and_then(|entries| entries.last())
-            .map(|entry| QaReportDocument {
-                markdown: entry.markdown.clone(),
-                verdict: entry.verdict.clone(),
-                updated_at: entry.updated_at.clone(),
-                revision: entry.revision,
-            });
+        let spec = crate::document_storage::read_latest_markdown_document(
+            documents.and_then(|docs| docs.get("spec")),
+            "openducktor.documents.spec",
+        );
+        let plan = crate::document_storage::read_latest_markdown_document(
+            documents.and_then(|docs| docs.get("implementationPlan")),
+            "openducktor.documents.implementationPlan",
+        );
+        let qa_report = crate::document_storage::read_latest_qa_document(
+            documents.and_then(|docs| docs.get("qaReports")),
+            "openducktor.documents.qaReports",
+        );
 
         let mut agent_sessions = namespace
             .and_then(|ns| ns.get("agentSessions"))

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -4,7 +4,7 @@ use super::{
     parse_agent_sessions, parse_issue_type, parse_markdown_entries, parse_metadata_root,
     parse_qa_entries, parse_task_status, read_latest_markdown_document, BeadsTaskStore,
     CommandRunner, ProcessCommandRunner, CUSTOM_STATUS_VALUES, DOCUMENT_ENCODING_GZIP_BASE64_V1,
-    TASK_LIST_CACHE_TTL_MS,
+    MAX_DECODED_MARKDOWN_BYTES, TASK_LIST_CACHE_TTL_MS,
 };
 use anyhow::{anyhow, Result};
 use chrono::{Duration as ChronoDuration, Utc};

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -2,8 +2,9 @@ use super::{
     default_ai_review_enabled, encode_markdown_for_storage, metadata_bool_qa_required,
     metadata_namespace, next_document_revision, normalize_labels, normalize_text_option,
     parse_agent_sessions, parse_issue_type, parse_markdown_entries, parse_metadata_root,
-    parse_qa_entries, parse_task_status, BeadsTaskStore, CommandRunner, ProcessCommandRunner,
-    CUSTOM_STATUS_VALUES, DOCUMENT_ENCODING_GZIP_BASE64_V1, TASK_LIST_CACHE_TTL_MS,
+    parse_qa_entries, parse_task_status, read_latest_markdown_document, BeadsTaskStore,
+    CommandRunner, ProcessCommandRunner, CUSTOM_STATUS_VALUES, DOCUMENT_ENCODING_GZIP_BASE64_V1,
+    TASK_LIST_CACHE_TTL_MS,
 };
 use anyhow::{anyhow, Result};
 use chrono::{Duration as ChronoDuration, Utc};

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1,9 +1,9 @@
 use super::{
     default_ai_review_enabled, encode_markdown_for_storage, metadata_bool_qa_required,
-    metadata_namespace, normalize_labels, normalize_text_option, parse_agent_sessions,
-    parse_issue_type, parse_markdown_entries, parse_metadata_root, parse_qa_entries,
-    parse_task_status, BeadsTaskStore, CommandRunner, ProcessCommandRunner, CUSTOM_STATUS_VALUES,
-    DOCUMENT_ENCODING_GZIP_BASE64_V1, TASK_LIST_CACHE_TTL_MS,
+    metadata_namespace, next_document_revision, normalize_labels, normalize_text_option,
+    parse_agent_sessions, parse_issue_type, parse_markdown_entries, parse_metadata_root,
+    parse_qa_entries, parse_task_status, BeadsTaskStore, CommandRunner, ProcessCommandRunner,
+    CUSTOM_STATUS_VALUES, DOCUMENT_ENCODING_GZIP_BASE64_V1, TASK_LIST_CACHE_TTL_MS,
 };
 use anyhow::{anyhow, Result};
 use chrono::{Duration as ChronoDuration, Utc};

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1,14 +1,15 @@
 use super::{
-    default_ai_review_enabled, metadata_bool_qa_required, metadata_namespace, normalize_labels,
-    normalize_text_option, parse_agent_sessions, parse_issue_type, parse_markdown_entries,
-    parse_metadata_root, parse_qa_entries, parse_task_status, BeadsTaskStore, CommandRunner,
-    ProcessCommandRunner, CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS,
+    default_ai_review_enabled, encode_markdown_for_storage, metadata_bool_qa_required,
+    metadata_namespace, normalize_labels, normalize_text_option, parse_agent_sessions,
+    parse_issue_type, parse_markdown_entries, parse_metadata_root, parse_qa_entries,
+    parse_task_status, BeadsTaskStore, CommandRunner, ProcessCommandRunner, CUSTOM_STATUS_VALUES,
+    DOCUMENT_ENCODING_GZIP_BASE64_V1, TASK_LIST_CACHE_TTL_MS,
 };
 use anyhow::{anyhow, Result};
 use chrono::{Duration as ChronoDuration, Utc};
 use host_domain::{
-    AgentSessionDocument, CreateTaskInput, IssueType, QaVerdict, TaskStatus, TaskStore,
-    UpdateTaskPatch, ODT_QA_APPROVED_SOURCE_TOOL, ODT_QA_REJECTED_SOURCE_TOOL,
+    AgentSessionDocument, CreateTaskInput, IssueType, QaVerdict, QaWorkflowVerdict, TaskStatus,
+    TaskStore, UpdateTaskPatch, ODT_QA_APPROVED_SOURCE_TOOL, ODT_QA_REJECTED_SOURCE_TOOL,
     ODT_SET_PLAN_SOURCE_TOOL, ODT_SET_SPEC_SOURCE_TOOL,
 };
 use host_infra_system::{

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/parsing.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/parsing.rs
@@ -116,10 +116,11 @@ fn strict_issue_type_and_status_parsers_return_actionable_errors() {
 }
 
 #[test]
-fn markdown_and_qa_entry_parsers_filter_invalid_entries() {
-    let markdown_entries = parse_markdown_entries(&json!([
+fn markdown_and_qa_entry_parsers_reject_invalid_entries() {
+    assert!(parse_markdown_entries(&json!([
         {
             "markdown": "# Spec",
+            "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
             "updatedAt": "2026-02-17T12:34:56Z",
             "updatedBy": "planner-agent",
             "sourceTool": ODT_SET_SPEC_SOURCE_TOOL,
@@ -129,13 +130,12 @@ fn markdown_and_qa_entry_parsers_filter_invalid_entries() {
             "markdown": 42
         }
     ]))
-    .expect("markdown entries");
-    assert_eq!(markdown_entries.len(), 1);
-    assert_eq!(markdown_entries[0].revision, 1);
+    .is_none());
 
-    let qa_entries = parse_qa_entries(&json!([
+    assert!(parse_qa_entries(&json!([
         {
             "markdown": "# QA",
+            "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
             "verdict": "approved",
             "updatedAt": "2026-02-17T13:10:00Z",
             "updatedBy": "qa-agent",
@@ -146,9 +146,7 @@ fn markdown_and_qa_entry_parsers_filter_invalid_entries() {
             "verdict": "rejected"
         }
     ]))
-    .expect("qa entries");
-    assert_eq!(qa_entries.len(), 1);
-    assert_eq!(qa_entries[0].revision, 2);
+    .is_none());
 
     let sessions = parse_agent_sessions(&json!([
         {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/parsing.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/parsing.rs
@@ -193,6 +193,23 @@ fn markdown_and_qa_entry_parsers_reject_invalid_entries() {
 }
 
 #[test]
+fn next_document_revision_rejects_u32_overflow() {
+    let error = next_document_revision(
+        Some(&json!([
+            {
+                "revision": 4294967295u64
+            }
+        ])),
+        "openducktor.documents.spec",
+    )
+    .expect_err("u32::MAX revision should fail cleanly");
+
+    assert!(error.to_string().contains(
+        "Invalid existing openducktor.documents.spec metadata: revision exceeds supported range"
+    ));
+}
+
+#[test]
 #[ignore = "manual benchmark scaffold; run with cargo test -p host-infra-beads metadata_parsing_benchmark_scaffold -- --ignored --nocapture"]
 fn metadata_parsing_benchmark_scaffold() {
     let markdown_payload = Value::Array(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/parsing.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/parsing.rs
@@ -210,6 +210,42 @@ fn next_document_revision_rejects_u32_overflow() {
 }
 
 #[test]
+fn revision_zero_is_rejected_in_both_validation_paths() {
+    let revision_error = next_document_revision(
+        Some(&json!([
+            {
+                "revision": 0
+            }
+        ])),
+        "openducktor.documents.spec",
+    )
+    .expect_err("revision 0 should fail cleanly");
+
+    assert!(revision_error.to_string().contains(
+        "Invalid existing openducktor.documents.spec metadata at index 0: revision must be a positive integer"
+    ));
+
+    let plan = read_latest_markdown_document(
+        Some(&json!([
+            {
+                "markdown": "# Plan",
+                "updatedAt": "2026-02-20T12:00:00Z",
+                "revision": 0
+            }
+        ])),
+        "openducktor.documents.implementationPlan",
+    );
+
+    assert!(plan.markdown.is_empty());
+    assert_eq!(plan.updated_at.as_deref(), Some("2026-02-20T12:00:00Z"));
+    assert!(plan.revision.is_none());
+    let error = plan
+        .error
+        .expect("revision 0 should surface a document error");
+    assert!(error.contains("revision must be a positive integer"));
+}
+
+#[test]
 #[ignore = "manual benchmark scaffold; run with cargo test -p host-infra-beads metadata_parsing_benchmark_scaffold -- --ignored --nocapture"]
 fn metadata_parsing_benchmark_scaffold() {
     let markdown_payload = Value::Array(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/parsing.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/parsing.rs
@@ -246,6 +246,33 @@ fn revision_zero_is_rejected_in_both_validation_paths() {
 }
 
 #[test]
+fn oversized_decoded_markdown_surfaces_size_limit_error() -> Result<()> {
+    let oversized = "a".repeat(MAX_DECODED_MARKDOWN_BYTES as usize + 1);
+    let encoded = encode_markdown_for_storage(&oversized)?;
+
+    let spec = read_latest_markdown_document(
+        Some(&json!([
+            {
+                "markdown": encoded,
+                "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
+                "updatedAt": "2026-02-20T12:00:00Z",
+                "revision": 1
+            }
+        ])),
+        "openducktor.documents.spec",
+    );
+
+    assert!(spec.markdown.is_empty());
+    assert_eq!(spec.updated_at.as_deref(), Some("2026-02-20T12:00:00Z"));
+    assert_eq!(spec.revision, Some(1));
+    let error = spec
+        .error
+        .expect("oversized payload should surface a decode error");
+    assert!(error.contains("decoded payload exceeds size limit"));
+    Ok(())
+}
+
+#[test]
 #[ignore = "manual benchmark scaffold; run with cargo test -p host-infra-beads metadata_parsing_benchmark_scaffold -- --ignored --nocapture"]
 fn metadata_parsing_benchmark_scaffold() {
     let markdown_payload = Value::Array(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_docs.rs
@@ -201,6 +201,38 @@ fn invalid_encoded_spec_returns_document_error_without_breaking_task_summary() -
 }
 
 #[test]
+fn malformed_plan_collection_surfaces_document_error() -> Result<()> {
+    let repo = RepoFixture::new("malformed-plan-collection");
+    let issue = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "documents": {
+                    "implementationPlan": { "unexpected": true }
+                }
+            }
+        })),
+    );
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([issue]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let plan = store.get_plan(repo.path(), "task-1")?;
+    assert!(plan.markdown.is_empty());
+    assert!(plan.updated_at.is_none());
+    assert!(plan.revision.is_none());
+    assert!(plan
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("expected an array")));
+    Ok(())
+}
+
+#[test]
 fn set_spec_trims_markdown_and_increments_revision() -> Result<()> {
     let repo = RepoFixture::new("set-spec");
     let current = issue_value(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_docs.rs
@@ -84,9 +84,119 @@ fn get_spec_reads_latest_entry_and_falls_back_to_empty() -> Result<()> {
     let latest = store.get_spec(repo.path(), "task-1")?;
     assert_eq!(latest.markdown, "# Spec v2");
     assert_eq!(latest.updated_at.as_deref(), Some("2026-02-20T12:00:00Z"));
+    assert!(latest.error.is_none());
     let missing = store.get_spec(repo.path(), "task-1")?;
     assert!(missing.markdown.is_empty());
     assert!(missing.updated_at.is_none());
+    assert!(missing.error.is_none());
+    Ok(())
+}
+
+#[test]
+fn get_task_metadata_reads_mixed_legacy_and_encoded_documents() -> Result<()> {
+    let repo = RepoFixture::new("mixed-documents");
+    let encoded_plan = encode_markdown_for_storage("# Encoded plan")?;
+    let encoded_qa = encode_markdown_for_storage("# Encoded QA")?;
+    let issue = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "documents": {
+                    "spec": [{
+                        "markdown": "# Legacy spec",
+                        "updatedAt": "2026-02-20T10:00:00Z",
+                        "updatedBy": "planner-agent",
+                        "sourceTool": ODT_SET_SPEC_SOURCE_TOOL,
+                        "revision": 1
+                    }],
+                    "implementationPlan": [{
+                        "markdown": encoded_plan,
+                        "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
+                        "updatedAt": "2026-02-20T11:00:00Z",
+                        "updatedBy": "planner-agent",
+                        "sourceTool": ODT_SET_PLAN_SOURCE_TOOL,
+                        "revision": 2
+                    }],
+                    "qaReports": [{
+                        "markdown": encoded_qa,
+                        "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
+                        "verdict": "approved",
+                        "updatedAt": "2026-02-20T12:00:00Z",
+                        "updatedBy": "qa-agent",
+                        "sourceTool": ODT_QA_APPROVED_SOURCE_TOOL,
+                        "revision": 3
+                    }]
+                }
+            }
+        })),
+    );
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([issue]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let metadata = store.get_task_metadata(repo.path(), "task-1")?;
+    assert_eq!(metadata.spec.markdown, "# Legacy spec");
+    assert!(metadata.spec.error.is_none());
+    assert_eq!(metadata.plan.markdown, "# Encoded plan");
+    assert!(metadata.plan.error.is_none());
+
+    let qa = metadata.qa_report.expect("qa report should be present");
+    assert_eq!(qa.markdown, "# Encoded QA");
+    assert_eq!(qa.verdict, QaWorkflowVerdict::Approved);
+    assert!(qa.error.is_none());
+    Ok(())
+}
+
+#[test]
+fn invalid_encoded_spec_returns_document_error_without_breaking_task_summary() -> Result<()> {
+    let repo = RepoFixture::new("broken-encoded-spec");
+    let issue = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "documents": {
+                    "spec": [{
+                        "markdown": "not-base64",
+                        "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
+                        "updatedAt": "2026-02-20T12:00:00Z",
+                        "updatedBy": "planner-agent",
+                        "sourceTool": ODT_SET_SPEC_SOURCE_TOOL,
+                        "revision": 1
+                    }]
+                }
+            }
+        })),
+    );
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([issue.clone()]).to_string())),
+        MockStep::WithEnv(Ok(json!([issue]).to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let spec = store.get_spec(repo.path(), "task-1")?;
+    assert!(spec.markdown.is_empty());
+    assert_eq!(spec.updated_at.as_deref(), Some("2026-02-20T12:00:00Z"));
+    assert_eq!(spec.revision, Some(1));
+    assert!(spec
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("invalid base64 payload")));
+
+    let tasks = store.list_tasks(repo.path())?;
+    assert_eq!(tasks.len(), 1);
+    assert!(tasks[0].document_summary.spec.has);
+    assert_eq!(
+        tasks[0].document_summary.spec.updated_at.as_deref(),
+        Some("2026-02-20T12:00:00Z")
+    );
     Ok(())
 }
 
@@ -111,12 +221,18 @@ fn set_spec_trims_markdown_and_increments_revision() -> Result<()> {
 
     let spec = store.set_spec(repo.path(), "task-1", "  ## Updated Spec  ")?;
     assert_eq!(spec.markdown, "## Updated Spec");
+    assert!(spec.updated_at.as_deref().is_some());
+    assert!(spec.error.is_none());
     let calls = runner.take_calls();
     let metadata_root = metadata_from_call(&calls[1]);
     let entry = &metadata_root["openducktor"]["documents"]["spec"][0];
     assert_eq!(
         entry["markdown"],
-        Value::String("## Updated Spec".to_string())
+        Value::String(encode_markdown_for_storage("## Updated Spec")?)
+    );
+    assert_eq!(
+        entry["encoding"],
+        Value::String(DOCUMENT_ENCODING_GZIP_BASE64_V1.to_string())
     );
     assert_eq!(entry["revision"], Value::Number(3.into()));
     Ok(())
@@ -144,12 +260,21 @@ fn get_and_set_plan_use_implementation_plan_metadata() -> Result<()> {
 
     let plan = store.get_plan(repo.path(), "task-1")?;
     assert_eq!(plan.markdown, "# Plan v4");
+    assert!(plan.error.is_none());
     let updated = store.set_plan(repo.path(), "task-1", "  # Plan v5 ")?;
     assert_eq!(updated.markdown, "# Plan v5");
+    assert!(updated.error.is_none());
     let calls = runner.take_calls();
     let metadata_root = metadata_from_call(&calls[2]);
     let entry = &metadata_root["openducktor"]["documents"]["implementationPlan"][0];
-    assert_eq!(entry["markdown"], Value::String("# Plan v5".to_string()));
+    assert_eq!(
+        entry["markdown"],
+        Value::String(encode_markdown_for_storage("# Plan v5")?)
+    );
+    assert_eq!(
+        entry["encoding"],
+        Value::String(DOCUMENT_ENCODING_GZIP_BASE64_V1.to_string())
+    );
     assert_eq!(entry["revision"], Value::Number(5.into()));
     Ok(())
 }
@@ -183,12 +308,21 @@ fn qa_reports_store_latest_entry_and_preserve_next_revision() -> Result<()> {
         QaVerdict::Rejected,
     )?;
     assert_eq!(appended.markdown, "Needs fixes");
-    assert_eq!(appended.verdict, QaVerdict::Rejected);
-    assert_eq!(appended.revision, 2);
+    assert_eq!(appended.verdict, QaWorkflowVerdict::Rejected);
+    assert_eq!(appended.revision, Some(2));
+    assert!(appended.error.is_none());
     let calls = runner.take_calls();
     let metadata_root = metadata_from_call(&calls[2]);
     let newest = metadata_root["openducktor"]["documents"]["qaReports"][0].clone();
     assert_eq!(newest["revision"], Value::Number(2.into()));
+    assert_eq!(
+        newest["markdown"],
+        Value::String(encode_markdown_for_storage("Needs fixes")?)
+    );
+    assert_eq!(
+        newest["encoding"],
+        Value::String(DOCUMENT_ENCODING_GZIP_BASE64_V1.to_string())
+    );
     assert_eq!(
         newest["sourceTool"],
         Value::String(ODT_QA_REJECTED_SOURCE_TOOL.to_string())
@@ -216,8 +350,75 @@ fn append_qa_report_rejects_malformed_existing_metadata() {
         .expect_err("malformed qaReports metadata should fail");
     assert!(error
         .to_string()
-        .contains("Invalid existing qaReports metadata: expected an array"));
+        .contains("Invalid existing openducktor.documents.qaReports metadata: expected an array"));
     assert_eq!(runner.take_calls().len(), 1);
+}
+
+#[test]
+fn malformed_qa_reports_surface_document_error_in_metadata_reads() -> Result<()> {
+    let repo = RepoFixture::new("qa-docs-metadata-malformed");
+    let malformed = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {"documents": {"qaReports": {"unexpected": true}}}})),
+    );
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([malformed]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let metadata = store.get_task_metadata(repo.path(), "task-1")?;
+    let qa = metadata
+        .qa_report
+        .expect("qa document should be present as error state");
+    assert!(qa.markdown.is_empty());
+    assert_eq!(qa.verdict, QaWorkflowVerdict::NotReviewed);
+    assert!(qa.updated_at.is_none());
+    assert!(qa.revision.is_none());
+    assert!(qa
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("expected an array")));
+    Ok(())
+}
+
+#[test]
+fn invalid_encoded_qa_report_surfaces_document_error() -> Result<()> {
+    let repo = RepoFixture::new("qa-docs-invalid-encoded");
+    let payload = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {"documents": {"qaReports": [{
+            "markdown": "not-base64",
+            "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
+            "verdict": "approved",
+            "updatedAt": "2026-02-20T11:00:00Z",
+            "updatedBy": "qa-agent",
+            "sourceTool": ODT_QA_APPROVED_SOURCE_TOOL,
+            "revision": 2
+        }]}}})),
+    );
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([payload]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let latest = store
+        .get_latest_qa_report(repo.path(), "task-1")?
+        .expect("qa document should be present as error state");
+    assert!(latest.markdown.is_empty());
+    assert_eq!(latest.verdict, QaWorkflowVerdict::Approved);
+    assert_eq!(latest.updated_at.as_deref(), Some("2026-02-20T11:00:00Z"));
+    assert_eq!(latest.revision, Some(2));
+    assert!(latest
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("invalid base64 payload")));
+    Ok(())
 }
 
 #[test]
@@ -265,7 +466,14 @@ fn record_qa_outcome_updates_status_and_metadata_in_one_update_call() -> Result<
     assert!(update_call.args.iter().any(|entry| entry == "human_review"));
     let metadata_root = metadata_from_call(update_call);
     let newest = metadata_root["openducktor"]["documents"]["qaReports"][0].clone();
-    assert_eq!(newest["markdown"], Value::String("Looks good".to_string()));
+    assert_eq!(
+        newest["markdown"],
+        Value::String(encode_markdown_for_storage("Looks good")?)
+    );
+    assert_eq!(
+        newest["encoding"],
+        Value::String(DOCUMENT_ENCODING_GZIP_BASE64_V1.to_string())
+    );
     assert_eq!(newest["verdict"], Value::String("approved".to_string()));
     assert_eq!(newest["revision"], Value::Number(2.into()));
     Ok(())
@@ -294,8 +502,9 @@ fn get_latest_qa_report_returns_latest_entry_when_present() -> Result<()> {
         .get_latest_qa_report(repo.path(), "task-1")?
         .expect("latest report should exist");
     assert_eq!(latest.markdown, "Second report");
-    assert_eq!(latest.verdict, QaVerdict::Approved);
-    assert_eq!(latest.updated_at, "2026-02-20T11:00:00Z");
-    assert_eq!(latest.revision, 2);
+    assert_eq!(latest.verdict, QaWorkflowVerdict::Approved);
+    assert_eq!(latest.updated_at.as_deref(), Some("2026-02-20T11:00:00Z"));
+    assert_eq!(latest.revision, Some(2));
+    assert!(latest.error.is_none());
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_docs.rs
@@ -417,6 +417,29 @@ fn malformed_qa_reports_surface_document_error_in_metadata_reads() -> Result<()>
 }
 
 #[test]
+fn empty_qa_reports_array_stays_absent_in_reads() -> Result<()> {
+    let repo = RepoFixture::new("qa-docs-empty-array");
+    let payload = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {"documents": {"qaReports": []}}})),
+    );
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([payload.clone()]).to_string())),
+        MockStep::WithEnv(Ok(json!([payload]).to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    assert!(store.get_latest_qa_report(repo.path(), "task-1")?.is_none());
+    let metadata = store.get_task_metadata(repo.path(), "task-1")?;
+    assert!(metadata.qa_report.is_none());
+    Ok(())
+}
+
+#[test]
 fn invalid_encoded_qa_report_surfaces_document_error() -> Result<()> {
     let repo = RepoFixture::new("qa-docs-invalid-encoded");
     let payload = issue_value(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_sessions.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_sessions.rs
@@ -208,15 +208,18 @@ fn get_task_metadata_fetches_all_fields_in_single_call() -> Result<()> {
         metadata.spec.updated_at.as_deref(),
         Some("2026-02-20T10:00:00Z")
     );
+    assert!(metadata.spec.error.is_none());
     assert_eq!(metadata.plan.markdown, "# Plan content");
     assert_eq!(
         metadata.plan.updated_at.as_deref(),
         Some("2026-02-20T11:00:00Z")
     );
+    assert!(metadata.plan.error.is_none());
     let qa = metadata.qa_report.expect("qa_report should be present");
     assert_eq!(qa.markdown, "# QA Report");
-    assert_eq!(qa.verdict, QaVerdict::Approved);
-    assert_eq!(qa.revision, 1);
+    assert_eq!(qa.verdict, QaWorkflowVerdict::Approved);
+    assert_eq!(qa.revision, Some(1));
+    assert!(qa.error.is_none());
     assert_eq!(metadata.agent_sessions.len(), 1);
     assert_eq!(metadata.agent_sessions[0].session_id, "session-1");
     assert_eq!(metadata.agent_sessions[0].role, "build");
@@ -239,8 +242,10 @@ fn get_task_metadata_handles_empty_metadata() -> Result<()> {
     let metadata = store.get_task_metadata(repo.path(), "task-1")?;
     assert!(metadata.spec.markdown.is_empty());
     assert!(metadata.spec.updated_at.is_none());
+    assert!(metadata.spec.error.is_none());
     assert!(metadata.plan.markdown.is_empty());
     assert!(metadata.plan.updated_at.is_none());
+    assert!(metadata.plan.error.is_none());
     assert!(metadata.qa_report.is_none());
     assert!(metadata.agent_sessions.is_empty());
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_tasks.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_tasks.rs
@@ -219,6 +219,62 @@ fn list_tasks_keeps_qa_verdict_but_marks_missing_content_when_latest_markdown_is
 }
 
 #[test]
+fn list_tasks_treats_encoded_empty_documents_as_missing_content() -> Result<()> {
+    let repo = RepoFixture::new("list-encoded-empty-markdown");
+    let encoded_empty = encode_markdown_for_storage("")?;
+    let payload = json!([issue_value(
+        "task-encoded-empty",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "qaRequired": true,
+                "documents": {
+                    "spec": [
+                        {
+                            "markdown": encoded_empty,
+                            "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
+                            "updatedAt": "2026-02-20T09:00:00Z",
+                            "updatedBy": "planner-agent",
+                            "sourceTool": ODT_SET_SPEC_SOURCE_TOOL,
+                            "revision": 1
+                        }
+                    ],
+                    "qaReports": [
+                        {
+                            "markdown": encode_markdown_for_storage("   ")?,
+                            "encoding": DOCUMENT_ENCODING_GZIP_BASE64_V1,
+                            "verdict": "rejected",
+                            "updatedAt": "2026-02-20T10:00:00Z",
+                            "updatedBy": "qa-agent",
+                            "sourceTool": ODT_QA_REJECTED_SOURCE_TOOL,
+                            "revision": 2
+                        }
+                    ]
+                }
+            }
+        })),
+    )]);
+    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(payload.to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let tasks = store.list_tasks(repo.path())?;
+    assert_eq!(tasks.len(), 1);
+    let task = &tasks[0];
+    assert!(!task.document_summary.spec.has);
+    assert!(task.document_summary.spec.updated_at.is_none());
+    assert!(!task.document_summary.qa_report.has);
+    assert!(task.document_summary.qa_report.updated_at.is_none());
+    assert_eq!(
+        task.document_summary.qa_report.verdict,
+        host_domain::QaWorkflowVerdict::Rejected
+    );
+    Ok(())
+}
+
+#[test]
 fn list_tasks_uses_short_lived_repo_cache() -> Result<()> {
     let repo = RepoFixture::new("list-cache-hit");
     let payload = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);

--- a/apps/desktop/src-tauri/src/commands/git/tests/fixtures/task_store.rs
+++ b/apps/desktop/src-tauri/src/commands/git/tests/fixtures/task_store.rs
@@ -1,7 +1,8 @@
 use anyhow::anyhow;
 use host_domain::{
     AgentSessionDocument, CreateTaskInput, DirectMergeRecord, PullRequestRecord, QaReportDocument,
-    QaVerdict, SpecDocument, TaskCard, TaskMetadata, TaskStatus, TaskStore, UpdateTaskPatch,
+    QaVerdict, QaWorkflowVerdict, SpecDocument, TaskCard, TaskMetadata, TaskStatus, TaskStore,
+    UpdateTaskPatch,
 };
 use std::path::Path;
 
@@ -12,6 +13,7 @@ fn empty_spec_document() -> SpecDocument {
         markdown: String::new(),
         updated_at: None,
         revision: None,
+        error: None,
     }
 }
 
@@ -72,6 +74,7 @@ impl TaskStore for CommandTaskStore {
             markdown: markdown.to_string(),
             updated_at: None,
             revision: None,
+            error: None,
         })
     }
 
@@ -89,6 +92,7 @@ impl TaskStore for CommandTaskStore {
             markdown: markdown.to_string(),
             updated_at: None,
             revision: None,
+            error: None,
         })
     }
 
@@ -109,9 +113,13 @@ impl TaskStore for CommandTaskStore {
     ) -> anyhow::Result<QaReportDocument> {
         Ok(QaReportDocument {
             markdown: markdown.to_string(),
-            verdict,
-            updated_at: String::new(),
-            revision: 0,
+            verdict: match verdict {
+                QaVerdict::Approved => QaWorkflowVerdict::Approved,
+                QaVerdict::Rejected => QaWorkflowVerdict::Rejected,
+            },
+            updated_at: Some(String::new()),
+            revision: Some(0),
+            error: None,
         })
     }
 

--- a/apps/desktop/src/components/features/task-composer/use-task-document-editor-state.test.tsx
+++ b/apps/desktop/src/components/features/task-composer/use-task-document-editor-state.test.tsx
@@ -193,6 +193,30 @@ describe("useTaskDocumentEditorState", () => {
     await harness.unmount();
   });
 
+  test("keeps document-level payload errors without treating the load as failed", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        loadSpecDocument: async () => ({
+          markdown: "",
+          updatedAt: "2026-02-20T12:00:00Z",
+          error: "Failed to decode openducktor.documents.spec[0]: invalid gzip payload",
+        }),
+      }),
+    );
+
+    await harness.mount();
+    await harness.waitFor((state) => state.documents.spec.loaded);
+
+    const state = harness.getLatest();
+    expect(state.documents.spec.loaded).toBe(true);
+    expect(state.documents.spec.isLoading).toBe(false);
+    expect(state.documents.spec.error).toBe(
+      "Failed to decode openducktor.documents.spec[0]: invalid gzip payload",
+    );
+
+    await harness.unmount();
+  });
+
   test("persists editor view per section and resets on task change", async () => {
     const harness = createHookHarness(createBaseProps({ activeSection: null }));
     await harness.mount();

--- a/apps/desktop/src/components/features/task-composer/use-task-document-editor-state.ts
+++ b/apps/desktop/src/components/features/task-composer/use-task-document-editor-state.ts
@@ -18,6 +18,7 @@ type TaskDocumentViewState = Record<TaskDocumentSection, DocumentEditorView>;
 type TaskDocumentPayload = {
   markdown: string;
   updatedAt: string | null;
+  error?: string | null;
 };
 
 type UseTaskDocumentEditorStateArgs = {
@@ -180,7 +181,7 @@ export function useTaskDocumentEditorState({
             updatedAt: payload.updatedAt,
             isLoading: false,
             loaded: true,
-            error: null,
+            error: payload.error ?? null,
           },
         };
         documentsRef.current = successSnapshot;

--- a/apps/desktop/src/components/features/task-details/task-document-state.ts
+++ b/apps/desktop/src/components/features/task-details/task-document-state.ts
@@ -30,7 +30,6 @@ export const resolveLoadedDocumentState = <TState extends TaskDocumentStateLike>
     return {
       ...current,
       isLoading: false,
-      error: null,
       loaded: true,
     };
   }

--- a/apps/desktop/src/components/features/task-details/task-document-state.ts
+++ b/apps/desktop/src/components/features/task-details/task-document-state.ts
@@ -40,7 +40,7 @@ export const resolveLoadedDocumentState = <TState extends TaskDocumentStateLike>
     markdown: incoming.markdown,
     updatedAt: incoming.updatedAt,
     isLoading: false,
-    error: null,
+    error: incoming.error ?? null,
     loaded: true,
   };
 };

--- a/apps/desktop/src/components/features/task-details/use-task-documents.test.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.test.ts
@@ -119,4 +119,30 @@ describe("resolveLoadedDocumentState", () => {
       loaded: true,
     });
   });
+
+  test("preserves document-level payload errors on the loaded state", () => {
+    const current = createDocumentState({
+      markdown: "# Previous spec",
+      updatedAt: "2026-02-22T09:00:00.000Z",
+      isLoading: true,
+      loaded: true,
+    });
+
+    const resolved = resolveLoadedDocumentState(
+      current,
+      createDocumentPayload({
+        markdown: "",
+        updatedAt: "2026-02-22T09:15:00.000Z",
+        error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
+      }),
+    );
+
+    expect(resolved).toEqual({
+      markdown: "",
+      updatedAt: "2026-02-22T09:15:00.000Z",
+      isLoading: false,
+      error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
+      loaded: true,
+    });
+  });
 });

--- a/apps/desktop/src/components/features/task-details/use-task-documents.test.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.test.ts
@@ -47,7 +47,7 @@ describe("resolveLoadedDocumentState", () => {
     });
   });
 
-  test("preserves the current document when the incoming timestamp is older", () => {
+  test("preserves the current document and its error when the incoming timestamp is older", () => {
     const current = createDocumentState({
       markdown: "# Updated spec",
       updatedAt: "2026-02-22T09:00:00.000Z",
@@ -68,7 +68,7 @@ describe("resolveLoadedDocumentState", () => {
       markdown: "# Updated spec",
       updatedAt: "2026-02-22T09:00:00.000Z",
       isLoading: false,
-      error: null,
+      error: "temporary",
       loaded: true,
     });
   });

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -46,7 +46,9 @@ const createTaskDocumentState = (input?: {
 const toErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : "Unable to load document.";
 
-const createHostDocumentLoader = <TResult extends { markdown: string; updatedAt: string | null }>(
+const createHostDocumentLoader = <
+  TResult extends { markdown: string; updatedAt: string | null; error?: string | null },
+>(
   cacheScope: string,
   readDocument: (repoPath: string, taskId: string) => Promise<TResult>,
 ): ((taskId: string) => Promise<TaskDocumentPayload>) => {
@@ -59,6 +61,7 @@ const createHostDocumentLoader = <TResult extends { markdown: string; updatedAt:
     return {
       markdown: document.markdown,
       updatedAt: document.updatedAt,
+      error: document.error ?? null,
     };
   };
 };
@@ -126,7 +129,7 @@ const toTaskDocumentState = (
     markdown: query.data?.markdown ?? "",
     updatedAt: query.data?.updatedAt ?? null,
     isLoading: enabled && query.isFetching && query.data === undefined,
-    error: query.error ? toErrorMessage(query.error) : null,
+    error: query.error ? toErrorMessage(query.error) : (query.data?.error ?? null),
     loaded: hasResolved,
   });
 };

--- a/apps/desktop/src/state/queries/documents.ts
+++ b/apps/desktop/src/state/queries/documents.ts
@@ -8,6 +8,7 @@ export const TASK_DOCUMENT_STALE_TIME_MS = 60_000;
 export type TaskDocument = {
   markdown: string;
   updatedAt: string | null;
+  error?: string | null;
 };
 
 export type TaskDocumentSection = "spec" | "plan" | "qa";

--- a/apps/desktop/src/types/task-documents.ts
+++ b/apps/desktop/src/types/task-documents.ts
@@ -1,4 +1,5 @@
 export type TaskDocumentPayload = {
   markdown: string;
   updatedAt: string | null;
+  error?: string | null;
 };

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -257,25 +257,38 @@ Constraints:
 - Requested document keys are returned consistently even when no persisted body exists yet.
 - Missing spec and plan return `{ "markdown": "", "updatedAt": null }`.
 - Missing latest QA report returns `{ "markdown": "", "updatedAt": null, "verdict": "not_reviewed" }`.
+- Legacy markdown-only metadata remains readable.
+- New or updated workflow documents are stored as `encoding: "gzip-base64-v1"` plus a base64-gzip payload in `markdown`.
+- The Rust host owns that encode/decode translation. Successful MCP reads still return plain markdown.
+- When the latest stored document cannot be decoded, the returned document includes an optional `error` field with an actionable host-supplied message.
+- There is no automatic migration of older markdown-only metadata.
 
 Output:
 
 ```json
 {
   "documents": {
-    "spec": { "markdown": "# Spec", "updatedAt": "<ISO 8601 timestamp>" },
+    "spec": {
+      "markdown": "# Spec",
+      "updatedAt": "<ISO 8601 timestamp>",
+      "error": "Failed to decode openducktor.documents.spec[0]: invalid base64 payload"
+    },
     "implementationPlan": { "markdown": "## Plan", "updatedAt": "<ISO 8601 timestamp>" },
     "latestQaReport": {
       "markdown": "## QA",
       "updatedAt": "<ISO 8601 timestamp>",
-      "verdict": "approved"
+      "verdict": "approved",
+      "error": "Failed to decode openducktor.documents.qaReports[0]: invalid gzip payload"
     }
   }
 }
 ```
 
+`error` is optional. It is omitted for healthy documents and for documents that do not exist yet.
+
 ## Architecture Notes
 
 - `packages/openducktor-mcp` owns MCP transport, request validation, response validation, and packaging.
 - The Rust host owns Beads attachment verification, shared Dolt lifecycle, task reads and writes, workflow transitions, recovery, and canonical metadata writes.
+- The Rust host also owns document compression and decompression for Beads metadata.
 - The host bridge surface mirrors the MCP tool names so desktop-managed and standalone MCP clients use the same execution path.

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -269,13 +269,13 @@ Output:
 {
   "documents": {
     "spec": {
-      "markdown": "# Spec",
+      "markdown": "",
       "updatedAt": "<ISO 8601 timestamp>",
       "error": "Failed to decode openducktor.documents.spec[0]: invalid base64 payload"
     },
     "implementationPlan": { "markdown": "## Plan", "updatedAt": "<ISO 8601 timestamp>" },
     "latestQaReport": {
-      "markdown": "## QA",
+      "markdown": "",
       "updatedAt": "<ISO 8601 timestamp>",
       "verdict": "approved",
       "error": "Failed to decode openducktor.documents.qaReports[0]: invalid gzip payload"

--- a/docs/task-workflow-status-model.md
+++ b/docs/task-workflow-status-model.md
@@ -99,7 +99,8 @@ Root namespace key is fixed to `openducktor`.
     "documents": {
       "spec": [
         {
-          "markdown": "## Spec",
+          "markdown": "<base64-gzip-payload>",
+          "encoding": "gzip-base64-v1",
           "updatedAt": "2026-02-17T12:34:56Z",
           "updatedBy": "planner-agent",
           "sourceTool": "odt_set_spec",
@@ -108,7 +109,8 @@ Root namespace key is fixed to `openducktor`.
       ],
       "implementationPlan": [
         {
-          "markdown": "## Plan",
+          "markdown": "<base64-gzip-payload>",
+          "encoding": "gzip-base64-v1",
           "updatedAt": "2026-02-17T12:40:10Z",
           "updatedBy": "planner-agent",
           "sourceTool": "odt_set_plan",
@@ -117,7 +119,8 @@ Root namespace key is fixed to `openducktor`.
       ],
       "qaReports": [
         {
-          "markdown": "## QA",
+          "markdown": "<base64-gzip-payload>",
+          "encoding": "gzip-base64-v1",
           "verdict": "approved",
           "updatedAt": "2026-02-17T13:02:00Z",
           "updatedBy": "qa-agent",
@@ -129,6 +132,13 @@ Root namespace key is fixed to `openducktor`.
   }
 }
 ```
+
+Notes:
+- Legacy entries without `encoding` remain readable. In those entries, `markdown` is stored as literal markdown.
+- New or updated spec, plan, and QA documents are stored with `encoding: "gzip-base64-v1"` and a base64-encoded gzip payload in `markdown`.
+- Encode and decode translation is owned by the Rust host. Frontend and MCP callers continue to receive plain markdown on successful reads.
+- When the latest stored document cannot be decoded, host-backed read APIs return an empty markdown string plus a document-level `error` field instead of silently treating the document as missing.
+- There is no automatic backfill migration for older markdown-only entries.
 
 ## Document History Policy
 - `qaReports`: list structure, but V1 retains only the latest entry in the list (list length = 1).

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1620,6 +1620,28 @@ describe("TauriHostClient", () => {
     ]);
   });
 
+  test("document reads preserve document-level decode errors from task metadata", async () => {
+    const { client } = createClient((command) => {
+      if (command === "task_metadata_get") {
+        return {
+          ...makeTaskMetadataPayload(),
+          spec: {
+            markdown: "",
+            updatedAt: "2026-02-20T09:00:00Z",
+            error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
+          },
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(client.specGet("/repo", "task-1")).resolves.toEqual({
+      markdown: "",
+      updatedAt: "2026-02-20T09:00:00Z",
+      error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
+    });
+  });
+
   test("forceFresh metadata reads bypass stale cache and repopulate steady-state reads", async () => {
     let metadataReadCount = 0;
     const { client, calls } = createClient((command) => {

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -46,7 +46,11 @@ export type SavePlanDocumentInput = {
 };
 
 export type TaskDocumentSection = "spec" | "plan" | "qa";
-export type TaskDocumentReadResult = { markdown: string; updatedAt: string | null };
+export type TaskDocumentReadResult = {
+  markdown: string;
+  updatedAt: string | null;
+  error?: string | null;
+};
 
 export class TauriTaskClient {
   constructor(
@@ -74,6 +78,7 @@ export class TauriTaskClient {
       return {
         markdown: payload.spec.markdown,
         updatedAt: payload.spec.updatedAt ?? null,
+        error: payload.spec.error ?? null,
       };
     }
 
@@ -81,12 +86,14 @@ export class TauriTaskClient {
       return {
         markdown: payload.plan.markdown,
         updatedAt: payload.plan.updatedAt ?? null,
+        error: payload.plan.error ?? null,
       };
     }
 
     return {
       markdown: payload.qaReport?.markdown ?? "",
       updatedAt: payload.qaReport?.updatedAt ?? null,
+      error: payload.qaReport?.error ?? null,
     };
   }
 

--- a/packages/contracts/src/document-contracts.test.ts
+++ b/packages/contracts/src/document-contracts.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { taskDocumentsReadSchema, taskMetadataPayloadSchema } from "./index";
+
+describe("document contracts", () => {
+  test("task metadata documents accept optional document-level decode errors", () => {
+    const parsed = taskMetadataPayloadSchema.parse({
+      spec: {
+        markdown: "",
+        updatedAt: "2026-02-20T09:00:00Z",
+        error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
+      },
+      plan: {
+        markdown: "# Plan",
+        updatedAt: null,
+      },
+      qaReport: {
+        markdown: "",
+        verdict: "not_reviewed",
+        updatedAt: null,
+        revision: null,
+        error: "Failed to decode openducktor.documents.qaReports[0]: invalid gzip payload",
+      },
+      agentSessions: [],
+    });
+
+    expect(parsed.spec.error).toContain("invalid base64 payload");
+    expect(parsed.qaReport?.verdict).toBe("not_reviewed");
+    expect(parsed.qaReport?.error).toContain("invalid gzip payload");
+  });
+
+  test("mcp document reads accept optional document-level decode errors", () => {
+    const parsed = taskDocumentsReadSchema.parse({
+      documents: {
+        spec: {
+          markdown: "",
+          updatedAt: "2026-02-20T09:00:00Z",
+          error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
+        },
+        latestQaReport: {
+          markdown: "",
+          updatedAt: null,
+          verdict: "not_reviewed",
+          error: "Failed to decode openducktor.documents.qaReports[0]: invalid gzip payload",
+        },
+      },
+    });
+
+    expect(parsed.documents.spec?.error).toContain("invalid base64 payload");
+    expect(parsed.documents.latestQaReport?.error).toContain("invalid gzip payload");
+  });
+});

--- a/packages/contracts/src/metadata-schemas.ts
+++ b/packages/contracts/src/metadata-schemas.ts
@@ -1,18 +1,23 @@
 import { z } from "zod";
 import { directMergeRecordSchema, pullRequestSchema } from "./git-schemas";
-import { qaReportVerdictSchema } from "./task-schemas";
+import { qaWorkflowVerdictSchema } from "./task-schemas";
 
 export const taskMetadataDocumentSchema = z.object({
   markdown: z.string().default(""),
   updatedAt: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
+  error: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
 });
 export type TaskMetadataDocument = z.infer<typeof taskMetadataDocumentSchema>;
 
 export const taskMetadataQaReportSchema = z.object({
   markdown: z.string(),
-  verdict: qaReportVerdictSchema,
-  updatedAt: z.string(),
-  revision: z.number().int().nonnegative(),
+  verdict: qaWorkflowVerdictSchema,
+  updatedAt: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
+  revision: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    z.number().int().nonnegative().optional(),
+  ),
+  error: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
 });
 export type TaskMetadataQaReport = z.infer<typeof taskMetadataQaReportSchema>;
 

--- a/packages/contracts/src/odt-mcp-schemas.ts
+++ b/packages/contracts/src/odt-mcp-schemas.ts
@@ -56,6 +56,7 @@ const markdownTaskDocumentSchema = z
   .object({
     markdown: z.string(),
     updatedAt: z.string().nullable(),
+    error: z.string().optional(),
   })
   .strict();
 
@@ -64,6 +65,7 @@ const latestQaReportSchema = z
     markdown: z.string(),
     updatedAt: z.string().nullable(),
     verdict: qaWorkflowVerdictSchema,
+    error: z.string().optional(),
   })
   .strict();
 

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -123,6 +123,11 @@ Use `odt_read_task_documents` only when you need document bodies:
 - Requested document keys are returned consistently even when no persisted body exists yet.
 - Missing spec and plan return empty markdown with `updatedAt: null`.
 - Missing latest QA report returns empty markdown with `updatedAt: null` and `verdict: "not_reviewed"`.
+- Legacy markdown-only metadata remains readable.
+- New or updated workflow documents are stored by the Rust host as `encoding: "gzip-base64-v1"` plus a base64-gzip payload in `markdown`.
+- Successful MCP reads still return plain markdown because the Rust host owns the encode/decode translation.
+- When the latest stored document cannot be decoded, the returned document includes an optional `error` field with the host-supplied decode failure.
+- There is no automatic backfill migration for older markdown-only entries.
 
 ```json
 {
@@ -138,12 +143,19 @@ It returns only the requested sections:
 ```json
 {
   "documents": {
-    "spec": { "markdown": "# Spec", "updatedAt": "<ISO 8601 timestamp>" },
+    "spec": {
+      "markdown": "# Spec",
+      "updatedAt": "<ISO 8601 timestamp>",
+      "error": "Failed to decode openducktor.documents.spec[0]: invalid base64 payload"
+    },
     "latestQaReport": {
       "markdown": "## QA",
       "updatedAt": "<ISO 8601 timestamp>",
-      "verdict": "approved"
+      "verdict": "approved",
+      "error": "Failed to decode openducktor.documents.qaReports[0]: invalid gzip payload"
     }
   }
 }
 ```
+
+`error` is optional. It is omitted for healthy documents and for documents that do not exist yet.

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -144,12 +144,12 @@ It returns only the requested sections:
 {
   "documents": {
     "spec": {
-      "markdown": "# Spec",
+      "markdown": "",
       "updatedAt": "<ISO 8601 timestamp>",
       "error": "Failed to decode openducktor.documents.spec[0]: invalid base64 payload"
     },
     "latestQaReport": {
-      "markdown": "## QA",
+      "markdown": "",
       "updatedAt": "<ISO 8601 timestamp>",
       "verdict": "approved",
       "error": "Failed to decode openducktor.documents.qaReports[0]: invalid gzip payload"

--- a/packages/openducktor-mcp/src/odt-task-store.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.test.ts
@@ -64,4 +64,40 @@ describe("OdtTaskStore", () => {
 
     await expect(store.createTask({ issueType: "task", priority: 2 })).rejects.toThrow();
   });
+
+  test("accepts document-level decode errors on odt_read_task_documents", async () => {
+    const client = {
+      ready: async () => ({
+        bridgeVersion: 1,
+        repoPath: "/repo",
+        toolNames: [],
+      }),
+      call: async () => ({
+        documents: {
+          spec: {
+            markdown: "",
+            updatedAt: "2026-04-09T00:00:00.000Z",
+            error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
+          },
+        },
+      }),
+    } as OdtHostBridgeClientPort;
+
+    const store = new OdtTaskStore(
+      { repoPath: "/repo", hostUrl: "http://127.0.0.1:14327" },
+      { client },
+    );
+
+    await expect(store.readTaskDocuments({ taskId: "task-1", includeSpec: true })).resolves.toEqual(
+      {
+        documents: {
+          spec: {
+            markdown: "",
+            updatedAt: "2026-04-09T00:00:00.000Z",
+            error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
+          },
+        },
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- store spec, implementation plan, and QA task documents in Beads metadata using explicit `gzip-base64-v1` encoded payloads while preserving backward-compatible reads of legacy plain-markdown entries
- decompress documents at the Rust host boundary and propagate document-level decode errors through host, contracts, adapters, desktop, and MCP surfaces instead of silently treating unreadable documents as missing
- add focused Rust and TypeScript coverage for mixed legacy/encoded metadata, malformed metadata collections, and spec/plan/QA decode-error handling, plus document the persisted format and migration behavior

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `cargo test -p host-infra-beads`
- `cargo test -p host-application`

## Notes
- branch includes the initial dual-format storage feature, the QA follow-up that preserves malformed latest `qaReports` as error-bearing documents, and a final decode-path refactor that keeps spec/plan/QA behavior aligned
- latest commits on this branch are:
  - `b468a9d8f feat(host): compress workflow documents in beads metadata`
  - `c59ae01ef fix(host): surface malformed QA document errors`
  - `e28c53959 refactor(host): unify workflow document decode handling`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents carry optional per-document error messages for decode/processing failures.
  * QA reports use a workflow verdict model and support optional timestamps and revisions.
  * Storage supports gzip+base64-encoded document bodies; host decodes for callers and preserves decode errors per document.
  * Presence/summary logic updated (encoded-empty treated as missing; metadata readers expose stored updatedAt/revision).

* **Documentation**
  * MCP and workflow docs/README updated to describe encoding/decoding and error behavior.

* **Tests**
  * Extensive tests added for encoding, decoding failures, error preservation, revisions, and metadata reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->