### PR TITLE
refactor(desktop): decompose settings modal controller flow

### DIFF
--- a/apps/desktop/src/components/features/settings/settings-modal-save-policy.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-save-policy.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import {
+  buildPromptValidationSaveError,
+  buildRepoScriptValidationSaveError,
+  hasAnyDirtySections,
+  hasSameNormalizedGlobalGitConfig,
+  isGlobalGitOnlySave,
+} from "./settings-modal-save-policy";
+import { EMPTY_DIRTY_SECTIONS } from "./use-settings-modal-dirty-state";
+
+const createSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  kanban: {
+    doneVisibleDays: 1,
+  },
+  autopilot: {
+    rules: [],
+  },
+  globalPromptOverrides: {},
+  workspaces: {},
+});
+
+describe("settings-modal-save-policy", () => {
+  test("derives dirty and global-git-only save modes", () => {
+    expect(hasAnyDirtySections(EMPTY_DIRTY_SECTIONS)).toBe(false);
+    expect(isGlobalGitOnlySave(EMPTY_DIRTY_SECTIONS)).toBe(false);
+
+    const globalGitOnly = {
+      ...EMPTY_DIRTY_SECTIONS,
+      globalGit: true,
+    };
+    expect(hasAnyDirtySections(globalGitOnly)).toBe(true);
+    expect(isGlobalGitOnlySave(globalGitOnly)).toBe(true);
+
+    expect(
+      isGlobalGitOnlySave({
+        ...globalGitOnly,
+        chat: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("compares normalized global git configs by persisted fields", () => {
+    expect(
+      hasSameNormalizedGlobalGitConfig(createSnapshot(), {
+        defaultMergeMethod: "merge_commit",
+      }),
+    ).toBe(true);
+    expect(
+      hasSameNormalizedGlobalGitConfig(createSnapshot(), {
+        defaultMergeMethod: "squash",
+      }),
+    ).toBe(false);
+    expect(
+      hasSameNormalizedGlobalGitConfig(null, {
+        defaultMergeMethod: "merge_commit",
+      }),
+    ).toBe(false);
+  });
+
+  test("builds the prompt and repo validation save errors", () => {
+    expect(buildPromptValidationSaveError(1)).toBe("Fix 1 prompt placeholder error before saving.");
+    expect(buildPromptValidationSaveError(2)).toBe(
+      "Fix 2 prompt placeholder errors before saving.",
+    );
+    expect(
+      buildRepoScriptValidationSaveError({
+        invalidRepoPathsWithDevServerErrors: ["repo", "repo-two"],
+        repoScriptValidationErrorCount: 2,
+        selectedWorkspaceId: "repo",
+      }),
+    ).toBe("Fix 2 dev server field errors in the selected repository, `repo-two` before saving.");
+  });
+});

--- a/apps/desktop/src/components/features/settings/settings-modal-save-policy.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-save-policy.ts
@@ -1,0 +1,51 @@
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import { normalizeGlobalGitConfigForSave } from "./settings-modal-normalization";
+import type { DirtySections } from "./use-settings-modal-dirty-state";
+
+export const hasAnyDirtySections = (dirtySections: DirtySections): boolean =>
+  dirtySections.chat ||
+  dirtySections.globalGit ||
+  dirtySections.kanban ||
+  dirtySections.autopilot ||
+  dirtySections.globalPromptOverrides ||
+  dirtySections.repoSettings;
+
+export const isGlobalGitOnlySave = (dirtySections: DirtySections): boolean =>
+  dirtySections.globalGit &&
+  !dirtySections.chat &&
+  !dirtySections.kanban &&
+  !dirtySections.autopilot &&
+  !dirtySections.globalPromptOverrides &&
+  !dirtySections.repoSettings;
+
+export const hasSameNormalizedGlobalGitConfig = (
+  loadedSnapshot: SettingsSnapshot | null,
+  normalizedGit: SettingsSnapshot["git"],
+): boolean =>
+  loadedSnapshot !== null &&
+  normalizeGlobalGitConfigForSave(loadedSnapshot.git).defaultMergeMethod ===
+    normalizedGit.defaultMergeMethod;
+
+export const buildPromptValidationSaveError = (totalErrorCount: number): string => {
+  const suffix = totalErrorCount > 1 ? "s" : "";
+  return `Fix ${totalErrorCount} prompt placeholder error${suffix} before saving.`;
+};
+
+export const buildRepoScriptValidationSaveError = ({
+  invalidRepoPathsWithDevServerErrors,
+  repoScriptValidationErrorCount,
+  selectedWorkspaceId,
+}: {
+  invalidRepoPathsWithDevServerErrors: string[];
+  repoScriptValidationErrorCount: number;
+  selectedWorkspaceId: string | null;
+}): string => {
+  const suffix = repoScriptValidationErrorCount > 1 ? "s" : "";
+  const invalidRepoSummary = invalidRepoPathsWithDevServerErrors
+    .map((workspaceId) =>
+      workspaceId === selectedWorkspaceId ? "the selected repository" : `\`${workspaceId}\``,
+    )
+    .join(", ");
+
+  return `Fix ${repoScriptValidationErrorCount} dev server field error${suffix} in ${invalidRepoSummary} before saving.`;
+};

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
@@ -424,6 +424,15 @@ describe("useSettingsModalController", () => {
         "Fix 1 dev server field error in the selected repository before saving.",
       );
       expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
+
+      await harness.run((state) => {
+        state.updateSelectedRepoConfig((repoConfig) => ({
+          ...repoConfig,
+          devServers: [{ id: "frontend", name: "Frontend", command: "pnpm dev" }],
+        }));
+      });
+
+      expect(harness.getLatest().saveError).toBeNull();
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
@@ -248,6 +248,30 @@ export const useSettingsModalController = ({
     saveGlobalGitConfig,
     saveSettingsSnapshot,
   });
+  const draftActions = useMemo(
+    () => ({
+      updateSelectedRepoConfig: applySelectedRepoConfigUpdate,
+      updateGlobalGitConfig: applyGlobalGitConfigUpdate,
+      updateGlobalChatSettings: applyGlobalChatSettingsUpdate,
+      updateGlobalKanbanSettings: applyGlobalKanbanSettingsUpdate,
+      updateGlobalAutopilotSettings: applyGlobalAutopilotSettingsUpdate,
+      updateGlobalPromptOverrides: applyGlobalPromptOverridesUpdate,
+      updateRepoPromptOverrides: applyRepoPromptOverridesUpdate,
+      updateSelectedRepoAgentDefault: applySelectedRepoAgentDefaultUpdate,
+      clearSelectedRepoAgentDefault: applyClearSelectedRepoAgentDefault,
+    }),
+    [
+      applySelectedRepoConfigUpdate,
+      applyGlobalGitConfigUpdate,
+      applyGlobalChatSettingsUpdate,
+      applyGlobalKanbanSettingsUpdate,
+      applyGlobalAutopilotSettingsUpdate,
+      applyGlobalPromptOverridesUpdate,
+      applyRepoPromptOverridesUpdate,
+      applySelectedRepoAgentDefaultUpdate,
+      applyClearSelectedRepoAgentDefault,
+    ],
+  );
   const {
     updateSelectedRepoConfig,
     updateGlobalGitConfig,
@@ -261,17 +285,7 @@ export const useSettingsModalController = ({
   } = useSettingsModalDirtyDraftActions({
     clearSaveError,
     markDirty,
-    draftActions: {
-      updateSelectedRepoConfig: applySelectedRepoConfigUpdate,
-      updateGlobalGitConfig: applyGlobalGitConfigUpdate,
-      updateGlobalChatSettings: applyGlobalChatSettingsUpdate,
-      updateGlobalKanbanSettings: applyGlobalKanbanSettingsUpdate,
-      updateGlobalAutopilotSettings: applyGlobalAutopilotSettingsUpdate,
-      updateGlobalPromptOverrides: applyGlobalPromptOverridesUpdate,
-      updateRepoPromptOverrides: applyRepoPromptOverridesUpdate,
-      updateSelectedRepoAgentDefault: applySelectedRepoAgentDefaultUpdate,
-      clearSelectedRepoAgentDefault: applyClearSelectedRepoAgentDefault,
-    },
+    draftActions,
   });
 
   const { detectSelectedRepoGithubRepository } = useSettingsModalRepositoryActions({

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
@@ -11,14 +11,8 @@ import type {
   WorkspaceRecord,
 } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
-import {
-  buildDevServerDraftValidationMap,
-  countDevServerDraftValidationErrors,
-  getNeededCatalogRuntimeKinds,
-} from "@/components/features/settings";
-import { errorMessage } from "@/lib/errors";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { getNeededCatalogRuntimeKinds } from "@/components/features/settings";
 import {
   ChecksStateContext,
   useRequiredContext,
@@ -27,33 +21,15 @@ import {
 } from "@/state/app-state-contexts";
 import type { PromptRoleTabId, SettingsSectionId } from "./settings-modal-constants";
 import type { PromptValidationState } from "./settings-modal-controller.types";
-import {
-  normalizeGlobalGitConfigForSave,
-  normalizeSnapshotForSave,
-} from "./settings-modal-normalization";
 import { useSettingsModalBranchesState } from "./use-settings-modal-branches-state";
 import { useSettingsModalCatalogState } from "./use-settings-modal-catalog-state";
+import { useSettingsModalDirtyState } from "./use-settings-modal-dirty-state";
 import { useSettingsModalDraftActions } from "./use-settings-modal-draft-actions";
 import { useSettingsModalPromptValidation } from "./use-settings-modal-prompt-validation";
+import { useSettingsModalRepoScriptValidation } from "./use-settings-modal-repo-script-validation";
+import { useSettingsModalRepositoryActions } from "./use-settings-modal-repository-actions";
+import { useSettingsModalSaveOrchestration } from "./use-settings-modal-save-orchestration";
 import { useSettingsModalSnapshotState } from "./use-settings-modal-snapshot-state";
-
-type DirtySections = {
-  chat: boolean;
-  globalGit: boolean;
-  kanban: boolean;
-  autopilot: boolean;
-  globalPromptOverrides: boolean;
-  repoSettings: boolean;
-};
-
-const EMPTY_DIRTY_SECTIONS: DirtySections = {
-  chat: false,
-  globalGit: false,
-  kanban: false,
-  autopilot: false,
-  globalPromptOverrides: false,
-  repoSettings: false,
-};
 
 export type SettingsModalController = {
   isLoadingSettings: boolean;
@@ -146,11 +122,6 @@ export const useSettingsModalController = ({
   const { runtimeDefinitions, isLoadingRuntimeDefinitions, runtimeDefinitionsError } =
     useRuntimeDefinitionsContext();
 
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [hasAttemptedRepoScriptSubmit, setHasAttemptedRepoScriptSubmit] = useState(false);
-  const [dirtySections, setDirtySections] = useState<DirtySections>(EMPTY_DIRTY_SECTIONS);
-
   const {
     loadedSnapshot,
     snapshotDraft,
@@ -231,6 +202,13 @@ export const useSettingsModalController = ({
     setSnapshotDraft,
   });
 
+  const clearSaveErrorRef = useRef<() => void>(() => {});
+  const { dirtySections, markDirty } = useSettingsModalDirtyState({
+    open,
+    loadedSnapshot,
+    onDirtyChange: () => clearSaveErrorRef.current(),
+  });
+
   const selectedRepoDefaultWorktreeBasePath = selectedWorkspace?.defaultWorktreeBasePath ?? null;
   const selectedRepoEffectiveWorktreeBasePath = useMemo(() => {
     const draftWorktreeBasePath = selectedRepoConfig?.worktreeBasePath?.trim();
@@ -240,61 +218,38 @@ export const useSettingsModalController = ({
 
     return selectedRepoDefaultWorktreeBasePath;
   }, [selectedRepoConfig?.worktreeBasePath, selectedRepoDefaultWorktreeBasePath]);
-  const selectedRepoDevServerValidationErrors = useMemo(() => {
-    if (!selectedRepoConfig) {
-      return {};
-    }
+  const {
+    selectedRepoDevServerValidationErrors,
+    invalidRepoPathsWithDevServerErrors,
+    repoScriptValidationErrorCount,
+    hasRepoScriptValidationErrors,
+  } = useSettingsModalRepoScriptValidation({
+    snapshotDraft,
+    selectedRepoConfig,
+  });
 
-    return buildDevServerDraftValidationMap(selectedRepoConfig.devServers ?? []);
-  }, [selectedRepoConfig]);
-  const repoScriptValidationSummary = useMemo(() => {
-    if (!snapshotDraft) {
-      return {
-        invalidRepoPathsWithDevServerErrors: [] as string[],
-        repoScriptValidationErrorCount: 0,
-      };
-    }
-
-    const invalidRepoPathsWithDevServerErrors: string[] = [];
-    let repoScriptValidationErrorCount = 0;
-
-    for (const [workspaceId, repoConfig] of Object.entries(snapshotDraft.workspaces)) {
-      const errorCount = countDevServerDraftValidationErrors(repoConfig.devServers ?? []);
-      if (errorCount > 0) {
-        invalidRepoPathsWithDevServerErrors.push(workspaceId);
-        repoScriptValidationErrorCount += errorCount;
-      }
-    }
-
-    invalidRepoPathsWithDevServerErrors.sort();
-
-    return {
-      invalidRepoPathsWithDevServerErrors,
-      repoScriptValidationErrorCount,
-    };
-  }, [snapshotDraft]);
-  const { invalidRepoPathsWithDevServerErrors, repoScriptValidationErrorCount } =
-    repoScriptValidationSummary;
-  const hasRepoScriptValidationErrors = repoScriptValidationErrorCount > 0;
-  const showRepoScriptValidationErrors =
-    hasAttemptedRepoScriptSubmit && hasRepoScriptValidationErrors;
-
-  const markRepoScriptSaveAttempt = useCallback((): void => {
-    setHasAttemptedRepoScriptSubmit(true);
-  }, []);
-
-  const markDirty = useCallback((section: keyof DirtySections): void => {
-    setSaveError(null);
-    setDirtySections((current) => {
-      if (current[section]) {
-        return current;
-      }
-      return {
-        ...current,
-        [section]: true,
-      };
-    });
-  }, []);
+  const {
+    isSaving,
+    saveError,
+    showRepoScriptValidationErrors,
+    clearSaveError,
+    markRepoScriptSaveAttempt,
+    submit,
+  } = useSettingsModalSaveOrchestration({
+    open,
+    loadedSnapshot,
+    snapshotDraft,
+    dirtySections,
+    hasPromptValidationErrors,
+    promptValidationState,
+    hasRepoScriptValidationErrors,
+    repoScriptValidationErrorCount,
+    invalidRepoPathsWithDevServerErrors,
+    selectedWorkspaceId,
+    saveGlobalGitConfig,
+    saveSettingsSnapshot,
+  });
+  clearSaveErrorRef.current = clearSaveError;
 
   const updateSelectedRepoConfig = useCallback(
     (updater: (current: RepoConfig) => RepoConfig): void => {
@@ -372,163 +327,17 @@ export const useSettingsModalController = ({
     [applyClearSelectedRepoAgentDefault, markDirty],
   );
 
+  const { detectSelectedRepoGithubRepository } = useSettingsModalRepositoryActions({
+    selectedRepoPath: selectedWorkspaceRepoPath,
+    detectGithubRepository,
+    updateSelectedRepoConfig,
+  });
+
   useEffect(() => {
     if (!open) {
-      setDirtySections(EMPTY_DIRTY_SECTIONS);
-      setSaveError(null);
-      setHasAttemptedRepoScriptSubmit(false);
       clearSettingsError();
     }
   }, [clearSettingsError, open]);
-
-  useEffect(() => {
-    if (!open || !loadedSnapshot) {
-      return;
-    }
-    setDirtySections(EMPTY_DIRTY_SECTIONS);
-    setHasAttemptedRepoScriptSubmit(false);
-  }, [loadedSnapshot, open]);
-
-  useEffect(() => {
-    if (!hasRepoScriptValidationErrors) {
-      setHasAttemptedRepoScriptSubmit(false);
-    }
-  }, [hasRepoScriptValidationErrors]);
-
-  const detectSelectedRepoGithubRepository = useCallback(async () => {
-    if (!selectedWorkspaceRepoPath) {
-      return null;
-    }
-
-    const detected = await detectGithubRepository(selectedWorkspaceRepoPath);
-    if (!detected) {
-      return null;
-    }
-
-    updateSelectedRepoConfig((repoConfig) => {
-      const currentGithub = repoConfig.git.providers.github ?? {
-        enabled: false,
-        autoDetected: false,
-      };
-      const hasExistingRepository = Boolean(currentGithub.repository);
-
-      return {
-        ...repoConfig,
-        git: {
-          ...repoConfig.git,
-          providers: {
-            ...repoConfig.git.providers,
-            github: {
-              enabled: hasExistingRepository ? currentGithub.enabled : true,
-              autoDetected: true,
-              repository: detected,
-            },
-          },
-        },
-      };
-    });
-
-    return detected;
-  }, [detectGithubRepository, selectedWorkspaceRepoPath, updateSelectedRepoConfig]);
-
-  const submit = useCallback(async (): Promise<boolean> => {
-    if (!snapshotDraft) {
-      return false;
-    }
-
-    if (hasPromptValidationErrors) {
-      const suffix = promptValidationState.totalErrorCount > 1 ? "s" : "";
-      const reason = `Fix ${promptValidationState.totalErrorCount} prompt placeholder error${suffix} before saving.`;
-      setSaveError(reason);
-      toast.error("Cannot save settings", {
-        description: reason,
-      });
-      return false;
-    }
-
-    if (hasRepoScriptValidationErrors) {
-      setHasAttemptedRepoScriptSubmit(true);
-      const suffix = repoScriptValidationErrorCount > 1 ? "s" : "";
-      const invalidRepoSummary = invalidRepoPathsWithDevServerErrors
-        .map((workspaceId) =>
-          workspaceId === selectedWorkspaceId ? "the selected repository" : `\`${workspaceId}\``,
-        )
-        .join(", ");
-      const reason = `Fix ${repoScriptValidationErrorCount} dev server field error${suffix} in ${invalidRepoSummary} before saving.`;
-      setSaveError(reason);
-      toast.error("Cannot save settings", {
-        description: reason,
-      });
-      return false;
-    }
-
-    setIsSaving(true);
-    setSaveError(null);
-
-    try {
-      if (
-        !dirtySections.chat &&
-        !dirtySections.globalGit &&
-        !dirtySections.kanban &&
-        !dirtySections.autopilot &&
-        !dirtySections.globalPromptOverrides &&
-        !dirtySections.repoSettings
-      ) {
-        return true;
-      }
-
-      const shouldUseGlobalGitSave =
-        dirtySections.globalGit &&
-        !dirtySections.chat &&
-        !dirtySections.kanban &&
-        !dirtySections.autopilot &&
-        !dirtySections.globalPromptOverrides &&
-        !dirtySections.repoSettings;
-
-      if (shouldUseGlobalGitSave) {
-        const normalizedGit = normalizeGlobalGitConfigForSave(snapshotDraft.git);
-        const loadedGit = loadedSnapshot
-          ? normalizeGlobalGitConfigForSave(loadedSnapshot.git)
-          : null;
-        if (loadedGit && loadedGit.defaultMergeMethod === normalizedGit.defaultMergeMethod) {
-          return true;
-        }
-
-        await saveGlobalGitConfig(normalizedGit);
-      } else {
-        const normalizedSnapshot = normalizeSnapshotForSave(snapshotDraft);
-        await saveSettingsSnapshot(normalizedSnapshot);
-      }
-
-      return true;
-    } catch (error: unknown) {
-      const reason = errorMessage(error);
-      setSaveError(reason);
-      toast.error("Failed to save workspace settings", {
-        description: reason,
-      });
-      return false;
-    } finally {
-      setIsSaving(false);
-    }
-  }, [
-    dirtySections.chat,
-    dirtySections.globalGit,
-    dirtySections.kanban,
-    dirtySections.autopilot,
-    dirtySections.globalPromptOverrides,
-    dirtySections.repoSettings,
-    hasPromptValidationErrors,
-    hasRepoScriptValidationErrors,
-    invalidRepoPathsWithDevServerErrors,
-    loadedSnapshot,
-    promptValidationState.totalErrorCount,
-    repoScriptValidationErrorCount,
-    selectedWorkspaceId,
-    saveGlobalGitConfig,
-    saveSettingsSnapshot,
-    snapshotDraft,
-  ]);
 
   return {
     isLoadingSettings,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
@@ -11,7 +11,7 @@ import type {
   WorkspaceRecord,
 } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 import { getNeededCatalogRuntimeKinds } from "@/components/features/settings";
 import {
   ChecksStateContext,
@@ -23,6 +23,7 @@ import type { PromptRoleTabId, SettingsSectionId } from "./settings-modal-consta
 import type { PromptValidationState } from "./settings-modal-controller.types";
 import { useSettingsModalBranchesState } from "./use-settings-modal-branches-state";
 import { useSettingsModalCatalogState } from "./use-settings-modal-catalog-state";
+import { useSettingsModalDirtyDraftActions } from "./use-settings-modal-dirty-draft-actions";
 import { useSettingsModalDirtyState } from "./use-settings-modal-dirty-state";
 import { useSettingsModalDraftActions } from "./use-settings-modal-draft-actions";
 import { useSettingsModalPromptValidation } from "./use-settings-modal-prompt-validation";
@@ -202,11 +203,9 @@ export const useSettingsModalController = ({
     setSnapshotDraft,
   });
 
-  const clearSaveErrorRef = useRef<() => void>(() => {});
   const { dirtySections, markDirty } = useSettingsModalDirtyState({
     open,
     loadedSnapshot,
-    onDirtyChange: () => clearSaveErrorRef.current(),
   });
 
   const selectedRepoDefaultWorktreeBasePath = selectedWorkspace?.defaultWorktreeBasePath ?? null;
@@ -249,83 +248,31 @@ export const useSettingsModalController = ({
     saveGlobalGitConfig,
     saveSettingsSnapshot,
   });
-  clearSaveErrorRef.current = clearSaveError;
-
-  const updateSelectedRepoConfig = useCallback(
-    (updater: (current: RepoConfig) => RepoConfig): void => {
-      markDirty("repoSettings");
-      applySelectedRepoConfigUpdate(updater);
+  const {
+    updateSelectedRepoConfig,
+    updateGlobalGitConfig,
+    updateGlobalChatSettings,
+    updateGlobalKanbanSettings,
+    updateGlobalAutopilotSettings,
+    updateGlobalPromptOverrides,
+    updateRepoPromptOverrides,
+    updateSelectedRepoAgentDefault,
+    clearSelectedRepoAgentDefault,
+  } = useSettingsModalDirtyDraftActions({
+    clearSaveError,
+    markDirty,
+    draftActions: {
+      updateSelectedRepoConfig: applySelectedRepoConfigUpdate,
+      updateGlobalGitConfig: applyGlobalGitConfigUpdate,
+      updateGlobalChatSettings: applyGlobalChatSettingsUpdate,
+      updateGlobalKanbanSettings: applyGlobalKanbanSettingsUpdate,
+      updateGlobalAutopilotSettings: applyGlobalAutopilotSettingsUpdate,
+      updateGlobalPromptOverrides: applyGlobalPromptOverridesUpdate,
+      updateRepoPromptOverrides: applyRepoPromptOverridesUpdate,
+      updateSelectedRepoAgentDefault: applySelectedRepoAgentDefaultUpdate,
+      clearSelectedRepoAgentDefault: applyClearSelectedRepoAgentDefault,
     },
-    [applySelectedRepoConfigUpdate, markDirty],
-  );
-
-  const updateGlobalGitConfig = useCallback(
-    (updater: (current: SettingsSnapshot["git"]) => SettingsSnapshot["git"]): void => {
-      markDirty("globalGit");
-      applyGlobalGitConfigUpdate(updater);
-    },
-    [applyGlobalGitConfigUpdate, markDirty],
-  );
-
-  const updateGlobalChatSettings = useCallback(
-    (updater: (current: SettingsSnapshot["chat"]) => SettingsSnapshot["chat"]): void => {
-      markDirty("chat");
-      applyGlobalChatSettingsUpdate(updater);
-    },
-    [applyGlobalChatSettingsUpdate, markDirty],
-  );
-
-  const updateGlobalKanbanSettings = useCallback(
-    (updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"]): void => {
-      markDirty("kanban");
-      applyGlobalKanbanSettingsUpdate(updater);
-    },
-    [applyGlobalKanbanSettingsUpdate, markDirty],
-  );
-
-  const updateGlobalPromptOverrides = useCallback(
-    (updater: (current: RepoPromptOverrides) => RepoPromptOverrides): void => {
-      markDirty("globalPromptOverrides");
-      applyGlobalPromptOverridesUpdate(updater);
-    },
-    [applyGlobalPromptOverridesUpdate, markDirty],
-  );
-
-  const updateGlobalAutopilotSettings = useCallback(
-    (updater: (current: SettingsSnapshot["autopilot"]) => SettingsSnapshot["autopilot"]): void => {
-      markDirty("autopilot");
-      applyGlobalAutopilotSettingsUpdate(updater);
-    },
-    [applyGlobalAutopilotSettingsUpdate, markDirty],
-  );
-
-  const updateRepoPromptOverrides = useCallback(
-    (updater: (current: RepoPromptOverrides) => RepoPromptOverrides): void => {
-      markDirty("repoSettings");
-      applyRepoPromptOverridesUpdate(updater);
-    },
-    [applyRepoPromptOverridesUpdate, markDirty],
-  );
-
-  const updateSelectedRepoAgentDefault = useCallback(
-    (
-      role: "spec" | "planner" | "build" | "qa",
-      field: "runtimeKind" | "providerId" | "modelId" | "variant" | "profileId",
-      value: string,
-    ): void => {
-      markDirty("repoSettings");
-      applySelectedRepoAgentDefaultUpdate(role, field, value);
-    },
-    [applySelectedRepoAgentDefaultUpdate, markDirty],
-  );
-
-  const clearSelectedRepoAgentDefault = useCallback(
-    (role: "spec" | "planner" | "build" | "qa"): void => {
-      markDirty("repoSettings");
-      applyClearSelectedRepoAgentDefault(role);
-    },
-    [applyClearSelectedRepoAgentDefault, markDirty],
-  );
+  });
 
   const { detectSelectedRepoGithubRepository } = useSettingsModalRepositoryActions({
     selectedRepoPath: selectedWorkspaceRepoPath,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-dirty-draft-actions.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-dirty-draft-actions.test.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import { useState } from "react";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "@/pages/agents/agent-studio-test-utils";
+import { useSettingsModalDirtyDraftActions } from "./use-settings-modal-dirty-draft-actions";
+import type { DirtySections } from "./use-settings-modal-dirty-state";
+import { useSettingsModalDraftActions } from "./use-settings-modal-draft-actions";
+
+enableReactActEnvironment();
+
+type HookArgs = {
+  selectedWorkspaceId: string | null;
+  initialSnapshot: SettingsSnapshot;
+};
+
+const createSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  kanban: {
+    doneVisibleDays: 1,
+  },
+  autopilot: {
+    rules: [],
+  },
+  globalPromptOverrides: {},
+  workspaces: {
+    repo: {
+      workspaceId: "repo",
+      workspaceName: "Repo",
+      repoPath: "/repo",
+      defaultRuntimeKind: "opencode",
+      branchPrefix: "odt",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: { providers: {} },
+      trustedHooks: false,
+      hooks: { preStart: [], postComplete: [] },
+      devServers: [],
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    },
+  },
+});
+
+const useDirtyDraftActionsHarness = ({ selectedWorkspaceId, initialSnapshot }: HookArgs) => {
+  const [snapshotDraft, setSnapshotDraft] = useState<SettingsSnapshot | null>(initialSnapshot);
+  const [dirtyCalls, setDirtyCalls] = useState<(keyof DirtySections)[]>([]);
+  const [clearSaveError] = useState(() => mock(() => {}));
+  const draftActions = useSettingsModalDraftActions({
+    selectedWorkspaceId,
+    setSnapshotDraft,
+  });
+  const actions = useSettingsModalDirtyDraftActions({
+    clearSaveError,
+    markDirty: (section) => {
+      setDirtyCalls((current) => [...current, section]);
+    },
+    draftActions,
+  });
+
+  return {
+    snapshotDraft,
+    dirtyCalls,
+    clearSaveError,
+    ...actions,
+  };
+};
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useDirtyDraftActionsHarness, initialProps);
+
+describe("useSettingsModalDirtyDraftActions", () => {
+  test("clears save errors and marks the matching section before updating draft state", async () => {
+    const harness = createHookHarness({
+      selectedWorkspaceId: "repo",
+      initialSnapshot: createSnapshot(),
+    });
+
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.updateGlobalChatSettings((chat) => ({
+        ...chat,
+        showThinkingMessages: true,
+      }));
+      state.updateSelectedRepoConfig((repoConfig) => ({
+        ...repoConfig,
+        branchPrefix: "feature/",
+      }));
+    });
+
+    expect(harness.getLatest().clearSaveError).toHaveBeenCalledTimes(2);
+    expect(harness.getLatest().dirtyCalls).toEqual(["chat", "repoSettings"]);
+    expect(harness.getLatest().snapshotDraft?.chat.showThinkingMessages).toBe(true);
+    expect(harness.getLatest().snapshotDraft?.workspaces.repo?.branchPrefix).toBe("feature/");
+
+    await harness.unmount();
+  });
+
+  test("routes repo prompt override and agent default edits through repo settings dirty tracking", async () => {
+    const harness = createHookHarness({
+      selectedWorkspaceId: "repo",
+      initialSnapshot: createSnapshot(),
+    });
+
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.updateRepoPromptOverrides((overrides) => ({
+        ...overrides,
+        "kickoff.spec_initial": {
+          template: "custom",
+          baseVersion: 1,
+          enabled: true,
+        },
+      }));
+      state.updateSelectedRepoAgentDefault("build", "profileId", "builder");
+    });
+
+    expect(harness.getLatest().dirtyCalls).toEqual(["repoSettings", "repoSettings"]);
+    expect(
+      harness.getLatest().snapshotDraft?.workspaces.repo?.promptOverrides["kickoff.spec_initial"]
+        ?.template,
+    ).toBe("custom");
+    expect(harness.getLatest().snapshotDraft?.workspaces.repo?.agentDefaults.build?.profileId).toBe(
+      "builder",
+    );
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/settings/use-settings-modal-dirty-draft-actions.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-dirty-draft-actions.ts
@@ -1,0 +1,124 @@
+import type { RepoConfig, RepoPromptOverrides, SettingsSnapshot } from "@openducktor/contracts";
+import { useCallback } from "react";
+import type { DirtySections } from "./use-settings-modal-dirty-state";
+import type { SettingsModalDraftActions } from "./use-settings-modal-draft-actions";
+
+type UseSettingsModalDirtyDraftActionsArgs = {
+  clearSaveError: () => void;
+  markDirty: (section: keyof DirtySections) => void;
+  draftActions: SettingsModalDraftActions;
+};
+
+type SettingsModalDirtyDraftActions = SettingsModalDraftActions;
+
+export const useSettingsModalDirtyDraftActions = ({
+  clearSaveError,
+  markDirty,
+  draftActions,
+}: UseSettingsModalDirtyDraftActionsArgs): SettingsModalDirtyDraftActions => {
+  const runDirtyAction = useCallback(
+    (section: keyof DirtySections, action: () => void): void => {
+      clearSaveError();
+      markDirty(section);
+      action();
+    },
+    [clearSaveError, markDirty],
+  );
+
+  const updateSelectedRepoConfig = useCallback(
+    (updater: (current: RepoConfig) => RepoConfig): void => {
+      runDirtyAction("repoSettings", () => {
+        draftActions.updateSelectedRepoConfig(updater);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  const updateGlobalGitConfig = useCallback(
+    (updater: (current: SettingsSnapshot["git"]) => SettingsSnapshot["git"]): void => {
+      runDirtyAction("globalGit", () => {
+        draftActions.updateGlobalGitConfig(updater);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  const updateGlobalChatSettings = useCallback(
+    (updater: (current: SettingsSnapshot["chat"]) => SettingsSnapshot["chat"]): void => {
+      runDirtyAction("chat", () => {
+        draftActions.updateGlobalChatSettings(updater);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  const updateGlobalKanbanSettings = useCallback(
+    (updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"]): void => {
+      runDirtyAction("kanban", () => {
+        draftActions.updateGlobalKanbanSettings(updater);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  const updateGlobalAutopilotSettings = useCallback(
+    (updater: (current: SettingsSnapshot["autopilot"]) => SettingsSnapshot["autopilot"]): void => {
+      runDirtyAction("autopilot", () => {
+        draftActions.updateGlobalAutopilotSettings(updater);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  const updateGlobalPromptOverrides = useCallback(
+    (updater: (current: RepoPromptOverrides) => RepoPromptOverrides): void => {
+      runDirtyAction("globalPromptOverrides", () => {
+        draftActions.updateGlobalPromptOverrides(updater);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  const updateRepoPromptOverrides = useCallback(
+    (updater: (current: RepoPromptOverrides) => RepoPromptOverrides): void => {
+      runDirtyAction("repoSettings", () => {
+        draftActions.updateRepoPromptOverrides(updater);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  const updateSelectedRepoAgentDefault = useCallback(
+    (
+      role: "spec" | "planner" | "build" | "qa",
+      field: "runtimeKind" | "providerId" | "modelId" | "variant" | "profileId",
+      value: string,
+    ): void => {
+      runDirtyAction("repoSettings", () => {
+        draftActions.updateSelectedRepoAgentDefault(role, field, value);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  const clearSelectedRepoAgentDefault = useCallback(
+    (role: "spec" | "planner" | "build" | "qa"): void => {
+      runDirtyAction("repoSettings", () => {
+        draftActions.clearSelectedRepoAgentDefault(role);
+      });
+    },
+    [draftActions, runDirtyAction],
+  );
+
+  return {
+    updateSelectedRepoConfig,
+    updateGlobalGitConfig,
+    updateGlobalChatSettings,
+    updateGlobalKanbanSettings,
+    updateGlobalAutopilotSettings,
+    updateGlobalPromptOverrides,
+    updateRepoPromptOverrides,
+    updateSelectedRepoAgentDefault,
+    clearSelectedRepoAgentDefault,
+  };
+};

--- a/apps/desktop/src/components/features/settings/use-settings-modal-dirty-state.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-dirty-state.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { SettingsSnapshot } from "@openducktor/contracts";
 import {
   createHookHarness as createSharedHookHarness,
@@ -32,12 +32,10 @@ const createSnapshot = (): SettingsSnapshot => ({
 });
 
 describe("useSettingsModalDirtyState", () => {
-  test("marks sections dirty, calls the dirty callback, and resets when the modal closes", async () => {
-    const onDirtyChange = mock(() => {});
+  test("marks sections dirty and resets when the modal closes", async () => {
     const harness = createHookHarness({
       open: true,
       loadedSnapshot: createSnapshot(),
-      onDirtyChange,
     });
 
     await harness.mount();
@@ -48,7 +46,6 @@ describe("useSettingsModalDirtyState", () => {
       state.markDirty("chat");
     });
 
-    expect(onDirtyChange).toHaveBeenCalledTimes(3);
     expect(harness.getLatest().dirtySections).toEqual({
       chat: true,
       globalGit: false,
@@ -61,7 +58,6 @@ describe("useSettingsModalDirtyState", () => {
     await harness.update({
       open: false,
       loadedSnapshot: createSnapshot(),
-      onDirtyChange,
     });
 
     expect(harness.getLatest().dirtySections).toEqual({

--- a/apps/desktop/src/components/features/settings/use-settings-modal-dirty-state.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-dirty-state.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "@/pages/agents/agent-studio-test-utils";
+import { useSettingsModalDirtyState } from "./use-settings-modal-dirty-state";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useSettingsModalDirtyState>[0];
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useSettingsModalDirtyState, initialProps);
+
+const createSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  kanban: {
+    doneVisibleDays: 1,
+  },
+  autopilot: {
+    rules: [],
+  },
+  globalPromptOverrides: {},
+  workspaces: {},
+});
+
+describe("useSettingsModalDirtyState", () => {
+  test("marks sections dirty, calls the dirty callback, and resets when the modal closes", async () => {
+    const onDirtyChange = mock(() => {});
+    const harness = createHookHarness({
+      open: true,
+      loadedSnapshot: createSnapshot(),
+      onDirtyChange,
+    });
+
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.markDirty("repoSettings");
+      state.markDirty("repoSettings");
+      state.markDirty("chat");
+    });
+
+    expect(onDirtyChange).toHaveBeenCalledTimes(3);
+    expect(harness.getLatest().dirtySections).toEqual({
+      chat: true,
+      globalGit: false,
+      kanban: false,
+      autopilot: false,
+      globalPromptOverrides: false,
+      repoSettings: true,
+    });
+
+    await harness.update({
+      open: false,
+      loadedSnapshot: createSnapshot(),
+      onDirtyChange,
+    });
+
+    expect(harness.getLatest().dirtySections).toEqual({
+      chat: false,
+      globalGit: false,
+      kanban: false,
+      autopilot: false,
+      globalPromptOverrides: false,
+      repoSettings: false,
+    });
+
+    await harness.unmount();
+  });
+
+  test("resets dirty sections when a fresh snapshot loads while open", async () => {
+    const harness = createHookHarness({
+      open: true,
+      loadedSnapshot: createSnapshot(),
+    });
+
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.markDirty("globalGit");
+    });
+
+    expect(harness.getLatest().dirtySections.globalGit).toBe(true);
+
+    await harness.update({
+      open: true,
+      loadedSnapshot: {
+        ...createSnapshot(),
+        chat: {
+          showThinkingMessages: true,
+        },
+      },
+    });
+
+    expect(harness.getLatest().dirtySections.globalGit).toBe(false);
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/settings/use-settings-modal-dirty-state.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-dirty-state.ts
@@ -1,0 +1,75 @@
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import { useCallback, useEffect, useState } from "react";
+
+export type DirtySections = {
+  chat: boolean;
+  globalGit: boolean;
+  kanban: boolean;
+  autopilot: boolean;
+  globalPromptOverrides: boolean;
+  repoSettings: boolean;
+};
+
+export const EMPTY_DIRTY_SECTIONS: DirtySections = {
+  chat: false,
+  globalGit: false,
+  kanban: false,
+  autopilot: false,
+  globalPromptOverrides: false,
+  repoSettings: false,
+};
+
+type UseSettingsModalDirtyStateArgs = {
+  open: boolean;
+  loadedSnapshot: SettingsSnapshot | null;
+  onDirtyChange?: () => void;
+};
+
+type SettingsModalDirtyState = {
+  dirtySections: DirtySections;
+  markDirty: (section: keyof DirtySections) => void;
+};
+
+export const useSettingsModalDirtyState = ({
+  open,
+  loadedSnapshot,
+  onDirtyChange,
+}: UseSettingsModalDirtyStateArgs): SettingsModalDirtyState => {
+  const [dirtySections, setDirtySections] = useState<DirtySections>(EMPTY_DIRTY_SECTIONS);
+
+  const markDirty = useCallback(
+    (section: keyof DirtySections): void => {
+      onDirtyChange?.();
+      setDirtySections((current) => {
+        if (current[section]) {
+          return current;
+        }
+
+        return {
+          ...current,
+          [section]: true,
+        };
+      });
+    },
+    [onDirtyChange],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setDirtySections(EMPTY_DIRTY_SECTIONS);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !loadedSnapshot) {
+      return;
+    }
+
+    setDirtySections(EMPTY_DIRTY_SECTIONS);
+  }, [loadedSnapshot, open]);
+
+  return {
+    dirtySections,
+    markDirty,
+  };
+};

--- a/apps/desktop/src/components/features/settings/use-settings-modal-dirty-state.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-dirty-state.ts
@@ -22,7 +22,6 @@ export const EMPTY_DIRTY_SECTIONS: DirtySections = {
 type UseSettingsModalDirtyStateArgs = {
   open: boolean;
   loadedSnapshot: SettingsSnapshot | null;
-  onDirtyChange?: () => void;
 };
 
 type SettingsModalDirtyState = {
@@ -33,26 +32,21 @@ type SettingsModalDirtyState = {
 export const useSettingsModalDirtyState = ({
   open,
   loadedSnapshot,
-  onDirtyChange,
 }: UseSettingsModalDirtyStateArgs): SettingsModalDirtyState => {
   const [dirtySections, setDirtySections] = useState<DirtySections>(EMPTY_DIRTY_SECTIONS);
 
-  const markDirty = useCallback(
-    (section: keyof DirtySections): void => {
-      onDirtyChange?.();
-      setDirtySections((current) => {
-        if (current[section]) {
-          return current;
-        }
+  const markDirty = useCallback((section: keyof DirtySections): void => {
+    setDirtySections((current) => {
+      if (current[section]) {
+        return current;
+      }
 
-        return {
-          ...current,
-          [section]: true,
-        };
-      });
-    },
-    [onDirtyChange],
-  );
+      return {
+        ...current,
+        [section]: true,
+      };
+    });
+  }, []);
 
   useEffect(() => {
     if (!open) {

--- a/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.ts
@@ -13,7 +13,7 @@ type UseSettingsModalDraftActionsArgs = {
   setSnapshotDraft: Dispatch<SetStateAction<SettingsSnapshot | null>>;
 };
 
-type SettingsModalDraftActions = {
+export type SettingsModalDraftActions = {
   updateSelectedRepoConfig: (updater: (current: RepoConfig) => RepoConfig) => void;
   updateGlobalGitConfig: (updater: (current: GlobalGitConfig) => GlobalGitConfig) => void;
   updateGlobalChatSettings: (

--- a/apps/desktop/src/components/features/settings/use-settings-modal-repo-script-validation.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-repo-script-validation.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "@/pages/agents/agent-studio-test-utils";
+import { useSettingsModalRepoScriptValidation } from "./use-settings-modal-repo-script-validation";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useSettingsModalRepoScriptValidation>[0];
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useSettingsModalRepoScriptValidation, initialProps);
+
+const createSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  kanban: {
+    doneVisibleDays: 1,
+  },
+  autopilot: {
+    rules: [],
+  },
+  globalPromptOverrides: {},
+  workspaces: {
+    "repo-a": {
+      workspaceId: "repo-a",
+      workspaceName: "Repo A",
+      repoPath: "/repo-a",
+      defaultRuntimeKind: "opencode",
+      branchPrefix: "odt",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: { providers: {} },
+      trustedHooks: false,
+      hooks: { preStart: [], postComplete: [] },
+      devServers: [{ id: "frontend", name: "Frontend", command: "" }],
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    },
+    "repo-b": {
+      workspaceId: "repo-b",
+      workspaceName: "Repo B",
+      repoPath: "/repo-b",
+      defaultRuntimeKind: "opencode",
+      branchPrefix: "odt",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: { providers: {} },
+      trustedHooks: false,
+      hooks: { preStart: [], postComplete: [] },
+      devServers: [{ id: "backend", name: "", command: "" }],
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    },
+  },
+});
+
+describe("useSettingsModalRepoScriptValidation", () => {
+  test("returns selected repo errors and aggregate error counts across repositories", async () => {
+    const snapshotDraft = createSnapshot();
+    const harness = createHookHarness({
+      snapshotDraft,
+      selectedRepoConfig: snapshotDraft.workspaces["repo-a"] ?? null,
+    });
+
+    await harness.mount();
+    const latest = harness.getLatest();
+
+    expect(latest.selectedRepoDevServerValidationErrors).toEqual({
+      frontend: {
+        command: "Command is required.",
+      },
+    });
+    expect(latest.invalidRepoPathsWithDevServerErrors).toEqual(["repo-a", "repo-b"]);
+    expect(latest.repoScriptValidationErrorCount).toBe(3);
+    expect(latest.hasRepoScriptValidationErrors).toBe(true);
+
+    await harness.unmount();
+  });
+
+  test("returns an empty validation state when the draft is missing", async () => {
+    const harness = createHookHarness({
+      snapshotDraft: null,
+      selectedRepoConfig: null,
+    });
+
+    await harness.mount();
+
+    expect(harness.getLatest()).toEqual({
+      selectedRepoDevServerValidationErrors: {},
+      invalidRepoPathsWithDevServerErrors: [],
+      repoScriptValidationErrorCount: 0,
+      hasRepoScriptValidationErrors: false,
+    });
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/settings/use-settings-modal-repo-script-validation.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-repo-script-validation.ts
@@ -1,0 +1,66 @@
+import type { RepoConfig, SettingsSnapshot } from "@openducktor/contracts";
+import { useMemo } from "react";
+import {
+  buildDevServerDraftValidationMap,
+  countDevServerDraftValidationErrors,
+} from "./settings-model";
+
+type UseSettingsModalRepoScriptValidationArgs = {
+  snapshotDraft: SettingsSnapshot | null;
+  selectedRepoConfig: RepoConfig | null;
+};
+
+type SettingsModalRepoScriptValidation = {
+  selectedRepoDevServerValidationErrors: Record<string, { name?: string; command?: string }>;
+  invalidRepoPathsWithDevServerErrors: string[];
+  repoScriptValidationErrorCount: number;
+  hasRepoScriptValidationErrors: boolean;
+};
+
+export const useSettingsModalRepoScriptValidation = ({
+  snapshotDraft,
+  selectedRepoConfig,
+}: UseSettingsModalRepoScriptValidationArgs): SettingsModalRepoScriptValidation => {
+  const selectedRepoDevServerValidationErrors = useMemo(() => {
+    if (!selectedRepoConfig) {
+      return {};
+    }
+
+    return buildDevServerDraftValidationMap(selectedRepoConfig.devServers ?? []);
+  }, [selectedRepoConfig]);
+
+  const repoScriptValidationSummary = useMemo(() => {
+    if (!snapshotDraft) {
+      return {
+        invalidRepoPathsWithDevServerErrors: [] as string[],
+        repoScriptValidationErrorCount: 0,
+      };
+    }
+
+    const invalidRepoPathsWithDevServerErrors: string[] = [];
+    let repoScriptValidationErrorCount = 0;
+
+    for (const [workspaceId, repoConfig] of Object.entries(snapshotDraft.workspaces)) {
+      const errorCount = countDevServerDraftValidationErrors(repoConfig.devServers ?? []);
+      if (errorCount > 0) {
+        invalidRepoPathsWithDevServerErrors.push(workspaceId);
+        repoScriptValidationErrorCount += errorCount;
+      }
+    }
+
+    invalidRepoPathsWithDevServerErrors.sort();
+
+    return {
+      invalidRepoPathsWithDevServerErrors,
+      repoScriptValidationErrorCount,
+    };
+  }, [snapshotDraft]);
+
+  return {
+    selectedRepoDevServerValidationErrors,
+    invalidRepoPathsWithDevServerErrors:
+      repoScriptValidationSummary.invalidRepoPathsWithDevServerErrors,
+    repoScriptValidationErrorCount: repoScriptValidationSummary.repoScriptValidationErrorCount,
+    hasRepoScriptValidationErrors: repoScriptValidationSummary.repoScriptValidationErrorCount > 0,
+  };
+};

--- a/apps/desktop/src/components/features/settings/use-settings-modal-repository-actions.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-repository-actions.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { GitProviderRepository, RepoConfig } from "@openducktor/contracts";
+import { useState } from "react";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "@/pages/agents/agent-studio-test-utils";
+import { useSettingsModalRepositoryActions } from "./use-settings-modal-repository-actions";
+
+enableReactActEnvironment();
+
+type HookArgs = {
+  selectedRepoPath: string | null;
+  initialRepoConfig: RepoConfig;
+  detectGithubRepository: (repoPath: string) => Promise<GitProviderRepository | null>;
+};
+
+const createRepoConfig = (): RepoConfig => ({
+  workspaceId: "repo-a",
+  workspaceName: "Repo A",
+  repoPath: "/repo-a",
+  defaultRuntimeKind: "opencode",
+  branchPrefix: "odt",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  git: {
+    providers: {},
+  },
+  trustedHooks: false,
+  hooks: { preStart: [], postComplete: [] },
+  devServers: [],
+  worktreeFileCopies: [],
+  promptOverrides: {},
+  agentDefaults: {},
+});
+
+const useRepositoryActionsHarness = ({
+  selectedRepoPath,
+  initialRepoConfig,
+  detectGithubRepository,
+}: HookArgs) => {
+  const [repoConfig, setRepoConfig] = useState(initialRepoConfig);
+  const actions = useSettingsModalRepositoryActions({
+    selectedRepoPath,
+    detectGithubRepository,
+    updateSelectedRepoConfig: (updater) => {
+      setRepoConfig((current) => updater(current));
+    },
+  });
+
+  return {
+    repoConfig,
+    ...actions,
+  };
+};
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useRepositoryActionsHarness, initialProps);
+
+describe("useSettingsModalRepositoryActions", () => {
+  test("no-ops when no repository is selected", async () => {
+    const detectGithubRepository = mock(async () => ({
+      host: "github.com",
+      owner: "duck",
+      name: "repo",
+    }));
+    const harness = createHookHarness({
+      selectedRepoPath: null,
+      initialRepoConfig: createRepoConfig(),
+      detectGithubRepository,
+    });
+
+    await harness.mount();
+
+    let detected: GitProviderRepository | null = null;
+    await harness.run(async (state) => {
+      detected = await state.detectSelectedRepoGithubRepository();
+    });
+
+    expect(detected).toBeNull();
+    expect(detectGithubRepository).toHaveBeenCalledTimes(0);
+    expect(harness.getLatest().repoConfig.git.providers.github).toBeUndefined();
+
+    await harness.unmount();
+  });
+
+  test("updates the selected repo github config and preserves an existing enabled state", async () => {
+    const detectGithubRepository = mock(async () => ({
+      host: "github.com",
+      owner: "duck",
+      name: "repo",
+    }));
+    const initialRepoConfig: RepoConfig = {
+      ...createRepoConfig(),
+      git: {
+        providers: {
+          github: {
+            enabled: false,
+            autoDetected: false,
+            repository: { host: "github.com", owner: "existing", name: "repo" },
+          },
+        },
+      },
+    };
+    const harness = createHookHarness({
+      selectedRepoPath: "/repo-a",
+      initialRepoConfig,
+      detectGithubRepository,
+    });
+
+    await harness.mount();
+
+    let detected: unknown = null;
+    await harness.run(async (state) => {
+      detected = await state.detectSelectedRepoGithubRepository();
+    });
+
+    expect(detectGithubRepository).toHaveBeenCalledWith("/repo-a");
+    expect(detected).not.toBeNull();
+    if (typeof detected !== "object" || detected === null) {
+      throw new Error("Expected detected repository");
+    }
+    const detectedRepo = detected as GitProviderRepository;
+    expect(detectedRepo.host).toBe("github.com");
+    expect(detectedRepo.owner).toBe("duck");
+    expect(detectedRepo.name).toBe("repo");
+    const githubProvider = harness.getLatest().repoConfig.git.providers.github;
+    if (!githubProvider) {
+      throw new Error("Expected GitHub provider settings");
+    }
+    expect(githubProvider.enabled).toBe(false);
+    expect(githubProvider.autoDetected).toBe(true);
+    expect(githubProvider.repository?.host).toBe("github.com");
+    expect(githubProvider.repository?.owner).toBe("duck");
+    expect(githubProvider.repository?.name).toBe("repo");
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/settings/use-settings-modal-repository-actions.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-repository-actions.ts
@@ -1,0 +1,58 @@
+import type { GitProviderRepository, RepoConfig } from "@openducktor/contracts";
+import { useCallback } from "react";
+
+type UseSettingsModalRepositoryActionsArgs = {
+  selectedRepoPath: string | null;
+  detectGithubRepository: (repoPath: string) => Promise<GitProviderRepository | null>;
+  updateSelectedRepoConfig: (updater: (current: RepoConfig) => RepoConfig) => void;
+};
+
+type SettingsModalRepositoryActions = {
+  detectSelectedRepoGithubRepository: () => Promise<GitProviderRepository | null>;
+};
+
+export const useSettingsModalRepositoryActions = ({
+  selectedRepoPath,
+  detectGithubRepository,
+  updateSelectedRepoConfig,
+}: UseSettingsModalRepositoryActionsArgs): SettingsModalRepositoryActions => {
+  const detectSelectedRepoGithubRepository = useCallback(async () => {
+    if (!selectedRepoPath) {
+      return null;
+    }
+
+    const detected = await detectGithubRepository(selectedRepoPath);
+    if (!detected) {
+      return null;
+    }
+
+    updateSelectedRepoConfig((repoConfig) => {
+      const currentGithub = repoConfig.git.providers.github ?? {
+        enabled: false,
+        autoDetected: false,
+      };
+      const hasExistingRepository = Boolean(currentGithub.repository);
+
+      return {
+        ...repoConfig,
+        git: {
+          ...repoConfig.git,
+          providers: {
+            ...repoConfig.git.providers,
+            github: {
+              enabled: hasExistingRepository ? currentGithub.enabled : true,
+              autoDetected: true,
+              repository: detected,
+            },
+          },
+        },
+      };
+    });
+
+    return detected;
+  }, [detectGithubRepository, selectedRepoPath, updateSelectedRepoConfig]);
+
+  return {
+    detectSelectedRepoGithubRepository,
+  };
+};

--- a/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
@@ -68,6 +68,18 @@ const createArgs = (
   ...overrides,
 });
 
+const createDeferred = <TValue,>() => {
+  let resolve!: (value: TValue | PromiseLike<TValue>) => void;
+  const promise = new Promise<TValue>((innerResolve) => {
+    resolve = innerResolve;
+  });
+
+  return {
+    promise,
+    resolve,
+  };
+};
+
 describe("useSettingsModalSaveOrchestration", () => {
   test("returns false when no draft exists", async () => {
     const harness = createHookHarness(
@@ -175,6 +187,53 @@ describe("useSettingsModalSaveOrchestration", () => {
     expect(didSave).toBe(true);
     expect(saveGlobalGitConfig).toHaveBeenCalledTimes(0);
     expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
+
+    await harness.unmount();
+  });
+
+  test("rejects concurrent submit attempts while a save is already in flight", async () => {
+    const deferredSave = createDeferred<void>();
+    const saveSettingsSnapshot = mock(async () => {
+      await deferredSave.promise;
+    });
+    const harness = createHookHarness(
+      createArgs(
+        {
+          saveSettingsSnapshot,
+        },
+        {
+          ...EMPTY_DIRTY_SECTIONS,
+          chat: true,
+        },
+      ),
+    );
+
+    await harness.mount();
+
+    let firstSubmit: Promise<boolean> | undefined;
+    let secondResult = true;
+    await harness.run(async (state) => {
+      firstSubmit = state.submit();
+      secondResult = await state.submit();
+    });
+
+    expect(saveSettingsSnapshot).toHaveBeenCalledTimes(1);
+    expect(secondResult).toBe(false);
+    expect(harness.getLatest().isSaving).toBe(true);
+
+    deferredSave.resolve();
+    if (!firstSubmit) {
+      throw new Error("Expected first submit promise");
+    }
+    await harness.run(async () => {
+      deferredSave.resolve();
+      await firstSubmit;
+    });
+    const firstResult = await firstSubmit;
+    await harness.waitFor((state) => !state.isSaving);
+
+    expect(firstResult).toBe(true);
+    expect(harness.getLatest().isSaving).toBe(false);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
@@ -1,0 +1,309 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "@/pages/agents/agent-studio-test-utils";
+import { EMPTY_PROMPT_VALIDATION_STATE } from "./settings-modal-controller.types";
+import { type DirtySections, EMPTY_DIRTY_SECTIONS } from "./use-settings-modal-dirty-state";
+import { useSettingsModalSaveOrchestration } from "./use-settings-modal-save-orchestration";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useSettingsModalSaveOrchestration>[0];
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useSettingsModalSaveOrchestration, initialProps);
+
+const createSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  kanban: {
+    doneVisibleDays: 1,
+  },
+  autopilot: {
+    rules: [],
+  },
+  globalPromptOverrides: {},
+  workspaces: {
+    repo: {
+      workspaceId: "repo",
+      workspaceName: "Repo",
+      repoPath: "/repo",
+      defaultRuntimeKind: "opencode",
+      branchPrefix: "odt",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: { providers: {} },
+      trustedHooks: false,
+      hooks: { preStart: [], postComplete: [] },
+      devServers: [],
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    },
+  },
+});
+
+const createArgs = (
+  overrides: Partial<HookArgs> = {},
+  dirtySections: DirtySections = EMPTY_DIRTY_SECTIONS,
+): HookArgs => ({
+  open: true,
+  loadedSnapshot: createSnapshot(),
+  snapshotDraft: createSnapshot(),
+  dirtySections,
+  hasPromptValidationErrors: false,
+  promptValidationState: EMPTY_PROMPT_VALIDATION_STATE,
+  hasRepoScriptValidationErrors: false,
+  repoScriptValidationErrorCount: 0,
+  invalidRepoPathsWithDevServerErrors: [],
+  selectedWorkspaceId: "repo",
+  saveGlobalGitConfig: mock(async () => {}),
+  saveSettingsSnapshot: mock(async () => {}),
+  ...overrides,
+});
+
+describe("useSettingsModalSaveOrchestration", () => {
+  test("returns false when no draft exists", async () => {
+    const harness = createHookHarness(
+      createArgs({
+        snapshotDraft: null,
+      }),
+    );
+
+    await harness.mount();
+
+    let didSave = true;
+    await harness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(false);
+
+    await harness.unmount();
+  });
+
+  test("blocks prompt validation errors before persistence", async () => {
+    const saveSettingsSnapshot = mock(async () => {});
+    const harness = createHookHarness(
+      createArgs({
+        hasPromptValidationErrors: true,
+        promptValidationState: {
+          ...EMPTY_PROMPT_VALIDATION_STATE,
+          totalErrorCount: 2,
+        },
+        saveSettingsSnapshot,
+      }),
+    );
+
+    await harness.mount();
+
+    let didSave = true;
+    await harness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(false);
+    expect(harness.getLatest().saveError).toBe("Fix 2 prompt placeholder errors before saving.");
+    expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
+
+    await harness.unmount();
+  });
+
+  test("blocks repo script validation errors, shows submit-gated errors, and resets the gate when validation clears", async () => {
+    const harness = createHookHarness(
+      createArgs({
+        hasRepoScriptValidationErrors: true,
+        repoScriptValidationErrorCount: 1,
+        invalidRepoPathsWithDevServerErrors: ["repo"],
+      }),
+    );
+
+    await harness.mount();
+
+    expect(harness.getLatest().showRepoScriptValidationErrors).toBe(false);
+
+    let didSave = true;
+    await harness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(false);
+    expect(harness.getLatest().showRepoScriptValidationErrors).toBe(true);
+    expect(harness.getLatest().saveError).toBe(
+      "Fix 1 dev server field error in the selected repository before saving.",
+    );
+
+    await harness.update(
+      createArgs(
+        {
+          hasRepoScriptValidationErrors: false,
+          repoScriptValidationErrorCount: 0,
+          invalidRepoPathsWithDevServerErrors: [],
+        },
+        EMPTY_DIRTY_SECTIONS,
+      ),
+    );
+
+    expect(harness.getLatest().showRepoScriptValidationErrors).toBe(false);
+
+    await harness.unmount();
+  });
+
+  test("returns true without persistence when nothing is dirty", async () => {
+    const saveGlobalGitConfig = mock(async () => {});
+    const saveSettingsSnapshot = mock(async () => {});
+    const harness = createHookHarness(
+      createArgs({
+        saveGlobalGitConfig,
+        saveSettingsSnapshot,
+      }),
+    );
+
+    await harness.mount();
+
+    let didSave = false;
+    await harness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(true);
+    expect(saveGlobalGitConfig).toHaveBeenCalledTimes(0);
+    expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
+
+    await harness.unmount();
+  });
+
+  test("short-circuits unchanged global git saves and uses the optimized git path when needed", async () => {
+    const unchangedSaveGlobalGitConfig = mock(async () => {});
+    const unchangedHarness = createHookHarness(
+      createArgs(
+        {
+          saveGlobalGitConfig: unchangedSaveGlobalGitConfig,
+        },
+        {
+          ...EMPTY_DIRTY_SECTIONS,
+          globalGit: true,
+        },
+      ),
+    );
+
+    await unchangedHarness.mount();
+
+    let didSave = false;
+    await unchangedHarness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(true);
+    expect(unchangedSaveGlobalGitConfig).toHaveBeenCalledTimes(0);
+
+    await unchangedHarness.unmount();
+
+    const saveGlobalGitConfig = mock(async () => {});
+    const changedSnapshot = createSnapshot();
+    changedSnapshot.git.defaultMergeMethod = "squash";
+    const changedHarness = createHookHarness(
+      createArgs(
+        {
+          snapshotDraft: changedSnapshot,
+          saveGlobalGitConfig,
+        },
+        {
+          ...EMPTY_DIRTY_SECTIONS,
+          globalGit: true,
+        },
+      ),
+    );
+
+    await changedHarness.mount();
+
+    await changedHarness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(true);
+    expect(saveGlobalGitConfig).toHaveBeenCalledWith({
+      defaultMergeMethod: "squash",
+    });
+
+    await changedHarness.unmount();
+  });
+
+  test("saves the normalized snapshot when non-git sections are dirty", async () => {
+    const saveSettingsSnapshot = mock(async () => {});
+    const snapshotDraft = createSnapshot();
+    snapshotDraft.chat.showThinkingMessages = true;
+    const harness = createHookHarness(
+      createArgs(
+        {
+          snapshotDraft,
+          saveSettingsSnapshot,
+        },
+        {
+          ...EMPTY_DIRTY_SECTIONS,
+          chat: true,
+        },
+      ),
+    );
+
+    await harness.mount();
+
+    let didSave = false;
+    await harness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(true);
+    expect(saveSettingsSnapshot).toHaveBeenCalledTimes(1);
+    expect(saveSettingsSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chat: {
+          showThinkingMessages: true,
+        },
+      }),
+    );
+
+    await harness.unmount();
+  });
+
+  test("surfaces normalization errors before persistence", async () => {
+    const saveSettingsSnapshot = mock(async () => {});
+    const snapshotDraft = createSnapshot();
+    const repoConfig = snapshotDraft.workspaces.repo;
+    if (!repoConfig) {
+      throw new Error("Expected repo settings fixture");
+    }
+    repoConfig.defaultRuntimeKind = "   ";
+    const harness = createHookHarness(
+      createArgs(
+        {
+          snapshotDraft,
+          saveSettingsSnapshot,
+        },
+        {
+          ...EMPTY_DIRTY_SECTIONS,
+          repoSettings: true,
+        },
+      ),
+    );
+
+    await harness.mount();
+
+    let didSave = true;
+    await harness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(false);
+    expect(harness.getLatest().saveError).toBe("Default runtime kind cannot be blank.");
+    expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.ts
@@ -1,0 +1,186 @@
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { errorMessage } from "@/lib/errors";
+import type { PromptValidationState } from "./settings-modal-controller.types";
+import {
+  normalizeGlobalGitConfigForSave,
+  normalizeSnapshotForSave,
+} from "./settings-modal-normalization";
+import type { DirtySections } from "./use-settings-modal-dirty-state";
+
+type UseSettingsModalSaveOrchestrationArgs = {
+  open: boolean;
+  loadedSnapshot: SettingsSnapshot | null;
+  snapshotDraft: SettingsSnapshot | null;
+  dirtySections: DirtySections;
+  hasPromptValidationErrors: boolean;
+  promptValidationState: PromptValidationState;
+  hasRepoScriptValidationErrors: boolean;
+  repoScriptValidationErrorCount: number;
+  invalidRepoPathsWithDevServerErrors: string[];
+  selectedWorkspaceId: string | null;
+  saveGlobalGitConfig: (config: SettingsSnapshot["git"]) => Promise<void>;
+  saveSettingsSnapshot: (snapshot: SettingsSnapshot) => Promise<void>;
+};
+
+type SettingsModalSaveOrchestration = {
+  isSaving: boolean;
+  saveError: string | null;
+  showRepoScriptValidationErrors: boolean;
+  clearSaveError: () => void;
+  markRepoScriptSaveAttempt: () => void;
+  submit: () => Promise<boolean>;
+};
+
+const hasAnyDirtySections = (dirtySections: DirtySections): boolean =>
+  dirtySections.chat ||
+  dirtySections.globalGit ||
+  dirtySections.kanban ||
+  dirtySections.autopilot ||
+  dirtySections.globalPromptOverrides ||
+  dirtySections.repoSettings;
+
+const isGlobalGitOnlySave = (dirtySections: DirtySections): boolean =>
+  dirtySections.globalGit &&
+  !dirtySections.chat &&
+  !dirtySections.kanban &&
+  !dirtySections.autopilot &&
+  !dirtySections.globalPromptOverrides &&
+  !dirtySections.repoSettings;
+
+export const useSettingsModalSaveOrchestration = ({
+  open,
+  loadedSnapshot,
+  snapshotDraft,
+  dirtySections,
+  hasPromptValidationErrors,
+  promptValidationState,
+  hasRepoScriptValidationErrors,
+  repoScriptValidationErrorCount,
+  invalidRepoPathsWithDevServerErrors,
+  selectedWorkspaceId,
+  saveGlobalGitConfig,
+  saveSettingsSnapshot,
+}: UseSettingsModalSaveOrchestrationArgs): SettingsModalSaveOrchestration => {
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [hasAttemptedRepoScriptSubmit, setHasAttemptedRepoScriptSubmit] = useState(false);
+
+  const clearSaveError = useCallback((): void => {
+    setSaveError(null);
+  }, []);
+
+  const markRepoScriptSaveAttempt = useCallback((): void => {
+    setHasAttemptedRepoScriptSubmit(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setSaveError(null);
+      setHasAttemptedRepoScriptSubmit(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !loadedSnapshot) {
+      return;
+    }
+
+    setHasAttemptedRepoScriptSubmit(false);
+  }, [loadedSnapshot, open]);
+
+  useEffect(() => {
+    if (!hasRepoScriptValidationErrors) {
+      setHasAttemptedRepoScriptSubmit(false);
+    }
+  }, [hasRepoScriptValidationErrors]);
+
+  const submit = useCallback(async (): Promise<boolean> => {
+    if (!snapshotDraft) {
+      return false;
+    }
+
+    if (hasPromptValidationErrors) {
+      const suffix = promptValidationState.totalErrorCount > 1 ? "s" : "";
+      const reason = `Fix ${promptValidationState.totalErrorCount} prompt placeholder error${suffix} before saving.`;
+      setSaveError(reason);
+      toast.error("Cannot save settings", {
+        description: reason,
+      });
+      return false;
+    }
+
+    if (hasRepoScriptValidationErrors) {
+      setHasAttemptedRepoScriptSubmit(true);
+      const suffix = repoScriptValidationErrorCount > 1 ? "s" : "";
+      const invalidRepoSummary = invalidRepoPathsWithDevServerErrors
+        .map((workspaceId) =>
+          workspaceId === selectedWorkspaceId ? "the selected repository" : `\`${workspaceId}\``,
+        )
+        .join(", ");
+      const reason = `Fix ${repoScriptValidationErrorCount} dev server field error${suffix} in ${invalidRepoSummary} before saving.`;
+      setSaveError(reason);
+      toast.error("Cannot save settings", {
+        description: reason,
+      });
+      return false;
+    }
+
+    setIsSaving(true);
+    setSaveError(null);
+
+    try {
+      if (!hasAnyDirtySections(dirtySections)) {
+        return true;
+      }
+
+      if (isGlobalGitOnlySave(dirtySections)) {
+        const normalizedGit = normalizeGlobalGitConfigForSave(snapshotDraft.git);
+        const loadedGit = loadedSnapshot
+          ? normalizeGlobalGitConfigForSave(loadedSnapshot.git)
+          : null;
+        if (loadedGit && loadedGit.defaultMergeMethod === normalizedGit.defaultMergeMethod) {
+          return true;
+        }
+
+        await saveGlobalGitConfig(normalizedGit);
+      } else {
+        const normalizedSnapshot = normalizeSnapshotForSave(snapshotDraft);
+        await saveSettingsSnapshot(normalizedSnapshot);
+      }
+
+      return true;
+    } catch (error: unknown) {
+      const reason = errorMessage(error);
+      setSaveError(reason);
+      toast.error("Failed to save workspace settings", {
+        description: reason,
+      });
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    dirtySections,
+    hasPromptValidationErrors,
+    hasRepoScriptValidationErrors,
+    invalidRepoPathsWithDevServerErrors,
+    loadedSnapshot,
+    promptValidationState.totalErrorCount,
+    repoScriptValidationErrorCount,
+    saveGlobalGitConfig,
+    saveSettingsSnapshot,
+    selectedWorkspaceId,
+    snapshotDraft,
+  ]);
+
+  return {
+    isSaving,
+    saveError,
+    showRepoScriptValidationErrors: hasAttemptedRepoScriptSubmit && hasRepoScriptValidationErrors,
+    clearSaveError,
+    markRepoScriptSaveAttempt,
+    submit,
+  };
+};

--- a/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.ts
@@ -7,6 +7,13 @@ import {
   normalizeGlobalGitConfigForSave,
   normalizeSnapshotForSave,
 } from "./settings-modal-normalization";
+import {
+  buildPromptValidationSaveError,
+  buildRepoScriptValidationSaveError,
+  hasAnyDirtySections,
+  hasSameNormalizedGlobalGitConfig,
+  isGlobalGitOnlySave,
+} from "./settings-modal-save-policy";
 import type { DirtySections } from "./use-settings-modal-dirty-state";
 
 type UseSettingsModalSaveOrchestrationArgs = {
@@ -32,22 +39,6 @@ type SettingsModalSaveOrchestration = {
   markRepoScriptSaveAttempt: () => void;
   submit: () => Promise<boolean>;
 };
-
-const hasAnyDirtySections = (dirtySections: DirtySections): boolean =>
-  dirtySections.chat ||
-  dirtySections.globalGit ||
-  dirtySections.kanban ||
-  dirtySections.autopilot ||
-  dirtySections.globalPromptOverrides ||
-  dirtySections.repoSettings;
-
-const isGlobalGitOnlySave = (dirtySections: DirtySections): boolean =>
-  dirtySections.globalGit &&
-  !dirtySections.chat &&
-  !dirtySections.kanban &&
-  !dirtySections.autopilot &&
-  !dirtySections.globalPromptOverrides &&
-  !dirtySections.repoSettings;
 
 export const useSettingsModalSaveOrchestration = ({
   open,
@@ -102,8 +93,7 @@ export const useSettingsModalSaveOrchestration = ({
     }
 
     if (hasPromptValidationErrors) {
-      const suffix = promptValidationState.totalErrorCount > 1 ? "s" : "";
-      const reason = `Fix ${promptValidationState.totalErrorCount} prompt placeholder error${suffix} before saving.`;
+      const reason = buildPromptValidationSaveError(promptValidationState.totalErrorCount);
       setSaveError(reason);
       toast.error("Cannot save settings", {
         description: reason,
@@ -113,13 +103,11 @@ export const useSettingsModalSaveOrchestration = ({
 
     if (hasRepoScriptValidationErrors) {
       setHasAttemptedRepoScriptSubmit(true);
-      const suffix = repoScriptValidationErrorCount > 1 ? "s" : "";
-      const invalidRepoSummary = invalidRepoPathsWithDevServerErrors
-        .map((workspaceId) =>
-          workspaceId === selectedWorkspaceId ? "the selected repository" : `\`${workspaceId}\``,
-        )
-        .join(", ");
-      const reason = `Fix ${repoScriptValidationErrorCount} dev server field error${suffix} in ${invalidRepoSummary} before saving.`;
+      const reason = buildRepoScriptValidationSaveError({
+        invalidRepoPathsWithDevServerErrors,
+        repoScriptValidationErrorCount,
+        selectedWorkspaceId,
+      });
       setSaveError(reason);
       toast.error("Cannot save settings", {
         description: reason,
@@ -137,10 +125,7 @@ export const useSettingsModalSaveOrchestration = ({
 
       if (isGlobalGitOnlySave(dirtySections)) {
         const normalizedGit = normalizeGlobalGitConfigForSave(snapshotDraft.git);
-        const loadedGit = loadedSnapshot
-          ? normalizeGlobalGitConfigForSave(loadedSnapshot.git)
-          : null;
-        if (loadedGit && loadedGit.defaultMergeMethod === normalizedGit.defaultMergeMethod) {
+        if (hasSameNormalizedGlobalGitConfig(loadedSnapshot, normalizedGit)) {
           return true;
         }
 

--- a/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-save-orchestration.ts
@@ -1,5 +1,5 @@
 import type { SettingsSnapshot } from "@openducktor/contracts";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import type { PromptValidationState } from "./settings-modal-controller.types";
@@ -57,6 +57,7 @@ export const useSettingsModalSaveOrchestration = ({
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [hasAttemptedRepoScriptSubmit, setHasAttemptedRepoScriptSubmit] = useState(false);
+  const saveInFlightRef = useRef(false);
 
   const clearSaveError = useCallback((): void => {
     setSaveError(null);
@@ -88,7 +89,7 @@ export const useSettingsModalSaveOrchestration = ({
   }, [hasRepoScriptValidationErrors]);
 
   const submit = useCallback(async (): Promise<boolean> => {
-    if (!snapshotDraft) {
+    if (saveInFlightRef.current || !snapshotDraft) {
       return false;
     }
 
@@ -115,20 +116,24 @@ export const useSettingsModalSaveOrchestration = ({
       return false;
     }
 
-    setIsSaving(true);
     setSaveError(null);
 
+    if (!hasAnyDirtySections(dirtySections)) {
+      return true;
+    }
+
+    const normalizedGit = isGlobalGitOnlySave(dirtySections)
+      ? normalizeGlobalGitConfigForSave(snapshotDraft.git)
+      : null;
+    if (normalizedGit && hasSameNormalizedGlobalGitConfig(loadedSnapshot, normalizedGit)) {
+      return true;
+    }
+
+    saveInFlightRef.current = true;
+    setIsSaving(true);
+
     try {
-      if (!hasAnyDirtySections(dirtySections)) {
-        return true;
-      }
-
-      if (isGlobalGitOnlySave(dirtySections)) {
-        const normalizedGit = normalizeGlobalGitConfigForSave(snapshotDraft.git);
-        if (hasSameNormalizedGlobalGitConfig(loadedSnapshot, normalizedGit)) {
-          return true;
-        }
-
+      if (normalizedGit) {
         await saveGlobalGitConfig(normalizedGit);
       } else {
         const normalizedSnapshot = normalizeSnapshotForSave(snapshotDraft);
@@ -144,6 +149,7 @@ export const useSettingsModalSaveOrchestration = ({
       });
       return false;
     } finally {
+      saveInFlightRef.current = false;
       setIsSaving(false);
     }
   }, [


### PR DESCRIPTION
## Summary
- split the settings modal controller into focused hooks for dirty tracking, repository actions, repo-script validation, and save orchestration
- route settings edits through dirty-tracked draft actions and extract save-policy helpers to keep controller and save orchestration responsibilities narrow
- add targeted settings tests that preserve existing save, validation, and error-clearing behavior through the refactor

## Goal
This pull request refactors the desktop settings modal internals without intentionally changing the user-facing behavior. The goal is to reduce the complexity concentrated in `use-settings-modal-controller.ts`, make the save path easier to reason about, and keep validation and repository-specific behavior in smaller, focused units.

## Implementation
The controller now acts primarily as a wiring layer that composes dedicated hooks for snapshot state, dirty tracking, dirty-aware draft actions, repository actions, validation aggregation, and save orchestration. The save orchestration still enforces the same prompt and repo-script validation gates, but the pure save-policy decisions were extracted into helpers so the hook can focus on state transitions, normalization, persistence, and toast/error handling.

The follow-up cleanup removes the prior bridge between dirty-state changes and save-error clearing. Instead, draft edits now flow through a dedicated dirty-tracked actions hook that explicitly clears stale save errors and marks the corresponding settings section dirty before applying the draft update. That keeps the behavior explicit at the action boundary and leaves the dirty-state hook responsible only for dirty-section bookkeeping.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized settings modal code architecture for improved maintainability, separating dirty state tracking, save orchestration, and repository detection into dedicated components.
  * Enhanced validation error messaging for repository configurations and prompt placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->