### PR TITLE
refactor(runtime): generalize ODT workflow tool normalization

### DIFF
--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
@@ -554,6 +554,7 @@ mod tests {
         RuntimeProvisioningMode, RuntimeRoute, RuntimeSupportedScope,
         REQUIRED_RUNTIME_SUPPORTED_SCOPES,
     };
+    use std::collections::BTreeMap;
 
     fn capabilities_with_scopes(scopes: Vec<RuntimeSupportedScope>) -> RuntimeCapabilities {
         RuntimeCapabilities {

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt;
 use url::Url;
 
@@ -40,6 +41,7 @@ impl AgentRuntimeKind {
                     "ast_grep_replace".to_string(),
                     "lsp_rename".to_string(),
                 ],
+                workflow_tool_aliases_by_canonical: opencode_workflow_tool_aliases_by_canonical(),
                 capabilities: RuntimeCapabilities {
                     supports_profiles: true,
                     supports_variants: true,
@@ -77,6 +79,36 @@ impl AgentRuntimeKind {
             endpoint: self.endpoint_for_port(port),
         }
     }
+}
+
+const ODT_WORKFLOW_TOOL_NAMES: [&str; 10] = [
+    "odt_read_task",
+    "odt_read_task_documents",
+    "odt_set_spec",
+    "odt_set_plan",
+    "odt_build_blocked",
+    "odt_build_resumed",
+    "odt_build_completed",
+    "odt_set_pull_request",
+    "odt_qa_approved",
+    "odt_qa_rejected",
+];
+
+const OPENCODE_ODT_WORKFLOW_TOOL_PREFIXES: [&str; 2] = ["openducktor_", "functions.openducktor_"];
+
+fn opencode_workflow_tool_aliases_by_canonical() -> BTreeMap<String, Vec<String>> {
+    ODT_WORKFLOW_TOOL_NAMES
+        .iter()
+        .map(|tool_name| {
+            (
+                (*tool_name).to_string(),
+                OPENCODE_ODT_WORKFLOW_TOOL_PREFIXES
+                    .iter()
+                    .map(|prefix| format!("{prefix}{tool_name}"))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect()
 }
 
 impl fmt::Display for AgentRuntimeKind {
@@ -174,6 +206,7 @@ pub struct RuntimeDescriptor {
     pub label: String,
     pub description: String,
     pub read_only_role_blocked_tools: Vec<String>,
+    pub workflow_tool_aliases_by_canonical: BTreeMap<String, Vec<String>>,
     pub capabilities: RuntimeCapabilities,
 }
 
@@ -577,6 +610,16 @@ mod tests {
         assert!(!descriptor
             .read_only_role_blocked_tools
             .contains(&"bash".to_string()));
+        assert_eq!(
+            descriptor
+                .workflow_tool_aliases_by_canonical
+                .get("odt_set_spec")
+                .cloned(),
+            Some(vec![
+                "openducktor_odt_set_spec".to_string(),
+                "functions.openducktor_odt_set_spec".to_string(),
+            ])
+        );
         assert!(descriptor.capabilities.supports_all_workflow_scopes());
     }
 
@@ -587,6 +630,7 @@ mod tests {
             label: "OpenCode".to_string(),
             description: "desc".to_string(),
             read_only_role_blocked_tools: vec![],
+            workflow_tool_aliases_by_canonical: BTreeMap::new(),
             capabilities: RuntimeCapabilities {
                 supports_profiles: true,
                 supports_variants: true,

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
@@ -81,6 +81,8 @@ impl AgentRuntimeKind {
     }
 }
 
+// Keep this list in sync with `agentToolNameValues` in
+// `packages/contracts/src/agent-workflow-schemas.ts`.
 const ODT_WORKFLOW_TOOL_NAMES: [&str; 10] = [
     "odt_read_task",
     "odt_read_task_documents",

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -1,3 +1,4 @@
+import type { RuntimeDescriptor } from "@openducktor/contracts";
 import {
   type AgentRole,
   type AgentUserMessageDisplayPart,
@@ -466,6 +467,7 @@ type MessageBodyProps = {
   timeLabel: string;
   systemPromptBody: string;
   sessionWorkingDirectory?: string | null | undefined;
+  workflowToolAliasesByCanonical?: RuntimeDescriptor["workflowToolAliasesByCanonical"] | undefined;
 };
 
 export const MessageBody = ({
@@ -475,6 +477,7 @@ export const MessageBody = ({
   timeLabel,
   systemPromptBody,
   sessionWorkingDirectory,
+  workflowToolAliasesByCanonical,
 }: MessageBodyProps): ReactElement => {
   const meta = message.meta;
 
@@ -483,12 +486,13 @@ export const MessageBody = ({
   }
 
   if (meta?.kind === "tool") {
-    if (isOdtWorkflowMutationToolName(meta.tool)) {
+    if (isOdtWorkflowMutationToolName(meta.tool, workflowToolAliasesByCanonical)) {
       return (
         <WorkflowToolMessage
           meta={meta}
           messageTimestamp={message.timestamp}
           sessionWorkingDirectory={sessionWorkingDirectory}
+          workflowToolAliasesByCanonical={workflowToolAliasesByCanonical}
         />
       );
     }
@@ -499,6 +503,7 @@ export const MessageBody = ({
         messageTimestamp={message.timestamp}
         timeLabel={timeLabel}
         sessionWorkingDirectory={sessionWorkingDirectory}
+        workflowToolAliasesByCanonical={workflowToolAliasesByCanonical}
       />
     );
   }

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -1,3 +1,4 @@
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { describe, expect, test } from "bun:test";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
@@ -76,7 +77,13 @@ describe("agent-chat-message-card-model", () => {
 
     test("maps odt tool names to display names", () => {
       expect(toolDisplayName("odt_set_plan")).toBe("set_plan");
-      expect(toolDisplayName("openducktor_odt_set_plan")).toBe("set_plan");
+      expect(toolDisplayName("openducktor_odt_set_plan")).toBe("openducktor_odt_set_plan");
+      expect(
+        toolDisplayName(
+          "openducktor_odt_set_plan",
+          OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+        ),
+      ).toBe("set_plan");
       expect(toolDisplayName("bash")).toBe("bash");
     });
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -1,5 +1,5 @@
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
   assistantRoleFromMessage,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
@@ -1,3 +1,4 @@
+import type { RuntimeDescriptor } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
 import {
   Bot,
@@ -120,12 +121,14 @@ type WorkflowToolMessageProps = {
   meta: ToolMeta;
   messageTimestamp: string;
   sessionWorkingDirectory?: string | null | undefined;
+  workflowToolAliasesByCanonical?: RuntimeDescriptor["workflowToolAliasesByCanonical"] | undefined;
 };
 
 export const WorkflowToolMessage = ({
   meta,
   messageTimestamp,
   sessionWorkingDirectory,
+  workflowToolAliasesByCanonical,
 }: WorkflowToolMessageProps): ReactElement => {
   const durationMs = getToolDuration(meta, messageTimestamp);
   const hasInput = hasNonEmptyInput(meta.input);
@@ -161,7 +164,7 @@ export const WorkflowToolMessage = ({
                     : "text-pending-surface-foreground",
           )}
         >
-          {toolDisplayName(meta.tool)}
+          {toolDisplayName(meta.tool, workflowToolAliasesByCanonical)}
         </p>
         {statusLabel ? (
           <span
@@ -220,6 +223,7 @@ type RegularToolMessageProps = {
   messageTimestamp: string;
   timeLabel: string;
   sessionWorkingDirectory?: string | null | undefined;
+  workflowToolAliasesByCanonical?: RuntimeDescriptor["workflowToolAliasesByCanonical"] | undefined;
 };
 
 export const RegularToolMessage = ({
@@ -228,6 +232,7 @@ export const RegularToolMessage = ({
   messageTimestamp,
   timeLabel,
   sessionWorkingDirectory,
+  workflowToolAliasesByCanonical,
 }: RegularToolMessageProps): ReactElement => {
   const lifecyclePhase = getToolLifecyclePhase(meta);
   const summary = buildToolSummary(meta, messageContent, sessionWorkingDirectory);
@@ -274,7 +279,9 @@ export const RegularToolMessage = ({
       >
         {toolIcon(meta.tool)}
       </span>
-      <p className="shrink-0 font-medium text-current">{toolDisplayName(meta.tool)}</p>
+      <p className="shrink-0 font-medium text-current">
+        {toolDisplayName(meta.tool, workflowToolAliasesByCanonical)}
+      </p>
       {summaryText.length > 0 ? (
         <p className="truncate text-muted-foreground">{summaryText}</p>
       ) : null}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -1,3 +1,4 @@
+import type { RuntimeDescriptor } from "@openducktor/contracts";
 import {
   type AgentModelSelection,
   type AgentRole,
@@ -26,6 +27,7 @@ type AgentChatMessageCardViewModelInput = {
   sessionRole: AgentRole | null;
   sessionSelectedModel: AgentModelSelection | null;
   sessionAgentColors: Record<string, string> | undefined;
+  workflowToolAliasesByCanonical?: RuntimeDescriptor["workflowToolAliasesByCanonical"] | undefined;
 };
 
 type AgentChatMessageCardViewModel = {
@@ -135,6 +137,7 @@ export const buildAgentChatMessageCardViewModel = ({
   sessionRole,
   sessionSelectedModel: _sessionSelectedModel,
   sessionAgentColors,
+  workflowToolAliasesByCanonical,
 }: AgentChatMessageCardViewModelInput): AgentChatMessageCardViewModel => {
   const timeLabel = formatTime(message.timestamp);
   const meta = message.meta;
@@ -143,7 +146,9 @@ export const buildAgentChatMessageCardViewModel = ({
   const isUserMessage = message.role === "user";
   const isQueuedUserMessage = isUserMessage && meta?.kind === "user" && meta.state === "queued";
   const isToolMessage = meta?.kind === "tool";
-  const isWorkflowToolMessage = meta?.kind === "tool" && isOdtWorkflowMutationToolName(meta.tool);
+  const isWorkflowToolMessage =
+    meta?.kind === "tool" &&
+    isOdtWorkflowMutationToolName(meta.tool, workflowToolAliasesByCanonical);
   const isRegularToolMessage = isToolMessage && !isWorkflowToolMessage;
   const isSubtaskMessage = meta?.kind === "subtask";
   const isSessionNoticeMessage = meta?.kind === "session_notice";

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -18,7 +18,7 @@ const TEST_RUNTIME_DEFINITIONS_CONTEXT = {
 } satisfies ComponentProps<typeof RuntimeDefinitionsContext.Provider>["value"];
 
 const createElement = (
-  type: typeof AgentChatMessageCard,
+  _type: typeof AgentChatMessageCard,
   props: React.ComponentProps<typeof AgentChatMessageCard>,
 ) => {
   return createReactElement(

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -1,7 +1,35 @@
 import { describe, expect, test } from "bun:test";
-import { createElement } from "react";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { type ComponentProps, createElement as createReactElement } from "react";
 import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server";
+import { RuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { AgentChatMessageCard } from "./agent-chat-message-card";
+
+const TEST_RUNTIME_DEFINITIONS_CONTEXT = {
+  runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+  isLoadingRuntimeDefinitions: false,
+  runtimeDefinitionsError: null,
+  refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],
+  loadRepoRuntimeCatalog: async () => {
+    throw new Error("Test runtime catalog loader was not configured.");
+  },
+  loadRepoRuntimeSlashCommands: async () => ({ commands: [] }),
+  loadRepoRuntimeFileSearch: async () => [],
+} satisfies ComponentProps<typeof RuntimeDefinitionsContext.Provider>["value"];
+
+const createElement = (
+  type: typeof AgentChatMessageCard,
+  props: React.ComponentProps<typeof AgentChatMessageCard>,
+) => {
+  return createReactElement(
+    RuntimeDefinitionsContext.Provider,
+    { value: TEST_RUNTIME_DEFINITIONS_CONTEXT },
+    createReactElement(AgentChatMessageCard, {
+      sessionRuntimeKind: "opencode",
+      ...props,
+    }),
+  );
+};
 
 const renderToHtml = async (element: ReturnType<typeof createElement>): Promise<string> => {
   const stream = await renderToReadableStream(element);

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
@@ -1,5 +1,8 @@
+import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
-import { memo, type ReactElement } from "react";
+import { memo, type ReactElement, useContext } from "react";
+import { findRuntimeDefinition } from "@/lib/agent-runtime";
+import { RuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import { MessageBody, MessageHeader } from "./agent-chat-message-card-content";
 import { buildAgentChatMessageCardViewModel } from "./agent-chat-message-card-view-model";
@@ -11,6 +14,7 @@ type AgentChatMessageCardProps = {
   sessionSelectedModel?: AgentModelSelection | null;
   sessionAgentColors?: Record<string, string>;
   sessionWorkingDirectory?: string | null | undefined;
+  sessionRuntimeKind?: RuntimeKind | null | undefined;
 };
 
 export const AgentChatMessageCard = memo(function AgentChatMessageCard({
@@ -20,12 +24,19 @@ export const AgentChatMessageCard = memo(function AgentChatMessageCard({
   sessionSelectedModel,
   sessionAgentColors,
   sessionWorkingDirectory,
+  sessionRuntimeKind,
 }: AgentChatMessageCardProps): ReactElement | null {
+  const runtimeDefinitionsContext = useContext(RuntimeDefinitionsContext);
+  const runtimeDefinitions = runtimeDefinitionsContext?.runtimeDefinitions ?? [];
+  const workflowToolAliasesByCanonical = sessionRuntimeKind
+    ? findRuntimeDefinition(runtimeDefinitions, sessionRuntimeKind)?.workflowToolAliasesByCanonical
+    : undefined;
   const vm = buildAgentChatMessageCardViewModel({
     message,
     sessionRole,
     sessionSelectedModel: sessionSelectedModel ?? null,
     sessionAgentColors,
+    workflowToolAliasesByCanonical,
   });
 
   return (
@@ -45,6 +56,7 @@ export const AgentChatMessageCard = memo(function AgentChatMessageCard({
         timeLabel={vm.timeLabel}
         systemPromptBody={vm.systemPromptBody}
         sessionWorkingDirectory={sessionWorkingDirectory}
+        workflowToolAliasesByCanonical={workflowToolAliasesByCanonical}
       />
     </article>
   );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
@@ -12,6 +12,7 @@ type AgentChatWindowRowProps = {
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
+  sessionRuntimeKind?: AgentSessionState["runtimeKind"] | null | undefined;
 };
 
 export const AgentChatThreadRow = memo(function AgentChatThreadRow({
@@ -20,6 +21,7 @@ export const AgentChatThreadRow = memo(function AgentChatThreadRow({
   sessionAgentColors,
   sessionRole,
   sessionWorkingDirectory,
+  sessionRuntimeKind,
 }: AgentChatWindowRowProps): ReactElement {
   switch (row.kind) {
     case "turn_duration": {
@@ -35,6 +37,7 @@ export const AgentChatThreadRow = memo(function AgentChatThreadRow({
             sessionRole={sessionRole}
             sessionAgentColors={sessionAgentColors}
             sessionWorkingDirectory={sessionWorkingDirectory}
+            sessionRuntimeKind={sessionRuntimeKind}
           />
         </div>
       );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -50,6 +50,7 @@ type AgentChatThreadMotionRowProps = {
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
+  sessionRuntimeKind: AgentSessionState["runtimeKind"] | null;
   resolveRowRef: (rowKey: string) => (element: HTMLDivElement | null) => void;
 };
 
@@ -66,6 +67,7 @@ type AgentChatTranscriptProps = {
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
+  sessionRuntimeKind: AgentSessionState["runtimeKind"] | null;
   messagesContainerRef: AgentChatThreadModel["messagesContainerRef"];
   messagesContentRef: RefObject<HTMLDivElement | null>;
   renderedTurns: AgentChatRenderedTurn[];
@@ -144,6 +146,7 @@ const AgentChatThreadMotionRow = memo(
     sessionAgentColors,
     sessionRole,
     sessionWorkingDirectory,
+    sessionRuntimeKind,
     resolveRowRef,
   }: AgentChatThreadMotionRowProps): ReactElement {
     return (
@@ -154,6 +157,7 @@ const AgentChatThreadMotionRow = memo(
           sessionRole={sessionRole}
           sessionAgentColors={sessionAgentColors}
           sessionWorkingDirectory={sessionWorkingDirectory}
+          sessionRuntimeKind={sessionRuntimeKind}
         />
       </div>
     );
@@ -161,6 +165,7 @@ const AgentChatThreadMotionRow = memo(
   (previousProps, nextProps) => {
     return (
       previousProps.sessionRole === nextProps.sessionRole &&
+      previousProps.sessionRuntimeKind === nextProps.sessionRuntimeKind &&
       previousProps.sessionWorkingDirectory === nextProps.sessionWorkingDirectory &&
       previousProps.isStreamingAssistantMessage === nextProps.isStreamingAssistantMessage &&
       previousProps.sessionAgentColors === nextProps.sessionAgentColors &&
@@ -176,6 +181,7 @@ const AgentChatTurnGroup = memo(function AgentChatTurnGroup({
   sessionAgentColors,
   sessionRole,
   sessionWorkingDirectory,
+  sessionRuntimeKind,
   resolveRowRef,
   allowTurnContainment,
 }: {
@@ -184,6 +190,7 @@ const AgentChatTurnGroup = memo(function AgentChatTurnGroup({
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
+  sessionRuntimeKind: AgentSessionState["runtimeKind"] | null;
   resolveRowRef: (rowKey: string) => (element: HTMLDivElement | null) => void;
   allowTurnContainment: boolean;
 }): ReactElement {
@@ -199,6 +206,7 @@ const AgentChatTurnGroup = memo(function AgentChatTurnGroup({
           sessionRole={sessionRole}
           sessionAgentColors={sessionAgentColors}
           sessionWorkingDirectory={sessionWorkingDirectory}
+          sessionRuntimeKind={sessionRuntimeKind}
           resolveRowRef={resolveRowRef}
         />
       ))}
@@ -219,6 +227,7 @@ const AgentChatTranscript = memo(function AgentChatTranscript({
   sessionAgentColors,
   sessionRole,
   sessionWorkingDirectory,
+  sessionRuntimeKind,
   messagesContainerRef,
   messagesContentRef,
   renderedTurns,
@@ -310,6 +319,7 @@ const AgentChatTranscript = memo(function AgentChatTranscript({
                 sessionRole={sessionRole}
                 sessionAgentColors={sessionAgentColors}
                 sessionWorkingDirectory={sessionWorkingDirectory}
+                sessionRuntimeKind={sessionRuntimeKind}
                 resolveRowRef={resolveRowRef}
                 allowTurnContainment={allowTurnContainment}
               />
@@ -593,6 +603,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     isSessionViewLoading: isTranscriptLoading,
   });
   const sessionRole = session?.role ?? null;
+  const sessionRuntimeKind = session?.runtimeKind ?? null;
   const sessionSelectedModel = session?.selectedModel ?? null;
   const sessionAccentColor = useMemo(() => {
     const profileId = sessionSelectedModel?.profileId;
@@ -723,6 +734,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
         sessionAgentColors={sessionAgentColors}
         sessionRole={sessionRole}
         sessionWorkingDirectory={sessionWorkingDirectory}
+        sessionRuntimeKind={sessionRuntimeKind}
         messagesContainerRef={messagesContainerRef}
         messagesContentRef={messagesContentRef}
         renderedTurns={rows.length > 0 && !hideTranscriptWhileHydrating ? renderedTurns : []}

--- a/apps/desktop/src/components/features/agents/agent-chat/message-formatting.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/message-formatting.ts
@@ -1,3 +1,4 @@
+import type { RuntimeDescriptor } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
 import { toOdtWorkflowToolDisplayName } from "@openducktor/core";
 import { AGENT_ROLE_LABELS } from "@/types";
@@ -35,8 +36,11 @@ export const formatRawJsonLikeText = (value: string): string => {
 
 export { stripToolPrefix };
 
-export const toolDisplayName = (tool: string): string => {
-  return toOdtWorkflowToolDisplayName(tool);
+export const toolDisplayName = (
+  tool: string,
+  workflowToolAliasesByCanonical?: RuntimeDescriptor["workflowToolAliasesByCanonical"],
+): string => {
+  return toOdtWorkflowToolDisplayName(tool, workflowToolAliasesByCanonical);
 };
 
 export const toSingleLineMarkdown = (value: string): string => {

--- a/apps/desktop/src/pages/agents/agent-studio-test-utils.tsx
+++ b/apps/desktop/src/pages/agents/agent-studio-test-utils.tsx
@@ -1,4 +1,4 @@
-import type { TaskCard } from "@openducktor/contracts";
+import { OPENCODE_RUNTIME_DESCRIPTOR, type TaskCard } from "@openducktor/contracts";
 import {
   type ComponentProps,
   createElement,
@@ -37,10 +37,10 @@ const PAGE_SESSION_DEFAULTS: Partial<AgentSessionState> = {
 };
 
 const TEST_RUNTIME_DEFINITIONS_CONTEXT = {
-  runtimeDefinitions: [],
+  runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
   isLoadingRuntimeDefinitions: false,
   runtimeDefinitionsError: null,
-  refreshRuntimeDefinitions: async () => [],
+  refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],
   loadRepoRuntimeCatalog: async () => {
     throw new Error("Test runtime catalog loader was not configured.");
   },

--- a/apps/desktop/src/pages/agents/agent-studio-test-utils.tsx
+++ b/apps/desktop/src/pages/agents/agent-studio-test-utils.tsx
@@ -1,4 +1,8 @@
-import { OPENCODE_RUNTIME_DESCRIPTOR, type TaskCard } from "@openducktor/contracts";
+import {
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type RuntimeDescriptor,
+  type TaskCard,
+} from "@openducktor/contracts";
 import {
   type ComponentProps,
   createElement,
@@ -20,6 +24,10 @@ type ReactActEnvironment = typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
 
+type RuntimeDefinitionsContextValue = NonNullable<
+  ComponentProps<typeof RuntimeDefinitionsContext.Provider>["value"]
+>;
+
 export const enableReactActEnvironment = (): void => {
   (globalThis as ReactActEnvironment).IS_REACT_ACT_ENVIRONMENT = true;
 };
@@ -36,17 +44,48 @@ const PAGE_SESSION_DEFAULTS: Partial<AgentSessionState> = {
   workingDirectory: "/repo",
 };
 
-const TEST_RUNTIME_DEFINITIONS_CONTEXT = {
-  runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
-  isLoadingRuntimeDefinitions: false,
-  runtimeDefinitionsError: null,
-  refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],
-  loadRepoRuntimeCatalog: async () => {
-    throw new Error("Test runtime catalog loader was not configured.");
+export const cloneRuntimeDescriptor = (descriptor: RuntimeDescriptor): RuntimeDescriptor => ({
+  ...descriptor,
+  readOnlyRoleBlockedTools: [...descriptor.readOnlyRoleBlockedTools],
+  workflowToolAliasesByCanonical: Object.fromEntries(
+    Object.entries(descriptor.workflowToolAliasesByCanonical).map(([toolName, aliases]) => [
+      toolName,
+      aliases ? [...aliases] : aliases,
+    ]),
+  ) as RuntimeDescriptor["workflowToolAliasesByCanonical"],
+  capabilities: {
+    ...descriptor.capabilities,
+    supportedScopes: [...descriptor.capabilities.supportedScopes],
   },
-  loadRepoRuntimeSlashCommands: async () => ({ commands: [] }),
-  loadRepoRuntimeFileSearch: async () => [],
-} satisfies ComponentProps<typeof RuntimeDefinitionsContext.Provider>["value"];
+});
+
+export const createDefaultRuntimeDefinitions = (): RuntimeDescriptor[] => [
+  cloneRuntimeDescriptor(OPENCODE_RUNTIME_DESCRIPTOR),
+];
+
+export const createRuntimeDefinitionsContextValue = (
+  overrides: Partial<RuntimeDefinitionsContextValue> = {},
+): RuntimeDefinitionsContextValue => {
+  const defaultRuntimeDefinitions = createDefaultRuntimeDefinitions();
+
+  return {
+    runtimeDefinitions: overrides.runtimeDefinitions
+      ? overrides.runtimeDefinitions.map(cloneRuntimeDescriptor)
+      : defaultRuntimeDefinitions,
+    isLoadingRuntimeDefinitions: overrides.isLoadingRuntimeDefinitions ?? false,
+    runtimeDefinitionsError: overrides.runtimeDefinitionsError ?? null,
+    refreshRuntimeDefinitions:
+      overrides.refreshRuntimeDefinitions ?? (async () => createDefaultRuntimeDefinitions()),
+    loadRepoRuntimeCatalog:
+      overrides.loadRepoRuntimeCatalog ??
+      (async () => {
+        throw new Error("Test runtime catalog loader was not configured.");
+      }),
+    loadRepoRuntimeSlashCommands:
+      overrides.loadRepoRuntimeSlashCommands ?? (async () => ({ commands: [] })),
+    loadRepoRuntimeFileSearch: overrides.loadRepoRuntimeFileSearch ?? (async () => []),
+  };
+};
 
 const TEST_CHECKS_OPERATIONS_CONTEXT = {
   refreshRuntimeCheck: async () => ({
@@ -85,13 +124,16 @@ export const createAgentSessionFixture = (
 export const createHookHarness = <Props, State>(
   useHook: (props: Props) => State,
   initialProps: Props,
+  options?: {
+    runtimeDefinitionsContext?: RuntimeDefinitionsContextValue;
+    runtimeDefinitionsContextRef?: { current: RuntimeDefinitionsContextValue };
+  },
 ) => {
   const checksOperationsContext = {
     ...TEST_CHECKS_OPERATIONS_CONTEXT,
   };
-  const runtimeDefinitionsContext = {
-    ...TEST_RUNTIME_DEFINITIONS_CONTEXT,
-    runtimeDefinitions: [...TEST_RUNTIME_DEFINITIONS_CONTEXT.runtimeDefinitions],
+  const runtimeDefinitionsContextRef = options?.runtimeDefinitionsContextRef ?? {
+    current: options?.runtimeDefinitionsContext ?? createRuntimeDefinitionsContextValue(),
   };
 
   const wrapper = ({ children }: PropsWithChildren): ReactElement =>
@@ -101,10 +143,11 @@ export const createHookHarness = <Props, State>(
       createElement(
         QueryProvider,
         { useIsolatedClient: true },
-        createElement(RuntimeDefinitionsContext.Provider, {
-          value: runtimeDefinitionsContext,
+        createElement(
+          RuntimeDefinitionsContext.Provider,
+          { value: runtimeDefinitionsContextRef.current },
           children,
-        }),
+        ),
       ),
     );
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -305,6 +305,76 @@ describe("useAgentStudioDocuments", () => {
     }
   });
 
+  test("applies optimistic updates from trusted runtime workflow aliases", async () => {
+    setTaskDocumentsState({
+      specDoc: createDocumentState({
+        markdown: "# Old spec",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+      }),
+    });
+
+    const activeSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "session-runtime-alias",
+      messages: [
+        createCompletedToolMessage({
+          tool: "openducktor_odt_set_spec",
+          input: { markdown: "# Updated spec from alias" },
+          output: "completed 2026-02-22T09:00:00.000Z",
+        }),
+      ],
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      selectedTask: null,
+      activeSession,
+    });
+
+    try {
+      await harness.mount();
+
+      expect(applyDocumentUpdateMock).toHaveBeenCalledTimes(1);
+      expect(applyDocumentUpdateMock).toHaveBeenCalledWith("spec", {
+        markdown: "# Updated spec from alias",
+        updatedAt: "2026-02-22T09:00:00.000Z",
+      });
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+      expect(reloadDocumentMock).toHaveBeenCalledWith("spec");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("ignores incorrect-case runtime aliases for document refresh", async () => {
+    const activeSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "session-bad-case",
+      messages: [
+        createCompletedToolMessage({
+          tool: "OpenDucktor_ODT_SET_SPEC",
+          input: { markdown: "# Should not apply" },
+          output: "completed 2026-02-22T09:00:00.000Z",
+        }),
+      ],
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      selectedTask: null,
+      activeSession,
+    });
+
+    try {
+      await harness.mount();
+
+      expect(applyDocumentUpdateMock).not.toHaveBeenCalled();
+      expect(reloadDocumentMock).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("reloads section when completion timestamp is unavailable", async () => {
     setTaskDocumentsState({
       planDoc: createDocumentState({ markdown: "", updatedAt: null, isLoading: false }),

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -2,9 +2,9 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
+  createAgentSessionFixture,
   createDefaultRuntimeDefinitions,
   createRuntimeDefinitionsContextValue,
-  createAgentSessionFixture,
   createHookHarness as createSharedHookHarness,
   createTaskCardFixture,
   enableReactActEnvironment,

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -1,17 +1,9 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR, type RuntimeDescriptor } from "@openducktor/contracts";
-import {
-  type ComponentProps,
-  createElement,
-  type PropsWithChildren,
-  type ReactElement,
-} from "react";
-import { QueryProvider } from "@/lib/query-provider";
-import { RuntimeDefinitionsContext } from "@/state/app-state-contexts";
-import { createHookHarness as createRawHookHarness } from "@/test-utils/react-hook-harness";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
+  createDefaultRuntimeDefinitions,
+  createRuntimeDefinitionsContextValue,
   createAgentSessionFixture,
   createHookHarness as createSharedHookHarness,
   createTaskCardFixture,
@@ -107,46 +99,16 @@ let useAgentStudioDocuments: UseAgentStudioDocumentsHook;
 
 type HookArgs = Parameters<UseAgentStudioDocumentsHook>[0];
 type AgentMessage = AgentChatMessage;
-type RuntimeDefinitionsContextValue = NonNullable<
-  ComponentProps<typeof RuntimeDefinitionsContext.Provider>["value"]
->;
 
-const cloneRuntimeDescriptor = (): RuntimeDescriptor => ({
-  ...OPENCODE_RUNTIME_DESCRIPTOR,
-  readOnlyRoleBlockedTools: [...OPENCODE_RUNTIME_DESCRIPTOR.readOnlyRoleBlockedTools],
-  workflowToolAliasesByCanonical: Object.fromEntries(
-    Object.entries(OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical).map(
-      ([toolName, aliases]) => [toolName, aliases ? [...aliases] : aliases],
-    ),
-  ) as RuntimeDescriptor["workflowToolAliasesByCanonical"],
-  capabilities: {
-    ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities,
-    supportedScopes: [...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.supportedScopes],
-  },
-});
-
-const createHookHarness = (initialProps: HookArgs) =>
-  createSharedHookHarness(useAgentStudioDocuments, initialProps);
-
-const createHookHarnessWithRuntimeDefinitions = (
+const createHookHarness = (
   initialProps: HookArgs,
-  runtimeDefinitionsRef: {
-    current: RuntimeDefinitionsContextValue;
+  options?: {
+    runtimeDefinitionsContext?: ReturnType<typeof createRuntimeDefinitionsContextValue>;
+    runtimeDefinitionsContextRef?: {
+      current: ReturnType<typeof createRuntimeDefinitionsContextValue>;
+    };
   },
-) => {
-  const wrapper = ({ children }: PropsWithChildren): ReactElement =>
-    createElement(
-      QueryProvider,
-      { useIsolatedClient: true },
-      createElement(
-        RuntimeDefinitionsContext.Provider,
-        { value: runtimeDefinitionsRef.current },
-        children,
-      ),
-    );
-
-  return createRawHookHarness(useAgentStudioDocuments, initialProps, { wrapper });
-};
+) => createSharedHookHarness(useAgentStudioDocuments, initialProps, options);
 
 const createBaseArgs = (): HookArgs => ({
   activeRepo: "/repo",
@@ -446,20 +408,13 @@ describe("useAgentStudioDocuments", () => {
       selectedTask: null,
       activeSession,
     };
-    const runtimeDefinitionsRef: { current: RuntimeDefinitionsContextValue } = {
-      current: {
+    const runtimeDefinitionsContextRef = {
+      current: createRuntimeDefinitionsContextValue({
         runtimeDefinitions: [],
         isLoadingRuntimeDefinitions: true,
-        runtimeDefinitionsError: null,
-        refreshRuntimeDefinitions: async () => [cloneRuntimeDescriptor()],
-        loadRepoRuntimeCatalog: async () => {
-          throw new Error("Test runtime catalog loader was not configured.");
-        },
-        loadRepoRuntimeSlashCommands: async () => ({ commands: [] }),
-        loadRepoRuntimeFileSearch: async () => [],
-      },
+      }),
     };
-    const harness = createHookHarnessWithRuntimeDefinitions(hookArgs, runtimeDefinitionsRef);
+    const harness = createHookHarness(hookArgs, { runtimeDefinitionsContextRef });
 
     try {
       await harness.mount();
@@ -467,17 +422,11 @@ describe("useAgentStudioDocuments", () => {
       expect(applyDocumentUpdateMock).not.toHaveBeenCalled();
       expect(reloadDocumentMock).not.toHaveBeenCalled();
 
-      const previousRuntimeDefinitionsContext = runtimeDefinitionsRef.current;
-      runtimeDefinitionsRef.current = {
-        runtimeDefinitions: [cloneRuntimeDescriptor()],
+      runtimeDefinitionsContextRef.current = createRuntimeDefinitionsContextValue({
+        ...runtimeDefinitionsContextRef.current,
+        runtimeDefinitions: createDefaultRuntimeDefinitions(),
         isLoadingRuntimeDefinitions: false,
-        runtimeDefinitionsError: null,
-        refreshRuntimeDefinitions: async () => [cloneRuntimeDescriptor()],
-        loadRepoRuntimeCatalog: previousRuntimeDefinitionsContext.loadRepoRuntimeCatalog,
-        loadRepoRuntimeSlashCommands:
-          previousRuntimeDefinitionsContext.loadRepoRuntimeSlashCommands,
-        loadRepoRuntimeFileSearch: previousRuntimeDefinitionsContext.loadRepoRuntimeFileSearch,
-      };
+      });
 
       await harness.update(hookArgs);
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -1,4 +1,14 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR, type RuntimeDescriptor } from "@openducktor/contracts";
+import {
+  type ComponentProps,
+  createElement,
+  type PropsWithChildren,
+  type ReactElement,
+} from "react";
+import { QueryProvider } from "@/lib/query-provider";
+import { RuntimeDefinitionsContext } from "@/state/app-state-contexts";
+import { createHookHarness as createRawHookHarness } from "@/test-utils/react-hook-harness";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
@@ -97,9 +107,46 @@ let useAgentStudioDocuments: UseAgentStudioDocumentsHook;
 
 type HookArgs = Parameters<UseAgentStudioDocumentsHook>[0];
 type AgentMessage = AgentChatMessage;
+type RuntimeDefinitionsContextValue = NonNullable<
+  ComponentProps<typeof RuntimeDefinitionsContext.Provider>["value"]
+>;
+
+const cloneRuntimeDescriptor = (): RuntimeDescriptor => ({
+  ...OPENCODE_RUNTIME_DESCRIPTOR,
+  readOnlyRoleBlockedTools: [...OPENCODE_RUNTIME_DESCRIPTOR.readOnlyRoleBlockedTools],
+  workflowToolAliasesByCanonical: Object.fromEntries(
+    Object.entries(OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical).map(
+      ([toolName, aliases]) => [toolName, aliases ? [...aliases] : aliases],
+    ),
+  ) as RuntimeDescriptor["workflowToolAliasesByCanonical"],
+  capabilities: {
+    ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities,
+    supportedScopes: [...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.supportedScopes],
+  },
+});
 
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioDocuments, initialProps);
+
+const createHookHarnessWithRuntimeDefinitions = (
+  initialProps: HookArgs,
+  runtimeDefinitionsRef: {
+    current: RuntimeDefinitionsContextValue;
+  },
+) => {
+  const wrapper = ({ children }: PropsWithChildren): ReactElement =>
+    createElement(
+      QueryProvider,
+      { useIsolatedClient: true },
+      createElement(
+        RuntimeDefinitionsContext.Provider,
+        { value: runtimeDefinitionsRef.current },
+        children,
+      ),
+    );
+
+  return createRawHookHarness(useAgentStudioDocuments, initialProps, { wrapper });
+};
 
 const createBaseArgs = (): HookArgs => ({
   activeRepo: "/repo",
@@ -370,6 +417,77 @@ describe("useAgentStudioDocuments", () => {
 
       expect(applyDocumentUpdateMock).not.toHaveBeenCalled();
       expect(reloadDocumentMock).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("reprocesses mounted runtime aliases after runtime definitions hydrate", async () => {
+    setTaskDocumentsState({
+      specDoc: createDocumentState({
+        markdown: "# Old spec",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+      }),
+    });
+
+    const activeSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "session-hydrated-aliases",
+      messages: [
+        createCompletedToolMessage({
+          tool: "openducktor_odt_set_spec",
+          input: { markdown: "# Updated spec after hydration" },
+          output: "completed 2026-02-22T09:00:00.000Z",
+        }),
+      ],
+    });
+    const hookArgs = {
+      ...createBaseArgs(),
+      selectedTask: null,
+      activeSession,
+    };
+    const runtimeDefinitionsRef: { current: RuntimeDefinitionsContextValue } = {
+      current: {
+        runtimeDefinitions: [],
+        isLoadingRuntimeDefinitions: true,
+        runtimeDefinitionsError: null,
+        refreshRuntimeDefinitions: async () => [cloneRuntimeDescriptor()],
+        loadRepoRuntimeCatalog: async () => {
+          throw new Error("Test runtime catalog loader was not configured.");
+        },
+        loadRepoRuntimeSlashCommands: async () => ({ commands: [] }),
+        loadRepoRuntimeFileSearch: async () => [],
+      },
+    };
+    const harness = createHookHarnessWithRuntimeDefinitions(hookArgs, runtimeDefinitionsRef);
+
+    try {
+      await harness.mount();
+
+      expect(applyDocumentUpdateMock).not.toHaveBeenCalled();
+      expect(reloadDocumentMock).not.toHaveBeenCalled();
+
+      const previousRuntimeDefinitionsContext = runtimeDefinitionsRef.current;
+      runtimeDefinitionsRef.current = {
+        runtimeDefinitions: [cloneRuntimeDescriptor()],
+        isLoadingRuntimeDefinitions: false,
+        runtimeDefinitionsError: null,
+        refreshRuntimeDefinitions: async () => [cloneRuntimeDescriptor()],
+        loadRepoRuntimeCatalog: previousRuntimeDefinitionsContext.loadRepoRuntimeCatalog,
+        loadRepoRuntimeSlashCommands:
+          previousRuntimeDefinitionsContext.loadRepoRuntimeSlashCommands,
+        loadRepoRuntimeFileSearch: previousRuntimeDefinitionsContext.loadRepoRuntimeFileSearch,
+      };
+
+      await harness.update(hookArgs);
+
+      expect(applyDocumentUpdateMock).toHaveBeenCalledTimes(1);
+      expect(applyDocumentUpdateMock).toHaveBeenCalledWith("spec", {
+        markdown: "# Updated spec after hydration",
+        updatedAt: "2026-02-22T09:00:00.000Z",
+      });
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+      expect(reloadDocumentMock).toHaveBeenCalledWith("spec");
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
@@ -83,6 +83,8 @@ export function useAgentStudioDocuments({
   const refreshedTaskVersionsRef = useRef(new Set<string>());
   const previousSessionIdRef = useRef<string | null>(null);
   const previousMessagesRef = useRef<AgentSessionState["messages"] | null>(null);
+  const previousWorkflowAliasMetadataReadyRef = useRef(false);
+  const workflowAliasMetadataReady = workflowToolAliasesByCanonical !== undefined;
   const taskDocumentVersionKey =
     taskId && selectedTask
       ? [
@@ -105,7 +107,23 @@ export function useAgentStudioDocuments({
     refreshedTaskVersionsRef.current.clear();
     previousSessionIdRef.current = null;
     previousMessagesRef.current = null;
+    previousWorkflowAliasMetadataReadyRef.current = workflowAliasMetadataReady;
   }, [documentContextKey]);
+
+  useEffect(() => {
+    if (!activeSession || activeSession.role === "build" || !activeSession.runtimeKind) {
+      previousWorkflowAliasMetadataReadyRef.current = workflowAliasMetadataReady;
+      return;
+    }
+
+    const didHydrateWorkflowAliasMetadata =
+      workflowAliasMetadataReady && !previousWorkflowAliasMetadataReadyRef.current;
+    previousWorkflowAliasMetadataReadyRef.current = workflowAliasMetadataReady;
+
+    if (didHydrateWorkflowAliasMetadata) {
+      previousMessagesRef.current = null;
+    }
+  }, [activeSession, workflowAliasMetadataReady]);
 
   useEffect(() => {
     if (!taskId || taskDocumentVersionKey === null) {

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
@@ -22,6 +22,24 @@ type WorkflowDocumentTarget = {
   inputKey: "markdown" | "reportMarkdown";
 };
 
+const shouldReplayWorkflowDocumentMessagesForAliasHydration = ({
+  activeSession,
+  workflowAliasMetadataReady,
+  previousWorkflowAliasMetadataReady,
+}: {
+  activeSession: AgentSessionState | null;
+  workflowAliasMetadataReady: boolean;
+  previousWorkflowAliasMetadataReady: boolean;
+}): boolean => {
+  return Boolean(
+    activeSession &&
+      activeSession.role !== "build" &&
+      activeSession.runtimeKind &&
+      workflowAliasMetadataReady &&
+      !previousWorkflowAliasMetadataReady,
+  );
+};
+
 const resolveWorkflowDocumentTarget = (
   normalizedTool: string | null,
   docs: {
@@ -111,16 +129,16 @@ export function useAgentStudioDocuments({
   }, [documentContextKey]);
 
   useEffect(() => {
-    if (!activeSession || activeSession.role === "build" || !activeSession.runtimeKind) {
-      previousWorkflowAliasMetadataReadyRef.current = workflowAliasMetadataReady;
-      return;
-    }
-
-    const didHydrateWorkflowAliasMetadata =
-      workflowAliasMetadataReady && !previousWorkflowAliasMetadataReadyRef.current;
+    const previousWorkflowAliasMetadataReady = previousWorkflowAliasMetadataReadyRef.current;
     previousWorkflowAliasMetadataReadyRef.current = workflowAliasMetadataReady;
 
-    if (didHydrateWorkflowAliasMetadata) {
+    if (
+      shouldReplayWorkflowDocumentMessagesForAliasHydration({
+        activeSession,
+        workflowAliasMetadataReady,
+        previousWorkflowAliasMetadataReady,
+      })
+    ) {
       previousMessagesRef.current = null;
     }
   }, [activeSession, workflowAliasMetadataReady]);

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
@@ -2,6 +2,8 @@ import type { TaskCard } from "@openducktor/contracts";
 import { normalizeOdtWorkflowToolName } from "@openducktor/core";
 import { useEffect, useRef } from "react";
 import { useTaskDocuments } from "@/components/features/task-details/use-task-documents";
+import { findRuntimeDefinition } from "@/lib/agent-runtime";
+import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { forEachSessionMessageFrom } from "@/state/operations/agent-orchestrator/support/messages";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { findFirstChangedMessageIndex } from "./agent-session-message-diff";
@@ -65,11 +67,16 @@ export function useAgentStudioDocuments({
   planDoc: ReturnType<typeof useTaskDocuments>["planDoc"];
   qaDoc: ReturnType<typeof useTaskDocuments>["qaDoc"];
 } {
+  const { runtimeDefinitions } = useRuntimeDefinitionsContext();
   const { specDoc, planDoc, qaDoc, reloadDocument, applyDocumentUpdate } = useTaskDocuments(
     taskId || null,
     true,
     activeRepo ?? "",
   );
+  const workflowToolAliasesByCanonical = activeSession?.runtimeKind
+    ? findRuntimeDefinition(runtimeDefinitions, activeSession.runtimeKind)
+        ?.workflowToolAliasesByCanonical
+    : undefined;
 
   const documentContextKey = `${taskId}:${activeSession?.sessionId ?? ""}`;
   const processedDocumentToolEventsRef = useRef(new Set<string>());
@@ -147,7 +154,10 @@ export function useAgentStudioDocuments({
       if (!meta || meta.kind !== "tool" || meta.status !== "completed") {
         return;
       }
-      const normalizedTool = normalizeOdtWorkflowToolName(meta.tool);
+      const normalizedTool = normalizeOdtWorkflowToolName(
+        meta.tool,
+        workflowToolAliasesByCanonical,
+      );
       const target = resolveWorkflowDocumentTarget(normalizedTool, {
         specDoc,
         planDoc,
@@ -200,6 +210,7 @@ export function useAgentStudioDocuments({
     reloadDocument,
     specDoc,
     taskId,
+    workflowToolAliasesByCanonical,
   ]);
 
   return {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
@@ -1,3 +1,4 @@
+import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
 import type { AgentEnginePort } from "@openducktor/core";
 import type { MutableRefObject } from "react";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -43,6 +44,7 @@ export type AttachAgentSessionListenerParams = {
   resolveTurnDurationMs: ResolveTurnDuration;
   clearTurnDuration: (sessionId: string) => void;
   refreshTaskData: (repoPath: string, taskIdOrIds?: string | string[]) => Promise<void>;
+  resolveRuntimeDefinition?: (runtimeKind: RuntimeKind) => RuntimeDescriptor | null;
 };
 
 export type SessionStoreContext = Pick<
@@ -73,7 +75,7 @@ export type SessionPermissionContext = Pick<AttachAgentSessionListenerParams, "a
 
 export type SessionRefreshContext = Pick<
   AttachAgentSessionListenerParams,
-  "repoPath" | "refreshTaskData"
+  "repoPath" | "refreshTaskData" | "resolveRuntimeDefinition"
 >;
 
 export type SessionLifecycleEventContext = {
@@ -165,6 +167,9 @@ export const createSessionEventHandlerContext = (
     refresh: {
       repoPath: context.repoPath,
       refreshTaskData: context.refreshTaskData,
+      ...(context.resolveRuntimeDefinition
+        ? { resolveRuntimeDefinition: context.resolveRuntimeDefinition }
+        : {}),
     },
   },
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { SessionPart } from "./session-event-types";
 import { resolveToolRefreshDecision } from "./session-tool-parts";
 
@@ -17,7 +18,14 @@ const buildToolPart = (tool: string): Extract<SessionPart, { kind: "tool" }> => 
 
 describe("session-tool-parts", () => {
   test("resolveToolRefreshDecision only triggers on first completion transition", () => {
-    const cases = [
+    const cases: Array<{
+      name: string;
+      tool: string;
+      status: Extract<SessionPart, { kind: "tool" }>["status"];
+      previousStatus: Extract<SessionPart, { kind: "tool" }>["status"];
+      aliases?: typeof OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical;
+      expected: { shouldRefreshTaskData: boolean };
+    }> = [
       {
         name: "workflow mutation first completion",
         tool: "odt_set_plan",
@@ -30,6 +38,22 @@ describe("session-tool-parts", () => {
         tool: "odt_set_plan",
         status: "completed",
         previousStatus: "completed",
+        expected: { shouldRefreshTaskData: false },
+      },
+      {
+        name: "trusted runtime alias first completion",
+        tool: "openducktor_odt_set_plan",
+        status: "completed",
+        previousStatus: "pending",
+        aliases: OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+        expected: { shouldRefreshTaskData: true },
+      },
+      {
+        name: "incorrect-case runtime alias stays unrecognized",
+        tool: "OpenDucktor_ODT_SET_PLAN",
+        status: "completed",
+        previousStatus: "pending",
+        aliases: OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
         expected: { shouldRefreshTaskData: false },
       },
       {
@@ -60,6 +84,7 @@ describe("session-tool-parts", () => {
         buildToolPart(scenario.tool),
         scenario.status,
         scenario.previousStatus,
+        scenario.aliases,
       );
       expect(decision).toEqual(scenario.expected);
     }

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
@@ -55,10 +55,13 @@ export const resolveToolRefreshDecision = (
   part: ToolPart,
   status: ToolPartStatus,
   previousStatus: ToolPartStatus | undefined,
+  workflowToolAliasesByCanonical?: Parameters<typeof isOdtWorkflowMutationToolName>[1],
 ): ToolRefreshDecision => {
   const transitionedToCompleted = status === "completed" && previousStatus !== "completed";
   return {
-    shouldRefreshTaskData: isOdtWorkflowMutationToolName(part.tool) && transitionedToCompleted,
+    shouldRefreshTaskData:
+      isOdtWorkflowMutationToolName(part.tool, workflowToolAliasesByCanonical) &&
+      transitionedToCompleted,
   };
 };
 
@@ -134,6 +137,7 @@ const composeToolPartSessionUpdate = ({
   error,
   todoUpdateFromTool,
   timestamp,
+  workflowToolAliasesByCanonical,
 }: {
   current: AgentSessionState;
   prepareCurrent: PrepareCurrent;
@@ -146,6 +150,7 @@ const composeToolPartSessionUpdate = ({
   error: string | undefined;
   todoUpdateFromTool: ReturnType<typeof resolveTodoUpdateFromTool>;
   timestamp: string;
+  workflowToolAliasesByCanonical?: Parameters<typeof isOdtWorkflowMutationToolName>[1];
 }): ToolPartSessionUpdate => {
   const prepared = prepareCurrent(current);
   const fallbackMessageId = `tool:${streamMessageKey}`;
@@ -162,7 +167,12 @@ const composeToolPartSessionUpdate = ({
   const existing = findSessionMessageById(prepared, messageId);
   const previousStatus = existing?.meta?.kind === "tool" ? existing.meta.status : undefined;
   const existingToolMeta = existing?.meta?.kind === "tool" ? existing.meta : null;
-  const refreshDecision = resolveToolRefreshDecision(part, status, previousStatus);
+  const refreshDecision = resolveToolRefreshDecision(
+    part,
+    status,
+    previousStatus,
+    workflowToolAliasesByCanonical,
+  );
   const timingMeta = composeToolTimingMeta(
     existingToolMeta,
     observedEventTimestampMs,
@@ -208,7 +218,13 @@ export const handleToolPart = (
   const observedEventTimestampMs = eventTimestampMs(event.timestamp);
   const todoUpdateFromTool = resolveTodoUpdateFromTool(part, input, output);
   let shouldRefreshTaskData = false;
-  const taskId = context.store.sessionsRef.current[context.store.sessionId]?.taskId;
+  const activeSession = context.store.sessionsRef.current[context.store.sessionId] ?? null;
+  const taskId = activeSession?.taskId;
+  const runtimeDescriptor =
+    activeSession?.runtimeKind && context.refresh.resolveRuntimeDefinition
+      ? context.refresh.resolveRuntimeDefinition(activeSession.runtimeKind)
+      : null;
+  const workflowToolAliasesByCanonical = runtimeDescriptor?.workflowToolAliasesByCanonical;
 
   context.store.updateSession(
     context.store.sessionId,
@@ -225,6 +241,7 @@ export const handleToolPart = (
         error,
         todoUpdateFromTool,
         timestamp: event.timestamp,
+        workflowToolAliasesByCanonical,
       });
 
       shouldRefreshTaskData = refreshDecision.shouldRefreshTaskData;

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -1,6 +1,7 @@
 import type { AgentSessionRecord, RunSummary, RuntimeKind, TaskCard } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentRuntimeConnection } from "@openducktor/core";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { findRuntimeDefinition } from "@/lib/agent-runtime";
 import { appQueryClient } from "@/lib/query-client";
 import type { AgentSessionsStore } from "@/state/agent-sessions-store";
 import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
@@ -267,6 +268,8 @@ export function useAgentOrchestratorOperations({
         resolveTurnDurationMs,
         clearTurnDuration,
         refreshTaskData,
+        resolveRuntimeDefinition: (runtimeKind) =>
+          findRuntimeDefinition(agentEngine.listRuntimeDefinitions(), runtimeKind),
       });
 
       unsubscribersRef.current.set(sessionId, unsubscribe);

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -99,6 +99,7 @@ const MOCK_RUNTIME_DESCRIPTOR: RuntimeDescriptor = {
   label: "Mock Runtime",
   description: "Mock runtime descriptor for per-kind health tests.",
   readOnlyRoleBlockedTools: [],
+  workflowToolAliasesByCanonical: {},
   capabilities: {
     ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities,
   },

--- a/apps/desktop/src/state/queries/runtime.test.ts
+++ b/apps/desktop/src/state/queries/runtime.test.ts
@@ -38,6 +38,7 @@ const runtimeFixture: RuntimeInstanceSummary = {
       supportsVariants: true,
     },
     readOnlyRoleBlockedTools: [],
+    workflowToolAliasesByCanonical: {},
   },
 };
 

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -33,11 +33,14 @@ It is the stable definition of a runtime kind:
 - `label`
 - `description`
 - `readOnlyRoleBlockedTools`
+- `workflowToolAliasesByCanonical`
 - `capabilities`
 
 Descriptors are static metadata. They are not live runtime instances.
 
 `readOnlyRoleBlockedTools` is the runtime-owned list of native tool IDs that must be denied for read-only OpenDucktor roles (`spec`, `planner`, `qa`). This list is runtime-specific. OpenDucktor must not hardcode another runtime's tool names in generic orchestration code or in a different runtime adapter.
+
+`workflowToolAliasesByCanonical` is the runtime-owned map from canonical `odt_*` workflow tool names to exact native runtime tool IDs for that runtime. Shared/core OpenDucktor code keeps canonical `odt_*` identity only and must consume this mapping when a caller needs to interpret runtime-native workflow tool IDs for authorization, tool selection, event refresh, or display.
 
 ### `RuntimeInstanceSummary`
 
@@ -160,7 +163,9 @@ Rules:
 
 - `AGENT_ROLE_TOOL_POLICY` continues to define which `odt_*` workflow tools each role may call.
 - Each runtime descriptor must declare `readOnlyRoleBlockedTools` for that runtime's native mutating tool IDs.
+- Each runtime descriptor must declare `workflowToolAliasesByCanonical` for any native workflow tool IDs that differ from canonical `odt_*` names.
 - Runtime adapters must consume `readOnlyRoleBlockedTools` both when constructing runtime permission rules and when building the runtime `tools` selection sent on prompt turns for `spec`, `planner`, and `qa`.
+- Runtime adapters and desktop workflow-tool consumers must resolve native workflow tool IDs through `workflowToolAliasesByCanonical` instead of hardcoded runtime prefixes in shared code.
 - Do not hardcode OpenCode tool IDs in generic orchestration code or assume another runtime uses the same tool names.
 - Do not block `bash` generically for read-only roles. Read-only roles still need shell access for inspections, tests, and lint commands; mutation control for shell commands remains a runtime/permission-flow concern.
 
@@ -177,6 +182,7 @@ A runtime is represented through:
 - a stable `runtimeKind`,
 - a `RuntimeDescriptor` that describes its implemented capabilities,
 - a runtime-owned `readOnlyRoleBlockedTools` list for native mutating tools,
+- a runtime-owned `workflowToolAliasesByCanonical` map for native workflow tool IDs,
 - a live `RuntimeRoute` compatible with current host-visible route schemas,
 - a request-scoped `RuntimeConnection`,
 - persisted session records that keep `runtimeKind`, `externalSessionId`, and `workingDirectory`.
@@ -256,6 +262,7 @@ What to add:
 - the new `runtimeKind` in any curated constant lists,
 - a descriptor constant whose capabilities describe implemented behavior,
 - a descriptor-level `readOnlyRoleBlockedTools` list for that runtime's native mutating tool IDs,
+- a descriptor-level `workflowToolAliasesByCanonical` map for native workflow tool IDs that are not already canonical `odt_*` names,
 - any new route or transport schema support if the runtime is not `local_http`,
 - config/session schema support for runtime-aware model defaults.
 

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -42,6 +42,23 @@ Descriptors are static metadata. They are not live runtime instances.
 
 `workflowToolAliasesByCanonical` is the runtime-owned map from canonical `odt_*` workflow tool names to exact native runtime tool IDs for that runtime. Shared/core OpenDucktor code keeps canonical `odt_*` identity only and must consume this mapping when a caller needs to interpret runtime-native workflow tool IDs for authorization, tool selection, event refresh, or display.
 
+Example:
+
+```ts
+{
+  odt_set_spec: [
+    "openducktor_odt_set_spec",
+    "functions.openducktor_odt_set_spec",
+  ],
+  odt_build_completed: [
+    "openducktor_odt_build_completed",
+    "functions.openducktor_odt_build_completed",
+  ],
+}
+```
+
+The canonical `odt_*` names stay implicit and do not need to be repeated in this field.
+
 ### `RuntimeInstanceSummary`
 
 Defined in `packages/contracts/src/run-schemas.ts` and mirrored in Rust runtime domain types.

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
@@ -65,6 +65,11 @@ describe("workflow-tool-permissions", () => {
       pattern: "*",
       action: "allow",
     });
+    expect(rules).toContainEqual({
+      permission: "functions.openducktor_odt_set_spec",
+      pattern: "*",
+      action: "allow",
+    });
     expect(rules).not.toContainEqual({
       permission: "openducktor_odt_set_plan",
       pattern: "*",

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
@@ -54,11 +54,10 @@ export const buildRoleScopedPermissionRules = (input: {
     if (!allowedTools.has(toolName)) {
       continue;
     }
-    for (const permission of [
+    for (const permission of new Set([
       toolName,
-      `openducktor_${toolName}`,
-      `functions.openducktor_${toolName}`,
-    ]) {
+      ...(runtimeDescriptor.workflowToolAliasesByCanonical[toolName] ?? []),
+    ])) {
       rules.push({
         permission,
         pattern: "*",

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
@@ -148,6 +148,7 @@ export const resolveWorkflowToolSelection = async (input: {
   const selection = buildRoleScopedOdtToolSelection(input.role, {
     includeCanonicalDefaults: true,
     runtimeToolIds,
+    workflowToolAliasesByCanonical: input.runtimeDescriptor.workflowToolAliasesByCanonical,
   });
 
   if (isReadOnlyRole(input.role)) {

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1256,6 +1256,8 @@ describe("TauriHostClient", () => {
               "ast_grep_replace",
               "lsp_rename",
             ],
+            workflowToolAliasesByCanonical:
+              OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
             capabilities: {
               supportsProfiles: true,
               supportsVariants: true,

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1431,12 +1431,21 @@ describe("TauriHostClient", () => {
     const stopped = await client.runtimeStop("runtime-1");
 
     expect(definitions[0]?.kind).toBe("opencode");
+    expect(definitions[0]?.workflowToolAliasesByCanonical).toEqual(
+      OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+    );
     expect(qaTarget).toEqual({
       workingDirectory: "/repo/worktrees/task-1",
       source: "active_build_run",
     });
     expect(runtimes).toHaveLength(1);
+    expect(runtimes[0]?.descriptor.workflowToolAliasesByCanonical).toEqual(
+      OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+    );
     expect(ensured.runtimeId).toBe("runtime-main");
+    expect(ensured.descriptor.workflowToolAliasesByCanonical).toEqual(
+      OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+    );
     expect(startupStatus.stage).toBe("waiting_for_runtime");
     expect(repoRuntimeHealth.mcp?.status).toBe("connected");
     expect(repoRuntimeHealthStatus.mcp?.status).toBe("checking");

--- a/packages/contracts/src/agent-runtime-schemas.ts
+++ b/packages/contracts/src/agent-runtime-schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { AgentRole } from "./agent-workflow-schemas";
-import { agentToolNameValues, type AgentToolName } from "./agent-workflow-schemas";
+import { type AgentToolName, agentToolNameValues } from "./agent-workflow-schemas";
 
 export const knownRuntimeKindValues = ["opencode"] as const;
 export const knownRuntimeKindSchema = z.enum(knownRuntimeKindValues);
@@ -162,7 +162,7 @@ const runtimeWorkflowToolAliasesByCanonicalSchema = z
           context.addIssue({
             code: "custom",
             path: [canonicalTool, index],
-            message: `Runtime workflow alias \"${alias}\" is already assigned to canonical tool \"${existingCanonicalTool}\".`,
+            message: `Runtime workflow alias "${alias}" is already assigned to canonical tool "${existingCanonicalTool}".`,
           });
           continue;
         }

--- a/packages/contracts/src/agent-runtime-schemas.ts
+++ b/packages/contracts/src/agent-runtime-schemas.ts
@@ -155,6 +155,7 @@ const runtimeWorkflowToolAliasesByCanonicalSchema = z
             path: [canonicalTool, index],
             message: "Runtime workflow aliases must not repeat canonical odt_* tool IDs.",
           });
+          continue;
         }
 
         const existingCanonicalTool = canonicalByAlias.get(alias);

--- a/packages/contracts/src/agent-runtime-schemas.ts
+++ b/packages/contracts/src/agent-runtime-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { AgentRole } from "./agent-workflow-schemas";
+import { agentToolNameValues, type AgentToolName } from "./agent-workflow-schemas";
 
 export const knownRuntimeKindValues = ["opencode"] as const;
 export const knownRuntimeKindSchema = z.enum(knownRuntimeKindValues);
@@ -129,11 +130,54 @@ const runtimeReadOnlyRoleBlockedToolsSchema = z
     message: "Read-only blocked runtime tool IDs must be unique.",
   });
 
+const runtimeWorkflowToolAliasesSchema = z
+  .array(runtimeToolIdSchema)
+  .min(1, { message: "Workflow tool alias lists must not be empty." })
+  .refine((toolIds) => new Set(toolIds).size === toolIds.length, {
+    message: "Workflow tool aliases for a canonical tool must be unique.",
+  });
+
+const runtimeWorkflowToolAliasesByCanonicalShape = Object.fromEntries(
+  agentToolNameValues.map((toolName) => [toolName, runtimeWorkflowToolAliasesSchema.optional()]),
+) as Record<AgentToolName, z.ZodOptional<typeof runtimeWorkflowToolAliasesSchema>>;
+
+const runtimeWorkflowToolAliasesByCanonicalSchema = z
+  .object(runtimeWorkflowToolAliasesByCanonicalShape)
+  .superRefine((aliasesByCanonical, context) => {
+    const canonicalByAlias = new Map<string, AgentToolName>();
+
+    for (const canonicalTool of agentToolNameValues) {
+      const aliases = aliasesByCanonical[canonicalTool] ?? [];
+      for (const [index, alias] of aliases.entries()) {
+        if (agentToolNameValues.includes(alias as AgentToolName)) {
+          context.addIssue({
+            code: "custom",
+            path: [canonicalTool, index],
+            message: "Runtime workflow aliases must not repeat canonical odt_* tool IDs.",
+          });
+        }
+
+        const existingCanonicalTool = canonicalByAlias.get(alias);
+        if (existingCanonicalTool && existingCanonicalTool !== canonicalTool) {
+          context.addIssue({
+            code: "custom",
+            path: [canonicalTool, index],
+            message: `Runtime workflow alias \"${alias}\" is already assigned to canonical tool \"${existingCanonicalTool}\".`,
+          });
+          continue;
+        }
+
+        canonicalByAlias.set(alias, canonicalTool);
+      }
+    }
+  });
+
 export const runtimeDescriptorSchema = z.object({
   kind: runtimeKindSchema,
   label: z.string().min(1),
   description: z.string().min(1),
   readOnlyRoleBlockedTools: runtimeReadOnlyRoleBlockedToolsSchema,
+  workflowToolAliasesByCanonical: runtimeWorkflowToolAliasesByCanonicalSchema,
   capabilities: runtimeCapabilitiesSchema,
 });
 export type RuntimeDescriptor = z.infer<typeof runtimeDescriptorSchema>;

--- a/packages/contracts/src/agent-runtime-schemas.ts
+++ b/packages/contracts/src/agent-runtime-schemas.ts
@@ -143,6 +143,7 @@ const runtimeWorkflowToolAliasesByCanonicalShape = Object.fromEntries(
 
 const runtimeWorkflowToolAliasesByCanonicalSchema = z
   .object(runtimeWorkflowToolAliasesByCanonicalShape)
+  .strict()
   .superRefine((aliasesByCanonical, context) => {
     const canonicalByAlias = new Map<string, AgentToolName>();
 

--- a/packages/contracts/src/runtime-descriptors.ts
+++ b/packages/contracts/src/runtime-descriptors.ts
@@ -3,6 +3,7 @@ import {
   type RuntimeDescriptor,
   requiredRuntimeSupportedScopes,
 } from "./agent-runtime-schemas";
+import { agentToolNameValues } from "./agent-workflow-schemas";
 
 const OPENCODE_READ_ONLY_ROLE_BLOCKED_TOOLS = [
   "edit",
@@ -11,6 +12,20 @@ const OPENCODE_READ_ONLY_ROLE_BLOCKED_TOOLS = [
   "ast_grep_replace",
   "lsp_rename",
 ] as const;
+const OPENCODE_ODT_WORKFLOW_TOOL_PREFIXES = ["openducktor_", "functions.openducktor_"] as const;
+
+const createOpencodeWorkflowToolAliasesByCanonical =
+  (): RuntimeDescriptor["workflowToolAliasesByCanonical"] => {
+    const aliasesByCanonical: RuntimeDescriptor["workflowToolAliasesByCanonical"] = {};
+
+    for (const toolName of agentToolNameValues) {
+      aliasesByCanonical[toolName] = OPENCODE_ODT_WORKFLOW_TOOL_PREFIXES.map(
+        (prefix) => `${prefix}${toolName}`,
+      );
+    }
+
+    return aliasesByCanonical;
+  };
 
 export const OPENCODE_RUNTIME_CAPABILITIES = {
   supportsProfiles: true,
@@ -35,5 +50,6 @@ export const OPENCODE_RUNTIME_DESCRIPTOR = {
   label: "OpenCode",
   description: "OpenCode local runtime with OpenDucktor MCP integration.",
   readOnlyRoleBlockedTools: [...OPENCODE_READ_ONLY_ROLE_BLOCKED_TOOLS],
+  workflowToolAliasesByCanonical: createOpencodeWorkflowToolAliasesByCanonical(),
   capabilities: OPENCODE_RUNTIME_CAPABILITIES,
 } as const satisfies RuntimeDescriptor;

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -740,6 +740,31 @@ describe("runtime schemas", () => {
     );
   });
 
+  test("runtime descriptor rejects unknown workflow alias keys", () => {
+    const result = runtimeDescriptorSchema.safeParse({
+      ...OPENCODE_RUNTIME_DESCRIPTOR,
+      workflowToolAliasesByCanonical: {
+        ...OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+        odt_set_specc: ["openducktor_odt_set_spec"],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "unrecognized_keys",
+          keys: ["odt_set_specc"],
+          path: ["workflowToolAliasesByCanonical"],
+        }),
+      ]),
+    );
+  });
+
   test("slash command catalog parses runtime command metadata", () => {
     const parsed = slashCommandCatalogSchema.parse({
       commands: [

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -25,6 +25,7 @@ import {
   OPENCODE_RUNTIME_DESCRIPTOR,
   repoConfigSchema,
   runEventSchema,
+  runtimeDescriptorSchema,
   runtimeInstanceSummaryRoleSchema,
   runtimeInstanceSummarySchema,
   slashCommandCatalogSchema,
@@ -678,6 +679,35 @@ describe("runtime schemas", () => {
     expect(parsed.descriptor.capabilities.supportsFileSearch).toBe(true);
     expect(parsed.descriptor.readOnlyRoleBlockedTools).toContain("apply_patch");
     expect(parsed.descriptor.readOnlyRoleBlockedTools).not.toContain("bash");
+    expect(parsed.descriptor.workflowToolAliasesByCanonical.odt_set_spec).toEqual([
+      "openducktor_odt_set_spec",
+      "functions.openducktor_odt_set_spec",
+    ]);
+  });
+
+  test("runtime descriptor rejects workflow alias collisions across canonical tools", () => {
+    expect(() =>
+      runtimeDescriptorSchema.parse({
+        ...OPENCODE_RUNTIME_DESCRIPTOR,
+        workflowToolAliasesByCanonical: {
+          ...OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+          odt_set_spec: ["openducktor_odt_set_spec"],
+          odt_set_plan: ["openducktor_odt_set_spec"],
+        },
+      }),
+    ).toThrow('assigned to canonical tool \\"odt_set_spec\\"');
+  });
+
+  test("runtime descriptor rejects canonical odt tool ids inside workflow alias metadata", () => {
+    expect(() =>
+      runtimeDescriptorSchema.parse({
+        ...OPENCODE_RUNTIME_DESCRIPTOR,
+        workflowToolAliasesByCanonical: {
+          ...OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+          odt_set_spec: ["odt_set_spec"],
+        },
+      }),
+    ).toThrow("Runtime workflow aliases must not repeat canonical odt_* tool IDs.");
   });
 
   test("slash command catalog parses runtime command metadata", () => {

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -710,6 +710,36 @@ describe("runtime schemas", () => {
     ).toThrow("Runtime workflow aliases must not repeat canonical odt_* tool IDs.");
   });
 
+  test("runtime descriptor reports only the canonical-id validation issue for repeated canonical aliases", () => {
+    const result = runtimeDescriptorSchema.safeParse({
+      ...OPENCODE_RUNTIME_DESCRIPTOR,
+      workflowToolAliasesByCanonical: {
+        ...OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical,
+        odt_set_spec: ["odt_set_spec"],
+        odt_set_plan: ["odt_set_spec"],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues).toHaveLength(2);
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["workflowToolAliasesByCanonical", "odt_set_spec", 0],
+          message: "Runtime workflow aliases must not repeat canonical odt_* tool IDs.",
+        }),
+        expect.objectContaining({
+          path: ["workflowToolAliasesByCanonical", "odt_set_plan", 0],
+          message: "Runtime workflow aliases must not repeat canonical odt_* tool IDs.",
+        }),
+      ]),
+    );
+  });
+
   test("slash command catalog parses runtime command metadata", () => {
     const parsed = slashCommandCatalogSchema.parse({
       commands: [

--- a/packages/core/src/services/odt-workflow-tools.test.ts
+++ b/packages/core/src/services/odt-workflow-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import {
   buildRoleScopedOdtToolSelection,
   isOdtWorkflowMutationToolName,
@@ -9,23 +10,49 @@ import {
 } from "./odt-workflow-tools";
 
 describe("odt workflow tools", () => {
-  test("normalizes plain and namespaced tool names", () => {
+  const workflowToolAliasesByCanonical = OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical;
+
+  test("normalizes canonical tool names without assuming runtime aliases", () => {
     expect(normalizeOdtWorkflowToolName("odt_set_spec")).toBe("odt_set_spec");
-    expect(normalizeOdtWorkflowToolName("OpenDucktor_ODT_SET_SPEC")).toBe("odt_set_spec");
-    expect(normalizeOdtWorkflowToolName("  openducktor_odt_qa_rejected  ")).toBe("odt_qa_rejected");
-    expect(normalizeOdtWorkflowToolName("functions.openducktor_odt_set_spec")).toBe("odt_set_spec");
+    expect(normalizeOdtWorkflowToolName("  odt_qa_rejected  ")).toBe("odt_qa_rejected");
+    expect(normalizeOdtWorkflowToolName("OpenDucktor_ODT_SET_SPEC")).toBeNull();
+    expect(normalizeOdtWorkflowToolName("functions.openducktor_odt_set_spec")).toBeNull();
     expect(normalizeOdtWorkflowToolName("customprefix_odt_set_plan")).toBeNull();
     expect(normalizeOdtWorkflowToolName("customprefix_odt_")).toBeNull();
     expect(normalizeOdtWorkflowToolName("customprefix_odt_set_plan_extra")).toBeNull();
     expect(normalizeOdtWorkflowToolName("ODT_")).toBeNull();
     expect(normalizeOdtWorkflowToolName("read")).toBeNull();
+  });
+
+  test("normalizes trusted runtime aliases only when runtime metadata is provided", () => {
+    expect(
+      normalizeOdtWorkflowToolName(
+        "  openducktor_odt_qa_rejected  ",
+        workflowToolAliasesByCanonical,
+      ),
+    ).toBe("odt_qa_rejected");
+    expect(
+      normalizeOdtWorkflowToolName(
+        "functions.openducktor_odt_set_spec",
+        workflowToolAliasesByCanonical,
+      ),
+    ).toBe("odt_set_spec");
     expect(normalizeOdtWorkflowToolName("openducktor_odt_set_spec_extra")).toBeNull();
+    expect(
+      normalizeOdtWorkflowToolName("OpenDucktor_ODT_SET_SPEC", workflowToolAliasesByCanonical),
+    ).toBeNull();
   });
 
   test("detects workflow tool ids", () => {
     expect(isOdtWorkflowToolName("odt_set_plan")).toBe(true);
-    expect(isOdtWorkflowToolName("openducktor_odt_set_plan")).toBe(true);
-    expect(isOdtWorkflowToolName("functions.openducktor_odt_set_plan")).toBe(true);
+    expect(isOdtWorkflowToolName("openducktor_odt_set_plan")).toBe(false);
+    expect(isOdtWorkflowToolName("functions.openducktor_odt_set_plan")).toBe(false);
+    expect(isOdtWorkflowToolName("openducktor_odt_set_plan", workflowToolAliasesByCanonical)).toBe(
+      true,
+    );
+    expect(
+      isOdtWorkflowToolName("functions.openducktor_odt_set_plan", workflowToolAliasesByCanonical),
+    ).toBe(true);
     expect(isOdtWorkflowToolName("customprefix_odt_set_plan")).toBe(false);
     expect(isOdtWorkflowToolName("glob")).toBe(false);
     expect(isOdtWorkflowMutationToolName("odt_set_plan")).toBe(true);
@@ -35,12 +62,19 @@ describe("odt workflow tools", () => {
 
   test("resolves trusted workflow tool ids for authorization with exact case-sensitive matching", () => {
     expect(resolveOdtWorkflowToolNameForAuthorization("odt_set_spec")).toBe("odt_set_spec");
-    expect(resolveOdtWorkflowToolNameForAuthorization("openducktor_odt_set_spec")).toBe(
-      "odt_set_spec",
-    );
-    expect(resolveOdtWorkflowToolNameForAuthorization("functions.openducktor_odt_set_spec")).toBe(
-      "odt_set_spec",
-    );
+    expect(resolveOdtWorkflowToolNameForAuthorization("openducktor_odt_set_spec")).toBeNull();
+    expect(
+      resolveOdtWorkflowToolNameForAuthorization(
+        "openducktor_odt_set_spec",
+        workflowToolAliasesByCanonical,
+      ),
+    ).toBe("odt_set_spec");
+    expect(
+      resolveOdtWorkflowToolNameForAuthorization(
+        "functions.openducktor_odt_set_spec",
+        workflowToolAliasesByCanonical,
+      ),
+    ).toBe("odt_set_spec");
     expect(resolveOdtWorkflowToolNameForAuthorization("openducktor_odt_set_spec_extra")).toBeNull();
     expect(resolveOdtWorkflowToolNameForAuthorization("OpenDucktor_ODT_SET_SPEC")).toBeNull();
     expect(resolveOdtWorkflowToolNameForAuthorization("odt_SET_SPEC")).toBeNull();
@@ -69,6 +103,7 @@ describe("odt workflow tools", () => {
         " odt_read_task ",
         "glob",
       ],
+      workflowToolAliasesByCanonical,
     });
     expect(selection.openducktor_odt_qa_approved).toBe(true);
     expect(selection.openducktor_odt_read_task_documents).toBe(true);
@@ -81,7 +116,12 @@ describe("odt workflow tools", () => {
 
   test("formats tool display name from normalized workflow ids", () => {
     expect(toOdtWorkflowToolDisplayName("odt_set_spec")).toBe("set_spec");
-    expect(toOdtWorkflowToolDisplayName("openducktor_odt_set_spec")).toBe("set_spec");
+    expect(toOdtWorkflowToolDisplayName("openducktor_odt_set_spec")).toBe(
+      "openducktor_odt_set_spec",
+    );
+    expect(
+      toOdtWorkflowToolDisplayName("openducktor_odt_set_spec", workflowToolAliasesByCanonical),
+    ).toBe("set_spec");
     expect(toOdtWorkflowToolDisplayName("read")).toBe("read");
   });
 });

--- a/packages/core/src/services/odt-workflow-tools.ts
+++ b/packages/core/src/services/odt-workflow-tools.ts
@@ -1,4 +1,4 @@
-import { agentToolNameValues } from "@openducktor/contracts";
+import { agentToolNameValues, type RuntimeDescriptor } from "@openducktor/contracts";
 import {
   AGENT_ROLE_TOOL_POLICY,
   type AgentRole,
@@ -11,65 +11,80 @@ export const ODT_WORKFLOW_READ_TOOL_NAMES = [
   "odt_read_task",
   "odt_read_task_documents",
 ] as const satisfies readonly AgentToolName[];
+type WorkflowToolAliasesByCanonical = RuntimeDescriptor["workflowToolAliasesByCanonical"];
+
+const ODT_WORKFLOW_TOOL_SET = new Set<AgentToolName>(ODT_WORKFLOW_TOOL_NAMES);
 const ODT_WORKFLOW_READ_TOOL_SET = new Set<AgentToolName>(ODT_WORKFLOW_READ_TOOL_NAMES);
 
 export const ODT_WORKFLOW_MUTATION_TOOL_NAMES = ODT_WORKFLOW_TOOL_NAMES.filter(
   (tool) => !ODT_WORKFLOW_READ_TOOL_SET.has(tool),
 );
 const ODT_WORKFLOW_MUTATION_TOOL_SET = new Set<AgentToolName>(ODT_WORKFLOW_MUTATION_TOOL_NAMES);
-const ODT_MCP_TOOL_PREFIXES = ["openducktor_", "functions.openducktor_"] as const;
 
-const createOdtWorkflowRuntimeToolIdMap = (
-  mapToolId: (toolId: string) => string,
-): ReadonlyMap<string, AgentToolName> => {
-  const runtimeToolIdMap = new Map<string, AgentToolName>();
-  for (const workflowTool of ODT_WORKFLOW_TOOL_NAMES) {
-    runtimeToolIdMap.set(mapToolId(workflowTool), workflowTool);
-    for (const prefix of ODT_MCP_TOOL_PREFIXES) {
-      runtimeToolIdMap.set(mapToolId(`${prefix}${workflowTool}`), workflowTool);
-    }
-  }
-  return runtimeToolIdMap;
-};
-
-const ODT_WORKFLOW_AUTHORIZATION_TOOL_ID_MAP = createOdtWorkflowRuntimeToolIdMap(
-  (toolId) => toolId,
-);
-const ODT_WORKFLOW_NORMALIZED_TOOL_ID_MAP = createOdtWorkflowRuntimeToolIdMap((toolId) =>
-  toolId.toLowerCase(),
-);
-
-export const normalizeOdtWorkflowToolName = (toolName: string): AgentToolName | null => {
-  const normalized = toolName.trim().toLowerCase();
-  if (normalized.length === 0) {
+const resolveCanonicalOdtWorkflowToolName = (toolId: string): AgentToolName | null => {
+  if (!ODT_WORKFLOW_TOOL_SET.has(toolId as AgentToolName)) {
     return null;
   }
 
-  return ODT_WORKFLOW_NORMALIZED_TOOL_ID_MAP.get(normalized) ?? null;
+  return toolId as AgentToolName;
 };
 
-export const resolveOdtWorkflowToolNameForAuthorization = (
+const resolveAliasedOdtWorkflowToolName = (
   toolId: string,
+  workflowToolAliasesByCanonical?: WorkflowToolAliasesByCanonical,
+): AgentToolName | null => {
+  for (const workflowTool of ODT_WORKFLOW_TOOL_NAMES) {
+    if ((workflowToolAliasesByCanonical?.[workflowTool] ?? []).includes(toolId)) {
+      return workflowTool;
+    }
+  }
+
+  return null;
+};
+
+const resolveOdtWorkflowToolName = (
+  toolId: string,
+  workflowToolAliasesByCanonical?: WorkflowToolAliasesByCanonical,
 ): AgentToolName | null => {
   const trimmedToolId = toolId.trim();
   if (trimmedToolId.length === 0) {
     return null;
   }
 
-  return ODT_WORKFLOW_AUTHORIZATION_TOOL_ID_MAP.get(trimmedToolId) ?? null;
+  return (
+    resolveCanonicalOdtWorkflowToolName(trimmedToolId) ??
+    resolveAliasedOdtWorkflowToolName(trimmedToolId, workflowToolAliasesByCanonical)
+  );
 };
 
-export const isOdtWorkflowToolName = (toolName: string): boolean => {
-  return normalizeOdtWorkflowToolName(toolName) !== null;
-};
+export const normalizeOdtWorkflowToolName = (
+  toolName: string,
+  workflowToolAliasesByCanonical?: WorkflowToolAliasesByCanonical,
+): AgentToolName | null => resolveOdtWorkflowToolName(toolName, workflowToolAliasesByCanonical);
 
-export const isOdtWorkflowMutationToolName = (toolName: string): boolean => {
-  const normalized = normalizeOdtWorkflowToolName(toolName);
+export const resolveOdtWorkflowToolNameForAuthorization = (
+  toolId: string,
+  workflowToolAliasesByCanonical?: WorkflowToolAliasesByCanonical,
+): AgentToolName | null => resolveOdtWorkflowToolName(toolId, workflowToolAliasesByCanonical);
+
+export const isOdtWorkflowToolName = (
+  toolName: string,
+  workflowToolAliasesByCanonical?: WorkflowToolAliasesByCanonical,
+): boolean => normalizeOdtWorkflowToolName(toolName, workflowToolAliasesByCanonical) !== null;
+
+export const isOdtWorkflowMutationToolName = (
+  toolName: string,
+  workflowToolAliasesByCanonical?: WorkflowToolAliasesByCanonical,
+): boolean => {
+  const normalized = normalizeOdtWorkflowToolName(toolName, workflowToolAliasesByCanonical);
   return normalized ? ODT_WORKFLOW_MUTATION_TOOL_SET.has(normalized) : false;
 };
 
-export const toOdtWorkflowToolDisplayName = (toolName: string): string => {
-  const normalized = normalizeOdtWorkflowToolName(toolName);
+export const toOdtWorkflowToolDisplayName = (
+  toolName: string,
+  workflowToolAliasesByCanonical?: WorkflowToolAliasesByCanonical,
+): string => {
+  const normalized = normalizeOdtWorkflowToolName(toolName, workflowToolAliasesByCanonical);
   return normalized ? normalized.slice(4) : toolName;
 };
 
@@ -78,6 +93,7 @@ export const buildRoleScopedOdtToolSelection = (
   options?: {
     runtimeToolIds?: readonly string[];
     includeCanonicalDefaults?: boolean;
+    workflowToolAliasesByCanonical?: WorkflowToolAliasesByCanonical;
   },
 ): Record<string, boolean> => {
   const allowed = new Set(AGENT_ROLE_TOOL_POLICY[role]);
@@ -91,7 +107,10 @@ export const buildRoleScopedOdtToolSelection = (
   }
 
   for (const toolId of options?.runtimeToolIds ?? []) {
-    const normalizedTool = resolveOdtWorkflowToolNameForAuthorization(toolId);
+    const normalizedTool = resolveOdtWorkflowToolNameForAuthorization(
+      toolId,
+      options?.workflowToolAliasesByCanonical,
+    );
     if (!normalizedTool) {
       continue;
     }

--- a/packages/core/src/services/odt-workflow-tools.ts
+++ b/packages/core/src/services/odt-workflow-tools.ts
@@ -115,9 +115,6 @@ export const buildRoleScopedOdtToolSelection = (
       continue;
     }
     const trimmedToolId = toolId.trim();
-    if (trimmedToolId.length === 0) {
-      continue;
-    }
     selection[trimmedToolId] = allowed.has(normalizedTool);
   }
 


### PR DESCRIPTION
## Summary
- move runtime-native ODT workflow aliases onto runtime descriptors so shared/core keeps canonical `odt_*` identity only
- update the OpenCode adapter and desktop workflow consumers to resolve trusted runtime aliases for tool selection, permissions, refresh, and display paths
- add regression coverage for delayed runtime-definition hydration, extract shared runtime-definition test helpers, and document the runtime alias contract with an explicit example

## Verification
- bun run --filter @openducktor/contracts test
- bun run --filter @openducktor/core test
- bun run --filter @openducktor/adapters-opencode-sdk test
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run typecheck
- bun run check:rust
- bun run test:rust

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for workflow tool aliases, enabling tools to be referenced by multiple names (canonical and runtime-specific aliases)
  * Tool recognition in agent chat messages now resolves aliases for proper identification and display

* **Documentation**
  * Updated runtime integration guide to document the new workflow tool aliases capability for new runtime integrations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->