### PR TITLE
fix(desktop): decouple build startup from local_http routes

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -92,16 +92,6 @@ impl AppService {
             runtime_summary,
             task_id,
         } = input;
-        runtime_summary
-            .runtime_route
-            .local_http_port()
-            .ok_or_else(|| {
-                anyhow!("Build sessions require a local_http runtime route with a port")
-            })?;
-        self.task_transition_to_in_progress_without_related_tasks(
-            prerequisites.repo_path.as_str(),
-            task_id,
-        )?;
 
         let working_directory = prepared_worktree
             .worktree_dir
@@ -109,11 +99,18 @@ impl AppService {
             .ok_or_else(|| anyhow!("Invalid worktree path"))?
             .to_string();
 
-        Ok(BuildSessionBootstrap {
+        let bootstrap = BuildSessionBootstrap {
             runtime_kind,
             runtime_route: runtime_summary.runtime_route,
             working_directory,
-        })
+        };
+
+        self.task_transition_to_in_progress_without_related_tasks(
+            prerequisites.repo_path.as_str(),
+            task_id,
+        )?;
+
+        Ok(bootstrap)
     }
 }
 
@@ -154,11 +151,11 @@ mod tests {
     }
 
     #[test]
-    fn initiate_build_mode_rejects_stdio_routes_before_transitioning_task() {
+    fn initiate_build_mode_allows_stdio_routes_and_transitions_task() {
         let (service, task_state, _git_state) =
             build_service_with_state(vec![make_task("task-1", "task", TaskStatus::Open)]);
 
-        let error = service
+        let bootstrap = service
             .initiate_build_mode(BuildModeStartInput {
                 runtime_kind: AgentRuntimeKind::opencode(),
                 prerequisites: make_build_prerequisites(),
@@ -168,15 +165,18 @@ mod tests {
                 runtime_summary: make_stdio_runtime_summary(),
                 task_id: "task-1",
             })
-            .expect_err("stdio build routes should fail fast");
+            .expect("stdio build routes should be accepted");
 
-        assert!(error
-            .to_string()
-            .contains("local_http runtime route with a port"));
+        assert_eq!(bootstrap.runtime_route, RuntimeRoute::Stdio);
+        assert_eq!(
+            bootstrap.working_directory,
+            "/tmp/worktrees/task-1".to_string()
+        );
         assert!(task_state
             .lock()
             .expect("task store lock poisoned")
             .updated_patches
-            .is_empty());
+            .iter()
+            .any(|(_, patch)| patch.status == Some(TaskStatus::InProgress)));
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
@@ -372,3 +372,90 @@ fn wait_for_local_server_with_process_honors_cancellation_epoch() {
     terminate_child_process(&mut child);
     assert_eq!(error.reason(), RuntimeStartupFailureReason::Cancelled);
 }
+
+#[test]
+fn build_start_preserves_task_state_when_runtime_adapter_rejects_external_startup() -> Result<()> {
+    let root = unique_temp_path("build-start-runtime-startup-failure");
+    let repo_path = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    crate::app_service::test_support::init_git_repo(&repo_path)?;
+
+    let runtime_registry = AppRuntimeRegistry::new(
+        vec![
+            Arc::new(TestRuntimeAdapter {
+                definition: builtin_opencode_runtime_definition(),
+                health: RuntimeHealth {
+                    kind: "opencode".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
+            }),
+            Arc::new(TestRuntimeAdapter {
+                definition: test_runtime_definition_with_provisioning(
+                    "test-runtime",
+                    "Test Runtime",
+                    RuntimeProvisioningMode::External,
+                ),
+                health: RuntimeHealth {
+                    kind: "test-runtime".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::ReturnError(
+                    "runtime-owned external startup rejected route",
+                ),
+            }),
+        ],
+        AgentRuntimeKind::opencode(),
+    )?;
+    let (service, task_state, _git_state) = build_service_with_runtime_registry(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        runtime_registry,
+    );
+    let repo_path_string = repo_path.to_string_lossy().to_string();
+    service.workspace_add(repo_path_string.as_str())?;
+    workspace_update_repo_config_by_repo_path(
+        &service,
+        repo_path_string.as_str(),
+        host_infra_system::RepoConfig {
+            default_runtime_kind: "test-runtime".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: None,
+                branch: "main".to_string(),
+            },
+            trusted_hooks: true,
+            ..Default::default()
+        },
+    )?;
+
+    let error = service
+        .build_start(repo_path_string.as_str(), "task-1", "test-runtime")
+        .expect_err("runtime-owned startup failures should surface from build_start");
+    let message = format!("{error:#}");
+
+    assert!(
+        message.contains("test-runtime build runtime failed to start for task task-1"),
+        "unexpected build_start error chain: {message}"
+    );
+    assert!(
+        message.contains("runtime-owned external startup rejected route"),
+        "unexpected runtime startup error chain: {message}"
+    );
+    assert!(task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .updated_patches
+        .is_empty());
+    assert!(service
+        .runtime_list("test-runtime", Some(repo_path_string.as_str()))?
+        .is_empty());
+
+    Ok(())
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
@@ -375,163 +375,53 @@ fn wait_for_local_server_with_process_honors_cancellation_epoch() {
 
 #[test]
 fn build_start_accepts_stdio_routes_from_runtime_adapter() -> Result<()> {
-    let root = unique_temp_path("build-start-stdio-runtime-route");
-    let repo_path = root.join("repo");
-    let worktree_base = root.join("worktrees");
-    crate::app_service::test_support::init_git_repo(&repo_path)?;
-
-    let runtime_registry = AppRuntimeRegistry::new(
-        vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition_with_provisioning(
-                    "test-runtime",
-                    "Test Runtime",
-                    RuntimeProvisioningMode::External,
-                ),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::ReturnRoute(
-                    host_domain::RuntimeRoute::Stdio,
-                ),
-            }),
-        ],
-        AgentRuntimeKind::opencode(),
+    let harness = build_external_runtime_build_start_harness(
+        "build-start-stdio-runtime-route",
+        ExternalStartBehavior::ReturnRoute(host_domain::RuntimeRoute::Stdio),
     )?;
-    let (service, task_state, _git_state) = build_service_with_runtime_registry(
-        vec![make_task("task-1", "task", TaskStatus::Open)],
-        runtime_registry,
+
+    let bootstrap =
+        harness
+            .service
+            .build_start(harness.repo_path_string.as_str(), "task-1", "test-runtime")?;
+
+    assert_eq!(
+        bootstrap.runtime_kind,
+        AgentRuntimeKind::from("test-runtime")
     );
-    let repo_path_string = repo_path.to_string_lossy().to_string();
-    service.workspace_add(repo_path_string.as_str())?;
-    workspace_update_repo_config_by_repo_path(
-        &service,
-        repo_path_string.as_str(),
-        host_infra_system::RepoConfig {
-            default_runtime_kind: "test-runtime".to_string(),
-            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
-            branch_prefix: "odt".to_string(),
-            default_target_branch: host_infra_system::GitTargetBranch {
-                remote: None,
-                branch: "main".to_string(),
-            },
-            trusted_hooks: true,
-            ..Default::default()
-        },
-    )?;
-
-    let bootstrap = service.build_start(repo_path_string.as_str(), "task-1", "test-runtime")?;
-
-    assert_eq!(bootstrap.runtime_kind, AgentRuntimeKind::from("test-runtime"));
     assert_eq!(bootstrap.runtime_route, host_domain::RuntimeRoute::Stdio);
     assert_eq!(
         bootstrap.working_directory,
-        worktree_base.join("task-1").to_string_lossy().to_string()
+        harness.expected_worktree_dir("task-1")
     );
-    assert!(task_state
+    assert!(harness
+        .task_state
         .lock()
         .expect("task store lock poisoned")
         .updated_patches
         .iter()
         .any(|(_, patch)| patch.status == Some(TaskStatus::InProgress)));
-    let runtimes = service.runtime_list("test-runtime", Some(repo_path_string.as_str()))?;
-    assert_eq!(runtimes.len(), 1);
-    let runtime = runtimes.first().expect("runtime should be registered");
-    let expected_repo_path = std::fs::canonicalize(&repo_path)?;
-    assert_eq!(runtime.kind, AgentRuntimeKind::from("test-runtime"));
-    assert_eq!(std::fs::canonicalize(&runtime.repo_path)?, expected_repo_path);
-    assert_eq!(runtime.task_id, None);
-    assert_eq!(runtime.role, RuntimeRole::Workspace);
-    assert_eq!(
-        std::fs::canonicalize(&runtime.working_directory)?,
-        expected_repo_path
-    );
-    assert_eq!(runtime.runtime_route, host_domain::RuntimeRoute::Stdio);
-    assert!(!runtime.runtime_id.is_empty());
-    assert!(!runtime.started_at.is_empty());
+    assert_registered_workspace_runtime(
+        &harness.service,
+        "test-runtime",
+        harness.repo_path_string.as_str(),
+        harness.repo_path.as_path(),
+        host_domain::RuntimeRoute::Stdio,
+    )?;
 
     Ok(())
 }
 
 #[test]
 fn build_start_preserves_task_state_when_runtime_adapter_rejects_external_startup() -> Result<()> {
-    let root = unique_temp_path("build-start-runtime-startup-failure");
-    let repo_path = root.join("repo");
-    let worktree_base = root.join("worktrees");
-    crate::app_service::test_support::init_git_repo(&repo_path)?;
-
-    let runtime_registry = AppRuntimeRegistry::new(
-        vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition_with_provisioning(
-                    "test-runtime",
-                    "Test Runtime",
-                    RuntimeProvisioningMode::External,
-                ),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::ReturnError(
-                    "runtime-owned external startup rejected route",
-                ),
-            }),
-        ],
-        AgentRuntimeKind::opencode(),
-    )?;
-    let (service, task_state, _git_state) = build_service_with_runtime_registry(
-        vec![make_task("task-1", "task", TaskStatus::Open)],
-        runtime_registry,
-    );
-    let repo_path_string = repo_path.to_string_lossy().to_string();
-    service.workspace_add(repo_path_string.as_str())?;
-    workspace_update_repo_config_by_repo_path(
-        &service,
-        repo_path_string.as_str(),
-        host_infra_system::RepoConfig {
-            default_runtime_kind: "test-runtime".to_string(),
-            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
-            branch_prefix: "odt".to_string(),
-            default_target_branch: host_infra_system::GitTargetBranch {
-                remote: None,
-                branch: "main".to_string(),
-            },
-            trusted_hooks: true,
-            ..Default::default()
-        },
+    let harness = build_external_runtime_build_start_harness(
+        "build-start-runtime-startup-failure",
+        ExternalStartBehavior::ReturnError("runtime-owned external startup rejected route"),
     )?;
 
-    let error = service
-        .build_start(repo_path_string.as_str(), "task-1", "test-runtime")
+    let error = harness
+        .service
+        .build_start(harness.repo_path_string.as_str(), "task-1", "test-runtime")
         .expect_err("runtime-owned startup failures should surface from build_start");
     let message = format!("{error:#}");
 
@@ -543,13 +433,15 @@ fn build_start_preserves_task_state_when_runtime_adapter_rejects_external_startu
         message.contains("runtime-owned external startup rejected route"),
         "unexpected runtime startup error chain: {message}"
     );
-    assert!(task_state
+    assert!(harness
+        .task_state
         .lock()
         .expect("task store lock poisoned")
         .updated_patches
         .is_empty());
-    assert!(service
-        .runtime_list("test-runtime", Some(repo_path_string.as_str()))?
+    assert!(harness
+        .service
+        .runtime_list("test-runtime", Some(harness.repo_path_string.as_str()))?
         .is_empty());
 
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
@@ -374,6 +374,101 @@ fn wait_for_local_server_with_process_honors_cancellation_epoch() {
 }
 
 #[test]
+fn build_start_accepts_stdio_routes_from_runtime_adapter() -> Result<()> {
+    let root = unique_temp_path("build-start-stdio-runtime-route");
+    let repo_path = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    crate::app_service::test_support::init_git_repo(&repo_path)?;
+
+    let runtime_registry = AppRuntimeRegistry::new(
+        vec![
+            Arc::new(TestRuntimeAdapter {
+                definition: builtin_opencode_runtime_definition(),
+                health: RuntimeHealth {
+                    kind: "opencode".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
+            }),
+            Arc::new(TestRuntimeAdapter {
+                definition: test_runtime_definition_with_provisioning(
+                    "test-runtime",
+                    "Test Runtime",
+                    RuntimeProvisioningMode::External,
+                ),
+                health: RuntimeHealth {
+                    kind: "test-runtime".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::ReturnRoute(
+                    host_domain::RuntimeRoute::Stdio,
+                ),
+            }),
+        ],
+        AgentRuntimeKind::opencode(),
+    )?;
+    let (service, task_state, _git_state) = build_service_with_runtime_registry(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        runtime_registry,
+    );
+    let repo_path_string = repo_path.to_string_lossy().to_string();
+    service.workspace_add(repo_path_string.as_str())?;
+    workspace_update_repo_config_by_repo_path(
+        &service,
+        repo_path_string.as_str(),
+        host_infra_system::RepoConfig {
+            default_runtime_kind: "test-runtime".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: None,
+                branch: "main".to_string(),
+            },
+            trusted_hooks: true,
+            ..Default::default()
+        },
+    )?;
+
+    let bootstrap = service.build_start(repo_path_string.as_str(), "task-1", "test-runtime")?;
+
+    assert_eq!(bootstrap.runtime_kind, AgentRuntimeKind::from("test-runtime"));
+    assert_eq!(bootstrap.runtime_route, host_domain::RuntimeRoute::Stdio);
+    assert_eq!(
+        bootstrap.working_directory,
+        worktree_base.join("task-1").to_string_lossy().to_string()
+    );
+    assert!(task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .updated_patches
+        .iter()
+        .any(|(_, patch)| patch.status == Some(TaskStatus::InProgress)));
+    let runtimes = service.runtime_list("test-runtime", Some(repo_path_string.as_str()))?;
+    assert_eq!(runtimes.len(), 1);
+    let runtime = runtimes.first().expect("runtime should be registered");
+    let expected_repo_path = std::fs::canonicalize(&repo_path)?;
+    assert_eq!(runtime.kind, AgentRuntimeKind::from("test-runtime"));
+    assert_eq!(std::fs::canonicalize(&runtime.repo_path)?, expected_repo_path);
+    assert_eq!(runtime.task_id, None);
+    assert_eq!(runtime.role, RuntimeRole::Workspace);
+    assert_eq!(
+        std::fs::canonicalize(&runtime.working_directory)?,
+        expected_repo_path
+    );
+    assert_eq!(runtime.runtime_route, host_domain::RuntimeRoute::Stdio);
+    assert!(!runtime.runtime_id.is_empty());
+    assert!(!runtime.started_at.is_empty());
+
+    Ok(())
+}
+
+#[test]
 fn build_start_preserves_task_state_when_runtime_adapter_rejects_external_startup() -> Result<()> {
     let root = unique_temp_path("build-start-runtime-startup-failure");
     let repo_path = root.join("repo");

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -27,7 +27,7 @@ pub(super) use crate::app_service::runtime_registry::{
 pub(super) use crate::app_service::test_support::{
     build_service_with_git_state, build_service_with_runtime_registry,
     builtin_opencode_runtime_definition, builtin_opencode_runtime_descriptor,
-    builtin_opencode_runtime_route, make_task, repo_config_for_workspace,
+    builtin_opencode_runtime_route, init_git_repo, make_task, repo_config_for_workspace,
     spawn_opencode_session_status_server, spawn_sleep_process, spawn_sleep_process_group,
     unique_temp_path, wait_for_process_exit, workspace_update_repo_config_by_repo_path,
     write_private_file, FakeTaskStore, TaskStoreState,
@@ -44,21 +44,6 @@ pub(super) use crate::app_service::{
     RuntimeSessionStatusProbeTargetResolution, RuntimeSessionStatusSnapshot,
     RuntimeStartupFailureReason, StartupEventContext, StartupEventCorrelation, StartupEventPayload,
 };
-
-pub(super) fn init_git_repo(path: &std::path::Path) -> Result<()> {
-    let status = Command::new("git")
-        .args(["init", "--quiet"])
-        .arg(path)
-        .status()?;
-    if status.success() {
-        return Ok(());
-    }
-
-    Err(anyhow::anyhow!(
-        "failed to initialize git repo for test at {}",
-        path.display()
-    ))
-}
 
 pub(super) fn insert_workspace_runtime(
     service: &AppService,
@@ -166,6 +151,124 @@ impl Default for ExternalStartBehavior {
             endpoint: "http://127.0.0.1:43123".to_string(),
         })
     }
+}
+
+pub(super) struct ExternalRuntimeBuildStartHarness {
+    pub(super) service: AppService,
+    pub(super) task_state: Arc<Mutex<TaskStoreState>>,
+    pub(super) repo_path: std::path::PathBuf,
+    pub(super) repo_path_string: String,
+    pub(super) worktree_base: std::path::PathBuf,
+}
+
+impl ExternalRuntimeBuildStartHarness {
+    pub(super) fn expected_worktree_dir(&self, task_id: &str) -> String {
+        self.worktree_base
+            .join(task_id)
+            .to_string_lossy()
+            .to_string()
+    }
+}
+
+pub(super) fn build_external_runtime_build_start_harness(
+    test_name: &str,
+    external_start_behavior: ExternalStartBehavior,
+) -> Result<ExternalRuntimeBuildStartHarness> {
+    let root = unique_temp_path(test_name);
+    let repo_path = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    init_git_repo(&repo_path)?;
+
+    let runtime_registry = AppRuntimeRegistry::new(
+        vec![
+            Arc::new(TestRuntimeAdapter {
+                definition: builtin_opencode_runtime_definition(),
+                health: RuntimeHealth {
+                    kind: "opencode".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
+            }),
+            Arc::new(TestRuntimeAdapter {
+                definition: test_runtime_definition_with_provisioning(
+                    "test-runtime",
+                    "Test Runtime",
+                    RuntimeProvisioningMode::External,
+                ),
+                health: RuntimeHealth {
+                    kind: "test-runtime".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior,
+            }),
+        ],
+        AgentRuntimeKind::opencode(),
+    )?;
+    let (service, task_state, _git_state) = build_service_with_runtime_registry(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        runtime_registry,
+    );
+    let repo_path_string = repo_path.to_string_lossy().to_string();
+    service.workspace_add(repo_path_string.as_str())?;
+    workspace_update_repo_config_by_repo_path(
+        &service,
+        repo_path_string.as_str(),
+        host_infra_system::RepoConfig {
+            default_runtime_kind: "test-runtime".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: None,
+                branch: "main".to_string(),
+            },
+            trusted_hooks: true,
+            ..Default::default()
+        },
+    )?;
+
+    Ok(ExternalRuntimeBuildStartHarness {
+        service,
+        task_state,
+        repo_path,
+        repo_path_string,
+        worktree_base,
+    })
+}
+
+pub(super) fn assert_registered_workspace_runtime(
+    service: &AppService,
+    runtime_kind: &str,
+    repo_path: &str,
+    expected_repo_path: &std::path::Path,
+    expected_route: host_domain::RuntimeRoute,
+) -> Result<()> {
+    let runtimes = service.runtime_list(runtime_kind, Some(repo_path))?;
+    assert_eq!(runtimes.len(), 1);
+    let runtime = runtimes.first().expect("runtime should be registered");
+    let expected_repo_path = fs::canonicalize(expected_repo_path)?;
+
+    assert_eq!(runtime.kind, AgentRuntimeKind::from(runtime_kind));
+    assert_eq!(
+        std::fs::canonicalize(&runtime.repo_path)?,
+        expected_repo_path
+    );
+    assert_eq!(runtime.task_id, None);
+    assert_eq!(runtime.role, RuntimeRole::Workspace);
+    assert_eq!(
+        std::fs::canonicalize(&runtime.working_directory)?,
+        expected_repo_path
+    );
+    assert_eq!(runtime.runtime_route, expected_route);
+    assert!(!runtime.runtime_id.is_empty());
+    assert!(!runtime.started_at.is_empty());
+
+    Ok(())
 }
 
 impl AppRuntime for TestRuntimeAdapter {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -151,6 +151,21 @@ pub(super) struct TestRuntimeAdapter {
     pub(super) definition: RuntimeDefinition,
     pub(super) health: RuntimeHealth,
     pub(super) session_probe_behavior: SessionProbeBehavior,
+    pub(super) external_start_behavior: ExternalStartBehavior,
+}
+
+#[derive(Clone)]
+pub(super) enum ExternalStartBehavior {
+    ReturnRoute(host_domain::RuntimeRoute),
+    ReturnError(&'static str),
+}
+
+impl Default for ExternalStartBehavior {
+    fn default() -> Self {
+        Self::ReturnRoute(host_domain::RuntimeRoute::LocalHttp {
+            endpoint: "http://127.0.0.1:43123".to_string(),
+        })
+    }
 }
 
 impl AppRuntime for TestRuntimeAdapter {
@@ -168,10 +183,13 @@ impl AppRuntime for TestRuntimeAdapter {
         _input: &crate::app_service::runtime_orchestrator::RuntimeStartInput<'_>,
         _runtime_id: &str,
     ) -> Result<ExternalRuntimeStart> {
-        Ok(ExternalRuntimeStart {
-            runtime_route: self.definition.route_for_port(43_123),
-            startup_report: crate::app_service::RuntimeStartupWaitReport::zero(),
-        })
+        match &self.external_start_behavior {
+            ExternalStartBehavior::ReturnRoute(runtime_route) => Ok(ExternalRuntimeStart {
+                runtime_route: runtime_route.clone(),
+                startup_report: crate::app_service::RuntimeStartupWaitReport::zero(),
+            }),
+            ExternalStartBehavior::ReturnError(message) => Err(anyhow::anyhow!(*message)),
+        }
     }
 
     fn track_process(&self, _service: &AppService, _child_id: u32) -> Result<RuntimeProcessGuard> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -260,6 +260,8 @@ pub(super) fn assert_registered_workspace_runtime(
     );
     assert_eq!(runtime.task_id, None);
     assert_eq!(runtime.role, RuntimeRole::Workspace);
+    // The registered workspace runtime stays rooted at the repo while the
+    // build bootstrap points at the per-task worktree created for the session.
     assert_eq!(
         std::fs::canonicalize(&runtime.working_directory)?,
         expected_repo_path

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime/registry.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime/registry.rs
@@ -535,6 +535,22 @@ mod tests {
     }
 
     #[test]
+    fn builtin_opencode_runtime_stays_host_managed_with_local_http_routes() {
+        let definition = super::builtin_runtime_registry()
+            .definition_by_str("opencode")
+            .expect("opencode runtime should be registered");
+
+        assert!(matches!(
+            definition.descriptor().capabilities.provisioning_mode,
+            RuntimeProvisioningMode::HostManaged
+        ));
+        assert_eq!(
+            definition.route_for_port(43123),
+            super::local_http_route_for_port(43123)
+        );
+    }
+
+    #[test]
     fn runtime_descriptor_validation_reports_mandatory_capabilities_and_scopes() {
         let descriptor = RuntimeDescriptor {
             kind: AgentRuntimeKind::opencode(),

--- a/apps/desktop/src/state/agent-runtime-registry.test.ts
+++ b/apps/desktop/src/state/agent-runtime-registry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { createAgentRuntimeRegistry, DEFAULT_RUNTIME_KIND } from "./agent-runtime-registry";
+
+describe("agent-runtime-registry", () => {
+  test("registers only the shipped opencode runtime adapter", () => {
+    const registry = createAgentRuntimeRegistry();
+
+    expect(registry.defaultRuntimeKind).toBe(DEFAULT_RUNTIME_KIND);
+    expect(registry.registeredRuntimeKinds).toEqual(["opencode"]);
+    expect(registry.getRuntimeDefinition("opencode").kind).toBe("opencode");
+    expect(
+      registry
+        .createAgentEngine()
+        .listRuntimeDefinitions()
+        .map((runtime) => runtime.kind),
+    ).toEqual(["opencode"]);
+  });
+
+  test("rejects unsupported runtime adapters", () => {
+    const registry = createAgentRuntimeRegistry();
+
+    expect(() => registry.getAdapter("test-runtime")).toThrow(
+      "Unsupported agent runtime 'test-runtime'.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- remove the shared `local_http`/port requirement from build startup so `BuildSessionBootstrap` preserves the runtime-owned route shape
- add service-level coverage for stdio build bootstrap success and runtime-owned startup failure handling
- refactor the build startup test fixtures and add runtime invariant tests that lock the current shipped OpenCode route assumptions in place

## Goal
This PR fixes a transport-coupling bug in the shared host build startup flow. The build lifecycle still assumed that every runtime startup returned a `local_http` route with a port, which made the generic builder path incompatible with runtimes that expose a different `RuntimeRoute` shape.

The goal is to keep shared build orchestration route-agnostic while preserving fail-fast behavior and leaving any transport-specific compatibility rules inside the runtime or adapter layer that owns that transport.

## Implementation
The main host change is in `build_lifecycle.rs`, where the shared `local_http` guard is removed. `initiate_build_mode(...)` now derives the worktree directory, constructs `BuildSessionBootstrap` directly from the runtime kind and returned `RuntimeRoute`, then transitions the task to `in_progress` only after the bootstrap payload is fully available.

On the testing side, the PR adds coverage for both the seam-level and service-level behavior. The host-application startup tests now prove that an external runtime can return `RuntimeRoute::Stdio` through `AppService::build_start(...)` without shared lifecycle rejection, and that runtime-owned external startup failures still leave task state unchanged.

The follow-up cleanup consolidates the startup test fixtures around one canonical repo initializer and one shared external-runtime harness, which keeps the success and failure tests smaller and less brittle.

The final review follow-up did not change production behavior. Instead, it added invariant tests on both the desktop and host sides to lock in the current shipped assumption that production only wires the OpenCode adapter and builtin OpenCode remains `HostManaged` with `local_http` routes. That makes the reviewed future integration hazard explicit without reintroducing the old shared transport check.

## Verification
### Bun
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun test apps/desktop/src/state/agent-runtime-registry.test.ts`
- `bun run --filter @openducktor/desktop lint`

### Cargo
- `rtk cargo fmt --all --check`
- `rtk cargo clippy --workspace --all-targets -- -D warnings`
- `rtk cargo check --workspace`
- `rtk cargo test --workspace`
- `rtk cargo build --workspace`
- `rtk cargo test -p host-domain builtin_opencode_runtime_stays_host_managed_with_local_http_routes`
- `rtk cargo test -p host-application`