### PR TITLE
fix(diagnostics): avoid false MCP startup failures

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mcp_bridge_process.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mcp_bridge_process.rs
@@ -3,7 +3,7 @@ use super::{terminate_child_process, AppService, McpBridgeProcess};
 use anyhow::{anyhow, Context, Result};
 use host_infra_system::pick_free_port;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -98,6 +98,13 @@ fn spawn_mcp_bridge_process(port: u16) -> Result<Child> {
     Ok(child)
 }
 
+fn mcp_bridge_fallback_binary_path(parent: &Path) -> PathBuf {
+    parent.join(format!(
+        "{MCP_BRIDGE_FALLBACK_BINARY_NAME}{}",
+        std::env::consts::EXE_SUFFIX
+    ))
+}
+
 fn resolve_mcp_bridge_binary_path() -> Result<PathBuf> {
     if let Ok(raw) = std::env::var(MCP_BRIDGE_BINARY_ENV) {
         let trimmed = raw.trim();
@@ -118,7 +125,7 @@ fn resolve_mcp_bridge_binary_path() -> Result<PathBuf> {
         .is_some_and(|value| value == "browser_backend")
     {
         if let Some(parent) = current_exe.parent() {
-            let fallback = parent.join(MCP_BRIDGE_FALLBACK_BINARY_NAME);
+            let fallback = mcp_bridge_fallback_binary_path(parent);
             if fallback.is_file() {
                 return Ok(fallback);
             }
@@ -192,5 +199,22 @@ impl AppService {
             self.unregister_mcp_bridge_port(port)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mcp_bridge_fallback_binary_path;
+    use std::path::Path;
+
+    #[test]
+    fn fallback_bridge_binary_appends_platform_executable_suffix() {
+        let expected = format!("openducktor-desktop{}", std::env::consts::EXE_SUFFIX);
+        let resolved = mcp_bridge_fallback_binary_path(Path::new("/tmp"));
+
+        assert_eq!(
+            resolved.file_name().and_then(|value| value.to_str()),
+            Some(expected.as_str())
+        );
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mcp_bridge_process.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mcp_bridge_process.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 const MCP_BRIDGE_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const MCP_BRIDGE_BINARY_ENV: &str = "OPENDUCKTOR_MCP_BRIDGE_BINARY";
+const MCP_BRIDGE_FALLBACK_BINARY_NAME: &str = "openducktor-desktop";
 
 fn read_child_pipe(pipe: &mut Option<impl Read>) -> String {
     let Some(mut reader) = pipe.take() else {
@@ -108,7 +109,23 @@ fn resolve_mcp_bridge_binary_path() -> Result<PathBuf> {
         return Ok(PathBuf::from(trimmed));
     }
 
-    std::env::current_exe().context("Failed to resolve current executable for MCP bridge")
+    let current_exe =
+        std::env::current_exe().context("Failed to resolve current executable for MCP bridge")?;
+
+    if current_exe
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .is_some_and(|value| value == "browser_backend")
+    {
+        if let Some(parent) = current_exe.parent() {
+            let fallback = parent.join(MCP_BRIDGE_FALLBACK_BINARY_NAME);
+            if fallback.is_file() {
+                return Ok(fallback);
+            }
+        }
+    }
+
+    Ok(current_exe)
 }
 
 impl AppService {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -838,10 +838,12 @@ mod tests {
     use crate::app_service::test_support::{build_service_with_state, make_task};
     use crate::app_service::{AgentRuntimeProcess, RunProcess};
     use anyhow::{anyhow, Result};
+    use chrono::{TimeDelta, Utc};
     use host_domain::{
-        AgentRuntimeKind, AgentSessionDocument, RepoRuntimeHealthMcp, RepoRuntimeHealthObservation,
-        RepoRuntimeHealthRuntime, RepoRuntimeHealthState, RepoRuntimeMcpStatus,
-        RepoRuntimeStartupFailureKind, RepoRuntimeStartupStage, RunSummary, TaskStatus,
+        now_rfc3339, AgentRuntimeKind, AgentSessionDocument, RepoRuntimeHealthMcp,
+        RepoRuntimeHealthObservation, RepoRuntimeHealthRuntime, RepoRuntimeHealthState,
+        RepoRuntimeMcpStatus, RepoRuntimeStartupFailureKind, RepoRuntimeStartupStage, RunSummary,
+        TaskStatus,
     };
     use host_infra_system::RepoConfig;
     use std::io::{Read, Write};
@@ -912,6 +914,46 @@ mod tests {
                     let _ = stream.flush();
                 }
             }
+            requests
+        });
+        Ok((port, handle))
+    }
+
+    fn spawn_runtime_http_server_until_idle(
+        responses: Vec<String>,
+        idle_timeout: Duration,
+    ) -> Result<(u16, std::thread::JoinHandle<Vec<String>>)> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let port = listener.local_addr()?.port();
+        let handle = std::thread::spawn(move || {
+            let mut requests = Vec::new();
+            let mut responses = responses.into_iter();
+            let mut last_activity = Instant::now();
+
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut request_buffer = [0_u8; 4096];
+                        let size = stream.read(&mut request_buffer).unwrap_or(0);
+                        requests.push(String::from_utf8_lossy(&request_buffer[..size]).to_string());
+                        if let Some(response) = responses.next() {
+                            let _ = stream.write_all(response.as_bytes());
+                            let _ = stream.flush();
+                        }
+                        last_activity = Instant::now();
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if requests.is_empty() || last_activity.elapsed() < idle_timeout {
+                            std::thread::sleep(Duration::from_millis(10));
+                            continue;
+                        }
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            }
+
             requests
         });
         Ok((port, handle))
@@ -1271,6 +1313,144 @@ mod tests {
             .is_some_and(
                 |value| value.contains("Failed to refresh runtime MCP status after reconnect")
             ));
+        service.runtime_stop(runtime.runtime_id.as_str())?;
+        Ok(())
+    }
+
+    #[test]
+    fn repo_runtime_health_keeps_startup_failed_mcp_checking_within_grace_window() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let started_at = (Utc::now() - TimeDelta::milliseconds(9_300)).to_rfc3339();
+        let (port, server_handle) = spawn_runtime_http_server_until_idle(
+            vec![
+                runtime_http_response(
+                    "200 OK",
+                    r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+                ),
+                runtime_http_response("200 OK", r#"true"#),
+                runtime_http_response(
+                    "200 OK",
+                    r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+                ),
+                runtime_http_response(
+                    "200 OK",
+                    r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+                ),
+                runtime_http_response(
+                    "200 OK",
+                    r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+                ),
+                runtime_http_response(
+                    "200 OK",
+                    r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+                ),
+                runtime_http_response(
+                    "200 OK",
+                    r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+                ),
+                runtime_http_response(
+                    "200 OK",
+                    r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+                ),
+                runtime_http_response(
+                    "200 OK",
+                    r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+                ),
+            ],
+            Duration::from_millis(150),
+        )?;
+        let runtime = host_domain::RuntimeInstanceSummary {
+            kind: AgentRuntimeKind::Opencode,
+            runtime_id: "runtime-startup-failed-mcp".to_string(),
+            repo_path: "/tmp/repo-health-startup-failed-mcp".to_string(),
+            task_id: None,
+            role: host_domain::RuntimeRole::Workspace,
+            working_directory: "/tmp/repo-health-startup-failed-mcp".to_string(),
+            runtime_route: host_domain::RuntimeRoute::LocalHttp {
+                endpoint: format!("http://127.0.0.1:{port}"),
+            },
+            started_at,
+            descriptor: AgentRuntimeKind::Opencode.descriptor(),
+        };
+        insert_workspace_runtime(&service, runtime.clone())?;
+
+        let health =
+            service.repo_runtime_health("opencode", "/tmp/repo-health-startup-failed-mcp")?;
+        let requests = server_handle.join().expect("server thread should finish");
+
+        assert!(requests[1].starts_with(
+            "POST /mcp/openducktor/connect?directory=%2Ftmp%2Frepo-health-startup-failed-mcp "
+        ));
+        assert_eq!(health.runtime.status, RepoRuntimeHealthState::Ready);
+        assert_eq!(health.status, RepoRuntimeHealthState::Checking);
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.status),
+            Some(RepoRuntimeMcpStatus::Reconnecting)
+        );
+        assert_eq!(
+            health.mcp.as_ref().and_then(|value| value.failure_kind),
+            Some(RepoRuntimeStartupFailureKind::Timeout)
+        );
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.tool_ids.clone()),
+            Some(Vec::new())
+        );
+        service.runtime_stop(runtime.runtime_id.as_str())?;
+        Ok(())
+    }
+
+    #[test]
+    fn repo_runtime_health_recovers_after_startup_failed_status_retries() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let started_at = now_rfc3339();
+        let (port, server_handle) = spawn_runtime_http_server(vec![
+            runtime_http_response(
+                "200 OK",
+                r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+            ),
+            runtime_http_response("200 OK", r#"true"#),
+            runtime_http_response(
+                "200 OK",
+                r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+            ),
+            runtime_http_response(
+                "200 OK",
+                r#"{"openducktor":{"status":"failed","error":"MCP error -32000: Connection closed"}}"#,
+            ),
+            runtime_http_response("200 OK", r#"{"openducktor":{"status":"connected"}}"#),
+            runtime_http_response("200 OK", r#"["odt_read_task"]"#),
+        ])?;
+        let runtime = host_domain::RuntimeInstanceSummary {
+            kind: AgentRuntimeKind::Opencode,
+            runtime_id: "runtime-startup-retry-success".to_string(),
+            repo_path: "/tmp/repo-health-startup-retry-success".to_string(),
+            task_id: None,
+            role: host_domain::RuntimeRole::Workspace,
+            working_directory: "/tmp/repo-health-startup-retry-success".to_string(),
+            runtime_route: host_domain::RuntimeRoute::LocalHttp {
+                endpoint: format!("http://127.0.0.1:{port}"),
+            },
+            started_at,
+            descriptor: AgentRuntimeKind::Opencode.descriptor(),
+        };
+        insert_workspace_runtime(&service, runtime.clone())?;
+
+        let health =
+            service.repo_runtime_health("opencode", "/tmp/repo-health-startup-retry-success")?;
+        let requests = server_handle.join().expect("server thread should finish");
+
+        assert!(requests[1].starts_with(
+            "POST /mcp/openducktor/connect?directory=%2Ftmp%2Frepo-health-startup-retry-success "
+        ));
+        assert_eq!(health.status, RepoRuntimeHealthState::Ready);
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.status),
+            Some(RepoRuntimeMcpStatus::Connected)
+        );
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.tool_ids.clone()),
+            Some(vec!["odt_read_task".to_string()])
+        );
         service.runtime_stop(runtime.runtime_id.as_str())?;
         Ok(())
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -1259,10 +1259,10 @@ mod tests {
             "POST /mcp/openducktor/connect?directory=%2Ftmp%2Frepo-health-refresh-failure "
         ));
         assert_eq!(health.runtime.status, RepoRuntimeHealthState::Ready);
-        assert_eq!(health.status, RepoRuntimeHealthState::Error);
+        assert_eq!(health.status, RepoRuntimeHealthState::Checking);
         assert_eq!(
             health.mcp.as_ref().map(|value| value.status),
-            Some(RepoRuntimeMcpStatus::Error)
+            Some(RepoRuntimeMcpStatus::Reconnecting)
         );
         assert!(health
             .mcp

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health.rs
@@ -1010,7 +1010,7 @@ impl AppService {
                         mcp_server_status: None,
                         available_tool_ids: Vec::new(),
                         progress: Some(repo_runtime_progress(RepoRuntimeProgressInput {
-                            stage: RuntimeHealthWorkflowStage::RuntimeReady,
+                            stage: checking_progress.stage,
                             observation,
                             host: host_status,
                             checked_at: checked_at.clone(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health.rs
@@ -7,6 +7,7 @@ use super::AppService;
 use crate::app_service::service_core::{RepoRuntimeHealthFlight, RepoRuntimeHealthFlightState};
 use crate::app_service::OpencodeStartupWaitFailure;
 use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
 use host_domain::{
     now_rfc3339, AgentRuntimeKind, RepoRuntimeHealthCheck, RepoRuntimeHealthObservation,
     RepoRuntimeStartupFailureKind, RepoRuntimeStartupStage, RepoRuntimeStartupStatus, RunState,
@@ -21,6 +22,7 @@ use url::{form_urlencoded, Url};
 
 const ODT_MCP_SERVER_NAME: &str = "openducktor";
 const RUNTIME_HEALTH_HTTP_TIMEOUT: Duration = Duration::from_secs(5);
+const MCP_CONNECT_STARTUP_GRACE_PERIOD: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy)]
 enum RuntimeHealthHttpMethod {
@@ -32,6 +34,7 @@ enum RuntimeHealthHttpMethod {
 struct RuntimeHealthHttpFailure {
     failure_kind: RepoRuntimeStartupFailureKind,
     message: String,
+    is_connect_failure: bool,
 }
 
 impl std::fmt::Display for RuntimeHealthHttpFailure {
@@ -47,6 +50,7 @@ impl RuntimeHealthHttpFailure {
         Self {
             failure_kind: RepoRuntimeStartupFailureKind::Error,
             message,
+            is_connect_failure: false,
         }
     }
 
@@ -54,6 +58,7 @@ impl RuntimeHealthHttpFailure {
         Self {
             failure_kind: classify_runtime_health_request_failure(error),
             message: format!("Failed to query OpenCode runtime to {action}: {error}"),
+            is_connect_failure: error.is_connect(),
         }
     }
 
@@ -61,6 +66,7 @@ impl RuntimeHealthHttpFailure {
         Self {
             failure_kind: classify_runtime_health_request_failure(&error),
             message: format!("Failed to read OpenCode runtime response body for {action}: {error}"),
+            is_connect_failure: error.is_connect(),
         }
     }
 }
@@ -585,6 +591,28 @@ impl AppService {
         )
     }
 
+    fn repo_runtime_normalize_mcp_probe_failure(
+        runtime: &RuntimeInstanceSummary,
+        host_status: Option<&RepoRuntimeStartupStatus>,
+        checked_at: &str,
+        error: RuntimeHealthHttpFailure,
+    ) -> RuntimeHealthHttpFailure {
+        if error.failure_kind == RepoRuntimeStartupFailureKind::Timeout {
+            return error;
+        }
+
+        if error.is_connect_failure
+            && repo_runtime_is_within_mcp_startup_grace_window(runtime, host_status, checked_at)
+        {
+            return RuntimeHealthHttpFailure {
+                failure_kind: RepoRuntimeStartupFailureKind::Timeout,
+                ..error
+            };
+        }
+
+        error
+    }
+
     fn repo_runtime_has_active_run(
         &self,
         repo_key: &str,
@@ -944,6 +972,12 @@ impl AppService {
         let status_by_server = match self.repo_runtime_load_mcp_status(&runtime) {
             Ok(status_by_server) => status_by_server,
             Err(error) => {
+                let error = Self::repo_runtime_normalize_mcp_probe_failure(
+                    &runtime,
+                    host_status.as_ref(),
+                    checked_at.as_str(),
+                    error,
+                );
                 if allow_restart
                     && Self::repo_runtime_should_restart_for_mcp_status_error(
                         error.message.as_str(),
@@ -1028,6 +1062,12 @@ impl AppService {
                     let refreshed = match self.repo_runtime_load_mcp_status(&runtime) {
                         Ok(refreshed) => refreshed,
                         Err(error) => {
+                            let error = Self::repo_runtime_normalize_mcp_probe_failure(
+                                &runtime,
+                                host_status.as_ref(),
+                                checked_at.as_str(),
+                                error,
+                            );
                             let refresh_message = format!(
                                 "Failed to refresh runtime MCP status after reconnect: {}",
                                 error.message
@@ -1067,6 +1107,12 @@ impl AppService {
                     mcp_status = Self::repo_runtime_resolve_mcp_status(&refreshed);
                 }
                 Err(error) => {
+                    let error = Self::repo_runtime_normalize_mcp_probe_failure(
+                        &runtime,
+                        host_status.as_ref(),
+                        checked_at.as_str(),
+                        error,
+                    );
                     let mcp_message = format!(
                         "Failed to reconnect MCP server '{ODT_MCP_SERVER_NAME}': {}",
                         error.message
@@ -1218,6 +1264,7 @@ fn runtime_health_http_status_failure(
             }
             None => format!("OpenCode runtime failed to {action}: HTTP {status_code}"),
         },
+        is_connect_failure: false,
     }
 }
 
@@ -1249,6 +1296,34 @@ fn classify_runtime_health_request_failure(
     }
 }
 
+fn repo_runtime_is_within_mcp_startup_grace_window(
+    runtime: &RuntimeInstanceSummary,
+    host_status: Option<&RepoRuntimeStartupStatus>,
+    checked_at: &str,
+) -> bool {
+    if host_status.is_some_and(|status| {
+        matches!(
+            status.stage,
+            RepoRuntimeStartupStage::StartupRequested | RepoRuntimeStartupStage::WaitingForRuntime
+        )
+    }) {
+        return true;
+    }
+
+    let Ok(started_at) = DateTime::parse_from_rfc3339(runtime.started_at.as_str()) else {
+        return false;
+    };
+    let Ok(checked_at) = DateTime::parse_from_rfc3339(checked_at) else {
+        return false;
+    };
+
+    let elapsed = checked_at.with_timezone(&Utc) - started_at.with_timezone(&Utc);
+    elapsed >= chrono::TimeDelta::zero()
+        && elapsed
+            .to_std()
+            .is_ok_and(|duration| duration <= MCP_CONNECT_STARTUP_GRACE_PERIOD)
+}
+
 fn lower_contains_any(haystack: &str, needles: &[&str]) -> bool {
     let normalized = haystack.to_ascii_lowercase();
     needles.iter().any(|needle| normalized.contains(needle))
@@ -1256,12 +1331,35 @@ fn lower_contains_any(haystack: &str, needles: &[&str]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{RepoRuntimeHealthHttpClient, RuntimeHealthMcpServerStatus};
+    use super::{
+        repo_runtime_is_within_mcp_startup_grace_window, RepoRuntimeHealthHttpClient,
+        RuntimeHealthMcpServerStatus,
+    };
+    use host_domain::{
+        AgentRuntimeKind, RepoRuntimeStartupStage, RepoRuntimeStartupStatus, RuntimeRole,
+        RuntimeRoute,
+    };
     use std::collections::HashMap;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::mpsc;
     use std::thread;
+
+    fn runtime_summary(started_at: &str) -> host_domain::RuntimeInstanceSummary {
+        host_domain::RuntimeInstanceSummary {
+            kind: AgentRuntimeKind::Opencode,
+            runtime_id: "runtime-1".to_string(),
+            repo_path: "/tmp/repo".to_string(),
+            task_id: None,
+            role: RuntimeRole::Workspace,
+            working_directory: "/tmp/repo".to_string(),
+            runtime_route: RuntimeRoute::LocalHttp {
+                endpoint: "http://127.0.0.1:4321".to_string(),
+            },
+            started_at: started_at.to_string(),
+            descriptor: AgentRuntimeKind::Opencode.descriptor(),
+        }
+    }
 
     #[test]
     fn load_mcp_status_does_not_wait_for_socket_close() {
@@ -1321,5 +1419,71 @@ mod tests {
             .send(())
             .expect("test should release the server thread");
         server.join().expect("server thread should exit cleanly");
+    }
+
+    #[test]
+    fn load_mcp_status_keeps_connect_errors_as_hard_failures_before_runtime_context() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+        let port = listener
+            .local_addr()
+            .expect("listener should expose local addr")
+            .port();
+        drop(listener);
+
+        let failure = RepoRuntimeHealthHttpClient::new(format!("http://127.0.0.1:{port}").as_str())
+            .load_mcp_status("/tmp/repo-health-not-ready")
+            .expect_err("connect errors should surface as failures");
+
+        assert_eq!(
+            failure.failure_kind,
+            super::RepoRuntimeStartupFailureKind::Error
+        );
+        assert!(failure.is_connect_failure);
+    }
+
+    #[test]
+    fn mcp_startup_grace_window_allows_recent_runtime_connect_failures_to_retry() {
+        let runtime = runtime_summary("2026-04-11T10:00:00Z");
+
+        assert!(repo_runtime_is_within_mcp_startup_grace_window(
+            &runtime,
+            None,
+            "2026-04-11T10:00:08Z"
+        ));
+    }
+
+    #[test]
+    fn mcp_startup_grace_window_expires_for_stale_runtime_routes() {
+        let runtime = runtime_summary("2026-04-11T10:00:00Z");
+
+        assert!(!repo_runtime_is_within_mcp_startup_grace_window(
+            &runtime,
+            None,
+            "2026-04-11T10:00:21Z"
+        ));
+    }
+
+    #[test]
+    fn mcp_startup_grace_window_stays_retryable_while_host_reports_runtime_starting() {
+        let runtime = runtime_summary("2026-04-11T10:00:00Z");
+        let host_status = RepoRuntimeStartupStatus {
+            runtime_kind: AgentRuntimeKind::Opencode,
+            repo_path: "/tmp/repo".to_string(),
+            stage: RepoRuntimeStartupStage::WaitingForRuntime,
+            runtime: None,
+            started_at: Some("2026-04-11T10:00:00Z".to_string()),
+            updated_at: "2026-04-11T10:00:45Z".to_string(),
+            elapsed_ms: Some(45_000),
+            attempts: Some(6),
+            failure_kind: None,
+            failure_reason: None,
+            detail: None,
+        };
+
+        assert!(repo_runtime_is_within_mcp_startup_grace_window(
+            &runtime,
+            Some(&host_status),
+            "2026-04-11T10:00:45Z"
+        ));
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health.rs
@@ -23,6 +23,7 @@ use url::{form_urlencoded, Url};
 const ODT_MCP_SERVER_NAME: &str = "openducktor";
 const RUNTIME_HEALTH_HTTP_TIMEOUT: Duration = Duration::from_secs(5);
 const MCP_CONNECT_STARTUP_GRACE_PERIOD: Duration = Duration::from_secs(10);
+const MCP_CONNECT_STATUS_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 #[derive(Clone, Copy)]
 enum RuntimeHealthHttpMethod {
@@ -591,6 +592,75 @@ impl AppService {
         )
     }
 
+    fn repo_runtime_normalize_mcp_server_status(
+        runtime: &RuntimeInstanceSummary,
+        host_status: Option<&RepoRuntimeStartupStatus>,
+        checked_at: &str,
+        status: ResolvedMcpServerStatus,
+    ) -> ResolvedMcpServerStatus {
+        if status.is_connected() {
+            return status;
+        }
+
+        if status.failure_kind != Some(RepoRuntimeStartupFailureKind::Error) {
+            return status;
+        }
+
+        if !repo_runtime_is_within_mcp_startup_grace_window(runtime, host_status, checked_at) {
+            return status;
+        }
+
+        ResolvedMcpServerStatus {
+            failure_kind: Some(RepoRuntimeStartupFailureKind::Timeout),
+            ..status
+        }
+    }
+
+    fn repo_runtime_refresh_mcp_status_after_connect(
+        &self,
+        runtime: &RuntimeInstanceSummary,
+        host_status: Option<&RepoRuntimeStartupStatus>,
+        initial_checked_at: &str,
+    ) -> std::result::Result<ResolvedMcpServerStatus, RuntimeHealthHttpFailure> {
+        let mut checked_at = initial_checked_at.to_string();
+        let mut latest_status = Self::repo_runtime_normalize_mcp_server_status(
+            runtime,
+            host_status,
+            checked_at.as_str(),
+            Self::repo_runtime_resolve_mcp_status(&self.repo_runtime_load_mcp_status(runtime)?),
+        );
+
+        if latest_status.is_connected()
+            || !repo_runtime_is_within_mcp_startup_grace_window(
+                runtime,
+                host_status,
+                checked_at.as_str(),
+            )
+        {
+            return Ok(latest_status);
+        }
+
+        while repo_runtime_is_within_mcp_startup_grace_window(
+            runtime,
+            host_status,
+            checked_at.as_str(),
+        ) {
+            std::thread::sleep(MCP_CONNECT_STATUS_RETRY_DELAY);
+            checked_at = now_rfc3339();
+            latest_status = Self::repo_runtime_normalize_mcp_server_status(
+                runtime,
+                host_status,
+                checked_at.as_str(),
+                Self::repo_runtime_resolve_mcp_status(&self.repo_runtime_load_mcp_status(runtime)?),
+            );
+            if latest_status.is_connected() {
+                return Ok(latest_status);
+            }
+        }
+
+        Ok(latest_status)
+    }
+
     fn repo_runtime_normalize_mcp_probe_failure(
         runtime: &RuntimeInstanceSummary,
         host_status: Option<&RepoRuntimeStartupStatus>,
@@ -1025,7 +1095,12 @@ impl AppService {
             }
         };
 
-        let mut mcp_status = Self::repo_runtime_resolve_mcp_status(&status_by_server);
+        let mut mcp_status = Self::repo_runtime_normalize_mcp_server_status(
+            &runtime,
+            host_status.as_ref(),
+            checked_at.as_str(),
+            Self::repo_runtime_resolve_mcp_status(&status_by_server),
+        );
         if !mcp_status.is_connected() {
             let reconnect_progress = repo_runtime_progress(RepoRuntimeProgressInput {
                 stage: RuntimeHealthWorkflowStage::ReconnectingMcp,
@@ -1059,8 +1134,12 @@ impl AppService {
 
             match self.repo_runtime_connect_mcp_server(&runtime, ODT_MCP_SERVER_NAME) {
                 Ok(()) => {
-                    let refreshed = match self.repo_runtime_load_mcp_status(&runtime) {
-                        Ok(refreshed) => refreshed,
+                    mcp_status = match self.repo_runtime_refresh_mcp_status_after_connect(
+                        &runtime,
+                        host_status.as_ref(),
+                        checked_at.as_str(),
+                    ) {
+                        Ok(status) => status,
                         Err(error) => {
                             let error = Self::repo_runtime_normalize_mcp_probe_failure(
                                 &runtime,
@@ -1104,7 +1183,6 @@ impl AppService {
                             );
                         }
                     };
-                    mcp_status = Self::repo_runtime_resolve_mcp_status(&refreshed);
                 }
                 Err(error) => {
                     let error = Self::repo_runtime_normalize_mcp_probe_failure(
@@ -1333,7 +1411,7 @@ fn lower_contains_any(haystack: &str, needles: &[&str]) -> bool {
 mod tests {
     use super::{
         repo_runtime_is_within_mcp_startup_grace_window, RepoRuntimeHealthHttpClient,
-        RuntimeHealthMcpServerStatus,
+        ResolvedMcpServerStatus, RuntimeHealthMcpServerStatus,
     };
     use host_domain::{
         AgentRuntimeKind, RepoRuntimeStartupStage, RepoRuntimeStartupStatus, RuntimeRole,
@@ -1485,5 +1563,45 @@ mod tests {
             Some(&host_status),
             "2026-04-11T10:00:45Z"
         ));
+    }
+
+    #[test]
+    fn normalize_mcp_server_status_downgrades_failed_status_within_startup_grace() {
+        let runtime = runtime_summary("2026-04-11T10:00:00Z");
+        let status = super::AppService::repo_runtime_normalize_mcp_server_status(
+            &runtime,
+            None,
+            "2026-04-11T10:00:08Z",
+            ResolvedMcpServerStatus::unavailable(
+                Some("failed".to_string()),
+                "Connection closed".to_string(),
+            ),
+        );
+
+        assert_eq!(
+            status.failure_kind,
+            Some(super::RepoRuntimeStartupFailureKind::Timeout)
+        );
+        assert_eq!(status.status.as_deref(), Some("failed"));
+    }
+
+    #[test]
+    fn normalize_mcp_server_status_keeps_failed_status_hard_after_startup_grace() {
+        let runtime = runtime_summary("2026-04-11T10:00:00Z");
+        let status = super::AppService::repo_runtime_normalize_mcp_server_status(
+            &runtime,
+            None,
+            "2026-04-11T10:00:21Z",
+            ResolvedMcpServerStatus::unavailable(
+                Some("failed".to_string()),
+                "Connection closed".to_string(),
+            ),
+        );
+
+        assert_eq!(
+            status.failure_kind,
+            Some(super::RepoRuntimeStartupFailureKind::Error)
+        );
+        assert_eq!(status.status.as_deref(), Some("failed"));
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health_snapshot.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health_snapshot.rs
@@ -229,6 +229,20 @@ fn summarize_mcp_status(
     if input.mcp_ok {
         return RepoRuntimeMcpStatus::Connected;
     }
+    if input.mcp_failure_kind == Some(RepoRuntimeStartupFailureKind::Timeout) {
+        let workflow_stage = input
+            .progress
+            .as_ref()
+            .map(|value| value.stage)
+            .unwrap_or_else(|| default_workflow_stage(input));
+        return match workflow_stage {
+            RuntimeHealthWorkflowStage::ReconnectingMcp => RepoRuntimeMcpStatus::Reconnecting,
+            RuntimeHealthWorkflowStage::RuntimeReady
+            | RuntimeHealthWorkflowStage::CheckingMcpStatus
+            | RuntimeHealthWorkflowStage::Ready => RepoRuntimeMcpStatus::Checking,
+            _ => RepoRuntimeMcpStatus::Error,
+        };
+    }
     if input.mcp_failure_kind.is_some() || input.mcp_error.is_some() {
         return RepoRuntimeMcpStatus::Error;
     }
@@ -276,5 +290,75 @@ fn default_workflow_stage(input: &RepoRuntimeHealthCheckInput) -> RuntimeHealthW
         RuntimeHealthWorkflowStage::StartupFailed
     } else {
         RuntimeHealthWorkflowStage::Idle
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_repo_runtime_health_check, repo_runtime_progress, RepoRuntimeHealthCheckInput,
+        RepoRuntimeProgressInput, RuntimeHealthWorkflowStage,
+    };
+    use host_domain::{
+        now_rfc3339, RepoRuntimeHealthState, RepoRuntimeMcpStatus, RepoRuntimeStartupFailureKind,
+    };
+
+    fn build_runtime_ready_timeout_health_check(
+        stage: RuntimeHealthWorkflowStage,
+    ) -> host_domain::RepoRuntimeHealthCheck {
+        let checked_at = now_rfc3339();
+        build_repo_runtime_health_check(RepoRuntimeHealthCheckInput {
+            checked_at: checked_at.clone(),
+            runtime: None,
+            runtime_ok: true,
+            runtime_error: None,
+            runtime_failure_kind: None,
+            supports_mcp_status: true,
+            mcp_ok: false,
+            mcp_error: Some("Timed out probing MCP startup".to_string()),
+            mcp_failure_kind: Some(RepoRuntimeStartupFailureKind::Timeout),
+            mcp_server_status: None,
+            available_tool_ids: Vec::new(),
+            progress: Some(repo_runtime_progress(RepoRuntimeProgressInput {
+                stage,
+                observation: None,
+                host: None,
+                checked_at,
+                failure_reason: None,
+                started_at: None,
+                updated_at: None,
+                elapsed_ms: Some(1_000),
+                attempts: Some(2),
+            })),
+        })
+    }
+
+    #[test]
+    fn timeout_mcp_probe_stays_checking_after_runtime_is_ready() {
+        let health =
+            build_runtime_ready_timeout_health_check(RuntimeHealthWorkflowStage::RuntimeReady);
+
+        assert_eq!(health.status, RepoRuntimeHealthState::Checking);
+        assert_eq!(health.runtime.status, RepoRuntimeHealthState::Ready);
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.status),
+            Some(RepoRuntimeMcpStatus::Checking)
+        );
+        assert_eq!(
+            health.mcp.as_ref().and_then(|value| value.failure_kind),
+            Some(RepoRuntimeStartupFailureKind::Timeout)
+        );
+    }
+
+    #[test]
+    fn timeout_mcp_reconnect_stays_reconnecting() {
+        let health =
+            build_runtime_ready_timeout_health_check(RuntimeHealthWorkflowStage::ReconnectingMcp);
+
+        assert_eq!(health.status, RepoRuntimeHealthState::Checking);
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.status),
+            Some(RepoRuntimeMcpStatus::Reconnecting)
+        );
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health_snapshot.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health_snapshot.rs
@@ -235,13 +235,7 @@ fn summarize_mcp_status(
             .as_ref()
             .map(|value| value.stage)
             .unwrap_or_else(|| default_workflow_stage(input));
-        return match workflow_stage {
-            RuntimeHealthWorkflowStage::ReconnectingMcp => RepoRuntimeMcpStatus::Reconnecting,
-            RuntimeHealthWorkflowStage::RuntimeReady
-            | RuntimeHealthWorkflowStage::CheckingMcpStatus
-            | RuntimeHealthWorkflowStage::Ready => RepoRuntimeMcpStatus::Checking,
-            _ => RepoRuntimeMcpStatus::Error,
-        };
+        return summarize_timeout_mcp_status(workflow_stage);
     }
     if input.mcp_failure_kind.is_some() || input.mcp_error.is_some() {
         return RepoRuntimeMcpStatus::Error;
@@ -251,6 +245,17 @@ fn summarize_mcp_status(
         Some(RuntimeHealthWorkflowStage::ReconnectingMcp) => RepoRuntimeMcpStatus::Reconnecting,
         Some(RuntimeHealthWorkflowStage::CheckingMcpStatus) => RepoRuntimeMcpStatus::Checking,
         _ => RepoRuntimeMcpStatus::Checking,
+    }
+}
+
+fn summarize_timeout_mcp_status(
+    workflow_stage: RuntimeHealthWorkflowStage,
+) -> RepoRuntimeMcpStatus {
+    match workflow_stage {
+        RuntimeHealthWorkflowStage::CheckingMcpStatus
+        | RuntimeHealthWorkflowStage::RestartSkippedActiveRun => RepoRuntimeMcpStatus::Checking,
+        RuntimeHealthWorkflowStage::ReconnectingMcp => RepoRuntimeMcpStatus::Reconnecting,
+        _ => RepoRuntimeMcpStatus::Error,
     }
 }
 
@@ -336,7 +341,7 @@ mod tests {
     #[test]
     fn timeout_mcp_probe_stays_checking_after_runtime_is_ready() {
         let health =
-            build_runtime_ready_timeout_health_check(RuntimeHealthWorkflowStage::RuntimeReady);
+            build_runtime_ready_timeout_health_check(RuntimeHealthWorkflowStage::CheckingMcpStatus);
 
         assert_eq!(health.status, RepoRuntimeHealthState::Checking);
         assert_eq!(health.runtime.status, RepoRuntimeHealthState::Ready);
@@ -359,6 +364,31 @@ mod tests {
         assert_eq!(
             health.mcp.as_ref().map(|value| value.status),
             Some(RepoRuntimeMcpStatus::Reconnecting)
+        );
+    }
+
+    #[test]
+    fn timeout_mcp_restart_skip_stays_checking() {
+        let health = build_runtime_ready_timeout_health_check(
+            RuntimeHealthWorkflowStage::RestartSkippedActiveRun,
+        );
+
+        assert_eq!(health.status, RepoRuntimeHealthState::Checking);
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.status),
+            Some(RepoRuntimeMcpStatus::Checking)
+        );
+    }
+
+    #[test]
+    fn timeout_mcp_outside_retry_stage_escalates_to_error() {
+        let health =
+            build_runtime_ready_timeout_health_check(RuntimeHealthWorkflowStage::RuntimeReady);
+
+        assert_eq!(health.status, RepoRuntimeHealthState::Error);
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.status),
+            Some(RepoRuntimeMcpStatus::Error)
         );
     }
 }

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-model.test.ts
@@ -36,4 +36,16 @@ describe("buildDiagnosticsSummary", () => {
 
     expect(summary.label).toBe("Healthy");
   });
+
+  test("keeps critical issues ahead of retrying state", () => {
+    const summary = buildDiagnosticsSummary({
+      hasActiveRepo: true,
+      isChecking: true,
+      hasCriticalIssues: true,
+      hasSetupIssues: false,
+    });
+
+    expect(summary.label).toBe("Critical issue");
+    expect(summary.toneClass).toBe("text-destructive-muted");
+  });
 });

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-model.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-model.ts
@@ -32,19 +32,19 @@ export const buildDiagnosticsSummary = ({
     };
   }
 
-  if (isChecking) {
-    return {
-      label: "Checking...",
-      toneClass: "text-muted-foreground",
-      iconClass: "text-muted-foreground",
-    };
-  }
-
   if (hasCriticalIssues) {
     return {
       label: "Critical issue",
       toneClass: "text-destructive-muted",
       iconClass: "text-destructive-accent",
+    };
+  }
+
+  if (isChecking) {
+    return {
+      label: "Checking...",
+      toneClass: "text-muted-foreground",
+      iconClass: "text-muted-foreground",
     };
   }
 

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -534,6 +534,8 @@ describe("buildDiagnosticsPanelModel", () => {
       expect.arrayContaining([expect.objectContaining({ label: "Tools detected" })]),
     );
     expect(mcpSection?.errors).toEqual([]);
+    expect(model.summaryState.label).toBe("Checking...");
+    expect(model.criticalReasons).toEqual([]);
   });
 
   test("keeps runtime and mcp progress details scoped to the relevant section", () => {
@@ -720,14 +722,80 @@ describe("buildDiagnosticsPanelModel", () => {
       isLoadingChecks: false,
     });
 
-    expect(model.isSummaryChecking).toBe(false);
-    expect(model.criticalReasons).toEqual(
-      expect.arrayContaining(["Runtime CLI checks still retrying", "Beads store still retrying"]),
-    );
+    expect(model.isSummaryChecking).toBe(true);
+    expect(model.summaryState.label).toBe("Checking...");
+    expect(model.criticalReasons).toEqual([]);
     expect(model.sections[1]?.badge).toEqual({ label: "Retrying", variant: "warning" });
     expect(model.sections[1]?.errors[0]).toContain("CLI tools are not yet available");
     expect(model.sections[4]?.badge).toEqual({ label: "Retrying", variant: "warning" });
     expect(model.sections[4]?.errors[0]).toContain("Beads store is not yet available");
+  });
+
+  test("keeps hard failures ahead of retrying summary state", () => {
+    const model = buildDiagnosticsPanelModel({
+      activeRepo: "/repo",
+      activeWorkspace: {
+        path: "/repo",
+        isActive: true,
+        hasConfig: true,
+        configuredWorktreeBasePath: "/worktrees",
+        defaultWorktreeBasePath: "/Users/dev/.openducktor/worktrees/repo",
+        effectiveWorktreeBasePath: "/worktrees",
+      },
+      runtimeDefinitions,
+      isLoadingRuntimeDefinitions: false,
+      runtimeDefinitionsError: null,
+      runtimeCheck: {
+        gitOk: false,
+        gitVersion: null,
+        ghOk: false,
+        ghVersion: null,
+        ghAuthOk: false,
+        ghAuthLogin: null,
+        ghAuthError: "Timed out after 15000ms",
+        runtimes: [{ kind: "opencode", ok: false, version: null }],
+        errors: ["Timed out after 15000ms"],
+      },
+      beadsCheck: {
+        beadsOk: true,
+        beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
+        beadsError: null,
+      },
+      runtimeCheckFailureKind: "timeout",
+      beadsCheckFailureKind: null,
+      runtimeHealthByRuntime: {
+        opencode: makeRepoHealth({
+          status: "error",
+          runtime: {
+            status: "error",
+            stage: "startup_failed",
+            observation: null,
+            instance: runtimeSummary,
+            startedAt: runtimeSummary.startedAt,
+            updatedAt: "2026-02-22T08:00:00.000Z",
+            elapsedMs: 20_000,
+            attempts: 4,
+            detail: "runtime failed",
+            failureKind: "error",
+            failureReason: null,
+          },
+          mcp: {
+            supported: true,
+            status: "waiting_for_runtime",
+            serverName: "openducktor",
+            serverStatus: null,
+            toolIds: [],
+            detail: "Runtime is unavailable, so MCP cannot be verified.",
+            failureKind: "timeout",
+          },
+        }),
+      },
+      isLoadingChecks: false,
+    });
+
+    expect(model.isSummaryChecking).toBe(true);
+    expect(model.summaryState.label).toBe("Critical issue");
+    expect(model.criticalReasons).toEqual(expect.arrayContaining(["runtime failed"]));
   });
 
   test("treats GitHub CLI auth failures as CLI issues even without query failure classification", () => {

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -19,6 +19,7 @@ import {
 import {
   buildTimeoutToastDescription,
   hasBeadsCheckFailure,
+  hasDiagnosticsRetryingState,
   hasRuntimeCheckFailure,
 } from "@/state/operations/workspace/check-diagnostics";
 import type { RepoRuntimeFailureKind, RepoRuntimeHealthMap } from "@/types/diagnostics";
@@ -287,12 +288,8 @@ export const buildDiagnosticsPanelModel = (
     if (runtimeDefinitionsError) {
       criticalReasons.push(runtimeDefinitionsError);
     }
-    if (hasRuntimeCheckFailure(runtimeCheck)) {
-      criticalReasons.push(
-        runtimeCheckFailureKind === "timeout"
-          ? "Runtime CLI checks still retrying"
-          : "Runtime CLI checks failing",
-      );
+    if (hasRuntimeCheckFailure(runtimeCheck) && runtimeCheckFailureKind !== "timeout") {
+      criticalReasons.push("Runtime CLI checks failing");
     }
     for (const { definition, runtimeHealth } of runtimeEntries) {
       if (runtimeHealth?.status === "error") {
@@ -302,12 +299,8 @@ export const buildDiagnosticsPanelModel = (
         );
       }
     }
-    if (hasBeadsCheckFailure(beadsCheck)) {
-      criticalReasons.push(
-        beadsCheckFailureKind === "timeout"
-          ? "Beads store still retrying"
-          : "Beads store unavailable",
-      );
+    if (hasBeadsCheckFailure(beadsCheck) && beadsCheckFailureKind !== "timeout") {
+      criticalReasons.push("Beads store unavailable");
     }
   }
 
@@ -323,7 +316,13 @@ export const buildDiagnosticsPanelModel = (
       runtimeCheck === null ||
       beadsCheck === null ||
       isRuntimeHealthPending ||
-      hasCheckingRuntimeHealth);
+      hasCheckingRuntimeHealth ||
+      hasDiagnosticsRetryingState({
+        runtimeDefinitions,
+        runtimeCheckFailureKind,
+        beadsCheckFailureKind,
+        runtimeHealthByRuntime,
+      }));
 
   const repositorySection: DiagnosticsSectionModel = {
     key: "repository",

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
@@ -91,9 +91,10 @@ describe("check-diagnostics helpers", () => {
     expect(issues).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: "diagnostics:beads-store", severity: "error" }),
+        expect.objectContaining({ id: "diagnostics:runtime:opencode", severity: "error" }),
       ]),
     );
-    expect(issues).toHaveLength(1);
+    expect(issues).toHaveLength(2);
   });
 
   test("restores unhealthy cli and beads payload toasts even without query failures", () => {
@@ -191,10 +192,10 @@ describe("check-diagnostics helpers", () => {
         beadsCheckFetching: true,
         runtimeHealthByRuntime: {
           opencode: makeRepoHealth({
-            status: "error",
+            status: "checking",
             mcp: {
               supported: true,
-              status: "error",
+              status: "checking",
               serverName: "openducktor",
               serverStatus: null,
               toolIds: [],
@@ -209,6 +210,36 @@ describe("check-diagnostics helpers", () => {
       retryRuntimeCheck: false,
       retryBeadsCheck: false,
       retryRuntimeHealth: true,
+    });
+
+    expect(
+      buildDiagnosticsRetryPlan({
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        runtimeCheckFailureKind: null,
+        runtimeCheckFetching: false,
+        beadsCheckFailureKind: null,
+        beadsCheckFetching: false,
+        runtimeHealthByRuntime: {
+          opencode: makeRepoHealth({
+            status: "error",
+            mcp: {
+              supported: true,
+              status: "error",
+              serverName: "openducktor",
+              serverStatus: null,
+              toolIds: [],
+              detail: "OpenCode MCP timed out after retries",
+              failureKind: "timeout",
+            },
+          }),
+        },
+        runtimeHealthFetching: false,
+      }),
+    ).toEqual({
+      retryRuntimeCheck: false,
+      retryBeadsCheck: false,
+      retryRuntimeHealth: false,
     });
   });
 });

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
@@ -58,7 +58,7 @@ describe("check-diagnostics helpers", () => {
     });
   });
 
-  test("builds toast issues across cli, beads, and runtime health checks", () => {
+  test("builds toast issues only for hard failures", () => {
     const issues = buildDiagnosticsToastIssues({
       activeRepo: "/repo",
       runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
@@ -90,11 +90,10 @@ describe("check-diagnostics helpers", () => {
 
     expect(issues).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: "diagnostics:cli-tools", severity: "timeout" }),
         expect.objectContaining({ id: "diagnostics:beads-store", severity: "error" }),
-        expect.objectContaining({ id: "diagnostics:runtime:opencode", severity: "timeout" }),
       ]),
     );
+    expect(issues).toHaveLength(1);
   });
 
   test("restores unhealthy cli and beads payload toasts even without query failures", () => {

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -235,7 +235,7 @@ const getRuntimeHealthIssueCandidates = (
         availabilityVerb: "is",
       },
       runtimeHealth.runtime.detail,
-      runtimeHealth.runtime.status === "error" ? runtimeHealth.runtime.failureKind : null,
+      runtimeHealth.runtime.status === "error" ? "error" : runtimeHealth.runtime.failureKind,
     );
 
     if (runtimeIssue !== null) {
@@ -254,7 +254,7 @@ const getRuntimeHealthIssueCandidates = (
         availabilityVerb: "is",
       },
       runtimeHealth.mcp?.detail ?? null,
-      runtimeHealth.mcp?.status === "error" ? runtimeHealth.mcp.failureKind : null,
+      runtimeHealth.mcp?.status === "error" ? "error" : (runtimeHealth.mcp?.failureKind ?? null),
     );
 
     if (mcpIssue !== null) {
@@ -303,8 +303,11 @@ export const hasRuntimeHealthTimeoutIssue = (
     }
 
     return (
-      runtimeHealth.runtime.failureKind === "timeout" ||
-      (definition.capabilities.supportsMcpStatus && runtimeHealth.mcp?.failureKind === "timeout")
+      (runtimeHealth.runtime.status !== "error" &&
+        runtimeHealth.runtime.failureKind === "timeout") ||
+      (definition.capabilities.supportsMcpStatus &&
+        runtimeHealth.mcp?.status !== "error" &&
+        runtimeHealth.mcp?.failureKind === "timeout")
     );
   });
 };

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -7,13 +7,14 @@ import type {
 } from "@/types/diagnostics";
 
 type NonNullRepoRuntimeFailureKind = Exclude<RepoRuntimeFailureKind, null>;
+type DiagnosticsToastSeverity = Exclude<RepoRuntimeFailureKind, "timeout" | null>;
 type AvailabilityVerb = "is" | "are";
 
 export type DiagnosticsToastIssue = {
   id: string;
   title: string;
   description: string;
-  severity: NonNullRepoRuntimeFailureKind;
+  severity: DiagnosticsToastSeverity;
 };
 
 export type DiagnosticsRetryPlan = {
@@ -169,24 +170,13 @@ const buildDiagnosticsToastIssue = ({
   id,
   label,
   detail,
-  failureKind,
-  availabilityVerb,
 }: DiagnosticsIssueCandidate): DiagnosticsToastIssue => {
-  return failureKind === "timeout"
-    ? {
-        id,
-        title: `${label} not yet available`,
-        description: buildTimeoutToastDescription(label, detail, {
-          availabilityVerb,
-        }),
-        severity: failureKind,
-      }
-    : {
-        id,
-        title: `${label} unavailable`,
-        description: buildErrorToastDescription(label, detail),
-        severity: failureKind,
-      };
+  return {
+    id,
+    title: `${label} unavailable`,
+    description: buildErrorToastDescription(label, detail),
+    severity: "error",
+  };
 };
 
 const buildDiagnosticsIssueCandidate = (
@@ -295,7 +285,10 @@ export const buildDiagnosticsToastIssues = ({
     getBeadsCheckIssueCandidate(beadsCheck, beadsCheckError, beadsCheckFailureKind),
     ...getRuntimeHealthIssueCandidates(runtimeDefinitions, runtimeHealthByRuntime),
   ]
-    .filter((issueCandidate) => issueCandidate !== null)
+    .filter(
+      (issueCandidate): issueCandidate is DiagnosticsIssueCandidate =>
+        issueCandidate !== null && issueCandidate.failureKind === "error",
+    )
     .map((issueCandidate) => buildDiagnosticsToastIssue(issueCandidate));
 };
 
@@ -314,6 +307,24 @@ export const hasRuntimeHealthTimeoutIssue = (
       (definition.capabilities.supportsMcpStatus && runtimeHealth.mcp?.failureKind === "timeout")
     );
   });
+};
+
+export const hasDiagnosticsRetryingState = ({
+  runtimeDefinitions,
+  runtimeCheckFailureKind,
+  beadsCheckFailureKind,
+  runtimeHealthByRuntime,
+}: {
+  runtimeDefinitions: RuntimeDescriptor[];
+  runtimeCheckFailureKind: RepoRuntimeFailureKind;
+  beadsCheckFailureKind: RepoRuntimeFailureKind;
+  runtimeHealthByRuntime: RepoRuntimeHealthMap;
+}): boolean => {
+  return (
+    runtimeCheckFailureKind === "timeout" ||
+    beadsCheckFailureKind === "timeout" ||
+    hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime)
+  );
 };
 
 export const buildDiagnosticsRetryPlan = ({

--- a/apps/desktop/src/state/operations/workspace/use-check-diagnostics-effects.ts
+++ b/apps/desktop/src/state/operations/workspace/use-check-diagnostics-effects.ts
@@ -27,19 +27,11 @@ export function useDiagnosticsToasts(diagnosticsToastIssues: DiagnosticsToastIss
         continue;
       }
 
-      if (issue.severity === "timeout") {
-        toast(issue.title, {
-          id: issue.id,
-          description: issue.description,
-          duration: Number.POSITIVE_INFINITY,
-        });
-      } else {
-        toast.error(issue.title, {
-          id: issue.id,
-          description: issue.description,
-          duration: Number.POSITIVE_INFINITY,
-        });
-      }
+      toast.error(issue.title, {
+        id: issue.id,
+        description: issue.description,
+        duration: Number.POSITIVE_INFINITY,
+      });
 
       issueSignaturesRef.current.set(issue.id, signature);
     }

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -797,10 +797,7 @@ describe("use-checks", () => {
           description: "runtime down",
         }),
       );
-      expect(toastMessage).toHaveBeenCalledWith(
-        "Beads store not yet available",
-        expect.objectContaining({ id: "diagnostics:beads-store" }),
-      );
+      expect(toastMessage).not.toHaveBeenCalled();
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
@@ -865,14 +862,7 @@ describe("use-checks", () => {
           value.isLoadingChecks === false,
       );
 
-      expect(toastMessage).toHaveBeenCalledWith(
-        "CLI tools not yet available",
-        expect.objectContaining({ id: "diagnostics:cli-tools" }),
-      );
-      expect(toastMessage).toHaveBeenCalledWith(
-        "Beads store not yet available",
-        expect.objectContaining({ id: "diagnostics:beads-store" }),
-      );
+      expect(toastMessage).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
       host.runtimeCheck = original.runtimeCheck;


### PR DESCRIPTION
## Summary
- stop treating expected OpenDucktor MCP warmup as a hard diagnostics failure during desktop startup
- keep transient MCP startup and reconnect probes in checking/retrying states while preserving real failure escalation
- prevent retrying startup checks from opening the diagnostics panel or raising persistent error toasts, while still surfacing true critical issues first

## Problem
When OpenDucktor started, the runtime health check could observe the OpenDucktor MCP before it finished coming up. That short window was normal, but the app treated it like a real failure:
- the host health snapshot could collapse transient MCP probe failures into `error`
- the frontend turned retrying timeout states into critical reasons and persistent toasts
- the diagnostics panel auto-opened, which made a healthy startup feel broken

## Implementation
### Host runtime health
- added MCP startup-grace handling in `repo_health.rs` so connection-refused probes only downgrade to retryable startup timeouts while the runtime is genuinely within startup grace or still reported as starting
- kept stale or dead runtime routes as hard failures once that grace window has expired
- updated `repo_health_snapshot.rs` so timeout-classified MCP probe failures remain `checking` or `reconnecting` when the runtime is otherwise ready

### Frontend diagnostics behavior
- updated `check-diagnostics.ts` so only hard failures generate diagnostics toast issues
- simplified `use-check-diagnostics-effects.ts` to surface only error toasts now that retry states are no longer toast-worthy
- updated `diagnostics-panel-model.ts` to keep retrying CLI/Beads states out of `criticalReasons`
- preserved retry visibility through section-level warning badges and messages instead of false critical errors
- adjusted `diagnostics-model.ts` so genuine critical issues still outrank background retrying/checking state in the summary

### Test coverage
- added Rust coverage for MCP timeout/checking mapping and startup-grace behavior, including stale-route expiry
- added frontend coverage for retry-only states, mixed retry-plus-hard-failure summaries, and diagnostics summary precedence

## Verification
- `bun test apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts apps/desktop/src/state/operations/workspace/use-checks.test.tsx apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts apps/desktop/src/components/features/diagnostics/diagnostics-model.test.ts`
- `rtk cargo test -p host-application repo_health`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run check:rust`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup grace window: early connect failures during recent runtime startup are treated as transient.

* **Bug Fixes**
  * Critical diagnostics now take precedence over “Checking…”.
  * Timeout/retry states no longer produce persistent toasts; only hard errors surface as error toasts.

* **Improvements**
  * MCP status/timeouts normalized to better reflect reconnecting vs error states and smoother post-reconnect refresh.
  * Cleaner summary messaging for retrying vs hard failures.

* **Tests**
  * Expanded unit tests for grace-window, MCP timeout handling, and diagnostics summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->