### PR TITLE
fix(dev-servers): stabilize log replay and terminal output

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/dev_server_manager/processes.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/dev_server_manager/processes.rs
@@ -18,6 +18,8 @@ use std::time::Duration;
 
 pub(super) const DEV_SERVER_STOP_TIMEOUT: Duration = Duration::from_secs(3);
 const DEV_SERVER_START_GRACE_PERIOD: Duration = Duration::from_millis(150);
+const DEV_SERVER_TERM: &str = "xterm-256color";
+const DEV_SERVER_COLORTERM: &str = "truecolor";
 
 impl AppService {
     pub(super) fn start_dev_server_script(
@@ -51,13 +53,7 @@ impl AppService {
             let mut command =
                 build_dev_server_command(script.command.as_str(), script.name.as_str())?;
             command.current_dir(worktree_path);
-            let path_value = subprocess_path_env().ok_or_else(|| {
-                anyhow!(
-                    "Failed to assemble subprocess PATH for dev server `{}`",
-                    script.name
-                )
-            })?;
-            command.env("PATH", path_value);
+            configure_dev_server_command_environment(&mut command, script.name.as_str())?;
             configure_process_group(&mut command);
 
             #[cfg(unix)]
@@ -182,6 +178,22 @@ impl AppService {
 
         start_result
     }
+}
+
+pub(super) fn configure_dev_server_command_environment(
+    command: &mut Command,
+    script_name: &str,
+) -> Result<()> {
+    let path_value = subprocess_path_env().ok_or_else(|| {
+        anyhow!(
+            "Failed to assemble subprocess PATH for dev server `{}`",
+            script_name
+        )
+    })?;
+    command.env("PATH", path_value);
+    command.env("TERM", DEV_SERVER_TERM);
+    command.env("COLORTERM", DEV_SERVER_COLORTERM);
+    Ok(())
 }
 
 fn wait_for_immediate_dev_server_exit(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/dev_server_manager/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/dev_server_manager/tests.rs
@@ -1,5 +1,6 @@
 use super::processes::{
-    spawn_dev_server_parent_death_watcher, stop_process_group, DEV_SERVER_STOP_TIMEOUT,
+    configure_dev_server_command_environment, spawn_dev_server_parent_death_watcher,
+    stop_process_group, DEV_SERVER_STOP_TIMEOUT,
 };
 use super::state::{build_group_state, dev_server_group_key, sync_group_state};
 use super::terminal::{
@@ -24,6 +25,7 @@ use host_infra_system::{AppConfigStore, RepoConfig, RepoDevServerScript};
 use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io::{self, Read};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -366,6 +368,34 @@ fn spawn_terminal_forwarder_skips_invalid_utf8_and_continues_streaming() {
         "Dev server terminal output contained invalid UTF-8 bytes and could not be fully rendered."
     ));
     assert!(captured.contains("ready\r\n"));
+}
+
+#[test]
+fn configure_dev_server_command_environment_sets_terminal_capabilities() {
+    let mut command = Command::new("/bin/sh");
+
+    configure_dev_server_command_environment(&mut command, "Frontend")
+        .expect("environment should configure");
+
+    let envs = command
+        .get_envs()
+        .map(|(key, value)| {
+            (
+                key.to_string_lossy().into_owned(),
+                value.map(|entry| entry.to_string_lossy().into_owned()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    assert!(matches!(envs.get("PATH"), Some(Some(path)) if !path.is_empty()));
+    assert_eq!(
+        envs.get("TERM").and_then(|value| value.as_deref()),
+        Some("xterm-256color")
+    );
+    assert_eq!(
+        envs.get("COLORTERM").and_then(|value| value.as_deref()),
+        Some("truecolor")
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/dev_server_manager/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/dev_server_manager/tests.rs
@@ -371,6 +371,66 @@ fn spawn_terminal_forwarder_skips_invalid_utf8_and_continues_streaming() {
 }
 
 #[test]
+fn spawn_terminal_forwarder_preserves_split_utf8_across_reads() {
+    let groups = build_runtime_groups_for_forwarder_test();
+    let emoji = "🎉".as_bytes();
+
+    spawn_terminal_forwarder(
+        groups.clone(),
+        "repo::task-forwarder".to_string(),
+        "repo".to_string(),
+        "task-forwarder".to_string(),
+        "server-1".to_string(),
+        ScriptedReader::new(vec![
+            ScriptedReadStep::Chunk(vec![emoji[0], emoji[1]]),
+            ScriptedReadStep::Chunk(vec![emoji[2], emoji[3], b' ', b'o', b'k', b'\r', b'\n']),
+            ScriptedReadStep::Eof,
+        ]),
+    );
+
+    let mut captured = String::new();
+    for _ in 0..20 {
+        thread::sleep(Duration::from_millis(25));
+        captured = read_forwarder_output(&groups);
+        if captured.contains("🎉 ok\r\n") {
+            break;
+        }
+    }
+
+    assert!(captured.contains("🎉 ok\r\n"));
+    assert!(!captured.contains("invalid UTF-8 bytes"));
+}
+
+#[test]
+fn spawn_terminal_forwarder_preserves_split_ansi_sequences_across_reads() {
+    let groups = build_runtime_groups_for_forwarder_test();
+
+    spawn_terminal_forwarder(
+        groups.clone(),
+        "repo::task-forwarder".to_string(),
+        "repo".to_string(),
+        "task-forwarder".to_string(),
+        "server-1".to_string(),
+        ScriptedReader::new(vec![
+            ScriptedReadStep::Chunk(b"\x1b[38;2;255;0".to_vec()),
+            ScriptedReadStep::Chunk(b";0mready\x1b[0m\r\n".to_vec()),
+            ScriptedReadStep::Eof,
+        ]),
+    );
+
+    let mut captured = String::new();
+    for _ in 0..20 {
+        thread::sleep(Duration::from_millis(25));
+        captured = read_forwarder_output(&groups);
+        if captured.contains("\u{1b}[38;2;255;0;0mready\u{1b}[0m\r\n") {
+            break;
+        }
+    }
+
+    assert!(captured.contains("\u{1b}[38;2;255;0;0mready\u{1b}[0m\r\n"));
+}
+
+#[test]
 fn configure_dev_server_command_environment_sets_terminal_capabilities() {
     let mut command = Command::new("/bin/sh");
 
@@ -767,6 +827,80 @@ sleep 5
         "expected fake dev-server command to resolve from augmented PATH"
     );
     stop_process_group(pid, DEV_SERVER_STOP_TIMEOUT).expect("stop dev server");
+}
+
+#[cfg(unix)]
+#[test]
+fn start_dev_server_script_sets_terminal_capabilities_for_color_aware_commands() {
+    let (service, _task_state, _git_state) = build_service_with_state(Vec::new());
+    let repo_path = "/repo";
+    let task_id = "task-color-env";
+    let worktree_path = unique_temp_path("dev-server-color-env-worktree");
+    fs::create_dir_all(&worktree_path).expect("create worktree path");
+    let worktree_path = worktree_path.to_string_lossy().to_string();
+    let group_key = dev_server_group_key(repo_path, task_id);
+    let script = RepoDevServerScript {
+        id: "frontend".to_string(),
+        name: "Frontend".to_string(),
+        command: "if [ \"$TERM\" = \"xterm-256color\" ] && [ \"$COLORTERM\" = \"truecolor\" ]; then printf '\\033[32mready\\033[0m\\r\\n'; else printf 'plain\\r\\n'; fi && sleep 5".to_string(),
+    };
+
+    service
+        .dev_server_groups
+        .lock()
+        .expect("group lock poisoned")
+        .insert(
+            group_key.clone(),
+            DevServerGroupRuntime {
+                state: build_group_state(
+                    repo_path,
+                    task_id,
+                    Some(worktree_path.clone()),
+                    &repo_config(vec![script.clone()]),
+                ),
+                emitter: None,
+            },
+        );
+
+    service
+        .start_dev_server_script(
+            group_key.as_str(),
+            repo_path,
+            task_id,
+            worktree_path.as_str(),
+            script,
+        )
+        .expect("dev server should start");
+
+    let mut pid = None;
+    let mut captured = String::new();
+    for _ in 0..30 {
+        thread::sleep(Duration::from_millis(100));
+        let groups = service
+            .dev_server_groups
+            .lock()
+            .expect("group lock poisoned");
+        let runtime = groups.get(&group_key).expect("runtime present");
+        let script = &runtime.state.scripts[0];
+        pid = script.pid;
+        captured = script
+            .buffered_terminal_chunks
+            .iter()
+            .map(|chunk| chunk.data.as_str())
+            .collect::<String>();
+        if captured.contains("ready") {
+            break;
+        }
+    }
+
+    assert!(
+        captured.contains("\u{1b}[32mready\u{1b}[0m\r"),
+        "captured output was {captured:?}"
+    );
+    assert!(!captured.contains("plain\r\n"));
+
+    let pid = pid.expect("dev server pid missing");
+    stop_process_group(pid, DEV_SERVER_STOP_TIMEOUT).expect("stop color-aware dev server");
 }
 
 #[cfg(unix)]

--- a/apps/desktop/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -166,6 +166,138 @@ describe("AgentStudioDevServerTerminal", () => {
     expect(reset).toHaveBeenCalledTimes(2);
   });
 
+  test("preserves split ANSI sequences across replay and incremental writes", async () => {
+    const open = mock((_container: HTMLElement) => {});
+    const loadAddon = mock((_addon: unknown) => {});
+    const fit = mock(() => {});
+    const reset = mock(() => {});
+    const writes: string[] = [];
+    let screen = "";
+    const write = mock((data: string, callback?: () => void) => {
+      writes.push(data);
+      screen += data;
+      callback?.();
+    });
+    const dispose = mock(() => {});
+    const onRendererError = () => {};
+    const createTerminalBinding = (container: HTMLElement) => {
+      open(container);
+      loadAddon({});
+      return {
+        terminal: {
+          dispose,
+          loadAddon,
+          open,
+          options: {},
+          reset: () => {
+            screen = "";
+            reset();
+          },
+          write,
+        },
+        fitAddon: { dispose, fit },
+      };
+    };
+
+    const view = render(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "\u001b[38;2;255;0",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+            {
+              scriptId: "frontend",
+              sequence: 1,
+              data: ";0mready",
+              timestamp: "2026-03-19T15:30:01.000Z",
+            },
+          ],
+          lastSequence: 1,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("\u001b[38;2;255;0;0mready");
+    });
+    expect(writes).toEqual(["\u001b[38;2;255;0;0mready"]);
+
+    view.rerender(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "\u001b[38;2;255;0",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+            {
+              scriptId: "frontend",
+              sequence: 1,
+              data: ";0mready",
+              timestamp: "2026-03-19T15:30:01.000Z",
+            },
+            {
+              scriptId: "frontend",
+              sequence: 2,
+              data: "\u001b[0m\r\n",
+              timestamp: "2026-03-19T15:30:02.000Z",
+            },
+          ],
+          lastSequence: 2,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("\u001b[38;2;255;0;0mready\u001b[0m\r\n");
+    });
+    expect(writes).toEqual(["\u001b[38;2;255;0;0mready", "\u001b[0m\r\n"]);
+
+    view.rerender(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "\u001b[38;2;255;0;0mready\u001b[0m\r\n",
+              timestamp: "2026-03-19T15:30:03.000Z",
+            },
+          ],
+          lastSequence: 0,
+          resetToken: 1,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("\u001b[38;2;255;0;0mready\u001b[0m\r\n");
+    });
+    expect(writes).toEqual([
+      "\u001b[38;2;255;0;0mready",
+      "\u001b[0m\r\n",
+      "\u001b[38;2;255;0;0mready\u001b[0m\r\n",
+    ]);
+    expect(reset).toHaveBeenCalledTimes(2);
+  });
+
   test("drops stale pending writes when switching scripts", async () => {
     const open = mock((_container: HTMLElement) => {});
     const loadAddon = mock((_addon: unknown) => {});

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -257,7 +257,7 @@ describe("dev-server-log-buffer", () => {
     ).toBe(true);
   });
 
-  test("preserves live-only chunks when a later empty snapshot no longer mirrors them", () => {
+  test("drops a stale snapshot prefix while preserving a newer live-only suffix", () => {
     const store = createDevServerTerminalBufferStore();
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
@@ -274,12 +274,68 @@ describe("dev-server-log-buffer", () => {
       timestamp: "2026-03-25T10:00:01.000Z",
     });
 
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [buildScript({ bufferedTerminalChunks: [] })],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    expect(getDevServerTerminalBuffer(store, "frontend")?.entries).toEqual([
+      {
+        scriptId: "frontend",
+        sequence: 1,
+        data: "live-only\r\n",
+        timestamp: "2026-03-25T10:00:01.000Z",
+      },
+    ]);
     expect(
       shouldReplaceDevServerTerminalBufferFromScript(
         getDevServerTerminalBufferReplacementContext(store, "frontend"),
         buildScript({ bufferedTerminalChunks: [] }),
       ),
     ).toBe(false);
+    expect(getDevServerTerminalBufferReplacementContext(store, "frontend")?.snapshot).toEqual({
+      count: 0,
+      firstSequence: null,
+      lastSequence: null,
+    });
+  });
+
+  test("derives snapshot metadata from the stored buffer after replacement", () => {
+    const store = createDevServerTerminalBufferStore();
+
+    replaceDevServerTerminalBuffer(store, "frontend", [
+      {
+        scriptId: "frontend",
+        sequence: 2,
+        data: "latest\r\n",
+        timestamp: "2026-03-25T10:00:02.000Z",
+      },
+      {
+        scriptId: "frontend",
+        sequence: 1,
+        data: "older\r\n",
+        timestamp: "2026-03-25T10:00:01.000Z",
+      },
+    ]);
+
+    expect(getDevServerTerminalBufferReplacementContext(store, "frontend")?.snapshot).toEqual({
+      count: 1,
+      firstSequence: 2,
+      lastSequence: 2,
+    });
+  });
+
+  test("does not bump reset token when replacing an empty buffer with another empty replay", () => {
+    const store = createDevServerTerminalBufferStore();
+
+    replaceDevServerTerminalBuffer(store, "frontend", []);
+    expect(getDevServerTerminalBuffer(store, "frontend")?.resetToken).toBe(0);
+
+    replaceDevServerTerminalBuffer(store, "frontend", []);
+    expect(getDevServerTerminalBuffer(store, "frontend")?.resetToken).toBe(0);
   });
 
   test("reconciles the store with authoritative snapshots while pruning removed scripts", () => {

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -225,4 +225,21 @@ describe("dev-server-log-buffer", () => {
 
     expect(shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, staleScript)).toBe(false);
   });
+
+  test("replaces a populated buffer when an authoritative snapshot clears replay", () => {
+    const store = createDevServerTerminalBufferStore();
+    replaceDevServerTerminalBuffer(store, "frontend", [
+      {
+        scriptId: "frontend",
+        sequence: 2,
+        data: "stale\r\n",
+        timestamp: "2026-03-25T10:02:00.000Z",
+      },
+    ]);
+
+    const currentBuffer = getDevServerTerminalBuffer(store, "frontend");
+    const clearedScript = buildScript({ bufferedTerminalChunks: [] });
+
+    expect(shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, clearedScript)).toBe(true);
+  });
 });

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -6,6 +6,7 @@ import {
   getDevServerTerminalBuffer,
   MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS,
   replaceDevServerTerminalBuffer,
+  shouldReplaceDevServerTerminalBufferFromScript,
   syncDevServerTerminalBufferStore,
   trimDevServerTerminalChunks,
 } from "./dev-server-log-buffer";
@@ -171,5 +172,57 @@ describe("dev-server-log-buffer", () => {
     const replacedBuffer = getDevServerTerminalBuffer(store, "frontend");
     expect(replacedBuffer?.entries[0]?.data).toBe("restarted\r\n");
     expect(replacedBuffer?.resetToken).toBe(2);
+  });
+
+  test("replaces a populated buffer when an authoritative snapshot is newer", () => {
+    const store = createDevServerTerminalBufferStore();
+    replaceDevServerTerminalBuffer(store, "frontend", [
+      {
+        scriptId: "frontend",
+        sequence: 0,
+        data: "stale\r\n",
+        timestamp: "2026-03-25T10:00:00.000Z",
+      },
+    ]);
+
+    const currentBuffer = getDevServerTerminalBuffer(store, "frontend");
+    const nextScript = buildScript({
+      bufferedTerminalChunks: [
+        {
+          scriptId: "frontend",
+          sequence: 1,
+          data: "fresh\r\n",
+          timestamp: "2026-03-25T10:01:00.000Z",
+        },
+      ],
+    });
+
+    expect(shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, nextScript)).toBe(true);
+  });
+
+  test("keeps a populated buffer when the local stream is newer than the snapshot", () => {
+    const store = createDevServerTerminalBufferStore();
+    replaceDevServerTerminalBuffer(store, "frontend", [
+      {
+        scriptId: "frontend",
+        sequence: 2,
+        data: "local-live\r\n",
+        timestamp: "2026-03-25T10:02:00.000Z",
+      },
+    ]);
+
+    const currentBuffer = getDevServerTerminalBuffer(store, "frontend");
+    const staleScript = buildScript({
+      bufferedTerminalChunks: [
+        {
+          scriptId: "frontend",
+          sequence: 1,
+          data: "stale\r\n",
+          timestamp: "2026-03-25T10:01:00.000Z",
+        },
+      ],
+    });
+
+    expect(shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, staleScript)).toBe(false);
   });
 });

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -4,7 +4,9 @@ import {
   appendDevServerTerminalChunk,
   createDevServerTerminalBufferStore,
   getDevServerTerminalBuffer,
+  getDevServerTerminalBufferReplacementContext,
   MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS,
+  reconcileDevServerTerminalBufferStore,
   replaceDevServerTerminalBuffer,
   shouldReplaceDevServerTerminalBufferFromScript,
   syncDevServerTerminalBufferStore,
@@ -185,7 +187,6 @@ describe("dev-server-log-buffer", () => {
       },
     ]);
 
-    const currentBuffer = getDevServerTerminalBuffer(store, "frontend");
     const nextScript = buildScript({
       bufferedTerminalChunks: [
         {
@@ -197,7 +198,12 @@ describe("dev-server-log-buffer", () => {
       ],
     });
 
-    expect(shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, nextScript)).toBe(true);
+    expect(
+      shouldReplaceDevServerTerminalBufferFromScript(
+        getDevServerTerminalBufferReplacementContext(store, "frontend"),
+        nextScript,
+      ),
+    ).toBe(true);
   });
 
   test("keeps a populated buffer when the local stream is newer than the snapshot", () => {
@@ -211,7 +217,6 @@ describe("dev-server-log-buffer", () => {
       },
     ]);
 
-    const currentBuffer = getDevServerTerminalBuffer(store, "frontend");
     const staleScript = buildScript({
       bufferedTerminalChunks: [
         {
@@ -223,7 +228,12 @@ describe("dev-server-log-buffer", () => {
       ],
     });
 
-    expect(shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, staleScript)).toBe(false);
+    expect(
+      shouldReplaceDevServerTerminalBufferFromScript(
+        getDevServerTerminalBufferReplacementContext(store, "frontend"),
+        staleScript,
+      ),
+    ).toBe(false);
   });
 
   test("replaces a populated buffer when an authoritative snapshot clears replay", () => {
@@ -237,9 +247,80 @@ describe("dev-server-log-buffer", () => {
       },
     ]);
 
-    const currentBuffer = getDevServerTerminalBuffer(store, "frontend");
     const clearedScript = buildScript({ bufferedTerminalChunks: [] });
 
-    expect(shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, clearedScript)).toBe(true);
+    expect(
+      shouldReplaceDevServerTerminalBufferFromScript(
+        getDevServerTerminalBufferReplacementContext(store, "frontend"),
+        clearedScript,
+      ),
+    ).toBe(true);
+  });
+
+  test("preserves live-only chunks when a later empty snapshot no longer mirrors them", () => {
+    const store = createDevServerTerminalBufferStore();
+    replaceDevServerTerminalBuffer(store, "frontend", [
+      {
+        scriptId: "frontend",
+        sequence: 0,
+        data: "snapshot\r\n",
+        timestamp: "2026-03-25T10:00:00.000Z",
+      },
+    ]);
+    appendDevServerTerminalChunk(store, {
+      scriptId: "frontend",
+      sequence: 1,
+      data: "live-only\r\n",
+      timestamp: "2026-03-25T10:00:01.000Z",
+    });
+
+    expect(
+      shouldReplaceDevServerTerminalBufferFromScript(
+        getDevServerTerminalBufferReplacementContext(store, "frontend"),
+        buildScript({ bufferedTerminalChunks: [] }),
+      ),
+    ).toBe(false);
+  });
+
+  test("reconciles the store with authoritative snapshots while pruning removed scripts", () => {
+    const store = createDevServerTerminalBufferStore();
+    replaceDevServerTerminalBuffer(store, "frontend", [
+      {
+        scriptId: "frontend",
+        sequence: 0,
+        data: "stale\r\n",
+        timestamp: "2026-03-25T10:00:00.000Z",
+      },
+    ]);
+    replaceDevServerTerminalBuffer(store, "removed", [
+      {
+        scriptId: "removed",
+        sequence: 0,
+        data: "removed\r\n",
+        timestamp: "2026-03-25T10:00:00.000Z",
+      },
+    ]);
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            bufferedTerminalChunks: [
+              {
+                scriptId: "frontend",
+                sequence: 2,
+                data: "fresh\r\n",
+                timestamp: "2026-03-25T10:02:00.000Z",
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    expect(getDevServerTerminalBuffer(store, "removed")).toBeNull();
+    expect(getDevServerTerminalBuffer(store, "frontend")?.entries[0]?.data).toBe("fresh\r\n");
   });
 });

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -11,10 +11,18 @@ export type AgentStudioDevServerTerminalChunkEntry = DevServerTerminalChunk;
 export type AgentStudioDevServerTerminalBuffer = {
   entries: readonly AgentStudioDevServerTerminalChunkEntry[];
   lastSequence: number | null;
-  firstSnapshotSequence?: number | null;
-  lastSnapshotSequence?: number | null;
   resetToken: number;
-  snapshotEntryCount?: number;
+};
+
+type DevServerTerminalSequenceWindow = {
+  count: number;
+  firstSequence: number | null;
+  lastSequence: number | null;
+};
+
+export type DevServerTerminalBufferReplacementContext = {
+  current: DevServerTerminalSequenceWindow;
+  snapshot: DevServerTerminalSequenceWindow;
 };
 
 type DevServerTerminalBufferState = {
@@ -42,15 +50,34 @@ export const trimDevServerTerminalChunks = (
 
 const readBufferedSequenceWindow = (
   chunks: readonly DevServerTerminalChunk[],
-): {
-  count: number;
-  firstSequence: number | null;
-  lastSequence: number | null;
-} => {
+): DevServerTerminalSequenceWindow => {
   return {
     count: chunks.length,
     firstSequence: chunks[0]?.sequence ?? null,
     lastSequence: chunks.at(-1)?.sequence ?? null,
+  };
+};
+
+const readCurrentBufferWindow = (
+  buffer: DevServerTerminalBufferState,
+): DevServerTerminalSequenceWindow => {
+  return {
+    count: buffer.size,
+    firstSequence:
+      buffer.size === 0
+        ? null
+        : (buffer.entries[buffer.head % MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS]?.sequence ?? null),
+    lastSequence: buffer.lastSequence,
+  };
+};
+
+const readSnapshotBufferWindow = (
+  buffer: DevServerTerminalBufferState,
+): DevServerTerminalSequenceWindow => {
+  return {
+    count: buffer.snapshotEntryCount,
+    firstSequence: buffer.firstSnapshotSequence,
+    lastSequence: buffer.lastSnapshotSequence,
   };
 };
 
@@ -149,6 +176,21 @@ export const syncDevServerTerminalBufferStore = (
   }
 };
 
+export const getDevServerTerminalBufferReplacementContext = (
+  store: DevServerTerminalBufferStore,
+  scriptId: string,
+): DevServerTerminalBufferReplacementContext | null => {
+  const buffer = store.get(scriptId);
+  if (!buffer) {
+    return null;
+  }
+
+  return {
+    current: readCurrentBufferWindow(buffer),
+    snapshot: readSnapshotBufferWindow(buffer),
+  };
+};
+
 export const getDevServerTerminalBuffer = (
   store: DevServerTerminalBufferStore,
   scriptId: string | null,
@@ -172,35 +214,27 @@ export const getDevServerTerminalBuffer = (
 
       return entry;
     }),
-    firstSnapshotSequence: buffer.firstSnapshotSequence,
     lastSequence: buffer.lastSequence,
-    lastSnapshotSequence: buffer.lastSnapshotSequence,
     resetToken: buffer.resetToken,
-    snapshotEntryCount: buffer.snapshotEntryCount,
   };
 };
 
 export const shouldReplaceDevServerTerminalBufferFromScript = (
-  currentBuffer: AgentStudioDevServerTerminalBuffer | null,
+  currentContext: DevServerTerminalBufferReplacementContext | null,
   script: DevServerScriptState,
   force = false,
 ): boolean => {
-  if (force || currentBuffer === null) {
+  if (force || currentContext === null) {
     return true;
   }
 
   const nextChunks = trimDevServerTerminalChunks(script.bufferedTerminalChunks);
-  const currentWindow = readBufferedSequenceWindow(currentBuffer.entries);
+  const currentWindow = currentContext.current;
   const nextWindow = readBufferedSequenceWindow(nextChunks);
-  const currentSnapshotEntryCount = currentBuffer.snapshotEntryCount ?? currentWindow.count;
-  const currentFirstSnapshotSequence =
-    currentBuffer.firstSnapshotSequence ?? currentWindow.firstSequence;
-  const currentLastSnapshotSequence =
-    currentBuffer.lastSnapshotSequence ?? currentWindow.lastSequence;
   const currentBufferMirrorsSnapshot =
-    currentWindow.count === currentSnapshotEntryCount &&
-    currentWindow.firstSequence === currentFirstSnapshotSequence &&
-    currentWindow.lastSequence === currentLastSnapshotSequence;
+    currentWindow.count === currentContext.snapshot.count &&
+    currentWindow.firstSequence === currentContext.snapshot.firstSequence &&
+    currentWindow.lastSequence === currentContext.snapshot.lastSequence;
 
   if (nextWindow.lastSequence === null) {
     return currentWindow.count > 0 && currentBufferMirrorsSnapshot;
@@ -222,6 +256,36 @@ export const shouldReplaceDevServerTerminalBufferFromScript = (
     nextWindow.count !== currentWindow.count ||
     nextWindow.firstSequence !== currentWindow.firstSequence
   );
+};
+
+export const reconcileDevServerTerminalBufferStore = (
+  store: DevServerTerminalBufferStore,
+  state: DevServerGroupState,
+  force = false,
+): boolean => {
+  let didChange = false;
+  const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
+
+  for (const scriptId of store.keys()) {
+    if (nextScriptIds.has(scriptId)) {
+      continue;
+    }
+
+    store.delete(scriptId);
+    didChange = true;
+  }
+
+  for (const script of state.scripts) {
+    const currentContext = getDevServerTerminalBufferReplacementContext(store, script.scriptId);
+    if (!shouldReplaceDevServerTerminalBufferFromScript(currentContext, script, force)) {
+      continue;
+    }
+
+    replaceDevServerTerminalBuffer(store, script.scriptId, script.bufferedTerminalChunks);
+    didChange = true;
+  }
+
+  return didChange;
 };
 
 export const getLatestBufferedTerminalSequence = (script: DevServerScriptState): number | null => {

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -34,6 +34,20 @@ export const trimDevServerTerminalChunks = (
   return chunks.slice(-MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS);
 };
 
+const readBufferedSequenceWindow = (
+  chunks: readonly DevServerTerminalChunk[],
+): {
+  count: number;
+  firstSequence: number | null;
+  lastSequence: number | null;
+} => {
+  return {
+    count: chunks.length,
+    firstSequence: chunks[0]?.sequence ?? null,
+    lastSequence: chunks.at(-1)?.sequence ?? null,
+  };
+};
+
 const createDevServerTerminalBufferState = (): DevServerTerminalBufferState => ({
   entries: [],
   head: 0,
@@ -145,6 +159,41 @@ export const getDevServerTerminalBuffer = (
     lastSequence: buffer.lastSequence,
     resetToken: buffer.resetToken,
   };
+};
+
+export const shouldReplaceDevServerTerminalBufferFromScript = (
+  currentBuffer: AgentStudioDevServerTerminalBuffer | null,
+  script: DevServerScriptState,
+  force = false,
+): boolean => {
+  if (force || currentBuffer === null) {
+    return true;
+  }
+
+  const nextChunks = trimDevServerTerminalChunks(script.bufferedTerminalChunks);
+  const currentWindow = readBufferedSequenceWindow(currentBuffer.entries);
+  const nextWindow = readBufferedSequenceWindow(nextChunks);
+
+  if (nextWindow.lastSequence === null) {
+    return false;
+  }
+
+  if (currentWindow.lastSequence === null) {
+    return true;
+  }
+
+  if (nextWindow.lastSequence > currentWindow.lastSequence) {
+    return true;
+  }
+
+  if (nextWindow.lastSequence < currentWindow.lastSequence) {
+    return false;
+  }
+
+  return (
+    nextWindow.count !== currentWindow.count ||
+    nextWindow.firstSequence !== currentWindow.firstSequence
+  );
 };
 
 export const getLatestBufferedTerminalSequence = (script: DevServerScriptState): number | null => {

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -22,7 +22,13 @@ type DevServerTerminalSequenceWindow = {
 
 export type DevServerTerminalBufferReplacementContext = {
   current: DevServerTerminalSequenceWindow;
+  currentEntries: readonly AgentStudioDevServerTerminalChunkEntry[];
   snapshot: DevServerTerminalSequenceWindow;
+};
+
+export type DevServerTerminalBufferReplacement = {
+  snapshotWindow: DevServerTerminalSequenceWindow;
+  terminalChunks: readonly DevServerTerminalChunk[];
 };
 
 type DevServerTerminalBufferState = {
@@ -69,6 +75,25 @@ const readCurrentBufferWindow = (
         : (buffer.entries[buffer.head % MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS]?.sequence ?? null),
     lastSequence: buffer.lastSequence,
   };
+};
+
+const readCurrentBufferEntries = (
+  buffer: DevServerTerminalBufferState,
+): AgentStudioDevServerTerminalChunkEntry[] => {
+  return Array.from({ length: buffer.size }, (_, offset) => {
+    const entry = buffer.entries[(buffer.head + offset) % MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS];
+    if (!entry) {
+      throw new Error(`Missing dev server terminal chunk at logical offset ${offset}.`);
+    }
+
+    return entry;
+  });
+};
+
+const EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW: DevServerTerminalSequenceWindow = {
+  count: 0,
+  firstSequence: null,
+  lastSequence: null,
 };
 
 const readSnapshotBufferWindow = (
@@ -136,6 +161,7 @@ export const replaceDevServerTerminalBuffer = (
 ): void => {
   const buffer = getOrCreateDevServerTerminalBufferState(store, scriptId);
   const trimmedChunks = trimDevServerTerminalChunks(terminalChunks);
+  const shouldResetTerminal = buffer.size > 0 || trimmedChunks.length > 0;
 
   buffer.entries.length = 0;
   buffer.head = 0;
@@ -143,16 +169,32 @@ export const replaceDevServerTerminalBuffer = (
   buffer.lastSequence = null;
   buffer.firstSnapshotSequence = null;
   buffer.lastSnapshotSequence = null;
-  buffer.resetToken += 1;
+  if (shouldResetTerminal) {
+    buffer.resetToken += 1;
+  }
   buffer.snapshotEntryCount = 0;
 
   for (const terminalChunk of trimmedChunks) {
     appendDevServerTerminalChunk(store, terminalChunk);
   }
 
-  buffer.firstSnapshotSequence = trimmedChunks[0]?.sequence ?? null;
-  buffer.lastSnapshotSequence = trimmedChunks.at(-1)?.sequence ?? null;
-  buffer.snapshotEntryCount = trimmedChunks.length;
+  const snapshotWindow = readCurrentBufferWindow(buffer);
+  buffer.firstSnapshotSequence = snapshotWindow.firstSequence;
+  buffer.lastSnapshotSequence = snapshotWindow.lastSequence;
+  buffer.snapshotEntryCount = snapshotWindow.count;
+};
+
+export const applyDevServerTerminalBufferReplacement = (
+  store: DevServerTerminalBufferStore,
+  scriptId: string,
+  replacement: DevServerTerminalBufferReplacement,
+): void => {
+  replaceDevServerTerminalBuffer(store, scriptId, [...replacement.terminalChunks]);
+
+  const buffer = getOrCreateDevServerTerminalBufferState(store, scriptId);
+  buffer.firstSnapshotSequence = replacement.snapshotWindow.firstSequence;
+  buffer.lastSnapshotSequence = replacement.snapshotWindow.lastSequence;
+  buffer.snapshotEntryCount = replacement.snapshotWindow.count;
 };
 
 export const syncDevServerTerminalBufferStore = (
@@ -187,6 +229,7 @@ export const getDevServerTerminalBufferReplacementContext = (
 
   return {
     current: readCurrentBufferWindow(buffer),
+    currentEntries: readCurrentBufferEntries(buffer),
     snapshot: readSnapshotBufferWindow(buffer),
   };
 };
@@ -205,18 +248,91 @@ export const getDevServerTerminalBuffer = (
   }
 
   return {
-    entries: Array.from({ length: buffer.size }, (_, offset) => {
-      const entry =
-        buffer.entries[(buffer.head + offset) % MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS];
-      if (!entry) {
-        throw new Error(`Missing dev server terminal chunk at logical offset ${offset}.`);
-      }
-
-      return entry;
-    }),
+    entries: readCurrentBufferEntries(buffer),
     lastSequence: buffer.lastSequence,
     resetToken: buffer.resetToken,
   };
+};
+
+export const getDevServerTerminalBufferReplacement = (
+  currentContext: DevServerTerminalBufferReplacementContext | null,
+  script: DevServerScriptState,
+  force = false,
+): DevServerTerminalBufferReplacement | null => {
+  const nextChunks = trimDevServerTerminalChunks(script.bufferedTerminalChunks);
+  const nextWindow = readBufferedSequenceWindow(nextChunks);
+
+  if (force || currentContext === null) {
+    return {
+      snapshotWindow: nextWindow,
+      terminalChunks: nextChunks,
+    };
+  }
+
+  const currentWindow = currentContext.current;
+  const currentBufferMirrorsSnapshot =
+    currentWindow.count === currentContext.snapshot.count &&
+    currentWindow.firstSequence === currentContext.snapshot.firstSequence &&
+    currentWindow.lastSequence === currentContext.snapshot.lastSequence;
+
+  if (nextWindow.lastSequence === null) {
+    if (currentWindow.count === 0 || currentContext.snapshot.lastSequence === null) {
+      return null;
+    }
+
+    const snapshotLastSequence = currentContext.snapshot.lastSequence;
+    const liveOnlyChunks = currentContext.currentEntries.filter(
+      (chunk) => chunk.sequence > snapshotLastSequence,
+    );
+    if (liveOnlyChunks.length > 0) {
+      return {
+        snapshotWindow: EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW,
+        terminalChunks: trimDevServerTerminalChunks([...liveOnlyChunks]),
+      };
+    }
+
+    if (!currentBufferMirrorsSnapshot) {
+      return {
+        snapshotWindow: EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW,
+        terminalChunks: [],
+      };
+    }
+
+    return {
+      snapshotWindow: nextWindow,
+      terminalChunks: nextChunks,
+    };
+  }
+
+  if (currentWindow.lastSequence === null) {
+    return {
+      snapshotWindow: nextWindow,
+      terminalChunks: nextChunks,
+    };
+  }
+
+  if (nextWindow.lastSequence > currentWindow.lastSequence) {
+    return {
+      snapshotWindow: nextWindow,
+      terminalChunks: nextChunks,
+    };
+  }
+
+  if (nextWindow.lastSequence < currentWindow.lastSequence) {
+    return null;
+  }
+
+  if (
+    nextWindow.count !== currentWindow.count ||
+    nextWindow.firstSequence !== currentWindow.firstSequence
+  ) {
+    return {
+      snapshotWindow: nextWindow,
+      terminalChunks: nextChunks,
+    };
+  }
+
+  return null;
 };
 
 export const shouldReplaceDevServerTerminalBufferFromScript = (
@@ -224,38 +340,7 @@ export const shouldReplaceDevServerTerminalBufferFromScript = (
   script: DevServerScriptState,
   force = false,
 ): boolean => {
-  if (force || currentContext === null) {
-    return true;
-  }
-
-  const nextChunks = trimDevServerTerminalChunks(script.bufferedTerminalChunks);
-  const currentWindow = currentContext.current;
-  const nextWindow = readBufferedSequenceWindow(nextChunks);
-  const currentBufferMirrorsSnapshot =
-    currentWindow.count === currentContext.snapshot.count &&
-    currentWindow.firstSequence === currentContext.snapshot.firstSequence &&
-    currentWindow.lastSequence === currentContext.snapshot.lastSequence;
-
-  if (nextWindow.lastSequence === null) {
-    return currentWindow.count > 0 && currentBufferMirrorsSnapshot;
-  }
-
-  if (currentWindow.lastSequence === null) {
-    return true;
-  }
-
-  if (nextWindow.lastSequence > currentWindow.lastSequence) {
-    return true;
-  }
-
-  if (nextWindow.lastSequence < currentWindow.lastSequence) {
-    return false;
-  }
-
-  return (
-    nextWindow.count !== currentWindow.count ||
-    nextWindow.firstSequence !== currentWindow.firstSequence
-  );
+  return getDevServerTerminalBufferReplacement(currentContext, script, force) !== null;
 };
 
 export const reconcileDevServerTerminalBufferStore = (
@@ -276,12 +361,16 @@ export const reconcileDevServerTerminalBufferStore = (
   }
 
   for (const script of state.scripts) {
-    const currentContext = getDevServerTerminalBufferReplacementContext(store, script.scriptId);
-    if (!shouldReplaceDevServerTerminalBufferFromScript(currentContext, script, force)) {
+    const replacement = getDevServerTerminalBufferReplacement(
+      getDevServerTerminalBufferReplacementContext(store, script.scriptId),
+      script,
+      force,
+    );
+    if (replacement === null) {
       continue;
     }
 
-    replaceDevServerTerminalBuffer(store, script.scriptId, script.bufferedTerminalChunks);
+    applyDevServerTerminalBufferReplacement(store, script.scriptId, replacement);
     didChange = true;
   }
 

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -11,15 +11,21 @@ export type AgentStudioDevServerTerminalChunkEntry = DevServerTerminalChunk;
 export type AgentStudioDevServerTerminalBuffer = {
   entries: readonly AgentStudioDevServerTerminalChunkEntry[];
   lastSequence: number | null;
+  firstSnapshotSequence?: number | null;
+  lastSnapshotSequence?: number | null;
   resetToken: number;
+  snapshotEntryCount?: number;
 };
 
 type DevServerTerminalBufferState = {
   entries: AgentStudioDevServerTerminalChunkEntry[];
+  firstSnapshotSequence: number | null;
   head: number;
+  lastSnapshotSequence: number | null;
   size: number;
   lastSequence: number | null;
   resetToken: number;
+  snapshotEntryCount: number;
 };
 
 export type DevServerTerminalBufferStore = Map<string, DevServerTerminalBufferState>;
@@ -50,10 +56,13 @@ const readBufferedSequenceWindow = (
 
 const createDevServerTerminalBufferState = (): DevServerTerminalBufferState => ({
   entries: [],
+  firstSnapshotSequence: null,
   head: 0,
+  lastSnapshotSequence: null,
   size: 0,
   lastSequence: null,
   resetToken: 0,
+  snapshotEntryCount: 0,
 });
 
 const getOrCreateDevServerTerminalBufferState = (
@@ -105,11 +114,18 @@ export const replaceDevServerTerminalBuffer = (
   buffer.head = 0;
   buffer.size = 0;
   buffer.lastSequence = null;
+  buffer.firstSnapshotSequence = null;
+  buffer.lastSnapshotSequence = null;
   buffer.resetToken += 1;
+  buffer.snapshotEntryCount = 0;
 
   for (const terminalChunk of trimmedChunks) {
     appendDevServerTerminalChunk(store, terminalChunk);
   }
+
+  buffer.firstSnapshotSequence = trimmedChunks[0]?.sequence ?? null;
+  buffer.lastSnapshotSequence = trimmedChunks.at(-1)?.sequence ?? null;
+  buffer.snapshotEntryCount = trimmedChunks.length;
 };
 
 export const syncDevServerTerminalBufferStore = (
@@ -156,8 +172,11 @@ export const getDevServerTerminalBuffer = (
 
       return entry;
     }),
+    firstSnapshotSequence: buffer.firstSnapshotSequence,
     lastSequence: buffer.lastSequence,
+    lastSnapshotSequence: buffer.lastSnapshotSequence,
     resetToken: buffer.resetToken,
+    snapshotEntryCount: buffer.snapshotEntryCount,
   };
 };
 
@@ -173,9 +192,18 @@ export const shouldReplaceDevServerTerminalBufferFromScript = (
   const nextChunks = trimDevServerTerminalChunks(script.bufferedTerminalChunks);
   const currentWindow = readBufferedSequenceWindow(currentBuffer.entries);
   const nextWindow = readBufferedSequenceWindow(nextChunks);
+  const currentSnapshotEntryCount = currentBuffer.snapshotEntryCount ?? currentWindow.count;
+  const currentFirstSnapshotSequence =
+    currentBuffer.firstSnapshotSequence ?? currentWindow.firstSequence;
+  const currentLastSnapshotSequence =
+    currentBuffer.lastSnapshotSequence ?? currentWindow.lastSequence;
+  const currentBufferMirrorsSnapshot =
+    currentWindow.count === currentSnapshotEntryCount &&
+    currentWindow.firstSequence === currentFirstSnapshotSequence &&
+    currentWindow.lastSequence === currentLastSnapshotSequence;
 
   if (nextWindow.lastSequence === null) {
-    return false;
+    return currentWindow.count > 0 && currentBufferMirrorsSnapshot;
   }
 
   if (currentWindow.lastSequence === null) {

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -1002,6 +1002,105 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
+  test("clears stale terminal replay when a normal state refetch reports an empty authoritative buffer", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const initialState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "stale output\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const refreshedState = buildState({
+      updatedAt: "2026-03-19T15:31:00.000Z",
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [],
+        }),
+      ],
+    });
+    let getStateCalls = 0;
+    devServerGetState = async () => {
+      getStateCalls += 1;
+      return getStateCalls === 1 ? initialState : refreshedState;
+    };
+
+    let latest: HookResult | null = null;
+    let queryClient: ReturnType<typeof useQueryClient> | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const CaptureQueryClient = () => {
+      queryClient = useQueryClient();
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <CaptureQueryClient />
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe("stale output\r\n");
+      });
+
+      if (queryClient === null) {
+        throw new Error("Expected query client to be captured");
+      }
+
+      await act(async () => {
+        await queryClient?.refetchQueries({
+          queryKey: devServerQueryKeys.state("/repo", "task-7"),
+          exact: true,
+          type: "active",
+        });
+      });
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries).toHaveLength(0);
+      });
+      expect(getLatest().selectedScript?.bufferedTerminalChunks).toHaveLength(0);
+      expect(getStateCalls).toBe(2);
+    } finally {
+      view.unmount();
+    }
+  });
+
   test("clears stale task state when switching to another task while enabled", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -781,6 +781,121 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
+  test("replaces mixed old and new replay when mutation state returns the reset window", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const initialState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 3,
+              data: "old run output\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const restartedState = buildState({
+      updatedAt: "2026-03-19T15:31:00.000Z",
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4343,
+          startedAt: "2026-03-19T15:31:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 4,
+              data: "new run output\r\n",
+              timestamp: "2026-03-19T15:31:01.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+
+    devServerGetState = async () => initialState;
+    const restartDeferred = createDeferred<DevServerGroupState>();
+    devServerRestart = async () => restartDeferred.promise;
+
+    let latest: HookResult | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
+          "old run output\r\n",
+        );
+      });
+
+      await act(async () => {
+        getLatest().onRestart();
+      });
+      await waitFor(() => {
+        expect(devServerEventListener).not.toBeNull();
+      });
+
+      await act(async () => {
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            sequence: 4,
+            data: "new run output\r\n",
+            timestamp: "2026-03-19T15:31:01.000Z",
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries).toHaveLength(2);
+      });
+
+      restartDeferred.resolve(restartedState);
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries).toHaveLength(1);
+      });
+      expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe("new run output\r\n");
+      expect(getLatest().isRestartPending).toBe(false);
+    } finally {
+      view.unmount();
+    }
+  });
+
   test("reopens in loading mode until a fresh dev-server refetch completes", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { DevServerGroupState, DevServerScriptState } from "@openducktor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
 import { act, render, waitFor } from "@testing-library/react";
 import { QueryProvider } from "@/lib/query-provider";
+import { devServerQueryKeys } from "@/state/queries/dev-servers";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import type { RepoSettingsInput } from "@/types/state-slices";
 
@@ -895,6 +897,111 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
+  test("reconciles terminal replay from a normal state refetch when local buffers are already populated", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const initialState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "stale output\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const refreshedState = buildState({
+      updatedAt: "2026-03-19T15:31:00.000Z",
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 1,
+              data: "fresh output\r\n",
+              timestamp: "2026-03-19T15:31:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    let getStateCalls = 0;
+    devServerGetState = async () => {
+      getStateCalls += 1;
+      return getStateCalls === 1 ? initialState : refreshedState;
+    };
+
+    let latest: HookResult | null = null;
+    let queryClient: ReturnType<typeof useQueryClient> | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const CaptureQueryClient = () => {
+      queryClient = useQueryClient();
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <CaptureQueryClient />
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe("stale output\r\n");
+      });
+
+      if (queryClient === null) {
+        throw new Error("Expected query client to be captured");
+      }
+
+      await act(async () => {
+        await queryClient?.refetchQueries({
+          queryKey: devServerQueryKeys.state("/repo", "task-7"),
+          exact: true,
+          type: "active",
+        });
+      });
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe("fresh output\r\n");
+      });
+      expect(getStateCalls).toBe(2);
+    } finally {
+      view.unmount();
+    }
+  });
+
   test("clears stale task state when switching to another task while enabled", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
@@ -1068,6 +1175,104 @@ describe("useAgentStudioDevServerPanel", () => {
       });
       expect(getStateCalls).toBe(2);
       restartDeferred.resolve(refreshedState);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test("rehydrates buffered terminal replay after a browser-live reconnect", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const initialState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "stale output\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const refreshedState = buildState({
+      updatedAt: "2026-03-19T15:31:00.000Z",
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 2,
+              data: "reconnected output\r\n",
+              timestamp: "2026-03-19T15:31:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    let getStateCalls = 0;
+    devServerGetState = async () => {
+      getStateCalls += 1;
+      return getStateCalls === 1 ? initialState : refreshedState;
+    };
+
+    let latest: HookResult | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe("stale output\r\n");
+      });
+      await waitFor(() => {
+        expect(devServerEventListener).not.toBeNull();
+      });
+
+      await act(async () => {
+        devServerEventListener?.({
+          __openducktorBrowserLive: true,
+          kind: "reconnected",
+        });
+      });
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
+          "reconnected output\r\n",
+        );
+      });
+      expect(getStateCalls).toBe(2);
     } finally {
       view.unmount();
     }

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -1216,6 +1216,133 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
+  test("drops stale replay but preserves newer live output when a refetch returns an empty authoritative buffer", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const initialState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "stale output\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const refreshedState = buildState({
+      updatedAt: "2026-03-19T15:31:00.000Z",
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [],
+        }),
+      ],
+    });
+    let getStateCalls = 0;
+    devServerGetState = async () => {
+      getStateCalls += 1;
+      return getStateCalls === 1 ? initialState : refreshedState;
+    };
+
+    let latest: HookResult | null = null;
+    let queryClient: ReturnType<typeof useQueryClient> | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const CaptureQueryClient = () => {
+      queryClient = useQueryClient();
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <CaptureQueryClient />
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe("stale output\r\n");
+      });
+      await waitFor(() => {
+        expect(devServerEventListener).not.toBeNull();
+      });
+
+      await act(async () => {
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            sequence: 1,
+            data: "live output\r\n",
+            timestamp: "2026-03-19T15:31:01.000Z",
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries).toHaveLength(2);
+      });
+
+      if (queryClient === null) {
+        throw new Error("Expected query client to be captured");
+      }
+
+      await act(async () => {
+        await queryClient?.refetchQueries({
+          queryKey: devServerQueryKeys.state("/repo", "task-7"),
+          exact: true,
+          type: "active",
+        });
+      });
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries).toEqual([
+          {
+            scriptId: "frontend",
+            sequence: 1,
+            data: "live output\r\n",
+            timestamp: "2026-03-19T15:31:01.000Z",
+          },
+        ]);
+      });
+      expect(getLatest().selectedScript?.bufferedTerminalChunks).toHaveLength(0);
+      expect(getStateCalls).toBe(2);
+    } finally {
+      view.unmount();
+    }
+  });
+
   test("preserves resumed live output after restart clears replay and later refetches stay empty", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -1101,6 +1101,148 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
+  test("preserves resumed live output after restart clears replay and later refetches stay empty", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const initialState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "stale output\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const restartedState = buildState({
+      updatedAt: "2026-03-19T15:31:00.000Z",
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4343,
+          startedAt: "2026-03-19T15:31:00.000Z",
+          bufferedTerminalChunks: [],
+        }),
+      ],
+    });
+    let phase: "initial" | "restarted" = "initial";
+    let getStateCalls = 0;
+    devServerGetState = async () => {
+      getStateCalls += 1;
+      return phase === "initial" ? initialState : restartedState;
+    };
+    const restartDeferred = createDeferred<DevServerGroupState>();
+    devServerRestart = async () => restartDeferred.promise;
+
+    let latest: HookResult | null = null;
+    let queryClient: ReturnType<typeof useQueryClient> | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+    const getSelectedTerminalData = (): string | undefined => {
+      const selectedTerminalBuffer = getLatest().selectedScriptTerminalBuffer;
+      if (!selectedTerminalBuffer) {
+        return undefined;
+      }
+
+      return selectedTerminalBuffer.entries[0]?.data;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const CaptureQueryClient = () => {
+      queryClient = useQueryClient();
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <CaptureQueryClient />
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getSelectedTerminalData()).toBe("stale output\r\n");
+      });
+
+      if (queryClient === null) {
+        throw new Error("Expected query client to be captured");
+      }
+
+      await act(async () => {
+        getLatest().onRestart();
+      });
+      await waitFor(() => {
+        expect(devServerEventListener).not.toBeNull();
+      });
+
+      phase = "restarted";
+      restartDeferred.resolve(restartedState);
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries).toHaveLength(0);
+      });
+
+      await act(async () => {
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            sequence: 0,
+            data: "new run output\r\n",
+            timestamp: "2026-03-19T15:31:01.000Z",
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(getSelectedTerminalData()).toBe("new run output\r\n");
+      });
+
+      await act(async () => {
+        await queryClient?.refetchQueries({
+          queryKey: devServerQueryKeys.state("/repo", "task-7"),
+          exact: true,
+          type: "active",
+        });
+      });
+
+      await waitFor(() => {
+        expect(getLatest().isRestartPending).toBe(false);
+      });
+      expect(getSelectedTerminalData()).toBe("new run output\r\n");
+      expect(getStateCalls).toBe(2);
+    } finally {
+      view.unmount();
+    }
+  });
+
   test("clears stale task state when switching to another task while enabled", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -6,9 +6,10 @@ import {
   createDevServerTerminalBufferStore,
   type DevServerTerminalBufferStore,
   getDevServerTerminalBuffer,
-  getLatestBufferedTerminalSequence,
+  getDevServerTerminalBufferReplacementContext,
   reconcileDevServerTerminalBufferStore,
   replaceDevServerTerminalBuffer,
+  shouldReplaceDevServerTerminalBufferFromScript,
   syncDevServerTerminalBufferStore,
 } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 
@@ -124,12 +125,16 @@ export const useAgentStudioDevServerTerminalBuffers =
           const currentLastSequence = currentBuffer?.lastSequence ?? null;
           const baselineLastSequence =
             pendingReplaySync.baselineByScriptId.get(script.scriptId) ?? null;
-          const nextLastSequence = getLatestBufferedTerminalSequence(script);
           const shouldReplaceReplay =
             !pendingReplaySync.observedScriptIds.has(script.scriptId) ||
             currentLastSequence === baselineLastSequence ||
-            (nextLastSequence !== null &&
-              (currentLastSequence === null || nextLastSequence > currentLastSequence));
+            shouldReplaceDevServerTerminalBufferFromScript(
+              getDevServerTerminalBufferReplacementContext(
+                terminalBuffersRef.current,
+                script.scriptId,
+              ),
+              script,
+            );
 
           if (shouldReplaceReplay) {
             replaceDevServerTerminalBuffer(

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -8,6 +8,7 @@ import {
   getDevServerTerminalBuffer,
   getLatestBufferedTerminalSequence,
   replaceDevServerTerminalBuffer,
+  shouldReplaceDevServerTerminalBufferFromScript,
   syncDevServerTerminalBufferStore,
 } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 
@@ -64,13 +65,41 @@ export const useAgentStudioDevServerTerminalBuffers =
 
     const hydrateTerminalBuffersFromState = useCallback(
       (state: DevServerGroupState | null, selectedScriptId: string | null, force = false): void => {
-        if (!force && terminalBuffersRef.current.size > 0) {
+        if (state === null) {
+          if (force) {
+            replaceTerminalBuffersFromState(null, selectedScriptId);
+          }
           return;
         }
 
-        replaceTerminalBuffersFromState(state, selectedScriptId);
+        if (force || terminalBuffersRef.current.size === 0) {
+          replaceTerminalBuffersFromState(state, selectedScriptId);
+          return;
+        }
+
+        let didChange = false;
+        for (const script of state.scripts) {
+          const currentBuffer = getDevServerTerminalBuffer(
+            terminalBuffersRef.current,
+            script.scriptId,
+          );
+          if (!shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, script)) {
+            continue;
+          }
+
+          replaceDevServerTerminalBuffer(
+            terminalBuffersRef.current,
+            script.scriptId,
+            script.bufferedTerminalChunks,
+          );
+          didChange = true;
+        }
+
+        if (didChange) {
+          syncSelectedScriptTerminalBuffer(selectedScriptId);
+        }
       },
-      [replaceTerminalBuffersFromState],
+      [replaceTerminalBuffersFromState, syncSelectedScriptTerminalBuffer],
     );
 
     const beginMutationReplaySync = useCallback((state: DevServerGroupState | null): void => {

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -78,6 +78,16 @@ export const useAgentStudioDevServerTerminalBuffers =
         }
 
         let didChange = false;
+        const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
+        for (const scriptId of terminalBuffersRef.current.keys()) {
+          if (nextScriptIds.has(scriptId)) {
+            continue;
+          }
+
+          terminalBuffersRef.current.delete(scriptId);
+          didChange = true;
+        }
+
         for (const script of state.scripts) {
           const currentBuffer = getDevServerTerminalBuffer(
             terminalBuffersRef.current,

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -7,8 +7,8 @@ import {
   type DevServerTerminalBufferStore,
   getDevServerTerminalBuffer,
   getLatestBufferedTerminalSequence,
+  reconcileDevServerTerminalBufferStore,
   replaceDevServerTerminalBuffer,
-  shouldReplaceDevServerTerminalBufferFromScript,
   syncDevServerTerminalBufferStore,
 } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 
@@ -77,35 +77,7 @@ export const useAgentStudioDevServerTerminalBuffers =
           return;
         }
 
-        let didChange = false;
-        const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
-        for (const scriptId of terminalBuffersRef.current.keys()) {
-          if (nextScriptIds.has(scriptId)) {
-            continue;
-          }
-
-          terminalBuffersRef.current.delete(scriptId);
-          didChange = true;
-        }
-
-        for (const script of state.scripts) {
-          const currentBuffer = getDevServerTerminalBuffer(
-            terminalBuffersRef.current,
-            script.scriptId,
-          );
-          if (!shouldReplaceDevServerTerminalBufferFromScript(currentBuffer, script)) {
-            continue;
-          }
-
-          replaceDevServerTerminalBuffer(
-            terminalBuffersRef.current,
-            script.scriptId,
-            script.bufferedTerminalChunks,
-          );
-          didChange = true;
-        }
-
-        if (didChange) {
+        if (reconcileDevServerTerminalBufferStore(terminalBuffersRef.current, state)) {
           syncSelectedScriptTerminalBuffer(selectedScriptId);
         }
       },

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -3,9 +3,11 @@ import { useCallback, useRef, useState } from "react";
 import {
   type AgentStudioDevServerTerminalBuffer,
   appendDevServerTerminalChunk,
+  applyDevServerTerminalBufferReplacement,
   createDevServerTerminalBufferStore,
   type DevServerTerminalBufferStore,
   getDevServerTerminalBuffer,
+  getDevServerTerminalBufferReplacement,
   getDevServerTerminalBufferReplacementContext,
   reconcileDevServerTerminalBufferStore,
   replaceDevServerTerminalBuffer,
@@ -125,22 +127,32 @@ export const useAgentStudioDevServerTerminalBuffers =
           const currentLastSequence = currentBuffer?.lastSequence ?? null;
           const baselineLastSequence =
             pendingReplaySync.baselineByScriptId.get(script.scriptId) ?? null;
+          const currentContext = getDevServerTerminalBufferReplacementContext(
+            terminalBuffersRef.current,
+            script.scriptId,
+          );
+          // Replace if no live replay was observed, if we only re-observed the baseline,
+          // or if the authoritative replay window proves the local buffer is stale.
           const shouldReplaceReplay =
             !pendingReplaySync.observedScriptIds.has(script.scriptId) ||
             currentLastSequence === baselineLastSequence ||
-            shouldReplaceDevServerTerminalBufferFromScript(
-              getDevServerTerminalBufferReplacementContext(
-                terminalBuffersRef.current,
-                script.scriptId,
-              ),
-              script,
-            );
+            shouldReplaceDevServerTerminalBufferFromScript(currentContext, script);
 
           if (shouldReplaceReplay) {
-            replaceDevServerTerminalBuffer(
+            const replacement =
+              !pendingReplaySync.observedScriptIds.has(script.scriptId) ||
+              currentLastSequence === baselineLastSequence
+                ? getDevServerTerminalBufferReplacement(null, script)
+                : getDevServerTerminalBufferReplacement(currentContext, script);
+            if (replacement === null) {
+              continue;
+            }
+
+            // Mutation success replaces the replay baseline when no new live output arrived yet.
+            applyDevServerTerminalBufferReplacement(
               terminalBuffersRef.current,
               script.scriptId,
-              script.bufferedTerminalChunks,
+              replacement,
             );
           }
         }


### PR DESCRIPTION
## Summary
- fix stale dev-server log replay across refetch, reconnect, restart, and mutation reconciliation paths
- restore consistent terminal rendering for ANSI colors, split escape sequences, and split UTF-8 output
- add focused frontend and Rust regression coverage for replay hydration and PTY log streaming

## Goal
This PR fixes the dev-server log issues in Agent Studio where stale output could survive restarts or refetches, fresh output could disappear until navigating away and back, and ANSI-colored terminal output could degrade compared to a real terminal.

The goal is to make the dev-server panel behave like an authoritative terminal view: backend replay should clear stale history when appropriate, newer live chunks should not be overwritten by stale snapshots, and terminal formatting should survive chunk boundaries.

## Implementation
The frontend now centralizes replay reconciliation in the dev-server log buffer layer. It keeps the authoritative snapshot window internal to the buffer store, compares snapshot and live windows explicitly, and uses the same replacement policy for normal hydration and mutation-success reconciliation.

The mutation path now reuses that authoritative replay policy so missed replay-clearing status events cannot leave mixed old/new logs in the buffer when the backend later returns a reset replay window.

On the Rust side, spawned PTY-backed dev-server commands now receive `TERM=xterm-256color` and `COLORTERM=truecolor`, and the forwarding path is covered for split UTF-8 and split ANSI sequences so terminal output remains faithful to what color-aware tools emit in a real terminal.

## Verification
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced terminal color support in dev server output with 256-color and true color capabilities.

* **Bug Fixes**
  * Improved reliability of terminal output rendering when UTF-8 characters and ANSI escape sequences are split across buffer chunks.
  * Better terminal buffer management during dev server restart and reconnect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->