### PR TITLE
fix(desktop): fail hydration without runtime fallback

### DIFF
--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import { canUseRepoRootWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
+
+const createRecord = (
+  role: AgentSessionRecord["role"],
+  workingDirectory: string,
+): Pick<AgentSessionRecord, "role" | "workingDirectory"> => ({
+  role,
+  workingDirectory,
+});
+
+describe("canUseRepoRootWorkspaceRuntimeForHydration", () => {
+  test("allows repo-root spec sessions", () => {
+    expect(
+      canUseRepoRootWorkspaceRuntimeForHydration(createRecord("spec", "/tmp/repo"), "/tmp/repo"),
+    ).toBe(true);
+  });
+
+  test("allows normalized-equivalent repo-root planner sessions", () => {
+    expect(
+      canUseRepoRootWorkspaceRuntimeForHydration(
+        createRecord("planner", "/tmp/repo/"),
+        "/tmp/repo",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects repo-root build sessions", () => {
+    expect(
+      canUseRepoRootWorkspaceRuntimeForHydration(createRecord("build", "/tmp/repo"), "/tmp/repo"),
+    ).toBe(false);
+  });
+
+  test("rejects worktree planner sessions", () => {
+    expect(
+      canUseRepoRootWorkspaceRuntimeForHydration(
+        createRecord("planner", "/tmp/repo/worktree"),
+        "/tmp/repo",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
@@ -1,0 +1,15 @@
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import { normalizeWorkingDirectory } from "../support/core";
+
+const HYDRATION_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["spec", "planner"]);
+
+export const canUseRepoRootWorkspaceRuntimeForHydration = (
+  record: Pick<AgentSessionRecord, "role" | "workingDirectory">,
+  repoPath: string,
+): boolean => {
+  if (!HYDRATION_WORKSPACE_RUNTIME_ROLES.has(record.role)) {
+    return false;
+  }
+
+  return normalizeWorkingDirectory(record.workingDirectory) === normalizeWorkingDirectory(repoPath);
+};

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -73,26 +73,26 @@ describe("createHydrationRuntimeResolver", () => {
     });
   });
 
-  test("attaches build sessions from the shared workspace runtime when no run is present", async () => {
+  test("fails build session hydration when only a shared workspace runtime exists", async () => {
+    let ensureCalls = 0;
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
       runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
         ["opencode", [createRuntime("/tmp/repo")]],
       ]),
-      ensureWorkspaceRuntime: async () => null,
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return null;
+      },
     });
 
     const result = await resolveHydrationRuntime(createRecord("build", "/tmp/repo/worktree"));
-    if (!result.ok) {
-      throw new Error("Expected runtime resolution to succeed");
-    }
-
-    expect(result.runtimeId).toBe("runtime-1");
-    expect(result.runtimeConnection).toEqual({
-      type: "local_http",
-      endpoint: "http://127.0.0.1:4555",
-      workingDirectory: "/tmp/repo/worktree",
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/repo/worktree.",
     });
+    expect(ensureCalls).toBe(0);
   });
 
   test("falls back to preloaded runtime connection when no run or runtime exists", async () => {
@@ -164,5 +164,25 @@ describe("createHydrationRuntimeResolver", () => {
     expect(result.runtimeRoute).toEqual({
       type: "stdio",
     });
+  });
+
+  test("includes the missing working directory when repo-root planner ensure cannot provide a runtime", async () => {
+    let ensureCalls = 0;
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return null;
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("planner", "/tmp/repo"));
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/repo.",
+    });
+    expect(ensureCalls).toBe(1);
   });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -8,6 +8,7 @@ import type { AgentRuntimeConnection } from "@openducktor/core";
 import { resolveRuntimeRouteConnection, runtimeConnectionToRoute } from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
+import { canUseRepoRootWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 import { runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
 
 export type ResolvedHydrationRuntime =
@@ -35,17 +36,6 @@ export const createHydrationRuntimeResolver = ({
   preloadedRuntimeConnectionsByKey?: Map<string, AgentRuntimeConnection>;
   ensureWorkspaceRuntime: (runtimeKind: RuntimeKind) => Promise<RuntimeInstanceSummary | null>;
 }): ((record: AgentSessionRecord) => Promise<ResolvedHydrationRuntime>) => {
-  const isRepoRootSession = (workingDirectory: string): boolean => {
-    return normalizeWorkingDirectory(workingDirectory) === normalizeWorkingDirectory(repoPath);
-  };
-
-  const canEnsureWorkspaceRuntime = (record: AgentSessionRecord): boolean => {
-    if (record.role === "spec" || record.role === "planner") {
-      return isRepoRootSession(record.workingDirectory);
-    }
-    return false;
-  };
-
   const findRuntimeByWorkingDirectory = (
     runtimeKind: RuntimeKind,
     workingDirectory: string,
@@ -91,7 +81,7 @@ export const createHydrationRuntimeResolver = ({
       };
     }
 
-    if (!canEnsureWorkspaceRuntime(record)) {
+    if (!canUseRepoRootWorkspaceRuntimeForHydration(record, repoPath)) {
       return {
         ok: false,
         runtimeKind,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -59,33 +59,11 @@ export const createHydrationRuntimeResolver = ({
     );
   };
 
-  const findWorkspaceRuntime = (runtimeKind: RuntimeKind): RuntimeInstanceSummary | null => {
-    const runtimes = runtimesByKind.get(runtimeKind) ?? [];
-    const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
-    return (
-      runtimes.find(
-        (runtime) =>
-          runtime.role === "workspace" &&
-          normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath,
-      ) ?? null
-    );
-  };
-
-  const findRuntimeForWorkingDirectory = (
-    runtimeKind: RuntimeKind,
-    workingDirectory: string,
-  ): RuntimeInstanceSummary | null => {
-    return (
-      findRuntimeByWorkingDirectory(runtimeKind, workingDirectory) ??
-      findWorkspaceRuntime(runtimeKind)
-    );
-  };
-
   return async (record: AgentSessionRecord): Promise<ResolvedHydrationRuntime> => {
     const runtimeKind = readPersistedRuntimeKind(record);
     const workingDirectory = record.workingDirectory;
 
-    const runtime = findRuntimeForWorkingDirectory(runtimeKind, workingDirectory);
+    const runtime = findRuntimeByWorkingDirectory(runtimeKind, workingDirectory);
     if (runtime) {
       const { runtimeConnection } = resolveRuntimeRouteConnection(
         runtime.runtimeRoute,
@@ -126,7 +104,7 @@ export const createHydrationRuntimeResolver = ({
       return {
         ok: false,
         runtimeKind,
-        reason: `Runtime ${runtimeKind} is unavailable for session hydration.`,
+        reason: `No live runtime found for working directory ${workingDirectory}.`,
       };
     }
     const { runtimeConnection } = resolveRuntimeRouteConnection(

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -423,7 +423,7 @@ describe("agent-orchestrator-load-sessions", () => {
         repoPath: "/tmp/repo",
         taskId: null,
         role: "workspace",
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
         runtimeRoute: {
           type: "local_http",
           endpoint: "http://127.0.0.1:4444",
@@ -897,7 +897,7 @@ describe("agent-orchestrator-load-sessions", () => {
             repoPath: "/tmp/repo",
             taskId: null,
             role: "workspace",
-            workingDirectory: "/tmp/repo",
+            workingDirectory: "/tmp/repo/worktree",
             runtimeRoute: {
               type: "local_http",
               endpoint: "http://127.0.0.1:4444",
@@ -1015,7 +1015,7 @@ describe("agent-orchestrator-load-sessions", () => {
               title: "PLANNER task-1",
               role: "planner",
               scenario: "planner_initial",
-              workingDirectory: "/tmp/repo",
+              workingDirectory: "/tmp/repo/worktree",
               startedAt: "2026-02-22T08:00:00.000Z",
               status: { type: "busy" },
               pendingPermissions: [
@@ -1431,7 +1431,7 @@ describe("agent-orchestrator-load-sessions", () => {
               repoPath: "/tmp/repo",
               taskId: null,
               role: "workspace",
-              workingDirectory: "/tmp/repo",
+              workingDirectory: "/tmp/repo/worktree",
               runtimeRoute: {
                 type: "local_http",
                 endpoint: "http://127.0.0.1:4444",
@@ -2728,7 +2728,7 @@ describe("agent-orchestrator-load-sessions", () => {
     }
   });
 
-  test("rehydrates qa sessions through the shared workspace runtime when no persisted build session exists", async () => {
+  test("fails fast for qa sessions when only a shared workspace runtime exists", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     let observedRuntimeEndpoint: string | null = null;
@@ -2811,24 +2811,21 @@ describe("agent-orchestrator-load-sessions", () => {
     ];
 
     try {
-      await loadAgentSessions("task-1", {
-        mode: "requested_history",
-        targetSessionId: "session-qa-1",
-        historyPolicy: "requested_only",
-      });
+      await expect(
+        loadAgentSessions("task-1", {
+          mode: "requested_history",
+          targetSessionId: "session-qa-1",
+          historyPolicy: "requested_only",
+        }),
+      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktree.");
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
     }
 
-    if (observedRuntimeEndpoint === null) {
-      throw new Error("Expected QA hydration to resolve a live runtime endpoint");
-    }
-    expect(String(observedRuntimeEndpoint)).toBe("http://127.0.0.1:4444");
-    expect(state["session-qa-1"]?.runtimeId).toBe("runtime-1");
-    expect(sessionMessageAt(getSession(state, "session-qa-1"), 0)?.id).toBe(
-      "history:session-start:session-qa-1",
-    );
+    expect(observedRuntimeEndpoint).toBeNull();
+    expect(state["session-qa-1"]?.runtimeId).toBeNull();
+    expect(state["session-qa-1"]?.messages ?? []).toEqual([]);
   });
 
   test("does not ensure a workspace runtime for qa sessions when repo root paths only differ by trailing slash", async () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -86,6 +86,21 @@ const taskWithSessionAt = (
   return task;
 };
 
+const plannerTaskWithSessionAt = (
+  taskId: string,
+  externalSessionId: string,
+  workingDirectory: string,
+): TaskCard => {
+  const task = taskWithSessionAt(taskId, externalSessionId, workingDirectory);
+  const session = task.agentSessions?.[0];
+  if (!session) {
+    throw new Error("Expected seeded task session");
+  }
+
+  task.agentSessions = [{ ...session, role: "planner", scenario: "planner_initial" }];
+  return task;
+};
+
 const createRuntimeInstance = ({
   runtimeId = "runtime-1",
   workingDirectory = worktreePath,
@@ -561,7 +576,7 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
-  test("reconcile ensures a missing runtime kind only once even when multiple directories are missing", async () => {
+  test("reconcile ensures a missing repo-root planner runtime only once", async () => {
     let runtimeEnsureCalls = 0;
     const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
@@ -585,8 +600,8 @@ describe("repo-session-hydration-service", () => {
       };
     };
 
-    const taskOne = taskWithSessionAt("task-1", "external-1", "/tmp/repo/worktree-a");
-    const taskTwo = taskWithSessionAt("task-2", "external-2", "/tmp/repo/worktree-b");
+    const taskOne = plannerTaskWithSessionAt("task-1", "external-1", repoPath);
+    const taskTwo = plannerTaskWithSessionAt("task-2", "external-2", repoPath);
 
     const service = createRepoSessionHydrationService({
       agentEngine: {
@@ -615,13 +630,66 @@ describe("repo-session-hydration-service", () => {
     expect(runtimeEnsureCalls).toBe(1);
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([
       {
-        directories: ["/tmp/repo/worktree-a", "/tmp/repo/worktree-b"],
+        directories: [repoPath],
       },
     ]);
     service.dispose();
   });
 
-  test("reconcile fans missing stdio worktrees out by per-directory scan identity", async () => {
+  test("reconcile scans normalized-equivalent repo-root planner directories", async () => {
+    let runtimeEnsureCalls = 0;
+    const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
+    const reconcileCalls: string[] = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    host.runtimeList = async () => [createRuntimeInstance({ workingDirectory: repoPath })];
+    host.runtimeEnsure = async () => {
+      runtimeEnsureCalls += 1;
+      return createRuntimeInstance({ workingDirectory: repoPath });
+    };
+
+    const service = createRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async (input) => {
+          listLiveAgentSessionSnapshotsCalls.push(
+            input.directories ? { directories: [...input.directories].sort() } : {},
+          );
+          return [
+            createLiveAgentSessionSnapshotFixture({
+              externalSessionId: "external-1",
+              workingDirectory: repoPath,
+            }),
+          ];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId }) => {
+          reconcileCalls.push(taskId);
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [plannerTaskWithSessionAt("task-1", "external-1", `${repoPath}/`)],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(runtimeEnsureCalls).toBe(0);
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([
+      {
+        directories: [repoPath],
+      },
+    ]);
+    expect(reconcileCalls).toEqual(["task-1"]);
+    service.dispose();
+  });
+
+  test("reconcile does not ensure missing stdio worktree runtimes", async () => {
     let runtimeEnsureCalls = 0;
     const listLiveAgentSessionSnapshotsCalls: Array<{
       runtimeConnection: unknown;
@@ -667,17 +735,8 @@ describe("repo-session-hydration-service", () => {
       isCurrentRepo: () => true,
     });
 
-    expect(runtimeEnsureCalls).toBe(1);
-    expect(listLiveAgentSessionSnapshotsCalls).toEqual([
-      {
-        runtimeConnection: stdioRuntimeConnection("/tmp/repo/worktree-a"),
-        directories: ["/tmp/repo/worktree-a"],
-      },
-      {
-        runtimeConnection: stdioRuntimeConnection("/tmp/repo/worktree-b"),
-        directories: ["/tmp/repo/worktree-b"],
-      },
-    ]);
+    expect(runtimeEnsureCalls).toBe(0);
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([]);
     service.dispose();
   });
 
@@ -714,7 +773,7 @@ describe("repo-session-hydration-service", () => {
 
     await service.reconcilePendingTasks({
       repoPath,
-      tasks: [taskWithSession("task-1", "external-1")],
+      tasks: [plannerTaskWithSessionAt("task-1", "external-1", repoPath)],
       isCancelled: () => false,
       isCurrentRepo: () => true,
     });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -849,6 +849,71 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
+  test("reconcile skips tasks atomically when a later persisted session has invalid runtime metadata", async () => {
+    const reconcileCalls: string[] = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    host.runtimeList = async () => [createRuntimeInstance()];
+
+    const partiallyInvalidTask = taskWithSession("task-invalid", "external-partial");
+    const partiallyInvalidSession = partiallyInvalidTask.agentSessions?.[0];
+    if (!partiallyInvalidSession) {
+      throw new Error("Expected partially invalid task session fixture");
+    }
+    partiallyInvalidTask.agentSessions = [
+      partiallyInvalidSession,
+      {
+        ...partiallyInvalidSession,
+        sessionId: "session-task-invalid-broken",
+        externalSessionId: "external-broken",
+        runtimeKind: undefined as unknown as typeof partiallyInvalidSession.runtimeKind,
+      },
+    ];
+
+    const service = createRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async () => [
+          {
+            externalSessionId: "external-valid",
+            title: "Valid task",
+            workingDirectory: worktreePath,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+            pendingPermissions: [],
+            pendingQuestions: [],
+          },
+          {
+            externalSessionId: "external-partial",
+            title: "Partially invalid task",
+            workingDirectory: worktreePath,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+            pendingPermissions: [],
+            pendingQuestions: [],
+          },
+        ],
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId }) => {
+          reconcileCalls.push(taskId);
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [taskWithSession("task-valid", "external-valid"), partiallyInvalidTask],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(reconcileCalls).toEqual(["task-valid"]);
+    service.dispose();
+  });
+
   afterEach(() => {
     host.runtimeList = originalRuntimeList;
     host.runtimeEnsure = originalRuntimeEnsure;

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -108,6 +108,11 @@ const collectReconcilePreloadMetadata = ({
   const skippedTaskErrors = new Map<string, unknown>();
 
   for (const { taskId, records } of persistedByTask) {
+    const taskRuntimeKinds = new Set<RuntimeKind>();
+    const taskLiveSessionKeys = new Set<string>();
+    const taskDesiredDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
+    const taskRuntimeKindsAllowedToEnsureRepoRoot = new Set<RuntimeKind>();
+
     try {
       for (const record of records) {
         const runtimeKind = readPersistedRuntimeKind(record);
@@ -116,16 +121,13 @@ const collectReconcilePreloadMetadata = ({
           continue;
         }
 
-        runtimeKinds.add(runtimeKind);
-        getOrCreateMapSet(
-          persistedTaskIdsByLiveSessionKey,
-          `${runtimeKind}::${externalSessionId}`,
-        ).add(taskId);
-        getOrCreateMapSet(desiredDirectoriesByRuntimeKind, runtimeKind).add(
+        taskRuntimeKinds.add(runtimeKind);
+        taskLiveSessionKeys.add(`${runtimeKind}::${externalSessionId}`);
+        getOrCreateMapSet(taskDesiredDirectoriesByRuntimeKind, runtimeKind).add(
           normalizeWorkingDirectory(record.workingDirectory),
         );
         if (canUseRepoRootWorkspaceRuntimeForHydration(record, repoPath)) {
-          runtimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
+          taskRuntimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
         }
       }
     } catch (error) {
@@ -138,6 +140,26 @@ const collectReconcilePreloadMetadata = ({
         error,
       );
       skippedTaskErrors.set(taskId, error);
+      continue;
+    }
+
+    for (const runtimeKind of taskRuntimeKinds) {
+      runtimeKinds.add(runtimeKind);
+    }
+
+    for (const liveSessionKey of taskLiveSessionKeys) {
+      getOrCreateMapSet(persistedTaskIdsByLiveSessionKey, liveSessionKey).add(taskId);
+    }
+
+    for (const [runtimeKind, workingDirectories] of taskDesiredDirectoriesByRuntimeKind) {
+      const desiredDirectories = getOrCreateMapSet(desiredDirectoriesByRuntimeKind, runtimeKind);
+      for (const workingDirectory of workingDirectories) {
+        desiredDirectories.add(workingDirectory);
+      }
+    }
+
+    for (const runtimeKind of taskRuntimeKindsAllowedToEnsureRepoRoot) {
+      runtimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
     }
   }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -19,6 +19,7 @@ import {
   isSessionRuntimeMetadataError,
   readPersistedRuntimeKind,
 } from "../support/session-runtime-metadata";
+import { canUseRepoRootWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 import {
   getLiveAgentSessionCacheKey,
   LiveAgentSessionCache,
@@ -45,6 +46,15 @@ type ReconcilePreloadPlan = {
   skippedTaskErrors: Map<string, unknown>;
 };
 
+type ReconcilePreloadMetadata = {
+  persistedByTask: Array<{ taskId: string; records: AgentSessionRecord[] }>;
+  persistedTaskIdsByLiveSessionKey: Map<string, Set<string>>;
+  runtimeKinds: Set<RuntimeKind>;
+  desiredDirectoriesByRuntimeKind: Map<RuntimeKind, Set<string>>;
+  runtimeKindsAllowedToEnsureRepoRoot: Set<RuntimeKind>;
+  skippedTaskErrors: Map<string, unknown>;
+};
+
 const nextSessionRetryDelayMs = (attempt: number): number => Math.min(5_000, 500 * 2 ** attempt);
 
 const invalidateRuntimeList = async (runtimeKind: RuntimeKind, repoPath: string): Promise<void> => {
@@ -68,15 +78,77 @@ const getOrCreateRepoTaskSet = (
   return created;
 };
 
-const canEnsureWorkspaceRuntimeForReconcile = (
-  record: AgentSessionRecord,
-  repoPath: string,
-): boolean => {
-  if (record.role !== "spec" && record.role !== "planner") {
-    return false;
+const getOrCreateMapSet = <K>(map: Map<K, Set<string>>, key: K): Set<string> => {
+  const existing = map.get(key);
+  if (existing) {
+    return existing;
   }
 
-  return normalizeWorkingDirectory(record.workingDirectory) === normalizeWorkingDirectory(repoPath);
+  const created = new Set<string>();
+  map.set(key, created);
+  return created;
+};
+
+const collectReconcilePreloadMetadata = ({
+  tasks,
+  repoPath,
+}: {
+  tasks: TaskCard[];
+  repoPath: string;
+}): ReconcilePreloadMetadata => {
+  const persistedByTask = tasks.map((task) => ({
+    taskId: task.id,
+    records: task.agentSessions ?? [],
+  }));
+
+  const persistedTaskIdsByLiveSessionKey = new Map<string, Set<string>>();
+  const runtimeKinds = new Set<RuntimeKind>();
+  const desiredDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
+  const runtimeKindsAllowedToEnsureRepoRoot = new Set<RuntimeKind>();
+  const skippedTaskErrors = new Map<string, unknown>();
+
+  for (const { taskId, records } of persistedByTask) {
+    try {
+      for (const record of records) {
+        const runtimeKind = readPersistedRuntimeKind(record);
+        const externalSessionId = record.externalSessionId ?? record.sessionId;
+        if (!externalSessionId) {
+          continue;
+        }
+
+        runtimeKinds.add(runtimeKind);
+        getOrCreateMapSet(
+          persistedTaskIdsByLiveSessionKey,
+          `${runtimeKind}::${externalSessionId}`,
+        ).add(taskId);
+        getOrCreateMapSet(desiredDirectoriesByRuntimeKind, runtimeKind).add(
+          normalizeWorkingDirectory(record.workingDirectory),
+        );
+        if (canUseRepoRootWorkspaceRuntimeForHydration(record, repoPath)) {
+          runtimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
+        }
+      }
+    } catch (error) {
+      if (!isSessionRuntimeMetadataError(error)) {
+        throw error;
+      }
+
+      console.error(
+        `Skipping reconcile preload for task '${taskId}' in repo '${repoPath}' because persisted session runtime metadata is invalid.`,
+        error,
+      );
+      skippedTaskErrors.set(taskId, error);
+    }
+  }
+
+  return {
+    persistedByTask,
+    persistedTaskIdsByLiveSessionKey,
+    runtimeKinds,
+    desiredDirectoriesByRuntimeKind,
+    runtimeKindsAllowedToEnsureRepoRoot,
+    skippedTaskErrors,
+  };
 };
 
 export const createRepoSessionHydrationService = ({
@@ -140,51 +212,14 @@ export const createRepoSessionHydrationService = ({
     tasks: TaskCard[];
     isCancelled: () => boolean;
   }): Promise<ReconcilePreloadPlan> => {
-    const persistedByTask = tasks.map((task) => ({
-      taskId: task.id,
-      records: task.agentSessions ?? [],
-    }));
-
-    const persistedTaskIdsByLiveSessionKey = new Map<string, Set<string>>();
-    const runtimeKinds = new Set<RuntimeKind>();
-    const desiredDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
-    const runtimeKindsAllowedToEnsureRepoRoot = new Set<RuntimeKind>();
-    const skippedTaskErrors = new Map<string, unknown>();
-
-    for (const { taskId, records } of persistedByTask) {
-      try {
-        for (const record of records) {
-          const runtimeKind = readPersistedRuntimeKind(record);
-          const externalSessionId = record.externalSessionId ?? record.sessionId;
-          if (!externalSessionId) {
-            continue;
-          }
-          runtimeKinds.add(runtimeKind);
-          const liveSessionKey = `${runtimeKind}::${externalSessionId}`;
-          const taskIds = persistedTaskIdsByLiveSessionKey.get(liveSessionKey) ?? new Set<string>();
-          taskIds.add(taskId);
-          persistedTaskIdsByLiveSessionKey.set(liveSessionKey, taskIds);
-
-          const desiredDirectories =
-            desiredDirectoriesByRuntimeKind.get(runtimeKind) ?? new Set<string>();
-          desiredDirectories.add(normalizeWorkingDirectory(record.workingDirectory));
-          desiredDirectoriesByRuntimeKind.set(runtimeKind, desiredDirectories);
-          if (canEnsureWorkspaceRuntimeForReconcile(record, repoPath)) {
-            runtimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
-          }
-        }
-      } catch (error) {
-        if (!isSessionRuntimeMetadataError(error)) {
-          throw error;
-        }
-
-        console.error(
-          `Skipping reconcile preload for task '${taskId}' in repo '${repoPath}' because persisted session runtime metadata is invalid.`,
-          error,
-        );
-        skippedTaskErrors.set(taskId, error);
-      }
-    }
+    const {
+      persistedByTask,
+      persistedTaskIdsByLiveSessionKey,
+      runtimeKinds,
+      desiredDirectoriesByRuntimeKind,
+      runtimeKindsAllowedToEnsureRepoRoot,
+      skippedTaskErrors,
+    } = collectReconcilePreloadMetadata({ tasks, repoPath });
 
     const runtimeConnections = new Map<string, RuntimeConnectionScan>();
     const preloadedRuntimeLists = new Map<RuntimeKind, RuntimeInstanceSummary[]>();

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -68,6 +68,17 @@ const getOrCreateRepoTaskSet = (
   return created;
 };
 
+const canEnsureWorkspaceRuntimeForReconcile = (
+  record: AgentSessionRecord,
+  repoPath: string,
+): boolean => {
+  if (record.role !== "spec" && record.role !== "planner") {
+    return false;
+  }
+
+  return normalizeWorkingDirectory(record.workingDirectory) === normalizeWorkingDirectory(repoPath);
+};
+
 export const createRepoSessionHydrationService = ({
   agentEngine,
   sessionHydration,
@@ -137,6 +148,7 @@ export const createRepoSessionHydrationService = ({
     const persistedTaskIdsByLiveSessionKey = new Map<string, Set<string>>();
     const runtimeKinds = new Set<RuntimeKind>();
     const desiredDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
+    const runtimeKindsAllowedToEnsureRepoRoot = new Set<RuntimeKind>();
     const skippedTaskErrors = new Map<string, unknown>();
 
     for (const { taskId, records } of persistedByTask) {
@@ -155,8 +167,11 @@ export const createRepoSessionHydrationService = ({
 
           const desiredDirectories =
             desiredDirectoriesByRuntimeKind.get(runtimeKind) ?? new Set<string>();
-          desiredDirectories.add(record.workingDirectory);
+          desiredDirectories.add(normalizeWorkingDirectory(record.workingDirectory));
           desiredDirectoriesByRuntimeKind.set(runtimeKind, desiredDirectories);
+          if (canEnsureWorkspaceRuntimeForReconcile(record, repoPath)) {
+            runtimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
+          }
         }
       } catch (error) {
         if (!isSessionRuntimeMetadataError(error)) {
@@ -188,11 +203,10 @@ export const createRepoSessionHydrationService = ({
       }
 
       const runtimeEntries = [...runtimes];
-      let ensuredRuntimeForKind: RuntimeInstanceSummary | null = null;
       const desiredDirectories = desiredDirectoriesByRuntimeKind.get(runtimeKind) ?? new Set();
       const repoPathKey = normalizeWorkingDirectory(repoPath);
       const needsRepoRootRuntime =
-        desiredDirectories.has(repoPath) &&
+        runtimeKindsAllowedToEnsureRepoRoot.has(runtimeKind) &&
         !runtimeEntries.some(
           (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey,
         );
@@ -214,14 +228,10 @@ export const createRepoSessionHydrationService = ({
             skippedTaskErrors,
           };
         }
-        ensuredRuntimeForKind = ensuredRuntime;
         runtimeEntries.push(ensuredRuntime);
       }
 
       preloadedRuntimeLists.set(runtimeKind, runtimeEntries);
-      const coveredDirectories = new Set(
-        runtimeEntries.map((runtime) => normalizeWorkingDirectory(runtime.workingDirectory)),
-      );
 
       for (const runtime of runtimeEntries) {
         const { runtimeConnection } = resolveRuntimeRouteConnection(
@@ -232,7 +242,7 @@ export const createRepoSessionHydrationService = ({
           runtimeWorkingDirectoryKey(runtimeKind, runtime.workingDirectory),
           runtimeConnection,
         );
-        if (!desiredDirectories.has(runtime.workingDirectory)) {
+        if (!desiredDirectories.has(normalizeWorkingDirectory(runtime.workingDirectory))) {
           continue;
         }
 
@@ -245,62 +255,6 @@ export const createRepoSessionHydrationService = ({
           });
         }
         runtimeConnections.get(scanKey)?.directories.add(runtime.workingDirectory);
-      }
-
-      const missingDesiredDirectories = Array.from(desiredDirectories).filter(
-        (workingDirectory) => !coveredDirectories.has(normalizeWorkingDirectory(workingDirectory)),
-      );
-      if (missingDesiredDirectories.length === 0) {
-        continue;
-      }
-
-      const routeSourceRuntime =
-        ensuredRuntimeForKind ??
-        runtimeEntries.find(
-          (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey,
-        ) ??
-        runtimeEntries[0] ??
-        (await ensureRuntimeAndInvalidateReadinessQueries({
-          repoPath,
-          runtimeKind,
-          ensureRuntime: (nextRepoPath, nextRuntimeKind) =>
-            host.runtimeEnsure(nextRepoPath, nextRuntimeKind),
-        }));
-      if (!ensuredRuntimeForKind && !runtimeEntries.includes(routeSourceRuntime)) {
-        await invalidateRuntimeList(runtimeKind, repoPath);
-      }
-      if (!ensuredRuntimeForKind && !runtimeEntries.includes(routeSourceRuntime)) {
-        if (isCancelled()) {
-          return {
-            persistedByTask,
-            taskIdsToReconcile: new Set<string>(),
-            preloadedRuntimeLists,
-            preloadedRuntimeConnectionsByKey,
-            preloadedLiveAgentSessionsByKey: new Map<string, LiveAgentSessionSnapshot[]>(),
-            skippedTaskErrors,
-          };
-        }
-        ensuredRuntimeForKind = routeSourceRuntime;
-        runtimeEntries.push(routeSourceRuntime);
-      }
-      for (const workingDirectory of missingDesiredDirectories) {
-        const { runtimeConnection } = resolveRuntimeRouteConnection(
-          routeSourceRuntime.runtimeRoute,
-          workingDirectory,
-        );
-        const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
-        if (!runtimeConnections.has(scanKey)) {
-          runtimeConnections.set(scanKey, {
-            runtimeKind,
-            runtimeConnection,
-            directories: new Set<string>(),
-          });
-        }
-        preloadedRuntimeConnectionsByKey.set(
-          runtimeWorkingDirectoryKey(runtimeKind, workingDirectory),
-          runtimeConnection,
-        );
-        runtimeConnections.get(scanKey)?.directories.add(workingDirectory);
       }
     }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -373,7 +373,7 @@ describe("use-agent-orchestrator-operations", () => {
       host.agentSessionsList = async () => [
         {
           ...persistedSessionFixture,
-          workingDirectory: "/tmp/repo/worktree",
+          workingDirectory: "/tmp/repo",
         },
       ];
       host.agentSessionUpsert = async () => {};
@@ -510,7 +510,7 @@ describe("use-agent-orchestrator-operations", () => {
         {
           externalSessionId: "external-1",
           title: "PLANNER task-1",
-          workingDirectory: "/tmp/repo",
+          workingDirectory: "/tmp/repo/worktree",
           startedAt: "2026-02-22T08:00:00.000Z",
           status: { type: "busy" },
           pendingPermissions: [],
@@ -2081,7 +2081,7 @@ describe("use-agent-orchestrator-operations", () => {
           repoPath: "/tmp/repo",
           taskId: null,
           role: "workspace",
-          workingDirectory: "/tmp/repo",
+          workingDirectory: "/tmp/repo/worktree",
           runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
           startedAt: "2026-02-22T08:00:00.000Z",
           descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
@@ -2144,7 +2144,7 @@ describe("use-agent-orchestrator-operations", () => {
         repoPath: "/tmp/repo",
         taskId: null,
         role: "workspace",
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         startedAt: "2026-02-22T08:00:00.000Z",
         descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
@@ -2244,7 +2244,7 @@ describe("use-agent-orchestrator-operations", () => {
         repoPath: "/tmp/repo",
         taskId: null,
         role: "workspace",
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         startedAt: "2026-02-22T08:00:00.000Z",
         descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
@@ -2353,7 +2353,7 @@ describe("use-agent-orchestrator-operations", () => {
         repoPath: "/tmp/repo",
         taskId: null,
         role: "workspace",
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         startedAt: "2026-02-22T08:00:00.000Z",
         descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
@@ -2441,7 +2441,7 @@ describe("use-agent-orchestrator-operations", () => {
         repoPath: "/tmp/repo",
         taskId: null,
         role: "workspace",
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         startedAt: "2026-02-22T08:00:00.000Z",
         descriptor: OPENCODE_RUNTIME_DESCRIPTOR,


### PR DESCRIPTION
## Summary
- fail session hydration for worktree build/qa sessions unless an exact runtime match exists
- remove reconcile-time runtime rebinding and centralize the repo-root spec/planner hydration policy
- align runtime recovery tests with the fail-fast hydration rule and verify the full Bun and Rust check suite

## Goal
This PR fixes a session hydration bug where persisted worktree sessions could be rebound to a repo-root workspace runtime of the same kind instead of failing fast. That behavior violated the runtime-routing rule for session-scoped reads and could attach history, todos, diff, or file status to the wrong live runtime.

## Implementation
The hydration resolver now accepts only exact `runtimeKind + workingDirectory` matches from live runtimes or exact preloaded runtime connections. Worktree `build` and `qa` sessions fail with an actionable missing-working-directory error instead of falling back to a shared workspace runtime.

On the reconcile path, the preload service no longer fabricates per-directory runtime connections from another runtime route. Repo-root runtime ensure remains allowed only for repo-root `spec` and `planner` sessions, and that policy is now centralized in a shared lifecycle helper so the resolver and reconcile service cannot drift.

I also extracted reconcile preload metadata collection into a dedicated helper to make the flow easier to reason about, and updated the runtime recovery tests to use exact worktree runtime fixtures where recovery is expected to succeed.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Implemented hydration runtime policy to optimize agent session runtime attachment, with improved handling for spec and planner sessions at the repository root and enhanced error messaging for missing runtimes.

* **Tests**
  * Expanded test coverage for hydration runtime resolution and session hydration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->