### PR TITLE
refactor(runtime): generalize runtime-backed fork and query flows

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup_status.rs
@@ -168,7 +168,8 @@ impl AppService {
             .get(status_key.as_str())
             .cloned()
         {
-            if snapshot.stage != RepoRuntimeStartupStage::RuntimeReady && existing_runtime.is_none() {
+            if snapshot.stage != RepoRuntimeStartupStage::RuntimeReady && existing_runtime.is_none()
+            {
                 return Ok(snapshot.to_public_status());
             }
         }
@@ -208,11 +209,11 @@ impl AppService {
 #[cfg(test)]
 mod tests {
     use super::{RuntimeStartupFailure, RuntimeStartupProgress};
-    use crate::AppService;
     use crate::app_service::service_core::AgentRuntimeProcess;
     use crate::app_service::test_support::{
         build_service_with_state, builtin_opencode_runtime_descriptor,
     };
+    use crate::AppService;
     use anyhow::Result;
     use host_domain::{
         AgentRuntimeKind, RepoRuntimeStartupFailureKind, RepoRuntimeStartupStage, RuntimeRole,
@@ -460,7 +461,10 @@ mod tests {
 
         assert_eq!(status.stage, RepoRuntimeStartupStage::RuntimeReady);
         assert_eq!(
-            status.runtime.as_ref().map(|value| value.runtime_id.as_str()),
+            status
+                .runtime
+                .as_ref()
+                .map(|value| value.runtime_id.as_str()),
             Some("runtime-live")
         );
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
@@ -59,9 +59,10 @@ const requireForkSourceRuntime = (
       runtimeKind: sourceRuntimeKind,
       runtimeConnection: resolveRuntimeConnection(sourceRuntime),
     };
-  } catch {
+  } catch (error) {
     throw new Error(
       `Session "${sourceSessionId}" is missing live runtime context required for forking.`,
+      { cause: error },
     );
   }
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
@@ -1,11 +1,6 @@
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RuntimeInfo } from "../runtime/runtime";
-import {
-  requireRuntimeConnectionSupport,
-  resolveRuntimeConnection,
-  resolveRuntimeRoute,
-} from "../runtime/runtime";
+import { requireRuntimeConnectionSupport, resolveRuntimeConnection } from "../runtime/runtime";
 import { throwIfRepoStale } from "../support/core";
 import { createSessionMessagesState, getSessionMessagesSlice } from "../support/messages";
 import { historyToChatMessages } from "../support/persistence";
@@ -46,50 +41,28 @@ export const executeForkStart = async ({
     deps,
     sourceSessionId: input.sourceSessionId,
   });
+  const sourceRuntimeKind = sourceSession.runtimeKind;
+  if (!sourceRuntimeKind) {
+    throw new Error(
+      `Session "${input.sourceSessionId}" is missing runtime kind metadata required for forking.`,
+    );
+  }
   const taskCard = resolveStartTask({ ctx, task: deps.task });
-  const resolved = await resolveRuntimeAndModel({
-    ctx,
-    scenario: input.scenario,
-    requestedRuntimeKind: input.selectedModel.runtimeKind,
-    targetWorkingDirectory: sourceSession.workingDirectory,
-    taskCard,
-    deps,
-  });
   const selectedModel = input.selectedModel;
 
-  if (
-    sourceSession.runtimeKind &&
-    selectedModel.runtimeKind &&
-    sourceSession.runtimeKind !== selectedModel.runtimeKind
-  ) {
+  if (selectedModel.runtimeKind && sourceRuntimeKind !== selectedModel.runtimeKind) {
     throw new Error(
-      `Session "${input.sourceSessionId}" cannot be forked with runtime "${selectedModel.runtimeKind}" because it belongs to runtime "${sourceSession.runtimeKind}".`,
+      `Session "${input.sourceSessionId}" cannot be forked with runtime "${selectedModel.runtimeKind}" because it belongs to runtime "${sourceRuntimeKind}".`,
     );
   }
 
-  assertScenarioStartPolicy({
-    role: ctx.role,
-    scenario: resolved.resolvedScenario,
-    startMode: input.startMode,
-  });
-
-  const runtimeKind =
-    sourceSession.runtimeKind ??
-    resolved.runtime.runtimeKind ??
-    selectedModel?.runtimeKind ??
-    DEFAULT_RUNTIME_KIND;
   const sourceRuntime: RuntimeInfo = {
-    runtimeKind,
-    runtimeId: sourceSession.runtimeId ?? resolved.runtime.runtimeId,
-    runId: sourceSession.runId ?? resolved.runtime.runId,
-    runtimeRoute: sourceSession.runtimeRoute ?? resolved.runtime.runtimeRoute,
+    runtimeKind: sourceRuntimeKind,
+    runtimeId: sourceSession.runtimeId,
+    runId: sourceSession.runId,
+    runtimeRoute: sourceSession.runtimeRoute,
     workingDirectory: sourceSession.workingDirectory,
-    ...(sourceSession.runtimeRoute
-      ? {}
-      : { runtimeConnection: resolved.runtime.runtimeConnection }),
-    ...(resolved.runtime.kind ? { kind: resolved.runtime.kind } : {}),
   };
-
   const runtimeConnection = (() => {
     try {
       return resolveRuntimeConnection(sourceRuntime);
@@ -99,6 +72,23 @@ export const executeForkStart = async ({
       );
     }
   })();
+
+  const resolved = await resolveRuntimeAndModel({
+    ctx,
+    scenario: input.scenario,
+    requestedRuntimeKind: selectedModel.runtimeKind,
+    targetWorkingDirectory: sourceSession.workingDirectory,
+    taskCard,
+    deps,
+  });
+
+  assertScenarioStartPolicy({
+    role: ctx.role,
+    scenario: resolved.resolvedScenario,
+    startMode: input.startMode,
+  });
+
+  const runtimeKind = sourceRuntimeKind;
   const supportedRuntimeConnection = requireRuntimeConnectionSupport(
     runtimeKind,
     runtimeConnection,
@@ -184,15 +174,12 @@ export const executeForkStart = async ({
 
   const forkedRuntime: RuntimeInfo = {
     runtimeKind,
-    runtimeId: sourceRuntime.runtimeId,
-    runId: sourceRuntime.runId,
-    runtimeRoute: resolveRuntimeRoute({
-      ...sourceRuntime,
-      runtimeConnection: supportedRuntimeConnection,
-    }),
+    runtimeId: sourceSession.runtimeId,
+    runId: sourceSession.runId,
+    runtimeRoute: sourceSession.runtimeRoute,
     runtimeConnection: supportedRuntimeConnection,
     workingDirectory: sourceSession.workingDirectory,
-    ...(sourceRuntime.kind ? { kind: sourceRuntime.kind } : {}),
+    ...(resolved.runtime.kind ? { kind: resolved.runtime.kind } : {}),
   };
 
   return registerStartedSession({

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
@@ -1,3 +1,4 @@
+import type { AgentRuntimeConnection } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RuntimeInfo } from "../runtime/runtime";
 import { requireRuntimeConnectionSupport, resolveRuntimeConnection } from "../runtime/runtime";
@@ -19,7 +20,7 @@ import {
   rollbackStartedSessionBeforeRegistration,
   stopSessionOnStaleAndThrow,
 } from "./start-session-rollback";
-import { resolveRuntimeAndModel } from "./start-session-runtime";
+import { resolveScenarioAndPrompt } from "./start-session-runtime";
 
 // Match the requested-history hydration cap so newly forked child sessions load
 // enough history to render immediately without pulling an unbounded transcript.
@@ -29,6 +30,40 @@ type ForkStrategyInput = {
   ctx: StartSessionContext;
   input: Extract<StartSessionCreationInput, { startMode: "fork" }>;
   deps: StartSessionExecutionDependencies;
+};
+
+const requireForkSourceRuntime = (
+  sourceSessionId: string,
+  sourceSession: AgentSessionState,
+): {
+  runtimeKind: NonNullable<AgentSessionState["runtimeKind"]>;
+  runtimeConnection: AgentRuntimeConnection;
+} => {
+  const sourceRuntimeKind = sourceSession.runtimeKind;
+  if (!sourceRuntimeKind) {
+    throw new Error(
+      `Session "${sourceSessionId}" is missing runtime kind metadata required for forking.`,
+    );
+  }
+
+  const sourceRuntime: RuntimeInfo = {
+    runtimeKind: sourceRuntimeKind,
+    runtimeId: sourceSession.runtimeId,
+    runId: sourceSession.runId,
+    runtimeRoute: sourceSession.runtimeRoute,
+    workingDirectory: sourceSession.workingDirectory,
+  };
+
+  try {
+    return {
+      runtimeKind: sourceRuntimeKind,
+      runtimeConnection: resolveRuntimeConnection(sourceRuntime),
+    };
+  } catch {
+    throw new Error(
+      `Session "${sourceSessionId}" is missing live runtime context required for forking.`,
+    );
+  }
 };
 
 export const executeForkStart = async ({
@@ -41,12 +76,8 @@ export const executeForkStart = async ({
     deps,
     sourceSessionId: input.sourceSessionId,
   });
-  const sourceRuntimeKind = sourceSession.runtimeKind;
-  if (!sourceRuntimeKind) {
-    throw new Error(
-      `Session "${input.sourceSessionId}" is missing runtime kind metadata required for forking.`,
-    );
-  }
+  const { runtimeKind: sourceRuntimeKind, runtimeConnection: sourceRuntimeConnection } =
+    requireForkSourceRuntime(input.sourceSessionId, sourceSession);
   const taskCard = resolveStartTask({ ctx, task: deps.task });
   const selectedModel = input.selectedModel;
 
@@ -56,42 +87,23 @@ export const executeForkStart = async ({
     );
   }
 
-  const sourceRuntime: RuntimeInfo = {
-    runtimeKind: sourceRuntimeKind,
-    runtimeId: sourceSession.runtimeId,
-    runId: sourceSession.runId,
-    runtimeRoute: sourceSession.runtimeRoute,
-    workingDirectory: sourceSession.workingDirectory,
-  };
-  const runtimeConnection = (() => {
-    try {
-      return resolveRuntimeConnection(sourceRuntime);
-    } catch {
-      throw new Error(
-        `Session "${input.sourceSessionId}" is missing live runtime context required for forking.`,
-      );
-    }
-  })();
-
-  const resolved = await resolveRuntimeAndModel({
+  const promptContext = await resolveScenarioAndPrompt({
     ctx,
     scenario: input.scenario,
-    requestedRuntimeKind: selectedModel.runtimeKind,
-    targetWorkingDirectory: sourceSession.workingDirectory,
     taskCard,
     deps,
   });
 
   assertScenarioStartPolicy({
     role: ctx.role,
-    scenario: resolved.resolvedScenario,
+    scenario: promptContext.resolvedScenario,
     startMode: input.startMode,
   });
 
   const runtimeKind = sourceRuntimeKind;
   const supportedRuntimeConnection = requireRuntimeConnectionSupport(
     runtimeKind,
-    runtimeConnection,
+    sourceRuntimeConnection,
     "fork session",
   );
 
@@ -102,8 +114,8 @@ export const executeForkStart = async ({
     workingDirectory: sourceSession.workingDirectory,
     taskId: ctx.taskId,
     role: ctx.role,
-    scenario: resolved.resolvedScenario,
-    systemPrompt: resolved.systemPrompt,
+    scenario: promptContext.resolvedScenario,
+    systemPrompt: promptContext.systemPrompt,
     ...(sourceSession.runtimeId ? { runtimeId: sourceSession.runtimeId } : {}),
     ...(selectedModel ? { model: selectedModel } : {}),
     parentExternalSessionId: sourceSession.externalSessionId,
@@ -111,7 +123,7 @@ export const executeForkStart = async ({
 
   const startedCtx = {
     ...ctx,
-    resolvedScenario: resolved.resolvedScenario,
+    resolvedScenario: promptContext.resolvedScenario,
     summary,
   };
 
@@ -157,8 +169,8 @@ export const executeForkStart = async ({
           messages: buildSessionHeaderMessages({
             sessionId: summary.sessionId,
             role: ctx.role,
-            scenario: resolved.resolvedScenario,
-            systemPrompt: resolved.systemPrompt,
+            scenario: promptContext.resolvedScenario,
+            systemPrompt: promptContext.systemPrompt,
             startedAt: summary.startedAt,
             eventLabel: "forked",
           }),
@@ -179,18 +191,17 @@ export const executeForkStart = async ({
     runtimeRoute: sourceSession.runtimeRoute,
     runtimeConnection: supportedRuntimeConnection,
     workingDirectory: sourceSession.workingDirectory,
-    ...(resolved.runtime.kind ? { kind: resolved.runtime.kind } : {}),
   };
 
   return registerStartedSession({
     ctx,
     startedCtx,
     runtimeInfo: forkedRuntime,
-    systemPrompt: resolved.systemPrompt,
-    promptOverrides: resolved.promptOverrides,
+    systemPrompt: promptContext.systemPrompt,
+    promptOverrides: promptContext.promptOverrides,
     selectedModel,
     initialMessages,
     deps,
-    taskCard: resolved.taskCard,
+    taskCard,
   });
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
@@ -1,7 +1,11 @@
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RuntimeInfo } from "../runtime/runtime";
-import { requireRuntimeConnectionSupport, resolveRuntimeRouteConnection } from "../runtime/runtime";
+import {
+  requireRuntimeConnectionSupport,
+  resolveRuntimeConnection,
+  resolveRuntimeRoute,
+} from "../runtime/runtime";
 import { throwIfRepoStale } from "../support/core";
 import { createSessionMessagesState, getSessionMessagesSlice } from "../support/messages";
 import { historyToChatMessages } from "../support/persistence";
@@ -74,16 +78,27 @@ export const executeForkStart = async ({
     resolved.runtime.runtimeKind ??
     selectedModel?.runtimeKind ??
     DEFAULT_RUNTIME_KIND;
-  const sourceRuntimeRoute = sourceSession.runtimeRoute ?? resolved.runtime.runtimeRoute;
-  if (!sourceRuntimeRoute) {
-    throw new Error(
-      `Session "${input.sourceSessionId}" is missing a live runtime route required for forking.`,
-    );
-  }
-  const runtimeConnection = resolveRuntimeRouteConnection(
-    sourceRuntimeRoute,
-    sourceSession.workingDirectory,
-  ).runtimeConnection;
+  const sourceRuntime: RuntimeInfo = {
+    runtimeKind,
+    runtimeId: sourceSession.runtimeId ?? resolved.runtime.runtimeId,
+    runId: sourceSession.runId ?? resolved.runtime.runId,
+    runtimeRoute: sourceSession.runtimeRoute ?? resolved.runtime.runtimeRoute,
+    workingDirectory: sourceSession.workingDirectory,
+    ...(sourceSession.runtimeRoute
+      ? {}
+      : { runtimeConnection: resolved.runtime.runtimeConnection }),
+    ...(resolved.runtime.kind ? { kind: resolved.runtime.kind } : {}),
+  };
+
+  const runtimeConnection = (() => {
+    try {
+      return resolveRuntimeConnection(sourceRuntime);
+    } catch {
+      throw new Error(
+        `Session "${input.sourceSessionId}" is missing live runtime context required for forking.`,
+      );
+    }
+  })();
   const supportedRuntimeConnection = requireRuntimeConnectionSupport(
     runtimeKind,
     runtimeConnection,
@@ -169,12 +184,15 @@ export const executeForkStart = async ({
 
   const forkedRuntime: RuntimeInfo = {
     runtimeKind,
-    runtimeId: sourceSession.runtimeId ?? resolved.runtime.runtimeId,
-    runId: sourceSession.runId ?? resolved.runtime.runId,
-    runtimeRoute: sourceRuntimeRoute,
+    runtimeId: sourceRuntime.runtimeId,
+    runId: sourceRuntime.runId,
+    runtimeRoute: resolveRuntimeRoute({
+      ...sourceRuntime,
+      runtimeConnection: supportedRuntimeConnection,
+    }),
     runtimeConnection: supportedRuntimeConnection,
     workingDirectory: sourceSession.workingDirectory,
-    ...(resolved.runtime.kind ? { kind: resolved.runtime.kind } : {}),
+    ...(sourceRuntime.kind ? { kind: sourceRuntime.kind } : {}),
   };
 
   return registerStartedSession({

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-runtime.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-runtime.ts
@@ -11,6 +11,42 @@ import type {
 } from "./start-session.types";
 import { requireBuildContinuationTarget, STALE_START_ERROR } from "./start-session-constants";
 
+export const resolveScenarioAndPrompt = async ({
+  ctx,
+  scenario,
+  taskCard,
+  deps,
+}: {
+  ctx: StartSessionContext;
+  scenario: AgentScenario | undefined;
+  taskCard: TaskCard;
+  deps: Pick<StartSessionExecutionDependencies, "model">;
+}): Promise<
+  Pick<ResolvedRuntimeAndModel, "resolvedScenario" | "systemPrompt" | "promptOverrides">
+> => {
+  const { promptOverrides } = await loadSessionPromptInputs({
+    workspaceId: ctx.workspaceId,
+    loadRepoPromptOverrides: deps.model.loadRepoPromptOverrides,
+  });
+  throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
+
+  const resolvedScenario = scenario ?? inferScenario(ctx.role, taskCard);
+  throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
+
+  const { systemPrompt } = createSessionPromptContext({
+    role: ctx.role,
+    scenario: resolvedScenario,
+    task: taskCard,
+    promptOverrides,
+  });
+
+  return {
+    resolvedScenario,
+    systemPrompt,
+    promptOverrides,
+  };
+};
+
 export const resolveRuntimeAndModel = async ({
   ctx,
   scenario,
@@ -26,15 +62,12 @@ export const resolveRuntimeAndModel = async ({
   taskCard: TaskCard;
   deps: Pick<StartSessionExecutionDependencies, "runtime" | "task" | "model">;
 }): Promise<ResolvedRuntimeAndModel> => {
-  const { promptOverrides } = await loadSessionPromptInputs({
-    workspaceId: ctx.workspaceId,
-    loadRepoPromptOverrides: deps.model.loadRepoPromptOverrides,
+  const promptContext = await resolveScenarioAndPrompt({
+    ctx,
+    scenario,
+    taskCard,
+    deps,
   });
-  throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
-
-  const resolvedScenario = scenario ?? inferScenario(ctx.role, taskCard);
-  throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
-
   const runtimeInfo = await deps.runtime.ensureRuntime(ctx.repoPath, ctx.taskId, ctx.role, {
     workspaceId: ctx.workspaceId,
     ...(targetWorkingDirectory !== undefined ? { targetWorkingDirectory } : {}),
@@ -42,19 +75,10 @@ export const resolveRuntimeAndModel = async ({
   });
   throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
 
-  const { systemPrompt } = createSessionPromptContext({
-    role: ctx.role,
-    scenario: resolvedScenario,
-    task: taskCard,
-    promptOverrides,
-  });
-
   return {
     taskCard,
     runtime: runtimeInfo,
-    resolvedScenario,
-    systemPrompt,
-    promptOverrides,
+    ...promptContext,
   };
 };
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1919,6 +1919,211 @@ describe("agent-orchestrator/handlers/start-session", () => {
     }
   });
 
+  test("forks from resolved live runtime connection when the hydrated source session has no route", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalForkSession = adapter.forkSession;
+    const originalLoadSessionHistory = adapter.loadSessionHistory;
+    const forkCalls: Array<{ runtimeConnection: unknown }> = [];
+    let sessionsById: Record<string, AgentSessionState> = {
+      "source-build": {
+        runtimeKind: "opencode",
+        sessionId: "source-build",
+        externalSessionId: "external-source-build",
+        taskId: "task-1",
+        repoPath: "/tmp/repo",
+        role: "build",
+        scenario: "build_implementation_start",
+        status: "idle",
+        startedAt: "2026-02-22T08:10:00.000Z",
+        runtimeId: "runtime-1",
+        runId: "run-2",
+        runtimeRoute: null,
+        workingDirectory: "/tmp/repo/worktree",
+        messages: [],
+        draftAssistantText: "",
+        draftAssistantMessageId: null,
+        draftReasoningText: "",
+        draftReasoningMessageId: null,
+        pendingPermissions: [],
+        pendingQuestions: [],
+        todos: [],
+        modelCatalog: null,
+        selectedModel: BUILD_SELECTION,
+        isLoadingModelCatalog: false,
+      },
+    };
+
+    adapter.forkSession = async (input) => {
+      forkCalls.push({ runtimeConnection: input.runtimeConnection });
+      return {
+        runtimeKind: "opencode",
+        sessionId: "forked-from-runtime-connection",
+        externalSessionId: "external-forked-from-runtime-connection",
+        startedAt: "2026-02-22T08:20:00.000Z",
+        role: "build",
+        scenario: "build_pull_request_generation",
+        status: "idle",
+      };
+    };
+    adapter.loadSessionHistory = async () => [];
+
+    const sessionsRef = { current: sessionsById };
+    const start = createStartAgentSessionWithFlatDeps({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: (updater) => {
+        sessionsById = typeof updater === "function" ? updater(sessionsById) : updater;
+        sessionsRef.current = sessionsById;
+      },
+      sessionsRef,
+      taskRef: { current: [taskFixture] },
+      repoEpochRef: { current: 1 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      inFlightStartsByWorkspaceTaskRef: { current: new Map() },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: "runtime-1",
+        runId: "run-2",
+        runtimeRoute: null,
+        runtimeConnection: {
+          type: "local_http",
+          endpoint: "http://127.0.0.1:5555",
+          workingDirectory: "/tmp/repo/worktree",
+        },
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {},
+      refreshTaskData: async () => {},
+      persistSessionRecord: async () => {},
+      sendAgentMessage: async () => {},
+    });
+
+    try {
+      const sessionId = await start({
+        taskId: "task-1",
+        role: "build",
+        scenario: "build_pull_request_generation",
+        startMode: "fork",
+        selectedModel: BUILD_SELECTION,
+        sourceSessionId: "source-build",
+      });
+
+      expect(sessionId).toBe("forked-from-runtime-connection");
+      expect(forkCalls).toEqual([
+        {
+          runtimeConnection: {
+            type: "local_http",
+            endpoint: "http://127.0.0.1:5555",
+            workingDirectory: "/tmp/repo/worktree",
+          },
+        },
+      ]);
+      expect(sessionsById["forked-from-runtime-connection"]?.runtimeRoute).toEqual({
+        type: "local_http",
+        endpoint: "http://127.0.0.1:5555",
+      });
+    } finally {
+      adapter.forkSession = originalForkSession;
+      adapter.loadSessionHistory = originalLoadSessionHistory;
+    }
+  });
+
+  test("fails explicitly when fork source runtime context cannot be resolved", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalForkSession = adapter.forkSession;
+    const forkCalls: unknown[] = [];
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "source-build": {
+          runtimeKind: "opencode",
+          sessionId: "source-build",
+          externalSessionId: "external-source-build",
+          taskId: "task-1",
+          repoPath: "/tmp/repo",
+          role: "build",
+          scenario: "build_implementation_start",
+          status: "idle",
+          startedAt: "2026-02-22T08:10:00.000Z",
+          runtimeId: null,
+          runId: null,
+          runtimeRoute: null,
+          workingDirectory: "/tmp/repo/worktree",
+          messages: [],
+          draftAssistantText: "",
+          draftAssistantMessageId: null,
+          draftReasoningText: "",
+          draftReasoningMessageId: null,
+          pendingPermissions: [],
+          pendingQuestions: [],
+          todos: [],
+          modelCatalog: null,
+          selectedModel: BUILD_SELECTION,
+          isLoadingModelCatalog: false,
+        },
+      },
+    };
+    adapter.forkSession = async (input) => {
+      forkCalls.push(input);
+      return {
+        runtimeKind: "opencode",
+        sessionId: "unexpected-fork",
+        externalSessionId: "unexpected-external-fork",
+        startedAt: "2026-02-22T08:20:00.000Z",
+        role: "build",
+        scenario: "build_pull_request_generation",
+        status: "idle",
+      };
+    };
+
+    const start = createStartAgentSessionWithFlatDeps({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [taskFixture] },
+      repoEpochRef: { current: 1 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      inFlightStartsByWorkspaceTaskRef: { current: new Map() },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: "runtime-1",
+        runId: "run-2",
+        runtimeRoute: null,
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {},
+      refreshTaskData: async () => {},
+      persistSessionRecord: async () => {},
+      sendAgentMessage: async () => {},
+    });
+
+    try {
+      await expect(
+        start({
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_pull_request_generation",
+          startMode: "fork",
+          selectedModel: BUILD_SELECTION,
+          sourceSessionId: "source-build",
+        }),
+      ).rejects.toThrow(
+        'Session "source-build" is missing live runtime context required for forking.',
+      );
+      expect(forkCalls).toHaveLength(0);
+    } finally {
+      adapter.forkSession = originalForkSession;
+    }
+  });
+
   test("stops the forked session when child history hydration fails", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalForkSession = adapter.forkSession;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1648,6 +1648,11 @@ describe("agent-orchestrator/handlers/start-session", () => {
     };
     adapter.loadSessionHistory = async (input) => {
       expect(input.runtimeKind).toBe("opencode");
+      expect(input.runtimeConnection).toEqual({
+        type: "local_http",
+        endpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo/worktree",
+      });
       expect(input.externalSessionId).toBe("external-forked-pr-session");
       return [
         {
@@ -1712,6 +1717,10 @@ describe("agent-orchestrator/handlers/start-session", () => {
       expect(sessionId).toBe("forked-pr-session");
       expect(sessionsById["forked-pr-session"]?.scenario).toBe("build_pull_request_generation");
       expect(sessionsById["forked-pr-session"]?.workingDirectory).toBe("/tmp/repo/worktree");
+      expect(sessionsById["forked-pr-session"]?.runtimeRoute).toEqual({
+        type: "local_http",
+        endpoint: "http://127.0.0.1:4444",
+      });
       expect(
         sessionsById["forked-pr-session"]
           ? sessionMessagesToArray(sessionsById["forked-pr-session"])

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1685,7 +1685,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
         kind: "opencode",
         runtimeId: "runtime-1",
         runId: "run-2",
-        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:5555" },
         workingDirectory: "/tmp/repo/worktree",
       }),
       loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
@@ -1919,11 +1919,10 @@ describe("agent-orchestrator/handlers/start-session", () => {
     }
   });
 
-  test("forks from resolved live runtime connection when the hydrated source session has no route", async () => {
+  test("fails when the hydrated source session has no live runtime context even if ensureRuntime resolves one", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalForkSession = adapter.forkSession;
-    const originalLoadSessionHistory = adapter.loadSessionHistory;
-    const forkCalls: Array<{ runtimeConnection: unknown }> = [];
+    const forkCalls: unknown[] = [];
     let sessionsById: Record<string, AgentSessionState> = {
       "source-build": {
         runtimeKind: "opencode",
@@ -1954,7 +1953,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     };
 
     adapter.forkSession = async (input) => {
-      forkCalls.push({ runtimeConnection: input.runtimeConnection });
+      forkCalls.push(input);
       return {
         runtimeKind: "opencode",
         sessionId: "forked-from-runtime-connection",
@@ -1965,7 +1964,6 @@ describe("agent-orchestrator/handlers/start-session", () => {
         status: "idle",
       };
     };
-    adapter.loadSessionHistory = async () => [];
 
     const sessionsRef = { current: sessionsById };
     const start = createStartAgentSessionWithFlatDeps({
@@ -2003,32 +2001,21 @@ describe("agent-orchestrator/handlers/start-session", () => {
     });
 
     try {
-      const sessionId = await start({
-        taskId: "task-1",
-        role: "build",
-        scenario: "build_pull_request_generation",
-        startMode: "fork",
-        selectedModel: BUILD_SELECTION,
-        sourceSessionId: "source-build",
-      });
-
-      expect(sessionId).toBe("forked-from-runtime-connection");
-      expect(forkCalls).toEqual([
-        {
-          runtimeConnection: {
-            type: "local_http",
-            endpoint: "http://127.0.0.1:5555",
-            workingDirectory: "/tmp/repo/worktree",
-          },
-        },
-      ]);
-      expect(sessionsById["forked-from-runtime-connection"]?.runtimeRoute).toEqual({
-        type: "local_http",
-        endpoint: "http://127.0.0.1:5555",
-      });
+      await expect(
+        start({
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_pull_request_generation",
+          startMode: "fork",
+          selectedModel: BUILD_SELECTION,
+          sourceSessionId: "source-build",
+        }),
+      ).rejects.toThrow(
+        'Session "source-build" is missing live runtime context required for forking.',
+      );
+      expect(forkCalls).toHaveLength(0);
     } finally {
       adapter.forkSession = originalForkSession;
-      adapter.loadSessionHistory = originalLoadSessionHistory;
     }
   });
 

--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
@@ -11,6 +11,7 @@ import { asUnknownRecord, readStringArrayProp, readStringProp } from "./guards";
 import { basename, isAbsolutePath, toProjectRelativePath } from "./path-utils";
 import { mapProviderListToCatalog, toToolIdList } from "./payload-mappers";
 import { toOpenCodeRequestError } from "./request-errors";
+import type { OpencodeRuntimeClientInput } from "./runtime-connection";
 import type { ClientFactory, McpServerStatus } from "./types";
 
 const OPENCODE_DEFAULT_AGENT_COLORS: Record<string, string> = {
@@ -19,6 +20,14 @@ const OPENCODE_DEFAULT_AGENT_COLORS: Record<string, string> = {
 };
 
 const FILE_SEARCH_LIMIT = 20;
+
+type OpencodeFileSearchInput = OpencodeRuntimeClientInput & {
+  query: string;
+};
+
+type OpencodeMcpConnectInput = OpencodeRuntimeClientInput & {
+  name: string;
+};
 
 type FindFilesClient = {
   find?: {
@@ -102,10 +111,7 @@ const toFileSearchResults = (
 
 export const listAvailableModels = async (
   createClient: ClientFactory,
-  input: {
-    runtimeEndpoint: string;
-    workingDirectory: string;
-  },
+  input: OpencodeRuntimeClientInput,
 ): Promise<AgentModelCatalog> => {
   const client = createClient({
     runtimeEndpoint: input.runtimeEndpoint,
@@ -173,10 +179,7 @@ export const listAvailableModels = async (
 
 export const listAvailableSlashCommands = async (
   createClient: ClientFactory,
-  input: {
-    runtimeEndpoint: string;
-    workingDirectory: string;
-  },
+  input: OpencodeRuntimeClientInput,
 ): Promise<AgentSlashCommandCatalog> => {
   try {
     const client = createClient({
@@ -240,11 +243,7 @@ export const listAvailableSlashCommands = async (
 
 export const searchFiles = async (
   createClient: ClientFactory,
-  input: {
-    runtimeEndpoint: string;
-    workingDirectory: string;
-    query: string;
-  },
+  input: OpencodeFileSearchInput,
 ): Promise<AgentFileSearchResult[]> => {
   try {
     const client = createClient({
@@ -270,10 +269,7 @@ export const searchFiles = async (
 
 export const listAvailableToolIds = async (
   createClient: ClientFactory,
-  input: {
-    runtimeEndpoint: string;
-    workingDirectory: string;
-  },
+  input: OpencodeRuntimeClientInput,
 ): Promise<string[]> => {
   const client = createClient({
     runtimeEndpoint: input.runtimeEndpoint,
@@ -288,10 +284,7 @@ export const listAvailableToolIds = async (
 
 export const getMcpStatus = async (
   createClient: ClientFactory,
-  input: {
-    runtimeEndpoint: string;
-    workingDirectory: string;
-  },
+  input: OpencodeRuntimeClientInput,
 ): Promise<Record<string, McpServerStatus>> => {
   try {
     const client = createClient({
@@ -325,11 +318,7 @@ export const getMcpStatus = async (
 
 export const connectMcpServer = async (
   createClient: ClientFactory,
-  input: {
-    runtimeEndpoint: string;
-    workingDirectory: string;
-    name: string;
-  },
+  input: OpencodeMcpConnectInput,
 ): Promise<void> => {
   const client = createClient({
     runtimeEndpoint: input.runtimeEndpoint,


### PR DESCRIPTION
## Summary
- generalize desktop runtime-backed fork and reuse orchestration so forked sessions stay pinned to the source session's live runtime connection
- align adapter catalog and MCP query helpers around shared runtime client input types instead of endpoint-shaped OpenCode-specific inputs
- keep the branch fully green by adding the fork/runtime regressions and normalizing the rustfmt drift in the startup status module

## Goal
This PR removes the last OpenCode-specific assumptions from the runtime-backed fork and query paths. The goal is to make session forking and runtime-backed desktop queries depend on runtime kind plus opaque runtime connection data, while preserving the repo's fail-fast runtime rules.

## What Changed
The desktop fork flow now treats a fork as an operation on the already-live source session runtime. It hydrates the source session first, requires that session to carry its own live runtime context, and fails explicitly instead of substituting `ensureRuntime(...)` when that context is missing.

To make that behavior clearer in code, prompt and scenario preparation were split out from runtime acquisition. Fork startup now follows a smaller sequence: load source session, require source runtime, prepare prompt and scenario, then fork.

On the adapter side, the runtime-backed catalog and MCP helper functions now share `OpencodeRuntimeClientInput` rather than repeating raw `runtimeEndpoint`-shaped helper inputs. That keeps the runtime abstraction generic at the adapter boundary without changing the public behavior.

A small Rust formatting-only commit is included because `cargo fmt --all --check` was failing on the branch due to formatting drift in `startup_status.rs`, and the PR requirement was to leave both Bun and Rust checks green.

## Technical Choices
- keep fork runtime selection source-owned: the fork handler now resolves the runtime connection only from the hydrated source session, which matches the runtime/session ownership rules in `AGENTS.md`
- separate prompt preparation from runtime startup: `resolveScenarioAndPrompt(...)` handles prompt inputs and scenario inference, while `resolveRuntimeAndModel(...)` remains the path that also ensures a runtime for fresh starts
- preserve fail-fast behavior: missing runtime kind or live source runtime context is surfaced as an explicit error instead of adding fallback behavior
- strengthen regression coverage around source-runtime precedence so reviewers can see that a different `ensureRuntime(...)` result is ignored for forking

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run check:rust`
- `bun run test:rust`
- `cargo build`