### PR TITLE
feat(desktop): add hover copy action for assistant messages

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -3,7 +3,7 @@ import {
   type AgentUserMessageDisplayPart,
   isOdtWorkflowMutationToolName,
 } from "@openducktor/core";
-import { Brain, Check, Copy, Hammer, MessageSquareQuote } from "lucide-react";
+import { Brain, Hammer, MessageSquareQuote } from "lucide-react";
 import {
   Fragment,
   lazy,
@@ -17,9 +17,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { Button } from "@/components/ui/button";
+import { CopyIconButton } from "@/components/ui/copy-icon-button";
 import type { MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { buildCopyPreview } from "@/lib/copy-preview";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
@@ -257,28 +256,23 @@ const ReasoningMessage = ({ content, streaming }: ReasoningMessageProps): ReactE
 type AssistantMessageProps = {
   message: AgentChatMessage;
   assistantAccentColor: string | undefined;
-  copyResetDelayMs?: number;
+  isStreamingAssistantMessage: boolean;
 };
 
-const canCopyAssistantMessage = (message: AgentChatMessage): boolean => {
+const canCopyAssistantMessage = (
+  message: AgentChatMessage,
+  isStreamingAssistantMessage: boolean,
+): boolean => {
   if (message.role !== "assistant" || message.content.trim().length === 0) {
     return false;
   }
 
-  const assistantMeta = message.meta?.kind === "assistant" ? message.meta : null;
-  return assistantMeta?.isFinal !== false;
+  return !isStreamingAssistantMessage;
 };
 
-function AssistantMessageCopyButton({
-  markdown,
-  copyResetDelayMs,
-}: {
-  markdown: string;
-  copyResetDelayMs?: number;
-}): ReactElement {
+function AssistantMessageCopyButton({ markdown }: { markdown: string }): ReactElement {
   const { copied, copyToClipboard } = useCopyToClipboard({
     getSuccessDescription: buildCopyPreview,
-    ...(copyResetDelayMs === undefined ? {} : { resetDelayMs: copyResetDelayMs }),
     errorLogContext: "AgentChatMessageCardContent",
   });
 
@@ -292,52 +286,29 @@ function AssistantMessageCopyButton({
   );
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="absolute top-0 right-0 z-10 size-7 opacity-0 pointer-events-none text-muted-foreground transition-opacity hover:bg-accent hover:text-foreground group-hover/message:opacity-100 group-hover/message:pointer-events-auto group-focus-within/message:opacity-100 group-focus-within/message:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
-            aria-label="Copy assistant message content"
-            data-testid="copy-assistant-message-content"
-            onClick={handleCopy}
-          >
-            {copied ? (
-              <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
-            ) : (
-              <Copy className="size-3.5" />
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="left">
-          <p>Copy</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <CopyIconButton
+      copied={copied}
+      ariaLabel="Copy assistant message content"
+      dataTestId="copy-assistant-message-content"
+      className="absolute top-0 right-0 z-10 opacity-0 pointer-events-none transition-opacity group-hover/message:opacity-100 group-hover/message:pointer-events-auto group-focus-within/message:opacity-100 group-focus-within/message:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+      onClick={handleCopy}
+    />
   );
 }
 
 const AssistantMessage = ({
   message,
   assistantAccentColor,
-  copyResetDelayMs,
+  isStreamingAssistantMessage,
 }: AssistantMessageProps): ReactElement => {
-  const assistantMeta = message.meta?.kind === "assistant" ? message.meta : null;
-  const streaming = assistantMeta?.isFinal === false;
-  const copyable = canCopyAssistantMessage(message);
+  const streaming = isStreamingAssistantMessage;
+  const copyable = canCopyAssistantMessage(message, isStreamingAssistantMessage);
   const pacedContent = usePacedStreamingText(message.content, streaming);
   const renderedContent = useDeferredValue(pacedContent);
   const footer = getAssistantFooterData(message);
   return (
     <div className={cn("group/message relative space-y-2", copyable ? "pr-9" : "")}>
-      {copyable ? (
-        <AssistantMessageCopyButton
-          markdown={message.content}
-          {...(copyResetDelayMs === undefined ? {} : { copyResetDelayMs })}
-        />
-      ) : null}
+      {copyable ? <AssistantMessageCopyButton markdown={message.content} /> : null}
       <DeferredMarkdownRenderer
         markdown={streaming ? renderedContent : pacedContent}
         variant="document"
@@ -491,19 +462,19 @@ const SessionNoticeMessage = ({ message, timeLabel }: SessionNoticeMessageProps)
 type MessageBodyProps = {
   message: AgentChatMessage;
   assistantAccentColor: string | undefined;
+  isStreamingAssistantMessage: boolean;
   timeLabel: string;
   systemPromptBody: string;
   sessionWorkingDirectory?: string | null | undefined;
-  copyResetDelayMs?: number;
 };
 
 export const MessageBody = ({
   message,
   assistantAccentColor,
+  isStreamingAssistantMessage,
   timeLabel,
   systemPromptBody,
   sessionWorkingDirectory,
-  copyResetDelayMs,
 }: MessageBodyProps): ReactElement => {
   const meta = message.meta;
 
@@ -618,7 +589,7 @@ export const MessageBody = ({
       <AssistantMessage
         message={message}
         assistantAccentColor={assistantAccentColor}
-        {...(copyResetDelayMs === undefined ? {} : { copyResetDelayMs })}
+        isStreamingAssistantMessage={isStreamingAssistantMessage}
       />
     );
   }

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -3,19 +3,25 @@ import {
   type AgentUserMessageDisplayPart,
   isOdtWorkflowMutationToolName,
 } from "@openducktor/core";
-import { Brain, Hammer, MessageSquareQuote } from "lucide-react";
+import { Brain, Check, Copy, Hammer, MessageSquareQuote } from "lucide-react";
 import {
   Fragment,
   lazy,
+  type MouseEvent,
   type ReactElement,
   type ReactNode,
   Suspense,
+  useCallback,
   useDeferredValue,
   useEffect,
   useRef,
   useState,
 } from "react";
+import { Button } from "@/components/ui/button";
 import type { MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { buildCopyPreview } from "@/lib/copy-preview";
+import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import { AgentChatAttachmentChip } from "./agent-chat-attachment-chip";
@@ -251,19 +257,87 @@ const ReasoningMessage = ({ content, streaming }: ReasoningMessageProps): ReactE
 type AssistantMessageProps = {
   message: AgentChatMessage;
   assistantAccentColor: string | undefined;
+  copyResetDelayMs?: number;
 };
+
+const canCopyAssistantMessage = (message: AgentChatMessage): boolean => {
+  if (message.role !== "assistant" || message.content.trim().length === 0) {
+    return false;
+  }
+
+  const assistantMeta = message.meta?.kind === "assistant" ? message.meta : null;
+  return assistantMeta?.isFinal !== false;
+};
+
+function AssistantMessageCopyButton({
+  markdown,
+  copyResetDelayMs,
+}: {
+  markdown: string;
+  copyResetDelayMs?: number;
+}): ReactElement {
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    getSuccessDescription: buildCopyPreview,
+    ...(copyResetDelayMs === undefined ? {} : { resetDelayMs: copyResetDelayMs }),
+    errorLogContext: "AgentChatMessageCardContent",
+  });
+
+  const handleCopy = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      void copyToClipboard(markdown);
+    },
+    [copyToClipboard, markdown],
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="absolute top-0 right-0 z-10 size-7 opacity-0 pointer-events-none text-muted-foreground transition-opacity hover:bg-accent hover:text-foreground group-hover/message:opacity-100 group-hover/message:pointer-events-auto group-focus-within/message:opacity-100 group-focus-within/message:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+            aria-label="Copy assistant message content"
+            data-testid="copy-assistant-message-content"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
+            ) : (
+              <Copy className="size-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          <p>Copy</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 const AssistantMessage = ({
   message,
   assistantAccentColor,
+  copyResetDelayMs,
 }: AssistantMessageProps): ReactElement => {
   const assistantMeta = message.meta?.kind === "assistant" ? message.meta : null;
   const streaming = assistantMeta?.isFinal === false;
+  const copyable = canCopyAssistantMessage(message);
   const pacedContent = usePacedStreamingText(message.content, streaming);
   const renderedContent = useDeferredValue(pacedContent);
   const footer = getAssistantFooterData(message);
   return (
-    <div className="space-y-2">
+    <div className={cn("group/message relative space-y-2", copyable ? "pr-9" : "")}>
+      {copyable ? (
+        <AssistantMessageCopyButton
+          markdown={message.content}
+          {...(copyResetDelayMs === undefined ? {} : { copyResetDelayMs })}
+        />
+      ) : null}
       <DeferredMarkdownRenderer
         markdown={streaming ? renderedContent : pacedContent}
         variant="document"
@@ -420,6 +494,7 @@ type MessageBodyProps = {
   timeLabel: string;
   systemPromptBody: string;
   sessionWorkingDirectory?: string | null | undefined;
+  copyResetDelayMs?: number;
 };
 
 export const MessageBody = ({
@@ -428,6 +503,7 @@ export const MessageBody = ({
   timeLabel,
   systemPromptBody,
   sessionWorkingDirectory,
+  copyResetDelayMs,
 }: MessageBodyProps): ReactElement => {
   const meta = message.meta;
 
@@ -538,7 +614,13 @@ export const MessageBody = ({
   }
 
   if (message.role === "assistant") {
-    return <AssistantMessage message={message} assistantAccentColor={assistantAccentColor} />;
+    return (
+      <AssistantMessage
+        message={message}
+        assistantAccentColor={assistantAccentColor}
+        {...(copyResetDelayMs === undefined ? {} : { copyResetDelayMs })}
+      />
+    );
   }
 
   return <DeferredMarkdownRenderer markdown={message.content} variant="document" />;

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -307,7 +307,7 @@ const AssistantMessage = ({
   const renderedContent = useDeferredValue(pacedContent);
   const footer = getAssistantFooterData(message);
   return (
-    <div className={cn("group/message relative space-y-2", copyable ? "pr-9" : "")}>
+    <div className="group/message relative space-y-2 pr-9">
       {copyable ? <AssistantMessageCopyButton markdown={message.content} /> : null}
       <DeferredMarkdownRenderer
         markdown={streaming ? renderedContent : pacedContent}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.copy.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.copy.test.tsx
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+
+enableReactActEnvironment();
+
+const toastSuccessMock = mock(() => {});
+const toastErrorMock = mock(() => {});
+const writeClipboardMock = mock(async (_value: string) => {});
+
+type AgentChatMessageCardComponent =
+  typeof import("./agent-chat-message-card").AgentChatMessageCard;
+let AgentChatMessageCard: AgentChatMessageCardComponent;
+
+describe("AgentChatMessageCard assistant copy", () => {
+  beforeAll(async () => {
+    mock.module("sonner", () => ({
+      toast: {
+        success: toastSuccessMock,
+        error: toastErrorMock,
+        loading: () => "",
+        dismiss: () => {},
+      },
+    }));
+
+    ({ AgentChatMessageCard } = await import("./agent-chat-message-card"));
+  });
+
+  afterAll(async () => {
+    await restoreMockedModules([["sonner", () => import("sonner")]]);
+  });
+
+  beforeEach(() => {
+    toastSuccessMock.mockClear();
+    toastErrorMock.mockClear();
+    writeClipboardMock.mockClear();
+    writeClipboardMock.mockImplementation(async () => {});
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: writeClipboardMock,
+      },
+    });
+  });
+
+  test("copies the raw assistant markdown and shows the shared success preview", async () => {
+    const markdown = "12345678901234567890123456789012345678901234567890tail";
+    const rendered = render(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "assistant-copy-success",
+          role: "assistant",
+          content: markdown,
+          timestamp: "2026-02-22T10:24:45.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "planner",
+            isFinal: true,
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    fireEvent.click(rendered.getByTestId("copy-assistant-message-content"));
+
+    await waitFor(() => {
+      expect(writeClipboardMock).toHaveBeenCalledWith(markdown);
+      expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
+        description: `${markdown.slice(0, 50)}...`,
+      });
+    });
+    rendered.unmount();
+  });
+
+  test("shows the copied-state icon and resets it after the shared delay", async () => {
+    const rendered = render(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "assistant-copy-reset",
+          role: "assistant",
+          content: "# Summary",
+          timestamp: "2026-02-22T10:24:50.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "planner",
+            isFinal: true,
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+        copyResetDelayMs: 5,
+      }),
+    );
+
+    try {
+      const button = rendered.getByTestId("copy-assistant-message-content");
+      expect(button.querySelector(".lucide-copy")).not.toBeNull();
+
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(button.querySelector(".lucide-check")).not.toBeNull();
+      });
+
+      await waitFor(() => {
+        expect(button.querySelector(".lucide-copy")).not.toBeNull();
+      });
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("shows the shared clipboard error toast when copying fails", async () => {
+    const error = new DOMException("blocked by browser", "NotAllowedError");
+    writeClipboardMock.mockImplementation(async () => {
+      throw error;
+    });
+
+    const rendered = render(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "assistant-copy-error",
+          role: "assistant",
+          content: "# Summary\n\nFailure case",
+          timestamp: "2026-02-22T10:24:55.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "planner",
+            isFinal: true,
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    fireEvent.click(rendered.getByTestId("copy-assistant-message-content"));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Permission denied: clipboard access not allowed",
+      );
+    });
+    rendered.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.copy.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.copy.test.tsx
@@ -1,26 +1,27 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
 import { buildCopyPreview } from "@/lib/copy-preview";
 import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { replaceNavigatorClipboard } from "@/test-utils/mock-clipboard";
 import { withMockedToast } from "@/test-utils/mock-toast";
 import { AgentChatMessageCard } from "./agent-chat-message-card";
 
 enableReactActEnvironment();
 
 const writeClipboardMock = mock(async (_value: string) => {});
+let restoreClipboard: (() => void) | null = null;
 
 describe("AgentChatMessageCard assistant copy", () => {
   beforeEach(() => {
     writeClipboardMock.mockClear();
     writeClipboardMock.mockImplementation(async () => {});
+    restoreClipboard = replaceNavigatorClipboard(writeClipboardMock);
+  });
 
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: {
-        writeText: writeClipboardMock,
-      },
-    });
+  afterEach(() => {
+    restoreClipboard?.();
+    restoreClipboard = null;
   });
 
   test("copies the raw assistant markdown and shows the shared success preview", async () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.copy.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.copy.test.tsx
@@ -1,40 +1,39 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
+import { toast } from "sonner";
+import { buildCopyPreview } from "@/lib/copy-preview";
 import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
-import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+import { AgentChatMessageCard } from "./agent-chat-message-card";
 
 enableReactActEnvironment();
 
-const toastSuccessMock = mock(() => {});
-const toastErrorMock = mock(() => {});
 const writeClipboardMock = mock(async (_value: string) => {});
 
-type AgentChatMessageCardComponent =
-  typeof import("./agent-chat-message-card").AgentChatMessageCard;
-let AgentChatMessageCard: AgentChatMessageCardComponent;
+const withMockedToast = async (
+  callback: (mocks: {
+    toastSuccessMock: ReturnType<typeof mock>;
+    toastErrorMock: ReturnType<typeof mock>;
+  }) => Promise<void>,
+): Promise<void> => {
+  const originalSuccess = toast.success;
+  const originalError = toast.error;
+  const toastSuccessMock = mock(() => "");
+  const toastErrorMock = mock(() => "");
+
+  toast.success = toastSuccessMock;
+  toast.error = toastErrorMock;
+
+  try {
+    await callback({ toastSuccessMock, toastErrorMock });
+  } finally {
+    toast.success = originalSuccess;
+    toast.error = originalError;
+  }
+};
 
 describe("AgentChatMessageCard assistant copy", () => {
-  beforeAll(async () => {
-    mock.module("sonner", () => ({
-      toast: {
-        success: toastSuccessMock,
-        error: toastErrorMock,
-        loading: () => "",
-        dismiss: () => {},
-      },
-    }));
-
-    ({ AgentChatMessageCard } = await import("./agent-chat-message-card"));
-  });
-
-  afterAll(async () => {
-    await restoreMockedModules([["sonner", () => import("sonner")]]);
-  });
-
   beforeEach(() => {
-    toastSuccessMock.mockClear();
-    toastErrorMock.mockClear();
     writeClipboardMock.mockClear();
     writeClipboardMock.mockImplementation(async () => {});
 
@@ -47,108 +46,155 @@ describe("AgentChatMessageCard assistant copy", () => {
   });
 
   test("copies the raw assistant markdown and shows the shared success preview", async () => {
-    const markdown = "12345678901234567890123456789012345678901234567890tail";
-    const rendered = render(
-      createElement(AgentChatMessageCard, {
-        message: {
-          id: "assistant-copy-success",
-          role: "assistant",
-          content: markdown,
-          timestamp: "2026-02-22T10:24:45.000Z",
-          meta: {
-            kind: "assistant",
-            agentRole: "planner",
-            isFinal: true,
+    await withMockedToast(async ({ toastSuccessMock }) => {
+      const markdown = "12345678901234567890123456789012345678901234567890tail";
+      const rendered = render(
+        createElement(AgentChatMessageCard, {
+          message: {
+            id: "assistant-copy-success",
+            role: "assistant",
+            content: markdown,
+            timestamp: "2026-02-22T10:24:45.000Z",
+            meta: {
+              kind: "assistant",
+              agentRole: "planner",
+            },
           },
-        },
-        sessionRole: "planner",
-        sessionSelectedModel: null,
-        sessionAgentColors: {},
-      }),
-    );
+          sessionRole: "planner",
+          sessionSelectedModel: null,
+          sessionAgentColors: {},
+        }),
+      );
 
-    fireEvent.click(rendered.getByTestId("copy-assistant-message-content"));
+      try {
+        fireEvent.click(rendered.getByTestId("copy-assistant-message-content"));
 
-    await waitFor(() => {
-      expect(writeClipboardMock).toHaveBeenCalledWith(markdown);
-      expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
-        description: `${markdown.slice(0, 50)}...`,
-      });
+        await waitFor(() => {
+          expect(writeClipboardMock).toHaveBeenCalledWith(markdown);
+          expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
+            description: buildCopyPreview(markdown),
+          });
+        });
+      } finally {
+        rendered.unmount();
+      }
     });
-    rendered.unmount();
+  });
+
+  test("copies completed intermediate assistant messages when isFinal is omitted", async () => {
+    await withMockedToast(async ({ toastSuccessMock }) => {
+      const markdown = "# Intermediate update\n\nStill working through the task.";
+      const rendered = render(
+        createElement(AgentChatMessageCard, {
+          message: {
+            id: "assistant-copy-intermediate",
+            role: "assistant",
+            content: markdown,
+            timestamp: "2026-02-22T10:24:47.000Z",
+            meta: {
+              kind: "assistant",
+              agentRole: "planner",
+            },
+          },
+          sessionRole: "planner",
+          sessionSelectedModel: null,
+          sessionAgentColors: {},
+        }),
+      );
+
+      try {
+        fireEvent.click(rendered.getByTestId("copy-assistant-message-content"));
+
+        await waitFor(() => {
+          expect(writeClipboardMock).toHaveBeenCalledWith(markdown);
+          expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
+            description: buildCopyPreview(markdown),
+          });
+        });
+      } finally {
+        rendered.unmount();
+      }
+    });
   });
 
   test("shows the copied-state icon and resets it after the shared delay", async () => {
-    const rendered = render(
-      createElement(AgentChatMessageCard, {
-        message: {
-          id: "assistant-copy-reset",
-          role: "assistant",
-          content: "# Summary",
-          timestamp: "2026-02-22T10:24:50.000Z",
-          meta: {
-            kind: "assistant",
-            agentRole: "planner",
-            isFinal: true,
+    await withMockedToast(async () => {
+      const rendered = render(
+        createElement(AgentChatMessageCard, {
+          message: {
+            id: "assistant-copy-reset",
+            role: "assistant",
+            content: "# Summary",
+            timestamp: "2026-02-22T10:24:50.000Z",
+            meta: {
+              kind: "assistant",
+              agentRole: "planner",
+              isFinal: true,
+            },
           },
-        },
-        sessionRole: "planner",
-        sessionSelectedModel: null,
-        sessionAgentColors: {},
-        copyResetDelayMs: 5,
-      }),
-    );
+          sessionRole: "planner",
+          sessionSelectedModel: null,
+          sessionAgentColors: {},
+          copyResetDelayMs: 5,
+        }),
+      );
 
-    try {
-      const button = rendered.getByTestId("copy-assistant-message-content");
-      expect(button.querySelector(".lucide-copy")).not.toBeNull();
-
-      fireEvent.click(button);
-
-      await waitFor(() => {
-        expect(button.querySelector(".lucide-check")).not.toBeNull();
-      });
-
-      await waitFor(() => {
+      try {
+        const button = rendered.getByTestId("copy-assistant-message-content");
         expect(button.querySelector(".lucide-copy")).not.toBeNull();
-      });
-    } finally {
-      rendered.unmount();
-    }
+
+        fireEvent.click(button);
+
+        await waitFor(() => {
+          expect(button.querySelector(".lucide-check")).not.toBeNull();
+        });
+
+        await waitFor(() => {
+          expect(button.querySelector(".lucide-copy")).not.toBeNull();
+        });
+      } finally {
+        rendered.unmount();
+      }
+    });
   });
 
   test("shows the shared clipboard error toast when copying fails", async () => {
-    const error = new DOMException("blocked by browser", "NotAllowedError");
-    writeClipboardMock.mockImplementation(async () => {
-      throw error;
-    });
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const error = new DOMException("blocked by browser", "NotAllowedError");
+      writeClipboardMock.mockImplementation(async () => {
+        throw error;
+      });
 
-    const rendered = render(
-      createElement(AgentChatMessageCard, {
-        message: {
-          id: "assistant-copy-error",
-          role: "assistant",
-          content: "# Summary\n\nFailure case",
-          timestamp: "2026-02-22T10:24:55.000Z",
-          meta: {
-            kind: "assistant",
-            agentRole: "planner",
-            isFinal: true,
+      const rendered = render(
+        createElement(AgentChatMessageCard, {
+          message: {
+            id: "assistant-copy-error",
+            role: "assistant",
+            content: "# Summary\n\nFailure case",
+            timestamp: "2026-02-22T10:24:55.000Z",
+            meta: {
+              kind: "assistant",
+              agentRole: "planner",
+              isFinal: true,
+            },
           },
-        },
-        sessionRole: "planner",
-        sessionSelectedModel: null,
-        sessionAgentColors: {},
-      }),
-    );
-
-    fireEvent.click(rendered.getByTestId("copy-assistant-message-content"));
-
-    await waitFor(() => {
-      expect(toastErrorMock).toHaveBeenCalledWith(
-        "Permission denied: clipboard access not allowed",
+          sessionRole: "planner",
+          sessionSelectedModel: null,
+          sessionAgentColors: {},
+        }),
       );
+
+      try {
+        fireEvent.click(rendered.getByTestId("copy-assistant-message-content"));
+
+        await waitFor(() => {
+          expect(toastErrorMock).toHaveBeenCalledWith(
+            "Permission denied: clipboard access not allowed",
+          );
+        });
+      } finally {
+        rendered.unmount();
+      }
     });
-    rendered.unmount();
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.copy.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.copy.test.tsx
@@ -1,36 +1,14 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
-import { toast } from "sonner";
 import { buildCopyPreview } from "@/lib/copy-preview";
 import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { withMockedToast } from "@/test-utils/mock-toast";
 import { AgentChatMessageCard } from "./agent-chat-message-card";
 
 enableReactActEnvironment();
 
 const writeClipboardMock = mock(async (_value: string) => {});
-
-const withMockedToast = async (
-  callback: (mocks: {
-    toastSuccessMock: ReturnType<typeof mock>;
-    toastErrorMock: ReturnType<typeof mock>;
-  }) => Promise<void>,
-): Promise<void> => {
-  const originalSuccess = toast.success;
-  const originalError = toast.error;
-  const toastSuccessMock = mock(() => "");
-  const toastErrorMock = mock(() => "");
-
-  toast.success = toastSuccessMock;
-  toast.error = toastErrorMock;
-
-  try {
-    await callback({ toastSuccessMock, toastErrorMock });
-  } finally {
-    toast.success = originalSuccess;
-    toast.error = originalError;
-  }
-};
 
 describe("AgentChatMessageCard assistant copy", () => {
   beforeEach(() => {
@@ -81,7 +59,7 @@ describe("AgentChatMessageCard assistant copy", () => {
     });
   });
 
-  test("copies completed intermediate assistant messages when isFinal is omitted", async () => {
+  test("copies completed intermediate assistant messages when they are not actively streaming", async () => {
     await withMockedToast(async ({ toastSuccessMock }) => {
       const markdown = "# Intermediate update\n\nStill working through the task.";
       const rendered = render(
@@ -94,8 +72,10 @@ describe("AgentChatMessageCard assistant copy", () => {
             meta: {
               kind: "assistant",
               agentRole: "planner",
+              isFinal: false,
             },
           },
+          isStreamingAssistantMessage: false,
           sessionRole: "planner",
           sessionSelectedModel: null,
           sessionAgentColors: {},
@@ -117,7 +97,7 @@ describe("AgentChatMessageCard assistant copy", () => {
     });
   });
 
-  test("shows the copied-state icon and resets it after the shared delay", async () => {
+  test("shows the copied-state icon after a successful copy", async () => {
     await withMockedToast(async () => {
       const rendered = render(
         createElement(AgentChatMessageCard, {
@@ -135,7 +115,6 @@ describe("AgentChatMessageCard assistant copy", () => {
           sessionRole: "planner",
           sessionSelectedModel: null,
           sessionAgentColors: {},
-          copyResetDelayMs: 5,
         }),
       );
 
@@ -147,10 +126,6 @@ describe("AgentChatMessageCard assistant copy", () => {
 
         await waitFor(() => {
           expect(button.querySelector(".lucide-check")).not.toBeNull();
-        });
-
-        await waitFor(() => {
-          expect(button.querySelector(".lucide-copy")).not.toBeNull();
         });
       } finally {
         rendered.unmount();

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -609,6 +609,29 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).toContain("group-hover/message:opacity-100");
   });
 
+  test("renders a hover-only copy button for completed intermediate assistant rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "assistant-intermediate-copyable",
+          role: "assistant",
+          content: "Intermediate progress update.",
+          timestamp: "2026-02-22T10:24:47.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "planner",
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("copy-assistant-message-content");
+    expect(html).toContain("group-hover/message:opacity-100");
+  });
+
   test("does not render a copy button for streaming assistant rows", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -620,8 +620,10 @@ describe("AgentChatMessageCard tool duration", () => {
           meta: {
             kind: "assistant",
             agentRole: "planner",
+            isFinal: false,
           },
         },
+        isStreamingAssistantMessage: false,
         sessionRole: "planner",
         sessionSelectedModel: null,
         sessionAgentColors: {},
@@ -646,6 +648,7 @@ describe("AgentChatMessageCard tool duration", () => {
             isFinal: false,
           },
         },
+        isStreamingAssistantMessage: true,
         sessionRole: "planner",
         sessionSelectedModel: null,
         sessionAgentColors: {},

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -584,6 +584,100 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain("background-color:#f97316");
   });
 
+  test("renders a hover-only copy button for completed assistant rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "assistant-copyable",
+          role: "assistant",
+          content: "# Summary\n\nImplemented the requested changes.",
+          timestamp: "2026-02-22T10:24:45.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "planner",
+            isFinal: true,
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("copy-assistant-message-content");
+    expect(html).toContain("group/message");
+    expect(html).toContain("group-hover/message:opacity-100");
+  });
+
+  test("does not render a copy button for streaming assistant rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "assistant-streaming",
+          role: "assistant",
+          content: "Still writing the answer",
+          timestamp: "2026-02-22T10:24:50.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "planner",
+            isFinal: false,
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).not.toContain("copy-assistant-message-content");
+  });
+
+  test("does not render a copy button for whitespace-only assistant rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "assistant-empty",
+          role: "assistant",
+          content: "   \n\t  ",
+          timestamp: "2026-02-22T10:24:55.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "planner",
+            isFinal: true,
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).not.toContain("copy-assistant-message-content");
+  });
+
+  test("does not render a copy button for reasoning rows", async () => {
+    const html = await renderToHtml(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "thinking-no-copy",
+          role: "thinking",
+          content: "Inspect the **diff** before applying.",
+          timestamp: "2026-02-22T10:25:00.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "part-thinking-no-copy",
+            completed: true,
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).not.toContain("copy-assistant-message-content");
+  });
+
   test("renders user messages with border color from send-time user agent metadata", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
@@ -6,20 +6,20 @@ import { buildAgentChatMessageCardViewModel } from "./agent-chat-message-card-vi
 
 type AgentChatMessageCardProps = {
   message: AgentChatMessage;
+  isStreamingAssistantMessage?: boolean;
   sessionRole: AgentRole | null;
   sessionSelectedModel?: AgentModelSelection | null;
   sessionAgentColors?: Record<string, string>;
   sessionWorkingDirectory?: string | null | undefined;
-  copyResetDelayMs?: number;
 };
 
 export const AgentChatMessageCard = memo(function AgentChatMessageCard({
   message,
+  isStreamingAssistantMessage = false,
   sessionRole,
   sessionSelectedModel,
   sessionAgentColors,
   sessionWorkingDirectory,
-  copyResetDelayMs,
 }: AgentChatMessageCardProps): ReactElement | null {
   const vm = buildAgentChatMessageCardViewModel({
     message,
@@ -41,10 +41,10 @@ export const AgentChatMessageCard = memo(function AgentChatMessageCard({
       <MessageBody
         message={message}
         assistantAccentColor={vm.assistantAccentColor}
+        isStreamingAssistantMessage={isStreamingAssistantMessage}
         timeLabel={vm.timeLabel}
         systemPromptBody={vm.systemPromptBody}
         sessionWorkingDirectory={sessionWorkingDirectory}
-        {...(copyResetDelayMs === undefined ? {} : { copyResetDelayMs })}
       />
     </article>
   );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
@@ -10,6 +10,7 @@ type AgentChatMessageCardProps = {
   sessionSelectedModel?: AgentModelSelection | null;
   sessionAgentColors?: Record<string, string>;
   sessionWorkingDirectory?: string | null | undefined;
+  copyResetDelayMs?: number;
 };
 
 export const AgentChatMessageCard = memo(function AgentChatMessageCard({
@@ -18,6 +19,7 @@ export const AgentChatMessageCard = memo(function AgentChatMessageCard({
   sessionSelectedModel,
   sessionAgentColors,
   sessionWorkingDirectory,
+  copyResetDelayMs,
 }: AgentChatMessageCardProps): ReactElement | null {
   const vm = buildAgentChatMessageCardViewModel({
     message,
@@ -42,6 +44,7 @@ export const AgentChatMessageCard = memo(function AgentChatMessageCard({
         timeLabel={vm.timeLabel}
         systemPromptBody={vm.systemPromptBody}
         sessionWorkingDirectory={sessionWorkingDirectory}
+        {...(copyResetDelayMs === undefined ? {} : { copyResetDelayMs })}
       />
     </article>
   );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-streaming.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-streaming.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { resolveActiveStreamingAssistantMessageId } from "./agent-chat-streaming";
+import { buildMessage, buildSession } from "./agent-chat-test-fixtures";
+
+describe("resolveActiveStreamingAssistantMessageId", () => {
+  test("returns the trailing non-final assistant row while a session is running", () => {
+    const session = buildSession({
+      status: "running",
+      messages: [
+        buildMessage("assistant", "Still working", {
+          id: "assistant-live",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: false,
+          },
+        }),
+      ],
+      pendingQuestions: [],
+    });
+
+    expect(resolveActiveStreamingAssistantMessageId(session)).toBe("assistant-live");
+  });
+
+  test("treats non-final assistant rows as stable once later transcript rows exist", () => {
+    const session = buildSession({
+      status: "running",
+      messages: [
+        buildMessage("assistant", "Let me inspect the code.", {
+          id: "assistant-intermediate",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: false,
+          },
+        }),
+        buildMessage("tool", "Tool read completed", {
+          id: "tool-1",
+          meta: {
+            kind: "tool",
+            partId: "part-1",
+            callId: "call-1",
+            tool: "read",
+            status: "completed",
+          },
+        }),
+      ],
+      pendingQuestions: [],
+    });
+
+    expect(resolveActiveStreamingAssistantMessageId(session)).toBeNull();
+  });
+
+  test("does not mark non-final assistant rows as streaming after the session stops", () => {
+    const session = buildSession({
+      status: "idle",
+      messages: [
+        buildMessage("assistant", "Intermediate summary", {
+          id: "assistant-history",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: false,
+          },
+        }),
+      ],
+      pendingQuestions: [],
+    });
+
+    expect(resolveActiveStreamingAssistantMessageId(session)).toBeNull();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-streaming.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-streaming.test.ts
@@ -22,7 +22,7 @@ describe("resolveActiveStreamingAssistantMessageId", () => {
     expect(resolveActiveStreamingAssistantMessageId(session)).toBe("assistant-live");
   });
 
-  test("treats non-final assistant rows as stable once later transcript rows exist", () => {
+  test("keeps tracking a live non-final assistant row after later tool rows are appended", () => {
     const session = buildSession({
       status: "running",
       messages: [
@@ -48,7 +48,36 @@ describe("resolveActiveStreamingAssistantMessageId", () => {
       pendingQuestions: [],
     });
 
-    expect(resolveActiveStreamingAssistantMessageId(session)).toBeNull();
+    expect(resolveActiveStreamingAssistantMessageId(session)).toBe("assistant-intermediate");
+  });
+
+  test("keeps tracking a live non-final assistant row after later subtask rows are appended", () => {
+    const session = buildSession({
+      status: "running",
+      messages: [
+        buildMessage("assistant", "Drafting the plan", {
+          id: "assistant-subtask-live",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: false,
+          },
+        }),
+        buildMessage("system", "Subtask (planner): inspect tests", {
+          id: "subtask:planner-1",
+          meta: {
+            kind: "subtask",
+            partId: "part-subtask-1",
+            agent: "planner",
+            prompt: "Inspect the tests",
+            description: "inspect tests",
+          },
+        }),
+      ],
+      pendingQuestions: [],
+    });
+
+    expect(resolveActiveStreamingAssistantMessageId(session)).toBe("assistant-subtask-live");
   });
 
   test("does not mark non-final assistant rows as streaming after the session stops", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-streaming.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-streaming.ts
@@ -1,0 +1,18 @@
+import { findLastSessionMessage } from "@/state/operations/agent-orchestrator/support/messages";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+
+export const resolveActiveStreamingAssistantMessageId = (
+  session: Pick<AgentSessionState, "sessionId" | "messages" | "status"> | null,
+): string | null => {
+  if (!session || session.status !== "running") {
+    return null;
+  }
+
+  const lastMessage = findLastSessionMessage(session);
+  if (!lastMessage || lastMessage.role !== "assistant") {
+    return null;
+  }
+
+  const assistantMeta = lastMessage.meta?.kind === "assistant" ? lastMessage.meta : null;
+  return assistantMeta?.isFinal === false ? lastMessage.id : null;
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-streaming.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-streaming.ts
@@ -1,4 +1,4 @@
-import { findLastSessionMessage } from "@/state/operations/agent-orchestrator/support/messages";
+import { findLastSessionMessageByRole } from "@/state/operations/agent-orchestrator/support/messages";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
 export const resolveActiveStreamingAssistantMessageId = (
@@ -8,11 +8,11 @@ export const resolveActiveStreamingAssistantMessageId = (
     return null;
   }
 
-  const lastMessage = findLastSessionMessage(session);
-  if (!lastMessage || lastMessage.role !== "assistant") {
-    return null;
-  }
+  const lastStreamingAssistantMessage = findLastSessionMessageByRole(
+    session,
+    "assistant",
+    (message) => message.meta?.kind === "assistant" && message.meta.isFinal === false,
+  );
 
-  const assistantMeta = lastMessage.meta?.kind === "assistant" ? lastMessage.meta : null;
-  return assistantMeta?.isFinal === false ? lastMessage.id : null;
+  return lastStreamingAssistantMessage?.id ?? null;
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.test.tsx
@@ -6,6 +6,7 @@ import { AgentChatThreadRow } from "./agent-chat-thread-row";
 import type { AgentChatWindowRow } from "./agent-chat-thread-windowing";
 
 const baseProps = {
+  activeStreamingAssistantMessageId: null,
   sessionAgentColors: {},
   sessionRole: "spec" as const,
   sessionWorkingDirectory: "/repo",

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.test.tsx
@@ -6,7 +6,7 @@ import { AgentChatThreadRow } from "./agent-chat-thread-row";
 import type { AgentChatWindowRow } from "./agent-chat-thread-windowing";
 
 const baseProps = {
-  activeStreamingAssistantMessageId: null,
+  isStreamingAssistantMessage: false,
   sessionAgentColors: {},
   sessionRole: "spec" as const,
   sessionWorkingDirectory: "/repo",

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
@@ -8,7 +8,7 @@ import { AgentTurnDurationSeparator } from "./agent-turn-duration-separator";
 
 type AgentChatWindowRowProps = {
   row: AgentChatWindowRow;
-  activeStreamingAssistantMessageId: string | null;
+  isStreamingAssistantMessage: boolean;
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
@@ -16,7 +16,7 @@ type AgentChatWindowRowProps = {
 
 export const AgentChatThreadRow = memo(function AgentChatThreadRow({
   row,
-  activeStreamingAssistantMessageId,
+  isStreamingAssistantMessage,
   sessionAgentColors,
   sessionRole,
   sessionWorkingDirectory,
@@ -31,7 +31,7 @@ export const AgentChatThreadRow = memo(function AgentChatThreadRow({
         <div className={cn("flow-root", isUserMessage ? "pt-4" : undefined)}>
           <AgentChatMessageCard
             message={row.message}
-            isStreamingAssistantMessage={row.message.id === activeStreamingAssistantMessageId}
+            isStreamingAssistantMessage={isStreamingAssistantMessage}
             sessionRole={sessionRole}
             sessionAgentColors={sessionAgentColors}
             sessionWorkingDirectory={sessionWorkingDirectory}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
@@ -8,6 +8,7 @@ import { AgentTurnDurationSeparator } from "./agent-turn-duration-separator";
 
 type AgentChatWindowRowProps = {
   row: AgentChatWindowRow;
+  activeStreamingAssistantMessageId: string | null;
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
@@ -15,6 +16,7 @@ type AgentChatWindowRowProps = {
 
 export const AgentChatThreadRow = memo(function AgentChatThreadRow({
   row,
+  activeStreamingAssistantMessageId,
   sessionAgentColors,
   sessionRole,
   sessionWorkingDirectory,
@@ -29,6 +31,7 @@ export const AgentChatThreadRow = memo(function AgentChatThreadRow({
         <div className={cn("flow-root", isUserMessage ? "pt-4" : undefined)}>
           <AgentChatMessageCard
             message={row.message}
+            isStreamingAssistantMessage={row.message.id === activeStreamingAssistantMessageId}
             sessionRole={sessionRole}
             sessionAgentColors={sessionAgentColors}
             sessionWorkingDirectory={sessionWorkingDirectory}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -20,6 +20,7 @@ import {
 import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
 import { resolveAgentAccentColor } from "../agent-accent-color";
 import type { AgentChatThreadModel } from "./agent-chat.types";
+import { resolveActiveStreamingAssistantMessageId } from "./agent-chat-streaming";
 import { AgentChatThreadRow } from "./agent-chat-thread-row";
 import { getAgentChatThreadState } from "./agent-chat-thread-state";
 import {
@@ -45,6 +46,7 @@ import { useAgentChatWindow } from "./use-agent-chat-window";
 
 type AgentChatThreadMotionRowProps = {
   row: AgentChatWindowRow;
+  activeStreamingAssistantMessageId: string | null;
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
@@ -52,6 +54,7 @@ type AgentChatThreadMotionRowProps = {
 };
 
 type AgentChatTranscriptProps = {
+  activeStreamingAssistantMessageId: string | null;
   hasSession: boolean;
   taskSelected: boolean;
   canKickoffNewSession: boolean;
@@ -137,6 +140,7 @@ const areChatRowsEquivalent = (left: AgentChatWindowRow, right: AgentChatWindowR
 const AgentChatThreadMotionRow = memo(
   function AgentChatThreadMotionRow({
     row,
+    activeStreamingAssistantMessageId,
     sessionAgentColors,
     sessionRole,
     sessionWorkingDirectory,
@@ -146,6 +150,7 @@ const AgentChatThreadMotionRow = memo(
       <div ref={resolveRowRef(row.key)} data-row-key={row.key} className="agent-chat-row-motion">
         <AgentChatThreadRow
           row={row}
+          activeStreamingAssistantMessageId={activeStreamingAssistantMessageId}
           sessionRole={sessionRole}
           sessionAgentColors={sessionAgentColors}
           sessionWorkingDirectory={sessionWorkingDirectory}
@@ -157,6 +162,8 @@ const AgentChatThreadMotionRow = memo(
     return (
       previousProps.sessionRole === nextProps.sessionRole &&
       previousProps.sessionWorkingDirectory === nextProps.sessionWorkingDirectory &&
+      previousProps.activeStreamingAssistantMessageId ===
+        nextProps.activeStreamingAssistantMessageId &&
       previousProps.sessionAgentColors === nextProps.sessionAgentColors &&
       previousProps.resolveRowRef === nextProps.resolveRowRef &&
       areChatRowsEquivalent(previousProps.row, nextProps.row)
@@ -166,6 +173,7 @@ const AgentChatThreadMotionRow = memo(
 
 const AgentChatTurnGroup = memo(function AgentChatTurnGroup({
   turn,
+  activeStreamingAssistantMessageId,
   sessionAgentColors,
   sessionRole,
   sessionWorkingDirectory,
@@ -173,6 +181,7 @@ const AgentChatTurnGroup = memo(function AgentChatTurnGroup({
   allowTurnContainment,
 }: {
   turn: AgentChatRenderedTurn;
+  activeStreamingAssistantMessageId: string | null;
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
@@ -185,6 +194,7 @@ const AgentChatTurnGroup = memo(function AgentChatTurnGroup({
         <AgentChatThreadMotionRow
           key={row.key}
           row={row}
+          activeStreamingAssistantMessageId={activeStreamingAssistantMessageId}
           sessionRole={sessionRole}
           sessionAgentColors={sessionAgentColors}
           sessionWorkingDirectory={sessionWorkingDirectory}
@@ -196,6 +206,7 @@ const AgentChatTurnGroup = memo(function AgentChatTurnGroup({
 });
 
 const AgentChatTranscript = memo(function AgentChatTranscript({
+  activeStreamingAssistantMessageId,
   hasSession,
   taskSelected,
   canKickoffNewSession,
@@ -294,6 +305,7 @@ const AgentChatTranscript = memo(function AgentChatTranscript({
               <AgentChatTurnGroup
                 key={turn.key}
                 turn={turn}
+                activeStreamingAssistantMessageId={activeStreamingAssistantMessageId}
                 sessionRole={sessionRole}
                 sessionAgentColors={sessionAgentColors}
                 sessionWorkingDirectory={sessionWorkingDirectory}
@@ -639,6 +651,9 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     const latestUserMessage = findLastUserSessionMessage(session);
     return latestUserMessage ? `${session.sessionId}:${latestUserMessage.id}` : null;
   }, [isSessionWorking, session]);
+  const activeStreamingAssistantMessageId = useMemo(() => {
+    return resolveActiveStreamingAssistantMessageId(session);
+  }, [session]);
   const renderedTurns = useMemo(() => {
     return stagedTurns.map((turn) => ({
       key: turn.key,
@@ -695,6 +710,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
       <AgentChatTranscript
+        activeStreamingAssistantMessageId={activeStreamingAssistantMessageId}
         hasSession={session !== null}
         taskSelected={taskSelected}
         canKickoffNewSession={canKickoffNewSession}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -46,7 +46,7 @@ import { useAgentChatWindow } from "./use-agent-chat-window";
 
 type AgentChatThreadMotionRowProps = {
   row: AgentChatWindowRow;
-  activeStreamingAssistantMessageId: string | null;
+  isStreamingAssistantMessage: boolean;
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
@@ -140,7 +140,7 @@ const areChatRowsEquivalent = (left: AgentChatWindowRow, right: AgentChatWindowR
 const AgentChatThreadMotionRow = memo(
   function AgentChatThreadMotionRow({
     row,
-    activeStreamingAssistantMessageId,
+    isStreamingAssistantMessage,
     sessionAgentColors,
     sessionRole,
     sessionWorkingDirectory,
@@ -150,7 +150,7 @@ const AgentChatThreadMotionRow = memo(
       <div ref={resolveRowRef(row.key)} data-row-key={row.key} className="agent-chat-row-motion">
         <AgentChatThreadRow
           row={row}
-          activeStreamingAssistantMessageId={activeStreamingAssistantMessageId}
+          isStreamingAssistantMessage={isStreamingAssistantMessage}
           sessionRole={sessionRole}
           sessionAgentColors={sessionAgentColors}
           sessionWorkingDirectory={sessionWorkingDirectory}
@@ -162,8 +162,7 @@ const AgentChatThreadMotionRow = memo(
     return (
       previousProps.sessionRole === nextProps.sessionRole &&
       previousProps.sessionWorkingDirectory === nextProps.sessionWorkingDirectory &&
-      previousProps.activeStreamingAssistantMessageId ===
-        nextProps.activeStreamingAssistantMessageId &&
+      previousProps.isStreamingAssistantMessage === nextProps.isStreamingAssistantMessage &&
       previousProps.sessionAgentColors === nextProps.sessionAgentColors &&
       previousProps.resolveRowRef === nextProps.resolveRowRef &&
       areChatRowsEquivalent(previousProps.row, nextProps.row)
@@ -194,7 +193,9 @@ const AgentChatTurnGroup = memo(function AgentChatTurnGroup({
         <AgentChatThreadMotionRow
           key={row.key}
           row={row}
-          activeStreamingAssistantMessageId={activeStreamingAssistantMessageId}
+          isStreamingAssistantMessage={
+            row.kind === "message" && row.message.id === activeStreamingAssistantMessageId
+          }
           sessionRole={sessionRole}
           sessionAgentColors={sessionAgentColors}
           sessionWorkingDirectory={sessionWorkingDirectory}

--- a/apps/desktop/src/components/features/agents/agent-studio-workspace-sidebar.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-workspace-sidebar.tsx
@@ -4,6 +4,7 @@ import type { TaskDocumentState } from "@/components/features/task-details/use-t
 import { Button } from "@/components/ui/button";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { buildCopyPreview } from "@/lib/copy-preview";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 
 export type AgentStudioWorkspaceDocument = {
@@ -41,15 +42,6 @@ type DocumentSectionProps = {
   emptyState: string;
   document: TaskDocumentState;
 };
-
-const DOCUMENT_COPY_PREVIEW_LENGTH = 50;
-
-function buildCopyPreview(markdown: string): string {
-  if (markdown.length <= DOCUMENT_COPY_PREVIEW_LENGTH) {
-    return markdown;
-  }
-  return `${markdown.slice(0, DOCUMENT_COPY_PREVIEW_LENGTH)}...`;
-}
 
 function AgentStudioDocumentCopyButton({ markdown }: { markdown: string }): ReactElement {
   const { copied, copyToClipboard } = useCopyToClipboard({

--- a/apps/desktop/src/components/features/agents/agent-studio-workspace-sidebar.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-workspace-sidebar.tsx
@@ -1,9 +1,7 @@
-import { Check, Copy } from "lucide-react";
 import { type MouseEvent, type ReactElement, useCallback } from "react";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
-import { Button } from "@/components/ui/button";
+import { CopyIconButton } from "@/components/ui/copy-icon-button";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { buildCopyPreview } from "@/lib/copy-preview";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 
@@ -59,30 +57,13 @@ function AgentStudioDocumentCopyButton({ markdown }: { markdown: string }): Reac
   );
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="absolute top-2 right-2 z-10 size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
-            aria-label="Copy document content"
-            data-testid="copy-agent-studio-document-content"
-            onClick={handleCopy}
-          >
-            {copied ? (
-              <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
-            ) : (
-              <Copy className="size-3.5" />
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="left">
-          <p>Copy</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <CopyIconButton
+      copied={copied}
+      ariaLabel="Copy document content"
+      dataTestId="copy-agent-studio-document-content"
+      className="absolute top-2 right-2 z-10"
+      onClick={handleCopy}
+    />
   );
 }
 

--- a/apps/desktop/src/components/features/task-details/task-details-markdown-content.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-markdown-content.test.tsx
@@ -1,26 +1,27 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
 import { buildCopyPreview } from "@/lib/copy-preview";
 import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { replaceNavigatorClipboard } from "@/test-utils/mock-clipboard";
 import { withMockedToast } from "@/test-utils/mock-toast";
 import { TaskDetailsMarkdownContent } from "./task-details-markdown-content";
 
 enableReactActEnvironment();
 
 const writeClipboardMock = mock(async (_value: string) => {});
+let restoreClipboard: (() => void) | null = null;
 
 describe("TaskDetailsMarkdownContent", () => {
   beforeEach(() => {
     writeClipboardMock.mockClear();
     writeClipboardMock.mockImplementation(async () => {});
+    restoreClipboard = replaceNavigatorClipboard(writeClipboardMock);
+  });
 
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: {
-        writeText: writeClipboardMock,
-      },
-    });
+  afterEach(() => {
+    restoreClipboard?.();
+    restoreClipboard = null;
   });
 
   test("renders floating copy button when copyable markdown is provided", () => {

--- a/apps/desktop/src/components/features/task-details/task-details-markdown-content.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-markdown-content.test.tsx
@@ -1,40 +1,17 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
+import { buildCopyPreview } from "@/lib/copy-preview";
 import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
-import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+import { withMockedToast } from "@/test-utils/mock-toast";
+import { TaskDetailsMarkdownContent } from "./task-details-markdown-content";
 
 enableReactActEnvironment();
 
-const toastSuccessMock = mock(() => {});
-const toastErrorMock = mock(() => {});
 const writeClipboardMock = mock(async (_value: string) => {});
 
-type TaskDetailsMarkdownContentComponent =
-  typeof import("./task-details-markdown-content").TaskDetailsMarkdownContent;
-let TaskDetailsMarkdownContent: TaskDetailsMarkdownContentComponent;
-
 describe("TaskDetailsMarkdownContent", () => {
-  beforeAll(async () => {
-    mock.module("sonner", () => ({
-      toast: {
-        success: toastSuccessMock,
-        error: toastErrorMock,
-        loading: () => "",
-        dismiss: () => {},
-      },
-    }));
-
-    ({ TaskDetailsMarkdownContent } = await import("./task-details-markdown-content"));
-  });
-
-  afterAll(async () => {
-    await restoreMockedModules([["sonner", () => import("sonner")]]);
-  });
-
   beforeEach(() => {
-    toastSuccessMock.mockClear();
-    toastErrorMock.mockClear();
     writeClipboardMock.mockClear();
     writeClipboardMock.mockImplementation(async () => {});
 
@@ -77,99 +54,111 @@ describe("TaskDetailsMarkdownContent", () => {
   });
 
   test("copies markdown and shows success toast", async () => {
-    const markdown = "12345678901234567890123456789012345678901234567890tail";
-    const rendered = render(
-      createElement(TaskDetailsMarkdownContent, {
-        markdown,
-        empty: "No doc",
-        active: true,
-        copyableMarkdown: markdown,
-      }),
-    );
+    await withMockedToast(async ({ toastSuccessMock }) => {
+      const markdown = "12345678901234567890123456789012345678901234567890tail";
+      const rendered = render(
+        createElement(TaskDetailsMarkdownContent, {
+          markdown,
+          empty: "No doc",
+          active: true,
+          copyableMarkdown: markdown,
+        }),
+      );
 
-    fireEvent.click(rendered.getByTestId("copy-document-content"));
+      try {
+        fireEvent.click(rendered.getByTestId("copy-document-content"));
 
-    await waitFor(() => {
-      expect(writeClipboardMock).toHaveBeenCalledWith(markdown);
-      expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
-        description: `${markdown.slice(0, 50)}...`,
-      });
+        await waitFor(() => {
+          expect(writeClipboardMock).toHaveBeenCalledWith(markdown);
+          expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
+            description: buildCopyPreview(markdown),
+          });
+        });
+      } finally {
+        rendered.unmount();
+      }
     });
-    rendered.unmount();
   });
 
   test("uses full markdown as success preview when text is short", async () => {
-    const markdown = "short text";
-    const rendered = render(
-      createElement(TaskDetailsMarkdownContent, {
-        markdown,
-        empty: "No doc",
-        active: true,
-        copyableMarkdown: markdown,
-      }),
-    );
+    await withMockedToast(async ({ toastSuccessMock }) => {
+      const markdown = "short text";
+      const rendered = render(
+        createElement(TaskDetailsMarkdownContent, {
+          markdown,
+          empty: "No doc",
+          active: true,
+          copyableMarkdown: markdown,
+        }),
+      );
 
-    fireEvent.click(rendered.getByTestId("copy-document-content"));
+      try {
+        fireEvent.click(rendered.getByTestId("copy-document-content"));
 
-    await waitFor(() => {
-      expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
-        description: markdown,
-      });
+        await waitFor(() => {
+          expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
+            description: buildCopyPreview(markdown),
+          });
+        });
+      } finally {
+        rendered.unmount();
+      }
     });
-    rendered.unmount();
   });
 
   test("shows error toast when clipboard copy fails", async () => {
-    const error = new DOMException("blocked by browser", "NotAllowedError");
-    writeClipboardMock.mockImplementation(async () => {
-      throw error;
-    });
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const error = new DOMException("blocked by browser", "NotAllowedError");
+      writeClipboardMock.mockImplementation(async () => {
+        throw error;
+      });
 
-    const rendered = render(
-      createElement(TaskDetailsMarkdownContent, {
-        markdown: "# QA\n\nfailed",
-        empty: "No QA",
-        active: true,
-        copyableMarkdown: "# QA\n\nfailed",
-      }),
-    );
-
-    fireEvent.click(rendered.getByTestId("copy-document-content"));
-
-    await waitFor(() => {
-      expect(toastErrorMock).toHaveBeenCalledWith(
-        "Permission denied: clipboard access not allowed",
+      const rendered = render(
+        createElement(TaskDetailsMarkdownContent, {
+          markdown: "# QA\n\nfailed",
+          empty: "No QA",
+          active: true,
+          copyableMarkdown: "# QA\n\nfailed",
+        }),
       );
+
+      try {
+        fireEvent.click(rendered.getByTestId("copy-document-content"));
+
+        await waitFor(() => {
+          expect(toastErrorMock).toHaveBeenCalledWith(
+            "Permission denied: clipboard access not allowed",
+          );
+        });
+      } finally {
+        rendered.unmount();
+      }
     });
-    rendered.unmount();
   });
 
-  test("shows check icon for two seconds after successful copy", async () => {
-    const rendered = render(
-      createElement(TaskDetailsMarkdownContent, {
-        markdown: "# Spec",
-        empty: "No doc",
-        active: true,
-        copyableMarkdown: "# Spec",
-        copyResetDelayMs: 5,
-      }),
-    );
+  test("shows check icon after successful copy", async () => {
+    await withMockedToast(async () => {
+      const rendered = render(
+        createElement(TaskDetailsMarkdownContent, {
+          markdown: "# Spec",
+          empty: "No doc",
+          active: true,
+          copyableMarkdown: "# Spec",
+        }),
+      );
 
-    try {
-      const button = rendered.getByTestId("copy-document-content");
-      expect(button.querySelector(".lucide-copy")).not.toBeNull();
-
-      fireEvent.click(button);
-
-      await waitFor(() => {
-        expect(button.querySelector(".lucide-check")).not.toBeNull();
-      });
-
-      await waitFor(() => {
+      try {
+        const button = rendered.getByTestId("copy-document-content");
         expect(button.querySelector(".lucide-copy")).not.toBeNull();
-      });
-    } finally {
-      rendered.unmount();
-    }
+
+        fireEvent.click(button);
+
+        await waitFor(() => {
+          expect(button.querySelector(".lucide-check")).not.toBeNull();
+        });
+      } finally {
+        rendered.unmount();
+      }
+    });
   });
 });

--- a/apps/desktop/src/components/features/task-details/task-details-markdown-content.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-markdown-content.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { buildCopyPreview } from "@/lib/copy-preview";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 
 type TaskDetailsMarkdownContentProps = {
@@ -23,8 +24,6 @@ type TaskDetailsMarkdownContentProps = {
 
 const LARGE_MARKDOWN_DEFER_THRESHOLD = 2000;
 const LABELED_CODE_FENCE_PATTERN = /^[ \t]{0,3}(?:```|~~~)[ \t]*[^\s`~]/im;
-const MARKDOWN_COPY_PREVIEW_LENGTH = 50;
-
 type TaskDetailsRenderedMarkdownProps = {
   markdown: string;
   hasLabeledCodeFence: boolean;
@@ -137,13 +136,6 @@ function TaskDetailsCopyButton({
       </Tooltip>
     </TooltipProvider>
   );
-}
-
-function buildCopyPreview(markdown: string): string {
-  if (markdown.length <= MARKDOWN_COPY_PREVIEW_LENGTH) {
-    return markdown;
-  }
-  return `${markdown.slice(0, MARKDOWN_COPY_PREVIEW_LENGTH)}...`;
 }
 
 export const TaskDetailsMarkdownContent = memo(function TaskDetailsMarkdownContent({

--- a/apps/desktop/src/components/features/task-details/task-details-markdown-content.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-markdown-content.tsx
@@ -1,4 +1,3 @@
-import { Check, Copy } from "lucide-react";
 import {
   type MouseEvent,
   memo,
@@ -8,9 +7,8 @@ import {
   useEffect,
   useState,
 } from "react";
-import { Button } from "@/components/ui/button";
+import { CopyIconButton } from "@/components/ui/copy-icon-button";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { buildCopyPreview } from "@/lib/copy-preview";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 
@@ -19,7 +17,6 @@ type TaskDetailsMarkdownContentProps = {
   empty: string;
   active: boolean;
   copyableMarkdown?: string;
-  copyResetDelayMs?: number;
 };
 
 const LARGE_MARKDOWN_DEFER_THRESHOLD = 2000;
@@ -98,43 +95,16 @@ function DeferredTaskDetailsMarkdown({
           hasLabeledCodeFence={hasLabeledCodeFence}
         />
       </div>
-      {copyableMarkdown ? <TaskDetailsCopyButton copied={copied} onClick={onCopy} /> : null}
+      {copyableMarkdown ? (
+        <CopyIconButton
+          copied={copied}
+          ariaLabel="Copy document content"
+          dataTestId="copy-document-content"
+          className="absolute top-2 right-2 z-10"
+          onClick={onCopy}
+        />
+      ) : null}
     </div>
-  );
-}
-
-function TaskDetailsCopyButton({
-  copied,
-  onClick,
-}: {
-  copied: boolean;
-  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
-}): ReactElement {
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="absolute top-2 right-2 z-10 size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
-            aria-label="Copy document content"
-            data-testid="copy-document-content"
-            onClick={onClick}
-          >
-            {copied ? (
-              <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
-            ) : (
-              <Copy className="size-3.5" />
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="left">
-          <p>Copy</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
   );
 }
 
@@ -143,11 +113,9 @@ export const TaskDetailsMarkdownContent = memo(function TaskDetailsMarkdownConte
   empty,
   active,
   copyableMarkdown,
-  copyResetDelayMs,
 }: TaskDetailsMarkdownContentProps): ReactElement {
   const { copied, copyToClipboard } = useCopyToClipboard({
     getSuccessDescription: buildCopyPreview,
-    ...(copyResetDelayMs === undefined ? {} : { resetDelayMs: copyResetDelayMs }),
     errorLogContext: "TaskDetailsMarkdownContent",
   });
   const hasContent = /\S/.test(markdown);
@@ -196,7 +164,15 @@ export const TaskDetailsMarkdownContent = memo(function TaskDetailsMarkdownConte
           hasLabeledCodeFence={hasLabeledCodeFence}
         />
       </div>
-      {copyableMarkdown ? <TaskDetailsCopyButton copied={copied} onClick={handleCopy} /> : null}
+      {copyableMarkdown ? (
+        <CopyIconButton
+          copied={copied}
+          ariaLabel="Copy document content"
+          dataTestId="copy-document-content"
+          className="absolute top-2 right-2 z-10"
+          onClick={handleCopy}
+        />
+      ) : null}
     </div>
   );
 });

--- a/apps/desktop/src/components/ui/copy-icon-button.tsx
+++ b/apps/desktop/src/components/ui/copy-icon-button.tsx
@@ -1,0 +1,53 @@
+import { Check, Copy } from "lucide-react";
+import type { MouseEventHandler, ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type CopyIconButtonProps = {
+  copied: boolean;
+  ariaLabel: string;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  className?: string;
+  dataTestId?: string;
+  tooltipLabel?: string;
+};
+
+export function CopyIconButton({
+  copied,
+  ariaLabel,
+  onClick,
+  className,
+  dataTestId,
+  tooltipLabel = "Copy",
+}: CopyIconButtonProps): ReactElement {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className={cn(
+              "size-7 text-muted-foreground hover:bg-accent hover:text-foreground",
+              className,
+            )}
+            aria-label={ariaLabel}
+            {...(dataTestId ? { "data-testid": dataTestId } : {})}
+            onClick={onClick}
+          >
+            {copied ? (
+              <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
+            ) : (
+              <Copy className="size-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          <p>{tooltipLabel}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/desktop/src/lib/copy-preview.ts
+++ b/apps/desktop/src/lib/copy-preview.ts
@@ -1,0 +1,9 @@
+const COPY_PREVIEW_LENGTH = 50;
+
+export function buildCopyPreview(value: string): string {
+  if (value.length <= COPY_PREVIEW_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, COPY_PREVIEW_LENGTH)}...`;
+}

--- a/apps/desktop/src/lib/use-copy-to-clipboard.test.tsx
+++ b/apps/desktop/src/lib/use-copy-to-clipboard.test.tsx
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement, type ReactElement } from "react";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { withMockedToast } from "@/test-utils/mock-toast";
+import { useCopyToClipboard } from "./use-copy-to-clipboard";
+
+enableReactActEnvironment();
+
+const writeClipboardMock = mock(async (_value: string) => {});
+
+function ClipboardHookHarness({ resetDelayMs }: { resetDelayMs: number }): ReactElement {
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    resetDelayMs,
+  });
+
+  return (
+    <button
+      type="button"
+      data-testid="copy-harness"
+      data-copied={copied ? "true" : "false"}
+      onClick={() => {
+        void copyToClipboard("# Spec");
+      }}
+    >
+      Copy
+    </button>
+  );
+}
+
+describe("useCopyToClipboard", () => {
+  beforeEach(() => {
+    writeClipboardMock.mockClear();
+    writeClipboardMock.mockImplementation(async () => {});
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: writeClipboardMock,
+      },
+    });
+  });
+
+  test("resets copied state after the configured delay", async () => {
+    await withMockedToast(async () => {
+      const rendered = render(createElement(ClipboardHookHarness, { resetDelayMs: 5 }));
+
+      try {
+        const button = rendered.getByTestId("copy-harness");
+        expect(button.getAttribute("data-copied")).toBe("false");
+
+        fireEvent.click(button);
+
+        await waitFor(() => {
+          expect(button.getAttribute("data-copied")).toBe("true");
+        });
+
+        await waitFor(() => {
+          expect(button.getAttribute("data-copied")).toBe("false");
+        });
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+});

--- a/apps/desktop/src/lib/use-copy-to-clipboard.test.tsx
+++ b/apps/desktop/src/lib/use-copy-to-clipboard.test.tsx
@@ -1,13 +1,15 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement, type ReactElement } from "react";
 import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { replaceNavigatorClipboard } from "@/test-utils/mock-clipboard";
 import { withMockedToast } from "@/test-utils/mock-toast";
 import { useCopyToClipboard } from "./use-copy-to-clipboard";
 
 enableReactActEnvironment();
 
 const writeClipboardMock = mock(async (_value: string) => {});
+let restoreClipboard: (() => void) | null = null;
 
 function ClipboardHookHarness({ resetDelayMs }: { resetDelayMs: number }): ReactElement {
   const { copied, copyToClipboard } = useCopyToClipboard({
@@ -32,13 +34,12 @@ describe("useCopyToClipboard", () => {
   beforeEach(() => {
     writeClipboardMock.mockClear();
     writeClipboardMock.mockImplementation(async () => {});
+    restoreClipboard = replaceNavigatorClipboard(writeClipboardMock);
+  });
 
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: {
-        writeText: writeClipboardMock,
-      },
-    });
+  afterEach(() => {
+    restoreClipboard?.();
+    restoreClipboard = null;
   });
 
   test("resets copied state after the configured delay", async () => {

--- a/apps/desktop/src/test-utils/mock-clipboard.ts
+++ b/apps/desktop/src/test-utils/mock-clipboard.ts
@@ -1,0 +1,21 @@
+export const replaceNavigatorClipboard = (
+  writeText: (value: string) => Promise<void>,
+): (() => void) => {
+  const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText,
+    },
+  });
+
+  return () => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+      return;
+    }
+
+    Reflect.deleteProperty(navigator, "clipboard");
+  };
+};

--- a/apps/desktop/src/test-utils/mock-toast.ts
+++ b/apps/desktop/src/test-utils/mock-toast.ts
@@ -15,6 +15,10 @@ export const withMockedToast = async (
   toast.success = toastSuccessMock;
   toast.error = toastErrorMock;
 
+  if (toast.success !== toastSuccessMock || toast.error !== toastErrorMock) {
+    throw new Error("withMockedToast: toast properties are not writable");
+  }
+
   try {
     await callback({ toastSuccessMock, toastErrorMock });
   } finally {

--- a/apps/desktop/src/test-utils/mock-toast.ts
+++ b/apps/desktop/src/test-utils/mock-toast.ts
@@ -1,0 +1,24 @@
+import { mock } from "bun:test";
+import { toast } from "sonner";
+
+export const withMockedToast = async (
+  callback: (mocks: {
+    toastSuccessMock: ReturnType<typeof mock>;
+    toastErrorMock: ReturnType<typeof mock>;
+  }) => Promise<void>,
+): Promise<void> => {
+  const originalSuccess = toast.success;
+  const originalError = toast.error;
+  const toastSuccessMock = mock(() => "");
+  const toastErrorMock = mock(() => "");
+
+  toast.success = toastSuccessMock;
+  toast.error = toastErrorMock;
+
+  try {
+    await callback({ toastSuccessMock, toastErrorMock });
+  } finally {
+    toast.success = originalSuccess;
+    toast.error = originalError;
+  }
+};


### PR DESCRIPTION
## Summary
- add a hover-only copy action for assistant transcript messages in Agent Studio and keep it available for completed intermediate assistant rows while hiding it for the active streaming row
- reuse the shared clipboard UX across assistant messages and task documents with a shared copy button component and centralized preview formatting
- strengthen frontend coverage for assistant copy eligibility, clipboard behavior, and shared copied-state reset handling

## Verification
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy-to-clipboard for assistant messages with visual feedback (copy → check) and success/error toasts

* **Refactor**
  * Introduced a reusable copy icon button and shared copy-preview generator used across message and task views

* **Behavior**
  * Copy control hidden while assistant output is actively streaming; shown only for completed, non-empty assistant messages

* **Tests**
  * Added tests covering copy success, failure, UI state transitions, and streaming-state visibility logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->