### PR TITLE
fix(host): isolate beads attachments from repo git ops

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/context.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/context.rs
@@ -5,7 +5,8 @@ use host_infra_system::{
 };
 use std::fs;
 use std::io::ErrorKind;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::{BeadsLifecycle, LifecycleError};
 
@@ -53,12 +54,7 @@ impl BeadsLifecycle {
             return Ok(());
         }
 
-        fs::write(&config_path, updated).with_context(|| {
-            format!(
-                "Failed writing Beads tool config to keep git ops disabled at {}",
-                config_path.display()
-            )
-        })?;
+        write_config_atomically(&config_path, updated.as_str())?;
         Ok(())
     }
 
@@ -110,13 +106,16 @@ impl BeadsLifecycle {
     }
 }
 
+// Beads' managed `config.yaml` is currently a flat key-value file. We only
+// normalize the top-level `no-git-ops` key here and intentionally avoid a full
+// YAML parser so the existing file layout stays intact.
 fn ensure_no_git_ops_config(config: &str) -> String {
     let mut replaced = false;
     let mut lines = Vec::new();
     for line in config.lines() {
-        if line.trim_start().starts_with("no-git-ops:") {
+        if let Some(rewritten) = rewrite_no_git_ops_line(line) {
             if !replaced {
-                lines.push("no-git-ops: true".to_string());
+                lines.push(rewritten);
                 replaced = true;
             }
             continue;
@@ -134,4 +133,82 @@ fn ensure_no_git_ops_config(config: &str) -> String {
     let mut normalized = lines.join("\n");
     normalized.push('\n');
     normalized
+}
+
+fn rewrite_no_git_ops_line(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with("no-git-ops:") {
+        return None;
+    }
+
+    let leading_whitespace_len = line.len() - trimmed.len();
+    let leading_whitespace = &line[..leading_whitespace_len];
+    let suffix = &trimmed["no-git-ops:".len()..];
+    let comment_suffix = match suffix.find('#') {
+        Some(comment_start) => {
+            let mut suffix_start = comment_start;
+            while suffix_start > 0 && suffix.as_bytes()[suffix_start - 1].is_ascii_whitespace() {
+                suffix_start -= 1;
+            }
+            &suffix[suffix_start..]
+        }
+        None => "",
+    };
+
+    let mut rewritten = format!("{leading_whitespace}no-git-ops: true");
+    rewritten.push_str(comment_suffix);
+    Some(rewritten)
+}
+
+fn write_config_atomically(config_path: &Path, contents: &str) -> Result<()> {
+    let tmp_path = temporary_config_path(config_path);
+    fs::write(&tmp_path, contents).with_context(|| {
+        format!(
+            "Failed writing Beads tool config to keep git ops disabled at {}",
+            config_path.display()
+        )
+    })?;
+
+    if let Err(error) = fs::rename(&tmp_path, config_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(error).with_context(|| {
+            format!(
+                "Failed finalizing Beads tool config update at {}",
+                config_path.display()
+            )
+        });
+    }
+
+    Ok(())
+}
+
+fn temporary_config_path(config_path: &Path) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    config_path.with_extension(format!("yaml.tmp.{nonce}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_no_git_ops_config;
+
+    #[test]
+    fn ensure_no_git_ops_config_preserves_indentation_and_comments() {
+        let config = "json: true\n  no-git-ops: false   # keep me\n";
+
+        let rewritten = ensure_no_git_ops_config(config);
+
+        assert_eq!(rewritten, "json: true\n  no-git-ops: true   # keep me\n");
+    }
+
+    #[test]
+    fn ensure_no_git_ops_config_appends_missing_key() {
+        let config = "json: true\n";
+
+        let rewritten = ensure_no_git_ops_config(config);
+
+        assert_eq!(rewritten, "json: true\n\nno-git-ops: true\n");
+    }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/context.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/context.rs
@@ -4,6 +4,7 @@ use host_infra_system::{
     resolve_repo_beads_attachment_root, SHARED_DOLT_SERVER_HOST, SHARED_DOLT_SERVER_USER,
 };
 use std::fs;
+use std::io::ErrorKind;
 use std::path::Path;
 
 use super::{BeadsLifecycle, LifecycleError};
@@ -21,7 +22,44 @@ impl BeadsLifecycle {
                 working_dir.display()
             )
         })?;
+        self.ensure_existing_attachment_runs_without_git_ops(repo_path)?;
         Ok(working_dir)
+    }
+
+    fn ensure_existing_attachment_runs_without_git_ops(&self, repo_path: &Path) -> Result<()> {
+        let beads_dir = resolve_repo_beads_attachment_dir(repo_path)?;
+        let metadata_path = beads_dir.join("metadata.json");
+        if !metadata_path.is_file() {
+            return Ok(());
+        }
+
+        let config_path = beads_dir.join("config.yaml");
+        let existing = match fs::read_to_string(&config_path) {
+            Ok(value) => Some(value),
+            Err(error) if error.kind() == ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed reading Beads tool config {}", config_path.display())
+                });
+            }
+        };
+
+        let updated = match existing.as_deref() {
+            Some(current) => ensure_no_git_ops_config(current),
+            None => "no-git-ops: true\n".to_string(),
+        };
+
+        if existing.as_deref() == Some(updated.as_str()) {
+            return Ok(());
+        }
+
+        fs::write(&config_path, updated).with_context(|| {
+            format!(
+                "Failed writing Beads tool config to keep git ops disabled at {}",
+                config_path.display()
+            )
+        })?;
+        Ok(())
     }
 
     pub(crate) fn build_bd_env(&self, repo_path: &Path) -> Result<Vec<(String, String)>> {
@@ -70,4 +108,30 @@ impl BeadsLifecycle {
 
         Ok(env)
     }
+}
+
+fn ensure_no_git_ops_config(config: &str) -> String {
+    let mut replaced = false;
+    let mut lines = Vec::new();
+    for line in config.lines() {
+        if line.trim_start().starts_with("no-git-ops:") {
+            if !replaced {
+                lines.push("no-git-ops: true".to_string());
+                replaced = true;
+            }
+            continue;
+        }
+        lines.push(line.to_string());
+    }
+
+    if !replaced {
+        if !lines.is_empty() && !lines.last().is_some_and(|line| line.is_empty()) {
+            lines.push(String::new());
+        }
+        lines.push("no-git-ops: true".to_string());
+    }
+
+    let mut normalized = lines.join("\n");
+    normalized.push('\n');
+    normalized
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/provisioner.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lifecycle/provisioner.rs
@@ -139,6 +139,7 @@ impl BeadsLifecycle {
                 "--server-user",
                 "root",
                 "--quiet",
+                "--stealth",
                 "--skip-hooks",
                 "--skip-agents",
                 "--prefix",

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::lifecycle::BeadsLifecycle;
 use crate::lifecycle::RepoReadiness;
 use host_infra_system::resolve_repo_beads_attachment_root;
 
@@ -330,8 +329,28 @@ fn ensure_repo_initialized_initializes_in_attachment_root_with_stealth() -> Resu
     let repo = RepoFixture::new("init-stealth");
     let attachment_root = resolve_repo_beads_attachment_root(repo.path())?;
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
+    let effective_port = match read_shared_dolt_server_state()? {
+        Some(state) => state.port,
+        None => 3307,
+    };
     let runner = MockCommandRunner::with_steps(vec![
-        MockStep::AllowFailureWithEnv(Ok((true, String::new(), String::new()))),
+        MockStep::AllowFailureWithEnvAndWrites {
+            result: Ok((true, String::new(), String::new())),
+            writes: vec![(
+                beads_dir.join("metadata.json"),
+                json!({
+                    "backend": "dolt",
+                    "dolt_mode": "server",
+                    "dolt_server_host": "127.0.0.1",
+                    "dolt_server_port": effective_port,
+                    "dolt_server_user": "root",
+                    "dolt_database": database_name,
+                })
+                .to_string(),
+            )],
+        },
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
         MockStep::AllowFailureWithEnv(Ok((
             true,
             json!({
@@ -348,17 +367,22 @@ fn ensure_repo_initialized_initializes_in_attachment_root_with_stealth() -> Resu
     store.ensure_repo_initialized(repo.path())?;
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 3);
+    assert_eq!(calls.len(), 4);
     assert_eq!(calls[0].args[0], "init");
     assert!(calls[0].args.iter().any(|arg| arg == "--stealth"));
     assert_eq!(calls[0].cwd.as_deref(), Some(attachment_root.as_path()));
-    assert_eq!(calls[1].args, vec!["where", "--json"]);
-    assert_eq!(calls[1].cwd.as_deref(), Some(attachment_root.as_path()));
+    assert_eq!(calls[1].program, "dolt");
     assert_eq!(
-        calls[2].args,
+        calls[1].args.last().expect("expected sql query"),
+        "show databases"
+    );
+    assert_eq!(calls[2].args, vec!["where", "--json"]);
+    assert_eq!(calls[2].cwd.as_deref(), Some(attachment_root.as_path()));
+    assert_eq!(
+        calls[3].args,
         vec!["config", "set", "status.custom", CUSTOM_STATUS_VALUES]
     );
-    assert_eq!(calls[2].cwd.as_deref(), Some(attachment_root.as_path()));
+    assert_eq!(calls[3].cwd.as_deref(), Some(attachment_root.as_path()));
     Ok(())
 }
 
@@ -366,6 +390,8 @@ fn ensure_repo_initialized_initializes_in_attachment_root_with_stealth() -> Resu
 fn ensure_repo_initialized_enforces_no_git_ops_for_existing_attachment() -> Result<()> {
     let repo = RepoFixture::new("existing-no-git-ops");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let attachment_root = resolve_repo_beads_attachment_root(repo.path())?;
+    let database_name = compute_beads_database_name(repo.path())?;
     write_attachment_metadata(&beads_dir, repo.path(), 3307);
     fs::write(
         beads_dir.join("config.yaml"),
@@ -373,6 +399,7 @@ fn ensure_repo_initialized_enforces_no_git_ops_for_existing_attachment() -> Resu
     )
     .expect("config.yaml should be writable");
     let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, format!("| {database_name} |"), String::new()))),
         MockStep::AllowFailureWithEnv(Ok((
             true,
             json!({
@@ -384,38 +411,30 @@ fn ensure_repo_initialized_enforces_no_git_ops_for_existing_attachment() -> Resu
         ))),
         MockStep::WithEnv(Ok("configured statuses".to_string())),
     ]);
-    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     store.ensure_repo_initialized(repo.path())?;
+    let calls = runner.take_calls();
 
     let config =
         fs::read_to_string(beads_dir.join("config.yaml")).expect("config.yaml should be readable");
     assert!(config.contains("json: true"));
     assert!(config.contains("no-git-ops: true"));
     assert!(!config.contains("no-git-ops: false"));
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].program, "dolt");
+    assert_eq!(
+        calls[0].args.last().expect("expected sql query"),
+        "show databases"
+    );
+    assert_eq!(calls[1].args, vec!["where", "--json"]);
+    assert_eq!(calls[1].cwd.as_deref(), Some(attachment_root.as_path()));
+    assert_eq!(
+        calls[2].args,
+        vec!["config", "set", "status.custom", CUSTOM_STATUS_VALUES]
+    );
+    assert_eq!(calls[2].cwd.as_deref(), Some(attachment_root.as_path()));
     Ok(())
-}
-
-#[test]
-fn lifecycle_verifier_only_restores_for_missing_shared_database_reasons() {
-    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
-        "database \"odt_demo_deadbeef\" not found on Dolt server"
-    ));
-    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
-        "database \"beads\" not found"
-    ));
-    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
-        "Error 1049: unknown database"
-    ));
-    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
-        "server not reachable"
-    ));
-    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
-        "dolt server unreachable"
-    ));
-    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
-        "attachment metadata is malformed"
-    ));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -395,7 +395,7 @@ fn ensure_repo_initialized_enforces_no_git_ops_for_existing_attachment() -> Resu
     write_attachment_metadata(&beads_dir, repo.path(), 3307);
     fs::write(
         beads_dir.join("config.yaml"),
-        "json: true\nno-git-ops: false\n",
+        "json: true\n  no-git-ops: false   # keep me\n",
     )
     .expect("config.yaml should be writable");
     let runner = MockCommandRunner::with_steps(vec![
@@ -419,7 +419,7 @@ fn ensure_repo_initialized_enforces_no_git_ops_for_existing_attachment() -> Resu
     let config =
         fs::read_to_string(beads_dir.join("config.yaml")).expect("config.yaml should be readable");
     assert!(config.contains("json: true"));
-    assert!(config.contains("no-git-ops: true"));
+    assert!(config.contains("  no-git-ops: true   # keep me"));
     assert!(!config.contains("no-git-ops: false"));
     assert_eq!(calls.len(), 3);
     assert_eq!(calls[0].program, "dolt");

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/lifecycle.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::lifecycle::BeadsLifecycle;
 use crate::lifecycle::RepoReadiness;
+use host_infra_system::resolve_repo_beads_attachment_root;
 
 #[test]
 fn verify_repo_initialized_parse_errors_do_not_include_raw_output() -> Result<()> {
@@ -321,6 +323,99 @@ fn ensure_repo_initialized_surfaces_stdout_when_init_fails() -> Result<()> {
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].args.first().expect("expected subcommand"), "init");
     Ok(())
+}
+
+#[test]
+fn ensure_repo_initialized_initializes_in_attachment_root_with_stealth() -> Result<()> {
+    let repo = RepoFixture::new("init-stealth");
+    let attachment_root = resolve_repo_beads_attachment_root(repo.path())?;
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((true, String::new(), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Ok("configured statuses".to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    store.ensure_repo_initialized(repo.path())?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].args[0], "init");
+    assert!(calls[0].args.iter().any(|arg| arg == "--stealth"));
+    assert_eq!(calls[0].cwd.as_deref(), Some(attachment_root.as_path()));
+    assert_eq!(calls[1].args, vec!["where", "--json"]);
+    assert_eq!(calls[1].cwd.as_deref(), Some(attachment_root.as_path()));
+    assert_eq!(
+        calls[2].args,
+        vec!["config", "set", "status.custom", CUSTOM_STATUS_VALUES]
+    );
+    assert_eq!(calls[2].cwd.as_deref(), Some(attachment_root.as_path()));
+    Ok(())
+}
+
+#[test]
+fn ensure_repo_initialized_enforces_no_git_ops_for_existing_attachment() -> Result<()> {
+    let repo = RepoFixture::new("existing-no-git-ops");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    fs::write(
+        beads_dir.join("config.yaml"),
+        "json: true\nno-git-ops: false\n",
+    )
+    .expect("config.yaml should be writable");
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Ok("configured statuses".to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    store.ensure_repo_initialized(repo.path())?;
+
+    let config =
+        fs::read_to_string(beads_dir.join("config.yaml")).expect("config.yaml should be readable");
+    assert!(config.contains("json: true"));
+    assert!(config.contains("no-git-ops: true"));
+    assert!(!config.contains("no-git-ops: false"));
+    Ok(())
+}
+
+#[test]
+fn lifecycle_verifier_only_restores_for_missing_shared_database_reasons() {
+    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
+        "database \"odt_demo_deadbeef\" not found on Dolt server"
+    ));
+    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
+        "database \"beads\" not found"
+    ));
+    assert!(BeadsLifecycle::reason_requires_shared_database_seed(
+        "Error 1049: unknown database"
+    ));
+    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
+        "server not reachable"
+    ));
+    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
+        "dolt server unreachable"
+    ));
+    assert!(!BeadsLifecycle::reason_requires_shared_database_seed(
+        "attachment metadata is malformed"
+    ));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/support.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/support.rs
@@ -25,6 +25,7 @@ pub(super) enum MockStep {
 pub(super) struct RecordedCall {
     pub(super) program: String,
     pub(super) args: Vec<String>,
+    pub(super) cwd: Option<PathBuf>,
 }
 
 #[derive(Debug, Default)]
@@ -101,6 +102,7 @@ impl MockCommandRunner {
             .push(RecordedCall {
                 program: program.to_string(),
                 args: args.iter().map(|entry| (*entry).to_string()).collect(),
+                cwd: _cwd.map(Path::to_path_buf),
             });
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/support.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/support.rs
@@ -93,7 +93,7 @@ impl MockCommandRunner {
         _kind: CallKind,
         program: &str,
         args: &[&str],
-        _cwd: Option<&Path>,
+        cwd: Option<&Path>,
         _env: &[(&str, &str)],
     ) {
         self.calls
@@ -102,7 +102,7 @@ impl MockCommandRunner {
             .push(RecordedCall {
                 program: program.to_string(),
                 args: args.iter().map(|entry| (*entry).to_string()).collect(),
-                cwd: _cwd.map(Path::to_path_buf),
+                cwd: cwd.map(Path::to_path_buf),
             });
     }
 }

--- a/docs/beads-shared-dolt-lifecycle.md
+++ b/docs/beads-shared-dolt-lifecycle.md
@@ -264,6 +264,7 @@ bd init \
   --server-port <shared-server-port> \
   --server-user root \
   --quiet \
+  --stealth \
   --skip-hooks \
   --skip-agents \
   --prefix <repo-slug> \
@@ -274,10 +275,13 @@ Why these flags matter:
 
 - `--server` and the server route flags force shared-server mode
 - `--quiet` keeps initialization noise down
+- `--stealth` persists Beads' `no-git-ops` mode so later commands stay isolated from the user repository
 - `--skip-hooks` avoids running repository hooks during internal setup
 - `--skip-agents` avoids Beads adding agent integration side effects during internal setup
 - `--prefix` gives the repo stable Beads issue ids
 - `--database` binds the attachment to the exact shared Dolt database OpenDucktor expects
+
+OpenDucktor also rewrites the managed attachment's `.beads/config.yaml` to keep `no-git-ops: true` on already-initialized attachments before running follow-up commands such as `bd where`, `bd config set`, or `bd doctor --fix`. That prevents older attachments from regressing into repo-local hook or agent-file writes.
 
 ## What Happens If The Shared Database Is Missing
 


### PR DESCRIPTION
## Summary
- initialize managed Beads attachments with `bd init --stealth` so Beads persists `no-git-ops: true` when OpenDucktor provisions attachment roots outside the user repository
- self-heal legacy managed attachments by rewriting the attachment-local `.beads/config.yaml` before follow-up `bd` commands, keeping later repair/config operations isolated from repo files
- add lifecycle regression coverage for attachment-root cwd selection, `--stealth` usage, and legacy config repair, and document the isolation contract in the shared Dolt lifecycle notes

## Investigation
- traced every current OpenDucktor Beads invocation and verified the host already runs `bd` from the managed attachment root, not from the selected repository
- checked upstream Beads documentation and local CLI behavior: `bd init --stealth` writes `no-git-ops: true`, while plain `bd init` does not
- tested the live Fairnest attachment state at `~/.openducktor-local/beads/fairnest-265440cf` and confirmed it was still missing `no-git-ops: true`, which makes legacy attachments the vulnerable path this change repairs
- exercised `bd doctor --fix --yes` against that live attachment; it did not reproduce repo pollution today, so this PR hardens the known Beads isolation gap even though the exact historical pollution path was not reproduced end-to-end

## Testing
- `cargo test -p host-infra-beads`
- disposable local `bd init` verification in `/tmp` confirmed `--stealth` writes `no-git-ops: true`
- live attachment verification against Fairnest confirmed the pre-fix legacy config state and showed no repo changes from the tested repair path

## Notes
- `cargo fmt --all --check` is currently blocked by unrelated formatting diffs already present elsewhere in the worktree, so only the touched Rust files were formatted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beads attachments now enforce "no-git-ops" mode: new initializations use stealth mode and existing attachments are automatically updated to disable repo-local git operations.

* **Behavior**
  * Lifecycle commands now operate from the attachment root to ensure configuration is applied consistently.

* **Documentation**
  * Docs updated to describe stealth initialization and automatic config rewriting to keep git operations disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->