### PR TITLE
test(desktop): expand live session internals coverage

### DIFF
--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-batching.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-batching.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+import { createSessionEventBatcher, isImmediateSessionEvent } from "./session-event-batching";
+import type { SessionEvent } from "./session-event-types";
+
+describe("session-event-batching", () => {
+  test("concatenates assistant deltas with the same message key before emitting", () => {
+    const batcher = createSessionEventBatcher();
+    const prepared = batcher.prepareQueuedSessionEvents([
+      {
+        type: "assistant_delta",
+        sessionId: "session-1",
+        channel: "text",
+        messageId: "assistant-1",
+        delta: "Hello",
+        timestamp: "2026-02-22T08:00:01.000Z",
+      },
+      {
+        type: "assistant_delta",
+        sessionId: "session-1",
+        channel: "text",
+        messageId: "assistant-1",
+        delta: " world",
+        timestamp: "2026-02-22T08:00:02.000Z",
+      },
+    ] satisfies SessionEvent[]);
+
+    expect(prepared.readyEvents).toEqual([
+      {
+        type: "assistant_delta",
+        sessionId: "session-1",
+        channel: "text",
+        messageId: "assistant-1",
+        delta: "Hello world",
+        timestamp: "2026-02-22T08:00:02.000Z",
+      },
+    ]);
+  });
+
+  test("drops streamed text events that are superseded by a final assistant message", () => {
+    const batcher = createSessionEventBatcher();
+    const prepared = batcher.prepareQueuedSessionEvents([
+      {
+        type: "assistant_delta",
+        sessionId: "session-1",
+        channel: "text",
+        messageId: "assistant-1",
+        delta: "Draft",
+        timestamp: "2026-02-22T08:00:01.000Z",
+      },
+      {
+        type: "assistant_part",
+        sessionId: "session-1",
+        timestamp: "2026-02-22T08:00:02.000Z",
+        part: {
+          kind: "text",
+          messageId: "assistant-1",
+          partId: "text-1",
+          text: "Draft refined",
+          completed: false,
+        },
+      },
+      {
+        type: "assistant_part",
+        sessionId: "session-1",
+        timestamp: "2026-02-22T08:00:02.500Z",
+        part: {
+          kind: "reasoning",
+          messageId: "assistant-1",
+          partId: "reasoning-1",
+          text: "Still visible",
+          completed: false,
+        },
+      },
+      {
+        type: "assistant_message",
+        sessionId: "session-1",
+        messageId: "assistant-1",
+        timestamp: "2026-02-22T08:00:03.000Z",
+        message: "Final answer",
+      },
+    ] satisfies SessionEvent[]);
+
+    expect(prepared.readyEvents).toEqual([
+      {
+        type: "assistant_part",
+        sessionId: "session-1",
+        timestamp: "2026-02-22T08:00:02.500Z",
+        part: {
+          kind: "reasoning",
+          messageId: "assistant-1",
+          partId: "reasoning-1",
+          text: "Still visible",
+          completed: false,
+        },
+      },
+      {
+        type: "assistant_message",
+        sessionId: "session-1",
+        messageId: "assistant-1",
+        timestamp: "2026-02-22T08:00:03.000Z",
+        message: "Final answer",
+      },
+    ]);
+  });
+
+  test("emits completed assistant parts immediately even inside the normal throttle window", () => {
+    let now = 1_000;
+    const batcher = createSessionEventBatcher({ nowMs: () => now });
+
+    const first = batcher.prepareQueuedSessionEvents([
+      {
+        type: "assistant_part",
+        sessionId: "session-1",
+        timestamp: "2026-02-22T08:00:01.000Z",
+        part: {
+          kind: "tool",
+          messageId: "assistant-1",
+          partId: "tool-1",
+          callId: "call-1",
+          tool: "bash",
+          status: "running",
+          input: { command: "pwd" },
+        },
+      },
+    ] satisfies SessionEvent[]);
+
+    now += 50;
+    const second = batcher.prepareQueuedSessionEvents([
+      {
+        type: "assistant_part",
+        sessionId: "session-1",
+        timestamp: "2026-02-22T08:00:01.050Z",
+        part: {
+          kind: "tool",
+          messageId: "assistant-1",
+          partId: "tool-1",
+          callId: "call-1",
+          tool: "bash",
+          status: "completed",
+          input: { command: "pwd" },
+          output: "/tmp/repo",
+        },
+      },
+    ] satisfies SessionEvent[]);
+
+    expect(first.readyEvents).toHaveLength(1);
+    expect(second.readyEvents).toHaveLength(1);
+    expect(second.deferredEvents).toHaveLength(0);
+    expect(second.nextDelayMs).toBeNull();
+  });
+
+  test("reports the shortest remaining delay across deferred event keys", () => {
+    let now = 1_000;
+    const batcher = createSessionEventBatcher({ nowMs: () => now });
+
+    batcher.prepareQueuedSessionEvents([
+      {
+        type: "assistant_message",
+        sessionId: "session-1",
+        messageId: "assistant-1",
+        timestamp: "2026-02-22T08:00:01.000Z",
+        message: "First",
+      },
+      {
+        type: "tool_call",
+        sessionId: "session-1",
+        timestamp: "2026-02-22T08:00:01.000Z",
+        call: {
+          tool: "odt_set_plan",
+          args: { taskId: "task-1", markdown: "# Plan" },
+        },
+      },
+    ] satisfies SessionEvent[]);
+
+    now += 150;
+    const prepared = batcher.prepareQueuedSessionEvents([
+      {
+        type: "assistant_message",
+        sessionId: "session-1",
+        messageId: "assistant-1",
+        timestamp: "2026-02-22T08:00:01.150Z",
+        message: "Second",
+      },
+      {
+        type: "tool_call",
+        sessionId: "session-1",
+        timestamp: "2026-02-22T08:00:01.150Z",
+        call: {
+          tool: "odt_set_plan",
+          args: { taskId: "task-1", markdown: "# Plan" },
+        },
+      },
+    ] satisfies SessionEvent[]);
+
+    expect(prepared.readyEvents).toHaveLength(0);
+    expect(prepared.deferredEvents).toHaveLength(2);
+    expect(prepared.nextDelayMs).toBe(250);
+  });
+
+  test("classifies only configured session events as immediate", () => {
+    expect(
+      isImmediateSessionEvent({
+        type: "user_message",
+        sessionId: "session-1",
+        messageId: "user-1",
+        timestamp: "2026-02-22T08:00:01.000Z",
+        message: "Continue",
+        parts: [{ kind: "text", text: "Continue" }],
+        state: "read",
+      }),
+    ).toBe(true);
+
+    expect(
+      isImmediateSessionEvent({
+        type: "assistant_delta",
+        sessionId: "session-1",
+        channel: "text",
+        messageId: "assistant-1",
+        delta: "Hello",
+        timestamp: "2026-02-22T08:00:01.000Z",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-batching.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-batching.test.ts
@@ -153,7 +153,7 @@ describe("session-event-batching", () => {
     let now = 1_000;
     const batcher = createSessionEventBatcher({ nowMs: () => now });
 
-    batcher.prepareQueuedSessionEvents([
+    const firstPrepared = batcher.prepareQueuedSessionEvents([
       {
         type: "assistant_message",
         sessionId: "session-1",
@@ -171,6 +171,8 @@ describe("session-event-batching", () => {
         },
       },
     ] satisfies SessionEvent[]);
+
+    expect(firstPrepared.readyEvents).toHaveLength(2);
 
     now += 150;
     const prepared = batcher.prepareQueuedSessionEvents([

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
@@ -12,9 +12,7 @@ import {
   runtimeWorkingDirectoryKey,
 } from "./live-agent-session-cache";
 
-const localRuntimeConnection = createLocalHttpRuntimeConnection({
-  endpoint: " http://127.0.0.1:4444 ",
-});
+const localRuntimeConnection = createLocalHttpRuntimeConnection();
 
 const stdioRuntimeConnection = createStdioRuntimeConnection("/tmp/runtime-root/");
 
@@ -23,7 +21,11 @@ const createSnapshot = (externalSessionId: string): LiveAgentSessionSnapshot =>
 
 describe("live-agent-session-cache", () => {
   test("builds cache keys from transport identity and normalized working directories", () => {
-    expect(getLiveAgentSessionCacheKey("opencode", localRuntimeConnection)).toBe(
+    const paddedLocalRuntimeConnection = createLocalHttpRuntimeConnection({
+      endpoint: " http://127.0.0.1:4444 ",
+    });
+
+    expect(getLiveAgentSessionCacheKey("opencode", paddedLocalRuntimeConnection)).toBe(
       "opencode::local_http:http://127.0.0.1:4444",
     );
     expect(getLiveAgentSessionCacheKey("opencode", stdioRuntimeConnection)).toBe(

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
+import {
+  getLiveAgentSessionCacheKey,
+  LiveAgentSessionCache,
+  liveAgentSessionLookupKey,
+  runtimeWorkingDirectoryKey,
+} from "./live-agent-session-cache";
+
+const localRuntimeConnection: AgentRuntimeConnection = {
+  type: "local_http",
+  endpoint: " http://127.0.0.1:4444 ",
+  workingDirectory: "/tmp/runtime-root",
+};
+
+const stdioRuntimeConnection: AgentRuntimeConnection = {
+  type: "stdio",
+  workingDirectory: "/tmp/runtime-root/",
+};
+
+const createSnapshot = (externalSessionId: string): LiveAgentSessionSnapshot => ({
+  externalSessionId,
+  title: `Session ${externalSessionId}`,
+  workingDirectory: "/tmp/repo/worktree",
+  startedAt: "2026-02-22T08:00:00.000Z",
+  status: { type: "busy" },
+  pendingPermissions: [],
+  pendingQuestions: [],
+});
+
+describe("live-agent-session-cache", () => {
+  test("builds cache keys from transport identity and normalized working directories", () => {
+    expect(getLiveAgentSessionCacheKey("opencode", localRuntimeConnection)).toBe(
+      "opencode::local_http:http://127.0.0.1:4444",
+    );
+    expect(getLiveAgentSessionCacheKey("opencode", stdioRuntimeConnection)).toBe(
+      "opencode::stdio::/tmp/runtime-root",
+    );
+    expect(runtimeWorkingDirectoryKey("opencode", "/tmp/repo/worktree/")).toBe(
+      "opencode::/tmp/repo/worktree",
+    );
+    expect(
+      liveAgentSessionLookupKey("opencode", stdioRuntimeConnection, "/tmp/repo/worktree/"),
+    ).toBe("opencode::stdio::/tmp/runtime-root::/tmp/repo/worktree");
+  });
+
+  test("reuses preloaded single-directory snapshots without scanning", async () => {
+    const preloadedSessions = [createSnapshot("external-1")];
+    const listLiveAgentSessionSnapshots = mock(async () => [createSnapshot("external-2")]);
+    const cache = new LiveAgentSessionCache(
+      { listLiveAgentSessionSnapshots },
+      new Map([
+        [
+          liveAgentSessionLookupKey("opencode", localRuntimeConnection, "/tmp/repo/worktree"),
+          preloadedSessions,
+        ],
+      ]),
+    );
+
+    const first = await cache.load({
+      runtimeKind: "opencode",
+      runtimeConnection: localRuntimeConnection,
+      directories: ["/tmp/repo/worktree/"],
+    });
+    const second = await cache.load({
+      runtimeKind: "opencode",
+      runtimeConnection: localRuntimeConnection,
+      directories: ["/tmp/repo/worktree"],
+    });
+
+    expect(first).toBe(preloadedSessions);
+    expect(second).toBe(preloadedSessions);
+    expect(listLiveAgentSessionSnapshots).not.toHaveBeenCalled();
+  });
+
+  test("normalizes, de-dupes, and sorts directory inputs before scanning and cache reuse", async () => {
+    const scannedSessions = [createSnapshot("external-1")];
+    const listLiveAgentSessionSnapshots = mock(async () => scannedSessions);
+    const cache = new LiveAgentSessionCache({ listLiveAgentSessionSnapshots });
+
+    const first = await cache.load({
+      runtimeKind: "opencode",
+      runtimeConnection: localRuntimeConnection,
+      directories: ["/tmp/repo/b/", "", " /tmp/repo/a ", "/tmp/repo/b"],
+    });
+    const second = await cache.load({
+      runtimeKind: "opencode",
+      runtimeConnection: localRuntimeConnection,
+      directories: ["/tmp/repo/a", "/tmp/repo/b"],
+    });
+
+    expect(first).toBe(scannedSessions);
+    expect(second).toBe(scannedSessions);
+    expect(listLiveAgentSessionSnapshots).toHaveBeenCalledTimes(1);
+    expect(listLiveAgentSessionSnapshots).toHaveBeenCalledWith({
+      runtimeKind: "opencode",
+      runtimeConnection: localRuntimeConnection,
+      directories: ["/tmp/repo/a", "/tmp/repo/b"],
+    });
+  });
+
+  test("bypasses preloaded single-directory data when scanning multiple directories", async () => {
+    const scannedSessions = [createSnapshot("external-2")];
+    const listLiveAgentSessionSnapshots = mock(async () => scannedSessions);
+    const cache = new LiveAgentSessionCache(
+      { listLiveAgentSessionSnapshots },
+      new Map([
+        [
+          liveAgentSessionLookupKey("opencode", localRuntimeConnection, "/tmp/repo/worktree"),
+          [createSnapshot("external-1")],
+        ],
+      ]),
+    );
+
+    const loaded = await cache.load({
+      runtimeKind: "opencode",
+      runtimeConnection: localRuntimeConnection,
+      directories: ["/tmp/repo/worktree", "/tmp/repo/other"],
+    });
+
+    expect(loaded).toBe(scannedSessions);
+    expect(listLiveAgentSessionSnapshots).toHaveBeenCalledTimes(1);
+  });
+
+  test("omits directories from the adapter call when every directory normalizes away", async () => {
+    const listLiveAgentSessionSnapshots = mock(async () => [createSnapshot("external-1")]);
+    const cache = new LiveAgentSessionCache({ listLiveAgentSessionSnapshots });
+
+    await cache.load({
+      runtimeKind: "opencode",
+      runtimeConnection: localRuntimeConnection,
+      directories: ["", "   "],
+    });
+
+    expect(listLiveAgentSessionSnapshots).toHaveBeenCalledWith({
+      runtimeKind: "opencode",
+      runtimeConnection: localRuntimeConnection,
+    });
+  });
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
+import type { LiveAgentSessionSnapshot } from "@openducktor/core";
+import {
+  createLiveAgentSessionSnapshotFixture,
+  createLocalHttpRuntimeConnection,
+  createStdioRuntimeConnection,
+} from "../test-utils";
 import {
   getLiveAgentSessionCacheKey,
   LiveAgentSessionCache,
@@ -7,26 +12,14 @@ import {
   runtimeWorkingDirectoryKey,
 } from "./live-agent-session-cache";
 
-const localRuntimeConnection: AgentRuntimeConnection = {
-  type: "local_http",
+const localRuntimeConnection = createLocalHttpRuntimeConnection({
   endpoint: " http://127.0.0.1:4444 ",
-  workingDirectory: "/tmp/runtime-root",
-};
-
-const stdioRuntimeConnection: AgentRuntimeConnection = {
-  type: "stdio",
-  workingDirectory: "/tmp/runtime-root/",
-};
-
-const createSnapshot = (externalSessionId: string): LiveAgentSessionSnapshot => ({
-  externalSessionId,
-  title: `Session ${externalSessionId}`,
-  workingDirectory: "/tmp/repo/worktree",
-  startedAt: "2026-02-22T08:00:00.000Z",
-  status: { type: "busy" },
-  pendingPermissions: [],
-  pendingQuestions: [],
 });
+
+const stdioRuntimeConnection = createStdioRuntimeConnection("/tmp/runtime-root/");
+
+const createSnapshot = (externalSessionId: string): LiveAgentSessionSnapshot =>
+  createLiveAgentSessionSnapshotFixture({ externalSessionId });
 
 describe("live-agent-session-cache", () => {
   test("builds cache keys from transport identity and normalized working directories", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-store.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-store.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
+import { liveAgentSessionLookupKey } from "./live-agent-session-cache";
+import { LiveAgentSessionStore } from "./live-agent-session-store";
+
+const localRuntimeConnection: AgentRuntimeConnection = {
+  type: "local_http",
+  endpoint: "http://127.0.0.1:4444",
+  workingDirectory: "/tmp/runtime-root",
+};
+
+const stdioRuntimeConnection: AgentRuntimeConnection = {
+  type: "stdio",
+  workingDirectory: "/tmp/runtime-root/",
+};
+
+const createSnapshot = (
+  externalSessionId: string,
+  workingDirectory: string,
+): LiveAgentSessionSnapshot => ({
+  externalSessionId,
+  title: `Session ${externalSessionId}`,
+  workingDirectory,
+  startedAt: "2026-02-22T08:00:00.000Z",
+  status: { type: "busy" },
+  pendingPermissions: [],
+  pendingQuestions: [],
+});
+
+describe("live-agent-session-store", () => {
+  test("returns matching snapshots for the same repo and lookup key", () => {
+    const store = new LiveAgentSessionStore();
+    const expectedSnapshot = createSnapshot("external-1", "/tmp/repo/worktree");
+
+    store.replaceRepoSnapshots(
+      "/tmp/repo",
+      new Map([
+        [
+          liveAgentSessionLookupKey("opencode", localRuntimeConnection, "/tmp/repo/worktree/"),
+          [expectedSnapshot],
+        ],
+      ]),
+      1_000,
+    );
+
+    expect(
+      store.readSnapshot({
+        repoPath: "/tmp/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: localRuntimeConnection,
+        workingDirectory: "/tmp/repo/worktree",
+        externalSessionId: "external-1",
+        nowMs: 5_500,
+      }),
+    ).toEqual(expectedSnapshot);
+  });
+
+  test("treats repo snapshots as isolated and clearable", () => {
+    const store = new LiveAgentSessionStore();
+    const repoOneSnapshot = createSnapshot("external-1", "/tmp/repo-one/worktree");
+
+    store.replaceRepoSnapshots(
+      "/tmp/repo-one",
+      new Map([
+        [
+          liveAgentSessionLookupKey("opencode", localRuntimeConnection, "/tmp/repo-one/worktree"),
+          [repoOneSnapshot],
+        ],
+      ]),
+      1_000,
+    );
+
+    expect(
+      store.readSnapshot({
+        repoPath: "/tmp/repo-two",
+        runtimeKind: "opencode",
+        runtimeConnection: localRuntimeConnection,
+        workingDirectory: "/tmp/repo-one/worktree",
+        externalSessionId: "external-1",
+        nowMs: 1_500,
+      }),
+    ).toBeNull();
+
+    store.clearRepo("/tmp/repo-one");
+
+    expect(
+      store.readSnapshot({
+        repoPath: "/tmp/repo-one",
+        runtimeKind: "opencode",
+        runtimeConnection: localRuntimeConnection,
+        workingDirectory: "/tmp/repo-one/worktree",
+        externalSessionId: "external-1",
+        nowMs: 1_500,
+      }),
+    ).toBeNull();
+  });
+
+  test("expires stale snapshots using the default or provided max age", () => {
+    const store = new LiveAgentSessionStore();
+    const snapshot = createSnapshot("external-1", "/tmp/repo/worktree");
+
+    store.replaceRepoSnapshots(
+      "/tmp/repo",
+      new Map([
+        [
+          liveAgentSessionLookupKey("opencode", stdioRuntimeConnection, "/tmp/repo/worktree"),
+          [snapshot],
+        ],
+      ]),
+      10_000,
+    );
+
+    expect(
+      store.readSnapshot({
+        repoPath: "/tmp/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: stdioRuntimeConnection,
+        workingDirectory: "/tmp/repo/worktree/",
+        externalSessionId: "external-1",
+        nowMs: 15_000,
+      }),
+    ).toEqual(snapshot);
+
+    expect(
+      store.readSnapshot({
+        repoPath: "/tmp/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: stdioRuntimeConnection,
+        workingDirectory: "/tmp/repo/worktree/",
+        externalSessionId: "external-1",
+        nowMs: 15_001,
+      }),
+    ).toBeNull();
+
+    expect(
+      store.readSnapshot({
+        repoPath: "/tmp/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: stdioRuntimeConnection,
+        workingDirectory: "/tmp/repo/worktree/",
+        externalSessionId: "external-1",
+        maxAgeMs: 10_000,
+        nowMs: 20_000,
+      }),
+    ).toEqual(snapshot);
+
+    expect(
+      store.readSnapshot({
+        repoPath: "/tmp/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: stdioRuntimeConnection,
+        workingDirectory: "/tmp/repo/worktree/",
+        externalSessionId: "external-1",
+        maxAgeMs: 9_999,
+        nowMs: 20_000,
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when the external session id is not present in the matched snapshot list", () => {
+    const store = new LiveAgentSessionStore();
+
+    store.replaceRepoSnapshots(
+      "/tmp/repo",
+      new Map([
+        [
+          liveAgentSessionLookupKey("opencode", localRuntimeConnection, "/tmp/repo/worktree"),
+          [createSnapshot("external-1", "/tmp/repo/worktree")],
+        ],
+      ]),
+      1_000,
+    );
+
+    expect(
+      store.readSnapshot({
+        repoPath: "/tmp/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: localRuntimeConnection,
+        workingDirectory: "/tmp/repo/worktree",
+        externalSessionId: "missing",
+        nowMs: 1_500,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-store.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-store.test.ts
@@ -1,31 +1,22 @@
 import { describe, expect, test } from "bun:test";
-import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
+import type { LiveAgentSessionSnapshot } from "@openducktor/core";
+import {
+  createLiveAgentSessionSnapshotFixture,
+  createLocalHttpRuntimeConnection,
+  createStdioRuntimeConnection,
+} from "../test-utils";
 import { liveAgentSessionLookupKey } from "./live-agent-session-cache";
 import { LiveAgentSessionStore } from "./live-agent-session-store";
 
-const localRuntimeConnection: AgentRuntimeConnection = {
-  type: "local_http",
-  endpoint: "http://127.0.0.1:4444",
-  workingDirectory: "/tmp/runtime-root",
-};
+const localRuntimeConnection = createLocalHttpRuntimeConnection();
 
-const stdioRuntimeConnection: AgentRuntimeConnection = {
-  type: "stdio",
-  workingDirectory: "/tmp/runtime-root/",
-};
+const stdioRuntimeConnection = createStdioRuntimeConnection("/tmp/runtime-root/");
 
 const createSnapshot = (
   externalSessionId: string,
   workingDirectory: string,
-): LiveAgentSessionSnapshot => ({
-  externalSessionId,
-  title: `Session ${externalSessionId}`,
-  workingDirectory,
-  startedAt: "2026-02-22T08:00:00.000Z",
-  status: { type: "busy" },
-  pendingPermissions: [],
-  pendingQuestions: [],
-});
+): LiveAgentSessionSnapshot =>
+  createLiveAgentSessionSnapshotFixture({ externalSessionId, workingDirectory });
 
 describe("live-agent-session-store", () => {
   test("returns matching snapshots for the same repo and lookup key", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -1,13 +1,19 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+  type AgentSessionRecord,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type RuntimeInstanceSummary,
   type TaskCard,
 } from "@openducktor/contracts";
 import { appQueryClient, clearAppQueryClient } from "@/lib/query-client";
+import {
+  createLiveAgentSessionSnapshotFixture,
+  createLocalHttpRuntimeConnection,
+} from "@/state/operations/agent-orchestrator/test-utils";
 import { runtimeQueryKeys } from "@/state/queries/runtime";
 import { host } from "../../shared/host";
 import { LiveAgentSessionStore } from "./live-agent-session-store";
+import { createRuntimeResolutionPlannerStage } from "./load-sessions-stages";
 import { createRepoSessionHydrationService } from "./repo-session-hydration-service";
 
 const createDeferred = <T>() => {
@@ -238,6 +244,143 @@ describe("repo-session-hydration-service", () => {
       })?.externalSessionId,
     ).toBe("external-1");
     expect(reconcileCalls.sort()).toEqual(["task-1", "task-2"]);
+    service.dispose();
+  });
+
+  test("reconcile preloads live snapshots for later reattach without rescanning", async () => {
+    const liveSnapshot = createLiveAgentSessionSnapshotFixture({
+      title: "Builder Session",
+      workingDirectory: worktreePath,
+    });
+    const runtimeConnection = createLocalHttpRuntimeConnection({
+      endpoint: "http://127.0.0.1:4555",
+      workingDirectory: worktreePath,
+    });
+    let preloadScanCalls = 0;
+    let reattachScanCalls = 0;
+    let reusedStoredSnapshot: string | null = null;
+    let reusedPreloadedSnapshot: string | null = null;
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    host.runtimeList = async () => [createRuntimeInstance()];
+
+    const service = createRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async () => {
+          preloadScanCalls += 1;
+          return [liveSnapshot];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({
+          taskId,
+          persistedRecords,
+          preloadedRuns,
+          preloadedRuntimeLists,
+          preloadedRuntimeConnectionsByKey,
+          preloadedLiveAgentSessionsByKey,
+          allowRuntimeEnsure,
+        }) => {
+          const record = persistedRecords?.[0] as AgentSessionRecord | undefined;
+          if (!record) {
+            throw new Error("Expected persisted session record for reattach verification");
+          }
+
+          const plannerOptions = {
+            ...(persistedRecords ? { persistedRecords } : {}),
+            ...(preloadedRuns ? { preloadedRuns } : {}),
+            ...(preloadedRuntimeLists ? { preloadedRuntimeLists } : {}),
+            ...(preloadedRuntimeConnectionsByKey ? { preloadedRuntimeConnectionsByKey } : {}),
+            ...(preloadedLiveAgentSessionsByKey ? { preloadedLiveAgentSessionsByKey } : {}),
+            ...(allowRuntimeEnsure !== undefined ? { allowRuntimeEnsure } : {}),
+          };
+
+          const createPlanner = (store?: LiveAgentSessionStore) =>
+            createRuntimeResolutionPlannerStage({
+              intent: {
+                repoPath,
+                taskId,
+                mode: "reconcile_live",
+                requestedSessionId: null,
+                requestedHistoryKey: null,
+                shouldHydrateRequestedSession: false,
+                shouldReconcileLiveSessions: true,
+                historyPolicy: "none",
+              },
+              options: plannerOptions,
+              adapter: {
+                hasSession: () => false,
+                loadSessionHistory: async () => [],
+                resumeSession: async (input) => ({
+                  sessionId: input.sessionId,
+                  externalSessionId: input.externalSessionId,
+                  role: input.role,
+                  scenario: input.scenario,
+                  startedAt: "2026-02-22T08:00:00.000Z",
+                  status: "idle",
+                  runtimeKind: input.runtimeKind,
+                }),
+                listLiveAgentSessionSnapshots: async () => {
+                  reattachScanCalls += 1;
+                  return [];
+                },
+              },
+              sessionsRef: { current: {} },
+              ...(store ? { liveAgentSessionStore: store } : {}),
+              recordsToHydrate: persistedRecords ?? [],
+              historyHydrationSessionIds: new Set<string>(),
+            });
+
+          const storedPlanner = await createPlanner(liveAgentSessionStore);
+          const storedResolution = await storedPlanner.resolveHydrationRuntime(record);
+          if (!storedResolution.ok) {
+            throw new Error(`Expected runtime resolution to succeed for ${taskId}`);
+          }
+          reusedStoredSnapshot =
+            (await storedPlanner.loadLiveAgentSessionSnapshot(record, storedResolution))
+              ?.externalSessionId ?? null;
+
+          liveAgentSessionStore.clearRepo(repoPath);
+
+          const preloadedPlanner = await createPlanner();
+          const preloadedResolution = await preloadedPlanner.resolveHydrationRuntime(record);
+          if (!preloadedResolution.ok) {
+            throw new Error(`Expected preloaded runtime resolution to succeed for ${taskId}`);
+          }
+          reusedPreloadedSnapshot =
+            (await preloadedPlanner.loadLiveAgentSessionSnapshot(record, preloadedResolution))
+              ?.externalSessionId ?? null;
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [taskWithSession("task-1", liveSnapshot.externalSessionId)],
+      runs: [],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(preloadScanCalls).toBe(1);
+    expect(reattachScanCalls).toBe(0);
+    if (reusedStoredSnapshot === null || reusedPreloadedSnapshot === null) {
+      throw new Error("Expected stored and preloaded live snapshot reuse to succeed");
+    }
+    expect(reusedStoredSnapshot === liveSnapshot.externalSessionId).toBe(true);
+    expect(reusedPreloadedSnapshot === liveSnapshot.externalSessionId).toBe(true);
+    expect(
+      liveAgentSessionStore.readSnapshot({
+        repoPath,
+        runtimeKind: "opencode",
+        runtimeConnection,
+        workingDirectory: worktreePath,
+        externalSessionId: liveSnapshot.externalSessionId,
+      }),
+    ).toBeNull();
     service.dispose();
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   type AgentSessionRecord,
   OPENCODE_RUNTIME_DESCRIPTOR,
@@ -715,9 +715,7 @@ describe("repo-session-hydration-service", () => {
     let retryRequests = 0;
     const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
-    const consoleError = mock(() => {});
-    const originalConsoleError = console.error;
-    console.error = consoleError as typeof console.error;
+    const retryTriggered = createDeferred<void>();
 
     host.runtimeList = async () => [createRuntimeInstance()];
 
@@ -756,27 +754,27 @@ describe("repo-session-hydration-service", () => {
       liveAgentSessionStore,
       onRetryRequested: () => {
         retryRequests += 1;
+        retryTriggered.resolve();
       },
     });
 
-    try {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [taskWithSession("task-valid", "external-valid"), invalidTask],
-        runs: [],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [taskWithSession("task-valid", "external-valid"), invalidTask],
+      runs: [],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
 
-      await Bun.sleep(600);
+    const retryResult = await Promise.race([
+      retryTriggered.promise.then(() => "retried" as const),
+      Bun.sleep(600).then(() => "timeout" as const),
+    ]);
 
-      expect(reconcileCalls).toEqual(["task-valid"]);
-      expect(retryRequests).toBe(0);
-      expect(consoleError).toHaveBeenCalledTimes(1);
-    } finally {
-      console.error = originalConsoleError;
-      service.dispose();
-    }
+    expect(reconcileCalls).toEqual(["task-valid"]);
+    expect(retryRequests).toBe(0);
+    expect(retryResult).toBe("timeout");
+    service.dispose();
   });
 
   afterEach(() => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -248,9 +248,11 @@ describe("repo-session-hydration-service", () => {
   });
 
   test("reconcile preloads live snapshots for later reattach without rescanning", async () => {
+    const expectedExternalSessionId = "external-1";
     const liveSnapshot = createLiveAgentSessionSnapshotFixture({
       title: "Builder Session",
       workingDirectory: worktreePath,
+      externalSessionId: expectedExternalSessionId,
     });
     const runtimeConnection = createLocalHttpRuntimeConnection({
       endpoint: "http://127.0.0.1:4555",
@@ -258,6 +260,8 @@ describe("repo-session-hydration-service", () => {
     });
     let preloadScanCalls = 0;
     let reattachScanCalls = 0;
+    let storedSnapshotBeforeClear: string | null = null;
+    let storedSnapshotAfterClear: string | null = null;
     let reusedStoredSnapshot: string | null = null;
     let reusedPreloadedSnapshot: string | null = null;
     const liveAgentSessionStore = new LiveAgentSessionStore();
@@ -341,7 +345,25 @@ describe("repo-session-hydration-service", () => {
             (await storedPlanner.loadLiveAgentSessionSnapshot(record, storedResolution))
               ?.externalSessionId ?? null;
 
+          storedSnapshotBeforeClear =
+            liveAgentSessionStore.readSnapshot({
+              repoPath,
+              runtimeKind: "opencode",
+              runtimeConnection,
+              workingDirectory: worktreePath,
+              externalSessionId: expectedExternalSessionId,
+            })?.externalSessionId ?? null;
+
           liveAgentSessionStore.clearRepo(repoPath);
+
+          storedSnapshotAfterClear =
+            liveAgentSessionStore.readSnapshot({
+              repoPath,
+              runtimeKind: "opencode",
+              runtimeConnection,
+              workingDirectory: worktreePath,
+              externalSessionId: expectedExternalSessionId,
+            })?.externalSessionId ?? null;
 
           const preloadedPlanner = await createPlanner();
           const preloadedResolution = await preloadedPlanner.resolveHydrationRuntime(record);
@@ -359,7 +381,7 @@ describe("repo-session-hydration-service", () => {
 
     await service.reconcilePendingTasks({
       repoPath,
-      tasks: [taskWithSession("task-1", liveSnapshot.externalSessionId)],
+      tasks: [taskWithSession("task-1", expectedExternalSessionId)],
       runs: [],
       isCancelled: () => false,
       isCurrentRepo: () => true,
@@ -367,20 +389,20 @@ describe("repo-session-hydration-service", () => {
 
     expect(preloadScanCalls).toBe(1);
     expect(reattachScanCalls).toBe(0);
-    if (reusedStoredSnapshot === null || reusedPreloadedSnapshot === null) {
+    const storedSnapshotId = storedSnapshotBeforeClear;
+    const reusedStoredSnapshotId = reusedStoredSnapshot;
+    const reusedPreloadedSnapshotId = reusedPreloadedSnapshot;
+    if (
+      storedSnapshotId == null ||
+      reusedStoredSnapshotId == null ||
+      reusedPreloadedSnapshotId == null
+    ) {
       throw new Error("Expected stored and preloaded live snapshot reuse to succeed");
     }
-    expect(reusedStoredSnapshot === liveSnapshot.externalSessionId).toBe(true);
-    expect(reusedPreloadedSnapshot === liveSnapshot.externalSessionId).toBe(true);
-    expect(
-      liveAgentSessionStore.readSnapshot({
-        repoPath,
-        runtimeKind: "opencode",
-        runtimeConnection,
-        workingDirectory: worktreePath,
-        externalSessionId: liveSnapshot.externalSessionId,
-      }),
-    ).toBeNull();
+    expect(storedSnapshotId as string).toBe(expectedExternalSessionId);
+    expect(storedSnapshotAfterClear).toBeNull();
+    expect(reusedStoredSnapshotId as string).toBe(expectedExternalSessionId);
+    expect(reusedPreloadedSnapshotId as string).toBe(expectedExternalSessionId);
     service.dispose();
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/test-utils.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/test-utils.ts
@@ -1,4 +1,5 @@
 import type { TaskCard } from "@openducktor/contracts";
+import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
 import {
   createDeferred as createSharedDeferred,
   createTaskCardFixture as createSharedTaskCardFixture,
@@ -26,3 +27,39 @@ export const withTimeout = async <T>(
 
 export const createTaskCardFixture = (overrides: Partial<TaskCard> = {}): TaskCard =>
   createSharedTaskCardFixture(ORCHESTRATOR_TASK_CARD_DEFAULTS, overrides);
+
+export const createLocalHttpRuntimeConnection = ({
+  endpoint = "http://127.0.0.1:4444",
+  workingDirectory = "/tmp/runtime-root",
+}: {
+  endpoint?: string;
+  workingDirectory?: string;
+} = {}): AgentRuntimeConnection => ({
+  type: "local_http",
+  endpoint,
+  workingDirectory,
+});
+
+export const createStdioRuntimeConnection = (
+  workingDirectory = "/tmp/runtime-root",
+): AgentRuntimeConnection => ({
+  type: "stdio",
+  workingDirectory,
+});
+
+export const createLiveAgentSessionSnapshotFixture = (
+  overrides: Partial<LiveAgentSessionSnapshot> = {},
+): LiveAgentSessionSnapshot => {
+  const externalSessionId = overrides.externalSessionId ?? "external-1";
+
+  return {
+    externalSessionId,
+    title: overrides.title ?? `Session ${externalSessionId}`,
+    workingDirectory: "/tmp/repo/worktree",
+    startedAt: "2026-02-22T08:00:00.000Z",
+    status: { type: "busy" },
+    pendingPermissions: [],
+    pendingQuestions: [],
+    ...overrides,
+  };
+};


### PR DESCRIPTION
## Summary
- add direct lifecycle and batching tests for live session store, cache, and session event batching internals
- add a higher-level hydration reuse test plus shared live-session fixtures to cover reattach behavior without rescanning
- harden the deterministic metadata-failure hydration test so it asserts no retry scheduling without patching process-global logging

## Goal
This PR improves confidence in the agent-orchestrator live session lifecycle code. The initial gap was that important cache, store, and event batching behavior was only covered indirectly, which made regressions in normalization, TTL handling, reuse paths, and batching semantics harder to catch quickly.

It also tightens one hydration test that previously used a process-global `console.error` mock across awaited work. That pattern could flake in Bun's shared test process if unrelated tests logged during the same window, so this PR removes that source of test nondeterminism.

## Implementation
I added focused direct tests for:
- `live-agent-session-store` lookup isolation, repo clearing, session matching, and expiry behavior
- `live-agent-session-cache` key normalization, directory normalization and dedupe, preload reuse, and empty-directory scan behavior
- `session-event-batching` delta concatenation, superseding final messages, immediate completed tool-part emission, and defer-window selection

To reduce duplication in the new lifecycle coverage, I extracted small shared test builders in `apps/desktop/src/state/operations/agent-orchestrator/test-utils.ts` for runtime connections and live session snapshots.

I also added a higher-level hydration reuse test in `repo-session-hydration-service.test.ts` that exercises the real preload and planner seams together. It proves that preloaded live snapshots and the in-memory store can satisfy a later reattach path without triggering an extra `listLiveAgentSessionSnapshots` scan.

Finally, I replaced the logger-mocking retry assertion with a local deferred callback seam. The test now verifies the same intended behavior by asserting the valid task reconciles, retry requests remain at zero, and no retry callback fires within the retry window.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`