### PR TITLE
fix(runtime): normalize host runtime session probing

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -73,7 +73,7 @@ pub(crate) type RuntimeSessionStatusProbeTarget =
 pub(crate) use runtime_session_status::{
     RuntimeSessionStatusProbeError, RuntimeSessionStatusProbeOutcome,
     RuntimeSessionStatusProbeTargetResolution,
-    RuntimeSessionStatusSnapshot, RuntimeSessionStatusSnapshotKind,
+    RuntimeSessionStatusSnapshot,
 };
 pub(crate) use process_registry::RuntimeProcessGuard;
 pub(crate) use service_core::{

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -27,9 +27,9 @@ mod mcp_bridge_process;
 mod mcp_bridge_registry;
 mod odt_mcp;
 mod opencode_runtime;
-mod opencode_session_status;
 mod process_registry;
 mod repo_init;
+mod runtime_session_status;
 mod runtime_orchestrator;
 mod runtime_registry;
 mod runtime_startup;
@@ -67,12 +67,12 @@ pub(crate) use opencode_runtime::{
     wait_for_local_server_with_process as wait_for_runtime_with_process,
     wait_for_process_exit_by_pid, StartupCancelEpoch,
 };
-pub(crate) type RuntimeSessionStatusMap = opencode_session_status::OpencodeSessionStatusMap;
+pub(crate) type RuntimeSessionStatusMap = runtime_session_status::RuntimeSessionStatusMap;
 pub(crate) type RuntimeSessionStatusProbeTarget =
-    opencode_session_status::OpencodeSessionStatusProbeTarget;
-pub(crate) use opencode_session_status::{
-    dedupe_probe_targets as dedupe_runtime_session_probe_targets,
-    has_live_opencode_session_status as has_live_runtime_session_status,
+    runtime_session_status::RuntimeSessionStatusProbeTarget;
+pub(crate) use runtime_session_status::{
+    has_live_runtime_session_status, RuntimeSessionStatusProbeError,
+    RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTargetResolution,
 };
 pub(crate) use process_registry::RuntimeProcessGuard;
 pub(crate) use service_core::{

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -71,8 +71,9 @@ pub(crate) type RuntimeSessionStatusMap = runtime_session_status::RuntimeSession
 pub(crate) type RuntimeSessionStatusProbeTarget =
     runtime_session_status::RuntimeSessionStatusProbeTarget;
 pub(crate) use runtime_session_status::{
-    has_live_runtime_session_status, RuntimeSessionStatusProbeError,
-    RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTargetResolution,
+    RuntimeSessionStatusProbeError, RuntimeSessionStatusProbeOutcome,
+    RuntimeSessionStatusProbeTargetResolution,
+    RuntimeSessionStatusSnapshot, RuntimeSessionStatusSnapshotKind,
 };
 pub(crate) use process_registry::RuntimeProcessGuard;
 pub(crate) use service_core::{

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/run_exposure.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/run_exposure.rs
@@ -95,6 +95,9 @@ impl RunExposurePlan {
                     .any(|external_session_id| snapshot.has_live_session(external_session_id)))
             }
             super::super::RuntimeSessionStatusProbeOutcome::Unsupported => Ok(true),
+            // Run visibility is best-effort: if probing fails, hide the run rather than
+            // surfacing a stale entry. Task reset/delete guards stay fail-safe and propagate
+            // the same probe failure instead of allowing destructive actions to continue.
             super::super::RuntimeSessionStatusProbeOutcome::ActionableError(_) => Ok(false),
         }
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/run_exposure.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/run_exposure.rs
@@ -85,8 +85,7 @@ impl RunExposurePlan {
 
         match probe_outcome {
             super::super::RuntimeSessionStatusProbeOutcome::Snapshot(snapshot) => {
-                if snapshot.kind() == super::super::RuntimeSessionStatusSnapshotKind::NoLiveSessions
-                {
+                if snapshot.has_no_live_sessions() {
                     return Ok(false);
                 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/run_exposure.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/run_exposure.rs
@@ -84,10 +84,16 @@ impl RunExposurePlan {
         })?;
 
         match probe_outcome {
-            super::super::RuntimeSessionStatusProbeOutcome::Statuses(statuses) => {
-                Ok(self.external_session_ids.iter().any(|external_session_id| {
-                    super::super::has_live_runtime_session_status(statuses, external_session_id)
-                }))
+            super::super::RuntimeSessionStatusProbeOutcome::Snapshot(snapshot) => {
+                if snapshot.kind() == super::super::RuntimeSessionStatusSnapshotKind::NoLiveSessions
+                {
+                    return Ok(false);
+                }
+
+                Ok(self
+                    .external_session_ids
+                    .iter()
+                    .any(|external_session_id| snapshot.has_live_session(external_session_id)))
             }
             super::super::RuntimeSessionStatusProbeOutcome::Unsupported => Ok(true),
             super::super::RuntimeSessionStatusProbeOutcome::ActionableError(_) => Ok(false),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/run_exposure.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/run_exposure.rs
@@ -35,7 +35,7 @@ impl RunExposureCandidate {
 struct RunExposurePlan {
     summary: RunSummary,
     external_session_ids: Vec<String>,
-    probe_target: Option<super::super::RuntimeSessionStatusProbeTarget>,
+    probe_target_resolution: Option<super::super::RuntimeSessionStatusProbeTargetResolution>,
 }
 
 impl RunExposurePlan {
@@ -43,19 +43,19 @@ impl RunExposurePlan {
         Self {
             summary,
             external_session_ids: Vec::new(),
-            probe_target: None,
+            probe_target_resolution: None,
         }
     }
 
     fn with_probe(
         summary: RunSummary,
         external_session_ids: Vec<String>,
-        probe_target: super::super::RuntimeSessionStatusProbeTarget,
+        probe_target_resolution: super::super::RuntimeSessionStatusProbeTargetResolution,
     ) -> Self {
         Self {
             summary,
             external_session_ids,
-            probe_target: Some(probe_target),
+            probe_target_resolution: Some(probe_target_resolution),
         }
     }
 
@@ -63,22 +63,35 @@ impl RunExposurePlan {
         &self,
         statuses_by_target: &HashMap<
             super::super::RuntimeSessionStatusProbeTarget,
-            super::super::RuntimeSessionStatusMap,
+            super::super::RuntimeSessionStatusProbeOutcome,
         >,
     ) -> Result<bool> {
-        let Some(probe_target) = self.probe_target.as_ref() else {
+        let Some(probe_target_resolution) = self.probe_target_resolution.as_ref() else {
             return Ok(true);
         };
 
-        let statuses = statuses_by_target.get(probe_target).ok_or_else(|| {
+        let super::super::RuntimeSessionStatusProbeTargetResolution::Target(probe_target) =
+            probe_target_resolution
+        else {
+            return Ok(true);
+        };
+
+        let probe_outcome = statuses_by_target.get(probe_target).ok_or_else(|| {
             anyhow!(
-                "Missing cached runtime session statuses for run {}",
+                "Missing cached runtime session status outcome for run {}",
                 self.summary.run_id
             )
         })?;
-        Ok(self.external_session_ids.iter().any(|external_session_id| {
-            super::super::has_live_runtime_session_status(statuses, external_session_id)
-        }))
+
+        match probe_outcome {
+            super::super::RuntimeSessionStatusProbeOutcome::Statuses(statuses) => {
+                Ok(self.external_session_ids.iter().any(|external_session_id| {
+                    super::super::has_live_runtime_session_status(statuses, external_session_id)
+                }))
+            }
+            super::super::RuntimeSessionStatusProbeOutcome::Unsupported => Ok(true),
+            super::super::RuntimeSessionStatusProbeOutcome::ActionableError(_) => Ok(false),
+        }
     }
 }
 
@@ -153,22 +166,22 @@ impl AppService {
                 continue;
             }
 
-            let probe_target = self
+            let probe_target_resolution = self
                 .runtime_registry
                 .runtime(&run.summary.runtime_kind)?
                 .session_status_probe_target(
                     &run.summary.runtime_route,
                     run.worktree_path.as_str(),
                 )?;
-            let Some(probe_target) = probe_target else {
-                exposure_plans.push(RunExposurePlan::without_probe(run.summary));
-                continue;
-            };
-            probe_targets.push(probe_target.clone());
+            if let super::super::RuntimeSessionStatusProbeTargetResolution::Target(probe_target) =
+                &probe_target_resolution
+            {
+                probe_targets.push(probe_target.clone());
+            }
             exposure_plans.push(RunExposurePlan::with_probe(
                 run.summary,
                 external_session_ids,
-                probe_target,
+                probe_target_resolution,
             ));
         }
 
@@ -198,7 +211,7 @@ impl AppService {
         exposure_plans: Vec<RunExposurePlan>,
         statuses_by_target: &HashMap<
             super::super::RuntimeSessionStatusProbeTarget,
-            super::super::RuntimeSessionStatusMap,
+            super::super::RuntimeSessionStatusProbeOutcome,
         >,
     ) -> Result<Vec<RunSummary>> {
         let mut list = Vec::new();

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
@@ -1,7 +1,8 @@
 mod health_http;
 mod open_code;
 use super::{
-    AppService, RuntimeProcessGuard, RuntimeRoute, RuntimeSessionStatusProbeTarget,
+    AppService, RuntimeProcessGuard, RuntimeRoute, RuntimeSessionStatusProbeOutcome,
+    RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeTargetResolution,
     RuntimeStartupReadinessPolicy, RuntimeStartupWaitReport,
 };
 use anyhow::{anyhow, Result};
@@ -137,16 +138,16 @@ pub(crate) trait AppRuntime: Send + Sync {
         &self,
         runtime_route: &RuntimeRoute,
         working_directory: &str,
-    ) -> Result<Option<RuntimeSessionStatusProbeTarget>> {
-        match runtime_route {
-            RuntimeRoute::LocalHttp { .. } => {
-                Ok(Some(RuntimeSessionStatusProbeTarget::for_runtime_route(
-                    runtime_route,
-                    working_directory,
-                )?))
-            }
-            RuntimeRoute::Stdio => Ok(None),
-        }
+    ) -> Result<RuntimeSessionStatusProbeTargetResolution> {
+        let _ = (runtime_route, working_directory);
+        Ok(RuntimeSessionStatusProbeTargetResolution::Unsupported)
+    }
+
+    fn probe_session_status(
+        &self,
+        _target: &RuntimeSessionStatusProbeTarget,
+    ) -> RuntimeSessionStatusProbeOutcome {
+        RuntimeSessionStatusProbeOutcome::Unsupported
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -11,8 +11,9 @@ use crate::app_service::{
     resolve_opencode_binary_path, wait_for_runtime_with_process, AppService, RuntimeProcessGuard,
     RuntimeRoute, RuntimeSessionStatusMap, RuntimeSessionStatusProbeError,
     RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
-    RuntimeSessionStatusProbeTargetResolution, RuntimeStartupReadinessPolicy,
-    RuntimeStartupWaitReport, StartupEventContext, StartupEventCorrelation, StartupEventPayload,
+    RuntimeSessionStatusProbeTargetResolution, RuntimeSessionStatusSnapshot,
+    RuntimeStartupReadinessPolicy, RuntimeStartupWaitReport, StartupEventContext,
+    StartupEventCorrelation, StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
@@ -447,7 +448,9 @@ impl AppRuntime for OpenCodeRuntime {
         target: &RuntimeSessionStatusProbeTarget,
     ) -> RuntimeSessionStatusProbeOutcome {
         match Self::load_session_statuses(target.runtime_route(), target.working_directory()) {
-            Ok(statuses) => RuntimeSessionStatusProbeOutcome::Statuses(statuses),
+            Ok(statuses) => RuntimeSessionStatusProbeOutcome::Snapshot(
+                RuntimeSessionStatusSnapshot::from_statuses(statuses),
+            ),
             Err(error) => RuntimeSessionStatusProbeOutcome::ActionableError(
                 RuntimeSessionStatusProbeError::ProbeFailed(error.to_string()),
             ),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -22,7 +22,7 @@ use host_domain::{
 };
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::path::Path;
 use std::process::Child;
 use std::time::Duration;
@@ -58,6 +58,7 @@ impl OpenCodeRuntime {
             .with_context(|| format!("Failed resolving OpenCode runtime endpoint: {endpoint}"))?
             .next()
             .ok_or_else(|| anyhow!("OpenCode runtime endpoint did not resolve: {endpoint}"))?;
+        let socket_address = Self::require_loopback_socket_address(socket_address, endpoint)?;
         let mut stream = TcpStream::connect_timeout(&socket_address, Duration::from_secs(2)).with_context(|| {
             format!(
                 "Failed to connect to OpenCode runtime at {endpoint} to inspect session status for {working_directory}"
@@ -93,7 +94,11 @@ impl OpenCodeRuntime {
         })?;
 
         if !(200..300).contains(&status_code) {
-            let response_body = Self::extract_http_response_body(response.as_str());
+            let response_body = Self::extract_http_response_body(response.as_str()).with_context(|| {
+                format!(
+                    "Failed decoding OpenCode session status response body for {working_directory}"
+                )
+            })?;
             let detail_suffix = if response_body.is_empty() {
                 String::new()
             } else {
@@ -104,7 +109,9 @@ impl OpenCodeRuntime {
             ));
         }
 
-        let body = Self::extract_http_response_body(response.as_str());
+        let body = Self::extract_http_response_body(response.as_str()).with_context(|| {
+            format!("Failed decoding OpenCode session status response body for {working_directory}")
+        })?;
         serde_json::from_str::<RuntimeSessionStatusMap>(body.as_str()).with_context(|| {
             format!("Failed parsing OpenCode session status response for {working_directory}")
         })
@@ -121,12 +128,62 @@ impl OpenCodeRuntime {
             .with_context(|| format!("Invalid OpenCode HTTP status code: {status_code}"))
     }
 
-    fn extract_http_response_body(response: &str) -> String {
-        response
+    fn require_loopback_socket_address(socket_address: SocketAddr, endpoint: &str) -> Result<SocketAddr> {
+        if socket_address.ip().is_loopback() {
+            return Ok(socket_address);
+        }
+
+        Err(anyhow!(
+            "OpenCode runtime endpoint for session status probes must resolve to a loopback address: {endpoint}"
+        ))
+    }
+
+    fn extract_http_response_body(response: &str) -> Result<String> {
+        let (headers, body) = response
             .split_once("\r\n\r\n")
             .or_else(|| response.split_once("\n\n"))
-            .map(|(_, body)| body.trim().to_string())
-            .unwrap_or_default()
+            .unwrap_or(("", response));
+
+        if headers
+            .lines()
+            .any(|line| line.eq_ignore_ascii_case("Transfer-Encoding: chunked"))
+        {
+            return Self::decode_chunked_http_body(body);
+        }
+
+        Ok(body.trim().to_string())
+    }
+
+    fn decode_chunked_http_body(body: &str) -> Result<String> {
+        let mut remaining = body;
+        let mut decoded = String::new();
+
+        loop {
+            let Some((size_line, rest)) = remaining.split_once("\r\n") else {
+                return Err(anyhow!("Chunked OpenCode response is missing a chunk size delimiter"));
+            };
+            let size_text = size_line
+                .split_once(';')
+                .map_or(size_line, |(size, _)| size)
+                .trim();
+            let size = usize::from_str_radix(size_text, 16).with_context(|| {
+                format!("Invalid chunk size in OpenCode response: {size_text}")
+            })?;
+            if size == 0 {
+                return Ok(decoded.trim().to_string());
+            }
+            if rest.len() < size + 2 {
+                return Err(anyhow!("Chunked OpenCode response ended before the declared chunk size"));
+            }
+
+            decoded.push_str(&rest[..size]);
+            let chunk_suffix = &rest[size..size + 2];
+            if chunk_suffix != "\r\n" {
+                return Err(anyhow!("Chunked OpenCode response is missing a chunk terminator"));
+            }
+
+            remaining = &rest[size + 2..];
+        }
     }
 
     fn read_http_response_body(
@@ -460,5 +517,52 @@ impl AppRuntime for OpenCodeRuntime {
                 RuntimeSessionStatusProbeError::ProbeFailed(error.to_string()),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OpenCodeRuntime;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn require_loopback_socket_address_accepts_loopback_addresses() {
+        let loopback = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+
+        let result = OpenCodeRuntime::require_loopback_socket_address(loopback, "http://127.0.0.1:8080")
+            .expect("loopback endpoint should be accepted");
+
+        assert_eq!(result, loopback);
+    }
+
+    #[test]
+    fn require_loopback_socket_address_rejects_non_loopback_addresses() {
+        let error = OpenCodeRuntime::require_loopback_socket_address(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)), 8080),
+            "http://192.168.1.10:8080",
+        )
+        .expect_err("non-loopback endpoint should be rejected");
+
+        assert!(error
+            .to_string()
+            .contains("must resolve to a loopback address"));
+    }
+
+    #[test]
+    fn extract_http_response_body_decodes_chunked_transfer_encoding() {
+        let response = concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Transfer-Encoding: chunked\r\n",
+            "\r\n",
+            "7\r\n",
+            "{\"a\":1}\r\n",
+            "0\r\n",
+            "\r\n"
+        );
+
+        let body = OpenCodeRuntime::extract_http_response_body(response)
+            .expect("chunked body should decode");
+
+        assert_eq!(body, "{\"a\":1}");
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -22,7 +22,7 @@ use host_domain::{
 };
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::Path;
 use std::process::Child;
 use std::time::Duration;
@@ -53,7 +53,12 @@ impl OpenCodeRuntime {
                 .append_pair("directory", working_directory)
                 .finish()
         );
-        let mut stream = TcpStream::connect((host, port)).with_context(|| {
+        let socket_address = (host, port)
+            .to_socket_addrs()
+            .with_context(|| format!("Failed resolving OpenCode runtime endpoint: {endpoint}"))?
+            .next()
+            .ok_or_else(|| anyhow!("OpenCode runtime endpoint did not resolve: {endpoint}"))?;
+        let mut stream = TcpStream::connect_timeout(&socket_address, Duration::from_secs(2)).with_context(|| {
             format!(
                 "Failed to connect to OpenCode runtime at {endpoint} to inspect session status for {working_directory}"
             )

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -9,12 +9,15 @@ use crate::app_service::opencode_runtime::{
 use crate::app_service::{
     read_opencode_version, require_local_http_endpoint, require_local_http_port,
     resolve_opencode_binary_path, wait_for_runtime_with_process, AppService, RuntimeProcessGuard,
-    RuntimeRoute, RuntimeStartupReadinessPolicy, RuntimeStartupWaitReport, StartupEventContext,
-    StartupEventCorrelation, StartupEventPayload,
+    RuntimeRoute, RuntimeSessionStatusMap, RuntimeSessionStatusProbeError,
+    RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
+    RuntimeSessionStatusProbeTargetResolution, RuntimeStartupReadinessPolicy,
+    RuntimeStartupWaitReport, StartupEventContext, StartupEventCorrelation, StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    RuntimeDefinition, RuntimeHealth, RuntimeInstanceSummary, RuntimeStartupReadinessConfig,
+    AgentRuntimeKind, RuntimeDefinition, RuntimeHealth, RuntimeInstanceSummary,
+    RuntimeStartupReadinessConfig,
 };
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -30,6 +33,96 @@ pub(crate) struct OpenCodeRuntime {
 }
 
 impl OpenCodeRuntime {
+    fn load_session_statuses(
+        runtime_route: &RuntimeRoute,
+        working_directory: &str,
+    ) -> Result<RuntimeSessionStatusMap> {
+        let endpoint = require_local_http_endpoint(runtime_route, "session status probes")?;
+        let parsed_endpoint = url::Url::parse(endpoint)
+            .with_context(|| format!("Invalid OpenCode runtime endpoint: {endpoint}"))?;
+        let host = parsed_endpoint
+            .host_str()
+            .ok_or_else(|| anyhow!("OpenCode runtime endpoint is missing a host: {endpoint}"))?;
+        let port = parsed_endpoint
+            .port()
+            .ok_or_else(|| anyhow!("OpenCode runtime route must expose a port: {endpoint}"))?;
+        let request_path = format!(
+            "/session/status?{}",
+            form_urlencoded::Serializer::new(String::new())
+                .append_pair("directory", working_directory)
+                .finish()
+        );
+        let mut stream = TcpStream::connect((host, port)).with_context(|| {
+            format!(
+                "Failed to connect to OpenCode runtime at {endpoint} to inspect session status for {working_directory}"
+            )
+        })?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .context("Failed configuring OpenCode session status read timeout")?;
+        stream
+            .set_write_timeout(Some(Duration::from_secs(2)))
+            .context("Failed configuring OpenCode session status write timeout")?;
+
+        let request = format!(
+            "GET {request_path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
+        );
+        stream.write_all(request.as_bytes()).with_context(|| {
+            format!("Failed sending OpenCode session status request for {working_directory}")
+        })?;
+        stream.flush().with_context(|| {
+            format!("Failed flushing OpenCode session status request for {working_directory}")
+        })?;
+
+        let mut reader = BufReader::new(stream);
+        let mut status_line = String::new();
+        reader.read_line(&mut status_line).with_context(|| {
+            format!("Failed reading OpenCode session status response for {working_directory}")
+        })?;
+        let status_code = Self::parse_http_status_code(status_line.as_str())?;
+
+        let mut response = String::new();
+        reader.read_to_string(&mut response).with_context(|| {
+            format!("Failed reading OpenCode session status body for {working_directory}")
+        })?;
+
+        if !(200..300).contains(&status_code) {
+            let response_body = Self::extract_http_response_body(response.as_str());
+            let detail_suffix = if response_body.is_empty() {
+                String::new()
+            } else {
+                format!(": {response_body}")
+            };
+            return Err(anyhow!(
+                "OpenCode runtime failed to load session status for {working_directory}: HTTP {status_code}{detail_suffix}"
+            ));
+        }
+
+        let body = Self::extract_http_response_body(response.as_str());
+        serde_json::from_str::<RuntimeSessionStatusMap>(body.as_str()).with_context(|| {
+            format!("Failed parsing OpenCode session status response for {working_directory}")
+        })
+    }
+
+    fn parse_http_status_code(status_line: &str) -> Result<u16> {
+        let trimmed = status_line.trim();
+        let status_code = trimmed
+            .split_whitespace()
+            .nth(1)
+            .ok_or_else(|| anyhow!("OpenCode response missing HTTP status code"))?;
+        status_code
+            .parse::<u16>()
+            .with_context(|| format!("Invalid OpenCode HTTP status code: {status_code}"))
+    }
+
+    fn extract_http_response_body(response: &str) -> String {
+        response
+            .split_once("\r\n\r\n")
+            .or_else(|| response.split_once("\n\n"))
+            .map(|(_, body)| body.trim().to_string())
+            .unwrap_or_default()
+    }
+
     fn read_http_response_body(
         reader: &mut BufReader<TcpStream>,
         external_session_id: &str,
@@ -328,5 +421,36 @@ impl AppRuntime for OpenCodeRuntime {
         working_directory: &str,
     ) -> Result<()> {
         Self::abort_session(runtime_route, external_session_id, working_directory)
+    }
+
+    fn session_status_probe_target(
+        &self,
+        runtime_route: &RuntimeRoute,
+        working_directory: &str,
+    ) -> Result<RuntimeSessionStatusProbeTargetResolution> {
+        match runtime_route {
+            RuntimeRoute::LocalHttp { .. } => {
+                Ok(RuntimeSessionStatusProbeTargetResolution::Target(
+                    RuntimeSessionStatusProbeTarget::new(
+                        AgentRuntimeKind::opencode(),
+                        runtime_route,
+                        working_directory,
+                    ),
+                ))
+            }
+            RuntimeRoute::Stdio => Ok(RuntimeSessionStatusProbeTargetResolution::Unsupported),
+        }
+    }
+
+    fn probe_session_status(
+        &self,
+        target: &RuntimeSessionStatusProbeTarget,
+    ) -> RuntimeSessionStatusProbeOutcome {
+        match Self::load_session_statuses(target.runtime_route(), target.working_directory()) {
+            Ok(statuses) => RuntimeSessionStatusProbeOutcome::Statuses(statuses),
+            Err(error) => RuntimeSessionStatusProbeOutcome::ActionableError(
+                RuntimeSessionStatusProbeError::ProbeFailed(error.to_string()),
+            ),
+        }
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
@@ -27,7 +27,7 @@ pub(crate) enum RuntimeExternalSessionStatus {
 
 pub(crate) type RuntimeSessionStatusMap = HashMap<String, RuntimeExternalSessionStatus>;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum RuntimeSessionStatusSnapshotKind {
     NoLiveSessions,
     HasLiveSessions,
@@ -55,13 +55,20 @@ impl RuntimeSessionStatusSnapshot {
         Self { statuses, kind }
     }
 
-    pub(crate) fn kind(&self) -> RuntimeSessionStatusSnapshotKind {
-        self.kind.clone()
+    pub(crate) fn has_any_live_sessions(&self) -> bool {
+        self.kind == RuntimeSessionStatusSnapshotKind::HasLiveSessions
+    }
+
+    pub(crate) fn has_no_live_sessions(&self) -> bool {
+        !self.has_any_live_sessions()
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn statuses(&self) -> &RuntimeSessionStatusMap {
-        &self.statuses
+    pub(crate) fn session_status(
+        &self,
+        external_session_id: &str,
+    ) -> Option<&RuntimeExternalSessionStatus> {
+        self.statuses.get(external_session_id)
     }
 
     pub(crate) fn has_live_session(&self, external_session_id: &str) -> bool {
@@ -502,7 +509,6 @@ mod tests {
         AppService, CachedRuntimeSessionStatusProbe, RuntimeExternalSessionStatus,
         RuntimeSessionStatusFlightGuard, RuntimeSessionStatusMap, RuntimeSessionStatusProbeOutcome,
         RuntimeSessionStatusProbeTarget, RuntimeSessionStatusSnapshot,
-        RuntimeSessionStatusSnapshotKind,
     };
     use crate::app_service::runtime_registry::{AppRuntime, OpenCodeRuntime};
     use crate::app_service::test_support::{
@@ -584,13 +590,10 @@ mod tests {
             panic!("status request should succeed");
         };
         assert!(matches!(
-            snapshot.statuses().get("external-session"),
+            snapshot.session_status("external-session"),
             Some(RuntimeExternalSessionStatus::Busy)
         ));
-        assert_eq!(
-            snapshot.kind(),
-            RuntimeSessionStatusSnapshotKind::HasLiveSessions
-        );
+        assert!(snapshot.has_any_live_sessions());
         assert!(snapshot.has_live_session("external-session"));
 
         server.join().expect("server thread should finish");
@@ -645,13 +648,10 @@ mod tests {
             service.load_cached_runtime_session_status_outcome_for_target(&target)?,
         );
         assert!(matches!(
-            statuses.statuses().get("external-session"),
+            statuses.session_status("external-session"),
             Some(RuntimeExternalSessionStatus::Busy)
         ));
-        assert_eq!(
-            statuses.kind(),
-            RuntimeSessionStatusSnapshotKind::HasLiveSessions
-        );
+        assert!(statuses.has_any_live_sessions());
 
         server.join().expect("server thread should finish");
         let captured_request = request_line
@@ -687,8 +687,8 @@ mod tests {
             .join()
             .expect("status server thread should finish");
 
-        assert!(first.statuses().contains_key("external-build-session"));
-        assert!(second.statuses().contains_key("external-build-session"));
+        assert!(first.session_status("external-build-session").is_some());
+        assert!(second.session_status("external-build-session").is_some());
         assert_eq!(connections.load(Ordering::SeqCst), 1);
         Ok(())
     }
@@ -774,11 +774,8 @@ mod tests {
             .join()
             .expect("status server thread should finish");
 
-        assert!(statuses.statuses().contains_key("external-build-session"));
-        assert_eq!(
-            statuses.kind(),
-            RuntimeSessionStatusSnapshotKind::HasLiveSessions
-        );
+        assert!(statuses.session_status("external-build-session").is_some());
+        assert!(statuses.has_any_live_sessions());
         let cache = service
             .runtime_session_status_cache
             .lock()
@@ -817,11 +814,8 @@ mod tests {
             for handle in handles {
                 let statuses =
                     expect_statuses(handle.join().expect("probe thread should not panic"));
-                assert!(statuses.statuses().contains_key("external-build-session"));
-                assert_eq!(
-                    statuses.kind(),
-                    RuntimeSessionStatusSnapshotKind::HasLiveSessions
-                );
+                assert!(statuses.session_status("external-build-session").is_some());
+                assert!(statuses.has_any_live_sessions());
             }
         });
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
@@ -1,24 +1,18 @@
-use super::require_local_http_endpoint;
 use super::service_core::{
-    AppService, CachedOpencodeSessionStatusProbe, CachedOpencodeSessionStatusProbeError,
-    CachedOpencodeSessionStatusProbeOutcome, OpencodeSessionStatusFlight,
-    OpencodeSessionStatusFlightState, OpencodeSessionStatusProbeLimiter,
+    AppService, CachedRuntimeSessionStatusProbe, RuntimeSessionStatusFlight,
+    RuntimeSessionStatusFlightState, RuntimeSessionStatusProbeLimiter,
 };
-use anyhow::{anyhow, Context, Result};
-use host_domain::RuntimeRoute;
+use anyhow::{anyhow, Result};
+use host_domain::{AgentRuntimeKind, RuntimeRoute};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
-use std::io::ErrorKind;
-use std::io::{BufRead, BufReader, Read, Write};
-use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use url::{form_urlencoded, Url};
 
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub(crate) enum OpencodeSessionStatus {
+pub(crate) enum RuntimeExternalSessionStatus {
     Idle,
     Retry {
         #[allow(dead_code)]
@@ -31,47 +25,59 @@ pub(crate) enum OpencodeSessionStatus {
     Busy,
 }
 
-pub(crate) type OpencodeSessionStatusMap = HashMap<String, OpencodeSessionStatus>;
+pub(crate) type RuntimeSessionStatusMap = HashMap<String, RuntimeExternalSessionStatus>;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct OpencodeSessionStatusProbeTarget {
-    endpoint: String,
+pub(crate) struct RuntimeSessionStatusProbeTarget {
+    runtime_kind: AgentRuntimeKind,
+    runtime_route: RuntimeRoute,
     working_directory: String,
 }
 
-impl OpencodeSessionStatusProbeTarget {
-    pub(crate) fn for_runtime_route(
+impl RuntimeSessionStatusProbeTarget {
+    pub(crate) fn new(
+        runtime_kind: AgentRuntimeKind,
         runtime_route: &RuntimeRoute,
         working_directory: &str,
-    ) -> Result<Self> {
-        let endpoint = require_local_http_endpoint(runtime_route, "session status probes")?;
-        Ok(Self {
-            endpoint: endpoint.to_string(),
+    ) -> Self {
+        Self {
+            runtime_kind,
+            runtime_route: runtime_route.clone(),
             working_directory: working_directory.to_string(),
-        })
+        }
     }
 
-    fn endpoint(&self) -> &str {
-        self.endpoint.as_str()
+    pub(crate) fn runtime_kind(&self) -> &AgentRuntimeKind {
+        &self.runtime_kind
     }
 
-    fn working_directory(&self) -> &str {
+    pub(crate) fn runtime_route(&self) -> &RuntimeRoute {
+        &self.runtime_route
+    }
+
+    pub(crate) fn working_directory(&self) -> &str {
         self.working_directory.as_str()
     }
 }
 
-struct OpencodeSessionStatusFlightGuard<'a> {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RuntimeSessionStatusProbeTargetResolution {
+    Unsupported,
+    Target(RuntimeSessionStatusProbeTarget),
+}
+
+struct RuntimeSessionStatusFlightGuard<'a> {
     service: &'a AppService,
-    target: OpencodeSessionStatusProbeTarget,
-    flight: Arc<OpencodeSessionStatusFlight>,
+    target: RuntimeSessionStatusProbeTarget,
+    flight: Arc<RuntimeSessionStatusFlight>,
     completed: bool,
 }
 
-impl<'a> OpencodeSessionStatusFlightGuard<'a> {
+impl<'a> RuntimeSessionStatusFlightGuard<'a> {
     fn new(
         service: &'a AppService,
-        target: &OpencodeSessionStatusProbeTarget,
-        flight: Arc<OpencodeSessionStatusFlight>,
+        target: &RuntimeSessionStatusProbeTarget,
+        flight: Arc<RuntimeSessionStatusFlight>,
     ) -> Self {
         Self {
             service,
@@ -81,39 +87,39 @@ impl<'a> OpencodeSessionStatusFlightGuard<'a> {
         }
     }
 
-    fn complete(&mut self, outcome: &CachedOpencodeSessionStatusProbeOutcome) -> Result<()> {
+    fn complete(&mut self, outcome: &RuntimeSessionStatusProbeOutcome) -> Result<()> {
         self.completed = true;
         self.service
-            .complete_opencode_session_status_flight(&self.target, &self.flight, outcome)
+            .complete_runtime_session_status_flight(&self.target, &self.flight, outcome)
     }
 }
 
-impl Drop for OpencodeSessionStatusFlightGuard<'_> {
+impl Drop for RuntimeSessionStatusFlightGuard<'_> {
     fn drop(&mut self) {
         if self.completed {
             return;
         }
 
-        let aborted = CachedOpencodeSessionStatusProbeOutcome::ActionableError(
-            CachedOpencodeSessionStatusProbeError::ProbeAborted,
+        let aborted = RuntimeSessionStatusProbeOutcome::ActionableError(
+            RuntimeSessionStatusProbeError::ProbeAborted,
         );
-        if let Err(error) = self.service.complete_opencode_session_status_flight(
+        if let Err(error) = self.service.complete_runtime_session_status_flight(
             &self.target,
             &self.flight,
             &aborted,
         ) {
             eprintln!(
-                "OpenDucktor warning: failed completing OpenCode session status flight after abort: {error:#}"
+                "OpenDucktor warning: failed completing runtime session status flight after abort: {error:#}"
             );
         }
     }
 }
 
-struct OpencodeSessionStatusProbePermit {
-    limiter: Arc<OpencodeSessionStatusProbeLimiter>,
+struct RuntimeSessionStatusProbePermit {
+    limiter: Arc<RuntimeSessionStatusProbeLimiter>,
 }
 
-impl Drop for OpencodeSessionStatusProbePermit {
+impl Drop for RuntimeSessionStatusProbePermit {
     fn drop(&mut self) {
         match self.limiter.active.lock() {
             Ok(mut active) => {
@@ -129,163 +135,50 @@ impl Drop for OpencodeSessionStatusProbePermit {
                 }
                 self.limiter.condvar.notify_one();
                 eprintln!(
-                    "OpenDucktor warning: OpenCode session status probe limiter lock poisoned during permit release"
+                    "OpenDucktor warning: runtime session status probe limiter lock poisoned during permit release"
                 );
             }
         }
     }
 }
 
-impl fmt::Display for CachedOpencodeSessionStatusProbeError {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RuntimeSessionStatusProbeError {
+    ProbeFailed(String),
+    ProbeAborted,
+}
+
+impl fmt::Display for RuntimeSessionStatusProbeError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ProbeFailed(message) => formatter.write_str(message),
             Self::ProbeAborted => {
-                formatter.write_str("OpenCode session status probe aborted unexpectedly")
+                formatter.write_str("Runtime session status probe aborted unexpectedly")
             }
         }
     }
 }
 
-impl CachedOpencodeSessionStatusProbeOutcome {
-    fn to_result(&self) -> Result<OpencodeSessionStatusMap> {
-        match self {
-            Self::Statuses(statuses) => Ok(statuses.clone()),
-            Self::ActionableError(error) => Err(anyhow!(error.to_string())),
-        }
-    }
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RuntimeSessionStatusProbeOutcome {
+    Statuses(RuntimeSessionStatusMap),
+    Unsupported,
+    ActionableError(RuntimeSessionStatusProbeError),
 }
 
-fn is_unreachable_opencode_session_status_error(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| {
-        cause
-            .downcast_ref::<std::io::Error>()
-            .is_some_and(|io_error| {
-                matches!(
-                    io_error.kind(),
-                    ErrorKind::ConnectionRefused
-                        | ErrorKind::ConnectionReset
-                        | ErrorKind::ConnectionAborted
-                        | ErrorKind::NotConnected
-                        | ErrorKind::TimedOut
-                        | ErrorKind::UnexpectedEof
-                )
-            })
-    })
-}
-
-pub(crate) fn has_live_opencode_session_status(
-    statuses: &OpencodeSessionStatusMap,
+pub(crate) fn has_live_runtime_session_status(
+    statuses: &RuntimeSessionStatusMap,
     external_session_id: &str,
 ) -> bool {
     matches!(
         statuses.get(external_session_id),
-        Some(OpencodeSessionStatus::Busy | OpencodeSessionStatus::Retry { .. })
+        Some(RuntimeExternalSessionStatus::Busy | RuntimeExternalSessionStatus::Retry { .. })
     )
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) fn load_opencode_session_statuses(
-    runtime_route: &RuntimeRoute,
-    working_directory: &str,
-) -> Result<OpencodeSessionStatusMap> {
-    let target =
-        OpencodeSessionStatusProbeTarget::for_runtime_route(runtime_route, working_directory)?;
-    load_opencode_session_statuses_for_target(&target)
-}
-
-fn load_opencode_session_statuses_for_target(
-    target: &OpencodeSessionStatusProbeTarget,
-) -> Result<OpencodeSessionStatusMap> {
-    let endpoint = target.endpoint();
-    let working_directory = target.working_directory();
-    let parsed_endpoint = Url::parse(endpoint)
-        .with_context(|| format!("Invalid OpenCode runtime endpoint: {endpoint}"))?;
-    let host = parsed_endpoint
-        .host_str()
-        .ok_or_else(|| anyhow!("OpenCode runtime endpoint is missing a host: {endpoint}"))?;
-    let port = parsed_endpoint
-        .port()
-        .ok_or_else(|| anyhow!("OpenCode runtime route must expose a port: {endpoint}"))?;
-    let request_path = format!(
-        "/session/status?{}",
-        form_urlencoded::Serializer::new(String::new())
-            .append_pair("directory", working_directory)
-            .finish()
-    );
-    let mut stream = TcpStream::connect((host, port)).with_context(|| {
-        format!(
-            "Failed to connect to OpenCode runtime at {endpoint} to inspect session status for {working_directory}"
-        )
-    })?;
-    stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
-        .context("Failed configuring OpenCode session status read timeout")?;
-    stream
-        .set_write_timeout(Some(Duration::from_secs(2)))
-        .context("Failed configuring OpenCode session status write timeout")?;
-
-    let request =
-        format!("GET {request_path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n");
-    stream.write_all(request.as_bytes()).with_context(|| {
-        format!("Failed sending OpenCode session status request for {working_directory}")
-    })?;
-    stream.flush().with_context(|| {
-        format!("Failed flushing OpenCode session status request for {working_directory}")
-    })?;
-
-    let mut reader = BufReader::new(stream);
-    let mut status_line = String::new();
-    reader.read_line(&mut status_line).with_context(|| {
-        format!("Failed reading OpenCode session status response for {working_directory}")
-    })?;
-    let status_code = parse_http_status_code(status_line.as_str())?;
-
-    let mut response = String::new();
-    reader.read_to_string(&mut response).with_context(|| {
-        format!("Failed reading OpenCode session status body for {working_directory}")
-    })?;
-
-    if !(200..300).contains(&status_code) {
-        let response_body = extract_http_response_body(response.as_str());
-        let detail_suffix = if response_body.is_empty() {
-            String::new()
-        } else {
-            format!(": {response_body}")
-        };
-        return Err(anyhow!(
-            "OpenCode runtime failed to load session status for {working_directory}: HTTP {status_code}{detail_suffix}"
-        ));
-    }
-
-    let body = extract_http_response_body(response.as_str());
-    serde_json::from_str::<OpencodeSessionStatusMap>(body.as_str()).with_context(|| {
-        format!("Failed parsing OpenCode session status response for {working_directory}")
-    })
-}
-
-fn parse_http_status_code(status_line: &str) -> Result<u16> {
-    let trimmed = status_line.trim();
-    let status_code = trimmed
-        .split_whitespace()
-        .nth(1)
-        .ok_or_else(|| anyhow!("OpenCode response missing HTTP status code"))?;
-    status_code
-        .parse::<u16>()
-        .with_context(|| format!("Invalid OpenCode HTTP status code: {status_code}"))
-}
-
-fn extract_http_response_body(response: &str) -> String {
-    response
-        .split_once("\r\n\r\n")
-        .or_else(|| response.split_once("\n\n"))
-        .map(|(_, body)| body.trim().to_string())
-        .unwrap_or_default()
-}
-
-pub(crate) fn dedupe_probe_targets<I>(targets: I) -> Vec<OpencodeSessionStatusProbeTarget>
+pub(crate) fn dedupe_probe_targets<I>(targets: I) -> Vec<RuntimeSessionStatusProbeTarget>
 where
-    I: IntoIterator<Item = OpencodeSessionStatusProbeTarget>,
+    I: IntoIterator<Item = RuntimeSessionStatusProbeTarget>,
 {
     let mut unique_targets = Vec::new();
     let mut seen = HashSet::new();
@@ -298,13 +191,13 @@ where
 }
 
 impl AppService {
-    pub(super) const OPENCODE_SESSION_STATUS_CACHE_TTL: Duration = Duration::from_secs(1);
-    const OPENCODE_SESSION_STATUS_BATCH_WORKER_LIMIT: usize = 16;
+    pub(super) const RUNTIME_SESSION_STATUS_CACHE_TTL: Duration = Duration::from_secs(1);
+    const RUNTIME_SESSION_STATUS_BATCH_WORKER_LIMIT: usize = 16;
 
     pub(super) fn load_cached_runtime_session_statuses_for_targets(
         &self,
-        targets: &[OpencodeSessionStatusProbeTarget],
-    ) -> Result<HashMap<OpencodeSessionStatusProbeTarget, OpencodeSessionStatusMap>> {
+        targets: &[RuntimeSessionStatusProbeTarget],
+    ) -> Result<HashMap<RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeOutcome>> {
         let unique_targets = dedupe_probe_targets(targets.iter().cloned());
 
         if unique_targets.is_empty() {
@@ -316,11 +209,11 @@ impl AppService {
 
     fn resolve_status_batch(
         &self,
-        unique_targets: Vec<OpencodeSessionStatusProbeTarget>,
-    ) -> Result<HashMap<OpencodeSessionStatusProbeTarget, OpencodeSessionStatusMap>> {
+        unique_targets: Vec<RuntimeSessionStatusProbeTarget>,
+    ) -> Result<HashMap<RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeOutcome>> {
         let worker_count = unique_targets.len().min(
-            Self::OPENCODE_SESSION_STATUS_BATCH_WORKER_LIMIT.max(
-                self.opencode_session_status_probe_limiter
+            Self::RUNTIME_SESSION_STATUS_BATCH_WORKER_LIMIT.max(
+                self.runtime_session_status_probe_limiter
                     .max_concurrent
                     .max(1),
             ),
@@ -346,12 +239,11 @@ impl AppService {
                             return Ok(());
                         };
 
-                        let statuses =
-                            service.resolve_cached_probe_outcome(&target)?.to_result()?;
+                        let outcome = service.resolve_cached_probe_outcome(&target)?;
                         let mut results = results.lock().map_err(|_| {
-                            anyhow!("OpenCode session status batch results lock poisoned")
+                            anyhow!("Runtime session status batch results lock poisoned")
                         })?;
-                        results.insert(target, statuses);
+                        results.insert(target, outcome);
                     }
                 }));
             }
@@ -359,7 +251,7 @@ impl AppService {
             for handle in handles {
                 handle
                     .join()
-                    .map_err(|_| anyhow!("OpenCode session status batch worker panicked"))??;
+                    .map_err(|_| anyhow!("Runtime session status batch worker panicked"))??;
             }
             Ok(())
         })?;
@@ -372,24 +264,24 @@ impl AppService {
     }
 
     #[cfg(test)]
-    fn load_cached_opencode_session_statuses_for_target(
+    fn load_cached_runtime_session_status_outcome_for_target(
         &self,
-        target: &OpencodeSessionStatusProbeTarget,
-    ) -> Result<OpencodeSessionStatusMap> {
-        self.resolve_cached_probe_outcome(target)?.to_result()
+        target: &RuntimeSessionStatusProbeTarget,
+    ) -> Result<RuntimeSessionStatusProbeOutcome> {
+        self.resolve_cached_probe_outcome(target)
     }
 
     fn resolve_cached_probe_outcome(
         &self,
-        target: &OpencodeSessionStatusProbeTarget,
-    ) -> Result<CachedOpencodeSessionStatusProbeOutcome> {
-        if let Some(cached) = self.cached_opencode_session_status_outcome(target)? {
+        target: &RuntimeSessionStatusProbeTarget,
+    ) -> Result<RuntimeSessionStatusProbeOutcome> {
+        if let Some(cached) = self.cached_runtime_session_status_outcome(target)? {
             return Ok(cached);
         }
 
-        let (flight, is_leader) = self.acquire_opencode_session_status_flight(target)?;
+        let (flight, is_leader) = self.acquire_runtime_session_status_flight(target)?;
         if !is_leader {
-            return Self::wait_for_opencode_session_status_flight(&flight);
+            return Self::wait_for_runtime_session_status_flight(&flight);
         }
 
         self.resolve_leader_probe_outcome(target, flight)
@@ -397,61 +289,57 @@ impl AppService {
 
     fn resolve_leader_probe_outcome(
         &self,
-        target: &OpencodeSessionStatusProbeTarget,
-        flight: Arc<OpencodeSessionStatusFlight>,
-    ) -> Result<CachedOpencodeSessionStatusProbeOutcome> {
-        let mut flight_guard = OpencodeSessionStatusFlightGuard::new(self, target, flight);
-        let _permit = self.acquire_opencode_session_status_probe_permit()?;
-        let outcome = Self::probe_uncached_opencode_session_status_target(target);
-        self.update_opencode_session_status_cache(target, &outcome)?;
+        target: &RuntimeSessionStatusProbeTarget,
+        flight: Arc<RuntimeSessionStatusFlight>,
+    ) -> Result<RuntimeSessionStatusProbeOutcome> {
+        let mut flight_guard = RuntimeSessionStatusFlightGuard::new(self, target, flight);
+        let _permit = self.acquire_runtime_session_status_probe_permit()?;
+        let outcome = self.probe_uncached_runtime_session_status_target(target)?;
+        self.update_runtime_session_status_cache(target, &outcome)?;
         flight_guard.complete(&outcome)?;
         Ok(outcome)
     }
 
-    fn probe_uncached_opencode_session_status_target(
-        target: &OpencodeSessionStatusProbeTarget,
-    ) -> CachedOpencodeSessionStatusProbeOutcome {
-        match load_opencode_session_statuses_for_target(target) {
-            Ok(statuses) => CachedOpencodeSessionStatusProbeOutcome::Statuses(statuses),
-            Err(error) if is_unreachable_opencode_session_status_error(&error) => {
-                CachedOpencodeSessionStatusProbeOutcome::Statuses(OpencodeSessionStatusMap::new())
-            }
-            Err(error) => CachedOpencodeSessionStatusProbeOutcome::ActionableError(
-                CachedOpencodeSessionStatusProbeError::ProbeFailed(error.to_string()),
-            ),
-        }
+    fn probe_uncached_runtime_session_status_target(
+        &self,
+        target: &RuntimeSessionStatusProbeTarget,
+    ) -> Result<RuntimeSessionStatusProbeOutcome> {
+        Ok(self
+            .runtime_registry
+            .runtime(target.runtime_kind())?
+            .probe_session_status(target))
     }
 
-    fn cached_opencode_session_status_outcome(
+    fn cached_runtime_session_status_outcome(
         &self,
-        target: &OpencodeSessionStatusProbeTarget,
-    ) -> Result<Option<CachedOpencodeSessionStatusProbeOutcome>> {
+        target: &RuntimeSessionStatusProbeTarget,
+    ) -> Result<Option<RuntimeSessionStatusProbeOutcome>> {
         let now = Instant::now();
         let mut cache = self
-            .opencode_session_status_cache
+            .runtime_session_status_cache
             .lock()
-            .map_err(|_| anyhow!("OpenCode session status cache lock poisoned"))?;
-        Self::prune_expired_opencode_session_status_cache(&mut cache, now);
+            .map_err(|_| anyhow!("Runtime session status cache lock poisoned"))?;
+        Self::prune_expired_runtime_session_status_cache(&mut cache, now);
         if let Some(entry) = cache.get(target) {
             return Ok(Some(entry.outcome.clone()));
         }
         Ok(None)
     }
 
-    fn update_opencode_session_status_cache(
+    fn update_runtime_session_status_cache(
         &self,
-        target: &OpencodeSessionStatusProbeTarget,
-        outcome: &CachedOpencodeSessionStatusProbeOutcome,
+        target: &RuntimeSessionStatusProbeTarget,
+        outcome: &RuntimeSessionStatusProbeOutcome,
     ) -> Result<()> {
         let now = Instant::now();
         let mut cache = self
-            .opencode_session_status_cache
+            .runtime_session_status_cache
             .lock()
-            .map_err(|_| anyhow!("OpenCode session status cache lock poisoned"))?;
-        Self::prune_expired_opencode_session_status_cache(&mut cache, now);
+            .map_err(|_| anyhow!("Runtime session status cache lock poisoned"))?;
+        Self::prune_expired_runtime_session_status_cache(&mut cache, now);
         cache.insert(
             target.clone(),
-            CachedOpencodeSessionStatusProbe {
+            CachedRuntimeSessionStatusProbe {
                 checked_at: now,
                 outcome: outcome.clone(),
             },
@@ -459,37 +347,37 @@ impl AppService {
         Ok(())
     }
 
-    fn prune_expired_opencode_session_status_cache(
-        cache: &mut HashMap<OpencodeSessionStatusProbeTarget, CachedOpencodeSessionStatusProbe>,
+    fn prune_expired_runtime_session_status_cache(
+        cache: &mut HashMap<RuntimeSessionStatusProbeTarget, CachedRuntimeSessionStatusProbe>,
         now: Instant,
     ) {
         cache.retain(|_, entry| {
-            now.duration_since(entry.checked_at) <= Self::OPENCODE_SESSION_STATUS_CACHE_TTL
+            now.duration_since(entry.checked_at) <= Self::RUNTIME_SESSION_STATUS_CACHE_TTL
         });
     }
 
-    fn acquire_opencode_session_status_flight(
+    fn acquire_runtime_session_status_flight(
         &self,
-        target: &OpencodeSessionStatusProbeTarget,
-    ) -> Result<(Arc<OpencodeSessionStatusFlight>, bool)> {
+        target: &RuntimeSessionStatusProbeTarget,
+    ) -> Result<(Arc<RuntimeSessionStatusFlight>, bool)> {
         let mut flights = self
-            .opencode_session_status_flights
+            .runtime_session_status_flights
             .lock()
-            .map_err(|_| anyhow!("OpenCode session status coordination state lock poisoned"))?;
+            .map_err(|_| anyhow!("Runtime session status coordination state lock poisoned"))?;
         if let Some(existing) = flights.get(target) {
             return Ok((existing.clone(), false));
         }
 
-        let flight = Arc::new(OpencodeSessionStatusFlight::new());
+        let flight = Arc::new(RuntimeSessionStatusFlight::new());
         flights.insert(target.clone(), flight.clone());
         Ok((flight, true))
     }
 
-    fn complete_opencode_session_status_flight(
+    fn complete_runtime_session_status_flight(
         &self,
-        target: &OpencodeSessionStatusProbeTarget,
-        flight: &Arc<OpencodeSessionStatusFlight>,
-        outcome: &CachedOpencodeSessionStatusProbeOutcome,
+        target: &RuntimeSessionStatusProbeTarget,
+        flight: &Arc<RuntimeSessionStatusFlight>,
+        outcome: &RuntimeSessionStatusProbeOutcome,
     ) -> Result<()> {
         let mut poisoned = false;
 
@@ -501,12 +389,12 @@ impl AppService {
                     poisoned_state.into_inner()
                 }
             };
-            *state = OpencodeSessionStatusFlightState::Finished(outcome.clone());
+            *state = RuntimeSessionStatusFlightState::Finished(outcome.clone());
             flight.condvar.notify_all();
         }
 
         {
-            let mut flights = match self.opencode_session_status_flights.lock() {
+            let mut flights = match self.runtime_session_status_flights.lock() {
                 Ok(flights) => flights,
                 Err(poisoned_flights) => {
                     poisoned = true;
@@ -518,67 +406,67 @@ impl AppService {
 
         if poisoned {
             return Err(anyhow!(
-                "OpenCode session status coordination state lock poisoned"
+                "Runtime session status coordination state lock poisoned"
             ));
         }
 
         Ok(())
     }
 
-    fn wait_for_opencode_session_status_flight(
-        flight: &Arc<OpencodeSessionStatusFlight>,
-    ) -> Result<CachedOpencodeSessionStatusProbeOutcome> {
+    fn wait_for_runtime_session_status_flight(
+        flight: &Arc<RuntimeSessionStatusFlight>,
+    ) -> Result<RuntimeSessionStatusProbeOutcome> {
         let mut state = flight
             .state
             .lock()
-            .map_err(|_| anyhow!("OpenCode session status coordination state lock poisoned"))?;
+            .map_err(|_| anyhow!("Runtime session status coordination state lock poisoned"))?;
         loop {
             match &*state {
-                OpencodeSessionStatusFlightState::Finished(outcome) => {
+                RuntimeSessionStatusFlightState::Finished(outcome) => {
                     return Ok(outcome.clone());
                 }
-                OpencodeSessionStatusFlightState::Loading => {
+                RuntimeSessionStatusFlightState::Loading => {
                     state = flight.condvar.wait(state).map_err(|_| {
-                        anyhow!("OpenCode session status coordination state lock poisoned")
+                        anyhow!("Runtime session status coordination state lock poisoned")
                     })?;
                 }
             }
         }
     }
 
-    fn acquire_opencode_session_status_probe_permit(
+    fn acquire_runtime_session_status_probe_permit(
         &self,
-    ) -> Result<OpencodeSessionStatusProbePermit> {
-        let limiter = Arc::clone(&self.opencode_session_status_probe_limiter);
+    ) -> Result<RuntimeSessionStatusProbePermit> {
+        let limiter = Arc::clone(&self.runtime_session_status_probe_limiter);
         let mut active = limiter
             .active
             .lock()
-            .map_err(|_| anyhow!("OpenCode session status probe limiter lock poisoned"))?;
+            .map_err(|_| anyhow!("Runtime session status probe limiter lock poisoned"))?;
         while *active >= limiter.max_concurrent {
             active = limiter
                 .condvar
                 .wait(active)
-                .map_err(|_| anyhow!("OpenCode session status probe limiter lock poisoned"))?;
+                .map_err(|_| anyhow!("Runtime session status probe limiter lock poisoned"))?;
         }
         *active += 1;
         drop(active);
-        Ok(OpencodeSessionStatusProbePermit { limiter })
+        Ok(RuntimeSessionStatusProbePermit { limiter })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        has_live_opencode_session_status, load_opencode_session_statuses, AppService,
-        CachedOpencodeSessionStatusProbe, CachedOpencodeSessionStatusProbeOutcome,
-        OpencodeSessionStatus, OpencodeSessionStatusFlightGuard, OpencodeSessionStatusMap,
-        OpencodeSessionStatusProbeTarget,
+        has_live_runtime_session_status, AppService, CachedRuntimeSessionStatusProbe,
+        RuntimeExternalSessionStatus, RuntimeSessionStatusFlightGuard, RuntimeSessionStatusMap,
+        RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
     };
+    use crate::app_service::runtime_registry::{AppRuntime, OpenCodeRuntime};
     use crate::app_service::test_support::{
         build_service_with_state, builtin_opencode_runtime_route,
     };
-    use anyhow::Result;
-    use host_domain::RuntimeRoute;
+    use anyhow::{anyhow, Result};
+    use host_domain::{AgentRuntimeKind, RuntimeRoute};
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -586,8 +474,30 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
+    fn runtime_target(port: u16, working_directory: &str) -> RuntimeSessionStatusProbeTarget {
+        RuntimeSessionStatusProbeTarget::new(
+            AgentRuntimeKind::opencode(),
+            &builtin_opencode_runtime_route(port),
+            working_directory,
+        )
+    }
+
+    fn expect_statuses(outcome: RuntimeSessionStatusProbeOutcome) -> RuntimeSessionStatusMap {
+        match outcome {
+            RuntimeSessionStatusProbeOutcome::Statuses(statuses) => statuses,
+            other => panic!("expected status snapshot, received {other:?}"),
+        }
+    }
+
+    fn expect_actionable_error(outcome: RuntimeSessionStatusProbeOutcome) -> anyhow::Error {
+        match outcome {
+            RuntimeSessionStatusProbeOutcome::ActionableError(error) => anyhow!(error.to_string()),
+            other => panic!("expected actionable error, received {other:?}"),
+        }
+    }
+
     #[test]
-    fn load_opencode_session_statuses_sends_directory_query_and_parses_response() {
+    fn probe_session_status_sends_directory_query_and_parses_response() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
         let port = listener
             .local_addr()
@@ -620,15 +530,21 @@ mod tests {
             stream.flush().expect("server should flush response");
         });
 
-        let runtime_route = builtin_opencode_runtime_route(port);
+        let target = RuntimeSessionStatusProbeTarget::new(
+            AgentRuntimeKind::opencode(),
+            &builtin_opencode_runtime_route(port),
+            "/tmp/repo path",
+        );
 
-        let statuses = load_opencode_session_statuses(&runtime_route, "/tmp/repo path")
-            .expect("status request should succeed");
+        let outcome = OpenCodeRuntime::default().probe_session_status(&target);
+        let RuntimeSessionStatusProbeOutcome::Statuses(statuses) = outcome else {
+            panic!("status request should succeed");
+        };
         assert!(matches!(
             statuses.get("external-session"),
-            Some(OpencodeSessionStatus::Busy)
+            Some(RuntimeExternalSessionStatus::Busy)
         ));
-        assert!(has_live_opencode_session_status(
+        assert!(has_live_runtime_session_status(
             &statuses,
             "external-session"
         ));
@@ -678,17 +594,15 @@ mod tests {
             stream.flush().expect("server should flush response");
         });
 
-        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(port),
-            "/tmp/repo ",
-        )
-        .expect("local_http route should build a probe target");
+        let target = runtime_target(port, "/tmp/repo ");
         assert_eq!(target.working_directory(), "/tmp/repo ");
 
-        let statuses = service.load_cached_opencode_session_statuses_for_target(&target)?;
+        let statuses = expect_statuses(
+            service.load_cached_runtime_session_status_outcome_for_target(&target)?,
+        );
         assert!(matches!(
             statuses.get("external-session"),
-            Some(OpencodeSessionStatus::Busy)
+            Some(RuntimeExternalSessionStatus::Busy)
         ));
 
         server.join().expect("server thread should finish");
@@ -713,14 +627,14 @@ mod tests {
             Duration::ZERO,
             Ok(r#"{"external-build-session":{"type":"busy"}}"#.to_string()),
         )?;
-        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(port),
-            "/tmp/repo",
-        )
-        .expect("local_http route should build a probe target");
+        let target = runtime_target(port, "/tmp/repo");
 
-        let first = service.load_cached_opencode_session_statuses_for_target(&target)?;
-        let second = service.load_cached_opencode_session_statuses_for_target(&target)?;
+        let first = expect_statuses(
+            service.load_cached_runtime_session_status_outcome_for_target(&target)?,
+        );
+        let second = expect_statuses(
+            service.load_cached_runtime_session_status_outcome_for_target(&target)?,
+        );
         server_handle
             .join()
             .expect("status server thread should finish");
@@ -732,12 +646,15 @@ mod tests {
     }
 
     #[test]
-    fn probe_target_rejects_stdio_runtime_routes() {
-        let error =
-            OpencodeSessionStatusProbeTarget::for_runtime_route(&RuntimeRoute::Stdio, "/tmp/repo")
-                .expect_err("stdio routes should not build OpenCode HTTP probe targets");
+    fn opencode_runtime_marks_stdio_session_probe_as_unsupported() -> Result<()> {
+        let resolution = OpenCodeRuntime::default()
+            .session_status_probe_target(&RuntimeRoute::Stdio, "/tmp/repo")?;
 
-        assert!(error.to_string().contains("local_http runtime route"));
+        assert!(matches!(
+            resolution,
+            super::RuntimeSessionStatusProbeTargetResolution::Unsupported
+        ));
+        Ok(())
     }
 
     #[test]
@@ -748,27 +665,23 @@ mod tests {
             Duration::ZERO,
             Ok(r#"{"external-build-session":{"type":"busy"}}"#.to_string()),
         )?;
-        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(port),
-            "/tmp/repo",
-        )
-        .expect("local_http route should build a probe target");
+        let target = runtime_target(port, "/tmp/repo");
 
-        service.load_cached_opencode_session_statuses_for_target(&target)?;
+        service.load_cached_runtime_session_status_outcome_for_target(&target)?;
         {
             let mut cache = service
-                .opencode_session_status_cache
+                .runtime_session_status_cache
                 .lock()
                 .expect("status cache lock should be available");
             let entry = cache
                 .get_mut(&target)
                 .expect("fresh cache entry should be present");
             entry.checked_at = Instant::now()
-                - AppService::OPENCODE_SESSION_STATUS_CACHE_TTL
+                - AppService::RUNTIME_SESSION_STATUS_CACHE_TTL
                 - Duration::from_millis(10);
         }
 
-        service.load_cached_opencode_session_statuses_for_target(&target)?;
+        service.load_cached_runtime_session_status_outcome_for_target(&target)?;
         server_handle
             .join()
             .expect("status server thread should finish");
@@ -785,43 +698,37 @@ mod tests {
             Duration::ZERO,
             Ok(r#"{"external-build-session":{"type":"busy"}}"#.to_string()),
         )?;
-        let live_target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(port),
-            "/tmp/repo-live",
-        )
-        .expect("local_http route should build a probe target");
-        let stale_target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(9999),
-            "/tmp/repo-stale",
-        )
-        .expect("local_http route should build a probe target");
+        let live_target = runtime_target(port, "/tmp/repo-live");
+        let stale_target = runtime_target(9999, "/tmp/repo-stale");
 
         {
             let mut cache = service
-                .opencode_session_status_cache
+                .runtime_session_status_cache
                 .lock()
                 .expect("status cache lock should be available");
             cache.insert(
                 stale_target.clone(),
-                CachedOpencodeSessionStatusProbe {
+                CachedRuntimeSessionStatusProbe {
                     checked_at: Instant::now()
-                        - AppService::OPENCODE_SESSION_STATUS_CACHE_TTL
+                        - AppService::RUNTIME_SESSION_STATUS_CACHE_TTL
                         - Duration::from_millis(10),
-                    outcome: CachedOpencodeSessionStatusProbeOutcome::Statuses(
-                        OpencodeSessionStatusMap::new(),
+                    outcome: RuntimeSessionStatusProbeOutcome::Statuses(
+                        RuntimeSessionStatusMap::new(),
                     ),
                 },
             );
         }
 
-        let statuses = service.load_cached_opencode_session_statuses_for_target(&live_target)?;
+        let statuses = expect_statuses(
+            service.load_cached_runtime_session_status_outcome_for_target(&live_target)?,
+        );
         server_handle
             .join()
             .expect("status server thread should finish");
 
         assert!(statuses.contains_key("external-build-session"));
         let cache = service
-            .opencode_session_status_cache
+            .runtime_session_status_cache
             .lock()
             .expect("status cache lock should be available");
         assert!(!cache.contains_key(&stale_target));
@@ -837,11 +744,7 @@ mod tests {
             Duration::from_millis(200),
             Ok(r#"{"external-build-session":{"type":"busy"}}"#.to_string()),
         )?;
-        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(port),
-            "/tmp/repo",
-        )
-        .expect("local_http route should build a probe target");
+        let target = runtime_target(port, "/tmp/repo");
         let barrier = Arc::new(Barrier::new(3));
 
         thread::scope(|scope| {
@@ -853,14 +756,15 @@ mod tests {
                 handles.push(scope.spawn(move || {
                     barrier.wait();
                     service
-                        .load_cached_opencode_session_statuses_for_target(&target)
+                        .load_cached_runtime_session_status_outcome_for_target(&target)
                         .expect("concurrent status probe should succeed")
                 }));
             }
 
             barrier.wait();
             for handle in handles {
-                let statuses = handle.join().expect("probe thread should not panic");
+                let statuses =
+                    expect_statuses(handle.join().expect("probe thread should not panic"));
                 assert!(statuses.contains_key("external-build-session"));
             }
         });
@@ -886,13 +790,7 @@ mod tests {
                     r#"{{"external-build-session-{index}":{{"type":"busy"}}}}"#
                 )),
             )?;
-            targets.push(
-                OpencodeSessionStatusProbeTarget::for_runtime_route(
-                    &builtin_opencode_runtime_route(port),
-                    format!("/tmp/repo-{index}").as_str(),
-                )
-                .expect("local_http route should build a probe target"),
-            );
+            targets.push(runtime_target(port, format!("/tmp/repo-{index}").as_str()));
             counters.push(connections);
             handles.push(server_handle);
         }
@@ -924,18 +822,14 @@ mod tests {
             Duration::ZERO,
             Err((500, "session status failed".to_string())),
         )?;
-        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(port),
-            "/tmp/repo",
-        )
-        .expect("local_http route should build a probe target");
+        let target = runtime_target(port, "/tmp/repo");
 
-        let first_error = service
-            .load_cached_opencode_session_statuses_for_target(&target)
-            .expect_err("HTTP failures should remain actionable");
-        let second_error = service
-            .load_cached_opencode_session_statuses_for_target(&target)
-            .expect_err("cached HTTP failures should remain actionable");
+        let first_error = expect_actionable_error(
+            service.load_cached_runtime_session_status_outcome_for_target(&target)?,
+        );
+        let second_error = expect_actionable_error(
+            service.load_cached_runtime_session_status_outcome_for_target(&target)?,
+        );
         server_handle
             .join()
             .expect("status server thread should finish");
@@ -951,18 +845,14 @@ mod tests {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
         let (port, connections, server_handle) =
             spawn_counting_status_server(1, Duration::ZERO, Ok("{not-json}".to_string()))?;
-        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(port),
-            "/tmp/repo",
-        )
-        .expect("local_http route should build a probe target");
+        let target = runtime_target(port, "/tmp/repo");
 
-        let first_error = service
-            .load_cached_opencode_session_statuses_for_target(&target)
-            .expect_err("parse failures should remain actionable");
-        let second_error = service
-            .load_cached_opencode_session_statuses_for_target(&target)
-            .expect_err("cached parse failures should remain actionable");
+        let first_error = expect_actionable_error(
+            service.load_cached_runtime_session_status_outcome_for_target(&target)?,
+        );
+        let second_error = expect_actionable_error(
+            service.load_cached_runtime_session_status_outcome_for_target(&target)?,
+        );
         server_handle
             .join()
             .expect("status server thread should finish");
@@ -980,39 +870,29 @@ mod tests {
     #[test]
     fn session_status_flight_guard_finishes_waiters_when_dropped_uncompleted() -> Result<()> {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
-        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(1234),
-            "/tmp/runtime-flight-guard",
-        )
-        .expect("local_http route should build a probe target");
-        let (flight, is_leader) = service.acquire_opencode_session_status_flight(&target)?;
+        let target = runtime_target(1234, "/tmp/runtime-flight-guard");
+        let (flight, is_leader) = service.acquire_runtime_session_status_flight(&target)?;
         assert!(is_leader);
 
         {
-            let _guard = OpencodeSessionStatusFlightGuard::new(&service, &target, flight.clone());
+            let _guard = RuntimeSessionStatusFlightGuard::new(&service, &target, flight.clone());
         }
 
-        let outcome = AppService::wait_for_opencode_session_status_flight(&flight)?;
-        let error = outcome
-            .to_result()
-            .expect_err("dropped leader should finish waiters with an error");
+        let outcome = AppService::wait_for_runtime_session_status_flight(&flight)?;
+        let error = expect_actionable_error(outcome);
         assert!(error
             .to_string()
-            .contains("OpenCode session status probe aborted unexpectedly"));
+            .contains("Runtime session status probe aborted unexpectedly"));
 
         Ok(())
     }
 
     #[test]
-    fn complete_opencode_session_status_flight_recovers_poisoned_state_and_removes_entry(
+    fn complete_runtime_session_status_flight_recovers_poisoned_state_and_removes_entry(
     ) -> Result<()> {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
-        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-            &builtin_opencode_runtime_route(1235),
-            "/tmp/runtime-flight-poison",
-        )
-        .expect("local_http route should build a probe target");
-        let (flight, is_leader) = service.acquire_opencode_session_status_flight(&target)?;
+        let target = runtime_target(1235, "/tmp/runtime-flight-poison");
+        let (flight, is_leader) = service.acquire_runtime_session_status_flight(&target)?;
         assert!(is_leader);
 
         let poison_handle = thread::spawn({
@@ -1028,18 +908,18 @@ mod tests {
         assert!(poison_handle.join().is_err());
 
         let error = service
-            .complete_opencode_session_status_flight(
+            .complete_runtime_session_status_flight(
                 &target,
                 &flight,
-                &CachedOpencodeSessionStatusProbeOutcome::Statuses(OpencodeSessionStatusMap::new()),
+                &RuntimeSessionStatusProbeOutcome::Statuses(RuntimeSessionStatusMap::new()),
             )
             .expect_err("poisoned completion should surface an error");
         assert!(error
             .to_string()
-            .contains("OpenCode session status coordination state lock poisoned"));
+            .contains("Runtime session status coordination state lock poisoned"));
 
         let flights = service
-            .opencode_session_status_flights
+            .runtime_session_status_flights
             .lock()
             .expect("status flights lock should remain available");
         assert!(flights.is_empty());

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
@@ -260,13 +260,9 @@ impl AppService {
         &self,
         unique_targets: Vec<RuntimeSessionStatusProbeTarget>,
     ) -> Result<HashMap<RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeOutcome>> {
-        let worker_count = unique_targets.len().min(
-            Self::RUNTIME_SESSION_STATUS_BATCH_WORKER_LIMIT.max(
-                self.runtime_session_status_probe_limiter
-                    .max_concurrent
-                    .max(1),
-            ),
-        );
+        let worker_count = unique_targets
+            .len()
+            .min(Self::RUNTIME_SESSION_STATUS_BATCH_WORKER_LIMIT);
         let queue = Mutex::new(VecDeque::from(unique_targets));
         let results = Mutex::new(HashMap::new());
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
@@ -27,6 +27,48 @@ pub(crate) enum RuntimeExternalSessionStatus {
 
 pub(crate) type RuntimeSessionStatusMap = HashMap<String, RuntimeExternalSessionStatus>;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RuntimeSessionStatusSnapshotKind {
+    NoLiveSessions,
+    HasLiveSessions,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RuntimeSessionStatusSnapshot {
+    statuses: RuntimeSessionStatusMap,
+    kind: RuntimeSessionStatusSnapshotKind,
+}
+
+impl RuntimeSessionStatusSnapshot {
+    pub(crate) fn from_statuses(statuses: RuntimeSessionStatusMap) -> Self {
+        let kind = if statuses.values().any(|status| {
+            matches!(
+                status,
+                RuntimeExternalSessionStatus::Busy | RuntimeExternalSessionStatus::Retry { .. }
+            )
+        }) {
+            RuntimeSessionStatusSnapshotKind::HasLiveSessions
+        } else {
+            RuntimeSessionStatusSnapshotKind::NoLiveSessions
+        };
+
+        Self { statuses, kind }
+    }
+
+    pub(crate) fn kind(&self) -> RuntimeSessionStatusSnapshotKind {
+        self.kind.clone()
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn statuses(&self) -> &RuntimeSessionStatusMap {
+        &self.statuses
+    }
+
+    pub(crate) fn has_live_session(&self, external_session_id: &str) -> bool {
+        has_live_runtime_session_status(&self.statuses, external_session_id)
+    }
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct RuntimeSessionStatusProbeTarget {
     runtime_kind: AgentRuntimeKind,
@@ -161,7 +203,7 @@ impl fmt::Display for RuntimeSessionStatusProbeError {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum RuntimeSessionStatusProbeOutcome {
-    Statuses(RuntimeSessionStatusMap),
+    Snapshot(RuntimeSessionStatusSnapshot),
     Unsupported,
     ActionableError(RuntimeSessionStatusProbeError),
 }
@@ -457,9 +499,10 @@ impl AppService {
 #[cfg(test)]
 mod tests {
     use super::{
-        has_live_runtime_session_status, AppService, CachedRuntimeSessionStatusProbe,
-        RuntimeExternalSessionStatus, RuntimeSessionStatusFlightGuard, RuntimeSessionStatusMap,
-        RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
+        AppService, CachedRuntimeSessionStatusProbe, RuntimeExternalSessionStatus,
+        RuntimeSessionStatusFlightGuard, RuntimeSessionStatusMap, RuntimeSessionStatusProbeOutcome,
+        RuntimeSessionStatusProbeTarget, RuntimeSessionStatusSnapshot,
+        RuntimeSessionStatusSnapshotKind,
     };
     use crate::app_service::runtime_registry::{AppRuntime, OpenCodeRuntime};
     use crate::app_service::test_support::{
@@ -482,9 +525,9 @@ mod tests {
         )
     }
 
-    fn expect_statuses(outcome: RuntimeSessionStatusProbeOutcome) -> RuntimeSessionStatusMap {
+    fn expect_statuses(outcome: RuntimeSessionStatusProbeOutcome) -> RuntimeSessionStatusSnapshot {
         match outcome {
-            RuntimeSessionStatusProbeOutcome::Statuses(statuses) => statuses,
+            RuntimeSessionStatusProbeOutcome::Snapshot(snapshot) => snapshot,
             other => panic!("expected status snapshot, received {other:?}"),
         }
     }
@@ -537,17 +580,18 @@ mod tests {
         );
 
         let outcome = OpenCodeRuntime::default().probe_session_status(&target);
-        let RuntimeSessionStatusProbeOutcome::Statuses(statuses) = outcome else {
+        let RuntimeSessionStatusProbeOutcome::Snapshot(snapshot) = outcome else {
             panic!("status request should succeed");
         };
         assert!(matches!(
-            statuses.get("external-session"),
+            snapshot.statuses().get("external-session"),
             Some(RuntimeExternalSessionStatus::Busy)
         ));
-        assert!(has_live_runtime_session_status(
-            &statuses,
-            "external-session"
-        ));
+        assert_eq!(
+            snapshot.kind(),
+            RuntimeSessionStatusSnapshotKind::HasLiveSessions
+        );
+        assert!(snapshot.has_live_session("external-session"));
 
         server.join().expect("server thread should finish");
         let captured_request = request_line
@@ -601,9 +645,13 @@ mod tests {
             service.load_cached_runtime_session_status_outcome_for_target(&target)?,
         );
         assert!(matches!(
-            statuses.get("external-session"),
+            statuses.statuses().get("external-session"),
             Some(RuntimeExternalSessionStatus::Busy)
         ));
+        assert_eq!(
+            statuses.kind(),
+            RuntimeSessionStatusSnapshotKind::HasLiveSessions
+        );
 
         server.join().expect("server thread should finish");
         let captured_request = request_line
@@ -639,8 +687,8 @@ mod tests {
             .join()
             .expect("status server thread should finish");
 
-        assert!(first.contains_key("external-build-session"));
-        assert!(second.contains_key("external-build-session"));
+        assert!(first.statuses().contains_key("external-build-session"));
+        assert!(second.statuses().contains_key("external-build-session"));
         assert_eq!(connections.load(Ordering::SeqCst), 1);
         Ok(())
     }
@@ -712,8 +760,8 @@ mod tests {
                     checked_at: Instant::now()
                         - AppService::RUNTIME_SESSION_STATUS_CACHE_TTL
                         - Duration::from_millis(10),
-                    outcome: RuntimeSessionStatusProbeOutcome::Statuses(
-                        RuntimeSessionStatusMap::new(),
+                    outcome: RuntimeSessionStatusProbeOutcome::Snapshot(
+                        RuntimeSessionStatusSnapshot::from_statuses(RuntimeSessionStatusMap::new()),
                     ),
                 },
             );
@@ -726,7 +774,11 @@ mod tests {
             .join()
             .expect("status server thread should finish");
 
-        assert!(statuses.contains_key("external-build-session"));
+        assert!(statuses.statuses().contains_key("external-build-session"));
+        assert_eq!(
+            statuses.kind(),
+            RuntimeSessionStatusSnapshotKind::HasLiveSessions
+        );
         let cache = service
             .runtime_session_status_cache
             .lock()
@@ -765,7 +817,11 @@ mod tests {
             for handle in handles {
                 let statuses =
                     expect_statuses(handle.join().expect("probe thread should not panic"));
-                assert!(statuses.contains_key("external-build-session"));
+                assert!(statuses.statuses().contains_key("external-build-session"));
+                assert_eq!(
+                    statuses.kind(),
+                    RuntimeSessionStatusSnapshotKind::HasLiveSessions
+                );
             }
         });
 
@@ -911,7 +967,9 @@ mod tests {
             .complete_runtime_session_status_flight(
                 &target,
                 &flight,
-                &RuntimeSessionStatusProbeOutcome::Statuses(RuntimeSessionStatusMap::new()),
+                &RuntimeSessionStatusProbeOutcome::Snapshot(
+                    RuntimeSessionStatusSnapshot::from_statuses(RuntimeSessionStatusMap::new()),
+                ),
             )
             .expect_err("poisoned completion should surface an error");
         assert!(error

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
@@ -108,32 +108,32 @@ impl RepoRuntimeHealthFlight {
     }
 }
 
-pub(super) struct OpencodeSessionStatusFlight {
-    pub(super) state: Mutex<OpencodeSessionStatusFlightState>,
+pub(super) struct RuntimeSessionStatusFlight {
+    pub(super) state: Mutex<RuntimeSessionStatusFlightState>,
     pub(super) condvar: Condvar,
 }
 
-pub(super) enum OpencodeSessionStatusFlightState {
+pub(super) enum RuntimeSessionStatusFlightState {
     Loading,
-    Finished(CachedOpencodeSessionStatusProbeOutcome),
+    Finished(RuntimeSessionStatusProbeOutcome),
 }
 
-impl OpencodeSessionStatusFlight {
+impl RuntimeSessionStatusFlight {
     pub(super) fn new() -> Self {
         Self {
-            state: Mutex::new(OpencodeSessionStatusFlightState::Loading),
+            state: Mutex::new(RuntimeSessionStatusFlightState::Loading),
             condvar: Condvar::new(),
         }
     }
 }
 
-pub(super) struct OpencodeSessionStatusProbeLimiter {
+pub(super) struct RuntimeSessionStatusProbeLimiter {
     pub(super) active: Mutex<usize>,
     pub(super) condvar: Condvar,
     pub(super) max_concurrent: usize,
 }
 
-impl OpencodeSessionStatusProbeLimiter {
+impl RuntimeSessionStatusProbeLimiter {
     pub(super) fn new(max_concurrent: usize) -> Self {
         Self {
             active: Mutex::new(0),
@@ -157,11 +157,11 @@ pub struct AppService {
         Arc<Mutex<HashMap<String, Arc<RepoRuntimeHealthFlight>>>>,
     pub(super) runtime_startup_status: Arc<Mutex<HashMap<String, RuntimeStartupStatusEntry>>>,
     pub(super) repo_runtime_health_snapshots: Arc<Mutex<HashMap<String, RepoRuntimeHealthCheck>>>,
-    pub(super) opencode_session_status_cache:
-        Arc<Mutex<HashMap<RuntimeSessionStatusProbeTarget, CachedOpencodeSessionStatusProbe>>>,
-    pub(super) opencode_session_status_flights:
-        Arc<Mutex<HashMap<RuntimeSessionStatusProbeTarget, Arc<OpencodeSessionStatusFlight>>>>,
-    pub(super) opencode_session_status_probe_limiter: Arc<OpencodeSessionStatusProbeLimiter>,
+    pub(super) runtime_session_status_cache:
+        Arc<Mutex<HashMap<RuntimeSessionStatusProbeTarget, CachedRuntimeSessionStatusProbe>>>,
+    pub(super) runtime_session_status_flights:
+        Arc<Mutex<HashMap<RuntimeSessionStatusProbeTarget, Arc<RuntimeSessionStatusFlight>>>>,
+    pub(super) runtime_session_status_probe_limiter: Arc<RuntimeSessionStatusProbeLimiter>,
     pub(super) mcp_bridge_registry_path: PathBuf,
     pub(super) instance_pid: u32,
     pub(super) initialized_repos: Arc<Mutex<HashSet<String>>>,
@@ -214,21 +214,9 @@ pub(crate) struct CachedOpenInToolList {
     pub(super) tools: Vec<SystemOpenInToolInfo>,
 }
 
-pub(crate) struct CachedOpencodeSessionStatusProbe {
+pub(crate) struct CachedRuntimeSessionStatusProbe {
     pub(super) checked_at: Instant,
-    pub(super) outcome: CachedOpencodeSessionStatusProbeOutcome,
-}
-
-#[derive(Clone)]
-pub(crate) enum CachedOpencodeSessionStatusProbeOutcome {
-    Statuses(RuntimeSessionStatusMap),
-    ActionableError(CachedOpencodeSessionStatusProbeError),
-}
-
-#[derive(Clone)]
-pub(crate) enum CachedOpencodeSessionStatusProbeError {
-    ProbeFailed(String),
-    ProbeAborted,
+    pub(super) outcome: RuntimeSessionStatusProbeOutcome,
 }
 
 pub(crate) struct DevServerGroupRuntime {
@@ -299,11 +287,11 @@ impl AppService {
             repo_runtime_health_flights: Arc::new(Mutex::new(HashMap::new())),
             runtime_startup_status: Arc::new(Mutex::new(HashMap::new())),
             repo_runtime_health_snapshots: Arc::new(Mutex::new(HashMap::new())),
-            opencode_session_status_cache: Arc::new(Mutex::new(HashMap::new())),
-            opencode_session_status_flights: Arc::new(Mutex::new(HashMap::new())),
-            opencode_session_status_probe_limiter: Arc::new(
-                OpencodeSessionStatusProbeLimiter::new(4),
-            ),
+            runtime_session_status_cache: Arc::new(Mutex::new(HashMap::new())),
+            runtime_session_status_flights: Arc::new(Mutex::new(HashMap::new())),
+            runtime_session_status_probe_limiter: Arc::new(RuntimeSessionStatusProbeLimiter::new(
+                4,
+            )),
             mcp_bridge_registry_path,
             instance_pid,
             initialized_repos: Arc::new(Mutex::new(HashSet::new())),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/mod.rs
@@ -3,19 +3,18 @@ use super::cleanup_plans::{
 };
 use crate::app_service::{
     service_core::AppService, RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
-    RuntimeSessionStatusProbeTargetResolution, RuntimeSessionStatusSnapshotKind,
+    RuntimeSessionStatusProbeTargetResolution,
 };
 use anyhow::{anyhow, Context, Result};
-use host_domain::{AgentSessionDocument, RunState, RuntimeRole, RuntimeRoute};
+use host_domain::{AgentSessionDocument, RunState};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 mod probe_support;
 
 use self::probe_support::{
-    build_run_probe_plans, build_session_probe_plans, collect_runtime_routes_by_worktree,
-    RunProbeCandidate, RunProbePlan, SessionProbePlan, SessionRuntimeLookupKey,
-    TaskActiveWorkEvidence, TaskActivityProbePlan,
+    build_run_probe_plans, build_session_probe_plans, RunProbeCandidate, RunProbePlan,
+    SessionProbePlan, TaskActiveWorkEvidence, TaskActivityProbePlan, TaskRuntimeRouteIndex,
 };
 
 pub(super) struct TaskActivityGuard<'a> {
@@ -118,7 +117,7 @@ impl<'a> TaskActivityGuard<'a> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
         let candidate_runs = self.collect_candidate_runs(&normalized_repo, task_id)?;
         let runtime_routes_by_session =
-            self.collect_runtime_routes_by_session(repo_path, task_id, &candidate_runs)?;
+            TaskRuntimeRouteIndex::collect(self.service, repo_path, task_id, &candidate_runs)?;
         let probe_plan = self.build_probe_plan(
             &candidate_runs,
             sessions,
@@ -175,7 +174,7 @@ impl<'a> TaskActivityGuard<'a> {
         candidate_runs: &[RunProbeCandidate],
         sessions: &[AgentSessionDocument],
         session_roles: &[&str],
-        runtime_routes_by_session: &HashMap<SessionRuntimeLookupKey, RuntimeRoute>,
+        runtime_route_index: &TaskRuntimeRouteIndex,
     ) -> Result<TaskActivityProbePlan> {
         let mut probe_targets = Vec::new();
         let run_plans =
@@ -184,7 +183,7 @@ impl<'a> TaskActivityGuard<'a> {
             self.service,
             sessions,
             session_roles,
-            runtime_routes_by_session,
+            runtime_route_index,
             &mut probe_targets,
         )?;
 
@@ -226,7 +225,7 @@ impl<'a> TaskActivityGuard<'a> {
 
             match probe_outcome {
                 RuntimeSessionStatusProbeOutcome::Snapshot(snapshot) => {
-                    if snapshot.kind() == RuntimeSessionStatusSnapshotKind::NoLiveSessions {
+                    if snapshot.has_no_live_sessions() {
                         continue;
                     }
 
@@ -278,7 +277,7 @@ impl<'a> TaskActivityGuard<'a> {
                             })?;
                     match probe_outcome {
                         RuntimeSessionStatusProbeOutcome::Snapshot(snapshot) => {
-                            if snapshot.kind() == RuntimeSessionStatusSnapshotKind::NoLiveSessions {
+                            if snapshot.has_no_live_sessions() {
                                 continue;
                             }
 
@@ -302,54 +301,5 @@ impl<'a> TaskActivityGuard<'a> {
         let mut active_session_roles = active_roles.into_iter().collect::<Vec<_>>();
         active_session_roles.sort_unstable();
         Ok(active_session_roles)
-    }
-
-    fn collect_runtime_routes_by_session(
-        &self,
-        repo_path: &str,
-        task_id: &str,
-        candidate_runs: &[RunProbeCandidate],
-    ) -> Result<HashMap<SessionRuntimeLookupKey, RuntimeRoute>> {
-        let normalized_repo = normalize_path_for_comparison(repo_path);
-        let run_routes_by_worktree = collect_runtime_routes_by_worktree(candidate_runs);
-        let mut routes_by_session = HashMap::new();
-        let runtimes = self
-            .service
-            .agent_runtimes
-            .lock()
-            .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-
-        for runtime in runtimes.values() {
-            if normalize_path_for_comparison(runtime.summary.repo_path.as_str()) != normalized_repo
-            {
-                continue;
-            }
-            if runtime.summary.task_id.as_deref() != Some(task_id) {
-                continue;
-            }
-            if runtime.summary.role == RuntimeRole::Workspace {
-                continue;
-            }
-
-            let key = SessionRuntimeLookupKey::new(
-                runtime.summary.kind.clone(),
-                runtime.summary.role,
-                runtime.summary.working_directory.as_str(),
-            );
-
-            if let Some(run_route) = run_routes_by_worktree
-                .get(&normalize_path_key(
-                    runtime.summary.working_directory.as_str(),
-                ))
-                .filter(|_| runtime.summary.role == RuntimeRole::Build)
-            {
-                routes_by_session.insert(key, run_route.clone());
-                continue;
-            }
-
-            routes_by_session.insert(key, runtime.summary.runtime_route.clone());
-        }
-
-        Ok(routes_by_session)
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/mod.rs
@@ -2,11 +2,11 @@ use super::cleanup_plans::{
     normalize_path_for_comparison, normalize_path_key, IMPLEMENTATION_SESSION_ROLES,
 };
 use crate::app_service::{
-    has_live_runtime_session_status, service_core::AppService, RuntimeSessionStatusProbeOutcome,
-    RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeTargetResolution,
+    service_core::AppService, RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
+    RuntimeSessionStatusProbeTargetResolution, RuntimeSessionStatusSnapshotKind,
 };
 use anyhow::{anyhow, Context, Result};
-use host_domain::{AgentSessionDocument, RunState, RuntimeRoute};
+use host_domain::{AgentSessionDocument, RunState, RuntimeRole, RuntimeRoute};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
@@ -14,8 +14,8 @@ mod probe_support;
 
 use self::probe_support::{
     build_run_probe_plans, build_session_probe_plans, collect_runtime_routes_by_worktree,
-    RunProbeCandidate, RunProbePlan, SessionProbePlan, TaskActiveWorkEvidence,
-    TaskActivityProbePlan,
+    RunProbeCandidate, RunProbePlan, SessionProbePlan, SessionRuntimeLookupKey,
+    TaskActiveWorkEvidence, TaskActivityProbePlan,
 };
 
 pub(super) struct TaskActivityGuard<'a> {
@@ -117,13 +117,13 @@ impl<'a> TaskActivityGuard<'a> {
     ) -> Result<TaskActiveWorkEvidence> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
         let candidate_runs = self.collect_candidate_runs(&normalized_repo, task_id)?;
-        let runtime_routes_by_worktree =
-            self.collect_runtime_routes_by_worktree(repo_path, &candidate_runs)?;
+        let runtime_routes_by_session =
+            self.collect_runtime_routes_by_session(repo_path, task_id, &candidate_runs)?;
         let probe_plan = self.build_probe_plan(
             &candidate_runs,
             sessions,
             session_roles,
-            &runtime_routes_by_worktree,
+            &runtime_routes_by_session,
         )?;
 
         let probe_outcomes_by_target = self
@@ -175,7 +175,7 @@ impl<'a> TaskActivityGuard<'a> {
         candidate_runs: &[RunProbeCandidate],
         sessions: &[AgentSessionDocument],
         session_roles: &[&str],
-        runtime_routes_by_worktree: &HashMap<String, RuntimeRoute>,
+        runtime_routes_by_session: &HashMap<SessionRuntimeLookupKey, RuntimeRoute>,
     ) -> Result<TaskActivityProbePlan> {
         let mut probe_targets = Vec::new();
         let run_plans =
@@ -184,7 +184,7 @@ impl<'a> TaskActivityGuard<'a> {
             self.service,
             sessions,
             session_roles,
-            runtime_routes_by_worktree,
+            runtime_routes_by_session,
             &mut probe_targets,
         )?;
 
@@ -225,13 +225,15 @@ impl<'a> TaskActivityGuard<'a> {
                 })?;
 
             match probe_outcome {
-                RuntimeSessionStatusProbeOutcome::Statuses(statuses) => {
+                RuntimeSessionStatusProbeOutcome::Snapshot(snapshot) => {
+                    if snapshot.kind() == RuntimeSessionStatusSnapshotKind::NoLiveSessions {
+                        continue;
+                    }
+
                     if run_probe_plan
                         .external_session_ids
                         .iter()
-                        .any(|external_session_id| {
-                            has_live_runtime_session_status(statuses, external_session_id)
-                        })
+                        .any(|external_session_id| snapshot.has_live_session(external_session_id))
                     {
                         return Ok(true);
                     }
@@ -275,11 +277,14 @@ impl<'a> TaskActivityGuard<'a> {
                                 )
                             })?;
                     match probe_outcome {
-                        RuntimeSessionStatusProbeOutcome::Statuses(statuses) => {
-                            if has_live_runtime_session_status(
-                                statuses,
-                                session_probe_plan.external_session_id.as_str(),
-                            ) {
+                        RuntimeSessionStatusProbeOutcome::Snapshot(snapshot) => {
+                            if snapshot.kind() == RuntimeSessionStatusSnapshotKind::NoLiveSessions {
+                                continue;
+                            }
+
+                            if snapshot
+                                .has_live_session(session_probe_plan.external_session_id.as_str())
+                            {
                                 active_roles.insert(session_probe_plan.role.clone());
                             }
                         }
@@ -299,13 +304,15 @@ impl<'a> TaskActivityGuard<'a> {
         Ok(active_session_roles)
     }
 
-    fn collect_runtime_routes_by_worktree(
+    fn collect_runtime_routes_by_session(
         &self,
         repo_path: &str,
+        task_id: &str,
         candidate_runs: &[RunProbeCandidate],
-    ) -> Result<HashMap<String, RuntimeRoute>> {
+    ) -> Result<HashMap<SessionRuntimeLookupKey, RuntimeRoute>> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
-        let mut routes_by_worktree = collect_runtime_routes_by_worktree(candidate_runs);
+        let run_routes_by_worktree = collect_runtime_routes_by_worktree(candidate_runs);
+        let mut routes_by_session = HashMap::new();
         let runtimes = self
             .service
             .agent_runtimes
@@ -317,14 +324,32 @@ impl<'a> TaskActivityGuard<'a> {
             {
                 continue;
             }
+            if runtime.summary.task_id.as_deref() != Some(task_id) {
+                continue;
+            }
+            if runtime.summary.role == RuntimeRole::Workspace {
+                continue;
+            }
 
-            routes_by_worktree
-                .entry(normalize_path_key(
+            let key = SessionRuntimeLookupKey::new(
+                runtime.summary.kind.clone(),
+                runtime.summary.role,
+                runtime.summary.working_directory.as_str(),
+            );
+
+            if let Some(run_route) = run_routes_by_worktree
+                .get(&normalize_path_key(
                     runtime.summary.working_directory.as_str(),
                 ))
-                .or_insert_with(|| runtime.summary.runtime_route.clone());
+                .filter(|_| runtime.summary.role == RuntimeRole::Build)
+            {
+                routes_by_session.insert(key, run_route.clone());
+                continue;
+            }
+
+            routes_by_session.insert(key, runtime.summary.runtime_route.clone());
         }
 
-        Ok(routes_by_worktree)
+        Ok(routes_by_session)
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/mod.rs
@@ -117,7 +117,7 @@ impl<'a> TaskActivityGuard<'a> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
         let candidate_runs = self.collect_candidate_runs(&normalized_repo, task_id)?;
         let runtime_routes_by_session =
-            TaskRuntimeRouteIndex::collect(self.service, repo_path, task_id, &candidate_runs)?;
+            TaskRuntimeRouteIndex::collect(self.service, repo_path, task_id)?;
         let probe_plan = self.build_probe_plan(
             &candidate_runs,
             sessions,
@@ -177,8 +177,13 @@ impl<'a> TaskActivityGuard<'a> {
         runtime_route_index: &TaskRuntimeRouteIndex,
     ) -> Result<TaskActivityProbePlan> {
         let mut probe_targets = Vec::new();
-        let run_plans =
-            build_run_probe_plans(self.service, candidate_runs, sessions, &mut probe_targets)?;
+        let run_plans = build_run_probe_plans(
+            self.service,
+            candidate_runs,
+            sessions,
+            runtime_route_index,
+            &mut probe_targets,
+        )?;
         let session_plans = build_session_probe_plans(
             self.service,
             sessions,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/mod.rs
@@ -2,11 +2,11 @@ use super::cleanup_plans::{
     normalize_path_for_comparison, normalize_path_key, IMPLEMENTATION_SESSION_ROLES,
 };
 use crate::app_service::{
-    has_live_runtime_session_status, service_core::AppService, RuntimeSessionStatusMap,
-    RuntimeSessionStatusProbeTarget,
+    has_live_runtime_session_status, service_core::AppService, RuntimeSessionStatusProbeOutcome,
+    RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeTargetResolution,
 };
 use anyhow::{anyhow, Context, Result};
-use host_domain::{AgentRuntimeKind, AgentSessionDocument, RunState, RuntimeRole, RuntimeRoute};
+use host_domain::{AgentSessionDocument, RunState, RuntimeRoute};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
@@ -14,8 +14,8 @@ mod probe_support;
 
 use self::probe_support::{
     build_run_probe_plans, build_session_probe_plans, collect_runtime_routes_by_worktree,
-    resolve_session_statuses, RunProbeCandidate, RunProbePlan, SessionProbePlan,
-    TaskActiveWorkEvidence, TaskActivityProbePlan,
+    RunProbeCandidate, RunProbePlan, SessionProbePlan, TaskActiveWorkEvidence,
+    TaskActivityProbePlan,
 };
 
 pub(super) struct TaskActivityGuard<'a> {
@@ -117,31 +117,22 @@ impl<'a> TaskActivityGuard<'a> {
     ) -> Result<TaskActiveWorkEvidence> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
         let candidate_runs = self.collect_candidate_runs(&normalized_repo, task_id)?;
-        let runtime_routes_by_worktree = collect_runtime_routes_by_worktree(&candidate_runs);
-        let repo_runtime_routes_by_kind = self.collect_repo_runtime_routes_by_kind(repo_path)?;
+        let runtime_routes_by_worktree =
+            self.collect_runtime_routes_by_worktree(repo_path, &candidate_runs)?;
         let probe_plan = self.build_probe_plan(
             &candidate_runs,
             sessions,
             session_roles,
             &runtime_routes_by_worktree,
-            &repo_runtime_routes_by_kind,
         )?;
 
-        let primary_statuses_by_target = self
+        let probe_outcomes_by_target = self
             .service
-            .load_cached_runtime_session_statuses_for_targets(&probe_plan.primary_probe_targets)?;
+            .load_cached_runtime_session_statuses_for_targets(&probe_plan.probe_targets)?;
         let has_active_run =
-            self.evaluate_run_activity(&probe_plan.run_plans, &primary_statuses_by_target)?;
-
-        let fallback_probe_targets = probe_plan.fallback_probe_targets(&primary_statuses_by_target);
-        let fallback_statuses_by_target = self
-            .service
-            .load_cached_runtime_session_statuses_for_targets(&fallback_probe_targets)?;
-        let active_session_roles = self.collect_active_session_roles(
-            &probe_plan.session_plans,
-            &primary_statuses_by_target,
-            &fallback_statuses_by_target,
-        )?;
+            self.evaluate_run_activity(&probe_plan.run_plans, &probe_outcomes_by_target)?;
+        let active_session_roles = self
+            .collect_active_session_roles(&probe_plan.session_plans, &probe_outcomes_by_target)?;
 
         Ok(TaskActiveWorkEvidence {
             has_active_run,
@@ -185,60 +176,70 @@ impl<'a> TaskActivityGuard<'a> {
         sessions: &[AgentSessionDocument],
         session_roles: &[&str],
         runtime_routes_by_worktree: &HashMap<String, RuntimeRoute>,
-        repo_runtime_routes_by_kind: &HashMap<AgentRuntimeKind, RuntimeRoute>,
     ) -> Result<TaskActivityProbePlan> {
-        let mut primary_probe_targets = Vec::new();
-        let run_plans = build_run_probe_plans(
-            self.service,
-            candidate_runs,
-            sessions,
-            &mut primary_probe_targets,
-        )?;
+        let mut probe_targets = Vec::new();
+        let run_plans =
+            build_run_probe_plans(self.service, candidate_runs, sessions, &mut probe_targets)?;
         let session_plans = build_session_probe_plans(
             self.service,
             sessions,
             session_roles,
             runtime_routes_by_worktree,
-            repo_runtime_routes_by_kind,
-            &mut primary_probe_targets,
+            &mut probe_targets,
         )?;
 
         Ok(TaskActivityProbePlan {
             run_plans,
             session_plans,
-            primary_probe_targets,
+            probe_targets,
         })
     }
 
     fn evaluate_run_activity(
         &self,
         run_plans: &[RunProbePlan],
-        primary_statuses_by_target: &HashMap<
+        probe_outcomes_by_target: &HashMap<
             RuntimeSessionStatusProbeTarget,
-            RuntimeSessionStatusMap,
+            RuntimeSessionStatusProbeOutcome,
         >,
     ) -> Result<bool> {
         for run_probe_plan in run_plans {
-            let Some(primary_target) = run_probe_plan.primary_target.as_ref() else {
+            let Some(probe_target_resolution) = run_probe_plan.probe_target_resolution.as_ref()
+            else {
+                continue;
+            };
+
+            let RuntimeSessionStatusProbeTargetResolution::Target(primary_target) =
+                probe_target_resolution
+            else {
                 return Ok(true);
             };
 
-            let statuses = primary_statuses_by_target
+            let probe_outcome = probe_outcomes_by_target
                 .get(primary_target)
                 .ok_or_else(|| {
                     anyhow!(
-                        "Missing cached runtime session statuses for {}",
+                        "Missing cached runtime session status outcome for {}",
                         run_probe_plan.worktree_path
                     )
                 })?;
-            if run_probe_plan
-                .external_session_ids
-                .iter()
-                .any(|external_session_id| {
-                    has_live_runtime_session_status(statuses, external_session_id)
-                })
-            {
-                return Ok(true);
+
+            match probe_outcome {
+                RuntimeSessionStatusProbeOutcome::Statuses(statuses) => {
+                    if run_probe_plan
+                        .external_session_ids
+                        .iter()
+                        .any(|external_session_id| {
+                            has_live_runtime_session_status(statuses, external_session_id)
+                        })
+                    {
+                        return Ok(true);
+                    }
+                }
+                RuntimeSessionStatusProbeOutcome::Unsupported => return Ok(true),
+                RuntimeSessionStatusProbeOutcome::ActionableError(error) => {
+                    return Err(anyhow!(error.to_string()))
+                }
             }
         }
 
@@ -248,33 +249,48 @@ impl<'a> TaskActivityGuard<'a> {
     fn collect_active_session_roles(
         &self,
         session_plans: &[SessionProbePlan],
-        primary_statuses_by_target: &HashMap<
+        probe_outcomes_by_target: &HashMap<
             RuntimeSessionStatusProbeTarget,
-            RuntimeSessionStatusMap,
-        >,
-        fallback_statuses_by_target: &HashMap<
-            RuntimeSessionStatusProbeTarget,
-            RuntimeSessionStatusMap,
+            RuntimeSessionStatusProbeOutcome,
         >,
     ) -> Result<Vec<String>> {
         let mut active_roles = HashSet::new();
         for session_probe_plan in session_plans {
-            if session_probe_plan.primary_target.is_none() {
-                active_roles.insert(session_probe_plan.role.clone());
+            let Some(probe_target_resolution) = session_probe_plan.probe_target_resolution.as_ref()
+            else {
                 continue;
-            }
-            let statuses = resolve_session_statuses(
-                session_probe_plan,
-                primary_statuses_by_target,
-                fallback_statuses_by_target,
-            )?;
-            if statuses.is_some_and(|statuses| {
-                has_live_runtime_session_status(
-                    statuses,
-                    session_probe_plan.external_session_id.as_str(),
-                )
-            }) {
-                active_roles.insert(session_probe_plan.role.clone());
+            };
+            match probe_target_resolution {
+                RuntimeSessionStatusProbeTargetResolution::Unsupported => {
+                    active_roles.insert(session_probe_plan.role.clone());
+                }
+                RuntimeSessionStatusProbeTargetResolution::Target(primary_target) => {
+                    let probe_outcome =
+                        probe_outcomes_by_target
+                            .get(primary_target)
+                            .ok_or_else(|| {
+                                anyhow!(
+                                    "Missing cached runtime session status outcome for {}",
+                                    session_probe_plan.worktree_key
+                                )
+                            })?;
+                    match probe_outcome {
+                        RuntimeSessionStatusProbeOutcome::Statuses(statuses) => {
+                            if has_live_runtime_session_status(
+                                statuses,
+                                session_probe_plan.external_session_id.as_str(),
+                            ) {
+                                active_roles.insert(session_probe_plan.role.clone());
+                            }
+                        }
+                        RuntimeSessionStatusProbeOutcome::Unsupported => {
+                            active_roles.insert(session_probe_plan.role.clone());
+                        }
+                        RuntimeSessionStatusProbeOutcome::ActionableError(error) => {
+                            return Err(anyhow!(error.to_string()))
+                        }
+                    }
+                }
             }
         }
 
@@ -283,17 +299,18 @@ impl<'a> TaskActivityGuard<'a> {
         Ok(active_session_roles)
     }
 
-    fn collect_repo_runtime_routes_by_kind(
+    fn collect_runtime_routes_by_worktree(
         &self,
         repo_path: &str,
-    ) -> Result<HashMap<AgentRuntimeKind, RuntimeRoute>> {
+        candidate_runs: &[RunProbeCandidate],
+    ) -> Result<HashMap<String, RuntimeRoute>> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
+        let mut routes_by_worktree = collect_runtime_routes_by_worktree(candidate_runs);
         let runtimes = self
             .service
             .agent_runtimes
             .lock()
             .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-        let mut routes_by_kind = HashMap::new();
 
         for runtime in runtimes.values() {
             if normalize_path_for_comparison(runtime.summary.repo_path.as_str()) != normalized_repo
@@ -301,19 +318,13 @@ impl<'a> TaskActivityGuard<'a> {
                 continue;
             }
 
-            if runtime.summary.role == RuntimeRole::Workspace {
-                routes_by_kind.insert(
-                    runtime.summary.kind.clone(),
-                    runtime.summary.runtime_route.clone(),
-                );
-                continue;
-            }
-
-            routes_by_kind
-                .entry(runtime.summary.kind.clone())
+            routes_by_worktree
+                .entry(normalize_path_key(
+                    runtime.summary.working_directory.as_str(),
+                ))
                 .or_insert_with(|| runtime.summary.runtime_route.clone());
         }
 
-        Ok(routes_by_kind)
+        Ok(routes_by_worktree)
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::app_service::dedupe_runtime_session_probe_targets;
+use host_domain::AgentRuntimeKind;
 
 #[derive(Default)]
 pub(super) struct TaskActiveWorkEvidence {
@@ -29,64 +29,37 @@ impl TaskActiveWorkEvidence {
 pub(super) struct TaskActivityProbePlan {
     pub(super) run_plans: Vec<RunProbePlan>,
     pub(super) session_plans: Vec<SessionProbePlan>,
-    pub(super) primary_probe_targets: Vec<RuntimeSessionStatusProbeTarget>,
-}
-
-impl TaskActivityProbePlan {
-    pub(super) fn fallback_probe_targets(
-        &self,
-        primary_statuses_by_target: &HashMap<
-            RuntimeSessionStatusProbeTarget,
-            RuntimeSessionStatusMap,
-        >,
-    ) -> Vec<RuntimeSessionStatusProbeTarget> {
-        dedupe_probe_targets(
-            self.session_plans
-                .iter()
-                .filter_map(|session_probe_plan| {
-                    let primary_target = session_probe_plan.primary_target.as_ref()?;
-                    let primary_statuses = primary_statuses_by_target.get(primary_target)?;
-                    if primary_statuses.is_empty() {
-                        session_probe_plan.fallback_target.clone()
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-        )
-    }
+    pub(super) probe_targets: Vec<RuntimeSessionStatusProbeTarget>,
 }
 
 pub(super) fn build_run_probe_plans(
     service: &AppService,
     candidate_runs: &[RunProbeCandidate],
     sessions: &[AgentSessionDocument],
-    primary_probe_targets: &mut Vec<RuntimeSessionStatusProbeTarget>,
+    probe_targets: &mut Vec<RuntimeSessionStatusProbeTarget>,
 ) -> Result<Vec<RunProbePlan>> {
     let mut run_plans = Vec::with_capacity(candidate_runs.len());
     for run_candidate in candidate_runs {
         let external_session_ids = collect_build_external_session_ids(run_candidate, sessions);
-        let primary_target = if external_session_ids.is_empty() {
+        let probe_target_resolution = if external_session_ids.is_empty() {
             None
         } else {
-            let target = service
+            let resolution = service
                 .runtime_registry
                 .runtime(&run_candidate.runtime_kind)?
                 .session_status_probe_target(
                     &run_candidate.runtime_route,
                     run_candidate.worktree_path.as_str(),
                 )?;
-            if let Some(target) = target {
-                primary_probe_targets.push(target.clone());
-                Some(target)
-            } else {
-                None
+            if let RuntimeSessionStatusProbeTargetResolution::Target(target) = &resolution {
+                probe_targets.push(target.clone());
             }
+            Some(resolution)
         };
         run_plans.push(RunProbePlan {
             worktree_path: run_candidate.worktree_path.clone(),
             external_session_ids,
-            primary_target,
+            probe_target_resolution,
         });
     }
     Ok(run_plans)
@@ -97,8 +70,7 @@ pub(super) fn build_session_probe_plans(
     sessions: &[AgentSessionDocument],
     session_roles: &[&str],
     runtime_routes_by_worktree: &HashMap<String, RuntimeRoute>,
-    repo_runtime_routes_by_kind: &HashMap<AgentRuntimeKind, RuntimeRoute>,
-    primary_probe_targets: &mut Vec<RuntimeSessionStatusProbeTarget>,
+    probe_targets: &mut Vec<RuntimeSessionStatusProbeTarget>,
 ) -> Result<Vec<SessionProbePlan>> {
     let allowed_roles = session_roles
         .iter()
@@ -119,46 +91,32 @@ pub(super) fn build_session_probe_plans(
         };
 
         let worktree_key = normalize_path_key(session.working_directory.as_str());
-        let fallback_runtime_kind = parse_runtime_kind(service, session.runtime_kind.as_str());
-        let worktree_runtime_route = runtime_routes_by_worktree.get(worktree_key.as_str());
-        let repo_runtime_route = fallback_runtime_kind
-            .as_ref()
-            .and_then(|kind| repo_runtime_routes_by_kind.get(kind));
-        let runtime_kind = worktree_runtime_route
-            .and_then(|_| parse_runtime_kind(service, session.runtime_kind.as_str()))
-            .or(fallback_runtime_kind);
-        let runtime_route = worktree_runtime_route.or(repo_runtime_route);
-        let Some(runtime_route) = runtime_route else {
-            continue;
-        };
-
-        let primary_target = runtime_kind
-            .as_ref()
-            .map(|kind| {
+        let probe_target_resolution = match (
+            parse_runtime_kind(service, session.runtime_kind.as_str()),
+            runtime_routes_by_worktree.get(worktree_key.as_str()),
+        ) {
+            (Some(runtime_kind), Some(runtime_route)) => Some(
                 service
                     .runtime_registry
-                    .runtime(kind)?
-                    .session_status_probe_target(runtime_route, session.working_directory.as_str())
-            })
-            .transpose()?
-            .flatten();
-        if let Some(target) = primary_target.as_ref() {
-            primary_probe_targets.push(target.clone());
+                    .runtime(&runtime_kind)?
+                    .session_status_probe_target(
+                        runtime_route,
+                        session.working_directory.as_str(),
+                    )?,
+            ),
+            _ => None,
+        };
+        if let Some(RuntimeSessionStatusProbeTargetResolution::Target(target)) =
+            &probe_target_resolution
+        {
+            probe_targets.push(target.clone());
         }
-        let fallback_target = select_fallback_probe_target(
-            service,
-            runtime_kind,
-            worktree_runtime_route,
-            repo_runtime_route,
-            session.working_directory.as_str(),
-        )?;
 
         session_plans.push(SessionProbePlan {
             worktree_key,
             role: session.role.trim().to_string(),
             external_session_id: external_session_id.to_string(),
-            primary_target,
-            fallback_target,
+            probe_target_resolution,
         });
     }
     Ok(session_plans)
@@ -176,80 +134,6 @@ pub(super) fn collect_runtime_routes_by_worktree(
             )
         })
         .collect()
-}
-
-pub(super) fn resolve_session_statuses<'a>(
-    session_probe_plan: &SessionProbePlan,
-    primary_statuses_by_target: &'a HashMap<
-        RuntimeSessionStatusProbeTarget,
-        RuntimeSessionStatusMap,
-    >,
-    fallback_statuses_by_target: &'a HashMap<
-        RuntimeSessionStatusProbeTarget,
-        RuntimeSessionStatusMap,
-    >,
-) -> Result<Option<&'a RuntimeSessionStatusMap>> {
-    let Some(primary_target) = session_probe_plan.primary_target.as_ref() else {
-        return Ok(None);
-    };
-    let primary_statuses = primary_statuses_by_target
-        .get(primary_target)
-        .ok_or_else(|| {
-            anyhow!(
-                "Missing cached runtime session statuses for {}",
-                session_probe_plan.worktree_key
-            )
-        })?;
-    if !primary_statuses.is_empty() {
-        return Ok(Some(primary_statuses));
-    }
-
-    let Some(fallback_target) = session_probe_plan.fallback_target.as_ref() else {
-        return Ok(Some(primary_statuses));
-    };
-    let fallback_statuses = fallback_statuses_by_target
-        .get(fallback_target)
-        .ok_or_else(|| {
-            anyhow!(
-                "Missing cached runtime session fallback statuses for {}",
-                session_probe_plan.worktree_key
-            )
-        })?;
-    if fallback_statuses.is_empty() {
-        Ok(Some(primary_statuses))
-    } else {
-        Ok(Some(fallback_statuses))
-    }
-}
-
-pub(super) fn select_fallback_probe_target(
-    service: &AppService,
-    runtime_kind: Option<AgentRuntimeKind>,
-    worktree_runtime_route: Option<&RuntimeRoute>,
-    repo_runtime_route: Option<&RuntimeRoute>,
-    working_directory: &str,
-) -> Result<Option<RuntimeSessionStatusProbeTarget>> {
-    let Some(runtime_kind) = runtime_kind.as_ref() else {
-        return Ok(None);
-    };
-    let (Some(primary_route), Some(fallback_route)) = (worktree_runtime_route, repo_runtime_route)
-    else {
-        return Ok(None);
-    };
-    if primary_route == fallback_route {
-        return Ok(None);
-    }
-
-    service
-        .runtime_registry
-        .runtime(runtime_kind)?
-        .session_status_probe_target(fallback_route, working_directory)
-}
-
-pub(super) fn dedupe_probe_targets(
-    targets: Vec<RuntimeSessionStatusProbeTarget>,
-) -> Vec<RuntimeSessionStatusProbeTarget> {
-    dedupe_runtime_session_probe_targets(targets)
 }
 
 pub(super) fn parse_runtime_kind(service: &AppService, value: &str) -> Option<AgentRuntimeKind> {
@@ -289,13 +173,12 @@ pub(super) struct RunProbeCandidate {
 pub(super) struct RunProbePlan {
     pub(super) worktree_path: String,
     pub(super) external_session_ids: Vec<String>,
-    pub(super) primary_target: Option<RuntimeSessionStatusProbeTarget>,
+    pub(super) probe_target_resolution: Option<RuntimeSessionStatusProbeTargetResolution>,
 }
 
 pub(super) struct SessionProbePlan {
     pub(super) worktree_key: String,
     pub(super) role: String,
     pub(super) external_session_id: String,
-    pub(super) primary_target: Option<RuntimeSessionStatusProbeTarget>,
-    pub(super) fallback_target: Option<RuntimeSessionStatusProbeTarget>,
+    pub(super) probe_target_resolution: Option<RuntimeSessionStatusProbeTargetResolution>,
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
@@ -1,5 +1,5 @@
 use super::*;
-use host_domain::AgentRuntimeKind;
+use host_domain::{AgentRuntimeKind, RuntimeRole};
 
 #[derive(Default)]
 pub(super) struct TaskActiveWorkEvidence {
@@ -30,6 +30,27 @@ pub(super) struct TaskActivityProbePlan {
     pub(super) run_plans: Vec<RunProbePlan>,
     pub(super) session_plans: Vec<SessionProbePlan>,
     pub(super) probe_targets: Vec<RuntimeSessionStatusProbeTarget>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(super) struct SessionRuntimeLookupKey {
+    runtime_kind: AgentRuntimeKind,
+    role: RuntimeRole,
+    working_directory_key: String,
+}
+
+impl SessionRuntimeLookupKey {
+    pub(super) fn new(
+        runtime_kind: AgentRuntimeKind,
+        role: RuntimeRole,
+        working_directory: &str,
+    ) -> Self {
+        Self {
+            runtime_kind,
+            role,
+            working_directory_key: normalize_path_key(working_directory),
+        }
+    }
 }
 
 pub(super) fn build_run_probe_plans(
@@ -69,7 +90,7 @@ pub(super) fn build_session_probe_plans(
     service: &AppService,
     sessions: &[AgentSessionDocument],
     session_roles: &[&str],
-    runtime_routes_by_worktree: &HashMap<String, RuntimeRoute>,
+    runtime_routes_by_session: &HashMap<SessionRuntimeLookupKey, RuntimeRoute>,
     probe_targets: &mut Vec<RuntimeSessionStatusProbeTarget>,
 ) -> Result<Vec<SessionProbePlan>> {
     let allowed_roles = session_roles
@@ -93,17 +114,24 @@ pub(super) fn build_session_probe_plans(
         let worktree_key = normalize_path_key(session.working_directory.as_str());
         let probe_target_resolution = match (
             parse_runtime_kind(service, session.runtime_kind.as_str()),
-            runtime_routes_by_worktree.get(worktree_key.as_str()),
+            parse_runtime_role(session.role.as_str()),
         ) {
-            (Some(runtime_kind), Some(runtime_route)) => Some(
-                service
-                    .runtime_registry
-                    .runtime(&runtime_kind)?
-                    .session_status_probe_target(
-                        runtime_route,
-                        session.working_directory.as_str(),
-                    )?,
-            ),
+            (Some(runtime_kind), Some(runtime_role)) => runtime_routes_by_session
+                .get(&SessionRuntimeLookupKey::new(
+                    runtime_kind.clone(),
+                    runtime_role,
+                    session.working_directory.as_str(),
+                ))
+                .map(|runtime_route| {
+                    service
+                        .runtime_registry
+                        .runtime(&runtime_kind)?
+                        .session_status_probe_target(
+                            runtime_route,
+                            session.working_directory.as_str(),
+                        )
+                })
+                .transpose()?,
             _ => None,
         };
         if let Some(RuntimeSessionStatusProbeTargetResolution::Target(target)) =
@@ -138,6 +166,16 @@ pub(super) fn collect_runtime_routes_by_worktree(
 
 pub(super) fn parse_runtime_kind(service: &AppService, value: &str) -> Option<AgentRuntimeKind> {
     service.runtime_registry.resolve_kind(value).ok()
+}
+
+pub(super) fn parse_runtime_role(value: &str) -> Option<RuntimeRole> {
+    match value.trim() {
+        "spec" => Some(RuntimeRole::Spec),
+        "planner" => Some(RuntimeRole::Planner),
+        "build" => Some(RuntimeRole::Build),
+        "qa" => Some(RuntimeRole::Qa),
+        _ => None,
+    }
 }
 
 pub(super) fn collect_build_external_session_ids(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
@@ -1,5 +1,5 @@
 use super::*;
-use host_domain::{AgentRuntimeKind, RuntimeRole};
+use host_domain::{AgentRuntimeKind, RuntimeRole, RuntimeRoute};
 
 #[derive(Default)]
 pub(super) struct TaskActiveWorkEvidence {
@@ -30,6 +30,92 @@ pub(super) struct TaskActivityProbePlan {
     pub(super) run_plans: Vec<RunProbePlan>,
     pub(super) session_plans: Vec<SessionProbePlan>,
     pub(super) probe_targets: Vec<RuntimeSessionStatusProbeTarget>,
+}
+
+pub(super) struct TaskRuntimeRouteIndex {
+    session_routes: HashMap<SessionRuntimeLookupKey, RuntimeRoute>,
+}
+
+impl TaskRuntimeRouteIndex {
+    pub(super) fn collect(
+        service: &AppService,
+        repo_path: &str,
+        task_id: &str,
+        candidate_runs: &[RunProbeCandidate],
+    ) -> Result<Self> {
+        let normalized_repo = normalize_path_for_comparison(repo_path);
+        let run_routes_by_worktree = collect_runtime_routes_by_worktree(candidate_runs);
+        let mut session_routes = HashMap::new();
+        let runtimes = service
+            .agent_runtimes
+            .lock()
+            .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
+
+        for runtime in runtimes.values() {
+            if normalize_path_for_comparison(runtime.summary.repo_path.as_str()) != normalized_repo
+            {
+                continue;
+            }
+            if runtime.summary.task_id.as_deref() != Some(task_id) {
+                continue;
+            }
+            if runtime.summary.role == RuntimeRole::Workspace {
+                continue;
+            }
+
+            let key = SessionRuntimeLookupKey::new(
+                runtime.summary.kind.clone(),
+                runtime.summary.role,
+                runtime.summary.working_directory.as_str(),
+            );
+
+            let route = run_routes_by_worktree
+                .get(&normalize_path_key(
+                    runtime.summary.working_directory.as_str(),
+                ))
+                .filter(|_| runtime.summary.role == RuntimeRole::Build)
+                .cloned()
+                .unwrap_or_else(|| runtime.summary.runtime_route.clone());
+
+            session_routes.insert(key, route);
+        }
+
+        Ok(Self { session_routes })
+    }
+
+    fn route_for_session(
+        &self,
+        session: &AgentSessionDocument,
+    ) -> Option<(AgentRuntimeKind, RuntimeRoute)> {
+        let runtime_kind = parse_runtime_kind_from_session(session)?;
+        let runtime_role = parse_runtime_role(session.role.as_str())?;
+        let runtime_route = self
+            .session_routes
+            .get(&SessionRuntimeLookupKey::new(
+                runtime_kind.clone(),
+                runtime_role,
+                session.working_directory.as_str(),
+            ))?
+            .clone();
+        Some((runtime_kind, runtime_route))
+    }
+
+    pub(super) fn probe_target_resolution_for_session(
+        &self,
+        service: &AppService,
+        session: &AgentSessionDocument,
+    ) -> Result<Option<RuntimeSessionStatusProbeTargetResolution>> {
+        let Some((runtime_kind, runtime_route)) = self.route_for_session(session) else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            service
+                .runtime_registry
+                .runtime(&runtime_kind)?
+                .session_status_probe_target(&runtime_route, session.working_directory.as_str())?,
+        ))
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -90,7 +176,7 @@ pub(super) fn build_session_probe_plans(
     service: &AppService,
     sessions: &[AgentSessionDocument],
     session_roles: &[&str],
-    runtime_routes_by_session: &HashMap<SessionRuntimeLookupKey, RuntimeRoute>,
+    runtime_route_index: &TaskRuntimeRouteIndex,
     probe_targets: &mut Vec<RuntimeSessionStatusProbeTarget>,
 ) -> Result<Vec<SessionProbePlan>> {
     let allowed_roles = session_roles
@@ -112,28 +198,8 @@ pub(super) fn build_session_probe_plans(
         };
 
         let worktree_key = normalize_path_key(session.working_directory.as_str());
-        let probe_target_resolution = match (
-            parse_runtime_kind(service, session.runtime_kind.as_str()),
-            parse_runtime_role(session.role.as_str()),
-        ) {
-            (Some(runtime_kind), Some(runtime_role)) => runtime_routes_by_session
-                .get(&SessionRuntimeLookupKey::new(
-                    runtime_kind.clone(),
-                    runtime_role,
-                    session.working_directory.as_str(),
-                ))
-                .map(|runtime_route| {
-                    service
-                        .runtime_registry
-                        .runtime(&runtime_kind)?
-                        .session_status_probe_target(
-                            runtime_route,
-                            session.working_directory.as_str(),
-                        )
-                })
-                .transpose()?,
-            _ => None,
-        };
+        let probe_target_resolution =
+            runtime_route_index.probe_target_resolution_for_session(service, session)?;
         if let Some(RuntimeSessionStatusProbeTargetResolution::Target(target)) =
             &probe_target_resolution
         {
@@ -164,8 +230,13 @@ pub(super) fn collect_runtime_routes_by_worktree(
         .collect()
 }
 
-pub(super) fn parse_runtime_kind(service: &AppService, value: &str) -> Option<AgentRuntimeKind> {
-    service.runtime_registry.resolve_kind(value).ok()
+fn parse_runtime_kind_from_session(session: &AgentSessionDocument) -> Option<AgentRuntimeKind> {
+    let runtime_kind = session.runtime_kind.trim();
+    if runtime_kind.is_empty() {
+        return None;
+    }
+
+    Some(AgentRuntimeKind::from(runtime_kind))
 }
 
 pub(super) fn parse_runtime_role(value: &str) -> Option<RuntimeRole> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
@@ -87,16 +87,21 @@ impl TaskRuntimeRouteIndex {
 
     fn route_for_session(
         &self,
+        service: &AppService,
         session: &AgentSessionDocument,
-    ) -> Option<(AgentRuntimeKind, RuntimeRoute)> {
-        let runtime_kind = parse_runtime_kind_from_session(session)?;
-        let runtime_role = parse_runtime_role(session.role.as_str())?;
-        let runtime_route = self.route_for_role(
+    ) -> Result<Option<(AgentRuntimeKind, RuntimeRoute)>> {
+        let runtime_kind = parse_runtime_kind_from_session(service, session)?;
+        let Some(runtime_role) = parse_runtime_role(session.role.as_str()) else {
+            return Ok(None);
+        };
+        let Some(runtime_route) = self.route_for_role(
             &runtime_kind,
             runtime_role,
             session.working_directory.as_str(),
-        )?;
-        Some((runtime_kind, runtime_route))
+        ) else {
+            return Ok(None);
+        };
+        Ok(Some((runtime_kind, runtime_route)))
     }
 
     fn route_for_role(
@@ -127,7 +132,7 @@ impl TaskRuntimeRouteIndex {
         service: &AppService,
         session: &AgentSessionDocument,
     ) -> Result<Option<RuntimeSessionStatusProbeTargetResolution>> {
-        let Some((runtime_kind, runtime_route)) = self.route_for_session(session) else {
+        let Some((runtime_kind, runtime_route)) = self.route_for_session(service, session)? else {
             return Ok(None);
         };
 
@@ -272,13 +277,33 @@ pub(super) fn build_session_probe_plans(
     Ok(session_plans)
 }
 
-fn parse_runtime_kind_from_session(session: &AgentSessionDocument) -> Option<AgentRuntimeKind> {
+fn parse_runtime_kind_from_session(
+    service: &AppService,
+    session: &AgentSessionDocument,
+) -> Result<AgentRuntimeKind> {
     let runtime_kind = session.runtime_kind.trim();
     if runtime_kind.is_empty() {
-        return None;
+        return Err(anyhow!(
+            "Persisted {} session '{}' is missing runtime kind metadata",
+            session.role.trim(),
+            session.session_id
+        ));
     }
 
-    Some(AgentRuntimeKind::from(runtime_kind))
+    let runtime_kind = AgentRuntimeKind::from(runtime_kind);
+    service
+        .runtime_registry
+        .runtime(&runtime_kind)
+        .with_context(|| {
+            format!(
+                "Persisted {} session '{}' references unsupported runtime kind '{}'",
+                session.role.trim(),
+                session.session_id,
+                session.runtime_kind.trim()
+            )
+        })?;
+
+    Ok(runtime_kind)
 }
 
 pub(super) fn parse_runtime_role(value: &str) -> Option<RuntimeRole> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard/probe_support.rs
@@ -33,19 +33,15 @@ pub(super) struct TaskActivityProbePlan {
 }
 
 pub(super) struct TaskRuntimeRouteIndex {
-    session_routes: HashMap<SessionRuntimeLookupKey, RuntimeRoute>,
+    task_routes: HashMap<SessionRuntimeLookupKey, RuntimeRoute>,
+    shared_routes: HashMap<SharedRuntimeLookupKey, RuntimeRoute>,
 }
 
 impl TaskRuntimeRouteIndex {
-    pub(super) fn collect(
-        service: &AppService,
-        repo_path: &str,
-        task_id: &str,
-        candidate_runs: &[RunProbeCandidate],
-    ) -> Result<Self> {
+    pub(super) fn collect(service: &AppService, repo_path: &str, task_id: &str) -> Result<Self> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
-        let run_routes_by_worktree = collect_runtime_routes_by_worktree(candidate_runs);
-        let mut session_routes = HashMap::new();
+        let mut task_routes = HashMap::new();
+        let mut shared_routes = HashMap::new();
         let runtimes = service
             .agent_runtimes
             .lock()
@@ -56,10 +52,21 @@ impl TaskRuntimeRouteIndex {
             {
                 continue;
             }
-            if runtime.summary.task_id.as_deref() != Some(task_id) {
+
+            if runtime.summary.role == RuntimeRole::Workspace {
+                if runtime.summary.task_id.is_none() {
+                    shared_routes.insert(
+                        SharedRuntimeLookupKey::new(
+                            runtime.summary.kind.clone(),
+                            runtime.summary.working_directory.as_str(),
+                        ),
+                        runtime.summary.runtime_route.clone(),
+                    );
+                }
                 continue;
             }
-            if runtime.summary.role == RuntimeRole::Workspace {
+
+            if runtime.summary.task_id.as_deref() != Some(task_id) {
                 continue;
             }
 
@@ -69,18 +76,13 @@ impl TaskRuntimeRouteIndex {
                 runtime.summary.working_directory.as_str(),
             );
 
-            let route = run_routes_by_worktree
-                .get(&normalize_path_key(
-                    runtime.summary.working_directory.as_str(),
-                ))
-                .filter(|_| runtime.summary.role == RuntimeRole::Build)
-                .cloned()
-                .unwrap_or_else(|| runtime.summary.runtime_route.clone());
-
-            session_routes.insert(key, route);
+            task_routes.insert(key, runtime.summary.runtime_route.clone());
         }
 
-        Ok(Self { session_routes })
+        Ok(Self {
+            task_routes,
+            shared_routes,
+        })
     }
 
     fn route_for_session(
@@ -89,15 +91,35 @@ impl TaskRuntimeRouteIndex {
     ) -> Option<(AgentRuntimeKind, RuntimeRoute)> {
         let runtime_kind = parse_runtime_kind_from_session(session)?;
         let runtime_role = parse_runtime_role(session.role.as_str())?;
-        let runtime_route = self
-            .session_routes
+        let runtime_route = self.route_for_role(
+            &runtime_kind,
+            runtime_role,
+            session.working_directory.as_str(),
+        )?;
+        Some((runtime_kind, runtime_route))
+    }
+
+    fn route_for_role(
+        &self,
+        runtime_kind: &AgentRuntimeKind,
+        runtime_role: RuntimeRole,
+        working_directory: &str,
+    ) -> Option<RuntimeRoute> {
+        self.task_routes
             .get(&SessionRuntimeLookupKey::new(
                 runtime_kind.clone(),
                 runtime_role,
-                session.working_directory.as_str(),
-            ))?
-            .clone();
-        Some((runtime_kind, runtime_route))
+                working_directory,
+            ))
+            .cloned()
+            .or_else(|| {
+                self.shared_routes
+                    .get(&SharedRuntimeLookupKey::new(
+                        runtime_kind.clone(),
+                        working_directory,
+                    ))
+                    .cloned()
+            })
     }
 
     pub(super) fn probe_target_resolution_for_session(
@@ -115,6 +137,41 @@ impl TaskRuntimeRouteIndex {
                 .runtime(&runtime_kind)?
                 .session_status_probe_target(&runtime_route, session.working_directory.as_str())?,
         ))
+    }
+
+    pub(super) fn probe_target_resolution_for_run(
+        &self,
+        service: &AppService,
+        run_candidate: &RunProbeCandidate,
+        runtime_role: RuntimeRole,
+    ) -> Result<RuntimeSessionStatusProbeTargetResolution> {
+        let runtime_route = self
+            .route_for_role(
+                &run_candidate.runtime_kind,
+                runtime_role,
+                run_candidate.worktree_path.as_str(),
+            )
+            .unwrap_or_else(|| run_candidate.runtime_route.clone());
+
+        service
+            .runtime_registry
+            .runtime(&run_candidate.runtime_kind)?
+            .session_status_probe_target(&runtime_route, run_candidate.worktree_path.as_str())
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct SharedRuntimeLookupKey {
+    runtime_kind: AgentRuntimeKind,
+    working_directory_key: String,
+}
+
+impl SharedRuntimeLookupKey {
+    fn new(runtime_kind: AgentRuntimeKind, working_directory: &str) -> Self {
+        Self {
+            runtime_kind,
+            working_directory_key: normalize_path_key(working_directory),
+        }
     }
 }
 
@@ -143,6 +200,7 @@ pub(super) fn build_run_probe_plans(
     service: &AppService,
     candidate_runs: &[RunProbeCandidate],
     sessions: &[AgentSessionDocument],
+    runtime_route_index: &TaskRuntimeRouteIndex,
     probe_targets: &mut Vec<RuntimeSessionStatusProbeTarget>,
 ) -> Result<Vec<RunProbePlan>> {
     let mut run_plans = Vec::with_capacity(candidate_runs.len());
@@ -151,13 +209,11 @@ pub(super) fn build_run_probe_plans(
         let probe_target_resolution = if external_session_ids.is_empty() {
             None
         } else {
-            let resolution = service
-                .runtime_registry
-                .runtime(&run_candidate.runtime_kind)?
-                .session_status_probe_target(
-                    &run_candidate.runtime_route,
-                    run_candidate.worktree_path.as_str(),
-                )?;
+            let resolution = runtime_route_index.probe_target_resolution_for_run(
+                service,
+                run_candidate,
+                RuntimeRole::Build,
+            )?;
             if let RuntimeSessionStatusProbeTargetResolution::Target(target) = &resolution {
                 probe_targets.push(target.clone());
             }
@@ -214,20 +270,6 @@ pub(super) fn build_session_probe_plans(
         });
     }
     Ok(session_plans)
-}
-
-pub(super) fn collect_runtime_routes_by_worktree(
-    candidate_runs: &[RunProbeCandidate],
-) -> HashMap<String, RuntimeRoute> {
-    candidate_runs
-        .iter()
-        .map(|run_candidate| {
-            (
-                normalize_path_key(run_candidate.worktree_path.as_str()),
-                run_candidate.runtime_route.clone(),
-            )
-        })
-        .collect()
 }
 
 fn parse_runtime_kind_from_session(session: &AgentSessionDocument) -> Option<AgentRuntimeKind> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
@@ -464,6 +464,88 @@ fn task_delete_uses_task_runtime_route_for_matching_runtime_kind_and_worktree() 
 }
 
 #[test]
+fn task_delete_uses_task_runtime_route_for_non_build_roles_sharing_a_worktree() -> Result<()> {
+    let repo_path = unique_temp_path("task-delete-mixed-runtime-qa-route-selection");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let runtime_registry = AppRuntimeRegistry::new(
+        vec![
+            Arc::new(TestRuntimeAdapter {
+                definition: builtin_opencode_runtime_definition(),
+                health: RuntimeHealth {
+                    kind: "opencode".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+            }),
+            Arc::new(TestRuntimeAdapter {
+                definition: test_runtime_definition("test-runtime", "Test Runtime"),
+                health: RuntimeHealth {
+                    kind: "test-runtime".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+            }),
+        ],
+        AgentRuntimeKind::opencode(),
+    )?;
+    let (service, task_state, _git_state) = build_service_with_runtime_registry(
+        vec![make_task("task-1", "task", TaskStatus::InProgress)],
+        runtime_registry,
+    );
+    let repo_path_string = repo_path.to_string_lossy().to_string();
+    let workspace = service.workspace_add(repo_path_string.as_str())?;
+    service.workspace_update_repo_config(
+        workspace.workspace_id.as_str(),
+        repo_config_for_workspace(
+            &workspace,
+            host_infra_system::RepoConfig {
+                branch_prefix: "odt".to_string(),
+                default_runtime_kind: "test-runtime".to_string(),
+                ..Default::default()
+            },
+        ),
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "qa-session".to_string(),
+        external_session_id: Some("external-qa-session".to_string()),
+        role: "qa".to_string(),
+        scenario: "qa_review".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "test-runtime".to_string(),
+        working_directory: repo_path_string.clone(),
+        selected_model: None,
+    }];
+    insert_workspace_runtime(&service, repo_path_string.as_str(), 43123)?;
+    insert_task_runtime_for_kind_role(
+        &service,
+        AgentRuntimeKind::from("test-runtime"),
+        "task-1",
+        RuntimeRole::Qa,
+        repo_path_string.as_str(),
+        repo_path_string.as_str(),
+        host_domain::RuntimeRoute::Stdio,
+    )?;
+
+    let error = service
+        .task_delete(repo_path_string.as_str(), "task-1", false)
+        .expect_err("matching task runtime should block QA delete conservatively");
+    assert!(error
+        .to_string()
+        .contains("Cannot delete tasks with active QA work in progress"));
+
+    Ok(())
+}
+
+#[test]
 fn runs_list_hides_runs_when_runtime_probe_returns_actionable_failure() -> Result<()> {
     let runtime_registry = AppRuntimeRegistry::new(
         vec![

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
@@ -361,9 +361,12 @@ fn task_delete_blocks_custom_runtime_sessions_via_service_runtime_registry() -> 
         working_directory: repo_path_string.clone(),
         selected_model: None,
     }];
-    insert_workspace_runtime_for_kind(
+    insert_task_runtime_for_kind_role(
         &service,
         AgentRuntimeKind::from("test-runtime"),
+        "task-1",
+        RuntimeRole::Build,
+        repo_path_string.as_str(),
         repo_path_string.as_str(),
         host_domain::RuntimeRoute::Stdio,
     )?;
@@ -371,6 +374,88 @@ fn task_delete_blocks_custom_runtime_sessions_via_service_runtime_registry() -> 
     let error = service
         .task_delete(repo_path_string.as_str(), "task-1", false)
         .expect_err("custom runtime session should block delete");
+    assert!(error
+        .to_string()
+        .contains("Cannot delete tasks with active builder work in progress"));
+
+    Ok(())
+}
+
+#[test]
+fn task_delete_uses_task_runtime_route_for_matching_runtime_kind_and_worktree() -> Result<()> {
+    let repo_path = unique_temp_path("task-delete-mixed-runtime-route-selection");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let runtime_registry = AppRuntimeRegistry::new(
+        vec![
+            Arc::new(TestRuntimeAdapter {
+                definition: builtin_opencode_runtime_definition(),
+                health: RuntimeHealth {
+                    kind: "opencode".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+            }),
+            Arc::new(TestRuntimeAdapter {
+                definition: test_runtime_definition("test-runtime", "Test Runtime"),
+                health: RuntimeHealth {
+                    kind: "test-runtime".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+            }),
+        ],
+        AgentRuntimeKind::opencode(),
+    )?;
+    let (service, task_state, _git_state) = build_service_with_runtime_registry(
+        vec![make_task("task-1", "task", TaskStatus::InProgress)],
+        runtime_registry,
+    );
+    let repo_path_string = repo_path.to_string_lossy().to_string();
+    let workspace = service.workspace_add(repo_path_string.as_str())?;
+    service.workspace_update_repo_config(
+        workspace.workspace_id.as_str(),
+        repo_config_for_workspace(
+            &workspace,
+            host_infra_system::RepoConfig {
+                branch_prefix: "odt".to_string(),
+                default_runtime_kind: "test-runtime".to_string(),
+                ..Default::default()
+            },
+        ),
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "test-runtime".to_string(),
+        working_directory: repo_path_string.clone(),
+        selected_model: None,
+    }];
+    insert_workspace_runtime(&service, repo_path_string.as_str(), 43123)?;
+    insert_task_runtime_for_kind_role(
+        &service,
+        AgentRuntimeKind::from("test-runtime"),
+        "task-1",
+        RuntimeRole::Build,
+        repo_path_string.as_str(),
+        repo_path_string.as_str(),
+        host_domain::RuntimeRoute::Stdio,
+    )?;
+
+    let error = service
+        .task_delete(repo_path_string.as_str(), "task-1", false)
+        .expect_err("matching task runtime should block delete conservatively");
     assert!(error
         .to_string()
         .contains("Cannot delete tasks with active builder work in progress"));

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
@@ -326,7 +326,7 @@ fn task_delete_blocks_custom_runtime_sessions_via_service_runtime_registry() -> 
                     version: None,
                     error: None,
                 },
-                session_probe_behavior: SessionProbeBehavior::ReturnNone,
+                session_probe_behavior: SessionProbeBehavior::ReturnUnsupported,
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -375,5 +375,88 @@ fn task_delete_blocks_custom_runtime_sessions_via_service_runtime_registry() -> 
         .to_string()
         .contains("Cannot delete tasks with active builder work in progress"));
 
+    Ok(())
+}
+
+#[test]
+fn runs_list_hides_runs_when_runtime_probe_returns_actionable_failure() -> Result<()> {
+    let runtime_registry = AppRuntimeRegistry::new(
+        vec![
+            Arc::new(TestRuntimeAdapter {
+                definition: builtin_opencode_runtime_definition(),
+                health: RuntimeHealth {
+                    kind: "opencode".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+            }),
+            Arc::new(TestRuntimeAdapter {
+                definition: test_runtime_definition("test-runtime", "Test Runtime"),
+                health: RuntimeHealth {
+                    kind: "test-runtime".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::ProbeFailure(
+                    "probe failed for test runtime",
+                ),
+            }),
+        ],
+        AgentRuntimeKind::opencode(),
+    )?;
+    let (service, task_state, _git_state) = build_service_with_runtime_registry(
+        vec![make_task("task-1", "task", TaskStatus::InProgress)],
+        runtime_registry,
+    );
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "test-runtime".to_string(),
+        working_directory: "/tmp/repo/worktree".to_string(),
+        selected_model: None,
+    }];
+    service
+        .runs
+        .lock()
+        .expect("run state lock poisoned")
+        .insert(
+            "run-1".to_string(),
+            crate::app_service::RunProcess {
+                summary: host_domain::RunSummary {
+                    run_id: "run-1".to_string(),
+                    runtime_kind: AgentRuntimeKind::from("test-runtime"),
+                    runtime_route: host_domain::RuntimeRoute::LocalHttp {
+                        endpoint: "http://127.0.0.1:43123".to_string(),
+                    },
+                    repo_path: "/tmp/repo".to_string(),
+                    task_id: "task-1".to_string(),
+                    branch: "odt/task-1".to_string(),
+                    worktree_path: "/tmp/repo/worktree".to_string(),
+                    port: Some(43_123),
+                    state: host_domain::RunState::Running,
+                    last_message: None,
+                    started_at: "2026-03-17T11:00:00Z".to_string(),
+                },
+                child: None,
+                _runtime_process_guard: None,
+                repo_path: "/tmp/repo".to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: "/tmp/repo/worktree".to_string(),
+                repo_config: host_infra_system::RepoConfig::default(),
+            },
+        );
+
+    let runs = service.runs_list(Some("/tmp/repo"))?;
+
+    assert!(runs.is_empty());
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -38,8 +38,9 @@ pub(super) use crate::app_service::{
     validate_plan_subtask_rules, validate_transition, wait_for_local_server,
     wait_for_local_server_with_process, AgentRuntimeProcess, AppService, DevServerGroupRuntime,
     OpencodeStartupMetricsSnapshot, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
-    RuntimeProcessGuard, RuntimeSessionStatusProbeTarget, RuntimeStartupFailureReason,
-    StartupEventContext, StartupEventCorrelation, StartupEventPayload,
+    RuntimeProcessGuard, RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
+    RuntimeSessionStatusProbeTargetResolution, RuntimeStartupFailureReason, StartupEventContext,
+    StartupEventCorrelation, StartupEventPayload,
 };
 
 pub(super) fn init_git_repo(path: &std::path::Path) -> Result<()> {
@@ -130,8 +131,9 @@ pub(super) fn insert_workspace_runtime_for_kind(
 #[derive(Clone)]
 pub(super) enum SessionProbeBehavior {
     Default,
-    ReturnNone,
+    ReturnUnsupported,
     ReturnError(&'static str),
+    ProbeFailure(&'static str),
 }
 
 #[derive(Clone)]
@@ -207,19 +209,54 @@ impl AppRuntime for TestRuntimeAdapter {
         &self,
         runtime_route: &host_domain::RuntimeRoute,
         working_directory: &str,
-    ) -> Result<Option<RuntimeSessionStatusProbeTarget>> {
+    ) -> Result<RuntimeSessionStatusProbeTargetResolution> {
         match self.session_probe_behavior {
             SessionProbeBehavior::Default => match runtime_route {
                 host_domain::RuntimeRoute::LocalHttp { .. } => {
-                    Ok(Some(RuntimeSessionStatusProbeTarget::for_runtime_route(
+                    Ok(RuntimeSessionStatusProbeTargetResolution::Target(
+                        RuntimeSessionStatusProbeTarget::new(
+                            self.definition.kind().clone(),
+                            runtime_route,
+                            working_directory,
+                        ),
+                    ))
+                }
+                host_domain::RuntimeRoute::Stdio => {
+                    Ok(RuntimeSessionStatusProbeTargetResolution::Unsupported)
+                }
+            },
+            SessionProbeBehavior::ReturnUnsupported => {
+                Ok(RuntimeSessionStatusProbeTargetResolution::Unsupported)
+            }
+            SessionProbeBehavior::ReturnError(message) => Err(anyhow::anyhow!(message)),
+            SessionProbeBehavior::ProbeFailure(_) => {
+                Ok(RuntimeSessionStatusProbeTargetResolution::Target(
+                    RuntimeSessionStatusProbeTarget::new(
+                        self.definition.kind().clone(),
                         runtime_route,
                         working_directory,
-                    )?))
-                }
-                host_domain::RuntimeRoute::Stdio => Ok(None),
-            },
-            SessionProbeBehavior::ReturnNone => Ok(None),
-            SessionProbeBehavior::ReturnError(message) => Err(anyhow::anyhow!(message)),
+                    ),
+                ))
+            }
+        }
+    }
+
+    fn probe_session_status(
+        &self,
+        _target: &RuntimeSessionStatusProbeTarget,
+    ) -> RuntimeSessionStatusProbeOutcome {
+        match self.session_probe_behavior {
+            SessionProbeBehavior::ProbeFailure(message) => {
+                RuntimeSessionStatusProbeOutcome::ActionableError(
+                    crate::app_service::RuntimeSessionStatusProbeError::ProbeFailed(
+                        message.to_string(),
+                    ),
+                )
+            }
+            SessionProbeBehavior::ReturnUnsupported => {
+                RuntimeSessionStatusProbeOutcome::Unsupported
+            }
+            _ => RuntimeSessionStatusProbeOutcome::Statuses(Default::default()),
         }
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -39,8 +39,8 @@ pub(super) use crate::app_service::{
     wait_for_local_server_with_process, AgentRuntimeProcess, AppService, DevServerGroupRuntime,
     OpencodeStartupMetricsSnapshot, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
     RuntimeProcessGuard, RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
-    RuntimeSessionStatusProbeTargetResolution, RuntimeStartupFailureReason, StartupEventContext,
-    StartupEventCorrelation, StartupEventPayload,
+    RuntimeSessionStatusProbeTargetResolution, RuntimeSessionStatusSnapshot,
+    RuntimeStartupFailureReason, StartupEventContext, StartupEventCorrelation, StartupEventPayload,
 };
 
 pub(super) fn init_git_repo(path: &std::path::Path) -> Result<()> {
@@ -90,10 +90,13 @@ pub(super) fn insert_workspace_runtime(
     Ok(())
 }
 
-pub(super) fn insert_workspace_runtime_for_kind(
+pub(super) fn insert_task_runtime_for_kind_role(
     service: &AppService,
     runtime_kind: AgentRuntimeKind,
+    task_id: &str,
+    role: RuntimeRole,
     repo_path: &str,
+    working_directory: &str,
     runtime_route: host_domain::RuntimeRoute,
 ) -> Result<()> {
     let descriptor = service
@@ -101,13 +104,18 @@ pub(super) fn insert_workspace_runtime_for_kind(
         .definition(&runtime_kind)?
         .descriptor()
         .clone();
+    let runtime_id = format!(
+        "runtime-{}-{task_id}-{}",
+        runtime_kind.as_str(),
+        role.as_str()
+    );
     let summary = RuntimeInstanceSummary {
         kind: runtime_kind,
-        runtime_id: "runtime-workspace-custom".to_string(),
+        runtime_id: runtime_id.clone(),
         repo_path: repo_path.to_string(),
-        task_id: None,
-        role: RuntimeRole::Workspace,
-        working_directory: repo_path.to_string(),
+        task_id: Some(task_id.to_string()),
+        role,
+        working_directory: working_directory.to_string(),
         runtime_route,
         started_at: "2026-03-17T11:00:00Z".to_string(),
         descriptor,
@@ -117,7 +125,7 @@ pub(super) fn insert_workspace_runtime_for_kind(
         .lock()
         .expect("runtime lock poisoned")
         .insert(
-            "runtime-workspace-custom".to_string(),
+            runtime_id,
             AgentRuntimeProcess {
                 summary,
                 child: Some(spawn_sleep_process(30)),
@@ -256,7 +264,9 @@ impl AppRuntime for TestRuntimeAdapter {
             SessionProbeBehavior::ReturnUnsupported => {
                 RuntimeSessionStatusProbeOutcome::Unsupported
             }
-            _ => RuntimeSessionStatusProbeOutcome::Statuses(Default::default()),
+            _ => RuntimeSessionStatusProbeOutcome::Snapshot(
+                RuntimeSessionStatusSnapshot::from_statuses(Default::default()),
+            ),
         }
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/task_workflow.rs
@@ -1293,6 +1293,54 @@ fn task_delete_ignores_stale_persisted_build_session_without_live_runtime() -> R
 }
 
 #[test]
+fn task_reset_fails_when_persisted_session_runtime_kind_is_unknown() -> Result<()> {
+    let repo_path = unique_temp_path("reset-task-unknown-session-runtime-kind-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    workspace_update_repo_config_by_repo_path(
+        &service,
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "unknown-runtime".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+
+    let error = service
+        .task_reset(&repo_path.to_string_lossy(), "task-1")
+        .expect_err("unknown persisted runtime kind should fail closed");
+    let error_text = format!("{error:#}");
+    assert!(error_text.contains("Failed checking live runtime state before"));
+    assert!(error_text.contains("references unsupported runtime kind 'unknown-runtime'"));
+    Ok(())
+}
+
+#[test]
 fn task_delete_rejects_live_build_session_status() -> Result<()> {
     let repo_path = unique_temp_path("delete-task-live-runtime-repo");
     fs::create_dir_all(&repo_path)?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/task_workflow.rs
@@ -563,7 +563,7 @@ fn task_reset_clears_workflow_artifacts_and_sets_status_to_open() -> Result<()> 
 }
 
 #[test]
-fn task_reset_rejects_live_spec_session_status_with_repo_runtime_without_run() -> Result<()> {
+fn task_reset_rejects_live_spec_session_status_with_task_runtime_without_run() -> Result<()> {
     assert_task_reset_rejects_live_session_status(
         TaskStatus::SpecReady,
         "spec",
@@ -573,7 +573,7 @@ fn task_reset_rejects_live_spec_session_status_with_repo_runtime_without_run() -
 }
 
 #[test]
-fn task_reset_rejects_live_planner_session_status_with_repo_runtime_without_run() -> Result<()> {
+fn task_reset_rejects_live_planner_session_status_with_task_runtime_without_run() -> Result<()> {
     assert_task_reset_rejects_live_session_status(
         TaskStatus::ReadyForDev,
         "planner",
@@ -583,7 +583,7 @@ fn task_reset_rejects_live_planner_session_status_with_repo_runtime_without_run(
 }
 
 #[test]
-fn task_reset_rejects_live_build_session_status_with_repo_runtime_without_run() -> Result<()> {
+fn task_reset_rejects_live_build_session_status_with_task_runtime_without_run() -> Result<()> {
     assert_task_reset_rejects_live_session_status(
         TaskStatus::InProgress,
         "build",
@@ -593,7 +593,7 @@ fn task_reset_rejects_live_build_session_status_with_repo_runtime_without_run() 
 }
 
 #[test]
-fn task_reset_rejects_live_qa_session_status_with_repo_runtime_without_run() -> Result<()> {
+fn task_reset_rejects_live_qa_session_status_with_task_runtime_without_run() -> Result<()> {
     assert_task_reset_rejects_live_session_status(
         TaskStatus::AiReview,
         "qa",
@@ -647,7 +647,22 @@ fn assert_task_reset_rejects_live_session_status(
     let status_payload = format!(r#"{{"external-{role}-session":{{"type":"busy"}}}}"#);
     let status_payload = Box::leak(status_payload.into_boxed_str());
     let (port, server_handle) = spawn_opencode_session_status_server(status_payload)?;
-    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+    let runtime_role = match role {
+        "spec" => RuntimeRole::Spec,
+        "planner" => RuntimeRole::Planner,
+        "build" => RuntimeRole::Build,
+        "qa" => RuntimeRole::Qa,
+        other => panic!("unsupported role fixture: {other}"),
+    };
+    insert_task_runtime_for_kind_role(
+        &service,
+        AgentRuntimeKind::opencode(),
+        "task-1",
+        runtime_role,
+        &repo_path.to_string_lossy(),
+        &repo_path.to_string_lossy(),
+        builtin_opencode_runtime_route(port),
+    )?;
 
     let error = service
         .task_reset(&repo_path.to_string_lossy(), "task-1")
@@ -1049,7 +1064,15 @@ fn task_delete_reports_qa_specific_message_when_session_role_has_trailing_whites
     }];
     let (port, server_handle) =
         spawn_opencode_session_status_server(r#"{"external-qa-session":{"type":"busy"}}"#)?;
-    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+    insert_task_runtime_for_kind_role(
+        &service,
+        AgentRuntimeKind::opencode(),
+        "task-1",
+        RuntimeRole::Qa,
+        &repo_path.to_string_lossy(),
+        &repo_path.to_string_lossy(),
+        builtin_opencode_runtime_route(port),
+    )?;
 
     let error = service
         .task_delete(&repo_path.to_string_lossy(), "task-1", false)
@@ -1113,7 +1136,7 @@ fn task_reset_reports_completed_cleanup_steps_when_later_cleanup_fails() -> Resu
 }
 
 #[test]
-fn task_reset_implementation_rejects_live_qa_session_status_with_repo_runtime_without_run(
+fn task_reset_implementation_rejects_live_qa_session_status_with_task_runtime_without_run(
 ) -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-live-qa-shared-runtime-repo");
     fs::create_dir_all(&repo_path)?;
@@ -1153,7 +1176,15 @@ fn task_reset_implementation_rejects_live_qa_session_status_with_repo_runtime_wi
     }];
     let (port, server_handle) =
         spawn_opencode_session_status_server(r#"{"external-qa-session":{"type":"busy"}}"#)?;
-    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+    insert_task_runtime_for_kind_role(
+        &service,
+        AgentRuntimeKind::opencode(),
+        "task-1",
+        RuntimeRole::Qa,
+        &repo_path.to_string_lossy(),
+        &repo_path.to_string_lossy(),
+        builtin_opencode_runtime_route(port),
+    )?;
 
     let error = service
         .task_reset_implementation(&repo_path.to_string_lossy(), "task-1")
@@ -1295,7 +1326,7 @@ fn task_delete_rejects_live_build_session_status() -> Result<()> {
 }
 
 #[test]
-fn task_delete_rejects_live_build_session_status_with_repo_runtime_without_run() -> Result<()> {
+fn task_delete_rejects_live_build_session_status_with_task_runtime_without_run() -> Result<()> {
     let repo_path = unique_temp_path("delete-task-live-shared-runtime-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -1334,7 +1365,15 @@ fn task_delete_rejects_live_build_session_status_with_repo_runtime_without_run()
     }];
     let (port, server_handle) =
         spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
-    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+    insert_task_runtime_for_kind_role(
+        &service,
+        AgentRuntimeKind::opencode(),
+        "task-1",
+        RuntimeRole::Build,
+        &repo_path.to_string_lossy(),
+        &repo_path.to_string_lossy(),
+        builtin_opencode_runtime_route(port),
+    )?;
 
     let error = service
         .task_delete(&repo_path.to_string_lossy(), "task-1", false)
@@ -1388,7 +1427,15 @@ fn task_delete_rejects_live_qa_session_status_with_qa_specific_message() -> Resu
     }];
     let (port, server_handle) =
         spawn_opencode_session_status_server(r#"{"external-qa-session":{"type":"busy"}}"#)?;
-    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+    insert_task_runtime_for_kind_role(
+        &service,
+        AgentRuntimeKind::opencode(),
+        "task-1",
+        RuntimeRole::Qa,
+        &repo_path.to_string_lossy(),
+        &repo_path.to_string_lossy(),
+        builtin_opencode_runtime_route(port),
+    )?;
 
     let error = service
         .task_delete(&repo_path.to_string_lossy(), "task-1", false)
@@ -1480,19 +1527,12 @@ fn task_delete_fails_when_stale_run_route_probe_cannot_be_reached() -> Result<()
             },
         );
 
-    let (port, server_handle) =
-        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
-    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
-
     let error = service
         .task_delete(&repo_path.to_string_lossy(), "task-1", false)
         .expect_err("stale run route probe failure should stop delete");
     assert!(error
         .to_string()
         .contains("Failed checking active task work before deleting task-1"));
-    server_handle
-        .join()
-        .expect("status server thread should finish");
     Ok(())
 }
 
@@ -1759,19 +1799,12 @@ fn task_reset_implementation_fails_when_stale_run_route_probe_cannot_be_reached(
             },
         );
 
-    let (port, server_handle) =
-        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
-    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
-
     let error = service
         .task_reset_implementation(&repo_path.to_string_lossy(), "task-1")
         .expect_err("stale run route probe failure should stop reset");
     assert!(error
         .to_string()
         .contains("Failed checking live runtime state before reset implementation task-1"));
-    server_handle
-        .join()
-        .expect("status server thread should finish");
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/task_workflow.rs
@@ -569,6 +569,7 @@ fn task_reset_rejects_live_spec_session_status_with_task_runtime_without_run() -
         "spec",
         "spec_authoring",
         "Cannot reset task while active spec session(s) exist",
+        false,
     )
 }
 
@@ -579,6 +580,7 @@ fn task_reset_rejects_live_planner_session_status_with_task_runtime_without_run(
         "planner",
         "plan_authoring",
         "Cannot reset task while active planner session(s) exist",
+        false,
     )
 }
 
@@ -589,6 +591,7 @@ fn task_reset_rejects_live_build_session_status_with_task_runtime_without_run() 
         "build",
         "build_implementation_start",
         "Cannot reset task while active build session(s) exist",
+        false,
     )
 }
 
@@ -599,6 +602,52 @@ fn task_reset_rejects_live_qa_session_status_with_task_runtime_without_run() -> 
         "qa",
         "qa_review",
         "Cannot reset task while active qa session(s) exist",
+        false,
+    )
+}
+
+#[test]
+fn task_reset_rejects_live_spec_session_status_with_workspace_runtime_without_run() -> Result<()> {
+    assert_task_reset_rejects_live_session_status(
+        TaskStatus::SpecReady,
+        "spec",
+        "spec_authoring",
+        "Cannot reset task while active spec session(s) exist",
+        true,
+    )
+}
+
+#[test]
+fn task_reset_rejects_live_planner_session_status_with_workspace_runtime_without_run() -> Result<()>
+{
+    assert_task_reset_rejects_live_session_status(
+        TaskStatus::ReadyForDev,
+        "planner",
+        "plan_authoring",
+        "Cannot reset task while active planner session(s) exist",
+        true,
+    )
+}
+
+#[test]
+fn task_reset_rejects_live_build_session_status_with_workspace_runtime_without_run() -> Result<()> {
+    assert_task_reset_rejects_live_session_status(
+        TaskStatus::InProgress,
+        "build",
+        "build_implementation_start",
+        "Cannot reset task while active build session(s) exist",
+        true,
+    )
+}
+
+#[test]
+fn task_reset_rejects_live_qa_session_status_with_workspace_runtime_without_run() -> Result<()> {
+    assert_task_reset_rejects_live_session_status(
+        TaskStatus::AiReview,
+        "qa",
+        "qa_review",
+        "Cannot reset task while active qa session(s) exist",
+        true,
     )
 }
 
@@ -607,6 +656,7 @@ fn assert_task_reset_rejects_live_session_status(
     role: &str,
     scenario: &str,
     expected_message: &str,
+    use_workspace_runtime: bool,
 ) -> Result<()> {
     let repo_path = unique_temp_path("reset-task-live-spec-shared-runtime-repo");
     fs::create_dir_all(&repo_path)?;
@@ -654,15 +704,19 @@ fn assert_task_reset_rejects_live_session_status(
         "qa" => RuntimeRole::Qa,
         other => panic!("unsupported role fixture: {other}"),
     };
-    insert_task_runtime_for_kind_role(
-        &service,
-        AgentRuntimeKind::opencode(),
-        "task-1",
-        runtime_role,
-        &repo_path.to_string_lossy(),
-        &repo_path.to_string_lossy(),
-        builtin_opencode_runtime_route(port),
-    )?;
+    if use_workspace_runtime {
+        insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+    } else {
+        insert_task_runtime_for_kind_role(
+            &service,
+            AgentRuntimeKind::opencode(),
+            "task-1",
+            runtime_role,
+            &repo_path.to_string_lossy(),
+            &repo_path.to_string_lossy(),
+            builtin_opencode_runtime_route(port),
+        )?;
+    }
 
     let error = service
         .task_reset(&repo_path.to_string_lossy(), "task-1")
@@ -1388,6 +1442,61 @@ fn task_delete_rejects_live_build_session_status_with_task_runtime_without_run()
 }
 
 #[test]
+fn task_delete_rejects_live_build_session_status_with_workspace_runtime_without_run() -> Result<()>
+{
+    let repo_path = unique_temp_path("delete-task-live-workspace-runtime-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    workspace_update_repo_config_by_repo_path(
+        &service,
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
+    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+
+    let error = service
+        .task_delete(&repo_path.to_string_lossy(), "task-1", false)
+        .expect_err("live workspace-runtime session should block delete");
+    assert!(error
+        .to_string()
+        .contains("Cannot delete tasks with active builder work in progress"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
+    Ok(())
+}
+
+#[test]
 fn task_delete_rejects_live_qa_session_status_with_qa_specific_message() -> Result<()> {
     let repo_path = unique_temp_path("task-delete-live-qa-shared-runtime-repo");
     fs::create_dir_all(&repo_path)?;
@@ -1450,7 +1559,62 @@ fn task_delete_rejects_live_qa_session_status_with_qa_specific_message() -> Resu
 }
 
 #[test]
-fn task_delete_fails_when_stale_run_route_probe_cannot_be_reached() -> Result<()> {
+fn task_delete_rejects_live_qa_session_status_with_workspace_runtime() -> Result<()> {
+    let repo_path = unique_temp_path("task-delete-live-qa-workspace-runtime-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::Open);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    workspace_update_repo_config_by_repo_path(
+        &service,
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "qa-session".to_string(),
+        external_session_id: Some("external-qa-session".to_string()),
+        role: "qa".to_string(),
+        scenario: "qa_review".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-qa-session":{"type":"busy"}}"#)?;
+    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+
+    let error = service
+        .task_delete(&repo_path.to_string_lossy(), "task-1", false)
+        .expect_err("live workspace-runtime QA session should block delete");
+    let error_text = error.to_string();
+    assert!(error_text.contains("Cannot delete tasks with active QA work in progress"));
+    assert!(error_text.contains("task-1 (qa session)"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
+    Ok(())
+}
+
+#[test]
+fn task_delete_rejects_live_build_session_when_stale_run_route_has_workspace_runtime() -> Result<()>
+{
     let repo_path = unique_temp_path("delete-task-live-shared-runtime-fallback-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -1487,6 +1651,9 @@ fn task_delete_fails_when_stale_run_route_probe_cannot_be_reached() -> Result<()
         working_directory: repo_path.to_string_lossy().to_string(),
         selected_model: None,
     }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
+    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
 
     let stale_route_port = {
         let listener = TcpListener::bind("127.0.0.1:0")?;
@@ -1529,10 +1696,13 @@ fn task_delete_fails_when_stale_run_route_probe_cannot_be_reached() -> Result<()
 
     let error = service
         .task_delete(&repo_path.to_string_lossy(), "task-1", false)
-        .expect_err("stale run route probe failure should stop delete");
+        .expect_err("live shared runtime should still block delete");
     assert!(error
         .to_string()
-        .contains("Failed checking active task work before deleting task-1"));
+        .contains("Cannot delete tasks with active builder work in progress"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
     Ok(())
 }
 
@@ -1722,7 +1892,8 @@ fn assert_task_reset_implementation_rejects_live_build_session_status(
 }
 
 #[test]
-fn task_reset_implementation_fails_when_stale_run_route_probe_cannot_be_reached() -> Result<()> {
+fn task_reset_implementation_rejects_live_build_session_when_stale_run_route_has_workspace_runtime(
+) -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-live-shared-runtime-fallback-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -1759,6 +1930,9 @@ fn task_reset_implementation_fails_when_stale_run_route_probe_cannot_be_reached(
         working_directory: repo_path.to_string_lossy().to_string(),
         selected_model: None,
     }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
+    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
 
     let stale_route_port = {
         let listener = TcpListener::bind("127.0.0.1:0")?;
@@ -1801,10 +1975,13 @@ fn task_reset_implementation_fails_when_stale_run_route_probe_cannot_be_reached(
 
     let error = service
         .task_reset_implementation(&repo_path.to_string_lossy(), "task-1")
-        .expect_err("stale run route probe failure should stop reset");
+        .expect_err("live shared runtime should still block reset");
     assert!(error
         .to_string()
-        .contains("Failed checking live runtime state before reset implementation task-1"));
+        .contains("Cannot reset implementation while builder work is active"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/task_workflow.rs
@@ -1403,8 +1403,7 @@ fn task_delete_rejects_live_qa_session_status_with_qa_specific_message() -> Resu
 }
 
 #[test]
-fn task_delete_rejects_live_build_session_status_with_stale_run_route_and_repo_runtime_fallback(
-) -> Result<()> {
+fn task_delete_fails_when_stale_run_route_probe_cannot_be_reached() -> Result<()> {
     let repo_path = unique_temp_path("delete-task-live-shared-runtime-fallback-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -1487,10 +1486,10 @@ fn task_delete_rejects_live_build_session_status_with_stale_run_route_and_repo_r
 
     let error = service
         .task_delete(&repo_path.to_string_lossy(), "task-1", false)
-        .expect_err("live shared-runtime session should block delete");
+        .expect_err("stale run route probe failure should stop delete");
     assert!(error
         .to_string()
-        .contains("Cannot delete tasks with active builder work in progress"));
+        .contains("Failed checking active task work before deleting task-1"));
     server_handle
         .join()
         .expect("status server thread should finish");
@@ -1683,8 +1682,7 @@ fn assert_task_reset_implementation_rejects_live_build_session_status(
 }
 
 #[test]
-fn task_reset_implementation_rejects_live_build_session_status_with_stale_run_route_and_repo_runtime_fallback(
-) -> Result<()> {
+fn task_reset_implementation_fails_when_stale_run_route_probe_cannot_be_reached() -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-live-shared-runtime-fallback-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -1767,10 +1765,10 @@ fn task_reset_implementation_rejects_live_build_session_status_with_stale_run_ro
 
     let error = service
         .task_reset_implementation(&repo_path.to_string_lossy(), "task-1")
-        .expect_err("live shared-runtime session should block reset");
+        .expect_err("stale run route probe failure should stop reset");
     assert!(error
         .to_string()
-        .contains("Cannot reset implementation while active build session(s) exist"));
+        .contains("Failed checking live runtime state before reset implementation task-1"));
     server_handle
         .join()
         .expect("status server thread should finish");
@@ -1895,8 +1893,7 @@ fn task_reset_implementation_ignores_stale_build_run_when_runtime_session_is_idl
 }
 
 #[test]
-fn task_reset_implementation_ignores_stale_build_run_when_status_endpoint_is_unreachable(
-) -> Result<()> {
+fn task_reset_implementation_fails_when_status_endpoint_is_unreachable() -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-stale-build-run-unreachable-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -2000,14 +1997,13 @@ fn task_reset_implementation_ignores_stale_build_run_when_status_endpoint_is_unr
             },
         );
 
-    let updated = service.task_reset_implementation(workspace.repo_path.as_str(), "task-1")?;
+    let error = service
+        .task_reset_implementation(workspace.repo_path.as_str(), "task-1")
+        .expect_err("unreachable probe should fail reset instead of masking the error");
 
-    assert_eq!(updated.status, TaskStatus::ReadyForDev);
-    assert!(service
-        .runs
-        .lock()
-        .expect("run state lock poisoned")
-        .is_empty());
+    assert!(error
+        .to_string()
+        .contains("Failed checking live runtime state before reset implementation task-1"));
     Ok(())
 }
 

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -433,8 +433,12 @@ describe("AgentStudioTaskTabs", () => {
       ),
     );
 
+    const inactiveTab = screen.getByRole("tab", { name: /Ship QA checklist/i });
+
     await act(async () => {
-      fireEvent.click(screen.getByRole("tab", { name: /Ship QA checklist/i }));
+      fireEvent.mouseDown(inactiveTab, { button: 0, buttons: 1 });
+      fireEvent.mouseUp(inactiveTab, { button: 0 });
+      fireEvent.click(inactiveTab, { button: 0 });
     });
 
     expect(onSelectTab).toHaveBeenCalledWith("task-2");


### PR DESCRIPTION
## Summary
- normalize host runtime session probing behind runtime-owned adapters
- restore safe task guard routing for shared workspace runtimes and stale build routes
- harden the agent studio inactive-tab selection test so the full desktop suite stays green

## Goal
This PR removes OpenCode-specific probing assumptions from generic host services while preserving the safety guarantees around task reset/delete and run visibility. It also fixes the review regressions where shared workspace runtimes stopped protecting live sessions and stale build run routes failed instead of detecting active work.

## Implementation
- moved session status probing to runtime-specific `AppRuntime` implementations and normalized host results through `RuntimeSessionStatusSnapshot`
- introduced task runtime route indexing that prefers task-owned role runtimes, then the matching shared workspace runtime for the same runtime kind and working directory, and only then the persisted run route
- updated task activity guards and run exposure to consume explicit snapshot semantics instead of backend-specific map inference
- expanded host-application regression coverage for task-scoped runtimes, shared workspace runtimes, mixed-runtime worktrees, and stale build routes
- stabilized the inactive agent-studio tab click test with a fuller click sequence so workspace-wide test runs stay deterministic

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `bun run test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mouse interaction handling for tab selection in task management interface.

* **Refactor**
  * Improved session status probing to support multiple runtime types, providing more accurate run visibility, activity detection, and task lifecycle blocking when active sessions are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->