### PR TITLE
fix(desktop): branch toaster dismissable interactions

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,6 +26,7 @@
     "@pierre/diffs": "^1.1.15",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dismissable-layer": "^1.1.11",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.3",

--- a/apps/desktop/src/components/ui/sonner.test.tsx
+++ b/apps/desktop/src/components/ui/sonner.test.tsx
@@ -39,6 +39,7 @@ describe("Toaster", () => {
 
     expect(branch.contains(toaster)).toBe(true);
     expect(props.position).toBe("bottom-right");
+    expect(props.richColors).toBe(false);
     expect(props.closeButton).toBe(true);
     expect(props.expand).toBe(true);
     expect(props.visibleToasts).toBe(5);

--- a/apps/desktop/src/components/ui/sonner.test.tsx
+++ b/apps/desktop/src/components/ui/sonner.test.tsx
@@ -1,48 +1,64 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
-import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+import { describe, expect, test } from "bun:test";
+import { DismissableLayer, DismissableLayerBranch } from "@radix-ui/react-dismissable-layer";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 
-enableReactActEnvironment();
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function BranchDismissHarness() {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <>
+      {open ? (
+        <DismissableLayer onDismiss={() => setOpen(false)}>
+          <div role="dialog">Overlay stays open</div>
+        </DismissableLayer>
+      ) : null}
+      <DismissableLayerBranch>
+        <button type="button">Close toast</button>
+      </DismissableLayerBranch>
+    </>
+  );
+}
+
+async function waitForDismissableLayerEffects() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 describe("Toaster", () => {
-  beforeEach(() => {
-    mock.module("@radix-ui/react-dismissable-layer", () => ({
-      DismissableLayerBranch: ({ children }: { children: ReactNode }) => (
-        <div data-testid="dismissable-layer-branch">{children}</div>
-      ),
-    }));
+  test("dismissable layer branches keep pointer interactions from dismissing overlays", async () => {
+    render(<BranchDismissHarness />);
 
-    mock.module("sonner", () => ({
-      Toaster: (props: Record<string, unknown>) => (
-        <div data-testid="sonner-toaster" data-props={JSON.stringify(props)} />
-      ),
-    }));
+    await waitForDismissableLayerEffects();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Close toast" }));
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
   });
 
-  afterAll(async () => {
-    await restoreMockedModules([
-      ["@radix-ui/react-dismissable-layer", () => import("@radix-ui/react-dismissable-layer")],
-      ["sonner", () => import("sonner")],
-    ]);
-  });
+  test("wraps the shared toaster in a dismissable layer branch with fixed defaults", async () => {
+    const source = await Bun.file(new URL("./sonner.tsx", import.meta.url)).text();
 
-  test("mounts the global toaster inside a dismissable layer branch", async () => {
-    const { Toaster } = await import("./sonner");
-
-    render(<Toaster duration={1234} />);
-
-    const branch = screen.getByTestId("dismissable-layer-branch");
-    const toaster = screen.getByTestId("sonner-toaster");
-    const props = JSON.parse(toaster.getAttribute("data-props") ?? "{}");
-
-    expect(branch.contains(toaster)).toBe(true);
-    expect(props.position).toBe("bottom-right");
-    expect(props.richColors).toBe(false);
-    expect(props.closeButton).toBe(true);
-    expect(props.expand).toBe(true);
-    expect(props.visibleToasts).toBe(5);
-    expect(props.duration).toBe(1234);
+    expect(source).toContain(
+      'import { DismissableLayerBranch } from "@radix-ui/react-dismissable-layer";',
+    );
+    expect(source).toContain("<DismissableLayerBranch>");
+    expect(source).toContain("</DismissableLayerBranch>");
+    expect(source).toContain('position="bottom-right"');
+    expect(source).toContain("richColors={false}");
+    expect(source).toContain("closeButton");
+    expect(source).toContain("expand");
+    expect(source).toContain("visibleToasts={5}");
   });
 });

--- a/apps/desktop/src/components/ui/sonner.test.tsx
+++ b/apps/desktop/src/components/ui/sonner.test.tsx
@@ -1,0 +1,47 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+
+enableReactActEnvironment();
+
+describe("Toaster", () => {
+  beforeEach(() => {
+    mock.module("@radix-ui/react-dismissable-layer", () => ({
+      DismissableLayerBranch: ({ children }: { children: ReactNode }) => (
+        <div data-testid="dismissable-layer-branch">{children}</div>
+      ),
+    }));
+
+    mock.module("sonner", () => ({
+      Toaster: (props: Record<string, unknown>) => (
+        <div data-testid="sonner-toaster" data-props={JSON.stringify(props)} />
+      ),
+    }));
+  });
+
+  afterAll(async () => {
+    await restoreMockedModules([
+      ["@radix-ui/react-dismissable-layer", () => import("@radix-ui/react-dismissable-layer")],
+      ["sonner", () => import("sonner")],
+    ]);
+  });
+
+  test("mounts the global toaster inside a dismissable layer branch", async () => {
+    const { Toaster } = await import("./sonner");
+
+    render(<Toaster duration={1234} />);
+
+    const branch = screen.getByTestId("dismissable-layer-branch");
+    const toaster = screen.getByTestId("sonner-toaster");
+    const props = JSON.parse(toaster.getAttribute("data-props") ?? "{}");
+
+    expect(branch.contains(toaster)).toBe(true);
+    expect(props.position).toBe("bottom-right");
+    expect(props.closeButton).toBe(true);
+    expect(props.expand).toBe(true);
+    expect(props.visibleToasts).toBe(5);
+    expect(props.duration).toBe(1234);
+  });
+});

--- a/apps/desktop/src/components/ui/sonner.tsx
+++ b/apps/desktop/src/components/ui/sonner.tsx
@@ -1,34 +1,37 @@
+import { DismissableLayerBranch } from "@radix-ui/react-dismissable-layer";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 export function Toaster(props: ToasterProps) {
   return (
-    <Sonner
-      position="bottom-right"
-      richColors={false}
-      closeButton
-      expand
-      visibleToasts={5}
-      toastOptions={{
-        classNames: {
-          toast:
-            "group border border-border bg-card/95 text-foreground shadow-xl shadow-foreground/10 backdrop-blur",
-          content: "gap-1.5",
-          title: "text-sm font-semibold",
-          description: "text-xs text-muted-foreground",
-          icon: "text-muted-foreground",
-          closeButton:
-            "!left-auto !right-3 !top-1/2 !mt-[-12px] !translate-x-0 !translate-y-0 !transform-none size-6 rounded-md border border-border bg-card text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100",
-          actionButton:
-            "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring/40",
-          cancelButton:
-            "bg-muted text-foreground hover:bg-secondary focus-visible:ring-2 focus-visible:ring-ring/40",
-          success: "border-l-4 border-l-success-accent [&_[data-icon]]:text-success-accent",
-          error: "border-l-4 border-l-destructive-accent [&_[data-icon]]:text-destructive-accent",
-          warning: "border-l-4 border-l-warning-accent [&_[data-icon]]:text-warning-accent",
-          info: "border-l-4 border-l-info-accent [&_[data-icon]]:text-info-accent",
-        },
-      }}
-      {...props}
-    />
+    <DismissableLayerBranch>
+      <Sonner
+        position="bottom-right"
+        richColors={false}
+        closeButton
+        expand
+        visibleToasts={5}
+        toastOptions={{
+          classNames: {
+            toast:
+              "group border border-border bg-card/95 text-foreground shadow-xl shadow-foreground/10 backdrop-blur",
+            content: "gap-1.5",
+            title: "text-sm font-semibold",
+            description: "text-xs text-muted-foreground",
+            icon: "text-muted-foreground",
+            closeButton:
+              "!left-auto !right-3 !top-1/2 !mt-[-12px] !translate-x-0 !translate-y-0 !transform-none size-6 rounded-md border border-border bg-card text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100",
+            actionButton:
+              "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring/40",
+            cancelButton:
+              "bg-muted text-foreground hover:bg-secondary focus-visible:ring-2 focus-visible:ring-ring/40",
+            success: "border-l-4 border-l-success-accent [&_[data-icon]]:text-success-accent",
+            error: "border-l-4 border-l-destructive-accent [&_[data-icon]]:text-destructive-accent",
+            warning: "border-l-4 border-l-warning-accent [&_[data-icon]]:text-warning-accent",
+            info: "border-l-4 border-l-info-accent [&_[data-icon]]:text-info-accent",
+          },
+        }}
+        {...props}
+      />
+    </DismissableLayerBranch>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "@openducktor/desktop",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "@openducktor/adapters-opencode-sdk": "workspace:*",
         "@openducktor/adapters-tauri-host": "workspace:*",
@@ -23,6 +23,7 @@
         "@pierre/diffs": "^1.1.15",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-dismissable-layer": "^1.1.11",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-slot": "^1.2.3",
@@ -67,7 +68,7 @@
     },
     "packages/adapters-opencode-sdk": {
       "name": "@openducktor/adapters-opencode-sdk",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "@opencode-ai/sdk": "^1.4.3",
         "@openducktor/contracts": "workspace:*",
@@ -76,7 +77,7 @@
     },
     "packages/adapters-tauri-host": {
       "name": "@openducktor/adapters-tauri-host",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "@openducktor/contracts": "workspace:*",
         "@openducktor/core": "workspace:*",
@@ -84,21 +85,21 @@
     },
     "packages/contracts": {
       "name": "@openducktor/contracts",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "zod": "^4.3.6",
       },
     },
     "packages/core": {
       "name": "@openducktor/core",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "@openducktor/contracts": "workspace:*",
       },
     },
     "packages/openducktor-mcp": {
       "name": "@openducktor/mcp",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "bin": {
         "openducktor-mcp": "./dist/index.js",
       },


### PR DESCRIPTION
## Summary
- mark the shared Sonner toaster as a Radix dismissable-layer branch so toast interactions do not dismiss overlays behind it
- keep the fix centralized in the toaster wrapper instead of adding per-component outside-dismiss guards
- add focused frontend coverage for the shared toaster wrapper and include the new Radix dependency in the desktop package

## Verification
- bun test \"src/components/ui/sonner.test.tsx\" --timeout 1000
- bun run typecheck
- bunx biome check \"src/components/ui/dialog.tsx\" \"src/components/ui/sheet.tsx\" \"src/components/ui/sonner.tsx\" \"src/components/ui/sonner.test.tsx\"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced toast notification dismissal with improved handling of user interactions when multiple overlays are present, ensuring proper notification dismissal sequence.

* **Tests**
  * Added comprehensive tests for toast dismissal behavior, verifying correct behavior when users interact with overlays, close controls, and other dismissable elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->