### PR TITLE
docs: align MCP docs with host bridge architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ At a high level:
 
 Under the hood, OpenDucktor exposes its own MCP server, `openducktor`.
 
-- Desktop-managed agent sessions use that MCP internally to read tasks and persist workflow updates.
+The Rust host remains the only Beads/Dolt owner in the desktop architecture. The MCP layer does not talk to Beads or Dolt directly; it validates `odt_*` inputs and forwards those calls back to the running host bridge.
+
+- Desktop-managed agent sessions launch that MCP as a sidecar and pass it `ODT_REPO_PATH` plus a loopback `ODT_HOST_URL`.
 - The same MCP surface can also be used outside the desktop app through `@openducktor/mcp`.
 - Public MCP tools cover task access such as `odt_create_task`, `odt_search_tasks`, `odt_read_task`, and `odt_read_task_documents`.
 - Internal workflow tools such as `odt_set_spec`, `odt_set_plan`, `odt_build_*`, and `odt_qa_*` let agent sessions write progress back into the canonical task workflow.
 
-That keeps the workflow task-centric and auditable: agents can act through a controlled tool surface, while OpenDucktor remains the place where task state, documents, approvals, and delivery history come together.
+That keeps the workflow task-centric and auditable: agents act through a controlled tool surface, the Rust host enforces the workflow and storage rules, and OpenDucktor remains the place where task state, documents, approvals, and delivery history come together.
 
 ## Current Scope
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,9 @@ At a high level:
 
 Under the hood, OpenDucktor exposes its own MCP server, `openducktor`.
 
-The Rust host remains the only Beads/Dolt owner in the desktop architecture. The MCP layer does not talk to Beads or Dolt directly; it validates `odt_*` inputs and forwards those calls back to the running host bridge.
+Desktop-managed sessions use that MCP internally, and the same task surface is also available outside the app through `@openducktor/mcp`.
 
-- Desktop-managed agent sessions launch that MCP as a sidecar and pass it `ODT_REPO_PATH` plus a loopback `ODT_HOST_URL`.
-- The same MCP surface can also be used outside the desktop app through `@openducktor/mcp`.
-- Public MCP tools cover task access such as `odt_create_task`, `odt_search_tasks`, `odt_read_task`, and `odt_read_task_documents`.
-- Internal workflow tools such as `odt_set_spec`, `odt_set_plan`, `odt_build_*`, and `odt_qa_*` let agent sessions write progress back into the canonical task workflow.
-
-That keeps the workflow task-centric and auditable: agents act through a controlled tool surface, the Rust host enforces the workflow and storage rules, and OpenDucktor remains the place where task state, documents, approvals, and delivery history come together.
+That keeps the workflow task-centric and auditable: agents act through a controlled task interface, while OpenDucktor keeps task state, documents, approvals, and delivery history connected in one place.
 
 ## Current Scope
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ This folder contains the project documentation that explains how OpenDucktor is 
 - [agent-runtime-implementation-plan.md](agent-runtime-implementation-plan.md): runtime abstraction plan and guardrails.
 - [agent-ui-library-evaluation.md](agent-ui-library-evaluation.md): reasoning behind the current agent UI approach.
 - [beads-shared-dolt-lifecycle.md](beads-shared-dolt-lifecycle.md): detailed Beads attachment and shared Dolt lifecycle, command inventory, startup, hydration, and shutdown rules.
-- [external-mcp.md](external-mcp.md): public MCP package usage, install config, and the external task tools.
+- [external-mcp.md](external-mcp.md): public MCP package usage, host-bridge startup contract, and the external task tools.
 - [runtime-integration-guide.md](runtime-integration-guide.md): runtime vocabulary, capability model, integration checklist, and verification path.
 
 ## Security And Maintenance Docs

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,7 +1,7 @@
 # End-to-End Architecture and Data Flow
 
 ## Purpose
-This document is the maintainer-facing map of how OpenDucktor moves data across layers, from React UI to Beads/MCP.
+This document is the maintainer-facing map of how OpenDucktor moves data across layers, from React UI through the Rust host to Beads-backed persistence and MCP clients.
 
 Use it to answer:
 - which layer owns a rule,
@@ -24,7 +24,7 @@ Current scope note:
 | Tauri command bridge (Rust) | `apps/desktop/src-tauri/src/lib.rs`, `apps/desktop/src-tauri/src/commands/*` | Typed command surface (`tauri::command`), argument mapping, command registration | Deep business policy (kept in `AppService`) |
 | Host application/domain (Rust) | `apps/desktop/src-tauri/crates/host-application/src/app_service/*`, `apps/desktop/src-tauri/crates/host-domain/src/*` | Workflow transition rules, task enrichment (`available_actions`, `agent_workflows`), runtime orchestration, `TaskStore` trait | UI concerns, view-level behavior |
 | Infrastructure/persistence (Rust) | `apps/desktop/src-tauri/crates/host-infra-beads/*`, `apps/desktop/src-tauri/crates/host-infra-system/*` | Beads-backed `TaskStore` persistence gateway, Beads lifecycle coordination, config/worktree/process integrations | UI workflow decisions |
-| MCP workflow service (TS) | `packages/openducktor-mcp/src/index.ts`, `packages/openducktor-mcp/src/lib.ts`, `packages/openducktor-mcp/src/host-bridge-client.ts`, `packages/openducktor-mcp/src/odt-task-store.ts` | MCP stdio transport, shared schema validation, host-bridge readiness checks, host-backed `odt_*` task/workflow calls | Frontend rendering/state |
+| MCP workflow service (TS) | `packages/openducktor-mcp/src/index.ts`, `packages/openducktor-mcp/src/lib.ts`, `packages/openducktor-mcp/src/host-bridge-client.ts`, `packages/openducktor-mcp/src/odt-task-store.ts` | MCP stdio transport, shared schema validation, host-bridge readiness checks, host-backed `odt_*` task/workflow calls | Frontend rendering/state, Beads/Dolt lifecycle ownership |
 
 ## Platform-specific native lifecycle seams
 
@@ -63,9 +63,10 @@ Key boundary:
  - `qa` role: `host.runtimeStart(runtimeKind, repo, task, "qa")` creates a task runtime for the selected kind.
  - `spec`/`planner`: `host.runtimeEnsure(runtimeKind, repo)` ensures a shared workspace runtime for the selected kind.
 6. Rust host resolves the requested runtime kind, then runs runtime-specific startup. For OpenCode this starts a local loopback bridge in the desktop host and spawns the MCP server `openducktor` with `ODT_REPO_PATH` and `ODT_HOST_URL`.
-7. `OpencodeSdkAdapter` (`AgentEnginePort` implementation) starts, resumes, or forks the session and subscribes to OpenCode stream events.
-8. On prompt send, adapter applies role-scoped tool gating from `AGENT_ROLE_TOOL_POLICY` (core) and runtime tool IDs, then sends `tools` selection to OpenCode.
-9. Session snapshots are persisted via `host.agentSessionUpsert` into task metadata for restart/reuse continuity.
+7. The MCP process uses only that host-bridge contract. Direct Beads/Dolt startup inputs are rejected so storage ownership stays in the Rust host.
+8. `OpencodeSdkAdapter` (`AgentEnginePort` implementation) starts, resumes, or forks the session and subscribes to OpenCode stream events.
+9. On prompt send, adapter applies role-scoped tool gating from `AGENT_ROLE_TOOL_POLICY` (core) and runtime tool IDs, then sends `tools` selection to OpenCode.
+10. Session snapshots are persisted via `host.agentSessionUpsert` into task metadata for restart/reuse continuity.
 
 For the exact Beads attachment and shared Dolt startup/shutdown command sequence, see `docs/beads-shared-dolt-lifecycle.md`.
 
@@ -74,7 +75,7 @@ Critical session invariants:
 - Stale workspace protection must roll back newly started/resumed sessions with best-effort `stopSession` cleanup.
 
 ### 3) Workflow transition
-OpenDucktor has two transition paths that converge on Beads as persistent truth.
+OpenDucktor has two transition paths that converge on the Rust host as the workflow mutation entry point and Beads as persistent truth.
 
 Human-triggered path:
 1. User clicks a workflow action surfaced from `availableActions`.
@@ -87,10 +88,14 @@ Human-triggered path:
 Agent-triggered path:
 1. Active OpenCode session calls `odt_*` tool through local MCP server `openducktor`.
 2. `packages/openducktor-mcp` validates input against shared `ODT_TOOL_SCHEMAS`.
-3. `OdtTaskStore` forwards the repo-scoped request to the running Rust host bridge.
+3. `OdtTaskStore` forwards the repo-scoped request to the running Rust host bridge; the MCP package does not talk to Beads or Dolt directly.
 4. `AppService` validates workflow rules and persists Beads metadata/status through `TaskStore`.
 5. Tool result is emitted in session stream.
 6. Frontend session-event handler detects completed ODT mutation tools and triggers task refresh.
+
+Key boundary:
+- Desktop-managed and standalone MCP clients use the same host-bridge execution path.
+- Beads and Dolt remain storage infrastructure concerns owned by the Rust host, not by agent runtimes or MCP clients.
 
 ### 4) Generate a pull request
 1. The approval flow starts a Builder session with scenario `build_pull_request_generation`.
@@ -131,6 +136,7 @@ Concrete adapters today:
 5. Keep Tauri commands as transport/mapping layer; place policy in `AppService`/domain layers.
 6. Preserve Beads as lifecycle source of truth; do not move lifecycle authority into UI-local state.
 7. Keep Rust host and MCP transition policy matrices aligned; when one changes, update the other in the same change set.
+8. Keep Beads attachment paths, Dolt coordinates, and metadata namespace ownership in the Rust host; do not reintroduce them into MCP startup or runtime-session contracts.
 
 ## Related Docs
 - `docs/agent-orchestrator-module-map.md`

--- a/docs/beads-shared-dolt-lifecycle.md
+++ b/docs/beads-shared-dolt-lifecycle.md
@@ -339,19 +339,6 @@ The Rust host owns the Beads attachment directory, shared Dolt connection detail
 
 The MCP sidecar no longer connects to Dolt or runs Beads directly. In desktop-managed mode the host injects a loopback `ODT_HOST_URL`, and the MCP forwards task, document, and workflow calls back to the running host. Standalone MCP use auto-discovers running host bridge ports from the local registry and can still use `ODT_HOST_URL` as an explicit override.
 
-Direct storage startup inputs are now rejected in the MCP package, including:
-
-- `ODT_BEADS_ATTACHMENT_DIR`
-- `ODT_DOLT_HOST`
-- `ODT_DOLT_PORT`
-- `ODT_DATABASE_NAME`
-- `ODT_METADATA_NAMESPACE`
-- `--beads-attachment-dir`
-- `--dolt-host`
-- `--dolt-port`
-- `--database-name` and `--database`
-- `--metadata-namespace`
-
 That keeps Beads and Dolt modeled as storage infrastructure, not as an agent runtime concern.
 
 ## What Happens On App Exit

--- a/docs/beads-shared-dolt-lifecycle.md
+++ b/docs/beads-shared-dolt-lifecycle.md
@@ -10,6 +10,8 @@ That means OpenDucktor needs two things to work well:
 - a Beads attachment for each repository
 - a Dolt database that Beads can read and write
 
+In the desktop architecture, the Rust host is the only owner of that storage lifecycle. MCP clients and agent runtimes never receive Beads attachment paths, Dolt connection details, or metadata-namespace control as part of their startup contract.
+
 The important design choice is that OpenDucktor does **not** run one Dolt process per repository.
 Instead, it runs **one shared local Dolt server per OpenDucktor config directory** and gives each repository its own database inside that server.
 
@@ -336,6 +338,21 @@ When OpenDucktor launches its MCP sidecar for OpenCode, it passes only the host 
 The Rust host owns the Beads attachment directory, shared Dolt connection details, attachment verification, repair, and all task reads and writes.
 
 The MCP sidecar no longer connects to Dolt or runs Beads directly. In desktop-managed mode the host injects a loopback `ODT_HOST_URL`, and the MCP forwards task, document, and workflow calls back to the running host. Standalone MCP use auto-discovers running host bridge ports from the local registry and can still use `ODT_HOST_URL` as an explicit override.
+
+Direct storage startup inputs are now rejected in the MCP package, including:
+
+- `ODT_BEADS_ATTACHMENT_DIR`
+- `ODT_DOLT_HOST`
+- `ODT_DOLT_PORT`
+- `ODT_DATABASE_NAME`
+- `ODT_METADATA_NAMESPACE`
+- `--beads-attachment-dir`
+- `--dolt-host`
+- `--dolt-port`
+- `--database-name` and `--database`
+- `--metadata-namespace`
+
+That keeps Beads and Dolt modeled as storage infrastructure, not as an agent runtime concern.
 
 ## What Happens On App Exit
 

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -101,6 +101,7 @@ Internal workflow tools remain on the same MCP server:
 - `odt_build_blocked`
 - `odt_build_resumed`
 - `odt_build_completed`
+- `odt_set_pull_request`
 - `odt_qa_approved`
 - `odt_qa_rejected`
 

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -11,6 +11,8 @@ Both desktop-managed and standalone MCP paths now route task operations through 
 - `ODT_HOST_URL` and `--host-url` remain available as explicit overrides.
 - Startup fails if the host bridge is unhealthy or does not expose the required ODT tool surface.
 
+The MCP package is transport and validation only. The Rust host remains the owner of Beads attachment readiness, shared Dolt lifecycle, workflow transitions, and metadata persistence.
+
 For the full Beads and shared Dolt lifecycle, including why the Rust host owns that lifecycle, see [beads-shared-dolt-lifecycle.md](beads-shared-dolt-lifecycle.md).
 
 Package name:
@@ -48,6 +50,23 @@ Equivalent environment variables:
 - `ODT_REPO_PATH`
 - `ODT_HOST_URL` optional override
 
+Unsupported legacy environment variables:
+
+- `ODT_BEADS_ATTACHMENT_DIR`
+- `ODT_DOLT_HOST`
+- `ODT_DOLT_PORT`
+- `ODT_DATABASE_NAME`
+- `ODT_METADATA_NAMESPACE`
+
+Unsupported legacy CLI flags:
+
+- `--beads-attachment-dir`
+- `--dolt-host`
+- `--dolt-port`
+- `--database-name`
+- `--database`
+- `--metadata-namespace`
+
 Automatic discovery:
 
 - The MCP reads bridge ports from `runtime/mcp-bridge-ports.json` under the OpenDucktor config directory.
@@ -63,6 +82,8 @@ Startup contract:
 5. Call the host bridge `/health` endpoint.
 6. Call `odt_mcp_ready` through the loopback host API.
 7. Refuse startup if any required ODT tool name is missing.
+
+Desktop-managed and standalone MCP clients intentionally use this same host-bridge path. The difference is only how the MCP learns the host URL: desktop mode injects it, while standalone mode usually discovers it.
 
 ## Public Tools
 
@@ -292,3 +313,4 @@ Output:
 - The Rust host owns Beads attachment verification, shared Dolt lifecycle, task reads and writes, workflow transitions, recovery, and canonical metadata writes.
 - The Rust host also owns document compression and decompression for Beads metadata.
 - The host bridge surface mirrors the MCP tool names so desktop-managed and standalone MCP clients use the same execution path.
+- Beads and Dolt stay modeled as storage infrastructure. They are not part of the MCP runtime contract beyond the host-owned bridge being healthy.

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -50,23 +50,6 @@ Equivalent environment variables:
 - `ODT_REPO_PATH`
 - `ODT_HOST_URL` optional override
 
-Unsupported legacy environment variables:
-
-- `ODT_BEADS_ATTACHMENT_DIR`
-- `ODT_DOLT_HOST`
-- `ODT_DOLT_PORT`
-- `ODT_DATABASE_NAME`
-- `ODT_METADATA_NAMESPACE`
-
-Unsupported legacy CLI flags:
-
-- `--beads-attachment-dir`
-- `--dolt-host`
-- `--dolt-port`
-- `--database-name`
-- `--database`
-- `--metadata-namespace`
-
 Automatic discovery:
 
 - The MCP reads bridge ports from `runtime/mcp-bridge-ports.json` under the OpenDucktor config directory.

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -6,6 +6,8 @@ The MCP package is a thin client of the running Rust host.
 
 The published package is intentionally a standalone CLI/server package. It does not expose a supported JavaScript or TypeScript library API from `@openducktor/mcp`.
 
+Desktop-managed sessions launch this same package as a sidecar. In both desktop-managed and standalone use, the package validates `odt_*` inputs and forwards them to the Rust host bridge instead of talking to Beads or Dolt directly.
+
 - Desktop-managed launches receive `ODT_HOST_URL` from the host automatically.
 - Standalone use auto-discovers a running host bridge from the local registry.
 - `ODT_HOST_URL` and `--host-url` remain available as explicit overrides.
@@ -38,6 +40,23 @@ Equivalent environment variables:
 - `ODT_REPO_PATH`
 - `ODT_HOST_URL` optional override
 
+Rejected legacy environment variables:
+
+- `ODT_BEADS_ATTACHMENT_DIR`
+- `ODT_DOLT_HOST`
+- `ODT_DOLT_PORT`
+- `ODT_DATABASE_NAME`
+- `ODT_METADATA_NAMESPACE`
+
+Rejected legacy CLI flags:
+
+- `--beads-attachment-dir`
+- `--dolt-host`
+- `--dolt-port`
+- `--database-name`
+- `--database`
+- `--metadata-namespace`
+
 Automatic discovery:
 
 - The MCP reads bridge ports from `runtime/mcp-bridge-ports.json` under the OpenDucktor config directory.
@@ -52,6 +71,8 @@ Startup behavior:
 - It checks the host bridge `/health` endpoint.
 - It calls `odt_mcp_ready` before serving requests.
 - Startup fails if the host does not expose the full ODT tool surface.
+
+The Rust host owns Beads attachment verification, shared Dolt lifecycle, workflow transitions, and document persistence. This package owns MCP transport and schema validation only.
 
 ## Public Tools
 

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -11,7 +11,6 @@ Desktop-managed sessions launch this same package as a sidecar. In both desktop-
 - Desktop-managed launches receive `ODT_HOST_URL` from the host automatically.
 - Standalone use auto-discovers a running host bridge from the local registry.
 - `ODT_HOST_URL` and `--host-url` remain available as explicit overrides.
-- Legacy direct `bd` / `dolt` startup parameters are rejected.
 
 For the full Beads and shared Dolt lifecycle, see `../../docs/beads-shared-dolt-lifecycle.md`.
 
@@ -39,23 +38,6 @@ Equivalent environment variables:
 
 - `ODT_REPO_PATH`
 - `ODT_HOST_URL` optional override
-
-Rejected legacy environment variables:
-
-- `ODT_BEADS_ATTACHMENT_DIR`
-- `ODT_DOLT_HOST`
-- `ODT_DOLT_PORT`
-- `ODT_DATABASE_NAME`
-- `ODT_METADATA_NAMESPACE`
-
-Rejected legacy CLI flags:
-
-- `--beads-attachment-dir`
-- `--dolt-host`
-- `--dolt-port`
-- `--database-name`
-- `--database`
-- `--metadata-namespace`
 
 Automatic discovery:
 


### PR DESCRIPTION
## Summary
- align the maintainer MCP and architecture docs with the current host-bridge flow where the Rust host owns Beads/Dolt lifecycle and workflow persistence
- fix the external MCP guide so it documents the full workflow tool surface, including `odt_set_pull_request`
- remove outdated startup-contract history from docs and keep the root README at a product-level overview