### PR TITLE
feat(agent-studio): improve task tab reordering UX

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,10 @@
     "lint": "biome check src scripts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@openducktor/adapters-opencode-sdk": "workspace:*",
     "@openducktor/adapters-tauri-host": "workspace:*",
     "@openducktor/contracts": "workspace:*",

--- a/apps/desktop/src-tauri/src/commands/git/tests/command_handlers.rs
+++ b/apps/desktop/src-tauri/src/commands/git/tests/command_handlers.rs
@@ -59,9 +59,11 @@ fn git_get_worktree_status_rejects_unauthorized_repo() {
 fn git_get_worktree_status_keeps_upstream_error_variant_and_snapshot_metadata() {
     let fixture = setup_command_git_fixture(
         "git-command-upstream-error",
-        WorktreeStatusResult::Ok(Box::new(sample_worktree_status_data(GitUpstreamAheadBehind::Error {
-            message: "upstream not configured".to_string(),
-        }))),
+        WorktreeStatusResult::Ok(Box::new(sample_worktree_status_data(
+            GitUpstreamAheadBehind::Error {
+                message: "upstream not configured".to_string(),
+            },
+        ))),
         true,
     );
 

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -336,7 +336,11 @@ pub async fn workspace_update_repo_hooks(
     workspace_id: String,
     hooks: HookSet,
 ) -> Result<host_domain::WorkspaceRecord, String> {
-    as_error(state.service.workspace_update_repo_hooks(&workspace_id, hooks))
+    as_error(
+        state
+            .service
+            .workspace_update_repo_hooks(&workspace_id, hooks),
+    )
 }
 
 #[tauri::command]
@@ -796,12 +800,11 @@ mod tests {
             .update_repo_hooks(&workspace_id, hooks)
             .expect("hooks should be persisted");
 
-        let task_store: Arc<dyn TaskStore> = Arc::new(
-            BeadsTaskStore::with_metadata_namespace_and_config(
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(BeadsTaskStore::with_metadata_namespace_and_config(
                 TASK_METADATA_NAMESPACE,
                 config_store.clone(),
-            ),
-        );
+            ));
         let service = Arc::new(AppService::with_git_port(
             task_store,
             config_store,
@@ -1663,10 +1666,11 @@ mod tests {
     fn workspace_get_settings_snapshot_returns_defaulted_chat_settings() -> Result<(), String> {
         let fixture = setup_workspace_command_fixture("snapshot-default-chat", HookSet::default());
 
-        let (_theme, _git, chat, kanban, _autopilot, _workspaces, _global_prompt_overrides) = fixture
-            .service
-            .workspace_get_settings_snapshot()
-            .map_err(|error| error.to_string())?;
+        let (_theme, _git, chat, kanban, _autopilot, _workspaces, _global_prompt_overrides) =
+            fixture
+                .service
+                .workspace_get_settings_snapshot()
+                .map_err(|error| error.to_string())?;
 
         assert_eq!(chat, ChatSettings::default());
         assert!(!chat.show_thinking_messages);

--- a/apps/desktop/src-tauri/src/headless/command_registry.rs
+++ b/apps/desktop/src-tauri/src/headless/command_registry.rs
@@ -120,10 +120,7 @@ mod tests {
         fs::create_dir_all(&root).expect("test root should exist");
         let config_store = AppConfigStore::from_path(root.join("config.json"));
         let task_store: Arc<dyn TaskStore> = Arc::new(
-            BeadsTaskStore::with_metadata_namespace_and_config(
-                "openducktor",
-                config_store.clone(),
-            ),
+            BeadsTaskStore::with_metadata_namespace_and_config("openducktor", config_store.clone()),
         );
         let service = Arc::new(AppService::new(task_store, config_store));
 

--- a/apps/desktop/src-tauri/src/headless/odt_mcp_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/odt_mcp_commands.rs
@@ -392,8 +392,9 @@ mod tests {
 
     #[test]
     fn ready_args_deserialize_workspace_id() {
-        let parsed: WorkspaceArgs = serde_json::from_value(serde_json::json!({ "workspaceId": "repo" }))
-            .expect("args should parse");
+        let parsed: WorkspaceArgs =
+            serde_json::from_value(serde_json::json!({ "workspaceId": "repo" }))
+                .expect("args should parse");
         assert_eq!(parsed.workspace_id, "repo");
     }
 

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -885,10 +885,7 @@ mod tests {
         fs::create_dir_all(&root).expect("test root should exist");
         let config_store = AppConfigStore::from_path(root.join("config.json"));
         let task_store: Arc<dyn TaskStore> = Arc::new(
-            BeadsTaskStore::with_metadata_namespace_and_config(
-                "openducktor",
-                config_store.clone(),
-            ),
+            BeadsTaskStore::with_metadata_namespace_and_config("openducktor", config_store.clone()),
         );
         let service = Arc::new(AppService::new(task_store, config_store));
         let registry = Arc::new(build_registry().expect("registry should build"));
@@ -910,7 +907,12 @@ mod tests {
 
     fn test_state_fixture_with_task_store(
         tasks: Vec<TaskCard>,
-    ) -> (TestStateFixture, Arc<Mutex<TestTaskStoreState>>, PathBuf, String) {
+    ) -> (
+        TestStateFixture,
+        Arc<Mutex<TestTaskStoreState>>,
+        PathBuf,
+        String,
+    ) {
         let root = unique_temp_path("server-task-store");
         fs::create_dir_all(&root).expect("test root should exist");
         let repo_path = root.join("repo");

--- a/apps/desktop/src-tauri/src/headless/workspace_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/workspace_commands.rs
@@ -139,7 +139,9 @@ pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), St
     registry.register(
         "workspace_prepare_trusted_hooks_challenge",
         |state, args| {
-            Box::pin(handle_workspace_prepare_trusted_hooks_challenge(state, args))
+            Box::pin(handle_workspace_prepare_trusted_hooks_challenge(
+                state, args,
+            ))
         },
     )?;
     registry.register("workspace_get_repo_config", |state, args| {

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { render, screen } from "@testing-library/react";
+import { describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { Tabs } from "@/components/ui/tabs";
@@ -25,6 +25,7 @@ const buildModel = () => ({
   isLoadingAvailableTabTasks: false,
   onCreateTab: () => {},
   onCloseTab: () => {},
+  onReorderTab: () => {},
   agentStudioReady: true,
 });
 
@@ -186,5 +187,93 @@ describe("AgentStudioTaskTabs", () => {
     expect(
       newTabButton.compareDocumentPosition(rightPanelToggle) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  test("reports browser-style tab reorders from drag and drop", () => {
+    const onReorderTab = mock(() => {});
+    render(
+      createElement(
+        Tabs,
+        { value: "task-1" },
+        createElement(AgentStudioTaskTabs, {
+          model: {
+            ...buildModel(),
+            onReorderTab,
+          },
+        }),
+      ),
+    );
+
+    const firstTabTrigger = screen.getByRole("tab", { name: /Add social login/i });
+    const secondTabTrigger = screen.getByRole("tab", { name: /Ship QA checklist/i });
+    const firstTab = firstTabTrigger.closest("[data-task-tab-id]");
+    const secondTab = secondTabTrigger.closest("[data-task-tab-id]");
+
+    expect(firstTab).not.toBeNull();
+    expect(secondTab).not.toBeNull();
+
+    Object.defineProperty(firstTabTrigger, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: 100,
+        bottom: 40,
+        width: 100,
+        height: 40,
+        toJSON: () => ({}),
+      }),
+    });
+    Object.defineProperty(secondTabTrigger, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        x: 100,
+        y: 0,
+        left: 100,
+        top: 0,
+        right: 200,
+        bottom: 40,
+        width: 100,
+        height: 40,
+        toJSON: () => ({}),
+      }),
+    });
+
+    const dataTransfer = {
+      effectAllowed: "all",
+      dropEffect: "move",
+      setData: () => {},
+      getData: () => "task-2",
+    };
+
+    const dragStartEvent = new Event("dragstart", { bubbles: true, cancelable: true });
+    Object.defineProperty(dragStartEvent, "dataTransfer", {
+      configurable: true,
+      value: dataTransfer,
+    });
+
+    const dragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
+    Object.defineProperty(dragOverEvent, "dataTransfer", {
+      configurable: true,
+      value: dataTransfer,
+    });
+    Object.defineProperty(dragOverEvent, "clientX", {
+      configurable: true,
+      value: 10,
+    });
+
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      configurable: true,
+      value: dataTransfer,
+    });
+
+    fireEvent(secondTabTrigger, dragStartEvent);
+    fireEvent(firstTabTrigger, dragOverEvent);
+    fireEvent(firstTabTrigger, dropEvent);
+
+    expect(onReorderTab).toHaveBeenCalledWith("task-2", "task-1", "before");
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -121,6 +121,9 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).not.toContain("bg-card/80");
     expect(html).toContain("bg-studio-chrome");
     expect(html).toContain("size-[1.4rem]");
+    expect(html).toContain("cursor-pointer");
+    expect(html).not.toContain("cursor-grab");
+    expect(html).not.toContain("cursor-inherit");
 
     const { unmount } = render(
       createElement(

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -434,10 +434,6 @@ describe("AgentStudioTaskTabs", () => {
     );
 
     await act(async () => {
-      fireEvent.mouseDown(screen.getByRole("tab", { name: /Ship QA checklist/i }), {
-        button: 0,
-        buttons: 1,
-      });
       fireEvent.click(screen.getByRole("tab", { name: /Ship QA checklist/i }));
     });
 
@@ -446,51 +442,54 @@ describe("AgentStudioTaskTabs", () => {
 
   test("does not start a reorder drag from the close button", async () => {
     const onReorderTab = mock(() => {});
-    render(
-      createElement(
-        Tabs,
-        { value: "task-1" },
-        createElement(AgentStudioTaskTabs, {
-          model: {
-            ...buildModel(),
-            onReorderTab,
-          },
-        }),
-      ),
-    );
 
-    const closeButton = screen.getByRole("button", { name: "Close tab for Ship QA checklist" });
-    const secondTab = screen
-      .getByRole("tab", { name: /Ship QA checklist/i })
-      .closest("[data-task-tab-id]") as HTMLElement;
+    await withMouseSensorFallback(async () => {
+      render(
+        createElement(
+          Tabs,
+          { value: "task-1" },
+          createElement(AgentStudioTaskTabs, {
+            model: {
+              ...buildModel(),
+              onReorderTab,
+            },
+          }),
+        ),
+      );
 
-    setElementRect(secondTab, {
-      x: 130,
-      y: 0,
-      left: 130,
-      top: 0,
-      right: 260,
-      bottom: 40,
-      width: 130,
-      height: 40,
-    });
+      const closeButton = screen.getByRole("button", { name: "Close tab for Ship QA checklist" });
+      const secondTab = screen
+        .getByRole("tab", { name: /Ship QA checklist/i })
+        .closest("[data-task-tab-id]") as HTMLElement;
 
-    await act(async () => {
-      fireEvent.mouseDown(closeButton, {
-        button: 0,
-        buttons: 1,
-        clientX: 200,
-        clientY: 20,
+      setElementRect(secondTab, {
+        x: 130,
+        y: 0,
+        left: 130,
+        top: 0,
+        right: 260,
+        bottom: 40,
+        width: 130,
+        height: 40,
       });
-      fireEvent.mouseMove(document, {
-        buttons: 1,
-        clientX: 240,
-        clientY: 20,
-      });
-    });
-    await finishMouseDrag({ clientX: 240, clientY: 20 });
 
-    expect(secondTab.getAttribute("data-dragging")).toBe("false");
-    expect(onReorderTab).toHaveBeenCalledTimes(0);
+      await act(async () => {
+        fireEvent.mouseDown(closeButton, {
+          button: 0,
+          buttons: 1,
+          clientX: 200,
+          clientY: 20,
+        });
+        fireEvent.mouseMove(document, {
+          buttons: 1,
+          clientX: 240,
+          clientY: 20,
+        });
+      });
+      await finishMouseDrag({ clientX: 240, clientY: 20 });
+
+      expect(secondTab.getAttribute("data-dragging")).toBe("false");
+      expect(onReorderTab).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -23,6 +23,7 @@ const buildModel = () => ({
   ],
   availableTabTasks: [buildTask({ id: "task-3", title: "Stabilize desktop startup" })],
   isLoadingAvailableTabTasks: false,
+  onSelectTab: () => {},
   onCreateTab: () => {},
   onCloseTab: () => {},
   onReorderTab: () => {},
@@ -90,6 +91,23 @@ const setDefaultTabRects = (firstTab: HTMLElement, secondTab: HTMLElement): void
     width: 130,
     height: 40,
   });
+};
+
+const withMouseSensorFallback = async (run: () => Promise<void>): Promise<void> => {
+  const originalPointerEvent = globalThis.PointerEvent;
+  Object.defineProperty(globalThis, "PointerEvent", {
+    configurable: true,
+    value: undefined,
+  });
+
+  try {
+    await run();
+  } finally {
+    Object.defineProperty(globalThis, "PointerEvent", {
+      configurable: true,
+      value: originalPointerEvent,
+    });
+  }
 };
 
 describe("AgentStudioTaskTabs", () => {
@@ -257,101 +275,173 @@ describe("AgentStudioTaskTabs", () => {
 
   test("reorders tabs with pointer dragging", async () => {
     const onReorderTab = mock(() => {});
-    render(
-      createElement(
-        Tabs,
-        { value: "task-1" },
-        createElement(AgentStudioTaskTabs, {
-          model: {
-            ...buildModel(),
-            onReorderTab,
-          },
-        }),
-      ),
-    );
+    await withMouseSensorFallback(async () => {
+      render(
+        createElement(
+          Tabs,
+          { value: "task-1" },
+          createElement(AgentStudioTaskTabs, {
+            model: {
+              ...buildModel(),
+              onReorderTab,
+            },
+          }),
+        ),
+      );
 
-    const firstTab = screen
-      .getByRole("tab", { name: /Add social login/i })
-      .closest("[data-task-tab-id]");
-    const secondTab = screen
-      .getByRole("tab", { name: /Ship QA checklist/i })
-      .closest("[data-task-tab-id]");
+      const firstTab = screen
+        .getByRole("tab", { name: /Add social login/i })
+        .closest("[data-task-tab-id]");
+      const secondTab = screen
+        .getByRole("tab", { name: /Ship QA checklist/i })
+        .closest("[data-task-tab-id]");
 
-    expect(firstTab).not.toBeNull();
-    expect(secondTab).not.toBeNull();
+      expect(firstTab).not.toBeNull();
+      expect(secondTab).not.toBeNull();
 
-    setDefaultTabRects(firstTab as HTMLElement, secondTab as HTMLElement);
+      setDefaultTabRects(firstTab as HTMLElement, secondTab as HTMLElement);
 
-    await dragWithMouse(secondTab as HTMLElement, { clientX: 170, clientY: 20 }, [
-      { clientX: 150, clientY: 20 },
-      { clientX: 50, clientY: 20 },
-    ]);
-    await finishMouseDrag({ clientX: 50, clientY: 20 });
+      await dragWithMouse(secondTab as HTMLElement, { clientX: 170, clientY: 20 }, [
+        { clientX: 150, clientY: 20 },
+        { clientX: 50, clientY: 20 },
+      ]);
+      await finishMouseDrag({ clientX: 50, clientY: 20 });
 
-    expect(onReorderTab).toHaveBeenCalledWith("task-2", "task-1", "before");
+      expect(onReorderTab).toHaveBeenCalledWith("task-2", "task-1", "before");
+    });
   });
 
   test("shows a dragged tab preview instead of only moving the source node", async () => {
-    render(
-      createElement(
-        Tabs,
-        { value: "task-1" },
-        createElement(AgentStudioTaskTabs, {
-          model: {
-            ...buildModel(),
-          },
-        }),
-      ),
-    );
+    await withMouseSensorFallback(async () => {
+      render(
+        createElement(
+          Tabs,
+          { value: "task-1" },
+          createElement(AgentStudioTaskTabs, {
+            model: {
+              ...buildModel(),
+            },
+          }),
+        ),
+      );
 
-    const firstTab = screen
-      .getByRole("tab", { name: /Add social login/i })
-      .closest("[data-task-tab-id]") as HTMLElement;
-    const secondTab = screen
-      .getByRole("tab", { name: /Ship QA checklist/i })
-      .closest("[data-task-tab-id]") as HTMLElement;
+      const firstTab = screen
+        .getByRole("tab", { name: /Add social login/i })
+        .closest("[data-task-tab-id]") as HTMLElement;
+      const secondTab = screen
+        .getByRole("tab", { name: /Ship QA checklist/i })
+        .closest("[data-task-tab-id]") as HTMLElement;
 
-    setDefaultTabRects(firstTab, secondTab);
+      setDefaultTabRects(firstTab, secondTab);
 
-    await dragWithMouse(firstTab, { clientX: 40, clientY: 20 }, [{ clientX: 60, clientY: 20 }]);
+      await dragWithMouse(firstTab, { clientX: 40, clientY: 20 }, [{ clientX: 60, clientY: 20 }]);
 
-    expect(firstTab.getAttribute("data-dragging")).toBe("true");
-    expect(screen.getAllByText("Add social login").length).toBeGreaterThan(1);
+      expect(firstTab.getAttribute("data-dragging")).toBe("true");
+      expect(screen.getAllByText("Add social login").length).toBeGreaterThan(1);
 
-    await finishMouseDrag({ clientX: 60, clientY: 20 });
+      await finishMouseDrag({ clientX: 60, clientY: 20 });
+    });
   });
 
   test("clears drag state when dragging ends without a drop", async () => {
     const onReorderTab = mock(() => {});
+    await withMouseSensorFallback(async () => {
+      render(
+        createElement(
+          Tabs,
+          { value: "task-1" },
+          createElement(AgentStudioTaskTabs, {
+            model: {
+              ...buildModel(),
+              onReorderTab,
+            },
+          }),
+        ),
+      );
+
+      const firstTab = screen
+        .getByRole("tab", { name: /Add social login/i })
+        .closest("[data-task-tab-id]") as HTMLElement;
+      const secondTab = screen
+        .getByRole("tab", { name: /Ship QA checklist/i })
+        .closest("[data-task-tab-id]") as HTMLElement;
+
+      setDefaultTabRects(firstTab, secondTab);
+
+      await dragWithMouse(firstTab, { clientX: 40, clientY: 20 }, [{ clientX: 55, clientY: 20 }]);
+      expect(firstTab.getAttribute("data-dragging")).toBe("true");
+
+      await finishMouseDrag({ clientX: 55, clientY: 20 });
+
+      expect(firstTab.getAttribute("data-dragging")).toBe("false");
+      expect(onReorderTab).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  test("dragging an inactive tab does not trigger selection side effects", async () => {
+    const onSelectTab = mock(() => {});
+    const onReorderTab = mock(() => {});
+
+    await withMouseSensorFallback(async () => {
+      render(
+        createElement(
+          Tabs,
+          { value: "task-1", onValueChange: onSelectTab },
+          createElement(AgentStudioTaskTabs, {
+            model: {
+              ...buildModel(),
+              onSelectTab,
+              onReorderTab,
+            },
+          }),
+        ),
+      );
+
+      const firstTab = screen
+        .getByRole("tab", { name: /Add social login/i })
+        .closest("[data-task-tab-id]") as HTMLElement;
+      const secondTab = screen
+        .getByRole("tab", { name: /Ship QA checklist/i })
+        .closest("[data-task-tab-id]") as HTMLElement;
+
+      setDefaultTabRects(firstTab, secondTab);
+
+      await dragWithMouse(secondTab, { clientX: 170, clientY: 20 }, [
+        { clientX: 150, clientY: 20 },
+        { clientX: 50, clientY: 20 },
+      ]);
+      await finishMouseDrag({ clientX: 50, clientY: 20 });
+
+      expect(onSelectTab).toHaveBeenCalledTimes(0);
+      expect(onReorderTab).toHaveBeenCalledWith("task-2", "task-1", "before");
+    });
+  });
+
+  test("clicking an inactive tab still selects it", async () => {
+    const onSelectTab = mock(() => {});
+
     render(
       createElement(
         Tabs,
-        { value: "task-1" },
+        { value: "task-1", onValueChange: onSelectTab },
         createElement(AgentStudioTaskTabs, {
           model: {
             ...buildModel(),
-            onReorderTab,
+            onSelectTab,
           },
         }),
       ),
     );
 
-    const firstTab = screen
-      .getByRole("tab", { name: /Add social login/i })
-      .closest("[data-task-tab-id]") as HTMLElement;
-    const secondTab = screen
-      .getByRole("tab", { name: /Ship QA checklist/i })
-      .closest("[data-task-tab-id]") as HTMLElement;
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByRole("tab", { name: /Ship QA checklist/i }), {
+        button: 0,
+        buttons: 1,
+      });
+      fireEvent.click(screen.getByRole("tab", { name: /Ship QA checklist/i }));
+    });
 
-    setDefaultTabRects(firstTab, secondTab);
-
-    await dragWithMouse(firstTab, { clientX: 40, clientY: 20 }, [{ clientX: 55, clientY: 20 }]);
-    expect(firstTab.getAttribute("data-dragging")).toBe("true");
-
-    await finishMouseDrag({ clientX: 55, clientY: 20 });
-
-    expect(firstTab.getAttribute("data-dragging")).toBe("false");
-    expect(onReorderTab).toHaveBeenCalledTimes(0);
+    expect(onSelectTab).toHaveBeenCalledWith("task-2");
   });
 
   test("does not start a reorder drag from the close button", async () => {
@@ -386,8 +476,17 @@ describe("AgentStudioTaskTabs", () => {
     });
 
     await act(async () => {
-      fireEvent.mouseDown(closeButton, { button: 0, buttons: 1, clientX: 200, clientY: 20 });
-      fireEvent.mouseMove(document, { buttons: 1, clientX: 240, clientY: 20 });
+      fireEvent.mouseDown(closeButton, {
+        button: 0,
+        buttons: 1,
+        clientX: 200,
+        clientY: 20,
+      });
+      fireEvent.mouseMove(document, {
+        buttons: 1,
+        clientX: 240,
+        clientY: 20,
+      });
     });
     await finishMouseDrag({ clientX: 240, clientY: 20 });
 

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { Tabs } from "@/components/ui/tabs";
@@ -29,30 +29,6 @@ const buildModel = () => ({
   agentStudioReady: true,
 });
 
-const createDragEvent = (
-  type: string,
-  dataTransfer: {
-    effectAllowed: string;
-    dropEffect: string;
-    setData: () => void;
-    getData: () => string;
-  },
-  extras: Record<string, number> = {},
-): Event => {
-  const event = new Event(type, { bubbles: true, cancelable: true });
-  Object.defineProperty(event, "dataTransfer", {
-    configurable: true,
-    value: dataTransfer,
-  });
-  for (const [key, value] of Object.entries(extras)) {
-    Object.defineProperty(event, key, {
-      configurable: true,
-      value,
-    });
-  }
-  return event;
-};
-
 const setElementRect = (element: HTMLElement, rect: Omit<DOMRect, "toJSON">): void => {
   Object.defineProperty(element, "getBoundingClientRect", {
     configurable: true,
@@ -60,6 +36,59 @@ const setElementRect = (element: HTMLElement, rect: Omit<DOMRect, "toJSON">): vo
       ...rect,
       toJSON: () => ({}),
     }),
+  });
+};
+
+const dragWithMouse = async (
+  element: HTMLElement,
+  start: { clientX: number; clientY: number },
+  moves: Array<{ clientX: number; clientY: number }>,
+): Promise<void> => {
+  await act(async () => {
+    fireEvent.mouseDown(element, {
+      button: 0,
+      buttons: 1,
+      ...start,
+    });
+
+    for (const move of moves) {
+      fireEvent.mouseMove(document, {
+        buttons: 1,
+        ...move,
+      });
+    }
+  });
+};
+
+const finishMouseDrag = async (position: { clientX: number; clientY: number }): Promise<void> => {
+  await act(async () => {
+    fireEvent.mouseUp(document, {
+      button: 0,
+      ...position,
+    });
+  });
+};
+
+const setDefaultTabRects = (firstTab: HTMLElement, secondTab: HTMLElement): void => {
+  setElementRect(firstTab, {
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    right: 120,
+    bottom: 40,
+    width: 120,
+    height: 40,
+  });
+  setElementRect(secondTab, {
+    x: 130,
+    y: 0,
+    left: 130,
+    top: 0,
+    right: 260,
+    bottom: 40,
+    width: 130,
+    height: 40,
   });
 };
 
@@ -223,7 +252,7 @@ describe("AgentStudioTaskTabs", () => {
     ).toBeTruthy();
   });
 
-  test("reports browser-style tab reorders from drag and drop", () => {
+  test("reorders tabs with pointer dragging", async () => {
     const onReorderTab = mock(() => {});
     render(
       createElement(
@@ -248,42 +277,48 @@ describe("AgentStudioTaskTabs", () => {
     expect(firstTab).not.toBeNull();
     expect(secondTab).not.toBeNull();
 
-    setElementRect(firstTab as HTMLElement, {
-      x: 0,
-      y: 0,
-      left: 0,
-      top: 0,
-      right: 100,
-      bottom: 40,
-      width: 100,
-      height: 40,
-    });
-    setElementRect(secondTab as HTMLElement, {
-      x: 100,
-      y: 0,
-      left: 100,
-      top: 0,
-      right: 200,
-      bottom: 40,
-      width: 100,
-      height: 40,
-    });
+    setDefaultTabRects(firstTab as HTMLElement, secondTab as HTMLElement);
 
-    const dataTransfer = {
-      effectAllowed: "all",
-      dropEffect: "move",
-      setData: () => {},
-      getData: () => "task-2",
-    };
-
-    fireEvent(secondTab as HTMLElement, createDragEvent("dragstart", dataTransfer));
-    fireEvent(firstTab as HTMLElement, createDragEvent("dragover", dataTransfer, { clientX: 10 }));
-    fireEvent(firstTab as HTMLElement, createDragEvent("drop", dataTransfer, { clientX: 10 }));
+    await dragWithMouse(secondTab as HTMLElement, { clientX: 170, clientY: 20 }, [
+      { clientX: 150, clientY: 20 },
+      { clientX: 50, clientY: 20 },
+    ]);
+    await finishMouseDrag({ clientX: 50, clientY: 20 });
 
     expect(onReorderTab).toHaveBeenCalledWith("task-2", "task-1", "before");
   });
 
-  test("uses the actual drop target when release happens before a matching dragover state update", () => {
+  test("shows a dragged tab preview instead of only moving the source node", async () => {
+    render(
+      createElement(
+        Tabs,
+        { value: "task-1" },
+        createElement(AgentStudioTaskTabs, {
+          model: {
+            ...buildModel(),
+          },
+        }),
+      ),
+    );
+
+    const firstTab = screen
+      .getByRole("tab", { name: /Add social login/i })
+      .closest("[data-task-tab-id]") as HTMLElement;
+    const secondTab = screen
+      .getByRole("tab", { name: /Ship QA checklist/i })
+      .closest("[data-task-tab-id]") as HTMLElement;
+
+    setDefaultTabRects(firstTab, secondTab);
+
+    await dragWithMouse(firstTab, { clientX: 40, clientY: 20 }, [{ clientX: 60, clientY: 20 }]);
+
+    expect(firstTab.getAttribute("data-dragging")).toBe("true");
+    expect(screen.getAllByText("Add social login").length).toBeGreaterThan(1);
+
+    await finishMouseDrag({ clientX: 60, clientY: 20 });
+  });
+
+  test("clears drag state when dragging ends without a drop", async () => {
     const onReorderTab = mock(() => {});
     render(
       createElement(
@@ -305,174 +340,18 @@ describe("AgentStudioTaskTabs", () => {
       .getByRole("tab", { name: /Ship QA checklist/i })
       .closest("[data-task-tab-id]") as HTMLElement;
 
-    setElementRect(firstTab, {
-      x: 0,
-      y: 0,
-      left: 0,
-      top: 0,
-      right: 100,
-      bottom: 40,
-      width: 100,
-      height: 40,
-    });
-    setElementRect(secondTab, {
-      x: 100,
-      y: 0,
-      left: 100,
-      top: 0,
-      right: 200,
-      bottom: 40,
-      width: 100,
-      height: 40,
-    });
+    setDefaultTabRects(firstTab, secondTab);
 
-    const dataTransfer = {
-      effectAllowed: "all",
-      dropEffect: "move",
-      setData: () => {},
-      getData: () => "task-1",
-    };
-
-    fireEvent(firstTab, createDragEvent("dragstart", dataTransfer));
-    fireEvent(firstTab, createDragEvent("dragover", dataTransfer, { clientX: 10 }));
-    fireEvent(secondTab, createDragEvent("drop", dataTransfer, { clientX: 190 }));
-
-    expect(onReorderTab).toHaveBeenCalledWith("task-1", "task-2", "after");
-  });
-
-  test("auto-scrolls the overflowed strip when dragging near the edge", () => {
-    const requestAnimationFrameCallbacks: FrameRequestCallback[] = [];
-    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
-    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
-
-    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      requestAnimationFrameCallbacks.push(callback);
-      return requestAnimationFrameCallbacks.length;
-    }) as typeof globalThis.requestAnimationFrame;
-    globalThis.cancelAnimationFrame = (() => 0) as typeof globalThis.cancelAnimationFrame;
-
-    try {
-      render(
-        createElement(
-          Tabs,
-          { value: "task-1" },
-          createElement(AgentStudioTaskTabs, {
-            model: {
-              ...buildModel(),
-              tabs: [
-                { taskId: "task-1", taskTitle: "Tab 1", status: "working", isActive: true },
-                { taskId: "task-2", taskTitle: "Tab 2", status: "idle", isActive: false },
-                { taskId: "task-3", taskTitle: "Tab 3", status: "idle", isActive: false },
-                { taskId: "task-4", taskTitle: "Tab 4", status: "idle", isActive: false },
-                { taskId: "task-5", taskTitle: "Tab 5", status: "idle", isActive: false },
-                { taskId: "task-6", taskTitle: "Tab 6", status: "idle", isActive: false },
-              ],
-            },
-          }),
-        ),
-      );
-
-      const tabList = screen.getByRole("tablist", { name: "Agent Studio task tabs" });
-      const scrollRegion = tabList.parentElement?.parentElement as HTMLDivElement | null;
-      const firstTab = screen.getByRole("tab", { name: /Tab 1/i }).closest("[data-task-tab-id]");
-      const secondTab = screen.getByRole("tab", { name: /Tab 2/i }).closest("[data-task-tab-id]");
-
-      expect(scrollRegion).not.toBeNull();
-      expect(firstTab).not.toBeNull();
-      expect(secondTab).not.toBeNull();
-
-      setElementRect(scrollRegion as HTMLDivElement, {
-        x: 0,
-        y: 0,
-        left: 0,
-        top: 0,
-        right: 200,
-        bottom: 40,
-        width: 200,
-        height: 40,
-      });
-      setElementRect(secondTab as HTMLElement, {
-        x: 90,
-        y: 0,
-        left: 90,
-        top: 0,
-        right: 180,
-        bottom: 40,
-        width: 90,
-        height: 40,
-      });
-      (scrollRegion as HTMLDivElement).scrollLeft = 0;
-
-      const dataTransfer = {
-        effectAllowed: "all",
-        dropEffect: "move",
-        setData: () => {},
-        getData: () => "task-1",
-      };
-
-      fireEvent(firstTab as HTMLElement, createDragEvent("dragstart", dataTransfer));
-      fireEvent(
-        secondTab as HTMLElement,
-        createDragEvent("dragover", dataTransfer, { clientX: 196 }),
-      );
-
-      expect(requestAnimationFrameCallbacks.length).toBeGreaterThan(0);
-      requestAnimationFrameCallbacks.shift()?.(0);
-
-      expect((scrollRegion as HTMLDivElement).scrollLeft).toBeGreaterThan(0);
-    } finally {
-      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
-      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
-    }
-  });
-
-  test("clears drag state when dragging ends without a drop", () => {
-    render(
-      createElement(
-        Tabs,
-        { value: "task-1" },
-        createElement(AgentStudioTaskTabs, { model: buildModel() }),
-      ),
-    );
-
-    const firstTab = screen
-      .getByRole("tab", { name: /Add social login/i })
-      .closest("[data-task-tab-id]") as HTMLElement;
-    const secondTab = screen
-      .getByRole("tab", { name: /Ship QA checklist/i })
-      .closest("[data-task-tab-id]") as HTMLElement;
-
-    setElementRect(secondTab, {
-      x: 100,
-      y: 0,
-      left: 100,
-      top: 0,
-      right: 200,
-      bottom: 40,
-      width: 100,
-      height: 40,
-    });
-
-    const dataTransfer = {
-      effectAllowed: "all",
-      dropEffect: "move",
-      setData: () => {},
-      getData: () => "task-1",
-    };
-
-    fireEvent(firstTab, createDragEvent("dragstart", dataTransfer));
-    fireEvent(secondTab, createDragEvent("dragover", dataTransfer, { clientX: 110 }));
-
+    await dragWithMouse(firstTab, { clientX: 40, clientY: 20 }, [{ clientX: 55, clientY: 20 }]);
     expect(firstTab.getAttribute("data-dragging")).toBe("true");
-    expect(secondTab.getAttribute("data-drop-position")).toBe("before");
 
-    fireEvent(firstTab, createDragEvent("dragend", dataTransfer));
+    await finishMouseDrag({ clientX: 55, clientY: 20 });
 
     expect(firstTab.getAttribute("data-dragging")).toBe("false");
-    expect(secondTab.hasAttribute("data-drop-position")).toBeFalse();
+    expect(onReorderTab).toHaveBeenCalledTimes(0);
   });
 
-  test("does not start a reorder drag from the close button", () => {
+  test("does not start a reorder drag from the close button", async () => {
     const onReorderTab = mock(() => {});
     render(
       createElement(
@@ -492,14 +371,22 @@ describe("AgentStudioTaskTabs", () => {
       .getByRole("tab", { name: /Ship QA checklist/i })
       .closest("[data-task-tab-id]") as HTMLElement;
 
-    const dataTransfer = {
-      effectAllowed: "all",
-      dropEffect: "move",
-      setData: () => {},
-      getData: () => "task-2",
-    };
+    setElementRect(secondTab, {
+      x: 130,
+      y: 0,
+      left: 130,
+      top: 0,
+      right: 260,
+      bottom: 40,
+      width: 130,
+      height: 40,
+    });
 
-    fireEvent(closeButton, createDragEvent("dragstart", dataTransfer));
+    await act(async () => {
+      fireEvent.mouseDown(closeButton, { button: 0, buttons: 1, clientX: 200, clientY: 20 });
+      fireEvent.mouseMove(document, { buttons: 1, clientX: 240, clientY: 20 });
+    });
+    await finishMouseDrag({ clientX: 240, clientY: 20 });
 
     expect(secondTab.getAttribute("data-dragging")).toBe("false");
     expect(onReorderTab).toHaveBeenCalledTimes(0);

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -53,6 +53,16 @@ const createDragEvent = (
   return event;
 };
 
+const setElementRect = (element: HTMLElement, rect: Omit<DOMRect, "toJSON">): void => {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      ...rect,
+      toJSON: () => ({}),
+    }),
+  });
+};
+
 describe("AgentStudioTaskTabs", () => {
   test("renders browser-style tabs and status icons", () => {
     const html = renderToStaticMarkup(
@@ -238,33 +248,25 @@ describe("AgentStudioTaskTabs", () => {
     expect(firstTab).not.toBeNull();
     expect(secondTab).not.toBeNull();
 
-    Object.defineProperty(firstTab as HTMLElement, "getBoundingClientRect", {
-      configurable: true,
-      value: () => ({
-        x: 0,
-        y: 0,
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 40,
-        width: 100,
-        height: 40,
-        toJSON: () => ({}),
-      }),
+    setElementRect(firstTab as HTMLElement, {
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 40,
+      width: 100,
+      height: 40,
     });
-    Object.defineProperty(secondTab as HTMLElement, "getBoundingClientRect", {
-      configurable: true,
-      value: () => ({
-        x: 100,
-        y: 0,
-        left: 100,
-        top: 0,
-        right: 200,
-        bottom: 40,
-        width: 100,
-        height: 40,
-        toJSON: () => ({}),
-      }),
+    setElementRect(secondTab as HTMLElement, {
+      x: 100,
+      y: 0,
+      left: 100,
+      top: 0,
+      right: 200,
+      bottom: 40,
+      width: 100,
+      height: 40,
     });
 
     const dataTransfer = {
@@ -322,33 +324,25 @@ describe("AgentStudioTaskTabs", () => {
       expect(firstTab).not.toBeNull();
       expect(secondTab).not.toBeNull();
 
-      Object.defineProperty(scrollRegion as HTMLDivElement, "getBoundingClientRect", {
-        configurable: true,
-        value: () => ({
-          x: 0,
-          y: 0,
-          left: 0,
-          top: 0,
-          right: 200,
-          bottom: 40,
-          width: 200,
-          height: 40,
-          toJSON: () => ({}),
-        }),
+      setElementRect(scrollRegion as HTMLDivElement, {
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: 200,
+        bottom: 40,
+        width: 200,
+        height: 40,
       });
-      Object.defineProperty(secondTab as HTMLElement, "getBoundingClientRect", {
-        configurable: true,
-        value: () => ({
-          x: 90,
-          y: 0,
-          left: 90,
-          top: 0,
-          right: 180,
-          bottom: 40,
-          width: 90,
-          height: 40,
-          toJSON: () => ({}),
-        }),
+      setElementRect(secondTab as HTMLElement, {
+        x: 90,
+        y: 0,
+        left: 90,
+        top: 0,
+        right: 180,
+        bottom: 40,
+        width: 90,
+        height: 40,
       });
       (scrollRegion as HTMLDivElement).scrollLeft = 0;
 
@@ -373,5 +367,84 @@ describe("AgentStudioTaskTabs", () => {
       globalThis.requestAnimationFrame = originalRequestAnimationFrame;
       globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
     }
+  });
+
+  test("clears drag state when dragging ends without a drop", () => {
+    render(
+      createElement(
+        Tabs,
+        { value: "task-1" },
+        createElement(AgentStudioTaskTabs, { model: buildModel() }),
+      ),
+    );
+
+    const firstTab = screen
+      .getByRole("tab", { name: /Add social login/i })
+      .closest("[data-task-tab-id]") as HTMLElement;
+    const secondTab = screen
+      .getByRole("tab", { name: /Ship QA checklist/i })
+      .closest("[data-task-tab-id]") as HTMLElement;
+
+    setElementRect(secondTab, {
+      x: 100,
+      y: 0,
+      left: 100,
+      top: 0,
+      right: 200,
+      bottom: 40,
+      width: 100,
+      height: 40,
+    });
+
+    const dataTransfer = {
+      effectAllowed: "all",
+      dropEffect: "move",
+      setData: () => {},
+      getData: () => "task-1",
+    };
+
+    fireEvent(firstTab, createDragEvent("dragstart", dataTransfer));
+    fireEvent(secondTab, createDragEvent("dragover", dataTransfer, { clientX: 110 }));
+
+    expect(firstTab.getAttribute("data-dragging")).toBe("true");
+    expect(secondTab.getAttribute("data-drop-position")).toBe("before");
+
+    fireEvent(firstTab, createDragEvent("dragend", dataTransfer));
+
+    expect(firstTab.getAttribute("data-dragging")).toBe("false");
+    expect(secondTab.hasAttribute("data-drop-position")).toBeFalse();
+  });
+
+  test("does not start a reorder drag from the close button", () => {
+    const onReorderTab = mock(() => {});
+    render(
+      createElement(
+        Tabs,
+        { value: "task-1" },
+        createElement(AgentStudioTaskTabs, {
+          model: {
+            ...buildModel(),
+            onReorderTab,
+          },
+        }),
+      ),
+    );
+
+    const closeButton = screen.getByRole("button", { name: "Close tab for Ship QA checklist" });
+    const secondTab = screen
+      .getByRole("tab", { name: /Ship QA checklist/i })
+      .closest("[data-task-tab-id]") as HTMLElement;
+
+    const dataTransfer = {
+      effectAllowed: "all",
+      dropEffect: "move",
+      setData: () => {},
+      getData: () => "task-2",
+    };
+
+    fireEvent(closeButton, createDragEvent("dragstart", dataTransfer));
+
+    expect(secondTab.getAttribute("data-dragging")).toBe("false");
+    expect(onReorderTab).toHaveBeenCalledTimes(0);
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -29,6 +29,30 @@ const buildModel = () => ({
   agentStudioReady: true,
 });
 
+const createDragEvent = (
+  type: string,
+  dataTransfer: {
+    effectAllowed: string;
+    dropEffect: string;
+    setData: () => void;
+    getData: () => string;
+  },
+  extras: Record<string, number> = {},
+): Event => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", {
+    configurable: true,
+    value: dataTransfer,
+  });
+  for (const [key, value] of Object.entries(extras)) {
+    Object.defineProperty(event, key, {
+      configurable: true,
+      value,
+    });
+  }
+  return event;
+};
+
 describe("AgentStudioTaskTabs", () => {
   test("renders browser-style tabs and status icons", () => {
     const html = renderToStaticMarkup(
@@ -204,15 +228,17 @@ describe("AgentStudioTaskTabs", () => {
       ),
     );
 
-    const firstTabTrigger = screen.getByRole("tab", { name: /Add social login/i });
-    const secondTabTrigger = screen.getByRole("tab", { name: /Ship QA checklist/i });
-    const firstTab = firstTabTrigger.closest("[data-task-tab-id]");
-    const secondTab = secondTabTrigger.closest("[data-task-tab-id]");
+    const firstTab = screen
+      .getByRole("tab", { name: /Add social login/i })
+      .closest("[data-task-tab-id]");
+    const secondTab = screen
+      .getByRole("tab", { name: /Ship QA checklist/i })
+      .closest("[data-task-tab-id]");
 
     expect(firstTab).not.toBeNull();
     expect(secondTab).not.toBeNull();
 
-    Object.defineProperty(firstTabTrigger, "getBoundingClientRect", {
+    Object.defineProperty(firstTab as HTMLElement, "getBoundingClientRect", {
       configurable: true,
       value: () => ({
         x: 0,
@@ -226,7 +252,7 @@ describe("AgentStudioTaskTabs", () => {
         toJSON: () => ({}),
       }),
     });
-    Object.defineProperty(secondTabTrigger, "getBoundingClientRect", {
+    Object.defineProperty(secondTab as HTMLElement, "getBoundingClientRect", {
       configurable: true,
       value: () => ({
         x: 100,
@@ -248,32 +274,104 @@ describe("AgentStudioTaskTabs", () => {
       getData: () => "task-2",
     };
 
-    const dragStartEvent = new Event("dragstart", { bubbles: true, cancelable: true });
-    Object.defineProperty(dragStartEvent, "dataTransfer", {
-      configurable: true,
-      value: dataTransfer,
-    });
-
-    const dragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
-    Object.defineProperty(dragOverEvent, "dataTransfer", {
-      configurable: true,
-      value: dataTransfer,
-    });
-    Object.defineProperty(dragOverEvent, "clientX", {
-      configurable: true,
-      value: 10,
-    });
-
-    const dropEvent = new Event("drop", { bubbles: true, cancelable: true });
-    Object.defineProperty(dropEvent, "dataTransfer", {
-      configurable: true,
-      value: dataTransfer,
-    });
-
-    fireEvent(secondTabTrigger, dragStartEvent);
-    fireEvent(firstTabTrigger, dragOverEvent);
-    fireEvent(firstTabTrigger, dropEvent);
+    fireEvent(secondTab as HTMLElement, createDragEvent("dragstart", dataTransfer));
+    fireEvent(firstTab as HTMLElement, createDragEvent("dragover", dataTransfer, { clientX: 10 }));
+    fireEvent(firstTab as HTMLElement, createDragEvent("drop", dataTransfer));
 
     expect(onReorderTab).toHaveBeenCalledWith("task-2", "task-1", "before");
+  });
+
+  test("auto-scrolls the overflowed strip when dragging near the edge", () => {
+    const requestAnimationFrameCallbacks: FrameRequestCallback[] = [];
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      requestAnimationFrameCallbacks.push(callback);
+      return requestAnimationFrameCallbacks.length;
+    }) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => 0) as typeof globalThis.cancelAnimationFrame;
+
+    try {
+      render(
+        createElement(
+          Tabs,
+          { value: "task-1" },
+          createElement(AgentStudioTaskTabs, {
+            model: {
+              ...buildModel(),
+              tabs: [
+                { taskId: "task-1", taskTitle: "Tab 1", status: "working", isActive: true },
+                { taskId: "task-2", taskTitle: "Tab 2", status: "idle", isActive: false },
+                { taskId: "task-3", taskTitle: "Tab 3", status: "idle", isActive: false },
+                { taskId: "task-4", taskTitle: "Tab 4", status: "idle", isActive: false },
+                { taskId: "task-5", taskTitle: "Tab 5", status: "idle", isActive: false },
+                { taskId: "task-6", taskTitle: "Tab 6", status: "idle", isActive: false },
+              ],
+            },
+          }),
+        ),
+      );
+
+      const tabList = screen.getByRole("tablist", { name: "Agent Studio task tabs" });
+      const scrollRegion = tabList.parentElement?.parentElement as HTMLDivElement | null;
+      const firstTab = screen.getByRole("tab", { name: /Tab 1/i }).closest("[data-task-tab-id]");
+      const secondTab = screen.getByRole("tab", { name: /Tab 2/i }).closest("[data-task-tab-id]");
+
+      expect(scrollRegion).not.toBeNull();
+      expect(firstTab).not.toBeNull();
+      expect(secondTab).not.toBeNull();
+
+      Object.defineProperty(scrollRegion as HTMLDivElement, "getBoundingClientRect", {
+        configurable: true,
+        value: () => ({
+          x: 0,
+          y: 0,
+          left: 0,
+          top: 0,
+          right: 200,
+          bottom: 40,
+          width: 200,
+          height: 40,
+          toJSON: () => ({}),
+        }),
+      });
+      Object.defineProperty(secondTab as HTMLElement, "getBoundingClientRect", {
+        configurable: true,
+        value: () => ({
+          x: 90,
+          y: 0,
+          left: 90,
+          top: 0,
+          right: 180,
+          bottom: 40,
+          width: 90,
+          height: 40,
+          toJSON: () => ({}),
+        }),
+      });
+      (scrollRegion as HTMLDivElement).scrollLeft = 0;
+
+      const dataTransfer = {
+        effectAllowed: "all",
+        dropEffect: "move",
+        setData: () => {},
+        getData: () => "task-1",
+      };
+
+      fireEvent(firstTab as HTMLElement, createDragEvent("dragstart", dataTransfer));
+      fireEvent(
+        secondTab as HTMLElement,
+        createDragEvent("dragover", dataTransfer, { clientX: 196 }),
+      );
+
+      expect(requestAnimationFrameCallbacks.length).toBeGreaterThan(0);
+      requestAnimationFrameCallbacks.shift()?.(0);
+
+      expect((scrollRegion as HTMLDivElement).scrollLeft).toBeGreaterThan(0);
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -278,9 +278,66 @@ describe("AgentStudioTaskTabs", () => {
 
     fireEvent(secondTab as HTMLElement, createDragEvent("dragstart", dataTransfer));
     fireEvent(firstTab as HTMLElement, createDragEvent("dragover", dataTransfer, { clientX: 10 }));
-    fireEvent(firstTab as HTMLElement, createDragEvent("drop", dataTransfer));
+    fireEvent(firstTab as HTMLElement, createDragEvent("drop", dataTransfer, { clientX: 10 }));
 
     expect(onReorderTab).toHaveBeenCalledWith("task-2", "task-1", "before");
+  });
+
+  test("uses the actual drop target when release happens before a matching dragover state update", () => {
+    const onReorderTab = mock(() => {});
+    render(
+      createElement(
+        Tabs,
+        { value: "task-1" },
+        createElement(AgentStudioTaskTabs, {
+          model: {
+            ...buildModel(),
+            onReorderTab,
+          },
+        }),
+      ),
+    );
+
+    const firstTab = screen
+      .getByRole("tab", { name: /Add social login/i })
+      .closest("[data-task-tab-id]") as HTMLElement;
+    const secondTab = screen
+      .getByRole("tab", { name: /Ship QA checklist/i })
+      .closest("[data-task-tab-id]") as HTMLElement;
+
+    setElementRect(firstTab, {
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 40,
+      width: 100,
+      height: 40,
+    });
+    setElementRect(secondTab, {
+      x: 100,
+      y: 0,
+      left: 100,
+      top: 0,
+      right: 200,
+      bottom: 40,
+      width: 100,
+      height: 40,
+    });
+
+    const dataTransfer = {
+      effectAllowed: "all",
+      dropEffect: "move",
+      setData: () => {},
+      getData: () => "task-1",
+    };
+
+    fireEvent(firstTab, createDragEvent("dragstart", dataTransfer));
+    fireEvent(firstTab, createDragEvent("dragover", dataTransfer, { clientX: 10 }));
+    fireEvent(secondTab, createDragEvent("drop", dataTransfer, { clientX: 190 }));
+
+    expect(onReorderTab).toHaveBeenCalledWith("task-1", "task-2", "after");
   });
 
   test("auto-scrolls the overflowed strip when dragging near the edge", () => {

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -6,6 +6,7 @@ import { Circle, CircleAlert, LoaderCircle, Plus, X } from "lucide-react";
 import {
   type CSSProperties,
   type ReactElement,
+  type MouseEvent as ReactMouseEvent,
   type RefCallback,
   useEffect,
   useMemo,
@@ -44,6 +45,7 @@ export type AgentStudioTaskTabsModel = {
   tabs: AgentStudioTaskTab[];
   availableTabTasks: TaskCard[];
   isLoadingAvailableTabTasks: boolean;
+  onSelectTab: (taskId: string) => void;
   onCreateTab: (taskId: string) => void;
   onCloseTab: (taskId: string) => void;
   onReorderTab: (draggedTaskId: string, targetTaskId: string, position: "before" | "after") => void;
@@ -57,15 +59,21 @@ type AgentStudioTaskTabShellProps = {
   style?: CSSProperties;
   isDragSource?: boolean;
   isDragOverlay?: boolean;
+  shouldSuppressSelection?: boolean;
+  onSelectTab?: (taskId: string) => void;
   onCloseTab?: (taskId: string) => void;
 };
 
 function AgentStudioTaskTabLabel({
   tab,
   isPreview = false,
+  onMouseDown,
+  onClick,
 }: {
   tab: AgentStudioTaskTab;
   isPreview?: boolean;
+  onMouseDown?: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  onClick?: (event: ReactMouseEvent<HTMLButtonElement>) => void;
 }): ReactElement {
   const className = cn(
     "h-9 max-w-[19rem] cursor-pointer items-center justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
@@ -93,7 +101,13 @@ function AgentStudioTaskTabLabel({
   }
 
   return (
-    <TabsTrigger id={`agent-studio-tab-${tab.taskId}`} value={tab.taskId} className={className}>
+    <TabsTrigger
+      id={`agent-studio-tab-${tab.taskId}`}
+      value={tab.taskId}
+      className={className}
+      onMouseDown={onMouseDown}
+      onClick={onClick}
+    >
       {content}
     </TabsTrigger>
   );
@@ -126,6 +140,8 @@ function AgentStudioTaskTabShell({
   style,
   isDragSource = false,
   isDragOverlay = false,
+  shouldSuppressSelection = false,
+  onSelectTab,
   onCloseTab,
 }: AgentStudioTaskTabShellProps): ReactElement {
   return (
@@ -136,17 +152,35 @@ function AgentStudioTaskTabShell({
       data-task-tab-id={tab.taskId}
       style={style}
       className={cn(
-        "group relative z-1 inline-flex h-10 shrink-0 select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
+        "group relative z-1 inline-flex h-10 shrink-0 touch-none select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
         "cursor-pointer",
         tab.isActive
           ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
           : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
         isDragSource && "opacity-0",
-        isDragOverlay && "z-50 border-input bg-card after:hidden",
+        isDragOverlay && "z-50 after:hidden",
       )}
       {...dragListeners}
     >
-      <AgentStudioTaskTabLabel tab={tab} isPreview={isDragOverlay} />
+      <AgentStudioTaskTabLabel
+        tab={tab}
+        isPreview={isDragOverlay}
+        {...(!isDragOverlay
+          ? {
+              onMouseDown: (event: ReactMouseEvent<HTMLButtonElement>) => {
+                event.preventDefault();
+              },
+              onClick: (event: ReactMouseEvent<HTMLButtonElement>) => {
+                if (shouldSuppressSelection) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  return;
+                }
+                onSelectTab?.(tab.taskId);
+              },
+            }
+          : {})}
+      />
       <button
         type="button"
         className={cn(
@@ -179,10 +213,14 @@ function AgentStudioTaskTabShell({
 function SortableAgentStudioTaskTab({
   tab,
   isActiveDrag,
+  shouldSuppressSelection,
+  onSelectTab,
   onCloseTab,
 }: {
   tab: AgentStudioTaskTab;
   isActiveDrag: boolean;
+  shouldSuppressSelection: boolean;
+  onSelectTab: (taskId: string) => void;
   onCloseTab: (taskId: string) => void;
 }): ReactElement {
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -199,6 +237,8 @@ function SortableAgentStudioTaskTab({
       shellRef={setNodeRef}
       dragListeners={listeners}
       isDragSource={isDragging || isActiveDrag}
+      shouldSuppressSelection={shouldSuppressSelection}
+      onSelectTab={onSelectTab}
       onCloseTab={onCloseTab}
       style={{
         transform: CSS.Transform.toString(transform),
@@ -219,6 +259,7 @@ export function AgentStudioTaskTabs({
     tabs,
     availableTabTasks,
     isLoadingAvailableTabTasks,
+    onSelectTab,
     onCreateTab,
     onCloseTab,
     onReorderTab,
@@ -227,6 +268,8 @@ export function AgentStudioTaskTabs({
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [pendingTaskId, setPendingTaskId] = useState("");
   const [isCreateDialogReady, setIsCreateDialogReady] = useState(false);
+  const suppressedSelectionTaskIdRef = useRef<string | null>(null);
+  const selectionSuppressionFrameRef = useRef<number | null>(null);
   const scrollRegionRef = useRef<HTMLDivElement | null>(null);
   const tabTaskIds = useMemo(() => tabs.map((tab) => tab.taskId), [tabs]);
   const {
@@ -273,6 +316,24 @@ export function AgentStudioTaskTabs({
     ? (tabs.find((tab) => tab.taskId === activeTaskId) ?? null)
     : null;
 
+  const scheduleSelectionSuppressionClear = (): void => {
+    if (selectionSuppressionFrameRef.current !== null) {
+      globalThis.cancelAnimationFrame(selectionSuppressionFrameRef.current);
+    }
+    selectionSuppressionFrameRef.current = globalThis.requestAnimationFrame(() => {
+      suppressedSelectionTaskIdRef.current = null;
+      selectionSuppressionFrameRef.current = null;
+    });
+  };
+
+  useEffect(() => {
+    return () => {
+      if (selectionSuppressionFrameRef.current !== null) {
+        globalThis.cancelAnimationFrame(selectionSuppressionFrameRef.current);
+      }
+    };
+  }, []);
+
   return (
     <div className="bg-studio-chrome px-2 pt-1.5 pb-0">
       <div className="flex min-w-0 items-center gap-1">
@@ -285,9 +346,18 @@ export function AgentStudioTaskTabs({
                   collisionDetection={collisionDetection}
                   measuring={measuring}
                   modifiers={modifiers}
-                  onDragStart={handleDragStart}
-                  onDragEnd={handleDragEnd}
-                  onDragCancel={handleDragCancel}
+                  onDragStart={(event) => {
+                    suppressedSelectionTaskIdRef.current = String(event.active.id);
+                    handleDragStart(event);
+                  }}
+                  onDragEnd={(event) => {
+                    handleDragEnd(event);
+                    scheduleSelectionSuppressionClear();
+                  }}
+                  onDragCancel={() => {
+                    handleDragCancel();
+                    scheduleSelectionSuppressionClear();
+                  }}
                 >
                   <SortableContext items={tabTaskIds} strategy={horizontalListSortingStrategy}>
                     <TabsList
@@ -299,6 +369,10 @@ export function AgentStudioTaskTabs({
                           key={tab.taskId}
                           tab={tab}
                           isActiveDrag={activeTaskId === tab.taskId}
+                          shouldSuppressSelection={
+                            suppressedSelectionTaskIdRef.current === tab.taskId
+                          }
+                          onSelectTab={onSelectTab}
                           onCloseTab={onCloseTab}
                         />
                       ))}

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -263,8 +263,10 @@ export function AgentStudioTaskTabs({
                   }}
                 >
                   {tabs.map((tab) => (
+                    // biome-ignore lint/a11y/noStaticElementInteractions: the full visible tab shell must be the draggable surface to match browser-like tab reordering.
                     <div
                       key={tab.taskId}
+                      draggable
                       data-active={tab.isActive ? "true" : "false"}
                       data-dragging={draggedTaskId === tab.taskId ? "true" : "false"}
                       data-drop-position={
@@ -278,6 +280,10 @@ export function AgentStudioTaskTabs({
                           ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
                           : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
                       )}
+                      onDragStart={handleTabDragStart(tab.taskId)}
+                      onDragOver={handleTabDragOver(tab.taskId)}
+                      onDragEnd={clearDragState}
+                      onDrop={handleTabDrop}
                     >
                       {dropTarget?.taskId === tab.taskId && dropTarget.position === "before" ? (
                         <span
@@ -294,16 +300,11 @@ export function AgentStudioTaskTabs({
                       <TabsTrigger
                         id={`agent-studio-tab-${tab.taskId}`}
                         value={tab.taskId}
-                        draggable
                         className={cn(
                           "h-9 max-w-[19rem] cursor-pointer justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
                           "text-inherit data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none",
                           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
                         )}
-                        onDragStart={handleTabDragStart(tab.taskId)}
-                        onDragOver={handleTabDragOver(tab.taskId)}
-                        onDragEnd={clearDragState}
-                        onDrop={handleTabDrop}
                       >
                         <span
                           role="img"

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -1,12 +1,6 @@
 import type { TaskCard } from "@openducktor/contracts";
 import { Circle, CircleAlert, LoaderCircle, Plus, X } from "lucide-react";
-import {
-  type DragEvent as ReactDragEvent,
-  type ReactElement,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type ComponentProps, type ReactElement, useEffect, useState } from "react";
 import { TaskSelector } from "@/components/features/tasks";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,6 +18,7 @@ import {
   AgentStudioRightPanelToggleButton,
   type AgentStudioRightPanelToggleModel,
 } from "./agent-studio-right-panel";
+import { useAgentStudioTaskTabReorderDrag } from "./use-agent-studio-task-tab-reorder-drag";
 
 export type AgentStudioTaskTabStatus = "working" | "idle" | "waiting_input";
 
@@ -43,9 +38,6 @@ export type AgentStudioTaskTabsModel = {
   onReorderTab: (draggedTaskId: string, targetTaskId: string, position: "before" | "after") => void;
   agentStudioReady: boolean;
 };
-
-const AUTO_SCROLL_EDGE_THRESHOLD = 48;
-const AUTO_SCROLL_MAX_STEP = 18;
 
 const statusLabelByTab = (status: AgentStudioTaskTabStatus): string => {
   if (status === "working") {
@@ -67,6 +59,10 @@ const statusIconByTab = (status: AgentStudioTaskTabStatus): ReactElement => {
   return <Circle className="size-3.5 fill-input text-input" />;
 };
 
+function AgentStudioTaskTabDragShell(props: ComponentProps<"div">): ReactElement {
+  return <div {...props} />;
+}
+
 export function AgentStudioTaskTabs({
   model,
   rightPanelToggleModel,
@@ -86,14 +82,14 @@ export function AgentStudioTaskTabs({
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [pendingTaskId, setPendingTaskId] = useState("");
   const [isCreateDialogReady, setIsCreateDialogReady] = useState(false);
-  const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
-  const [dropTarget, setDropTarget] = useState<{
-    taskId: string;
-    position: "before" | "after";
-  } | null>(null);
-  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
-  const autoScrollFrameRef = useRef<number | null>(null);
-  const autoScrollStepRef = useRef(0);
+  const {
+    scrollRegionRef,
+    draggedTaskId,
+    dropTarget,
+    handleStripDragOver,
+    handleStripDrop,
+    getTabDragHandlers,
+  } = useAgentStudioTaskTabReorderDrag({ onReorderTab });
 
   useEffect(() => {
     if (!isCreateDialogOpen) {
@@ -122,124 +118,6 @@ export function AgentStudioTaskTabs({
   const hasCreatableTasks = availableTabTasks.length > 0;
   const hasAnyTab = tabs.length > 0;
 
-  const stopAutoScroll = (): void => {
-    if (autoScrollFrameRef.current !== null) {
-      globalThis.cancelAnimationFrame(autoScrollFrameRef.current);
-      autoScrollFrameRef.current = null;
-    }
-    autoScrollStepRef.current = 0;
-  };
-
-  const updateAutoScroll = (clientX: number): void => {
-    const scrollRegion = scrollRegionRef.current;
-    if (!scrollRegion) {
-      stopAutoScroll();
-      return;
-    }
-
-    const bounds = scrollRegion.getBoundingClientRect();
-    let nextStep = 0;
-
-    if (clientX < bounds.left + AUTO_SCROLL_EDGE_THRESHOLD) {
-      const distanceToEdge = bounds.left + AUTO_SCROLL_EDGE_THRESHOLD - clientX;
-      nextStep = -Math.min(
-        AUTO_SCROLL_MAX_STEP,
-        Math.max(4, (distanceToEdge / AUTO_SCROLL_EDGE_THRESHOLD) * AUTO_SCROLL_MAX_STEP),
-      );
-    } else if (clientX > bounds.right - AUTO_SCROLL_EDGE_THRESHOLD) {
-      const distanceToEdge = clientX - (bounds.right - AUTO_SCROLL_EDGE_THRESHOLD);
-      nextStep = Math.min(
-        AUTO_SCROLL_MAX_STEP,
-        Math.max(4, (distanceToEdge / AUTO_SCROLL_EDGE_THRESHOLD) * AUTO_SCROLL_MAX_STEP),
-      );
-    }
-
-    autoScrollStepRef.current = nextStep;
-
-    if (nextStep === 0) {
-      stopAutoScroll();
-      return;
-    }
-
-    if (autoScrollFrameRef.current !== null) {
-      return;
-    }
-
-    const step = (): void => {
-      const nextScrollRegion = scrollRegionRef.current;
-      if (!nextScrollRegion || autoScrollStepRef.current === 0) {
-        autoScrollFrameRef.current = null;
-        return;
-      }
-
-      nextScrollRegion.scrollLeft += autoScrollStepRef.current;
-      autoScrollFrameRef.current = globalThis.requestAnimationFrame(step);
-    };
-
-    autoScrollFrameRef.current = globalThis.requestAnimationFrame(step);
-  };
-
-  const clearDragState = (): void => {
-    setDraggedTaskId(null);
-    setDropTarget(null);
-    stopAutoScroll();
-  };
-
-  useEffect(() => {
-    return () => {
-      if (autoScrollFrameRef.current !== null) {
-        globalThis.cancelAnimationFrame(autoScrollFrameRef.current);
-      }
-    };
-  }, []);
-
-  const handleTabDragStart =
-    (taskId: string) =>
-    (event: ReactDragEvent<HTMLElement>): void => {
-      event.dataTransfer.effectAllowed = "move";
-      event.dataTransfer.setData("text/plain", taskId);
-      setDraggedTaskId(taskId);
-      setDropTarget(null);
-    };
-
-  const handleTabDragOver =
-    (taskId: string) =>
-    (event: ReactDragEvent<HTMLElement>): void => {
-      if (!draggedTaskId) {
-        return;
-      }
-
-      event.preventDefault();
-      event.dataTransfer.dropEffect = "move";
-      updateAutoScroll(event.clientX);
-
-      if (draggedTaskId === taskId) {
-        setDropTarget(null);
-        return;
-      }
-
-      const bounds = event.currentTarget.getBoundingClientRect();
-      const position = event.clientX <= bounds.left + bounds.width / 2 ? "before" : "after";
-      setDropTarget((current) => {
-        if (current?.taskId === taskId && current.position === position) {
-          return current;
-        }
-        return { taskId, position };
-      });
-    };
-
-  const handleTabDrop = (event: ReactDragEvent<HTMLElement>): void => {
-    if (!draggedTaskId || !dropTarget) {
-      clearDragState();
-      return;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-    onReorderTab(draggedTaskId, dropTarget.taskId, dropTarget.position);
-    clearDragState();
-  };
-
   return (
     <div className="bg-studio-chrome px-2 pt-1.5 pb-0">
       <div className="flex min-w-0 items-center gap-1">
@@ -250,93 +128,86 @@ export function AgentStudioTaskTabs({
                 <TabsList
                   aria-label="Agent Studio task tabs"
                   className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
-                  onDragOver={(event) => {
-                    if (!draggedTaskId) {
-                      return;
-                    }
-                    event.preventDefault();
-                    event.dataTransfer.dropEffect = "move";
-                    updateAutoScroll(event.clientX);
-                  }}
-                  onDrop={() => {
-                    clearDragState();
-                  }}
+                  onDragOver={handleStripDragOver}
+                  onDrop={handleStripDrop}
                 >
-                  {tabs.map((tab) => (
-                    // biome-ignore lint/a11y/noStaticElementInteractions: the full visible tab shell must be the draggable surface to match browser-like tab reordering.
-                    <div
-                      key={tab.taskId}
-                      draggable
-                      data-active={tab.isActive ? "true" : "false"}
-                      data-dragging={draggedTaskId === tab.taskId ? "true" : "false"}
-                      data-drop-position={
-                        dropTarget?.taskId === tab.taskId ? dropTarget.position : undefined
-                      }
-                      data-task-tab-id={tab.taskId}
-                      className={cn(
-                        "group relative z-1 inline-flex h-10 shrink-0 items-center gap-1 rounded-t-[10px] pl-2 pr-1",
-                        draggedTaskId === tab.taskId && "cursor-grabbing opacity-60",
-                        tab.isActive
-                          ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
-                          : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
-                      )}
-                      onDragStart={handleTabDragStart(tab.taskId)}
-                      onDragOver={handleTabDragOver(tab.taskId)}
-                      onDragEnd={clearDragState}
-                      onDrop={handleTabDrop}
-                    >
-                      {dropTarget?.taskId === tab.taskId && dropTarget.position === "before" ? (
-                        <span
-                          aria-hidden
-                          className="pointer-events-none absolute inset-y-1 left-0 z-20 w-0.5 -translate-x-1/2 rounded-full bg-primary"
-                        />
-                      ) : null}
-                      {dropTarget?.taskId === tab.taskId && dropTarget.position === "after" ? (
-                        <span
-                          aria-hidden
-                          className="pointer-events-none absolute inset-y-1 right-0 z-20 w-0.5 translate-x-1/2 rounded-full bg-primary"
-                        />
-                      ) : null}
-                      <TabsTrigger
-                        id={`agent-studio-tab-${tab.taskId}`}
-                        value={tab.taskId}
-                        className={cn(
-                          "h-9 max-w-[19rem] cursor-pointer justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
-                          "text-inherit data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none",
-                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                        )}
-                      >
-                        <span
-                          role="img"
-                          aria-label={statusLabelByTab(tab.status)}
-                          title={statusLabelByTab(tab.status)}
-                          className="inline-flex size-5 shrink-0 items-center justify-center"
-                        >
-                          {statusIconByTab(tab.status)}
-                        </span>
-                        <span className="max-w-52 truncate">{tab.taskTitle}</span>
-                      </TabsTrigger>
-                      <button
-                        type="button"
-                        draggable={false}
-                        className={cn(
-                          "mr-1 cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-secondary hover:text-foreground",
-                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                          "opacity-60 group-hover:opacity-100 data-[active=true]:opacity-100",
-                        )}
+                  {tabs.map((tab) => {
+                    const tabDragHandlers = getTabDragHandlers(tab.taskId);
+
+                    return (
+                      <AgentStudioTaskTabDragShell
+                        key={tab.taskId}
                         data-active={tab.isActive ? "true" : "false"}
-                        tabIndex={tab.isActive ? 0 : -1}
-                        aria-label={`Close tab for ${tab.taskTitle}`}
-                        onClick={(event) => {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          onCloseTab(tab.taskId);
-                        }}
+                        data-dragging={draggedTaskId === tab.taskId ? "true" : "false"}
+                        data-drop-position={
+                          dropTarget?.taskId === tab.taskId ? dropTarget.position : undefined
+                        }
+                        data-task-tab-id={tab.taskId}
+                        className={cn(
+                          "group relative z-1 inline-flex h-10 shrink-0 items-center gap-1 rounded-t-[10px] pl-2 pr-1",
+                          draggedTaskId === tab.taskId && "cursor-grabbing opacity-60",
+                          tab.isActive
+                            ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
+                            : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
+                        )}
+                        {...tabDragHandlers}
                       >
-                        <X className="size-3.5" />
-                      </button>
-                    </div>
-                  ))}
+                        {dropTarget?.taskId === tab.taskId && dropTarget.position === "before" ? (
+                          <span
+                            aria-hidden
+                            className="pointer-events-none absolute inset-y-1 left-0 z-20 w-0.5 -translate-x-1/2 rounded-full bg-primary"
+                          />
+                        ) : null}
+                        {dropTarget?.taskId === tab.taskId && dropTarget.position === "after" ? (
+                          <span
+                            aria-hidden
+                            className="pointer-events-none absolute inset-y-1 right-0 z-20 w-0.5 translate-x-1/2 rounded-full bg-primary"
+                          />
+                        ) : null}
+                        <TabsTrigger
+                          id={`agent-studio-tab-${tab.taskId}`}
+                          value={tab.taskId}
+                          className={cn(
+                            "h-9 max-w-[19rem] cursor-pointer justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
+                            "text-inherit data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                          )}
+                        >
+                          <span
+                            role="img"
+                            aria-label={statusLabelByTab(tab.status)}
+                            title={statusLabelByTab(tab.status)}
+                            className="inline-flex size-5 shrink-0 items-center justify-center"
+                          >
+                            {statusIconByTab(tab.status)}
+                          </span>
+                          <span className="max-w-52 truncate">{tab.taskTitle}</span>
+                        </TabsTrigger>
+                        <button
+                          type="button"
+                          draggable={false}
+                          className={cn(
+                            "mr-1 cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-secondary hover:text-foreground",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                            "opacity-60 group-hover:opacity-100 data-[active=true]:opacity-100",
+                          )}
+                          data-active={tab.isActive ? "true" : "false"}
+                          tabIndex={tab.isActive ? 0 : -1}
+                          aria-label={`Close tab for ${tab.taskTitle}`}
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            onCloseTab(tab.taskId);
+                          }}
+                          onDragStart={(event) => {
+                            event.stopPropagation();
+                          }}
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      </AgentStudioTaskTabDragShell>
+                    );
+                  })}
                 </TabsList>
               ) : (
                 <p className="text-sm text-muted-foreground">

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -68,7 +68,7 @@ function AgentStudioTaskTabLabel({
   isPreview?: boolean;
 }): ReactElement {
   const className = cn(
-    "h-9 max-w-[19rem] cursor-inherit justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
+    "h-9 max-w-[19rem] cursor-pointer items-center justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
     "text-inherit",
     !isPreview &&
       "data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
@@ -137,13 +137,12 @@ function AgentStudioTaskTabShell({
       style={style}
       className={cn(
         "group relative z-1 inline-flex h-10 shrink-0 select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
-        "cursor-grab active:cursor-grabbing",
+        "cursor-pointer",
         tab.isActive
           ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
           : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
         isDragSource && "opacity-0",
-        isDragOverlay &&
-          "z-50 scale-[1.03] border-input bg-card shadow-xl ring-1 ring-border/60 after:hidden",
+        isDragOverlay && "z-50 border-input bg-card after:hidden",
       )}
       {...dragListeners}
     >

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -1,6 +1,12 @@
 import type { TaskCard } from "@openducktor/contracts";
 import { Circle, CircleAlert, LoaderCircle, Plus, X } from "lucide-react";
-import { type ReactElement, useEffect, useState } from "react";
+import {
+  type DragEvent as ReactDragEvent,
+  type ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { TaskSelector } from "@/components/features/tasks";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,8 +40,12 @@ export type AgentStudioTaskTabsModel = {
   isLoadingAvailableTabTasks: boolean;
   onCreateTab: (taskId: string) => void;
   onCloseTab: (taskId: string) => void;
+  onReorderTab: (draggedTaskId: string, targetTaskId: string, position: "before" | "after") => void;
   agentStudioReady: boolean;
 };
+
+const AUTO_SCROLL_EDGE_THRESHOLD = 48;
+const AUTO_SCROLL_MAX_STEP = 18;
 
 const statusLabelByTab = (status: AgentStudioTaskTabStatus): string => {
   if (status === "working") {
@@ -70,11 +80,20 @@ export function AgentStudioTaskTabs({
     isLoadingAvailableTabTasks,
     onCreateTab,
     onCloseTab,
+    onReorderTab,
     agentStudioReady,
   } = model;
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [pendingTaskId, setPendingTaskId] = useState("");
   const [isCreateDialogReady, setIsCreateDialogReady] = useState(false);
+  const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{
+    taskId: string;
+    position: "before" | "after";
+  } | null>(null);
+  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
+  const autoScrollFrameRef = useRef<number | null>(null);
+  const autoScrollStepRef = useRef(0);
 
   useEffect(() => {
     if (!isCreateDialogOpen) {
@@ -103,36 +122,188 @@ export function AgentStudioTaskTabs({
   const hasCreatableTasks = availableTabTasks.length > 0;
   const hasAnyTab = tabs.length > 0;
 
+  const stopAutoScroll = (): void => {
+    if (autoScrollFrameRef.current !== null) {
+      globalThis.cancelAnimationFrame(autoScrollFrameRef.current);
+      autoScrollFrameRef.current = null;
+    }
+    autoScrollStepRef.current = 0;
+  };
+
+  const updateAutoScroll = (clientX: number): void => {
+    const scrollRegion = scrollRegionRef.current;
+    if (!scrollRegion) {
+      stopAutoScroll();
+      return;
+    }
+
+    const bounds = scrollRegion.getBoundingClientRect();
+    let nextStep = 0;
+
+    if (clientX < bounds.left + AUTO_SCROLL_EDGE_THRESHOLD) {
+      const distanceToEdge = bounds.left + AUTO_SCROLL_EDGE_THRESHOLD - clientX;
+      nextStep = -Math.min(
+        AUTO_SCROLL_MAX_STEP,
+        Math.max(4, (distanceToEdge / AUTO_SCROLL_EDGE_THRESHOLD) * AUTO_SCROLL_MAX_STEP),
+      );
+    } else if (clientX > bounds.right - AUTO_SCROLL_EDGE_THRESHOLD) {
+      const distanceToEdge = clientX - (bounds.right - AUTO_SCROLL_EDGE_THRESHOLD);
+      nextStep = Math.min(
+        AUTO_SCROLL_MAX_STEP,
+        Math.max(4, (distanceToEdge / AUTO_SCROLL_EDGE_THRESHOLD) * AUTO_SCROLL_MAX_STEP),
+      );
+    }
+
+    autoScrollStepRef.current = nextStep;
+
+    if (nextStep === 0) {
+      stopAutoScroll();
+      return;
+    }
+
+    if (autoScrollFrameRef.current !== null) {
+      return;
+    }
+
+    const step = (): void => {
+      const nextScrollRegion = scrollRegionRef.current;
+      if (!nextScrollRegion || autoScrollStepRef.current === 0) {
+        autoScrollFrameRef.current = null;
+        return;
+      }
+
+      nextScrollRegion.scrollLeft += autoScrollStepRef.current;
+      autoScrollFrameRef.current = globalThis.requestAnimationFrame(step);
+    };
+
+    autoScrollFrameRef.current = globalThis.requestAnimationFrame(step);
+  };
+
+  const clearDragState = (): void => {
+    setDraggedTaskId(null);
+    setDropTarget(null);
+    stopAutoScroll();
+  };
+
+  useEffect(() => {
+    return () => {
+      if (autoScrollFrameRef.current !== null) {
+        globalThis.cancelAnimationFrame(autoScrollFrameRef.current);
+      }
+    };
+  }, []);
+
+  const handleTabDragStart =
+    (taskId: string) =>
+    (event: ReactDragEvent<HTMLElement>): void => {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", taskId);
+      setDraggedTaskId(taskId);
+      setDropTarget(null);
+    };
+
+  const handleTabDragOver =
+    (taskId: string) =>
+    (event: ReactDragEvent<HTMLElement>): void => {
+      if (!draggedTaskId) {
+        return;
+      }
+
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+      updateAutoScroll(event.clientX);
+
+      if (draggedTaskId === taskId) {
+        setDropTarget(null);
+        return;
+      }
+
+      const bounds = event.currentTarget.getBoundingClientRect();
+      const position = event.clientX <= bounds.left + bounds.width / 2 ? "before" : "after";
+      setDropTarget((current) => {
+        if (current?.taskId === taskId && current.position === position) {
+          return current;
+        }
+        return { taskId, position };
+      });
+    };
+
+  const handleTabDrop = (event: ReactDragEvent<HTMLElement>): void => {
+    if (!draggedTaskId || !dropTarget) {
+      clearDragState();
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    onReorderTab(draggedTaskId, dropTarget.taskId, dropTarget.position);
+    clearDragState();
+  };
+
   return (
     <div className="bg-studio-chrome px-2 pt-1.5 pb-0">
       <div className="flex min-w-0 items-center gap-1">
         <div className="flex min-w-0 flex-1 items-center gap-1">
-          <div className="hide-scrollbar min-w-0 max-w-full overflow-x-auto">
+          <div ref={scrollRegionRef} className="hide-scrollbar min-w-0 max-w-full overflow-x-auto">
             <div className="inline-flex h-10 min-w-max items-center gap-1 pl-2">
               {hasAnyTab ? (
                 <TabsList
                   aria-label="Agent Studio task tabs"
                   className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
+                  onDragOver={(event) => {
+                    if (!draggedTaskId) {
+                      return;
+                    }
+                    event.preventDefault();
+                    event.dataTransfer.dropEffect = "move";
+                    updateAutoScroll(event.clientX);
+                  }}
+                  onDrop={() => {
+                    clearDragState();
+                  }}
                 >
                   {tabs.map((tab) => (
                     <div
                       key={tab.taskId}
                       data-active={tab.isActive ? "true" : "false"}
+                      data-dragging={draggedTaskId === tab.taskId ? "true" : "false"}
+                      data-drop-position={
+                        dropTarget?.taskId === tab.taskId ? dropTarget.position : undefined
+                      }
+                      data-task-tab-id={tab.taskId}
                       className={cn(
                         "group relative z-1 inline-flex h-10 shrink-0 items-center gap-1 rounded-t-[10px] pl-2 pr-1",
+                        draggedTaskId === tab.taskId && "cursor-grabbing opacity-60",
                         tab.isActive
                           ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
                           : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
                       )}
                     >
+                      {dropTarget?.taskId === tab.taskId && dropTarget.position === "before" ? (
+                        <span
+                          aria-hidden
+                          className="pointer-events-none absolute inset-y-1 left-0 z-20 w-0.5 -translate-x-1/2 rounded-full bg-primary"
+                        />
+                      ) : null}
+                      {dropTarget?.taskId === tab.taskId && dropTarget.position === "after" ? (
+                        <span
+                          aria-hidden
+                          className="pointer-events-none absolute inset-y-1 right-0 z-20 w-0.5 translate-x-1/2 rounded-full bg-primary"
+                        />
+                      ) : null}
                       <TabsTrigger
                         id={`agent-studio-tab-${tab.taskId}`}
                         value={tab.taskId}
+                        draggable
                         className={cn(
                           "h-9 max-w-[19rem] cursor-pointer justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
                           "text-inherit data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none",
                           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
                         )}
+                        onDragStart={handleTabDragStart(tab.taskId)}
+                        onDragOver={handleTabDragOver(tab.taskId)}
+                        onDragEnd={clearDragState}
+                        onDrop={handleTabDrop}
                       >
                         <span
                           role="img"
@@ -146,6 +317,7 @@ export function AgentStudioTaskTabs({
                       </TabsTrigger>
                       <button
                         type="button"
+                        draggable={false}
                         className={cn(
                           "mr-1 cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-secondary hover:text-foreground",
                           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -1,6 +1,17 @@
+import { DndContext, type DraggableSyntheticListeners, DragOverlay } from "@dnd-kit/core";
+import { horizontalListSortingStrategy, SortableContext, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import type { TaskCard } from "@openducktor/contracts";
 import { Circle, CircleAlert, LoaderCircle, Plus, X } from "lucide-react";
-import { type ComponentProps, type ReactElement, useEffect, useState } from "react";
+import {
+  type CSSProperties,
+  type ReactElement,
+  type RefCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { TaskSelector } from "@/components/features/tasks";
 import { Button } from "@/components/ui/button";
 import {
@@ -39,6 +50,55 @@ export type AgentStudioTaskTabsModel = {
   agentStudioReady: boolean;
 };
 
+type AgentStudioTaskTabShellProps = {
+  tab: AgentStudioTaskTab;
+  dragListeners?: DraggableSyntheticListeners;
+  shellRef?: RefCallback<HTMLDivElement>;
+  style?: CSSProperties;
+  isDragSource?: boolean;
+  isDragOverlay?: boolean;
+  onCloseTab?: (taskId: string) => void;
+};
+
+function AgentStudioTaskTabLabel({
+  tab,
+  isPreview = false,
+}: {
+  tab: AgentStudioTaskTab;
+  isPreview?: boolean;
+}): ReactElement {
+  const className = cn(
+    "h-9 max-w-[19rem] cursor-inherit justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
+    "text-inherit",
+    !isPreview &&
+      "data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+  );
+
+  const content = (
+    <>
+      <span
+        role="img"
+        aria-label={statusLabelByTab(tab.status)}
+        title={statusLabelByTab(tab.status)}
+        className="inline-flex size-5 shrink-0 items-center justify-center"
+      >
+        {statusIconByTab(tab.status)}
+      </span>
+      <span className="max-w-52 truncate">{tab.taskTitle}</span>
+    </>
+  );
+
+  if (isPreview) {
+    return <div className={cn(className, "inline-flex")}>{content}</div>;
+  }
+
+  return (
+    <TabsTrigger id={`agent-studio-tab-${tab.taskId}`} value={tab.taskId} className={className}>
+      {content}
+    </TabsTrigger>
+  );
+}
+
 const statusLabelByTab = (status: AgentStudioTaskTabStatus): string => {
   if (status === "working") {
     return "Working";
@@ -59,8 +119,94 @@ const statusIconByTab = (status: AgentStudioTaskTabStatus): ReactElement => {
   return <Circle className="size-3.5 fill-input text-input" />;
 };
 
-function AgentStudioTaskTabDragShell(props: ComponentProps<"div">): ReactElement {
-  return <div {...props} />;
+function AgentStudioTaskTabShell({
+  tab,
+  dragListeners,
+  shellRef,
+  style,
+  isDragSource = false,
+  isDragOverlay = false,
+  onCloseTab,
+}: AgentStudioTaskTabShellProps): ReactElement {
+  return (
+    <div
+      ref={shellRef}
+      data-active={tab.isActive ? "true" : "false"}
+      data-dragging={isDragSource ? "true" : "false"}
+      data-task-tab-id={tab.taskId}
+      style={style}
+      className={cn(
+        "group relative z-1 inline-flex h-10 shrink-0 select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
+        "cursor-grab active:cursor-grabbing",
+        tab.isActive
+          ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
+          : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
+        isDragSource && "opacity-0",
+        isDragOverlay &&
+          "z-50 scale-[1.03] border-input bg-card shadow-xl ring-1 ring-border/60 after:hidden",
+      )}
+      {...dragListeners}
+    >
+      <AgentStudioTaskTabLabel tab={tab} isPreview={isDragOverlay} />
+      <button
+        type="button"
+        className={cn(
+          "mr-1 rounded-md p-1 text-muted-foreground transition-opacity hover:bg-secondary hover:text-foreground",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          "opacity-60 group-hover:opacity-100 data-[active=true]:opacity-100",
+          onCloseTab ? "cursor-pointer" : "pointer-events-none",
+        )}
+        data-active={tab.isActive ? "true" : "false"}
+        tabIndex={onCloseTab && tab.isActive ? 0 : -1}
+        aria-label={`Close tab for ${tab.taskTitle}`}
+        onMouseDown={(event) => {
+          event.stopPropagation();
+        }}
+        onPointerDown={(event) => {
+          event.stopPropagation();
+        }}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onCloseTab?.(tab.taskId);
+        }}
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}
+
+function SortableAgentStudioTaskTab({
+  tab,
+  isActiveDrag,
+  onCloseTab,
+}: {
+  tab: AgentStudioTaskTab;
+  isActiveDrag: boolean;
+  onCloseTab: (taskId: string) => void;
+}): ReactElement {
+  const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: tab.taskId,
+    transition: {
+      duration: 180,
+      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+    },
+  });
+
+  return (
+    <AgentStudioTaskTabShell
+      tab={tab}
+      shellRef={setNodeRef}
+      dragListeners={listeners}
+      isDragSource={isDragging || isActiveDrag}
+      onCloseTab={onCloseTab}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+    />
+  );
 }
 
 export function AgentStudioTaskTabs({
@@ -82,14 +228,21 @@ export function AgentStudioTaskTabs({
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [pendingTaskId, setPendingTaskId] = useState("");
   const [isCreateDialogReady, setIsCreateDialogReady] = useState(false);
+  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
+  const tabTaskIds = useMemo(() => tabs.map((tab) => tab.taskId), [tabs]);
   const {
-    scrollRegionRef,
-    draggedTaskId,
-    dropTarget,
-    handleStripDragOver,
-    handleStripDrop,
-    getTabDragHandlers,
-  } = useAgentStudioTaskTabReorderDrag({ onReorderTab });
+    activeTaskId,
+    sensors,
+    collisionDetection,
+    measuring,
+    modifiers,
+    handleDragStart,
+    handleDragEnd,
+    handleDragCancel,
+  } = useAgentStudioTaskTabReorderDrag({
+    tabTaskIds,
+    onReorderTab,
+  });
 
   useEffect(() => {
     if (!isCreateDialogOpen) {
@@ -117,6 +270,9 @@ export function AgentStudioTaskTabs({
   const canOpenCreateDialog = agentStudioReady;
   const hasCreatableTasks = availableTabTasks.length > 0;
   const hasAnyTab = tabs.length > 0;
+  const activeDragTab = activeTaskId
+    ? (tabs.find((tab) => tab.taskId === activeTaskId) ?? null)
+    : null;
 
   return (
     <div className="bg-studio-chrome px-2 pt-1.5 pb-0">
@@ -125,90 +281,43 @@ export function AgentStudioTaskTabs({
           <div ref={scrollRegionRef} className="hide-scrollbar min-w-0 max-w-full overflow-x-auto">
             <div className="inline-flex h-10 min-w-max items-center gap-1 pl-2">
               {hasAnyTab ? (
-                <TabsList
-                  aria-label="Agent Studio task tabs"
-                  className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
-                  onDragOver={handleStripDragOver}
-                  onDrop={handleStripDrop}
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={collisionDetection}
+                  measuring={measuring}
+                  modifiers={modifiers}
+                  onDragStart={handleDragStart}
+                  onDragEnd={handleDragEnd}
+                  onDragCancel={handleDragCancel}
                 >
-                  {tabs.map((tab) => {
-                    const tabDragHandlers = getTabDragHandlers(tab.taskId);
+                  <SortableContext items={tabTaskIds} strategy={horizontalListSortingStrategy}>
+                    <TabsList
+                      aria-label="Agent Studio task tabs"
+                      className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
+                    >
+                      {tabs.map((tab) => (
+                        <SortableAgentStudioTaskTab
+                          key={tab.taskId}
+                          tab={tab}
+                          isActiveDrag={activeTaskId === tab.taskId}
+                          onCloseTab={onCloseTab}
+                        />
+                      ))}
+                    </TabsList>
+                  </SortableContext>
 
-                    return (
-                      <AgentStudioTaskTabDragShell
-                        key={tab.taskId}
-                        data-active={tab.isActive ? "true" : "false"}
-                        data-dragging={draggedTaskId === tab.taskId ? "true" : "false"}
-                        data-drop-position={
-                          dropTarget?.taskId === tab.taskId ? dropTarget.position : undefined
-                        }
-                        data-task-tab-id={tab.taskId}
-                        className={cn(
-                          "group relative z-1 inline-flex h-10 shrink-0 items-center gap-1 rounded-t-[10px] pl-2 pr-1",
-                          draggedTaskId === tab.taskId && "cursor-grabbing opacity-60",
-                          tab.isActive
-                            ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
-                            : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
-                        )}
-                        {...tabDragHandlers}
-                      >
-                        {dropTarget?.taskId === tab.taskId && dropTarget.position === "before" ? (
-                          <span
-                            aria-hidden
-                            className="pointer-events-none absolute inset-y-1 left-0 z-20 w-0.5 -translate-x-1/2 rounded-full bg-primary"
-                          />
-                        ) : null}
-                        {dropTarget?.taskId === tab.taskId && dropTarget.position === "after" ? (
-                          <span
-                            aria-hidden
-                            className="pointer-events-none absolute inset-y-1 right-0 z-20 w-0.5 translate-x-1/2 rounded-full bg-primary"
-                          />
-                        ) : null}
-                        <TabsTrigger
-                          id={`agent-studio-tab-${tab.taskId}`}
-                          value={tab.taskId}
-                          className={cn(
-                            "h-9 max-w-[19rem] cursor-pointer justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
-                            "text-inherit data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                          )}
-                        >
-                          <span
-                            role="img"
-                            aria-label={statusLabelByTab(tab.status)}
-                            title={statusLabelByTab(tab.status)}
-                            className="inline-flex size-5 shrink-0 items-center justify-center"
-                          >
-                            {statusIconByTab(tab.status)}
-                          </span>
-                          <span className="max-w-52 truncate">{tab.taskTitle}</span>
-                        </TabsTrigger>
-                        <button
-                          type="button"
-                          draggable={false}
-                          className={cn(
-                            "mr-1 cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-secondary hover:text-foreground",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                            "opacity-60 group-hover:opacity-100 data-[active=true]:opacity-100",
-                          )}
-                          data-active={tab.isActive ? "true" : "false"}
-                          tabIndex={tab.isActive ? 0 : -1}
-                          aria-label={`Close tab for ${tab.taskTitle}`}
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            onCloseTab(tab.taskId);
-                          }}
-                          onDragStart={(event) => {
-                            event.stopPropagation();
-                          }}
-                        >
-                          <X className="size-3.5" />
-                        </button>
-                      </AgentStudioTaskTabDragShell>
-                    );
-                  })}
-                </TabsList>
+                  <DragOverlay
+                    dropAnimation={{
+                      duration: 220,
+                      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+                    }}
+                    zIndex={40}
+                  >
+                    {activeDragTab ? (
+                      <AgentStudioTaskTabShell tab={activeDragTab} isDragOverlay />
+                    ) : null}
+                  </DragOverlay>
+                </DndContext>
               ) : (
                 <p className="text-sm text-muted-foreground">
                   Open a task tab to start working with an agent.

--- a/apps/desktop/src/components/features/agents/use-agent-studio-task-tab-reorder-drag.ts
+++ b/apps/desktop/src/components/features/agents/use-agent-studio-task-tab-reorder-drag.ts
@@ -1,0 +1,183 @@
+import { type DragEvent as ReactDragEvent, useEffect, useRef, useState } from "react";
+
+type DropPosition = "before" | "after";
+
+type DropTarget = {
+  taskId: string;
+  position: DropPosition;
+};
+
+type UseAgentStudioTaskTabReorderDragArgs = {
+  onReorderTab: (draggedTaskId: string, targetTaskId: string, position: DropPosition) => void;
+};
+
+type TabDragHandlers = {
+  draggable: true;
+  onDragStart: (event: ReactDragEvent<HTMLElement>) => void;
+  onDragOver: (event: ReactDragEvent<HTMLElement>) => void;
+  onDragEnd: () => void;
+  onDrop: (event: ReactDragEvent<HTMLElement>) => void;
+};
+
+const AUTO_SCROLL_EDGE_THRESHOLD = 48;
+const AUTO_SCROLL_MAX_STEP = 18;
+
+const getDragDropPosition = (event: ReactDragEvent<HTMLElement>): DropPosition => {
+  const bounds = event.currentTarget.getBoundingClientRect();
+  return event.clientX <= bounds.left + bounds.width / 2 ? "before" : "after";
+};
+
+export function useAgentStudioTaskTabReorderDrag({
+  onReorderTab,
+}: UseAgentStudioTaskTabReorderDragArgs): {
+  scrollRegionRef: React.RefObject<HTMLDivElement | null>;
+  draggedTaskId: string | null;
+  dropTarget: DropTarget | null;
+  handleStripDragOver: (event: ReactDragEvent<HTMLElement>) => void;
+  handleStripDrop: () => void;
+  getTabDragHandlers: (taskId: string) => TabDragHandlers;
+} {
+  const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
+  const autoScrollFrameRef = useRef<number | null>(null);
+  const autoScrollStepRef = useRef(0);
+
+  const stopAutoScroll = (): void => {
+    if (autoScrollFrameRef.current !== null) {
+      globalThis.cancelAnimationFrame(autoScrollFrameRef.current);
+      autoScrollFrameRef.current = null;
+    }
+    autoScrollStepRef.current = 0;
+  };
+
+  const clearDragState = (): void => {
+    setDraggedTaskId(null);
+    setDropTarget(null);
+    stopAutoScroll();
+  };
+
+  const updateAutoScroll = (clientX: number): void => {
+    const scrollRegion = scrollRegionRef.current;
+    if (!scrollRegion) {
+      stopAutoScroll();
+      return;
+    }
+
+    const bounds = scrollRegion.getBoundingClientRect();
+    let nextStep = 0;
+
+    if (clientX < bounds.left + AUTO_SCROLL_EDGE_THRESHOLD) {
+      const distanceToEdge = bounds.left + AUTO_SCROLL_EDGE_THRESHOLD - clientX;
+      nextStep = -Math.min(
+        AUTO_SCROLL_MAX_STEP,
+        Math.max(4, (distanceToEdge / AUTO_SCROLL_EDGE_THRESHOLD) * AUTO_SCROLL_MAX_STEP),
+      );
+    } else if (clientX > bounds.right - AUTO_SCROLL_EDGE_THRESHOLD) {
+      const distanceToEdge = clientX - (bounds.right - AUTO_SCROLL_EDGE_THRESHOLD);
+      nextStep = Math.min(
+        AUTO_SCROLL_MAX_STEP,
+        Math.max(4, (distanceToEdge / AUTO_SCROLL_EDGE_THRESHOLD) * AUTO_SCROLL_MAX_STEP),
+      );
+    }
+
+    autoScrollStepRef.current = nextStep;
+
+    if (nextStep === 0) {
+      stopAutoScroll();
+      return;
+    }
+
+    if (autoScrollFrameRef.current !== null) {
+      return;
+    }
+
+    const step = (): void => {
+      const nextScrollRegion = scrollRegionRef.current;
+      if (!nextScrollRegion || autoScrollStepRef.current === 0) {
+        autoScrollFrameRef.current = null;
+        return;
+      }
+
+      nextScrollRegion.scrollLeft += autoScrollStepRef.current;
+      autoScrollFrameRef.current = globalThis.requestAnimationFrame(step);
+    };
+
+    autoScrollFrameRef.current = globalThis.requestAnimationFrame(step);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (autoScrollFrameRef.current !== null) {
+        globalThis.cancelAnimationFrame(autoScrollFrameRef.current);
+      }
+    };
+  }, []);
+
+  const handleStripDragOver = (event: ReactDragEvent<HTMLElement>): void => {
+    if (!draggedTaskId) {
+      return;
+    }
+
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    updateAutoScroll(event.clientX);
+  };
+
+  const handleStripDrop = (): void => {
+    clearDragState();
+  };
+
+  const getTabDragHandlers = (taskId: string): TabDragHandlers => ({
+    draggable: true,
+    onDragStart: (event) => {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", taskId);
+      setDraggedTaskId(taskId);
+      setDropTarget(null);
+    },
+    onDragOver: (event) => {
+      if (!draggedTaskId) {
+        return;
+      }
+
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+      updateAutoScroll(event.clientX);
+
+      if (draggedTaskId === taskId) {
+        setDropTarget(null);
+        return;
+      }
+
+      const position = getDragDropPosition(event);
+      setDropTarget((current) => {
+        if (current?.taskId === taskId && current.position === position) {
+          return current;
+        }
+        return { taskId, position };
+      });
+    },
+    onDragEnd: clearDragState,
+    onDrop: (event) => {
+      if (!draggedTaskId || !dropTarget) {
+        clearDragState();
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      onReorderTab(draggedTaskId, dropTarget.taskId, dropTarget.position);
+      clearDragState();
+    },
+  });
+
+  return {
+    scrollRegionRef,
+    draggedTaskId,
+    dropTarget,
+    handleStripDragOver,
+    handleStripDrop,
+    getTabDragHandlers,
+  };
+}

--- a/apps/desktop/src/components/features/agents/use-agent-studio-task-tab-reorder-drag.ts
+++ b/apps/desktop/src/components/features/agents/use-agent-studio-task-tab-reorder-drag.ts
@@ -160,14 +160,20 @@ export function useAgentStudioTaskTabReorderDrag({
     },
     onDragEnd: clearDragState,
     onDrop: (event) => {
-      if (!draggedTaskId || !dropTarget) {
+      if (!draggedTaskId) {
         clearDragState();
         return;
       }
 
       event.preventDefault();
       event.stopPropagation();
-      onReorderTab(draggedTaskId, dropTarget.taskId, dropTarget.position);
+
+      if (draggedTaskId === taskId) {
+        clearDragState();
+        return;
+      }
+
+      onReorderTab(draggedTaskId, taskId, getDragDropPosition(event));
       clearDragState();
     },
   });

--- a/apps/desktop/src/components/features/agents/use-agent-studio-task-tab-reorder-drag.ts
+++ b/apps/desktop/src/components/features/agents/use-agent-studio-task-tab-reorder-drag.ts
@@ -1,189 +1,88 @@
-import { type DragEvent as ReactDragEvent, useEffect, useRef, useState } from "react";
+import {
+  closestCenter,
+  type DragEndEvent,
+  type DragStartEvent,
+  MeasuringStrategy,
+  MouseSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
+import { useState } from "react";
 
 type DropPosition = "before" | "after";
 
-type DropTarget = {
-  taskId: string;
-  position: DropPosition;
-};
-
 type UseAgentStudioTaskTabReorderDragArgs = {
+  tabTaskIds: string[];
   onReorderTab: (draggedTaskId: string, targetTaskId: string, position: DropPosition) => void;
 };
 
-type TabDragHandlers = {
-  draggable: true;
-  onDragStart: (event: ReactDragEvent<HTMLElement>) => void;
-  onDragOver: (event: ReactDragEvent<HTMLElement>) => void;
-  onDragEnd: () => void;
-  onDrop: (event: ReactDragEvent<HTMLElement>) => void;
-};
-
-const AUTO_SCROLL_EDGE_THRESHOLD = 48;
-const AUTO_SCROLL_MAX_STEP = 18;
-
-const getDragDropPosition = (event: ReactDragEvent<HTMLElement>): DropPosition => {
-  const bounds = event.currentTarget.getBoundingClientRect();
-  return event.clientX <= bounds.left + bounds.width / 2 ? "before" : "after";
-};
-
 export function useAgentStudioTaskTabReorderDrag({
+  tabTaskIds,
   onReorderTab,
 }: UseAgentStudioTaskTabReorderDragArgs): {
-  scrollRegionRef: React.RefObject<HTMLDivElement | null>;
-  draggedTaskId: string | null;
-  dropTarget: DropTarget | null;
-  handleStripDragOver: (event: ReactDragEvent<HTMLElement>) => void;
-  handleStripDrop: () => void;
-  getTabDragHandlers: (taskId: string) => TabDragHandlers;
+  activeTaskId: string | null;
+  sensors: ReturnType<typeof useSensors>;
+  collisionDetection: typeof closestCenter;
+  measuring: {
+    droppable: {
+      strategy: MeasuringStrategy;
+    };
+  };
+  modifiers: [typeof restrictToHorizontalAxis];
+  handleDragStart: (event: DragStartEvent) => void;
+  handleDragEnd: (event: DragEndEvent) => void;
+  handleDragCancel: () => void;
 } {
-  const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
-  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
-  const scrollRegionRef = useRef<HTMLDivElement | null>(null);
-  const autoScrollFrameRef = useRef<number | null>(null);
-  const autoScrollStepRef = useRef(0);
+  const sensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 6,
+      },
+    }),
+  );
 
-  const stopAutoScroll = (): void => {
-    if (autoScrollFrameRef.current !== null) {
-      globalThis.cancelAnimationFrame(autoScrollFrameRef.current);
-      autoScrollFrameRef.current = null;
-    }
-    autoScrollStepRef.current = 0;
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+
+  const handleDragStart = (event: DragStartEvent): void => {
+    setActiveTaskId(String(event.active.id));
   };
 
-  const clearDragState = (): void => {
-    setDraggedTaskId(null);
-    setDropTarget(null);
-    stopAutoScroll();
+  const handleDragCancel = (): void => {
+    setActiveTaskId(null);
   };
 
-  const updateAutoScroll = (clientX: number): void => {
-    const scrollRegion = scrollRegionRef.current;
-    if (!scrollRegion) {
-      stopAutoScroll();
+  const handleDragEnd = (event: DragEndEvent): void => {
+    const draggedTaskId = String(event.active.id);
+    const overTaskId = event.over ? String(event.over.id) : null;
+    setActiveTaskId(null);
+
+    if (!overTaskId || draggedTaskId === overTaskId) {
       return;
     }
 
-    const bounds = scrollRegion.getBoundingClientRect();
-    let nextStep = 0;
+    const draggedIndex = tabTaskIds.indexOf(draggedTaskId);
+    const overIndex = tabTaskIds.indexOf(overTaskId);
 
-    if (clientX < bounds.left + AUTO_SCROLL_EDGE_THRESHOLD) {
-      const distanceToEdge = bounds.left + AUTO_SCROLL_EDGE_THRESHOLD - clientX;
-      nextStep = -Math.min(
-        AUTO_SCROLL_MAX_STEP,
-        Math.max(4, (distanceToEdge / AUTO_SCROLL_EDGE_THRESHOLD) * AUTO_SCROLL_MAX_STEP),
-      );
-    } else if (clientX > bounds.right - AUTO_SCROLL_EDGE_THRESHOLD) {
-      const distanceToEdge = clientX - (bounds.right - AUTO_SCROLL_EDGE_THRESHOLD);
-      nextStep = Math.min(
-        AUTO_SCROLL_MAX_STEP,
-        Math.max(4, (distanceToEdge / AUTO_SCROLL_EDGE_THRESHOLD) * AUTO_SCROLL_MAX_STEP),
-      );
-    }
-
-    autoScrollStepRef.current = nextStep;
-
-    if (nextStep === 0) {
-      stopAutoScroll();
+    if (draggedIndex < 0 || overIndex < 0) {
       return;
     }
 
-    if (autoScrollFrameRef.current !== null) {
-      return;
-    }
-
-    const step = (): void => {
-      const nextScrollRegion = scrollRegionRef.current;
-      if (!nextScrollRegion || autoScrollStepRef.current === 0) {
-        autoScrollFrameRef.current = null;
-        return;
-      }
-
-      nextScrollRegion.scrollLeft += autoScrollStepRef.current;
-      autoScrollFrameRef.current = globalThis.requestAnimationFrame(step);
-    };
-
-    autoScrollFrameRef.current = globalThis.requestAnimationFrame(step);
+    onReorderTab(draggedTaskId, overTaskId, draggedIndex < overIndex ? "after" : "before");
   };
-
-  useEffect(() => {
-    return () => {
-      if (autoScrollFrameRef.current !== null) {
-        globalThis.cancelAnimationFrame(autoScrollFrameRef.current);
-      }
-    };
-  }, []);
-
-  const handleStripDragOver = (event: ReactDragEvent<HTMLElement>): void => {
-    if (!draggedTaskId) {
-      return;
-    }
-
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "move";
-    updateAutoScroll(event.clientX);
-  };
-
-  const handleStripDrop = (): void => {
-    clearDragState();
-  };
-
-  const getTabDragHandlers = (taskId: string): TabDragHandlers => ({
-    draggable: true,
-    onDragStart: (event) => {
-      event.dataTransfer.effectAllowed = "move";
-      event.dataTransfer.setData("text/plain", taskId);
-      setDraggedTaskId(taskId);
-      setDropTarget(null);
-    },
-    onDragOver: (event) => {
-      if (!draggedTaskId) {
-        return;
-      }
-
-      event.preventDefault();
-      event.dataTransfer.dropEffect = "move";
-      updateAutoScroll(event.clientX);
-
-      if (draggedTaskId === taskId) {
-        setDropTarget(null);
-        return;
-      }
-
-      const position = getDragDropPosition(event);
-      setDropTarget((current) => {
-        if (current?.taskId === taskId && current.position === position) {
-          return current;
-        }
-        return { taskId, position };
-      });
-    },
-    onDragEnd: clearDragState,
-    onDrop: (event) => {
-      if (!draggedTaskId) {
-        clearDragState();
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (draggedTaskId === taskId) {
-        clearDragState();
-        return;
-      }
-
-      onReorderTab(draggedTaskId, taskId, getDragDropPosition(event));
-      clearDragState();
-    },
-  });
 
   return {
-    scrollRegionRef,
-    draggedTaskId,
-    dropTarget,
-    handleStripDragOver,
-    handleStripDrop,
-    getTabDragHandlers,
+    activeTaskId,
+    sensors,
+    collisionDetection: closestCenter,
+    measuring: {
+      droppable: {
+        strategy: MeasuringStrategy.Always,
+      },
+    },
+    modifiers: [restrictToHorizontalAxis],
+    handleDragStart,
+    handleDragEnd,
+    handleDragCancel,
   };
 }

--- a/apps/desktop/src/components/features/agents/use-agent-studio-task-tab-reorder-drag.ts
+++ b/apps/desktop/src/components/features/agents/use-agent-studio-task-tab-reorder-drag.ts
@@ -4,6 +4,7 @@ import {
   type DragStartEvent,
   MeasuringStrategy,
   MouseSensor,
+  PointerSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -34,8 +35,10 @@ export function useAgentStudioTaskTabReorderDrag({
   handleDragEnd: (event: DragEndEvent) => void;
   handleDragCancel: () => void;
 } {
+  const PrimarySensor = typeof globalThis.PointerEvent === "function" ? PointerSensor : MouseSensor;
+
   const sensors = useSensors(
-    useSensor(MouseSensor, {
+    useSensor(PrimarySensor, {
       activationConstraint: {
         distance: 6,
       },

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
@@ -17,6 +17,7 @@ import {
   getAvailableTabTasks,
   getTabStatusForTask,
   parsePersistedTaskTabs,
+  reorderTaskTabs,
   resolveFallbackTaskId,
   toPersistedTaskTabs,
 } from "./agents-page-session-tabs";
@@ -105,6 +106,48 @@ describe("agents-page-session-tabs", () => {
     const tabIds = ensureActiveTaskTab(["task-1"], "task-2");
     expect(tabIds).toEqual(["task-1", "task-2"]);
     expect(ensureActiveTaskTab(tabIds, "task-2")).toEqual(["task-1", "task-2"]);
+  });
+
+  test("reorders tabs before or after the hovered tab without duplicates", () => {
+    expect(
+      reorderTaskTabs({
+        tabTaskIds: ["task-1", "task-2", "task-3", "task-4"],
+        draggedTaskId: "task-3",
+        targetTaskId: "task-1",
+        position: "before",
+      }),
+    ).toEqual(["task-3", "task-1", "task-2", "task-4"]);
+
+    expect(
+      reorderTaskTabs({
+        tabTaskIds: ["task-1", "task-2", "task-3", "task-4"],
+        draggedTaskId: "task-2",
+        targetTaskId: "task-4",
+        position: "after",
+      }),
+    ).toEqual(["task-1", "task-3", "task-4", "task-2"]);
+  });
+
+  test("treats invalid or self-reorder requests as no-ops", () => {
+    const tabTaskIds = ["task-1", "task-2", "task-3"];
+
+    expect(
+      reorderTaskTabs({
+        tabTaskIds,
+        draggedTaskId: "task-2",
+        targetTaskId: "task-2",
+        position: "before",
+      }),
+    ).toBe(tabTaskIds);
+
+    expect(
+      reorderTaskTabs({
+        tabTaskIds,
+        draggedTaskId: "task-9",
+        targetTaskId: "task-1",
+        position: "after",
+      }),
+    ).toBe(tabTaskIds);
   });
 
   test("parses persisted task tabs and deduplicates invalid entries", () => {

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -199,6 +199,32 @@ export const ensureActiveTaskTab = (openTaskTabs: string[], activeTaskId: string
   return [...openTaskTabs, activeTaskId];
 };
 
+export const reorderTaskTabs = (params: {
+  tabTaskIds: string[];
+  draggedTaskId: string;
+  targetTaskId: string;
+  position: "before" | "after";
+}): string[] => {
+  const { tabTaskIds, draggedTaskId, targetTaskId, position } = params;
+  const sourceIndex = tabTaskIds.indexOf(draggedTaskId);
+  const targetIndex = tabTaskIds.indexOf(targetTaskId);
+
+  if (sourceIndex < 0 || targetIndex < 0 || draggedTaskId === targetTaskId) {
+    return tabTaskIds;
+  }
+
+  const nextTabTaskIds = tabTaskIds.filter((taskId) => taskId !== draggedTaskId);
+  const nextTargetIndex = nextTabTaskIds.indexOf(targetTaskId);
+
+  if (nextTargetIndex < 0) {
+    return tabTaskIds;
+  }
+
+  const insertionIndex = position === "before" ? nextTargetIndex : nextTargetIndex + 1;
+  nextTabTaskIds.splice(insertionIndex, 0, draggedTaskId);
+  return nextTabTaskIds;
+};
+
 export const parsePersistedTaskTabs = (raw: string | null): PersistedTaskTabsState => {
   if (!raw) {
     return DEFAULT_PERSISTED_TABS_STATE;

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -92,6 +92,7 @@ describe("agents-page-view-model", () => {
   test("buildAgentStudioTaskTabsModel maps tab model fields", () => {
     const onCreateTab = mock(() => {});
     const onCloseTab = mock(() => {});
+    const onReorderTab = mock(() => {});
     const task = createTaskCard("task-1");
 
     const model = buildAgentStudioTaskTabsModel({
@@ -100,6 +101,7 @@ describe("agents-page-view-model", () => {
       isLoadingTasks: true,
       onCreateTab,
       onCloseTab,
+      onReorderTab,
       agentStudioReady: false,
     });
 
@@ -107,6 +109,8 @@ describe("agents-page-view-model", () => {
     expect(model.availableTabTasks[0]?.id).toBe("task-1");
     expect(model.isLoadingAvailableTabTasks).toBe(true);
     expect(model.agentStudioReady).toBe(false);
+    model.onReorderTab("task-1", "task-1", "before");
+    expect(onReorderTab).toHaveBeenCalledWith("task-1", "task-1", "before");
   });
 
   test("buildAgentStudioHeaderModel keeps selector and workflow contracts", () => {

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -90,6 +90,7 @@ describe("agents-page-view-model", () => {
   });
 
   test("buildAgentStudioTaskTabsModel maps tab model fields", () => {
+    const onSelectTab = mock(() => {});
     const onCreateTab = mock(() => {});
     const onCloseTab = mock(() => {});
     const onReorderTab = mock(() => {});
@@ -99,6 +100,7 @@ describe("agents-page-view-model", () => {
       taskTabs: [{ taskId: task.id, taskTitle: task.title, status: "idle", isActive: true }],
       availableTabTasks: [task],
       isLoadingTasks: true,
+      onSelectTab,
       onCreateTab,
       onCloseTab,
       onReorderTab,
@@ -109,6 +111,8 @@ describe("agents-page-view-model", () => {
     expect(model.availableTabTasks[0]?.id).toBe("task-1");
     expect(model.isLoadingAvailableTabTasks).toBe(true);
     expect(model.agentStudioReady).toBe(false);
+    model.onSelectTab("task-1");
+    expect(onSelectTab).toHaveBeenCalledWith("task-1");
     model.onReorderTab("task-1", "task-1", "before");
     expect(onReorderTab).toHaveBeenCalledWith("task-1", "task-1", "before");
   });

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -34,6 +34,7 @@ export const buildAgentStudioTaskTabsModel = (args: {
   isLoadingTasks: boolean;
   onCreateTab: (taskId: string) => void;
   onCloseTab: (taskId: string) => void;
+  onReorderTab: (draggedTaskId: string, targetTaskId: string, position: "before" | "after") => void;
   agentStudioReady: boolean;
 }): AgentStudioTaskTabsModel => ({
   tabs: args.taskTabs,
@@ -41,6 +42,7 @@ export const buildAgentStudioTaskTabsModel = (args: {
   isLoadingAvailableTabTasks: args.isLoadingTasks,
   onCreateTab: args.onCreateTab,
   onCloseTab: args.onCloseTab,
+  onReorderTab: args.onReorderTab,
   agentStudioReady: args.agentStudioReady,
 });
 

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -32,6 +32,7 @@ export const buildAgentStudioTaskTabsModel = (args: {
   taskTabs: AgentStudioTaskTabsModel["tabs"];
   availableTabTasks: TaskCard[];
   isLoadingTasks: boolean;
+  onSelectTab: (taskId: string) => void;
   onCreateTab: (taskId: string) => void;
   onCloseTab: (taskId: string) => void;
   onReorderTab: (draggedTaskId: string, targetTaskId: string, position: "before" | "after") => void;
@@ -40,6 +41,7 @@ export const buildAgentStudioTaskTabsModel = (args: {
   tabs: args.taskTabs,
   availableTabTasks: args.availableTabTasks,
   isLoadingAvailableTabTasks: args.isLoadingTasks,
+  onSelectTab: args.onSelectTab,
   onCreateTab: args.onCreateTab,
   onCloseTab: args.onCloseTab,
   onReorderTab: args.onReorderTab,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -22,6 +22,7 @@ const session = createAgentSessionFixture({
 });
 const onCreateTab = () => {};
 const onCloseTab = () => {};
+const onReorderTab = () => {};
 const handleSelectAgent = () => {};
 const handleSelectModel = () => {};
 const handleSelectVariant = () => {};
@@ -49,6 +50,7 @@ const baseArgs: BuildArgs = {
     isLoadingTasks: false,
     handleCreateTab: onCreateTab,
     handleCloseTab: onCloseTab,
+    handleReorderTab: onReorderTab,
   },
   documents: {
     specDoc: taskDocument,
@@ -125,6 +127,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(mapped.core.isWaitingForRuntimeReadiness).toBe(false);
     expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
     expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
+    expect(mapped.taskTabs.onReorderTab).toBe(onReorderTab);
     expect(mapped.documents.planDoc.markdown).toBe("# doc");
     expect(mapped.readiness.agentStudioReadinessState).toBe("ready");
     expect(mapped.modelSelection.onSelectAgent).toBe(handleSelectAgent);

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -20,6 +20,7 @@ const session = createAgentSessionFixture({
   role: "planner",
   scenario: "planner_initial",
 });
+const onSelectTab = () => {};
 const onCreateTab = () => {};
 const onCloseTab = () => {};
 const onReorderTab = () => {};
@@ -48,6 +49,7 @@ const baseArgs: BuildArgs = {
     taskTabs: [],
     availableTabTasks: [task],
     isLoadingTasks: false,
+    handleSelectTab: onSelectTab,
     handleCreateTab: onCreateTab,
     handleCloseTab: onCloseTab,
     handleReorderTab: onReorderTab,
@@ -125,6 +127,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(mapped.core.contextSwitchVersion).toBe(4);
     expect(mapped.core.isSessionHistoryHydrationFailed).toBe(false);
     expect(mapped.core.isWaitingForRuntimeReadiness).toBe(false);
+    expect(mapped.taskTabs.onSelectTab).toBe(onSelectTab);
     expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
     expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
     expect(mapped.taskTabs.onReorderTab).toBe(onReorderTab);

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -102,6 +102,7 @@ type AgentStudioPageModelsTabsContext = Pick<
   | "isLoadingTasks"
   | "handleCreateTab"
   | "handleCloseTab"
+  | "handleReorderTab"
 >;
 
 type AgentStudioPageModelsDocumentsContext = Pick<
@@ -163,7 +164,7 @@ export const buildAgentStudioPageModelsArgs = ({
   chatSettings,
   composer,
 }: BuildAgentStudioPageModelsArgsInput): Parameters<typeof useAgentStudioPageModels>[0] => {
-  const { activeTaskTabId, handleCreateTab, handleCloseTab, ...taskTabs } = tabs;
+  const { activeTaskTabId, handleCreateTab, handleCloseTab, handleReorderTab, ...taskTabs } = tabs;
   const { handleSelectAgent, handleSelectModel, handleSelectVariant, ...restOfModelSelection } =
     modelSelection;
 
@@ -188,6 +189,7 @@ export const buildAgentStudioPageModelsArgs = ({
       ...taskTabs,
       onCreateTab: handleCreateTab,
       onCloseTab: handleCloseTab,
+      onReorderTab: handleReorderTab,
     },
     documents,
     readiness,
@@ -227,6 +229,7 @@ export function useAgentStudioOrchestrationController({
     isActiveTaskHydrated,
     handleCreateTab,
     handleCloseTab,
+    handleReorderTab,
   } = selection;
   const { agentStudioReady } = readiness;
   const {
@@ -366,6 +369,7 @@ export function useAgentStudioOrchestrationController({
       isLoadingTasks,
       handleCreateTab,
       handleCloseTab,
+      handleReorderTab,
     },
     documents: {
       specDoc,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -100,6 +100,7 @@ type AgentStudioPageModelsTabsContext = Pick<
   | "taskTabs"
   | "availableTabTasks"
   | "isLoadingTasks"
+  | "handleSelectTab"
   | "handleCreateTab"
   | "handleCloseTab"
   | "handleReorderTab"
@@ -164,7 +165,14 @@ export const buildAgentStudioPageModelsArgs = ({
   chatSettings,
   composer,
 }: BuildAgentStudioPageModelsArgsInput): Parameters<typeof useAgentStudioPageModels>[0] => {
-  const { activeTaskTabId, handleCreateTab, handleCloseTab, handleReorderTab, ...taskTabs } = tabs;
+  const {
+    activeTaskTabId,
+    handleSelectTab,
+    handleCreateTab,
+    handleCloseTab,
+    handleReorderTab,
+    ...taskTabs
+  } = tabs;
   const { handleSelectAgent, handleSelectModel, handleSelectVariant, ...restOfModelSelection } =
     modelSelection;
 
@@ -187,6 +195,7 @@ export const buildAgentStudioPageModelsArgs = ({
     },
     taskTabs: {
       ...taskTabs,
+      onSelectTab: handleSelectTab,
       onCreateTab: handleCreateTab,
       onCloseTab: handleCloseTab,
       onReorderTab: handleReorderTab,
@@ -227,6 +236,7 @@ export function useAgentStudioOrchestrationController({
     contextSwitchVersion,
     isLoadingTasks,
     isActiveTaskHydrated,
+    handleSelectTab,
     handleCreateTab,
     handleCloseTab,
     handleReorderTab,
@@ -367,6 +377,7 @@ export function useAgentStudioOrchestrationController({
       taskTabs,
       availableTabTasks,
       isLoadingTasks,
+      handleSelectTab,
       handleCreateTab,
       handleCloseTab,
       handleReorderTab,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -102,6 +102,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
       isLoadingTasks: false,
       onCreateTab: () => {},
       onCloseTab: () => {},
+      onReorderTab: () => {},
       ...overrides.taskTabs,
     },
     documents: {

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -100,6 +100,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
       taskTabs: [{ taskId: "task-1", taskTitle: "Task 1", status: "idle", isActive: true }],
       availableTabTasks: [createTask()],
       isLoadingTasks: false,
+      onSelectTab: () => {},
       onCreateTab: () => {},
       onCloseTab: () => {},
       onReorderTab: () => {},

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -49,6 +49,7 @@ type AgentStudioTaskTabsContext = {
   taskTabs: AgentStudioTaskTabsModel["tabs"];
   availableTabTasks: TaskCard[];
   isLoadingTasks: boolean;
+  onSelectTab: (taskId: string) => void;
   onCreateTab: (taskId: string) => void;
   onCloseTab: (taskId: string) => void;
   onReorderTab: (draggedTaskId: string, targetTaskId: string, position: "before" | "after") => void;
@@ -184,6 +185,7 @@ export function useAgentStudioPageModels({
         taskTabs: taskTabs.taskTabs,
         availableTabTasks: taskTabs.availableTabTasks,
         isLoadingTasks: taskTabs.isLoadingTasks,
+        onSelectTab: taskTabs.onSelectTab,
         onCreateTab: taskTabs.onCreateTab,
         onCloseTab: taskTabs.onCloseTab,
         onReorderTab: taskTabs.onReorderTab,
@@ -196,6 +198,7 @@ export function useAgentStudioPageModels({
       taskTabs.onCloseTab,
       taskTabs.onCreateTab,
       taskTabs.onReorderTab,
+      taskTabs.onSelectTab,
       taskTabs.taskTabs,
     ],
   );

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -51,6 +51,7 @@ type AgentStudioTaskTabsContext = {
   isLoadingTasks: boolean;
   onCreateTab: (taskId: string) => void;
   onCloseTab: (taskId: string) => void;
+  onReorderTab: (draggedTaskId: string, targetTaskId: string, position: "before" | "after") => void;
 };
 
 type AgentStudioSessionActionsContext = {
@@ -185,6 +186,7 @@ export function useAgentStudioPageModels({
         isLoadingTasks: taskTabs.isLoadingTasks,
         onCreateTab: taskTabs.onCreateTab,
         onCloseTab: taskTabs.onCloseTab,
+        onReorderTab: taskTabs.onReorderTab,
         agentStudioReady: readiness.agentStudioReady,
       }),
     [
@@ -193,6 +195,7 @@ export function useAgentStudioPageModels({
       taskTabs.isLoadingTasks,
       taskTabs.onCloseTab,
       taskTabs.onCreateTab,
+      taskTabs.onReorderTab,
       taskTabs.taskTabs,
     ],
   );

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -75,6 +75,11 @@ export type AgentStudioSelectionControllerResult = {
   handleSelectTab: (nextTaskId: string) => void;
   handleCreateTab: (nextTaskId: string) => void;
   handleCloseTab: (taskIdToClose: string) => void;
+  handleReorderTab: (
+    draggedTaskId: string,
+    targetTaskId: string,
+    position: "before" | "after",
+  ) => void;
   viewTaskId: string;
   viewSelectedTask: TaskCard | null;
   viewSessionsForTask: AgentSessionSummary[];
@@ -294,6 +299,7 @@ export function useAgentStudioSelectionController({
     handleSelectTab,
     handleCreateTab,
     handleCloseTab,
+    handleReorderTab,
   } = useAgentStudioTaskTabs({
     activeWorkspace,
     isRepoNavigationBoundaryPending,
@@ -405,6 +411,7 @@ export function useAgentStudioSelectionController({
     handleSelectTab,
     handleCreateTab,
     handleCloseTab,
+    handleReorderTab,
     viewTaskId,
     viewSelectedTask,
     viewSessionsForTask,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.test.tsx
@@ -95,6 +95,7 @@ describe("useTaskTabActions", () => {
     expect(harness.getLatest()).toEqual({
       handleCreateTab: harness.getLatest().handleCreateTab,
       handleCloseTab: harness.getLatest().handleCloseTab,
+      handleReorderTab: harness.getLatest().handleReorderTab,
       openTaskTabs: ["task-1"],
       persistedActiveTaskId: "task-1",
       intentActiveTaskId: null,
@@ -140,6 +141,7 @@ describe("useTaskTabActions", () => {
       expect(latest.openTaskTabs).toEqual(["task-1", "task-3"]);
       expect(latest.persistedActiveTaskId).toBe("task-3");
       expect(latest.intentActiveTaskId).toBe("task-3");
+      expect(typeof latest.handleReorderTab).toBe("function");
       expect(clearComposerInput).toHaveBeenCalledTimes(1);
       expect(onContextSwitchIntent).toHaveBeenCalledTimes(1);
       expect(clearTaskSelection).toHaveBeenCalledTimes(0);
@@ -179,9 +181,48 @@ describe("useTaskTabActions", () => {
     expect(latest.openTaskTabs).toEqual([]);
     expect(latest.persistedActiveTaskId).toBeNull();
     expect(latest.intentActiveTaskId).toBeNull();
+    expect(typeof latest.handleReorderTab).toBe("function");
     expect(clearComposerInput).toHaveBeenCalledTimes(1);
     expect(onContextSwitchIntent).toHaveBeenCalledTimes(1);
     expect(clearTaskSelection).toHaveBeenCalledTimes(1);
+    expect(navigateToTaskIntent).toHaveBeenCalledTimes(0);
+
+    await harness.unmount();
+  });
+
+  test("reordering tabs updates order without changing active-tab side effects", async () => {
+    const clearComposerInput = mock(() => {});
+    const onContextSwitchIntent = mock(() => {});
+    const clearTaskSelection = mock(() => {});
+    const navigateToTaskIntent = mock(() => {});
+    const harness = createHookHarness({
+      initialOpenTaskTabs: ["task-1", "task-2", "task-3"],
+      initialPersistedActiveTaskId: "task-2",
+      initialIntentActiveTaskId: "task-2",
+      activeTaskTabId: "task-2",
+      clearComposerInput,
+      onContextSwitchIntent,
+      clearTaskSelection,
+      navigateToTaskIntent,
+      handleSelectTab: () => {},
+    });
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.handleReorderTab("task-3", "task-1", "before");
+    });
+
+    expect(harness.getLatest()).toEqual({
+      handleCreateTab: harness.getLatest().handleCreateTab,
+      handleCloseTab: harness.getLatest().handleCloseTab,
+      handleReorderTab: harness.getLatest().handleReorderTab,
+      openTaskTabs: ["task-3", "task-1", "task-2"],
+      persistedActiveTaskId: "task-2",
+      intentActiveTaskId: "task-2",
+    });
+    expect(clearComposerInput).toHaveBeenCalledTimes(0);
+    expect(onContextSwitchIntent).toHaveBeenCalledTimes(0);
+    expect(clearTaskSelection).toHaveBeenCalledTimes(0);
     expect(navigateToTaskIntent).toHaveBeenCalledTimes(0);
 
     await harness.unmount();

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
@@ -1,6 +1,6 @@
 import { type Dispatch, type SetStateAction, useCallback } from "react";
 import type { NavigateToTaskIntent } from "./agent-studio-types";
-import { closeTaskTab } from "./agents-page-session-tabs";
+import { closeTaskTab, reorderTaskTabs } from "./agents-page-session-tabs";
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 
@@ -33,6 +33,11 @@ type UseTaskTabActionsArgs = {
 type UseTaskTabActionsResult = {
   handleCreateTab: (nextTaskId: string) => void;
   handleCloseTab: (taskIdToClose: string) => void;
+  handleReorderTab: (
+    draggedTaskId: string,
+    targetTaskId: string,
+    position: "before" | "after",
+  ) => void;
 };
 
 export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabActionsResult {
@@ -100,8 +105,27 @@ export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabAction
     ],
   );
 
+  const handleReorderTab = useCallback(
+    (draggedTaskId: string, targetTaskId: string, position: "before" | "after"): void => {
+      const nextTabTaskIds = reorderTaskTabs({
+        tabTaskIds,
+        draggedTaskId,
+        targetTaskId,
+        position,
+      });
+
+      if (nextTabTaskIds === tabTaskIds) {
+        return;
+      }
+
+      setOpenTaskTabs(nextTabTaskIds);
+    },
+    [setOpenTaskTabs, tabTaskIds],
+  );
+
   return {
     handleCreateTab,
     handleCloseTab,
+    handleReorderTab,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -13,7 +13,7 @@ import {
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
 import { toTabsStorageKey } from "./agents-page-selection";
-import { toPersistedTaskTabs } from "./agents-page-session-tabs";
+import { parsePersistedTaskTabs, toPersistedTaskTabs } from "./agents-page-session-tabs";
 import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
 
 enableReactActEnvironment();
@@ -388,6 +388,47 @@ describe("useAgentStudioTaskTabs", () => {
         value: originalStorage,
       });
     }
+  });
+
+  test("reordering tabs updates persisted order without changing the active task", async () => {
+    const memoryStorage = createMemoryStorage();
+    await withMockedLocalStorage(memoryStorage, async () => {
+      seedWorkspaceTaskTabs(memoryStorage, {
+        "workspace-repo": {
+          tabs: ["task-1", "task-2", "task-3"],
+          activeTaskId: "task-2",
+        },
+      });
+
+      const harness = createHookHarness(
+        withPersistenceWorkspaceId({
+          activeRepo: "/repo",
+          taskId: "task-2",
+          selectedTask: createTask("task-2"),
+          tasks: [createTask("task-1"), createTask("task-2"), createTask("task-3")],
+          isLoadingTasks: false,
+          latestSessionByTaskId: new Map(),
+          updateQuery: () => {},
+          clearComposerInput: () => {},
+        }),
+      );
+
+      await harness.mount();
+      await harness.run((state) => {
+        state.handleReorderTab("task-3", "task-1", "before");
+      });
+
+      expect(harness.getLatest().tabTaskIds).toEqual(["task-3", "task-1", "task-2"]);
+      expect(harness.getLatest().activeTaskTabId).toBe("task-2");
+      expect(
+        parsePersistedTaskTabs(memoryStorage.getItem(toTabsStorageKey("workspace-repo"))),
+      ).toEqual({
+        tabs: ["task-3", "task-1", "task-2"],
+        activeTaskId: "task-2",
+      });
+
+      await harness.unmount();
+    });
   });
 
   test("routes fallback tab after hydration when URL task is empty", async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -402,7 +402,7 @@ describe("useAgentStudioTaskTabs", () => {
 
       const harness = createHookHarness(
         withPersistenceWorkspaceId({
-          activeRepo: "/repo",
+          workspaceRepoPath: "/repo",
           taskId: "task-2",
           selectedTask: createTask("task-2"),
           tasks: [createTask("task-1"), createTask("task-2"), createTask("task-3")],

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
@@ -52,6 +52,11 @@ export function useAgentStudioTaskTabs(args: {
   handleSelectTab: (nextTaskId: string) => void;
   handleCreateTab: (nextTaskId: string) => void;
   handleCloseTab: (taskIdToClose: string) => void;
+  handleReorderTab: (
+    draggedTaskId: string,
+    targetTaskId: string,
+    position: "before" | "after",
+  ) => void;
 } {
   const {
     activeWorkspace,
@@ -142,7 +147,7 @@ export function useAgentStudioTaskTabs(args: {
     [activeTaskTabId, activeSessionByTaskId, latestSessionByTaskId, tabTaskIds, tasks],
   );
 
-  const { handleCreateTab, handleCloseTab } = useTaskTabActions({
+  const { handleCreateTab, handleCloseTab, handleReorderTab } = useTaskTabActions({
     tabTaskIds,
     activeTaskTabId,
     clearComposerInput,
@@ -163,5 +168,6 @@ export function useAgentStudioTaskTabs(args: {
     handleSelectTab,
     handleCreateTab,
     handleCloseTab,
+    handleReorderTab,
   };
 }

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,10 @@
       "name": "@openducktor/desktop",
       "version": "0.0.5",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@openducktor/adapters-opencode-sdk": "workspace:*",
         "@openducktor/adapters-tauri-host": "workspace:*",
         "@openducktor/contracts": "workspace:*",
@@ -181,6 +185,16 @@
     "@commitlint/types": ["@commitlint/types@20.5.0", "", { "dependencies": { "conventional-commits-parser": "^6.3.0", "picocolors": "^1.1.1" } }, "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA=="],
 
     "@conventional-changelog/git-client": ["@conventional-changelog/git-client@2.7.0", "", { "dependencies": { "@simple-libs/child-process-utils": "^1.0.0", "@simple-libs/stream-utils": "^1.2.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.4.0" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/modifiers": ["@dnd-kit/modifiers@9.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 


### PR DESCRIPTION
## Summary
- replace the original native HTML5 tab drag-and-drop path with a `dnd-kit` sortable implementation for Agent Studio task tabs
- add smoother drag presentation with a real dragged-tab overlay, reliable pointer-driven reordering, and polish for cursor/alignment behavior
- preserve tab-order persistence and selection rules while extending test coverage and fixing rebase-time verification drift

## Goal
This PR fixes the Agent Studio tab reordering experience. The original native browser drag-and-drop approach produced poor UX: an almost invisible drop marker, unreliable drops, the browser's green plus cursor and drag ghost, and an interaction that felt far from Chrome-style tab reordering.

The goal here is to make tab reordering feel clean and predictable while keeping the existing application behavior intact. Users should be able to drag tabs confidently, see where the tab is going, and keep working without the tab strip fighting the browser's default drag behavior.

## Implementation
I replaced the native drag handling with `dnd-kit` in the desktop app and rewrote the tab-strip interaction around pointer-driven sortable state. The new implementation renders a real dragged-tab preview with `DragOverlay`, lets sibling tabs shift smoothly in place, and removes dependence on native browser drag ghosts and cursor states.

The tab strip still keeps order persistence in the existing Agent Studio state flow, so reordering remains compatible with the stored tab state and active-tab rules already used by the page-model chain. The follow-up fixes in this branch also resolved stale drop-target behavior, moved the drag surface to the full visible tab shell, and then polished the visual presentation so the dragged tab keeps the same shape and alignment as the resting tab.

I also updated the relevant tests to cover pointer-driven reordering, drag preview behavior, close-button drag guarding, persistence, and the rebased test harness shape. To get the required verification fully green after the rebase, I applied the Rust formatter output that `cargo fmt --check` required in the Tauri workspace.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check` via rerun after formatting
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `cargo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support for reordering agent studio task tabs with visual drag previews and cursor feedback.
  * Users can now rearrange tabs by dragging them to desired positions relative to other tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->