### PR TITLE
feat(agent-studio): add open in worktree menu

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1573,6 +1573,7 @@ name = "host-infra-system"
 version = "0.0.5"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "dirs",
  "fs2",

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -123,9 +123,7 @@ pub(crate) fn require_opencode_local_http_port(
     runtime_route: &RuntimeRoute,
     action: &str,
 ) -> Result<u16> {
-    runtime_route.local_http_port().ok_or_else(|| {
-        anyhow!(
-            "OpenCode {action} requires a local_http runtime route with a port"
-        )
-    })
+    runtime_route
+        .local_http_port()
+        .ok_or_else(|| anyhow!("OpenCode {action} requires a local_http runtime route with a port"))
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
@@ -4,7 +4,7 @@ use super::workspace_policy::HookTrustChallenge;
 use super::*;
 use host_domain::{
     now_rfc3339, AgentRuntimeKind, RepoRuntimeHealthCheck, RepoRuntimeStartupFailureKind,
-    RepoRuntimeStartupStage, RepoRuntimeStartupStatus,
+    RepoRuntimeStartupStage, RepoRuntimeStartupStatus, SystemOpenInToolInfo,
 };
 
 pub type RunEmitter = Arc<dyn Fn(RunEvent) + Send + Sync + 'static>;
@@ -167,6 +167,7 @@ pub struct AppService {
     pub(super) instance_pid: u32,
     pub(super) initialized_repos: Arc<Mutex<HashSet<String>>>,
     pub(super) runtime_check_cache: Arc<Mutex<Option<CachedRuntimeCheck>>>,
+    pub(super) open_in_tool_cache: Arc<Mutex<Option<CachedOpenInToolList>>>,
     pub(super) startup_cancel_epoch: StartupCancelEpoch,
     pub(super) startup_metrics: Arc<Mutex<OpencodeStartupMetrics>>,
     pub(super) enforce_repo_allowlist: bool,
@@ -207,6 +208,11 @@ pub(crate) struct RuntimeCleanupTarget {
 pub(crate) struct CachedRuntimeCheck {
     pub(super) checked_at: Instant,
     pub(super) value: RuntimeCheck,
+}
+
+pub(crate) struct CachedOpenInToolList {
+    pub(super) checked_at: Instant,
+    pub(super) tools: Vec<SystemOpenInToolInfo>,
 }
 
 pub(crate) struct CachedOpencodeSessionStatusProbe {
@@ -285,6 +291,7 @@ impl AppService {
             instance_pid,
             initialized_repos: Arc::new(Mutex::new(HashSet::new())),
             runtime_check_cache: Arc::new(Mutex::new(None)),
+            open_in_tool_cache: Arc::new(Mutex::new(None)),
             startup_cancel_epoch: Arc::new(AtomicU64::new(0)),
             startup_metrics: Arc::new(Mutex::new(OpencodeStartupMetrics::default())),
             enforce_repo_allowlist,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -309,7 +309,7 @@ impl AppService {
         self.open_directory_in_tool_with_launcher(
             directory_path,
             tool_id,
-            |directory, selected_tool| open_directory_in_tool_with_system(directory, selected_tool),
+            open_directory_in_tool_with_system,
         )
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -2,6 +2,7 @@ use super::{
     read_opencode_version, resolve_opencode_binary_path, AppService, CachedRuntimeCheck,
     WorkspaceSettingsSnapshotUpdate,
 };
+use crate::app_service::service_core::CachedOpenInToolList;
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     BeadsCheck, GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult,
@@ -11,10 +12,11 @@ use host_domain::{
     GitResetWorktreeSelectionRequest, GitResetWorktreeSelectionResult, GitWorktreeSummary,
     RepoStoreAttachmentHealth, RepoStoreHealth, RepoStoreHealthCategory, RepoStoreHealthStatus,
     RepoStoreSharedServerHealth, RepoStoreSharedServerOwnershipState, RuntimeCheck, RuntimeHealth,
-    SystemCheck, WorkspaceRecord,
+    SystemCheck, SystemOpenInToolId, SystemOpenInToolInfo, WorkspaceRecord,
 };
 use host_infra_system::{
-    command_exists, copy_configured_worktree_files, remove_worktree,
+    command_exists, copy_configured_worktree_files, discover_open_in_tools,
+    open_directory_in_tool as open_directory_in_tool_with_system, remove_worktree,
     remove_worktree_path_if_present, repo_script_fingerprint, resolve_effective_worktree_base_dir,
     run_command, run_command_allow_failure_with_env, version_command, AutopilotSettings,
     ChatSettings, GlobalGitConfig, HookSet, KanbanSettings, PromptOverrides, RepoConfig,
@@ -25,6 +27,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const RUNTIME_CHECK_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+const OPEN_IN_TOOL_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 const GH_NON_INTERACTIVE_ENV: [(&str, &str); 1] = [("GH_PROMPT_DISABLED", "1")];
 
 fn is_definitive_non_worktree_git_error(error: &anyhow::Error) -> bool {
@@ -240,6 +243,98 @@ impl AppService {
             value: check,
         });
         Ok(())
+    }
+
+    fn cached_open_in_tools(&self) -> Result<Option<Vec<SystemOpenInToolInfo>>> {
+        let mut cache = self
+            .open_in_tool_cache
+            .lock()
+            .map_err(|_| anyhow!("Open In tool cache lock poisoned in `cached_open_in_tools`"))?;
+        if let Some(entry) = cache.as_ref() {
+            if entry.checked_at.elapsed() <= OPEN_IN_TOOL_CACHE_TTL {
+                return Ok(Some(entry.tools.clone()));
+            }
+        }
+        *cache = None;
+        Ok(None)
+    }
+
+    fn update_open_in_tool_cache(&self, tools: Vec<SystemOpenInToolInfo>) -> Result<()> {
+        let mut cache = self.open_in_tool_cache.lock().map_err(|_| {
+            anyhow!("Open In tool cache lock poisoned in `update_open_in_tool_cache`")
+        })?;
+        *cache = Some(CachedOpenInToolList {
+            checked_at: Instant::now(),
+            tools,
+        });
+        Ok(())
+    }
+
+    fn clear_open_in_tool_cache(&self) -> Result<()> {
+        let mut cache = self.open_in_tool_cache.lock().map_err(|_| {
+            anyhow!("Open In tool cache lock poisoned in `clear_open_in_tool_cache`")
+        })?;
+        *cache = None;
+        Ok(())
+    }
+
+    pub(super) fn list_open_in_tools_with_discovery<F>(
+        &self,
+        force_refresh: bool,
+        discover: F,
+    ) -> Result<Vec<SystemOpenInToolInfo>>
+    where
+        F: FnOnce() -> Result<Vec<SystemOpenInToolInfo>>,
+    {
+        if force_refresh {
+            self.clear_open_in_tool_cache()?;
+        } else if let Some(cached) = self.cached_open_in_tools()? {
+            return Ok(cached);
+        }
+
+        let tools = discover()?;
+        self.update_open_in_tool_cache(tools.clone())?;
+        Ok(tools)
+    }
+
+    pub fn list_open_in_tools(&self, force_refresh: bool) -> Result<Vec<SystemOpenInToolInfo>> {
+        self.list_open_in_tools_with_discovery(force_refresh, discover_open_in_tools)
+    }
+
+    pub fn open_directory_in_tool(
+        &self,
+        directory_path: &str,
+        tool_id: SystemOpenInToolId,
+    ) -> Result<()> {
+        self.open_directory_in_tool_with_launcher(
+            directory_path,
+            tool_id,
+            |directory, selected_tool| open_directory_in_tool_with_system(directory, selected_tool),
+        )
+    }
+
+    pub(super) fn open_directory_in_tool_with_launcher<F>(
+        &self,
+        directory_path: &str,
+        tool_id: SystemOpenInToolId,
+        launcher: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(&Path, SystemOpenInToolId) -> Result<()>,
+    {
+        if directory_path.trim().is_empty() {
+            return Err(anyhow!("Cannot open an empty directory path."));
+        }
+
+        let directory = Path::new(directory_path);
+        if !directory.exists() {
+            return Err(anyhow!("Directory does not exist: {directory_path}"));
+        }
+        if !directory.is_dir() {
+            return Err(anyhow!("Path is not a directory: {directory_path}"));
+        }
+
+        launcher(directory, tool_id)
     }
 
     pub fn beads_check(&self, repo_path: &str) -> Result<BeadsCheck> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -2,7 +2,8 @@ use anyhow::{Context, Result};
 use host_domain::{
     AgentRuntimeKind, AgentSessionDocument, CreateTaskInput, GitBranch, IssueType,
     PlanSubtaskInput, PullRequestRecord, QaWorkflowVerdict, RuntimeInstanceSummary, RuntimeRole,
-    TaskAction, TaskCard, TaskStatus, TaskStore, UpdateTaskPatch,
+    SystemOpenInToolId, SystemOpenInToolInfo, TaskAction, TaskCard, TaskStatus, TaskStore,
+    UpdateTaskPatch,
 };
 use host_infra_system::{
     AppConfigStore, OpencodeStartupReadinessConfig, RuntimeConfig, RuntimeConfigStore,
@@ -120,6 +121,219 @@ fn app_service_new_constructor_is_callable() -> Result<()> {
 
     let service = AppService::new(task_store, config_store);
     let _ = service.runtime_check()?;
+    Ok(())
+}
+
+#[test]
+fn open_in_tool_discovery_uses_cached_results_without_rerunning_discovery() -> Result<()> {
+    let (service, _task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let discovery_calls = Arc::new(AtomicU64::new(0));
+
+    let first_result = {
+        let discovery_calls = discovery_calls.clone();
+        service.list_open_in_tools_with_discovery(false, move || {
+            discovery_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![
+                SystemOpenInToolInfo {
+                    tool_id: SystemOpenInToolId::Finder,
+                    icon_data_url: None,
+                },
+                SystemOpenInToolInfo {
+                    tool_id: SystemOpenInToolId::Ghostty,
+                    icon_data_url: Some("data:image/png;base64,ghostty".to_string()),
+                },
+            ])
+        })?
+    };
+    let second_result = {
+        let discovery_calls = discovery_calls.clone();
+        service.list_open_in_tools_with_discovery(false, move || {
+            discovery_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![SystemOpenInToolInfo {
+                tool_id: SystemOpenInToolId::Finder,
+                icon_data_url: None,
+            }])
+        })?
+    };
+
+    assert_eq!(discovery_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(first_result, second_result);
+    Ok(())
+}
+
+#[test]
+fn open_in_tool_discovery_force_refresh_bypasses_cached_results() -> Result<()> {
+    let (service, _task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let discovery_calls = Arc::new(AtomicU64::new(0));
+
+    let _ = {
+        let discovery_calls = discovery_calls.clone();
+        service.list_open_in_tools_with_discovery(false, move || {
+            discovery_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![SystemOpenInToolInfo {
+                tool_id: SystemOpenInToolId::Finder,
+                icon_data_url: None,
+            }])
+        })?
+    };
+    let refreshed_result = {
+        let discovery_calls = discovery_calls.clone();
+        service.list_open_in_tools_with_discovery(true, move || {
+            discovery_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![SystemOpenInToolInfo {
+                tool_id: SystemOpenInToolId::Zed,
+                icon_data_url: Some("data:image/png;base64,zed".to_string()),
+            }])
+        })?
+    };
+
+    assert_eq!(discovery_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(refreshed_result[0].tool_id, SystemOpenInToolId::Zed);
+    Ok(())
+}
+
+#[test]
+fn open_directory_in_tool_rejects_missing_directory_paths_before_launch() {
+    let (service, _task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let missing_path = unique_temp_path("open-in-missing-directory");
+
+    let error = service
+        .open_directory_in_tool(
+            missing_path.to_string_lossy().as_ref(),
+            SystemOpenInToolId::Finder,
+        )
+        .expect_err("missing directory should fail before launch");
+
+    assert!(error.to_string().contains("Directory does not exist"));
+}
+
+#[test]
+fn open_directory_in_tool_rejects_non_directory_paths_before_launch() {
+    let (service, _task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let file_path = unique_temp_path("open-in-file-path");
+    fs::write(&file_path, "not a directory").expect("test file should be created");
+
+    let error = service
+        .open_directory_in_tool(
+            file_path.to_string_lossy().as_ref(),
+            SystemOpenInToolId::Finder,
+        )
+        .expect_err("file path should fail before launch");
+
+    assert!(error.to_string().contains("Path is not a directory"));
+    let _ = fs::remove_file(file_path);
+}
+
+#[test]
+fn open_directory_in_tool_passes_validated_directory_and_tool_to_launcher() -> Result<()> {
+    let (service, _task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let directory_path = unique_temp_path("open-in-valid-directory");
+    fs::create_dir_all(&directory_path).context("test directory should be created")?;
+    let launched = Arc::new(Mutex::new(None::<(std::path::PathBuf, SystemOpenInToolId)>));
+
+    service.open_directory_in_tool_with_launcher(
+        directory_path.to_string_lossy().as_ref(),
+        SystemOpenInToolId::Ghostty,
+        {
+            let launched = launched.clone();
+            move |directory, tool_id| {
+                *launched
+                    .lock()
+                    .expect("launcher capture lock should not be poisoned") =
+                    Some((directory.to_path_buf(), tool_id));
+                Ok(())
+            }
+        },
+    )?;
+
+    assert_eq!(
+        *launched
+            .lock()
+            .expect("launcher capture lock should not be poisoned"),
+        Some((directory_path.clone(), SystemOpenInToolId::Ghostty))
+    );
+    fs::remove_dir_all(&directory_path).context("test directory should be removed")?;
+    Ok(())
+}
+
+#[test]
+fn open_directory_in_tool_preserves_significant_spaces_in_directory_path() -> Result<()> {
+    let (service, _task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let parent_directory = unique_temp_path("open-in-space-parent");
+    let padded_directory = parent_directory.join(" repo-with-space ");
+    fs::create_dir_all(&padded_directory).context("padded test directory should be created")?;
+    let launched = Arc::new(Mutex::new(None::<std::path::PathBuf>));
+
+    service.open_directory_in_tool_with_launcher(
+        padded_directory.to_string_lossy().as_ref(),
+        SystemOpenInToolId::Finder,
+        {
+            let launched = launched.clone();
+            move |directory, _tool_id| {
+                *launched
+                    .lock()
+                    .expect("launcher capture lock should not be poisoned") =
+                    Some(directory.to_path_buf());
+                Ok(())
+            }
+        },
+    )?;
+
+    assert_eq!(
+        *launched
+            .lock()
+            .expect("launcher capture lock should not be poisoned"),
+        Some(padded_directory.clone())
+    );
+    fs::remove_dir_all(&parent_directory).context("padded test directories should be removed")?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -37,7 +37,8 @@ pub use store::TaskStore;
 pub use system::{
     BeadsCheck, RepoStoreAttachmentHealth, RepoStoreHealth, RepoStoreHealthCategory,
     RepoStoreHealthStatus, RepoStoreSharedServerHealth, RepoStoreSharedServerOwnershipState,
-    RuntimeCheck, RuntimeHealth, SystemCheck, WorkspaceRecord,
+    RuntimeCheck, RuntimeHealth, SystemCheck, SystemOpenInToolId, SystemOpenInToolInfo,
+    WorkspaceRecord,
 };
 pub use task::{
     is_syncable_pull_request_state, is_terminal_task_status, CreateTaskInput, IssueType,

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -134,9 +134,9 @@ mod tests {
             RepoStoreHealth, RepoStoreHealthCategory, RepoStoreHealthStatus,
             RepoStoreSharedServerHealth, RepoStoreSharedServerOwnershipState, RunEvent, RunState,
             RunSummary, RuntimeCheck, RuntimeInstanceSummary, RuntimeRole, SpecDocument,
-            SystemCheck, TaskAction, TaskCard, TaskDirectMergeResult, TaskDocumentPresence,
-            TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence, TaskStatus, TaskStore,
-            UpdateTaskPatch, WorkspaceRecord,
+            SystemCheck, SystemOpenInToolId, SystemOpenInToolInfo, TaskAction, TaskCard,
+            TaskDirectMergeResult, TaskDocumentPresence, TaskDocumentSummary, TaskMetadata,
+            TaskQaDocumentPresence, TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
         };
 
         macro_rules! check_types_exported {
@@ -217,6 +217,8 @@ mod tests {
             RuntimeRole,
             SpecDocument,
             SystemCheck,
+            SystemOpenInToolId,
+            SystemOpenInToolInfo,
             TaskAction,
             TaskCard,
             TaskDirectMergeResult,

--- a/apps/desktop/src-tauri/crates/host-domain/src/system.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/system.rs
@@ -118,3 +118,30 @@ pub struct WorkspaceRecord {
     pub default_worktree_base_path: Option<String>,
     pub effective_worktree_base_path: Option<String>,
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case")]
+pub enum SystemOpenInToolId {
+    Finder,
+    Terminal,
+    Iterm2,
+    Ghostty,
+    Vscode,
+    Cursor,
+    Zed,
+    IntellijIdea,
+    Webstorm,
+    Pycharm,
+    Phpstorm,
+    Rider,
+    Rustrover,
+    AndroidStudio,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemOpenInToolInfo {
+    pub tool_id: SystemOpenInToolId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_data_url: Option<String>,
+}

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = "1"
+base64 = "0.22"
 dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -1,6 +1,7 @@
 mod beads;
 mod config;
 mod git;
+mod open_in;
 mod process;
 mod user_paths;
 mod worktree;
@@ -27,6 +28,7 @@ pub use config::{
     SoftGuardrails,
 };
 pub use git::GitCliPort;
+pub use open_in::{discover_open_in_tools, open_directory_in_tool};
 pub use process::{
     bundled_command, command_exists, command_path, resolve_command_path, run_command,
     run_command_allow_failure, run_command_allow_failure_with_env, run_command_with_env,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/open_in.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/open_in.rs
@@ -1,0 +1,776 @@
+use crate::{resolve_command_path, run_command_allow_failure};
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose, Engine as _};
+use host_domain::{SystemOpenInToolId, SystemOpenInToolInfo};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Copy)]
+struct OpenInToolMetadata {
+    id: SystemOpenInToolId,
+    label: &'static str,
+    app_names: &'static [&'static str],
+    launch_strategy: OpenInLaunchStrategy,
+    cli_command: Option<&'static str>,
+}
+
+#[derive(Clone)]
+struct OpenInLaunchSpec {
+    program: String,
+    args: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum OpenInLaunchStrategy {
+    OpenDirectory,
+    Editor,
+    Jetbrains,
+}
+
+const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Finder,
+        label: "Finder",
+        app_names: &["Finder"],
+        launch_strategy: OpenInLaunchStrategy::OpenDirectory,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Terminal,
+        label: "Terminal",
+        app_names: &["Terminal"],
+        launch_strategy: OpenInLaunchStrategy::OpenDirectory,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Iterm2,
+        label: "iTerm2",
+        app_names: &["iTerm2", "iTerm"],
+        launch_strategy: OpenInLaunchStrategy::OpenDirectory,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Ghostty,
+        label: "Ghostty",
+        app_names: &["Ghostty"],
+        launch_strategy: OpenInLaunchStrategy::OpenDirectory,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Vscode,
+        label: "VS Code",
+        app_names: &["Visual Studio Code"],
+        launch_strategy: OpenInLaunchStrategy::Editor,
+        cli_command: Some("code"),
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Cursor,
+        label: "Cursor",
+        app_names: &["Cursor"],
+        launch_strategy: OpenInLaunchStrategy::Editor,
+        cli_command: Some("cursor"),
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Zed,
+        label: "Zed",
+        app_names: &["Zed"],
+        launch_strategy: OpenInLaunchStrategy::Editor,
+        cli_command: Some("zed"),
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::IntellijIdea,
+        label: "IntelliJ IDEA",
+        app_names: &["IntelliJ IDEA", "IntelliJ IDEA CE"],
+        launch_strategy: OpenInLaunchStrategy::Jetbrains,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Webstorm,
+        label: "WebStorm",
+        app_names: &["WebStorm"],
+        launch_strategy: OpenInLaunchStrategy::Jetbrains,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Pycharm,
+        label: "PyCharm",
+        app_names: &["PyCharm", "PyCharm CE"],
+        launch_strategy: OpenInLaunchStrategy::Jetbrains,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Phpstorm,
+        label: "PhpStorm",
+        app_names: &["PhpStorm"],
+        launch_strategy: OpenInLaunchStrategy::Jetbrains,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Rider,
+        label: "Rider",
+        app_names: &["Rider"],
+        launch_strategy: OpenInLaunchStrategy::Jetbrains,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::Rustrover,
+        label: "RustRover",
+        app_names: &["RustRover"],
+        launch_strategy: OpenInLaunchStrategy::Jetbrains,
+        cli_command: None,
+    },
+    OpenInToolMetadata {
+        id: SystemOpenInToolId::AndroidStudio,
+        label: "Android Studio",
+        app_names: &["Android Studio"],
+        launch_strategy: OpenInLaunchStrategy::Jetbrains,
+        cli_command: None,
+    },
+];
+
+fn open_in_tool_metadata(tool_id: SystemOpenInToolId) -> Result<&'static OpenInToolMetadata> {
+    OPEN_IN_TOOL_CATALOG
+        .iter()
+        .find(|metadata| metadata.id == tool_id)
+        .ok_or_else(|| anyhow!("Unsupported Open In tool: {tool_id:?}"))
+}
+
+fn process_output_message(stdout: &str, stderr: &str) -> String {
+    let trimmed_stdout = stdout.trim();
+    let trimmed_stderr = stderr.trim();
+
+    if trimmed_stdout.is_empty() {
+        return trimmed_stderr.to_string();
+    }
+    if trimmed_stderr.is_empty() {
+        return trimmed_stdout.to_string();
+    }
+
+    format!("{trimmed_stdout}\n{trimmed_stderr}")
+}
+
+#[cfg(target_os = "macos")]
+fn bundle_name_for_app(app_name: &str) -> String {
+    if app_name.ends_with(".app") {
+        app_name.to_string()
+    } else {
+        format!("{app_name}.app")
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_application_path_by_name(app_name: &str) -> Option<PathBuf> {
+    let bundle_name = bundle_name_for_app(app_name);
+    let candidates = [
+        format!("/Applications/{bundle_name}"),
+        format!("/System/Applications/{bundle_name}"),
+        format!("/System/Applications/Utilities/{bundle_name}"),
+        format!("/System/Library/CoreServices/{bundle_name}"),
+    ];
+
+    for candidate in candidates {
+        let path = PathBuf::from(&candidate);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    if let Some(home) = env::var_os("HOME") {
+        let user_app_path = PathBuf::from(home).join("Applications").join(&bundle_name);
+        if user_app_path.exists() {
+            return Some(user_app_path);
+        }
+    }
+
+    if let Ok((true, stdout, _stderr)) =
+        run_command_allow_failure("mdfind", &["-name", &bundle_name], None)
+    {
+        for line in stdout.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let path = PathBuf::from(trimmed);
+            if path.exists() {
+                return Some(path);
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_application_path(metadata: &OpenInToolMetadata) -> Result<Option<PathBuf>> {
+    for app_name in metadata.app_names {
+        if let Some(app_path) = resolve_application_path_by_name(app_name) {
+            return Ok(Some(app_path));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(target_os = "macos")]
+fn read_bundle_icon_file(app_path: &Path) -> Option<String> {
+    let plist_path = app_path.join("Contents").join("Info.plist");
+    if !plist_path.exists() {
+        return None;
+    }
+
+    let plist_path_string = plist_path.to_string_lossy().to_string();
+    let (ok, stdout, _stderr) = run_command_allow_failure(
+        "defaults",
+        &["read", plist_path_string.as_str(), "CFBundleIconFile"],
+        None,
+    )
+    .ok()?;
+    if !ok {
+        return None;
+    }
+
+    let icon_name = stdout.trim();
+    if icon_name.is_empty() {
+        return None;
+    }
+
+    Some(if icon_name.ends_with(".icns") {
+        icon_name.to_string()
+    } else {
+        format!("{icon_name}.icns")
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_app_icon_path(app_path: &Path) -> Option<PathBuf> {
+    if !app_path.exists() {
+        return None;
+    }
+
+    if let Some(icon_file) = read_bundle_icon_file(app_path) {
+        let icon_path = app_path.join("Contents").join("Resources").join(&icon_file);
+        if icon_path.exists() {
+            return Some(icon_path);
+        }
+    }
+
+    let app_path_string = app_path.to_string_lossy().to_string();
+    if let Ok((true, stdout, _stderr)) = run_command_allow_failure(
+        "mdls",
+        &["-name", "kMDItemIconFile", "-raw", app_path_string.as_str()],
+        None,
+    ) {
+        let icon_name = stdout.trim();
+        if !icon_name.is_empty() && icon_name != "(null)" {
+            let icon_file = if icon_name.ends_with(".icns") {
+                icon_name.to_string()
+            } else {
+                format!("{icon_name}.icns")
+            };
+            let icon_path = app_path.join("Contents").join("Resources").join(icon_file);
+            if icon_path.exists() {
+                return Some(icon_path);
+            }
+        }
+    }
+
+    let resources_path = app_path.join("Contents").join("Resources");
+    if let Ok(entries) = fs::read_dir(resources_path) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(ext) = path.extension().and_then(|value| value.to_str()) {
+                if ext.eq_ignore_ascii_case("icns") {
+                    return Some(path);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn sanitized_temp_name(app_name: &str) -> String {
+    let sanitized: String = app_name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    if sanitized.is_empty() {
+        "app".to_string()
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn temp_icon_output_path(app_name: &str, extension: &str) -> PathBuf {
+    let sanitized = sanitized_temp_name(app_name);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis())
+        .unwrap_or(0);
+    env::temp_dir().join(format!(
+        "openducktor-open-in-icon-{sanitized}-{timestamp}.{extension}"
+    ))
+}
+
+#[cfg(target_os = "macos")]
+const MAX_OPEN_IN_ICON_DIMENSION: u32 = 256;
+
+#[cfg(target_os = "macos")]
+fn iconset_representation_score(icon_name: &str) -> Option<u32> {
+    let stem = icon_name.strip_suffix(".png")?;
+    let stem = stem.strip_prefix("icon_")?;
+    let (dimensions, scale_suffix) = match stem.split_once('@') {
+        Some((value, suffix)) => (value, Some(suffix)),
+        None => (stem, None),
+    };
+    let (width, height) = dimensions.split_once('x')?;
+    let width = width.parse::<u32>().ok()?;
+    let height = height.parse::<u32>().ok()?;
+    let scale = match scale_suffix {
+        Some(suffix) => suffix.strip_suffix('x')?.parse::<u32>().ok()?,
+        None => 1,
+    };
+
+    let effective_width = width * scale;
+    let effective_height = height * scale;
+
+    if effective_width > MAX_OPEN_IN_ICON_DIMENSION || effective_height > MAX_OPEN_IN_ICON_DIMENSION
+    {
+        return None;
+    }
+
+    Some(effective_width * effective_height)
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_best_iconset_representation(iconset_dir: &Path) -> Option<PathBuf> {
+    let mut best_match: Option<(u32, PathBuf)> = None;
+
+    for entry in fs::read_dir(iconset_dir).ok()? {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let path = entry.path();
+        let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        let Some(score) = iconset_representation_score(file_name) else {
+            continue;
+        };
+
+        match &best_match {
+            Some((best_score, _)) if *best_score >= score => {}
+            _ => {
+                best_match = Some((score, path));
+            }
+        }
+    }
+
+    best_match.map(|(_, path)| path)
+}
+
+#[cfg(target_os = "macos")]
+fn extract_best_png_from_iconset(icon_path: &Path, app_name: &str) -> Option<Vec<u8>> {
+    let iconset_dir = temp_icon_output_path(app_name, "iconset");
+    let icon_path_string = icon_path.to_string_lossy().to_string();
+    let iconset_dir_string = iconset_dir.to_string_lossy().to_string();
+    let (ok, _stdout, _stderr) = run_command_allow_failure(
+        "iconutil",
+        &[
+            "-c",
+            "iconset",
+            icon_path_string.as_str(),
+            "-o",
+            iconset_dir_string.as_str(),
+        ],
+        None,
+    )
+    .ok()?;
+    if !ok {
+        let _ = fs::remove_dir_all(&iconset_dir);
+        return None;
+    }
+
+    let best_icon_path = resolve_best_iconset_representation(&iconset_dir);
+    let bytes = best_icon_path.and_then(|path| fs::read(path).ok());
+    let _ = fs::remove_dir_all(&iconset_dir);
+    bytes.filter(|value| !value.is_empty())
+}
+
+#[cfg(target_os = "macos")]
+fn convert_icon_to_png(icon_path: &Path, app_name: &str) -> Option<Vec<u8>> {
+    let icon_path_string = icon_path.to_string_lossy().to_string();
+    let temp_path = temp_icon_output_path(app_name, "png");
+    let temp_path_string = temp_path.to_string_lossy().to_string();
+    let (ok, _stdout, _stderr) = run_command_allow_failure(
+        "sips",
+        &[
+            "-s",
+            "format",
+            "png",
+            "-Z",
+            "256",
+            icon_path_string.as_str(),
+            "--out",
+            temp_path_string.as_str(),
+        ],
+        None,
+    )
+    .ok()?;
+
+    if !ok {
+        return None;
+    }
+
+    let bytes = fs::read(&temp_path).ok();
+    let _ = fs::remove_file(&temp_path);
+    bytes.filter(|value| !value.is_empty())
+}
+
+#[cfg(target_os = "macos")]
+fn icon_to_data_url(icon_path: &Path, app_name: &str) -> Option<String> {
+    if !icon_path.exists() {
+        return None;
+    }
+
+    let bytes = extract_best_png_from_iconset(icon_path, app_name)
+        .or_else(|| convert_icon_to_png(icon_path, app_name))?;
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let encoded = general_purpose::STANDARD.encode(bytes);
+    Some(format!("data:image/png;base64,{encoded}"))
+}
+
+#[cfg(target_os = "macos")]
+fn build_tool_info(metadata: &OpenInToolMetadata, app_path: &Path) -> SystemOpenInToolInfo {
+    let icon_data_url = resolve_app_icon_path(app_path)
+        .and_then(|icon_path| icon_to_data_url(&icon_path, metadata.label));
+
+    SystemOpenInToolInfo {
+        tool_id: metadata.id,
+        icon_data_url,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn discover_open_in_tools_with_resolver<F>(mut resolver: F) -> Result<Vec<SystemOpenInToolInfo>>
+where
+    F: FnMut(&OpenInToolMetadata) -> Result<Option<PathBuf>>,
+{
+    let mut tools = Vec::new();
+
+    for metadata in OPEN_IN_TOOL_CATALOG {
+        if let Some(app_path) = resolver(&metadata)? {
+            tools.push(build_tool_info(&metadata, &app_path));
+        }
+    }
+
+    Ok(tools)
+}
+
+pub fn discover_open_in_tools() -> Result<Vec<SystemOpenInToolInfo>> {
+    #[cfg(target_os = "macos")]
+    {
+        return discover_open_in_tools_with_resolver(resolve_application_path);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err(anyhow!(
+            "Open In tool discovery is only supported on macOS."
+        ))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn build_open_app_spec(
+    app_path: &Path,
+    directory_path: &Path,
+    new_instance: bool,
+) -> OpenInLaunchSpec {
+    let mut args = Vec::new();
+    if new_instance {
+        args.push("-n".to_string());
+    }
+    args.push("-a".to_string());
+    args.push(app_path.to_string_lossy().to_string());
+    args.push(directory_path.to_string_lossy().to_string());
+    OpenInLaunchSpec {
+        program: "open".to_string(),
+        args,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn build_cli_spec(command_path: &str, directory_path: &Path) -> OpenInLaunchSpec {
+    OpenInLaunchSpec {
+        program: command_path.to_string(),
+        args: vec![
+            "-n".to_string(),
+            directory_path.to_string_lossy().to_string(),
+        ],
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn build_jetbrains_open_spec(app_path: &Path, directory_path: &Path) -> OpenInLaunchSpec {
+    OpenInLaunchSpec {
+        program: "open".to_string(),
+        args: vec![
+            "-na".to_string(),
+            app_path.to_string_lossy().to_string(),
+            "--args".to_string(),
+            directory_path.to_string_lossy().to_string(),
+        ],
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn build_open_directory_launch_specs(
+    metadata: &OpenInToolMetadata,
+    app_path: &Path,
+    directory_path: &Path,
+) -> Vec<OpenInLaunchSpec> {
+    let mut specs = Vec::new();
+
+    match metadata.launch_strategy {
+        OpenInLaunchStrategy::OpenDirectory => {
+            specs.push(build_open_app_spec(app_path, directory_path, false));
+        }
+        OpenInLaunchStrategy::Editor => {
+            if let Some(cli_path) = metadata
+                .cli_command
+                .and_then(|command| resolve_command_path(command).ok().flatten())
+            {
+                specs.push(build_cli_spec(&cli_path, directory_path));
+            }
+            specs.push(build_open_app_spec(app_path, directory_path, false));
+        }
+        OpenInLaunchStrategy::Jetbrains => {
+            specs.push(build_jetbrains_open_spec(app_path, directory_path));
+            specs.push(build_open_app_spec(app_path, directory_path, true));
+            specs.push(build_open_app_spec(app_path, directory_path, false));
+        }
+    }
+
+    specs
+}
+
+#[cfg(target_os = "macos")]
+fn execute_launch_specs(
+    metadata: &OpenInToolMetadata,
+    directory_path: &Path,
+    specs: &[OpenInLaunchSpec],
+) -> Result<()> {
+    let mut failures = Vec::new();
+
+    for spec in specs {
+        let arg_refs = spec.args.iter().map(String::as_str).collect::<Vec<_>>();
+        let (ok, stdout, stderr) =
+            run_command_allow_failure(spec.program.as_str(), &arg_refs, None).with_context(
+                || {
+                    format!(
+                        "Failed launching {} for {}",
+                        metadata.label,
+                        directory_path.display()
+                    )
+                },
+            )?;
+
+        if ok {
+            return Ok(());
+        }
+
+        let failure_detail = process_output_message(stdout.as_str(), stderr.as_str());
+        failures.push(if failure_detail.is_empty() {
+            format!(
+                "{} {} failed without additional details",
+                spec.program,
+                spec.args.join(" ")
+            )
+        } else {
+            format!(
+                "{} {} failed: {failure_detail}",
+                spec.program,
+                spec.args.join(" ")
+            )
+        });
+    }
+
+    Err(anyhow!(
+        "Failed to open {} in {}: {}",
+        directory_path.display(),
+        metadata.label,
+        failures.join("; ")
+    ))
+}
+
+pub fn open_directory_in_tool(directory_path: &Path, tool_id: SystemOpenInToolId) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let metadata = open_in_tool_metadata(tool_id)?;
+        let app_path = resolve_application_path(metadata)?.ok_or_else(|| {
+            anyhow!(
+                "{} is not installed or is no longer discoverable on this Mac.",
+                metadata.label
+            )
+        })?;
+        let specs = build_open_directory_launch_specs(metadata, &app_path, directory_path);
+        return execute_launch_specs(metadata, directory_path, &specs);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = directory_path;
+        let _ = tool_id;
+        Err(anyhow!(
+            "Opening directories in external tools is only supported on macOS."
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_jetbrains_open_spec, build_open_app_spec, build_open_directory_launch_specs,
+        discover_open_in_tools_with_resolver, iconset_representation_score, open_in_tool_metadata,
+        OPEN_IN_TOOL_CATALOG,
+    };
+    use host_domain::SystemOpenInToolId;
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn discover_open_in_tools_preserves_catalog_order_and_filters_missing_apps() {
+        let available = HashSet::from([
+            SystemOpenInToolId::Finder,
+            SystemOpenInToolId::Terminal,
+            SystemOpenInToolId::Ghostty,
+            SystemOpenInToolId::Zed,
+        ]);
+
+        let discovered = discover_open_in_tools_with_resolver(|metadata| {
+            Ok(available
+                .contains(&metadata.id)
+                .then(|| PathBuf::from("/Applications/Test.app")))
+        })
+        .expect("tool discovery should succeed");
+
+        assert_eq!(
+            discovered
+                .iter()
+                .map(|tool| tool.tool_id)
+                .collect::<Vec<_>>(),
+            vec![
+                SystemOpenInToolId::Finder,
+                SystemOpenInToolId::Terminal,
+                SystemOpenInToolId::Ghostty,
+                SystemOpenInToolId::Zed,
+            ]
+        );
+        assert_eq!(OPEN_IN_TOOL_CATALOG[0].id, SystemOpenInToolId::Finder);
+    }
+
+    #[test]
+    fn build_open_app_spec_preserves_paths_with_spaces() {
+        let spec = build_open_app_spec(
+            Path::new("/Applications/Visual Studio Code.app"),
+            Path::new("/tmp/worktrees/task 24"),
+            false,
+        );
+
+        assert_eq!(spec.program, "open");
+        assert_eq!(
+            spec.args,
+            vec![
+                "-a".to_string(),
+                "/Applications/Visual Studio Code.app".to_string(),
+                "/tmp/worktrees/task 24".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_open_directory_launch_specs_uses_cli_before_open_fallback_for_editors() {
+        let metadata = open_in_tool_metadata(SystemOpenInToolId::Vscode)
+            .expect("VS Code metadata should exist");
+        let specs = build_open_directory_launch_specs(
+            metadata,
+            Path::new("/Applications/Visual Studio Code.app"),
+            Path::new("/tmp/worktrees/task-24"),
+        );
+
+        assert_eq!(
+            specs.last().expect("fallback spec should exist").program,
+            "open"
+        );
+    }
+
+    #[test]
+    fn build_jetbrains_open_spec_uses_args_mode() {
+        let spec = build_jetbrains_open_spec(
+            Path::new("/Applications/RustRover.app"),
+            Path::new("/tmp/worktrees/task 24"),
+        );
+
+        assert_eq!(spec.program, "open");
+        assert_eq!(
+            spec.args,
+            vec![
+                "-na".to_string(),
+                "/Applications/RustRover.app".to_string(),
+                "--args".to_string(),
+                "/tmp/worktrees/task 24".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_open_directory_launch_specs_use_open_directory_strategy_for_terminals() {
+        let metadata = open_in_tool_metadata(SystemOpenInToolId::Terminal)
+            .expect("Terminal metadata should exist");
+        let specs = build_open_directory_launch_specs(
+            metadata,
+            Path::new("/System/Applications/Utilities/Terminal.app"),
+            Path::new("/tmp/worktrees/task 24"),
+        );
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].program, "open");
+        assert_eq!(specs[0].args[0], "-a");
+    }
+
+    #[test]
+    fn iconset_representation_score_prefers_larger_scaled_icons() {
+        assert_eq!(iconset_representation_score("icon_16x16.png"), Some(256));
+        assert_eq!(
+            iconset_representation_score("icon_16x16@2x.png"),
+            Some(1024)
+        );
+        assert_eq!(
+            iconset_representation_score("icon_128x128@2x.png"),
+            Some(65_536)
+        );
+        assert_eq!(
+            iconset_representation_score("icon_256x256.png"),
+            Some(65_536)
+        );
+        assert_eq!(iconset_representation_score("icon_256x256@2x.png"), None);
+        assert_eq!(iconset_representation_score("icon_512x512@2x.png"), None);
+        assert_eq!(iconset_representation_score("not-an-icon.png"), None);
+    }
+}

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/open_in.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/open_in.rs
@@ -1,12 +1,23 @@
-use crate::{resolve_command_path, run_command_allow_failure};
-use anyhow::{anyhow, Context, Result};
-use base64::{engine::general_purpose, Engine as _};
+use anyhow::{anyhow, Result};
 use host_domain::{SystemOpenInToolId, SystemOpenInToolInfo};
+use std::path::Path;
+
+#[cfg(target_os = "macos")]
+use crate::{resolve_command_path, run_command_allow_failure};
+#[cfg(target_os = "macos")]
+use anyhow::Context;
+#[cfg(target_os = "macos")]
+use base64::{engine::general_purpose, Engine as _};
+#[cfg(target_os = "macos")]
 use std::env;
+#[cfg(target_os = "macos")]
 use std::fs;
-use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(target_os = "macos")]
 #[derive(Clone, Copy)]
 struct OpenInToolMetadata {
     id: SystemOpenInToolId,
@@ -14,14 +25,17 @@ struct OpenInToolMetadata {
     app_names: &'static [&'static str],
     launch_strategy: OpenInLaunchStrategy,
     cli_command: Option<&'static str>,
+    cli_new_window_arg: Option<&'static str>,
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Clone)]
 struct OpenInLaunchSpec {
     program: String,
     args: Vec<String>,
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Clone, Copy)]
 enum OpenInLaunchStrategy {
     OpenDirectory,
@@ -29,6 +43,7 @@ enum OpenInLaunchStrategy {
     Jetbrains,
 }
 
+#[cfg(target_os = "macos")]
 const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
     OpenInToolMetadata {
         id: SystemOpenInToolId::Finder,
@@ -36,6 +51,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["Finder"],
         launch_strategy: OpenInLaunchStrategy::OpenDirectory,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Terminal,
@@ -43,6 +59,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["Terminal"],
         launch_strategy: OpenInLaunchStrategy::OpenDirectory,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Iterm2,
@@ -50,6 +67,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["iTerm2", "iTerm"],
         launch_strategy: OpenInLaunchStrategy::OpenDirectory,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Ghostty,
@@ -57,6 +75,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["Ghostty"],
         launch_strategy: OpenInLaunchStrategy::OpenDirectory,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Vscode,
@@ -64,6 +83,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["Visual Studio Code"],
         launch_strategy: OpenInLaunchStrategy::Editor,
         cli_command: Some("code"),
+        cli_new_window_arg: Some("-n"),
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Cursor,
@@ -71,6 +91,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["Cursor"],
         launch_strategy: OpenInLaunchStrategy::Editor,
         cli_command: Some("cursor"),
+        cli_new_window_arg: Some("-n"),
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Zed,
@@ -78,6 +99,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["Zed"],
         launch_strategy: OpenInLaunchStrategy::Editor,
         cli_command: Some("zed"),
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::IntellijIdea,
@@ -85,6 +107,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["IntelliJ IDEA", "IntelliJ IDEA CE"],
         launch_strategy: OpenInLaunchStrategy::Jetbrains,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Webstorm,
@@ -92,6 +115,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["WebStorm"],
         launch_strategy: OpenInLaunchStrategy::Jetbrains,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Pycharm,
@@ -99,6 +123,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["PyCharm", "PyCharm CE"],
         launch_strategy: OpenInLaunchStrategy::Jetbrains,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Phpstorm,
@@ -106,6 +131,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["PhpStorm"],
         launch_strategy: OpenInLaunchStrategy::Jetbrains,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Rider,
@@ -113,6 +139,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["Rider"],
         launch_strategy: OpenInLaunchStrategy::Jetbrains,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::Rustrover,
@@ -120,6 +147,7 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["RustRover"],
         launch_strategy: OpenInLaunchStrategy::Jetbrains,
         cli_command: None,
+        cli_new_window_arg: None,
     },
     OpenInToolMetadata {
         id: SystemOpenInToolId::AndroidStudio,
@@ -127,9 +155,11 @@ const OPEN_IN_TOOL_CATALOG: [OpenInToolMetadata; 14] = [
         app_names: &["Android Studio"],
         launch_strategy: OpenInLaunchStrategy::Jetbrains,
         cli_command: None,
+        cli_new_window_arg: None,
     },
 ];
 
+#[cfg(target_os = "macos")]
 fn open_in_tool_metadata(tool_id: SystemOpenInToolId) -> Result<&'static OpenInToolMetadata> {
     OPEN_IN_TOOL_CATALOG
         .iter()
@@ -137,6 +167,7 @@ fn open_in_tool_metadata(tool_id: SystemOpenInToolId) -> Result<&'static OpenInT
         .ok_or_else(|| anyhow!("Unsupported Open In tool: {tool_id:?}"))
 }
 
+#[cfg(target_os = "macos")]
 fn process_output_message(stdout: &str, stderr: &str) -> String {
     let trimmed_stdout = stdout.trim();
     let trimmed_stderr = stderr.trim();
@@ -149,6 +180,49 @@ fn process_output_message(stdout: &str, stderr: &str) -> String {
     }
 
     format!("{trimmed_stdout}\n{trimmed_stderr}")
+}
+
+#[cfg(target_os = "macos")]
+enum TempCleanupKind {
+    File,
+    Directory,
+}
+
+#[cfg(target_os = "macos")]
+struct TempPathCleanup {
+    path: PathBuf,
+    kind: TempCleanupKind,
+}
+
+#[cfg(target_os = "macos")]
+impl TempPathCleanup {
+    fn file(path: PathBuf) -> Self {
+        Self {
+            path,
+            kind: TempCleanupKind::File,
+        }
+    }
+
+    fn directory(path: PathBuf) -> Self {
+        Self {
+            path,
+            kind: TempCleanupKind::Directory,
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for TempPathCleanup {
+    fn drop(&mut self) {
+        match self.kind {
+            TempCleanupKind::File => {
+                let _ = fs::remove_file(&self.path);
+            }
+            TempCleanupKind::Directory => {
+                let _ = fs::remove_dir_all(&self.path);
+            }
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -177,8 +251,8 @@ fn resolve_application_path_by_name(app_name: &str) -> Option<PathBuf> {
         }
     }
 
-    if let Some(home) = env::var_os("HOME") {
-        let user_app_path = PathBuf::from(home).join("Applications").join(&bundle_name);
+    if let Some(home) = dirs::home_dir() {
+        let user_app_path = home.join("Applications").join(&bundle_name);
         if user_app_path.exists() {
             return Some(user_app_path);
         }
@@ -194,7 +268,12 @@ fn resolve_application_path_by_name(app_name: &str) -> Option<PathBuf> {
             }
 
             let path = PathBuf::from(trimmed);
-            if path.exists() {
+            if path.is_dir()
+                && path
+                    .extension()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|value| value.eq_ignore_ascii_case("app"))
+            {
                 return Some(path);
             }
         }
@@ -384,6 +463,7 @@ fn resolve_best_iconset_representation(iconset_dir: &Path) -> Option<PathBuf> {
 #[cfg(target_os = "macos")]
 fn extract_best_png_from_iconset(icon_path: &Path, app_name: &str) -> Option<Vec<u8>> {
     let iconset_dir = temp_icon_output_path(app_name, "iconset");
+    let _iconset_cleanup = TempPathCleanup::directory(iconset_dir.clone());
     let icon_path_string = icon_path.to_string_lossy().to_string();
     let iconset_dir_string = iconset_dir.to_string_lossy().to_string();
     let (ok, _stdout, _stderr) = run_command_allow_failure(
@@ -399,13 +479,11 @@ fn extract_best_png_from_iconset(icon_path: &Path, app_name: &str) -> Option<Vec
     )
     .ok()?;
     if !ok {
-        let _ = fs::remove_dir_all(&iconset_dir);
         return None;
     }
 
     let best_icon_path = resolve_best_iconset_representation(&iconset_dir);
     let bytes = best_icon_path.and_then(|path| fs::read(path).ok());
-    let _ = fs::remove_dir_all(&iconset_dir);
     bytes.filter(|value| !value.is_empty())
 }
 
@@ -413,6 +491,7 @@ fn extract_best_png_from_iconset(icon_path: &Path, app_name: &str) -> Option<Vec
 fn convert_icon_to_png(icon_path: &Path, app_name: &str) -> Option<Vec<u8>> {
     let icon_path_string = icon_path.to_string_lossy().to_string();
     let temp_path = temp_icon_output_path(app_name, "png");
+    let _temp_file_cleanup = TempPathCleanup::file(temp_path.clone());
     let temp_path_string = temp_path.to_string_lossy().to_string();
     let (ok, _stdout, _stderr) = run_command_allow_failure(
         "sips",
@@ -435,7 +514,6 @@ fn convert_icon_to_png(icon_path: &Path, app_name: &str) -> Option<Vec<u8>> {
     }
 
     let bytes = fs::read(&temp_path).ok();
-    let _ = fs::remove_file(&temp_path);
     bytes.filter(|value| !value.is_empty())
 }
 
@@ -485,7 +563,7 @@ where
 pub fn discover_open_in_tools() -> Result<Vec<SystemOpenInToolInfo>> {
     #[cfg(target_os = "macos")]
     {
-        return discover_open_in_tools_with_resolver(resolve_application_path);
+        discover_open_in_tools_with_resolver(resolve_application_path)
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -516,13 +594,21 @@ fn build_open_app_spec(
 }
 
 #[cfg(target_os = "macos")]
-fn build_cli_spec(command_path: &str, directory_path: &Path) -> OpenInLaunchSpec {
+fn build_cli_spec(
+    command_path: &str,
+    directory_path: &Path,
+    new_window_arg: Option<&str>,
+) -> OpenInLaunchSpec {
+    let mut args = Vec::new();
+    if let Some(flag) = new_window_arg {
+        args.push(flag.to_string());
+    }
+
+    args.push(directory_path.to_string_lossy().to_string());
+
     OpenInLaunchSpec {
         program: command_path.to_string(),
-        args: vec![
-            "-n".to_string(),
-            directory_path.to_string_lossy().to_string(),
-        ],
+        args,
     }
 }
 
@@ -556,7 +642,11 @@ fn build_open_directory_launch_specs(
                 .cli_command
                 .and_then(|command| resolve_command_path(command).ok().flatten())
             {
-                specs.push(build_cli_spec(&cli_path, directory_path));
+                specs.push(build_cli_spec(
+                    &cli_path,
+                    directory_path,
+                    metadata.cli_new_window_arg,
+                ));
             }
             specs.push(build_open_app_spec(app_path, directory_path, false));
         }
@@ -630,7 +720,7 @@ pub fn open_directory_in_tool(directory_path: &Path, tool_id: SystemOpenInToolId
             )
         })?;
         let specs = build_open_directory_launch_specs(metadata, &app_path, directory_path);
-        return execute_launch_specs(metadata, directory_path, &specs);
+        execute_launch_specs(metadata, directory_path, &specs)
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -643,12 +733,12 @@ pub fn open_directory_in_tool(directory_path: &Path, tool_id: SystemOpenInToolId
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::{
-        build_jetbrains_open_spec, build_open_app_spec, build_open_directory_launch_specs,
-        discover_open_in_tools_with_resolver, iconset_representation_score, open_in_tool_metadata,
-        OPEN_IN_TOOL_CATALOG,
+        build_cli_spec, build_jetbrains_open_spec, build_open_app_spec,
+        build_open_directory_launch_specs, discover_open_in_tools_with_resolver,
+        iconset_representation_score, open_in_tool_metadata, OPEN_IN_TOOL_CATALOG,
     };
     use host_domain::SystemOpenInToolId;
     use std::collections::HashSet;
@@ -718,6 +808,31 @@ mod tests {
             specs.last().expect("fallback spec should exist").program,
             "open"
         );
+    }
+
+    #[test]
+    fn build_cli_spec_uses_new_window_flag_when_supported() {
+        let spec = build_cli_spec(
+            "/usr/local/bin/code",
+            Path::new("/tmp/worktrees/task-24"),
+            Some("-n"),
+        );
+
+        assert_eq!(
+            spec.args,
+            vec!["-n".to_string(), "/tmp/worktrees/task-24".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_open_directory_launch_specs_skips_new_window_flag_for_zed() {
+        let spec = build_cli_spec(
+            "/usr/local/bin/zed",
+            Path::new("/tmp/worktrees/task-24"),
+            None,
+        );
+
+        assert_eq!(spec.args, vec!["/tmp/worktrees/task-24".to_string()]);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -1,7 +1,47 @@
-use crate::{as_error, run_service_blocking};
+use crate::{as_error, run_service_blocking, AppState};
 use anyhow::{anyhow, Result};
+use host_domain::{SystemOpenInToolId, SystemOpenInToolInfo};
+use serde::Deserialize;
 use serde_json::json;
 use std::process::{Command, Stdio};
+use tauri::State;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemListOpenInToolsArgs {
+    force_refresh: Option<bool>,
+}
+
+#[tauri::command]
+pub async fn system_list_open_in_tools(
+    state: State<'_, AppState>,
+    args: Option<SystemListOpenInToolsArgs>,
+) -> Result<Vec<SystemOpenInToolInfo>, String> {
+    let service = state.service.clone();
+    let result = run_service_blocking("system_list_open_in_tools", move || {
+        service.list_open_in_tools(args.and_then(|value| value.force_refresh).unwrap_or(false))
+    })
+    .await;
+
+    as_error(result)
+}
+
+#[tauri::command]
+pub async fn system_open_directory_in_tool(
+    state: State<'_, AppState>,
+    directory_path: String,
+    tool_id: SystemOpenInToolId,
+) -> Result<serde_json::Value, String> {
+    let service = state.service.clone();
+    let result = run_service_blocking("system_open_directory_in_tool", move || {
+        service
+            .open_directory_in_tool(&directory_path, tool_id)
+            .map(|_| json!({ "ok": true }))
+    })
+    .await;
+
+    as_error(result)
+}
 
 #[tauri::command]
 pub async fn open_external_url(url: String) -> Result<serde_json::Value, String> {

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -1,25 +1,18 @@
 use crate::{as_error, run_service_blocking, AppState};
 use anyhow::{anyhow, Result};
 use host_domain::{SystemOpenInToolId, SystemOpenInToolInfo};
-use serde::Deserialize;
 use serde_json::json;
 use std::process::{Command, Stdio};
 use tauri::State;
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SystemListOpenInToolsArgs {
-    force_refresh: Option<bool>,
-}
-
 #[tauri::command]
 pub async fn system_list_open_in_tools(
     state: State<'_, AppState>,
-    args: Option<SystemListOpenInToolsArgs>,
+    force_refresh: Option<bool>,
 ) -> Result<Vec<SystemOpenInToolInfo>, String> {
     let service = state.service.clone();
     let result = run_service_blocking("system_list_open_in_tools", move || {
-        service.list_open_in_tools(args.and_then(|value| value.force_refresh).unwrap_or(false))
+        service.list_open_in_tools(force_refresh.unwrap_or(false))
     })
     .await;
 

--- a/apps/desktop/src-tauri/src/headless/command_registry.rs
+++ b/apps/desktop/src-tauri/src/headless/command_registry.rs
@@ -1,5 +1,8 @@
 use super::command_support::{CommandResult, HeadlessCommandError, HeadlessState};
-use super::{git_commands, odt_mcp_commands, runtime_commands, task_commands, workspace_commands};
+use super::{
+    git_commands, odt_mcp_commands, runtime_commands, system_commands, task_commands,
+    workspace_commands,
+};
 use anyhow::anyhow;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -45,6 +48,7 @@ impl CommandRegistry {
 pub(super) fn build_registry() -> anyhow::Result<CommandRegistry> {
     let mut registry = CommandRegistry::default();
     workspace_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
+    system_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
     git_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
     task_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
     odt_mcp_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
@@ -148,6 +152,7 @@ mod tests {
         let registry = build_registry().expect("registry should build");
 
         assert!(registry.contains("workspace_list"));
+        assert!(registry.contains("system_list_open_in_tools"));
         assert!(registry.contains("git_get_status"));
         assert!(registry.contains("task_create"));
         assert!(registry.contains("odt_read_task"));

--- a/apps/desktop/src-tauri/src/headless/command_registry.rs
+++ b/apps/desktop/src-tauri/src/headless/command_registry.rs
@@ -153,6 +153,7 @@ mod tests {
 
         assert!(registry.contains("workspace_list"));
         assert!(registry.contains("system_list_open_in_tools"));
+        assert!(registry.contains("system_open_directory_in_tool"));
         assert!(registry.contains("git_get_status"));
         assert!(registry.contains("task_create"));
         assert!(registry.contains("odt_read_task"));

--- a/apps/desktop/src-tauri/src/headless/mod.rs
+++ b/apps/desktop/src-tauri/src/headless/mod.rs
@@ -5,6 +5,7 @@ mod git_commands;
 mod odt_mcp_commands;
 mod runtime_commands;
 mod server;
+mod system_commands;
 mod task_commands;
 mod workspace_commands;
 

--- a/apps/desktop/src-tauri/src/headless/system_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/system_commands.rs
@@ -1,0 +1,57 @@
+use super::command_registry::CommandRegistry;
+use super::command_support::{
+    deserialize_args, run_headless_blocking, serialize_value, CommandResult, HeadlessState,
+};
+use host_domain::SystemOpenInToolId;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenDirectoryInToolArgs {
+    directory_path: String,
+    tool_id: SystemOpenInToolId,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SystemListOpenInToolsArgs {
+    force_refresh: Option<bool>,
+}
+
+pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), String> {
+    registry.register("system_list_open_in_tools", |state, args| {
+        Box::pin(async move { handle_system_list_open_in_tools(state, args).await })
+    })?;
+    registry.register("system_open_directory_in_tool", |state, args| {
+        Box::pin(async move { handle_system_open_directory_in_tool(state, args).await })
+    })?;
+    Ok(())
+}
+
+async fn handle_system_list_open_in_tools(state: &HeadlessState, args: Value) -> CommandResult {
+    let force_refresh = match deserialize_args::<SystemListOpenInToolsArgs>(args) {
+        Ok(parsed) => parsed.force_refresh.unwrap_or(false),
+        Err(_) => false,
+    };
+    let service = state.service.clone();
+    serialize_value(
+        run_headless_blocking("system_list_open_in_tools", move || {
+            service.list_open_in_tools(force_refresh)
+        })
+        .await?,
+    )
+}
+
+async fn handle_system_open_directory_in_tool(state: &HeadlessState, args: Value) -> CommandResult {
+    let OpenDirectoryInToolArgs {
+        directory_path,
+        tool_id,
+    } = deserialize_args(args)?;
+    let service = state.service.clone();
+    run_headless_blocking("system_open_directory_in_tool", move || {
+        service.open_directory_in_tool(&directory_path, tool_id)
+    })
+    .await?;
+    Ok(json!({ "ok": true }))
+}

--- a/apps/desktop/src-tauri/src/headless/system_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/system_commands.rs
@@ -16,7 +16,8 @@ struct OpenDirectoryInToolArgs {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SystemListOpenInToolsArgs {
-    force_refresh: Option<bool>,
+    #[serde(default)]
+    force_refresh: bool,
 }
 
 pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), String> {
@@ -30,10 +31,7 @@ pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), St
 }
 
 async fn handle_system_list_open_in_tools(state: &HeadlessState, args: Value) -> CommandResult {
-    let force_refresh = match deserialize_args::<SystemListOpenInToolsArgs>(args) {
-        Ok(parsed) => parsed.force_refresh.unwrap_or(false),
-        Err(_) => false,
-    };
+    let SystemListOpenInToolsArgs { force_refresh } = deserialize_args(args)?;
     let service = state.service.clone();
     serialize_value(
         run_headless_blocking("system_list_open_in_tools", move || {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -342,6 +342,8 @@ fn startup_phase_command_registration<R: tauri::Runtime>(
 ) -> tauri::Builder<R> {
     builder.invoke_handler(tauri::generate_handler![
         system_check,
+        system_list_open_in_tools,
+        system_open_directory_in_tool,
         open_external_url,
         runtime_check,
         beads_check,

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -1,6 +1,11 @@
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
-import { fireEvent, type RenderResult, render } from "@testing-library/react";
-import { act, createElement } from "react";
+import {
+  fireEvent,
+  type RenderResult,
+  render as testingLibraryRender,
+} from "@testing-library/react";
+import { act, createElement, type ReactElement } from "react";
+import { QueryProvider } from "@/lib/query-provider";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 
 const omitDialogDomProps = ({
@@ -132,6 +137,16 @@ const flush = async (): Promise<void> => {
   await Promise.resolve();
   await Promise.resolve();
 };
+
+const render = (element: ReactElement): RenderResult =>
+  testingLibraryRender(createElement(QueryProvider, { useIsolatedClient: true }, element));
+
+const renderAgentStudioGitPanelElement = (model: AgentStudioGitPanelModel): ReactElement =>
+  createElement(
+    QueryProvider,
+    { useIsolatedClient: true },
+    createElement(AgentStudioGitPanel, { model }),
+  );
 
 type DomTestNode = {
   readonly element: Element;
@@ -736,14 +751,14 @@ describe("AgentStudioGitPanel", () => {
 
     await act(async () => {
       ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, {
-          model: baseModel({
+        renderAgentStudioGitPanelElement(
+          baseModel({
             fileStatuses: [{ path: "src/a.ts", staged: false, status: "M" }],
             isPushing: true,
             diffScope: "uncommitted",
             commitAll,
           }),
-        }),
+        ),
       );
       await flush();
     });
@@ -751,13 +766,13 @@ describe("AgentStudioGitPanel", () => {
 
     await act(async () => {
       ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, {
-          model: baseModel({
+        renderAgentStudioGitPanelElement(
+          baseModel({
             fileStatuses: [{ path: "src/a.ts", staged: false, status: "M" }],
             diffScope: "uncommitted",
             commitAll,
           }),
-        }),
+        ),
       );
       findByTestId(root, "agent-studio-git-commit-message-input").props.onChange({
         currentTarget: { value: "feat: commit all files" },
@@ -815,8 +830,8 @@ describe("AgentStudioGitPanel", () => {
 
     await act(async () => {
       ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, {
-          model: baseModel({
+        renderAgentStudioGitPanelElement(
+          baseModel({
             diffScope: "uncommitted",
             setDiffScope,
             commitAll,
@@ -824,7 +839,7 @@ describe("AgentStudioGitPanel", () => {
             fileStatuses: [{ path: "src/a.ts", staged: false, status: "M" }],
             commitError: "",
           }),
-        }),
+        ),
       );
       await flush();
     });
@@ -1006,8 +1021,8 @@ describe("AgentStudioGitPanel", () => {
 
     await act(async () => {
       ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, {
-          model: baseModel({
+        renderAgentStudioGitPanelElement(
+          baseModel({
             branch: null,
             diffScope: "uncommitted",
             fileStatuses: [{ path: "src/a.ts", staged: false, status: "M" }],
@@ -1017,7 +1032,7 @@ describe("AgentStudioGitPanel", () => {
             rebaseOntoTarget,
             pullFromUpstream,
           }),
-        }),
+        ),
       );
       await flush();
     });
@@ -1031,8 +1046,8 @@ describe("AgentStudioGitPanel", () => {
 
     await act(async () => {
       ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, {
-          model: baseModel({
+        renderAgentStudioGitPanelElement(
+          baseModel({
             branch: null,
             diffScope: "uncommitted",
             fileStatuses: [{ path: "src/a.ts", staged: false, status: "M" }],
@@ -1044,7 +1059,7 @@ describe("AgentStudioGitPanel", () => {
             rebaseOntoTarget,
             pullFromUpstream,
           }),
-        }),
+        ),
       );
       await flush();
     });
@@ -1397,9 +1412,7 @@ describe("AgentStudioGitPanel", () => {
     });
 
     await act(async () => {
-      ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, { model: persistedConflictModel }),
-      );
+      ensureRenderer(renderer).rerender(renderAgentStudioGitPanelElement(persistedConflictModel));
       await flush();
     });
 
@@ -1419,9 +1432,7 @@ describe("AgentStudioGitPanel", () => {
     });
 
     await act(async () => {
-      ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, { model: actionConflictModel }),
-      );
+      ensureRenderer(renderer).rerender(renderAgentStudioGitPanelElement(actionConflictModel));
       await flush();
     });
 
@@ -1455,9 +1466,7 @@ describe("AgentStudioGitPanel", () => {
     });
 
     await act(async () => {
-      ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, { model: abortPendingModel }),
-      );
+      ensureRenderer(renderer).rerender(renderAgentStudioGitPanelElement(abortPendingModel));
       await flush();
     });
 
@@ -1508,9 +1517,7 @@ describe("AgentStudioGitPanel", () => {
     });
 
     await act(async () => {
-      ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, { model: askBuilderPendingModel }),
-      );
+      ensureRenderer(renderer).rerender(renderAgentStudioGitPanelElement(askBuilderPendingModel));
       await flush();
     });
 
@@ -1559,9 +1566,7 @@ describe("AgentStudioGitPanel", () => {
     });
 
     await act(async () => {
-      ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, { model: conflictModel }),
-      );
+      ensureRenderer(renderer).rerender(renderAgentStudioGitPanelElement(conflictModel));
       await flush();
     });
 
@@ -1730,8 +1735,8 @@ describe("AgentStudioGitPanel", () => {
 
     await act(async () => {
       ensureRenderer(renderer).rerender(
-        createElement(AgentStudioGitPanel, {
-          model: baseModel({
+        renderAgentStudioGitPanelElement(
+          baseModel({
             diffScope: "target",
             fileDiffs: [
               {
@@ -1744,7 +1749,7 @@ describe("AgentStudioGitPanel", () => {
             ],
             fileStatuses: [{ path: "src/main.ts", staged: false, status: "modified" }],
           }),
-        }),
+        ),
       );
       await flush();
     });

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -272,6 +272,8 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
         <GitInfoHeader
           contextMode={model.contextMode ?? "worktree"}
           pullRequest={model.pullRequest ?? null}
+          openInTargetPath={model.openInTargetPath ?? null}
+          openInDisabledReason={model.openInDisabledReason ?? null}
           branch={displayedScopeState.branch}
           targetBranch={model.targetBranch}
           diffScope={uiDiffScope}
@@ -298,6 +300,7 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
           {...(model.onUpdateTargetBranch
             ? { onUpdateTargetBranch: model.onUpdateTargetBranch }
             : {})}
+          {...(model.openDirectoryInTool ? { openDirectoryInTool: model.openDirectoryInTool } : {})}
           setDiffScope={handleDiffScopeChange}
           onRefresh={() => {
             void model.refresh();

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { PullRequest, SystemOpenInToolInfo } from "@openducktor/contracts";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { QueryProvider } from "@/lib/query-provider";
+import { host } from "@/state/operations/host";
+import { GitInfoHeader } from "./git-info-header";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const pullRequest: PullRequest = {
+  providerId: "github",
+  number: 42,
+  url: "https://github.com/maxsky5/openducktor/pull/42",
+  state: "open",
+  createdAt: "2026-04-12T10:00:00.000Z",
+  updatedAt: "2026-04-12T10:00:00.000Z",
+};
+
+describe("GitInfoHeader", () => {
+  let rendered: ReturnType<typeof render> | null = null;
+
+  afterEach(async () => {
+    if (rendered) {
+      await act(async () => {
+        rendered?.unmount();
+      });
+      rendered = null;
+    }
+  });
+
+  test("replaces the duplicate changed-files badge with the Open In trigger while keeping the PR badge", async () => {
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    host.systemListOpenInTools = mock(
+      async () =>
+        [
+          { toolId: "finder", iconDataUrl: "data:image/png;base64,finder" },
+        ] satisfies SystemOpenInToolInfo[],
+    );
+
+    try {
+      rendered = render(
+        <QueryProvider useIsolatedClient>
+          <TooltipProvider>
+            <GitInfoHeader
+              contextMode="worktree"
+              pullRequest={pullRequest}
+              openInTargetPath="/tmp/worktrees/task-24"
+              openInDisabledReason={null}
+              branch="feature/task-24"
+              targetBranch="origin/main"
+              commitsAheadBehind={null}
+              upstreamAheadBehind={null}
+              upstreamStatus="tracking"
+              diffScope="target"
+              uncommittedFileCount={3}
+              isLoading={false}
+              isCommitting={false}
+              isPushing={false}
+              isRebasing={false}
+              isDetectingPullRequest={false}
+              isGitActionsLocked={false}
+              gitActionsLockReason={null}
+              showLockReasonBanner={false}
+              pushError={null}
+              rebaseError={null}
+              pushBranch={async () => {}}
+              rebaseOntoTarget={async () => {}}
+              pullFromUpstream={async () => {}}
+              setDiffScope={() => {}}
+              onRefresh={() => {}}
+              openDirectoryInTool={async () => {}}
+            />
+          </TooltipProvider>
+        </QueryProvider>,
+      );
+
+      await screen.findByTestId("agent-studio-git-open-in-icon-finder");
+
+      expect(screen.getByTestId("agent-studio-git-open-in-default-button").textContent).toContain(
+        "Finder",
+      );
+      expect(screen.queryByTestId("agent-studio-git-open-in-trigger")).toBeNull();
+      expect(screen.getByText("PR #42")).toBeTruthy();
+      expect(screen.queryByText("3 files changed")).toBeNull();
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+    }
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
@@ -13,13 +13,13 @@ import {
 import { memo, type ReactElement, useEffect, useState } from "react";
 import { BranchSelector } from "@/components/features/repository/branch-selector";
 import { TaskPullRequestLink } from "@/components/features/task-pull-request-link";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { DiffScope } from "@/features/agent-studio-git";
 import { cn } from "@/lib/utils";
 import { DIFF_SCOPE_OPTIONS } from "./constants";
+import { OpenInMenu } from "./open-in-menu";
 import type { AgentStudioGitPanelModel } from "./types";
 
 const TARGET_BRANCH_LABEL_ID = "agent-studio-git-target-branch-label";
@@ -28,6 +28,8 @@ type GitInfoHeaderProps = Pick<
   AgentStudioGitPanelModel,
   | "contextMode"
   | "pullRequest"
+  | "openInTargetPath"
+  | "openInDisabledReason"
   | "branch"
   | "targetBranch"
   | "commitsAheadBehind"
@@ -47,6 +49,7 @@ type GitInfoHeaderProps = Pick<
   | "targetBranchOptions"
   | "targetBranchSelectionValue"
   | "onUpdateTargetBranch"
+  | "openDirectoryInTool"
   | "setDiffScope"
 > & {
   uncommittedFileCount: number;
@@ -127,13 +130,17 @@ function GitActionIconButton({
 type GitInfoHeaderSummaryRowProps = {
   isRepositoryMode: boolean;
   pullRequest: GitInfoHeaderProps["pullRequest"];
-  uncommittedFileCount: number;
+  openInTargetPath: string | null;
+  openInDisabledReason: string | null;
+  onOpenInTool: GitInfoHeaderProps["openDirectoryInTool"];
 };
 
 function GitInfoHeaderSummaryRow({
   isRepositoryMode,
   pullRequest,
-  uncommittedFileCount,
+  openInTargetPath,
+  openInDisabledReason,
+  onOpenInTool,
 }: GitInfoHeaderSummaryRowProps): ReactElement {
   return (
     <div className="mb-2 flex flex-wrap items-center justify-between gap-2 px-3 pt-3">
@@ -142,9 +149,12 @@ function GitInfoHeaderSummaryRow({
       </span>
       <div className="flex flex-wrap items-center justify-end gap-2">
         {pullRequest ? <TaskPullRequestLink pullRequest={pullRequest} /> : null}
-        <Badge variant="outline" className="px-2 py-0.5 text-[10px]">
-          {uncommittedFileCount} file{uncommittedFileCount === 1 ? "" : "s"} changed
-        </Badge>
+        <OpenInMenu
+          contextMode={isRepositoryMode ? "repository" : "worktree"}
+          targetPath={openInTargetPath}
+          disabledReason={openInDisabledReason}
+          onOpenInTool={onOpenInTool}
+        />
       </div>
     </div>
   );
@@ -512,6 +522,8 @@ function GitInfoHeaderErrors({
 export const GitInfoHeader = memo(function GitInfoHeader({
   contextMode = "worktree",
   pullRequest,
+  openInTargetPath,
+  openInDisabledReason,
   branch,
   targetBranch,
   commitsAheadBehind,
@@ -538,6 +550,7 @@ export const GitInfoHeader = memo(function GitInfoHeader({
   targetBranchOptions = [],
   targetBranchSelectionValue = "",
   onUpdateTargetBranch,
+  openDirectoryInTool,
 }: GitInfoHeaderProps): ReactElement {
   const [isEditingTargetBranch, setIsEditingTargetBranch] = useState(false);
   const [targetBranchDraft, setTargetBranchDraft] = useState(targetBranchSelectionValue);
@@ -691,7 +704,9 @@ export const GitInfoHeader = memo(function GitInfoHeader({
       <GitInfoHeaderSummaryRow
         isRepositoryMode={isRepositoryMode}
         pullRequest={pullRequest}
-        uncommittedFileCount={uncommittedFileCount}
+        openInTargetPath={openInTargetPath ?? null}
+        openInDisabledReason={openInDisabledReason ?? null}
+        onOpenInTool={openDirectoryInTool}
       />
 
       <GitBranchContextRow

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-menu.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-menu.test.tsx
@@ -1,0 +1,297 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { SystemOpenInToolInfo } from "@openducktor/contracts";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { QueryProvider } from "@/lib/query-provider";
+import { toRightPanelStorageKey } from "@/pages/agents/agents-page-selection";
+import { host } from "@/state/operations/host";
+import { withMockedToast } from "@/test-utils/mock-toast";
+import { OpenInMenu } from "./open-in-menu";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("OpenInMenu", () => {
+  let rendered: ReturnType<typeof render> | null = null;
+
+  afterEach(async () => {
+    if (rendered) {
+      await act(async () => {
+        rendered?.unmount();
+      });
+      rendered = null;
+    }
+    globalThis.localStorage.clear();
+  });
+
+  test("renders discovered tools with icons and dispatches the selected tool", async () => {
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    const systemListOpenInTools = mock(
+      async () =>
+        [
+          { toolId: "finder", iconDataUrl: "data:image/png;base64,finder" },
+          { toolId: "ghostty", iconDataUrl: "data:image/png;base64,ghostty" },
+          { toolId: "zed", iconDataUrl: "data:image/png;base64,zed" },
+        ] satisfies SystemOpenInToolInfo[],
+    );
+    const onOpenInTool = mock(async () => {});
+    host.systemListOpenInTools = systemListOpenInTools;
+    const storageKey = toRightPanelStorageKey();
+
+    try {
+      rendered = render(
+        <QueryProvider useIsolatedClient>
+          <TooltipProvider>
+            <OpenInMenu
+              contextMode="worktree"
+              targetPath="/tmp/worktrees/task-24"
+              disabledReason={null}
+              onOpenInTool={onOpenInTool}
+            />
+          </TooltipProvider>
+        </QueryProvider>,
+      );
+
+      await screen.findByTestId("agent-studio-git-open-in-icon-finder");
+      expect(screen.getByTestId("agent-studio-git-open-in-default-button").textContent).toContain(
+        "Finder",
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("agent-studio-git-open-in-trigger"));
+      });
+
+      expect(await screen.findByTestId("agent-studio-git-open-in-icon-finder")).toBeTruthy();
+      expect(screen.getByTestId("agent-studio-git-open-in-icon-ghostty")).toBeTruthy();
+      expect(screen.getByTestId("agent-studio-git-open-in-icon-zed")).toBeTruthy();
+      expect(screen.queryByText("Files")).toBeNull();
+      expect(screen.queryByText("Terminals")).toBeNull();
+      expect(screen.queryByText("Editors & IDEs")).toBeNull();
+      expect(screen.queryByTestId("agent-studio-git-open-in-item-finder")).toBeNull();
+      expect(
+        (screen.getByTestId("agent-studio-git-open-in-icon-zed") as HTMLImageElement).tagName,
+      ).toBe("IMG");
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("agent-studio-git-open-in-item-ghostty"));
+      });
+
+      expect(onOpenInTool).toHaveBeenCalledWith("ghostty");
+      expect(globalThis.localStorage.getItem(storageKey)).toContain("ghostty");
+      expect(systemListOpenInTools).toHaveBeenCalledTimes(1);
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+    }
+  });
+
+  test("shows an actionable disabled reason when the target path is unavailable", async () => {
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    host.systemListOpenInTools = mock(
+      async () =>
+        [
+          { toolId: "finder", iconDataUrl: "data:image/png;base64,finder" },
+        ] satisfies SystemOpenInToolInfo[],
+    );
+
+    try {
+      rendered = render(
+        <QueryProvider useIsolatedClient>
+          <TooltipProvider>
+            <OpenInMenu
+              contextMode="worktree"
+              targetPath={null}
+              disabledReason="Builder worktree path is unavailable. Refresh the Git panel and try again."
+            />
+          </TooltipProvider>
+        </QueryProvider>,
+      );
+
+      const trigger = screen.getByTestId("agent-studio-git-open-in-trigger") as HTMLButtonElement;
+      const disabledTrigger = screen.getByTestId("agent-studio-git-open-in-disabled-trigger");
+
+      expect(trigger.disabled).toBe(true);
+      expect(disabledTrigger).toBeTruthy();
+      expect(
+        screen.getByText(
+          "Builder worktree path is unavailable. Refresh the Git panel and try again.",
+          { selector: "span.sr-only" },
+        ).textContent,
+      ).toContain("Builder worktree path is unavailable. Refresh the Git panel and try again.");
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+    }
+  });
+
+  test("disables the trigger even when the caller forgot to provide a disabled reason", async () => {
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    host.systemListOpenInTools = mock(
+      async () =>
+        [
+          { toolId: "finder", iconDataUrl: "data:image/png;base64,finder" },
+        ] satisfies SystemOpenInToolInfo[],
+    );
+
+    try {
+      rendered = render(
+        <QueryProvider useIsolatedClient>
+          <TooltipProvider>
+            <OpenInMenu contextMode="worktree" targetPath={null} disabledReason={null} />
+          </TooltipProvider>
+        </QueryProvider>,
+      );
+
+      const trigger = screen.getByTestId("agent-studio-git-open-in-trigger") as HTMLButtonElement;
+
+      expect(trigger.disabled).toBe(true);
+      expect(
+        screen.getByText(
+          "Builder worktree path is unavailable. Refresh the Git panel and try again.",
+          { selector: "span.sr-only" },
+        ).textContent,
+      ).toContain("Builder worktree path is unavailable");
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+    }
+  });
+
+  test("surfaces launch failures with a toast that names the selected tool", async () => {
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const originalSystemListOpenInTools = host.systemListOpenInTools;
+      host.systemListOpenInTools = mock(
+        async () =>
+          [
+            { toolId: "zed", iconDataUrl: "data:image/png;base64,zed" },
+          ] satisfies SystemOpenInToolInfo[],
+      );
+
+      try {
+        rendered = render(
+          <QueryProvider useIsolatedClient>
+            <TooltipProvider>
+              <OpenInMenu
+                contextMode="worktree"
+                targetPath="/tmp/worktrees/task-24"
+                disabledReason={null}
+                onOpenInTool={async () => {
+                  throw new Error("launch failed");
+                }}
+              />
+            </TooltipProvider>
+          </QueryProvider>,
+        );
+
+        await screen.findByTestId("agent-studio-git-open-in-icon-zed");
+        await act(async () => {
+          fireEvent.click(screen.getByTestId("agent-studio-git-open-in-default-button"));
+          await Promise.resolve();
+        });
+
+        expect(toastErrorMock).toHaveBeenCalledWith("Failed to open in Zed", {
+          description: "launch failed",
+        });
+      } finally {
+        host.systemListOpenInTools = originalSystemListOpenInTools;
+      }
+    });
+  });
+
+  test("uses the persisted last-used tool as the default action and keeps only alternatives in the menu", async () => {
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    const storageKey = toRightPanelStorageKey();
+    globalThis.localStorage.setItem(storageKey, JSON.stringify({ openInToolId: "zed" }));
+    host.systemListOpenInTools = mock(
+      async () =>
+        [
+          { toolId: "finder", iconDataUrl: "data:image/png;base64,finder" },
+          { toolId: "terminal", iconDataUrl: "data:image/png;base64,terminal" },
+          { toolId: "zed", iconDataUrl: "data:image/png;base64,zed" },
+        ] satisfies SystemOpenInToolInfo[],
+    );
+    const onOpenInTool = mock(async () => {});
+
+    try {
+      rendered = render(
+        <QueryProvider useIsolatedClient>
+          <TooltipProvider>
+            <OpenInMenu
+              contextMode="worktree"
+              targetPath="/tmp/worktrees/task-24"
+              disabledReason={null}
+              onOpenInTool={onOpenInTool}
+            />
+          </TooltipProvider>
+        </QueryProvider>,
+      );
+
+      await screen.findByTestId("agent-studio-git-open-in-icon-zed");
+      expect(screen.getByTestId("agent-studio-git-open-in-default-button").textContent).toContain(
+        "Zed",
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("agent-studio-git-open-in-default-button"));
+      });
+
+      expect(onOpenInTool).toHaveBeenCalledWith("zed");
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("agent-studio-git-open-in-trigger"));
+      });
+
+      expect(screen.queryByTestId("agent-studio-git-open-in-item-zed")).toBeNull();
+      expect(screen.getByTestId("agent-studio-git-open-in-item-finder")).toBeTruthy();
+      expect(screen.getByTestId("agent-studio-git-open-in-item-terminal")).toBeTruthy();
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+    }
+  });
+
+  test("retry forces a fresh discovery request after a discovery error", async () => {
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    const systemListOpenInTools = mock(async (forceRefresh = false) => {
+      if (!forceRefresh) {
+        throw new Error("initial discovery failed");
+      }
+
+      return [
+        { toolId: "finder", iconDataUrl: "data:image/png;base64,finder" },
+      ] satisfies SystemOpenInToolInfo[];
+    });
+    host.systemListOpenInTools = systemListOpenInTools;
+
+    try {
+      rendered = render(
+        <QueryProvider useIsolatedClient>
+          <TooltipProvider>
+            <OpenInMenu
+              contextMode="worktree"
+              targetPath="/tmp/worktrees/task-24"
+              disabledReason={null}
+              onOpenInTool={async () => {}}
+            />
+          </TooltipProvider>
+        </QueryProvider>,
+      );
+
+      await act(async () => {
+        fireEvent.click(await screen.findByTestId("agent-studio-git-open-in-trigger"));
+      });
+
+      expect(await screen.findByTestId("agent-studio-git-open-in-error")).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(await screen.findByTestId("agent-studio-git-open-in-icon-finder")).toBeTruthy();
+      expect(systemListOpenInTools).toHaveBeenNthCalledWith(1, false);
+      expect(systemListOpenInTools).toHaveBeenNthCalledWith(2, true);
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+    }
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-menu.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-menu.test.tsx
@@ -288,10 +288,53 @@ describe("OpenInMenu", () => {
       });
 
       expect(await screen.findByTestId("agent-studio-git-open-in-icon-finder")).toBeTruthy();
-      expect(systemListOpenInTools).toHaveBeenNthCalledWith(1, false);
+      expect(systemListOpenInTools).toHaveBeenNthCalledWith(1);
       expect(systemListOpenInTools).toHaveBeenNthCalledWith(2, true);
     } finally {
       host.systemListOpenInTools = originalSystemListOpenInTools;
     }
+  });
+
+  test("retry surfaces a toast when refresh discovery also fails", async () => {
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const originalSystemListOpenInTools = host.systemListOpenInTools;
+      const systemListOpenInTools = mock(async () => {
+        throw new Error("refresh discovery failed");
+      });
+      host.systemListOpenInTools = systemListOpenInTools;
+
+      try {
+        rendered = render(
+          <QueryProvider useIsolatedClient>
+            <TooltipProvider>
+              <OpenInMenu
+                contextMode="worktree"
+                targetPath="/tmp/worktrees/task-24"
+                disabledReason={null}
+                onOpenInTool={async () => {}}
+              />
+            </TooltipProvider>
+          </QueryProvider>,
+        );
+
+        await act(async () => {
+          fireEvent.click(await screen.findByTestId("agent-studio-git-open-in-trigger"));
+        });
+
+        expect(await screen.findByTestId("agent-studio-git-open-in-error")).toBeTruthy();
+
+        await act(async () => {
+          fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
+        expect(toastErrorMock).toHaveBeenCalledWith("Failed to refresh supported apps", {
+          description: "refresh discovery failed",
+        });
+      } finally {
+        host.systemListOpenInTools = originalSystemListOpenInTools;
+      }
+    });
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-menu.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-menu.tsx
@@ -1,7 +1,7 @@
 import type { SystemOpenInToolId } from "@openducktor/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, FolderOpen, LoaderCircle, RefreshCw } from "lucide-react";
-import { type ReactElement, type ReactNode, useEffect, useId, useMemo, useState } from "react";
+import { type ReactElement, type ReactNode, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -163,13 +163,10 @@ export function OpenInMenu({
   const [preferredToolId, setPreferredToolId] = useState<SystemOpenInToolId | null>(() =>
     readPreferredOpenInTool(),
   );
+  const [isRefreshingTools, setIsRefreshingTools] = useState(false);
   const queryClient = useQueryClient();
   const toolsQuery = useQuery(openInToolsQueryOptions());
   const targetLabel = contextMode === "repository" ? "repository root" : "builder worktree";
-
-  useEffect(() => {
-    setPreferredToolId(readPreferredOpenInTool());
-  }, []);
 
   const defaultTool = useMemo(() => {
     const tools = toolsQuery.data ?? [];
@@ -225,6 +222,23 @@ export function OpenInMenu({
       });
     } finally {
       setPendingToolId(null);
+    }
+  };
+
+  const handleRefreshTools = async (): Promise<void> => {
+    if (isRefreshingTools) {
+      return;
+    }
+
+    setIsRefreshingTools(true);
+    try {
+      await refreshOpenInToolsFromQuery(queryClient);
+    } catch (error) {
+      toast.error("Failed to refresh supported apps", {
+        description: errorMessage(error),
+      });
+    } finally {
+      setIsRefreshingTools(false);
     }
   };
 
@@ -293,10 +307,15 @@ export function OpenInMenu({
                 size="sm"
                 className="h-7 text-[11px]"
                 onClick={() => {
-                  void refreshOpenInToolsFromQuery(queryClient);
+                  void handleRefreshTools();
                 }}
+                disabled={isRefreshingTools}
               >
-                <RefreshCw className="size-3.5" />
+                {isRefreshingTools ? (
+                  <LoaderCircle className="size-3.5 animate-spin" />
+                ) : (
+                  <RefreshCw className="size-3.5" />
+                )}
                 Retry
               </Button>
             </div>

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-menu.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-menu.tsx
@@ -1,0 +1,341 @@
+import type { SystemOpenInToolId } from "@openducktor/contracts";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, FolderOpen, LoaderCircle, RefreshCw } from "lucide-react";
+import { type ReactElement, type ReactNode, useEffect, useId, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { errorMessage } from "@/lib/errors";
+import { openInToolsQueryOptions, refreshOpenInToolsFromQuery } from "@/state/queries/system";
+import { persistPreferredOpenInTool, readPreferredOpenInTool } from "./open-in-preferences";
+import { getOpenInToolLabel, OpenInToolIcon } from "./open-in-tool-metadata";
+
+function renderOpenInMenuTriggerButton({ disabled }: { disabled: boolean }): ReactElement {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-7 rounded-l-none border-l-0 px-1.5 text-[11px]"
+      data-testid="agent-studio-git-open-in-trigger"
+      aria-label="Choose a different tool"
+      disabled={disabled}
+    >
+      <ChevronDown className="size-3" />
+    </Button>
+  );
+}
+
+function renderOpenInDefaultButton({
+  targetLabel,
+  defaultToolLabel,
+  defaultToolIcon,
+  onClick,
+  disabled,
+  isPending,
+  hasMenuTrigger,
+}: {
+  targetLabel: string;
+  defaultToolLabel: string;
+  defaultToolIcon: ReactNode;
+  onClick: (() => void) | null;
+  disabled: boolean;
+  isPending: boolean;
+  hasMenuTrigger: boolean;
+}): ReactElement {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className={
+        hasMenuTrigger
+          ? "h-7 gap-1.5 rounded-r-none px-2 text-[11px]"
+          : "h-7 gap-1.5 px-2 text-[11px]"
+      }
+      data-testid="agent-studio-git-open-in-default-button"
+      aria-label={`Open ${targetLabel} in ${defaultToolLabel}`}
+      onClick={onClick ?? undefined}
+      disabled={disabled}
+    >
+      {isPending ? <LoaderCircle className="size-3.5 animate-spin" /> : defaultToolIcon}
+      <span className="truncate">{defaultToolLabel}</span>
+    </Button>
+  );
+}
+
+function DisabledOpenInTrigger({
+  disabledReason,
+  trigger,
+}: {
+  disabledReason: string;
+  trigger: ReactElement;
+}): ReactElement {
+  const descriptionId = useId();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex cursor-not-allowed"
+          data-testid="agent-studio-git-open-in-disabled-trigger"
+        >
+          {trigger}
+          <span id={descriptionId} className="sr-only">
+            {disabledReason}
+          </span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-80">
+        <p>{disabledReason}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function OpenInMenuBody({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <PopoverContent align="end" className="w-80 p-0">
+      {children}
+    </PopoverContent>
+  );
+}
+
+function defaultUnavailableReason(contextMode: "repository" | "worktree"): string {
+  if (contextMode === "repository") {
+    return "Repository path is unavailable. Select a repository and try again.";
+  }
+
+  return "Builder worktree path is unavailable. Refresh the Git panel and try again.";
+}
+
+function resolveOpenInDisabledReason({
+  contextMode,
+  targetLabel,
+  targetPath,
+  disabledReason,
+  onOpenInTool,
+}: {
+  contextMode: "repository" | "worktree";
+  targetLabel: string;
+  targetPath: string | null;
+  disabledReason: string | null;
+  onOpenInTool?: ((toolId: SystemOpenInToolId) => Promise<void>) | undefined;
+}): string | null {
+  if (disabledReason) {
+    return disabledReason;
+  }
+
+  if (!targetPath) {
+    return defaultUnavailableReason(contextMode);
+  }
+
+  if (!onOpenInTool) {
+    return `Open ${targetLabel} is unavailable right now.`;
+  }
+
+  return null;
+}
+
+function OpenInActionGroup({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <div className="flex items-center" data-testid="agent-studio-git-open-in-actions">
+      {children}
+    </div>
+  );
+}
+
+export function OpenInMenu({
+  contextMode,
+  targetPath,
+  disabledReason,
+  onOpenInTool,
+}: {
+  contextMode: "repository" | "worktree";
+  targetPath: string | null;
+  disabledReason: string | null;
+  onOpenInTool?: ((toolId: SystemOpenInToolId) => Promise<void>) | undefined;
+}): ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+  const [pendingToolId, setPendingToolId] = useState<SystemOpenInToolId | null>(null);
+  const [preferredToolId, setPreferredToolId] = useState<SystemOpenInToolId | null>(() =>
+    readPreferredOpenInTool(),
+  );
+  const queryClient = useQueryClient();
+  const toolsQuery = useQuery(openInToolsQueryOptions());
+  const targetLabel = contextMode === "repository" ? "repository root" : "builder worktree";
+
+  useEffect(() => {
+    setPreferredToolId(readPreferredOpenInTool());
+  }, []);
+
+  const defaultTool = useMemo(() => {
+    const tools = toolsQuery.data ?? [];
+    if (tools.length === 0) {
+      return null;
+    }
+
+    if (preferredToolId) {
+      const preferredTool = tools.find((tool) => tool.toolId === preferredToolId);
+      if (preferredTool) {
+        return preferredTool;
+      }
+    }
+
+    return tools[0] ?? null;
+  }, [preferredToolId, toolsQuery.data]);
+  const alternativeTools = useMemo(() => {
+    const tools = toolsQuery.data ?? [];
+    if (!defaultTool) {
+      return tools;
+    }
+
+    return tools.filter((tool) => tool.toolId !== defaultTool.toolId);
+  }, [defaultTool, toolsQuery.data]);
+  const resolvedDisabledReason = resolveOpenInDisabledReason({
+    contextMode,
+    targetLabel,
+    targetPath,
+    disabledReason,
+    onOpenInTool,
+  });
+  const isTriggerDisabled = resolvedDisabledReason != null;
+  const hasMenuTrigger =
+    alternativeTools.length > 0 ||
+    toolsQuery.isPending ||
+    toolsQuery.isError ||
+    defaultTool == null;
+
+  const handleOpenInTool = async (toolId: SystemOpenInToolId): Promise<void> => {
+    if (!targetPath || !onOpenInTool) {
+      return;
+    }
+
+    setPendingToolId(toolId);
+    try {
+      await onOpenInTool(toolId);
+      persistPreferredOpenInTool(toolId);
+      setPreferredToolId(toolId);
+      setIsOpen(false);
+    } catch (error) {
+      toast.error(`Failed to open in ${getOpenInToolLabel(toolId)}`, {
+        description: errorMessage(error),
+      });
+    } finally {
+      setPendingToolId(null);
+    }
+  };
+
+  const defaultToolLabel = defaultTool ? getOpenInToolLabel(defaultTool.toolId) : "Open In";
+  const defaultToolIcon = defaultTool ? (
+    <OpenInToolIcon tool={defaultTool} />
+  ) : (
+    <FolderOpen className="size-3.5" />
+  );
+  const defaultToolIsPending = defaultTool != null && pendingToolId === defaultTool.toolId;
+  const defaultButton = renderOpenInDefaultButton({
+    targetLabel,
+    defaultToolLabel,
+    defaultToolIcon,
+    onClick: defaultTool ? () => void handleOpenInTool(defaultTool.toolId) : null,
+    disabled: isTriggerDisabled,
+    isPending: defaultToolIsPending,
+    hasMenuTrigger,
+  });
+  const menuTrigger = renderOpenInMenuTriggerButton({ disabled: isTriggerDisabled });
+  const trigger = hasMenuTrigger ? (
+    <OpenInActionGroup>
+      {defaultButton}
+      {menuTrigger}
+    </OpenInActionGroup>
+  ) : (
+    defaultButton
+  );
+
+  if (resolvedDisabledReason) {
+    return <DisabledOpenInTrigger disabledReason={resolvedDisabledReason} trigger={trigger} />;
+  }
+
+  if (!hasMenuTrigger) {
+    return defaultButton;
+  }
+
+  return (
+    <OpenInActionGroup>
+      {defaultButton}
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>{menuTrigger}</PopoverTrigger>
+        <OpenInMenuBody>
+          <div className="border-b border-border px-3 py-2">
+            <p className="text-xs font-medium text-foreground">Other tools for {targetLabel}</p>
+            <p
+              className="mt-1 truncate text-[11px] text-muted-foreground"
+              title={targetPath ?? undefined}
+            >
+              {targetPath ?? "Select a tool to continue."}
+            </p>
+          </div>
+
+          {toolsQuery.isPending ? (
+            <div className="flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground">
+              <LoaderCircle className="size-4 animate-spin" />
+              <span>Looking for supported apps...</span>
+            </div>
+          ) : toolsQuery.isError ? (
+            <div className="space-y-3 px-3 py-3" data-testid="agent-studio-git-open-in-error">
+              <p className="text-sm text-foreground">Supported app discovery failed.</p>
+              <p className="text-[11px] text-muted-foreground">{errorMessage(toolsQuery.error)}</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 text-[11px]"
+                onClick={() => {
+                  void refreshOpenInToolsFromQuery(queryClient);
+                }}
+              >
+                <RefreshCw className="size-3.5" />
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <ScrollArea className="max-h-80">
+              <div className="space-y-1 p-1">
+                {alternativeTools.map((tool) => {
+                  const isPending = pendingToolId === tool.toolId;
+
+                  return (
+                    <Button
+                      key={tool.toolId}
+                      type="button"
+                      variant="ghost"
+                      className="h-auto w-full justify-start px-2 py-2 text-left text-sm"
+                      onClick={() => {
+                        void handleOpenInTool(tool.toolId);
+                      }}
+                      disabled={pendingToolId !== null}
+                      data-testid={`agent-studio-git-open-in-item-${tool.toolId}`}
+                    >
+                      <OpenInToolIcon tool={tool} />
+                      <span className="min-w-0 flex-1 truncate">
+                        {getOpenInToolLabel(tool.toolId)}
+                      </span>
+                      {isPending ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+                    </Button>
+                  );
+                })}
+                {toolsQuery.data?.length === 0 ? (
+                  <div className="px-3 py-3 text-sm text-muted-foreground">
+                    No supported apps are currently available on this Mac.
+                  </div>
+                ) : null}
+              </div>
+            </ScrollArea>
+          )}
+        </OpenInMenuBody>
+      </Popover>
+    </OpenInActionGroup>
+  );
+}

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-preferences.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-preferences.ts
@@ -1,0 +1,87 @@
+import type { SystemOpenInToolId } from "@openducktor/contracts";
+import { toRightPanelStorageKey } from "@/pages/agents/agents-page-selection";
+
+type PersistedOpenInPreference = {
+  openInToolId?: string;
+};
+
+const isSystemOpenInToolId = (value: string): value is SystemOpenInToolId => {
+  switch (value) {
+    case "finder":
+    case "terminal":
+    case "iterm2":
+    case "ghostty":
+    case "vscode":
+    case "cursor":
+    case "zed":
+    case "intellij-idea":
+    case "webstorm":
+    case "pycharm":
+    case "phpstorm":
+    case "rider":
+    case "rustrover":
+    case "android-studio":
+      return true;
+    default:
+      return false;
+  }
+};
+
+const openInPreferencesStorageKey = (): string => toRightPanelStorageKey();
+
+export function readPreferredOpenInTool(): SystemOpenInToolId | null {
+  if (typeof globalThis.localStorage === "undefined") {
+    return null;
+  }
+
+  const storageKey = openInPreferencesStorageKey();
+
+  try {
+    const raw = globalThis.localStorage.getItem(storageKey);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+
+    const toolId = (parsed as PersistedOpenInPreference).openInToolId;
+    if (typeof toolId !== "string" || !isSystemOpenInToolId(toolId)) {
+      return null;
+    }
+
+    return toolId;
+  } catch (error) {
+    console.error("[agent-studio-open-in] Failed to read persisted preferred tool.", {
+      storageKey,
+      error,
+    });
+    return null;
+  }
+}
+
+export function persistPreferredOpenInTool(toolId: SystemOpenInToolId): void {
+  if (typeof globalThis.localStorage === "undefined") {
+    return;
+  }
+
+  const storageKey = openInPreferencesStorageKey();
+
+  try {
+    const raw = globalThis.localStorage.getItem(storageKey);
+    const parsed = raw ? (JSON.parse(raw) as unknown) : null;
+    const nextValue =
+      parsed && typeof parsed === "object"
+        ? { ...parsed, openInToolId: toolId }
+        : { openInToolId: toolId };
+    globalThis.localStorage.setItem(storageKey, JSON.stringify(nextValue));
+  } catch (error) {
+    console.error("[agent-studio-open-in] Failed to persist preferred tool.", {
+      storageKey,
+      toolId,
+      error,
+    });
+  }
+}

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-preferences.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-preferences.ts
@@ -1,31 +1,14 @@
-import type { SystemOpenInToolId } from "@openducktor/contracts";
+import { type SystemOpenInToolId, systemOpenInToolIdValues } from "@openducktor/contracts";
 import { toRightPanelStorageKey } from "@/pages/agents/agents-page-selection";
 
 type PersistedOpenInPreference = {
   openInToolId?: string;
 };
 
-const isSystemOpenInToolId = (value: string): value is SystemOpenInToolId => {
-  switch (value) {
-    case "finder":
-    case "terminal":
-    case "iterm2":
-    case "ghostty":
-    case "vscode":
-    case "cursor":
-    case "zed":
-    case "intellij-idea":
-    case "webstorm":
-    case "pycharm":
-    case "phpstorm":
-    case "rider":
-    case "rustrover":
-    case "android-studio":
-      return true;
-    default:
-      return false;
-  }
-};
+const systemOpenInToolIdSet = new Set<string>(systemOpenInToolIdValues);
+
+const isSystemOpenInToolId = (value: string): value is SystemOpenInToolId =>
+  systemOpenInToolIdSet.has(value);
 
 const openInPreferencesStorageKey = (): string => toRightPanelStorageKey();
 

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-tool-metadata.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/open-in-tool-metadata.tsx
@@ -1,0 +1,76 @@
+import type { SystemOpenInToolId, SystemOpenInToolInfo } from "@openducktor/contracts";
+import { AppWindowMac, FolderOpen, Terminal } from "lucide-react";
+import type { ReactElement } from "react";
+import { cn } from "@/lib/utils";
+
+type OpenInToolUiMetadata = {
+  label: string;
+  fallbackKind: "finder" | "terminal" | "generic";
+};
+
+const OPEN_IN_TOOL_METADATA: Record<SystemOpenInToolId, OpenInToolUiMetadata> = {
+  finder: { label: "Finder", fallbackKind: "finder" },
+  terminal: { label: "Terminal", fallbackKind: "terminal" },
+  iterm2: { label: "iTerm2", fallbackKind: "terminal" },
+  ghostty: { label: "Ghostty", fallbackKind: "terminal" },
+  vscode: { label: "VS Code", fallbackKind: "generic" },
+  cursor: { label: "Cursor", fallbackKind: "generic" },
+  zed: { label: "Zed", fallbackKind: "generic" },
+  "intellij-idea": { label: "IntelliJ IDEA", fallbackKind: "generic" },
+  webstorm: { label: "WebStorm", fallbackKind: "generic" },
+  pycharm: { label: "PyCharm", fallbackKind: "generic" },
+  phpstorm: { label: "PhpStorm", fallbackKind: "generic" },
+  rider: { label: "Rider", fallbackKind: "generic" },
+  rustrover: { label: "RustRover", fallbackKind: "generic" },
+  "android-studio": { label: "Android Studio", fallbackKind: "generic" },
+};
+
+export function getOpenInToolLabel(toolId: SystemOpenInToolId): string {
+  return OPEN_IN_TOOL_METADATA[toolId].label;
+}
+
+function fallbackIconForTool(toolId: SystemOpenInToolId) {
+  const { fallbackKind } = OPEN_IN_TOOL_METADATA[toolId];
+
+  if (fallbackKind === "finder") {
+    return FolderOpen;
+  }
+
+  if (fallbackKind === "terminal") {
+    return Terminal;
+  }
+
+  return AppWindowMac;
+}
+
+function OpenInFallbackIcon({ toolId }: { toolId: SystemOpenInToolId }): ReactElement {
+  const Icon = fallbackIconForTool(toolId);
+
+  return (
+    <span
+      className={cn(
+        "flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground",
+      )}
+      data-testid={`agent-studio-git-open-in-icon-${toolId}`}
+      aria-hidden="true"
+    >
+      <Icon className="size-3.5" />
+    </span>
+  );
+}
+
+export function OpenInToolIcon({ tool }: { tool: SystemOpenInToolInfo }): ReactElement {
+  if (tool.iconDataUrl) {
+    return (
+      <img
+        src={tool.iconDataUrl}
+        alt=""
+        className="size-6 shrink-0 rounded-md"
+        data-testid={`agent-studio-git-open-in-icon-${tool.toolId}`}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return <OpenInFallbackIcon toolId={tool.toolId} />;
+}

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/types.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/types.ts
@@ -1,4 +1,4 @@
-import type { PullRequest } from "@openducktor/contracts";
+import type { PullRequest, SystemOpenInToolId } from "@openducktor/contracts";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import type {
   AgentStudioPendingForcePush,
@@ -12,6 +12,8 @@ import type {
 export type AgentStudioGitPanelModel = DiffDataState & {
   contextMode?: "repository" | "worktree";
   pullRequest?: PullRequest | null;
+  openInTargetPath?: string | null;
+  openInDisabledReason?: string | null;
   isCommitting?: boolean;
   isPushing?: boolean;
   isRebasing?: boolean;
@@ -49,6 +51,7 @@ export type AgentStudioGitPanelModel = DiffDataState & {
   askBuilderToResolveGitConflict?: () => Promise<void>;
   pullFromUpstream?: () => Promise<void>;
   onDetectPullRequest?: () => Promise<void> | void;
+  openDirectoryInTool?: (toolId: SystemOpenInToolId) => Promise<void>;
   targetBranchOptions?: ComboboxOption[];
   targetBranchSelectionValue?: string;
   onUpdateTargetBranch?: (selection: string) => Promise<void>;

--- a/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -4,6 +4,7 @@ import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import type { DiffScopeState } from "@/features/agent-studio-git/contracts";
+import { QueryProvider } from "@/lib/query-provider";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import type { AgentStudioDevServerPanelModel } from "./agent-studio-dev-server-panel";
 import type { AgentStudioGitPanelModel } from "./agent-studio-git-panel";
@@ -179,22 +180,26 @@ describe("AgentStudioRightPanelToggleButton", () => {
 describe("AgentStudioRightPanel", () => {
   test("renders documents content via workspace sidebar", () => {
     const html = renderToStaticMarkup(
-      createElement(AgentStudioRightPanel, {
-        model: {
-          kind: "documents",
-          documentsModel: {
-            activeDocument: {
-              title: "Specification",
-              description: "Current specification document for this task.",
-              emptyState: "No spec document yet.",
-              document: {
-                ...emptyDoc,
-                markdown: "# Spec",
+      createElement(
+        QueryProvider,
+        { useIsolatedClient: true },
+        createElement(AgentStudioRightPanel, {
+          model: {
+            kind: "documents",
+            documentsModel: {
+              activeDocument: {
+                title: "Specification",
+                description: "Current specification document for this task.",
+                emptyState: "No spec document yet.",
+                document: {
+                  ...emptyDoc,
+                  markdown: "# Spec",
+                },
               },
             },
           },
-        },
-      }),
+        }),
+      ),
     );
 
     expect(html).toContain("Specification");
@@ -204,13 +209,17 @@ describe("AgentStudioRightPanel", () => {
 
   test("renders builder tools panel with git and dev server content", () => {
     const html = renderToStaticMarkup(
-      createElement(AgentStudioRightPanel, {
-        model: {
-          kind: "build_tools",
-          diffModel,
-          devServerModel,
-        },
-      }),
+      createElement(
+        QueryProvider,
+        { useIsolatedClient: true },
+        createElement(AgentStudioRightPanel, {
+          model: {
+            kind: "build_tools",
+            diffModel,
+            devServerModel,
+          },
+        }),
+      ),
     );
 
     expect(html).toContain("Current");

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-right-panel.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-right-panel.ts
@@ -43,22 +43,35 @@ const cloneDefaultOpenByRole = (): Record<AgentRole, boolean> => ({
   ...DEFAULT_OPEN_BY_ROLE,
 });
 
+const readPersistedRightPanelPayload = (): Record<string, unknown> | null => {
+  if (typeof globalThis.localStorage === "undefined") {
+    return null;
+  }
+
+  const raw = globalThis.localStorage.getItem(toRightPanelStorageKey());
+  if (!raw) {
+    return null;
+  }
+
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+
+  return parsed as Record<string, unknown>;
+};
+
 const readPersistedOpenByRole = (): Record<AgentRole, boolean> => {
   if (typeof globalThis.localStorage === "undefined") {
     return cloneDefaultOpenByRole();
   }
 
-  const raw = globalThis.localStorage.getItem(toRightPanelStorageKey());
-  if (!raw) {
-    return cloneDefaultOpenByRole();
-  }
-
   try {
-    const parsed: unknown = JSON.parse(raw);
+    const parsed = readPersistedRightPanelPayload();
     const next = cloneDefaultOpenByRole();
-    if (parsed && typeof parsed === "object") {
+    if (parsed) {
       for (const role of RIGHT_PANEL_ROLES) {
-        const value = (parsed as Record<AgentRole, unknown>)[role];
+        const value = parsed[role];
         if (typeof value === "boolean") {
           next[role] = value;
         }
@@ -67,7 +80,7 @@ const readPersistedOpenByRole = (): Record<AgentRole, boolean> => {
     return next;
   } catch (error) {
     console.error("[agent-studio-right-panel] Failed to parse persisted panel state.", {
-      raw,
+      raw: globalThis.localStorage.getItem(toRightPanelStorageKey()),
       error,
     });
     return cloneDefaultOpenByRole();
@@ -134,7 +147,16 @@ export function useAgentStudioRightPanel({
       return;
     }
 
-    globalThis.localStorage.setItem(toRightPanelStorageKey(), JSON.stringify(isOpenByRole));
+    try {
+      const persisted = readPersistedRightPanelPayload();
+      const nextValue = persisted ? { ...persisted, ...isOpenByRole } : isOpenByRole;
+      globalThis.localStorage.setItem(toRightPanelStorageKey(), JSON.stringify(nextValue));
+    } catch (error) {
+      console.error("[agent-studio-right-panel] Failed to persist panel state.", {
+        nextState: isOpenByRole,
+        error,
+      });
+    }
   }, [isOpenByRole]);
 
   const panelKindForRole = PANEL_KIND_BY_ROLE[role];

--- a/apps/desktop/src/pages/agents/right-panel/use-agents-page-right-panel-model.test.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agents-page-right-panel-model.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { createTaskCardFixture } from "../agent-studio-test-utils";
+import {
+  resolveAgentStudioGitPanelOpenInTarget,
+  resolveBuildContinuationTargetTaskId,
+} from "./use-agents-page-right-panel-model";
+
+describe("resolveBuildContinuationTargetTaskId", () => {
+  test("uses the stable tab task id while selected task hydration is still pending", () => {
+    expect(
+      resolveBuildContinuationTargetTaskId({
+        viewTaskId: "task-24",
+        viewSelectedTask: null,
+      }),
+    ).toBe("task-24");
+  });
+
+  test("prefers the hydrated selected task id when available", () => {
+    expect(
+      resolveBuildContinuationTargetTaskId({
+        viewTaskId: "task-24",
+        viewSelectedTask: createTaskCardFixture({ id: "task-24-hydrated" }),
+      }),
+    ).toBe("task-24-hydrated");
+  });
+});
+
+describe("resolveAgentStudioGitPanelOpenInTarget", () => {
+  test("uses the repository root in repository mode even without a worktree path", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "repository",
+        activeRepo: "/repo",
+        worktreePath: null,
+        runWorktreePath: null,
+        sessionWorkingDirectory: null,
+        continuationTargetWorkingDirectory: null,
+        isContinuationTargetResolving: false,
+      }),
+    ).toEqual({
+      path: "/repo",
+      disabledReason: null,
+    });
+  });
+
+  test("uses the builder worktree in worktree mode", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "worktree",
+        activeRepo: "/repo",
+        worktreePath: "/worktrees/task-24",
+        runWorktreePath: null,
+        sessionWorkingDirectory: null,
+        continuationTargetWorkingDirectory: null,
+        isContinuationTargetResolving: false,
+      }),
+    ).toEqual({
+      path: "/worktrees/task-24",
+      disabledReason: null,
+    });
+  });
+
+  test("preserves significant leading and trailing spaces in a valid target path", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "repository",
+        activeRepo: "  /repo with padded name  ",
+        worktreePath: null,
+        runWorktreePath: null,
+        sessionWorkingDirectory: null,
+        continuationTargetWorkingDirectory: null,
+        isContinuationTargetResolving: false,
+      }),
+    ).toEqual({
+      path: "  /repo with padded name  ",
+      disabledReason: null,
+    });
+  });
+
+  test("disables Open In when no worktree-specific path is available", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "worktree",
+        activeRepo: "/repo",
+        worktreePath: null,
+        runWorktreePath: null,
+        sessionWorkingDirectory: null,
+        continuationTargetWorkingDirectory: null,
+        isContinuationTargetResolving: false,
+      }),
+    ).toEqual({
+      path: null,
+      disabledReason: "Builder worktree path is unavailable. Refresh the Git panel and try again.",
+    });
+  });
+
+  test("falls back to the active builder working directory before diff worktree resolution completes", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "worktree",
+        activeRepo: "/repo",
+        worktreePath: null,
+        runWorktreePath: null,
+        sessionWorkingDirectory: "/repo/.worktrees/task-24",
+        continuationTargetWorkingDirectory: null,
+        isContinuationTargetResolving: false,
+      }),
+    ).toEqual({
+      path: "/repo/.worktrees/task-24",
+      disabledReason: null,
+    });
+  });
+
+  test("does not treat the repo root as a valid builder worktree path", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "worktree",
+        activeRepo: "/repo",
+        worktreePath: null,
+        runWorktreePath: null,
+        sessionWorkingDirectory: "/repo",
+        continuationTargetWorkingDirectory: null,
+        isContinuationTargetResolving: false,
+      }),
+    ).toEqual({
+      path: null,
+      disabledReason: "Builder worktree path is unavailable. Refresh the Git panel and try again.",
+    });
+  });
+
+  test("uses the canonical continuation target before direct session fallback", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "worktree",
+        activeRepo: "/repo",
+        worktreePath: null,
+        runWorktreePath: null,
+        sessionWorkingDirectory: "/repo/.worktrees/older-task-23",
+        continuationTargetWorkingDirectory: "/repo/.worktrees/task-24",
+        isContinuationTargetResolving: false,
+      }),
+    ).toEqual({
+      path: "/repo/.worktrees/task-24",
+      disabledReason: null,
+    });
+  });
+
+  test("shows a resolving message while continuation target resolution is still loading", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "worktree",
+        activeRepo: "/repo",
+        worktreePath: null,
+        runWorktreePath: null,
+        sessionWorkingDirectory: null,
+        continuationTargetWorkingDirectory: null,
+        isContinuationTargetResolving: true,
+      }),
+    ).toEqual({
+      path: null,
+      disabledReason: "Resolving builder worktree path...",
+    });
+  });
+
+  test("uses the matching run worktree path before task hydration catches up", () => {
+    expect(
+      resolveAgentStudioGitPanelOpenInTarget({
+        contextMode: "worktree",
+        activeRepo: "/repo",
+        worktreePath: null,
+        runWorktreePath: "/repo/.worktrees/task-24",
+        sessionWorkingDirectory: "/repo",
+        continuationTargetWorkingDirectory: null,
+        isContinuationTargetResolving: false,
+      }),
+    ).toEqual({
+      path: "/repo/.worktrees/task-24",
+      disabledReason: null,
+    });
+  });
+});

--- a/apps/desktop/src/pages/agents/right-panel/use-agents-page-right-panel-model.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agents-page-right-panel-model.ts
@@ -1,8 +1,10 @@
-import type { GitBranch } from "@openducktor/contracts";
+import type { GitBranch, SystemOpenInToolId } from "@openducktor/contracts";
+import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { toBranchSelectorOptions } from "@/components/features/repository/branch-selector-model";
 import type { BuildToolsSessionDescriptor } from "@/features/agent-studio-build-tools/use-agent-studio-build-tools-bootstrap";
 import { useAgentStudioBuildToolsReadModel } from "@/features/agent-studio-build-tools/use-agent-studio-build-tools-read-model";
+import { hostClient } from "@/lib/host-client";
 import {
   canonicalTargetBranch,
   resolveTaskTargetBranchState,
@@ -10,6 +12,7 @@ import {
 } from "@/lib/target-branch";
 import { canDetectTaskPullRequest } from "@/lib/task-display";
 import type { useTasksState, useWorkspaceState } from "@/state";
+import { buildContinuationTargetQueryOptions } from "@/state/queries/build-runtime";
 import { useAgentStudioGitActions } from "../use-agent-studio-git-actions";
 import type {
   AgentStudioOrchestrationSelectionContext,
@@ -22,6 +25,7 @@ export type UseAgentsPageRightPanelModelArgs = {
   branches?: GitBranch[];
   activeBranch: ReturnType<typeof useWorkspaceState>["activeBranch"];
   viewRole: AgentStudioOrchestrationSelectionContext["viewRole"];
+  viewTaskId: AgentStudioOrchestrationSelectionContext["viewTaskId"];
   session: BuildToolsSessionDescriptor;
   viewSelectedTask: AgentStudioOrchestrationSelectionContext["viewSelectedTask"];
   panelKind: Parameters<typeof buildAgentStudioRightPanelModel>[0]["panelKind"];
@@ -37,11 +41,95 @@ export type UseAgentsPageRightPanelModelArgs = {
   onResolveGitConflict: Parameters<typeof useAgentStudioGitActions>[0]["onResolveGitConflict"];
 };
 
+export const resolveBuildContinuationTargetTaskId = ({
+  viewTaskId,
+  viewSelectedTask,
+}: {
+  viewTaskId: AgentStudioOrchestrationSelectionContext["viewTaskId"];
+  viewSelectedTask: AgentStudioOrchestrationSelectionContext["viewSelectedTask"];
+}): string => viewSelectedTask?.id ?? viewTaskId;
+
+function firstNonRepoWorktreePath(repoPath: string, paths: Array<string | null>): string | null {
+  for (const candidate of paths) {
+    if (!candidate || candidate.trim().length === 0) {
+      continue;
+    }
+
+    if (repoPath.trim().length > 0 && candidate === repoPath) {
+      continue;
+    }
+
+    return candidate;
+  }
+
+  return null;
+}
+
+export const resolveAgentStudioGitPanelOpenInTarget = ({
+  contextMode,
+  activeRepo,
+  worktreePath,
+  runWorktreePath,
+  sessionWorkingDirectory,
+  continuationTargetWorkingDirectory,
+  isContinuationTargetResolving,
+}: {
+  contextMode: "repository" | "worktree";
+  activeRepo: string | null;
+  worktreePath: string | null;
+  runWorktreePath: string | null;
+  sessionWorkingDirectory: string | null;
+  continuationTargetWorkingDirectory: string | null;
+  isContinuationTargetResolving: boolean;
+}): { path: string | null; disabledReason: string | null } => {
+  const repoPath = activeRepo ?? "";
+  const resolvedContextWorkingDirectory = firstNonRepoWorktreePath(repoPath, [
+    worktreePath,
+    runWorktreePath,
+    continuationTargetWorkingDirectory,
+    sessionWorkingDirectory,
+  ]);
+
+  if (contextMode === "repository") {
+    if (repoPath.trim().length > 0) {
+      return {
+        path: repoPath,
+        disabledReason: null,
+      };
+    }
+
+    return {
+      path: null,
+      disabledReason: "Repository path is unavailable. Select a repository and try again.",
+    };
+  }
+
+  if (resolvedContextWorkingDirectory) {
+    return {
+      path: resolvedContextWorkingDirectory,
+      disabledReason: null,
+    };
+  }
+
+  if (isContinuationTargetResolving) {
+    return {
+      path: null,
+      disabledReason: "Resolving builder worktree path...",
+    };
+  }
+
+  return {
+    path: null,
+    disabledReason: "Builder worktree path is unavailable. Refresh the Git panel and try again.",
+  };
+};
+
 export function useAgentsPageRightPanelModel({
   activeRepo,
   branches = [],
   activeBranch,
   viewRole,
+  viewTaskId,
   session,
   viewSelectedTask,
   panelKind,
@@ -73,8 +161,32 @@ export function useAgentsPageRightPanelModel({
       runCompletionRecoverySignal,
     });
 
+  const buildContinuationTargetRepoPath = activeRepo ?? "";
+  const buildContinuationTargetTaskId = resolveBuildContinuationTargetTaskId({
+    viewTaskId,
+    viewSelectedTask,
+  });
+  const matchingRunWorktreePath =
+    session.runId == null
+      ? null
+      : (runs.find((run) => run.runId === session.runId)?.worktreePath ?? null);
+  const shouldResolveBuildContinuationTarget =
+    panelKind === "build_tools" &&
+    isPanelOpen &&
+    gitPanelContextMode === "worktree" &&
+    buildContinuationTargetRepoPath.length > 0 &&
+    buildContinuationTargetTaskId.length > 0;
+
   const isActiveBuilderWorking =
     sessionRole === "build" && (sessionStatus === "running" || sessionStatus === "starting");
+  const continuationTargetQuery = useQuery({
+    ...buildContinuationTargetQueryOptions(
+      buildContinuationTargetRepoPath,
+      buildContinuationTargetTaskId,
+      hostClient,
+    ),
+    enabled: shouldResolveBuildContinuationTarget,
+  });
   const gitActions = useAgentStudioGitActions({
     repoPath: activeRepo,
     workingDir: diffData.worktreePath,
@@ -116,10 +228,28 @@ export function useAgentsPageRightPanelModel({
         : [],
     });
 
+    const openInTarget = resolveAgentStudioGitPanelOpenInTarget({
+      contextMode: gitPanelContextMode,
+      activeRepo,
+      worktreePath: diffData.worktreePath,
+      runWorktreePath: matchingRunWorktreePath,
+      sessionWorkingDirectory: session.workingDirectory,
+      continuationTargetWorkingDirectory: continuationTargetQuery.data?.workingDirectory ?? null,
+      isContinuationTargetResolving: continuationTargetQuery.isPending,
+    });
+
     return {
       ...diffData,
       contextMode: gitPanelContextMode,
       branch: resolvedGitPanelBranch,
+      openInTargetPath: openInTarget.path,
+      openInDisabledReason: openInTarget.disabledReason,
+      ...(openInTarget.path
+        ? {
+            openDirectoryInTool: (toolId: SystemOpenInToolId) =>
+              hostClient.systemOpenDirectoryInTool(openInTarget.path as string, toolId),
+          }
+        : {}),
       ...(taskTargetBranchState.validationError
         ? {
             targetBranch: taskTargetBranchState.displayTargetBranch,
@@ -156,6 +286,7 @@ export function useAgentsPageRightPanelModel({
     };
   }, [
     branches,
+    activeRepo,
     diffData,
     gitActions,
     gitPanelContextMode,
@@ -165,6 +296,10 @@ export function useAgentsPageRightPanelModel({
     resolvedGitPanelBranch,
     runs,
     setTaskTargetBranch,
+    continuationTargetQuery.data?.workingDirectory,
+    continuationTargetQuery.isPending,
+    matchingRunWorktreePath,
+    session.workingDirectory,
     viewSelectedTask,
   ]);
 

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -412,6 +412,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
         branches={branches}
         activeBranch={activeBranch}
         viewRole={selection.viewRole}
+        viewTaskId={selection.viewTaskId}
         session={rightPanelSession}
         viewSelectedTask={selection.viewSelectedTask}
         panelKind={orchestration.rightPanel.panelKind}

--- a/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
@@ -313,6 +313,30 @@ describe("useAgentStudioRightPanel", () => {
     await secondHarness.unmount();
   });
 
+  test("preserves the stored preferred open-in tool when panel state changes", async () => {
+    globalThis.localStorage.setItem(
+      toRightPanelStorageKey(),
+      JSON.stringify({ openInToolId: "zed", build: true }),
+    );
+
+    const harness = createHookHarness({
+      role: "build",
+      hasDocumentPanel: false,
+      hasBuildToolsPanel: true,
+    });
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.rightPanelToggleModel?.onToggle();
+    });
+
+    const persisted = JSON.parse(globalThis.localStorage.getItem(toRightPanelStorageKey()) ?? "{}");
+    expect(persisted.openInToolId).toBe("zed");
+    expect(persisted.build).toBe(false);
+
+    await harness.unmount();
+  });
+
   test("logs malformed persisted panel state before recovering defaults", async () => {
     const originalError = console.error;
     const errorCalls: unknown[][] = [];

--- a/apps/desktop/src/state/agent-sessions-store.test.ts
+++ b/apps/desktop/src/state/agent-sessions-store.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { createAgentSessionFixture } from "@/pages/agents/agent-studio-test-utils";
+import { toAgentSessionSummary } from "./agent-sessions-store";
+
+describe("toAgentSessionSummary", () => {
+  test("preserves runId for build-session consumers", () => {
+    const session = createAgentSessionFixture({
+      role: "build",
+      runId: "run-24",
+      workingDirectory: "/repo",
+    });
+
+    expect(toAgentSessionSummary(session)).toMatchObject({
+      sessionId: session.sessionId,
+      role: "build",
+      runId: "run-24",
+      workingDirectory: "/repo",
+    });
+  });
+});

--- a/apps/desktop/src/state/agent-sessions-store.ts
+++ b/apps/desktop/src/state/agent-sessions-store.ts
@@ -9,6 +9,7 @@ export type AgentSessionSummary = Pick<
   | "scenario"
   | "status"
   | "startedAt"
+  | "runId"
   | "workingDirectory"
   | "pendingPermissions"
   | "pendingQuestions"
@@ -38,6 +39,7 @@ export const toAgentSessionSummary = (session: AgentSessionState): AgentSessionS
   scenario: session.scenario,
   status: session.status,
   startedAt: session.startedAt,
+  runId: session.runId,
   workingDirectory: session.workingDirectory,
   selectedModel: session.selectedModel,
   runtimeKind: session.runtimeKind,
@@ -56,6 +58,7 @@ const areSummariesEquivalent = (
     left.scenario === right.scenario &&
     left.status === right.status &&
     left.startedAt === right.startedAt &&
+    left.runId === right.runId &&
     left.workingDirectory === right.workingDirectory &&
     left.selectedModel === right.selectedModel &&
     left.runtimeKind === right.runtimeKind &&

--- a/apps/desktop/src/state/queries/build-runtime.test.ts
+++ b/apps/desktop/src/state/queries/build-runtime.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { BuildContinuationTarget } from "@openducktor/contracts";
+import { QueryClient } from "@tanstack/react-query";
+import { buildContinuationTargetQueryOptions, buildRuntimeQueryKeys } from "./build-runtime";
+
+describe("build runtime queries", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  test("uses a repo and task scoped query key for continuation targets", () => {
+    expect(buildRuntimeQueryKeys.continuationTarget("/repo", "task-24")).toEqual([
+      "build-runtime",
+      "continuation-target",
+      "/repo",
+      "task-24",
+    ]);
+  });
+
+  test("buildContinuationTargetQueryOptions loads the canonical working directory", async () => {
+    const buildContinuationTargetGet = mock(
+      async (): Promise<BuildContinuationTarget> => ({
+        workingDirectory: "/repo/.worktrees/task-24",
+        source: "active_build_run",
+      }),
+    );
+
+    const result = await queryClient.fetchQuery(
+      buildContinuationTargetQueryOptions("/repo", "task-24", {
+        buildContinuationTargetGet,
+      }),
+    );
+
+    expect(result).toEqual({
+      workingDirectory: "/repo/.worktrees/task-24",
+      source: "active_build_run",
+    });
+    expect(buildContinuationTargetGet).toHaveBeenCalledWith("/repo", "task-24");
+  });
+});

--- a/apps/desktop/src/state/queries/build-runtime.ts
+++ b/apps/desktop/src/state/queries/build-runtime.ts
@@ -1,0 +1,25 @@
+import type { BuildContinuationTarget } from "@openducktor/contracts";
+import { queryOptions } from "@tanstack/react-query";
+import { host } from "../operations/host";
+
+type BuildContinuationTargetQueryHost = Pick<typeof host, "buildContinuationTargetGet">;
+
+const BUILD_CONTINUATION_TARGET_STALE_TIME_MS = 30_000;
+
+export const buildRuntimeQueryKeys = {
+  all: ["build-runtime"] as const,
+  continuationTarget: (repoPath: string, taskId: string) =>
+    [...buildRuntimeQueryKeys.all, "continuation-target", repoPath, taskId] as const,
+};
+
+export const buildContinuationTargetQueryOptions = (
+  repoPath: string,
+  taskId: string,
+  hostClient: BuildContinuationTargetQueryHost = host,
+) =>
+  queryOptions({
+    queryKey: buildRuntimeQueryKeys.continuationTarget(repoPath, taskId),
+    queryFn: (): Promise<BuildContinuationTarget | null> =>
+      hostClient.buildContinuationTargetGet(repoPath, taskId),
+    staleTime: BUILD_CONTINUATION_TARGET_STALE_TIME_MS,
+  });

--- a/apps/desktop/src/state/queries/system.test.ts
+++ b/apps/desktop/src/state/queries/system.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SystemOpenInToolInfo } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
-import { host } from "../operations/host";
 import {
   ensureOpenInToolsFromQuery,
   loadOpenInToolsFromQuery,
@@ -28,19 +27,14 @@ describe("system queries", () => {
           { toolId: "ghostty", iconDataUrl: "data:image/png;base64,ghostty" },
         ] satisfies SystemOpenInToolInfo[],
     );
-    const originalSystemListOpenInTools = host.systemListOpenInTools;
-    host.systemListOpenInTools = systemListOpenInTools;
+    const hostClient = { systemListOpenInTools };
 
-    try {
-      await loadOpenInToolsFromQuery(queryClient);
-      expect(systemListOpenInTools).toHaveBeenCalledTimes(1);
+    await loadOpenInToolsFromQuery(queryClient, hostClient);
+    expect(systemListOpenInTools).toHaveBeenCalledTimes(1);
 
-      await ensureOpenInToolsFromQuery(queryClient);
-      expect(systemListOpenInTools).toHaveBeenCalledTimes(1);
-    } finally {
-      host.systemListOpenInTools = originalSystemListOpenInTools;
-      queryClient.clear();
-    }
+    await ensureOpenInToolsFromQuery(queryClient, hostClient);
+    expect(systemListOpenInTools).toHaveBeenCalledTimes(1);
+    queryClient.clear();
   });
 
   test("refreshOpenInToolsFromQuery bypasses the cached discovery result", async () => {
@@ -53,20 +47,15 @@ describe("system queries", () => {
           },
         ] satisfies SystemOpenInToolInfo[],
     );
-    const originalSystemListOpenInTools = host.systemListOpenInTools;
-    host.systemListOpenInTools = systemListOpenInTools;
+    const hostClient = { systemListOpenInTools };
 
-    try {
-      const first = await loadOpenInToolsFromQuery(queryClient);
-      const refreshed = await refreshOpenInToolsFromQuery(queryClient);
+    const first = await loadOpenInToolsFromQuery(queryClient, hostClient);
+    const refreshed = await refreshOpenInToolsFromQuery(queryClient, hostClient);
 
-      expect(first[0]?.toolId).toBe("finder");
-      expect(refreshed[0]?.toolId).toBe("zed");
-      expect(systemListOpenInTools).toHaveBeenNthCalledWith(1, false);
-      expect(systemListOpenInTools).toHaveBeenNthCalledWith(2, true);
-    } finally {
-      host.systemListOpenInTools = originalSystemListOpenInTools;
-      queryClient.clear();
-    }
+    expect(first[0]?.toolId).toBe("finder");
+    expect(refreshed[0]?.toolId).toBe("zed");
+    expect(systemListOpenInTools).toHaveBeenNthCalledWith(1);
+    expect(systemListOpenInTools).toHaveBeenNthCalledWith(2, true);
+    queryClient.clear();
   });
 });

--- a/apps/desktop/src/state/queries/system.test.ts
+++ b/apps/desktop/src/state/queries/system.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { SystemOpenInToolInfo } from "@openducktor/contracts";
+import { QueryClient } from "@tanstack/react-query";
+import { host } from "../operations/host";
+import {
+  ensureOpenInToolsFromQuery,
+  loadOpenInToolsFromQuery,
+  refreshOpenInToolsFromQuery,
+  systemQueryKeys,
+} from "./system";
+
+describe("system queries", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  test("uses a global query key for Open In tool discovery", () => {
+    expect(systemQueryKeys.openInTools()).toEqual(["system", "open-in-tools"]);
+  });
+
+  test("ensureOpenInToolsFromQuery reuses cached discovery data without refetching", async () => {
+    const systemListOpenInTools = mock(
+      async () =>
+        [
+          { toolId: "finder", iconDataUrl: null },
+          { toolId: "ghostty", iconDataUrl: "data:image/png;base64,ghostty" },
+        ] satisfies SystemOpenInToolInfo[],
+    );
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    host.systemListOpenInTools = systemListOpenInTools;
+
+    try {
+      await loadOpenInToolsFromQuery(queryClient);
+      expect(systemListOpenInTools).toHaveBeenCalledTimes(1);
+
+      await ensureOpenInToolsFromQuery(queryClient);
+      expect(systemListOpenInTools).toHaveBeenCalledTimes(1);
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+      queryClient.clear();
+    }
+  });
+
+  test("refreshOpenInToolsFromQuery bypasses the cached discovery result", async () => {
+    const systemListOpenInTools = mock(
+      async (forceRefresh = false) =>
+        [
+          {
+            toolId: forceRefresh ? "zed" : "finder",
+            iconDataUrl: null,
+          },
+        ] satisfies SystemOpenInToolInfo[],
+    );
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    host.systemListOpenInTools = systemListOpenInTools;
+
+    try {
+      const first = await loadOpenInToolsFromQuery(queryClient);
+      const refreshed = await refreshOpenInToolsFromQuery(queryClient);
+
+      expect(first[0]?.toolId).toBe("finder");
+      expect(refreshed[0]?.toolId).toBe("zed");
+      expect(systemListOpenInTools).toHaveBeenNthCalledWith(1, false);
+      expect(systemListOpenInTools).toHaveBeenNthCalledWith(2, true);
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+      queryClient.clear();
+    }
+  });
+});

--- a/apps/desktop/src/state/queries/system.ts
+++ b/apps/desktop/src/state/queries/system.ts
@@ -11,13 +11,10 @@ export const systemQueryKeys = {
   openInTools: () => [...systemQueryKeys.all, "open-in-tools"] as const,
 };
 
-export const openInToolsQueryOptions = (
-  hostClient: SystemOpenInToolsQueryHost = host,
-  forceRefresh = false,
-) =>
+export const openInToolsQueryOptions = (hostClient: SystemOpenInToolsQueryHost = host) =>
   queryOptions({
     queryKey: systemQueryKeys.openInTools(),
-    queryFn: (): Promise<SystemOpenInToolInfo[]> => hostClient.systemListOpenInTools(forceRefresh),
+    queryFn: (): Promise<SystemOpenInToolInfo[]> => hostClient.systemListOpenInTools(),
     staleTime: OPEN_IN_TOOLS_STALE_TIME_MS,
   });
 

--- a/apps/desktop/src/state/queries/system.ts
+++ b/apps/desktop/src/state/queries/system.ts
@@ -1,0 +1,43 @@
+import type { SystemOpenInToolInfo } from "@openducktor/contracts";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { host } from "../operations/host";
+
+type SystemOpenInToolsQueryHost = Pick<typeof host, "systemListOpenInTools">;
+
+const OPEN_IN_TOOLS_STALE_TIME_MS = 5 * 60 * 1000;
+
+export const systemQueryKeys = {
+  all: ["system"] as const,
+  openInTools: () => [...systemQueryKeys.all, "open-in-tools"] as const,
+};
+
+export const openInToolsQueryOptions = (
+  hostClient: SystemOpenInToolsQueryHost = host,
+  forceRefresh = false,
+) =>
+  queryOptions({
+    queryKey: systemQueryKeys.openInTools(),
+    queryFn: (): Promise<SystemOpenInToolInfo[]> => hostClient.systemListOpenInTools(forceRefresh),
+    staleTime: OPEN_IN_TOOLS_STALE_TIME_MS,
+  });
+
+export const loadOpenInToolsFromQuery = (
+  queryClient: QueryClient,
+  hostClient?: SystemOpenInToolsQueryHost,
+): Promise<SystemOpenInToolInfo[]> => queryClient.fetchQuery(openInToolsQueryOptions(hostClient));
+
+export const ensureOpenInToolsFromQuery = (
+  queryClient: QueryClient,
+  hostClient?: SystemOpenInToolsQueryHost,
+): Promise<SystemOpenInToolInfo[]> =>
+  queryClient.ensureQueryData(openInToolsQueryOptions(hostClient));
+
+export const refreshOpenInToolsFromQuery = (
+  queryClient: QueryClient,
+  hostClient: SystemOpenInToolsQueryHost = host,
+): Promise<SystemOpenInToolInfo[]> => {
+  return hostClient.systemListOpenInTools(true).then((tools) => {
+    queryClient.setQueryData(systemQueryKeys.openInTools(), tools);
+    return tools;
+  });
+};

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -204,6 +204,8 @@ describe("TauriHostClient", () => {
       "workspaceSaveSettingsSnapshot",
       "workspacePrepareTrustedHooksChallenge",
       "workspaceSetTrustedHooks",
+      "systemListOpenInTools",
+      "systemOpenDirectoryInTool",
       "setTheme",
       "tasksList",
       "taskCreate",
@@ -296,6 +298,54 @@ describe("TauriHostClient", () => {
           repoPath: "/repo",
           taskId: "task-77",
           markdown: "# Updated Spec",
+        },
+      },
+    ]);
+  });
+
+  test("systemListOpenInTools uses the dedicated discovery IPC route", async () => {
+    const { client, calls } = createClient((command) => {
+      if (command === "system_list_open_in_tools") {
+        return [
+          { toolId: "finder", iconDataUrl: null },
+          { toolId: "ghostty", iconDataUrl: "data:image/png;base64,ghostty" },
+          { toolId: "zed", iconDataUrl: "data:image/png;base64,zed" },
+        ];
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const tools = await client.systemListOpenInTools(true);
+
+    expect(tools).toEqual([
+      { toolId: "finder", iconDataUrl: null },
+      { toolId: "ghostty", iconDataUrl: "data:image/png;base64,ghostty" },
+      { toolId: "zed", iconDataUrl: "data:image/png;base64,zed" },
+    ]);
+    expect(calls).toEqual([
+      {
+        command: "system_list_open_in_tools",
+        args: { forceRefresh: true },
+      },
+    ]);
+  });
+
+  test("systemOpenDirectoryInTool uses the dedicated launch IPC route", async () => {
+    const { client, calls } = createClient((command) => {
+      if (command === "system_open_directory_in_tool") {
+        return { ok: true };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await client.systemOpenDirectoryInTool("/tmp/worktrees/task 1", "ghostty");
+
+    expect(calls).toEqual([
+      {
+        command: "system_open_directory_in_tool",
+        args: {
+          directoryPath: "/tmp/worktrees/task 1",
+          toolId: "ghostty",
         },
       },
     ]);

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -2,6 +2,7 @@ import type { PlannerTools } from "@openducktor/core";
 import { TauriAgentClient } from "./build-runtime-client";
 import { TauriGitClient } from "./git-client";
 import type { InvokeFn } from "./invoke-utils";
+import { TauriSystemClient } from "./system-client";
 import { TauriTaskClient } from "./task-client";
 import { TaskMetadataCache } from "./task-metadata-cache";
 import { TauriWorkspaceClient } from "./workspace-client";
@@ -30,6 +31,11 @@ const WORKSPACE_METHODS = [
   "workspaceResolveLocalAttachmentPath",
   "setTheme",
 ] as const satisfies readonly MethodName<TauriWorkspaceClient>[];
+
+const SYSTEM_METHODS = [
+  "systemListOpenInTools",
+  "systemOpenDirectoryInTool",
+] as const satisfies readonly MethodName<TauriSystemClient>[];
 
 const TASK_METHODS = [
   "tasksList",
@@ -117,11 +123,13 @@ const GIT_METHODS = [
 ] as const satisfies readonly MethodName<TauriGitClient>[];
 
 type WorkspaceMethodName = (typeof WORKSPACE_METHODS)[number];
+type SystemMethodName = (typeof SYSTEM_METHODS)[number];
 type TaskMethodName = (typeof TASK_METHODS)[number];
 type AgentMethodName = (typeof AGENT_METHODS)[number];
 type GitMethodName = (typeof GIT_METHODS)[number];
 
 type TauriHostClientApi = Pick<TauriWorkspaceClient, WorkspaceMethodName> &
+  Pick<TauriSystemClient, SystemMethodName> &
   Pick<TauriTaskClient, TaskMethodName> &
   Pick<TauriAgentClient, AgentMethodName> &
   Pick<TauriGitClient, GitMethodName>;
@@ -163,12 +171,14 @@ export type { BuildRespondInput } from "./build-runtime-client";
 const createTauriHostClientApi = (invokeFn: InvokeFn): TauriHostClientApi => {
   const metadataCache = new TaskMetadataCache();
   const workspaceClient = new TauriWorkspaceClient(invokeFn);
+  const systemClient = new TauriSystemClient(invokeFn);
   const taskClient = new TauriTaskClient(invokeFn, metadataCache);
   const agentClient = new TauriAgentClient(invokeFn, metadataCache);
   const gitClient = new TauriGitClient(invokeFn);
   const hostClient = {} as TauriHostClientApi;
 
   bindDelegates(hostClient, workspaceClient, WORKSPACE_METHODS);
+  bindDelegates(hostClient, systemClient, SYSTEM_METHODS);
   bindDelegates(hostClient, taskClient, TASK_METHODS);
   bindDelegates(hostClient, agentClient, AGENT_METHODS);
   bindDelegates(hostClient, gitClient, GIT_METHODS);

--- a/packages/adapters-tauri-host/src/system-client.ts
+++ b/packages/adapters-tauri-host/src/system-client.ts
@@ -1,0 +1,47 @@
+import {
+  type SystemOpenDirectoryInToolRequest,
+  type SystemOpenInToolId,
+  type SystemOpenInToolInfo,
+  systemListOpenInToolsRequestSchema,
+  systemOpenDirectoryInToolRequestSchema,
+  systemOpenInToolInfoSchema,
+} from "@openducktor/contracts";
+import type { InvokeFn } from "./invoke-utils";
+import { parseArray, parseOkResult } from "./invoke-utils";
+
+const systemListOpenInTools = async (
+  invokeFn: InvokeFn,
+  forceRefresh = false,
+): Promise<SystemOpenInToolInfo[]> => {
+  const request = systemListOpenInToolsRequestSchema.parse({ forceRefresh });
+  const payload = await invokeFn("system_list_open_in_tools", request);
+  return parseArray(systemOpenInToolInfoSchema, payload, "system_list_open_in_tools");
+};
+
+const systemOpenDirectoryInTool = async (
+  invokeFn: InvokeFn,
+  directoryPath: string,
+  toolId: SystemOpenInToolId,
+): Promise<void> => {
+  const request: SystemOpenDirectoryInToolRequest = systemOpenDirectoryInToolRequestSchema.parse({
+    directoryPath,
+    toolId,
+  });
+  const payload = await invokeFn("system_open_directory_in_tool", request);
+  parseOkResult(payload, "system_open_directory_in_tool");
+};
+
+export class TauriSystemClient {
+  constructor(private readonly invokeFn: InvokeFn) {}
+
+  async systemListOpenInTools(forceRefresh = false): Promise<SystemOpenInToolInfo[]> {
+    return systemListOpenInTools(this.invokeFn, forceRefresh);
+  }
+
+  async systemOpenDirectoryInTool(
+    directoryPath: string,
+    toolId: SystemOpenInToolId,
+  ): Promise<void> {
+    return systemOpenDirectoryInTool(this.invokeFn, directoryPath, toolId);
+  }
+}

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -99,6 +99,9 @@ import type {
   SlashCommandSource,
   SoftGuardrails,
   SystemCheck,
+  SystemListOpenInToolsRequest,
+  SystemOpenInToolId,
+  SystemOpenInToolInfo,
   TaskAction,
   TaskCard,
   TaskCreateInput,
@@ -312,6 +315,12 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "settingsSnapshotSchema",
   "specTemplateSections",
   "systemCheckSchema",
+  "systemListOpenInToolsRequestSchema",
+  "systemOpenDirectoryInToolRequestSchema",
+  "systemOpenInToolIdSchema",
+  "systemOpenInToolInfoSchema",
+  "systemOpenInToolIdValues",
+  "systemOpenInToolListSchema",
   "planSubtaskInputSchema",
   "planSubtaskIssueTypeSchema",
   "planSubtaskPrioritySchema",
@@ -442,6 +451,9 @@ type ExportedTypeContract = {
   RuntimeSupportedScope: RuntimeSupportedScope;
   SettingsSnapshot: SettingsSnapshot;
   SystemCheck: SystemCheck;
+  SystemListOpenInToolsRequest: SystemListOpenInToolsRequest;
+  SystemOpenInToolId: SystemOpenInToolId;
+  SystemOpenInToolInfo: SystemOpenInToolInfo;
   TaskAction: TaskAction;
   TaskCard: TaskCard;
   TaskCreateInput: TaskCreateInput;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -15,4 +15,5 @@ export * from "./session-schemas";
 export * from "./session-todo-parsing";
 export * from "./slash-command-schemas";
 export * from "./spec-template";
+export * from "./system-open-schemas";
 export * from "./task-schemas";

--- a/packages/contracts/src/system-open-schemas.ts
+++ b/packages/contracts/src/system-open-schemas.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+export const systemOpenInToolIdValues = [
+  "finder",
+  "terminal",
+  "iterm2",
+  "ghostty",
+  "vscode",
+  "cursor",
+  "zed",
+  "intellij-idea",
+  "webstorm",
+  "pycharm",
+  "phpstorm",
+  "rider",
+  "rustrover",
+  "android-studio",
+] as const;
+
+export const systemOpenInToolIdSchema = z.enum(systemOpenInToolIdValues);
+export type SystemOpenInToolId = z.infer<typeof systemOpenInToolIdSchema>;
+
+export const systemOpenInToolInfoSchema = z.object({
+  toolId: systemOpenInToolIdSchema,
+  iconDataUrl: z.string().min(1).nullable().optional(),
+});
+export type SystemOpenInToolInfo = z.infer<typeof systemOpenInToolInfoSchema>;
+
+export const systemOpenInToolListSchema = z.array(systemOpenInToolInfoSchema);
+export type SystemOpenInToolList = z.infer<typeof systemOpenInToolListSchema>;
+
+export const systemListOpenInToolsRequestSchema = z.object({
+  forceRefresh: z.boolean().optional(),
+});
+export type SystemListOpenInToolsRequest = z.infer<typeof systemListOpenInToolsRequestSchema>;
+
+export const systemOpenDirectoryInToolRequestSchema = z.object({
+  directoryPath: z
+    .string()
+    .min(1)
+    .refine((value) => value.trim().length > 0, {
+      message: "Directory path is required",
+    }),
+  toolId: systemOpenInToolIdSchema,
+});
+export type SystemOpenDirectoryInToolRequest = z.infer<
+  typeof systemOpenDirectoryInToolRequestSchema
+>;


### PR DESCRIPTION
## Summary
- add an `Open In` control to the Agent Studio git panel so builders can open the active worktree or repository in supported macOS tools
- detect installed apps through the typed Tauri/host boundary, extract real app icons from bundle metadata, and launch tools with app-specific strategies instead of generic fallbacks
- persist the preferred Open In app, keep Retry truly refreshing discovery, and harden worktree resolution so worktree mode never silently opens the repository root

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo test`
- `cargo build`
- live browser-mode validation of the Open In default action and persistence flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Open In" added: discover installed apps (Finder, terminals, editors, IDEs) and open a repository/worktree folder in a chosen tool; discovery is cached and preferences are persisted.
  * Icons for discovered tools are shown where available.

* **UI Changes**
  * Git panel header replaces the "files changed" badge with an interactive "Open In" menu and default-tool action.

* **Tests**
  * Coverage added for discovery, opening flows, persistence, and UI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->