### PR TITLE
fix(desktop): preserve agent session transcript state

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
@@ -1,6 +1,7 @@
 import {
   findFirstChangedSessionMessageIndex,
   forEachSessionMessage,
+  isFinalAssistantChatMessage,
 } from "@/state/operations/agent-orchestrator/support/messages";
 import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
 
@@ -57,8 +58,7 @@ const appendMessageRows = (
   const assistantMeta = message.meta?.kind === "assistant" ? message.meta : null;
   const turnDurationMs = assistantMeta?.durationMs;
   const shouldShowTurnDuration =
-    message.role === "assistant" &&
-    assistantMeta?.isFinal === true &&
+    isFinalAssistantChatMessage(message) &&
     typeof turnDurationMs === "number" &&
     turnDurationMs > 0;
 

--- a/apps/desktop/src/components/features/agents/agent-chat/message-formatting.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/message-formatting.ts
@@ -1,6 +1,7 @@
 import type { RuntimeDescriptor } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
 import { toOdtWorkflowToolDisplayName } from "@openducktor/core";
+import { isFinalAssistantChatMessage } from "@/state/operations/agent-orchestrator/support/messages";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import { stripToolPrefix } from "./tool-text-utils";
@@ -82,14 +83,11 @@ export const roleLabel = (
 };
 
 export const getAssistantFooterData = (message: AgentChatMessage): { infoParts: string[] } => {
-  if (message.role !== "assistant") {
+  if (!isFinalAssistantChatMessage(message)) {
     return { infoParts: [] };
   }
 
-  const assistantMeta = message.meta?.kind === "assistant" ? message.meta : null;
-  if (!assistantMeta || assistantMeta.isFinal !== true) {
-    return { infoParts: [] };
-  }
+  const assistantMeta = message.meta;
   const parts: string[] = [];
 
   const agentLabel = assistantMeta.profileId;

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -466,12 +466,12 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
   });
 
   const { startSessionRequest } = orchestration;
-  const activeSessionSummary = selection.activeSession
-    ? toAgentSessionSummary(selection.activeSession)
-    : null;
-  const viewActiveSessionSummary = selection.viewActiveSession
-    ? toAgentSessionSummary(selection.viewActiveSession)
-    : null;
+  const activeSessionSummary =
+    selection.activeSessionSummary ??
+    (selection.activeSession ? toAgentSessionSummary(selection.activeSession) : null);
+  const viewActiveSessionSummary =
+    selection.viewActiveSessionSummary ??
+    (selection.viewActiveSession ? toAgentSessionSummary(selection.viewActiveSession) : null);
 
   const { handleResolveRebaseConflict } = useAgentStudioRebaseConflictResolution({
     activeWorkspace,

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -13,7 +13,10 @@ import {
   createDeferred,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
-import { useAgentStudioModelSelection } from "./use-agent-studio-model-selection";
+import {
+  resolveActiveSessionSelectionState,
+  useAgentStudioModelSelection,
+} from "./use-agent-studio-model-selection";
 
 enableReactActEnvironment();
 
@@ -202,6 +205,7 @@ const createAssistantMessage = (
 const createBaseProps = (overrides: Partial<LegacyHookArgs> = {}): LegacyHookArgs => ({
   activeWorkspace: createActiveWorkspace("/repo"),
   activeSession: null,
+  activeSessionSummary: null,
   role: "spec",
   repoSettings: null,
   updateAgentSessionModel: () => {},
@@ -210,6 +214,75 @@ const createBaseProps = (overrides: Partial<LegacyHookArgs> = {}): LegacyHookArg
 });
 
 describe("useAgentStudioModelSelection", () => {
+  test("prefers hydrated session runtime fields while preserving summary selection fallback", () => {
+    const hydratedSession = createActiveSession({
+      runtimeKind: "opencode",
+      runtimeRoute: { type: "local_http", endpoint: "http://localhost:3000" },
+      workingDirectory: "/repo/session-worktree",
+    });
+    const summary = {
+      sessionId: "session-1",
+      taskId: "task-1",
+      role: "spec" as const,
+      scenario: "spec_initial" as const,
+      status: "idle" as const,
+      startedAt: "2026-02-20T10:00:00.000Z",
+      workingDirectory: "/repo",
+      runtimeKind: "opencode" as const,
+      selectedModel: {
+        runtimeKind: "opencode" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+        profileId: "build-agent",
+      },
+      pendingPermissions: [],
+      pendingQuestions: [],
+    };
+
+    const state = resolveActiveSessionSelectionState(hydratedSession, summary);
+
+    expect(state.sessionId).toBe("session-1");
+    expect(state.selectedModel).toEqual(hydratedSession.selectedModel);
+    expect(state.runtimeKind).toBe("opencode");
+    expect(state.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://localhost:3000",
+    });
+    expect(state.workingDirectory).toBe("/repo/session-worktree");
+    expect(state.isLoadingModelCatalog).toBe(false);
+    expect(state.hasSelection).toBe(true);
+  });
+
+  test("keeps summary selection available while the hydrated session is missing", () => {
+    const summary = {
+      sessionId: "session-1",
+      taskId: "task-1",
+      role: "spec" as const,
+      scenario: "spec_initial" as const,
+      status: "idle" as const,
+      startedAt: "2026-02-20T10:00:00.000Z",
+      workingDirectory: "/repo",
+      runtimeKind: "opencode" as const,
+      selectedModel: {
+        runtimeKind: "opencode" as const,
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+        profileId: "build-agent",
+      },
+      pendingPermissions: [],
+      pendingQuestions: [],
+    };
+
+    const state = resolveActiveSessionSelectionState(null, summary);
+
+    expect(state.sessionId).toBe("session-1");
+    expect(state.selectedModel).toEqual(summary.selectedModel);
+    expect(state.runtimeKind).toBe("opencode");
+    expect(state.runtimeRoute).toBeNull();
+    expect(state.isLoadingModelCatalog).toBe(true);
+    expect(state.hasSelection).toBe(true);
+  });
+
   test("uses repo role defaults when available", async () => {
     const harness = createHookHarness(
       createBaseProps({
@@ -317,6 +390,46 @@ describe("useAgentStudioModelSelection", () => {
     });
 
     await harness.unmount();
+  });
+
+  test("keeps the selected session model while the full session object is still hydrating", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession: null,
+        activeSessionSummary: {
+          sessionId: "session-1",
+          taskId: "task-1",
+          role: "spec",
+          scenario: "spec_initial",
+          status: "idle",
+          startedAt: "2026-02-20T10:00:00.000Z",
+          workingDirectory: "/repo",
+          runtimeKind: "opencode",
+          selectedModel: {
+            runtimeKind: "opencode",
+            providerId: "anthropic",
+            modelId: "claude-sonnet",
+            profileId: "build-agent",
+          },
+          pendingPermissions: [],
+          pendingQuestions: [],
+        },
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(harness.getLatest().isSelectionCatalogLoading).toBe(true);
+      expect(harness.getLatest().selectedModelSelection).toEqual({
+        runtimeKind: "opencode",
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+        profileId: "build-agent",
+      });
+    } finally {
+      await harness.unmount();
+    }
   });
 
   test("does not query session slash commands until the active session exposes its runtime kind", async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -278,6 +278,7 @@ describe("useAgentStudioModelSelection", () => {
     expect(state.sessionId).toBe("session-1");
     expect(state.selectedModel).toEqual(summary.selectedModel);
     expect(state.runtimeKind).toBe("opencode");
+    expect(state.workingDirectory).toBe("/repo");
     expect(state.runtimeRoute).toBeNull();
     expect(state.isLoadingModelCatalog).toBe(true);
     expect(state.hasSelection).toBe(true);

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -128,7 +128,10 @@ export const resolveActiveSessionSelectionState = (
     modelCatalog: activeSession?.modelCatalog ?? null,
     runtimeKind: activeSession?.runtimeKind ?? activeSessionSummary?.runtimeKind ?? null,
     runtimeRoute: activeSession?.runtimeRoute ?? null,
-    workingDirectory: activeSession?.workingDirectory?.trim() ?? "",
+    workingDirectory:
+      activeSession?.workingDirectory?.trim() ??
+      activeSessionSummary?.workingDirectory?.trim() ??
+      "",
     isLoadingModelCatalog:
       activeSession?.isLoadingModelCatalog === true ||
       (activeSession == null && activeSessionSummary != null),

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -17,6 +17,7 @@ import {
 } from "@/components/features/agents";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
+import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { findFirstChangedSessionMessageIndex } from "@/state/operations/agent-orchestrator/support/messages";
 import {
@@ -51,6 +52,7 @@ import {
 type UseAgentStudioModelSelectionArgs = {
   activeWorkspace: ActiveWorkspace | null;
   activeSession: AgentSessionState | null;
+  activeSessionSummary: AgentSessionSummary | null;
   role: AgentRole;
   repoSettings: RepoSettingsInput | null;
   updateAgentSessionModel: (sessionId: string, selection: AgentModelSelection | null) => void;
@@ -98,6 +100,44 @@ type AgentStudioModelSelectionState = {
   handleSelectVariant: (variant: string) => void;
 };
 
+type ActiveSessionSelectionState = {
+  sessionId: string | null;
+  status: AgentSessionState["status"] | null;
+  selectedModel: AgentModelSelection | null;
+  modelCatalog: AgentSessionState["modelCatalog"] | null;
+  runtimeKind: AgentSessionState["runtimeKind"] | null;
+  runtimeRoute: AgentSessionState["runtimeRoute"] | null;
+  workingDirectory: string;
+  isLoadingModelCatalog: boolean;
+  liveContextUsage: AgentSessionState["contextUsage"] | null;
+  messages: AgentSessionState["messages"] | null;
+  hasSelection: boolean;
+};
+
+export const resolveActiveSessionSelectionState = (
+  activeSession: AgentSessionState | null,
+  activeSessionSummary: AgentSessionSummary | null,
+): ActiveSessionSelectionState => {
+  const sessionId = activeSession?.sessionId ?? activeSessionSummary?.sessionId ?? null;
+  const selectedModel = activeSession?.selectedModel ?? activeSessionSummary?.selectedModel ?? null;
+
+  return {
+    sessionId,
+    status: activeSession?.status ?? activeSessionSummary?.status ?? null,
+    selectedModel,
+    modelCatalog: activeSession?.modelCatalog ?? null,
+    runtimeKind: activeSession?.runtimeKind ?? activeSessionSummary?.runtimeKind ?? null,
+    runtimeRoute: activeSession?.runtimeRoute ?? null,
+    workingDirectory: activeSession?.workingDirectory?.trim() ?? "",
+    isLoadingModelCatalog:
+      activeSession?.isLoadingModelCatalog === true ||
+      (activeSession == null && activeSessionSummary != null),
+    liveContextUsage: activeSession?.contextUsage ?? null,
+    messages: activeSession?.messages ?? null,
+    hasSelection: sessionId !== null,
+  };
+};
+
 const emptyDraftSelectionTouchedByRole = (): Record<AgentRole, boolean> => ({
   spec: false,
   planner: false,
@@ -108,6 +148,7 @@ const emptyDraftSelectionTouchedByRole = (): Record<AgentRole, boolean> => ({
 export function useAgentStudioModelSelection({
   activeWorkspace,
   activeSession,
+  activeSessionSummary,
   role,
   repoSettings,
   updateAgentSessionModel,
@@ -148,17 +189,21 @@ export function useAgentStudioModelSelection({
   const [draftSelectionTouchedByRole, setDraftSelectionTouchedByRole] = useState<
     Record<AgentRole, boolean>
   >(emptyDraftSelectionTouchedByRole);
-  const activeSessionId = activeSession?.sessionId ?? null;
-  const activeSessionStatus = activeSession?.status ?? null;
-  const activeSessionSelectedModel = activeSession?.selectedModel ?? null;
-  const activeSessionModelCatalog = activeSession?.modelCatalog ?? null;
-  const activeSessionRuntimeKind = activeSession?.runtimeKind ?? null;
-  const activeSessionRuntimeRoute = activeSession?.runtimeRoute ?? null;
-  const activeSessionWorkingDirectory = activeSession?.workingDirectory?.trim() ?? "";
-  const activeSessionIsLoadingModelCatalog = activeSession?.isLoadingModelCatalog === true;
-  const activeSessionLiveContextUsage = activeSession?.contextUsage ?? null;
-  const activeSessionMessages = activeSession?.messages ?? null;
-  const hasActiveSession = activeSessionId !== null;
+  const activeSessionSelection = useMemo(
+    () => resolveActiveSessionSelectionState(activeSession, activeSessionSummary),
+    [activeSession, activeSessionSummary],
+  );
+  const activeSessionId = activeSessionSelection.sessionId;
+  const activeSessionStatus = activeSessionSelection.status;
+  const activeSessionSelectedModel = activeSessionSelection.selectedModel;
+  const activeSessionModelCatalog = activeSessionSelection.modelCatalog;
+  const activeSessionRuntimeKind = activeSessionSelection.runtimeKind;
+  const activeSessionRuntimeRoute = activeSessionSelection.runtimeRoute;
+  const activeSessionWorkingDirectory = activeSessionSelection.workingDirectory;
+  const activeSessionIsLoadingModelCatalog = activeSessionSelection.isLoadingModelCatalog;
+  const activeSessionLiveContextUsage = activeSessionSelection.liveContextUsage ?? null;
+  const activeSessionMessages = activeSessionSelection.messages;
+  const hasActiveSession = activeSessionSelection.hasSelection;
   const roleDefaultSelection = useMemo<AgentModelSelection | null>(() => {
     return toRoleDefaultSelection(repoSettings?.agentDefaults[role]);
   }, [repoSettings?.agentDefaults, role]);
@@ -250,7 +295,7 @@ export function useAgentStudioModelSelection({
       composerRuntimeKind,
       loadCatalogForRepo,
     ),
-    enabled: workspaceRepoPath !== null && activeSession == null,
+    enabled: workspaceRepoPath !== null && activeSessionId === null,
     queryFn: async (): Promise<AgentModelCatalog> => {
       if (!workspaceRepoPath) {
         throw new Error("No repository selected.");
@@ -287,7 +332,7 @@ export function useAgentStudioModelSelection({
       composerRuntimeKind,
       loadSlashCommandsForRepo,
     ),
-    enabled: supportsSlashCommands && workspaceRepoPath !== null && activeSession == null,
+    enabled: supportsSlashCommands && workspaceRepoPath !== null && activeSessionId === null,
   });
   const hasDraftSelectionForWorkspaceRepoPath =
     previousWorkspaceRepoPathRef.current === workspaceRepoPath;
@@ -360,7 +405,7 @@ export function useAgentStudioModelSelection({
 
   const draftSelection = hasDraftSelectionForWorkspaceRepoPath ? draftSelectionByRole[role] : null;
   const roleDefaultSelectionForComposer = useMemo<AgentModelSelection | null>(() => {
-    if (activeSession) {
+    if (hasActiveSession) {
       return roleDefaultSelection;
     }
     if (!composerCatalog) {
@@ -368,18 +413,18 @@ export function useAgentStudioModelSelection({
     }
     return coerceVisibleSelectionToCatalog(composerCatalog, roleDefaultSelection);
   }, [
-    activeSession,
+    hasActiveSession,
     composerCatalog,
     isAwaitingRepoSettingsForWorkspaceRepoPath,
     roleDefaultSelection,
   ]);
   const selectionCatalog = activeSessionModelCatalog ?? composerCatalog;
-  const slashCommandCatalog = activeSession
+  const slashCommandCatalog = hasActiveSession
     ? (activeSessionSlashCommandsQuery.data ?? null)
     : (repoSlashCommandsQuery.data ?? null);
   const slashCommands = slashCommandCatalog?.commands ?? [];
   const slashCommandsError = supportsSlashCommands
-    ? activeSession
+    ? hasActiveSession
       ? activeSessionSlashCommandsQuery.error instanceof Error
         ? activeSessionSlashCommandsQuery.error.message
         : null
@@ -388,7 +433,7 @@ export function useAgentStudioModelSelection({
         : null
     : null;
   const isSlashCommandsLoading = supportsSlashCommands
-    ? activeSession
+    ? hasActiveSession
       ? activeSessionSlashCommandsQuery.isLoading
       : repoSlashCommandsQuery.isLoading
     : false;

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -237,6 +237,7 @@ export function useAgentStudioOrchestrationController({
     viewScenario,
     viewSelectedTask,
     viewSessionsForTask,
+    viewActiveSessionSummary,
     viewActiveSession,
     viewSessionRuntimeDataError = null,
     activeTaskTabId,
@@ -306,6 +307,7 @@ export function useAgentStudioOrchestrationController({
   } = useAgentStudioModelSelection({
     activeWorkspace,
     activeSession: viewActiveSession,
+    activeSessionSummary: viewActiveSessionSummary,
     role: viewRole,
     repoSettings,
     updateAgentSessionModel,

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -74,6 +74,7 @@ export type AgentStudioSelectionControllerResult = {
   taskId: string;
   selectedTask: TaskCard | null;
   sessionsForTask: AgentSessionSummary[];
+  activeSessionSummary: AgentSessionSummary | null;
   activeSession: AgentSessionState | null;
   activeSessionRuntimeDataError?: string | null;
   isLoadingTasks: boolean;
@@ -91,6 +92,7 @@ export type AgentStudioSelectionControllerResult = {
   viewTaskId: string;
   viewSelectedTask: TaskCard | null;
   viewSessionsForTask: AgentSessionSummary[];
+  viewActiveSessionSummary: AgentSessionSummary | null;
   viewActiveSession: AgentSessionState | null;
   viewSessionRuntimeDataError?: string | null;
   viewRole: AgentRole;
@@ -427,6 +429,7 @@ export function useAgentStudioSelectionController({
     taskId,
     selectedTask,
     sessionsForTask,
+    activeSessionSummary,
     activeSession: activeSessionRuntimeData.session,
     activeSessionRuntimeDataError: activeSessionRuntimeData.runtimeDataError,
     isLoadingTasks,
@@ -440,6 +443,7 @@ export function useAgentStudioSelectionController({
     viewTaskId,
     viewSelectedTask,
     viewSessionsForTask,
+    viewActiveSessionSummary: viewSelection.activeSession,
     viewActiveSession: viewSessionRuntimeData.session,
     viewSessionRuntimeDataError: viewSessionRuntimeData.runtimeDataError,
     viewRole,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -195,6 +195,52 @@ describe("load-sessions-stages", () => {
     });
   });
 
+  test("does not coerce a same-id non-assistant message into a final assistant row", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "shared-id",
+          role: "assistant",
+          content: "Final complete response",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+          },
+        },
+      ],
+      [
+        {
+          id: "shared-id",
+          role: "tool",
+          content: "Tool output",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "completed",
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(1);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)).toMatchObject({
+      id: "shared-id",
+      role: "tool",
+      content: "Tool output",
+      meta: {
+        kind: "tool",
+        tool: "bash",
+        status: "completed",
+      },
+    });
+  });
+
   test("uses the in-memory requested session record without reloading persisted sessions", async () => {
     const existingSession = createSession({
       runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -14,6 +14,7 @@ import {
   createHydrationPromptAssemblerStage,
   createRuntimeResolutionPlannerStage,
   hydrateSessionRecordsStage,
+  mergeHydratedMessages,
   preparePersistedSessionMergeStage,
   type SessionLoadIntent,
 } from "./load-sessions-stages";
@@ -149,6 +150,51 @@ const createRuntime = (
 });
 
 describe("load-sessions-stages", () => {
+  test("prefers hydrated final assistant messages over stale local streamed rows with the same id", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Final complete response",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+            providerId: "openai",
+            modelId: "gpt-5",
+          },
+        },
+      ],
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Partial streamed response",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: false,
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(1);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)?.content).toBe(
+      "Final complete response",
+    );
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)?.meta).toMatchObject({
+      kind: "assistant",
+      isFinal: true,
+      providerId: "openai",
+      modelId: "gpt-5",
+    });
+  });
+
   test("uses the in-memory requested session record without reloading persisted sessions", async () => {
     const existingSession = createSession({
       runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -202,6 +202,15 @@ export const mergeHydratedMessages = (
   currentMessages: AgentSessionState["messages"],
 ): AgentSessionState["messages"] => {
   const currentOwner = { sessionId, messages: currentMessages };
+  const isFinalAssistantMessage = (
+    message: import("@/types/agent-orchestrator").AgentChatMessage,
+  ): boolean => {
+    return (
+      message.role === "assistant" &&
+      message.meta?.kind === "assistant" &&
+      message.meta.isFinal === true
+    );
+  };
   const mergeSameMessageId = (
     hydratedMessage: import("@/types/agent-orchestrator").AgentChatMessage,
     currentMessage: import("@/types/agent-orchestrator").AgentChatMessage | undefined,
@@ -220,6 +229,18 @@ export const mergeHydratedMessages = (
       currentMessage.meta.state === "queued";
 
     if (currentIsQueuedUser && !hydratedIsQueuedUser) {
+      const mergedMeta =
+        currentMessage.meta && hydratedMessage.meta
+          ? { ...currentMessage.meta, ...hydratedMessage.meta }
+          : (hydratedMessage.meta ?? currentMessage.meta);
+      return {
+        ...currentMessage,
+        ...hydratedMessage,
+        ...(mergedMeta ? { meta: mergedMeta } : {}),
+      };
+    }
+
+    if (isFinalAssistantMessage(hydratedMessage) && !isFinalAssistantMessage(currentMessage)) {
       const mergedMeta =
         currentMessage.meta && hydratedMessage.meta
           ? { ...currentMessage.meta, ...hydratedMessage.meta }

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -235,6 +235,7 @@ export const mergeHydratedMessages = (
 
     if (
       isFinalAssistantChatMessage(hydratedMessage) &&
+      currentMessage.role === "assistant" &&
       !isFinalAssistantChatMessage(currentMessage)
     ) {
       const mergedMeta =

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -10,6 +10,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { appQueryClient } from "@/lib/query-client";
 import { loadRuntimeListFromQuery } from "@/state/queries/runtime";
 import type {
+  AgentChatMessage,
   AgentSessionHistoryHydrationPolicy,
   AgentSessionHistoryPreludeMode,
   AgentSessionLoadMode,
@@ -26,6 +27,7 @@ import {
   findSessionMessageById,
   forEachSessionMessage,
   getSessionMessagesSlice,
+  isFinalAssistantChatMessage,
 } from "../support/messages";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
 import {
@@ -202,18 +204,9 @@ export const mergeHydratedMessages = (
   currentMessages: AgentSessionState["messages"],
 ): AgentSessionState["messages"] => {
   const currentOwner = { sessionId, messages: currentMessages };
-  const isFinalAssistantMessage = (
-    message: import("@/types/agent-orchestrator").AgentChatMessage,
-  ): boolean => {
-    return (
-      message.role === "assistant" &&
-      message.meta?.kind === "assistant" &&
-      message.meta.isFinal === true
-    );
-  };
   const mergeSameMessageId = (
-    hydratedMessage: import("@/types/agent-orchestrator").AgentChatMessage,
-    currentMessage: import("@/types/agent-orchestrator").AgentChatMessage | undefined,
+    hydratedMessage: AgentChatMessage,
+    currentMessage: AgentChatMessage | undefined,
   ) => {
     if (!currentMessage) {
       return hydratedMessage;
@@ -240,7 +233,10 @@ export const mergeHydratedMessages = (
       };
     }
 
-    if (isFinalAssistantMessage(hydratedMessage) && !isFinalAssistantMessage(currentMessage)) {
+    if (
+      isFinalAssistantChatMessage(hydratedMessage) &&
+      !isFinalAssistantChatMessage(currentMessage)
+    ) {
       const mergedMeta =
         currentMessage.meta && hydratedMessage.meta
           ? { ...currentMessage.meta, ...hydratedMessage.meta }

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/messages.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/messages.test.ts
@@ -7,6 +7,7 @@ import {
   findLastToolSessionMessage,
   findLastUserSessionMessage,
   getSessionMessageCount,
+  isFinalAssistantChatMessage,
   updateLastSessionMessage,
   updateLastToolSessionMessage,
   upsertSessionMessage,
@@ -119,5 +120,35 @@ describe("agent-orchestrator/support/messages", () => {
 
   test("matches Array.every semantics for empty collections", () => {
     expect(everySessionMessage(createSession([]), () => false)).toBe(true);
+  });
+
+  test("detects final assistant chat messages", () => {
+    expect(
+      isFinalAssistantChatMessage({
+        id: "assistant-final",
+        role: "assistant",
+        content: "done",
+        timestamp: "2026-02-22T08:00:00.000Z",
+        meta: {
+          kind: "assistant",
+          agentRole: "build",
+          isFinal: true,
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      isFinalAssistantChatMessage({
+        id: "assistant-streaming",
+        role: "assistant",
+        content: "still going",
+        timestamp: "2026-02-22T08:00:01.000Z",
+        meta: {
+          kind: "assistant",
+          agentRole: "build",
+          isFinal: false,
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/messages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/messages.ts
@@ -423,6 +423,21 @@ export const findLastToolSessionMessage = (
   return findLastSessionMessageByRole(owner, "tool", predicate);
 };
 
+export const isFinalAssistantChatMessage = (
+  message: AgentChatMessage | undefined | null,
+): message is AgentChatMessage & {
+  role: "assistant";
+  meta: Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "assistant" }> & {
+    isFinal: true;
+  };
+} => {
+  return (
+    message?.role === "assistant" &&
+    message.meta?.kind === "assistant" &&
+    message.meta.isFinal === true
+  );
+};
+
 export const appendSessionMessage = (
   owner: SessionMessageOwner,
   message: AgentChatMessage,


### PR DESCRIPTION
Summary
This pull request fixes two related desktop regressions in Agent Studio session rendering and transcript hydration. It preserves the correct selected agent/model presentation while a session is still hydrating, and it ensures requested history hydration can replace stale streamed assistant rows with the authoritative final assistant message.

Goal
The goal of this PR is to restore the session UX that existed before the reusable chat refactor and to fix the transcript correctness issue that appeared when switching away from a live session and coming back after it finished. Before these changes, Agent Studio could briefly show the wrong agent profile color while a selected session was loading, and completed sessions could reopen with a partial transcript that was missing the final assistant message until a full app reload.

Technical choices
The selection-side regression is fixed at the source of truth rather than with UI fallbacks. Agent Studio now keeps using the selected session summary while the full session object hydrates, so the selected model/profile stays stable on first paint and the composer/thread styling does not flicker to a default or unrelated profile. That keeps the interaction path fast and avoids introducing extra state or delayed rendering behavior.

On the transcript side, the fix is in the hydrated-history merge path. When requested history hydration returns a final assistant message with the same id as an existing stale streamed row, the hydrated final message now wins. That preserves canonical runtime history instead of keeping an outdated in-memory snapshot. I also extracted the normalized `AgentChatMessage` final-assistant check into a shared helper and reused it in the affected rendering and merge paths so the message-finality rules stay consistent across the app.

Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun --bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`

Notes
The standard `bun run build` path uses the desktop app's signed Node binary in this environment, which trips macOS library validation for the local `rolldown` native binding. The build itself is green through the Bun-native execution path used above (`bun --bun run build`), which validates the actual workspace build output without changing repository code.
