### PR TITLE
refactor(beads): make readiness fully contract-probe based

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/coordinator.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/coordinator.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use host_infra_system::resolve_repo_beads_attachment_dir;
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::command_runner::CommandRunner;
 
-use super::LifecycleError;
+use super::{LifecycleError, RepoReadiness};
 
 pub(crate) struct BeadsLifecycle {
     command_runner: Arc<dyn CommandRunner>,
@@ -71,73 +71,51 @@ impl BeadsLifecycle {
             .map_err(|_| anyhow!("Beads repo lock poisoned"))?;
 
         let beads_dir = resolve_repo_beads_attachment_dir(repo_path)?;
-        let store_exists = beads_store_footprint_exists(&beads_dir)?;
 
         self.ensure_dolt_server_running(repo_path)?;
 
-        let (is_ready, reason) = if store_exists {
-            self.verify_repo_initialized(repo_path, &beads_dir)?
-        } else {
-            (false, "bd init failed".to_string())
-        };
+        let readiness = self.verify_repo_initialized(repo_path, &beads_dir)?;
 
-        if self.is_repo_cached_initialized(&repo_key)? && store_exists && is_ready {
+        if self.is_repo_cached_initialized(&repo_key)? && matches!(readiness, RepoReadiness::Ready)
+        {
             return Ok(());
         }
 
-        if !is_ready {
-            if store_exists {
-                self.ensure_existing_store_is_ready(repo_path, &beads_dir, &reason)?;
-            } else {
-                self.ensure_new_store_is_ready(repo_path, &beads_dir, &reason)?;
+        match readiness {
+            RepoReadiness::Ready => {}
+            RepoReadiness::MissingAttachment => {
+                self.ensure_new_store_is_ready(repo_path, &beads_dir)?;
+            }
+            RepoReadiness::MissingSharedDatabase { .. } => {
+                self.materialize_shared_database_from_attachment(repo_path, &beads_dir)?;
+                self.ensure_repo_ready_after_recovery(
+                    repo_path,
+                    &beads_dir,
+                    "shared database restore",
+                )?;
+            }
+            RepoReadiness::AttachmentVerificationFailed { .. } => {
+                self.repair_repo_store(repo_path)?;
+                self.ensure_repo_ready_after_recovery(repo_path, &beads_dir, "repair")?;
+            }
+            RepoReadiness::BrokenAttachmentContract { reason } => {
+                return Err(LifecycleError::AttachmentContractInvalid {
+                    beads_dir: beads_dir.to_path_buf(),
+                    reason,
+                }
+                .into());
+            }
+            RepoReadiness::SharedDoltUnavailable { reason } => {
+                return Err(LifecycleError::SharedDoltUnavailable {
+                    repo_path: repo_path.to_path_buf(),
+                    reason,
+                }
+                .into());
             }
         }
 
         self.ensure_custom_statuses(repo_path)?;
         self.mark_repo_initialized(&repo_key)?;
         Ok(())
-    }
-
-    fn ensure_existing_store_is_ready(
-        &self,
-        repo_path: &Path,
-        beads_dir: &Path,
-        reason: &str,
-    ) -> Result<()> {
-        let attempted_restore = Self::reason_requires_shared_database_seed(reason);
-        if attempted_restore {
-            self.materialize_shared_database_from_attachment(repo_path, beads_dir)?;
-        } else {
-            self.repair_repo_store(repo_path)?;
-        }
-
-        let (is_ready_after_repair, reason_after_repair) =
-            self.verify_repo_initialized(repo_path, beads_dir)?;
-        if !is_ready_after_repair {
-            return Err(LifecycleError::StoreStillNotReady {
-                beads_dir: beads_dir.to_path_buf(),
-                recovery_step: if attempted_restore {
-                    "shared database restore"
-                } else {
-                    "repair"
-                },
-                reason: reason_after_repair,
-            }
-            .into());
-        }
-        Ok(())
-    }
-}
-
-fn beads_store_footprint_exists(beads_dir: &Path) -> Result<bool> {
-    match fs::metadata(beads_dir) {
-        Ok(_) => Ok(true),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error).with_context(|| {
-            format!(
-                "Failed to inspect Beads attachment path {}",
-                beads_dir.display()
-            )
-        }),
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/error.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/error.rs
@@ -17,6 +17,18 @@ pub(crate) enum LifecycleError {
     InvalidServerPort { value: String },
 
     #[error(
+        "Beads attachment contract is invalid at {beads_dir}: {reason}",
+        beads_dir = .beads_dir.display()
+    )]
+    AttachmentContractInvalid { beads_dir: PathBuf, reason: String },
+
+    #[error(
+        "Shared Dolt readiness probe failed for {repo_path}: {reason}",
+        repo_path = .repo_path.display()
+    )]
+    SharedDoltUnavailable { repo_path: PathBuf, reason: String },
+
+    #[error(
         "Shared Dolt database is missing for {beads_dir} and no attachment backup exists at {backup_dir}",
         beads_dir = .beads_dir.display(),
         backup_dir = .backup_dir.display()

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/mod.rs
@@ -6,3 +6,4 @@ mod verifier;
 
 pub(crate) use coordinator::BeadsLifecycle;
 pub(crate) use error::LifecycleError;
+pub(crate) use verifier::RepoReadiness;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/provisioner.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/provisioner.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use crate::constants::CUSTOM_STATUS_VALUES;
 
-use super::{BeadsLifecycle, LifecycleError};
+use super::{BeadsLifecycle, LifecycleError, RepoReadiness};
 
 impl BeadsLifecycle {
     pub(crate) fn repair_repo_store(&self, repo_path: &Path) -> Result<()> {
@@ -114,7 +114,6 @@ impl BeadsLifecycle {
         &self,
         repo_path: &Path,
         beads_dir: &Path,
-        init_failure_reason: &str,
     ) -> Result<()> {
         let slug = compute_repo_slug(repo_path);
         let database_name = compute_beads_database_name(repo_path)?;
@@ -153,7 +152,7 @@ impl BeadsLifecycle {
 
         if !ok {
             let details = if stderr.trim().is_empty() {
-                init_failure_reason.to_string()
+                "Beads attachment is missing".to_string()
             } else {
                 stderr.trim().to_string()
             };
@@ -164,17 +163,29 @@ impl BeadsLifecycle {
             .into());
         }
 
-        let (is_ready_after_init, reason_after_init) =
-            self.verify_repo_initialized(repo_path, beads_dir)?;
-        if !is_ready_after_init {
-            return Err(LifecycleError::StoreStillNotReady {
-                beads_dir: beads_dir.to_path_buf(),
-                recovery_step: "init",
-                reason: reason_after_init,
-            }
-            .into());
-        }
+        self.ensure_repo_ready_after_recovery(repo_path, beads_dir, "init")
+    }
 
-        Ok(())
+    pub(crate) fn ensure_repo_ready_after_recovery(
+        &self,
+        repo_path: &Path,
+        beads_dir: &Path,
+        recovery_step: &'static str,
+    ) -> Result<()> {
+        match self.verify_repo_initialized(repo_path, beads_dir) {
+            Ok(RepoReadiness::Ready) => Ok(()),
+            Ok(readiness) => Err(LifecycleError::StoreStillNotReady {
+                beads_dir: beads_dir.to_path_buf(),
+                recovery_step,
+                reason: readiness.description(),
+            }
+            .into()),
+            Err(error) => Err(LifecycleError::StoreStillNotReady {
+                beads_dir: beads_dir.to_path_buf(),
+                recovery_step,
+                reason: error.to_string(),
+            }
+            .into()),
+        }
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/provisioner.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/provisioner.rs
@@ -127,7 +127,7 @@ impl BeadsLifecycle {
             .find_map(|(key, value)| (key == "BEADS_DOLT_SERVER_PORT").then_some(value.as_str()))
             .ok_or_else(|| anyhow!("Missing BEADS_DOLT_SERVER_PORT while initializing repo"))?;
         let working_dir = self.ensure_beads_working_dir(repo_path)?;
-        let (ok, _stdout, stderr) = self.command_runner().run_allow_failure_with_env(
+        let (ok, stdout, stderr) = self.command_runner().run_allow_failure_with_env(
             "bd",
             &[
                 "init",
@@ -151,11 +151,8 @@ impl BeadsLifecycle {
         )?;
 
         if !ok {
-            let details = if stderr.trim().is_empty() {
-                "Beads attachment is missing".to_string()
-            } else {
-                stderr.trim().to_string()
-            };
+            let details =
+                Self::command_failure_reason("Beads attachment is missing", &stdout, &stderr);
             return Err(LifecycleError::InitFailed {
                 beads_dir: beads_dir.to_path_buf(),
                 details,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
@@ -359,13 +359,25 @@ impl BeadsLifecycle {
     }
 
     fn attachment_paths_match(&self, actual_path: &str, expected_path: &Path) -> Result<bool> {
-        let actual = fs::canonicalize(actual_path).unwrap_or_else(|_| actual_path.into());
-        let expected =
-            fs::canonicalize(expected_path).unwrap_or_else(|_| expected_path.to_path_buf());
+        let actual = fs::canonicalize(actual_path).with_context(|| {
+            format!(
+                "Failed to canonicalize Beads attachment path reported by `bd where --json`: {actual_path}"
+            )
+        })?;
+        let expected = fs::canonicalize(expected_path).with_context(|| {
+            format!(
+                "Failed to canonicalize expected Beads attachment path {}",
+                expected_path.display()
+            )
+        })?;
         Ok(actual == expected)
     }
 
-    fn command_failure_reason(default_message: &str, stdout: &str, stderr: &str) -> String {
+    pub(super) fn command_failure_reason(
+        default_message: &str,
+        stdout: &str,
+        stderr: &str,
+    ) -> String {
         let stderr = stderr.trim();
         if !stderr.is_empty() {
             return stderr.to_string();
@@ -381,17 +393,19 @@ impl BeadsLifecycle {
 
     fn database_list_contains(output: &str, expected_database: &str) -> bool {
         output.lines().any(|line| {
-            line.split(|character: char| {
-                character.is_whitespace() || matches!(character, '|' | '+' | '-')
-            })
-            .any(|token| token == expected_database)
+            let trimmed = line.trim();
+            trimmed == expected_database
+                || trimmed
+                    .split('|')
+                    .map(str::trim)
+                    .any(|cell| cell == expected_database)
         })
     }
 }
 
 fn attachment_dir_exists(beads_dir: &Path) -> Result<bool> {
     match fs::metadata(beads_dir) {
-        Ok(_) => Ok(true),
+        Ok(metadata) => Ok(metadata.is_dir()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(error) => Err(error).with_context(|| {
             format!(
@@ -399,5 +413,20 @@ fn attachment_dir_exists(beads_dir: &Path) -> Result<bool> {
                 beads_dir.display()
             )
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BeadsLifecycle;
+
+    #[test]
+    fn database_list_contains_matches_hyphenated_database_names() {
+        let output = "+------------------+\n| Database         |\n+------------------+\n| repo-my-feature  |\n+------------------+";
+
+        assert!(BeadsLifecycle::database_list_contains(
+            output,
+            "repo-my-feature"
+        ));
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
@@ -124,9 +124,7 @@ impl BeadsLifecycle {
         }
 
         if !ok {
-            return Ok(RepoReadiness::AttachmentVerificationFailed {
-                reason: Self::command_failure_reason("bd where failed", &stdout, &stderr),
-            });
+            return Err(anyhow!("bd where failed without a decodable JSON payload"));
         }
 
         Err(anyhow!("bd where returned empty payload"))

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
@@ -160,17 +160,13 @@ impl BeadsLifecycle {
         stderr: &'a str,
     ) -> BdWhereCommandOutput<'a> {
         let stderr_payload = Self::extract_stderr_json_payload(stderr);
-        if Self::payload_decodes_as_bd_where_payload(stderr_payload) {
+        if !stderr_payload.is_empty() {
             return BdWhereCommandOutput::Json(stderr_payload);
         }
 
         let stdout_payload = Self::extract_stdout_json_payload(stdout);
         if !stdout_payload.is_empty() {
             return BdWhereCommandOutput::Json(stdout_payload);
-        }
-
-        if !stderr_payload.is_empty() {
-            return BdWhereCommandOutput::Json(stderr_payload);
         }
 
         if ok {
@@ -227,11 +223,22 @@ impl BeadsLifecycle {
 
     fn extract_stdout_json_payload(stdout: &str) -> &str {
         let trimmed_stdout = stdout.trim();
-        if !trimmed_stdout.is_empty() {
+        if trimmed_stdout.is_empty() {
+            return "";
+        }
+
+        if Self::payload_decodes_as_bd_where_payload(trimmed_stdout) {
             return trimmed_stdout;
         }
 
-        ""
+        if let Some(payload_start) = Self::locate_json_payload_start(trimmed_stdout) {
+            let candidate = &trimmed_stdout[payload_start..];
+            if Self::payload_decodes_as_bd_where_payload(candidate) {
+                return candidate;
+            }
+        }
+
+        trimmed_stdout
     }
 
     fn extract_stderr_json_payload(stderr: &str) -> &str {
@@ -240,18 +247,42 @@ impl BeadsLifecycle {
             return "";
         }
 
-        let object_index = trimmed_stderr.find('{');
-        let array_index = trimmed_stderr.find('[');
-        let start_index = [object_index, array_index].into_iter().flatten().min();
-        if let Some(index) = start_index {
-            return &trimmed_stderr[index..];
+        if Self::payload_decodes_as_bd_where_payload(trimmed_stderr) {
+            return trimmed_stderr;
+        }
+
+        if let Some(payload_start) = Self::locate_json_payload_start(trimmed_stderr) {
+            let candidate = &trimmed_stderr[payload_start..];
+            if Self::payload_decodes_as_bd_where_payload(candidate) {
+                return candidate;
+            }
         }
 
         ""
     }
 
     fn payload_decodes_as_bd_where_payload(payload: &str) -> bool {
-        !payload.is_empty() && serde_json::from_str::<BeadsWherePayload>(payload).is_ok()
+        serde_json::from_str::<BeadsWherePayload>(payload)
+            .ok()
+            .map(|parsed| {
+                parsed
+                    .path
+                    .as_deref()
+                    .map(str::trim)
+                    .is_some_and(|path| !path.is_empty())
+                    || parsed
+                        .error
+                        .as_deref()
+                        .map(str::trim)
+                        .is_some_and(|error| !error.is_empty())
+            })
+            .unwrap_or(false)
+    }
+
+    fn locate_json_payload_start(payload: &str) -> Option<usize> {
+        let object_index = payload.find('{');
+        let array_index = payload.find('[');
+        [object_index, array_index].into_iter().flatten().min()
     }
 
     fn probe_shared_database_presence(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
@@ -1,11 +1,35 @@
 use anyhow::{anyhow, Context, Result};
 use host_infra_system::compute_beads_database_name;
 use serde::Deserialize;
-use serde_json::Value;
 use std::fs;
 use std::path::Path;
 
 use super::{BeadsLifecycle, LifecycleError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RepoReadiness {
+    Ready,
+    MissingAttachment,
+    BrokenAttachmentContract { reason: String },
+    SharedDoltUnavailable { reason: String },
+    MissingSharedDatabase { database_name: String },
+    AttachmentVerificationFailed { reason: String },
+}
+
+impl RepoReadiness {
+    pub(crate) fn description(&self) -> String {
+        match self {
+            Self::Ready => "ready".to_string(),
+            Self::MissingAttachment => "Beads attachment is missing".to_string(),
+            Self::BrokenAttachmentContract { reason } => reason.clone(),
+            Self::SharedDoltUnavailable { reason } => reason.clone(),
+            Self::MissingSharedDatabase { database_name } => {
+                format!("Shared Dolt database {database_name} is missing")
+            }
+            Self::AttachmentVerificationFailed { reason } => reason.clone(),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct BeadsAttachmentMetadata {
@@ -23,23 +47,39 @@ struct BeadsWherePayload {
     error: Option<String>,
 }
 
-impl BeadsLifecycle {
-    pub(crate) fn reason_requires_shared_database_seed(reason: &str) -> bool {
-        let normalized = reason.to_ascii_lowercase();
-        normalized.contains("not found on dolt server")
-            || normalized.contains("error 1049")
-            || (normalized.contains("database ") && normalized.contains(" not found"))
-    }
+enum SharedDatabaseProbe {
+    Available,
+    Missing { database_name: String },
+    Unavailable { reason: String },
+}
 
+impl BeadsLifecycle {
     pub(crate) fn verify_repo_initialized(
         &self,
         repo_path: &Path,
         beads_dir: &Path,
-    ) -> Result<(bool, String)> {
+    ) -> Result<RepoReadiness> {
+        if !attachment_dir_exists(beads_dir)? {
+            return Ok(RepoReadiness::MissingAttachment);
+        }
+
         let env = self.build_bd_env(repo_path)?;
         if let Err(error) = self.verify_repo_attachment_contract(repo_path, beads_dir, &env) {
-            return Ok((false, error.to_string()));
+            return Ok(RepoReadiness::BrokenAttachmentContract {
+                reason: error.to_string(),
+            });
         }
+
+        match self.probe_shared_database_presence(repo_path, &env)? {
+            SharedDatabaseProbe::Available => {}
+            SharedDatabaseProbe::Missing { database_name } => {
+                return Ok(RepoReadiness::MissingSharedDatabase { database_name });
+            }
+            SharedDatabaseProbe::Unavailable { reason } => {
+                return Ok(RepoReadiness::SharedDoltUnavailable { reason });
+            }
+        }
+
         let env_refs = env
             .iter()
             .map(|(key, value)| (key.as_str(), value.as_str()))
@@ -55,47 +95,41 @@ impl BeadsLifecycle {
         let json_payload = Self::extract_json_payload(&stdout, &stderr);
 
         if !json_payload.is_empty() {
-            let payload: Value = serde_json::from_str(json_payload)
-                .context("Failed to parse `bd where --json` output")?;
-            let where_payload: BeadsWherePayload = serde_json::from_value(payload.clone())
+            let where_payload: BeadsWherePayload = serde_json::from_str(json_payload)
                 .context("Failed to decode `bd where --json` payload")?;
             if let Some(path) = where_payload.path.as_deref() {
                 if self.attachment_paths_match(path, beads_dir)? {
-                    return Ok((true, String::new()));
+                    return Ok(RepoReadiness::Ready);
                 }
 
-                return Ok((
-                    false,
-                    format!(
+                return Ok(RepoReadiness::AttachmentVerificationFailed {
+                    reason: format!(
                         "Beads attachment resolves to {}, expected {}",
                         path,
                         beads_dir.display()
                     ),
-                ));
+                });
             }
             if let Some(error) = where_payload.error.as_deref() {
-                return Ok((false, error.trim().to_string()));
-            }
-            if payload.get("path").and_then(Value::as_str).is_some() {
-                return Ok((true, String::new()));
-            }
-            if let Some(error) = payload.get("error").and_then(Value::as_str) {
-                return Ok((false, error.trim().to_string()));
+                let reason = error.trim();
+                if reason.is_empty() {
+                    return Err(anyhow!("bd where returned empty error payload"));
+                }
+                return Ok(RepoReadiness::AttachmentVerificationFailed {
+                    reason: reason.to_string(),
+                });
             }
 
-            return Ok((false, "bd where returned malformed payload".to_string()));
+            return Err(anyhow!("bd where returned malformed payload"));
         }
 
         if !ok {
-            let error = if stderr.trim().is_empty() {
-                "bd where failed".to_string()
-            } else {
-                stderr.trim().to_string()
-            };
-            return Ok((false, error));
+            return Ok(RepoReadiness::AttachmentVerificationFailed {
+                reason: Self::command_failure_reason("bd where failed", &stdout, &stderr),
+            });
         }
 
-        Ok((false, "bd where returned empty payload".to_string()))
+        Err(anyhow!("bd where returned empty payload"))
     }
 
     fn extract_json_payload<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
@@ -119,6 +153,56 @@ impl BeadsLifecycle {
         ""
     }
 
+    fn probe_shared_database_presence(
+        &self,
+        repo_path: &Path,
+        env: &[(String, String)],
+    ) -> Result<SharedDatabaseProbe> {
+        let expected_database = compute_beads_database_name(repo_path)?;
+        let host = Self::required_env_value(env, "BEADS_DOLT_SERVER_HOST")?;
+        let port = Self::required_env_value(env, "BEADS_DOLT_SERVER_PORT")?;
+        let user = Self::required_env_value(env, "BEADS_DOLT_SERVER_USER")?;
+        let args = [
+            "--host",
+            host.as_str(),
+            "--port",
+            port.as_str(),
+            "--no-tls",
+            "-u",
+            user.as_str(),
+            "-p",
+            "",
+            "sql",
+            "-q",
+            "show databases",
+        ];
+        let (ok, stdout, stderr) =
+            self.command_runner()
+                .run_allow_failure_with_env("dolt", &args, None, &[])?;
+
+        if !ok {
+            return Ok(SharedDatabaseProbe::Unavailable {
+                reason: Self::command_failure_reason(
+                    "Shared Dolt database probe failed",
+                    &stdout,
+                    &stderr,
+                ),
+            });
+        }
+        if stdout.trim().is_empty() {
+            return Ok(SharedDatabaseProbe::Unavailable {
+                reason: "Shared Dolt database probe returned empty output".to_string(),
+            });
+        }
+        if Self::database_list_contains(&stdout, expected_database.as_str()) {
+            return Ok(SharedDatabaseProbe::Available);
+        }
+
+        Ok(SharedDatabaseProbe::Missing {
+            database_name: expected_database,
+        })
+    }
+
     fn verify_repo_attachment_contract(
         &self,
         repo_path: &Path,
@@ -127,9 +211,6 @@ impl BeadsLifecycle {
     ) -> Result<()> {
         let metadata_path = beads_dir.join("metadata.json");
         if !metadata_path.is_file() {
-            if !self.command_runner().uses_real_processes() {
-                return Ok(());
-            }
             return Err(anyhow!(
                 "Beads attachment metadata is missing at {}",
                 metadata_path.display()
@@ -223,5 +304,41 @@ impl BeadsLifecycle {
         let expected =
             fs::canonicalize(expected_path).unwrap_or_else(|_| expected_path.to_path_buf());
         Ok(actual == expected)
+    }
+
+    fn command_failure_reason(default_message: &str, stdout: &str, stderr: &str) -> String {
+        let stderr = stderr.trim();
+        if !stderr.is_empty() {
+            return stderr.to_string();
+        }
+
+        let stdout = stdout.trim();
+        if !stdout.is_empty() {
+            return stdout.to_string();
+        }
+
+        default_message.to_string()
+    }
+
+    fn database_list_contains(output: &str, expected_database: &str) -> bool {
+        output.lines().any(|line| {
+            line.split(|character: char| {
+                character.is_whitespace() || matches!(character, '|' | '+' | '-')
+            })
+            .any(|token| token == expected_database)
+        })
+    }
+}
+
+fn attachment_dir_exists(beads_dir: &Path) -> Result<bool> {
+    match fs::metadata(beads_dir) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "Failed to inspect Beads attachment path {}",
+                beads_dir.display()
+            )
+        }),
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
@@ -47,10 +47,49 @@ struct BeadsWherePayload {
     error: Option<String>,
 }
 
+#[derive(Debug)]
+struct SharedDoltConnection {
+    host: String,
+    port: String,
+    user: String,
+}
+
+impl SharedDoltConnection {
+    fn from_env(env: &[(String, String)]) -> Result<Self> {
+        Ok(Self {
+            host: BeadsLifecycle::required_env_value(env, "BEADS_DOLT_SERVER_HOST")?,
+            port: BeadsLifecycle::required_env_value(env, "BEADS_DOLT_SERVER_PORT")?,
+            user: BeadsLifecycle::required_env_value(env, "BEADS_DOLT_SERVER_USER")?,
+        })
+    }
+
+    fn show_databases_args(&self) -> [&str; 11] {
+        [
+            "--host",
+            self.host.as_str(),
+            "--port",
+            self.port.as_str(),
+            "--no-tls",
+            "-u",
+            self.user.as_str(),
+            "-p",
+            "",
+            "sql",
+            "-q",
+        ]
+    }
+}
+
 enum SharedDatabaseProbe {
     Available,
     Missing { database_name: String },
     Unavailable { reason: String },
+}
+
+enum BdWhereCommandOutput<'a> {
+    Json(&'a str),
+    EmptySuccess,
+    MissingJsonFailure,
 }
 
 impl BeadsLifecycle {
@@ -70,7 +109,8 @@ impl BeadsLifecycle {
             });
         }
 
-        match self.probe_shared_database_presence(repo_path, &env)? {
+        let shared_dolt_connection = SharedDoltConnection::from_env(&env)?;
+        match self.probe_shared_database_presence(repo_path, &shared_dolt_connection)? {
             SharedDatabaseProbe::Available => {}
             SharedDatabaseProbe::Missing { database_name } => {
                 return Ok(RepoReadiness::MissingSharedDatabase { database_name });
@@ -80,6 +120,15 @@ impl BeadsLifecycle {
             }
         }
 
+        self.probe_beads_where(repo_path, beads_dir, &env)
+    }
+
+    fn probe_beads_where(
+        &self,
+        repo_path: &Path,
+        beads_dir: &Path,
+        env: &[(String, String)],
+    ) -> Result<RepoReadiness> {
         let env_refs = env
             .iter()
             .map(|(key, value)| (key.as_str(), value.as_str()))
@@ -92,42 +141,69 @@ impl BeadsLifecycle {
             &env_refs,
         )?;
 
-        let json_payload = Self::extract_json_payload(&stdout, &stderr);
+        match Self::classify_bd_where_command_output(ok, &stdout, &stderr) {
+            BdWhereCommandOutput::Json(json_payload) => {
+                self.parse_bd_where_payload(json_payload, beads_dir)
+            }
+            BdWhereCommandOutput::EmptySuccess => Err(anyhow!(
+                "bd where --json exited successfully but returned no JSON payload"
+            )),
+            BdWhereCommandOutput::MissingJsonFailure => Err(anyhow!(
+                "bd where --json exited unsuccessfully without a decodable JSON payload"
+            )),
+        }
+    }
 
+    fn classify_bd_where_command_output<'a>(
+        ok: bool,
+        stdout: &'a str,
+        stderr: &'a str,
+    ) -> BdWhereCommandOutput<'a> {
+        let json_payload = Self::extract_json_payload(stdout, stderr);
         if !json_payload.is_empty() {
-            let where_payload: BeadsWherePayload = serde_json::from_str(json_payload)
-                .context("Failed to decode `bd where --json` payload")?;
-            if let Some(path) = where_payload.path.as_deref() {
-                if self.attachment_paths_match(path, beads_dir)? {
-                    return Ok(RepoReadiness::Ready);
-                }
-
-                return Ok(RepoReadiness::AttachmentVerificationFailed {
-                    reason: format!(
-                        "Beads attachment resolves to {}, expected {}",
-                        path,
-                        beads_dir.display()
-                    ),
-                });
-            }
-            if let Some(error) = where_payload.error.as_deref() {
-                let reason = error.trim();
-                if reason.is_empty() {
-                    return Err(anyhow!("bd where returned empty error payload"));
-                }
-                return Ok(RepoReadiness::AttachmentVerificationFailed {
-                    reason: reason.to_string(),
-                });
-            }
-
-            return Err(anyhow!("bd where returned malformed payload"));
+            return BdWhereCommandOutput::Json(json_payload);
         }
 
-        if !ok {
-            return Err(anyhow!("bd where failed without a decodable JSON payload"));
+        if ok {
+            return BdWhereCommandOutput::EmptySuccess;
         }
 
-        Err(anyhow!("bd where returned empty payload"))
+        BdWhereCommandOutput::MissingJsonFailure
+    }
+
+    fn parse_bd_where_payload(
+        &self,
+        json_payload: &str,
+        beads_dir: &Path,
+    ) -> Result<RepoReadiness> {
+        let where_payload: BeadsWherePayload = serde_json::from_str(json_payload)
+            .context("Failed to decode `bd where --json` payload")?;
+        if let Some(path) = where_payload.path.as_deref() {
+            if self.attachment_paths_match(path, beads_dir)? {
+                return Ok(RepoReadiness::Ready);
+            }
+
+            return Ok(RepoReadiness::AttachmentVerificationFailed {
+                reason: format!(
+                    "Beads attachment resolves to {}, expected {}",
+                    path,
+                    beads_dir.display()
+                ),
+            });
+        }
+        if let Some(error) = where_payload.error.as_deref() {
+            let reason = error.trim();
+            if reason.is_empty() {
+                return Err(anyhow!("bd where --json returned an empty error field"));
+            }
+            return Ok(RepoReadiness::AttachmentVerificationFailed {
+                reason: reason.to_string(),
+            });
+        }
+
+        Err(anyhow!(
+            "bd where --json returned a JSON payload without path or error"
+        ))
     }
 
     fn extract_json_payload<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
@@ -154,26 +230,11 @@ impl BeadsLifecycle {
     fn probe_shared_database_presence(
         &self,
         repo_path: &Path,
-        env: &[(String, String)],
+        shared_dolt_connection: &SharedDoltConnection,
     ) -> Result<SharedDatabaseProbe> {
         let expected_database = compute_beads_database_name(repo_path)?;
-        let host = Self::required_env_value(env, "BEADS_DOLT_SERVER_HOST")?;
-        let port = Self::required_env_value(env, "BEADS_DOLT_SERVER_PORT")?;
-        let user = Self::required_env_value(env, "BEADS_DOLT_SERVER_USER")?;
-        let args = [
-            "--host",
-            host.as_str(),
-            "--port",
-            port.as_str(),
-            "--no-tls",
-            "-u",
-            user.as_str(),
-            "-p",
-            "",
-            "sql",
-            "-q",
-            "show databases",
-        ];
+        let mut args = shared_dolt_connection.show_databases_args().to_vec();
+        args.push("show databases");
         let (ok, stdout, stderr) =
             self.command_runner()
                 .run_allow_failure_with_env("dolt", &args, None, &[])?;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/verifier.rs
@@ -159,9 +159,18 @@ impl BeadsLifecycle {
         stdout: &'a str,
         stderr: &'a str,
     ) -> BdWhereCommandOutput<'a> {
-        let json_payload = Self::extract_json_payload(stdout, stderr);
-        if !json_payload.is_empty() {
-            return BdWhereCommandOutput::Json(json_payload);
+        let stderr_payload = Self::extract_stderr_json_payload(stderr);
+        if Self::payload_decodes_as_bd_where_payload(stderr_payload) {
+            return BdWhereCommandOutput::Json(stderr_payload);
+        }
+
+        let stdout_payload = Self::extract_stdout_json_payload(stdout);
+        if !stdout_payload.is_empty() {
+            return BdWhereCommandOutput::Json(stdout_payload);
+        }
+
+        if !stderr_payload.is_empty() {
+            return BdWhereCommandOutput::Json(stderr_payload);
         }
 
         if ok {
@@ -178,7 +187,18 @@ impl BeadsLifecycle {
     ) -> Result<RepoReadiness> {
         let where_payload: BeadsWherePayload = serde_json::from_str(json_payload)
             .context("Failed to decode `bd where --json` payload")?;
-        if let Some(path) = where_payload.path.as_deref() {
+        let path = where_payload.path.as_deref().map(str::trim);
+        let error = where_payload.error.as_deref().map(str::trim);
+
+        if path.is_some() && error.is_some() {
+            return Err(anyhow!("bd where --json returned both path and error"));
+        }
+
+        if let Some(path) = path {
+            if path.is_empty() {
+                return Err(anyhow!("bd where --json returned an empty path field"));
+            }
+
             if self.attachment_paths_match(path, beads_dir)? {
                 return Ok(RepoReadiness::Ready);
             }
@@ -191,8 +211,7 @@ impl BeadsLifecycle {
                 ),
             });
         }
-        if let Some(error) = where_payload.error.as_deref() {
-            let reason = error.trim();
+        if let Some(reason) = error {
             if reason.is_empty() {
                 return Err(anyhow!("bd where --json returned an empty error field"));
             }
@@ -206,12 +225,16 @@ impl BeadsLifecycle {
         ))
     }
 
-    fn extract_json_payload<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
+    fn extract_stdout_json_payload(stdout: &str) -> &str {
         let trimmed_stdout = stdout.trim();
         if !trimmed_stdout.is_empty() {
             return trimmed_stdout;
         }
 
+        ""
+    }
+
+    fn extract_stderr_json_payload(stderr: &str) -> &str {
         let trimmed_stderr = stderr.trim();
         if trimmed_stderr.is_empty() {
             return "";
@@ -225,6 +248,10 @@ impl BeadsLifecycle {
         }
 
         ""
+    }
+
+    fn payload_decodes_as_bd_where_payload(payload: &str) -> bool {
+        !payload.is_empty() && serde_json::from_str::<BeadsWherePayload>(payload).is_ok()
     }
 
     fn probe_shared_database_presence(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -291,6 +291,46 @@ fn ensure_repo_initialized_fails_fast_for_malformed_where_output() -> Result<()>
 }
 
 #[test]
+fn ensure_repo_initialized_fails_fast_for_non_json_where_failure_output() -> Result<()> {
+    let repo = RepoFixture::new("non-json-where-failure-output");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            false,
+            String::new(),
+            "plain text failure output".to_string(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let error = store
+        .ensure_repo_initialized(repo.path())
+        .expect_err("non-JSON where failure output should fail without fallback recovery");
+    assert!(error
+        .to_string()
+        .contains("bd where failed without a decodable JSON payload"));
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].program, "dolt");
+    assert_eq!(calls[1].args, vec!["where", "--json"]);
+    assert!(!calls
+        .iter()
+        .any(|call| call.args == vec!["doctor", "--fix", "--yes"]));
+    assert!(!calls
+        .iter()
+        .any(|call| call.args.first().map(String::as_str) == Some("init")));
+    assert!(!calls
+        .iter()
+        .any(|call| call.program == "dolt"
+            && call.args.first().map(String::as_str) == Some("backup")));
+    Ok(())
+}
+
+#[test]
 fn ensure_repo_initialized_fails_fast_when_shared_dolt_probe_fails() -> Result<()> {
     let repo = RepoFixture::new("shared-dolt-unavailable");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -189,6 +189,27 @@ fn ensure_repo_initialized_uses_init_for_missing_attachment() -> Result<()> {
 }
 
 #[test]
+fn ensure_repo_initialized_surfaces_stdout_when_init_fails() -> Result<()> {
+    let repo = RepoFixture::new("init-failure-stdout");
+    let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
+        false,
+        "init failed from stdout".to_string(),
+        String::new(),
+    )))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let error = store
+        .ensure_repo_initialized(repo.path())
+        .expect_err("stdout diagnostics should be preserved for bd init failures");
+    assert!(error.to_string().contains("init failed from stdout"));
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].args.first().expect("expected subcommand"), "init");
+    Ok(())
+}
+
+#[test]
 fn ensure_repo_initialized_restores_when_shared_database_is_missing() -> Result<()> {
     let repo = RepoFixture::new("missing-shared-database");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
@@ -234,6 +255,30 @@ fn ensure_repo_initialized_restores_when_shared_database_is_missing() -> Result<
 }
 
 #[test]
+fn verify_repo_initialized_treats_file_attachment_path_as_missing_attachment() -> Result<()> {
+    let repo = RepoFixture::new("attachment-path-is-file");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    fs::create_dir_all(
+        beads_dir
+            .parent()
+            .expect("beads dir should have a parent attachment root"),
+    )
+    .expect("attachment root should be writable");
+    fs::write(&beads_dir, "not-a-directory").expect("attachment path file should be writable");
+    let runner = MockCommandRunner::with_steps(vec![]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let readiness = store
+        .lifecycle
+        .verify_repo_initialized(repo.path(), &beads_dir)?;
+    assert_eq!(readiness, RepoReadiness::MissingAttachment);
+
+    let calls = runner.take_calls();
+    assert!(calls.is_empty());
+    Ok(())
+}
+
+#[test]
 fn ensure_repo_initialized_fails_fast_for_broken_metadata() -> Result<()> {
     let repo = RepoFixture::new("broken-metadata");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
@@ -251,6 +296,37 @@ fn ensure_repo_initialized_fails_fast_for_broken_metadata() -> Result<()> {
 
     let calls = runner.take_calls();
     assert!(calls.is_empty());
+    Ok(())
+}
+
+#[test]
+fn verify_repo_initialized_fails_when_where_path_cannot_be_canonicalized() -> Result<()> {
+    let repo = RepoFixture::new("uncanonicalizable-where-path");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let missing_path = beads_dir.join("missing-reported-path");
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": missing_path,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let error = store
+        .lifecycle
+        .verify_repo_initialized(repo.path(), &beads_dir)
+        .expect_err("non-canonicalizable reported paths should fail fast");
+    assert!(error
+        .to_string()
+        .contains("Failed to canonicalize Beads attachment path reported by `bd where --json`"));
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -60,6 +60,64 @@ fn verify_repo_initialized_reads_json_errors_from_nonzero_exit() -> Result<()> {
 }
 
 #[test]
+fn verify_repo_initialized_prefers_decodable_stderr_json_over_noisy_stdout() -> Result<()> {
+    let repo = RepoFixture::new("where-stderr-json-wins");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            false,
+            "bd debug log line".to_string(),
+            "warning before json\n{\"error\":\"database \\\"beads\\\" not found\"}".to_string(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let readiness = store
+        .lifecycle
+        .verify_repo_initialized(repo.path(), &beads_dir)?;
+    assert_eq!(
+        readiness,
+        RepoReadiness::AttachmentVerificationFailed {
+            reason: "database \"beads\" not found".to_string(),
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn verify_repo_initialized_rejects_where_payloads_with_path_and_error() -> Result<()> {
+    let repo = RepoFixture::new("where-path-and-error");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "error": "unexpected-error"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let error = store
+        .lifecycle
+        .verify_repo_initialized(repo.path(), &beads_dir)
+        .expect_err("payloads with both path and error should fail fast");
+    assert!(error
+        .to_string()
+        .contains("bd where --json returned both path and error"));
+    Ok(())
+}
+
+#[test]
 fn lifecycle_repo_init_caches_success_only_after_custom_status_configuration() -> Result<()> {
     let repo = RepoFixture::new("lifecycle-config-before-cache");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -88,6 +88,62 @@ fn verify_repo_initialized_prefers_decodable_stderr_json_over_noisy_stdout() -> 
 }
 
 #[test]
+fn verify_repo_initialized_accepts_noisy_stdout_before_json_payload() -> Result<()> {
+    let repo = RepoFixture::new("where-noisy-stdout-before-json");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            format!(
+                "warning before payload\n{}",
+                json!({
+                    "path": beads_dir,
+                    "prefix": "openducktor"
+                })
+            ),
+            String::new(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let readiness = store
+        .lifecycle
+        .verify_repo_initialized(repo.path(), &beads_dir)?;
+    assert_eq!(readiness, RepoReadiness::Ready);
+    Ok(())
+}
+
+#[test]
+fn verify_repo_initialized_does_not_let_unrelated_stderr_json_shadow_stdout() -> Result<()> {
+    let repo = RepoFixture::new("where-unrelated-stderr-json");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            "{\"level\":\"warn\"}".to_string(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let readiness = store
+        .lifecycle
+        .verify_repo_initialized(repo.path(), &beads_dir)?;
+    assert_eq!(readiness, RepoReadiness::Ready);
+    Ok(())
+}
+
+#[test]
 fn verify_repo_initialized_rejects_where_payloads_with_path_and_error() -> Result<()> {
     let repo = RepoFixture::new("where-path-and-error");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
@@ -461,6 +517,36 @@ fn ensure_repo_initialized_fails_fast_for_non_json_where_failure_output() -> Res
         .iter()
         .any(|call| call.program == "dolt"
             && call.args.first().map(String::as_str) == Some("backup")));
+    Ok(())
+}
+
+#[test]
+fn ensure_repo_initialized_treats_bracket_prefixed_stderr_as_plain_text_failure() -> Result<()> {
+    let repo = RepoFixture::new("bracket-prefixed-stderr-failure");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            false,
+            String::new(),
+            "[warn] server unreachable".to_string(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let error = store
+        .ensure_repo_initialized(repo.path())
+        .expect_err("bracket-prefixed stderr should stay a plain-text failure");
+    assert!(error
+        .to_string()
+        .contains("bd where --json exited unsuccessfully without a decodable JSON payload"));
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].program, "dolt");
+    assert_eq!(calls[1].args, vec!["where", "--json"]);
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -1,17 +1,21 @@
 use super::*;
-use crate::lifecycle::BeadsLifecycle;
+use crate::lifecycle::RepoReadiness;
 
 #[test]
 fn verify_repo_initialized_parse_errors_do_not_include_raw_output() -> Result<()> {
     let repo = RepoFixture::new("where-parse-redaction");
     let sensitive = "secret-path";
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
     write_attachment_metadata(&beads_dir, repo.path(), 3307);
-    let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
-        true,
-        format!("invalid-json-{sensitive}"),
-        String::new(),
-    )))]);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            format!("invalid-json-{sensitive}"),
+            String::new(),
+        ))),
+    ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner);
 
     let error = store
@@ -19,7 +23,7 @@ fn verify_repo_initialized_parse_errors_do_not_include_raw_output() -> Result<()
         .verify_repo_initialized(repo.path(), &beads_dir)
         .expect_err("invalid where payload should fail");
     let message = error.to_string();
-    assert!(message.contains("Failed to parse `bd where --json` output"));
+    assert!(message.contains("Failed to decode `bd where --json` payload"));
     assert!(!message.contains(sensitive));
     Ok(())
 }
@@ -28,22 +32,30 @@ fn verify_repo_initialized_parse_errors_do_not_include_raw_output() -> Result<()
 fn verify_repo_initialized_reads_json_errors_from_nonzero_exit() -> Result<()> {
     let repo = RepoFixture::new("where-json-error");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
     write_attachment_metadata(&beads_dir, repo.path(), 3307);
-    let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
-        false,
-        json!({
-            "error": "database \"beads\" not found"
-        })
-        .to_string(),
-        String::new(),
-    )))]);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            false,
+            json!({
+                "error": "database \"beads\" not found"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+    ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner);
 
-    let (is_ready, reason) = store
+    let readiness = store
         .lifecycle
         .verify_repo_initialized(repo.path(), &beads_dir)?;
-    assert!(!is_ready);
-    assert_eq!(reason, "database \"beads\" not found");
+    assert_eq!(
+        readiness,
+        RepoReadiness::AttachmentVerificationFailed {
+            reason: "database \"beads\" not found".to_string(),
+        }
+    );
     Ok(())
 }
 
@@ -51,7 +63,9 @@ fn verify_repo_initialized_reads_json_errors_from_nonzero_exit() -> Result<()> {
 fn lifecycle_repo_init_caches_success_only_after_custom_status_configuration() -> Result<()> {
     let repo = RepoFixture::new("lifecycle-config-before-cache");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
     let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
         MockStep::AllowFailureWithEnv(Ok((
             true,
             json!({
@@ -62,6 +76,7 @@ fn lifecycle_repo_init_caches_success_only_after_custom_status_configuration() -
             String::new(),
         ))),
         MockStep::WithEnv(Err("status config failed".to_string())),
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
         MockStep::AllowFailureWithEnv(Ok((
             true,
             json!({
@@ -86,135 +101,266 @@ fn lifecycle_repo_init_caches_success_only_after_custom_status_configuration() -
     store.ensure_repo_initialized(repo.path())?;
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 4);
-    assert_eq!(calls[0].args, vec!["where", "--json"]);
+    assert_eq!(calls.len(), 6);
+    assert_eq!(calls[0].program, "dolt");
     assert_eq!(
-        calls[1].args,
+        calls[0].args.last().expect("expected sql query"),
+        "show databases"
+    );
+    assert_eq!(calls[1].args, vec!["where", "--json"]);
+    assert_eq!(
+        calls[2].args,
         vec!["config", "set", "status.custom", CUSTOM_STATUS_VALUES]
+    );
+    assert_eq!(calls[3].program, "dolt");
+    assert_eq!(
+        calls[3].args.last().expect("expected sql query"),
+        "show databases"
+    );
+    assert_eq!(calls[4].args, vec!["where", "--json"]);
+    assert_eq!(
+        calls[5].args,
+        vec!["config", "set", "status.custom", CUSTOM_STATUS_VALUES]
+    );
+    Ok(())
+}
+
+#[test]
+fn ensure_repo_initialized_uses_init_for_missing_attachment() -> Result<()> {
+    let repo = RepoFixture::new("missing-attachment");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    let effective_port = match read_shared_dolt_server_state()? {
+        Some(state) => state.port,
+        None => 3307,
+    };
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnvAndWrites {
+            result: Ok((true, String::new(), String::new())),
+            writes: vec![(
+                beads_dir.join("metadata.json"),
+                json!({
+                    "backend": "dolt",
+                    "dolt_mode": "server",
+                    "dolt_server_host": "127.0.0.1",
+                    "dolt_server_port": effective_port,
+                    "dolt_server_user": "root",
+                    "dolt_database": database_name,
+                })
+                .to_string(),
+            )],
+        },
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Ok("configured statuses".to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    store.ensure_repo_initialized(repo.path())?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls[0].args.first().expect("expected subcommand"), "init");
+    assert_eq!(calls[1].program, "dolt");
+    assert_eq!(
+        calls[1].args.last().expect("expected sql query"),
+        "show databases"
     );
     assert_eq!(calls[2].args, vec!["where", "--json"]);
     assert_eq!(
         calls[3].args,
         vec!["config", "set", "status.custom", CUSTOM_STATUS_VALUES]
     );
+    assert!(!calls
+        .iter()
+        .any(|call| call.args == vec!["doctor", "--fix", "--yes"]));
+    assert!(!calls
+        .iter()
+        .any(|call| call.program == "dolt"
+            && call.args.first().map(String::as_str) == Some("backup")));
     Ok(())
 }
 
 #[test]
-fn lifecycle_verifier_only_restores_for_missing_shared_database_reasons() {
-    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
-        "database \"odt_demo_deadbeef\" not found on Dolt server"
-    ));
-    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
-        "database \"beads\" not found"
-    ));
-    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
-        "Error 1049: unknown database"
-    ));
-    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
-        "server not reachable"
-    ));
-    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
-        "dolt server unreachable"
-    ));
-    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
-        "attachment metadata is malformed"
-    ));
+fn ensure_repo_initialized_restores_when_shared_database_is_missing() -> Result<()> {
+    let repo = RepoFixture::new("missing-shared-database");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let backup_dir = beads_dir.join("backup");
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    fs::create_dir_all(&backup_dir).expect("backup dir should be writable");
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, "| other_database |".to_string(), String::new()))),
+        MockStep::WithEnv(Ok("restored backup".to_string())),
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Ok("configured statuses".to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    store.ensure_repo_initialized(repo.path())?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls[0].program, "dolt");
+    assert_eq!(calls[1].program, "dolt");
+    assert_eq!(calls[1].args[0], "backup");
+    assert_eq!(calls[1].args[1], "restore");
+    assert_eq!(calls[1].args[2], format!("file://{}", backup_dir.display()));
+    assert_eq!(calls[1].args[3], database_name);
+    assert_eq!(calls[2].program, "dolt");
+    assert_eq!(calls[3].args, vec!["where", "--json"]);
+    assert!(!calls
+        .iter()
+        .any(|call| call.args == vec!["doctor", "--fix", "--yes"]));
+    assert!(!calls
+        .iter()
+        .any(|call| call.args.first().map(String::as_str) == Some("init")));
+    Ok(())
 }
 
 #[test]
-fn ensure_repo_initialized_treats_existing_beads_directory_as_existing_attachment() -> Result<()> {
-    let repo = RepoFixture::new("existing-beads-dir");
+fn ensure_repo_initialized_fails_fast_for_broken_metadata() -> Result<()> {
+    let repo = RepoFixture::new("broken-metadata");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
     fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
-    let runner = MockCommandRunner::with_steps(vec![
-        MockStep::AllowFailureWithEnv(Ok((false, String::new(), "bd where failed".to_string()))),
-        MockStep::WithEnv(Ok("doctor fixed".to_string())),
-        MockStep::AllowFailureWithEnv(Ok((
-            false,
-            String::new(),
-            "attachment still points at the wrong database".to_string(),
-        ))),
-    ]);
+    fs::write(beads_dir.join("metadata.json"), "not-json").expect("metadata should be writable");
+    let runner = MockCommandRunner::with_steps(vec![]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     let error = store
         .ensure_repo_initialized(repo.path())
-        .expect_err("existing beads dir should use repair path and fail fast");
+        .expect_err("broken metadata should fail without repair fallback");
     assert!(error
         .to_string()
-        .contains("Beads repair completed but store is still not ready"));
+        .contains("Beads attachment contract is invalid"));
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 3);
-    assert_eq!(calls[0].args, vec!["where", "--json"]);
-    assert_eq!(calls[1].args, vec!["doctor", "--fix", "--yes"]);
-    assert!(!calls
-        .iter()
-        .any(|call| call.args.first().map(String::as_str) == Some("init")));
+    assert!(calls.is_empty());
     Ok(())
 }
 
 #[test]
-fn ensure_repo_initialized_repairs_when_verifier_reports_connectivity_error() -> Result<()> {
-    for reason in ["server not reachable", "dolt server unreachable"] {
-        let repo = RepoFixture::new("init-connectivity-error");
-        let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
-        write_attachment_metadata(&beads_dir, repo.path(), 3307);
-        fs::write(beads_dir.join("beads.db"), "stale").expect("beads.db should be writable");
-        let runner = MockCommandRunner::with_steps(vec![
-            MockStep::AllowFailureWithEnv(Ok((false, String::new(), reason.to_string()))),
-            MockStep::WithEnv(Ok("doctor fixed".to_string())),
-            MockStep::AllowFailureWithEnv(Ok((
-                true,
-                json!({
-                    "path": beads_dir,
-                    "prefix": "openducktor"
-                })
-                .to_string(),
-                String::new(),
-            ))),
-            MockStep::WithEnv(Ok("configured statuses".to_string())),
-        ]);
-        let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
-
-        store.ensure_repo_initialized(repo.path())?;
-
-        let calls = runner.take_calls();
-        assert_eq!(calls[1].args, vec!["doctor", "--fix", "--yes"]);
-        assert!(!calls.iter().any(|call| call.program == "dolt"));
-    }
-    Ok(())
-}
-
-#[test]
-fn ensure_repo_initialized_errors_when_existing_store_is_still_not_ready_after_repair() {
-    let repo = RepoFixture::new("init-still-unready-after-repair");
-    let beads_dir = resolve_repo_beads_attachment_dir(repo.path()).expect("expected beads dir");
+fn ensure_repo_initialized_fails_fast_for_malformed_where_output() -> Result<()> {
+    let repo = RepoFixture::new("malformed-where-output");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
     write_attachment_metadata(&beads_dir, repo.path(), 3307);
-    fs::write(beads_dir.join("beads.db"), "stale").expect("beads.db should be writable");
     let runner = MockCommandRunner::with_steps(vec![
-        MockStep::AllowFailureWithEnv(Ok((false, String::new(), "bd where failed".to_string()))),
-        MockStep::WithEnv(Ok("doctor fixed".to_string())),
-        MockStep::AllowFailureWithEnv(Ok((
-            false,
-            String::new(),
-            "attachment still points at the wrong database".to_string(),
-        ))),
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((true, String::new(), String::new()))),
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     let error = store
         .ensure_repo_initialized(repo.path())
-        .expect_err("existing store should fail instead of re-running init");
+        .expect_err("malformed where output should fail without fallback recovery");
     assert!(error
         .to_string()
-        .contains("Beads repair completed but store is still not ready"));
+        .contains("bd where returned empty payload"));
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 3);
-    assert_eq!(calls[1].args, vec!["doctor", "--fix", "--yes"]);
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].program, "dolt");
+    assert_eq!(calls[1].args, vec!["where", "--json"]);
     assert!(!calls
         .iter()
         .any(|call| call.args.first().map(String::as_str) == Some("init")));
+    assert!(!calls
+        .iter()
+        .any(|call| call.args == vec!["doctor", "--fix", "--yes"]));
+    assert!(!calls
+        .iter()
+        .any(|call| call.program == "dolt"
+            && call.args.first().map(String::as_str) == Some("backup")));
+    Ok(())
+}
+
+#[test]
+fn ensure_repo_initialized_fails_fast_when_shared_dolt_probe_fails() -> Result<()> {
+    let repo = RepoFixture::new("shared-dolt-unavailable");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
+        false,
+        String::new(),
+        "server not reachable".to_string(),
+    )))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let error = store
+        .ensure_repo_initialized(repo.path())
+        .expect_err("shared Dolt probe failure should not fall back to repair");
+    assert!(error
+        .to_string()
+        .contains("Shared Dolt readiness probe failed"));
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].program, "dolt");
+    assert!(!calls
+        .iter()
+        .any(|call| call.args == vec!["doctor", "--fix", "--yes"]));
+    assert!(!calls
+        .iter()
+        .any(|call| call.args.first().map(String::as_str) == Some("init")));
+    Ok(())
+}
+
+#[test]
+fn ensure_repo_initialized_succeeds_for_healthy_attachment_without_recovery() -> Result<()> {
+    let repo = RepoFixture::new("healthy-attachment");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Ok("configured statuses".to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    store.ensure_repo_initialized(repo.path())?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].program, "dolt");
+    assert_eq!(calls[1].args, vec!["where", "--json"]);
+    assert_eq!(
+        calls[2].args,
+        vec!["config", "set", "status.custom", CUSTOM_STATUS_VALUES]
+    );
+    assert!(!calls
+        .iter()
+        .any(|call| call.args == vec!["doctor", "--fix", "--yes"]));
+    assert!(!calls
+        .iter()
+        .any(|call| call.args.first().map(String::as_str) == Some("init")));
+    assert!(!calls
+        .iter()
+        .any(|call| call.program == "dolt"
+            && call.args.first().map(String::as_str) == Some("backup")));
+    Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -271,7 +271,7 @@ fn ensure_repo_initialized_fails_fast_for_malformed_where_output() -> Result<()>
         .expect_err("malformed where output should fail without fallback recovery");
     assert!(error
         .to_string()
-        .contains("bd where returned empty payload"));
+        .contains("bd where --json exited successfully but returned no JSON payload"));
 
     let calls = runner.take_calls();
     assert_eq!(calls.len(), 2);
@@ -311,7 +311,7 @@ fn ensure_repo_initialized_fails_fast_for_non_json_where_failure_output() -> Res
         .expect_err("non-JSON where failure output should fail without fallback recovery");
     assert!(error
         .to_string()
-        .contains("bd where failed without a decodable JSON payload"));
+        .contains("bd where --json exited unsuccessfully without a decodable JSON payload"));
 
     let calls = runner.take_calls();
     assert_eq!(calls.len(), 2);

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/support.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/support.rs
@@ -15,6 +15,10 @@ pub(super) enum CallKind {
 pub(super) enum MockStep {
     WithEnv(std::result::Result<String, String>),
     AllowFailureWithEnv(std::result::Result<(bool, String, String), String>),
+    AllowFailureWithEnvAndWrites {
+        result: std::result::Result<(bool, String, String), String>,
+        writes: Vec<(PathBuf, String)>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -63,11 +67,23 @@ impl MockCommandRunner {
             .expect("unexpected command invocation");
         match (&step, &expected_kind) {
             (MockStep::WithEnv(_), CallKind::WithEnv)
-            | (MockStep::AllowFailureWithEnv(_), CallKind::AllowFailureWithEnv) => step,
+            | (MockStep::AllowFailureWithEnv(_), CallKind::AllowFailureWithEnv)
+            | (MockStep::AllowFailureWithEnvAndWrites { .. }, CallKind::AllowFailureWithEnv) => {
+                step
+            }
             _ => panic!(
                 "unexpected command invocation kind, expected {:?}, got {:?}",
                 expected_kind, step
             ),
+        }
+    }
+
+    fn apply_writes(&self, writes: &[(PathBuf, String)]) {
+        for (path, contents) in writes {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("mock write parent should be writable");
+            }
+            fs::write(path, contents).expect("mock write target should be writable");
         }
     }
 
@@ -113,6 +129,9 @@ impl CommandRunner for MockCommandRunner {
         self.record_call(CallKind::WithEnv, program, args, cwd, env);
         match self.pop_step(CallKind::WithEnv) {
             MockStep::WithEnv(result) => result.map_err(|message| anyhow!(message)),
+            MockStep::AllowFailureWithEnvAndWrites { .. } => {
+                unreachable!("call kind already checked")
+            }
             MockStep::AllowFailureWithEnv(_) => unreachable!("call kind already checked"),
         }
     }
@@ -127,6 +146,10 @@ impl CommandRunner for MockCommandRunner {
         self.record_call(CallKind::AllowFailureWithEnv, program, args, cwd, env);
         match self.pop_step(CallKind::AllowFailureWithEnv) {
             MockStep::AllowFailureWithEnv(result) => result.map_err(|message| anyhow!(message)),
+            MockStep::AllowFailureWithEnvAndWrites { result, writes } => {
+                self.apply_writes(&writes);
+                result.map_err(|message| anyhow!(message))
+            }
             MockStep::WithEnv(_) => unreachable!("call kind already checked"),
         }
     }


### PR DESCRIPTION
## Summary
- replace the Beads lifecycle's footprint-first and reason-string-based readiness routing with explicit contract and probe classification
- distinguish missing attachment, broken attachment metadata, shared Dolt probe failure, missing shared database, attachment verification failure, and healthy attachment with source-aligned recovery behavior
- keep malformed `bd where --json` responses as hard failures, then isolate shared Dolt connection setup and `bd where` parsing into dedicated verifier helpers for maintainability

## Problem
The host-side Beads readiness flow had already improved, but it still mixed explicit checks with weaker lifecycle heuristics:
- coordinator routing branched on attachment footprint existence before full readiness evaluation
- recovery for missing shared databases depended on reason-string matching instead of an explicit probe
- malformed CLI cases could still be misclassified unless every path was handled carefully

That made the lifecycle harder to debug and easier to regress.

## Changes
- add a typed `RepoReadiness` model in `host-infra-beads` for the readiness states the lifecycle actually cares about
- make verifier readiness depend on:
  - attachment metadata contract validation
  - shared Dolt database presence probing via `dolt sql -q "show databases"`
  - explicit `bd where --json` verification
- remove coordinator branching based on attachment footprint existence and old reason-string recovery routing
- route recovery explicitly:
  - missing attachment -> `bd init`
  - missing shared database -> restore from backup
  - other attachment verification failures -> `bd doctor --fix --yes`
  - broken attachment contract / shared Dolt unavailability / malformed CLI payloads -> fail fast
- add terminal error variants for broken attachment contracts and shared Dolt probe failures
- refactor verifier internals to isolate shared Dolt connection setup plus `bd where --json` command classification and payload parsing
- expand lifecycle test coverage, including:
  - missing attachment
  - missing shared database
  - broken metadata
  - malformed successful empty `bd where --json` output
  - malformed nonzero-exit plain-text `bd where --json` output
  - shared Dolt probe failure
  - healthy attachment
  - cache/config ordering after successful readiness

## Verification
- `cargo test -p host-infra-beads lifecycle`
- `cargo test -p host-infra-beads`
- LSP diagnostics on `apps/desktop/src-tauri/crates/host-infra-beads/src`
- `rustfmt --check` on touched files

## Notes
- this PR intentionally keeps filesystem footprint checks as supporting evidence only, not the primary lifecycle state machine
- no fallback behavior was added to mask readiness failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate repository initialization with clearer, specific errors for missing/corrupt attachments and unavailable shared databases.
  * Faster fail‑fast behavior that avoids unnecessary repair/backup actions when recovery is impossible.

* **Refactor**
  * Streamlined readiness verification and centralized recovery handling for more consistent, predictable initialization and automatic recoveries.

* **Tests**
  * Expanded coverage for initialization paths, noisy command output, and various failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->