### PR TITLE
fix(git): separate soft refreshes from fetches

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/remote.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/remote.rs
@@ -322,6 +322,8 @@ impl GitCliPort {
             ));
         }
 
+        self.sync_pushed_remote_tracking_ref_impl(repo_path, remote.as_str(), branch.as_str())?;
+
         Ok(GitPushResult::Pushed {
             remote,
             branch,
@@ -529,6 +531,36 @@ impl GitCliPort {
             merge_ref: normalized_merge_ref,
             upstream_ref,
         }))
+    }
+
+    fn sync_pushed_remote_tracking_ref_impl(
+        &self,
+        repo_path: &Path,
+        remote: &str,
+        branch: &str,
+    ) -> Result<()> {
+        if remote == "." {
+            return Ok(());
+        }
+
+        let local_branch_ref = normalize_merge_ref(branch);
+        let local_branch_oid =
+            self.run_git(repo_path, &["rev-parse", local_branch_ref.as_str()])?;
+        let local_branch_oid = local_branch_oid.trim();
+        if local_branch_oid.is_empty() {
+            return Err(anyhow!(
+                "git rev-parse returned an empty revision for {}",
+                local_branch_ref
+            ));
+        }
+
+        let upstream_ref = resolve_upstream_ref(remote, local_branch_ref.as_str());
+        self.run_git(
+            repo_path,
+            &["update-ref", upstream_ref.as_str(), local_branch_oid],
+        )?;
+
+        Ok(())
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/remote.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/remote.rs
@@ -322,7 +322,24 @@ impl GitCliPort {
             ));
         }
 
-        self.sync_pushed_remote_tracking_ref_impl(repo_path, remote.as_str(), branch.as_str())?;
+        let output = match self.sync_pushed_remote_tracking_ref_impl(
+            repo_path,
+            remote.as_str(),
+            branch.as_str(),
+        ) {
+            Ok(()) => output,
+            Err(error) => {
+                if output.trim().is_empty() {
+                    format!(
+                        "Push succeeded, but local upstream tracking status may remain stale until the next fetch: {error:#}"
+                    )
+                } else {
+                    format!(
+                        "{output}\nPush succeeded, but local upstream tracking status may remain stale until the next fetch: {error:#}"
+                    )
+                }
+            }
+        };
 
         Ok(GitPushResult::Pushed {
             remote,
@@ -539,11 +556,12 @@ impl GitCliPort {
         remote: &str,
         branch: &str,
     ) -> Result<()> {
-        if remote == "." {
+        let Some((local_branch_ref, upstream_ref)) =
+            self.resolve_push_tracking_sync_refs_impl(repo_path, remote, branch)?
+        else {
             return Ok(());
-        }
+        };
 
-        let local_branch_ref = normalize_merge_ref(branch);
         let local_branch_oid =
             self.run_git(repo_path, &["rev-parse", local_branch_ref.as_str()])?;
         let local_branch_oid = local_branch_oid.trim();
@@ -554,13 +572,42 @@ impl GitCliPort {
             ));
         }
 
-        let upstream_ref = resolve_upstream_ref(remote, local_branch_ref.as_str());
         self.run_git(
             repo_path,
             &["update-ref", upstream_ref.as_str(), local_branch_oid],
         )?;
 
         Ok(())
+    }
+
+    fn resolve_push_tracking_sync_refs_impl(
+        &self,
+        repo_path: &Path,
+        remote: &str,
+        branch: &str,
+    ) -> Result<Option<(String, String)>> {
+        if remote == "." {
+            return Ok(None);
+        }
+
+        let local_branch_ref = if branch == "HEAD" {
+            let current_branch = self.get_current_branch_unchecked(repo_path)?;
+            let Some(current_branch_name) = current_branch.name else {
+                return Ok(None);
+            };
+            normalize_merge_ref(current_branch_name.as_str())
+        } else if branch.contains(':') {
+            return Ok(None);
+        } else if branch.starts_with("refs/heads/") {
+            branch.to_string()
+        } else if branch.starts_with("refs/") {
+            return Ok(None);
+        } else {
+            normalize_merge_ref(branch)
+        };
+
+        let upstream_ref = resolve_upstream_ref(remote, local_branch_ref.as_str());
+        Ok(Some((local_branch_ref, upstream_ref)))
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/remote_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/remote_tests.rs
@@ -1,5 +1,8 @@
 use host_domain::GitPort;
-use host_domain::{GitFetchRequest, GitPullRequest, GitPullResult, GitPushResult};
+use host_domain::{
+    GitDiffScope, GitFetchRequest, GitPullRequest, GitPullResult, GitPushResult,
+    GitUpstreamAheadBehind,
+};
 use std::fs;
 
 use super::super::GitCliPort;
@@ -18,6 +21,7 @@ fn push_branch_pushes_to_remote_with_typed_result() {
         &repo.path,
         &["remote", "add", "origin", remote_path.as_str()],
     );
+    run_git_ok(&repo.path, &["push", "origin", "main"]);
     let git = GitCliPort::new();
 
     git.switch_branch(&repo.path, "feature/push", true)
@@ -52,6 +56,24 @@ fn push_branch_pushes_to_remote_with_typed_result() {
     assert!(
         ls_remote.contains("refs/heads/feature/push"),
         "remote should contain pushed branch"
+    );
+
+    let local_head = run_git_ok(&repo.path, &["rev-parse", "HEAD"]);
+    let tracked_remote_head = run_git_ok(
+        &repo.path,
+        &["rev-parse", "refs/remotes/origin/feature/push"],
+    );
+    assert_eq!(tracked_remote_head, local_head);
+
+    let status = git
+        .get_worktree_status(&repo.path, "origin/main", GitDiffScope::Target)
+        .expect("worktree status should reflect a freshly pushed upstream branch");
+    assert_eq!(
+        status.upstream_ahead_behind,
+        GitUpstreamAheadBehind::Tracking {
+            ahead: 0,
+            behind: 0,
+        }
     );
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/remote_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/remote_tests.rs
@@ -386,6 +386,54 @@ fn push_branch_returns_non_fast_forward_rejection() {
 }
 
 #[test]
+fn push_branch_accepts_head_ref_without_failing_tracking_sync() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("push-head-ref");
+    let remote = setup_bare_remote("push-head-ref-remote");
+    let remote_path = remote.path.to_string_lossy().to_string();
+    run_git_ok(
+        &repo.path,
+        &["remote", "add", "origin", remote_path.as_str()],
+    );
+    run_git_ok(&repo.path, &["push", "-u", "origin", "main"]);
+
+    fs::write(repo.path.join("head-push.txt"), "head push\n").expect("head push file should write");
+    run_git_ok(&repo.path, &["add", "head-push.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "push head ref"]);
+
+    let git = GitCliPort::new();
+    let result = git
+        .push_branch(&repo.path, "origin", "HEAD", false, false)
+        .expect("pushing HEAD should still succeed");
+
+    match result {
+        GitPushResult::Pushed { remote, branch, .. } => {
+            assert_eq!(remote, "origin");
+            assert_eq!(branch, "HEAD");
+        }
+        other => panic!("expected pushed result, got {other:?}"),
+    }
+
+    let local_head = run_git_ok(&repo.path, &["rev-parse", "HEAD"]);
+    let tracked_remote_head = run_git_ok(&repo.path, &["rev-parse", "refs/remotes/origin/main"]);
+    assert_eq!(tracked_remote_head, local_head);
+
+    let status = git
+        .get_worktree_status(&repo.path, "origin/main", GitDiffScope::Target)
+        .expect("worktree status should reflect a freshly pushed HEAD ref");
+    assert_eq!(
+        status.upstream_ahead_behind,
+        GitUpstreamAheadBehind::Tracking {
+            ahead: 0,
+            behind: 0,
+        }
+    );
+}
+
+#[test]
 fn push_branch_rejects_option_like_remote_input() {
     if !git_available() {
         return;

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -67,7 +67,7 @@ const baseModel = (overrides: Partial<AgentStudioGitPanelModel> = {}): AgentStud
     uncommittedFileCount: 1,
     isLoading: false,
     error: null,
-    refresh: () => {},
+    refresh: async () => {},
     setDiffScope: () => {},
     isCommitting: false,
     isPushing: false,
@@ -354,7 +354,7 @@ describe("AgentStudioGitPanel", () => {
   });
 
   test("renders branch context labels and git action controls", async () => {
-    const refresh = mock(() => {});
+    const refresh = mock(async () => {});
     const setDiffScope = mock((_scope: "target" | "uncommitted") => {});
     let renderer: RenderResult | null = null;
     await act(async () => {
@@ -622,7 +622,7 @@ describe("AgentStudioGitPanel", () => {
   });
 
   test("renders repository mode without target branch or rebase action", async () => {
-    const refresh = mock(() => {});
+    const refresh = mock(async () => {});
     const setDiffScope = mock((_scope: "target" | "uncommitted") => {});
     const commitAll = mock(async (_message: string) => true);
     const pushBranch = mock(async () => {});
@@ -783,7 +783,7 @@ describe("AgentStudioGitPanel", () => {
   test("switches diff scope and validates commit-all message input", async () => {
     const setDiffScope = mock((_scope: "target" | "uncommitted") => {});
     const commitAll = mock(async (_message: string) => true);
-    const refresh = mock(() => {});
+    const refresh = mock(async () => {});
 
     let renderer: RenderResult | null = null;
     await act(async () => {

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -299,7 +299,9 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
             ? { onUpdateTargetBranch: model.onUpdateTargetBranch }
             : {})}
           setDiffScope={handleDiffScopeChange}
-          onRefresh={model.refresh}
+          onRefresh={() => {
+            void model.refresh();
+          }}
         />
 
         {displayedError ? (

--- a/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -87,7 +87,7 @@ const diffModel: AgentStudioGitPanelModel = {
   uncommittedFileCount: 0,
   isLoading: false,
   error: null,
-  refresh: () => {},
+  refresh: async () => {},
   setDiffScope: () => {},
   isCommitting: false,
   isPushing: false,

--- a/apps/desktop/src/features/agent-studio-git/contracts.ts
+++ b/apps/desktop/src/features/agent-studio-git/contracts.ts
@@ -9,6 +9,8 @@ export type DiffScope = "target" | "uncommitted";
 
 export type GitDiffRefreshMode = "hard" | "soft" | "scheduled";
 
+export type GitDiffRefresh = (mode?: GitDiffRefreshMode) => Promise<void>;
+
 export type DiffScopeState = {
   branch: string | null;
   fileDiffs: FileDiff[];
@@ -42,7 +44,7 @@ export type DiffDataState = {
   uncommittedFileCount: number;
   isLoading: boolean;
   error: string | null;
-  refresh: (mode?: GitDiffRefreshMode) => void;
+  refresh: GitDiffRefresh;
   setDiffScope: (scope: DiffScope) => void;
 };
 

--- a/apps/desktop/src/features/agent-studio-git/contracts.ts
+++ b/apps/desktop/src/features/agent-studio-git/contracts.ts
@@ -7,6 +7,8 @@ import type {
 
 export type DiffScope = "target" | "uncommitted";
 
+export type GitDiffRefreshMode = "hard" | "soft" | "scheduled";
+
 export type DiffScopeState = {
   branch: string | null;
   fileDiffs: FileDiff[];
@@ -40,7 +42,7 @@ export type DiffDataState = {
   uncommittedFileCount: number;
   isLoading: boolean;
   error: string | null;
-  refresh: () => void;
+  refresh: (mode?: GitDiffRefreshMode) => void;
   setDiffScope: (scope: DiffScope) => void;
 };
 

--- a/apps/desktop/src/features/agent-studio-git/index.ts
+++ b/apps/desktop/src/features/agent-studio-git/index.ts
@@ -7,5 +7,6 @@ export type {
   GitConflict,
   GitConflictAction,
   GitConflictOperation,
+  GitDiffRefreshMode,
 } from "./contracts";
 export { useAgentStudioDiffData } from "./use-agent-studio-diff-data";

--- a/apps/desktop/src/features/agent-studio-git/index.ts
+++ b/apps/desktop/src/features/agent-studio-git/index.ts
@@ -7,6 +7,7 @@ export type {
   GitConflict,
   GitConflictAction,
   GitConflictOperation,
+  GitDiffRefresh,
   GitDiffRefreshMode,
 } from "./contracts";
 export { useAgentStudioDiffData } from "./use-agent-studio-diff-data";

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
@@ -16,7 +16,6 @@ import {
   type LoadRequestContext,
   useAgentStudioDiffBatchState,
 } from "./use-agent-studio-diff-batch-state";
-import { useAgentStudioDiffPolling } from "./use-agent-studio-diff-polling";
 import { useAgentStudioDiffRequestController } from "./use-agent-studio-diff-request-controller";
 
 type LoadDataContext = {
@@ -41,7 +40,6 @@ type UseAgentStudioDiffControllerArgs = {
   targetBranch: string;
   workingDir: string | null;
   requestContextKey: string | null;
-  enablePolling: boolean;
   shouldBlockDiffLoading: boolean;
 };
 
@@ -54,6 +52,9 @@ type UseAgentStudioDiffControllerResult = {
   refreshActiveScope: (
     context?: Pick<LoadDataContext, "repoPath" | "targetBranch" | "workingDir" | "scope">,
   ) => Promise<void>;
+  refreshActiveScopeSummary: (
+    context?: Pick<LoadDataContext, "repoPath" | "targetBranch" | "workingDir" | "scope">,
+  ) => Promise<void>;
   reloadActiveScope: (showLoading?: boolean) => void;
 };
 
@@ -62,7 +63,6 @@ export function useAgentStudioDiffController({
   targetBranch,
   workingDir,
   requestContextKey,
-  enablePolling,
   shouldBlockDiffLoading,
 }: UseAgentStudioDiffControllerArgs): UseAgentStudioDiffControllerResult {
   const [diffScope, setDiffScope] = useState<DiffScope>("uncommitted");
@@ -398,27 +398,6 @@ export function useAgentStudioDiffController({
     workingDir,
   ]);
 
-  const pollActiveScopeSummary = useCallback((): void => {
-    if (!repoPathRef.current) {
-      return;
-    }
-
-    void loadData(false, {
-      repoPath: repoPathRef.current,
-      targetBranch: targetBranchRef.current,
-      workingDir: workingDirRef.current,
-      scope: diffScopeRef.current,
-      mode: "summary",
-    });
-  }, [loadData]);
-
-  useAgentStudioDiffPolling({
-    enablePolling,
-    repoPath,
-    shouldBlockDiffLoading,
-    poll: pollActiveScopeSummary,
-  });
-
   const refreshActiveScope = useCallback(
     async (
       context?: Pick<LoadDataContext, "repoPath" | "targetBranch" | "workingDir" | "scope">,
@@ -441,6 +420,32 @@ export function useAgentStudioDiffController({
         scope: refreshContext.scope,
         force: true,
         replayIfInFlight: true,
+      });
+    },
+    [loadData, shouldBlockDiffLoading],
+  );
+
+  const refreshActiveScopeSummary = useCallback(
+    async (
+      context?: Pick<LoadDataContext, "repoPath" | "targetBranch" | "workingDir" | "scope">,
+    ): Promise<void> => {
+      const refreshContext = context ?? {
+        repoPath: repoPathRef.current,
+        targetBranch: targetBranchRef.current,
+        workingDir: workingDirRef.current,
+        scope: diffScopeRef.current,
+      };
+
+      if (shouldBlockDiffLoading || !refreshContext.repoPath) {
+        return;
+      }
+
+      await loadData(false, {
+        repoPath: refreshContext.repoPath,
+        targetBranch: refreshContext.targetBranch,
+        workingDir: refreshContext.workingDir,
+        scope: refreshContext.scope,
+        mode: "summary",
       });
     },
     [loadData, shouldBlockDiffLoading],
@@ -472,6 +477,7 @@ export function useAgentStudioDiffController({
     state,
     statusSnapshotKey,
     refreshActiveScope,
+    refreshActiveScopeSummary,
     reloadActiveScope,
   };
 }

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -198,6 +198,10 @@ const dispatchDiffRefresh = (): void => {
   document.dispatchEvent(new Event("visibilitychange"));
 };
 
+const dispatchScheduledRefresh = (): void => {
+  globalThis.dispatchEvent(new Event("focus"));
+};
+
 beforeAll(async () => {
   ({ useAgentStudioDiffData } = await import("./use-agent-studio-diff-data"));
 });
@@ -434,6 +438,166 @@ describe("useAgentStudioDiffData", () => {
       );
       expect(harness.getLatest().error).toBeNull();
     } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("soft refresh reloads local status without fetching remote", async () => {
+    const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.refresh("soft");
+      });
+
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      expect(gitFetchRemoteMock).toHaveBeenCalledTimes(0);
+      expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
+        2,
+        "/repo",
+        "origin/main",
+        "uncommitted",
+        undefined,
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("scheduled refresh fetches at most once within the cooldown window", async () => {
+    const originalDateNow = Date.now;
+    let nowMs = 1_731_000_000_000;
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      enablePolling: true,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      Date.now = () => nowMs;
+      await harness.run(() => {
+        dispatchScheduledRefresh();
+      });
+      Date.now = originalDateNow;
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+      expect(gitFetchRemoteMock).toHaveBeenCalledTimes(1);
+
+      Date.now = () => nowMs;
+      await harness.run(() => {
+        dispatchScheduledRefresh();
+      });
+      Date.now = originalDateNow;
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+      expect(gitFetchRemoteMock).toHaveBeenCalledTimes(1);
+
+      nowMs += 5 * 60 * 1000 + 1;
+      Date.now = () => nowMs;
+      await harness.run(() => {
+        dispatchScheduledRefresh();
+      });
+      Date.now = originalDateNow;
+      await harness.waitFor(() => gitFetchRemoteMock.mock.calls.length >= 2);
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+      expect(gitFetchRemoteMock).toHaveBeenCalledTimes(2);
+    } finally {
+      Date.now = originalDateNow;
+      await harness.unmount();
+    }
+  });
+
+  test("manual refresh bypasses the scheduled refresh cooldown", async () => {
+    const originalDateNow = Date.now;
+    let nowMs = 1_731_000_000_000;
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      enablePolling: true,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      Date.now = () => nowMs;
+      await harness.run(() => {
+        dispatchScheduledRefresh();
+      });
+      Date.now = originalDateNow;
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+      expect(gitFetchRemoteMock).toHaveBeenCalledTimes(1);
+
+      nowMs += 60_000;
+      Date.now = () => nowMs;
+      await harness.run((state) => {
+        state.refresh();
+      });
+      Date.now = originalDateNow;
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      expect(gitFetchRemoteMock).toHaveBeenCalledTimes(2);
+    } finally {
+      Date.now = originalDateNow;
+      await harness.unmount();
+    }
+  });
+
+  test("scheduled refresh updates the cooldown when fetch is skipped for no remote", async () => {
+    const originalDateNow = Date.now;
+    let nowMs = 1_731_000_000_000;
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      enablePolling: true,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      gitFetchRemoteMock.mockResolvedValueOnce({
+        outcome: "skipped_no_remote",
+        output:
+          "Skipped git fetch because no applicable remote is configured for this repo or branch.",
+      });
+
+      Date.now = () => nowMs;
+      await harness.run(() => {
+        dispatchScheduledRefresh();
+      });
+      Date.now = originalDateNow;
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+      expect(gitFetchRemoteMock).toHaveBeenCalledTimes(1);
+
+      nowMs += 60_000;
+      Date.now = () => nowMs;
+      await harness.run(() => {
+        dispatchScheduledRefresh();
+      });
+      Date.now = originalDateNow;
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 2);
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+      expect(gitFetchRemoteMock).toHaveBeenCalledTimes(1);
+    } finally {
+      Date.now = originalDateNow;
       await harness.unmount();
     }
   });

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -467,6 +467,75 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("refresh returns a promise that settles after the queued soft reload finishes", async () => {
+    const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      const deferredRefresh = createDeferred<GitWorktreeStatus>();
+      gitGetWorktreeStatusMock.mockImplementationOnce(
+        async (
+          _repoPath: string,
+          targetBranch: string,
+          diffScope?: "target" | "uncommitted",
+          workingDir?: string,
+        ): Promise<GitWorktreeStatus> =>
+          deferredRefresh.promise.then((snapshot) => ({
+            ...snapshot,
+            snapshot: {
+              ...snapshot.snapshot,
+              targetBranch,
+              diffScope: diffScope ?? snapshot.snapshot.diffScope,
+              effectiveWorkingDir: workingDir ?? snapshot.snapshot.effectiveWorkingDir,
+            },
+          })),
+      );
+
+      let didSettle = false;
+      let refreshPromise: Promise<void> | null = null;
+      await harness.run((state) => {
+        refreshPromise = state.refresh("soft");
+        void refreshPromise.then(() => {
+          didSettle = true;
+        });
+      });
+
+      expect(harness.getLatest().isLoading).toBe(true);
+      expect(didSettle).toBe(false);
+
+      if (!refreshPromise) {
+        throw new Error("Expected refresh promise");
+      }
+
+      await harness.run(async () => {
+        deferredRefresh.resolve(
+          withSnapshotHashes({
+            currentBranch: { name: "feature/task-10", detached: false },
+            fileStatuses: [{ path: "src/after-refresh.ts", status: "M", staged: false }],
+            fileDiffs: [],
+            targetAheadBehind: { ahead: 0, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: "/repo",
+              targetBranch: "origin/main",
+              diffScope: "uncommitted",
+              observedAtMs: 1731000001111,
+            },
+          }),
+        );
+
+        await refreshPromise;
+      });
+      await harness.waitFor((state) => !state.isLoading);
+      expect(didSettle).toBe(true);
+      expect(harness.getLatest().fileStatuses[0]?.path).toBe("src/after-refresh.ts");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("scheduled refresh fetches at most once within the cooldown window", async () => {
     const originalDateNow = Date.now;
     let nowMs = 1_731_000_000_000;

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -3046,6 +3046,95 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("keeps polling listeners stable across rerenders with unchanged inputs", async () => {
+    const originalWindowAddEventListener = globalThis.addEventListener.bind(globalThis);
+    const originalWindowRemoveEventListener = globalThis.removeEventListener.bind(globalThis);
+    const originalDocumentAddEventListener = document.addEventListener.bind(document);
+    const originalDocumentRemoveEventListener = document.removeEventListener.bind(document);
+    const windowAddEventListenerMock = mock(
+      (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: AddEventListenerOptions | boolean,
+      ) => {
+        originalWindowAddEventListener(type, listener, options);
+      },
+    );
+    const windowRemoveEventListenerMock = mock(
+      (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: EventListenerOptions | boolean,
+      ) => {
+        originalWindowRemoveEventListener(type, listener, options);
+      },
+    );
+    const documentAddEventListenerMock = mock(
+      (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: AddEventListenerOptions | boolean,
+      ) => {
+        originalDocumentAddEventListener(type, listener, options);
+      },
+    );
+    const documentRemoveEventListenerMock = mock(
+      (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: EventListenerOptions | boolean,
+      ) => {
+        originalDocumentRemoveEventListener(type, listener, options);
+      },
+    );
+    globalThis.addEventListener = windowAddEventListenerMock as typeof globalThis.addEventListener;
+    globalThis.removeEventListener =
+      windowRemoveEventListenerMock as typeof globalThis.removeEventListener;
+    document.addEventListener = documentAddEventListenerMock as typeof document.addEventListener;
+    document.removeEventListener =
+      documentRemoveEventListenerMock as typeof document.removeEventListener;
+
+    const pollingArgs = {
+      ...createBaseArgs(),
+      enablePolling: true,
+    } satisfies HookArgs;
+    const harness = createHookHarness(pollingArgs);
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      expect(windowAddEventListenerMock).toHaveBeenCalledWith("focus", expect.any(Function));
+      expect(documentAddEventListenerMock).toHaveBeenCalledWith(
+        "visibilitychange",
+        expect.any(Function),
+      );
+      expect(windowRemoveEventListenerMock).not.toHaveBeenCalled();
+      expect(documentRemoveEventListenerMock).not.toHaveBeenCalled();
+
+      windowAddEventListenerMock.mockClear();
+      windowRemoveEventListenerMock.mockClear();
+      documentAddEventListenerMock.mockClear();
+      documentRemoveEventListenerMock.mockClear();
+
+      await harness.update(pollingArgs);
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+
+      expect(windowAddEventListenerMock).not.toHaveBeenCalled();
+      expect(windowRemoveEventListenerMock).not.toHaveBeenCalled();
+      expect(documentAddEventListenerMock).not.toHaveBeenCalled();
+      expect(documentRemoveEventListenerMock).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+      globalThis.addEventListener = originalWindowAddEventListener;
+      globalThis.removeEventListener = originalWindowRemoveEventListener;
+      document.addEventListener = originalDocumentAddEventListener;
+      document.removeEventListener = originalDocumentRemoveEventListener;
+    }
+  });
+
   test("canonicalizes short target branch names to origin-prefixed refs", async () => {
     const harness = createHookHarness({
       ...createBaseArgs(),

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
@@ -4,8 +4,9 @@ import { appQueryClient } from "@/lib/query-client";
 import { canonicalTargetBranch } from "@/lib/target-branch";
 import { invalidateRepoBranchesQuery } from "@/state/queries/git";
 import type { UseAgentStudioDiffDataInput } from "./agent-studio-diff-data-model";
-import type { DiffDataState } from "./contracts";
+import type { DiffDataState, GitDiffRefreshMode } from "./contracts";
 import { useAgentStudioDiffController } from "./use-agent-studio-diff-controller";
+import { useAgentStudioDiffPolling } from "./use-agent-studio-diff-polling";
 import { useAgentStudioWorktreeResolution } from "./use-agent-studio-worktree-resolution";
 
 type RefreshContext = {
@@ -15,6 +16,42 @@ type RefreshContext = {
   workingDir: string | null;
   scope: DiffDataState["diffScope"];
 };
+
+type RefreshRequest = {
+  context: RefreshContext;
+  mode: GitDiffRefreshMode;
+};
+
+const SCHEDULED_FETCH_COOLDOWN_MS = 5 * 60 * 1000;
+
+const refreshModePriority = (mode: GitDiffRefreshMode): number => {
+  switch (mode) {
+    case "hard":
+      return 3;
+    case "soft":
+      return 2;
+    case "scheduled":
+      return 1;
+  }
+};
+
+const mergeRefreshRequests = (
+  current: RefreshRequest | null,
+  next: RefreshRequest,
+): RefreshRequest => {
+  if (current == null || current.context.requestContextKey !== next.context.requestContextKey) {
+    return next;
+  }
+
+  return refreshModePriority(next.mode) > refreshModePriority(current.mode) ? next : current;
+};
+
+const buildScheduledFetchCooldownKey = ({
+  repoPath,
+  targetBranch,
+  workingDir,
+}: Pick<RefreshContext, "repoPath" | "targetBranch" | "workingDir">): string =>
+  `${repoPath}::${targetBranch}::${workingDir ?? ""}`;
 
 export function useAgentStudioDiffData({
   repoPath,
@@ -56,6 +93,7 @@ export function useAgentStudioDiffData({
     activeScopeState,
     diffScope,
     refreshActiveScope,
+    refreshActiveScopeSummary,
     setDiffScope,
     state,
     statusSnapshotKey,
@@ -64,7 +102,6 @@ export function useAgentStudioDiffData({
     targetBranch,
     workingDir: worktreePath,
     requestContextKey,
-    enablePolling,
     shouldBlockDiffLoading: shouldBlockDiffLoading || preconditionError != null,
   });
   const refreshContext = useMemo<RefreshContext | null>(() => {
@@ -85,8 +122,9 @@ export function useAgentStudioDiffData({
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const refreshPromiseRef = useRef<Promise<void> | null>(null);
-  const queuedRefreshContextRef = useRef<RefreshContext | null>(null);
+  const queuedRefreshRequestRef = useRef<RefreshRequest | null>(null);
   const refreshContextRef = useRef<RefreshContext | null>(refreshContext);
+  const scheduledFetchAtByContextRef = useRef(new Map<string, number>());
   refreshContextRef.current = refreshContext;
   const previousIsLoadingRef = useRef(state.isLoading);
 
@@ -97,7 +135,7 @@ export function useAgentStudioDiffData({
     }
 
     setRefreshError(null);
-    queuedRefreshContextRef.current = null;
+    queuedRefreshRequestRef.current = null;
     refreshPromiseRef.current = null;
     setIsRefreshing(false);
   }, [refreshContextKey]);
@@ -111,92 +149,179 @@ export function useAgentStudioDiffData({
     }
   }, [activeScopeState.error, refreshError, state.isLoading]);
 
-  const refresh = useCallback((): void => {
-    if (preconditionError != null) {
-      return;
-    }
+  const refresh = useCallback(
+    (mode: GitDiffRefreshMode = "hard"): void => {
+      if (preconditionError != null) {
+        return;
+      }
 
-    if (worktreeResolutionError != null) {
-      retryWorktreeResolution();
-      return;
-    }
+      if (worktreeResolutionError != null) {
+        retryWorktreeResolution();
+        return;
+      }
 
-    if (shouldBlockDiffLoading) {
-      return;
-    }
+      if (shouldBlockDiffLoading) {
+        return;
+      }
 
-    const nextRefreshContext = refreshContextRef.current;
-    if (nextRefreshContext == null) {
-      return;
-    }
+      const nextRefreshContext = refreshContextRef.current;
+      if (nextRefreshContext == null) {
+        return;
+      }
 
-    queuedRefreshContextRef.current = nextRefreshContext;
-    if (refreshPromiseRef.current != null) {
-      return;
-    }
-
-    const runRefreshLoop = async (): Promise<void> => {
-      while (queuedRefreshContextRef.current != null) {
-        const activeRefreshContext = queuedRefreshContextRef.current;
-        queuedRefreshContextRef.current = null;
-        const hasSameRefreshContext = (): boolean =>
-          refreshContextRef.current?.requestContextKey === activeRefreshContext.requestContextKey;
-
-        if (!hasSameRefreshContext()) {
-          break;
+      if (refreshPromiseRef.current != null) {
+        if (mode === "scheduled") {
+          return;
         }
 
-        setIsRefreshing(true);
+        queuedRefreshRequestRef.current = mergeRefreshRequests(queuedRefreshRequestRef.current, {
+          context: nextRefreshContext,
+          mode,
+        });
+        return;
+      }
 
-        try {
-          const fetchResult = await hostClient.gitFetchRemote(
-            activeRefreshContext.repoPath,
-            activeRefreshContext.targetBranch,
-            activeRefreshContext.workingDir ?? undefined,
-          );
+      queuedRefreshRequestRef.current = {
+        context: nextRefreshContext,
+        mode,
+      };
+
+      const runRefreshLoop = async (): Promise<void> => {
+        while (queuedRefreshRequestRef.current != null) {
+          const activeRefreshRequest = queuedRefreshRequestRef.current;
+          queuedRefreshRequestRef.current = null;
+          const activeRefreshContext = activeRefreshRequest.context;
+          const hasSameRefreshContext = (): boolean =>
+            refreshContextRef.current?.requestContextKey === activeRefreshContext.requestContextKey;
+          const showLoading = activeRefreshRequest.mode !== "scheduled";
+          const scheduledFetchCooldownKey = buildScheduledFetchCooldownKey(activeRefreshContext);
+          const shouldRunScheduledFetch = (): boolean => {
+            const lastFetchedAt =
+              scheduledFetchAtByContextRef.current.get(scheduledFetchCooldownKey);
+            return (
+              lastFetchedAt == null || Date.now() - lastFetchedAt >= SCHEDULED_FETCH_COOLDOWN_MS
+            );
+          };
+          const updateScheduledFetchCooldown = (): void => {
+            scheduledFetchAtByContextRef.current.set(scheduledFetchCooldownKey, Date.now());
+          };
+          const fetchRemote = async (): Promise<boolean> => {
+            const fetchResult = await hostClient.gitFetchRemote(
+              activeRefreshContext.repoPath,
+              activeRefreshContext.targetBranch,
+              activeRefreshContext.workingDir ?? undefined,
+            );
+            if (!hasSameRefreshContext()) {
+              return false;
+            }
+
+            if (fetchResult.outcome === "fetched") {
+              await invalidateRepoBranchesQuery(appQueryClient, activeRefreshContext.repoPath);
+              if (!hasSameRefreshContext()) {
+                return false;
+              }
+            }
+
+            updateScheduledFetchCooldown();
+            return true;
+          };
+
           if (!hasSameRefreshContext()) {
             break;
           }
 
-          if (fetchResult.outcome === "fetched") {
-            await invalidateRepoBranchesQuery(appQueryClient, activeRefreshContext.repoPath);
-            if (!hasSameRefreshContext()) {
-              break;
+          if (showLoading) {
+            setIsRefreshing(true);
+          }
+
+          try {
+            if (activeRefreshRequest.mode === "hard") {
+              const fetchCompleted = await fetchRemote();
+              if (!fetchCompleted) {
+                break;
+              }
+
+              setRefreshError(null);
+              await refreshActiveScope({
+                repoPath: activeRefreshContext.repoPath,
+                targetBranch: activeRefreshContext.targetBranch,
+                workingDir: activeRefreshContext.workingDir,
+                scope: activeRefreshContext.scope,
+              });
+              continue;
+            }
+
+            if (activeRefreshRequest.mode === "soft") {
+              setRefreshError(null);
+              await refreshActiveScope({
+                repoPath: activeRefreshContext.repoPath,
+                targetBranch: activeRefreshContext.targetBranch,
+                workingDir: activeRefreshContext.workingDir,
+                scope: activeRefreshContext.scope,
+              });
+              continue;
+            }
+
+            let scheduledFetchError: string | null = null;
+            if (shouldRunScheduledFetch()) {
+              try {
+                const fetchCompleted = await fetchRemote();
+                if (!fetchCompleted) {
+                  break;
+                }
+              } catch (error) {
+                if (hasSameRefreshContext()) {
+                  scheduledFetchError = String(error);
+                }
+              }
+            }
+
+            if (hasSameRefreshContext()) {
+              setRefreshError(scheduledFetchError);
+            }
+            await refreshActiveScopeSummary({
+              repoPath: activeRefreshContext.repoPath,
+              targetBranch: activeRefreshContext.targetBranch,
+              workingDir: activeRefreshContext.workingDir,
+              scope: activeRefreshContext.scope,
+            });
+          } catch (error) {
+            if (hasSameRefreshContext()) {
+              setRefreshError(String(error));
+            }
+          } finally {
+            if (showLoading && hasSameRefreshContext()) {
+              setIsRefreshing(false);
             }
           }
-
-          setRefreshError(null);
-          await refreshActiveScope({
-            repoPath: activeRefreshContext.repoPath,
-            targetBranch: activeRefreshContext.targetBranch,
-            workingDir: activeRefreshContext.workingDir,
-            scope: activeRefreshContext.scope,
-          });
-        } catch (error) {
-          if (hasSameRefreshContext()) {
-            setRefreshError(String(error));
-          }
-        } finally {
-          if (hasSameRefreshContext()) {
-            setIsRefreshing(false);
-          }
         }
-      }
-    };
+      };
 
-    const refreshPromise = runRefreshLoop().finally(() => {
-      if (refreshPromiseRef.current === refreshPromise) {
-        refreshPromiseRef.current = null;
-      }
-    });
-    refreshPromiseRef.current = refreshPromise;
-  }, [
-    refreshActiveScope,
-    preconditionError,
-    retryWorktreeResolution,
-    shouldBlockDiffLoading,
-    worktreeResolutionError,
-  ]);
+      const refreshPromise = runRefreshLoop().finally(() => {
+        if (refreshPromiseRef.current === refreshPromise) {
+          refreshPromiseRef.current = null;
+        }
+      });
+      refreshPromiseRef.current = refreshPromise;
+    },
+    [
+      refreshActiveScope,
+      preconditionError,
+      retryWorktreeResolution,
+      shouldBlockDiffLoading,
+      worktreeResolutionError,
+      refreshActiveScopeSummary,
+    ],
+  );
+
+  useAgentStudioDiffPolling({
+    enablePolling,
+    repoPath: effectiveRepoPath,
+    shouldBlockDiffLoading: shouldBlockDiffLoading || preconditionError != null,
+    poll: () => {
+      refresh("scheduled");
+    },
+  });
 
   const displayError =
     preconditionError ?? worktreeResolutionError ?? refreshError ?? activeScopeState.error;

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { canonicalTargetBranch } from "@/lib/target-branch";
 import type { UseAgentStudioDiffDataInput } from "./agent-studio-diff-data-model";
 import type { DiffDataState } from "./contracts";
@@ -87,14 +87,15 @@ export function useAgentStudioDiffData({
     refreshActiveScope,
     refreshActiveScopeSummary,
   });
+  const scheduledPoll = useCallback(() => {
+    void refresh("scheduled");
+  }, [refresh]);
 
   useAgentStudioDiffPolling({
     enablePolling,
     repoPath: effectiveRepoPath,
     shouldBlockDiffLoading: shouldBlockDiffLoading || preconditionError != null,
-    poll: () => {
-      void refresh("scheduled");
-    },
+    poll: scheduledPoll,
   });
 
   const displayError =

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
@@ -150,35 +150,35 @@ export function useAgentStudioDiffData({
   }, [activeScopeState.error, refreshError, state.isLoading]);
 
   const refresh = useCallback(
-    (mode: GitDiffRefreshMode = "hard"): void => {
+    (mode: GitDiffRefreshMode = "hard"): Promise<void> => {
       if (preconditionError != null) {
-        return;
+        return Promise.resolve();
       }
 
       if (worktreeResolutionError != null) {
         retryWorktreeResolution();
-        return;
+        return Promise.resolve();
       }
 
       if (shouldBlockDiffLoading) {
-        return;
+        return Promise.resolve();
       }
 
       const nextRefreshContext = refreshContextRef.current;
       if (nextRefreshContext == null) {
-        return;
+        return Promise.resolve();
       }
 
       if (refreshPromiseRef.current != null) {
         if (mode === "scheduled") {
-          return;
+          return refreshPromiseRef.current;
         }
 
         queuedRefreshRequestRef.current = mergeRefreshRequests(queuedRefreshRequestRef.current, {
           context: nextRefreshContext,
           mode,
         });
-        return;
+        return refreshPromiseRef.current;
       }
 
       queuedRefreshRequestRef.current = {
@@ -303,6 +303,7 @@ export function useAgentStudioDiffData({
         }
       });
       refreshPromiseRef.current = refreshPromise;
+      return refreshPromise;
     },
     [
       refreshActiveScope,
@@ -319,7 +320,7 @@ export function useAgentStudioDiffData({
     repoPath: effectiveRepoPath,
     shouldBlockDiffLoading: shouldBlockDiffLoading || preconditionError != null,
     poll: () => {
-      refresh("scheduled");
+      void refresh("scheduled");
     },
   });
 

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
@@ -1,57 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { hostClient } from "@/lib/host-client";
-import { appQueryClient } from "@/lib/query-client";
+import { useMemo } from "react";
 import { canonicalTargetBranch } from "@/lib/target-branch";
-import { invalidateRepoBranchesQuery } from "@/state/queries/git";
 import type { UseAgentStudioDiffDataInput } from "./agent-studio-diff-data-model";
-import type { DiffDataState, GitDiffRefreshMode } from "./contracts";
+import type { DiffDataState } from "./contracts";
 import { useAgentStudioDiffController } from "./use-agent-studio-diff-controller";
 import { useAgentStudioDiffPolling } from "./use-agent-studio-diff-polling";
+import {
+  type DiffRefreshContext,
+  useAgentStudioDiffRefreshController,
+} from "./use-agent-studio-diff-refresh-controller";
 import { useAgentStudioWorktreeResolution } from "./use-agent-studio-worktree-resolution";
-
-type RefreshContext = {
-  requestContextKey: string;
-  repoPath: string;
-  targetBranch: string;
-  workingDir: string | null;
-  scope: DiffDataState["diffScope"];
-};
-
-type RefreshRequest = {
-  context: RefreshContext;
-  mode: GitDiffRefreshMode;
-};
-
-const SCHEDULED_FETCH_COOLDOWN_MS = 5 * 60 * 1000;
-
-const refreshModePriority = (mode: GitDiffRefreshMode): number => {
-  switch (mode) {
-    case "hard":
-      return 3;
-    case "soft":
-      return 2;
-    case "scheduled":
-      return 1;
-  }
-};
-
-const mergeRefreshRequests = (
-  current: RefreshRequest | null,
-  next: RefreshRequest,
-): RefreshRequest => {
-  if (current == null || current.context.requestContextKey !== next.context.requestContextKey) {
-    return next;
-  }
-
-  return refreshModePriority(next.mode) > refreshModePriority(current.mode) ? next : current;
-};
-
-const buildScheduledFetchCooldownKey = ({
-  repoPath,
-  targetBranch,
-  workingDir,
-}: Pick<RefreshContext, "repoPath" | "targetBranch" | "workingDir">): string =>
-  `${repoPath}::${targetBranch}::${workingDir ?? ""}`;
 
 export function useAgentStudioDiffData({
   repoPath,
@@ -104,7 +61,7 @@ export function useAgentStudioDiffData({
     requestContextKey,
     shouldBlockDiffLoading: shouldBlockDiffLoading || preconditionError != null,
   });
-  const refreshContext = useMemo<RefreshContext | null>(() => {
+  const refreshContext = useMemo<DiffRefreshContext | null>(() => {
     if (requestContextKey == null || effectiveRepoPath == null) {
       return null;
     }
@@ -118,202 +75,18 @@ export function useAgentStudioDiffData({
     };
   }, [diffScope, effectiveRepoPath, requestContextKey, targetBranch, worktreePath]);
   const refreshContextKey = refreshContext?.requestContextKey ?? null;
-
-  const [refreshError, setRefreshError] = useState<string | null>(null);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const refreshPromiseRef = useRef<Promise<void> | null>(null);
-  const queuedRefreshRequestRef = useRef<RefreshRequest | null>(null);
-  const refreshContextRef = useRef<RefreshContext | null>(refreshContext);
-  const scheduledFetchAtByContextRef = useRef(new Map<string, number>());
-  refreshContextRef.current = refreshContext;
-  const previousIsLoadingRef = useRef(state.isLoading);
-
-  useEffect(() => {
-    // Skip cleanup from stale renders if a newer refresh context won the race to commit.
-    if (refreshContextKey !== (refreshContextRef.current?.requestContextKey ?? null)) {
-      return;
-    }
-
-    setRefreshError(null);
-    queuedRefreshRequestRef.current = null;
-    refreshPromiseRef.current = null;
-    setIsRefreshing(false);
-  }, [refreshContextKey]);
-
-  useEffect(() => {
-    const wasLoading = previousIsLoadingRef.current;
-    previousIsLoadingRef.current = state.isLoading;
-
-    if (refreshError != null && wasLoading && !state.isLoading && activeScopeState.error == null) {
-      setRefreshError(null);
-    }
-  }, [activeScopeState.error, refreshError, state.isLoading]);
-
-  const refresh = useCallback(
-    (mode: GitDiffRefreshMode = "hard"): Promise<void> => {
-      if (preconditionError != null) {
-        return Promise.resolve();
-      }
-
-      if (worktreeResolutionError != null) {
-        retryWorktreeResolution();
-        return Promise.resolve();
-      }
-
-      if (shouldBlockDiffLoading) {
-        return Promise.resolve();
-      }
-
-      const nextRefreshContext = refreshContextRef.current;
-      if (nextRefreshContext == null) {
-        return Promise.resolve();
-      }
-
-      if (refreshPromiseRef.current != null) {
-        if (mode === "scheduled") {
-          return refreshPromiseRef.current;
-        }
-
-        queuedRefreshRequestRef.current = mergeRefreshRequests(queuedRefreshRequestRef.current, {
-          context: nextRefreshContext,
-          mode,
-        });
-        return refreshPromiseRef.current;
-      }
-
-      queuedRefreshRequestRef.current = {
-        context: nextRefreshContext,
-        mode,
-      };
-
-      const runRefreshLoop = async (): Promise<void> => {
-        while (queuedRefreshRequestRef.current != null) {
-          const activeRefreshRequest = queuedRefreshRequestRef.current;
-          queuedRefreshRequestRef.current = null;
-          const activeRefreshContext = activeRefreshRequest.context;
-          const hasSameRefreshContext = (): boolean =>
-            refreshContextRef.current?.requestContextKey === activeRefreshContext.requestContextKey;
-          const showLoading = activeRefreshRequest.mode !== "scheduled";
-          const scheduledFetchCooldownKey = buildScheduledFetchCooldownKey(activeRefreshContext);
-          const shouldRunScheduledFetch = (): boolean => {
-            const lastFetchedAt =
-              scheduledFetchAtByContextRef.current.get(scheduledFetchCooldownKey);
-            return (
-              lastFetchedAt == null || Date.now() - lastFetchedAt >= SCHEDULED_FETCH_COOLDOWN_MS
-            );
-          };
-          const updateScheduledFetchCooldown = (): void => {
-            scheduledFetchAtByContextRef.current.set(scheduledFetchCooldownKey, Date.now());
-          };
-          const fetchRemote = async (): Promise<boolean> => {
-            const fetchResult = await hostClient.gitFetchRemote(
-              activeRefreshContext.repoPath,
-              activeRefreshContext.targetBranch,
-              activeRefreshContext.workingDir ?? undefined,
-            );
-            if (!hasSameRefreshContext()) {
-              return false;
-            }
-
-            if (fetchResult.outcome === "fetched") {
-              await invalidateRepoBranchesQuery(appQueryClient, activeRefreshContext.repoPath);
-              if (!hasSameRefreshContext()) {
-                return false;
-              }
-            }
-
-            updateScheduledFetchCooldown();
-            return true;
-          };
-
-          if (!hasSameRefreshContext()) {
-            break;
-          }
-
-          if (showLoading) {
-            setIsRefreshing(true);
-          }
-
-          try {
-            if (activeRefreshRequest.mode === "hard") {
-              const fetchCompleted = await fetchRemote();
-              if (!fetchCompleted) {
-                break;
-              }
-
-              setRefreshError(null);
-              await refreshActiveScope({
-                repoPath: activeRefreshContext.repoPath,
-                targetBranch: activeRefreshContext.targetBranch,
-                workingDir: activeRefreshContext.workingDir,
-                scope: activeRefreshContext.scope,
-              });
-              continue;
-            }
-
-            if (activeRefreshRequest.mode === "soft") {
-              setRefreshError(null);
-              await refreshActiveScope({
-                repoPath: activeRefreshContext.repoPath,
-                targetBranch: activeRefreshContext.targetBranch,
-                workingDir: activeRefreshContext.workingDir,
-                scope: activeRefreshContext.scope,
-              });
-              continue;
-            }
-
-            let scheduledFetchError: string | null = null;
-            if (shouldRunScheduledFetch()) {
-              try {
-                const fetchCompleted = await fetchRemote();
-                if (!fetchCompleted) {
-                  break;
-                }
-              } catch (error) {
-                if (hasSameRefreshContext()) {
-                  scheduledFetchError = String(error);
-                }
-              }
-            }
-
-            if (hasSameRefreshContext()) {
-              setRefreshError(scheduledFetchError);
-            }
-            await refreshActiveScopeSummary({
-              repoPath: activeRefreshContext.repoPath,
-              targetBranch: activeRefreshContext.targetBranch,
-              workingDir: activeRefreshContext.workingDir,
-              scope: activeRefreshContext.scope,
-            });
-          } catch (error) {
-            if (hasSameRefreshContext()) {
-              setRefreshError(String(error));
-            }
-          } finally {
-            if (showLoading && hasSameRefreshContext()) {
-              setIsRefreshing(false);
-            }
-          }
-        }
-      };
-
-      const refreshPromise = runRefreshLoop().finally(() => {
-        if (refreshPromiseRef.current === refreshPromise) {
-          refreshPromiseRef.current = null;
-        }
-      });
-      refreshPromiseRef.current = refreshPromise;
-      return refreshPromise;
-    },
-    [
-      refreshActiveScope,
-      preconditionError,
-      retryWorktreeResolution,
-      shouldBlockDiffLoading,
-      worktreeResolutionError,
-      refreshActiveScopeSummary,
-    ],
-  );
+  const { refresh, refreshError, isRefreshing } = useAgentStudioDiffRefreshController({
+    refreshContext,
+    refreshContextKey,
+    preconditionError,
+    shouldBlockDiffLoading,
+    worktreeResolutionError,
+    retryWorktreeResolution,
+    isControllerLoading: state.isLoading,
+    activeScopeError: activeScopeState.error,
+    refreshActiveScope,
+    refreshActiveScopeSummary,
+  });
 
   useAgentStudioDiffPolling({
     enablePolling,

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-refresh-controller.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-refresh-controller.ts
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { hostClient } from "@/lib/host-client";
+import { appQueryClient } from "@/lib/query-client";
+import { invalidateRepoBranchesQuery } from "@/state/queries/git";
+import type { DiffDataState, GitDiffRefresh, GitDiffRefreshMode } from "./contracts";
+
+export type DiffRefreshContext = {
+  requestContextKey: string;
+  repoPath: string;
+  targetBranch: string;
+  workingDir: string | null;
+  scope: DiffDataState["diffScope"];
+};
+
+type RefreshRequest = {
+  context: DiffRefreshContext;
+  mode: GitDiffRefreshMode;
+};
+
+type UseAgentStudioDiffRefreshControllerArgs = {
+  refreshContext: DiffRefreshContext | null;
+  refreshContextKey: string | null;
+  preconditionError: string | null;
+  shouldBlockDiffLoading: boolean;
+  worktreeResolutionError: string | null;
+  retryWorktreeResolution: () => void;
+  isControllerLoading: boolean;
+  activeScopeError: string | null;
+  refreshActiveScope: (
+    context: Pick<DiffRefreshContext, "repoPath" | "targetBranch" | "workingDir" | "scope">,
+  ) => Promise<void>;
+  refreshActiveScopeSummary: (
+    context: Pick<DiffRefreshContext, "repoPath" | "targetBranch" | "workingDir" | "scope">,
+  ) => Promise<void>;
+};
+
+type UseAgentStudioDiffRefreshControllerResult = {
+  refresh: GitDiffRefresh;
+  refreshError: string | null;
+  isRefreshing: boolean;
+};
+
+const SCHEDULED_FETCH_COOLDOWN_MS = 5 * 60 * 1000;
+
+const refreshModePriority = (mode: GitDiffRefreshMode): number => {
+  switch (mode) {
+    case "hard":
+      return 3;
+    case "soft":
+      return 2;
+    case "scheduled":
+      return 1;
+  }
+};
+
+const mergeRefreshRequests = (
+  current: RefreshRequest | null,
+  next: RefreshRequest,
+): RefreshRequest => {
+  if (current == null || current.context.requestContextKey !== next.context.requestContextKey) {
+    return next;
+  }
+
+  return refreshModePriority(next.mode) > refreshModePriority(current.mode) ? next : current;
+};
+
+const buildScheduledFetchCooldownKey = ({
+  repoPath,
+  targetBranch,
+  workingDir,
+}: Pick<DiffRefreshContext, "repoPath" | "targetBranch" | "workingDir">): string =>
+  `${repoPath}::${targetBranch}::${workingDir ?? ""}`;
+
+export function useAgentStudioDiffRefreshController({
+  refreshContext,
+  refreshContextKey,
+  preconditionError,
+  shouldBlockDiffLoading,
+  worktreeResolutionError,
+  retryWorktreeResolution,
+  isControllerLoading,
+  activeScopeError,
+  refreshActiveScope,
+  refreshActiveScopeSummary,
+}: UseAgentStudioDiffRefreshControllerArgs): UseAgentStudioDiffRefreshControllerResult {
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshPromiseRef = useRef<Promise<void> | null>(null);
+  const queuedRefreshRequestRef = useRef<RefreshRequest | null>(null);
+  const refreshContextRef = useRef<DiffRefreshContext | null>(refreshContext);
+  const scheduledFetchAtByContextRef = useRef(new Map<string, number>());
+  const previousIsLoadingRef = useRef(isControllerLoading);
+  refreshContextRef.current = refreshContext;
+
+  useEffect(() => {
+    // Skip cleanup from stale renders if a newer refresh context won the race to commit.
+    if (refreshContextKey !== (refreshContextRef.current?.requestContextKey ?? null)) {
+      return;
+    }
+
+    setRefreshError(null);
+    queuedRefreshRequestRef.current = null;
+    refreshPromiseRef.current = null;
+    setIsRefreshing(false);
+  }, [refreshContextKey]);
+
+  useEffect(() => {
+    const wasLoading = previousIsLoadingRef.current;
+    previousIsLoadingRef.current = isControllerLoading;
+
+    if (refreshError != null && wasLoading && !isControllerLoading && activeScopeError == null) {
+      setRefreshError(null);
+    }
+  }, [activeScopeError, isControllerLoading, refreshError]);
+
+  const runRefreshRequest = useCallback(
+    async (activeRefreshRequest: RefreshRequest): Promise<boolean> => {
+      const activeRefreshContext = activeRefreshRequest.context;
+      const hasSameRefreshContext = (): boolean =>
+        refreshContextRef.current?.requestContextKey === activeRefreshContext.requestContextKey;
+      const showLoading = activeRefreshRequest.mode !== "scheduled";
+      const scheduledFetchCooldownKey = buildScheduledFetchCooldownKey(activeRefreshContext);
+      const shouldRunScheduledFetch = (): boolean => {
+        const lastFetchedAt = scheduledFetchAtByContextRef.current.get(scheduledFetchCooldownKey);
+        return lastFetchedAt == null || Date.now() - lastFetchedAt >= SCHEDULED_FETCH_COOLDOWN_MS;
+      };
+      const updateScheduledFetchCooldown = (): void => {
+        scheduledFetchAtByContextRef.current.set(scheduledFetchCooldownKey, Date.now());
+      };
+      const fetchRemote = async (): Promise<boolean> => {
+        const fetchResult = await hostClient.gitFetchRemote(
+          activeRefreshContext.repoPath,
+          activeRefreshContext.targetBranch,
+          activeRefreshContext.workingDir ?? undefined,
+        );
+        if (!hasSameRefreshContext()) {
+          return false;
+        }
+
+        if (fetchResult.outcome === "fetched") {
+          await invalidateRepoBranchesQuery(appQueryClient, activeRefreshContext.repoPath);
+          if (!hasSameRefreshContext()) {
+            return false;
+          }
+        }
+
+        updateScheduledFetchCooldown();
+        return true;
+      };
+
+      if (!hasSameRefreshContext()) {
+        return false;
+      }
+
+      if (showLoading) {
+        setIsRefreshing(true);
+      }
+
+      try {
+        if (activeRefreshRequest.mode === "hard") {
+          const fetchCompleted = await fetchRemote();
+          if (!fetchCompleted) {
+            return false;
+          }
+
+          setRefreshError(null);
+          await refreshActiveScope(activeRefreshContext);
+          return true;
+        }
+
+        if (activeRefreshRequest.mode === "soft") {
+          setRefreshError(null);
+          await refreshActiveScope(activeRefreshContext);
+          return true;
+        }
+
+        let scheduledFetchError: string | null = null;
+        if (shouldRunScheduledFetch()) {
+          try {
+            const fetchCompleted = await fetchRemote();
+            if (!fetchCompleted) {
+              return false;
+            }
+          } catch (error) {
+            if (hasSameRefreshContext()) {
+              scheduledFetchError = String(error);
+            }
+          }
+        }
+
+        if (hasSameRefreshContext()) {
+          setRefreshError(scheduledFetchError);
+        }
+        await refreshActiveScopeSummary(activeRefreshContext);
+        return true;
+      } catch (error) {
+        if (hasSameRefreshContext()) {
+          setRefreshError(String(error));
+        }
+        return true;
+      } finally {
+        if (showLoading && hasSameRefreshContext()) {
+          setIsRefreshing(false);
+        }
+      }
+    },
+    [refreshActiveScope, refreshActiveScopeSummary],
+  );
+
+  const refresh = useCallback<GitDiffRefresh>(
+    (mode = "hard") => {
+      if (preconditionError != null) {
+        return Promise.resolve();
+      }
+
+      if (worktreeResolutionError != null) {
+        retryWorktreeResolution();
+        return Promise.resolve();
+      }
+
+      if (shouldBlockDiffLoading) {
+        return Promise.resolve();
+      }
+
+      const nextRefreshContext = refreshContextRef.current;
+      if (nextRefreshContext == null) {
+        return Promise.resolve();
+      }
+
+      if (refreshPromiseRef.current != null) {
+        if (mode === "scheduled") {
+          return refreshPromiseRef.current;
+        }
+
+        queuedRefreshRequestRef.current = mergeRefreshRequests(queuedRefreshRequestRef.current, {
+          context: nextRefreshContext,
+          mode,
+        });
+        return refreshPromiseRef.current;
+      }
+
+      queuedRefreshRequestRef.current = {
+        context: nextRefreshContext,
+        mode,
+      };
+
+      const refreshPromise = (async (): Promise<void> => {
+        while (queuedRefreshRequestRef.current != null) {
+          const activeRefreshRequest = queuedRefreshRequestRef.current;
+          queuedRefreshRequestRef.current = null;
+
+          const shouldContinue = await runRefreshRequest(activeRefreshRequest);
+          if (!shouldContinue) {
+            break;
+          }
+        }
+      })().finally(() => {
+        if (refreshPromiseRef.current === refreshPromise) {
+          refreshPromiseRef.current = null;
+        }
+      });
+      refreshPromiseRef.current = refreshPromise;
+      return refreshPromise;
+    },
+    [
+      preconditionError,
+      retryWorktreeResolution,
+      runRefreshRequest,
+      shouldBlockDiffLoading,
+      worktreeResolutionError,
+    ],
+  );
+
+  return {
+    refresh,
+    refreshError,
+    isRefreshing,
+  };
+}

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -1,5 +1,4 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { render, waitFor } from "@testing-library/react";
 import { createElement, type ReactElement, type ReactNode } from "react";
 import type { SessionStartModalModel } from "@/components/features/agents";
 import * as appStateContexts from "@/state/app-state-contexts";
@@ -45,8 +44,8 @@ type QuerySyncState = {
 
 type SelectionState = {
   viewTaskId: string;
-  viewRole: "planner" | "build";
-  viewScenario: "planner_initial" | "build_implementation_start";
+  viewRole: "planner";
+  viewScenario: "planner_initial";
   viewSelectedTask: typeof task | null;
   viewSessionsForTask: SessionFixture[];
   viewActiveSession: SessionFixture | null;
@@ -87,7 +86,7 @@ type OrchestrationState = {
   agentStudioWorkspaceSidebarModel: { activeDocument: null };
   agentChatModel: { kind: string };
   rightPanel: {
-    panelKind: "documents" | "build_tools";
+    panelKind: "documents";
     isPanelOpen: boolean;
     rightPanelToggleModel: { label: string };
   };
@@ -610,95 +609,6 @@ const createHookHarness = () =>
   createSharedHookHarness((_: undefined) => useAgentsPageShellModel(), undefined);
 
 describe("useAgentsPageShellModel", () => {
-  test("forwards soft refresh mode through the shell worktree refresh ref", async () => {
-    const buildSession = createAgentSessionFixture({
-      sessionId: "builder-session-1",
-      taskId: "task-1",
-      role: "build",
-      scenario: "build_implementation_start",
-      runtimeKind: "opencode",
-      messages: [],
-    });
-    const completedToolSession = createAgentSessionFixture({
-      ...buildSession,
-      messages: [
-        {
-          id: "tool-1",
-          role: "tool",
-          content: "",
-          timestamp: "2026-02-22T08:10:00.000Z",
-          meta: {
-            kind: "tool",
-            partId: "part-tool-1",
-            callId: "call-tool-1",
-            tool: "apply_patch",
-            status: "completed",
-          },
-        },
-      ],
-    });
-
-    selectionState = {
-      ...selectionState,
-      viewRole: "build",
-      viewScenario: "build_implementation_start",
-      viewActiveSession: buildSession,
-      activeSession: buildSession,
-      viewSessionsForTask: [buildSession],
-      sessionsForTask: [buildSession],
-      selectedSessionById: { [buildSession.sessionId]: buildSession },
-    };
-    agentSessions = [buildSession];
-    orchestrationState = {
-      ...orchestrationState,
-      rightPanel: {
-        panelKind: "build_tools",
-        isPanelOpen: true,
-        rightPanelToggleModel,
-      },
-    };
-
-    const harness = createHookHarness();
-
-    try {
-      await harness.mount();
-      const initialContent = harness.getLatest().rightPanelContent;
-      if (!initialContent) {
-        throw new Error("Expected right panel content");
-      }
-
-      const view = render(initialContent);
-      await waitFor(() => {
-        expect(refreshWorktreeMock).toHaveBeenCalledTimes(0);
-      });
-
-      selectionState = {
-        ...selectionState,
-        viewActiveSession: completedToolSession,
-        activeSession: completedToolSession,
-        viewSessionsForTask: [completedToolSession],
-        sessionsForTask: [completedToolSession],
-        selectedSessionById: { [completedToolSession.sessionId]: completedToolSession },
-      };
-      agentSessions = [completedToolSession];
-
-      await harness.update(undefined);
-      const updatedContent = harness.getLatest().rightPanelContent;
-      if (!updatedContent) {
-        throw new Error("Expected updated right panel content");
-      }
-      view.rerender(updatedContent);
-
-      await waitFor(() => {
-        expect(refreshWorktreeMock).toHaveBeenCalledWith("soft");
-      });
-
-      view.unmount();
-    } finally {
-      await harness.unmount();
-    }
-  });
-
   test("surfaces hook state and wires modal/controller elements", async () => {
     tasksState = {
       ...tasksState,

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { render, waitFor } from "@testing-library/react";
 import { createElement, type ReactElement, type ReactNode } from "react";
 import type { SessionStartModalModel } from "@/components/features/agents";
 import * as appStateContexts from "@/state/app-state-contexts";
@@ -44,8 +45,8 @@ type QuerySyncState = {
 
 type SelectionState = {
   viewTaskId: string;
-  viewRole: "planner";
-  viewScenario: "planner_initial";
+  viewRole: "planner" | "build";
+  viewScenario: "planner_initial" | "build_implementation_start";
   viewSelectedTask: typeof task | null;
   viewSessionsForTask: SessionFixture[];
   viewActiveSession: SessionFixture | null;
@@ -86,7 +87,7 @@ type OrchestrationState = {
   agentStudioWorkspaceSidebarModel: { activeDocument: null };
   agentChatModel: { kind: string };
   rightPanel: {
-    panelKind: "documents";
+    panelKind: "documents" | "build_tools";
     isPanelOpen: boolean;
     rightPanelToggleModel: { label: string };
   };
@@ -95,6 +96,7 @@ type OrchestrationState = {
 type RightPanelState = {
   isRightPanelVisible: boolean;
   rightPanelModel: { kind: string };
+  refreshWorktree: (mode?: "hard" | "soft" | "scheduled") => Promise<void>;
 };
 
 type AgentsPageShellModelState = {
@@ -260,9 +262,11 @@ let orchestrationState: OrchestrationState = {
     rightPanelToggleModel,
   },
 };
+const refreshWorktreeMock = mock(async (_mode?: "hard" | "soft" | "scheduled") => {});
 let rightPanelState: RightPanelState = {
   isRightPanelVisible: true,
   rightPanelModel,
+  refreshWorktree: refreshWorktreeMock,
 };
 
 let useAgentsPageShellModel: () => AgentsPageShellModelState;
@@ -551,7 +555,9 @@ beforeEach(async () => {
   rightPanelState = {
     isRightPanelVisible: true,
     rightPanelModel,
+    refreshWorktree: refreshWorktreeMock,
   };
+  refreshWorktreeMock.mockClear();
 });
 
 afterEach(async () => {
@@ -604,6 +610,95 @@ const createHookHarness = () =>
   createSharedHookHarness((_: undefined) => useAgentsPageShellModel(), undefined);
 
 describe("useAgentsPageShellModel", () => {
+  test("forwards soft refresh mode through the shell worktree refresh ref", async () => {
+    const buildSession = createAgentSessionFixture({
+      sessionId: "builder-session-1",
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_implementation_start",
+      runtimeKind: "opencode",
+      messages: [],
+    });
+    const completedToolSession = createAgentSessionFixture({
+      ...buildSession,
+      messages: [
+        {
+          id: "tool-1",
+          role: "tool",
+          content: "",
+          timestamp: "2026-02-22T08:10:00.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-tool-1",
+            callId: "call-tool-1",
+            tool: "apply_patch",
+            status: "completed",
+          },
+        },
+      ],
+    });
+
+    selectionState = {
+      ...selectionState,
+      viewRole: "build",
+      viewScenario: "build_implementation_start",
+      viewActiveSession: buildSession,
+      activeSession: buildSession,
+      viewSessionsForTask: [buildSession],
+      sessionsForTask: [buildSession],
+      selectedSessionById: { [buildSession.sessionId]: buildSession },
+    };
+    agentSessions = [buildSession];
+    orchestrationState = {
+      ...orchestrationState,
+      rightPanel: {
+        panelKind: "build_tools",
+        isPanelOpen: true,
+        rightPanelToggleModel,
+      },
+    };
+
+    const harness = createHookHarness();
+
+    try {
+      await harness.mount();
+      const initialContent = harness.getLatest().rightPanelContent;
+      if (!initialContent) {
+        throw new Error("Expected right panel content");
+      }
+
+      const view = render(initialContent);
+      await waitFor(() => {
+        expect(refreshWorktreeMock).toHaveBeenCalledTimes(0);
+      });
+
+      selectionState = {
+        ...selectionState,
+        viewActiveSession: completedToolSession,
+        activeSession: completedToolSession,
+        viewSessionsForTask: [completedToolSession],
+        sessionsForTask: [completedToolSession],
+        selectedSessionById: { [completedToolSession.sessionId]: completedToolSession },
+      };
+      agentSessions = [completedToolSession];
+
+      await harness.update(undefined);
+      const updatedContent = harness.getLatest().rightPanelContent;
+      if (!updatedContent) {
+        throw new Error("Expected updated right panel content");
+      }
+      view.rerender(updatedContent);
+
+      await waitFor(() => {
+        expect(refreshWorktreeMock).toHaveBeenCalledWith("soft");
+      });
+
+      view.unmount();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("surfaces hook state and wires modal/controller elements", async () => {
     tasksState = {
       ...tasksState,

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -1,14 +1,5 @@
 import type { AgentRole, AgentScenario } from "@openducktor/core";
-import {
-  type MutableRefObject,
-  memo,
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigationType, useSearchParams } from "react-router-dom";
 import { SessionStartModal } from "@/components/features/agents";
 import { MemoizedAgentStudioRightPanel } from "@/components/features/agents/agent-studio-right-panel";
@@ -55,6 +46,10 @@ import {
   type UseAgentsPageRightPanelModelArgs,
   useAgentsPageRightPanelModel,
 } from "../use-agents-page-right-panel-model";
+import {
+  useForwardedWorktreeRefresh,
+  type WorktreeRefreshRef,
+} from "./use-forwarded-worktree-refresh";
 
 type AgentsPageShellModel = {
   activeRepo: string | null;
@@ -87,7 +82,7 @@ const AgentsPageRightPanelRuntime = memo(function AgentsPageRightPanelRuntime({
   refreshWorktreeRef,
   ...args
 }: UseAgentsPageRightPanelModelArgs & {
-  refreshWorktreeRef: MutableRefObject<GitDiffRefresh | null>;
+  refreshWorktreeRef: WorktreeRefreshRef;
 }): ReactElement | null {
   const { rightPanelModel, refreshWorktree } = useAgentsPageRightPanelModel(args);
 
@@ -116,14 +111,9 @@ function AgentsPageBuildWorktreeRefreshRuntime({
   viewRole: UseAgentsPageRightPanelModelArgs["viewRole"];
   activeSession: AgentStudioOrchestrationSelectionContext["viewActiveSession"];
   isSessionHistoryHydrating: boolean;
-  refreshWorktreeRef: MutableRefObject<GitDiffRefresh | null>;
+  refreshWorktreeRef: WorktreeRefreshRef;
 }): null {
-  const refreshWorktree = useCallback<GitDiffRefresh>(
-    (mode) => {
-      return refreshWorktreeRef.current?.(mode) ?? Promise.resolve();
-    },
-    [refreshWorktreeRef],
-  );
+  const refreshWorktree = useForwardedWorktreeRefresh(refreshWorktreeRef);
 
   useAgentStudioBuildWorktreeRefresh({
     viewRole: panelKind === "build_tools" && isPanelOpen ? viewRole : null,

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -22,6 +22,7 @@ import {
   type TaskDetailsSheetControllerHandle,
 } from "@/components/features/task-details/task-details-sheet-controller";
 import type { BuildToolsSessionDescriptor } from "@/features/agent-studio-build-tools/use-agent-studio-build-tools-bootstrap";
+import type { GitDiffRefresh } from "@/features/agent-studio-git";
 import { HumanReviewFeedbackModal } from "@/features/human-review-feedback/human-review-feedback-modal";
 import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import {
@@ -86,7 +87,7 @@ const AgentsPageRightPanelRuntime = memo(function AgentsPageRightPanelRuntime({
   refreshWorktreeRef,
   ...args
 }: UseAgentsPageRightPanelModelArgs & {
-  refreshWorktreeRef: MutableRefObject<(() => void) | null>;
+  refreshWorktreeRef: MutableRefObject<GitDiffRefresh | null>;
 }): ReactElement | null {
   const { rightPanelModel, refreshWorktree } = useAgentsPageRightPanelModel(args);
 
@@ -115,11 +116,14 @@ function AgentsPageBuildWorktreeRefreshRuntime({
   viewRole: UseAgentsPageRightPanelModelArgs["viewRole"];
   activeSession: AgentStudioOrchestrationSelectionContext["viewActiveSession"];
   isSessionHistoryHydrating: boolean;
-  refreshWorktreeRef: MutableRefObject<(() => void) | null>;
+  refreshWorktreeRef: MutableRefObject<GitDiffRefresh | null>;
 }): null {
-  const refreshWorktree = useCallback(() => {
-    refreshWorktreeRef.current?.();
-  }, [refreshWorktreeRef]);
+  const refreshWorktree = useCallback<GitDiffRefresh>(
+    (mode) => {
+      return refreshWorktreeRef.current?.(mode) ?? Promise.resolve();
+    },
+    [refreshWorktreeRef],
+  );
 
   useAgentStudioBuildWorktreeRefresh({
     viewRole: panelKind === "build_tools" && isPanelOpen ? viewRole : null,
@@ -182,7 +186,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
   const navigationType = useNavigationType();
   const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
   const taskDetailsSheetRef = useRef<TaskDetailsSheetControllerHandle | null>(null);
-  const rightPanelRefreshWorktreeRef = useRef<(() => void) | null>(null);
+  const rightPanelRefreshWorktreeRef = useRef<GitDiffRefresh | null>(null);
   const { runCompletionSignal } = useDelegationEventsContext();
 
   const {

--- a/apps/desktop/src/pages/agents/shell/use-forwarded-worktree-refresh.test.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-forwarded-worktree-refresh.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "../agent-studio-test-utils";
+import {
+  useForwardedWorktreeRefresh,
+  type WorktreeRefreshRef,
+} from "./use-forwarded-worktree-refresh";
+
+enableReactActEnvironment();
+
+type HookArgs = WorktreeRefreshRef;
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useForwardedWorktreeRefresh, initialProps);
+
+describe("useForwardedWorktreeRefresh", () => {
+  test("forwards refresh mode to the current worktree refresh callback", async () => {
+    const refreshWorktree = mock(async (_mode?: "hard" | "soft" | "scheduled") => {});
+    const harness = createHookHarness({ current: refreshWorktree });
+
+    try {
+      await harness.mount();
+      await harness.getLatest()("soft");
+
+      expect(refreshWorktree).toHaveBeenCalledWith("soft");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("returns a resolved promise when no callback is registered", async () => {
+    const harness = createHookHarness({ current: null });
+
+    try {
+      await harness.mount();
+
+      await expect(harness.getLatest()("soft")).resolves.toBeUndefined();
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/shell/use-forwarded-worktree-refresh.ts
+++ b/apps/desktop/src/pages/agents/shell/use-forwarded-worktree-refresh.ts
@@ -1,0 +1,17 @@
+import { useCallback } from "react";
+import type { GitDiffRefresh } from "@/features/agent-studio-git";
+
+export type WorktreeRefreshRef = {
+  current: GitDiffRefresh | null;
+};
+
+export function useForwardedWorktreeRefresh(
+  refreshWorktreeRef: WorktreeRefreshRef,
+): GitDiffRefresh {
+  return useCallback<GitDiffRefresh>(
+    (mode) => {
+      return refreshWorktreeRef.current?.(mode) ?? Promise.resolve();
+    },
+    [refreshWorktreeRef],
+  );
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
@@ -16,7 +16,7 @@ type UseAgentStudioBuildWorktreeRefreshHook =
 
 let useAgentStudioBuildWorktreeRefresh: UseAgentStudioBuildWorktreeRefreshHook;
 
-const refreshWorktreeMock = mock(() => {});
+const refreshWorktreeMock = mock(async (_mode?: string) => {});
 
 type HookArgs = Parameters<UseAgentStudioBuildWorktreeRefreshHook>[0];
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
@@ -99,6 +99,7 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
         activeSession: createCompletedToolSession("apply_patch", "tool-1"),
       });
       expect(refreshWorktreeMock).toHaveBeenCalledTimes(1);
+      expect(refreshWorktreeMock).toHaveBeenLastCalledWith("soft");
 
       await harness.update({
         ...createBaseArgs(),
@@ -112,6 +113,7 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
         }),
       });
       expect(refreshWorktreeMock).toHaveBeenCalledTimes(2);
+      expect(refreshWorktreeMock).toHaveBeenLastCalledWith("soft");
     } finally {
       await harness.unmount();
     }
@@ -273,6 +275,7 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
       });
 
       expect(refreshWorktreeMock).toHaveBeenCalledTimes(1);
+      expect(refreshWorktreeMock).toHaveBeenLastCalledWith("soft");
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import type { GitDiffRefreshMode } from "@/features/agent-studio-git";
+import type { GitDiffRefresh } from "@/features/agent-studio-git";
 import {
   forEachSessionMessage,
   forEachSessionMessageFrom,
@@ -13,7 +13,7 @@ type UseAgentStudioBuildWorktreeRefreshArgs = {
   viewRole: string | null;
   activeSession: AgentSessionState | null;
   isSessionHistoryHydrating: boolean;
-  refreshWorktree: (mode?: GitDiffRefreshMode) => void;
+  refreshWorktree: GitDiffRefresh;
 };
 
 const EXPLICIT_NON_WORKTREE_TOOL_NAMES = new Set([
@@ -169,7 +169,7 @@ export function useAgentStudioBuildWorktreeRefresh({
     previousMessagesRef.current = activeSession.messages;
 
     if (shouldRefresh) {
-      refreshWorktree("soft");
+      void refreshWorktree("soft");
     }
   }, [activeSession, isSessionHistoryHydrating, refreshWorktree, viewRole]);
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import type { GitDiffRefreshMode } from "@/features/agent-studio-git";
 import {
   forEachSessionMessage,
   forEachSessionMessageFrom,
@@ -12,7 +13,7 @@ type UseAgentStudioBuildWorktreeRefreshArgs = {
   viewRole: string | null;
   activeSession: AgentSessionState | null;
   isSessionHistoryHydrating: boolean;
-  refreshWorktree: () => void;
+  refreshWorktree: (mode?: GitDiffRefreshMode) => void;
 };
 
 const EXPLICIT_NON_WORKTREE_TOOL_NAMES = new Set([
@@ -168,7 +169,7 @@ export function useAgentStudioBuildWorktreeRefresh({
     previousMessagesRef.current = activeSession.messages;
 
     if (shouldRefresh) {
-      refreshWorktree();
+      refreshWorktree("soft");
     }
   }, [activeSession, isSessionHistoryHydrating, refreshWorktree, viewRole]);
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-action-utils.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-action-utils.ts
@@ -1,9 +1,13 @@
-import type { GitConflict, GitConflictOperation } from "@/features/agent-studio-git";
+import type {
+  GitConflict,
+  GitConflictOperation,
+  GitDiffRefreshMode,
+} from "@/features/agent-studio-git";
 import { getGitConflictCopy } from "@/features/git-conflict-resolution";
 
 export type GitActionKind = "commit" | "push" | "rebase";
 
-export type RefreshGitDiffData = () => void | Promise<void>;
+export type RefreshGitDiffData = (mode?: GitDiffRefreshMode) => void | Promise<void>;
 
 export const BUILDER_LOCK_REASON = "Git actions are disabled while the Builder session is working.";
 export const CONFLICT_LOCK_REASON = "Git actions are disabled while git conflicts are unresolved.";

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-action-utils.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-action-utils.ts
@@ -1,13 +1,13 @@
 import type {
   GitConflict,
   GitConflictOperation,
-  GitDiffRefreshMode,
+  GitDiffRefresh,
 } from "@/features/agent-studio-git";
 import { getGitConflictCopy } from "@/features/git-conflict-resolution";
 
 export type GitActionKind = "commit" | "push" | "rebase";
 
-export type RefreshGitDiffData = (mode?: GitDiffRefreshMode) => void | Promise<void>;
+export type RefreshGitDiffData = GitDiffRefresh;
 
 export const BUILDER_LOCK_REASON = "Git actions are disabled while the Builder session is working.";
 export const CONFLICT_LOCK_REASON = "Git actions are disabled while git conflicts are unresolved.";

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
@@ -131,6 +131,7 @@ describe("useAgentStudioGitActions", () => {
 
       await harness.waitFor((state) => state.isCommitting === false);
       expect(refreshDiffData).toHaveBeenCalledTimes(1);
+      expect(refreshDiffData).toHaveBeenCalledWith("soft");
       expect(harness.getLatest().commitError).toBeNull();
     } finally {
       await harness.unmount();
@@ -162,6 +163,7 @@ describe("useAgentStudioGitActions", () => {
         undefined,
       );
       expect(refreshDiffData).toHaveBeenCalledTimes(1);
+      expect(refreshDiffData).toHaveBeenCalledWith("soft");
       expect(harness.getLatest().commitError).toBe("Refresh exploded");
     } finally {
       await harness.unmount();
@@ -233,6 +235,7 @@ describe("useAgentStudioGitActions", () => {
       pushDeferred.resolve({ remote: "origin", branch: "feature/task-10", output: "done" });
       await pushHarness.waitFor((state) => state.isPushing === false);
       expect(refreshDiffData).toHaveBeenCalledTimes(1);
+      expect(refreshDiffData).toHaveBeenCalledWith("soft");
       expect(pushHarness.getLatest().pushError).toBeNull();
       expect(toastSuccessMock).toHaveBeenCalledWith("Pushed feature/task-10", {
         description: "Remote: origin",
@@ -270,7 +273,35 @@ describe("useAgentStudioGitActions", () => {
       rebaseDeferred.resolve({ outcome: "rebased" });
       await harness.waitFor((state) => state.isRebasing === false);
       expect(refreshDiffData).toHaveBeenCalledTimes(1);
+      expect(refreshDiffData).toHaveBeenCalledWith("soft");
       expect(harness.getLatest().rebaseError).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("keeps commit actions in flight until the soft refresh settles", async () => {
+    const refreshDeferred = createDeferred<void>();
+    const refreshDiffData = mock(async (_mode?: string) => refreshDeferred.promise);
+    const harness = createHookHarness(
+      createBaseArgs({
+        refreshDiffData,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        void state.commitAll("fix: preserve disabled state");
+      });
+
+      await harness.waitFor((state) => state.isCommitting === true);
+      expect(refreshDiffData).toHaveBeenCalledWith("soft");
+      expect(harness.getLatest().isCommitting).toBe(true);
+
+      refreshDeferred.resolve();
+      await harness.waitFor((state) => state.isCommitting === false);
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
@@ -6,7 +6,7 @@ import type {
   AgentStudioPendingReset,
   GitConflict,
   GitConflictAction,
-  GitDiffRefreshMode,
+  GitDiffRefresh,
 } from "@/features/agent-studio-git";
 import { useAgentStudioGitActionErrors } from "./use-agent-studio-git-action-errors";
 import { BUILDER_LOCK_REASON, type GitActionKind } from "./use-agent-studio-git-action-utils";
@@ -65,7 +65,7 @@ type UseAgentStudioGitActionsInput = {
   upstreamAheadBehind?: CommitsAheadBehind | null;
   detectedConflictedFiles?: string[];
   worktreeStatusSnapshotKey?: string | null;
-  refreshDiffData: (mode?: GitDiffRefreshMode) => void | Promise<void>;
+  refreshDiffData: GitDiffRefresh;
   isDiffDataLoading?: boolean;
   isBuilderSessionWorking?: boolean;
   onResolveGitConflict?: (conflict: GitConflict) => Promise<boolean>;

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
@@ -6,6 +6,7 @@ import type {
   AgentStudioPendingReset,
   GitConflict,
   GitConflictAction,
+  GitDiffRefreshMode,
 } from "@/features/agent-studio-git";
 import { useAgentStudioGitActionErrors } from "./use-agent-studio-git-action-errors";
 import { BUILDER_LOCK_REASON, type GitActionKind } from "./use-agent-studio-git-action-utils";
@@ -64,7 +65,7 @@ type UseAgentStudioGitActionsInput = {
   upstreamAheadBehind?: CommitsAheadBehind | null;
   detectedConflictedFiles?: string[];
   worktreeStatusSnapshotKey?: string | null;
-  refreshDiffData: () => void | Promise<void>;
+  refreshDiffData: (mode?: GitDiffRefreshMode) => void | Promise<void>;
   isDiffDataLoading?: boolean;
   isBuilderSessionWorking?: boolean;
   onResolveGitConflict?: (conflict: GitConflict) => Promise<boolean>;

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-commit-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-commit-actions.ts
@@ -57,7 +57,7 @@ export function useAgentStudioGitCommitActions({
         }
 
         try {
-          await refreshDiffData();
+          await refreshDiffData("soft");
         } catch (error) {
           setCommitError(toErrorMessage(error, "Diff refresh failed."));
         }

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.ts
@@ -245,7 +245,7 @@ export function useAgentStudioGitConflictController({
       toast.success(getGitConflictCopy(activeGitConflict.operation).abortedToastTitle);
 
       try {
-        await refreshDiffData();
+        await refreshDiffData("soft");
       } catch (error) {
         const message = toErrorMessage(error, "Git conflict was aborted, but diff refresh failed.");
         setRebaseError(message);

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-push-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-push-actions.ts
@@ -94,7 +94,7 @@ export function useAgentStudioGitPushActions({
         toast.success(`Pushed ${pushResult.branch}`, {
           description: `Remote: ${pushResult.remote}`,
         });
-        await refreshDiffData();
+        await refreshDiffData("soft");
       } catch (error) {
         const message = toErrorMessage(
           error,

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-rebase-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-rebase-actions.ts
@@ -98,7 +98,7 @@ export function useAgentStudioGitRebaseActions({
           const message = toConflictMessage(result.conflictedFiles, "pull_rebase");
           captureFreshConflict(conflict);
           toast.error("Pull requires conflict resolution", { description: message });
-          await refreshDiffData();
+          await refreshDiffData("soft");
           return;
         }
 
@@ -115,7 +115,7 @@ export function useAgentStudioGitRebaseActions({
         } else {
           toast.success("Pulled from upstream");
         }
-        await refreshDiffData();
+        await refreshDiffData("soft");
       } catch (error) {
         const message = toErrorMessage(error, "Pull failed.");
         setRebaseError(message);
@@ -176,12 +176,12 @@ export function useAgentStudioGitRebaseActions({
           const message = toConflictMessage(result.conflictedFiles, "rebase");
           captureFreshConflict(conflict);
           toast.error("Rebase requires conflict resolution", { description: message });
-          await refreshDiffData();
+          await refreshDiffData("soft");
           return;
         }
 
         clearActionErrors();
-        await refreshDiffData();
+        await refreshDiffData("soft");
       } catch (error) {
         setRebaseError(toErrorMessage(error, fallbackError));
       } finally {

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-reset-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-reset-actions.ts
@@ -189,7 +189,7 @@ export function useAgentStudioGitResetActions({
       });
 
       try {
-        await refreshDiffData();
+        await refreshDiffData("soft");
       } catch (error) {
         const message = toErrorMessage(error, "Reset was applied, but diff refresh failed.");
         setResetError(message);

--- a/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
@@ -102,7 +102,7 @@ const diffModel: AgentStudioGitPanelModel = {
   uncommittedFileCount: 0,
   isLoading: false,
   error: null,
-  refresh: () => {},
+  refresh: async () => {},
   setDiffScope: () => {},
   isCommitting: false,
   isPushing: false,


### PR DESCRIPTION
## Summary
- split git panel refreshes into hard, soft, and scheduled modes so manual refreshes still fetch, but action-driven and builder-triggered follow-up refreshes stay local-only
- make the refresh contract awaitable end-to-end and preserve refresh modes through the shell wiring so git action buttons remain disabled until the real follow-up refresh completes
- keep post-push upstream status accurate without an extra fetch by syncing the local remote-tracking ref after successful pushes, with desktop and Rust regression coverage

## Verification
- bun test src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx src/pages/agents/shell/use-forwarded-worktree-refresh.test.tsx src/pages/agents/shell/use-agents-page-shell-model.test.tsx
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- cargo test -p host-infra-system remote_tests::push_branch_pushes_to_remote_with_typed_result
- bun run test:rust
- bun run check:rust