### PR TITLE
feat(agent-chat): support pasted image attachments

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildComposerAttachmentFromFile,
   buildComposerAttachmentFromPath,
+  readAttachmentFileName,
   validateComposerAttachments,
 } from "./agent-chat-attachments";
 
@@ -38,6 +39,16 @@ describe("agent-chat-attachments", () => {
     });
     expect(attachment?.file).toBeInstanceOf(File);
     expect(attachment?.file?.name).toBe("pasted-image.png");
+  });
+
+  test("returns a non-empty fallback label for unnamed unsupported files", () => {
+    expect(readAttachmentFileName({ name: "", mime: "application/zip" })).toBe("pasted-attachment");
+  });
+
+  test("preserves existing non-empty filenames verbatim", () => {
+    expect(readAttachmentFileName({ name: " report .pdf ", mime: "application/pdf" })).toBe(
+      " report .pdf ",
+    );
   });
 
   test("rehydrates uncommon supported extensions from their path", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
@@ -26,6 +26,20 @@ describe("agent-chat-attachments", () => {
     expect(buildComposerAttachmentFromFile(file)).toBeNull();
   });
 
+  test("normalizes unnamed browser files to a usable attachment filename", () => {
+    const file = new File(["image"], "", { type: "image/png" });
+
+    const attachment = buildComposerAttachmentFromFile(file);
+
+    expect(attachment).toMatchObject({
+      name: "pasted-image.png",
+      kind: "image",
+      mime: "image/png",
+    });
+    expect(attachment?.file).toBeInstanceOf(File);
+    expect(attachment?.file?.name).toBe("pasted-image.png");
+  });
+
   test("rehydrates uncommon supported extensions from their path", () => {
     const attachment = buildComposerAttachmentFromPath("/tmp/preview.avif");
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.ts
@@ -80,6 +80,8 @@ const ATTACHMENT_KIND_DEFAULT_NAME: Record<AgentAttachmentKind, string> = {
   pdf: "pasted-pdf",
 };
 
+const GENERIC_ATTACHMENT_DEFAULT_NAME = "pasted-attachment";
+
 export const CHAT_ATTACHMENT_ACCEPT = "image/*,audio/*,video/*,.pdf,application/pdf";
 
 const readFileExtension = (name: string): string => {
@@ -124,15 +126,44 @@ const inferAttachmentMime = (name: string, mime?: string): string | undefined =>
   return ATTACHMENT_EXTENSION_MIME[readFileExtension(name)];
 };
 
-const normalizeAttachmentFileName = (file: File, kind: AgentAttachmentKind): File => {
-  if (file.name.trim().length > 0) {
+const buildGeneratedAttachmentName = (kind: AgentAttachmentKind | null, mime?: string): string => {
+  const normalizedMime = mime?.trim().toLowerCase();
+  const extension = normalizedMime ? (ATTACHMENT_MIME_EXTENSION[normalizedMime] ?? "") : "";
+  const baseName = kind ? ATTACHMENT_KIND_DEFAULT_NAME[kind] : GENERIC_ATTACHMENT_DEFAULT_NAME;
+
+  return `${baseName}${extension}`;
+};
+
+export const readAttachmentFileName = (input: {
+  name: string;
+  mime?: string;
+  kind?: AgentAttachmentKind | null;
+}): string => {
+  if (input.name.trim().length > 0) {
+    return input.name;
+  }
+
+  return buildGeneratedAttachmentName(
+    input.kind ??
+      classifyAttachment({
+        name: input.name,
+        ...(input.mime ? { mime: input.mime } : {}),
+      }),
+    input.mime,
+  );
+};
+
+const normalizeAttachmentFile = (file: File, kind: AgentAttachmentKind): File => {
+  const normalizedName = readAttachmentFileName({
+    name: file.name,
+    mime: file.type,
+    kind,
+  });
+  if (normalizedName === file.name) {
     return file;
   }
 
-  const extension = ATTACHMENT_MIME_EXTENSION[file.type.trim().toLowerCase()] ?? "";
-  const name = `${ATTACHMENT_KIND_DEFAULT_NAME[kind]}${extension}`;
-
-  return new File([file], name, {
+  return new File([file], normalizedName, {
     type: file.type,
     lastModified: file.lastModified,
   });
@@ -143,7 +174,7 @@ export const buildComposerAttachmentFromFile = (file: File): AgentChatComposerAt
   if (!kind) {
     return null;
   }
-  const normalizedFile = normalizeAttachmentFileName(file, kind);
+  const normalizedFile = normalizeAttachmentFile(file, kind);
   const mime = inferAttachmentMime(normalizedFile.name, normalizedFile.type);
 
   return createComposerAttachment({

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.ts
@@ -66,6 +66,20 @@ const ATTACHMENT_EXTENSION_MIME: Record<string, string> = {
   ".pdf": "application/pdf",
 };
 
+const ATTACHMENT_MIME_EXTENSION = Object.entries(ATTACHMENT_EXTENSION_MIME).reduce<
+  Record<string, string>
+>((acc, [extension, mime]) => {
+  acc[mime] ??= extension;
+  return acc;
+}, {});
+
+const ATTACHMENT_KIND_DEFAULT_NAME: Record<AgentAttachmentKind, string> = {
+  image: "pasted-image",
+  audio: "pasted-audio",
+  video: "pasted-video",
+  pdf: "pasted-pdf",
+};
+
 export const CHAT_ATTACHMENT_ACCEPT = "image/*,audio/*,video/*,.pdf,application/pdf";
 
 const readFileExtension = (name: string): string => {
@@ -110,18 +124,33 @@ const inferAttachmentMime = (name: string, mime?: string): string | undefined =>
   return ATTACHMENT_EXTENSION_MIME[readFileExtension(name)];
 };
 
+const normalizeAttachmentFileName = (file: File, kind: AgentAttachmentKind): File => {
+  if (file.name.trim().length > 0) {
+    return file;
+  }
+
+  const extension = ATTACHMENT_MIME_EXTENSION[file.type.trim().toLowerCase()] ?? "";
+  const name = `${ATTACHMENT_KIND_DEFAULT_NAME[kind]}${extension}`;
+
+  return new File([file], name, {
+    type: file.type,
+    lastModified: file.lastModified,
+  });
+};
+
 export const buildComposerAttachmentFromFile = (file: File): AgentChatComposerAttachment | null => {
   const kind = classifyAttachment({ name: file.name, mime: file.type });
   if (!kind) {
     return null;
   }
-  const mime = inferAttachmentMime(file.name, file.type);
+  const normalizedFile = normalizeAttachmentFileName(file, kind);
+  const mime = inferAttachmentMime(normalizedFile.name, normalizedFile.type);
 
   return createComposerAttachment({
-    name: file.name,
+    name: normalizedFile.name,
     kind,
     ...(mime ? { mime } : {}),
-    file,
+    file: normalizedFile,
   });
 };
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -120,6 +120,7 @@ const EditorHarness = ({
   onSend,
   initialDraft = createComposerDraft(""),
   disabled = false,
+  onAddFiles,
 }: {
   slashCommandsError: string | null;
   slashCommands: typeof COMMANDS;
@@ -128,6 +129,7 @@ const EditorHarness = ({
   onSend?: () => void;
   initialDraft?: AgentChatComposerDraft;
   disabled?: boolean;
+  onAddFiles?: (files: File[]) => void;
 }): ReactElement => {
   const [draft, setDraft] = useState<AgentChatComposerDraft>(initialDraft);
   const editorRef = useRef<HTMLDivElement>(null);
@@ -148,6 +150,7 @@ const EditorHarness = ({
         slashCommandsError={slashCommandsError}
         isSlashCommandsLoading={false}
         searchFiles={searchFiles}
+        onAddFiles={onAddFiles ?? (() => {})}
       />
       <output data-testid="draft-state">{JSON.stringify(draft)}</output>
     </>
@@ -269,12 +272,19 @@ const selectRangeAcrossTextSegments = (
 const createClipboardData = ({
   plainText = "",
   htmlText = "",
+  items = [],
   types = ["text/plain", "text/html"],
 }: {
   plainText?: string;
   htmlText?: string;
+  items?: Array<{
+    kind: string;
+    type: string;
+    getAsFile: () => File | null;
+  }>;
   types?: string[];
 }) => ({
+  items,
   types,
   getData: (type: string): string => {
     if (type === "text/plain") {
@@ -287,6 +297,12 @@ const createClipboardData = ({
 
     return "";
   },
+});
+
+const createClipboardFileItem = (file: File) => ({
+  kind: "file",
+  type: file.type,
+  getAsFile: () => file,
 });
 
 describe("AgentChatComposerEditor", () => {
@@ -394,6 +410,81 @@ describe("AgentChatComposerEditor", () => {
     expect(screen.getByTestId("draft-state").textContent).toContain("hello bold words");
   });
 
+  test("forwards pasted images to attachment intake without replacing selected text", async () => {
+    const onAddFiles = mock(() => {});
+    const image = new File(["image"], "pasted-image.png", { type: "image/png" });
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        initialDraft={createComposerDraft("keep this")}
+        onAddFiles={onAddFiles}
+      />,
+    );
+
+    const editorRoot = selectComposerContentRange(rendered.container);
+    fireEvent.paste(editorRoot, {
+      clipboardData: createClipboardData({
+        items: [createClipboardFileItem(image)],
+        types: ["Files"],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(onAddFiles).toHaveBeenCalledWith([image]);
+    });
+    await expectComposerText(rendered.container, "keep this");
+    expect(screen.getByTestId("draft-state").textContent).toContain("keep this");
+  });
+
+  test("prefers pasted images over clipboard text when both are present", async () => {
+    const onAddFiles = mock(() => {});
+    const image = new File(["image"], "clipboard-image.png", { type: "image/png" });
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        initialDraft={createComposerDraft("keep this")}
+        onAddFiles={onAddFiles}
+      />,
+    );
+
+    fireEvent.paste(getEditorRoot(rendered.container), {
+      clipboardData: createClipboardData({
+        plainText: "should not appear",
+        htmlText: "<strong>should not appear</strong>",
+        items: [createClipboardFileItem(image)],
+        types: ["Files", "text/plain", "text/html"],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(onAddFiles).toHaveBeenCalledWith([image]);
+    });
+    await expectComposerText(rendered.container, "keep this");
+    expect(screen.getByTestId("draft-state").textContent).not.toContain("should not appear");
+  });
+
+  test("forwards every supported pasted image from one clipboard event", async () => {
+    const onAddFiles = mock(() => {});
+    const firstImage = new File(["image-1"], "one.png", { type: "image/png" });
+    const secondImage = new File(["image-2"], "two.jpg", { type: "image/jpeg" });
+    const rendered = render(
+      <EditorHarness slashCommands={COMMANDS} slashCommandsError={null} onAddFiles={onAddFiles} />,
+    );
+
+    fireEvent.paste(getEditorRoot(rendered.container), {
+      clipboardData: createClipboardData({
+        items: [createClipboardFileItem(firstImage), createClipboardFileItem(secondImage)],
+        types: ["Files"],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(onAddFiles).toHaveBeenCalledWith([firstImage, secondImage]);
+    });
+  });
+
   test("replaces a full composer selection with pasted plain text", async () => {
     const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
 
@@ -411,27 +502,37 @@ describe("AgentChatComposerEditor", () => {
     expect(screen.getByTestId("draft-state").textContent).toContain("line one\\nline two");
   });
 
-  test("ignores non-text clipboard payloads without clearing the composer", async () => {
-    const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
+  test("ignores unsupported file-only clipboard payloads without clearing the composer", async () => {
+    const onAddFiles = mock(() => {});
+    const rendered = render(
+      <EditorHarness slashCommands={COMMANDS} slashCommandsError={null} onAddFiles={onAddFiles} />,
+    );
 
     typeIntoEditor(rendered.container, "keep this");
     selectComposerContentRange(rendered.container);
+    const pdf = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
 
     fireEvent.paste(getEditorRoot(rendered.container), {
-      clipboardData: createClipboardData({ types: ["Files"] }),
+      clipboardData: createClipboardData({
+        items: [createClipboardFileItem(pdf)],
+        types: ["Files"],
+      }),
     });
 
     await expectComposerText(rendered.container, "keep this");
     expect(screen.getByTestId("draft-state").textContent).toContain("keep this");
+    expect(onAddFiles).not.toHaveBeenCalled();
   });
 
   test("ignores paste while the composer is disabled", async () => {
+    const onAddFiles = mock(() => {});
     const rendered = render(
       <EditorHarness
         slashCommands={COMMANDS}
         slashCommandsError={null}
         initialDraft={createComposerDraft("keep this")}
         disabled
+        onAddFiles={onAddFiles}
       />,
     );
 
@@ -444,11 +545,16 @@ describe("AgentChatComposerEditor", () => {
       clipboardData: createClipboardData({
         plainText: "should not apply",
         htmlText: "<strong>should not apply</strong>",
+        items: [
+          createClipboardFileItem(new File(["image"], "disabled.png", { type: "image/png" })),
+        ],
+        types: ["Files", "text/plain", "text/html"],
       }),
     });
 
     await expectComposerText(rendered.container, "keep this");
     expect(screen.getByTestId("draft-state").textContent).toContain("keep this");
+    expect(onAddFiles).not.toHaveBeenCalled();
   });
 
   test("replaces selections spanning a file chip with normalized plain text", async () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -510,21 +510,28 @@ describe("AgentChatComposerEditor", () => {
 
   test("deduplicates pasted images exposed through both clipboard items and files", async () => {
     const onAddFiles = mock(() => {});
-    const image = new File(["image"], "duplicate.png", { type: "image/png" });
+    const itemImage = new File(["image"], "duplicate.png", {
+      type: "image/png",
+      lastModified: 1,
+    });
+    const filesImage = new File(["image"], "duplicate.png", {
+      type: "image/png",
+      lastModified: 2,
+    });
     const rendered = render(
       <EditorHarness slashCommands={COMMANDS} slashCommandsError={null} onAddFiles={onAddFiles} />,
     );
 
     fireEvent.paste(getEditorRoot(rendered.container), {
       clipboardData: createClipboardData({
-        items: [createClipboardFileItem(image)],
-        files: [image],
+        items: [createClipboardFileItem(itemImage)],
+        files: [filesImage],
         types: ["Files"],
       }),
     });
 
     await waitFor(() => {
-      expect(onAddFiles).toHaveBeenCalledWith([image]);
+      expect(onAddFiles).toHaveBeenCalledWith([itemImage]);
     });
   });
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -273,6 +273,7 @@ const createClipboardData = ({
   plainText = "",
   htmlText = "",
   items = [],
+  files = [],
   types = ["text/plain", "text/html"],
 }: {
   plainText?: string;
@@ -282,9 +283,11 @@ const createClipboardData = ({
     type: string;
     getAsFile: () => File | null;
   }>;
+  files?: File[];
   types?: string[];
 }) => ({
   items,
+  files,
   types,
   getData: (type: string): string => {
     if (type === "text/plain") {
@@ -482,6 +485,46 @@ describe("AgentChatComposerEditor", () => {
 
     await waitFor(() => {
       expect(onAddFiles).toHaveBeenCalledWith([firstImage, secondImage]);
+    });
+  });
+
+  test("falls back to clipboard files when clipboard items omit pasted images", async () => {
+    const onAddFiles = mock(() => {});
+    const image = new File(["image"], "fallback.png", { type: "image/png" });
+    const rendered = render(
+      <EditorHarness slashCommands={COMMANDS} slashCommandsError={null} onAddFiles={onAddFiles} />,
+    );
+
+    fireEvent.paste(getEditorRoot(rendered.container), {
+      clipboardData: createClipboardData({
+        items: [],
+        files: [image],
+        types: ["Files"],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(onAddFiles).toHaveBeenCalledWith([image]);
+    });
+  });
+
+  test("deduplicates pasted images exposed through both clipboard items and files", async () => {
+    const onAddFiles = mock(() => {});
+    const image = new File(["image"], "duplicate.png", { type: "image/png" });
+    const rendered = render(
+      <EditorHarness slashCommands={COMMANDS} slashCommandsError={null} onAddFiles={onAddFiles} />,
+    );
+
+    fireEvent.paste(getEditorRoot(rendered.container), {
+      clipboardData: createClipboardData({
+        items: [createClipboardFileItem(image)],
+        files: [image],
+        types: ["Files"],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(onAddFiles).toHaveBeenCalledWith([image]);
     });
   });
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -574,6 +574,36 @@ describe("AgentChatComposerEditor", () => {
     expect(onAddFiles).not.toHaveBeenCalled();
   });
 
+  test("blocks html-only paste payloads without mutating the composer draft", async () => {
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        initialDraft={createComposerDraft("keep this")}
+      />,
+    );
+
+    const editorRoot = getEditorRoot(rendered.container);
+    const pasteEvent = new Event("paste", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    Object.defineProperty(pasteEvent, "clipboardData", {
+      value: createClipboardData({
+        htmlText: "<strong>should not appear</strong>",
+        types: ["text/html"],
+      }),
+    });
+
+    fireEvent(editorRoot, pasteEvent);
+
+    expect(pasteEvent.defaultPrevented).toBe(true);
+    await expectComposerText(rendered.container, "keep this");
+    expect(screen.getByTestId("draft-state").textContent).toContain("keep this");
+    expect(screen.getByTestId("draft-state").textContent).not.toContain("should not appear");
+  });
+
   test("ignores paste while the composer is disabled", async () => {
     const onAddFiles = mock(() => {});
     const rendered = render(

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
@@ -232,6 +232,7 @@ const shouldRedirectShellClickToComposer = (
 type AgentChatComposerEditorProps = {
   draft: AgentChatComposerDraft;
   onDraftChange: (draft: AgentChatComposerDraft) => void;
+  onAddFiles: (files: File[]) => void;
   placeholder: string;
   disabled: boolean;
   editorRef: React.RefObject<HTMLDivElement | null>;
@@ -248,6 +249,7 @@ type AgentChatComposerEditorProps = {
 export function AgentChatComposerEditor({
   draft,
   onDraftChange,
+  onAddFiles,
   placeholder,
   disabled,
   editorRef,
@@ -284,6 +286,7 @@ export function AgentChatComposerEditor({
   } = useAgentChatComposerEditor({
     draft,
     onDraftChange,
+    onAddFiles,
     editorRef,
     disabled,
     onEditorInput,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -96,14 +96,17 @@ const typeIntoComposer = (container: HTMLElement, value: string): void => {
   fireEvent.input(editable);
 };
 
-const createClipboardData = (file: File) => ({
-  items: [
-    {
-      kind: "file",
-      type: file.type,
-      getAsFile: () => file,
-    },
-  ],
+const createClipboardData = ({ itemFile, files }: { itemFile?: File; files?: File[] }) => ({
+  items: itemFile
+    ? [
+        {
+          kind: "file",
+          type: itemFile.type,
+          getAsFile: () => itemFile,
+        },
+      ]
+    : [],
+  files: files ?? [],
   types: ["Files"],
   getData: () => "",
 });
@@ -260,7 +263,7 @@ describe("AgentChatComposer attachments", () => {
     const unnamedImage = new File(["image"], "", { type: "image/png" });
 
     fireEvent.paste(getEditorRoot(container), {
-      clipboardData: createClipboardData(unnamedImage),
+      clipboardData: createClipboardData({ itemFile: unnamedImage }),
     });
 
     await screen.findByTitle("pasted-image.png");
@@ -295,9 +298,9 @@ describe("AgentChatComposer attachments", () => {
     );
 
     fireEvent.paste(getEditorRoot(container), {
-      clipboardData: createClipboardData(
-        new File(["image"], "clipboard-image.png", { type: "image/png" }),
-      ),
+      clipboardData: createClipboardData({
+        itemFile: new File(["image"], "clipboard-image.png", { type: "image/png" }),
+      }),
     });
 
     await screen.findByTitle("clipboard-image.png");
@@ -307,5 +310,42 @@ describe("AgentChatComposer attachments", () => {
     expect(
       screen.getByRole("button", { name: "Send message" }).getAttribute("disabled"),
     ).not.toBeNull();
+  });
+
+  test("stages one attachment when the same paste is exposed through items and files", async () => {
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          selectedModelDescriptor: {
+            id: "openai/gpt-5.3-codex",
+            providerId: "openai",
+            providerName: "OpenAI",
+            modelId: "gpt-5.3-codex",
+            modelName: "GPT-5.3 Codex",
+            variants: ["high"],
+            contextWindow: 400_000,
+            outputLimit: 128_000,
+            attachmentSupport: {
+              image: true,
+              audio: false,
+              video: false,
+              pdf: true,
+            },
+          },
+        }}
+      />,
+    );
+
+    fireEvent.paste(getEditorRoot(container), {
+      clipboardData: createClipboardData({
+        itemFile: new File(["image"], "image.png", { type: "image/png", lastModified: 1 }),
+        files: [new File(["image"], "image.png", { type: "image/png", lastModified: 2 })],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTitle("image.png")).toHaveLength(1);
+    });
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -61,6 +61,53 @@ const buildModel = () => ({
   syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
 });
 
+const getEditorRoot = (container: HTMLElement): HTMLElement => {
+  const editorRoot = container.querySelector('[contenteditable="true"]');
+  if (!(editorRoot instanceof HTMLElement)) {
+    throw new Error("Expected editable composer root");
+  }
+
+  return editorRoot;
+};
+
+const getLastTextSegment = (container: HTMLElement): HTMLElement => {
+  const textSegments = Array.from(container.querySelectorAll("[data-text-segment-id]"));
+  const editable = textSegments.at(-1);
+  if (!(editable instanceof HTMLElement)) {
+    throw new Error("Expected editable composer text segment");
+  }
+
+  return editable;
+};
+
+const typeIntoComposer = (container: HTMLElement, value: string): void => {
+  const editable = getLastTextSegment(container);
+  editable.textContent = value;
+  const textNode = editable.firstChild;
+  if (textNode) {
+    const range = document.createRange();
+    range.setStart(textNode, value.length);
+    range.collapse(true);
+    const selection = globalThis.getSelection?.();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  }
+
+  fireEvent.input(editable);
+};
+
+const createClipboardData = (file: File) => ({
+  items: [
+    {
+      kind: "file",
+      type: file.type,
+      getAsFile: () => file,
+    },
+  ],
+  types: ["Files"],
+  getData: () => "",
+});
+
 describe("AgentChatComposer attachments", () => {
   test("stages attachments, revalidates on model changes, and removes them", async () => {
     const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
@@ -182,5 +229,83 @@ describe("AgentChatComposer attachments", () => {
     await waitFor(() => {
       expect(syncBottomAfterComposerLayout.current).toHaveBeenCalledTimes(2);
     });
+  });
+
+  test("pastes unnamed images as attachments without disturbing existing text", async () => {
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          selectedModelDescriptor: {
+            id: "openai/gpt-5.3-codex",
+            providerId: "openai",
+            providerName: "OpenAI",
+            modelId: "gpt-5.3-codex",
+            modelName: "GPT-5.3 Codex",
+            variants: ["high"],
+            contextWindow: 400_000,
+            outputLimit: 128_000,
+            attachmentSupport: {
+              image: true,
+              audio: false,
+              video: false,
+              pdf: true,
+            },
+          },
+        }}
+      />,
+    );
+
+    typeIntoComposer(container, "existing text");
+    const unnamedImage = new File(["image"], "", { type: "image/png" });
+
+    fireEvent.paste(getEditorRoot(container), {
+      clipboardData: createClipboardData(unnamedImage),
+    });
+
+    await screen.findByTitle("pasted-image.png");
+    expect(screen.getByRole("button", { name: "Remove pasted-image.png" })).toBeDefined();
+    const contentRoot = container.querySelector("[data-composer-content-root]");
+    expect(contentRoot?.textContent).toContain("existing text");
+  });
+
+  test("shows existing attachment validation errors for pasted images", async () => {
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          selectedModelDescriptor: {
+            id: "openai/gpt-5.3-codex",
+            providerId: "openai",
+            providerName: "OpenAI",
+            modelId: "gpt-5.3-codex",
+            modelName: "GPT-5.3 Codex",
+            variants: ["high"],
+            contextWindow: 400_000,
+            outputLimit: 128_000,
+            attachmentSupport: {
+              image: false,
+              audio: false,
+              video: false,
+              pdf: true,
+            },
+          },
+        }}
+      />,
+    );
+
+    fireEvent.paste(getEditorRoot(container), {
+      clipboardData: createClipboardData(
+        new File(["image"], "clipboard-image.png", { type: "image/png" }),
+      ),
+    });
+
+    await screen.findByTitle("clipboard-image.png");
+    expect(
+      screen.getByText("The selected model does not support image attachments."),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Send message" }).getAttribute("disabled"),
+    ).not.toBeNull();
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -576,6 +576,7 @@ export const AgentChatComposer = forwardRef<
           <AgentChatComposerEditor
             draft={draft}
             onDraftChange={handleDraftChange}
+            onAddFiles={handleAddFiles}
             placeholder={composerPlaceholder}
             disabled={isComposerInputDisabled || isSubmitting}
             editorRef={composerEditorRef}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -29,6 +29,7 @@ import { AgentChatAttachmentChip } from "./agent-chat-attachment-chip";
 import {
   buildComposerAttachmentFromFile,
   CHAT_ATTACHMENT_ACCEPT,
+  readAttachmentFileName,
   validateComposerAttachments,
 } from "./agent-chat-attachments";
 import {
@@ -322,7 +323,9 @@ export const AgentChatComposer = forwardRef<
         const attachment = buildComposerAttachmentFromFile(file);
         if (!attachment) {
           toast.error("Unsupported attachment type", {
-            description: renderUnsupportedAttachmentDescription(file.name),
+            description: renderUnsupportedAttachmentDescription(
+              readAttachmentFileName({ name: file.name, mime: file.type }),
+            ),
           });
           return [];
         }

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -14,6 +14,7 @@ import {
   useState,
 } from "react";
 import { flushSync } from "react-dom";
+import { classifyAttachment } from "./agent-chat-attachments";
 import {
   type AgentChatComposerDraft,
   type AgentChatComposerDraftEditResult,
@@ -52,6 +53,7 @@ type FileMenuState = {
 type UseAgentChatComposerEditorArgs = {
   draft: AgentChatComposerDraft;
   onDraftChange: (draft: AgentChatComposerDraft) => void;
+  onAddFiles: (files: File[]) => void;
   editorRef: RefObject<HTMLDivElement | null>;
   disabled: boolean;
   onEditorInput: () => void;
@@ -101,6 +103,23 @@ type PendingInputState = TextSelectionTarget & {
 };
 
 const AUTOCOMPLETE_NAVIGATION_KEYS = new Set(["ArrowDown", "ArrowUp", "Enter", "Tab", "Escape"]);
+
+const readPastedImageFiles = (clipboardData: DataTransfer): File[] => {
+  return Array.from(clipboardData.items ?? []).flatMap((item) => {
+    if (item.kind !== "file") {
+      return [];
+    }
+
+    const file = item.getAsFile();
+    if (!file) {
+      return [];
+    }
+
+    return classifyAttachment({ name: file.name, mime: item.type || file.type }) === "image"
+      ? [file]
+      : [];
+  });
+};
 
 const findTextSegment = (
   draft: AgentChatComposerDraft,
@@ -425,6 +444,7 @@ const usePendingFocus = (editorRef: RefObject<HTMLDivElement | null>) => {
 export const useAgentChatComposerEditor = ({
   draft,
   onDraftChange,
+  onAddFiles,
   editorRef,
   disabled,
   onEditorInput,
@@ -893,7 +913,15 @@ export const useAgentChatComposerEditor = ({
         return;
       }
 
-      event.preventDefault();
+      const imageFiles = readPastedImageFiles(event.clipboardData);
+      if (imageFiles.length > 0) {
+        event.preventDefault();
+        pendingInputStateRef.current = null;
+        setSlashMenuState(null);
+        closeFileMenu();
+        onAddFiles(imageFiles);
+        return;
+      }
 
       const clipboardTypes = Array.from(event.clipboardData.types ?? []);
       const hasPlainText = clipboardTypes.includes("text/plain");
@@ -901,6 +929,8 @@ export const useAgentChatComposerEditor = ({
         pendingInputStateRef.current = null;
         return;
       }
+
+      event.preventDefault();
 
       const plainText = event.clipboardData.getData("text/plain");
 
@@ -935,6 +965,7 @@ export const useAgentChatComposerEditor = ({
       closeFileMenu,
       disabled,
       handleEditorInput,
+      onAddFiles,
       rememberSelectionTarget,
       resolveActiveTextSelection,
     ],

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -953,6 +953,7 @@ export const useAgentChatComposerEditor = ({
       const clipboardTypes = Array.from(event.clipboardData.types ?? []);
       const hasPlainText = clipboardTypes.includes("text/plain");
       if (!hasPlainText) {
+        event.preventDefault();
         pendingInputStateRef.current = null;
         return;
       }

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -108,9 +108,8 @@ const isPastedImageFile = (file: File, mime?: string): boolean => {
   return classifyAttachment({ name: file.name, mime: mime || file.type }) === "image";
 };
 
-const readPastedImageFiles = (clipboardData: DataTransfer): File[] => {
-  const filesBySignature = new Map<string, File>();
-
+const readPastedImageFilesFromItems = (clipboardData: DataTransfer): File[] => {
+  const files: File[] = [];
   for (const item of Array.from(clipboardData.items ?? [])) {
     if (item.kind !== "file") {
       continue;
@@ -121,18 +120,32 @@ const readPastedImageFiles = (clipboardData: DataTransfer): File[] => {
       continue;
     }
 
-    filesBySignature.set(`${file.name}:${file.type}:${file.size}:${file.lastModified}`, file);
+    files.push(file);
   }
 
+  return files;
+};
+
+const readPastedImageFilesFromFiles = (clipboardData: DataTransfer): File[] => {
+  const files: File[] = [];
   for (const file of Array.from(clipboardData.files ?? [])) {
     if (!isPastedImageFile(file)) {
       continue;
     }
 
-    filesBySignature.set(`${file.name}:${file.type}:${file.size}:${file.lastModified}`, file);
+    files.push(file);
   }
 
-  return Array.from(filesBySignature.values());
+  return files;
+};
+
+const readPastedImageFiles = (clipboardData: DataTransfer): File[] => {
+  const itemFiles = readPastedImageFilesFromItems(clipboardData);
+  if (itemFiles.length > 0) {
+    return itemFiles;
+  }
+
+  return readPastedImageFilesFromFiles(clipboardData);
 };
 
 const findTextSegment = (

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -104,21 +104,35 @@ type PendingInputState = TextSelectionTarget & {
 
 const AUTOCOMPLETE_NAVIGATION_KEYS = new Set(["ArrowDown", "ArrowUp", "Enter", "Tab", "Escape"]);
 
+const isPastedImageFile = (file: File, mime?: string): boolean => {
+  return classifyAttachment({ name: file.name, mime: mime || file.type }) === "image";
+};
+
 const readPastedImageFiles = (clipboardData: DataTransfer): File[] => {
-  return Array.from(clipboardData.items ?? []).flatMap((item) => {
+  const filesBySignature = new Map<string, File>();
+
+  for (const item of Array.from(clipboardData.items ?? [])) {
     if (item.kind !== "file") {
-      return [];
+      continue;
     }
 
     const file = item.getAsFile();
-    if (!file) {
-      return [];
+    if (!file || !isPastedImageFile(file, item.type)) {
+      continue;
     }
 
-    return classifyAttachment({ name: file.name, mime: item.type || file.type }) === "image"
-      ? [file]
-      : [];
-  });
+    filesBySignature.set(`${file.name}:${file.type}:${file.size}:${file.lastModified}`, file);
+  }
+
+  for (const file of Array.from(clipboardData.files ?? [])) {
+    if (!isPastedImageFile(file)) {
+      continue;
+    }
+
+    filesBySignature.set(`${file.name}:${file.type}:${file.size}:${file.lastModified}`, file);
+  }
+
+  return Array.from(filesBySignature.values());
 };
 
 const findTextSegment = (


### PR DESCRIPTION
## Summary
- add clipboard image paste support to the agent chat composer by routing pasted images through the existing attachment intake path instead of introducing a second attachment pipeline
- normalize unnamed pasted files to stable generated names, reuse those names for unsupported-file messaging, and preserve the existing rule that mixed clipboard payloads prefer image attachments over text insertion
- harden clipboard handling so browser payloads that expose images through `DataTransfer.files` still work while a single paste event only stages one attachment

## Testing
- bun test apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
- bun test apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
- bun test apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

## Notes
- lint still reports the existing unrelated warning in `apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts:270` for a non-null assertion; no new lint issues were introduced in this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now paste images and files directly from the clipboard into the chat composer.
  * Pasted files without names are automatically assigned descriptive names based on file type (e.g., "pasted-image.png").
  * Enhanced file type detection and classification for improved attachment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->