### PR TITLE
refactor(runtime): tighten orchestration payload boundaries

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -125,10 +125,10 @@ const toArticleClassName = (
         : isSystemPromptMessage
           ? "rounded-md border border-border bg-muted px-3 py-2 text-foreground"
           : message.role === "assistant"
-            ? "px-1 py-1 text-foreground"
+            ? "px-1 pt-1 pb-3 text-foreground"
             : isUserMessage
               ? ""
-              : "border-none bg-transparent px-0 py-0 text-foreground",
+              : "border-none bg-transparent px-0 py-2 text-foreground",
   );
 };
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-batching.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-batching.ts
@@ -12,6 +12,11 @@ type SessionEventBatchRules = {
   [TType in SessionEvent["type"]]: SessionEventBatchRule<Extract<SessionEvent, { type: TType }>>;
 };
 
+type SessionEventOfType<TType extends SessionEvent["type"]> = Extract<
+  SessionEvent,
+  { type: TType }
+>;
+
 type QueuedSessionEventEntry = {
   key: string | null;
   event: SessionEvent;
@@ -112,6 +117,50 @@ const SESSION_EVENT_BATCH_RULES: SessionEventBatchRules = {
   },
 };
 
+const isSessionEventType = <TType extends SessionEvent["type"]>(
+  event: SessionEvent,
+  type: TType,
+): event is SessionEventOfType<TType> => event.type === type;
+
+const withTypedSessionEvent = <T>(
+  event: SessionEvent,
+  callback: <TType extends SessionEvent["type"]>(
+    typedEvent: SessionEventOfType<TType>,
+    rule: SessionEventBatchRules[TType],
+  ) => T,
+): T => {
+  switch (event.type) {
+    case "session_started":
+      return callback(event, SESSION_EVENT_BATCH_RULES.session_started);
+    case "assistant_delta":
+      return callback(event, SESSION_EVENT_BATCH_RULES.assistant_delta);
+    case "assistant_part":
+      return callback(event, SESSION_EVENT_BATCH_RULES.assistant_part);
+    case "assistant_message":
+      return callback(event, SESSION_EVENT_BATCH_RULES.assistant_message);
+    case "user_message":
+      return callback(event, SESSION_EVENT_BATCH_RULES.user_message);
+    case "session_status":
+      return callback(event, SESSION_EVENT_BATCH_RULES.session_status);
+    case "permission_required":
+      return callback(event, SESSION_EVENT_BATCH_RULES.permission_required);
+    case "question_required":
+      return callback(event, SESSION_EVENT_BATCH_RULES.question_required);
+    case "session_todos_updated":
+      return callback(event, SESSION_EVENT_BATCH_RULES.session_todos_updated);
+    case "session_error":
+      return callback(event, SESSION_EVENT_BATCH_RULES.session_error);
+    case "session_idle":
+      return callback(event, SESSION_EVENT_BATCH_RULES.session_idle);
+    case "session_finished":
+      return callback(event, SESSION_EVENT_BATCH_RULES.session_finished);
+    case "tool_call":
+      return callback(event, SESSION_EVENT_BATCH_RULES.tool_call);
+    case "tool_result":
+      return callback(event, SESSION_EVENT_BATCH_RULES.tool_result);
+  }
+};
+
 export const isImmediateSessionEvent = (event: SessionEvent): boolean => {
   return SESSION_EVENT_BATCH_RULES[event.type].immediate;
 };
@@ -121,48 +170,51 @@ const mergeQueuedSessionEvents = (events: SessionEvent[]): QueuedSessionEventEnt
   let keyIndex = new Map<string, number>();
 
   for (const event of events) {
-    const rule = SESSION_EVENT_BATCH_RULES[event.type];
+    withTypedSessionEvent(event, (typedEvent, rule) => {
+      if (rule.supersedes) {
+        let removed = false;
+        for (let index = entries.length - 1; index >= 0; index -= 1) {
+          const candidate = entries[index]?.event;
+          if (!candidate || !rule.supersedes(candidate, typedEvent)) {
+            continue;
+          }
 
-    if (rule.supersedes) {
-      let removed = false;
-      for (let index = entries.length - 1; index >= 0; index -= 1) {
-        const candidate = entries[index]?.event;
-        if (!candidate || !rule.supersedes(candidate, event as never)) {
-          continue;
+          entries.splice(index, 1);
+          removed = true;
         }
 
-        entries.splice(index, 1);
-        removed = true;
+        if (removed) {
+          keyIndex = rebuildKeyIndex(entries);
+        }
       }
 
-      if (removed) {
-        keyIndex = rebuildKeyIndex(entries);
+      const key = rule.dedupeKey?.(typedEvent) ?? null;
+      if (!key) {
+        entries.push({ key: null, event: typedEvent });
+        return;
       }
-    }
 
-    const key = rule.dedupeKey?.(event as never) ?? null;
-    if (!key) {
-      entries.push({ key: null, event });
-      continue;
-    }
+      const existingIndex = keyIndex.get(key);
+      if (existingIndex === undefined) {
+        keyIndex.set(key, entries.length);
+        entries.push({ key, event: typedEvent });
+        return;
+      }
 
-    const existingIndex = keyIndex.get(key);
-    if (existingIndex === undefined) {
-      keyIndex.set(key, entries.length);
-      entries.push({ key, event });
-      continue;
-    }
+      const previous = entries[existingIndex]?.event;
+      if (!previous) {
+        entries[existingIndex] = { key, event: typedEvent };
+        return;
+      }
 
-    const previous = entries[existingIndex]?.event;
-    if (!previous) {
-      entries[existingIndex] = { key, event };
-      continue;
-    }
-
-    entries[existingIndex] = {
-      key,
-      event: rule.merge ? rule.merge(previous as never, event as never) : event,
-    };
+      entries[existingIndex] = {
+        key,
+        event:
+          rule.merge && isSessionEventType(previous, typedEvent.type)
+            ? rule.merge(previous, typedEvent)
+            : typedEvent,
+      };
+    });
   }
 
   return entries;
@@ -197,37 +249,38 @@ export const createSessionEventBatcher = (
       const emittedAtMs = nowMs();
 
       for (const entry of mergedEntries) {
-        const rule = SESSION_EVENT_BATCH_RULES[entry.event.type];
-        const minEmitIntervalMs =
-          typeof rule.minEmitIntervalMs === "function"
-            ? rule.minEmitIntervalMs(entry.event as never)
-            : (rule.minEmitIntervalMs ?? null);
+        withTypedSessionEvent(entry.event, (typedEvent, rule) => {
+          const minEmitIntervalMs =
+            typeof rule.minEmitIntervalMs === "function"
+              ? rule.minEmitIntervalMs(typedEvent)
+              : (rule.minEmitIntervalMs ?? null);
 
-        if (!entry.key || !minEmitIntervalMs) {
-          readyEvents.push(entry.event);
-          if (entry.key) {
-            lastEmittedAtByKey.set(entry.key, emittedAtMs);
+          if (!entry.key || !minEmitIntervalMs) {
+            readyEvents.push(typedEvent);
+            if (entry.key) {
+              lastEmittedAtByKey.set(entry.key, emittedAtMs);
+            }
+            return;
           }
-          continue;
-        }
 
-        const lastEmittedAt = lastEmittedAtByKey.get(entry.key);
-        if (lastEmittedAt === undefined) {
-          lastEmittedAtByKey.set(entry.key, emittedAtMs);
-          readyEvents.push(entry.event);
-          continue;
-        }
+          const lastEmittedAt = lastEmittedAtByKey.get(entry.key);
+          if (lastEmittedAt === undefined) {
+            lastEmittedAtByKey.set(entry.key, emittedAtMs);
+            readyEvents.push(typedEvent);
+            return;
+          }
 
-        const elapsedMs = emittedAtMs - lastEmittedAt;
-        if (elapsedMs >= minEmitIntervalMs) {
-          lastEmittedAtByKey.set(entry.key, emittedAtMs);
-          readyEvents.push(entry.event);
-          continue;
-        }
+          const elapsedMs = emittedAtMs - lastEmittedAt;
+          if (elapsedMs >= minEmitIntervalMs) {
+            lastEmittedAtByKey.set(entry.key, emittedAtMs);
+            readyEvents.push(typedEvent);
+            return;
+          }
 
-        deferredEvents.push(entry.event);
-        const remainingMs = minEmitIntervalMs - elapsedMs;
-        nextDelayMs = nextDelayMs === null ? remainingMs : Math.min(nextDelayMs, remainingMs);
+          deferredEvents.push(typedEvent);
+          const remainingMs = minEmitIntervalMs - elapsedMs;
+          nextDelayMs = nextDelayMs === null ? remainingMs : Math.min(nextDelayMs, remainingMs);
+        });
       }
 
       return {

--- a/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
@@ -105,6 +105,41 @@ describe("message-normalizers", () => {
     ]);
   });
 
+  test("ignores malformed source text payloads when normalizing file references", () => {
+    const parts: Part[] = [
+      {
+        id: "file-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "text/plain",
+        filename: "main.ts",
+        url: "file:///repo/src/main.ts",
+        source: {
+          type: "file",
+          path: "src/main.ts",
+          text: {
+            value: "@src/main.ts",
+            start: "6",
+            end: 19,
+          },
+        },
+      } as Part,
+    ];
+
+    expect(normalizeUserMessageDisplayParts(parts)).toEqual([
+      {
+        kind: "file_reference",
+        file: {
+          id: "file-1",
+          path: "src/main.ts",
+          name: "main.ts",
+          kind: "code",
+        },
+      },
+    ]);
+  });
+
   test("keeps only the slash-command envelope text when OpenCode echoes instruction text separately", () => {
     const parts: Part[] = [
       {
@@ -561,5 +596,39 @@ describe("message-normalizers", () => {
 
     const total = extractMessageTotalTokens({}, parts);
     expect(total).toBe(70);
+  });
+
+  test("extractMessageTotalTokens ignores malformed nested token payloads", () => {
+    const total = extractMessageTotalTokens(
+      {
+        tokens: {
+          input: "300",
+          cache: {
+            read: "10",
+          },
+        },
+      },
+      [
+        {
+          id: "part-1",
+          tokens: {
+            input: 2,
+            output: "60",
+          },
+        },
+        {
+          id: "part-2",
+          tokens: {
+            input: 10,
+            output: 5,
+            cache: {
+              read: 2,
+            },
+          },
+        },
+      ],
+    );
+
+    expect(total).toBe(17);
   });
 });

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -6,7 +6,7 @@ import type {
   AgentUserMessageSourceText,
 } from "@openducktor/core";
 import { detectAgentFileReferenceKind } from "./file-reference-utils";
-import { asUnknownRecord, readRecordProp, readUnknownProp } from "./guards";
+import { asUnknownRecord, readNumberProp, readRecordProp, readUnknownProp } from "./guards";
 import { buildOpenCodeVisibleText } from "./opencode-user-message-encoding";
 
 const AUTO_SLASH_COMMAND_OPEN = "<auto-slash-command>";
@@ -51,14 +51,14 @@ const readFilePathFromUrl = (url: string): string | null => {
 };
 
 const normalizeSourceText = (value: unknown): AgentUserMessageSourceText | undefined => {
-  if (!value || typeof value !== "object") {
+  const record = asUnknownRecord(value);
+  if (!record) {
     return undefined;
   }
 
-  const record = value as Record<string, unknown>;
-  const textValue = record.value;
-  const start = record.start;
-  const end = record.end;
+  const textValue = readUnknownProp(record, "value");
+  const start = readNumberProp(record, ["start"]);
+  const end = readNumberProp(record, ["end"]);
   if (typeof textValue !== "string" || typeof start !== "number" || typeof end !== "number") {
     return undefined;
   }
@@ -343,6 +343,34 @@ const toFiniteNumber = (value: unknown): number | null => {
   return value;
 };
 
+const readTokenBreakdown = (value: unknown): TokenBreakdown | undefined => {
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const input = readNumberProp(record, ["input"]);
+  const output = readNumberProp(record, ["output"]);
+  const reasoning = readNumberProp(record, ["reasoning"]);
+  const cacheRecord = readRecordProp(record, "cache");
+  const cacheRead = cacheRecord ? readNumberProp(cacheRecord, ["read"]) : undefined;
+  const cacheWrite = cacheRecord ? readNumberProp(cacheRecord, ["write"]) : undefined;
+  const cache =
+    cacheRead !== undefined || cacheWrite !== undefined
+      ? {
+          ...(cacheRead !== undefined ? { read: cacheRead } : {}),
+          ...(cacheWrite !== undefined ? { write: cacheWrite } : {}),
+        }
+      : undefined;
+
+  return {
+    ...(input !== undefined ? { input } : {}),
+    ...(output !== undefined ? { output } : {}),
+    ...(reasoning !== undefined ? { reasoning } : {}),
+    ...(cache ? { cache } : {}),
+  };
+};
+
 const sumTokenBreakdown = (breakdown: TokenBreakdown | null | undefined): number => {
   if (!breakdown || typeof breakdown !== "object") {
     return 0;
@@ -360,18 +388,21 @@ export const toTokenTotal = (value: unknown): number | undefined => {
   if (direct !== null) {
     return Math.max(0, direct);
   }
-  if (value && typeof value === "object") {
-    const summed = sumTokenBreakdown(value as TokenBreakdown);
-    if (summed > 0) {
-      return summed;
-    }
+  const breakdown = readTokenBreakdown(value);
+  if (!breakdown) {
+    return undefined;
+  }
+
+  const summed = sumTokenBreakdown(breakdown);
+  if (summed > 0) {
+    return summed;
   }
   return undefined;
 };
 
 export const extractMessageTotalTokens = (
   info: unknown,
-  parts: Array<Part | Record<string, unknown>>,
+  parts: Part[] | unknown[],
 ): number | undefined => {
   const infoTokens = toTokenTotal(readUnknownProp(info, "tokens"));
   if (typeof infoTokens === "number" && infoTokens > 0) {

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -66,7 +66,7 @@ class RuntimeEnsureError extends Error {
 }
 
 const readUnknownProp = (value: unknown, key: string): unknown => {
-  if (!value || typeof value !== "object") {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return undefined;
   }
 
@@ -84,6 +84,28 @@ const readFailureKind = (value: unknown): RuntimeEnsureFailureKind | undefined =
   return result.success ? result.data : undefined;
 };
 
+type RuntimeEnsureFailureEnvelope = {
+  message?: string;
+  error?: string;
+  failureKind: RuntimeEnsureFailureKind;
+};
+
+const readRuntimeEnsureFailureEnvelope = (value: unknown): RuntimeEnsureFailureEnvelope | null => {
+  const failureKind = readFailureKind(value);
+  if (!failureKind) {
+    return null;
+  }
+
+  const message = readStringProp(value, "message");
+  const error = readStringProp(value, "error");
+
+  return {
+    failureKind,
+    ...(message !== undefined ? { message } : {}),
+    ...(error !== undefined ? { error } : {}),
+  };
+};
+
 const buildRuntimeEnsureFailureSources = (error: unknown): unknown[] => {
   return [error, readUnknownProp(error, "cause")];
 };
@@ -98,21 +120,22 @@ const extractRuntimeEnsureFailure = (error: unknown): NormalizedRuntimeEnsureFai
   }
 
   const sources = buildRuntimeEnsureFailureSources(error);
-  const failureSource = sources.find((source) => readFailureKind(source) !== undefined);
-  const failureKind = failureSource ? readFailureKind(failureSource) : undefined;
-  if (!failureKind) {
+  const failureEnvelope = sources
+    .map((source) => readRuntimeEnsureFailureEnvelope(source))
+    .find((source): source is RuntimeEnsureFailureEnvelope => source !== null);
+  if (!failureEnvelope?.failureKind) {
     return null;
   }
 
   const message =
-    readStringProp(failureSource, "message") ??
-    readStringProp(failureSource, "error") ??
+    failureEnvelope.message ??
+    failureEnvelope.error ??
     (error instanceof Error && error.message.trim().length > 0 ? error.message : undefined) ??
     "Failed to ensure runtime.";
 
   return {
     message,
-    failureKind,
+    failureKind: failureEnvelope.failureKind,
     ...(error !== undefined ? { cause: error } : {}),
   };
 };

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1789,6 +1789,36 @@ describe("TauriHostClient", () => {
     );
   });
 
+  test("agentSessionsList preserves non-session metadata schema errors", async () => {
+    const { client } = createClient((command) => {
+      if (command === "task_metadata_get") {
+        return {
+          spec: null,
+          plan: { markdown: "", updatedAt: null },
+          qaReport: null,
+          agentSessions: [
+            {
+              sessionId: "legacy-spec",
+              externalSessionId: "legacy-ext-1",
+              role: "spec",
+              scenario: "spec_revision",
+              startedAt: "2026-02-18T17:20:00Z",
+              runtimeKind: "opencode",
+              workingDirectory: "/repo",
+              selectedModel: null,
+            },
+          ],
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(client.agentSessionsList("/repo", "task-1")).rejects.toThrow("spec");
+    await expect(client.agentSessionsList("/repo", "task-1")).rejects.not.toThrow(
+      "Task metadata for task-1 contains invalid persisted agent sessions",
+    );
+  });
+
   test("spec, plan, qa, and session reads share one metadata IPC call per task", async () => {
     const { client, calls } = createClient((command) => {
       if (command === "task_metadata_get") {

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1755,6 +1755,9 @@ describe("TauriHostClient", () => {
     await expect(client.agentSessionsList("/repo", "task-1")).rejects.toThrow(
       "Task metadata for task-1 contains invalid persisted agent sessions",
     );
+    await expect(client.agentSessionsList("/repo", "task-1")).rejects.toThrow(
+      "agentSessions[0].scenario",
+    );
   });
 
   test("agentSessionsList rejects invalid persisted agent session entries", async () => {

--- a/packages/adapters-tauri-host/src/task-metadata-cache.ts
+++ b/packages/adapters-tauri-host/src/task-metadata-cache.ts
@@ -1,24 +1,25 @@
-import {
-  type AgentSessionRecord,
-  type TaskMetadataPayload,
-  taskMetadataPayloadSchema,
-} from "@openducktor/contracts";
+import { type TaskMetadataPayload, taskMetadataPayloadSchema } from "@openducktor/contracts";
 import type { InvokeFn } from "./invoke-utils";
 
 type MetadataIssue = {
-  path: PropertyKey[];
+  path: Array<string | number>;
   message: string;
 };
 
-export type ParsedTaskMetadata = Omit<TaskMetadataPayload, "agentSessions"> & {
-  agentSessions: AgentSessionRecord[];
-};
+export type ParsedTaskMetadata = TaskMetadataPayload;
 
 export type TaskMetadataReadOptions = {
   forceFresh?: boolean;
 };
 
 const isAgentSessionIssue = (issue: MetadataIssue): boolean => issue.path[0] === "agentSessions";
+
+const toMetadataIssue = (issue: { path: PropertyKey[]; message: string }): MetadataIssue => ({
+  path: issue.path.map((segment) =>
+    typeof segment === "string" || typeof segment === "number" ? segment : String(segment),
+  ),
+  message: issue.message,
+});
 
 const formatAgentSessionIssue = (issue: MetadataIssue): string => {
   const path = issue.path.length > 1 ? issue.path.slice(1) : ["unknown"];
@@ -33,12 +34,14 @@ const parseTaskMetadataPayload = (payload: unknown, taskId: string): TaskMetadat
     return parsed.data;
   }
 
-  if (!parsed.error.issues.every(isAgentSessionIssue)) {
+  const metadataIssues = parsed.error.issues.map(toMetadataIssue);
+
+  if (!metadataIssues.every(isAgentSessionIssue)) {
     throw parsed.error;
   }
 
   throw new Error(
-    `Task metadata for ${taskId} contains invalid persisted agent sessions: ${parsed.error.issues
+    `Task metadata for ${taskId} contains invalid persisted agent sessions: ${metadataIssues
       .map(formatAgentSessionIssue)
       .join(" | ")}`,
   );

--- a/packages/adapters-tauri-host/src/task-metadata-cache.ts
+++ b/packages/adapters-tauri-host/src/task-metadata-cache.ts
@@ -1,6 +1,5 @@
 import {
   type AgentSessionRecord,
-  agentSessionRecordSchema,
   type TaskMetadataPayload,
   taskMetadataPayloadSchema,
 } from "@openducktor/contracts";
@@ -19,31 +18,6 @@ export type TaskMetadataReadOptions = {
   forceFresh?: boolean;
 };
 
-const parseAgentSessions = (entries: unknown[], taskId: string): AgentSessionRecord[] => {
-  const sessions: AgentSessionRecord[] = [];
-  const invalidEntries: string[] = [];
-
-  for (const [index, entry] of entries.entries()) {
-    const parsed = agentSessionRecordSchema.safeParse(entry);
-    if (parsed.success) {
-      sessions.push(parsed.data);
-      continue;
-    }
-
-    invalidEntries.push(
-      `agentSessions[${index}]: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`,
-    );
-  }
-
-  if (invalidEntries.length > 0) {
-    throw new Error(
-      `Task metadata for ${taskId} contains invalid persisted agent sessions: ${invalidEntries.join(" | ")}`,
-    );
-  }
-
-  return sessions;
-};
-
 const isAgentSessionIssue = (issue: MetadataIssue): boolean => issue.path[0] === "agentSessions";
 
 const formatAgentSessionIssue = (issue: MetadataIssue): string => {
@@ -59,13 +33,12 @@ const parseTaskMetadataPayload = (payload: unknown, taskId: string): TaskMetadat
     return parsed.data;
   }
 
-  const agentSessionIssues = parsed.error.issues.filter(isAgentSessionIssue);
-  if (agentSessionIssues.length === 0) {
+  if (!parsed.error.issues.every(isAgentSessionIssue)) {
     throw parsed.error;
   }
 
   throw new Error(
-    `Task metadata for ${taskId} contains invalid persisted agent sessions: ${agentSessionIssues
+    `Task metadata for ${taskId} contains invalid persisted agent sessions: ${parsed.error.issues
       .map(formatAgentSessionIssue)
       .join(" | ")}`,
   );
@@ -146,10 +119,7 @@ export class TaskMetadataCache {
     const next = invokeFn("task_metadata_get", { repoPath, taskId })
       .then((payload) => {
         const parsed = parseTaskMetadataPayload(payload, taskId);
-        const metadata = {
-          ...parsed,
-          agentSessions: parseAgentSessions(parsed.agentSessions, taskId),
-        };
+        const metadata: ParsedTaskMetadata = parsed;
 
         if (this.latestFetchTokenByKey.get(cacheKey) === fetchToken) {
           this.cache.set(cacheKey, metadata);

--- a/packages/adapters-tauri-host/src/task-metadata-cache.ts
+++ b/packages/adapters-tauri-host/src/task-metadata-cache.ts
@@ -6,6 +6,11 @@ import {
 } from "@openducktor/contracts";
 import type { InvokeFn } from "./invoke-utils";
 
+type MetadataIssue = {
+  path: PropertyKey[];
+  message: string;
+};
+
 export type ParsedTaskMetadata = Omit<TaskMetadataPayload, "agentSessions"> & {
   agentSessions: AgentSessionRecord[];
 };
@@ -37,6 +42,33 @@ const parseAgentSessions = (entries: unknown[], taskId: string): AgentSessionRec
   }
 
   return sessions;
+};
+
+const isAgentSessionIssue = (issue: MetadataIssue): boolean => issue.path[0] === "agentSessions";
+
+const formatAgentSessionIssue = (issue: MetadataIssue): string => {
+  const path = issue.path.length > 1 ? issue.path.slice(1) : ["unknown"];
+  const [index, ...rest] = path;
+  const suffix = rest.length > 0 ? `.${rest.join(".")}` : "";
+  return `agentSessions[${String(index)}]${suffix}: ${issue.message}`;
+};
+
+const parseTaskMetadataPayload = (payload: unknown, taskId: string): TaskMetadataPayload => {
+  const parsed = taskMetadataPayloadSchema.safeParse(payload);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  const agentSessionIssues = parsed.error.issues.filter(isAgentSessionIssue);
+  if (agentSessionIssues.length === 0) {
+    throw parsed.error;
+  }
+
+  throw new Error(
+    `Task metadata for ${taskId} contains invalid persisted agent sessions: ${agentSessionIssues
+      .map(formatAgentSessionIssue)
+      .join(" | ")}`,
+  );
 };
 
 export class TaskMetadataCache {
@@ -113,7 +145,7 @@ export class TaskMetadataCache {
 
     const next = invokeFn("task_metadata_get", { repoPath, taskId })
       .then((payload) => {
-        const parsed = taskMetadataPayloadSchema.parse(payload);
+        const parsed = parseTaskMetadataPayload(payload, taskId);
         const metadata = {
           ...parsed,
           agentSessions: parseAgentSessions(parsed.agentSessions, taskId),

--- a/packages/contracts/src/document-contracts.test.ts
+++ b/packages/contracts/src/document-contracts.test.ts
@@ -33,6 +33,53 @@ describe("document contracts", () => {
     expect(parsed.qaReport?.error).toContain("invalid gzip payload");
   });
 
+  test("task metadata payload normalizes legacy delivery fields and validates canonical sessions", () => {
+    const parsed = taskMetadataPayloadSchema.parse({
+      spec: {
+        markdown: "",
+        updatedAt: null,
+      },
+      plan: {
+        markdown: "",
+        updatedAt: null,
+      },
+      delivery: {
+        linkedPullRequest: {
+          providerId: "github",
+          number: 42,
+          url: "https://github.com/openai/openducktor/pull/42",
+          state: "open",
+          createdAt: "2026-02-20T09:30:00Z",
+          updatedAt: "2026-02-20T09:45:00Z",
+        },
+        directMerge: {
+          method: "squash",
+          sourceBranch: "task/openducktor-dpp",
+          targetBranch: {
+            remote: "origin",
+            branch: "main",
+          },
+          mergedAt: "2026-02-20T10:00:00Z",
+        },
+      },
+      agentSessions: [
+        {
+          sessionId: "session-1",
+          role: "build",
+          scenario: "build_implementation_start",
+          startedAt: "2026-02-18T17:20:00Z",
+          runtimeKind: "opencode",
+          workingDirectory: "/repo",
+        },
+      ],
+    });
+
+    expect(parsed.pullRequest?.number).toBe(42);
+    expect(parsed.directMerge?.method).toBe("squash");
+    expect(parsed.agentSessions).toHaveLength(1);
+    expect(parsed.agentSessions[0]?.scenario).toBe("build_implementation_start");
+  });
+
   test("mcp document reads accept optional document-level decode errors", () => {
     const parsed = taskDocumentsReadSchema.parse({
       documents: {

--- a/packages/contracts/src/document-contracts.test.ts
+++ b/packages/contracts/src/document-contracts.test.ts
@@ -80,6 +80,50 @@ describe("document contracts", () => {
     expect(parsed.agentSessions[0]?.scenario).toBe("build_implementation_start");
   });
 
+  test("task metadata payload normalizes missing top-level delivery fields independently", () => {
+    const parsed = taskMetadataPayloadSchema.parse({
+      spec: {
+        markdown: "",
+        updatedAt: null,
+      },
+      plan: {
+        markdown: "",
+        updatedAt: null,
+      },
+      pullRequest: {
+        providerId: "github",
+        number: 77,
+        url: "https://github.com/openai/openducktor/pull/77",
+        state: "draft",
+        createdAt: "2026-02-21T09:30:00Z",
+        updatedAt: "2026-02-21T09:45:00Z",
+      },
+      delivery: {
+        linkedPullRequest: {
+          providerId: "github",
+          number: 42,
+          url: "https://github.com/openai/openducktor/pull/42",
+          state: "open",
+          createdAt: "2026-02-20T09:30:00Z",
+          updatedAt: "2026-02-20T09:45:00Z",
+        },
+        directMerge: {
+          method: "rebase",
+          sourceBranch: "task/openducktor-dpp",
+          targetBranch: {
+            remote: "origin",
+            branch: "main",
+          },
+          mergedAt: "2026-02-21T10:00:00Z",
+        },
+      },
+      agentSessions: [],
+    });
+
+    expect(parsed.pullRequest?.number).toBe(77);
+    expect(parsed.directMerge?.method).toBe("rebase");
+  });
+
   test("mcp document reads accept optional document-level decode errors", () => {
     const parsed = taskDocumentsReadSchema.parse({
       documents: {

--- a/packages/contracts/src/metadata-schemas.ts
+++ b/packages/contracts/src/metadata-schemas.ts
@@ -31,10 +31,6 @@ const normalizeLegacyTaskMetadataPayload = (value: unknown): unknown => {
   }
 
   const payload = value;
-  if ("pullRequest" in payload || "directMerge" in payload) {
-    return value;
-  }
-
   const delivery = payload.delivery;
   if (!isPlainObject(delivery)) {
     return value;
@@ -42,8 +38,8 @@ const normalizeLegacyTaskMetadataPayload = (value: unknown): unknown => {
 
   return {
     ...payload,
-    pullRequest: delivery.linkedPullRequest ?? payload.pullRequest,
-    directMerge: delivery.directMerge ?? payload.directMerge,
+    pullRequest: payload.pullRequest ?? delivery.linkedPullRequest,
+    directMerge: payload.directMerge ?? delivery.directMerge,
   };
 };
 

--- a/packages/contracts/src/metadata-schemas.ts
+++ b/packages/contracts/src/metadata-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { directMergeRecordSchema, gitTargetBranchSchema, pullRequestSchema } from "./git-schemas";
+import { agentSessionRecordSchema } from "./session-schemas";
 import { qaWorkflowVerdictSchema } from "./task-schemas";
 
 export const taskMetadataDocumentSchema = z.object({
@@ -21,21 +22,21 @@ export const taskMetadataQaReportSchema = z.object({
 });
 export type TaskMetadataQaReport = z.infer<typeof taskMetadataQaReportSchema>;
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const normalizeLegacyTaskMetadataPayload = (value: unknown): unknown => {
-  if (!value || typeof value !== "object") {
+  if (!isPlainObject(value)) {
     return value;
   }
 
-  const payload = value as Record<string, unknown>;
+  const payload = value;
   if ("pullRequest" in payload || "directMerge" in payload) {
     return value;
   }
 
-  const delivery =
-    payload.delivery && typeof payload.delivery === "object"
-      ? (payload.delivery as Record<string, unknown>)
-      : null;
-  if (!delivery) {
+  const delivery = payload.delivery;
+  if (!isPlainObject(delivery)) {
     return value;
   }
 
@@ -67,7 +68,7 @@ export const taskMetadataPayloadSchema = z.preprocess(
       (value) => (value === null ? undefined : value),
       directMergeRecordSchema.optional(),
     ),
-    agentSessions: z.array(z.unknown()).default([]),
+    agentSessions: z.array(agentSessionRecordSchema).default([]),
   }),
 );
 export type TaskMetadataPayload = z.infer<typeof taskMetadataPayloadSchema>;

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -1,6 +1,7 @@
 // @ts-expect-error
 import { describe, expect, test } from "bun:test";
 import {
+  agentSessionPermissionRequestSchema,
   agentSessionRecordSchema,
   buildContinuationTargetSchema,
   buildContinuationTargetSourceSchema,
@@ -965,6 +966,39 @@ describe("runtime schemas", () => {
     expect(parsed.externalSessionId).toBeUndefined();
     expect(parsed.runtimeKind).toBe("claude-code");
     expect(parsed.selectedModel).toBeNull();
+  });
+
+  test("agent session permission request accepts recursive metadata values", () => {
+    const parsed = agentSessionPermissionRequestSchema.parse({
+      requestId: "perm-1",
+      permission: "exec",
+      metadata: {
+        command: "bun test",
+        retryCount: 2,
+        approved: false,
+        context: {
+          cwd: "/repo",
+          env: {
+            CI: "1",
+          },
+        },
+        targets: ["packages/core", { kind: "file", path: "src/index.ts" }, null],
+      },
+    });
+
+    expect(parsed.metadata).toEqual({
+      command: "bun test",
+      retryCount: 2,
+      approved: false,
+      context: {
+        cwd: "/repo",
+        env: {
+          CI: "1",
+        },
+      },
+      targets: ["packages/core", { kind: "file", path: "src/index.ts" }, null],
+    });
+    expect(parsed.patterns).toEqual([]);
   });
 
   test("repo config rejects missing runtime-bearing defaults", () => {

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -14,6 +14,20 @@ export type AgentSessionScenario = z.infer<typeof agentSessionScenarioSchema>;
 const optionalFromNullable = <T extends z.ZodTypeAny>(schema: T) =>
   z.preprocess((value) => (value === null ? undefined : value), schema.optional());
 
+const agentSessionMetadataValueSchema: z.ZodType<
+  string | number | boolean | null | undefined | Array<unknown> | Record<string, unknown>
+> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.undefined(),
+    z.array(agentSessionMetadataValueSchema),
+    z.record(z.string(), agentSessionMetadataValueSchema),
+  ]),
+);
+
 export const agentSessionModelSelectionSchema = z.object({
   runtimeKind: runtimeKindSchema,
   providerId: z.string(),
@@ -27,7 +41,7 @@ export const agentSessionPermissionRequestSchema = z.object({
   requestId: z.string(),
   permission: z.string(),
   patterns: z.array(z.string()).default([]),
-  metadata: z.record(z.string(), z.unknown()).optional(),
+  metadata: z.record(z.string(), agentSessionMetadataValueSchema).optional(),
 });
 export type AgentSessionPermissionRequest = z.infer<typeof agentSessionPermissionRequestSchema>;
 


### PR DESCRIPTION
## Summary
- tighten session, task metadata, and runtime failure payload parsing so invalid runtime-orchestration data fails fast at the intended boundary
- preserve durable session compatibility and existing batching behavior while removing unsafe hot-path casts and broad record coercions
- add regression coverage for recursive permission metadata, legacy metadata normalization, indexed persisted-session errors, malformed token/source payloads, and mixed schema-error handling

## Goal
This PR hardens the runtime and session typing boundaries used by the orchestration flow. The goal is to stop malformed payloads at the nearest contract or adapter edge instead of letting loosely typed data leak deeper into the system, while keeping the durable session model stable and avoiding fallback behavior.

## Context
The task focused on boundary safety across the shared contracts, the Tauri host adapter, the OpenCode SDK adapter, and the desktop session event batcher. These paths sit between persisted task/session metadata, runtime ensure failures, streamed message payloads, and the frontend orchestration state. They already had compatibility expectations around durable session reads, legacy metadata normalization, and batching semantics, so the change needed to tighten validation without widening the persisted contract or changing behavior that downstream tests rely on.

## Technical Choices
- tightened `agentSessionPermissionRequestSchema.metadata` to a bounded recursive value schema instead of `unknown`, while keeping `agentSessionRecordSchema` durable-only and non-strict for legacy persisted fields
- tightened `taskMetadataPayloadSchema.agentSessions` to canonical session records and kept legacy delivery normalization, then preserved actionable persisted-session errors by remapping all-session validation failures into the existing indexed `agentSessions[i]...` format in the Tauri metadata cache
- switched metadata normalization to field-by-field precedence so a present top-level `pullRequest` no longer blocks legacy `directMerge` normalization, and vice versa
- replaced broad record casts in the OpenCode SDK message normalizers with explicit guarded parsing for source text and token breakdown payloads so malformed nested values are ignored safely instead of accessed unchecked
- replaced the runtime ensure adapter's loose failure probing with a typed failure-envelope parser that preserves the existing precedence for `failureKind`, `message`, nested `cause`, and outer error handling
- removed `as never` hot-path casts from the desktop session event batcher through an exhaustive typed dispatch over `SessionEvent[\"type\"]`, while keeping supersession, dedupe, merge, and emit timing behavior unchanged
- added regression tests across contracts, adapters, and desktop orchestration to lock in the compatibility and fail-fast expectations above

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when processing malformed message data and metadata; the system now handles invalid formats gracefully without data loss.
  * Enhanced error messages for metadata validation to better pinpoint issues.

* **Improvements**
  * Refined message display styling.
  * Strengthened validation for agent session metadata.

* **Tests**
  * Added test coverage for edge cases with malformed payloads and invalid data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->