### PR TITLE
refactor(runtime): move message encoding behind runtime adapters

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-scroll-regression.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-scroll-regression.test.tsx
@@ -260,6 +260,7 @@ describe("agent chat scroll regression", () => {
 
     container.scrollTop = 500;
     await act(async () => {
+      fireEvent.pointerDown(container);
       fireEvent.scroll(container);
     });
     await flushAnimationFrames();
@@ -345,6 +346,7 @@ describe("agent chat scroll regression", () => {
 
     container.scrollTop = 500;
     await act(async () => {
+      fireEvent.pointerDown(container);
       fireEvent.scroll(container);
     });
     await flushAnimationFrames();

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -216,6 +216,11 @@ export function useAgentChatScrollController({
         return;
       }
 
+      if (!userScrolledRef.current && userScrollIntentVersionRef.current === 0) {
+        scrollToBottomNow(false);
+        return;
+      }
+
       if (!userScrolledRef.current) {
         setUserScrolledState(true);
         updateOverflowAnchor();

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
@@ -131,6 +131,51 @@ describe("useAgentChatTurnStaging", () => {
     await harness.unmount();
   });
 
+  test("does not stage turns when switching to another session", async () => {
+    const turns = buildTurns(6);
+    const harness = createHookHarness(
+      ({ activeSessionId, windowStart, nextTurns }) =>
+        useAgentChatTurnStaging({
+          activeSessionId,
+          windowStart,
+          turns: nextTurns,
+          disabled: false,
+        }),
+      {
+        activeSessionId: "session-qa",
+        windowStart: 10,
+        nextTurns: turns,
+      },
+    );
+
+    await harness.mount();
+
+    await act(async () => {
+      while (animationFrameCallbacks.size > 0) {
+        const queuedCallbacks = Array.from(animationFrameCallbacks.values());
+        animationFrameCallbacks.clear();
+        for (const callback of queuedCallbacks) {
+          callback(16);
+        }
+        await flush();
+      }
+    });
+
+    const builderTurns = buildTurns(8);
+    await harness.update({
+      activeSessionId: "session-builder",
+      windowStart: 14,
+      nextTurns: builderTurns,
+    });
+
+    expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual(
+      builderTurns.map((turn) => turn.key),
+    );
+    expect(animationFrameCallbacks.size).toBe(0);
+
+    await harness.unmount();
+  });
+
   test("returns all turns immediately when staging is disabled", async () => {
     const turns = buildTurns(6);
     const harness = createHookHarness(

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
@@ -20,7 +20,8 @@ export function useAgentChatTurnStaging({
   const [count, setCount] = useState(turns.length);
   const frameRef = useRef<number | null>(null);
   const activeSessionRef = useRef<string | null>(null);
-  const completedSessionRef = useRef<string | null>(null);
+  const completedSessionIdsRef = useRef<Set<string>>(new Set());
+  const previousSessionIdRef = useRef<string | null>(activeSessionId);
 
   useEffect(() => {
     if (frameRef.current !== null) {
@@ -28,12 +29,23 @@ export function useAgentChatTurnStaging({
       frameRef.current = null;
     }
 
+    const previousSessionId = previousSessionIdRef.current;
+    const switchedSessions =
+      previousSessionId !== null &&
+      activeSessionId !== null &&
+      previousSessionId !== activeSessionId;
+    previousSessionIdRef.current = activeSessionId;
+
+    if (switchedSessions) {
+      completedSessionIdsRef.current.add(activeSessionId);
+    }
+
     const shouldStage =
       !disabled &&
       activeSessionId !== null &&
       windowStart > 0 &&
       turns.length > STAGE_INIT &&
-      completedSessionRef.current !== activeSessionId;
+      !completedSessionIdsRef.current.has(activeSessionId);
 
     if (!shouldStage) {
       activeSessionRef.current = null;
@@ -62,7 +74,7 @@ export function useAgentChatTurnStaging({
       if (nextCount >= turns.length) {
         frameRef.current = null;
         activeSessionRef.current = null;
-        completedSessionRef.current = sessionId;
+        completedSessionIdsRef.current.add(sessionId);
         return;
       }
 

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -263,6 +263,11 @@ const dispatchScroll = async (container: HTMLDivElement): Promise<void> => {
   await flush();
 };
 
+const dispatchPointerDown = async (container: HTMLDivElement): Promise<void> => {
+  container.dispatchEvent(new PointerEvent("pointerdown"));
+  await flush();
+};
+
 describe("useAgentChatWindow", () => {
   const originalResizeObserver = globalThis.ResizeObserver;
   const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
@@ -469,6 +474,7 @@ describe("useAgentChatWindow", () => {
 
     container.scrollTop = 160;
     await act(async () => {
+      await dispatchPointerDown(container);
       await dispatchScroll(container);
     });
 
@@ -533,6 +539,33 @@ describe("useAgentChatWindow", () => {
       buildAgentChatWindowTurns(rows)[2]?.start ?? 0,
     );
     expect(container.scrollTop).toBe(getMaxScrollTop(container));
+
+    await harness.unmount();
+  });
+
+  test("ignores non-user scroll restoration while following the transcript", async () => {
+    const rows = createTurnRows(12);
+    const harness = await mountHarness(
+      {
+        rows,
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+      },
+      { attachDom: true },
+    );
+
+    const container = harness.messagesContainerRef.current;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+
+    container.scrollTop = Math.floor(getMaxScrollTop(container) / 2);
+    await act(async () => {
+      await dispatchScroll(container);
+    });
+
+    expect(container.scrollTop).toBe(getMaxScrollTop(container));
+    expect(harness.getLatestResult().isNearBottom).toBe(true);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -166,13 +166,15 @@ export function useAgentChatWindow({
   ]);
 
   useLayoutEffect(() => {
+    void visibleWindowKey;
+
     if (!pendingBottomResetRef.current) {
       return;
     }
 
     pendingBottomResetRef.current = false;
     forceScrollToBottom();
-  }, [forceScrollToBottom]);
+  }, [forceScrollToBottom, visibleWindowKey]);
 
   useLayoutEffect(() => {
     void visibleWindowKey;

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -4,6 +4,8 @@ import { createElement, type PropsWithChildren, type ReactElement } from "react"
 import {
   type AgentChatComposerDraft,
   createComposerAttachment,
+  createFileReferenceSegment,
+  createSlashCommandSegment,
   createTextSegment,
 } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
 import { clearAppQueryClient } from "@/lib/query-client";
@@ -30,6 +32,20 @@ const createComposerDraft = (text: string): AgentChatComposerDraft => ({
   segments: [createTextSegment(text)],
   attachments: [],
 });
+
+const COMMAND = {
+  id: "compact",
+  trigger: "compact",
+  title: "compact",
+  hints: ["compact"],
+};
+
+const FILE_REFERENCE = {
+  id: "file-src-main",
+  path: "src/main.ts",
+  name: "main.ts",
+  kind: "code" as const,
+};
 
 const createAttachmentDraft = (input: {
   id: string;
@@ -315,6 +331,64 @@ describe("useAgentStudioSessionActions", () => {
     expect(startAgentSession).not.toHaveBeenCalled();
     expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
       { kind: "text", text: "  hello world  " },
+    ]);
+
+    await harness.unmount();
+  });
+
+  test("onSend allows slash-command-only drafts without relying on serialized text", async () => {
+    const sendAgentMessage = mock(async () => {});
+    const draft: AgentChatComposerDraft = {
+      segments: [
+        createTextSegment("", "text-before"),
+        createSlashCommandSegment(COMMAND, "slash-1"),
+        createTextSegment("", "text-after"),
+      ],
+      attachments: [],
+    };
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: createSession({ sessionId: "session-existing" }),
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await expect(state.onSend(draft)).resolves.toBe(true);
+    });
+
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "slash_command", command: COMMAND },
+    ]);
+
+    await harness.unmount();
+  });
+
+  test("onSend allows file-reference-only drafts without relying on serialized text", async () => {
+    const sendAgentMessage = mock(async () => {});
+    const draft: AgentChatComposerDraft = {
+      segments: [
+        createTextSegment("", "text-before"),
+        createFileReferenceSegment(FILE_REFERENCE, "file-1"),
+        createTextSegment("", "text-after"),
+      ],
+      attachments: [],
+    };
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: createSession({ sessionId: "session-existing" }),
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await expect(state.onSend(draft)).resolves.toBe(true);
+    });
+
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "file_reference", file: FILE_REFERENCE },
     ]);
 
     await harness.unmount();

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.ts
@@ -13,7 +13,6 @@ import {
   type AgentChatComposerDraft,
   draftHasMeaningfulContent,
   draftHasSlashCommandSegment,
-  draftToSerializedText,
   resolveDraftToUserMessageParts,
 } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
 import type { HumanReviewFeedbackModalModel } from "@/features/human-review-feedback/human-review-feedback-types";
@@ -254,12 +253,7 @@ export function useAgentStudioSessionActions({
         }
       }
 
-      const serializedDraft = draftToSerializedText(draft).trim();
-      if (
-        !draftHasMeaningfulContent(draft) ||
-        (!serializedDraft && (draft.attachments ?? []).length === 0) ||
-        !taskId
-      ) {
+      if (!draftHasMeaningfulContent(draft) || !taskId) {
         return false;
       }
       const sendContextKeys = new Set<string>();

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -450,6 +450,60 @@ describe("event-stream", () => {
     expect(userMessages[1]?.parts).toEqual([{ kind: "text", text: "New text" }]);
   });
 
+  test("suppresses redundant slash-command instruction echo parts in live user messages", async () => {
+    const slashEnvelope = `<auto-slash-command>\n# /test-command Command\n\n**Description**: A command for testing slash commands\n\n**User Arguments**: pouet\n\n**Scope**: opencode\n\n---\n\n## Command Instructions\n\nI just want to test the slash commands mechanism.\nReturn the arguments of this command: pouet\n\n\n---\n\n## User Request\n\npouet\n</auto-slash-command>`;
+
+    const emitted = await runEventStream([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "user-message-slash-1",
+            role: "user",
+            sessionID: "external-session-1",
+            time: {
+              created: Date.parse("2026-02-22T12:00:06.500Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "user-part-slash-envelope",
+            sessionID: "external-session-1",
+            messageID: "user-message-slash-1",
+            type: "text",
+            text: slashEnvelope,
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "user-part-slash-echo",
+            sessionID: "external-session-1",
+            messageID: "user-message-slash-1",
+            type: "text",
+            text: "I just want to test the slash commands mechanism.\nReturn the arguments of this command: pouet",
+          },
+        },
+      } as unknown as Event,
+    ]);
+
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    expect(userMessages).toHaveLength(1);
+    const latestUserMessage = userMessages[userMessages.length - 1];
+    if (!latestUserMessage || latestUserMessage.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+
+    expect(latestUserMessage.message).toBe(slashEnvelope);
+    expect(latestUserMessage.parts).toEqual([{ kind: "text", text: slashEnvelope }]);
+  });
+
   test("preserves visible user text when later file parts arrive without visible text parts", async () => {
     const emitted = await runEventStream([
       {

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1529,6 +1529,55 @@ describe("OpencodeSdkAdapter", () => {
     ]);
   });
 
+  test("loadSessionHistory collapses redundant slash-command echo text parts", async () => {
+    const slashEnvelope = `<auto-slash-command>\n# /test-command Command\n\n**Description**: A command for testing slash commands\n\n**User Arguments**: pouet\n\n**Scope**: opencode\n\n---\n\n## Command Instructions\n\nI just want to test the slash commands mechanism.\nReturn the arguments of this command: pouet\n\n\n---\n\n## User Request\n\npouet\n</auto-slash-command>`;
+    const mock = makeMockClient({
+      messagesResponse: [
+        {
+          info: {
+            id: "msg-user-slash-1",
+            role: "user",
+            time: { created: Date.parse("2026-02-17T11:59:00Z") },
+          },
+          parts: [
+            {
+              id: "text-user-envelope",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-slash-1",
+              type: "text",
+              text: slashEnvelope,
+            } as Part,
+            {
+              id: "text-user-echo",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-slash-1",
+              type: "text",
+              text: "I just want to test the slash commands mechanism.\nReturn the arguments of this command: pouet",
+            } as Part,
+          ],
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const history = await adapter.loadSessionHistory({
+      runtimeKind: "opencode",
+      runtimeConnection: defaultRuntimeConnection,
+      externalSessionId: "session-opencode-1",
+      limit: 100,
+    });
+
+    expect(history).toHaveLength(1);
+    if (history[0]?.role !== "user") {
+      throw new Error("Expected user history entry");
+    }
+    expect(history[0].text).toBe(slashEnvelope);
+    expect(history[0].displayParts).toEqual([{ kind: "text", text: slashEnvelope }]);
+  });
+
   test("loadSessionHistory preserves local attachment preview paths from the live session metadata", async () => {
     const mock = makeMockClient({
       messagesResponse: [

--- a/packages/adapters-opencode-sdk/src/message-execution.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.test.ts
@@ -151,6 +151,48 @@ describe("message-execution", () => {
     expect(promptAsync).not.toHaveBeenCalled();
   });
 
+  test("tracks queued file-reference sends using OpenCode-visible text and source spans", async () => {
+    const { session, promptAsync } = createSession();
+    session.activeAssistantMessageId = "msg-200";
+
+    await sendUserMessage({
+      session,
+      request: {
+        sessionId: "session-1",
+        parts: [{ kind: "file_reference", file: FILE_REFERENCE }],
+      },
+      tools: {},
+    });
+
+    expect(session.pendingQueuedUserMessages).toEqual([
+      {
+        signature: buildQueuedRequestSignature(
+          [{ kind: "file_reference", file: FILE_REFERENCE }],
+          undefined,
+        ),
+      },
+    ]);
+    expect(promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parts: [
+          { type: "text", text: "@src/main.ts" },
+          expect.objectContaining({
+            type: "file",
+            source: {
+              type: "file",
+              path: "src/main.ts",
+              text: {
+                value: "@src/main.ts",
+                start: 0,
+                end: 12,
+              },
+            },
+          }),
+        ],
+      }),
+    );
+  });
+
   test("removes the exact queued slash follow-up entry when duplicate content send fails", async () => {
     const { session } = createSession({
       commandResult: {
@@ -295,6 +337,54 @@ describe("message-execution", () => {
       tools: {},
       parts: [
         { type: "text", text: "describe this" },
+        {
+          type: "file",
+          mime: "image/png",
+          url: "file:///tmp/diagram.png",
+          filename: "diagram.png",
+        },
+      ],
+    });
+  });
+
+  test("keeps file-reference spans aligned when attachments are skipped from prompt text", async () => {
+    const { session, promptAsync } = createSession();
+
+    await sendUserMessage({
+      session,
+      request: {
+        sessionId: "session-1",
+        parts: [
+          { kind: "text", text: "review " },
+          { kind: "attachment", attachment: IMAGE_ATTACHMENT },
+          { kind: "text", text: "with " },
+          { kind: "file_reference", file: FILE_REFERENCE },
+        ],
+      },
+      tools: {},
+    });
+
+    expect(promptAsync).toHaveBeenCalledWith({
+      sessionID: "session-opencode-1",
+      directory: "/repo",
+      tools: {},
+      parts: [
+        { type: "text", text: "review with @src/main.ts" },
+        {
+          type: "file",
+          mime: "text/plain",
+          url: "file:///repo/src/main.ts",
+          filename: "main.ts",
+          source: {
+            type: "file",
+            path: "src/main.ts",
+            text: {
+              value: "@src/main.ts",
+              start: 12,
+              end: 24,
+            },
+          },
+        },
         {
           type: "file",
           mime: "image/png",
@@ -482,6 +572,27 @@ describe("message-execution", () => {
     ).rejects.toThrow(
       "OpenCode request failed: run slash command: OpenCode slash commands do not support structured attachments or file references.",
     );
+  });
+
+  test("fails explicitly when text appears before a slash command", () => {
+    expect(() =>
+      __testExports.toSlashCommandExecutionRequest([
+        { kind: "text", text: "before " },
+        { kind: "slash_command", command: COMMAND },
+      ]),
+    ).toThrow("OpenCode slash commands must be the first meaningful message segment.");
+  });
+
+  test("fails explicitly when a message contains multiple slash commands", () => {
+    expect(() =>
+      __testExports.toSlashCommandExecutionRequest([
+        { kind: "slash_command", command: COMMAND },
+        {
+          kind: "slash_command",
+          command: { ...COMMAND, id: "review", trigger: "review", title: "review" },
+        },
+      ]),
+    ).toThrow("OpenCode supports only one slash command token per message.");
   });
 
   test("preserves slash-command error context without wrapping it as a prompt failure", async () => {

--- a/packages/adapters-opencode-sdk/src/message-execution.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.ts
@@ -1,12 +1,11 @@
 import {
   type AgentUserMessageDisplayPart,
-  buildAgentUserMessagePromptText,
   normalizeAgentUserMessageParts,
   type SendAgentUserMessageInput,
-  serializeAgentUserMessagePartsToText,
 } from "@openducktor/core";
 import { setSessionActive } from "./event-stream/shared";
 import { detectAgentFileReferenceMime } from "./file-reference-utils";
+import { buildOpenCodePromptText } from "./opencode-user-message-encoding";
 import { resolveAgainstWorkingDirectory, toFileUrl } from "./path-utils";
 import { normalizeModelInput, resolveAssistantResponseMessageId } from "./payload-mappers";
 import { toOpenCodeRequestError } from "./request-errors";
@@ -64,7 +63,7 @@ const toCommandModelInput = (
 };
 
 const toPromptFilePart = (
-  fileReference: ReturnType<typeof buildAgentUserMessagePromptText>["fileReferences"][number],
+  fileReference: ReturnType<typeof buildOpenCodePromptText>["fileReferences"][number],
   workingDirectory: string,
 ): Extract<OpenCodePromptPart, { type: "file" }> => {
   const normalizedPath = fileReference.file.path.trim();
@@ -89,7 +88,7 @@ const toPromptParts = (
   parts: SendAgentUserMessageInput["parts"],
   workingDirectory: string,
 ): OpenCodePromptPart[] => {
-  const promptText = buildAgentUserMessagePromptText(parts);
+  const promptText = buildOpenCodePromptText(parts);
   return [
     { type: "text", text: promptText.text },
     ...promptText.fileReferences.map((fileReference) =>
@@ -149,8 +148,8 @@ const toSlashCommandExecutionRequest = (
     return null;
   }
 
-  const leadingText = serializeAgentUserMessagePartsToText(normalizedParts.slice(0, commandIndex));
-  if (leadingText.trim().length > 0) {
+  const leadingParts = normalizedParts.slice(0, commandIndex);
+  if (leadingParts.some((part) => part.kind !== "text" || part.text.trim().length > 0)) {
     throw new Error("OpenCode slash commands must be the first meaningful message segment.");
   }
 
@@ -159,9 +158,10 @@ const toSlashCommandExecutionRequest = (
     return null;
   }
 
-  const trailingText = serializeAgentUserMessagePartsToText(
-    normalizedParts.slice(commandIndex + 1),
-  );
+  const trailingText = normalizedParts
+    .slice(commandIndex + 1)
+    .flatMap((part) => (part.kind === "text" ? [part.text] : []))
+    .join("");
   return {
     command: commandPart.command.trigger,
     arguments: trailingText.trim(),

--- a/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
@@ -105,6 +105,32 @@ describe("message-normalizers", () => {
     ]);
   });
 
+  test("keeps only the slash-command envelope text when OpenCode echoes instruction text separately", () => {
+    const parts: Part[] = [
+      {
+        id: "slash-envelope",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "text",
+        text: "<auto-slash-command>\n# /test-command Command\n\n## User Request\n\npouet\n</auto-slash-command>",
+      } as Part,
+      {
+        id: "slash-echo",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "text",
+        text: "I just want to test the slash commands mechanism.\nReturn the arguments of this command: pouet",
+      } as Part,
+    ];
+
+    expect(normalizeUserMessageDisplayParts(parts)).toEqual([
+      {
+        kind: "text",
+        text: "<auto-slash-command>\n# /test-command Command\n\n## User Request\n\npouet\n</auto-slash-command>",
+      },
+    ]);
+  });
+
   test("normalizes local multimodal file parts into attachment display parts", () => {
     const parts: Part[] = [
       {

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -9,6 +9,9 @@ import { detectAgentFileReferenceKind } from "./file-reference-utils";
 import { asUnknownRecord, readRecordProp, readUnknownProp } from "./guards";
 import { buildOpenCodeVisibleText } from "./opencode-user-message-encoding";
 
+const AUTO_SLASH_COMMAND_OPEN = "<auto-slash-command>";
+const AUTO_SLASH_COMMAND_CLOSE = "</auto-slash-command>";
+
 export const readTextFromParts = (parts: Part[]): string => {
   return parts
     .filter((part): part is Extract<Part, { type: "text" }> => part.type === "text")
@@ -160,22 +163,43 @@ const normalizeFileReferencePart = (
   };
 };
 
+const isAutoSlashCommandEnvelopeText = (text: string): boolean => {
+  return text.startsWith(AUTO_SLASH_COMMAND_OPEN) && text.includes(AUTO_SLASH_COMMAND_CLOSE);
+};
+
 export const normalizeUserMessageDisplayParts = (parts: Part[]): AgentUserMessageDisplayPart[] => {
-  return parts.flatMap((part) => {
+  const normalizedParts: AgentUserMessageDisplayPart[] = [];
+  let hasAutoSlashCommandEnvelope = false;
+
+  for (const part of parts) {
     if (part.type === "text") {
       if (part.synthetic || part.ignored || part.text.length === 0) {
-        return [];
+        continue;
       }
-      return [{ kind: "text", text: part.text } satisfies AgentUserMessageDisplayPart];
+
+      if (isAutoSlashCommandEnvelopeText(part.text)) {
+        if (!hasAutoSlashCommandEnvelope) {
+          normalizedParts.push({ kind: "text", text: part.text });
+          hasAutoSlashCommandEnvelope = true;
+        }
+        continue;
+      }
+
+      if (!hasAutoSlashCommandEnvelope) {
+        normalizedParts.push({ kind: "text", text: part.text });
+      }
+      continue;
     }
 
     if (part.type === "file") {
       const fileReference = normalizeFileReferencePart(part);
-      return fileReference ? [fileReference] : [];
+      if (fileReference) {
+        normalizedParts.push(fileReference);
+      }
     }
+  }
 
-    return [];
-  });
+  return normalizedParts;
 };
 
 export const hasVisibleUserTextDisplayPart = (parts: AgentUserMessageDisplayPart[]): boolean => {

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -1,13 +1,13 @@
 import type { Part } from "@opencode-ai/sdk/v2/client";
-import {
-  type AgentModelSelection,
-  type AgentUserMessageDisplayPart,
-  type AgentUserMessagePart,
-  type AgentUserMessageSourceText,
-  serializeAgentUserMessagePartsToText,
+import type {
+  AgentModelSelection,
+  AgentUserMessageDisplayPart,
+  AgentUserMessagePart,
+  AgentUserMessageSourceText,
 } from "@openducktor/core";
 import { detectAgentFileReferenceKind } from "./file-reference-utils";
 import { asUnknownRecord, readRecordProp, readUnknownProp } from "./guards";
+import { buildOpenCodeVisibleText } from "./opencode-user-message-encoding";
 
 export const readTextFromParts = (parts: Part[]): string => {
   return parts
@@ -260,7 +260,7 @@ export const readVisibleUserTextFromDisplayParts = (
     return [{ kind: "file_reference", file: part.file }];
   });
 
-  return serializeAgentUserMessagePartsToText(userMessageParts);
+  return buildOpenCodeVisibleText(userMessageParts);
 };
 
 export const readTextFromMessageInfo = (info: unknown): string => {

--- a/packages/adapters-opencode-sdk/src/opencode-user-message-encoding.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-user-message-encoding.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildOpenCodePromptText,
+  buildOpenCodeVisibleText,
+} from "./opencode-user-message-encoding";
+import { buildQueuedRequestSignature } from "./user-message-signatures";
+
+const FIRST_FILE = {
+  id: "file-a",
+  path: "src/a.ts",
+  name: "a.ts",
+  kind: "code" as const,
+};
+
+const SECOND_FILE = {
+  id: "file-b",
+  path: "src/b.ts",
+  name: "b.ts",
+  kind: "code" as const,
+};
+
+const ATTACHMENT = {
+  id: "attachment-1",
+  path: "/tmp/diagram.png",
+  name: "diagram.png",
+  kind: "image" as const,
+  mime: "image/png",
+};
+
+describe("opencode-user-message-encoding", () => {
+  test("does not leave doubled synthetic spaces when skipped attachments sit between file references", () => {
+    const parts = [
+      { kind: "file_reference" as const, file: FIRST_FILE },
+      { kind: "attachment" as const, attachment: ATTACHMENT },
+      { kind: "file_reference" as const, file: SECOND_FILE },
+    ];
+
+    expect(buildOpenCodeVisibleText(parts)).toBe("@src/a.ts @src/b.ts");
+    expect(buildOpenCodePromptText(parts)).toEqual({
+      text: "@src/a.ts @src/b.ts",
+      fileReferences: [
+        {
+          file: FIRST_FILE,
+          sourceText: {
+            value: "@src/a.ts",
+            start: 0,
+            end: 9,
+          },
+        },
+        {
+          file: SECOND_FILE,
+          sourceText: {
+            value: "@src/b.ts",
+            start: 10,
+            end: 19,
+          },
+        },
+      ],
+    });
+  });
+
+  test("queued request signatures reuse the same visible text as prompt encoding", () => {
+    const parts = [
+      { kind: "file_reference" as const, file: FIRST_FILE },
+      { kind: "attachment" as const, attachment: ATTACHMENT },
+      { kind: "file_reference" as const, file: SECOND_FILE },
+    ];
+
+    expect(JSON.parse(buildQueuedRequestSignature(parts))).toEqual({
+      visible: "@src/a.ts @src/b.ts",
+      nonTextParts: [
+        {
+          kind: "file_reference",
+          path: "src/a.ts",
+          name: "a.ts",
+          sourceText: {
+            value: "@src/a.ts",
+            start: 0,
+            end: 9,
+          },
+        },
+        {
+          kind: "file_reference",
+          path: "src/b.ts",
+          name: "b.ts",
+          sourceText: {
+            value: "@src/b.ts",
+            start: 10,
+            end: 19,
+          },
+        },
+        {
+          kind: "attachment",
+          path: "/tmp/diagram.png",
+          name: "diagram.png",
+          attachmentKind: "image",
+          mime: "image/png",
+        },
+      ],
+      providerId: null,
+      modelId: null,
+      variant: null,
+      profileId: null,
+    });
+  });
+});

--- a/packages/adapters-opencode-sdk/src/opencode-user-message-encoding.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-user-message-encoding.ts
@@ -62,14 +62,14 @@ const buildOpenCodeMessageEncoding = (
   let skippedStructuredPart = false;
 
   for (const part of normalized) {
-    if (shouldInsertSyntheticSpaceBeforePart(previousPart, part)) {
-      text += " ";
-    }
-
     const encodedPart = encodeOpenCodePartToText(part);
     if (encodedPart === null) {
       skippedStructuredPart = true;
       continue;
+    }
+
+    if (shouldInsertSyntheticSpaceBeforePart(previousPart, part)) {
+      text += " ";
     }
 
     if (part.kind === "text") {

--- a/packages/adapters-opencode-sdk/src/opencode-user-message-encoding.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-user-message-encoding.ts
@@ -1,0 +1,117 @@
+import {
+  type AgentUserMessagePart,
+  type AgentUserMessagePromptFileReference,
+  normalizeAgentUserMessageParts,
+} from "@openducktor/core";
+
+const WORDLIKE_TEXT_START_PATTERN = /[\p{L}\p{N}_]/u;
+
+const encodeOpenCodePartToText = (part: AgentUserMessagePart): string | null => {
+  if (part.kind === "text") {
+    return part.text;
+  }
+  if (part.kind === "slash_command") {
+    return `/${part.command.trigger}`;
+  }
+  if (part.kind === "file_reference") {
+    return `@${part.file.path}`;
+  }
+  return null;
+};
+
+const shouldInsertSyntheticSpaceBeforePart = (
+  previousPart: AgentUserMessagePart | null,
+  part: AgentUserMessagePart,
+): boolean => {
+  if (!previousPart || previousPart.kind === "text") {
+    return false;
+  }
+
+  if (part.kind !== "text") {
+    return true;
+  }
+
+  const firstCharacter = part.text.at(0);
+  return firstCharacter !== undefined && WORDLIKE_TEXT_START_PATTERN.test(firstCharacter);
+};
+
+const collapseLeadingWhitespaceAfterSkippedPart = (
+  existingText: string,
+  nextText: string,
+  skippedStructuredPart: boolean,
+): string => {
+  if (!skippedStructuredPart) {
+    return nextText;
+  }
+  if (!/\s$/u.test(existingText)) {
+    return nextText;
+  }
+  return nextText.replace(/^\s+/u, "");
+};
+
+const buildOpenCodeMessageEncoding = (
+  parts: AgentUserMessagePart[],
+): {
+  text: string;
+  fileReferences: AgentUserMessagePromptFileReference[];
+} => {
+  const normalized = normalizeAgentUserMessageParts(parts);
+  let text = "";
+  const fileReferences: AgentUserMessagePromptFileReference[] = [];
+  let previousPart: AgentUserMessagePart | null = null;
+  let skippedStructuredPart = false;
+
+  for (const part of normalized) {
+    if (shouldInsertSyntheticSpaceBeforePart(previousPart, part)) {
+      text += " ";
+    }
+
+    const encodedPart = encodeOpenCodePartToText(part);
+    if (encodedPart === null) {
+      skippedStructuredPart = true;
+      continue;
+    }
+
+    if (part.kind === "text") {
+      text += collapseLeadingWhitespaceAfterSkippedPart(text, encodedPart, skippedStructuredPart);
+      previousPart = part;
+      skippedStructuredPart = false;
+      continue;
+    }
+
+    if (part.kind === "file_reference") {
+      const start = text.length;
+      text += encodedPart;
+      fileReferences.push({
+        file: part.file,
+        sourceText: {
+          value: encodedPart,
+          start,
+          end: text.length,
+        },
+      });
+      previousPart = part;
+      skippedStructuredPart = false;
+      continue;
+    }
+
+    text += encodedPart;
+    previousPart = part;
+    skippedStructuredPart = false;
+  }
+
+  return { text, fileReferences };
+};
+
+export const buildOpenCodeVisibleText = (parts: AgentUserMessagePart[]): string => {
+  return buildOpenCodeMessageEncoding(parts).text;
+};
+
+export const buildOpenCodePromptText = (
+  parts: AgentUserMessagePart[],
+): {
+  text: string;
+  fileReferences: AgentUserMessagePromptFileReference[];
+} => {
+  return buildOpenCodeMessageEncoding(parts);
+};

--- a/packages/adapters-opencode-sdk/src/user-message-signatures.ts
+++ b/packages/adapters-opencode-sdk/src/user-message-signatures.ts
@@ -4,10 +4,7 @@ import {
   type AgentUserMessagePart,
   normalizeAgentUserMessageParts,
 } from "@openducktor/core";
-import {
-  buildOpenCodePromptText,
-  buildOpenCodeVisibleText,
-} from "./opencode-user-message-encoding";
+import { buildOpenCodePromptText } from "./opencode-user-message-encoding";
 
 type ComparableNonTextPart =
   | {
@@ -92,7 +89,7 @@ const buildQueuedRequestSignatureWithAttachmentPathMode = (
   ];
 
   return buildComparableSignature({
-    visible: buildOpenCodeVisibleText(normalizedParts),
+    visible: promptText.text,
     nonTextParts,
     ...(model ? { model } : {}),
   });

--- a/packages/adapters-opencode-sdk/src/user-message-signatures.ts
+++ b/packages/adapters-opencode-sdk/src/user-message-signatures.ts
@@ -2,10 +2,12 @@ import {
   type AgentModelSelection,
   type AgentUserMessageDisplayPart,
   type AgentUserMessagePart,
-  buildAgentUserMessagePromptText,
   normalizeAgentUserMessageParts,
-  serializeAgentUserMessagePartsToText,
 } from "@openducktor/core";
+import {
+  buildOpenCodePromptText,
+  buildOpenCodeVisibleText,
+} from "./opencode-user-message-encoding";
 
 type ComparableNonTextPart =
   | {
@@ -64,7 +66,7 @@ const buildQueuedRequestSignatureWithAttachmentPathMode = (
   attachmentPathMode: AttachmentPathMode,
 ): string => {
   const normalizedParts = normalizeAgentUserMessageParts(parts);
-  const promptText = buildAgentUserMessagePromptText(normalizedParts);
+  const promptText = buildOpenCodePromptText(normalizedParts);
   const nonTextParts: ComparableNonTextPart[] = [
     ...promptText.fileReferences.map(({ file, sourceText }) => ({
       kind: "file_reference" as const,
@@ -90,7 +92,7 @@ const buildQueuedRequestSignatureWithAttachmentPathMode = (
   ];
 
   return buildComparableSignature({
-    visible: serializeAgentUserMessagePartsToText(normalizedParts),
+    visible: buildOpenCodeVisibleText(normalizedParts),
     nonTextParts,
     ...(model ? { model } : {}),
   });

--- a/packages/core/src/services/agent-user-message-parts.test.ts
+++ b/packages/core/src/services/agent-user-message-parts.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-  buildAgentUserMessagePromptText,
   hasMeaningfulAgentUserMessageParts,
   normalizeAgentUserMessageParts,
   serializeAgentUserMessagePartsToText,
@@ -163,72 +162,6 @@ describe("agent-user-message-parts", () => {
         { kind: "text", text: ")." },
       ]),
     ).toBe("check (@src/index.ts).");
-  });
-
-  test("builds upstream prompt text with inline file-reference spans", () => {
-    const file = createFileReference();
-    const attachment = createAttachment();
-
-    expect(
-      buildAgentUserMessagePromptText([
-        { kind: "text", text: "check " },
-        { kind: "file_reference", file },
-        { kind: "text", text: " please" },
-      ]),
-    ).toEqual({
-      text: "check @src/index.ts please",
-      fileReferences: [
-        {
-          file,
-          sourceText: {
-            value: "@src/index.ts",
-            start: 6,
-            end: 19,
-          },
-        },
-      ],
-    });
-
-    expect(
-      buildAgentUserMessagePromptText([
-        { kind: "text", text: "compare " },
-        { kind: "file_reference", file },
-        { kind: "text", text: "and docs" },
-      ]),
-    ).toEqual({
-      text: "compare @src/index.ts and docs",
-      fileReferences: [
-        {
-          file,
-          sourceText: {
-            value: "@src/index.ts",
-            start: 8,
-            end: 21,
-          },
-        },
-      ],
-    });
-
-    expect(
-      buildAgentUserMessagePromptText([
-        { kind: "text", text: "review " },
-        { kind: "attachment", attachment },
-        { kind: "text", text: "with " },
-        { kind: "file_reference", file },
-      ]),
-    ).toEqual({
-      text: "review with @src/index.ts",
-      fileReferences: [
-        {
-          file,
-          sourceText: {
-            value: "@src/index.ts",
-            start: 12,
-            end: 25,
-          },
-        },
-      ],
-    });
   });
 
   test("does not flatten attachments into serialized prompt text", () => {

--- a/packages/core/src/services/agent-user-message-parts.ts
+++ b/packages/core/src/services/agent-user-message-parts.ts
@@ -1,7 +1,4 @@
-import type {
-  AgentUserMessagePart,
-  AgentUserMessagePromptFileReference,
-} from "../types/agent-orchestrator";
+import type { AgentUserMessagePart } from "../types/agent-orchestrator";
 
 const WORDLIKE_TEXT_START_PATTERN = /[\p{L}\p{N}_]/u;
 
@@ -98,6 +95,8 @@ export const hasMeaningfulAgentUserMessageParts = (parts: AgentUserMessagePart[]
   return normalizeAgentUserMessageParts(parts).length > 0;
 };
 
+// This display helper preserves the current UI text conventions. Runtime adapters must do their
+// own final encoding for sends instead of treating this as the runtime contract.
 export const serializeAgentUserMessagePartsToText = (parts: AgentUserMessagePart[]): string => {
   const normalized = normalizeAgentUserMessageParts(parts);
   let text = "";
@@ -122,59 +121,4 @@ export const serializeAgentUserMessagePartsToText = (parts: AgentUserMessagePart
   }
 
   return text;
-};
-
-export const buildAgentUserMessagePromptText = (
-  parts: AgentUserMessagePart[],
-): {
-  text: string;
-  fileReferences: AgentUserMessagePromptFileReference[];
-} => {
-  const normalized = normalizeAgentUserMessageParts(parts);
-  let text = "";
-  const fileReferences: AgentUserMessagePromptFileReference[] = [];
-  let previousPart: AgentUserMessagePart | null = null;
-  let skippedStructuredPart = false;
-
-  for (const part of normalized) {
-    if (shouldInsertSyntheticSpaceBeforePart(previousPart, part)) {
-      text += " ";
-    }
-
-    const serializedPart = serializeAgentUserMessagePart(part);
-
-    if (serializedPart === null) {
-      skippedStructuredPart = true;
-      continue;
-    }
-
-    if (part.kind === "text" || part.kind === "slash_command") {
-      text +=
-        part.kind === "text"
-          ? collapseLeadingWhitespaceAfterSkippedPart(text, serializedPart, skippedStructuredPart)
-          : serializedPart;
-      previousPart = part;
-      skippedStructuredPart = false;
-      continue;
-    }
-
-    if (part.kind !== "file_reference") {
-      continue;
-    }
-
-    const start = text.length;
-    text += serializedPart;
-    fileReferences.push({
-      file: part.file,
-      sourceText: {
-        value: serializedPart,
-        start,
-        end: text.length,
-      },
-    });
-    previousPart = part;
-    skippedStructuredPart = false;
-  }
-
-  return { text, fileReferences };
 };


### PR DESCRIPTION
## Summary
- remove OpenCode-specific slash-command and file-reference encoding from the shared core send path
- move final OpenCode visible-text, prompt-text, and file-reference span generation into an adapter-local encoder used by sends, queued signatures, and display fallback
- stop desktop send eligibility from depending on serialized OpenCode text so slash-only and file-reference-only drafts stay sendable through the generic message-part model

## Testing
- bun run --filter @openducktor/core test
- bun run --filter @openducktor/adapters-opencode-sdk test
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/core typecheck
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/core lint
- bun run --filter @openducktor/adapters-opencode-sdk lint
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced support for composing messages with slash commands and file references
  
* **Refactor**
  * Streamlined message text encoding and tracking system for improved reliability and accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->