### PR TITLE
feat(release): automate Homebrew tap publishing

### DIFF
--- a/.github/workflows/publish-homebrew-tap.yml
+++ b/.github/workflows/publish-homebrew-tap.yml
@@ -63,11 +63,6 @@ jobs:
             echo "Using default Homebrew tap repository: $DEFAULT_HOMEBREW_TAP_REPOSITORY"
           fi
 
-      - name: Checkout release tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ steps.release_meta.outputs.tag }}
-
       - name: Verify published stable release exists
         env:
           GH_TOKEN: ${{ github.token }}
@@ -87,6 +82,11 @@ jobs:
             echo "Release $TAG is marked as a prerelease. Homebrew tap updates are limited to published stable releases." >&2
             exit 1
           fi
+
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.release_meta.outputs.tag }}
 
       - name: Resolve DMG assets
         id: assets

--- a/.github/workflows/publish-homebrew-tap.yml
+++ b/.github/workflows/publish-homebrew-tap.yml
@@ -1,0 +1,206 @@
+name: Publish Homebrew Tap
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published release tag to mirror into the Homebrew tap (for example v0.1.0)"
+        required: true
+        type: string
+
+env:
+  BUN_VERSION: 1.3.11
+  DEFAULT_HOMEBREW_TAP_BRANCH: main
+  DEFAULT_HOMEBREW_TAP_REPOSITORY: ${{ format('{0}/homebrew-openducktor', github.repository_owner) }}
+
+jobs:
+  publish-homebrew-tap:
+    name: Update Homebrew tap cask
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      HOMEBREW_TAP_REPOSITORY: ${{ vars.HOMEBREW_TAP_REPOSITORY }}
+      HOMEBREW_TAP_BRANCH: ${{ vars.HOMEBREW_TAP_BRANCH }}
+    steps:
+      - name: Resolve release tag
+        id: release_meta
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-${EVENT_TAG:-}}"
+          if [[ -z "$TAG" ]]; then
+            echo "Unable to resolve a release tag for the Homebrew publish workflow." >&2
+            exit 1
+          fi
+
+          if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Expected release tag like v0.1.0 or v0.1.0-rc.1." >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Homebrew tap configuration
+        env:
+          TAP_REPOSITORY: ${{ env.HOMEBREW_TAP_REPOSITORY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+            echo "Missing HOMEBREW_TAP_TOKEN. Create a token that can push to the Homebrew tap repository." >&2
+            exit 1
+          fi
+
+          if [[ -z "${TAP_REPOSITORY:-}" ]]; then
+            echo "Using default Homebrew tap repository: $DEFAULT_HOMEBREW_TAP_REPOSITORY"
+          fi
+
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.release_meta.outputs.tag }}
+
+      - name: Verify published stable release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release_meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          RELEASE_JSON="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease,url)"
+          IS_DRAFT="$(printf '%s' "$RELEASE_JSON" | jq -r '.isDraft')"
+          IS_PRERELEASE="$(printf '%s' "$RELEASE_JSON" | jq -r '.isPrerelease')"
+
+          if [[ "$IS_DRAFT" != "false" ]]; then
+            echo "Release $TAG is still a draft. Publish the GitHub release before updating Homebrew." >&2
+            exit 1
+          fi
+
+          if [[ "$IS_PRERELEASE" != "false" ]]; then
+            echo "Release $TAG is marked as a prerelease. Homebrew tap updates are limited to published stable releases." >&2
+            exit 1
+          fi
+
+      - name: Resolve DMG assets
+        id: assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release_meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          ASSETS_JSON="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets)"
+
+          ARM_COUNT="$(printf '%s' "$ASSETS_JSON" | jq '[.assets[] | select(.name | test("\\.dmg$"; "i")) | select(.name | test("(aarch64|arm64)"; "i"))] | length')"
+          INTEL_COUNT="$(printf '%s' "$ASSETS_JSON" | jq '[.assets[] | select(.name | test("\\.dmg$"; "i")) | select(.name | test("(x64|x86_64|amd64|intel)"; "i"))] | length')"
+
+          if [[ "$ARM_COUNT" != "1" || "$INTEL_COUNT" != "1" ]]; then
+            echo "Expected exactly one arm64 DMG and one Intel DMG on release $TAG." >&2
+            printf '%s' "$ASSETS_JSON" | jq -r '.assets[].name' >&2
+            exit 1
+          fi
+
+          ARM_ASSET_NAME="$(printf '%s' "$ASSETS_JSON" | jq -r '.assets[] | select(.name | test("\\.dmg$"; "i")) | select(.name | test("(aarch64|arm64)"; "i")) | .name')"
+          INTEL_ASSET_NAME="$(printf '%s' "$ASSETS_JSON" | jq -r '.assets[] | select(.name | test("\\.dmg$"; "i")) | select(.name | test("(x64|x86_64|amd64|intel)"; "i")) | .name')"
+
+          echo "arm_asset_name=$ARM_ASSET_NAME" >> "$GITHUB_OUTPUT"
+          echo "intel_asset_name=$INTEL_ASSET_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Download DMG assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release_meta.outputs.tag }}
+          ARM_ASSET_NAME: ${{ steps.assets.outputs.arm_asset_name }}
+          INTEL_ASSET_NAME: ${{ steps.assets.outputs.intel_asset_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/homebrew-assets"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir "$RUNNER_TEMP/homebrew-assets" --pattern "$ARM_ASSET_NAME"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir "$RUNNER_TEMP/homebrew-assets" --pattern "$INTEL_ASSET_NAME"
+
+      - name: Compute asset checksums
+        id: checksums
+        env:
+          ARM_ASSET_NAME: ${{ steps.assets.outputs.arm_asset_name }}
+          INTEL_ASSET_NAME: ${{ steps.assets.outputs.intel_asset_name }}
+        run: |
+          set -euo pipefail
+          ARM_SHA256="$(sha256sum "$RUNNER_TEMP/homebrew-assets/$ARM_ASSET_NAME" | cut -d ' ' -f 1)"
+          INTEL_SHA256="$(sha256sum "$RUNNER_TEMP/homebrew-assets/$INTEL_ASSET_NAME" | cut -d ' ' -f 1)"
+
+          echo "arm_sha256=$ARM_SHA256" >> "$GITHUB_OUTPUT"
+          echo "intel_sha256=$INTEL_SHA256" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Checkout Homebrew tap repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ env.HOMEBREW_TAP_REPOSITORY || env.DEFAULT_HOMEBREW_TAP_REPOSITORY }}
+          ref: ${{ env.HOMEBREW_TAP_BRANCH || env.DEFAULT_HOMEBREW_TAP_BRANCH }}
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Render Homebrew cask
+        env:
+          VERSION: ${{ steps.release_meta.outputs.version }}
+          ARM_ASSET_NAME: ${{ steps.assets.outputs.arm_asset_name }}
+          ARM_SHA256: ${{ steps.checksums.outputs.arm_sha256 }}
+          INTEL_ASSET_NAME: ${{ steps.assets.outputs.intel_asset_name }}
+          INTEL_SHA256: ${{ steps.checksums.outputs.intel_sha256 }}
+        run: |
+          set -euo pipefail
+          bun run release:homebrew:cask \
+            --version "$VERSION" \
+            --repository "$GITHUB_REPOSITORY" \
+            --arm-asset-name "$ARM_ASSET_NAME" \
+            --arm-sha256 "$ARM_SHA256" \
+            --intel-asset-name "$INTEL_ASSET_NAME" \
+            --intel-sha256 "$INTEL_SHA256" \
+            --output "homebrew-tap/Casks/openducktor.rb"
+
+      - name: Commit and push tap update
+        id: tap_commit
+        env:
+          TAP_BRANCH: ${{ env.HOMEBREW_TAP_BRANCH || env.DEFAULT_HOMEBREW_TAP_BRANCH }}
+          VERSION: ${{ steps.release_meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          git -C homebrew-tap config user.name "github-actions[bot]"
+          git -C homebrew-tap config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C homebrew-tap add Casks/openducktor.rb
+
+          if git -C homebrew-tap diff --cached --quiet; then
+            echo "created_commit=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git -C homebrew-tap commit -m "openducktor ${VERSION}"
+          git -C homebrew-tap push origin HEAD:"$TAP_BRANCH"
+          echo "created_commit=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish workflow summary
+        env:
+          TAG: ${{ steps.release_meta.outputs.tag }}
+          TAP_BRANCH: ${{ env.HOMEBREW_TAP_BRANCH || env.DEFAULT_HOMEBREW_TAP_BRANCH }}
+          TAP_REPOSITORY: ${{ env.HOMEBREW_TAP_REPOSITORY || env.DEFAULT_HOMEBREW_TAP_REPOSITORY }}
+          CREATED_COMMIT: ${{ steps.tap_commit.outputs.created_commit }}
+        run: |
+          {
+            echo "## Homebrew tap updated"
+            echo
+            echo "- Release tag: $TAG"
+            echo "- Tap repository: $TAP_REPOSITORY"
+            echo "- Tap branch: $TAP_BRANCH"
+            echo "- Cask path: Casks/openducktor.rb"
+            echo "- Commit created: ${CREATED_COMMIT:-false}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -31,11 +31,22 @@ It uses [Beads](https://github.com/steveyegge/beads) as the task source of truth
 
 ## Install OpenDucktor
 
+### Homebrew
+
+```sh
+brew tap Maxsky5/openducktor
+brew install --cask openducktor
+```
+
+### Direct Download
+
 1. Open the [GitHub Releases page](https://github.com/Maxsky5/openducktor/releases).
 2. Download the latest macOS asset that matches your machine.
 3. Launch OpenDucktor and open the local repository you want to work on.
 
 If macOS blocks the first launch, use Finder's standard `Open` action once to confirm you want to run the app.
+
+Homebrew installs the same signed and notarized desktop app that is published on GitHub Releases.
 
 ## User Prerequisites
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -9,6 +9,7 @@ The release flow is split into three workflows:
 - `.github/workflows/release-prep.yml`
 - `.github/workflows/release-desktop.yml`
 - `.github/workflows/publish-mcp.yml`
+- `.github/workflows/publish-homebrew-tap.yml`
 
 ### 1. Prepare Release
 
@@ -56,6 +57,21 @@ It:
 - verifies the MCP package
 - publishes `@openducktor/mcp` to npmjs
 
+### 4. Publish Homebrew Tap
+
+`Publish Homebrew Tap` runs when a GitHub release is published and can also be rerun manually with the same tag if needed.
+
+It:
+
+- verifies that the GitHub release exists and is no longer a draft
+- rejects prereleases so the tap only tracks stable published desktop releases
+- downloads the signed macOS arm64 and Intel DMG assets from that release
+- computes SHA-256 checksums for both assets
+- renders `Casks/openducktor.rb` from repo metadata plus the published asset names and checksums
+- commits and pushes the cask update to the configured Homebrew tap repository
+
+The tap workflow is intentionally separate from `Release Desktop` because the release draft remains private to maintainers until smoke testing is complete. Homebrew should only point at the final published GitHub release.
+
 ## Why this design
 
 OpenDucktor uses a CEF-specific Tauri flow:
@@ -98,6 +114,18 @@ Notes:
 
 - None. MCP publishing uses npm Trusted Publisher via GitHub Actions OIDC.
 
+### Homebrew tap secret
+
+- `HOMEBREW_TAP_TOKEN`
+
+Notes:
+
+- The token must be able to push to the Homebrew tap repository.
+- By default the workflow targets `${owner}/homebrew-openducktor` on branch `main`.
+- You can override those defaults with repository variables:
+  - `HOMEBREW_TAP_REPOSITORY`
+  - `HOMEBREW_TAP_BRANCH`
+
 ### Release automation secret
 
 - `RELEASE_AUTOMATION_TOKEN`
@@ -133,9 +161,29 @@ The helper script remains useful because this repo spans three version domains:
 6. Wait for `Publish MCP Package` to finish publishing `@openducktor/mcp`.
 7. Open the draft GitHub release and smoke-test the desktop assets.
 8. Publish the draft release when the assets and notes look correct.
+9. Wait for `Publish Homebrew Tap` to finish updating `Casks/openducktor.rb` in the tap repository.
+
+## Homebrew tap setup
+
+Before the first Homebrew release, create the tap repository and grant the workflow push access.
+
+Recommended defaults:
+
+- repository: `homebrew-openducktor`
+- path: `Casks/openducktor.rb`
+- default branch: `main`
+
+Once the tap exists and the workflow is configured, users can install OpenDucktor with:
+
+```sh
+brew tap Maxsky5/openducktor
+brew install --cask openducktor
+```
 
 ## Asset policy for the first release line
 
 OpenDucktor is currently macOS-first, so the desktop workflow publishes macOS artifacts only.
 
 The workflow does **not** generate a public updater channel yet. That should wait until the in-app updater flow is explicitly wired and tested. The current release pipeline is focused on reliable GitHub Releases distribution first, plus npm publishing for `@openducktor/mcp`.
+
+Homebrew distribution also stays GitHub Releases based. The cask generator fails if the desktop asset naming stops being architecture-derivable, so maintainers update the generator at the same time the bundle naming changes instead of silently publishing a broken cask.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "prepare": "bun run hooks:install",
     "release:version:set": "bun run scripts/release-version.ts set",
     "release:version:check": "bun run scripts/release-version.ts check",
+    "release:homebrew:cask": "bun run scripts/release-homebrew-cask.ts",
+    "test:release:homebrew:cask": "bun test scripts/release-homebrew-cask.test.ts",
     "release:cef:env": "bun run --cwd apps/desktop scripts/resolve-cef-release-env.ts",
     "tauri": "cd apps/desktop && bun run tauri",
     "tauri:dev": "cd apps/desktop && bun run tauri:dev",

--- a/scripts/release-homebrew-cask.test.ts
+++ b/scripts/release-homebrew-cask.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import {
+  renderHomebrewCask,
+  resolveAssetPattern,
+  resolveHomebrewMacosRequirement,
+} from "./release-homebrew-cask";
+
+test("resolveAssetPattern creates an arch-aware Tauri DMG pattern", () => {
+  expect(
+    resolveAssetPattern("0.0.5", "OpenDucktor_0.0.5_aarch64.dmg", "OpenDucktor_0.0.5_x64.dmg"),
+  ).toEqual({
+    armArchToken: "aarch64",
+    intelArchToken: "x64",
+    assetPattern: "OpenDucktor_#{version}_#{arch}.dmg",
+  });
+});
+
+test("resolveHomebrewMacosRequirement maps macOS 12 to monterey", () => {
+  expect(resolveHomebrewMacosRequirement("12.0")).toBe(">= :monterey");
+});
+
+test("renderHomebrewCask renders the expected OpenDucktor cask", () => {
+  const contents = renderHomebrewCask({
+    version: "0.0.5",
+    repository: "Maxsky5/openducktor",
+    productName: "OpenDucktor",
+    bundleIdentifier: "dev.openducktor.desktop",
+    minimumSystemVersion: "12.0",
+    armAssetName: "OpenDucktor_0.0.5_aarch64.dmg",
+    armSha256: "a".repeat(64),
+    intelAssetName: "OpenDucktor_0.0.5_x64.dmg",
+    intelSha256: "b".repeat(64),
+  });
+
+  expect(contents).toContain('cask "openducktor" do');
+  expect(contents).toContain('arch arm: "aarch64", intel: "x64"');
+  expect(contents).toContain('version "0.0.5"');
+  expect(contents).toContain(
+    'url "https://github.com/Maxsky5/openducktor/releases/download/v#{version}/OpenDucktor_#{version}_#{arch}.dmg"',
+  );
+  expect(contents).toContain('depends_on macos: ">= :monterey"');
+  expect(contents).toContain('app "OpenDucktor.app"');
+  expect(contents).toContain('"~/.openducktor"');
+  expect(contents).toContain('"~/Library/Preferences/dev.openducktor.desktop.plist"');
+});

--- a/scripts/release-homebrew-cask.test.ts
+++ b/scripts/release-homebrew-cask.test.ts
@@ -15,8 +15,54 @@ test("resolveAssetPattern creates an arch-aware Tauri DMG pattern", () => {
   });
 });
 
+test("resolveAssetPattern prefers x86_64 over x64 substring matches", () => {
+  expect(
+    resolveAssetPattern("0.0.5", "OpenDucktor_0.0.5_aarch64.dmg", "OpenDucktor_0.0.5_x86_64.dmg"),
+  ).toEqual({
+    armArchToken: "aarch64",
+    intelArchToken: "x86_64",
+    assetPattern: "OpenDucktor_#{version}_#{arch}.dmg",
+  });
+});
+
+test("resolveAssetPattern preserves original asset token casing", () => {
+  expect(
+    resolveAssetPattern("0.0.5", "OpenDucktor_0.0.5_AARCH64.dmg", "OpenDucktor_0.0.5_X64.dmg"),
+  ).toEqual({
+    armArchToken: "AARCH64",
+    intelArchToken: "X64",
+    assetPattern: "OpenDucktor_#{version}_#{arch}.dmg",
+  });
+});
+
+test("resolveAssetPattern replaces version before architecture tokens in prerelease names", () => {
+  expect(
+    resolveAssetPattern(
+      "1.0.0-arm64",
+      "OpenDucktor_1.0.0-arm64_arm64.dmg",
+      "OpenDucktor_1.0.0-arm64_x64.dmg",
+    ),
+  ).toEqual({
+    armArchToken: "arm64",
+    intelArchToken: "x64",
+    assetPattern: "OpenDucktor_#{version}_#{arch}.dmg",
+  });
+});
+
+test("resolveAssetPattern rejects asset names without the version token", () => {
+  expect(() =>
+    resolveAssetPattern("0.0.5", "OpenDucktor_aarch64.dmg", "OpenDucktor_x64.dmg"),
+  ).toThrow("Could not derive a `#{version}` placeholder");
+});
+
 test("resolveHomebrewMacosRequirement maps macOS 12 to monterey", () => {
   expect(resolveHomebrewMacosRequirement("12.0")).toBe(">= :monterey");
+});
+
+test("resolveHomebrewMacosRequirement rejects unsupported future macOS symbols", () => {
+  expect(() => resolveHomebrewMacosRequirement("26.0")).toThrow(
+    "Unsupported macOS minimum system version `26.0`",
+  );
 });
 
 test("renderHomebrewCask renders the expected OpenDucktor cask", () => {

--- a/scripts/release-homebrew-cask.ts
+++ b/scripts/release-homebrew-cask.ts
@@ -1,0 +1,301 @@
+/// <reference types="node" />
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const tauriConfigPath = "apps/desktop/src-tauri/tauri.conf.json";
+const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/;
+const desktopDescription = "Task-first agentic development environment";
+const armArchCandidates = ["aarch64", "arm64"] as const;
+const intelArchCandidates = ["x64", "x86_64", "amd64", "intel"] as const;
+
+const macosVersionSymbols: Record<string, string> = {
+  "11": "big_sur",
+  "12": "monterey",
+  "13": "ventura",
+  "14": "sonoma",
+  "15": "sequoia",
+  "26": "tahoe",
+};
+
+type TauriConfig = {
+  productName?: string;
+  identifier?: string;
+  bundle?: {
+    macOS?: {
+      minimumSystemVersion?: string;
+    };
+  };
+};
+
+export type HomebrewCaskRenderInput = {
+  version: string;
+  repository: string;
+  productName: string;
+  bundleIdentifier: string;
+  minimumSystemVersion: string;
+  armAssetName: string;
+  armSha256: string;
+  intelAssetName: string;
+  intelSha256: string;
+};
+
+type CliOptions = {
+  version: string;
+  repository: string;
+  armAssetName: string;
+  armSha256: string;
+  intelAssetName: string;
+  intelSha256: string;
+  output: string;
+  workspaceRoot: string;
+};
+
+export function validateVersion(version: string): void {
+  if (!semverPattern.test(version)) {
+    throw new Error(`Invalid version \`${version}\`. Expected semver like 0.1.0 or 0.1.0-rc.1.`);
+  }
+}
+
+function validateRepository(repository: string): void {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error(
+      `Invalid repository \`${repository}\`. Expected owner/repo, for example Maxsky5/openducktor.`,
+    );
+  }
+}
+
+function validateSha256(value: string, name: string): void {
+  if (!/^[a-f0-9]{64}$/i.test(value)) {
+    throw new Error(`Invalid ${name} SHA-256 \`${value}\`.`);
+  }
+}
+
+function extractArchToken(assetName: string, candidates: readonly string[]): string {
+  const normalizedAssetName = assetName.toLowerCase();
+  const token = candidates.find((candidate) => normalizedAssetName.includes(candidate));
+
+  if (!token) {
+    throw new Error(`Could not resolve an architecture token from asset name \`${assetName}\`.`);
+  }
+
+  return token;
+}
+
+export function resolveAssetPattern(
+  version: string,
+  armAssetName: string,
+  intelAssetName: string,
+): { armArchToken: string; intelArchToken: string; assetPattern: string } {
+  validateVersion(version);
+
+  if (armAssetName === intelAssetName) {
+    throw new Error(
+      "Arm and Intel asset names must differ so the cask can select by architecture.",
+    );
+  }
+
+  const armArchToken = extractArchToken(armAssetName, armArchCandidates);
+  const intelArchToken = extractArchToken(intelAssetName, intelArchCandidates);
+
+  const armPattern = armAssetName
+    .replace(armArchToken, "#{arch}")
+    .replaceAll(version, "#{version}");
+  const intelPattern = intelAssetName
+    .replace(intelArchToken, "#{arch}")
+    .replaceAll(version, "#{version}");
+
+  if (armPattern !== intelPattern) {
+    throw new Error(
+      `Could not derive a shared asset pattern from \`${armAssetName}\` and \`${intelAssetName}\`.`,
+    );
+  }
+
+  if (armPattern === armAssetName && armAssetName.includes(version)) {
+    throw new Error(
+      `Could not replace version \`${version}\` inside asset pattern derived from \`${armAssetName}\`.`,
+    );
+  }
+
+  return {
+    armArchToken,
+    intelArchToken,
+    assetPattern: armPattern,
+  };
+}
+
+export function resolveHomebrewMacosRequirement(minimumSystemVersion: string): string {
+  const majorVersion = minimumSystemVersion.trim().split(".")[0];
+  const symbol = majorVersion ? macosVersionSymbols[majorVersion] : undefined;
+
+  if (!symbol) {
+    throw new Error(
+      `Unsupported macOS minimum system version \`${minimumSystemVersion}\`. Add a Homebrew symbol mapping before releasing.`,
+    );
+  }
+
+  return `>= :${symbol}`;
+}
+
+export function readDesktopReleaseMetadata(workspaceRoot = process.cwd()): {
+  productName: string;
+  bundleIdentifier: string;
+  minimumSystemVersion: string;
+} {
+  const absolutePath = resolve(workspaceRoot, tauriConfigPath);
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as TauriConfig;
+  const productName = parsed.productName?.trim();
+  const bundleIdentifier = parsed.identifier?.trim();
+  const minimumSystemVersion = parsed.bundle?.macOS?.minimumSystemVersion?.trim();
+
+  if (!productName) {
+    throw new Error(`Missing productName in ${tauriConfigPath}`);
+  }
+
+  if (!bundleIdentifier) {
+    throw new Error(`Missing identifier in ${tauriConfigPath}`);
+  }
+
+  if (!minimumSystemVersion) {
+    throw new Error(`Missing bundle.macOS.minimumSystemVersion in ${tauriConfigPath}`);
+  }
+
+  return {
+    productName,
+    bundleIdentifier,
+    minimumSystemVersion,
+  };
+}
+
+function rubyStringLiteral(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+export function renderHomebrewCask(input: HomebrewCaskRenderInput): string {
+  validateVersion(input.version);
+  validateRepository(input.repository);
+  validateSha256(input.armSha256, "arm");
+  validateSha256(input.intelSha256, "intel");
+
+  const { armArchToken, intelArchToken, assetPattern } = resolveAssetPattern(
+    input.version,
+    input.armAssetName,
+    input.intelAssetName,
+  );
+  const minimumMacosRequirement = resolveHomebrewMacosRequirement(input.minimumSystemVersion);
+  const homepage = `https://github.com/${input.repository}`;
+  const downloadUrl = `${homepage}/releases/download/v#{version}/${assetPattern}`;
+
+  return [
+    'cask "openducktor" do',
+    `  arch arm: "${rubyStringLiteral(armArchToken)}", intel: "${rubyStringLiteral(intelArchToken)}"`,
+    "",
+    `  version "${rubyStringLiteral(input.version)}"`,
+    `  sha256 arm:   "${rubyStringLiteral(input.armSha256.toLowerCase())}",`,
+    `         intel: "${rubyStringLiteral(input.intelSha256.toLowerCase())}"`,
+    "",
+    `  url "${rubyStringLiteral(downloadUrl)}"`,
+    `  name "${rubyStringLiteral(input.productName)}"`,
+    `  desc "${rubyStringLiteral(desktopDescription)}"`,
+    `  homepage "${rubyStringLiteral(homepage)}"`,
+    "",
+    "  livecheck do",
+    "    url :url",
+    "    strategy :github_latest",
+    "  end",
+    "",
+    `  depends_on macos: "${rubyStringLiteral(minimumMacosRequirement)}"`,
+    "",
+    `  app "${rubyStringLiteral(`${input.productName}.app`)}"`,
+    "",
+    "  zap trash: [",
+    '    "~/.openducktor",',
+    `    "~/Library/Preferences/${rubyStringLiteral(input.bundleIdentifier)}.plist",`,
+    `    "~/Library/Saved Application State/${rubyStringLiteral(input.bundleIdentifier)}.savedState",`,
+    "  ]",
+    "end",
+    "",
+  ].join("\n");
+}
+
+function usage(): never {
+  console.error(
+    "Usage: bun run scripts/release-homebrew-cask.ts --version <version> --repository <owner/repo> --arm-asset-name <name> --arm-sha256 <sha256> --intel-asset-name <name> --intel-sha256 <sha256> --output <path> [--workspace-root <path>]",
+  );
+  process.exit(1);
+}
+
+function parseCliOptions(argv: string[]): CliOptions {
+  const options = new Map<string, string>();
+
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+
+    if (!flag?.startsWith("--") || value === undefined || value.startsWith("--")) {
+      usage();
+    }
+
+    options.set(flag, value);
+  }
+
+  const version = options.get("--version");
+  const repository = options.get("--repository");
+  const armAssetName = options.get("--arm-asset-name");
+  const armSha256 = options.get("--arm-sha256");
+  const intelAssetName = options.get("--intel-asset-name");
+  const intelSha256 = options.get("--intel-sha256");
+  const output = options.get("--output");
+
+  if (
+    !version ||
+    !repository ||
+    !armAssetName ||
+    !armSha256 ||
+    !intelAssetName ||
+    !intelSha256 ||
+    !output
+  ) {
+    usage();
+  }
+
+  return {
+    version,
+    repository,
+    armAssetName,
+    armSha256,
+    intelAssetName,
+    intelSha256,
+    output,
+    workspaceRoot: options.get("--workspace-root") ?? process.cwd(),
+  };
+}
+
+export function runCli(argv = process.argv.slice(2)): void {
+  const options = parseCliOptions(argv);
+  const desktopMetadata = readDesktopReleaseMetadata(options.workspaceRoot);
+  const outputPath = resolve(options.workspaceRoot, options.output);
+  const caskContents = renderHomebrewCask({
+    version: options.version,
+    repository: options.repository,
+    productName: desktopMetadata.productName,
+    bundleIdentifier: desktopMetadata.bundleIdentifier,
+    minimumSystemVersion: desktopMetadata.minimumSystemVersion,
+    armAssetName: options.armAssetName,
+    armSha256: options.armSha256,
+    intelAssetName: options.intelAssetName,
+    intelSha256: options.intelSha256,
+  });
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, caskContents);
+}
+
+if (import.meta.main) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/release-homebrew-cask.ts
+++ b/scripts/release-homebrew-cask.ts
@@ -7,7 +7,7 @@ const tauriConfigPath = "apps/desktop/src-tauri/tauri.conf.json";
 const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/;
 const desktopDescription = "Task-first agentic development environment";
 const armArchCandidates = ["aarch64", "arm64"] as const;
-const intelArchCandidates = ["x64", "x86_64", "amd64", "intel"] as const;
+const intelArchCandidates = ["x86_64", "x64", "amd64", "intel"] as const;
 
 const macosVersionSymbols: Record<string, string> = {
   "11": "big_sur",
@@ -15,7 +15,6 @@ const macosVersionSymbols: Record<string, string> = {
   "13": "ventura",
   "14": "sonoma",
   "15": "sequoia",
-  "26": "tahoe",
 };
 
 type TauriConfig = {
@@ -73,13 +72,28 @@ function validateSha256(value: string, name: string): void {
 
 function extractArchToken(assetName: string, candidates: readonly string[]): string {
   const normalizedAssetName = assetName.toLowerCase();
-  const token = candidates.find((candidate) => normalizedAssetName.includes(candidate));
-
-  if (!token) {
-    throw new Error(`Could not resolve an architecture token from asset name \`${assetName}\`.`);
+  for (const candidate of candidates) {
+    const startIndex = normalizedAssetName.indexOf(candidate);
+    if (startIndex !== -1) {
+      return assetName.slice(startIndex, startIndex + candidate.length);
+    }
   }
 
-  return token;
+  throw new Error(`Could not resolve an architecture token from asset name \`${assetName}\`.`);
+}
+
+function validateDerivedAssetPattern(assetPattern: string, assetName: string): void {
+  if (!assetPattern.includes("#{arch}")) {
+    throw new Error(
+      `Could not derive a \`#{arch}\` placeholder from asset name \`${assetName}\`. Expected an architecture token like arm64, aarch64, x86_64, or x64 in the asset filename.`,
+    );
+  }
+
+  if (!assetPattern.includes("#{version}")) {
+    throw new Error(
+      `Could not derive a \`#{version}\` placeholder from asset name \`${assetName}\`. Expected the version string to appear in the asset filename.`,
+    );
+  }
 }
 
 export function resolveAssetPattern(
@@ -99,21 +113,18 @@ export function resolveAssetPattern(
   const intelArchToken = extractArchToken(intelAssetName, intelArchCandidates);
 
   const armPattern = armAssetName
-    .replace(armArchToken, "#{arch}")
-    .replaceAll(version, "#{version}");
+    .replaceAll(version, "#{version}")
+    .replaceAll(armArchToken, "#{arch}");
   const intelPattern = intelAssetName
-    .replace(intelArchToken, "#{arch}")
-    .replaceAll(version, "#{version}");
+    .replaceAll(version, "#{version}")
+    .replaceAll(intelArchToken, "#{arch}");
+
+  validateDerivedAssetPattern(armPattern, armAssetName);
+  validateDerivedAssetPattern(intelPattern, intelAssetName);
 
   if (armPattern !== intelPattern) {
     throw new Error(
       `Could not derive a shared asset pattern from \`${armAssetName}\` and \`${intelAssetName}\`.`,
-    );
-  }
-
-  if (armPattern === armAssetName && armAssetName.includes(version)) {
-    throw new Error(
-      `Could not replace version \`${version}\` inside asset pattern derived from \`${armAssetName}\`.`,
     );
   }
 


### PR DESCRIPTION
## Summary
- add a Homebrew cask generator plus focused tests so macOS desktop releases can be published to a dedicated tap without manual checksum edits
- add a GitHub Actions workflow that updates `homebrew-openducktor` after a stable GitHub release is published
- document the Brew install path in the root README and extend release-process docs with the tap setup and release flow

## Verification
- `bun run test:release:homebrew:cask`
- `bun run release:homebrew:cask --version 0.0.5 --repository Maxsky5/openducktor --arm-asset-name OpenDucktor_0.0.5_aarch64.dmg --arm-sha256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --intel-asset-name OpenDucktor_0.0.5_x64.dmg --intel-sha256 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --output /tmp/openducktor-homebrew-cask.rb`
- `ruby -c /tmp/openducktor-homebrew-cask.rb`
- `ruby -e 'require \"yaml\"; data = YAML.load_file(\".github/workflows/publish-homebrew-tap.yml\"); on_key = data.key?(\"on\") ? \"on\" : true; abort(\"missing workflow\") unless data[\"name\"] == \"Publish Homebrew Tap\"; abort(\"missing release trigger\") unless data[on_key][\"release\"][\"types\"].include?(\"published\"); abort(\"missing dispatch\") unless data[on_key].key?(\"workflow_dispatch\"); puts \"workflow ok\"'`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew tap installation support for macOS users as an alternative to direct GitHub Releases downloads.

* **Documentation**
  * Updated macOS installation instructions with Homebrew setup commands.
  * Enhanced release process documentation with Homebrew publishing workflow details.

* **Chores**
  * Implemented automated workflow for publishing updates to Homebrew tap on release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->