### PR TITLE
fix(desktop): decouple session hydration from runtime routes

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -210,7 +210,9 @@ impl AppRuntime for TestRuntimeAdapter {
         _external_session_id: &str,
         _working_directory: &str,
     ) -> Result<()> {
-        Err(anyhow::anyhow!("stop_session should not be used in this test"))
+        Err(anyhow::anyhow!(
+            "stop_session should not be used in this test"
+        ))
     }
 
     fn session_status_probe_target(

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -135,12 +135,11 @@ mod tests {
             RepoRuntimeHealthState, RepoRuntimeMcpStatus, RepoRuntimeStartupFailureKind,
             RepoRuntimeStartupStage, RepoRuntimeStartupStatus, RepoStoreAttachmentHealth,
             RepoStoreHealth, RepoStoreHealthCategory, RepoStoreHealthStatus,
-            RepoStoreSharedServerHealth, RepoStoreSharedServerOwnershipState, RunEvent,
-            RunState, RunSummary, RuntimeCheck, RuntimeInstanceSummary, RuntimeRole,
-            SpecDocument, SystemCheck, SystemOpenInToolId, SystemOpenInToolInfo, TaskAction,
-            TaskCard, TaskDirectMergeResult, TaskDocumentPresence, TaskDocumentSummary,
-            TaskMetadata, TaskQaDocumentPresence, TaskStatus, TaskStore, UpdateTaskPatch,
-            WorkspaceRecord,
+            RepoStoreSharedServerHealth, RepoStoreSharedServerOwnershipState, RunEvent, RunState,
+            RunSummary, RuntimeCheck, RuntimeInstanceSummary, RuntimeRole, SpecDocument,
+            SystemCheck, SystemOpenInToolId, SystemOpenInToolInfo, TaskAction, TaskCard,
+            TaskDirectMergeResult, TaskDocumentPresence, TaskDocumentSummary, TaskMetadata,
+            TaskQaDocumentPresence, TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
         };
 
         macro_rules! check_types_exported {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/workspace_icons.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/workspace_icons.rs
@@ -23,8 +23,11 @@ fn discover_workspace_icon_data_url_returns_svg_data_for_src_assets_logo() {
     let repo = harness.root().join("repo");
     fake_git_workspace(&repo);
     fs::create_dir_all(repo.join("src/assets")).expect("src assets dir");
-    fs::write(repo.join("src/assets/logo.svg"), b"<svg viewBox='0 0 1 1'></svg>")
-        .expect("svg icon");
+    fs::write(
+        repo.join("src/assets/logo.svg"),
+        b"<svg viewBox='0 0 1 1'></svg>",
+    )
+    .expect("svg icon");
 
     let icon_data_url = discover_workspace_icon_data_url(repo.to_string_lossy().as_ref());
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/workspace_icons.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/workspace_icons.rs
@@ -132,7 +132,8 @@ pub(super) fn discover_workspace_icon_data_url(repo_path: &str) -> Option<String
                 let Some(mime_type) = workspace_icon_mime_type(&candidate_path) else {
                     continue;
                 };
-                let Some((modified_at, byte_len)) = workspace_icon_signature(&candidate_path) else {
+                let Some((modified_at, byte_len)) = workspace_icon_signature(&candidate_path)
+                else {
                     continue;
                 };
                 let Some(bytes) = read_workspace_icon_bytes(&candidate_path) else {

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -1034,7 +1034,10 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(payload["workspaces"].as_array().map(Vec::len), Some(1));
         assert_eq!(payload["workspaces"][0]["workspaceId"], json!(workspace_id));
-        assert_eq!(payload["workspaces"][0]["repoPath"], json!(expected_repo_path));
+        assert_eq!(
+            payload["workspaces"][0]["repoPath"],
+            json!(expected_repo_path)
+        );
     }
 
     #[tokio::test]

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -274,6 +274,7 @@ export const AgentChatComposer = forwardRef<
     supportsFileSearch,
     slashCommands,
     slashCommandsError,
+    sessionRuntimeDataError = null,
     isSlashCommandsLoading,
     searchFiles,
     agentOptions,
@@ -616,6 +617,11 @@ export const AgentChatComposer = forwardRef<
               : undefined
           }
         >
+          {sessionRuntimeDataError ? (
+            <div className="border-b border-border px-3 py-2 text-sm text-destructive">
+              {sessionRuntimeDataError}
+            </div>
+          ) : null}
           <AgentChatComposerEditor
             draft={draft}
             onDraftChange={handleDraftChange}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -274,7 +274,6 @@ export const AgentChatComposer = forwardRef<
     supportsFileSearch,
     slashCommands,
     slashCommandsError,
-    sessionRuntimeDataError = null,
     isSlashCommandsLoading,
     searchFiles,
     agentOptions,
@@ -617,11 +616,6 @@ export const AgentChatComposer = forwardRef<
               : undefined
           }
         >
-          {sessionRuntimeDataError ? (
-            <div className="border-b border-border px-3 py-2 text-sm text-destructive">
-              {sessionRuntimeDataError}
-            </div>
-          ) : null}
           <AgentChatComposerEditor
             draft={draft}
             onDraftChange={handleDraftChange}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-tauri.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-tauri.test.ts
@@ -28,6 +28,7 @@ const buildBaseModel = () => ({
   permissionReplyErrorByRequestId: {},
   onSubmitQuestionAnswers: async () => {},
   onReplyPermission: async () => {},
+  sessionRuntimeDataError: null,
   todoPanelCollapsed: false,
   onToggleTodoPanel: () => {},
   messagesContainerRef: createRef<HTMLDivElement>(),

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -605,6 +605,7 @@ describe("AgentChatThread", () => {
             pendingQuestions: [],
             pendingPermissions: [],
             todos: [],
+            selectedModel: null,
           }),
           sessionRuntimeDataError:
             "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
@@ -617,6 +618,9 @@ describe("AgentChatThread", () => {
     expect(bottomStack).not.toBeNull();
     expect(bottomStack?.textContent).toContain("active session runtime data access");
     expect(bottomStack?.className).toContain("pb-3");
+    expect(screen.getByText(/active session runtime data access/).className).toContain(
+      "border-l border-input",
+    );
 
     rendered.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -596,6 +596,31 @@ describe("AgentChatThread", () => {
     rendered.unmount();
   });
 
+  test("renders runtime data errors even when the session has no questions, permissions, or todos", async () => {
+    const rendered = render(
+      createElement(AgentChatThread, {
+        model: {
+          ...buildBaseModel(),
+          session: buildSession({
+            pendingQuestions: [],
+            pendingPermissions: [],
+            todos: [],
+          }),
+          sessionRuntimeDataError:
+            "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
+        },
+      }),
+    );
+    await act(flush);
+
+    const bottomStack = rendered.container.querySelector(".agent-chat-bottom-stack");
+    expect(bottomStack).not.toBeNull();
+    expect(bottomStack?.textContent).toContain("active session runtime data access");
+    expect(bottomStack?.className).toContain("pb-3");
+
+    rendered.unmount();
+  });
+
   test("keeps the todo panel flush with the composer when todo is the last bottom-stack item", async () => {
     const rendered = render(
       createElement(AgentChatThread, {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -42,6 +42,7 @@ const buildBaseModel = () => ({
   permissionReplyErrorByRequestId: {},
   onSubmitQuestionAnswers: async () => {},
   onReplyPermission: async () => {},
+  sessionRuntimeDataError: null,
   todoPanelCollapsed: false,
   onToggleTodoPanel: () => {},
   messagesContainerRef: createRef<HTMLDivElement>(),

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -399,8 +399,8 @@ const AgentChatBottomStack = memo(function AgentChatBottomStack({
         <div className="border border-input border-b-0 border-l-0 bg-card">
           <div
             className={cn(
-              "border-l-4 px-3 py-2 text-sm text-destructive",
-              !sessionAccentColor && "border-l-0",
+              "px-3 py-2 text-sm text-destructive",
+              sessionAccentColor ? "border-l-4" : "border-l border-input",
             )}
             style={sessionAccentColor ? { borderLeftColor: sessionAccentColor } : undefined}
           >

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -99,6 +99,7 @@ type AgentChatBottomStackProps = {
   pendingQuestions: AgentSessionState["pendingQuestions"];
   pendingPermissions: AgentSessionState["pendingPermissions"];
   todos: AgentSessionState["todos"];
+  sessionRuntimeDataError: string | null;
   agentStudioReady: boolean;
   isSubmittingQuestionByRequestId: AgentChatThreadModel["isSubmittingQuestionByRequestId"];
   onSubmitQuestionAnswers: AgentChatThreadModel["onSubmitQuestionAnswers"];
@@ -350,6 +351,7 @@ const AgentChatBottomStack = memo(function AgentChatBottomStack({
   pendingQuestions,
   pendingPermissions,
   todos,
+  sessionRuntimeDataError,
   agentStudioReady,
   isSubmittingQuestionByRequestId,
   onSubmitQuestionAnswers,
@@ -393,6 +395,20 @@ const AgentChatBottomStack = memo(function AgentChatBottomStack({
         </div>
       ))}
 
+      {sessionRuntimeDataError ? (
+        <div className="border border-input border-b-0 border-l-0 bg-card">
+          <div
+            className={cn(
+              "border-l-4 px-3 py-2 text-sm text-destructive",
+              !sessionAccentColor && "border-l-0",
+            )}
+            style={sessionAccentColor ? { borderLeftColor: sessionAccentColor } : undefined}
+          >
+            {sessionRuntimeDataError}
+          </div>
+        </div>
+      ) : null}
+
       <AgentSessionTodoPanel
         todos={todos}
         collapsed={todoPanelCollapsed}
@@ -428,6 +444,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     isSubmittingPermissionByRequestId,
     permissionReplyErrorByRequestId,
     onReplyPermission,
+    sessionRuntimeDataError,
     isSessionWorking,
     todoPanelCollapsed,
     onToggleTodoPanel,
@@ -769,6 +786,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
             isSubmittingPermissionByRequestId={isSubmittingPermissionByRequestId}
             permissionReplyErrorByRequestId={permissionReplyErrorByRequestId}
             onReplyPermission={onReplyPermission}
+            sessionRuntimeDataError={sessionRuntimeDataError}
             todoPanelCollapsed={todoPanelCollapsed}
             isSessionWorking={isSessionWorking}
             sessionAccentColor={sessionAccentColor}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -663,7 +663,8 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     session &&
       (session.pendingQuestions.length > 0 ||
         session.pendingPermissions.length > 0 ||
-        hasVisibleTodo),
+        hasVisibleTodo ||
+        sessionRuntimeDataError),
   );
 
   const resolveRowRef = useCallback(

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
@@ -33,6 +33,7 @@ const buildModel = () => ({
     permissionReplyErrorByRequestId: {},
     onSubmitQuestionAnswers: async () => {},
     onReplyPermission: async () => {},
+    sessionRuntimeDataError: null,
     todoPanelCollapsed: false,
     onToggleTodoPanel: () => {},
     messagesContainerRef: createRef<HTMLDivElement>(),

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -38,6 +38,7 @@ const buildModel = () => ({
     permissionReplyErrorByRequestId: {},
     onSubmitQuestionAnswers: async () => {},
     onReplyPermission: async () => {},
+    sessionRuntimeDataError: null,
     todoPanelCollapsed: false,
     onToggleTodoPanel: () => {},
     messagesContainerRef: createRef<HTMLDivElement>(),
@@ -156,5 +157,27 @@ describe("AgentChat", () => {
     expect(html).toContain("Keep todo anchored");
     expect(html).toContain("border-left-color:#123456");
     expect(html.indexOf("agent-chat-bottom-stack")).toBeLessThan(html.indexOf("<form"));
+  });
+
+  test("renders session runtime data errors in the bottom stack above the composer", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChat, {
+        model: {
+          ...buildModel(),
+          thread: {
+            ...buildModel().thread,
+            session: buildSession({
+              status: "idle",
+              todos: [buildTodoItem({ content: "Keep todo anchored", status: "in_progress" })],
+            }),
+            sessionRuntimeDataError:
+              "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
+          },
+        },
+      }),
+    );
+
+    expect(html).toContain("active session runtime data access");
+    expect(html.indexOf("active session runtime data access")).toBeLessThan(html.indexOf("<form"));
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -73,6 +73,7 @@ export type AgentChatComposerModel = {
   slashCommandCatalog: AgentSlashCommandCatalog | null;
   slashCommands: AgentSlashCommand[];
   slashCommandsError: string | null;
+  sessionRuntimeDataError?: string | null;
   isSlashCommandsLoading: boolean;
   searchFiles: (query: string) => Promise<AgentFileSearchResult[]>;
   agentOptions: ComboboxOption[];

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -42,6 +42,7 @@ export type AgentChatThreadModel = {
   isSubmittingPermissionByRequestId: Record<string, boolean>;
   permissionReplyErrorByRequestId: Record<string, string>;
   onReplyPermission: (requestId: string, reply: "once" | "always" | "reject") => Promise<void>;
+  sessionRuntimeDataError: string | null;
   todoPanelCollapsed: boolean;
   onToggleTodoPanel: () => void;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
@@ -73,7 +74,6 @@ export type AgentChatComposerModel = {
   slashCommandCatalog: AgentSlashCommandCatalog | null;
   slashCommands: AgentSlashCommand[];
   slashCommandsError: string | null;
-  sessionRuntimeDataError?: string | null;
   isSlashCommandsLoading: boolean;
   searchFiles: (query: string) => Promise<AgentFileSearchResult[]>;
   agentOptions: ComboboxOption[];

--- a/apps/desktop/src/pages/agents/agent-studio-session-runtime.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-session-runtime.ts
@@ -1,4 +1,5 @@
 import type { RuntimeKind } from "@openducktor/contracts";
+import type { AgentRuntimeConnection } from "@openducktor/core";
 import {
   getRuntimeConnectionSupportError,
   runtimeRouteToConnection,
@@ -9,6 +10,21 @@ const WORKTREE_RUNTIME_ROLES = new Set<AgentSessionState["role"]>(["build", "qa"
 
 type RuntimeAttachmentState = Pick<AgentSessionState, "runId" | "runtimeId" | "runtimeRoute">;
 type WorktreeRuntimeRole = Pick<AgentSessionState, "role">;
+type SessionRuntimeAccessState = {
+  runtimeKind?: AgentSessionState["runtimeKind"] | null;
+  runtimeRoute: AgentSessionState["runtimeRoute"];
+  workingDirectory: string;
+};
+
+export type AgentStudioSessionRuntimeQueryInput = {
+  runtimeKind: RuntimeKind;
+  runtimeConnection: AgentRuntimeConnection;
+};
+
+export type AgentStudioSessionRuntimeQueryState = {
+  runtimeQueryInput: AgentStudioSessionRuntimeQueryInput | null;
+  runtimeQueryError: string | null;
+};
 
 export const requiresLiveWorktreeRuntime = (
   session: WorktreeRuntimeRole | null | undefined,
@@ -58,6 +74,25 @@ export const getAttachedSessionRuntimeConnectionError = (
     runtimeRouteToConnection(session.runtimeRoute, session.workingDirectory),
     action,
   );
+};
+
+export const resolveAttachedSessionRuntimeQueryState = (
+  session: SessionRuntimeAccessState | null | undefined,
+  action = "attached session runtime access",
+): AgentStudioSessionRuntimeQueryState => {
+  const runtimeConnection = toAttachedSessionRuntimeConnection(session);
+  const runtimeKind = session?.runtimeKind ?? null;
+
+  return {
+    runtimeQueryInput:
+      runtimeKind && runtimeConnection
+        ? {
+            runtimeKind,
+            runtimeConnection,
+          }
+        : null,
+    runtimeQueryError: getAttachedSessionRuntimeConnectionError(session, runtimeKind, action),
+  };
 };
 
 export const isWaitingForAttachedWorktreeRuntime = (

--- a/apps/desktop/src/pages/agents/agent-studio-session-runtime.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-session-runtime.ts
@@ -32,22 +32,12 @@ export const toAttachedSessionRuntimeConnection = (
     | { runtimeRoute: AgentSessionState["runtimeRoute"]; workingDirectory: string }
     | null
     | undefined,
-  runtimeKind: RuntimeKind | null | undefined,
-  action = "attached session runtime access",
 ) => {
   if (!session?.runtimeRoute) {
     return null;
   }
 
-  const runtimeConnection = runtimeRouteToConnection(
-    session.runtimeRoute,
-    session.workingDirectory,
-  );
-  if (getRuntimeConnectionSupportError(runtimeKind, runtimeConnection, action)) {
-    return null;
-  }
-
-  return runtimeConnection;
+  return runtimeRouteToConnection(session.runtimeRoute, session.workingDirectory);
 };
 
 export const getAttachedSessionRuntimeConnectionError = (

--- a/apps/desktop/src/pages/agents/agent-studio-task-hydration-state.test.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-task-hydration-state.test.ts
@@ -73,6 +73,28 @@ describe("getAgentStudioTaskHydrationDecision", () => {
     expect(decision.shouldHydrateSessionHistory).toBe(false);
   });
 
+  test("treats attached stdio build sessions as ready for history hydration", () => {
+    const decision = getAgentStudioTaskHydrationDecision({
+      activeWorkspace: createActiveWorkspace("/repo-a"),
+      activeTaskId: "task-1",
+      activeSession: {
+        sessionId: "session-1",
+        role: "build",
+        runId: null,
+        runtimeId: null,
+        runtimeRoute: { type: "stdio" },
+        runtimeRecoveryState: "idle",
+      },
+      historyHydrationState: "not_requested",
+      sessionNeedsHydration: true,
+      agentStudioReadinessState: "ready",
+    });
+
+    expect(decision.shouldWaitForSessionRuntime).toBe(false);
+    expect(decision.isWaitingForRuntimeReadiness).toBe(false);
+    expect(decision.shouldHydrateSessionHistory).toBe(true);
+  });
+
   test("allows recovery to retry after a session runtime recovery failure", () => {
     const decision = getAgentStudioTaskHydrationDecision({
       activeWorkspace: createActiveWorkspace("/repo-a"),

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -311,6 +311,7 @@ describe("agents-page-view-model", () => {
       permissionReplyErrorByRequestId: {},
       onReplyPermission,
       onSubmitQuestionAnswers,
+      sessionRuntimeDataError: null,
       todoPanelCollapsed: false,
       onToggleTodoPanel,
       messagesContainerRef: { current: null },

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -131,6 +131,7 @@ type AgentChatThreadModelArgs = {
   isSubmittingPermissionByRequestId: Record<string, boolean>;
   permissionReplyErrorByRequestId: Record<string, string>;
   onReplyPermission: (requestId: string, reply: "once" | "always" | "reject") => Promise<void>;
+  sessionRuntimeDataError: string | null;
   todoPanelCollapsed: boolean;
   onToggleTodoPanel: () => void;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
@@ -162,7 +163,6 @@ type AgentChatComposerModelArgs = {
   slashCommandCatalog: AgentChatModel["composer"]["slashCommandCatalog"];
   slashCommands: AgentChatModel["composer"]["slashCommands"];
   slashCommandsError: string | null;
-  sessionRuntimeDataError?: string | null;
   isSlashCommandsLoading: boolean;
   searchFiles: AgentChatModel["composer"]["searchFiles"];
   agentOptions: ComboboxOption[];
@@ -210,6 +210,7 @@ export const buildAgentChatThreadModel = (
   isSubmittingPermissionByRequestId: args.isSubmittingPermissionByRequestId,
   permissionReplyErrorByRequestId: args.permissionReplyErrorByRequestId,
   onReplyPermission: args.onReplyPermission,
+  sessionRuntimeDataError: args.sessionRuntimeDataError,
   todoPanelCollapsed: args.todoPanelCollapsed,
   onToggleTodoPanel: args.onToggleTodoPanel,
   messagesContainerRef: args.messagesContainerRef,
@@ -245,7 +246,6 @@ export const buildAgentChatComposerModel = (
   slashCommandCatalog: args.slashCommandCatalog,
   slashCommands: args.slashCommands,
   slashCommandsError: args.slashCommandsError,
-  sessionRuntimeDataError: args.sessionRuntimeDataError ?? null,
   isSlashCommandsLoading: args.isSlashCommandsLoading,
   searchFiles: args.searchFiles,
   agentOptions: args.agentOptions,

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -162,6 +162,7 @@ type AgentChatComposerModelArgs = {
   slashCommandCatalog: AgentChatModel["composer"]["slashCommandCatalog"];
   slashCommands: AgentChatModel["composer"]["slashCommands"];
   slashCommandsError: string | null;
+  sessionRuntimeDataError?: string | null;
   isSlashCommandsLoading: boolean;
   searchFiles: AgentChatModel["composer"]["searchFiles"];
   agentOptions: ComboboxOption[];
@@ -244,6 +245,7 @@ export const buildAgentChatComposerModel = (
   slashCommandCatalog: args.slashCommandCatalog,
   slashCommands: args.slashCommands,
   slashCommandsError: args.slashCommandsError,
+  sessionRuntimeDataError: args.sessionRuntimeDataError ?? null,
   isSlashCommandsLoading: args.isSlashCommandsLoading,
   searchFiles: args.searchFiles,
   agentOptions: args.agentOptions,

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
@@ -51,7 +51,8 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
 
       expect(readSessionModelCatalog).not.toHaveBeenCalled();
       expect(readSessionTodos).not.toHaveBeenCalled();
-      expect(harness.getLatest()?.isLoadingModelCatalog).toBe(true);
+      expect(harness.getLatest()?.session?.isLoadingModelCatalog).toBe(true);
+      expect(harness.getLatest()?.runtimeDataError).toBeNull();
     } finally {
       await harness.unmount();
     }
@@ -79,14 +80,17 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
     try {
       await harness.mount();
 
-      expect(harness.getLatest()?.isLoadingModelCatalog).toBe(true);
+      expect(harness.getLatest()?.session?.isLoadingModelCatalog).toBe(true);
       expect(readSessionModelCatalog).toHaveBeenCalledTimes(1);
 
       catalogLoad.resolve(CATALOG);
-      await harness.waitFor((state) => state !== null && state.isLoadingModelCatalog === false);
+      await harness.waitFor(
+        (state) => state.session !== null && state.session.isLoadingModelCatalog === false,
+      );
 
-      expect(harness.getLatest()?.modelCatalog).toEqual(CATALOG);
-      expect(harness.getLatest()?.isLoadingModelCatalog).toBe(false);
+      expect(harness.getLatest()?.session?.modelCatalog).toEqual(CATALOG);
+      expect(harness.getLatest()?.session?.isLoadingModelCatalog).toBe(false);
+      expect(harness.getLatest()?.runtimeDataError).toBeNull();
     } finally {
       await harness.unmount();
     }
@@ -116,7 +120,7 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
 
       expect(readSessionModelCatalog).not.toHaveBeenCalled();
       expect(readSessionTodos).not.toHaveBeenCalled();
-      expect(harness.getLatest()?.isLoadingModelCatalog).toBe(true);
+      expect(harness.getLatest()?.session?.isLoadingModelCatalog).toBe(true);
 
       await harness.update({
         session,
@@ -126,21 +130,22 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
       });
       await harness.waitFor((state) =>
         Boolean(
-          state?.modelCatalog?.models[0]?.id === CATALOG.models[0]?.id &&
-            state?.isLoadingModelCatalog === false,
+          state.session?.modelCatalog?.models[0]?.id === CATALOG.models[0]?.id &&
+            state.session?.isLoadingModelCatalog === false,
         ),
       );
 
       expect(readSessionModelCatalog).toHaveBeenCalledTimes(1);
       expect(readSessionTodos).toHaveBeenCalledTimes(1);
-      expect(harness.getLatest()?.modelCatalog).toEqual(CATALOG);
-      expect(harness.getLatest()?.isLoadingModelCatalog).toBe(false);
+      expect(harness.getLatest()?.session?.modelCatalog).toEqual(CATALOG);
+      expect(harness.getLatest()?.session?.isLoadingModelCatalog).toBe(false);
+      expect(harness.getLatest()?.runtimeDataError).toBeNull();
     } finally {
       await harness.unmount();
     }
   });
 
-  test("does not query runtime-backed session data for unsupported stdio OpenCode sessions", async () => {
+  test("surfaces an explicit error for unsupported stdio OpenCode session runtime data", async () => {
     const readSessionModelCatalog = mock(async () => CATALOG);
     const readSessionTodos = mock(async () => []);
     const harness = createHookHarness(useAgentStudioActiveSessionRuntimeData, {
@@ -163,7 +168,8 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
 
       expect(readSessionModelCatalog).not.toHaveBeenCalled();
       expect(readSessionTodos).not.toHaveBeenCalled();
-      expect(harness.getLatest()?.isLoadingModelCatalog).toBe(false);
+      expect(harness.getLatest()?.session?.isLoadingModelCatalog).toBe(false);
+      expect(harness.getLatest()?.runtimeDataError).toContain("local_http is required");
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
@@ -174,4 +174,47 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
       await harness.unmount();
     }
   });
+
+  test("keeps model-catalog loading active while todos fail but catalog hydration is still pending", async () => {
+    const catalogLoad = createDeferred<AgentModelCatalog>();
+    const readSessionModelCatalog = mock(() => catalogLoad.promise);
+    const readSessionTodos = mock(async () => {
+      throw new Error("todos unavailable");
+    });
+    const harness = createHookHarness(useAgentStudioActiveSessionRuntimeData, {
+      session: createAgentSessionFixture({
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        runtimeKind: "opencode",
+        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+        workingDirectory: "/repo",
+        modelCatalog: null,
+        isLoadingModelCatalog: true,
+      }),
+      agentStudioReadinessState: "ready",
+      readSessionModelCatalog,
+      readSessionTodos,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (state) =>
+          state.runtimeDataError === "todos unavailable" &&
+          state.session?.isLoadingModelCatalog === true,
+      );
+
+      expect(harness.getLatest()?.session?.modelCatalog).toBeNull();
+
+      catalogLoad.resolve(CATALOG);
+      await harness.waitFor(
+        (state) =>
+          state.runtimeDataError === "todos unavailable" &&
+          state.session?.isLoadingModelCatalog === false &&
+          state.session?.modelCatalog?.models[0]?.id === CATALOG.models[0]?.id,
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
@@ -13,9 +13,8 @@ import {
 } from "@/state/queries/agent-session-runtime";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import {
-  getAttachedSessionRuntimeConnectionError,
   hasAttachedSessionRuntime,
-  toAttachedSessionRuntimeConnection,
+  resolveAttachedSessionRuntimeQueryState,
 } from "./agent-studio-session-runtime";
 import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
 
@@ -33,22 +32,9 @@ type UseAgentStudioActiveSessionRuntimeDataArgs = {
   ) => Promise<AgentSessionTodoItem[]>;
 };
 
-type ActiveSessionRuntimeDataResult = {
+export type AgentStudioSessionRuntimeDataState = {
   session: AgentSessionState | null;
   runtimeDataError: string | null;
-};
-
-const toRuntimeQueryInput = (session: AgentSessionState | null) => {
-  const runtimeKind = session?.runtimeKind ?? null;
-  const hasRuntimeAttachment = hasAttachedSessionRuntime(session);
-  const runtimeConnection = session ? toAttachedSessionRuntimeConnection(session) : null;
-  if (!session || !runtimeKind || !hasRuntimeAttachment || runtimeConnection === null) {
-    return null;
-  }
-  return {
-    runtimeKind,
-    runtimeConnection,
-  };
 };
 
 export const useAgentStudioActiveSessionRuntimeData = ({
@@ -56,21 +42,15 @@ export const useAgentStudioActiveSessionRuntimeData = ({
   agentStudioReadinessState,
   readSessionModelCatalog,
   readSessionTodos,
-}: UseAgentStudioActiveSessionRuntimeDataArgs): ActiveSessionRuntimeDataResult => {
-  const runtimeQueryInput = toRuntimeQueryInput(session);
-  const runtimeDataSupportError = useMemo(() => {
-    if (!session) {
-      return null;
-    }
-
-    return getAttachedSessionRuntimeConnectionError(
-      session,
-      session.runtimeKind,
-      "active session runtime data access",
-    );
-  }, [session]);
+}: UseAgentStudioActiveSessionRuntimeDataArgs): AgentStudioSessionRuntimeDataState => {
+  const { runtimeQueryInput, runtimeQueryError: runtimeDataSupportError } = useMemo(
+    () => resolveAttachedSessionRuntimeQueryState(session, "active session runtime data access"),
+    [session],
+  );
+  const hasRuntimeAttachment = hasAttachedSessionRuntime(session);
   const shouldHydrateRuntimeData =
     agentStudioReadinessState === "ready" &&
+    hasRuntimeAttachment &&
     runtimeQueryInput !== null &&
     runtimeDataSupportError === null &&
     session?.status !== "starting";

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
@@ -13,6 +13,7 @@ import {
 } from "@/state/queries/agent-session-runtime";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import {
+  getAttachedSessionRuntimeConnectionError,
   hasAttachedSessionRuntime,
   toAttachedSessionRuntimeConnection,
 } from "./agent-studio-session-runtime";
@@ -32,12 +33,15 @@ type UseAgentStudioActiveSessionRuntimeDataArgs = {
   ) => Promise<AgentSessionTodoItem[]>;
 };
 
+type ActiveSessionRuntimeDataResult = {
+  session: AgentSessionState | null;
+  runtimeDataError: string | null;
+};
+
 const toRuntimeQueryInput = (session: AgentSessionState | null) => {
   const runtimeKind = session?.runtimeKind ?? null;
   const hasRuntimeAttachment = hasAttachedSessionRuntime(session);
-  const runtimeConnection = session
-    ? toAttachedSessionRuntimeConnection(session, runtimeKind)
-    : null;
+  const runtimeConnection = session ? toAttachedSessionRuntimeConnection(session) : null;
   if (!session || !runtimeKind || !hasRuntimeAttachment || runtimeConnection === null) {
     return null;
   }
@@ -52,11 +56,23 @@ export const useAgentStudioActiveSessionRuntimeData = ({
   agentStudioReadinessState,
   readSessionModelCatalog,
   readSessionTodos,
-}: UseAgentStudioActiveSessionRuntimeDataArgs): AgentSessionState | null => {
+}: UseAgentStudioActiveSessionRuntimeDataArgs): ActiveSessionRuntimeDataResult => {
   const runtimeQueryInput = toRuntimeQueryInput(session);
+  const runtimeDataSupportError = useMemo(() => {
+    if (!session) {
+      return null;
+    }
+
+    return getAttachedSessionRuntimeConnectionError(
+      session,
+      session.runtimeKind,
+      "active session runtime data access",
+    );
+  }, [session]);
   const shouldHydrateRuntimeData =
     agentStudioReadinessState === "ready" &&
     runtimeQueryInput !== null &&
+    runtimeDataSupportError === null &&
     session?.status !== "starting";
   const catalogQuery = useQuery({
     queryKey:
@@ -105,34 +121,55 @@ export const useAgentStudioActiveSessionRuntimeData = ({
 
   return useMemo(() => {
     if (!session) {
-      return null;
+      return {
+        session: null,
+        runtimeDataError: null,
+      };
     }
 
+    const runtimeDataQueryError =
+      catalogQuery.error instanceof Error
+        ? catalogQuery.error.message
+        : todosQuery.error instanceof Error
+          ? todosQuery.error.message
+          : null;
+    const runtimeDataError = runtimeDataSupportError ?? runtimeDataQueryError;
     const resolvedCatalog = session.modelCatalog ?? catalogQuery.data ?? null;
     const resolvedTodos = session.todos.length > 0 ? session.todos : (todosQuery.data ?? []);
-    const isLoadingModelCatalog = shouldHydrateRuntimeData
-      ? resolvedCatalog === null && catalogQuery.isPending
-      : session.isLoadingModelCatalog && resolvedCatalog === null;
+    const isLoadingModelCatalog = runtimeDataError
+      ? false
+      : shouldHydrateRuntimeData
+        ? resolvedCatalog === null && catalogQuery.isPending
+        : session.isLoadingModelCatalog && resolvedCatalog === null;
 
     if (
       resolvedCatalog === session.modelCatalog &&
       resolvedTodos === session.todos &&
       isLoadingModelCatalog === session.isLoadingModelCatalog
     ) {
-      return session;
+      return {
+        session,
+        runtimeDataError,
+      };
     }
 
     return {
-      ...session,
-      modelCatalog: resolvedCatalog,
-      todos: resolvedTodos,
-      isLoadingModelCatalog,
+      session: {
+        ...session,
+        modelCatalog: resolvedCatalog,
+        todos: resolvedTodos,
+        isLoadingModelCatalog,
+      },
+      runtimeDataError,
     };
   }, [
     catalogQuery.data,
+    catalogQuery.error,
     catalogQuery.isPending,
     session,
     shouldHydrateRuntimeData,
     todosQuery.data,
+    todosQuery.error,
+    runtimeDataSupportError,
   ]);
 };

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
@@ -107,20 +107,19 @@ export const useAgentStudioActiveSessionRuntimeData = ({
       };
     }
 
-    const runtimeDataQueryError =
-      catalogQuery.error instanceof Error
-        ? catalogQuery.error.message
-        : todosQuery.error instanceof Error
-          ? todosQuery.error.message
-          : null;
+    const catalogQueryError =
+      catalogQuery.error instanceof Error ? catalogQuery.error.message : null;
+    const todosQueryError = todosQuery.error instanceof Error ? todosQuery.error.message : null;
+    const runtimeDataQueryError = catalogQueryError ?? todosQueryError;
     const runtimeDataError = runtimeDataSupportError ?? runtimeDataQueryError;
     const resolvedCatalog = session.modelCatalog ?? catalogQuery.data ?? null;
     const resolvedTodos = session.todos.length > 0 ? session.todos : (todosQuery.data ?? []);
-    const isLoadingModelCatalog = runtimeDataError
-      ? false
-      : shouldHydrateRuntimeData
-        ? resolvedCatalog === null && catalogQuery.isPending
-        : session.isLoadingModelCatalog && resolvedCatalog === null;
+    const isLoadingModelCatalog =
+      runtimeDataSupportError || catalogQueryError
+        ? false
+        : shouldHydrateRuntimeData
+          ? resolvedCatalog === null && catalogQuery.isPending
+          : session.isLoadingModelCatalog && resolvedCatalog === null;
 
     if (
       resolvedCatalog === session.modelCatalog &&

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -439,7 +439,7 @@ describe("useAgentStudioModelSelection", () => {
       await harness.waitFor((state) => state.isSlashCommandsLoading === false);
 
       expect(readSessionSlashCommands).not.toHaveBeenCalled();
-      expect(harness.getLatest().slashCommandsError).toContain("local_http is required");
+      expect(harness.getLatest().slashCommandsError).toBeNull();
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -380,10 +380,9 @@ export function useAgentStudioModelSelection({
   const slashCommands = slashCommandCatalog?.commands ?? [];
   const slashCommandsError = supportsSlashCommands
     ? activeSession
-      ? (activeSessionRuntimeQueryError ??
-        (activeSessionSlashCommandsQuery.error instanceof Error
-          ? activeSessionSlashCommandsQuery.error.message
-          : null))
+      ? activeSessionSlashCommandsQuery.error instanceof Error
+        ? activeSessionSlashCommandsQuery.error.message
+        : null
       : repoSlashCommandsQuery.error instanceof Error
         ? repoSlashCommandsQuery.error.message
         : null

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -30,10 +30,7 @@ import {
 } from "@/state/queries/runtime-catalog";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { ActiveWorkspace, RepoSettingsInput } from "@/types/state-slices";
-import {
-  getAttachedSessionRuntimeConnectionError,
-  toAttachedSessionRuntimeConnection,
-} from "./agent-studio-session-runtime";
+import { resolveAttachedSessionRuntimeQueryState } from "./agent-studio-session-runtime";
 import {
   coerceVisibleSelectionToCatalog,
   emptyDraftSelections,
@@ -108,33 +105,6 @@ const emptyDraftSelectionTouchedByRole = (): Record<AgentRole, boolean> => ({
   qa: false,
 });
 
-const toRuntimeQueryInput = (
-  session: {
-    runtimeKind: RuntimeKind | null;
-    runtimeRoute: AgentSessionState["runtimeRoute"];
-    workingDirectory: string;
-  } | null,
-  runtimeKind: RuntimeKind | null,
-): {
-  runtimeKind: RuntimeKind;
-  runtimeConnection: AgentRuntimeConnection;
-} | null => {
-  const runtimeConnection =
-    session === null
-      ? null
-      : toAttachedSessionRuntimeConnection({
-          runtimeRoute: session.runtimeRoute,
-          workingDirectory: session.workingDirectory,
-        });
-  if (!session || runtimeKind == null || runtimeConnection === null) {
-    return null;
-  }
-  return {
-    runtimeKind,
-    runtimeConnection,
-  };
-};
-
 export function useAgentStudioModelSelection({
   activeWorkspace,
   activeSession,
@@ -207,9 +177,9 @@ export function useAgentStudioModelSelection({
     role,
     roleDefaultSelection?.runtimeKind,
   ]);
-  const activeSessionRuntimeQueryInput = useMemo(
+  const activeSessionRuntimeQueryState = useMemo(
     () =>
-      toRuntimeQueryInput(
+      resolveAttachedSessionRuntimeQueryState(
         hasActiveSession
           ? {
               runtimeKind: activeSessionRuntimeKind,
@@ -217,7 +187,7 @@ export function useAgentStudioModelSelection({
               workingDirectory: activeSessionWorkingDirectory,
             }
           : null,
-        activeSessionRuntimeKind,
+        "active session runtime queries",
       ),
     [
       activeSessionRuntimeKind,
@@ -226,25 +196,8 @@ export function useAgentStudioModelSelection({
       hasActiveSession,
     ],
   );
-  const activeSessionRuntimeQueryError = useMemo(
-    () =>
-      hasActiveSession
-        ? getAttachedSessionRuntimeConnectionError(
-            {
-              runtimeRoute: activeSessionRuntimeRoute,
-              workingDirectory: activeSessionWorkingDirectory,
-            },
-            activeSessionRuntimeKind,
-            "active session runtime queries",
-          )
-        : null,
-    [
-      activeSessionRuntimeKind,
-      activeSessionRuntimeRoute,
-      activeSessionWorkingDirectory,
-      hasActiveSession,
-    ],
-  );
+  const activeSessionRuntimeQueryInput = activeSessionRuntimeQueryState.runtimeQueryInput;
+  const activeSessionRuntimeQueryError = activeSessionRuntimeQueryState.runtimeQueryError;
   const slashCommandRuntimeKind =
     activeSessionRuntimeQueryInput?.runtimeKind ?? composerRuntimeKind;
   const supportsSlashCommands = useMemo(() => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -115,7 +115,6 @@ const toRuntimeQueryInput = (
     workingDirectory: string;
   } | null,
   runtimeKind: RuntimeKind | null,
-  action = "active session runtime queries",
 ): {
   runtimeKind: RuntimeKind;
   runtimeConnection: AgentRuntimeConnection;
@@ -123,14 +122,10 @@ const toRuntimeQueryInput = (
   const runtimeConnection =
     session === null
       ? null
-      : toAttachedSessionRuntimeConnection(
-          {
-            runtimeRoute: session.runtimeRoute,
-            workingDirectory: session.workingDirectory,
-          },
-          runtimeKind,
-          action,
-        );
+      : toAttachedSessionRuntimeConnection({
+          runtimeRoute: session.runtimeRoute,
+          workingDirectory: session.workingDirectory,
+        });
   if (!session || runtimeKind == null || runtimeConnection === null) {
     return null;
   }
@@ -223,7 +218,6 @@ export function useAgentStudioModelSelection({
             }
           : null,
         activeSessionRuntimeKind,
-        "active session runtime queries",
       ),
     [
       activeSessionRuntimeKind,
@@ -331,6 +325,7 @@ export function useAgentStudioModelSelection({
       hasActiveSession &&
       activeSessionStatus !== "starting" &&
       activeSessionRuntimeQueryInput !== null &&
+      activeSessionRuntimeQueryError === null &&
       readSessionSlashCommands !== undefined,
   });
   const repoSlashCommandsQuery = useQuery({

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -136,7 +136,9 @@ type AgentStudioPageModelsModelSelectionContext = Pick<
   | "handleSelectAgent"
   | "handleSelectModel"
   | "handleSelectVariant"
->;
+> & {
+  sessionRuntimeDataError?: string | null;
+};
 
 type BuildAgentStudioPageModelsArgsInput = {
   view: AgentStudioPageModelsViewContext;
@@ -230,6 +232,7 @@ export function useAgentStudioOrchestrationController({
     viewSelectedTask,
     viewSessionsForTask,
     viewActiveSession,
+    viewSessionRuntimeDataError = null,
     activeTaskTabId,
     taskTabs,
     availableTabTasks,
@@ -416,6 +419,7 @@ export function useAgentStudioOrchestrationController({
       slashCommandCatalog,
       slashCommands,
       slashCommandsError,
+      sessionRuntimeDataError: viewSessionRuntimeDataError,
       isSlashCommandsLoading,
       searchFiles,
       agentOptions,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -91,7 +91,7 @@ type AgentStudioPageModelsViewContext = Pick<
 
 type AgentStudioPageModelsSessionsContext = Pick<
   AgentStudioOrchestrationSelectionContext,
-  "viewSessionsForTask" | "viewActiveSession"
+  "viewSessionsForTask" | "viewActiveSession" | "viewSessionRuntimeDataError"
 >;
 
 type AgentStudioPageModelsTabsContext = Pick<
@@ -136,9 +136,7 @@ type AgentStudioPageModelsModelSelectionContext = Pick<
   | "handleSelectAgent"
   | "handleSelectModel"
   | "handleSelectVariant"
-> & {
-  sessionRuntimeDataError?: string | null;
-};
+>;
 
 type BuildAgentStudioPageModelsArgsInput = {
   view: AgentStudioPageModelsViewContext;
@@ -187,6 +185,7 @@ export const buildAgentStudioPageModelsArgs = ({
       sessionsForTask: sessions.viewSessionsForTask,
       contextSessionsLength: sessions.viewSessionsForTask.length,
       activeSession: sessions.viewActiveSession,
+      sessionRuntimeDataError: sessions.viewSessionRuntimeDataError ?? null,
       isTaskHydrating: Boolean(
         view.viewTaskId && !view.isActiveTaskHydrated && !view.isActiveTaskHydrationFailed,
       ),
@@ -374,6 +373,7 @@ export function useAgentStudioOrchestrationController({
     sessions: {
       viewSessionsForTask,
       viewActiveSession,
+      viewSessionRuntimeDataError,
     },
     tabs: {
       activeTaskTabId,
@@ -419,7 +419,6 @@ export function useAgentStudioOrchestrationController({
       slashCommandCatalog,
       slashCommands,
       slashCommandsError,
-      sessionRuntimeDataError: viewSessionRuntimeDataError,
       isSlashCommandsLoading,
       searchFiles,
       agentOptions,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -234,6 +234,25 @@ describe("useAgentStudioPageModels", () => {
     await harness.unmount();
   });
 
+  test("forwards session runtime data errors into the composer model", async () => {
+    const harness = createHookHarness(
+      createHookArgs({
+        modelSelection: {
+          sessionRuntimeDataError:
+            "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
+        },
+      }),
+    );
+
+    await harness.mount();
+
+    expect(harness.getLatest().agentChatModel.composer.sessionRuntimeDataError).toContain(
+      "local_http is required",
+    );
+
+    await harness.unmount();
+  });
+
   test("scrolls to bottom immediately when sending a message", async () => {
     const sendResolver = { current: null as ((value: boolean) => void) | null };
     const onSend = mock(

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -83,6 +83,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     taskId: "task-1",
     role: "spec",
     selectedTask: createTask(),
+    sessionRuntimeDataError: null,
     isTaskHydrating: false,
     isSessionHistoryHydrating: false,
     isWaitingForRuntimeReadiness: false,
@@ -237,7 +238,7 @@ describe("useAgentStudioPageModels", () => {
   test("forwards session runtime data errors into the composer model", async () => {
     const harness = createHookHarness(
       createHookArgs({
-        modelSelection: {
+        core: {
           sessionRuntimeDataError:
             "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
         },
@@ -246,7 +247,7 @@ describe("useAgentStudioPageModels", () => {
 
     await harness.mount();
 
-    expect(harness.getLatest().agentChatModel.composer.sessionRuntimeDataError).toContain(
+    expect(harness.getLatest().agentChatModel.thread.sessionRuntimeDataError).toContain(
       "local_http is required",
     );
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -38,6 +38,7 @@ type AgentStudioCoreContext = {
   sessionsForTask: AgentSessionSummary[];
   contextSessionsLength: number;
   activeSession: AgentSessionState | null;
+  sessionRuntimeDataError: string | null;
   isTaskHydrating: boolean;
   isSessionHistoryHydrating: boolean;
   isWaitingForRuntimeReadiness: boolean;
@@ -92,7 +93,6 @@ type AgentStudioModelSelectionContext = {
   slashCommandCatalog: AgentChatModel["composer"]["slashCommandCatalog"];
   slashCommands: AgentChatModel["composer"]["slashCommands"];
   slashCommandsError: string | null;
-  sessionRuntimeDataError?: string | null;
   isSlashCommandsLoading: boolean;
   searchFiles: AgentChatModel["composer"]["searchFiles"];
   agentOptions: ComboboxOption[];
@@ -330,6 +330,7 @@ export function useAgentStudioPageModels({
     isContextSwitching,
     isSessionHistoryLoading: core.isSessionHistoryHydrating,
     isWaitingForRuntimeReadiness: core.isWaitingForRuntimeReadiness,
+    sessionRuntimeDataError: core.sessionRuntimeDataError,
     taskId: core.taskId,
     activeSessionAgentColors: modelSelection.activeSessionAgentColors,
     agentStudioReadinessState: readiness.agentStudioReadinessState,
@@ -379,7 +380,6 @@ export function useAgentStudioPageModels({
     slashCommandCatalog: modelSelection.slashCommandCatalog,
     slashCommands: modelSelection.slashCommands,
     slashCommandsError: modelSelection.slashCommandsError,
-    sessionRuntimeDataError: modelSelection.sessionRuntimeDataError ?? null,
     isSlashCommandsLoading: modelSelection.isSlashCommandsLoading,
     searchFiles: modelSelection.searchFiles,
     agentOptions: modelSelection.agentOptions,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -92,6 +92,7 @@ type AgentStudioModelSelectionContext = {
   slashCommandCatalog: AgentChatModel["composer"]["slashCommandCatalog"];
   slashCommands: AgentChatModel["composer"]["slashCommands"];
   slashCommandsError: string | null;
+  sessionRuntimeDataError?: string | null;
   isSlashCommandsLoading: boolean;
   searchFiles: AgentChatModel["composer"]["searchFiles"];
   agentOptions: ComboboxOption[];
@@ -378,6 +379,7 @@ export function useAgentStudioPageModels({
     slashCommandCatalog: modelSelection.slashCommandCatalog,
     slashCommands: modelSelection.slashCommands,
     slashCommandsError: modelSelection.slashCommandsError,
+    sessionRuntimeDataError: modelSelection.sessionRuntimeDataError ?? null,
     isSlashCommandsLoading: modelSelection.isSlashCommandsLoading,
     searchFiles: modelSelection.searchFiles,
     agentOptions: modelSelection.agentOptions,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
@@ -25,6 +25,7 @@ const resetInlineComments = (): void => {
 
 const createHookArgs = (showThinkingMessages = false): HookArgs => ({
   threadSession: null,
+  sessionRuntimeDataError: null,
   isSessionWorking: false,
   showThinkingMessages,
   isContextSwitching: false,
@@ -177,6 +178,23 @@ describe("useAgentStudioThreadModel", () => {
     });
     expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(true);
     expect(harness.getLatest().isSessionHistoryLoading).toBe(false);
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("forwards session runtime data errors into the thread model", async () => {
+    const harness = createHookHarness({
+      ...createHookArgs(false),
+      sessionRuntimeDataError:
+        "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
+    });
+
+    await act(async () => {
+      await harness.mount();
+    });
+    expect(harness.getLatest().sessionRuntimeDataError).toContain("local_http is required");
 
     await act(async () => {
       await harness.unmount();

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -289,6 +289,7 @@ type UseAgentStudioComposerModelArgs = {
   slashCommandCatalog: AgentChatModel["composer"]["slashCommandCatalog"];
   slashCommands: AgentChatModel["composer"]["slashCommands"];
   slashCommandsError: string | null;
+  sessionRuntimeDataError?: string | null;
   isSlashCommandsLoading: boolean;
   searchFiles: AgentChatModel["composer"]["searchFiles"];
   agentOptions: ComboboxOption[];
@@ -330,6 +331,7 @@ export const useAgentStudioComposerModel = ({
   slashCommandCatalog,
   slashCommands,
   slashCommandsError,
+  sessionRuntimeDataError,
   isSlashCommandsLoading,
   searchFiles,
   agentOptions,
@@ -447,6 +449,7 @@ export const useAgentStudioComposerModel = ({
         slashCommandCatalog,
         slashCommands,
         slashCommandsError,
+        sessionRuntimeDataError: sessionRuntimeDataError ?? null,
         isSlashCommandsLoading,
         searchFiles,
         agentOptions,
@@ -503,6 +506,7 @@ export const useAgentStudioComposerModel = ({
       slashCommandCatalog,
       slashCommands,
       slashCommandsError,
+      sessionRuntimeDataError,
       supportsSlashCommands,
       supportsFileSearch,
       taskId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -115,6 +115,7 @@ export const useAgentStudioHeaderModel = ({
 
 type UseAgentStudioThreadModelArgs = {
   threadSession: AgentSessionState | null;
+  sessionRuntimeDataError: string | null;
   isSessionWorking: boolean;
   showThinkingMessages: boolean;
   isContextSwitching: boolean;
@@ -147,6 +148,7 @@ type UseAgentStudioThreadModelArgs = {
 
 export const useAgentStudioThreadModel = ({
   threadSession,
+  sessionRuntimeDataError,
   isSessionWorking,
   showThinkingMessages,
   isContextSwitching,
@@ -218,6 +220,7 @@ export const useAgentStudioThreadModel = ({
         isSubmittingPermissionByRequestId,
         permissionReplyErrorByRequestId,
         onReplyPermission: handlePermissionReply,
+        sessionRuntimeDataError,
         todoPanelCollapsed,
         onToggleTodoPanel,
         messagesContainerRef,
@@ -246,6 +249,7 @@ export const useAgentStudioThreadModel = ({
       messagesContainerRef,
       onSubmitQuestionAnswers,
       permissionReplyErrorByRequestId,
+      sessionRuntimeDataError,
       scrollToBottomOnSendRef,
       selectedRoleAvailable,
       showThinkingMessages,
@@ -289,7 +293,6 @@ type UseAgentStudioComposerModelArgs = {
   slashCommandCatalog: AgentChatModel["composer"]["slashCommandCatalog"];
   slashCommands: AgentChatModel["composer"]["slashCommands"];
   slashCommandsError: string | null;
-  sessionRuntimeDataError?: string | null;
   isSlashCommandsLoading: boolean;
   searchFiles: AgentChatModel["composer"]["searchFiles"];
   agentOptions: ComboboxOption[];
@@ -331,7 +334,6 @@ export const useAgentStudioComposerModel = ({
   slashCommandCatalog,
   slashCommands,
   slashCommandsError,
-  sessionRuntimeDataError,
   isSlashCommandsLoading,
   searchFiles,
   agentOptions,
@@ -449,7 +451,6 @@ export const useAgentStudioComposerModel = ({
         slashCommandCatalog,
         slashCommands,
         slashCommandsError,
-        sessionRuntimeDataError: sessionRuntimeDataError ?? null,
         isSlashCommandsLoading,
         searchFiles,
         agentOptions,
@@ -506,7 +507,6 @@ export const useAgentStudioComposerModel = ({
       slashCommandCatalog,
       slashCommands,
       slashCommandsError,
-      sessionRuntimeDataError,
       supportsSlashCommands,
       supportsFileSearch,
       taskId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -263,7 +263,7 @@ export function useAgentStudioSelectionController({
     sessionsForTask,
   ]);
   const activeSession = useAgentSession(activeSessionSummary?.sessionId ?? null);
-  const hydratedActiveSession = useAgentStudioActiveSessionRuntimeData({
+  const activeSessionRuntimeData = useAgentStudioActiveSessionRuntimeData({
     session: activeSession,
     agentStudioReadinessState,
     readSessionModelCatalog,
@@ -364,7 +364,7 @@ export function useAgentStudioSelectionController({
     viewSessionsForTask,
   ]);
   const viewActiveSession = useAgentSession(viewSelection.activeSession?.sessionId ?? null);
-  const hydratedViewActiveSession = useAgentStudioActiveSessionRuntimeData({
+  const viewSessionRuntimeData = useAgentStudioActiveSessionRuntimeData({
     session: viewActiveSession,
     agentStudioReadinessState,
     readSessionModelCatalog,
@@ -376,10 +376,10 @@ export function useAgentStudioSelectionController({
     () =>
       selectRuntimeAttachmentCandidates({
         repoPath: workspaceRepoPath ?? "",
-        session: hydratedViewActiveSession.session,
+        session: viewSessionRuntimeData.session,
         runtimeSources: runtimeAttachmentSources,
       }),
-    [workspaceRepoPath, hydratedViewActiveSession.session, runtimeAttachmentSources],
+    [workspaceRepoPath, viewSessionRuntimeData.session, runtimeAttachmentSources],
   );
 
   const {
@@ -392,7 +392,7 @@ export function useAgentStudioSelectionController({
   } = useAgentStudioTaskHydration({
     activeWorkspace,
     activeTaskId: viewTaskId,
-    activeSession: hydratedViewActiveSession.session,
+    activeSession: viewSessionRuntimeData.session,
     agentStudioReadinessState,
     hydrateRequestedTaskSessionHistory,
     retrySessionRuntimeAttachment,
@@ -405,8 +405,8 @@ export function useAgentStudioSelectionController({
     taskId,
     selectedTask,
     sessionsForTask,
-    activeSession: hydratedActiveSession.session,
-    activeSessionRuntimeDataError: hydratedActiveSession.runtimeDataError,
+    activeSession: activeSessionRuntimeData.session,
+    activeSessionRuntimeDataError: activeSessionRuntimeData.runtimeDataError,
     isLoadingTasks,
     activeTaskTabId,
     availableTabTasks,
@@ -418,8 +418,8 @@ export function useAgentStudioSelectionController({
     viewTaskId,
     viewSelectedTask,
     viewSessionsForTask,
-    viewActiveSession: hydratedViewActiveSession.session,
-    viewSessionRuntimeDataError: hydratedViewActiveSession.runtimeDataError,
+    viewActiveSession: viewSessionRuntimeData.session,
+    viewSessionRuntimeDataError: viewSessionRuntimeData.runtimeDataError,
     viewRole,
     viewScenario,
     isActiveTaskHydrated,

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -68,6 +68,7 @@ export type AgentStudioSelectionControllerResult = {
   selectedTask: TaskCard | null;
   sessionsForTask: AgentSessionSummary[];
   activeSession: AgentSessionState | null;
+  activeSessionRuntimeDataError?: string | null;
   isLoadingTasks: boolean;
   activeTaskTabId: string;
   availableTabTasks: TaskCard[];
@@ -84,6 +85,7 @@ export type AgentStudioSelectionControllerResult = {
   viewSelectedTask: TaskCard | null;
   viewSessionsForTask: AgentSessionSummary[];
   viewActiveSession: AgentSessionState | null;
+  viewSessionRuntimeDataError?: string | null;
   viewRole: AgentRole;
   viewScenario: AgentScenario;
   isActiveTaskHydrated: boolean;
@@ -374,10 +376,10 @@ export function useAgentStudioSelectionController({
     () =>
       selectRuntimeAttachmentCandidates({
         repoPath: workspaceRepoPath ?? "",
-        session: hydratedViewActiveSession,
+        session: hydratedViewActiveSession.session,
         runtimeSources: runtimeAttachmentSources,
       }),
-    [workspaceRepoPath, hydratedViewActiveSession, runtimeAttachmentSources],
+    [workspaceRepoPath, hydratedViewActiveSession.session, runtimeAttachmentSources],
   );
 
   const {
@@ -390,7 +392,7 @@ export function useAgentStudioSelectionController({
   } = useAgentStudioTaskHydration({
     activeWorkspace,
     activeTaskId: viewTaskId,
-    activeSession: hydratedViewActiveSession,
+    activeSession: hydratedViewActiveSession.session,
     agentStudioReadinessState,
     hydrateRequestedTaskSessionHistory,
     retrySessionRuntimeAttachment,
@@ -403,7 +405,8 @@ export function useAgentStudioSelectionController({
     taskId,
     selectedTask,
     sessionsForTask,
-    activeSession: hydratedActiveSession,
+    activeSession: hydratedActiveSession.session,
+    activeSessionRuntimeDataError: hydratedActiveSession.runtimeDataError,
     isLoadingTasks,
     activeTaskTabId,
     availableTabTasks,
@@ -415,7 +418,8 @@ export function useAgentStudioSelectionController({
     viewTaskId,
     viewSelectedTask,
     viewSessionsForTask,
-    viewActiveSession: hydratedViewActiveSession,
+    viewActiveSession: hydratedViewActiveSession.session,
+    viewSessionRuntimeDataError: hydratedViewActiveSession.runtimeDataError,
     viewRole,
     viewScenario,
     isActiveTaskHydrated,


### PR DESCRIPTION
## Summary
- decouple Agent Studio session attachment from transport-specific `runtimeEndpoint` checks and derive attached runtime access from resolved `runtimeRoute` data
- surface unsupported runtime-data access errors in the session bottom stack, including empty sessions, instead of hiding them in composer state
- consolidate runtime query-state derivation shared by hydration and model-selection flows, and keep the Rust workspace formatted after verification

## Goal
This PR fixes desktop session hydration and attachment behavior that still treated localhost HTTP endpoint availability as the definition of an attached runtime. That caused attached OpenCode sessions using non-HTTP routes such as `stdio` to fall into misleading "not attached" or "not ready" states, and it also made runtime-backed features harder to diagnose.

The goal is to make attachment/readiness follow the durable runtime-route model from the spec and plan: persisted sessions store durable identifiers plus working-directory metadata, and desktop runtime access resolves from live routes/connections at hydration time without reintroducing `runtimeEndpoint` coupling.

## Technical Choices
The main implementation change is splitting attachment from transport support. Agent Studio now treats any resolved `runtimeRoute` as an attached runtime and converts it into an adapter-local runtime connection only at the boundary where runtime-backed reads are performed. Transport support validation remains fail-fast and explicit for features that truly require `local_http`, such as session runtime data queries.

I also consolidated the repeated runtime-query derivation into a shared helper so hydration and model-selection flows cannot drift apart, and moved runtime-data error presentation to the thread bottom stack near todos and other runtime-backed session state. That keeps the UI explanation adjacent to the affected features and ensures empty sessions still surface the error.

The only Rust changes are `cargo fmt` output required to keep the verified workspace clean.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Display of runtime data access error messages in the agent chat interface, shown in the bottom stack even when no pending actions are present.

* **Tests**
  * Added test coverage for runtime data error rendering and propagation across chat components.
  * Added test scenarios for unsupported runtime configurations and connection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->