### PR TITLE
test(agent-studio): add direct orchestration hook coverage

### DIFF
--- a/apps/desktop/src/pages/agents/use-agent-studio-git-action-errors.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-action-errors.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { createHookHarness as createCoreHookHarness } from "@/test-utils/react-hook-harness";
+import { enableReactActEnvironment } from "./agent-studio-test-utils";
+import { useAgentStudioGitActionErrors } from "./use-agent-studio-git-action-errors";
+
+enableReactActEnvironment();
+
+const createHookHarness = () =>
+  createCoreHookHarness(() => useAgentStudioGitActionErrors(), undefined);
+
+describe("useAgentStudioGitActionErrors", () => {
+  test("keeps error buckets isolated, clears them together, and remains writable after clear", async () => {
+    const harness = createHookHarness();
+
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.setCommitError("commit failed");
+      state.setPushError("push failed");
+    });
+
+    expect(harness.getLatest()).toMatchObject({
+      commitError: "commit failed",
+      pushError: "push failed",
+      rebaseError: null,
+      resetError: null,
+    });
+
+    await harness.run((state) => {
+      state.setRebaseError("rebase failed");
+      state.setResetError("reset failed");
+    });
+
+    expect(harness.getLatest()).toMatchObject({
+      commitError: "commit failed",
+      pushError: "push failed",
+      rebaseError: "rebase failed",
+      resetError: "reset failed",
+    });
+
+    await harness.run((state) => {
+      state.clearActionErrors();
+    });
+
+    expect(harness.getLatest()).toMatchObject({
+      commitError: null,
+      pushError: null,
+      rebaseError: null,
+      resetError: null,
+    });
+
+    await harness.run((state) => {
+      state.setPushError("push failed again");
+    });
+
+    expect(harness.getLatest()).toMatchObject({
+      commitError: null,
+      pushError: "push failed again",
+      rebaseError: null,
+      resetError: null,
+    });
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.test.tsx
@@ -1,0 +1,469 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { TaskCard } from "@openducktor/contracts";
+import { NEW_BUILDER_SESSION_TARGET } from "@/features/human-review-feedback/human-review-feedback-state";
+import type { NewSessionStartRequest } from "@/features/session-start";
+import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const toastErrorMock = mock(() => {});
+
+type UseHumanReviewHook =
+  typeof import("./use-agent-studio-human-review-feedback-flow")["useAgentStudioHumanReviewFeedbackFlow"];
+
+let useAgentStudioHumanReviewFeedbackFlow: UseHumanReviewHook;
+
+type HookArgs = Parameters<UseHumanReviewHook>[0];
+
+const MODEL_SELECTION = {
+  runtimeKind: "opencode" as const,
+  providerId: "openai",
+  modelId: "gpt-5",
+  variant: "default",
+  profileId: "builder",
+};
+
+const createTask = (overrides: Partial<TaskCard> = {}): TaskCard =>
+  createTaskCardFixture({
+    id: "task-1",
+    title: "Task 1",
+    status: "human_review",
+    ...overrides,
+  });
+
+const createSession = (overrides: Partial<ReturnType<typeof createAgentSessionFixture>> = {}) =>
+  createAgentSessionFixture({
+    sessionId: "session-build-1",
+    externalSessionId: "ext-session-build-1",
+    taskId: "task-1",
+    role: "build",
+    scenario: "build_implementation_start",
+    status: "idle",
+    startedAt: "2026-02-22T12:00:00.000Z",
+    ...overrides,
+  });
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioHumanReviewFeedbackFlow, initialProps);
+
+const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  activeRepo: "/repo",
+  taskId: "task-1",
+  role: "spec",
+  activeSession: null,
+  sessionsForTask: [],
+  selectedTask: createTask(),
+  startAgentSession: async () => "session-new",
+  sendAgentMessage: async () => {},
+  bootstrapTaskSessions: async () => {},
+  hydrateRequestedTaskSessionHistory: async () => {},
+  humanRequestChangesTask: async () => {},
+  updateQuery: () => {},
+  executeRequestedSessionStart: async () => undefined,
+  ...overrides,
+});
+
+const waitForFeedbackModal = async (
+  harness: ReturnType<typeof createHookHarness>,
+): Promise<NonNullable<ReturnType<typeof harness.getLatest>["humanReviewFeedbackModal"]>> => {
+  await harness.waitFor((state) => state.humanReviewFeedbackModal !== null);
+  const modal = harness.getLatest().humanReviewFeedbackModal;
+  expect(modal).not.toBeNull();
+  if (!modal) {
+    throw new Error("Expected human review feedback modal to be open.");
+  }
+  return modal;
+};
+
+beforeAll(async () => {
+  mock.module("sonner", () => ({
+    toast: {
+      error: toastErrorMock,
+    },
+  }));
+  ({ useAgentStudioHumanReviewFeedbackFlow } = await import(
+    "./use-agent-studio-human-review-feedback-flow"
+  ));
+});
+
+afterAll(async () => {
+  await restoreMockedModules([["sonner", () => import("sonner")]]);
+});
+
+beforeEach(() => {
+  toastErrorMock.mockClear();
+});
+
+describe("useAgentStudioHumanReviewFeedbackFlow", () => {
+  test("intercepts only build-after-human-request-changes session creation", async () => {
+    const harness = createHookHarness(createBaseArgs());
+
+    await harness.mount();
+
+    expect(
+      harness.getLatest().shouldInterceptCreateSession({
+        id: "build:build_after_human_request_changes:fresh",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        label: "Builder",
+        description: "Create builder session",
+        disabled: false,
+      }),
+    ).toBe(true);
+    expect(
+      harness.getLatest().shouldInterceptCreateSession({
+        id: "build:build_implementation_start:fresh",
+        role: "build",
+        scenario: "build_implementation_start",
+        label: "Builder",
+        description: "Create builder session",
+        disabled: false,
+      }),
+    ).toBe(false);
+    expect(
+      harness.getLatest().shouldInterceptCreateSession({
+        id: "qa:qa_review:fresh",
+        role: "qa",
+        scenario: "qa_review",
+        label: "QA",
+        description: "Create QA session",
+        disabled: false,
+      }),
+    ).toBe(false);
+
+    await harness.unmount();
+  });
+
+  test("opens the feedback modal immediately when builder sessions already exist", async () => {
+    const bootstrapTaskSessions = mock(async () => {});
+    const latestBuilderSession = createSession({
+      sessionId: "session-build-latest",
+      startedAt: "2026-02-22T13:00:00.000Z",
+    });
+    const olderBuilderSession = createSession({
+      sessionId: "session-build-older",
+      startedAt: "2026-02-22T11:00:00.000Z",
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        bootstrapTaskSessions,
+        sessionsForTask: [olderBuilderSession, latestBuilderSession],
+      }),
+    );
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.openHumanReviewFeedback();
+    });
+
+    const modal = await waitForFeedbackModal(harness);
+
+    expect(bootstrapTaskSessions).toHaveBeenCalledWith("task-1");
+    expect(modal.selectedTarget).toBe("session-build-latest");
+    expect(modal.targetOptions.map((option) => option.value)).toEqual([
+      NEW_BUILDER_SESSION_TARGET,
+      "session-build-latest",
+      "session-build-older",
+    ]);
+
+    await harness.unmount();
+  });
+
+  test("opens the feedback modal after delayed builder-session hydration", async () => {
+    const bootstrapTaskSessions = mock(async () => {});
+    const harness = createHookHarness(
+      createBaseArgs({
+        bootstrapTaskSessions,
+        sessionsForTask: [],
+      }),
+    );
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.openHumanReviewFeedback();
+    });
+
+    expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
+
+    await harness.update(
+      createBaseArgs({
+        bootstrapTaskSessions,
+        sessionsForTask: [createSession({ sessionId: "session-build-hydrated" })],
+      }),
+    );
+
+    const modal = await waitForFeedbackModal(harness);
+    expect(modal.selectedTarget).toBe("session-build-hydrated");
+
+    await harness.unmount();
+  });
+
+  test("clears pending hydration and toasts when builder session bootstrap fails", async () => {
+    const bootstrapTaskSessions = mock(async () => {
+      throw new Error("bootstrap failed");
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        bootstrapTaskSessions,
+      }),
+    );
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.openHumanReviewFeedback();
+    });
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Failed to load Builder sessions for this task.");
+    expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
+
+    await harness.update(
+      createBaseArgs({
+        bootstrapTaskSessions,
+        sessionsForTask: [createSession({ sessionId: "session-build-late" })],
+      }),
+    );
+
+    expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
+
+    await harness.unmount();
+  });
+
+  test("rejects blank feedback without starting or reusing a builder session", async () => {
+    const humanRequestChangesTask = mock(async () => {});
+    const executeRequestedSessionStart = mock(async () => undefined);
+    const harness = createHookHarness(
+      createBaseArgs({
+        humanRequestChangesTask,
+        executeRequestedSessionStart,
+        sessionsForTask: [createSession({ sessionId: "session-build-existing" })],
+      }),
+    );
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.openHumanReviewFeedback();
+    });
+    await waitForFeedbackModal(harness);
+
+    await harness.run((state) => {
+      state.humanReviewFeedbackModal?.onMessageChange("   ");
+    });
+    await harness.run(async (state) => {
+      await state.humanReviewFeedbackModal?.onConfirm();
+    });
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Feedback message is required.");
+    expect(humanRequestChangesTask).toHaveBeenCalledTimes(0);
+    expect(executeRequestedSessionStart).toHaveBeenCalledTimes(0);
+    expect(harness.getLatest().humanReviewFeedbackModal?.open).toBe(true);
+
+    await harness.unmount();
+  });
+
+  test("reuses an existing builder session and surfaces partial follow-up failures", async () => {
+    const humanRequestChangesTask = mock(async () => {});
+    const hydrateRequestedTaskSessionHistory = mock(async () => {
+      throw new Error("hydrate failed");
+    });
+    const sendAgentMessage = mock(async () => {
+      throw new Error("send failed");
+    });
+    const onContextSwitchIntent = mock(() => {});
+    const updateCalls: Array<Record<string, string | undefined>> = [];
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSession: createSession({
+          sessionId: "session-spec-active",
+          externalSessionId: "ext-session-spec-active",
+          role: "spec",
+          scenario: "spec_initial",
+        }),
+        humanRequestChangesTask,
+        hydrateRequestedTaskSessionHistory,
+        sendAgentMessage,
+        onContextSwitchIntent,
+        sessionsForTask: [
+          createSession({
+            sessionId: "session-build-latest",
+            startedAt: "2026-02-22T13:00:00.000Z",
+          }),
+          createSession({
+            sessionId: "session-build-older",
+            startedAt: "2026-02-22T11:00:00.000Z",
+          }),
+        ],
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+      }),
+    );
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.openHumanReviewFeedback();
+    });
+    await waitForFeedbackModal(harness);
+
+    await harness.run((state) => {
+      state.humanReviewFeedbackModal?.onTargetChange("session-build-older");
+      state.humanReviewFeedbackModal?.onMessageChange("  Apply the requested human changes.  ");
+    });
+    await harness.run(async (state) => {
+      await state.humanReviewFeedbackModal?.onConfirm();
+    });
+
+    expect(humanRequestChangesTask).toHaveBeenCalledWith(
+      "task-1",
+      "Apply the requested human changes.",
+    );
+    expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
+      taskId: "task-1",
+      sessionId: "session-build-older",
+    });
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-build-older", [
+      { kind: "text", text: "Apply the requested human changes." },
+    ]);
+    expect(onContextSwitchIntent).toHaveBeenCalledTimes(1);
+    expect(updateCalls).toEqual([
+      {
+        task: "task-1",
+        session: "session-build-older",
+        agent: "build",
+        scenario: undefined,
+        autostart: undefined,
+        start: undefined,
+      },
+    ]);
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Changes requested, but refreshing Builder sessions failed.",
+    );
+    expect(toastErrorMock).toHaveBeenCalledWith("Changes requested, but feedback message failed.");
+    expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
+
+    await harness.unmount();
+  });
+
+  test("starts a new builder session through the requested-session workflow", async () => {
+    const humanRequestChangesTask = mock(async () => {});
+    const startAgentSession = mock(async () => "session-build-new");
+    const sendAgentMessage = mock(async () => {});
+    const hydrateRequestedTaskSessionHistory = mock(async () => {});
+    const requestedStarts: Array<Omit<NewSessionStartRequest, "selectedModel">> = [];
+    const updateCalls: Array<Record<string, string | undefined>> = [];
+    const executeRequestedSessionStart: HookArgs["executeRequestedSessionStart"] = async (
+      request,
+      executeWithDecision,
+    ) => {
+      requestedStarts.push(request);
+      return executeWithDecision({
+        startMode: "fresh",
+        selectedModel: MODEL_SELECTION,
+      });
+    };
+    const harness = createHookHarness(
+      createBaseArgs({
+        humanRequestChangesTask,
+        startAgentSession,
+        sendAgentMessage,
+        hydrateRequestedTaskSessionHistory,
+        executeRequestedSessionStart,
+        sessionsForTask: [createSession({ sessionId: "session-build-existing" })],
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+      }),
+    );
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.openHumanReviewFeedback();
+    });
+    await waitForFeedbackModal(harness);
+
+    await harness.run((state) => {
+      state.humanReviewFeedbackModal?.onTargetChange(NEW_BUILDER_SESSION_TARGET);
+      state.humanReviewFeedbackModal?.onMessageChange("  Ship the requested fixes.  ");
+    });
+    await harness.run(async (state) => {
+      await state.humanReviewFeedbackModal?.onConfirm();
+    });
+    await harness.waitFor(() => sendAgentMessage.mock.calls.length > 0);
+
+    expect(requestedStarts).toEqual([
+      {
+        taskId: "task-1",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        reason: "create_session",
+        existingSessionOptions: expect.any(Array),
+        initialSourceSessionId: "session-build-existing",
+      },
+    ]);
+    expect(humanRequestChangesTask).toHaveBeenCalledWith("task-1", "Ship the requested fixes.");
+    expect(startAgentSession).toHaveBeenCalledWith({
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_after_human_request_changes",
+      selectedModel: MODEL_SELECTION,
+      startMode: "fresh",
+    });
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-build-new", [
+      { kind: "text", text: "Ship the requested fixes." },
+    ]);
+    expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
+      taskId: "task-1",
+      sessionId: "session-build-new",
+    });
+    expect(updateCalls).toEqual([
+      {
+        task: "task-1",
+        session: "session-build-new",
+        agent: "build",
+        scenario: undefined,
+        autostart: undefined,
+        start: undefined,
+      },
+    ]);
+    expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
+
+    await harness.unmount();
+  });
+
+  test("rejects a stale selected builder target before requesting changes", async () => {
+    const humanRequestChangesTask = mock(async () => {});
+    const harness = createHookHarness(
+      createBaseArgs({
+        humanRequestChangesTask,
+        sessionsForTask: [createSession({ sessionId: "session-build-existing" })],
+      }),
+    );
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.openHumanReviewFeedback();
+    });
+    await waitForFeedbackModal(harness);
+
+    await harness.run((state) => {
+      state.humanReviewFeedbackModal?.onTargetChange("session-build-missing");
+      state.humanReviewFeedbackModal?.onMessageChange("Apply the latest review feedback.");
+    });
+    await harness.run(async (state) => {
+      await state.humanReviewFeedbackModal?.onConfirm();
+    });
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "The selected builder session is no longer available for this task.",
+    );
+    expect(humanRequestChangesTask).toHaveBeenCalledTimes(0);
+    expect(harness.getLatest().humanReviewFeedbackModal?.open).toBe(true);
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.test.tsx
@@ -1,25 +1,19 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { TaskCard } from "@openducktor/contracts";
 import { NEW_BUILDER_SESSION_TARGET } from "@/features/human-review-feedback/human-review-feedback-state";
 import type { NewSessionStartRequest } from "@/features/session-start";
-import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+import { withMockedToast } from "@/test-utils/mock-toast";
 import {
   createAgentSessionFixture,
   createHookHarness as createSharedHookHarness,
   createTaskCardFixture,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
+import { useAgentStudioHumanReviewFeedbackFlow } from "./use-agent-studio-human-review-feedback-flow";
 
 enableReactActEnvironment();
 
-const toastErrorMock = mock(() => {});
-
-type UseHumanReviewHook =
-  typeof import("./use-agent-studio-human-review-feedback-flow")["useAgentStudioHumanReviewFeedbackFlow"];
-
-let useAgentStudioHumanReviewFeedbackFlow: UseHumanReviewHook;
-
-type HookArgs = Parameters<UseHumanReviewHook>[0];
+type HookArgs = Parameters<typeof useAgentStudioHumanReviewFeedbackFlow>[0];
 
 const MODEL_SELECTION = {
   runtimeKind: "opencode" as const,
@@ -80,25 +74,6 @@ const waitForFeedbackModal = async (
   }
   return modal;
 };
-
-beforeAll(async () => {
-  mock.module("sonner", () => ({
-    toast: {
-      error: toastErrorMock,
-    },
-  }));
-  ({ useAgentStudioHumanReviewFeedbackFlow } = await import(
-    "./use-agent-studio-human-review-feedback-flow"
-  ));
-});
-
-afterAll(async () => {
-  await restoreMockedModules([["sonner", () => import("sonner")]]);
-});
-
-beforeEach(() => {
-  toastErrorMock.mockClear();
-});
 
 describe("useAgentStudioHumanReviewFeedbackFlow", () => {
   test("intercepts only build-after-human-request-changes session creation", async () => {
@@ -205,148 +180,156 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
   });
 
   test("clears pending hydration and toasts when builder session bootstrap fails", async () => {
-    const bootstrapTaskSessions = mock(async () => {
-      throw new Error("bootstrap failed");
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const bootstrapTaskSessions = mock(async () => {
+        throw new Error("bootstrap failed");
+      });
+      const harness = createHookHarness(
+        createBaseArgs({
+          bootstrapTaskSessions,
+        }),
+      );
+
+      await harness.mount();
+      await harness.run((state) => {
+        state.openHumanReviewFeedback();
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to load Builder sessions for this task.");
+      expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
+
+      await harness.update(
+        createBaseArgs({
+          bootstrapTaskSessions,
+          sessionsForTask: [createSession({ sessionId: "session-build-late" })],
+        }),
+      );
+
+      expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
+
+      await harness.unmount();
     });
-    const harness = createHookHarness(
-      createBaseArgs({
-        bootstrapTaskSessions,
-      }),
-    );
-
-    await harness.mount();
-    await harness.run((state) => {
-      state.openHumanReviewFeedback();
-    });
-
-    expect(toastErrorMock).toHaveBeenCalledWith("Failed to load Builder sessions for this task.");
-    expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
-
-    await harness.update(
-      createBaseArgs({
-        bootstrapTaskSessions,
-        sessionsForTask: [createSession({ sessionId: "session-build-late" })],
-      }),
-    );
-
-    expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
-
-    await harness.unmount();
   });
 
   test("rejects blank feedback without starting or reusing a builder session", async () => {
-    const humanRequestChangesTask = mock(async () => {});
-    const executeRequestedSessionStart = mock(async () => undefined);
-    const harness = createHookHarness(
-      createBaseArgs({
-        humanRequestChangesTask,
-        executeRequestedSessionStart,
-        sessionsForTask: [createSession({ sessionId: "session-build-existing" })],
-      }),
-    );
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const humanRequestChangesTask = mock(async () => {});
+      const executeRequestedSessionStart = mock(async () => undefined);
+      const harness = createHookHarness(
+        createBaseArgs({
+          humanRequestChangesTask,
+          executeRequestedSessionStart,
+          sessionsForTask: [createSession({ sessionId: "session-build-existing" })],
+        }),
+      );
 
-    await harness.mount();
-    await harness.run((state) => {
-      state.openHumanReviewFeedback();
+      await harness.mount();
+      await harness.run((state) => {
+        state.openHumanReviewFeedback();
+      });
+      await waitForFeedbackModal(harness);
+
+      await harness.run((state) => {
+        state.humanReviewFeedbackModal?.onMessageChange("   ");
+      });
+      await harness.run(async (state) => {
+        await state.humanReviewFeedbackModal?.onConfirm();
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Feedback message is required.");
+      expect(humanRequestChangesTask).toHaveBeenCalledTimes(0);
+      expect(executeRequestedSessionStart).toHaveBeenCalledTimes(0);
+      expect(harness.getLatest().humanReviewFeedbackModal?.open).toBe(true);
+
+      await harness.unmount();
     });
-    await waitForFeedbackModal(harness);
-
-    await harness.run((state) => {
-      state.humanReviewFeedbackModal?.onMessageChange("   ");
-    });
-    await harness.run(async (state) => {
-      await state.humanReviewFeedbackModal?.onConfirm();
-    });
-
-    expect(toastErrorMock).toHaveBeenCalledWith("Feedback message is required.");
-    expect(humanRequestChangesTask).toHaveBeenCalledTimes(0);
-    expect(executeRequestedSessionStart).toHaveBeenCalledTimes(0);
-    expect(harness.getLatest().humanReviewFeedbackModal?.open).toBe(true);
-
-    await harness.unmount();
   });
 
   test("reuses an existing builder session and surfaces partial follow-up failures", async () => {
-    const humanRequestChangesTask = mock(async () => {});
-    const hydrateRequestedTaskSessionHistory = mock(async () => {
-      throw new Error("hydrate failed");
-    });
-    const sendAgentMessage = mock(async () => {
-      throw new Error("send failed");
-    });
-    const onContextSwitchIntent = mock(() => {});
-    const updateCalls: Array<Record<string, string | undefined>> = [];
-    const harness = createHookHarness(
-      createBaseArgs({
-        activeSession: createSession({
-          sessionId: "session-spec-active",
-          externalSessionId: "ext-session-spec-active",
-          role: "spec",
-          scenario: "spec_initial",
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const humanRequestChangesTask = mock(async () => {});
+      const hydrateRequestedTaskSessionHistory = mock(async () => {
+        throw new Error("hydrate failed");
+      });
+      const sendAgentMessage = mock(async () => {
+        throw new Error("send failed");
+      });
+      const onContextSwitchIntent = mock(() => {});
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+      const harness = createHookHarness(
+        createBaseArgs({
+          activeSession: createSession({
+            sessionId: "session-spec-active",
+            externalSessionId: "ext-session-spec-active",
+            role: "spec",
+            scenario: "spec_initial",
+          }),
+          humanRequestChangesTask,
+          hydrateRequestedTaskSessionHistory,
+          sendAgentMessage,
+          onContextSwitchIntent,
+          sessionsForTask: [
+            createSession({
+              sessionId: "session-build-latest",
+              startedAt: "2026-02-22T13:00:00.000Z",
+            }),
+            createSession({
+              sessionId: "session-build-older",
+              startedAt: "2026-02-22T11:00:00.000Z",
+            }),
+          ],
+          updateQuery: (updates) => {
+            updateCalls.push(updates);
+          },
         }),
-        humanRequestChangesTask,
-        hydrateRequestedTaskSessionHistory,
-        sendAgentMessage,
-        onContextSwitchIntent,
-        sessionsForTask: [
-          createSession({
-            sessionId: "session-build-latest",
-            startedAt: "2026-02-22T13:00:00.000Z",
-          }),
-          createSession({
-            sessionId: "session-build-older",
-            startedAt: "2026-02-22T11:00:00.000Z",
-          }),
-        ],
-        updateQuery: (updates) => {
-          updateCalls.push(updates);
+      );
+
+      await harness.mount();
+      await harness.run((state) => {
+        state.openHumanReviewFeedback();
+      });
+      await waitForFeedbackModal(harness);
+
+      await harness.run((state) => {
+        state.humanReviewFeedbackModal?.onTargetChange("session-build-older");
+        state.humanReviewFeedbackModal?.onMessageChange("  Apply the requested human changes.  ");
+      });
+      await harness.run(async (state) => {
+        await state.humanReviewFeedbackModal?.onConfirm();
+      });
+
+      expect(humanRequestChangesTask).toHaveBeenCalledWith(
+        "task-1",
+        "Apply the requested human changes.",
+      );
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
+        taskId: "task-1",
+        sessionId: "session-build-older",
+      });
+      expect(sendAgentMessage).toHaveBeenCalledWith("session-build-older", [
+        { kind: "text", text: "Apply the requested human changes." },
+      ]);
+      expect(onContextSwitchIntent).toHaveBeenCalledTimes(1);
+      expect(updateCalls).toEqual([
+        {
+          task: "task-1",
+          session: "session-build-older",
+          agent: "build",
+          scenario: undefined,
+          autostart: undefined,
+          start: undefined,
         },
-      }),
-    );
+      ]);
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Changes requested, but refreshing Builder sessions failed.",
+      );
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Changes requested, but feedback message failed.",
+      );
+      expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
 
-    await harness.mount();
-    await harness.run((state) => {
-      state.openHumanReviewFeedback();
+      await harness.unmount();
     });
-    await waitForFeedbackModal(harness);
-
-    await harness.run((state) => {
-      state.humanReviewFeedbackModal?.onTargetChange("session-build-older");
-      state.humanReviewFeedbackModal?.onMessageChange("  Apply the requested human changes.  ");
-    });
-    await harness.run(async (state) => {
-      await state.humanReviewFeedbackModal?.onConfirm();
-    });
-
-    expect(humanRequestChangesTask).toHaveBeenCalledWith(
-      "task-1",
-      "Apply the requested human changes.",
-    );
-    expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
-      taskId: "task-1",
-      sessionId: "session-build-older",
-    });
-    expect(sendAgentMessage).toHaveBeenCalledWith("session-build-older", [
-      { kind: "text", text: "Apply the requested human changes." },
-    ]);
-    expect(onContextSwitchIntent).toHaveBeenCalledTimes(1);
-    expect(updateCalls).toEqual([
-      {
-        task: "task-1",
-        session: "session-build-older",
-        agent: "build",
-        scenario: undefined,
-        autostart: undefined,
-        start: undefined,
-      },
-    ]);
-    expect(toastErrorMock).toHaveBeenCalledWith(
-      "Changes requested, but refreshing Builder sessions failed.",
-    );
-    expect(toastErrorMock).toHaveBeenCalledWith("Changes requested, but feedback message failed.");
-    expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
-
-    await harness.unmount();
   });
 
   test("starts a new builder session through the requested-session workflow", async () => {
@@ -435,35 +418,119 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
     await harness.unmount();
   });
 
+  test("surfaces detached follow-up message failures after starting a new builder session", async () => {
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const humanRequestChangesTask = mock(async () => {});
+      const startAgentSession = mock(async () => "session-build-new");
+      const sendAgentMessage = mock(async () => {
+        throw new Error("detached send failed");
+      });
+      const hydrateRequestedTaskSessionHistory = mock(async () => {});
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+      const executeRequestedSessionStart: HookArgs["executeRequestedSessionStart"] = async (
+        _request,
+        executeWithDecision,
+      ) => {
+        return executeWithDecision({
+          startMode: "fresh",
+          selectedModel: MODEL_SELECTION,
+        });
+      };
+      const harness = createHookHarness(
+        createBaseArgs({
+          humanRequestChangesTask,
+          startAgentSession,
+          sendAgentMessage,
+          hydrateRequestedTaskSessionHistory,
+          executeRequestedSessionStart,
+          sessionsForTask: [createSession({ sessionId: "session-build-existing" })],
+          updateQuery: (updates) => {
+            updateCalls.push(updates);
+          },
+        }),
+      );
+
+      await harness.mount();
+      await harness.run((state) => {
+        state.openHumanReviewFeedback();
+      });
+      await waitForFeedbackModal(harness);
+
+      await harness.run((state) => {
+        state.humanReviewFeedbackModal?.onTargetChange(NEW_BUILDER_SESSION_TARGET);
+        state.humanReviewFeedbackModal?.onMessageChange("  Ship the requested fixes.  ");
+      });
+      await harness.run(async (state) => {
+        await state.humanReviewFeedbackModal?.onConfirm();
+      });
+      await harness.waitFor(() => toastErrorMock.mock.calls.length > 0);
+
+      expect(humanRequestChangesTask).toHaveBeenCalledWith("task-1", "Ship the requested fixes.");
+      expect(startAgentSession).toHaveBeenCalledWith({
+        taskId: "task-1",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        selectedModel: MODEL_SELECTION,
+        startMode: "fresh",
+      });
+      expect(sendAgentMessage).toHaveBeenCalledWith("session-build-new", [
+        { kind: "text", text: "Ship the requested fixes." },
+      ]);
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
+        taskId: "task-1",
+        sessionId: "session-build-new",
+      });
+      expect(updateCalls).toEqual([
+        {
+          task: "task-1",
+          session: "session-build-new",
+          agent: "build",
+          scenario: undefined,
+          autostart: undefined,
+          start: undefined,
+        },
+      ]);
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Changes requested, but feedback message failed.",
+        { description: "detached send failed" },
+      );
+      expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
+
+      await harness.unmount();
+    });
+  });
+
   test("rejects a stale selected builder target before requesting changes", async () => {
-    const humanRequestChangesTask = mock(async () => {});
-    const harness = createHookHarness(
-      createBaseArgs({
-        humanRequestChangesTask,
-        sessionsForTask: [createSession({ sessionId: "session-build-existing" })],
-      }),
-    );
+    await withMockedToast(async ({ toastErrorMock }) => {
+      const humanRequestChangesTask = mock(async () => {});
+      const harness = createHookHarness(
+        createBaseArgs({
+          humanRequestChangesTask,
+          sessionsForTask: [createSession({ sessionId: "session-build-existing" })],
+        }),
+      );
 
-    await harness.mount();
-    await harness.run((state) => {
-      state.openHumanReviewFeedback();
+      await harness.mount();
+      await harness.run((state) => {
+        state.openHumanReviewFeedback();
+      });
+      await waitForFeedbackModal(harness);
+
+      await harness.run((state) => {
+        state.humanReviewFeedbackModal?.onTargetChange("session-build-missing");
+        state.humanReviewFeedbackModal?.onMessageChange("Apply the latest review feedback.");
+      });
+      await harness.run(async (state) => {
+        await state.humanReviewFeedbackModal?.onConfirm();
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "The selected builder session is no longer available for this task.",
+      );
+      expect(humanRequestChangesTask).toHaveBeenCalledTimes(0);
+      expect(harness.getLatest().humanReviewFeedbackModal?.open).toBe(true);
+
+      await harness.unmount();
     });
-    await waitForFeedbackModal(harness);
-
-    await harness.run((state) => {
-      state.humanReviewFeedbackModal?.onTargetChange("session-build-missing");
-      state.humanReviewFeedbackModal?.onMessageChange("Apply the latest review feedback.");
-    });
-    await harness.run(async (state) => {
-      await state.humanReviewFeedbackModal?.onConfirm();
-    });
-
-    expect(toastErrorMock).toHaveBeenCalledWith(
-      "The selected builder session is no longer available for this task.",
-    );
-    expect(humanRequestChangesTask).toHaveBeenCalledTimes(0);
-    expect(harness.getLatest().humanReviewFeedbackModal?.open).toBe(true);
-
-    await harness.unmount();
   });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.test.tsx
@@ -75,6 +75,56 @@ const waitForFeedbackModal = async (
   return modal;
 };
 
+const openFeedbackModal = async (harness: ReturnType<typeof createHookHarness>) => {
+  await harness.mount();
+  await harness.run((state) => {
+    state.openHumanReviewFeedback();
+  });
+  return waitForFeedbackModal(harness);
+};
+
+const updateFeedbackModal = async (
+  harness: ReturnType<typeof createHookHarness>,
+  {
+    target,
+    message,
+  }: {
+    target?: string;
+    message?: string;
+  },
+) => {
+  await harness.run((state) => {
+    if (target) {
+      state.humanReviewFeedbackModal?.onTargetChange(target);
+    }
+    if (message !== undefined) {
+      state.humanReviewFeedbackModal?.onMessageChange(message);
+    }
+  });
+};
+
+const confirmFeedbackModal = async (harness: ReturnType<typeof createHookHarness>) => {
+  await harness.run(async (state) => {
+    await state.humanReviewFeedbackModal?.onConfirm();
+  });
+};
+
+const expectBuilderSelectionUpdate = (
+  updateCalls: Array<Record<string, string | undefined>>,
+  sessionId: string,
+) => {
+  expect(updateCalls).toEqual([
+    {
+      task: "task-1",
+      session: sessionId,
+      agent: "build",
+      scenario: undefined,
+      autostart: undefined,
+      start: undefined,
+    },
+  ]);
+};
+
 describe("useAgentStudioHumanReviewFeedbackFlow", () => {
   test("intercepts only build-after-human-request-changes session creation", async () => {
     const harness = createHookHarness(createBaseArgs());
@@ -132,12 +182,7 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
       }),
     );
 
-    await harness.mount();
-    await harness.run((state) => {
-      state.openHumanReviewFeedback();
-    });
-
-    const modal = await waitForFeedbackModal(harness);
+    const modal = await openFeedbackModal(harness);
 
     expect(bootstrapTaskSessions).toHaveBeenCalledWith("task-1");
     expect(modal.selectedTarget).toBe("session-build-latest");
@@ -223,18 +268,9 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
         }),
       );
 
-      await harness.mount();
-      await harness.run((state) => {
-        state.openHumanReviewFeedback();
-      });
-      await waitForFeedbackModal(harness);
-
-      await harness.run((state) => {
-        state.humanReviewFeedbackModal?.onMessageChange("   ");
-      });
-      await harness.run(async (state) => {
-        await state.humanReviewFeedbackModal?.onConfirm();
-      });
+      await openFeedbackModal(harness);
+      await updateFeedbackModal(harness, { message: "   " });
+      await confirmFeedbackModal(harness);
 
       expect(toastErrorMock).toHaveBeenCalledWith("Feedback message is required.");
       expect(humanRequestChangesTask).toHaveBeenCalledTimes(0);
@@ -284,19 +320,12 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
         }),
       );
 
-      await harness.mount();
-      await harness.run((state) => {
-        state.openHumanReviewFeedback();
+      await openFeedbackModal(harness);
+      await updateFeedbackModal(harness, {
+        target: "session-build-older",
+        message: "  Apply the requested human changes.  ",
       });
-      await waitForFeedbackModal(harness);
-
-      await harness.run((state) => {
-        state.humanReviewFeedbackModal?.onTargetChange("session-build-older");
-        state.humanReviewFeedbackModal?.onMessageChange("  Apply the requested human changes.  ");
-      });
-      await harness.run(async (state) => {
-        await state.humanReviewFeedbackModal?.onConfirm();
-      });
+      await confirmFeedbackModal(harness);
 
       expect(humanRequestChangesTask).toHaveBeenCalledWith(
         "task-1",
@@ -310,16 +339,7 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
         { kind: "text", text: "Apply the requested human changes." },
       ]);
       expect(onContextSwitchIntent).toHaveBeenCalledTimes(1);
-      expect(updateCalls).toEqual([
-        {
-          task: "task-1",
-          session: "session-build-older",
-          agent: "build",
-          scenario: undefined,
-          autostart: undefined,
-          start: undefined,
-        },
-      ]);
+      expectBuilderSelectionUpdate(updateCalls, "session-build-older");
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Changes requested, but refreshing Builder sessions failed.",
       );
@@ -363,19 +383,12 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
       }),
     );
 
-    await harness.mount();
-    await harness.run((state) => {
-      state.openHumanReviewFeedback();
+    await openFeedbackModal(harness);
+    await updateFeedbackModal(harness, {
+      target: NEW_BUILDER_SESSION_TARGET,
+      message: "  Ship the requested fixes.  ",
     });
-    await waitForFeedbackModal(harness);
-
-    await harness.run((state) => {
-      state.humanReviewFeedbackModal?.onTargetChange(NEW_BUILDER_SESSION_TARGET);
-      state.humanReviewFeedbackModal?.onMessageChange("  Ship the requested fixes.  ");
-    });
-    await harness.run(async (state) => {
-      await state.humanReviewFeedbackModal?.onConfirm();
-    });
+    await confirmFeedbackModal(harness);
     await harness.waitFor(() => sendAgentMessage.mock.calls.length > 0);
 
     expect(requestedStarts).toEqual([
@@ -403,16 +416,7 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
       taskId: "task-1",
       sessionId: "session-build-new",
     });
-    expect(updateCalls).toEqual([
-      {
-        task: "task-1",
-        session: "session-build-new",
-        agent: "build",
-        scenario: undefined,
-        autostart: undefined,
-        start: undefined,
-      },
-    ]);
+    expectBuilderSelectionUpdate(updateCalls, "session-build-new");
     expect(harness.getLatest().humanReviewFeedbackModal).toBeNull();
 
     await harness.unmount();
@@ -450,19 +454,12 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
         }),
       );
 
-      await harness.mount();
-      await harness.run((state) => {
-        state.openHumanReviewFeedback();
+      await openFeedbackModal(harness);
+      await updateFeedbackModal(harness, {
+        target: NEW_BUILDER_SESSION_TARGET,
+        message: "  Ship the requested fixes.  ",
       });
-      await waitForFeedbackModal(harness);
-
-      await harness.run((state) => {
-        state.humanReviewFeedbackModal?.onTargetChange(NEW_BUILDER_SESSION_TARGET);
-        state.humanReviewFeedbackModal?.onMessageChange("  Ship the requested fixes.  ");
-      });
-      await harness.run(async (state) => {
-        await state.humanReviewFeedbackModal?.onConfirm();
-      });
+      await confirmFeedbackModal(harness);
       await harness.waitFor(() => toastErrorMock.mock.calls.length > 0);
 
       expect(humanRequestChangesTask).toHaveBeenCalledWith("task-1", "Ship the requested fixes.");
@@ -480,16 +477,7 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
         taskId: "task-1",
         sessionId: "session-build-new",
       });
-      expect(updateCalls).toEqual([
-        {
-          task: "task-1",
-          session: "session-build-new",
-          agent: "build",
-          scenario: undefined,
-          autostart: undefined,
-          start: undefined,
-        },
-      ]);
+      expectBuilderSelectionUpdate(updateCalls, "session-build-new");
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Changes requested, but feedback message failed.",
         { description: "detached send failed" },
@@ -510,19 +498,12 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
         }),
       );
 
-      await harness.mount();
-      await harness.run((state) => {
-        state.openHumanReviewFeedback();
+      await openFeedbackModal(harness);
+      await updateFeedbackModal(harness, {
+        target: "session-build-missing",
+        message: "Apply the latest review feedback.",
       });
-      await waitForFeedbackModal(harness);
-
-      await harness.run((state) => {
-        state.humanReviewFeedbackModal?.onTargetChange("session-build-missing");
-        state.humanReviewFeedbackModal?.onMessageChange("Apply the latest review feedback.");
-      });
-      await harness.run(async (state) => {
-        await state.humanReviewFeedbackModal?.onConfirm();
-      });
+      await confirmFeedbackModal(harness);
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "The selected builder session is no longer available for this task.",

--- a/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.test.tsx
@@ -15,13 +15,13 @@ enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioHumanReviewFeedbackFlow>[0];
 
-const MODEL_SELECTION = {
+const createModelSelection = () => ({
   runtimeKind: "opencode" as const,
   providerId: "openai",
   modelId: "gpt-5",
   variant: "default",
   profileId: "builder",
-};
+});
 
 const createTask = (overrides: Partial<TaskCard> = {}): TaskCard =>
   createTaskCardFixture({
@@ -94,7 +94,7 @@ const updateFeedbackModal = async (
   },
 ) => {
   await harness.run((state) => {
-    if (target) {
+    if (target !== undefined) {
       state.humanReviewFeedbackModal?.onTargetChange(target);
     }
     if (message !== undefined) {
@@ -366,7 +366,7 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
       requestedStarts.push(request);
       return executeWithDecision({
         startMode: "fresh",
-        selectedModel: MODEL_SELECTION,
+        selectedModel: createModelSelection(),
       });
     };
     const harness = createHookHarness(
@@ -406,7 +406,7 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
       taskId: "task-1",
       role: "build",
       scenario: "build_after_human_request_changes",
-      selectedModel: MODEL_SELECTION,
+      selectedModel: createModelSelection(),
       startMode: "fresh",
     });
     expect(sendAgentMessage).toHaveBeenCalledWith("session-build-new", [
@@ -437,7 +437,7 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
       ) => {
         return executeWithDecision({
           startMode: "fresh",
-          selectedModel: MODEL_SELECTION,
+          selectedModel: createModelSelection(),
         });
       };
       const harness = createHookHarness(
@@ -467,7 +467,7 @@ describe("useAgentStudioHumanReviewFeedbackFlow", () => {
         taskId: "task-1",
         role: "build",
         scenario: "build_after_human_request_changes",
-        selectedModel: MODEL_SELECTION,
+        selectedModel: createModelSelection(),
         startMode: "fresh",
       });
       expect(sendAgentMessage).toHaveBeenCalledWith("session-build-new", [

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.test.tsx
@@ -1,0 +1,186 @@
+import { describe, expect, mock, test } from "bun:test";
+import { useState } from "react";
+import { createHookHarness as createCoreHookHarness } from "@/test-utils/react-hook-harness";
+import { enableReactActEnvironment } from "./agent-studio-test-utils";
+import { useTaskTabActions } from "./use-agent-studio-task-tabs-actions";
+
+enableReactActEnvironment();
+
+type HookArgs = Omit<
+  Parameters<typeof useTaskTabActions>[0],
+  "tabTaskIds" | "setOpenTaskTabs" | "setPersistedActiveTaskId" | "setIntentActiveTaskId"
+> & {
+  initialOpenTaskTabs: string[];
+  initialPersistedActiveTaskId?: string | null;
+  initialIntentActiveTaskId?: string | null;
+};
+
+const useTaskTabActionsHarness = (props: HookArgs) => {
+  const [openTaskTabs, setOpenTaskTabs] = useState(props.initialOpenTaskTabs);
+  const [persistedActiveTaskId, setPersistedActiveTaskId] = useState(
+    props.initialPersistedActiveTaskId ?? null,
+  );
+  const [intentActiveTaskId, setIntentActiveTaskId] = useState(
+    props.initialIntentActiveTaskId ?? null,
+  );
+
+  const actions = useTaskTabActions({
+    tabTaskIds: openTaskTabs,
+    activeTaskTabId: props.activeTaskTabId,
+    clearComposerInput: props.clearComposerInput,
+    onContextSwitchIntent: props.onContextSwitchIntent,
+    clearTaskSelection: props.clearTaskSelection,
+    navigateToTaskIntent: props.navigateToTaskIntent,
+    handleSelectTab: props.handleSelectTab,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+  });
+
+  return {
+    ...actions,
+    openTaskTabs,
+    persistedActiveTaskId,
+    intentActiveTaskId,
+  };
+};
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createCoreHookHarness(useTaskTabActionsHarness, initialProps);
+
+describe("useTaskTabActions", () => {
+  test("delegates create-tab actions to the select handler", async () => {
+    const handleSelectTab = mock(() => {});
+    const harness = createHookHarness({
+      initialOpenTaskTabs: ["task-1"],
+      activeTaskTabId: "task-1",
+      clearComposerInput: () => {},
+      onContextSwitchIntent: undefined,
+      clearTaskSelection: () => {},
+      navigateToTaskIntent: () => {},
+      handleSelectTab,
+    });
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.handleCreateTab("task-2");
+    });
+
+    expect(handleSelectTab).toHaveBeenCalledWith("task-2");
+
+    await harness.unmount();
+  });
+
+  test("closing an inactive tab avoids active-tab side effects", async () => {
+    const clearComposerInput = mock(() => {});
+    const onContextSwitchIntent = mock(() => {});
+    const clearTaskSelection = mock(() => {});
+    const navigateToTaskIntent = mock(() => {});
+    const harness = createHookHarness({
+      initialOpenTaskTabs: ["task-1", "task-2"],
+      initialPersistedActiveTaskId: "task-1",
+      activeTaskTabId: "task-1",
+      clearComposerInput,
+      onContextSwitchIntent,
+      clearTaskSelection,
+      navigateToTaskIntent,
+      handleSelectTab: () => {},
+    });
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.handleCloseTab("task-2");
+    });
+
+    expect(harness.getLatest()).toEqual({
+      handleCreateTab: harness.getLatest().handleCreateTab,
+      handleCloseTab: harness.getLatest().handleCloseTab,
+      openTaskTabs: ["task-1"],
+      persistedActiveTaskId: "task-1",
+      intentActiveTaskId: null,
+    });
+    expect(clearComposerInput).toHaveBeenCalledTimes(0);
+    expect(onContextSwitchIntent).toHaveBeenCalledTimes(0);
+    expect(clearTaskSelection).toHaveBeenCalledTimes(0);
+    expect(navigateToTaskIntent).toHaveBeenCalledTimes(0);
+
+    await harness.unmount();
+  });
+
+  test("closing the active tab focuses and navigates to the adjacent replacement tab", async () => {
+    const clearComposerInput = mock(() => {});
+    const onContextSwitchIntent = mock(() => {});
+    const clearTaskSelection = mock(() => {});
+    const navigateToTaskIntent = mock(() => {});
+    const nextTrigger = globalThis.document.createElement("button");
+    nextTrigger.id = "agent-studio-tab-task-3";
+    globalThis.document.body.appendChild(nextTrigger);
+
+    const harness = createHookHarness({
+      initialOpenTaskTabs: ["task-1", "task-2", "task-3"],
+      initialPersistedActiveTaskId: "task-2",
+      activeTaskTabId: "task-2",
+      clearComposerInput,
+      onContextSwitchIntent,
+      clearTaskSelection,
+      navigateToTaskIntent,
+      handleSelectTab: () => {},
+    });
+
+    try {
+      await harness.mount();
+      await harness.run((state) => {
+        state.handleCloseTab("task-2");
+      });
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, 0);
+      });
+
+      const latest = harness.getLatest();
+      expect(latest.openTaskTabs).toEqual(["task-1", "task-3"]);
+      expect(latest.persistedActiveTaskId).toBe("task-3");
+      expect(latest.intentActiveTaskId).toBe("task-3");
+      expect(clearComposerInput).toHaveBeenCalledTimes(1);
+      expect(onContextSwitchIntent).toHaveBeenCalledTimes(1);
+      expect(clearTaskSelection).toHaveBeenCalledTimes(0);
+      expect(navigateToTaskIntent).toHaveBeenCalledWith("task-3");
+      expect(globalThis.document.activeElement).toBe(nextTrigger);
+    } finally {
+      await harness.unmount();
+      nextTrigger.remove();
+    }
+  });
+
+  test("closing the last active tab clears the current selection", async () => {
+    const clearComposerInput = mock(() => {});
+    const onContextSwitchIntent = mock(() => {});
+    const clearTaskSelection = mock(() => {});
+    const navigateToTaskIntent = mock(() => {});
+    const harness = createHookHarness({
+      initialOpenTaskTabs: ["task-1"],
+      initialPersistedActiveTaskId: "task-1",
+      activeTaskTabId: "task-1",
+      clearComposerInput,
+      onContextSwitchIntent,
+      clearTaskSelection,
+      navigateToTaskIntent,
+      handleSelectTab: () => {},
+    });
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.handleCloseTab("task-1");
+    });
+
+    const latest = harness.getLatest();
+    expect(latest.openTaskTabs).toEqual([]);
+    expect(latest.persistedActiveTaskId).toBeNull();
+    expect(latest.intentActiveTaskId).toBeNull();
+    expect(clearComposerInput).toHaveBeenCalledTimes(1);
+    expect(onContextSwitchIntent).toHaveBeenCalledTimes(1);
+    expect(clearTaskSelection).toHaveBeenCalledTimes(1);
+    expect(navigateToTaskIntent).toHaveBeenCalledTimes(0);
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.test.tsx
@@ -146,8 +146,11 @@ describe("useTaskTabActions", () => {
       expect(navigateToTaskIntent).toHaveBeenCalledWith("task-3");
       expect(globalThis.document.activeElement).toBe(nextTrigger);
     } finally {
-      await harness.unmount();
-      nextTrigger.remove();
+      try {
+        await harness.unmount();
+      } finally {
+        nextTrigger.remove();
+      }
     }
   });
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.test.tsx
@@ -72,6 +72,36 @@ const createThrowingStorage = (args: {
   };
 };
 
+const createTrackedStorage = (): {
+  storage: TestStorageLike;
+  setItem: ReturnType<typeof mock>;
+  store: Map<string, string>;
+} => {
+  const store = new Map<string, string>();
+  const setItem = mock((key: string, value: string) => {
+    store.set(key, value);
+  });
+
+  return {
+    storage: {
+      getItem: (key) => store.get(key) ?? null,
+      setItem,
+      removeItem: (key) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+      key: (index) => Array.from(store.keys())[index] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+    setItem,
+    store,
+  };
+};
+
 const useTaskTabPersistenceHarness = (props: HookArgs) => {
   const [openTaskTabs, setOpenTaskTabs] = useState(props.initialOpenTaskTabs ?? []);
   const [persistedActiveTaskId, setPersistedActiveTaskId] = useState(
@@ -169,24 +199,7 @@ describe("useTaskTabPersistence", () => {
   });
 
   test("persists task tabs only after hydration matches the active repo", async () => {
-    const store = new Map<string, string>();
-    const setItem = mock((key: string, value: string) => {
-      store.set(key, value);
-    });
-    const storage: TestStorageLike = {
-      getItem: (key) => store.get(key) ?? null,
-      setItem,
-      removeItem: (key) => {
-        store.delete(key);
-      },
-      clear: () => {
-        store.clear();
-      },
-      key: (index) => Array.from(store.keys())[index] ?? null,
-      get length() {
-        return store.size;
-      },
-    };
+    const { storage, setItem } = createTrackedStorage();
 
     await withMockedLocalStorage(storage, async () => {
       const harness = createHookHarness({
@@ -214,6 +227,56 @@ describe("useTaskTabPersistence", () => {
         intentActiveTaskId: null,
         tabsStorageHydratedRepo: "/repo",
       });
+
+      await harness.unmount();
+    });
+  });
+
+  test("does not persist stale tabs into the next repo during a repo switch", async () => {
+    const { storage, setItem, store } = createTrackedStorage();
+
+    await withMockedLocalStorage(storage, async () => {
+      seedRepoTaskTabs(storage, {
+        "/repo-a": { tabs: ["task-a"], activeTaskId: "task-a" },
+        "/repo-b": { tabs: ["task-b"], activeTaskId: "task-b" },
+      });
+
+      const harness = createHookHarness({
+        activeRepo: "/repo-a",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask({ id: "task-a" }), createTask({ id: "task-b" })],
+        isLoadingTasks: false,
+        activeTaskTabId: "task-a",
+      });
+
+      await harness.mount();
+      setItem.mockClear();
+
+      await harness.update({
+        activeRepo: "/repo-b",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask({ id: "task-a" }), createTask({ id: "task-b" })],
+        isLoadingTasks: false,
+        activeTaskTabId: "task-b",
+      });
+
+      expect(harness.getLatest()).toEqual({
+        openTaskTabs: ["task-b"],
+        persistedActiveTaskId: "task-b",
+        intentActiveTaskId: null,
+        tabsStorageHydratedRepo: "/repo-b",
+      });
+      expect(setItem.mock.calls).toEqual([
+        [
+          toTabsStorageKey("/repo-b"),
+          toPersistedTaskTabs({ tabs: ["task-b"], activeTaskId: "task-b" }),
+        ],
+      ]);
+      expect(store.get(toTabsStorageKey("/repo-b"))).toBe(
+        toPersistedTaskTabs({ tabs: ["task-b"], activeTaskId: "task-b" }),
+      );
 
       await harness.unmount();
     });

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.test.tsx
@@ -1,0 +1,331 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { TaskCard } from "@openducktor/contracts";
+import { useState } from "react";
+import { createHookHarness as createCoreHookHarness } from "@/test-utils/react-hook-harness";
+import {
+  createMemoryStorage,
+  seedRepoTaskTabs,
+  type TestStorageLike,
+  withMockedLocalStorage,
+} from "./agent-studio-repo-persistence-test-utils";
+import { createTaskCardFixture, enableReactActEnvironment } from "./agent-studio-test-utils";
+import { toTabsStorageKey } from "./agents-page-selection";
+import { toPersistedTaskTabs } from "./agents-page-session-tabs";
+import { useTaskTabPersistence } from "./use-agent-studio-task-tabs-persistence";
+
+enableReactActEnvironment();
+
+type HookArgs = Omit<
+  Parameters<typeof useTaskTabPersistence>[0],
+  | "openTaskTabs"
+  | "tabsStorageHydratedRepo"
+  | "setOpenTaskTabs"
+  | "setPersistedActiveTaskId"
+  | "setIntentActiveTaskId"
+  | "setTabsStorageHydratedRepo"
+> & {
+  initialOpenTaskTabs?: string[];
+  initialPersistedActiveTaskId?: string | null;
+  initialIntentActiveTaskId?: string | null;
+  initialTabsStorageHydratedRepo?: string | null;
+};
+
+const createTask = (overrides: Partial<TaskCard> = {}): TaskCard =>
+  createTaskCardFixture({
+    id: "task-1",
+    title: "Task 1",
+    status: "in_progress",
+    ...overrides,
+  });
+
+const createThrowingStorage = (args: {
+  throwOnGetItem?: boolean;
+  throwOnSetItem?: boolean;
+  message?: string;
+}): TestStorageLike => {
+  const store = new Map<string, string>();
+  const message = args.message ?? "storage unavailable";
+
+  return {
+    getItem: (key) => {
+      if (args.throwOnGetItem) {
+        throw new Error(message);
+      }
+      return store.get(key) ?? null;
+    },
+    setItem: (key, value) => {
+      if (args.throwOnSetItem) {
+        throw new Error(message);
+      }
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+};
+
+const useTaskTabPersistenceHarness = (props: HookArgs) => {
+  const [openTaskTabs, setOpenTaskTabs] = useState(props.initialOpenTaskTabs ?? []);
+  const [persistedActiveTaskId, setPersistedActiveTaskId] = useState(
+    props.initialPersistedActiveTaskId ?? null,
+  );
+  const [intentActiveTaskId, setIntentActiveTaskId] = useState(
+    props.initialIntentActiveTaskId ?? null,
+  );
+  const [tabsStorageHydratedRepo, setTabsStorageHydratedRepo] = useState(
+    props.initialTabsStorageHydratedRepo ?? null,
+  );
+
+  useTaskTabPersistence({
+    activeRepo: props.activeRepo,
+    taskId: props.taskId,
+    selectedTask: props.selectedTask,
+    tasks: props.tasks,
+    isLoadingTasks: props.isLoadingTasks,
+    activeTaskTabId: props.activeTaskTabId,
+    openTaskTabs,
+    tabsStorageHydratedRepo,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+    setTabsStorageHydratedRepo,
+  });
+
+  return {
+    openTaskTabs,
+    persistedActiveTaskId,
+    intentActiveTaskId,
+    tabsStorageHydratedRepo,
+  };
+};
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createCoreHookHarness(useTaskTabPersistenceHarness, initialProps);
+
+describe("useTaskTabPersistence", () => {
+  test("resets tab state when the active repo is cleared", async () => {
+    const harness = createHookHarness({
+      activeRepo: null,
+      taskId: "",
+      selectedTask: null,
+      tasks: [],
+      isLoadingTasks: false,
+      activeTaskTabId: "",
+      initialOpenTaskTabs: ["task-1", "task-2"],
+      initialPersistedActiveTaskId: "task-2",
+      initialIntentActiveTaskId: "task-2",
+      initialTabsStorageHydratedRepo: "/repo",
+    });
+
+    await harness.mount();
+
+    expect(harness.getLatest()).toEqual({
+      openTaskTabs: [],
+      persistedActiveTaskId: null,
+      intentActiveTaskId: null,
+      tabsStorageHydratedRepo: null,
+    });
+
+    await harness.unmount();
+  });
+
+  test("hydrates repo-scoped tabs from the active repo storage key", async () => {
+    const storage = createMemoryStorage();
+
+    await withMockedLocalStorage(storage, async () => {
+      seedRepoTaskTabs(storage, {
+        "/repo-a": { tabs: ["task-a"], activeTaskId: "task-a" },
+        "/repo-b": { tabs: ["task-b", "task-c"], activeTaskId: "task-c" },
+      });
+
+      const harness = createHookHarness({
+        activeRepo: "/repo-b",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask({ id: "task-b" }), createTask({ id: "task-c" })],
+        isLoadingTasks: false,
+        activeTaskTabId: "",
+      });
+
+      await harness.mount();
+
+      expect(harness.getLatest()).toEqual({
+        openTaskTabs: ["task-b", "task-c"],
+        persistedActiveTaskId: "task-c",
+        intentActiveTaskId: null,
+        tabsStorageHydratedRepo: "/repo-b",
+      });
+
+      await harness.unmount();
+    });
+  });
+
+  test("persists task tabs only after hydration matches the active repo", async () => {
+    const store = new Map<string, string>();
+    const setItem = mock((key: string, value: string) => {
+      store.set(key, value);
+    });
+    const storage: TestStorageLike = {
+      getItem: (key) => store.get(key) ?? null,
+      setItem,
+      removeItem: (key) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+      key: (index) => Array.from(store.keys())[index] ?? null,
+      get length() {
+        return store.size;
+      },
+    };
+
+    await withMockedLocalStorage(storage, async () => {
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "task-1",
+        selectedTask: createTask({ id: "task-1" }),
+        tasks: [createTask({ id: "task-1" })],
+        isLoadingTasks: false,
+        activeTaskTabId: "task-1",
+        initialOpenTaskTabs: ["stale-task"],
+        initialPersistedActiveTaskId: "stale-task",
+        initialTabsStorageHydratedRepo: null,
+      });
+
+      await harness.mount();
+
+      expect(setItem).toHaveBeenCalledTimes(1);
+      expect(setItem).toHaveBeenCalledWith(
+        toTabsStorageKey("/repo"),
+        toPersistedTaskTabs({ tabs: ["task-1"], activeTaskId: "task-1" }),
+      );
+      expect(harness.getLatest()).toEqual({
+        openTaskTabs: ["task-1"],
+        persistedActiveTaskId: null,
+        intentActiveTaskId: null,
+        tabsStorageHydratedRepo: "/repo",
+      });
+
+      await harness.unmount();
+    });
+  });
+
+  test("prunes closed task tabs after tasks finish loading", async () => {
+    const storage = createMemoryStorage();
+
+    await withMockedLocalStorage(storage, async () => {
+      seedRepoTaskTabs(storage, {
+        "/repo": { tabs: ["task-1", "task-closed"], activeTaskId: "task-1" },
+      });
+
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [
+          createTask({ id: "task-1", status: "in_progress" }),
+          createTask({ id: "task-closed", status: "closed" }),
+        ],
+        isLoadingTasks: true,
+        activeTaskTabId: "task-1",
+      });
+
+      await harness.mount();
+      expect(harness.getLatest().openTaskTabs).toEqual(["task-1", "task-closed"]);
+
+      await harness.update({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [
+          createTask({ id: "task-1", status: "in_progress" }),
+          createTask({ id: "task-closed", status: "closed" }),
+        ],
+        isLoadingTasks: false,
+        activeTaskTabId: "task-1",
+      });
+
+      expect(harness.getLatest().openTaskTabs).toEqual(["task-1"]);
+
+      await harness.unmount();
+    });
+  });
+
+  test("auto-opens the selected non-closed task when it is missing from the tab list", async () => {
+    const storage = createMemoryStorage();
+
+    await withMockedLocalStorage(storage, async () => {
+      seedRepoTaskTabs(storage, {
+        "/repo": { tabs: ["task-1"], activeTaskId: "task-1" },
+      });
+
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "task-2",
+        selectedTask: createTask({ id: "task-2", status: "in_progress" }),
+        tasks: [createTask({ id: "task-1" }), createTask({ id: "task-2" })],
+        isLoadingTasks: false,
+        activeTaskTabId: "task-2",
+      });
+
+      await harness.mount();
+
+      expect(harness.getLatest().openTaskTabs).toEqual(["task-1", "task-2"]);
+
+      await harness.unmount();
+    });
+  });
+
+  test("throws an actionable error when reading task tabs storage fails", async () => {
+    const storage = createThrowingStorage({
+      throwOnGetItem: true,
+      message: "read blocked",
+    });
+
+    await withMockedLocalStorage(storage, async () => {
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask({ id: "task-1" })],
+        isLoadingTasks: false,
+        activeTaskTabId: "",
+      });
+
+      await expect(harness.mount()).rejects.toThrow(
+        `Failed to read agent studio task tabs storage key "${toTabsStorageKey("/repo")}": read blocked`,
+      );
+    });
+  });
+
+  test("throws an actionable error when persisting task tabs storage fails", async () => {
+    const storage = createThrowingStorage({
+      throwOnSetItem: true,
+      message: "write blocked",
+    });
+
+    await withMockedLocalStorage(storage, async () => {
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "task-1",
+        selectedTask: createTask({ id: "task-1" }),
+        tasks: [createTask({ id: "task-1" })],
+        isLoadingTasks: false,
+        activeTaskTabId: "task-1",
+      });
+
+      await expect(harness.mount()).rejects.toThrow(
+        `Failed to persist agent studio task tabs storage key "${toTabsStorageKey("/repo")}": write blocked`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add direct hook tests for Agent Studio task-tab persistence, tab actions, human-review feedback flow, and git action error state
- close QA coverage gaps for repo-switch persistence and detached post-start builder-message failures
- simplify the human-review hook test suite with small local helpers while keeping the same assertions and coverage

## Goal
This PR adds focused direct coverage for four Agent Studio orchestration hooks that previously had no standalone tests. These hooks coordinate repo-scoped tab restoration, active-tab close behavior, human-review handoff into Builder sessions, and independent git action error buckets, so regressions here can silently break state restoration and review workflows even when broader page tests still pass.

The follow-up QA fixes make that coverage more complete by proving stale tabs are not persisted across repo switches, verifying the detached post-start error path when a new Builder session fails to send its follow-up message, and aligning toast mocking with the repo's Bun module-mocking guidance.

## Implementation
The change is test-only and adds four new direct hook suites under `apps/desktop/src/pages/agents`.

Technical choices:
- use direct hook harnesses instead of broader page-level tests so the assertions stay focused on orchestration behavior and avoid unnecessary integration setup
- use small stateful wrapper hooks for the tab persistence and tab actions suites to exercise real React state updates and functional setter behavior
- use the existing isolated QueryProvider-based harness for the human-review hook because the hook depends on TanStack Query state
- prefer repo-approved seams such as `withMockedToast` over file-lifetime `mock.module(...)` patterns
- keep the later cleanup limited to test-local helpers in the human-review suite so readability improves without obscuring the explicit workflow assertions

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites validating agent studio error handling, human review feedback workflows, task tab management (creation, selection, closing), and task persistence behaviors to ensure proper state management and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->