### PR TITLE
fix(agent-studio): keep runtime readiness in sync with diagnostics

### DIFF
--- a/apps/desktop/src/lib/repo-runtime-health.ts
+++ b/apps/desktop/src/lib/repo-runtime-health.ts
@@ -40,6 +40,31 @@ export const isRepoRuntimeReady = (runtimeHealth: RepoRuntimeHealthCheck | null)
   return runtimeHealth?.status === "ready";
 };
 
+export const isRepoRuntimeHealthTransient = (
+  runtimeHealth: RepoRuntimeHealthCheck | null,
+): boolean => {
+  if (!runtimeHealth) {
+    return false;
+  }
+
+  if (runtimeHealth.runtime.status === "checking") {
+    return true;
+  }
+
+  if (runtimeHealth.runtime.status !== "ready") {
+    return false;
+  }
+
+  switch (runtimeHealth.mcp?.status) {
+    case "checking":
+    case "reconnecting":
+    case "waiting_for_runtime":
+      return true;
+    default:
+      return false;
+  }
+};
+
 export const getRepoRuntimeBadge = (
   runtimeHealth: RepoRuntimeHealthCheck | null,
 ): RuntimeHealthBadge => {

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createElement, type ReactElement, type ReactNode } from "react";
 import type { SessionStartModalModel } from "@/components/features/agents";
 import * as appStateContexts from "@/state/app-state-contexts";
@@ -267,6 +267,50 @@ let rightPanelState: RightPanelState = {
 
 let useAgentsPageShellModel: () => AgentsPageShellModelState;
 
+const mockedModuleResets = [
+  ["react-router-dom", () => import("react-router-dom")],
+  ["@/state/app-state-provider", () => import("@/state/app-state-provider")],
+  ["@/state/app-state-contexts", () => import("@/state/app-state-contexts")],
+  ["../use-agent-studio-query-sync", () => import("../use-agent-studio-query-sync")],
+  [
+    "../use-agent-studio-selection-controller",
+    () => import("../use-agent-studio-selection-controller"),
+  ],
+  [
+    "../use-agent-studio-query-session-sync",
+    () => import("../use-agent-studio-query-session-sync"),
+  ],
+  ["../use-agents-page-readiness", () => import("../use-agents-page-readiness")],
+  [
+    "../use-agent-studio-orchestration-controller",
+    () => import("../use-agent-studio-orchestration-controller"),
+  ],
+  [
+    "../use-agent-studio-rebase-conflict-resolution",
+    () => import("../use-agent-studio-rebase-conflict-resolution"),
+  ],
+  ["../use-agents-page-right-panel-model", () => import("../use-agents-page-right-panel-model")],
+  ["@/components/features/agents", () => import("@/components/features/agents")],
+  [
+    "@/components/features/agents/agent-studio-right-panel",
+    () => import("@/components/features/agents/agent-studio-right-panel"),
+  ],
+  ["@/contexts/DiffWorkerProvider", () => import("@/contexts/DiffWorkerProvider")],
+  ["@pierre/diffs/react", () => import("@pierre/diffs/react")],
+  [
+    "@/features/human-review-feedback/human-review-feedback-modal",
+    () => import("@/features/human-review-feedback/human-review-feedback-modal"),
+  ],
+  [
+    "@/components/features/task-details/task-details-sheet-controller",
+    () => import("@/components/features/task-details/task-details-sheet-controller"),
+  ],
+  [
+    "@/components/features/pull-requests/merged-pull-request-confirm-dialog",
+    () => import("@/components/features/pull-requests/merged-pull-request-confirm-dialog"),
+  ],
+] as const;
+
 const registerModuleMocks = (): void => {
   const stateModule = {
     AppStateProvider: ({ children }: { children: ReactElement }) => children,
@@ -508,6 +552,10 @@ beforeEach(async () => {
     isRightPanelVisible: true,
     rightPanelModel,
   };
+});
+
+afterEach(async () => {
+  await restoreMockedModules(mockedModuleResets);
 });
 
 afterAll(async () => {

--- a/apps/desktop/src/pages/agents/use-agents-page-readiness.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agents-page-readiness.test.tsx
@@ -1,28 +1,41 @@
 import { describe, expect, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR, type RuntimeDescriptor } from "@openducktor/contracts";
+import {
+  type BeadsCheck,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type RuntimeCheck,
+  type RuntimeDescriptor,
+} from "@openducktor/contracts";
+import type { PropsWithChildren, ReactElement } from "react";
+import { QueryProvider } from "@/lib/query-provider";
+import { host } from "@/state/operations/shared/host";
+import { useChecks } from "@/state/operations/workspace/use-checks";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
+import { createBeadsCheckFixture } from "@/test-utils/shared-test-fixtures";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { useAgentStudioReadiness } from "./use-agents-page-readiness";
 
-const makeRepoHealth = (
-  overrides: Partial<RepoRuntimeHealthCheck> = {},
-): RepoRuntimeHealthCheck => ({
-  status: "ready",
-  checkedAt: "2026-02-20T12:01:00.000Z",
-  runtime: {
+type RepoHealthOverrides = Omit<Partial<RepoRuntimeHealthCheck>, "runtime" | "mcp"> & {
+  runtime?: Partial<RepoRuntimeHealthCheck["runtime"]>;
+  mcp?: Partial<NonNullable<RepoRuntimeHealthCheck["mcp"]>>;
+};
+
+const makeRepoHealth = (overrides: RepoHealthOverrides = {}): RepoRuntimeHealthCheck => {
+  const checkedAt = overrides.checkedAt ?? "2026-02-20T12:01:00.000Z";
+  const runtime: RepoRuntimeHealthCheck["runtime"] = {
     status: "ready",
     stage: "runtime_ready",
     observation: null,
     instance: null,
     startedAt: null,
-    updatedAt: "2026-02-20T12:01:00.000Z",
+    updatedAt: checkedAt,
     elapsedMs: null,
     attempts: null,
     detail: null,
     failureKind: null,
     failureReason: null,
-  },
-  mcp: {
+    ...overrides.runtime,
+  };
+  const mcp: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
     supported: true,
     status: "connected",
     serverName: "openducktor",
@@ -30,9 +43,24 @@ const makeRepoHealth = (
     toolIds: [],
     detail: null,
     failureKind: null,
-  },
-  ...overrides,
-});
+    ...overrides.mcp,
+  };
+
+  return {
+    status:
+      overrides.status ??
+      (runtime.status === "error" || mcp.status === "error"
+        ? "error"
+        : mcp.status === "checking" ||
+            mcp.status === "reconnecting" ||
+            mcp.status === "waiting_for_runtime"
+          ? "checking"
+          : runtime.status),
+    checkedAt,
+    runtime,
+    mcp,
+  };
+};
 
 const SECOND_RUNTIME_DESCRIPTOR: RuntimeDescriptor = {
   ...OPENCODE_RUNTIME_DESCRIPTOR,
@@ -234,6 +262,98 @@ describe("useAgentStudioReadiness", () => {
       expect(readiness.agentStudioBlockedReason).not.toContain("mock runtime failed");
     } finally {
       await harness.unmount();
+    }
+  });
+
+  test("transitions to ready after transient runtime health polling settles", async () => {
+    let latest: ReturnType<typeof useAgentStudioReadiness> | null = null;
+    let repoHealthCallCount = 0;
+    const originalRuntimeCheck = host.runtimeCheck;
+    const originalBeadsCheck = host.beadsCheck;
+
+    host.runtimeCheck = async (_force?: boolean): Promise<RuntimeCheck> => ({
+      gitOk: true,
+      gitVersion: "2.45.0",
+      ghOk: true,
+      ghVersion: "2.73.0",
+      ghAuthOk: true,
+      ghAuthLogin: "octocat",
+      ghAuthError: null,
+      runtimes: [{ kind: "opencode", ok: true, version: "0.12.0" }],
+      errors: [],
+    });
+    host.beadsCheck = async (): Promise<BeadsCheck> => createBeadsCheckFixture();
+
+    const checkRepoRuntimeHealth = async (): Promise<RepoRuntimeHealthCheck> => {
+      repoHealthCallCount += 1;
+      if (repoHealthCallCount === 1) {
+        return makeRepoHealth({
+          status: "checking",
+          runtime: {
+            status: "ready",
+            stage: "runtime_ready",
+            observation: "observed_existing_runtime",
+          },
+          mcp: {
+            supported: true,
+            status: "checking",
+            serverName: "openducktor",
+            serverStatus: null,
+            toolIds: [],
+            detail: "Checking OpenDucktor MCP",
+            failureKind: null,
+          },
+        });
+      }
+
+      return makeRepoHealth();
+    };
+
+    const Harness = () => {
+      const checks = useChecks({
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        checkRepoRuntimeHealth,
+      });
+      latest = useAgentStudioReadiness({
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        isLoadingRuntimeDefinitions: false,
+        runtimeDefinitionsError: null,
+        runtimeHealthByRuntime: checks.activeRepoRuntimeHealthByRuntime,
+        isLoadingChecks: checks.isLoadingChecks,
+        refreshChecks: checks.refreshChecks,
+      });
+      return null;
+    };
+
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryProvider useIsolatedClient>{children}</QueryProvider>
+    );
+
+    const harness = createSharedHookHarness(Harness, {}, { wrapper });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        () =>
+          latest?.agentStudioReadinessState === "checking" &&
+          latest.agentStudioBlockedReason?.includes("Checking OpenDucktor MCP") === true,
+      );
+      await harness.waitFor(() => latest?.agentStudioReadinessState === "ready", 5000);
+      if (!latest) {
+        throw new Error("Expected readiness hook to mount");
+      }
+
+      const readiness = latest as ReturnType<typeof useAgentStudioReadiness>;
+
+      expect(repoHealthCallCount).toBe(2);
+      expect(readiness.agentStudioReady).toBe(true);
+      expect(readiness.agentStudioBlockedReason).toBeNull();
+    } finally {
+      await harness.unmount();
+      host.runtimeCheck = originalRuntimeCheck;
+      host.beadsCheck = originalBeadsCheck;
     }
   });
 });

--- a/apps/desktop/src/pages/agents/use-agents-page-readiness.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agents-page-readiness.test.tsx
@@ -7,59 +7,25 @@ import {
 } from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
 import { QueryProvider } from "@/lib/query-provider";
-import { host } from "@/state/operations/shared/host";
+import type { DiagnosticsToastApi } from "@/state/operations/workspace/use-check-diagnostics-effects";
 import { useChecks } from "@/state/operations/workspace/use-checks";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
-import { createBeadsCheckFixture } from "@/test-utils/shared-test-fixtures";
+import {
+  createBeadsCheckFixture,
+  createRepoRuntimeHealthFixture,
+  type RepoRuntimeHealthFixtureOverrides,
+} from "@/test-utils/shared-test-fixtures";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { useAgentStudioReadiness } from "./use-agents-page-readiness";
 
-type RepoHealthOverrides = Omit<Partial<RepoRuntimeHealthCheck>, "runtime" | "mcp"> & {
-  runtime?: Partial<RepoRuntimeHealthCheck["runtime"]>;
-  mcp?: Partial<NonNullable<RepoRuntimeHealthCheck["mcp"]>>;
-};
+const makeRepoHealth = (
+  overrides: RepoRuntimeHealthFixtureOverrides = {},
+): RepoRuntimeHealthCheck =>
+  createRepoRuntimeHealthFixture({ checkedAt: "2026-02-20T12:01:00.000Z" }, overrides);
 
-const makeRepoHealth = (overrides: RepoHealthOverrides = {}): RepoRuntimeHealthCheck => {
-  const checkedAt = overrides.checkedAt ?? "2026-02-20T12:01:00.000Z";
-  const runtime: RepoRuntimeHealthCheck["runtime"] = {
-    status: "ready",
-    stage: "runtime_ready",
-    observation: null,
-    instance: null,
-    startedAt: null,
-    updatedAt: checkedAt,
-    elapsedMs: null,
-    attempts: null,
-    detail: null,
-    failureKind: null,
-    failureReason: null,
-    ...overrides.runtime,
-  };
-  const mcp: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
-    supported: true,
-    status: "connected",
-    serverName: "openducktor",
-    serverStatus: "connected",
-    toolIds: [],
-    detail: null,
-    failureKind: null,
-    ...overrides.mcp,
-  };
-
-  return {
-    status:
-      overrides.status ??
-      (runtime.status === "error" || mcp.status === "error"
-        ? "error"
-        : mcp.status === "checking" ||
-            mcp.status === "reconnecting" ||
-            mcp.status === "waiting_for_runtime"
-          ? "checking"
-          : runtime.status),
-    checkedAt,
-    runtime,
-    mcp,
-  };
+const testToastApi: DiagnosticsToastApi = {
+  error: () => undefined,
+  dismiss: () => undefined,
 };
 
 const SECOND_RUNTIME_DESCRIPTOR: RuntimeDescriptor = {
@@ -268,10 +234,7 @@ describe("useAgentStudioReadiness", () => {
   test("transitions to ready after transient runtime health polling settles", async () => {
     let latest: ReturnType<typeof useAgentStudioReadiness> | null = null;
     let repoHealthCallCount = 0;
-    const originalRuntimeCheck = host.runtimeCheck;
-    const originalBeadsCheck = host.beadsCheck;
-
-    host.runtimeCheck = async (_force?: boolean): Promise<RuntimeCheck> => ({
+    const runtimeCheck = async (_force?: boolean): Promise<RuntimeCheck> => ({
       gitOk: true,
       gitVersion: "2.45.0",
       ghOk: true,
@@ -282,7 +245,7 @@ describe("useAgentStudioReadiness", () => {
       runtimes: [{ kind: "opencode", ok: true, version: "0.12.0" }],
       errors: [],
     });
-    host.beadsCheck = async (): Promise<BeadsCheck> => createBeadsCheckFixture();
+    const beadsCheck = async (): Promise<BeadsCheck> => createBeadsCheckFixture();
 
     const checkRepoRuntimeHealth = async (): Promise<RepoRuntimeHealthCheck> => {
       repoHealthCallCount += 1;
@@ -314,6 +277,9 @@ describe("useAgentStudioReadiness", () => {
         activeRepo: "/repo",
         runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
         checkRepoRuntimeHealth,
+        runtimeCheck,
+        beadsCheck,
+        toastApi: testToastApi,
       });
       latest = useAgentStudioReadiness({
         activeRepo: "/repo",
@@ -352,8 +318,6 @@ describe("useAgentStudioReadiness", () => {
       expect(readiness.agentStudioBlockedReason).toBeNull();
     } finally {
       await harness.unmount();
-      host.runtimeCheck = originalRuntimeCheck;
-      host.beadsCheck = originalBeadsCheck;
     }
-  });
+  }, 5000);
 });

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
@@ -7,27 +7,31 @@ import {
   buildDiagnosticsToastIssues,
   buildRuntimeCheckErrorState,
   buildRuntimeHealthErrorMap,
+  hasRuntimeHealthCheckingState,
 } from "./check-diagnostics";
 
-const makeRepoHealth = (
-  overrides: Partial<RepoRuntimeHealthCheck> = {},
-): RepoRuntimeHealthCheck => ({
-  status: "ready",
-  checkedAt: "2026-02-22T08:00:00.000Z",
-  runtime: {
+type RepoHealthOverrides = Omit<Partial<RepoRuntimeHealthCheck>, "runtime" | "mcp"> & {
+  runtime?: Partial<RepoRuntimeHealthCheck["runtime"]>;
+  mcp?: Partial<NonNullable<RepoRuntimeHealthCheck["mcp"]>>;
+};
+
+const makeRepoHealth = (overrides: RepoHealthOverrides = {}): RepoRuntimeHealthCheck => {
+  const checkedAt = overrides.checkedAt ?? "2026-02-22T08:00:00.000Z";
+  const runtime: RepoRuntimeHealthCheck["runtime"] = {
     status: "ready",
     stage: "runtime_ready",
     observation: null,
     instance: null,
     startedAt: null,
-    updatedAt: "2026-02-22T08:00:00.000Z",
+    updatedAt: checkedAt,
     elapsedMs: null,
     attempts: null,
     detail: null,
     failureKind: null,
     failureReason: null,
-  },
-  mcp: {
+    ...overrides.runtime,
+  };
+  const mcp: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
     supported: true,
     status: "connected",
     serverName: "openducktor",
@@ -35,9 +39,24 @@ const makeRepoHealth = (
     toolIds: [],
     detail: null,
     failureKind: null,
-  },
-  ...overrides,
-});
+    ...overrides.mcp,
+  };
+
+  return {
+    status:
+      overrides.status ??
+      (runtime.status === "error" || mcp.status === "error"
+        ? "error"
+        : mcp.status === "checking" ||
+            mcp.status === "reconnecting" ||
+            mcp.status === "waiting_for_runtime"
+          ? "checking"
+          : runtime.status),
+    checkedAt,
+    runtime,
+    mcp,
+  };
+};
 
 describe("check-diagnostics helpers", () => {
   test("projects runtime and beads query failures into concrete error states", () => {
@@ -237,6 +256,40 @@ describe("check-diagnostics helpers", () => {
         beadsCheckFetching: false,
         runtimeHealthByRuntime: {
           opencode: makeRepoHealth({
+            status: "checking",
+            runtime: {
+              status: "ready",
+              stage: "runtime_ready",
+            },
+            mcp: {
+              supported: true,
+              status: "checking",
+              serverName: "openducktor",
+              serverStatus: null,
+              toolIds: [],
+              detail: "Checking OpenDucktor MCP",
+              failureKind: null,
+            },
+          }),
+        },
+        runtimeHealthFetching: false,
+      }),
+    ).toEqual({
+      retryRuntimeCheck: false,
+      retryBeadsCheck: false,
+      retryRuntimeHealth: true,
+    });
+
+    expect(
+      buildDiagnosticsRetryPlan({
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        runtimeCheckFailureKind: null,
+        runtimeCheckFetching: false,
+        beadsCheckFailureKind: null,
+        beadsCheckFetching: false,
+        runtimeHealthByRuntime: {
+          opencode: makeRepoHealth({
             status: "error",
             mcp: {
               supported: true,
@@ -256,5 +309,34 @@ describe("check-diagnostics helpers", () => {
       retryBeadsCheck: false,
       retryRuntimeHealth: false,
     });
+  });
+
+  test("detects runtime-health checking states that still need polling", () => {
+    expect(
+      hasRuntimeHealthCheckingState([OPENCODE_RUNTIME_DESCRIPTOR], {
+        opencode: makeRepoHealth({
+          status: "checking",
+          runtime: {
+            status: "ready",
+            stage: "runtime_ready",
+          },
+          mcp: {
+            supported: true,
+            status: "checking",
+            serverName: "openducktor",
+            serverStatus: null,
+            toolIds: [],
+            detail: "Checking OpenDucktor MCP",
+            failureKind: null,
+          },
+        }),
+      }),
+    ).toBe(true);
+
+    expect(
+      hasRuntimeHealthCheckingState([OPENCODE_RUNTIME_DESCRIPTOR], {
+        opencode: makeRepoHealth(),
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import {
+  createRepoRuntimeHealthFixture,
+  type RepoRuntimeHealthFixtureOverrides,
+} from "@/test-utils/shared-test-fixtures";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import {
   buildBeadsCheckErrorState,
@@ -9,53 +13,10 @@ import {
   buildRuntimeHealthErrorMap,
 } from "./check-diagnostics";
 
-type RepoHealthOverrides = Omit<Partial<RepoRuntimeHealthCheck>, "runtime" | "mcp"> & {
-  runtime?: Partial<RepoRuntimeHealthCheck["runtime"]>;
-  mcp?: Partial<NonNullable<RepoRuntimeHealthCheck["mcp"]>>;
-};
-
-const makeRepoHealth = (overrides: RepoHealthOverrides = {}): RepoRuntimeHealthCheck => {
-  const checkedAt = overrides.checkedAt ?? "2026-02-22T08:00:00.000Z";
-  const runtime: RepoRuntimeHealthCheck["runtime"] = {
-    status: "ready",
-    stage: "runtime_ready",
-    observation: null,
-    instance: null,
-    startedAt: null,
-    updatedAt: checkedAt,
-    elapsedMs: null,
-    attempts: null,
-    detail: null,
-    failureKind: null,
-    failureReason: null,
-    ...overrides.runtime,
-  };
-  const mcp: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
-    supported: true,
-    status: "connected",
-    serverName: "openducktor",
-    serverStatus: "connected",
-    toolIds: [],
-    detail: null,
-    failureKind: null,
-    ...overrides.mcp,
-  };
-
-  return {
-    status:
-      overrides.status ??
-      (runtime.status === "error" || mcp.status === "error"
-        ? "error"
-        : mcp.status === "checking" ||
-            mcp.status === "reconnecting" ||
-            mcp.status === "waiting_for_runtime"
-          ? "checking"
-          : runtime.status),
-    checkedAt,
-    runtime,
-    mcp,
-  };
-};
+const makeRepoHealth = (
+  overrides: RepoRuntimeHealthFixtureOverrides = {},
+): RepoRuntimeHealthCheck =>
+  createRepoRuntimeHealthFixture({ checkedAt: "2026-02-22T08:00:00.000Z" }, overrides);
 
 describe("check-diagnostics helpers", () => {
   test("projects runtime and beads query failures into concrete error states", () => {

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
@@ -7,7 +7,6 @@ import {
   buildDiagnosticsToastIssues,
   buildRuntimeCheckErrorState,
   buildRuntimeHealthErrorMap,
-  hasRuntimeHealthCheckingState,
 } from "./check-diagnostics";
 
 type RepoHealthOverrides = Omit<Partial<RepoRuntimeHealthCheck>, "runtime" | "mcp"> & {
@@ -277,7 +276,7 @@ describe("check-diagnostics helpers", () => {
     ).toEqual({
       retryRuntimeCheck: false,
       retryBeadsCheck: false,
-      retryRuntimeHealth: true,
+      retryRuntimeHealth: false,
     });
 
     expect(
@@ -309,34 +308,5 @@ describe("check-diagnostics helpers", () => {
       retryBeadsCheck: false,
       retryRuntimeHealth: false,
     });
-  });
-
-  test("detects runtime-health checking states that still need polling", () => {
-    expect(
-      hasRuntimeHealthCheckingState([OPENCODE_RUNTIME_DESCRIPTOR], {
-        opencode: makeRepoHealth({
-          status: "checking",
-          runtime: {
-            status: "ready",
-            stage: "runtime_ready",
-          },
-          mcp: {
-            supported: true,
-            status: "checking",
-            serverName: "openducktor",
-            serverStatus: null,
-            toolIds: [],
-            detail: "Checking OpenDucktor MCP",
-            failureKind: null,
-          },
-        }),
-      }),
-    ).toBe(true);
-
-    expect(
-      hasRuntimeHealthCheckingState([OPENCODE_RUNTIME_DESCRIPTOR], {
-        opencode: makeRepoHealth(),
-      }),
-    ).toBe(false);
   });
 });

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -368,6 +368,8 @@ export const buildDiagnosticsRetryPlan = ({
   const retryRuntimeHealth =
     activeRepo !== null &&
     runtimeDefinitions.length > 0 &&
+    // Transient startup polling now lives in the runtime-health query refetchInterval.
+    // Keep the timeout retry here so stalled probes still force a fresh invalidation.
     hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime) &&
     !runtimeHealthFetching;
 

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -334,16 +334,6 @@ export const hasRuntimeHealthTimeoutIssue = (
   });
 };
 
-export const hasRuntimeHealthCheckingState = (
-  runtimeDefinitions: RuntimeDescriptor[],
-  runtimeHealthByRuntime: RepoRuntimeHealthMap,
-): boolean => {
-  return runtimeDefinitions.some((definition) => {
-    const runtimeHealth = runtimeHealthByRuntime[definition.kind];
-    return runtimeHealth?.status === "checking";
-  });
-};
-
 export const hasDiagnosticsRetryingState = ({
   runtimeDefinitions,
   runtimeCheckFailureKind,
@@ -378,8 +368,7 @@ export const buildDiagnosticsRetryPlan = ({
   const retryRuntimeHealth =
     activeRepo !== null &&
     runtimeDefinitions.length > 0 &&
-    (hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime) ||
-      hasRuntimeHealthCheckingState(runtimeDefinitions, runtimeHealthByRuntime)) &&
+    hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime) &&
     !runtimeHealthFetching;
 
   return {

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -334,6 +334,16 @@ export const hasRuntimeHealthTimeoutIssue = (
   });
 };
 
+export const hasRuntimeHealthCheckingState = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeHealthByRuntime: RepoRuntimeHealthMap,
+): boolean => {
+  return runtimeDefinitions.some((definition) => {
+    const runtimeHealth = runtimeHealthByRuntime[definition.kind];
+    return runtimeHealth?.status === "checking";
+  });
+};
+
 export const hasDiagnosticsRetryingState = ({
   runtimeDefinitions,
   runtimeCheckFailureKind,
@@ -368,7 +378,8 @@ export const buildDiagnosticsRetryPlan = ({
   const retryRuntimeHealth =
     activeRepo !== null &&
     runtimeDefinitions.length > 0 &&
-    hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime) &&
+    (hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime) ||
+      hasRuntimeHealthCheckingState(runtimeDefinitions, runtimeHealthByRuntime)) &&
     !runtimeHealthFetching;
 
   return {

--- a/apps/desktop/src/state/operations/workspace/use-check-diagnostics-effects.ts
+++ b/apps/desktop/src/state/operations/workspace/use-check-diagnostics-effects.ts
@@ -6,7 +6,18 @@ import type { DiagnosticsRetryPlan, DiagnosticsToastIssue } from "./check-diagno
 
 const RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS = 2_000;
 
-export function useDiagnosticsToasts(diagnosticsToastIssues: DiagnosticsToastIssue[]): void {
+export type DiagnosticsToastApi = {
+  error: (
+    message: string,
+    options?: { description?: string; id?: string; duration?: number },
+  ) => unknown;
+  dismiss: (toastId?: string | number) => unknown;
+};
+
+export function useDiagnosticsToasts(
+  diagnosticsToastIssues: DiagnosticsToastIssue[],
+  toastApi: DiagnosticsToastApi = toast,
+): void {
   const issueSignaturesRef = useRef(new Map<string, string>());
 
   useEffect(() => {
@@ -17,7 +28,7 @@ export function useDiagnosticsToasts(diagnosticsToastIssues: DiagnosticsToastIss
         continue;
       }
 
-      toast.dismiss(issueId);
+      toastApi.dismiss(issueId);
       issueSignaturesRef.current.delete(issueId);
     }
 
@@ -27,7 +38,7 @@ export function useDiagnosticsToasts(diagnosticsToastIssues: DiagnosticsToastIss
         continue;
       }
 
-      toast.error(issue.title, {
+      toastApi.error(issue.title, {
         id: issue.id,
         description: issue.description,
         duration: Number.POSITIVE_INFINITY,
@@ -35,16 +46,16 @@ export function useDiagnosticsToasts(diagnosticsToastIssues: DiagnosticsToastIss
 
       issueSignaturesRef.current.set(issue.id, signature);
     }
-  }, [diagnosticsToastIssues]);
+  }, [diagnosticsToastIssues, toastApi]);
 
   useEffect(() => {
     return () => {
       for (const issueId of issueSignaturesRef.current.keys()) {
-        toast.dismiss(issueId);
+        toastApi.dismiss(issueId);
       }
       issueSignaturesRef.current.clear();
     };
-  }, []);
+  }, [toastApi]);
 }
 
 type UseDiagnosticsRetrySchedulerArgs = {

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -379,6 +379,71 @@ describe("use-checks", () => {
     }
   });
 
+  test("automatically refreshes runtime health while MCP connectivity is still checking", async () => {
+    const runtimeCheck = mock(
+      async (_force?: boolean): Promise<RuntimeCheck> => makeRuntimeCheck(),
+    );
+    const beadsCheck = mock(async (): Promise<BeadsCheck> => makeBeadsCheck());
+    let repoHealthCallCount = 0;
+    repoHealthHandler = async () => {
+      repoHealthCallCount += 1;
+      if (repoHealthCallCount === 1) {
+        return makeRepoHealth({
+          status: "checking",
+          runtime: {
+            status: "ready",
+            stage: "runtime_ready",
+          },
+          mcp: {
+            supported: true,
+            status: "checking",
+            serverName: "openducktor",
+            serverStatus: null,
+            toolIds: [],
+            detail: "Checking OpenDucktor MCP",
+            failureKind: null,
+          },
+        });
+      }
+
+      return makeRepoHealth();
+    };
+
+    const original = {
+      runtimeCheck: host.runtimeCheck,
+      beadsCheck: host.beadsCheck,
+    };
+    host.runtimeCheck = runtimeCheck;
+    host.beadsCheck = beadsCheck;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    try {
+      await waitForInitialChecksToSettle(harness);
+
+      expect(harness.getLatest().activeRepoRuntimeHealthByRuntime.opencode?.status).toBe(
+        "checking",
+      );
+
+      await harness.waitFor(
+        (value) => value.activeRepoRuntimeHealthByRuntime.opencode?.status === "ready",
+        5000,
+      );
+
+      expect(checkRepoRuntimeHealthMock).toHaveBeenCalledTimes(2);
+      expect(harness.getLatest().activeRepoRuntimeHealthByRuntime.opencode?.mcp?.status).toBe(
+        "connected",
+      );
+    } finally {
+      await harness.unmount();
+      host.runtimeCheck = original.runtimeCheck;
+      host.beadsCheck = original.beadsCheck;
+    }
+  });
+
   test("tracks per-repo cache and projects cached checks when active repo changes", async () => {
     const beadsCheck = mock(
       async (repoPath: string): Promise<BeadsCheck> =>

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   type BeadsCheck,
   OPENCODE_RUNTIME_DESCRIPTOR,
@@ -8,27 +8,22 @@ import {
 } from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
 import { QueryProvider } from "@/lib/query-provider";
-import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
 import {
   type BeadsCheckFixtureOverrides,
   createBeadsCheckFixture,
   createDeferred,
+  createRepoRuntimeHealthFixture,
+  type RepoRuntimeHealthFixtureOverrides,
 } from "@/test-utils/shared-test-fixtures";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
-import { host } from "../shared/host";
+import type { DiagnosticsToastApi } from "./use-check-diagnostics-effects";
+import { useChecks } from "./use-checks";
 
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
 reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
-
-const HOST_METHOD_NAMES = ["runtimeCheck", "beadsCheck"] as const;
-type HostMethodName = (typeof HOST_METHOD_NAMES)[number];
-type HostMethodMap = Pick<typeof host, HostMethodName>;
-const originalHostMethods = Object.fromEntries(
-  HOST_METHOD_NAMES.map((name) => [name, host[name]]),
-) as HostMethodMap;
 
 const makeRuntimeCheck = (overrides: Partial<RuntimeCheck> = {}): RuntimeCheck => ({
   gitOk: true,
@@ -46,53 +41,10 @@ const makeRuntimeCheck = (overrides: Partial<RuntimeCheck> = {}): RuntimeCheck =
 const makeBeadsCheck = (overrides: BeadsCheckFixtureOverrides = {}): BeadsCheck =>
   createBeadsCheckFixture({}, overrides);
 
-type RepoHealthOverrides = Omit<Partial<RepoRuntimeHealthCheck>, "runtime" | "mcp"> & {
-  runtime?: Partial<RepoRuntimeHealthCheck["runtime"]>;
-  mcp?: Partial<NonNullable<RepoRuntimeHealthCheck["mcp"]>>;
-};
-
-const makeRepoHealth = (overrides: RepoHealthOverrides = {}): RepoRuntimeHealthCheck => {
-  const checkedAt = overrides.checkedAt ?? "2026-02-22T08:00:00.000Z";
-  const runtime: RepoRuntimeHealthCheck["runtime"] = {
-    status: "ready",
-    stage: "runtime_ready",
-    observation: null,
-    instance: null,
-    startedAt: null,
-    updatedAt: checkedAt,
-    elapsedMs: null,
-    attempts: null,
-    detail: null,
-    failureKind: null,
-    failureReason: null,
-    ...overrides.runtime,
-  };
-  const mcp: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
-    supported: true,
-    status: "connected",
-    serverName: "openducktor",
-    serverStatus: "connected",
-    toolIds: ["odt_read_task"],
-    detail: null,
-    failureKind: null,
-    ...overrides.mcp,
-  };
-
-  return {
-    status:
-      overrides.status ??
-      (runtime.status === "error" || mcp.status === "error"
-        ? "error"
-        : mcp.status === "checking" ||
-            mcp.status === "reconnecting" ||
-            mcp.status === "waiting_for_runtime"
-          ? "checking"
-          : runtime.status),
-    checkedAt,
-    runtime,
-    mcp,
-  };
-};
+const makeRepoHealth = (
+  overrides: RepoRuntimeHealthFixtureOverrides = {},
+): RepoRuntimeHealthCheck =>
+  createRepoRuntimeHealthFixture({ mcp: { toolIds: ["odt_read_task"] } }, overrides);
 
 const MOCK_RUNTIME_DESCRIPTOR: RuntimeDescriptor = {
   kind: "mock-runtime",
@@ -112,6 +64,14 @@ const toastError = mock(
   (_message: string, _options?: { description?: string; id?: string; duration?: number }) => {},
 );
 const toastDismiss = mock((_toastId?: string | number) => {});
+const testToastApi: DiagnosticsToastApi = {
+  error: (message, options) => toastError(message, options),
+  dismiss: (toastId) => toastDismiss(toastId),
+};
+let runtimeCheckHandler = async (_force?: boolean): Promise<RuntimeCheck> => makeRuntimeCheck();
+let beadsCheckHandler = async (_repoPath: string): Promise<BeadsCheck> => makeBeadsCheck();
+const runtimeCheckMock = mock((force?: boolean) => runtimeCheckHandler(force));
+const beadsCheckMock = mock((repoPath: string) => beadsCheckHandler(repoPath));
 let repoHealthHandler = async (
   _repoPath: string,
   _runtimeKind: RuntimeKind,
@@ -126,18 +86,40 @@ type HookResult = ReturnType<UseChecksHook>;
 type HookHarnessArgs = Omit<HookArgs, "checkRepoRuntimeHealth"> & {
   checkRepoRuntimeHealth?: HookArgs["checkRepoRuntimeHealth"];
 };
+type ResolvedHookArgs = HookArgs &
+  Required<Pick<HookArgs, "runtimeCheck" | "beadsCheck" | "toastApi" | "checkRepoRuntimeHealth">>;
 
-let useChecks: UseChecksHook;
+const buildHookArgs = (
+  args: Partial<HookHarnessArgs>,
+  previous?: ResolvedHookArgs,
+): ResolvedHookArgs => {
+  const activeRepo = args.activeRepo !== undefined ? args.activeRepo : previous?.activeRepo;
+  const runtimeDefinitions =
+    args.runtimeDefinitions !== undefined ? args.runtimeDefinitions : previous?.runtimeDefinitions;
 
-const createHookHarness = (initialArgs: HookHarnessArgs) => {
-  let latest: HookResult | null = null;
-  let currentArgs: HookArgs = {
-    ...initialArgs,
+  if (activeRepo === undefined || runtimeDefinitions === undefined) {
+    throw new Error("Hook args must include activeRepo and runtimeDefinitions");
+  }
+
+  return {
+    ...previous,
+    ...args,
+    activeRepo,
+    runtimeDefinitions,
+    runtimeCheck: args.runtimeCheck ?? previous?.runtimeCheck ?? runtimeCheckMock,
+    beadsCheck: args.beadsCheck ?? previous?.beadsCheck ?? beadsCheckMock,
+    toastApi: args.toastApi ?? previous?.toastApi ?? testToastApi,
     checkRepoRuntimeHealth:
-      initialArgs.checkRepoRuntimeHealth ??
+      args.checkRepoRuntimeHealth ??
+      previous?.checkRepoRuntimeHealth ??
       ((repoPath: string, runtimeKind: RuntimeKind) =>
         checkRepoRuntimeHealthMock(repoPath, runtimeKind)),
   };
+};
+
+const createHookHarness = (initialArgs: HookHarnessArgs) => {
+  let latest: HookResult | null = null;
+  let currentArgs = buildHookArgs(initialArgs);
 
   const Harness = ({ args }: { args: HookArgs }) => {
     latest = useChecks(args);
@@ -155,12 +137,7 @@ const createHookHarness = (initialArgs: HookHarnessArgs) => {
       await sharedHarness.mount();
     },
     updateArgs: async (nextArgs: Partial<HookHarnessArgs>) => {
-      currentArgs = {
-        ...currentArgs,
-        ...nextArgs,
-        checkRepoRuntimeHealth:
-          nextArgs.checkRepoRuntimeHealth ?? currentArgs.checkRepoRuntimeHealth,
-      };
+      currentArgs = buildHookArgs(nextArgs, currentArgs);
       await sharedHarness.update({ args: currentArgs });
     },
     run: async (fn: (value: HookResult) => Promise<void> | void) => {
@@ -178,7 +155,7 @@ const createHookHarness = (initialArgs: HookHarnessArgs) => {
       return latest;
     },
     waitFor: async (predicate: (value: HookResult) => boolean, timeoutMs?: number) => {
-      await sharedHarness.waitFor(() => latest !== null && predicate(latest), timeoutMs);
+      await sharedHarness.waitFor(() => latest !== null && predicate(latest), timeoutMs ?? 5000);
     },
     unmount: async () => {
       try {
@@ -214,39 +191,16 @@ const waitForInitialChecksToSettle = async (
   });
 };
 
-beforeAll(async () => {
-  mock.module("sonner", () => ({
-    toast: Object.assign(
-      (message: string, options?: { description?: string; id?: string; duration?: number }) =>
-        toastMessage(message, options),
-      {
-        success: (
-          message: string,
-          options?: { description?: string; id?: string; duration?: number },
-        ) => toastMessage(message, options),
-        error: (
-          message: string,
-          options?: { description?: string; id?: string; duration?: number },
-        ) => toastError(message, options),
-        dismiss: (toastId?: string | number) => toastDismiss(toastId),
-      },
-    ),
-  }));
-  ({ useChecks } = await import("./use-checks"));
-});
-
 beforeEach(async () => {
-  Object.assign(host, originalHostMethods);
   toastMessage.mockClear();
   toastError.mockClear();
   toastDismiss.mockClear();
+  runtimeCheckMock.mockClear();
+  beadsCheckMock.mockClear();
   checkRepoRuntimeHealthMock.mockClear();
+  runtimeCheckHandler = async (_force?: boolean) => makeRuntimeCheck();
+  beadsCheckHandler = async (_repoPath: string) => makeBeadsCheck();
   repoHealthHandler = async () => makeRepoHealth();
-});
-
-afterAll(async () => {
-  Object.assign(host, originalHostMethods);
-  await restoreMockedModules([["sonner", () => import("sonner")]]);
 });
 
 describe("use-checks", () => {
@@ -256,12 +210,8 @@ describe("use-checks", () => {
     );
     const beadsCheck = mock(async (): Promise<BeadsCheck> => makeBeadsCheck());
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: null,
@@ -285,10 +235,8 @@ describe("use-checks", () => {
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
     }
-  });
+  }, 5000);
 
   test("does not surface Beads failures while backend reports initialization in progress", async () => {
     const runtimeCheck = mock(
@@ -317,12 +265,8 @@ describe("use-checks", () => {
           },
         }),
     );
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -341,20 +285,15 @@ describe("use-checks", () => {
       expect(toastError).not.toHaveBeenCalledWith("Beads store unavailable", expect.anything());
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
     }
-  });
+  }, 5000);
 
   test("refreshRuntimeCheck caches and supports force retries", async () => {
     const runtimeCheck = mock(
       async (_force?: boolean): Promise<RuntimeCheck> => makeRuntimeCheck(),
     );
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
+    runtimeCheckHandler = runtimeCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -375,9 +314,8 @@ describe("use-checks", () => {
       expect(harness.getLatest().hasRuntimeCheck()).toBe(true);
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
     }
-  });
+  }, 5000);
 
   test("automatically refreshes runtime health while MCP connectivity is still checking", async () => {
     const runtimeCheck = mock(
@@ -409,12 +347,8 @@ describe("use-checks", () => {
       return makeRepoHealth();
     };
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -439,10 +373,8 @@ describe("use-checks", () => {
       );
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
     }
-  });
+  }, 5000);
 
   test("tracks per-repo cache and projects cached checks when active repo changes", async () => {
     const beadsCheck = mock(
@@ -452,10 +384,7 @@ describe("use-checks", () => {
     repoHealthHandler = async (repoPath: string) =>
       makeRepoHealth({ checkedAt: `${repoPath}-checked`, mcp: { toolIds: [repoPath] } });
 
-    const original = {
-      beadsCheck: host.beadsCheck,
-    };
-    host.beadsCheck = beadsCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -500,9 +429,8 @@ describe("use-checks", () => {
       expect(checkRepoRuntimeHealthMock).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
-      host.beadsCheck = original.beadsCheck;
     }
-  });
+  }, 5000);
 
   test("deduplicates runtime health error toasts across manual refreshes", async () => {
     const runtimeCheck = mock(
@@ -523,12 +451,8 @@ describe("use-checks", () => {
         },
       });
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -556,10 +480,8 @@ describe("use-checks", () => {
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
     }
-  });
+  }, 5000);
 
   test("shows cli and beads toasts for unhealthy successful payloads", async () => {
     let runtimeCallCount = 0;
@@ -600,12 +522,8 @@ describe("use-checks", () => {
           });
     });
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -636,10 +554,8 @@ describe("use-checks", () => {
       );
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
     }
-  });
+  }, 5000);
 
   test("refreshChecks starts independent probes in parallel", async () => {
     const runtimeDeferred = createDeferred<RuntimeCheck>();
@@ -661,12 +577,8 @@ describe("use-checks", () => {
       return runtimeHealthCallCount === 1 ? makeRepoHealth() : runtimeHealthDeferred.promise;
     };
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -701,10 +613,8 @@ describe("use-checks", () => {
       await harness.waitFor((value) => value.isLoadingChecks === false);
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
     }
-  });
+  }, 5000);
 
   test("refreshChecks forces a fresh runtime check and surfaces errors", async () => {
     let callCount = 0;
@@ -722,12 +632,8 @@ describe("use-checks", () => {
     const beadsCheck = mock(async (): Promise<BeadsCheck> => makeBeadsCheck());
     repoHealthHandler = async () => makeRepoHealth();
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -757,10 +663,8 @@ describe("use-checks", () => {
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
     }
-  });
+  }, 5000);
 
   test("refreshChecks waits for all failed probes before surfacing unavailable diagnostics", async () => {
     const runtimeDeferred = createDeferred<RuntimeCheck>();
@@ -782,12 +686,8 @@ describe("use-checks", () => {
       return runtimeHealthCallCount === 1 ? makeRepoHealth() : runtimeHealthDeferred.promise;
     };
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -829,10 +729,14 @@ describe("use-checks", () => {
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
+      void runtimeDeferred.promise.catch(() => {});
+      void beadsDeferred.promise.catch(() => {});
+      void runtimeHealthDeferred.promise.catch(() => {});
+      runtimeDeferred.reject(new Error("cleanup"));
+      beadsDeferred.reject(new Error("cleanup"));
+      runtimeHealthDeferred.reject(new Error("cleanup"));
     }
-  });
+  }, 5000);
 
   test("refreshChecks times out hung probes and clears loading state", async () => {
     let runtimeCallCount = 0;
@@ -851,10 +755,6 @@ describe("use-checks", () => {
     });
     repoHealthHandler = async () => makeRepoHealth();
 
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
     const originalSetTimeout = globalThis.setTimeout;
     const originalClearTimeout = globalThis.clearTimeout;
     const diagnosticsTimeoutHandlers = new Map<number, () => void>();
@@ -886,8 +786,8 @@ describe("use-checks", () => {
       originalClearTimeout(timeoutId);
     });
 
-    host.runtimeCheck = runtimeCheck;
-    host.beadsCheck = beadsCheck;
+    runtimeCheckHandler = runtimeCheck;
+    beadsCheckHandler = beadsCheck;
     globalThis.setTimeout = setTimeoutMock as unknown as typeof globalThis.setTimeout;
     globalThis.clearTimeout = clearTimeoutMock as unknown as typeof globalThis.clearTimeout;
 
@@ -932,26 +832,21 @@ describe("use-checks", () => {
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;
+      void beadsDeferred.promise.catch(() => {});
       beadsDeferred.reject(new Error("cleanup"));
     }
-  });
+  }, 5000);
 
   test("projects runtime and beads query timeouts into concrete states instead of leaving checks pending", async () => {
     const runtimeDeferred = createDeferred<RuntimeCheck>();
     const beadsDeferred = createDeferred<BeadsCheck>();
-    const original = {
-      runtimeCheck: host.runtimeCheck,
-      beadsCheck: host.beadsCheck,
-    };
     const originalSetTimeout = globalThis.setTimeout;
     const originalClearTimeout = globalThis.clearTimeout;
 
-    host.runtimeCheck = mock(async () => runtimeDeferred.promise);
-    host.beadsCheck = mock(async () => beadsDeferred.promise);
+    runtimeCheckHandler = mock(async () => runtimeDeferred.promise);
+    beadsCheckHandler = mock(async () => beadsDeferred.promise);
     repoHealthHandler = async () => makeRepoHealth();
 
     globalThis.setTimeout = ((handler: TimerHandler, delay?: number) => {
@@ -996,14 +891,14 @@ describe("use-checks", () => {
       expect(toastMessage).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
-      host.runtimeCheck = original.runtimeCheck;
-      host.beadsCheck = original.beadsCheck;
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;
+      void runtimeDeferred.promise.catch(() => {});
+      void beadsDeferred.promise.catch(() => {});
       runtimeDeferred.reject(new Error("cleanup"));
       beadsDeferred.reject(new Error("cleanup"));
     }
-  });
+  }, 5000);
 
   test("projects runtime health query failures as unhealthy runtime state", async () => {
     repoHealthHandler = async () => {

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/types/diagnostics";
 import {
   beadsCheckQueryOptions,
+  type ChecksQueryDependencies,
   checksQueryKeys,
   classifyDiagnosticsQueryError,
   loadBeadsCheckFromQuery,
@@ -32,6 +33,7 @@ import {
   type DiagnosticsToastIssue,
 } from "./check-diagnostics";
 import {
+  type DiagnosticsToastApi,
   useDiagnosticsRetryScheduler,
   useDiagnosticsToasts,
 } from "./use-check-diagnostics-effects";
@@ -43,6 +45,9 @@ type UseChecksArgs = {
     repoPath: string,
     runtimeKind: RuntimeKind,
   ) => Promise<RepoRuntimeHealthCheck>;
+  runtimeCheck?: ChecksQueryDependencies["runtimeCheck"];
+  beadsCheck?: ChecksQueryDependencies["beadsCheck"];
+  toastApi?: DiagnosticsToastApi;
 };
 
 type UseChecksResult = {
@@ -71,12 +76,15 @@ export function useChecks({
   activeRepo,
   runtimeDefinitions,
   checkRepoRuntimeHealth,
+  runtimeCheck,
+  beadsCheck,
+  toastApi,
 }: UseChecksArgs): UseChecksResult {
   const queryClient = useQueryClient();
   const [isManualLoadingChecks, setIsManualLoadingChecks] = useState(false);
-  const runtimeCheckQuery = useQuery(runtimeCheckQueryOptions());
+  const runtimeCheckQuery = useQuery(runtimeCheckQueryOptions(false, runtimeCheck));
   const beadsCheckQuery = useQuery({
-    ...beadsCheckQueryOptions(activeRepo ?? "__disabled__"),
+    ...beadsCheckQueryOptions(activeRepo ?? "__disabled__", beadsCheck),
     enabled: activeRepo !== null,
   });
   const runtimeHealthQuery = useQuery({
@@ -96,12 +104,12 @@ export function useChecks({
           exact: true,
           refetchType: "none",
         });
-        return queryClient.fetchQuery(runtimeCheckQueryOptions(true));
+        return queryClient.fetchQuery(runtimeCheckQueryOptions(true, runtimeCheck));
       }
 
-      return loadRuntimeCheckFromQuery(queryClient);
+      return loadRuntimeCheckFromQuery(queryClient, runtimeCheck);
     },
-    [queryClient],
+    [queryClient, runtimeCheck],
   );
 
   const refreshBeadsCheckForRepo = useCallback(
@@ -115,10 +123,10 @@ export function useChecks({
       }
 
       return force
-        ? queryClient.fetchQuery(beadsCheckQueryOptions(repoPath))
-        : loadBeadsCheckFromQuery(queryClient, repoPath);
+        ? queryClient.fetchQuery(beadsCheckQueryOptions(repoPath, beadsCheck))
+        : loadBeadsCheckFromQuery(queryClient, repoPath, beadsCheck);
     },
-    [queryClient],
+    [beadsCheck, queryClient],
   );
 
   const refreshRepoRuntimeHealthForRepo = useCallback(
@@ -190,9 +198,12 @@ export function useChecks({
 
   const hasCachedBeadsCheck = useCallback(
     (repoPath: string): boolean => {
-      return queryClient.getQueryData(beadsCheckQueryOptions(repoPath).queryKey) !== undefined;
+      return (
+        queryClient.getQueryData(beadsCheckQueryOptions(repoPath, beadsCheck).queryKey) !==
+        undefined
+      );
     },
-    [queryClient],
+    [beadsCheck, queryClient],
   );
 
   const hasCachedRepoRuntimeHealth = useCallback(
@@ -206,8 +217,10 @@ export function useChecks({
   );
 
   const hasRuntimeCheck = useCallback((): boolean => {
-    return queryClient.getQueryData(runtimeCheckQueryOptions().queryKey) !== undefined;
-  }, [queryClient]);
+    return (
+      queryClient.getQueryData(runtimeCheckQueryOptions(false, runtimeCheck).queryKey) !== undefined
+    );
+  }, [queryClient, runtimeCheck]);
 
   const clearActiveBeadsCheck = useCallback(() => {
     setIsManualLoadingChecks(false);
@@ -346,7 +359,7 @@ export function useChecks({
     ],
   );
 
-  useDiagnosticsToasts(diagnosticsToastIssues);
+  useDiagnosticsToasts(diagnosticsToastIssues, toastApi);
   useDiagnosticsRetryScheduler({
     activeRepo,
     retryPlan: diagnosticsRetryPlan,

--- a/apps/desktop/src/state/queries/checks.test.ts
+++ b/apps/desktop/src/state/queries/checks.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
+import {
+  createRepoRuntimeHealthFixture,
+  type RepoRuntimeHealthFixtureOverrides,
+} from "@/test-utils/shared-test-fixtures";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import {
   classifyDiagnosticsQueryError,
@@ -8,53 +12,10 @@ import {
   repoRuntimeHealthQueryOptions,
 } from "./checks";
 
-type RepoHealthOverrides = Omit<Partial<RepoRuntimeHealthCheck>, "runtime" | "mcp"> & {
-  runtime?: Partial<RepoRuntimeHealthCheck["runtime"]>;
-  mcp?: Partial<NonNullable<RepoRuntimeHealthCheck["mcp"]>>;
-};
-
-const makeRepoHealth = (overrides: RepoHealthOverrides = {}): RepoRuntimeHealthCheck => {
-  const checkedAt = overrides.checkedAt ?? "2026-02-22T08:00:00.000Z";
-  const runtime: RepoRuntimeHealthCheck["runtime"] = {
-    status: "ready",
-    stage: "runtime_ready",
-    observation: null,
-    instance: null,
-    startedAt: null,
-    updatedAt: checkedAt,
-    elapsedMs: null,
-    attempts: null,
-    detail: null,
-    failureKind: null,
-    failureReason: null,
-    ...overrides.runtime,
-  };
-  const mcp: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
-    supported: true,
-    status: "connected",
-    serverName: "openducktor",
-    serverStatus: "connected",
-    toolIds: [],
-    detail: null,
-    failureKind: null,
-    ...overrides.mcp,
-  };
-
-  return {
-    status:
-      overrides.status ??
-      (runtime.status === "error" || mcp.status === "error"
-        ? "error"
-        : mcp.status === "checking" ||
-            mcp.status === "reconnecting" ||
-            mcp.status === "waiting_for_runtime"
-          ? "checking"
-          : runtime.status),
-    checkedAt,
-    runtime,
-    mcp,
-  };
-};
+const makeRepoHealth = (
+  overrides: RepoRuntimeHealthFixtureOverrides = {},
+): RepoRuntimeHealthCheck =>
+  createRepoRuntimeHealthFixture({ checkedAt: "2026-02-22T08:00:00.000Z" }, overrides);
 
 describe("classifyDiagnosticsQueryError", () => {
   test("keeps query timeout errors explicit", () => {

--- a/apps/desktop/src/state/queries/checks.test.ts
+++ b/apps/desktop/src/state/queries/checks.test.ts
@@ -1,11 +1,60 @@
 import { describe, expect, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
+import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import {
   classifyDiagnosticsQueryError,
   DiagnosticsQueryTimeoutError,
   repoRuntimeHealthQueryOptions,
 } from "./checks";
+
+type RepoHealthOverrides = Omit<Partial<RepoRuntimeHealthCheck>, "runtime" | "mcp"> & {
+  runtime?: Partial<RepoRuntimeHealthCheck["runtime"]>;
+  mcp?: Partial<NonNullable<RepoRuntimeHealthCheck["mcp"]>>;
+};
+
+const makeRepoHealth = (overrides: RepoHealthOverrides = {}): RepoRuntimeHealthCheck => {
+  const checkedAt = overrides.checkedAt ?? "2026-02-22T08:00:00.000Z";
+  const runtime: RepoRuntimeHealthCheck["runtime"] = {
+    status: "ready",
+    stage: "runtime_ready",
+    observation: null,
+    instance: null,
+    startedAt: null,
+    updatedAt: checkedAt,
+    elapsedMs: null,
+    attempts: null,
+    detail: null,
+    failureKind: null,
+    failureReason: null,
+    ...overrides.runtime,
+  };
+  const mcp: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
+    supported: true,
+    status: "connected",
+    serverName: "openducktor",
+    serverStatus: "connected",
+    toolIds: [],
+    detail: null,
+    failureKind: null,
+    ...overrides.mcp,
+  };
+
+  return {
+    status:
+      overrides.status ??
+      (runtime.status === "error" || mcp.status === "error"
+        ? "error"
+        : mcp.status === "checking" ||
+            mcp.status === "reconnecting" ||
+            mcp.status === "waiting_for_runtime"
+          ? "checking"
+          : runtime.status),
+    checkedAt,
+    runtime,
+    mcp,
+  };
+};
 
 describe("classifyDiagnosticsQueryError", () => {
   test("keeps query timeout errors explicit", () => {
@@ -93,6 +142,66 @@ describe("repoRuntimeHealthQueryOptions", () => {
           }),
         }),
       );
+    } finally {
+      queryClient.clear();
+    }
+  });
+
+  test("keeps polling while runtime health is still transient", () => {
+    const queryClient = new QueryClient();
+
+    try {
+      const queryOptions = repoRuntimeHealthQueryOptions(
+        "/repo",
+        [OPENCODE_RUNTIME_DESCRIPTOR],
+        async () => makeRepoHealth(),
+      );
+      const refetchInterval = queryOptions.refetchInterval;
+      if (typeof refetchInterval !== "function") {
+        throw new Error("Expected runtime health query to define a refetch interval resolver");
+      }
+      const resolveRefetchInterval = refetchInterval as Exclude<
+        typeof refetchInterval,
+        false | number | undefined
+      >;
+      type RefetchIntervalQuery = Parameters<typeof resolveRefetchInterval>[0];
+
+      queryClient.setQueryData(queryOptions.queryKey, {
+        opencode: makeRepoHealth({
+          status: "checking",
+          runtime: {
+            status: "ready",
+            stage: "runtime_ready",
+          },
+          mcp: {
+            supported: true,
+            status: "checking",
+            serverName: "openducktor",
+            serverStatus: null,
+            toolIds: [],
+            detail: "Checking OpenDucktor MCP",
+            failureKind: null,
+          },
+        }),
+      });
+
+      const transientQuery = queryClient.getQueryCache().find({ queryKey: queryOptions.queryKey });
+      if (!transientQuery) {
+        throw new Error("Expected runtime health query cache entry to exist");
+      }
+
+      expect(resolveRefetchInterval(transientQuery as unknown as RefetchIntervalQuery)).toBe(1000);
+
+      queryClient.setQueryData(queryOptions.queryKey, {
+        opencode: makeRepoHealth(),
+      });
+
+      const settledQuery = queryClient.getQueryCache().find({ queryKey: queryOptions.queryKey });
+      if (!settledQuery) {
+        throw new Error("Expected runtime health query cache entry to exist");
+      }
+
+      expect(resolveRefetchInterval(settledQuery as unknown as RefetchIntervalQuery)).toBe(false);
     } finally {
       queryClient.clear();
     }

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -15,11 +15,21 @@ import type {
 } from "@/types/diagnostics";
 import { host } from "../operations/host";
 
+export type ChecksQueryDependencies = {
+  runtimeCheck: (force?: boolean) => Promise<RuntimeCheck>;
+  beadsCheck: (repoPath: string) => Promise<BeadsCheck>;
+};
+
 const RUNTIME_CHECK_STALE_TIME_MS = 5 * 60_000;
 const BEADS_CHECK_STALE_TIME_MS = 60_000;
 const RUNTIME_HEALTH_STALE_TIME_MS = 60_000;
 const RUNTIME_HEALTH_TRANSIENT_REFETCH_INTERVAL_MS = 1_000;
 const DIAGNOSTICS_QUERY_TIMEOUT_MS = 15_000;
+
+const DEFAULT_CHECKS_QUERY_DEPENDENCIES: ChecksQueryDependencies = {
+  runtimeCheck: (force = false) => host.runtimeCheck(force),
+  beadsCheck: (repoPath) => host.beadsCheck(repoPath),
+};
 
 const buildRuntimeHealthErrorCheck = (
   runtimeHealthError: string,
@@ -124,17 +134,23 @@ export const checksQueryKeys = {
     ] as const,
 };
 
-export const runtimeCheckQueryOptions = (force = false) =>
+export const runtimeCheckQueryOptions = (
+  force = false,
+  runtimeCheck: ChecksQueryDependencies["runtimeCheck"] = DEFAULT_CHECKS_QUERY_DEPENDENCIES.runtimeCheck,
+) =>
   queryOptions({
     queryKey: checksQueryKeys.runtime(),
-    queryFn: (): Promise<RuntimeCheck> => withDiagnosticsQueryTimeout(host.runtimeCheck(force)),
+    queryFn: (): Promise<RuntimeCheck> => withDiagnosticsQueryTimeout(runtimeCheck(force)),
     staleTime: RUNTIME_CHECK_STALE_TIME_MS,
   });
 
-export const beadsCheckQueryOptions = (repoPath: string) =>
+export const beadsCheckQueryOptions = (
+  repoPath: string,
+  beadsCheck: ChecksQueryDependencies["beadsCheck"] = DEFAULT_CHECKS_QUERY_DEPENDENCIES.beadsCheck,
+) =>
   queryOptions({
     queryKey: checksQueryKeys.beads(repoPath),
-    queryFn: (): Promise<BeadsCheck> => withDiagnosticsQueryTimeout(host.beadsCheck(repoPath)),
+    queryFn: (): Promise<BeadsCheck> => withDiagnosticsQueryTimeout(beadsCheck(repoPath)),
     staleTime: BEADS_CHECK_STALE_TIME_MS,
   });
 
@@ -176,13 +192,16 @@ export const repoRuntimeHealthQueryOptions = (
     },
   });
 
-export const loadRuntimeCheckFromQuery = (queryClient: QueryClient): Promise<RuntimeCheck> =>
-  queryClient.fetchQuery(runtimeCheckQueryOptions());
+export const loadRuntimeCheckFromQuery = (
+  queryClient: QueryClient,
+  runtimeCheck: ChecksQueryDependencies["runtimeCheck"] = DEFAULT_CHECKS_QUERY_DEPENDENCIES.runtimeCheck,
+): Promise<RuntimeCheck> => queryClient.fetchQuery(runtimeCheckQueryOptions(false, runtimeCheck));
 
 export const loadBeadsCheckFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
-): Promise<BeadsCheck> => queryClient.fetchQuery(beadsCheckQueryOptions(repoPath));
+  beadsCheck: ChecksQueryDependencies["beadsCheck"] = DEFAULT_CHECKS_QUERY_DEPENDENCIES.beadsCheck,
+): Promise<BeadsCheck> => queryClient.fetchQuery(beadsCheckQueryOptions(repoPath, beadsCheck));
 
 export const loadRepoRuntimeHealthFromQuery = (
   queryClient: QueryClient,

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -7,6 +7,7 @@ import type {
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
+import { isRepoRuntimeHealthTransient } from "@/lib/repo-runtime-health";
 import type {
   RepoRuntimeFailureKind,
   RepoRuntimeHealthCheck,
@@ -17,6 +18,7 @@ import { host } from "../operations/host";
 const RUNTIME_CHECK_STALE_TIME_MS = 5 * 60_000;
 const BEADS_CHECK_STALE_TIME_MS = 60_000;
 const RUNTIME_HEALTH_STALE_TIME_MS = 60_000;
+const RUNTIME_HEALTH_TRANSIENT_REFETCH_INTERVAL_MS = 1_000;
 const DIAGNOSTICS_QUERY_TIMEOUT_MS = 15_000;
 
 const buildRuntimeHealthErrorCheck = (
@@ -51,6 +53,19 @@ const buildRuntimeHealthErrorCheck = (
 
 const normalizeRuntimeKinds = (runtimeKinds: RuntimeKind[]): RuntimeKind[] =>
   [...runtimeKinds].sort();
+
+const hasTransientRepoRuntimeHealth = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeHealthByRuntime: RepoRuntimeHealthMap | undefined,
+): boolean => {
+  if (!runtimeHealthByRuntime) {
+    return false;
+  }
+
+  return runtimeDefinitions.some((definition) =>
+    isRepoRuntimeHealthTransient(runtimeHealthByRuntime[definition.kind] ?? null),
+  );
+};
 
 export class DiagnosticsQueryTimeoutError extends Error {
   readonly failureKind = "timeout" as const;
@@ -154,6 +169,11 @@ export const repoRuntimeHealthQueryOptions = (
       return Object.fromEntries(checks) as RepoRuntimeHealthMap;
     },
     staleTime: RUNTIME_HEALTH_STALE_TIME_MS,
+    refetchInterval: (query) => {
+      return hasTransientRepoRuntimeHealth(runtimeDefinitions, query.state.data)
+        ? RUNTIME_HEALTH_TRANSIENT_REFETCH_INTERVAL_MS
+        : false;
+    },
   });
 
 export const loadRuntimeCheckFromQuery = (queryClient: QueryClient): Promise<RuntimeCheck> =>

--- a/apps/desktop/src/test-utils/shared-test-fixtures.ts
+++ b/apps/desktop/src/test-utils/shared-test-fixtures.ts
@@ -1,5 +1,6 @@
 import type { BeadsCheck, TaskCard } from "@openducktor/contracts";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 
 const BASE_BEADS_CHECK_FIXTURE: BeadsCheck = {
   beadsOk: true,
@@ -32,6 +33,14 @@ type RepoStoreHealthFixtureOverrides = Omit<
 
 export type BeadsCheckFixtureOverrides = Omit<Partial<BeadsCheck>, "repoStoreHealth"> & {
   repoStoreHealth?: RepoStoreHealthFixtureOverrides;
+};
+
+export type RepoRuntimeHealthFixtureOverrides = Omit<
+  Partial<RepoRuntimeHealthCheck>,
+  "runtime" | "mcp"
+> & {
+  runtime?: Partial<RepoRuntimeHealthCheck["runtime"]>;
+  mcp?: Partial<NonNullable<RepoRuntimeHealthCheck["mcp"]>>;
 };
 
 const BASE_TASK_CARD_FIXTURE: TaskCard = {
@@ -90,6 +99,35 @@ const BASE_AGENT_SESSION_FIXTURE: AgentSessionState = {
   modelCatalog: null,
   selectedModel: null,
   isLoadingModelCatalog: false,
+};
+
+const BASE_REPO_RUNTIME_HEALTH_FIXTURE: RepoRuntimeHealthCheck = {
+  status: "ready",
+  checkedAt: "2026-02-22T08:00:00.000Z",
+  runtime: {
+    status: "ready",
+    stage: "runtime_ready",
+    observation: null,
+    instance: null,
+    startedAt: null,
+    updatedAt: "2026-02-22T08:00:00.000Z",
+    elapsedMs: null,
+    attempts: null,
+    detail: null,
+    failureKind: null,
+    failureReason: null,
+  },
+  mcp: null,
+};
+
+const BASE_REPO_RUNTIME_MCP_FIXTURE: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
+  supported: true,
+  status: "connected",
+  serverName: "openducktor",
+  serverStatus: "connected",
+  toolIds: [],
+  detail: null,
+  failureKind: null,
 };
 
 export const createDeferred = <T>() => {
@@ -202,6 +240,58 @@ export const createAgentSessionFixture = (
     ...defaults,
     ...overrides,
   } satisfies AgentSessionState;
+
+  return structuredClone(merged);
+};
+
+export const createRepoRuntimeHealthFixture = (
+  defaults: RepoRuntimeHealthFixtureOverrides = {},
+  overrides: RepoRuntimeHealthFixtureOverrides = {},
+): RepoRuntimeHealthCheck => {
+  const checkedAt =
+    overrides.checkedAt ?? defaults.checkedAt ?? BASE_REPO_RUNTIME_HEALTH_FIXTURE.checkedAt;
+  const runtimeDefaults = defaults.runtime ?? {};
+  const runtimeOverrides = overrides.runtime ?? {};
+  const mcpDefaults = defaults.mcp ?? {};
+  const mcpOverrides = overrides.mcp ?? {};
+  const mergedMcp = {
+    ...BASE_REPO_RUNTIME_MCP_FIXTURE,
+    ...mcpDefaults,
+    ...mcpOverrides,
+  };
+  const runtime: RepoRuntimeHealthCheck["runtime"] = {
+    ...BASE_REPO_RUNTIME_HEALTH_FIXTURE.runtime,
+    ...runtimeDefaults,
+    ...runtimeOverrides,
+    updatedAt: runtimeOverrides.updatedAt ?? runtimeDefaults.updatedAt ?? checkedAt,
+  };
+  const mcp: NonNullable<RepoRuntimeHealthCheck["mcp"]> = {
+    supported: mergedMcp.supported ?? BASE_REPO_RUNTIME_MCP_FIXTURE.supported,
+    status: mergedMcp.status ?? BASE_REPO_RUNTIME_MCP_FIXTURE.status,
+    serverName: mergedMcp.serverName ?? BASE_REPO_RUNTIME_MCP_FIXTURE.serverName,
+    serverStatus: mergedMcp.serverStatus ?? BASE_REPO_RUNTIME_MCP_FIXTURE.serverStatus,
+    toolIds: mergedMcp.toolIds ?? BASE_REPO_RUNTIME_MCP_FIXTURE.toolIds,
+    detail: mergedMcp.detail ?? BASE_REPO_RUNTIME_MCP_FIXTURE.detail,
+    failureKind: mergedMcp.failureKind ?? BASE_REPO_RUNTIME_MCP_FIXTURE.failureKind,
+  };
+  const merged = {
+    ...BASE_REPO_RUNTIME_HEALTH_FIXTURE,
+    ...defaults,
+    ...overrides,
+    status:
+      overrides.status ??
+      defaults.status ??
+      (runtime.status === "error" || mcp.status === "error"
+        ? "error"
+        : mcp.status === "checking" ||
+            mcp.status === "reconnecting" ||
+            mcp.status === "waiting_for_runtime"
+          ? "checking"
+          : runtime.status),
+    checkedAt,
+    runtime,
+    mcp,
+  } satisfies RepoRuntimeHealthCheck;
 
   return structuredClone(merged);
 };


### PR DESCRIPTION
## Summary
- keep polling repo runtime health while Agent Studio is blocked on transient runtime or MCP readiness states
- move transient runtime readiness polling into the runtime-health query layer instead of diagnostics retry helpers
- add regression coverage for query polling, `useChecks`, and the Agent Studio readiness transition without reload

## Verification
- bun test "apps/desktop/src/state/queries/checks.test.ts" "apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts" "apps/desktop/src/state/operations/workspace/use-checks.test.tsx" "apps/desktop/src/pages/agents/use-agents-page-readiness.test.tsx"
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved runtime health polling during MCP connectivity checks for better startup responsiveness.
  * Enhanced diagnostic system with improved notification handling abstraction.

* **Tests**
  * Expanded test infrastructure with new fixtures and improved mocking patterns.
  * Added test coverage for runtime health and connectivity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->