### PR TITLE
feat(release): add desktop and MCP release workflows

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+    - title: 🐛 Fixes
+      labels:
+        - bug
+    - title: 📝 Documentation
+      labels:
+        - documentation
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - question
+      - wontfix

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -2,9 +2,11 @@ name: Publish MCP Package
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "mcp-v*"
+    inputs:
+      tag:
+        description: "Release tag to publish (for example v0.1.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -20,13 +22,32 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Checkout
+      - name: Checkout MCP tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Validate MCP tag matches package version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Expected release tag like v0.1.0 or v0.1.0-rc.1." >&2
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          PACKAGE_VERSION="$(bun --print 'JSON.parse(require("node:fs").readFileSync("packages/openducktor-mcp/package.json", "utf8")).version')"
+          if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
+            echo "MCP package version $PACKAGE_VERSION does not match tag $TAG." >&2
+            exit 1
+          fi
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -43,3 +64,14 @@ jobs:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
         run: bun publish --access public
+
+      - name: Publish workflow summary
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          {
+            echo "## MCP package published"
+            echo
+            echo "- Tag: $TAG"
+            echo "- Package: @openducktor/mcp"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,274 @@
+name: Release Desktop
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (for example v0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: 1.3.11
+  CARGO_TERM_COLOR: always
+  APPLE_SIGNING_ENABLED: ${{ vars.APPLE_SIGNING_ENABLED || 'false' }}
+
+jobs:
+  create-release:
+    name: Create desktop release draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      release_id: ${{ steps.create_release.outputs.id }}
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Resolve release metadata
+        id: meta
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="$INPUT_TAG"
+          if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must look like v0.1.0 or v0.1.0-rc.1." >&2
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify repo version matches tag
+        run: bun run release:version:check "${{ steps.meta.outputs.version }}"
+
+      - name: Create or reuse draft release
+        id: create_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            IS_DRAFT="$(gh release view "$TAG" --json isDraft --jq '.isDraft')"
+            if [[ "$IS_DRAFT" != "true" ]]; then
+              echo "Release $TAG already exists and is not a draft. Refusing to overwrite a published release." >&2
+              exit 1
+            fi
+
+            RELEASE_ID="$(gh api "repos/$REPO/releases/tags/$TAG" --jq '.id')"
+            echo "id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh release create "$TAG" --draft --title "OpenDucktor v$VERSION" --generate-notes
+          RELEASE_ID="$(gh api "repos/$REPO/releases/tags/$TAG" --jq '.id')"
+          echo "id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+
+  build-macos:
+    name: Build ${{ matrix.label }} desktop assets
+    needs: create-release
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS Apple Silicon
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - label: macOS Intel
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.create-release.outputs.tag }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Resolve CEF cache metadata
+        id: cef_cache
+        run: bun run --cwd apps/desktop scripts/resolve-cef-cache-metadata.ts >> "$GITHUB_OUTPUT"
+
+      - name: Cache Bun download cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: |
+            apps/desktop/src-tauri
+          shared-key: desktop-release-${{ matrix.target }}
+
+      - name: Cache OpenDucktor CEF toolchain and runtime
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.cef_cache.outputs.cargo_tauri_root }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-${{ steps.cef_cache.outputs.tauri_revision_short }}
+
+      - name: Cache export-cef-dir tool
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.cef_cache.outputs.export_cef_tool_root }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-export-cef-dir-${{ steps.cef_cache.outputs.cef_version }}
+
+      - name: Cache exported CEF bundle
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.cef_cache.outputs.cef_path }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cef-runtime-${{ steps.cef_cache.outputs.cef_version }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify CEF native build prerequisites
+        run: |
+          set -euo pipefail
+          cmake --version
+          ninja --version
+
+      - name: Verify repo version matches tag
+        run: bun run release:version:check "${{ needs.create-release.outputs.version }}"
+
+      - name: Validate release secrets
+        if: env.APPLE_SIGNING_ENABLED == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            printf 'Missing required desktop release secrets:\n' >&2
+            printf ' - %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+
+      - name: Install Apple signing certificate
+        if: env.APPLE_SIGNING_ENABLED == 'true'
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Prime CEF toolchain
+        run: bun run tauri:setup:cef
+
+      - name: Resolve CEF build paths
+        id: cef
+        run: bun run --cwd apps/desktop scripts/resolve-cef-release-env.ts >> "$GITHUB_OUTPUT"
+
+      - name: Build and upload signed desktop assets
+        if: env.APPLE_SIGNING_ENABLED == 'true'
+        uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
+        timeout-minutes: 60
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CEF_PATH: ${{ steps.cef.outputs.cef_path }}
+          OPENDUCKTOR_PREPARE_SIDECARS: "1"
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          projectPath: apps/desktop
+          tauriScript: ${{ steps.cef.outputs.cargo_tauri_path }}
+          args: --target ${{ matrix.target }} --config src-tauri/bundle.sidecars.json --features cef -- --no-default-features
+          releaseDraft: true
+          uploadUpdaterJson: false
+          uploadUpdaterSignatures: false
+          retryAttempts: 2
+
+      - name: Build and upload unsigned desktop assets
+        if: env.APPLE_SIGNING_ENABLED != 'true'
+        uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
+        timeout-minutes: 60
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CEF_PATH: ${{ steps.cef.outputs.cef_path }}
+          OPENDUCKTOR_PREPARE_SIDECARS: "1"
+        with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          projectPath: apps/desktop
+          tauriScript: ${{ steps.cef.outputs.cargo_tauri_path }}
+          args: --target ${{ matrix.target }} --config src-tauri/bundle.sidecars.json --features cef -- --no-default-features
+          releaseDraft: true
+          uploadUpdaterJson: false
+          uploadUpdaterSignatures: false
+          retryAttempts: 2
+
+  finalize-release:
+    name: Summarize release draft
+    needs:
+      - create-release
+      - build-macos
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Publish workflow summary
+        env:
+          APPLE_SIGNING_ENABLED: ${{ env.APPLE_SIGNING_ENABLED }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.create-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          RELEASE_URL="$(gh release view "$TAG" --json url --jq '.url')"
+          {
+            echo "## Desktop release draft ready"
+            echo
+            echo "- Tag: $TAG"
+            echo "- Draft release: $RELEASE_URL"
+            echo "- Assets uploaded by tauri-action for macOS arm64 and macOS Intel"
+            echo "- Apple signing enabled: $APPLE_SIGNING_ENABLED"
+            echo "- Release notes source: GitHub generated notes using .github/release.yml"
+            echo "- Next step: smoke-test the draft assets, then publish the draft in GitHub Releases"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -143,18 +143,24 @@ jobs:
         with:
           path: ${{ steps.cef_cache.outputs.cargo_tauri_root }}
           key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-${{ steps.cef_cache.outputs.tauri_revision_short }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-
 
       - name: Cache export-cef-dir tool
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.cef_cache.outputs.export_cef_tool_root }}
           key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-export-cef-dir-${{ steps.cef_cache.outputs.cef_version }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-export-cef-dir-
 
       - name: Cache exported CEF bundle
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.cef_cache.outputs.cef_path }}
           key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cef-runtime-${{ steps.cef_cache.outputs.cef_version }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cef-runtime-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -194,7 +200,7 @@ jobs:
 
       - name: Install Apple signing certificate
         if: env.APPLE_SIGNING_ENABLED == 'true'
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,118 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (for example 0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: release-prep
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: 1.3.11
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
+jobs:
+  prepare-release:
+    name: Bump, commit, tag, and dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ env.DEFAULT_BRANCH }}
+          token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Ensure release refs do not already exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          TAG="v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists locally." >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin." >&2
+            exit 1
+          fi
+
+      - name: Apply version bump
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          bun run release:version:set "$VERSION"
+          bun install
+          bun run release:version:check "$VERSION"
+
+      - name: Commit release bump
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json bun.lock apps/desktop/package.json apps/desktop/src-tauri/Cargo.toml apps/desktop/src-tauri/tauri.conf.json packages
+          git commit -m "chore(release): v$VERSION"
+
+      - name: Create release tags
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git tag -a "v$VERSION" -m "OpenDucktor v$VERSION"
+
+      - name: Push release commit and tags
+        env:
+          DEFAULT_BRANCH: ${{ env.DEFAULT_BRANCH }}
+        run: |
+          set -euo pipefail
+          git push origin HEAD:"$DEFAULT_BRANCH"
+          git push origin --tags
+
+      - name: Dispatch desktop publish workflow
+        env:
+          DEFAULT_BRANCH: ${{ env.DEFAULT_BRANCH }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+          VERSION: ${{ inputs.version }}
+        run: gh workflow run release-desktop.yml --ref "$DEFAULT_BRANCH" -f tag="v$VERSION"
+
+      - name: Dispatch MCP publish workflow
+        env:
+          DEFAULT_BRANCH: ${{ env.DEFAULT_BRANCH }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+          VERSION: ${{ inputs.version }}
+        run: gh workflow run publish-mcp.yml --ref "$DEFAULT_BRANCH" -f tag="v$VERSION"
+
+      - name: Publish workflow summary
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "## Release prepared"
+            echo
+            echo "- Release commit created on default branch"
+            echo "- Desktop tag: v$VERSION"
+            echo "- Shared release tag: v$VERSION"
+            echo "- Dispatched workflows: Release Desktop, Publish MCP Package"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -31,7 +31,17 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ env.DEFAULT_BRANCH }}
-          token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+          persist-credentials: false
+
+      - name: Validate release automation token
+        env:
+          RELEASE_AUTOMATION_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RELEASE_AUTOMATION_TOKEN:-}" ]]; then
+            echo "Missing RELEASE_AUTOMATION_TOKEN. Release prep refuses to push with the default GitHub token." >&2
+            exit 1
+          fi
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -85,22 +95,23 @@ jobs:
       - name: Push release commit and tags
         env:
           DEFAULT_BRANCH: ${{ env.DEFAULT_BRANCH }}
+          RELEASE_AUTOMATION_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
         run: |
           set -euo pipefail
-          git push origin HEAD:"$DEFAULT_BRANCH"
-          git push origin --tags
+          git remote set-url origin "https://x-access-token:${RELEASE_AUTOMATION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --follow-tags origin HEAD:"$DEFAULT_BRANCH"
 
       - name: Dispatch desktop publish workflow
         env:
           DEFAULT_BRANCH: ${{ env.DEFAULT_BRANCH }}
-          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
           VERSION: ${{ inputs.version }}
         run: gh workflow run release-desktop.yml --ref "$DEFAULT_BRANCH" -f tag="v$VERSION"
 
       - name: Dispatch MCP publish workflow
         env:
           DEFAULT_BRANCH: ${{ env.DEFAULT_BRANCH }}
-          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
           VERSION: ${{ inputs.version }}
         run: gh workflow run publish-mcp.yml --ref "$DEFAULT_BRANCH" -f tag="v$VERSION"
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,20 @@ OpenDucktor currently targets local macOS development.
 - Bun `1.3.11`
 - Rust stable toolchain
 - Xcode Command Line Tools
+- `cmake`
+- `ninja`
 - `git`
 - `gh`
 - `bd` (Beads CLI)
 - `opencode` (OpenCode CLI/runtime)
 
 OpenDucktor resolves `opencode` from `PATH` first, then falls back to `~/.opencode/bin/opencode`. You can also override the binary path with `OPENDUCKTOR_OPENCODE_BINARY`.
+
+On macOS, you can install the native CEF build helpers with Homebrew:
+
+```sh
+brew install cmake ninja
+```
 
 ### Install Dependencies
 
@@ -81,13 +89,15 @@ bun run tauri:setup:cef
 
 That command:
 
+- requires `cmake` and `ninja` to already be available on `PATH`
 - installs the CEF toolchain into a shared OpenDucktor cache directory
 - exports CEF into a shared OpenDucktor cache directory that is versioned by the resolved `cef` crate version
 - clears the macOS quarantine attribute from the downloaded CEF bundle
 
 By default, worktrees share the same contributor-local cache under `~/.openducktor/cache/`, so you do not need to rerun the full CEF bootstrap for every git worktree.
 
-- CEF tools default to `~/.openducktor/cache/cargo-tools/tauri-feat-cef/<tauri-revision>/`
+- `cargo-tauri` defaults to `~/.openducktor/cache/cargo-tools/tauri-feat-cef/<tauri-revision>/`
+- `export-cef-dir` defaults to `~/.openducktor/cache/cargo-tools/export-cef-dir/<cef-version>/`
 - Exported CEF bundles default to `~/.openducktor/cache/cef/<cef-version>/`
 
 The setup script installs `cargo-tauri` from the exact Tauri git revision locked in `apps/desktop/src-tauri/Cargo.lock`, so the CEF CLI matches the app runtime instead of following the moving `feat/cef` branch head.
@@ -182,6 +192,7 @@ Key references:
 
 - [docs/architecture-overview.md](docs/architecture-overview.md)
 - [docs/runtime-integration-guide.md](docs/runtime-integration-guide.md)
+- [docs/release-process.md](docs/release-process.md)
 - [docs/task-workflow-status-model.md](docs/task-workflow-status-model.md)
 - [docs/task-workflow-actions.md](docs/task-workflow-actions.md)
 - [docs/task-workflow-transition-matrix.md](docs/task-workflow-transition-matrix.md)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ That command:
 
 By default, worktrees share the same contributor-local cache under `~/.openducktor/cache/`, so you do not need to rerun the full CEF bootstrap for every git worktree.
 
-- `cargo-tauri` defaults to `~/.openducktor/cache/cargo-tools/tauri-feat-cef/<tauri-revision>/`
+- `cargo-tauri` defaults to `~/.openducktor/cache/cargo-tools/tauri-feat-cef/<tauri-revision-prefix>/` (12-character prefix)
 - `export-cef-dir` defaults to `~/.openducktor/cache/cargo-tools/export-cef-dir/<cef-version>/`
 - Exported CEF bundles default to `~/.openducktor/cache/cef/<cef-version>/`
 

--- a/apps/desktop/scripts/cef-paths.test.ts
+++ b/apps/desktop/scripts/cef-paths.test.ts
@@ -6,8 +6,10 @@ import { join, resolve } from "node:path";
 import {
   readCefVersion,
   readTauriCefRevision,
+  resolveCargoTauriToolsRoot,
   resolveCargoToolsRoot,
   resolveCefPath,
+  resolveExportCefToolsRoot,
 } from "./cef-paths";
 
 const ENV_KEYS = [
@@ -79,6 +81,19 @@ describe("cef-paths", () => {
           "1234567890ab",
         ),
       );
+      expect(resolveCargoTauriToolsRoot(tauriRoot)).toBe(
+        resolve(
+          homedir(),
+          ".openducktor-dev",
+          "cache",
+          "cargo-tools",
+          "tauri-feat-cef",
+          "1234567890ab",
+        ),
+      );
+      expect(resolveExportCefToolsRoot(tauriRoot)).toBe(
+        resolve(homedir(), ".openducktor-dev", "cache", "cargo-tools", "export-cef-dir", "136.2.1"),
+      );
       expect(resolveCefPath(tauriRoot)).toBe(
         resolve(homedir(), ".openducktor-dev", "cache", "cef", "136.2.1"),
       );
@@ -97,6 +112,8 @@ describe("cef-paths", () => {
 
     try {
       expect(resolveCargoToolsRoot(tauriRoot)).toBe(resolve(homedir(), "custom-tools"));
+      expect(resolveCargoTauriToolsRoot(tauriRoot)).toBe(resolve(homedir(), "custom-tools"));
+      expect(resolveExportCefToolsRoot(tauriRoot)).toBe(resolve(homedir(), "custom-tools"));
       expect(resolveCefPath(tauriRoot)).toBe(resolve(homedir(), "custom-cef"));
     } finally {
       rmSync(tauriRoot, { force: true, recursive: true });

--- a/apps/desktop/scripts/cef-paths.ts
+++ b/apps/desktop/scripts/cef-paths.ts
@@ -7,6 +7,10 @@ const OPENDUCKTOR_CARGO_TOOLS_ROOT_ENV = "OPENDUCKTOR_CARGO_TOOLS_ROOT";
 const OPENDUCKTOR_CEF_PATH_ENV = "OPENDUCKTOR_CEF_PATH";
 const UPSTREAM_CEF_PATH_ENV = "CEF_PATH";
 
+function readTauriRevisionPrefix(tauriRoot: string): string {
+  return readTauriCefRevision(tauriRoot).slice(0, 12);
+}
+
 function expandHome(path: string): string {
   if (path === "~") {
     return homedir();
@@ -105,6 +109,10 @@ export function resolveOpenducktorDataRoot(): string {
 }
 
 export function resolveCargoToolsRoot(tauriRoot: string): string {
+  return resolveCargoTauriToolsRoot(tauriRoot);
+}
+
+export function resolveCargoTauriToolsRoot(tauriRoot: string): string {
   return (
     resolveConfiguredPath(OPENDUCKTOR_CARGO_TOOLS_ROOT_ENV) ??
     resolve(
@@ -112,7 +120,20 @@ export function resolveCargoToolsRoot(tauriRoot: string): string {
       "cache",
       "cargo-tools",
       "tauri-feat-cef",
-      readTauriCefRevision(tauriRoot).slice(0, 12),
+      readTauriRevisionPrefix(tauriRoot),
+    )
+  );
+}
+
+export function resolveExportCefToolsRoot(tauriRoot: string): string {
+  return (
+    resolveConfiguredPath(OPENDUCKTOR_CARGO_TOOLS_ROOT_ENV) ??
+    resolve(
+      resolveOpenducktorDataRoot(),
+      "cache",
+      "cargo-tools",
+      "export-cef-dir",
+      readCefVersion(tauriRoot),
     )
   );
 }

--- a/apps/desktop/scripts/resolve-cef-cache-metadata.ts
+++ b/apps/desktop/scripts/resolve-cef-cache-metadata.ts
@@ -1,0 +1,28 @@
+import { resolve } from "node:path";
+
+import {
+  readCefVersion,
+  readTauriCefRevision,
+  resolveCargoTauriToolsRoot,
+  resolveCefPath,
+  resolveExportCefToolsRoot,
+} from "./cef-paths";
+
+const desktopRoot = process.cwd();
+const tauriRoot = resolve(desktopRoot, "src-tauri");
+const binaryExtension = process.platform === "win32" ? ".exe" : "";
+const tauriRevision = readTauriCefRevision(tauriRoot);
+const cefVersion = readCefVersion(tauriRoot);
+const cargoTauriRoot = resolveCargoTauriToolsRoot(tauriRoot);
+const exportCefToolRoot = resolveExportCefToolsRoot(tauriRoot);
+
+console.log(`tauri_revision=${tauriRevision}`);
+console.log(`tauri_revision_short=${tauriRevision.slice(0, 12)}`);
+console.log(`cef_version=${cefVersion}`);
+console.log(`cargo_tauri_root=${cargoTauriRoot}`);
+console.log(`cargo_tauri_path=${resolve(cargoTauriRoot, "bin", `cargo-tauri${binaryExtension}`)}`);
+console.log(`export_cef_tool_root=${exportCefToolRoot}`);
+console.log(
+  `export_cef_dir_path=${resolve(exportCefToolRoot, "bin", `export-cef-dir${binaryExtension}`)}`,
+);
+console.log(`cef_path=${resolveCefPath(tauriRoot)}`);

--- a/apps/desktop/scripts/resolve-cef-release-env.ts
+++ b/apps/desktop/scripts/resolve-cef-release-env.ts
@@ -1,0 +1,25 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { resolveCargoTauriToolsRoot, resolveCefPath } from "./cef-paths";
+
+const desktopRoot = process.cwd();
+const tauriRoot = resolve(desktopRoot, "src-tauri");
+const binaryExtension = process.platform === "win32" ? ".exe" : "";
+const cargoTauriPath = resolve(
+  resolveCargoTauriToolsRoot(tauriRoot),
+  "bin",
+  `cargo-tauri${binaryExtension}`,
+);
+const cefPath = resolveCefPath(tauriRoot);
+
+if (!existsSync(cargoTauriPath)) {
+  throw new Error(`Missing cargo-tauri at ${cargoTauriPath}. Run tauri:setup:cef first.`);
+}
+
+if (!existsSync(cefPath)) {
+  throw new Error(`Missing CEF bundle at ${cefPath}. Run tauri:setup:cef first.`);
+}
+
+console.log(`cargo_tauri_path=${cargoTauriPath}`);
+console.log(`cef_path=${cefPath}`);

--- a/apps/desktop/scripts/setup-cef.ts
+++ b/apps/desktop/scripts/setup-cef.ts
@@ -6,18 +6,22 @@ import { delimiter, join, resolve } from "node:path";
 import {
   readCefVersion,
   readTauriCefRevision,
-  resolveCargoToolsRoot,
+  resolveCargoTauriToolsRoot,
   resolveCefPath,
+  resolveExportCefToolsRoot,
 } from "./cef-paths";
 
 const desktopRoot = process.cwd();
 const tauriRoot = resolve(desktopRoot, "src-tauri");
-const toolRoot = resolveCargoToolsRoot(tauriRoot);
-const toolBinRoot = resolve(toolRoot, "bin");
+const cargoTauriRoot = resolveCargoTauriToolsRoot(tauriRoot);
+const cargoTauriBinRoot = resolve(cargoTauriRoot, "bin");
+const exportCefToolRoot = resolveExportCefToolsRoot(tauriRoot);
+const exportCefToolBinRoot = resolve(exportCefToolRoot, "bin");
 const cefPath = resolveCefPath(tauriRoot);
 const tauriRevision = readTauriCefRevision(tauriRoot);
 const binaryExtension = process.platform === "win32" ? ".exe" : "";
-const exportCefDirPath = resolve(toolBinRoot, `export-cef-dir${binaryExtension}`);
+const cargoTauriPath = resolve(cargoTauriBinRoot, `cargo-tauri${binaryExtension}`);
+const exportCefDirPath = resolve(exportCefToolBinRoot, `export-cef-dir${binaryExtension}`);
 
 function cargoHomeBinPath(): string {
   return resolve(process.env.CARGO_HOME ?? join(homedir(), ".cargo"), "bin");
@@ -27,7 +31,9 @@ function commandEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     ...process.env,
     ...extra,
-    PATH: [toolBinRoot, cargoHomeBinPath(), process.env.PATH].filter(Boolean).join(delimiter),
+    PATH: [cargoTauriBinRoot, exportCefToolBinRoot, cargoHomeBinPath(), process.env.PATH]
+      .filter(Boolean)
+      .join(delimiter),
   };
 }
 
@@ -70,41 +76,45 @@ await (async () => {
     await run("rustup", ["target", "add", "x86_64-apple-darwin"]);
   }
 
-  await run("rustup", [
-    "run",
-    "stable",
-    "cargo",
-    "install",
-    "--locked",
-    "--root",
-    toolRoot,
-    "tauri-cli",
-    "--git",
-    "https://github.com/tauri-apps/tauri",
-    "--rev",
-    tauriRevision,
-    "--force",
-  ]);
+  if (!existsSync(cargoTauriPath)) {
+    await run("rustup", [
+      "run",
+      "stable",
+      "cargo",
+      "install",
+      "--locked",
+      "--root",
+      cargoTauriRoot,
+      "tauri-cli",
+      "--git",
+      "https://github.com/tauri-apps/tauri",
+      "--rev",
+      tauriRevision,
+    ]);
+  }
 
-  await run("rustup", [
-    "run",
-    "stable",
-    "cargo",
-    "install",
-    "--locked",
-    "--root",
-    toolRoot,
-    "export-cef-dir",
-    "--version",
-    readCefVersion(tauriRoot),
-    "--force",
-  ]);
+  if (!existsSync(exportCefDirPath)) {
+    await run("rustup", [
+      "run",
+      "stable",
+      "cargo",
+      "install",
+      "--locked",
+      "--root",
+      exportCefToolRoot,
+      "export-cef-dir",
+      "--version",
+      readCefVersion(tauriRoot),
+    ]);
+  }
 
   if (!existsSync(exportCefDirPath)) {
     throw new Error(`Missing export-cef-dir at ${exportCefDirPath}`);
   }
 
-  await run(exportCefDirPath, ["--force", cefPath]);
+  if (!existsSync(cefPath)) {
+    await run(exportCefDirPath, [cefPath]);
+  }
 
   if (process.platform === "darwin") {
     await run("xattr", ["-dr", "com.apple.quarantine", cefPath]);

--- a/apps/desktop/scripts/setup-cef.ts
+++ b/apps/desktop/scripts/setup-cef.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 
@@ -22,6 +22,7 @@ const tauriRevision = readTauriCefRevision(tauriRoot);
 const binaryExtension = process.platform === "win32" ? ".exe" : "";
 const cargoTauriPath = resolve(cargoTauriBinRoot, `cargo-tauri${binaryExtension}`);
 const exportCefDirPath = resolve(exportCefToolBinRoot, `export-cef-dir${binaryExtension}`);
+const cefVersion = readCefVersion(tauriRoot);
 
 function cargoHomeBinPath(): string {
   return resolve(process.env.CARGO_HOME ?? join(homedir(), ".cargo"), "bin");
@@ -71,12 +72,53 @@ function run(command: string, args: string[], env = commandEnv()): Promise<void>
   });
 }
 
+function isRunnableBinary(binaryPath: string, args: string[]): boolean {
+  if (!existsSync(binaryPath)) {
+    return false;
+  }
+
+  try {
+    if (!statSync(binaryPath).isFile()) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  const result = spawnSync(binaryPath, args, {
+    cwd: desktopRoot,
+    env: commandEnv(),
+    stdio: "ignore",
+  });
+
+  return result.status === 0;
+}
+
+function hasValidExportedCefBundle(): boolean {
+  if (!existsSync(cefPath)) {
+    return false;
+  }
+
+  const requiredEntries = [
+    resolve(cefPath, "archive.json"),
+    resolve(cefPath, "include"),
+    resolve(cefPath, "libcef_dll"),
+  ];
+
+  if (process.platform === "darwin") {
+    requiredEntries.push(resolve(cefPath, "Chromium Embedded Framework.framework"));
+  }
+
+  return requiredEntries.every((entryPath) => existsSync(entryPath));
+}
+
 await (async () => {
   if (process.platform === "darwin") {
     await run("rustup", ["target", "add", "x86_64-apple-darwin"]);
   }
 
-  if (!existsSync(cargoTauriPath)) {
+  if (!isRunnableBinary(cargoTauriPath, ["--version"])) {
+    rmSync(cargoTauriRoot, { force: true, recursive: true });
     await run("rustup", [
       "run",
       "stable",
@@ -93,7 +135,8 @@ await (async () => {
     ]);
   }
 
-  if (!existsSync(exportCefDirPath)) {
+  if (!isRunnableBinary(exportCefDirPath, ["--help"])) {
+    rmSync(exportCefToolRoot, { force: true, recursive: true });
     await run("rustup", [
       "run",
       "stable",
@@ -104,7 +147,7 @@ await (async () => {
       exportCefToolRoot,
       "export-cef-dir",
       "--version",
-      readCefVersion(tauriRoot),
+      cefVersion,
     ]);
   }
 
@@ -112,7 +155,8 @@ await (async () => {
     throw new Error(`Missing export-cef-dir at ${exportCefDirPath}`);
   }
 
-  if (!existsSync(cefPath)) {
+  if (!hasValidExportedCefBundle()) {
+    rmSync(cefPath, { force: true, recursive: true });
     await run(exportCefDirPath, [cefPath]);
   }
 

--- a/apps/desktop/scripts/tauri-cef-build.ts
+++ b/apps/desktop/scripts/tauri-cef-build.ts
@@ -2,12 +2,12 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { resolveCargoToolsRoot, resolveCefPath } from "./cef-paths";
+import { resolveCargoTauriToolsRoot, resolveCefPath } from "./cef-paths";
 
 const desktopRoot = process.cwd();
 const tauriRoot = resolve(desktopRoot, "src-tauri");
 const cargoTauriPath = resolve(
-  resolveCargoToolsRoot(tauriRoot),
+  resolveCargoTauriToolsRoot(tauriRoot),
   "bin",
   process.platform === "win32" ? "cargo-tauri.exe" : "cargo-tauri",
 );

--- a/apps/desktop/scripts/tauri-cef-dev.ts
+++ b/apps/desktop/scripts/tauri-cef-dev.ts
@@ -2,13 +2,13 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { resolveCargoToolsRoot, resolveCefPath } from "./cef-paths";
+import { resolveCargoTauriToolsRoot, resolveCefPath } from "./cef-paths";
 
 const desktopRoot = process.cwd();
 const tauriRoot = resolve(desktopRoot, "src-tauri");
 const macosCefDevConfigPath = resolve(tauriRoot, "tauri.cef-dev.conf.json");
 const cargoTauriPath = resolve(
-  resolveCargoToolsRoot(tauriRoot),
+  resolveCargoTauriToolsRoot(tauriRoot),
   "bin",
   process.platform === "win32" ? "cargo-tauri.exe" : "cargo-tauri",
 );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -459,7 +459,7 @@ export const AgentChatComposer = forwardRef<
       scheduleComposerFocus();
     }
   }, [onComposerEditorInput, scheduleComposerFocus]);
-  let composerPlaceholder = "@ for files; / for commands; ! for shell";
+  let composerPlaceholder = "@ for files; / for commands";
   if (isReadOnly && readOnlyReason) {
     composerPlaceholder = readOnlyReason;
   }

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "openducktor",
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
+        "@iarna/toml": "^2.2.5",
         "@types/node": "^25.5.2",
         "knip": "^6.3.0",
         "typescript": "^5.7.3",
@@ -157,6 +158,8 @@
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.9" } }, "sha512-DtZeRRHY9A/bisTJziUBBPrdnPui7+R185G/hzi6/Boymhqh7/wi53AY+IvQHS1+7OPaqfO/1XNpngNwthLz+A=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
+    "@iarna/toml": ["@iarna/toml@2.2.5", "", {}, "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ This folder contains the project documentation that explains how OpenDucktor is 
 - [mcp-runtime-security.md](mcp-runtime-security.md): current MCP transport and threat assumptions.
 - [desktop-csp-hardening.md](desktop-csp-hardening.md): current desktop CSP baseline and hardening plan.
 - [dependency-hygiene.md](dependency-hygiene.md): dependency update and audit policy.
+- [release-process.md](release-process.md): desktop release workflow, required secrets, version sync, and draft publishing steps.
 
 ## Notes On Scope
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -100,11 +100,11 @@ Notes:
 
 - `NPM_TOKEN`
 
-### Optional release automation token
+### Release automation secret
 
 - `RELEASE_AUTOMATION_TOKEN`
 
-This is only needed when repository settings or branch protection rules prevent the default GitHub Actions token from pushing the release commit and tags.
+`Prepare Release` requires this token and refuses to push with the default GitHub Actions token. That keeps release automation aligned with normal repository protection and review expectations.
 
 ## How versioning works
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,142 @@
+# Desktop and MCP release process
+
+OpenDucktor releases are now owned by GitHub Actions. Maintainers do not need to run local release commands or create tags by hand.
+
+## Workflow layout
+
+The release flow is split into three workflows:
+
+- `.github/workflows/release-prep.yml`
+- `.github/workflows/release-desktop.yml`
+- `.github/workflows/publish-mcp.yml`
+
+### 1. Prepare Release
+
+`Prepare Release` is the only workflow a maintainer starts manually.
+
+- Trigger: `workflow_dispatch`
+- Input: `version` like `0.1.0`
+
+It does all release preparation work:
+
+- validates the requested version
+- updates repo version manifests
+- refreshes `bun.lock`
+- creates the release bump commit on the default branch
+- creates one tag:
+  - `v0.1.0` for the desktop release and MCP publish
+- dispatches the desktop and MCP publish workflows
+
+### 2. Release Desktop
+
+`Release Desktop` is dispatched by `Prepare Release` with a desktop tag input such as `v0.1.0`.
+
+It:
+
+- validates that the checked-out repo state matches the tag version
+- creates or reuses a **draft GitHub release**
+- runs the repo's CEF bootstrap step
+- builds macOS assets for:
+  - Apple Silicon (`aarch64-apple-darwin`)
+  - Intel (`x86_64-apple-darwin`)
+- uploads those assets to the draft GitHub release via `tauri-action`
+
+Signing is controlled by the repository variable `APPLE_SIGNING_ENABLED`:
+
+- when `false` or unset, the workflow builds unsigned desktop binaries
+- when `true`, the workflow requires Apple signing credentials and produces signed builds
+
+The release remains a **draft** so maintainers can smoke-test the downloaded assets before publishing.
+
+### 3. Publish MCP Package
+
+`Publish MCP Package` is dispatched by `Prepare Release` with the shared release tag such as `v0.1.0`.
+
+It:
+
+- validates that `packages/openducktor-mcp/package.json` matches the tag version
+- verifies the MCP package
+- publishes `@openducktor/mcp` to npmjs
+
+## Why this design
+
+OpenDucktor uses a CEF-specific Tauri flow:
+
+- `bun run tauri:setup:cef`
+- repo-specific path resolution from `apps/desktop/scripts/cef-paths.ts`
+
+Those scripts pin `cargo-tauri` to the exact Tauri `feat/cef` revision locked in `apps/desktop/src-tauri/Cargo.lock`, export CEF into the shared OpenDucktor cache, and clear the downloaded bundle's macOS quarantine bit.
+
+The release workflow keeps those OpenDucktor-specific setup steps, then hands the actual desktop build/upload to `tauri-action`. That gives you a more standard Tauri publish layer without throwing away the CEF bootstrap the repo already depends on.
+
+## Release notes
+
+Desktop release notes use **GitHub-generated release notes**.
+
+- `.github/release.yml` defines the category mapping
+- the draft GitHub release is created with `--generate-notes`
+- maintainers can review and edit the draft notes before publishing
+
+That keeps release notes simple and reviewable for the first release line.
+
+## Required GitHub secrets
+
+### Desktop release secrets
+
+- `APPLE_CERTIFICATE`
+- `APPLE_CERTIFICATE_PASSWORD`
+- `APPLE_SIGNING_IDENTITY`
+- `APPLE_ID`
+- `APPLE_PASSWORD`
+- `APPLE_TEAM_ID`
+
+Notes:
+
+- `APPLE_CERTIFICATE` must be a base64-encoded `.p12` signing certificate.
+- The Apple secrets are only required when `APPLE_SIGNING_ENABLED=true`.
+- Certificate import is handled by `apple-actions/import-codesign-certs`.
+
+### MCP publish secrets
+
+- `NPM_TOKEN`
+
+### Optional release automation token
+
+- `RELEASE_AUTOMATION_TOKEN`
+
+This is only needed when repository settings or branch protection rules prevent the default GitHub Actions token from pushing the release commit and tags.
+
+## How versioning works
+
+The repo still uses a small helper script to keep version sources aligned, but the workflow owns when it runs.
+
+The version sync touches:
+
+- root `package.json`
+- workspace package manifests discovered from the root `workspaces` configuration
+- `apps/desktop/src-tauri/tauri.conf.json`
+- `apps/desktop/src-tauri/Cargo.toml` (`[package]` and `[workspace.package]`)
+- `bun.lock`
+
+The helper script remains useful because this repo spans three version domains:
+
+- Bun workspace package manifests
+- Tauri config
+- Cargo workspace/root package metadata
+
+## Recommended release sequence
+
+1. Open GitHub Actions.
+2. Run `Prepare Release`.
+3. Enter the target version, for example `0.1.0`.
+4. Wait for `Prepare Release` to finish.
+5. Wait for `Release Desktop` to finish.
+6. Wait for `Publish MCP Package` to finish.
+7. Open the draft GitHub release and smoke-test the desktop assets.
+8. Publish the draft release when the assets and notes look correct.
+
+## Asset policy for the first release line
+
+OpenDucktor is currently macOS-first, so the desktop workflow publishes macOS artifacts only.
+
+The workflow does **not** generate a public updater channel yet. That should wait until the in-app updater flow is explicitly wired and tested. The current release pipeline is focused on reliable GitHub Releases distribution first, plus npm publishing for `@openducktor/mcp`.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
+    "@iarna/toml": "^2.2.5",
     "@types/node": "^25.5.2",
     "knip": "^6.3.0",
     "typescript": "^5.7.3"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "dev": "bun run --filter @openducktor/desktop dev",
     "browser:dev": "bun run scripts/browser-dev.ts",
+    "release:version:set": "bun run scripts/release-version.ts set",
+    "release:version:check": "bun run scripts/release-version.ts check",
+    "release:cef:env": "bun run --cwd apps/desktop scripts/resolve-cef-release-env.ts",
     "tauri": "cd apps/desktop && bun run tauri",
     "tauri:dev": "cd apps/desktop && bun run tauri:dev",
     "tauri:build": "cd apps/desktop && bun run tauri:build",

--- a/scripts/release-version.ts
+++ b/scripts/release-version.ts
@@ -1,0 +1,204 @@
+/// <reference types="node" />
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const workspaceRoot = process.cwd();
+
+const tauriConfigPath = "apps/desktop/src-tauri/tauri.conf.json";
+const cargoTomlPath = "apps/desktop/src-tauri/Cargo.toml";
+
+type Mode = "check" | "set";
+
+function usage(): never {
+  console.error("Usage: bun run scripts/release-version.ts <check|set> <version>");
+  process.exit(1);
+  throw new Error("unreachable");
+}
+
+function validateVersion(version: string): void {
+  if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid version \`${version}\`. Expected semver like 0.1.0 or 0.1.0-rc.1.`);
+  }
+}
+
+function readRootWorkspacePatterns(): string[] {
+  const rootPackageJsonPath = resolve(workspaceRoot, "package.json");
+  const parsed = JSON.parse(readFileSync(rootPackageJsonPath, "utf8")) as { workspaces?: unknown };
+
+  if (!Array.isArray(parsed.workspaces)) {
+    throw new Error("Root package.json must define workspaces as an array.");
+  }
+
+  return parsed.workspaces.filter((value): value is string => typeof value === "string");
+}
+
+function expandWorkspacePattern(pattern: string): string[] {
+  if (!pattern.endsWith("/*")) {
+    throw new Error(
+      `Unsupported workspace pattern \`${pattern}\`. Expected a trailing /* pattern.`,
+    );
+  }
+
+  const parentRelativePath = pattern.slice(0, -2);
+  const parentAbsolutePath = resolve(workspaceRoot, parentRelativePath);
+  const childNames = readdirSync(parentAbsolutePath).sort((left, right) =>
+    left.localeCompare(right),
+  );
+
+  return childNames.flatMap((childName) => {
+    const childRelativePath = join(parentRelativePath, childName);
+    const childAbsolutePath = resolve(workspaceRoot, childRelativePath);
+
+    if (!statSync(childAbsolutePath).isDirectory()) {
+      return [];
+    }
+
+    return [`${childRelativePath}/package.json`];
+  });
+}
+
+function collectWorkspacePackageJsonPaths(): string[] {
+  return [
+    "package.json",
+    ...readRootWorkspacePatterns().flatMap((pattern) => expandWorkspacePattern(pattern)),
+  ];
+}
+
+function readJsonVersion(relativePath: string): string {
+  const absolutePath = resolve(workspaceRoot, relativePath);
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as { version?: string };
+  if (!parsed.version) {
+    throw new Error(`Missing version in ${relativePath}`);
+  }
+  return parsed.version;
+}
+
+function writeJsonVersion(relativePath: string, version: string): void {
+  const absolutePath = resolve(workspaceRoot, relativePath);
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as Record<string, unknown>;
+  parsed.version = version;
+  writeFileSync(absolutePath, `${JSON.stringify(parsed, null, 2)}\n`);
+}
+
+function readTauriConfigVersion(): string {
+  const absolutePath = resolve(workspaceRoot, tauriConfigPath);
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as { version?: string };
+  if (!parsed.version) {
+    throw new Error(`Missing version in ${tauriConfigPath}`);
+  }
+  return parsed.version;
+}
+
+function writeTauriConfigVersion(version: string): void {
+  const absolutePath = resolve(workspaceRoot, tauriConfigPath);
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as Record<string, unknown>;
+  parsed.version = version;
+  writeFileSync(absolutePath, `${JSON.stringify(parsed, null, 2)}\n`);
+}
+
+function replaceCargoVersion(source: string, sectionName: string, version: string): string {
+  const sectionHeader = `[${sectionName}]`;
+  const sectionIndex = source.indexOf(sectionHeader);
+  if (sectionIndex === -1) {
+    throw new Error(`Missing ${sectionHeader} in ${cargoTomlPath}`);
+  }
+
+  const nextSectionIndex = source.indexOf("\n[", sectionIndex + sectionHeader.length);
+  const sectionEnd = nextSectionIndex === -1 ? source.length : nextSectionIndex + 1;
+  const section = source.slice(sectionIndex, sectionEnd);
+  const updatedSection = section.replace(/^version\s*=\s*"[^"]+"$/m, `version = "${version}"`);
+
+  if (updatedSection === section) {
+    throw new Error(`Missing version entry in [${sectionName}] inside ${cargoTomlPath}`);
+  }
+
+  return `${source.slice(0, sectionIndex)}${updatedSection}${source.slice(sectionEnd)}`;
+}
+
+function readCargoVersions(): { packageVersion: string; workspaceVersion: string } {
+  const absolutePath = resolve(workspaceRoot, cargoTomlPath);
+  const source = readFileSync(absolutePath, "utf8");
+  const packageMatch = source.match(/\[package\][\s\S]*?^version\s*=\s*"([^"]+)"$/m);
+  const workspaceMatch = source.match(/\[workspace\.package\][\s\S]*?^version\s*=\s*"([^"]+)"$/m);
+
+  if (!packageMatch?.[1] || !workspaceMatch?.[1]) {
+    throw new Error(`Could not resolve Cargo versions from ${cargoTomlPath}`);
+  }
+
+  return {
+    packageVersion: packageMatch[1],
+    workspaceVersion: workspaceMatch[1],
+  };
+}
+
+function writeCargoVersions(version: string): void {
+  const absolutePath = resolve(workspaceRoot, cargoTomlPath);
+  const source = readFileSync(absolutePath, "utf8");
+  const updatedPackage = replaceCargoVersion(source, "package", version);
+  const updatedWorkspace = replaceCargoVersion(updatedPackage, "workspace.package", version);
+  writeFileSync(absolutePath, updatedWorkspace);
+}
+
+function collectCurrentVersions(): Array<{ file: string; version: string }> {
+  const entries: Array<{ file: string; version: string }> = collectWorkspacePackageJsonPaths().map(
+    (relativePath) => ({
+      file: relativePath,
+      version: readJsonVersion(relativePath),
+    }),
+  );
+
+  entries.push({ file: tauriConfigPath, version: readTauriConfigVersion() });
+  const cargoVersions = readCargoVersions();
+  entries.push({ file: `${cargoTomlPath} [package]`, version: cargoVersions.packageVersion });
+  entries.push({
+    file: `${cargoTomlPath} [workspace.package]`,
+    version: cargoVersions.workspaceVersion,
+  });
+  return entries;
+}
+
+function checkVersions(expectedVersion: string): void {
+  const mismatches = collectCurrentVersions().filter((entry) => entry.version !== expectedVersion);
+
+  if (mismatches.length > 0) {
+    console.error(`Release version mismatch. Expected ${expectedVersion}.`);
+    for (const mismatch of mismatches) {
+      console.error(`- ${mismatch.file}: ${mismatch.version}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`All release versions match ${expectedVersion}.`);
+}
+
+function setVersions(version: string): void {
+  for (const relativePath of collectWorkspacePackageJsonPaths()) {
+    writeJsonVersion(relativePath, version);
+  }
+
+  writeTauriConfigVersion(version);
+  writeCargoVersions(version);
+
+  console.log(`Updated release version to ${version} in package manifests and Tauri config.`);
+}
+
+const [, , rawMode, rawVersion] = process.argv;
+
+if (!rawMode || !rawVersion) {
+  usage();
+}
+
+if (rawMode !== "check" && rawMode !== "set") {
+  usage();
+}
+
+validateVersion(rawVersion);
+
+const mode: Mode = rawMode;
+
+if (mode === "check") {
+  checkVersions(rawVersion);
+} else {
+  setVersions(rawVersion);
+}

--- a/scripts/release-version.ts
+++ b/scripts/release-version.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import TOML from "@iarna/toml";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const workspaceRoot = process.cwd();
@@ -9,6 +10,11 @@ const tauriConfigPath = "apps/desktop/src-tauri/tauri.conf.json";
 const cargoTomlPath = "apps/desktop/src-tauri/Cargo.toml";
 
 type Mode = "check" | "set";
+
+type CargoManifest = {
+  package?: { version?: string };
+  workspace?: { package?: { version?: string } };
+};
 
 function usage(): never {
   console.error("Usage: bun run scripts/release-version.ts <check|set> <version>");
@@ -54,6 +60,11 @@ function expandWorkspacePattern(pattern: string): string[] {
       return [];
     }
 
+    const packageJsonPath = resolve(childAbsolutePath, "package.json");
+    if (!existsSync(packageJsonPath)) {
+      return [];
+    }
+
     return [`${childRelativePath}/package.json`];
   });
 }
@@ -77,6 +88,11 @@ function readJsonVersion(relativePath: string): string {
 function writeJsonVersion(relativePath: string, version: string): void {
   const absolutePath = resolve(workspaceRoot, relativePath);
   const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as Record<string, unknown>;
+
+  if (parsed.version === version) {
+    return;
+  }
+
   parsed.version = version;
   writeFileSync(absolutePath, `${JSON.stringify(parsed, null, 2)}\n`);
 }
@@ -93,51 +109,54 @@ function readTauriConfigVersion(): string {
 function writeTauriConfigVersion(version: string): void {
   const absolutePath = resolve(workspaceRoot, tauriConfigPath);
   const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as Record<string, unknown>;
+
+  if (parsed.version === version) {
+    return;
+  }
+
   parsed.version = version;
   writeFileSync(absolutePath, `${JSON.stringify(parsed, null, 2)}\n`);
 }
 
-function replaceCargoVersion(source: string, sectionName: string, version: string): string {
-  const sectionHeader = `[${sectionName}]`;
-  const sectionIndex = source.indexOf(sectionHeader);
-  if (sectionIndex === -1) {
-    throw new Error(`Missing ${sectionHeader} in ${cargoTomlPath}`);
-  }
-
-  const nextSectionIndex = source.indexOf("\n[", sectionIndex + sectionHeader.length);
-  const sectionEnd = nextSectionIndex === -1 ? source.length : nextSectionIndex + 1;
-  const section = source.slice(sectionIndex, sectionEnd);
-  const updatedSection = section.replace(/^version\s*=\s*"[^"]+"$/m, `version = "${version}"`);
-
-  if (updatedSection === section) {
-    throw new Error(`Missing version entry in [${sectionName}] inside ${cargoTomlPath}`);
-  }
-
-  return `${source.slice(0, sectionIndex)}${updatedSection}${source.slice(sectionEnd)}`;
+function readCargoManifest(): CargoManifest {
+  const absolutePath = resolve(workspaceRoot, cargoTomlPath);
+  return TOML.parse(readFileSync(absolutePath, "utf8")) as CargoManifest;
 }
 
 function readCargoVersions(): { packageVersion: string; workspaceVersion: string } {
-  const absolutePath = resolve(workspaceRoot, cargoTomlPath);
-  const source = readFileSync(absolutePath, "utf8");
-  const packageMatch = source.match(/\[package\][\s\S]*?^version\s*=\s*"([^"]+)"$/m);
-  const workspaceMatch = source.match(/\[workspace\.package\][\s\S]*?^version\s*=\s*"([^"]+)"$/m);
+  const manifest = readCargoManifest();
+  const packageVersion = manifest.package?.version;
+  const workspaceVersion = manifest.workspace?.package?.version;
 
-  if (!packageMatch?.[1] || !workspaceMatch?.[1]) {
+  if (!packageVersion || !workspaceVersion) {
     throw new Error(`Could not resolve Cargo versions from ${cargoTomlPath}`);
   }
 
   return {
-    packageVersion: packageMatch[1],
-    workspaceVersion: workspaceMatch[1],
+    packageVersion,
+    workspaceVersion,
   };
 }
 
 function writeCargoVersions(version: string): void {
   const absolutePath = resolve(workspaceRoot, cargoTomlPath);
-  const source = readFileSync(absolutePath, "utf8");
-  const updatedPackage = replaceCargoVersion(source, "package", version);
-  const updatedWorkspace = replaceCargoVersion(updatedPackage, "workspace.package", version);
-  writeFileSync(absolutePath, updatedWorkspace);
+  const manifest = readCargoManifest();
+
+  if (!manifest.package) {
+    throw new Error(`Missing [package] in ${cargoTomlPath}`);
+  }
+
+  if (!manifest.workspace?.package) {
+    throw new Error(`Missing [workspace.package] in ${cargoTomlPath}`);
+  }
+
+  if (manifest.package.version === version && manifest.workspace.package.version === version) {
+    return;
+  }
+
+  manifest.package.version = version;
+  manifest.workspace.package.version = version;
+  writeFileSync(absolutePath, TOML.stringify(manifest));
 }
 
 function collectCurrentVersions(): Array<{ file: string; version: string }> {


### PR DESCRIPTION
## Summary
- add a workflow-driven release process that bumps versions, tags releases, drafts desktop GitHub releases, and publishes `@openducktor/mcp`
- harden the CEF release path with incremental local/CI caching, explicit `cmake`/`ninja` prerequisites, and an unsigned-by-default signing toggle for early releases
- align GitHub release note categories with the repo's real labels and simplify the agent chat composer hint text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated GitHub Actions workflows for desktop and package releases with version synchronization across manifests

* **Documentation**
  * Added detailed release process documentation covering workflow steps, required secrets, and asset publishing procedures

* **UI Changes**
  * Updated composer placeholder text to reflect available shortcuts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->