### PR TITLE
fix(desktop): speed up long transcript session switching

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.test.ts
@@ -138,6 +138,35 @@ describe("agent-chat-thread windowing helpers", () => {
     expect(revisitedState.turns).toBe(firstState.turns);
   });
 
+  test("resolveAgentChatWindowRowsState invalidates cached rows when a raw message array is mutated in place", () => {
+    const messages = [buildMessage("assistant", "Message 1", { id: "message-1" })];
+    const session = buildSession({
+      sessionId: "session-mutable-array",
+      messages,
+    });
+    const cache = new Map();
+
+    const firstState = resolveAgentChatWindowRowsState({
+      session,
+      showThinkingMessages: true,
+      cache,
+    });
+
+    messages[0] = buildMessage("assistant", "Message 1 updated", { id: "message-1" });
+
+    const nextState = resolveAgentChatWindowRowsState({
+      session,
+      showThinkingMessages: true,
+      cache,
+    });
+
+    expect(nextState.rows).not.toBe(firstState.rows);
+    expect(nextState.rows.some((row) => row.kind === "message")).toBe(true);
+    expect(nextState.rows.find((row) => row.kind === "message")?.message.content).toBe(
+      "Message 1 updated",
+    );
+  });
+
   test("buildAgentChatWindowRows keeps row keys distinct across sessions with repeated message ids", () => {
     const firstSession = buildSession({
       runtimeKind: "opencode",
@@ -450,5 +479,64 @@ describe("agent-chat-thread windowing helpers", () => {
     expect(nextState.hasAttachmentMessages).toBe(false);
     expect(nextState.lastUserMessageId).toBe("user-1");
     expect(nextState.activeStreamingAssistantMessageId).toBeNull();
+  });
+
+  test("resolveAgentChatWindowRowsState rebases cached suffix metadata arrays with prefix state", () => {
+    const initialSession = buildSession({
+      sessionId: "session-rebased-metadata",
+      role: "build",
+      status: "running",
+      messages: [
+        buildMessage("assistant", "Prelude", { id: "assistant-0" }),
+        buildMessage("user", "Question 1", {
+          id: "user-1",
+          meta: {
+            kind: "user",
+            state: "read",
+            parts: [
+              {
+                kind: "attachment",
+                attachment: {
+                  id: "attachment-1",
+                  path: "/tmp/spec.md",
+                  name: "spec.md",
+                  kind: "pdf",
+                },
+              },
+            ],
+          },
+        }),
+        buildMessage("assistant", "Answer 1", { id: "assistant-1" }),
+        buildMessage("user", "Question 2", { id: "user-2" }),
+        buildMessage("assistant", "Answer 2", { id: "assistant-2" }),
+      ],
+    });
+    const updatedSession = buildSession({
+      ...initialSession,
+      messages: [
+        ...(Array.isArray(initialSession.messages) ? initialSession.messages.slice(0, 4) : []),
+        buildMessage("assistant", "Answer 2 updated", { id: "assistant-2" }),
+      ],
+    });
+    const cache = new Map();
+
+    resolveAgentChatWindowRowsState({
+      session: initialSession,
+      showThinkingMessages: true,
+      cache,
+    });
+    resolveAgentChatWindowRowsState({
+      session: updatedSession,
+      showThinkingMessages: true,
+      cache,
+    });
+
+    const cacheEntry = Array.from(cache.values())[0];
+    if (!cacheEntry) {
+      throw new Error("Expected cached transcript state");
+    }
+
+    expect(cacheEntry.hasAttachmentMessagesByMessageIndex[3]).toBe(true);
+    expect(cacheEntry.lastUserMessageIdByMessageIndex[3]).toBe("user-2");
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.test.ts
@@ -7,6 +7,7 @@ import {
   CHAT_TURN_WINDOW_BATCH,
   CHAT_TURN_WINDOW_INIT,
   getAgentChatWindowRowsKey,
+  resolveAgentChatWindowRowsState,
 } from "./agent-chat-thread-windowing";
 
 const createMessageIdentityResolver = (): ((message: AgentChatMessage) => number) => {
@@ -80,21 +81,61 @@ describe("agent-chat-thread windowing helpers", () => {
         key: "session-1:assistant-0:duration",
         start: 0,
         end: 1,
-        rows: rows.slice(0, 2),
       },
       {
         key: "session-1:user-1",
         start: 2,
         end: 4,
-        rows: rows.slice(2, 5),
       },
       {
         key: "session-1:user-2",
         start: 5,
         end: 7,
-        rows: rows.slice(5, 8),
       },
     ]);
+  });
+
+  test("resolveAgentChatWindowRowsState reuses cached rows when switching back to a previously built session", () => {
+    const firstSession = buildSession({
+      sessionId: "session-a",
+      messages: [
+        buildMessage("assistant", "Prelude", { id: "assistant-a-0" }),
+        buildMessage("user", "Question A", { id: "user-a-1" }),
+        buildMessage("assistant", "Answer A", { id: "assistant-a-1" }),
+      ],
+      pendingQuestions: [],
+    });
+    const secondSession = buildSession({
+      sessionId: "session-b",
+      messages: [
+        buildMessage("assistant", "Prelude", { id: "assistant-b-0" }),
+        buildMessage("user", "Question B", { id: "user-b-1" }),
+        buildMessage("assistant", "Answer B", { id: "assistant-b-1" }),
+      ],
+      pendingQuestions: [],
+    });
+    const cache = new Map();
+
+    const firstState = resolveAgentChatWindowRowsState({
+      session: firstSession,
+      showThinkingMessages: true,
+      cache,
+    });
+
+    resolveAgentChatWindowRowsState({
+      session: secondSession,
+      showThinkingMessages: true,
+      cache,
+    });
+
+    const revisitedState = resolveAgentChatWindowRowsState({
+      session: firstSession,
+      showThinkingMessages: true,
+      cache,
+    });
+
+    expect(revisitedState.rows).toBe(firstState.rows);
+    expect(revisitedState.turns).toBe(firstState.turns);
   });
 
   test("buildAgentChatWindowRows keeps row keys distinct across sessions with repeated message ids", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.test.ts
@@ -322,4 +322,133 @@ describe("agent-chat-thread windowing helpers", () => {
     expect(rows.map((row) => row.kind)).toEqual(["message"]);
     expect(rows[0]?.key).toBe("session-1:assistant-live");
   });
+
+  test("resolveAgentChatWindowRowsState clears cached streaming state when only session status changes", () => {
+    const sharedMessages = [
+      buildMessage("assistant", "Working", {
+        id: "assistant-live",
+        meta: {
+          kind: "assistant",
+          agentRole: "build",
+          isFinal: false,
+          profileId: "Hephaestus (Deep Agent)",
+        },
+      }),
+    ];
+    const runningSession = buildSession({
+      sessionId: "session-status",
+      role: "build",
+      status: "running",
+      messages: sharedMessages,
+    });
+    const idleSession = buildSession({
+      ...runningSession,
+      status: "idle",
+      messages: [...sharedMessages],
+    });
+    const cache = new Map();
+
+    const runningState = resolveAgentChatWindowRowsState({
+      session: runningSession,
+      showThinkingMessages: true,
+      cache,
+    });
+    const idleState = resolveAgentChatWindowRowsState({
+      session: idleSession,
+      showThinkingMessages: true,
+      cache,
+    });
+
+    expect(runningState.activeStreamingAssistantMessageId).toBe("assistant-live");
+    expect(idleState.activeStreamingAssistantMessageId).toBeNull();
+    expect(idleState.rows).toBe(runningState.rows);
+  });
+
+  test("resolveAgentChatWindowRowsState does not retain suffix metadata during incremental rebuilds", () => {
+    const baseMessages = [
+      buildMessage("assistant", "Prelude", { id: "assistant-0" }),
+      buildMessage("user", "Question 1", { id: "user-1" }),
+      buildMessage("assistant", "Answer 1", { id: "assistant-1" }),
+      buildMessage("user", "Question 2", {
+        id: "user-2",
+        meta: {
+          kind: "user",
+          state: "read",
+          parts: [
+            {
+              kind: "attachment",
+              attachment: {
+                id: "attachment-1",
+                path: "/tmp/spec.md",
+                name: "spec.md",
+                kind: "pdf",
+              },
+            },
+          ],
+        },
+      }),
+      buildMessage("assistant", "Working", {
+        id: "assistant-live",
+        meta: {
+          kind: "assistant",
+          agentRole: "build",
+          isFinal: false,
+          profileId: "Hephaestus (Deep Agent)",
+        },
+      }),
+    ];
+    const [assistantPrelude, firstUser, firstAnswer] = baseMessages;
+    if (!assistantPrelude || !firstUser || !firstAnswer) {
+      throw new Error("Expected prefix messages to exist");
+    }
+    const initialSession = buildSession({
+      sessionId: "session-incremental",
+      role: "build",
+      status: "running",
+      messages: baseMessages,
+    });
+    const updatedSession = buildSession({
+      ...initialSession,
+      status: "idle",
+      messages: [
+        assistantPrelude,
+        firstUser,
+        firstAnswer,
+        buildMessage("assistant", "Answer 2", {
+          id: "user-2",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+            profileId: "Hephaestus (Deep Agent)",
+          },
+        }),
+        buildMessage("assistant", "Done", {
+          id: "assistant-live",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+            profileId: "Hephaestus (Deep Agent)",
+          },
+        }),
+      ],
+    });
+    const cache = new Map();
+
+    resolveAgentChatWindowRowsState({
+      session: initialSession,
+      showThinkingMessages: true,
+      cache,
+    });
+    const nextState = resolveAgentChatWindowRowsState({
+      session: updatedSession,
+      showThinkingMessages: true,
+      cache,
+    });
+
+    expect(nextState.hasAttachmentMessages).toBe(false);
+    expect(nextState.lastUserMessageId).toBe("user-1");
+    expect(nextState.activeStreamingAssistantMessageId).toBeNull();
+  });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
@@ -40,6 +40,9 @@ export type AgentChatWindowRowsCacheEntry = {
   rows: AgentChatWindowRow[];
   rowStartByMessageIndex: number[];
   rebuildStartByMessageIndex: number[];
+  hasAttachmentMessagesByMessageIndex: boolean[];
+  lastUserMessageIdByMessageIndex: Array<string | null>;
+  activeStreamingAssistantMessageIdByMessageIndex: Array<string | null>;
   latestRebuildStartMessageIndex: number;
   turns: AgentChatWindowTurn[];
   hasAttachmentMessages: boolean;
@@ -80,6 +83,9 @@ export type AgentChatWindowRowsState = {
   rows: AgentChatWindowRow[];
   rowStartByMessageIndex: number[];
   rebuildStartByMessageIndex: number[];
+  hasAttachmentMessagesByMessageIndex: boolean[];
+  lastUserMessageIdByMessageIndex: Array<string | null>;
+  activeStreamingAssistantMessageIdByMessageIndex: Array<string | null>;
   latestRebuildStartMessageIndex: number;
   turns: AgentChatWindowTurn[];
   hasAttachmentMessages: boolean;
@@ -157,6 +163,32 @@ const appendMessageRows = (
   });
 };
 
+const getPrefixMetadata = (
+  cacheEntry: AgentChatWindowRowsCacheEntry,
+  rebuildStartMessageIndex: number,
+): {
+  hasAttachmentMessages: boolean;
+  lastUserMessageId: string | null;
+  activeStreamingAssistantMessageId: string | null;
+} => {
+  const previousMessageIndex = rebuildStartMessageIndex - 1;
+  if (previousMessageIndex < 0) {
+    return {
+      hasAttachmentMessages: false,
+      lastUserMessageId: null,
+      activeStreamingAssistantMessageId: null,
+    };
+  }
+
+  return {
+    hasAttachmentMessages:
+      cacheEntry.hasAttachmentMessagesByMessageIndex[previousMessageIndex] ?? false,
+    lastUserMessageId: cacheEntry.lastUserMessageIdByMessageIndex[previousMessageIndex] ?? null,
+    activeStreamingAssistantMessageId:
+      cacheEntry.activeStreamingAssistantMessageIdByMessageIndex[previousMessageIndex] ?? null,
+  };
+};
+
 export function buildAgentChatWindowRowsState(
   session: AgentSessionState,
   { showThinkingMessages }: BuildAgentChatWindowRowsOptions,
@@ -164,6 +196,9 @@ export function buildAgentChatWindowRowsState(
   const rows: AgentChatWindowRow[] = [];
   const rowStartByMessageIndex: number[] = [];
   const rebuildStartByMessageIndex: number[] = [];
+  const hasAttachmentMessagesByMessageIndex: boolean[] = [];
+  const lastUserMessageIdByMessageIndex: Array<string | null> = [];
+  const activeStreamingAssistantMessageIdByMessageIndex: Array<string | null> = [];
   const turnStartIndices: number[] = [];
   let currentRebuildStartMessageIndex = 0;
   let hasVisibleMessages = false;
@@ -195,6 +230,11 @@ export function buildAgentChatWindowRowsState(
         activeStreamingAssistantMessageId = message.id;
       }
     }
+
+    hasAttachmentMessagesByMessageIndex[messageIndex] = hasAttachmentMessages;
+    lastUserMessageIdByMessageIndex[messageIndex] = lastUserMessageId;
+    activeStreamingAssistantMessageIdByMessageIndex[messageIndex] =
+      activeStreamingAssistantMessageId;
 
     if (isVisibleMessage) {
       if (!hasVisibleMessages) {
@@ -233,6 +273,9 @@ export function buildAgentChatWindowRowsState(
     rows,
     rowStartByMessageIndex,
     rebuildStartByMessageIndex,
+    hasAttachmentMessagesByMessageIndex,
+    lastUserMessageIdByMessageIndex,
+    activeStreamingAssistantMessageIdByMessageIndex,
     latestRebuildStartMessageIndex: currentRebuildStartMessageIndex,
     turns: turnStartIndices.map((start, index) => ({
       key: rows[start]?.key ?? `turn-${index}`,
@@ -278,7 +321,8 @@ export function resolveAgentChatWindowRowsState({
         turns: cachedRows.turns,
         hasAttachmentMessages: cachedRows.hasAttachmentMessages,
         lastUserMessageId: cachedRows.lastUserMessageId,
-        activeStreamingAssistantMessageId: cachedRows.activeStreamingAssistantMessageId,
+        activeStreamingAssistantMessageId:
+          session.status === "running" ? cachedRows.activeStreamingAssistantMessageId : null,
       };
     }
 
@@ -290,7 +334,8 @@ export function resolveAgentChatWindowRowsState({
         turns: cachedRows.turns,
         hasAttachmentMessages: cachedRows.hasAttachmentMessages,
         lastUserMessageId: cachedRows.lastUserMessageId,
-        activeStreamingAssistantMessageId: cachedRows.activeStreamingAssistantMessageId,
+        activeStreamingAssistantMessageId:
+          session.status === "running" ? cachedRows.activeStreamingAssistantMessageId : null,
       };
     }
 
@@ -309,6 +354,7 @@ export function resolveAgentChatWindowRowsState({
     })();
 
     if (rebuildStartMessageIndex > 0) {
+      const prefixMetadata = getPrefixMetadata(cachedRows, rebuildStartMessageIndex);
       const prefixRowEnd =
         cachedRows.rowStartByMessageIndex[rebuildStartMessageIndex] ?? cachedRows.rows.length;
       const nextRows = cachedRows.rows.slice(0, prefixRowEnd);
@@ -359,15 +405,33 @@ export function resolveAgentChatWindowRowsState({
             (index) => rebuildStartMessageIndex + index,
           ),
         ],
+        hasAttachmentMessagesByMessageIndex: [
+          ...cachedRows.hasAttachmentMessagesByMessageIndex.slice(0, rebuildStartMessageIndex),
+          ...incrementalRowsState.hasAttachmentMessagesByMessageIndex,
+        ],
+        lastUserMessageIdByMessageIndex: [
+          ...cachedRows.lastUserMessageIdByMessageIndex.slice(0, rebuildStartMessageIndex),
+          ...incrementalRowsState.lastUserMessageIdByMessageIndex,
+        ],
+        activeStreamingAssistantMessageIdByMessageIndex: [
+          ...cachedRows.activeStreamingAssistantMessageIdByMessageIndex.slice(
+            0,
+            rebuildStartMessageIndex,
+          ),
+          ...incrementalRowsState.activeStreamingAssistantMessageIdByMessageIndex,
+        ],
         latestRebuildStartMessageIndex:
           rebuildStartMessageIndex + incrementalRowsState.latestRebuildStartMessageIndex,
         turns: nextTurns,
         hasAttachmentMessages:
-          cachedRows.hasAttachmentMessages || incrementalRowsState.hasAttachmentMessages,
-        lastUserMessageId: incrementalRowsState.lastUserMessageId ?? cachedRows.lastUserMessageId,
+          prefixMetadata.hasAttachmentMessages || incrementalRowsState.hasAttachmentMessages,
+        lastUserMessageId:
+          incrementalRowsState.lastUserMessageId ?? prefixMetadata.lastUserMessageId,
         activeStreamingAssistantMessageId:
-          incrementalRowsState.activeStreamingAssistantMessageId ??
-          cachedRows.activeStreamingAssistantMessageId,
+          session.status === "running"
+            ? (incrementalRowsState.activeStreamingAssistantMessageId ??
+              prefixMetadata.activeStreamingAssistantMessageId)
+            : null,
       };
       touchAgentChatWindowRowsCacheEntry(cache, cacheKey, nextCacheEntry);
       return {
@@ -386,6 +450,10 @@ export function resolveAgentChatWindowRowsState({
     rows: nextRowsState.rows,
     rowStartByMessageIndex: nextRowsState.rowStartByMessageIndex,
     rebuildStartByMessageIndex: nextRowsState.rebuildStartByMessageIndex,
+    hasAttachmentMessagesByMessageIndex: nextRowsState.hasAttachmentMessagesByMessageIndex,
+    lastUserMessageIdByMessageIndex: nextRowsState.lastUserMessageIdByMessageIndex,
+    activeStreamingAssistantMessageIdByMessageIndex:
+      nextRowsState.activeStreamingAssistantMessageIdByMessageIndex,
     latestRebuildStartMessageIndex: nextRowsState.latestRebuildStartMessageIndex,
     turns: nextRowsState.turns,
     hasAttachmentMessages: nextRowsState.hasAttachmentMessages,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
@@ -35,20 +35,42 @@ export type AgentChatWindowTurn = {
   end: number;
 };
 
-export type AgentChatWindowRowsCacheEntry = {
-  messages: AgentSessionState["messages"];
-  messageSignatures: string[] | null;
-  rows: AgentChatWindowRow[];
-  rowStartByMessageIndex: number[];
-  rebuildStartByMessageIndex: number[];
-  hasAttachmentMessagesByMessageIndex: boolean[];
-  lastUserMessageIdByMessageIndex: Array<string | null>;
-  activeStreamingAssistantMessageIdByMessageIndex: Array<string | null>;
-  latestRebuildStartMessageIndex: number;
-  turns: AgentChatWindowTurn[];
+type AgentChatWindowAggregateMetadata = {
   hasAttachmentMessages: boolean;
   lastUserMessageId: string | null;
   activeStreamingAssistantMessageId: string | null;
+};
+
+type AgentChatWindowMetadataTimeline = {
+  hasAttachmentMessagesByMessageIndex: boolean[];
+  lastUserMessageIdByMessageIndex: Array<string | null>;
+  activeStreamingAssistantMessageIdByMessageIndex: Array<string | null>;
+};
+
+type AgentChatWindowRowsCoreState = {
+  rows: AgentChatWindowRow[];
+  rowStartByMessageIndex: number[];
+  rebuildStartByMessageIndex: number[];
+  latestRebuildStartMessageIndex: number;
+  turns: AgentChatWindowTurn[];
+};
+
+export type AgentChatWindowRowsState = AgentChatWindowRowsCoreState &
+  AgentChatWindowMetadataTimeline &
+  AgentChatWindowAggregateMetadata;
+
+type AgentChatWindowResolvedState = Pick<
+  AgentChatWindowRowsState,
+  | "rows"
+  | "turns"
+  | "hasAttachmentMessages"
+  | "lastUserMessageId"
+  | "activeStreamingAssistantMessageId"
+>;
+
+export type AgentChatWindowRowsCacheEntry = AgentChatWindowRowsState & {
+  messages: AgentSessionState["messages"];
+  rawMessageSignatures: string[] | null;
 };
 
 const CHAT_WINDOW_ROWS_CACHE_LIMIT = 6;
@@ -80,20 +102,6 @@ type BuildAgentChatWindowRowsOptions = {
   showThinkingMessages: boolean;
 };
 
-export type AgentChatWindowRowsState = {
-  rows: AgentChatWindowRow[];
-  rowStartByMessageIndex: number[];
-  rebuildStartByMessageIndex: number[];
-  hasAttachmentMessagesByMessageIndex: boolean[];
-  lastUserMessageIdByMessageIndex: Array<string | null>;
-  activeStreamingAssistantMessageIdByMessageIndex: Array<string | null>;
-  latestRebuildStartMessageIndex: number;
-  turns: AgentChatWindowTurn[];
-  hasAttachmentMessages: boolean;
-  lastUserMessageId: string | null;
-  activeStreamingAssistantMessageId: string | null;
-};
-
 const isSessionMessagesState = (
   messages: AgentSessionMessages,
 ): messages is SessionMessagesState => {
@@ -115,7 +123,7 @@ const buildAgentChatMessageSignature = (message: AgentChatMessage): string => {
   ]);
 };
 
-const buildAgentChatMessageSignatures = (messages: AgentSessionMessages): string[] | null => {
+const buildRawMessageSignatures = (messages: AgentSessionMessages): string[] | null => {
   if (!Array.isArray(messages)) {
     return null;
   }
@@ -144,48 +152,55 @@ const areSessionMessageContainersEquivalent = (
   return false;
 };
 
-const findFirstChangedCachedMessageIndex = (
-  cachedRows: AgentChatWindowRowsCacheEntry,
-  session: AgentSessionState,
+const findFirstChangedRawMessageSignatureIndex = (
+  previousSignatures: string[],
+  nextMessages: AgentSessionMessages,
 ): number => {
-  if (Array.isArray(cachedRows.messages) && Array.isArray(session.messages)) {
-    const previousSignatures = cachedRows.messageSignatures;
-    if (!previousSignatures) {
-      return 0;
-    }
+  const nextSignatures = buildRawMessageSignatures(nextMessages);
+  if (!nextSignatures) {
+    return 0;
+  }
 
-    const nextSignatures = buildAgentChatMessageSignatures(session.messages);
-    if (!nextSignatures) {
-      return 0;
-    }
+  if (nextSignatures.length < previousSignatures.length) {
+    return 0;
+  }
 
-    if (nextSignatures.length < previousSignatures.length) {
-      return 0;
+  const sharedLength = Math.min(previousSignatures.length, nextSignatures.length);
+  let changedTailIndex = sharedLength - 1;
+  while (changedTailIndex >= 0) {
+    if (previousSignatures[changedTailIndex] !== nextSignatures[changedTailIndex]) {
+      break;
     }
+    changedTailIndex -= 1;
+  }
 
-    const sharedLength = Math.min(previousSignatures.length, nextSignatures.length);
-    let changedTailIndex = sharedLength - 1;
-    while (changedTailIndex >= 0) {
-      if (previousSignatures[changedTailIndex] !== nextSignatures[changedTailIndex]) {
+  if (changedTailIndex >= 0) {
+    while (changedTailIndex > 0) {
+      if (previousSignatures[changedTailIndex - 1] === nextSignatures[changedTailIndex - 1]) {
         break;
       }
       changedTailIndex -= 1;
     }
-
-    if (changedTailIndex >= 0) {
-      while (changedTailIndex > 0) {
-        if (previousSignatures[changedTailIndex - 1] === nextSignatures[changedTailIndex - 1]) {
-          break;
-        }
-        changedTailIndex -= 1;
-      }
-      return changedTailIndex;
-    }
-
-    return nextSignatures.length > previousSignatures.length ? previousSignatures.length : -1;
+    return changedTailIndex;
   }
 
-  return findFirstChangedChatMessageIndex(cachedRows.messages, session);
+  return nextSignatures.length > previousSignatures.length ? previousSignatures.length : -1;
+};
+
+const findFirstChangedCachedMessageIndex = (
+  cacheEntry: AgentChatWindowRowsCacheEntry,
+  session: AgentSessionState,
+): number => {
+  if (Array.isArray(cacheEntry.messages) && Array.isArray(session.messages)) {
+    const previousSignatures = cacheEntry.rawMessageSignatures;
+    if (!previousSignatures) {
+      return 0;
+    }
+
+    return findFirstChangedRawMessageSignatureIndex(previousSignatures, session.messages);
+  }
+
+  return findFirstChangedChatMessageIndex(cacheEntry.messages, session);
 };
 
 const appendMessageRows = (
@@ -229,11 +244,7 @@ const appendMessageRows = (
 const getPrefixMetadata = (
   cacheEntry: AgentChatWindowRowsCacheEntry,
   rebuildStartMessageIndex: number,
-): {
-  hasAttachmentMessages: boolean;
-  lastUserMessageId: string | null;
-  activeStreamingAssistantMessageId: string | null;
-} => {
+): AgentChatWindowAggregateMetadata => {
   const previousMessageIndex = rebuildStartMessageIndex - 1;
   if (previousMessageIndex < 0) {
     return {
@@ -253,33 +264,52 @@ const getPrefixMetadata = (
 };
 
 const rebaseIncrementalMetadata = ({
-  incrementalRowsState,
+  suffixRowsState,
   prefixMetadata,
   sessionStatus,
 }: {
-  incrementalRowsState: AgentChatWindowRowsState;
-  prefixMetadata: ReturnType<typeof getPrefixMetadata>;
+  suffixRowsState: AgentChatWindowRowsState;
+  prefixMetadata: AgentChatWindowAggregateMetadata;
   sessionStatus: AgentSessionState["status"];
-}): Pick<
-  AgentChatWindowRowsState,
-  | "hasAttachmentMessagesByMessageIndex"
-  | "lastUserMessageIdByMessageIndex"
-  | "activeStreamingAssistantMessageIdByMessageIndex"
-> => {
+}): AgentChatWindowMetadataTimeline => {
   return {
-    hasAttachmentMessagesByMessageIndex:
-      incrementalRowsState.hasAttachmentMessagesByMessageIndex.map(
-        (value) => prefixMetadata.hasAttachmentMessages || value,
-      ),
-    lastUserMessageIdByMessageIndex: incrementalRowsState.lastUserMessageIdByMessageIndex.map(
+    hasAttachmentMessagesByMessageIndex: suffixRowsState.hasAttachmentMessagesByMessageIndex.map(
+      (value) => prefixMetadata.hasAttachmentMessages || value,
+    ),
+    lastUserMessageIdByMessageIndex: suffixRowsState.lastUserMessageIdByMessageIndex.map(
       (value) => value ?? prefixMetadata.lastUserMessageId,
     ),
     activeStreamingAssistantMessageIdByMessageIndex:
-      incrementalRowsState.activeStreamingAssistantMessageIdByMessageIndex.map((value) =>
+      suffixRowsState.activeStreamingAssistantMessageIdByMessageIndex.map((value) =>
         sessionStatus === "running"
           ? (value ?? prefixMetadata.activeStreamingAssistantMessageId)
           : null,
       ),
+  };
+};
+
+const toResolvedWindowRowsState = (
+  cacheEntry: AgentChatWindowRowsCacheEntry,
+  sessionStatus: AgentSessionState["status"],
+): AgentChatWindowResolvedState => {
+  return {
+    rows: cacheEntry.rows,
+    turns: cacheEntry.turns,
+    hasAttachmentMessages: cacheEntry.hasAttachmentMessages,
+    lastUserMessageId: cacheEntry.lastUserMessageId,
+    activeStreamingAssistantMessageId:
+      sessionStatus === "running" ? cacheEntry.activeStreamingAssistantMessageId : null,
+  };
+};
+
+const createWindowRowsCacheEntry = (
+  sessionMessages: AgentSessionState["messages"],
+  rowsState: AgentChatWindowRowsState,
+): AgentChatWindowRowsCacheEntry => {
+  return {
+    ...rowsState,
+    messages: sessionMessages,
+    rawMessageSignatures: buildRawMessageSignatures(sessionMessages),
   };
 };
 
@@ -293,9 +323,9 @@ export function buildAgentChatWindowRowsState(
   const hasAttachmentMessagesByMessageIndex: boolean[] = [];
   const lastUserMessageIdByMessageIndex: Array<string | null> = [];
   const activeStreamingAssistantMessageIdByMessageIndex: Array<string | null> = [];
-  const turnStartIndices: number[] = [];
-  let currentRebuildStartMessageIndex = 0;
-  let hasVisibleMessages = false;
+  const turnRowStartIndexes: number[] = [];
+  let currentVisibleTurnStartMessageIndex = 0;
+  let hasEnteredVisibleTranscript = false;
   let hasAttachmentMessages = false;
   let lastUserMessageId: string | null = null;
   let activeStreamingAssistantMessageId: string | null = null;
@@ -331,17 +361,18 @@ export function buildAgentChatWindowRowsState(
       activeStreamingAssistantMessageId;
 
     if (isVisibleMessage) {
-      if (!hasVisibleMessages) {
-        currentRebuildStartMessageIndex = messageIndex;
-        hasVisibleMessages = true;
+      if (!hasEnteredVisibleTranscript) {
+        currentVisibleTurnStartMessageIndex = messageIndex;
+        hasEnteredVisibleTranscript = true;
       }
 
       if (message.role === "user") {
-        currentRebuildStartMessageIndex = messageIndex;
+        currentVisibleTurnStartMessageIndex = messageIndex;
       }
     }
 
-    rebuildStartByMessageIndex[messageIndex] = currentRebuildStartMessageIndex;
+    // If this message changes later, rebuild from the first visible message in its turn.
+    rebuildStartByMessageIndex[messageIndex] = currentVisibleTurnStartMessageIndex;
 
     if (!isVisibleMessage) {
       rowStartByMessageIndex[messageIndex] = rows.length;
@@ -350,7 +381,7 @@ export function buildAgentChatWindowRowsState(
 
     const nextRowStart = rows.length;
     if (nextRowStart === 0 || message.role === "user") {
-      turnStartIndices.push(nextRowStart);
+      turnRowStartIndexes.push(nextRowStart);
     }
 
     appendMessageRows(
@@ -370,11 +401,11 @@ export function buildAgentChatWindowRowsState(
     hasAttachmentMessagesByMessageIndex,
     lastUserMessageIdByMessageIndex,
     activeStreamingAssistantMessageIdByMessageIndex,
-    latestRebuildStartMessageIndex: currentRebuildStartMessageIndex,
-    turns: turnStartIndices.map((start, index) => ({
+    latestRebuildStartMessageIndex: currentVisibleTurnStartMessageIndex,
+    turns: turnRowStartIndexes.map((start, index) => ({
       key: rows[start]?.key ?? `turn-${index}`,
       start,
-      end: (turnStartIndices[index + 1] ?? rows.length) - 1,
+      end: (turnRowStartIndexes[index + 1] ?? rows.length) - 1,
     })),
     hasAttachmentMessages,
     lastUserMessageId,
@@ -390,51 +421,30 @@ export function resolveAgentChatWindowRowsState({
   session: AgentSessionState;
   showThinkingMessages: boolean;
   cache: Map<string, AgentChatWindowRowsCacheEntry>;
-}): Pick<
-  AgentChatWindowRowsState,
-  | "rows"
-  | "turns"
-  | "hasAttachmentMessages"
-  | "lastUserMessageId"
-  | "activeStreamingAssistantMessageId"
-> {
+}): Pick<AgentChatWindowRowsState, keyof AgentChatWindowResolvedState> {
   const cacheKey = toAgentChatWindowRowsCacheKey(session.sessionId, showThinkingMessages);
-  const cachedRows = cache.get(cacheKey);
+  const cacheEntry = cache.get(cacheKey);
 
-  if (cachedRows) {
+  if (cacheEntry) {
     if (
       areSessionMessageContainersEquivalent(
-        cachedRows.messages,
+        cacheEntry.messages,
         session.messages,
         session.sessionId,
       )
     ) {
-      touchAgentChatWindowRowsCacheEntry(cache, cacheKey, cachedRows);
-      return {
-        rows: cachedRows.rows,
-        turns: cachedRows.turns,
-        hasAttachmentMessages: cachedRows.hasAttachmentMessages,
-        lastUserMessageId: cachedRows.lastUserMessageId,
-        activeStreamingAssistantMessageId:
-          session.status === "running" ? cachedRows.activeStreamingAssistantMessageId : null,
-      };
+      touchAgentChatWindowRowsCacheEntry(cache, cacheKey, cacheEntry);
+      return toResolvedWindowRowsState(cacheEntry, session.status);
     }
 
-    const firstChangedMessageIndex = findFirstChangedCachedMessageIndex(cachedRows, session);
+    const firstChangedMessageIndex = findFirstChangedCachedMessageIndex(cacheEntry, session);
     if (firstChangedMessageIndex < 0) {
-      touchAgentChatWindowRowsCacheEntry(cache, cacheKey, cachedRows);
-      return {
-        rows: cachedRows.rows,
-        turns: cachedRows.turns,
-        hasAttachmentMessages: cachedRows.hasAttachmentMessages,
-        lastUserMessageId: cachedRows.lastUserMessageId,
-        activeStreamingAssistantMessageId:
-          session.status === "running" ? cachedRows.activeStreamingAssistantMessageId : null,
-      };
+      touchAgentChatWindowRowsCacheEntry(cache, cacheKey, cacheEntry);
+      return toResolvedWindowRowsState(cacheEntry, session.status);
     }
 
     const rebuildStartMessageIndex = (() => {
-      const cachedRebuildStart = cachedRows.rebuildStartByMessageIndex[firstChangedMessageIndex];
+      const cachedRebuildStart = cacheEntry.rebuildStartByMessageIndex[firstChangedMessageIndex];
       if (typeof cachedRebuildStart === "number") {
         return cachedRebuildStart;
       }
@@ -444,130 +454,101 @@ export function resolveAgentChatWindowRowsState({
         return firstChangedMessageIndex;
       }
 
-      return cachedRows.latestRebuildStartMessageIndex;
+      return cacheEntry.latestRebuildStartMessageIndex;
     })();
 
     if (rebuildStartMessageIndex > 0) {
-      const prefixMetadata = getPrefixMetadata(cachedRows, rebuildStartMessageIndex);
-      const prefixRowEnd =
-        cachedRows.rowStartByMessageIndex[rebuildStartMessageIndex] ?? cachedRows.rows.length;
-      const nextRows = cachedRows.rows.slice(0, prefixRowEnd);
-      const nextRowStartByMessageIndex = cachedRows.rowStartByMessageIndex.slice(
+      const prefixMetadata = getPrefixMetadata(cacheEntry, rebuildStartMessageIndex);
+      const prefixRowCount =
+        cacheEntry.rowStartByMessageIndex[rebuildStartMessageIndex] ?? cacheEntry.rows.length;
+      const rebuiltRows = cacheEntry.rows.slice(0, prefixRowCount);
+      const rebuiltRowStartByMessageIndex = cacheEntry.rowStartByMessageIndex.slice(
         0,
         rebuildStartMessageIndex,
       );
-      const incrementalRowsState = buildAgentChatWindowRowsState(
+      const suffixRowsState = buildAgentChatWindowRowsState(
         {
           ...session,
           messages: getSessionMessagesSlice(session, rebuildStartMessageIndex),
         },
         { showThinkingMessages },
       );
-      const rebasedIncrementalMetadata = rebaseIncrementalMetadata({
-        incrementalRowsState,
+      const rebasedSuffixMetadata = rebaseIncrementalMetadata({
+        suffixRowsState,
         prefixMetadata,
         sessionStatus: session.status,
       });
 
-      for (let index = 0; index < incrementalRowsState.rowStartByMessageIndex.length; index += 1) {
-        const rowStart = incrementalRowsState.rowStartByMessageIndex[index];
+      for (let index = 0; index < suffixRowsState.rowStartByMessageIndex.length; index += 1) {
+        const rowStart = suffixRowsState.rowStartByMessageIndex[index];
         if (typeof rowStart !== "number") {
           continue;
         }
-        nextRowStartByMessageIndex[rebuildStartMessageIndex + index] = prefixRowEnd + rowStart;
+        rebuiltRowStartByMessageIndex[rebuildStartMessageIndex + index] = prefixRowCount + rowStart;
       }
 
-      const nextTurns = cachedRows.turns.slice();
-      while (nextTurns.length > 0) {
-        const lastTurn = nextTurns[nextTurns.length - 1];
-        if (!lastTurn || lastTurn.start < prefixRowEnd) {
+      const rebuiltTurns = cacheEntry.turns.slice();
+      while (rebuiltTurns.length > 0) {
+        const lastTurn = rebuiltTurns[rebuiltTurns.length - 1];
+        if (!lastTurn || lastTurn.start < prefixRowCount) {
           break;
         }
-        nextTurns.pop();
+        rebuiltTurns.pop();
       }
-      nextTurns.push(
-        ...incrementalRowsState.turns.map((turn) => ({
+      rebuiltTurns.push(
+        ...suffixRowsState.turns.map((turn) => ({
           key: turn.key,
-          start: prefixRowEnd + turn.start,
-          end: prefixRowEnd + turn.end,
+          start: prefixRowCount + turn.start,
+          end: prefixRowCount + turn.end,
         })),
       );
-      nextRows.push(...incrementalRowsState.rows);
+      rebuiltRows.push(...suffixRowsState.rows);
 
-      const nextCacheEntry: AgentChatWindowRowsCacheEntry = {
-        messages: session.messages,
-        messageSignatures: buildAgentChatMessageSignatures(session.messages),
-        rows: nextRows,
-        rowStartByMessageIndex: nextRowStartByMessageIndex,
+      const nextCacheEntry = createWindowRowsCacheEntry(session.messages, {
+        rows: rebuiltRows,
+        rowStartByMessageIndex: rebuiltRowStartByMessageIndex,
         rebuildStartByMessageIndex: [
-          ...cachedRows.rebuildStartByMessageIndex.slice(0, rebuildStartMessageIndex),
-          ...incrementalRowsState.rebuildStartByMessageIndex.map(
+          ...cacheEntry.rebuildStartByMessageIndex.slice(0, rebuildStartMessageIndex),
+          ...suffixRowsState.rebuildStartByMessageIndex.map(
             (index) => rebuildStartMessageIndex + index,
           ),
         ],
         hasAttachmentMessagesByMessageIndex: [
-          ...cachedRows.hasAttachmentMessagesByMessageIndex.slice(0, rebuildStartMessageIndex),
-          ...rebasedIncrementalMetadata.hasAttachmentMessagesByMessageIndex,
+          ...cacheEntry.hasAttachmentMessagesByMessageIndex.slice(0, rebuildStartMessageIndex),
+          ...rebasedSuffixMetadata.hasAttachmentMessagesByMessageIndex,
         ],
         lastUserMessageIdByMessageIndex: [
-          ...cachedRows.lastUserMessageIdByMessageIndex.slice(0, rebuildStartMessageIndex),
-          ...rebasedIncrementalMetadata.lastUserMessageIdByMessageIndex,
+          ...cacheEntry.lastUserMessageIdByMessageIndex.slice(0, rebuildStartMessageIndex),
+          ...rebasedSuffixMetadata.lastUserMessageIdByMessageIndex,
         ],
         activeStreamingAssistantMessageIdByMessageIndex: [
-          ...cachedRows.activeStreamingAssistantMessageIdByMessageIndex.slice(
+          ...cacheEntry.activeStreamingAssistantMessageIdByMessageIndex.slice(
             0,
             rebuildStartMessageIndex,
           ),
-          ...rebasedIncrementalMetadata.activeStreamingAssistantMessageIdByMessageIndex,
+          ...rebasedSuffixMetadata.activeStreamingAssistantMessageIdByMessageIndex,
         ],
         latestRebuildStartMessageIndex:
-          rebuildStartMessageIndex + incrementalRowsState.latestRebuildStartMessageIndex,
-        turns: nextTurns,
+          rebuildStartMessageIndex + suffixRowsState.latestRebuildStartMessageIndex,
+        turns: rebuiltTurns,
         hasAttachmentMessages:
-          prefixMetadata.hasAttachmentMessages || incrementalRowsState.hasAttachmentMessages,
-        lastUserMessageId:
-          incrementalRowsState.lastUserMessageId ?? prefixMetadata.lastUserMessageId,
+          prefixMetadata.hasAttachmentMessages || suffixRowsState.hasAttachmentMessages,
+        lastUserMessageId: suffixRowsState.lastUserMessageId ?? prefixMetadata.lastUserMessageId,
         activeStreamingAssistantMessageId:
           session.status === "running"
-            ? (incrementalRowsState.activeStreamingAssistantMessageId ??
+            ? (suffixRowsState.activeStreamingAssistantMessageId ??
               prefixMetadata.activeStreamingAssistantMessageId)
             : null,
-      };
+      });
       touchAgentChatWindowRowsCacheEntry(cache, cacheKey, nextCacheEntry);
-      return {
-        rows: nextRows,
-        turns: nextTurns,
-        hasAttachmentMessages: nextCacheEntry.hasAttachmentMessages,
-        lastUserMessageId: nextCacheEntry.lastUserMessageId,
-        activeStreamingAssistantMessageId: nextCacheEntry.activeStreamingAssistantMessageId,
-      };
+      return toResolvedWindowRowsState(nextCacheEntry, session.status);
     }
   }
 
-  const nextRowsState = buildAgentChatWindowRowsState(session, { showThinkingMessages });
-  touchAgentChatWindowRowsCacheEntry(cache, cacheKey, {
-    messages: session.messages,
-    messageSignatures: buildAgentChatMessageSignatures(session.messages),
-    rows: nextRowsState.rows,
-    rowStartByMessageIndex: nextRowsState.rowStartByMessageIndex,
-    rebuildStartByMessageIndex: nextRowsState.rebuildStartByMessageIndex,
-    hasAttachmentMessagesByMessageIndex: nextRowsState.hasAttachmentMessagesByMessageIndex,
-    lastUserMessageIdByMessageIndex: nextRowsState.lastUserMessageIdByMessageIndex,
-    activeStreamingAssistantMessageIdByMessageIndex:
-      nextRowsState.activeStreamingAssistantMessageIdByMessageIndex,
-    latestRebuildStartMessageIndex: nextRowsState.latestRebuildStartMessageIndex,
-    turns: nextRowsState.turns,
-    hasAttachmentMessages: nextRowsState.hasAttachmentMessages,
-    lastUserMessageId: nextRowsState.lastUserMessageId,
-    activeStreamingAssistantMessageId: nextRowsState.activeStreamingAssistantMessageId,
-  });
-  return {
-    rows: nextRowsState.rows,
-    turns: nextRowsState.turns,
-    hasAttachmentMessages: nextRowsState.hasAttachmentMessages,
-    lastUserMessageId: nextRowsState.lastUserMessageId,
-    activeStreamingAssistantMessageId: nextRowsState.activeStreamingAssistantMessageId,
-  };
+  const rebuiltRowsState = buildAgentChatWindowRowsState(session, { showThinkingMessages });
+  const nextCacheEntry = createWindowRowsCacheEntry(session.messages, rebuiltRowsState);
+  touchAgentChatWindowRowsCacheEntry(cache, cacheKey, nextCacheEntry);
+  return toResolvedWindowRowsState(nextCacheEntry, session.status);
 }
 
 export function buildAgentChatWindowRows(

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
@@ -37,6 +37,7 @@ export type AgentChatWindowTurn = {
 
 export type AgentChatWindowRowsCacheEntry = {
   messages: AgentSessionState["messages"];
+  messageSignatures: string[] | null;
   rows: AgentChatWindowRow[];
   rowStartByMessageIndex: number[];
   rebuildStartByMessageIndex: number[];
@@ -104,16 +105,34 @@ const isSessionMessagesState = (
   );
 };
 
+const buildAgentChatMessageSignature = (message: AgentChatMessage): string => {
+  return JSON.stringify([
+    message.id,
+    message.role,
+    message.content,
+    message.timestamp,
+    message.meta ?? null,
+  ]);
+};
+
+const buildAgentChatMessageSignatures = (messages: AgentSessionMessages): string[] | null => {
+  if (!Array.isArray(messages)) {
+    return null;
+  }
+
+  return messages.map(buildAgentChatMessageSignature);
+};
+
 const areSessionMessageContainersEquivalent = (
   previousMessages: AgentSessionMessages,
   nextMessages: AgentSessionMessages,
   sessionId: string,
 ): boolean => {
-  if (previousMessages === nextMessages) {
-    return true;
-  }
-
   if (isSessionMessagesState(previousMessages) && isSessionMessagesState(nextMessages)) {
+    if (previousMessages === nextMessages) {
+      return true;
+    }
+
     return (
       previousMessages.sessionId === sessionId &&
       nextMessages.sessionId === sessionId &&
@@ -123,6 +142,50 @@ const areSessionMessageContainersEquivalent = (
   }
 
   return false;
+};
+
+const findFirstChangedCachedMessageIndex = (
+  cachedRows: AgentChatWindowRowsCacheEntry,
+  session: AgentSessionState,
+): number => {
+  if (Array.isArray(cachedRows.messages) && Array.isArray(session.messages)) {
+    const previousSignatures = cachedRows.messageSignatures;
+    if (!previousSignatures) {
+      return 0;
+    }
+
+    const nextSignatures = buildAgentChatMessageSignatures(session.messages);
+    if (!nextSignatures) {
+      return 0;
+    }
+
+    if (nextSignatures.length < previousSignatures.length) {
+      return 0;
+    }
+
+    const sharedLength = Math.min(previousSignatures.length, nextSignatures.length);
+    let changedTailIndex = sharedLength - 1;
+    while (changedTailIndex >= 0) {
+      if (previousSignatures[changedTailIndex] !== nextSignatures[changedTailIndex]) {
+        break;
+      }
+      changedTailIndex -= 1;
+    }
+
+    if (changedTailIndex >= 0) {
+      while (changedTailIndex > 0) {
+        if (previousSignatures[changedTailIndex - 1] === nextSignatures[changedTailIndex - 1]) {
+          break;
+        }
+        changedTailIndex -= 1;
+      }
+      return changedTailIndex;
+    }
+
+    return nextSignatures.length > previousSignatures.length ? previousSignatures.length : -1;
+  }
+
+  return findFirstChangedChatMessageIndex(cachedRows.messages, session);
 };
 
 const appendMessageRows = (
@@ -186,6 +249,37 @@ const getPrefixMetadata = (
     lastUserMessageId: cacheEntry.lastUserMessageIdByMessageIndex[previousMessageIndex] ?? null,
     activeStreamingAssistantMessageId:
       cacheEntry.activeStreamingAssistantMessageIdByMessageIndex[previousMessageIndex] ?? null,
+  };
+};
+
+const rebaseIncrementalMetadata = ({
+  incrementalRowsState,
+  prefixMetadata,
+  sessionStatus,
+}: {
+  incrementalRowsState: AgentChatWindowRowsState;
+  prefixMetadata: ReturnType<typeof getPrefixMetadata>;
+  sessionStatus: AgentSessionState["status"];
+}): Pick<
+  AgentChatWindowRowsState,
+  | "hasAttachmentMessagesByMessageIndex"
+  | "lastUserMessageIdByMessageIndex"
+  | "activeStreamingAssistantMessageIdByMessageIndex"
+> => {
+  return {
+    hasAttachmentMessagesByMessageIndex:
+      incrementalRowsState.hasAttachmentMessagesByMessageIndex.map(
+        (value) => prefixMetadata.hasAttachmentMessages || value,
+      ),
+    lastUserMessageIdByMessageIndex: incrementalRowsState.lastUserMessageIdByMessageIndex.map(
+      (value) => value ?? prefixMetadata.lastUserMessageId,
+    ),
+    activeStreamingAssistantMessageIdByMessageIndex:
+      incrementalRowsState.activeStreamingAssistantMessageIdByMessageIndex.map((value) =>
+        sessionStatus === "running"
+          ? (value ?? prefixMetadata.activeStreamingAssistantMessageId)
+          : null,
+      ),
   };
 };
 
@@ -326,7 +420,7 @@ export function resolveAgentChatWindowRowsState({
       };
     }
 
-    const firstChangedMessageIndex = findFirstChangedChatMessageIndex(cachedRows.messages, session);
+    const firstChangedMessageIndex = findFirstChangedCachedMessageIndex(cachedRows, session);
     if (firstChangedMessageIndex < 0) {
       touchAgentChatWindowRowsCacheEntry(cache, cacheKey, cachedRows);
       return {
@@ -369,6 +463,11 @@ export function resolveAgentChatWindowRowsState({
         },
         { showThinkingMessages },
       );
+      const rebasedIncrementalMetadata = rebaseIncrementalMetadata({
+        incrementalRowsState,
+        prefixMetadata,
+        sessionStatus: session.status,
+      });
 
       for (let index = 0; index < incrementalRowsState.rowStartByMessageIndex.length; index += 1) {
         const rowStart = incrementalRowsState.rowStartByMessageIndex[index];
@@ -397,6 +496,7 @@ export function resolveAgentChatWindowRowsState({
 
       const nextCacheEntry: AgentChatWindowRowsCacheEntry = {
         messages: session.messages,
+        messageSignatures: buildAgentChatMessageSignatures(session.messages),
         rows: nextRows,
         rowStartByMessageIndex: nextRowStartByMessageIndex,
         rebuildStartByMessageIndex: [
@@ -407,18 +507,18 @@ export function resolveAgentChatWindowRowsState({
         ],
         hasAttachmentMessagesByMessageIndex: [
           ...cachedRows.hasAttachmentMessagesByMessageIndex.slice(0, rebuildStartMessageIndex),
-          ...incrementalRowsState.hasAttachmentMessagesByMessageIndex,
+          ...rebasedIncrementalMetadata.hasAttachmentMessagesByMessageIndex,
         ],
         lastUserMessageIdByMessageIndex: [
           ...cachedRows.lastUserMessageIdByMessageIndex.slice(0, rebuildStartMessageIndex),
-          ...incrementalRowsState.lastUserMessageIdByMessageIndex,
+          ...rebasedIncrementalMetadata.lastUserMessageIdByMessageIndex,
         ],
         activeStreamingAssistantMessageIdByMessageIndex: [
           ...cachedRows.activeStreamingAssistantMessageIdByMessageIndex.slice(
             0,
             rebuildStartMessageIndex,
           ),
-          ...incrementalRowsState.activeStreamingAssistantMessageIdByMessageIndex,
+          ...rebasedIncrementalMetadata.activeStreamingAssistantMessageIdByMessageIndex,
         ],
         latestRebuildStartMessageIndex:
           rebuildStartMessageIndex + incrementalRowsState.latestRebuildStartMessageIndex,
@@ -447,6 +547,7 @@ export function resolveAgentChatWindowRowsState({
   const nextRowsState = buildAgentChatWindowRowsState(session, { showThinkingMessages });
   touchAgentChatWindowRowsCacheEntry(cache, cacheKey, {
     messages: session.messages,
+    messageSignatures: buildAgentChatMessageSignatures(session.messages),
     rows: nextRowsState.rows,
     rowStartByMessageIndex: nextRowsState.rowStartByMessageIndex,
     rebuildStartByMessageIndex: nextRowsState.rebuildStartByMessageIndex,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-windowing.ts
@@ -1,9 +1,16 @@
 import {
   findFirstChangedSessionMessageIndex,
   forEachSessionMessage,
+  getSessionMessageAt,
+  getSessionMessagesSlice,
   isFinalAssistantChatMessage,
 } from "@/state/operations/agent-orchestrator/support/messages";
-import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
+import type {
+  AgentChatMessage,
+  AgentSessionMessages,
+  AgentSessionState,
+  SessionMessagesState,
+} from "@/types/agent-orchestrator";
 
 /** Initial number of user turns rendered from the bottom of the transcript. */
 export const CHAT_TURN_WINDOW_INIT = 10;
@@ -26,7 +33,43 @@ export type AgentChatWindowTurn = {
   key: string;
   start: number;
   end: number;
+};
+
+export type AgentChatWindowRowsCacheEntry = {
+  messages: AgentSessionState["messages"];
   rows: AgentChatWindowRow[];
+  rowStartByMessageIndex: number[];
+  rebuildStartByMessageIndex: number[];
+  latestRebuildStartMessageIndex: number;
+  turns: AgentChatWindowTurn[];
+  hasAttachmentMessages: boolean;
+  lastUserMessageId: string | null;
+  activeStreamingAssistantMessageId: string | null;
+};
+
+const CHAT_WINDOW_ROWS_CACHE_LIMIT = 6;
+
+const toAgentChatWindowRowsCacheKey = (sessionId: string, showThinkingMessages: boolean): string =>
+  `${sessionId}:${showThinkingMessages ? "thinking:on" : "thinking:off"}`;
+
+const touchAgentChatWindowRowsCacheEntry = (
+  cache: Map<string, AgentChatWindowRowsCacheEntry>,
+  cacheKey: string,
+  entry: AgentChatWindowRowsCacheEntry,
+): void => {
+  if (cache.has(cacheKey)) {
+    cache.delete(cacheKey);
+  }
+
+  cache.set(cacheKey, entry);
+
+  while (cache.size > CHAT_WINDOW_ROWS_CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value;
+    if (typeof oldestKey !== "string") {
+      break;
+    }
+    cache.delete(oldestKey);
+  }
 };
 
 type BuildAgentChatWindowRowsOptions = {
@@ -39,6 +82,41 @@ export type AgentChatWindowRowsState = {
   rebuildStartByMessageIndex: number[];
   latestRebuildStartMessageIndex: number;
   turns: AgentChatWindowTurn[];
+  hasAttachmentMessages: boolean;
+  lastUserMessageId: string | null;
+  activeStreamingAssistantMessageId: string | null;
+};
+
+const isSessionMessagesState = (
+  messages: AgentSessionMessages,
+): messages is SessionMessagesState => {
+  return (
+    typeof messages === "object" &&
+    messages !== null &&
+    "count" in messages &&
+    "version" in messages
+  );
+};
+
+const areSessionMessageContainersEquivalent = (
+  previousMessages: AgentSessionMessages,
+  nextMessages: AgentSessionMessages,
+  sessionId: string,
+): boolean => {
+  if (previousMessages === nextMessages) {
+    return true;
+  }
+
+  if (isSessionMessagesState(previousMessages) && isSessionMessagesState(nextMessages)) {
+    return (
+      previousMessages.sessionId === sessionId &&
+      nextMessages.sessionId === sessionId &&
+      previousMessages.version === nextMessages.version &&
+      previousMessages.count === nextMessages.count
+    );
+  }
+
+  return false;
 };
 
 const appendMessageRows = (
@@ -89,9 +167,34 @@ export function buildAgentChatWindowRowsState(
   const turnStartIndices: number[] = [];
   let currentRebuildStartMessageIndex = 0;
   let hasVisibleMessages = false;
+  let hasAttachmentMessages = false;
+  let lastUserMessageId: string | null = null;
+  let activeStreamingAssistantMessageId: string | null = null;
 
   forEachSessionMessage(session, (message, messageIndex) => {
     const isVisibleMessage = !(message.role === "thinking" && !showThinkingMessages);
+
+    if (
+      !hasAttachmentMessages &&
+      message.meta?.kind === "user" &&
+      message.meta.parts?.some((part) => part.kind === "attachment")
+    ) {
+      hasAttachmentMessages = true;
+    }
+
+    if (message.role === "user") {
+      lastUserMessageId = message.id;
+    }
+
+    if (session.status === "running") {
+      const isStreamingAssistantMessage =
+        message.role === "assistant" &&
+        message.meta?.kind === "assistant" &&
+        message.meta.isFinal === false;
+      if (isStreamingAssistantMessage) {
+        activeStreamingAssistantMessageId = message.id;
+      }
+    }
 
     if (isVisibleMessage) {
       if (!hasVisibleMessages) {
@@ -135,8 +238,166 @@ export function buildAgentChatWindowRowsState(
       key: rows[start]?.key ?? `turn-${index}`,
       start,
       end: (turnStartIndices[index + 1] ?? rows.length) - 1,
-      rows: rows.slice(start, turnStartIndices[index + 1] ?? rows.length),
     })),
+    hasAttachmentMessages,
+    lastUserMessageId,
+    activeStreamingAssistantMessageId,
+  };
+}
+
+export function resolveAgentChatWindowRowsState({
+  session,
+  showThinkingMessages,
+  cache,
+}: {
+  session: AgentSessionState;
+  showThinkingMessages: boolean;
+  cache: Map<string, AgentChatWindowRowsCacheEntry>;
+}): Pick<
+  AgentChatWindowRowsState,
+  | "rows"
+  | "turns"
+  | "hasAttachmentMessages"
+  | "lastUserMessageId"
+  | "activeStreamingAssistantMessageId"
+> {
+  const cacheKey = toAgentChatWindowRowsCacheKey(session.sessionId, showThinkingMessages);
+  const cachedRows = cache.get(cacheKey);
+
+  if (cachedRows) {
+    if (
+      areSessionMessageContainersEquivalent(
+        cachedRows.messages,
+        session.messages,
+        session.sessionId,
+      )
+    ) {
+      touchAgentChatWindowRowsCacheEntry(cache, cacheKey, cachedRows);
+      return {
+        rows: cachedRows.rows,
+        turns: cachedRows.turns,
+        hasAttachmentMessages: cachedRows.hasAttachmentMessages,
+        lastUserMessageId: cachedRows.lastUserMessageId,
+        activeStreamingAssistantMessageId: cachedRows.activeStreamingAssistantMessageId,
+      };
+    }
+
+    const firstChangedMessageIndex = findFirstChangedChatMessageIndex(cachedRows.messages, session);
+    if (firstChangedMessageIndex < 0) {
+      touchAgentChatWindowRowsCacheEntry(cache, cacheKey, cachedRows);
+      return {
+        rows: cachedRows.rows,
+        turns: cachedRows.turns,
+        hasAttachmentMessages: cachedRows.hasAttachmentMessages,
+        lastUserMessageId: cachedRows.lastUserMessageId,
+        activeStreamingAssistantMessageId: cachedRows.activeStreamingAssistantMessageId,
+      };
+    }
+
+    const rebuildStartMessageIndex = (() => {
+      const cachedRebuildStart = cachedRows.rebuildStartByMessageIndex[firstChangedMessageIndex];
+      if (typeof cachedRebuildStart === "number") {
+        return cachedRebuildStart;
+      }
+
+      const changedMessage = getSessionMessageAt(session, firstChangedMessageIndex);
+      if (changedMessage?.role === "user") {
+        return firstChangedMessageIndex;
+      }
+
+      return cachedRows.latestRebuildStartMessageIndex;
+    })();
+
+    if (rebuildStartMessageIndex > 0) {
+      const prefixRowEnd =
+        cachedRows.rowStartByMessageIndex[rebuildStartMessageIndex] ?? cachedRows.rows.length;
+      const nextRows = cachedRows.rows.slice(0, prefixRowEnd);
+      const nextRowStartByMessageIndex = cachedRows.rowStartByMessageIndex.slice(
+        0,
+        rebuildStartMessageIndex,
+      );
+      const incrementalRowsState = buildAgentChatWindowRowsState(
+        {
+          ...session,
+          messages: getSessionMessagesSlice(session, rebuildStartMessageIndex),
+        },
+        { showThinkingMessages },
+      );
+
+      for (let index = 0; index < incrementalRowsState.rowStartByMessageIndex.length; index += 1) {
+        const rowStart = incrementalRowsState.rowStartByMessageIndex[index];
+        if (typeof rowStart !== "number") {
+          continue;
+        }
+        nextRowStartByMessageIndex[rebuildStartMessageIndex + index] = prefixRowEnd + rowStart;
+      }
+
+      const nextTurns = cachedRows.turns.slice();
+      while (nextTurns.length > 0) {
+        const lastTurn = nextTurns[nextTurns.length - 1];
+        if (!lastTurn || lastTurn.start < prefixRowEnd) {
+          break;
+        }
+        nextTurns.pop();
+      }
+      nextTurns.push(
+        ...incrementalRowsState.turns.map((turn) => ({
+          key: turn.key,
+          start: prefixRowEnd + turn.start,
+          end: prefixRowEnd + turn.end,
+        })),
+      );
+      nextRows.push(...incrementalRowsState.rows);
+
+      const nextCacheEntry: AgentChatWindowRowsCacheEntry = {
+        messages: session.messages,
+        rows: nextRows,
+        rowStartByMessageIndex: nextRowStartByMessageIndex,
+        rebuildStartByMessageIndex: [
+          ...cachedRows.rebuildStartByMessageIndex.slice(0, rebuildStartMessageIndex),
+          ...incrementalRowsState.rebuildStartByMessageIndex.map(
+            (index) => rebuildStartMessageIndex + index,
+          ),
+        ],
+        latestRebuildStartMessageIndex:
+          rebuildStartMessageIndex + incrementalRowsState.latestRebuildStartMessageIndex,
+        turns: nextTurns,
+        hasAttachmentMessages:
+          cachedRows.hasAttachmentMessages || incrementalRowsState.hasAttachmentMessages,
+        lastUserMessageId: incrementalRowsState.lastUserMessageId ?? cachedRows.lastUserMessageId,
+        activeStreamingAssistantMessageId:
+          incrementalRowsState.activeStreamingAssistantMessageId ??
+          cachedRows.activeStreamingAssistantMessageId,
+      };
+      touchAgentChatWindowRowsCacheEntry(cache, cacheKey, nextCacheEntry);
+      return {
+        rows: nextRows,
+        turns: nextTurns,
+        hasAttachmentMessages: nextCacheEntry.hasAttachmentMessages,
+        lastUserMessageId: nextCacheEntry.lastUserMessageId,
+        activeStreamingAssistantMessageId: nextCacheEntry.activeStreamingAssistantMessageId,
+      };
+    }
+  }
+
+  const nextRowsState = buildAgentChatWindowRowsState(session, { showThinkingMessages });
+  touchAgentChatWindowRowsCacheEntry(cache, cacheKey, {
+    messages: session.messages,
+    rows: nextRowsState.rows,
+    rowStartByMessageIndex: nextRowsState.rowStartByMessageIndex,
+    rebuildStartByMessageIndex: nextRowsState.rebuildStartByMessageIndex,
+    latestRebuildStartMessageIndex: nextRowsState.latestRebuildStartMessageIndex,
+    turns: nextRowsState.turns,
+    hasAttachmentMessages: nextRowsState.hasAttachmentMessages,
+    lastUserMessageId: nextRowsState.lastUserMessageId,
+    activeStreamingAssistantMessageId: nextRowsState.activeStreamingAssistantMessageId,
+  });
+  return {
+    rows: nextRowsState.rows,
+    turns: nextRowsState.turns,
+    hasAttachmentMessages: nextRowsState.hasAttachmentMessages,
+    lastUserMessageId: nextRowsState.lastUserMessageId,
+    activeStreamingAssistantMessageId: nextRowsState.activeStreamingAssistantMessageId,
   };
 }
 
@@ -174,7 +435,6 @@ export function buildAgentChatWindowTurns(rows: AgentChatWindowRow[]): AgentChat
     key: rows[start]?.key ?? `turn-${index}`,
     start,
     end: (turnStartIndices[index + 1] ?? rows.length) - 1,
-    rows: rows.slice(start, turnStartIndices[index + 1] ?? rows.length),
   }));
 }
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -11,23 +11,16 @@ import {
 } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import {
-  findLastUserSessionMessage,
-  getSessionMessageAt,
-  getSessionMessagesSlice,
-  someSessionMessage,
-} from "@/state/operations/agent-orchestrator/support/messages";
-import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { resolveAgentAccentColor } from "../agent-accent-color";
 import type { AgentChatThreadModel } from "./agent-chat.types";
-import { resolveActiveStreamingAssistantMessageId } from "./agent-chat-streaming";
 import { AgentChatThreadRow } from "./agent-chat-thread-row";
 import { getAgentChatThreadState } from "./agent-chat-thread-state";
 import {
   type AgentChatWindowRow,
+  type AgentChatWindowRowsCacheEntry,
   type AgentChatWindowTurn,
-  buildAgentChatWindowRowsState,
-  findFirstChangedChatMessageIndex,
+  resolveAgentChatWindowRowsState,
 } from "./agent-chat-thread-windowing";
 import { AgentSessionPermissionCard } from "./agent-session-permission-card";
 import { AgentSessionQuestionCard } from "./agent-session-question-card";
@@ -41,6 +34,7 @@ import { ScrollToTopButton } from "./scroll-to-top-button";
 import { useAgentChatDeferredTranscript } from "./use-agent-chat-deferred-transcript";
 import { useAgentChatLoadingOverlay } from "./use-agent-chat-loading-overlay";
 import { useAgentChatRowMotion } from "./use-agent-chat-row-motion";
+import { useAgentChatRowStaging } from "./use-agent-chat-row-staging";
 import { useAgentChatTurnStaging } from "./use-agent-chat-turn-staging";
 import { useAgentChatWindow } from "./use-agent-chat-window";
 
@@ -114,12 +108,6 @@ type AgentChatRenderedTurn = {
   isActive: boolean;
 };
 
-const messageHasAttachmentDisplayParts = (message: AgentChatMessage): boolean => {
-  return Boolean(
-    message.meta?.kind === "user" && message.meta.parts?.some((part) => part.kind === "attachment"),
-  );
-};
-
 type AgentChatBottomStackProps = {
   sessionId: string;
   pendingQuestions: AgentSessionState["pendingQuestions"];
@@ -140,16 +128,6 @@ type AgentChatBottomStackProps = {
 };
 
 const EMPTY_ROWS: AgentChatWindowRow[] = [];
-type RowsCacheEntry = {
-  sessionId: string;
-  showThinkingMessages: boolean;
-  messages: AgentSessionState["messages"];
-  rows: AgentChatWindowRow[];
-  rowStartByMessageIndex: number[];
-  rebuildStartByMessageIndex: number[];
-  latestRebuildStartMessageIndex: number;
-  turns: AgentChatWindowTurn[];
-};
 const TURN_CONTENT_VISIBILITY_STYLE = {
   contentVisibility: "auto",
   containIntrinsicSize: "auto 500px",
@@ -493,133 +471,28 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     blockedReason,
     isTranscriptRenderDeferred,
   });
-  const rowsCacheRef = useRef<RowsCacheEntry | null>(null);
+  const rowsCacheRef = useRef<Map<string, AgentChatWindowRowsCacheEntry>>(new Map());
 
   const transcriptState = useMemo(() => {
     if (!session || hideTranscriptWhileHydrating) {
-      rowsCacheRef.current = null;
       return {
         rows: EMPTY_ROWS,
         turns: [] as AgentChatWindowTurn[],
+        hasAttachmentMessages: false,
+        lastUserMessageId: null,
+        activeStreamingAssistantMessageId: null,
       };
     }
 
-    const cachedRows = rowsCacheRef.current;
-    if (
-      cachedRows &&
-      cachedRows.sessionId === session.sessionId &&
-      cachedRows.showThinkingMessages === showThinkingMessages
-    ) {
-      const firstChangedMessageIndex = findFirstChangedChatMessageIndex(
-        cachedRows.messages,
-        session,
-      );
-      if (firstChangedMessageIndex < 0) {
-        return {
-          rows: cachedRows.rows,
-          turns: cachedRows.turns,
-        };
-      }
-
-      const rebuildStartMessageIndex = (() => {
-        const cachedRebuildStart = cachedRows.rebuildStartByMessageIndex[firstChangedMessageIndex];
-        if (typeof cachedRebuildStart === "number") {
-          return cachedRebuildStart;
-        }
-
-        const changedMessage = getSessionMessageAt(session, firstChangedMessageIndex);
-        if (changedMessage?.role === "user") {
-          return firstChangedMessageIndex;
-        }
-
-        return cachedRows.latestRebuildStartMessageIndex;
-      })();
-      if (rebuildStartMessageIndex > 0) {
-        const prefixRowEnd =
-          cachedRows.rowStartByMessageIndex[rebuildStartMessageIndex] ?? cachedRows.rows.length;
-        const nextRows = cachedRows.rows.slice(0, prefixRowEnd);
-        const nextRowStartByMessageIndex = cachedRows.rowStartByMessageIndex.slice(
-          0,
-          rebuildStartMessageIndex,
-        );
-        const incrementalRowsState = buildAgentChatWindowRowsState(
-          {
-            ...session,
-            messages: getSessionMessagesSlice(session, rebuildStartMessageIndex),
-          },
-          { showThinkingMessages },
-        );
-
-        for (
-          let index = 0;
-          index < incrementalRowsState.rowStartByMessageIndex.length;
-          index += 1
-        ) {
-          const rowStart = incrementalRowsState.rowStartByMessageIndex[index];
-          if (typeof rowStart !== "number") {
-            continue;
-          }
-          nextRowStartByMessageIndex[rebuildStartMessageIndex + index] = prefixRowEnd + rowStart;
-        }
-
-        const nextTurns = cachedRows.turns.slice();
-        while (nextTurns.length > 0) {
-          const lastTurn = nextTurns[nextTurns.length - 1];
-          if (!lastTurn || lastTurn.start < prefixRowEnd) {
-            break;
-          }
-          nextTurns.pop();
-        }
-        nextTurns.push(
-          ...incrementalRowsState.turns.map((turn) => ({
-            key: turn.key,
-            start: prefixRowEnd + turn.start,
-            end: prefixRowEnd + turn.end,
-            rows: turn.rows,
-          })),
-        );
-        nextRows.push(...incrementalRowsState.rows);
-        rowsCacheRef.current = {
-          sessionId: session.sessionId,
-          showThinkingMessages,
-          messages: session.messages,
-          rows: nextRows,
-          rowStartByMessageIndex: nextRowStartByMessageIndex,
-          rebuildStartByMessageIndex: [
-            ...cachedRows.rebuildStartByMessageIndex.slice(0, rebuildStartMessageIndex),
-            ...incrementalRowsState.rebuildStartByMessageIndex.map(
-              (index) => rebuildStartMessageIndex + index,
-            ),
-          ],
-          latestRebuildStartMessageIndex:
-            rebuildStartMessageIndex + incrementalRowsState.latestRebuildStartMessageIndex,
-          turns: nextTurns,
-        };
-        return {
-          rows: nextRows,
-          turns: nextTurns,
-        };
-      }
-    }
-
-    const nextRowsState = buildAgentChatWindowRowsState(session, { showThinkingMessages });
-    rowsCacheRef.current = {
-      sessionId: session.sessionId,
+    return resolveAgentChatWindowRowsState({
+      session,
       showThinkingMessages,
-      messages: session.messages,
-      rows: nextRowsState.rows,
-      rowStartByMessageIndex: nextRowsState.rowStartByMessageIndex,
-      rebuildStartByMessageIndex: nextRowsState.rebuildStartByMessageIndex,
-      latestRebuildStartMessageIndex: nextRowsState.latestRebuildStartMessageIndex,
-      turns: nextRowsState.turns,
-    };
-    return {
-      rows: nextRowsState.rows,
-      turns: nextRowsState.turns,
-    };
+      cache: rowsCacheRef.current,
+    });
   }, [hideTranscriptWhileHydrating, session, showThinkingMessages]);
   const rows = transcriptState.rows;
   const transcriptTurns = transcriptState.turns;
+  const hasAttachmentMessages = transcriptState.hasAttachmentMessages;
 
   const messagesContentRef = useRef<HTMLDivElement | null>(null);
   const {
@@ -663,10 +536,6 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     return resolveAgentAccentColor(profileId, sessionAgentColors[profileId]);
   }, [sessionAgentColors, sessionSelectedModel?.profileId]);
   const sessionWorkingDirectory = session?.workingDirectory ?? null;
-  const rowKeys = useMemo(() => windowedRows.map((row) => row.key), [windowedRows]);
-  const hasAttachmentMessages = useMemo(() => {
-    return session ? someSessionMessage(session, messageHasAttachmentDisplayParts) : false;
-  }, [session]);
   // Attachment-bearing sessions are kept fully materialized because staged turn reveal and
   // containment can under-measure transcript height during hydration and break bottom pinning.
   const stagedTurns = useAgentChatTurnStaging({
@@ -675,6 +544,15 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     turns: windowedTurns,
     disabled: hasAttachmentMessages,
   });
+  const stagedTranscript = useAgentChatRowStaging({
+    activeSessionId,
+    rows: windowedRows,
+    turns: stagedTurns,
+    disabled: hasAttachmentMessages,
+  });
+  const stagedRows = stagedTranscript.rows;
+  const stagedWindowTurns = stagedTranscript.turns;
+  const rowKeys = useMemo(() => stagedRows.map((row) => row.key), [stagedRows]);
   const rowRefByKeyRef = useRef<Map<string, (element: HTMLDivElement | null) => void>>(new Map());
   const { registerRowElement } = useAgentChatRowMotion({
     activeSessionId,
@@ -706,23 +584,20 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     [registerRowElement],
   );
   const activeTurnKey = useMemo(() => {
-    if (!session || !isSessionWorking) {
+    if (!session || !isSessionWorking || !transcriptState.lastUserMessageId) {
       return null;
     }
 
-    const latestUserMessage = findLastUserSessionMessage(session);
-    return latestUserMessage ? `${session.sessionId}:${latestUserMessage.id}` : null;
-  }, [isSessionWorking, session]);
-  const activeStreamingAssistantMessageId = useMemo(() => {
-    return resolveActiveStreamingAssistantMessageId(session);
-  }, [session]);
+    return `${session.sessionId}:${transcriptState.lastUserMessageId}`;
+  }, [isSessionWorking, session, transcriptState.lastUserMessageId]);
+  const activeStreamingAssistantMessageId = transcriptState.activeStreamingAssistantMessageId;
   const renderedTurns = useMemo(() => {
-    return stagedTurns.map((turn) => ({
+    return stagedWindowTurns.map((turn) => ({
       key: turn.key,
-      rows: turn.rows,
+      rows: stagedRows.slice(turn.start, turn.end + 1),
       isActive: turn.key === activeTurnKey,
     }));
-  }, [activeTurnKey, stagedTurns]);
+  }, [activeTurnKey, stagedRows, stagedWindowTurns]);
   const allowTurnContainment = !hasAttachmentMessages;
   const bottomStackRef = useRef<HTMLDivElement | null>(null);
   const bottomStackHeightRef = useRef<number | null>(null);

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-history-window.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-history-window.ts
@@ -12,6 +12,7 @@ import { CHAT_TURN_REVEAL_EDGE_THRESHOLD_PX } from "./agent-chat-window-shared";
 type UseAgentChatHistoryWindowInput = {
   rows: AgentChatWindowRow[];
   turns?: AgentChatWindowTurn[];
+  activeSessionId: string | null;
   isSessionViewLoading: boolean;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   userScrolledRef: RefObject<boolean>;
@@ -27,9 +28,39 @@ type UseAgentChatHistoryWindowResult = {
   revealAllHistory: () => void;
 };
 
+export const resolveAgentChatEffectiveTurnStart = ({
+  activeSessionId,
+  previousSessionId,
+  turnStart,
+  latestTurnStart,
+  rowsLength,
+  pendingLatestReset,
+}: {
+  activeSessionId: string | null;
+  previousSessionId: string | null;
+  turnStart: number;
+  latestTurnStart: number;
+  rowsLength: number;
+  pendingLatestReset: boolean;
+}): number => {
+  const clampedTurnStart =
+    rowsLength === 0 ? turnStart : Math.max(0, Math.min(turnStart, latestTurnStart));
+
+  if (pendingLatestReset && rowsLength > 0) {
+    return latestTurnStart;
+  }
+
+  if (previousSessionId !== activeSessionId) {
+    return latestTurnStart;
+  }
+
+  return clampedTurnStart;
+};
+
 export function useAgentChatHistoryWindow({
   rows,
   turns: providedTurns,
+  activeSessionId,
   isSessionViewLoading,
   messagesContainerRef,
   userScrolledRef,
@@ -47,15 +78,22 @@ export function useAgentChatHistoryWindow({
   const fillFrameRef = useRef<number | null>(null);
   const continuationFrameRef = useRef<number | null>(null);
   const pendingLatestResetRef = useRef(isSessionViewLoading && rows.length === 0);
+  const previousSessionIdRef = useRef<string | null>(activeSessionId);
   const pendingScrollRestoreRef = useRef<{
     beforeScrollHeight: number;
     beforeScrollTop: number;
   } | null>(null);
   const latestTurnStart = getLatestTurnStart();
-  const clampedTurnStart =
-    rows.length === 0 ? turnStart : Math.max(0, Math.min(turnStart, latestTurnStart));
   const shouldUsePendingLatestTurnStart = pendingLatestResetRef.current && rows.length > 0;
-  const effectiveTurnStart = shouldUsePendingLatestTurnStart ? latestTurnStart : clampedTurnStart;
+  const didSessionChange = previousSessionIdRef.current !== activeSessionId;
+  const effectiveTurnStart = resolveAgentChatEffectiveTurnStart({
+    activeSessionId,
+    previousSessionId: previousSessionIdRef.current,
+    turnStart,
+    latestTurnStart,
+    rowsLength: rows.length,
+    pendingLatestReset: shouldUsePendingLatestTurnStart,
+  });
 
   const setTurnStartState = useCallback(
     (nextTurnStart: number) => {
@@ -164,11 +202,15 @@ export function useAgentChatHistoryWindow({
   // Intentionally runs after every commit so pending scroll restoration and
   // deferred-session latest-turn rebasing happen on the very next DOM update.
   useLayoutEffect(() => {
-    if (shouldUsePendingLatestTurnStart) {
+    if (didSessionChange) {
+      previousSessionIdRef.current = activeSessionId;
+      pendingLatestResetRef.current = isSessionViewLoading && rows.length === 0;
+    } else if (shouldUsePendingLatestTurnStart) {
       pendingLatestResetRef.current = false;
-      if (turnStart !== latestTurnStart) {
-        setTurnStartState(latestTurnStart);
-      }
+    }
+
+    if ((didSessionChange || shouldUsePendingLatestTurnStart) && turnStart !== latestTurnStart) {
+      setTurnStartState(latestTurnStart);
     }
 
     turnStartRef.current = effectiveTurnStart;
@@ -279,7 +321,6 @@ export function useAgentChatHistoryWindow({
         key: turn.key,
         start: turn.start - windowStart,
         end: turn.end - windowStart,
-        rows: turn.rows,
       })),
     [effectiveTurnStart, turns, windowStart],
   );

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { createHookHarness } from "@/test-utils/react-hook-harness";
+import type { AgentChatWindowRow, AgentChatWindowTurn } from "./agent-chat-thread-windowing";
+import { useAgentChatRowStaging } from "./use-agent-chat-row-staging";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const buildRows = (count: number, sessionId = "session-1"): AgentChatWindowRow[] =>
+  Array.from({ length: count }, (_, index) => ({
+    kind: "message" as const,
+    key: `${sessionId}:row-${index}`,
+    message: {
+      id: `row-${index}`,
+      role: "assistant" as const,
+      content: `Row ${index}`,
+      timestamp: "2026-04-21T12:00:00.000Z",
+    },
+  }));
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("useAgentChatRowStaging", () => {
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+  const animationFrameCallbacks = new Map<number, FrameRequestCallback>();
+  let nextAnimationFrameId = 1;
+
+  beforeEach(() => {
+    animationFrameCallbacks.clear();
+    nextAnimationFrameId = 1;
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      const frameId = nextAnimationFrameId;
+      nextAnimationFrameId += 1;
+      animationFrameCallbacks.set(frameId, callback);
+      return frameId;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((frameId: number) => {
+      animationFrameCallbacks.delete(frameId);
+    }) as typeof cancelAnimationFrame;
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  test("shows only the latest rows first for a large single-turn transcript", async () => {
+    const rows = buildRows(80);
+    const turns: AgentChatWindowTurn[] = [{ key: "turn-0", start: 0, end: 79 }];
+    const harness = createHookHarness(
+      ({ activeSessionId, nextRows, nextTurns }) =>
+        useAgentChatRowStaging({
+          activeSessionId,
+          rows: nextRows,
+          turns: nextTurns,
+          disabled: false,
+        }),
+      {
+        activeSessionId: "session-1",
+        nextRows: rows,
+        nextTurns: turns,
+      },
+    );
+
+    await harness.mount();
+
+    expect(harness.getLatest().rows).toHaveLength(24);
+    expect(harness.getLatest().turns).toEqual([{ key: "turn-0", start: 0, end: 23 }]);
+
+    await harness.unmount();
+  });
+
+  test("stages rows again when revisiting a session", async () => {
+    const rows = buildRows(80);
+    const turns: AgentChatWindowTurn[] = [{ key: "turn-0", start: 0, end: 79 }];
+    const harness = createHookHarness(
+      ({ activeSessionId, nextRows, nextTurns }) =>
+        useAgentChatRowStaging({
+          activeSessionId,
+          rows: nextRows,
+          turns: nextTurns,
+          disabled: false,
+        }),
+      {
+        activeSessionId: "session-a",
+        nextRows: rows,
+        nextTurns: turns,
+      },
+    );
+
+    await harness.mount();
+
+    await act(async () => {
+      while (animationFrameCallbacks.size > 0) {
+        const queuedCallbacks = Array.from(animationFrameCallbacks.values());
+        animationFrameCallbacks.clear();
+        for (const callback of queuedCallbacks) {
+          callback(16);
+        }
+        await flush();
+      }
+    });
+
+    await harness.update({
+      activeSessionId: "session-b",
+      nextRows: buildRows(12, "session-b"),
+      nextTurns: [{ key: "turn-b", start: 0, end: 11 }],
+    });
+
+    await harness.update({
+      activeSessionId: "session-a",
+      nextRows: rows,
+      nextTurns: turns,
+    });
+
+    expect(harness.getLatest().rows).toHaveLength(24);
+    expect(animationFrameCallbacks.size).toBeGreaterThan(0);
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
@@ -4,11 +4,9 @@ import { createHookHarness } from "@/test-utils/react-hook-harness";
 import type { AgentChatWindowRow, AgentChatWindowTurn } from "./agent-chat-thread-windowing";
 import { useAgentChatRowStaging } from "./use-agent-chat-row-staging";
 
-(
-  globalThis as typeof globalThis & {
-    IS_REACT_ACT_ENVIRONMENT?: boolean;
-  }
-).IS_REACT_ACT_ENVIRONMENT = true;
+const reactActGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
 
 const buildRows = (count: number, sessionId = "session-1"): AgentChatWindowRow[] =>
   Array.from({ length: count }, (_, index) => ({
@@ -32,8 +30,11 @@ describe("useAgentChatRowStaging", () => {
   const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
   const animationFrameCallbacks = new Map<number, FrameRequestCallback>();
   let nextAnimationFrameId = 1;
+  let originalIsReactActEnvironment: boolean | undefined;
 
   beforeEach(() => {
+    originalIsReactActEnvironment = reactActGlobal.IS_REACT_ACT_ENVIRONMENT;
+    reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true;
     animationFrameCallbacks.clear();
     nextAnimationFrameId = 1;
     globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
@@ -48,6 +49,11 @@ describe("useAgentChatRowStaging", () => {
   });
 
   afterEach(() => {
+    if (typeof originalIsReactActEnvironment === "undefined") {
+      delete reactActGlobal.IS_REACT_ACT_ENVIRONMENT;
+    } else {
+      reactActGlobal.IS_REACT_ACT_ENVIRONMENT = originalIsReactActEnvironment;
+    }
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;
     globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
@@ -126,4 +126,54 @@ describe("useAgentChatRowStaging", () => {
 
     await harness.unmount();
   });
+
+  test("resumes staging when rows grow for the active session", async () => {
+    const harness = createHookHarness(
+      ({ activeSessionId, nextRows, nextTurns }) =>
+        useAgentChatRowStaging({
+          activeSessionId,
+          rows: nextRows,
+          turns: nextTurns,
+          disabled: false,
+        }),
+      {
+        activeSessionId: "session-1",
+        nextRows: buildRows(80),
+        nextTurns: [{ key: "turn-0", start: 0, end: 79 }],
+      },
+    );
+
+    await harness.mount();
+
+    await act(async () => {
+      const callback = animationFrameCallbacks.values().next().value;
+      animationFrameCallbacks.clear();
+      callback?.(16);
+      await flush();
+    });
+
+    expect(harness.getLatest().rows).toHaveLength(56);
+
+    await harness.update({
+      activeSessionId: "session-1",
+      nextRows: buildRows(96),
+      nextTurns: [{ key: "turn-0", start: 0, end: 95 }],
+    });
+
+    await act(async () => {
+      while (animationFrameCallbacks.size > 0) {
+        const queuedCallbacks = Array.from(animationFrameCallbacks.values());
+        animationFrameCallbacks.clear();
+        for (const callback of queuedCallbacks) {
+          callback(16);
+        }
+        await flush();
+      }
+    });
+
+    expect(harness.getLatest().rows).toHaveLength(96);
+    expect(harness.getLatest().turns).toEqual([{ key: "turn-0", start: 0, end: 95 }]);
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
@@ -23,12 +23,18 @@ export function useAgentChatRowStaging({
   disabled = false,
 }: UseAgentChatRowStagingArgs): UseAgentChatRowStagingResult {
   const [rowCount, setRowCount] = useState(rows.length);
+  const rowCountRef = useRef(rowCount);
   const frameRef = useRef<number | null>(null);
   const activeSessionRef = useRef<string | null>(null);
   const completedSessionIdsRef = useRef<Set<string>>(new Set());
   const previousSessionIdRef = useRef<string | null>(activeSessionId);
 
   useEffect(() => {
+    const updateRowCount = (nextRowCount: number): void => {
+      rowCountRef.current = nextRowCount;
+      setRowCount((current) => (current === nextRowCount ? current : nextRowCount));
+    };
+
     if (frameRef.current !== null) {
       globalThis.cancelAnimationFrame(frameRef.current);
       frameRef.current = null;
@@ -53,18 +59,24 @@ export function useAgentChatRowStaging({
 
     if (!shouldStage) {
       activeSessionRef.current = null;
-      setRowCount((current) => (current === rows.length ? current : rows.length));
-      return;
-    }
-
-    if (activeSessionRef.current === activeSessionId) {
+      updateRowCount(rows.length);
       return;
     }
 
     const sessionId = activeSessionId;
+    const isContinuingActiveSession = activeSessionRef.current === activeSessionId;
     activeSessionRef.current = sessionId;
-    let nextRowCount = Math.min(rows.length, ROW_STAGE_INIT);
-    setRowCount((current) => (current === nextRowCount ? current : nextRowCount));
+    let nextRowCount = Math.min(
+      rows.length,
+      isContinuingActiveSession ? rowCountRef.current : ROW_STAGE_INIT,
+    );
+    updateRowCount(nextRowCount);
+
+    if (nextRowCount >= rows.length) {
+      activeSessionRef.current = null;
+      completedSessionIdsRef.current.add(sessionId);
+      return;
+    }
 
     const step = () => {
       if (activeSessionRef.current !== sessionId) {
@@ -73,7 +85,7 @@ export function useAgentChatRowStaging({
       }
 
       nextRowCount = Math.min(rows.length, nextRowCount + ROW_STAGE_BATCH);
-      setRowCount((current) => (current === nextRowCount ? current : nextRowCount));
+      updateRowCount(nextRowCount);
 
       if (nextRowCount >= rows.length) {
         frameRef.current = null;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
@@ -1,23 +1,28 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { AgentChatWindowTurn } from "./agent-chat-thread-windowing";
+import type { AgentChatWindowRow, AgentChatWindowTurn } from "./agent-chat-thread-windowing";
 
-const STAGE_INIT = 1;
-const STAGE_BATCH = 3;
+const ROW_STAGE_INIT = 24;
+const ROW_STAGE_BATCH = 32;
 
-type UseAgentChatTurnStagingArgs = {
+type UseAgentChatRowStagingArgs = {
   activeSessionId: string | null;
-  windowStart: number;
+  rows: AgentChatWindowRow[];
   turns: AgentChatWindowTurn[];
   disabled?: boolean;
 };
 
-export function useAgentChatTurnStaging({
+type UseAgentChatRowStagingResult = {
+  rows: AgentChatWindowRow[];
+  turns: AgentChatWindowTurn[];
+};
+
+export function useAgentChatRowStaging({
   activeSessionId,
-  windowStart,
+  rows,
   turns,
   disabled = false,
-}: UseAgentChatTurnStagingArgs): AgentChatWindowTurn[] {
-  const [count, setCount] = useState(turns.length);
+}: UseAgentChatRowStagingArgs): UseAgentChatRowStagingResult {
+  const [rowCount, setRowCount] = useState(rows.length);
   const frameRef = useRef<number | null>(null);
   const activeSessionRef = useRef<string | null>(null);
   const completedSessionIdsRef = useRef<Set<string>>(new Set());
@@ -43,13 +48,12 @@ export function useAgentChatTurnStaging({
     const shouldStage =
       !disabled &&
       activeSessionId !== null &&
-      windowStart > 0 &&
-      turns.length > STAGE_INIT &&
+      rows.length > ROW_STAGE_INIT &&
       !completedSessionIdsRef.current.has(activeSessionId);
 
     if (!shouldStage) {
       activeSessionRef.current = null;
-      setCount((current) => (current === turns.length ? current : turns.length));
+      setRowCount((current) => (current === rows.length ? current : rows.length));
       return;
     }
 
@@ -59,8 +63,8 @@ export function useAgentChatTurnStaging({
 
     const sessionId = activeSessionId;
     activeSessionRef.current = sessionId;
-    let nextCount = Math.min(turns.length, STAGE_INIT);
-    setCount((current) => (current === nextCount ? current : nextCount));
+    let nextRowCount = Math.min(rows.length, ROW_STAGE_INIT);
+    setRowCount((current) => (current === nextRowCount ? current : nextRowCount));
 
     const step = () => {
       if (activeSessionRef.current !== sessionId) {
@@ -68,10 +72,10 @@ export function useAgentChatTurnStaging({
         return;
       }
 
-      nextCount = Math.min(turns.length, nextCount + STAGE_BATCH);
-      setCount((current) => (current === nextCount ? current : nextCount));
+      nextRowCount = Math.min(rows.length, nextRowCount + ROW_STAGE_BATCH);
+      setRowCount((current) => (current === nextRowCount ? current : nextRowCount));
 
-      if (nextCount >= turns.length) {
+      if (nextRowCount >= rows.length) {
         frameRef.current = null;
         activeSessionRef.current = null;
         completedSessionIdsRef.current.add(sessionId);
@@ -88,13 +92,23 @@ export function useAgentChatTurnStaging({
         frameRef.current = null;
       }
     };
-  }, [activeSessionId, disabled, turns.length, windowStart]);
+  }, [activeSessionId, disabled, rows.length]);
 
   return useMemo(() => {
-    if (count >= turns.length) {
-      return turns;
+    if (rowCount >= rows.length) {
+      return { rows, turns };
     }
 
-    return turns.slice(Math.max(0, turns.length - count));
-  }, [count, turns]);
+    const rowStart = Math.max(0, rows.length - rowCount);
+    return {
+      rows: rows.slice(rowStart),
+      turns: turns
+        .filter((turn) => turn.end >= rowStart)
+        .map((turn) => ({
+          key: turn.key,
+          start: Math.max(turn.start, rowStart) - rowStart,
+          end: turn.end - rowStart,
+        })),
+    };
+  }, [rowCount, rows, turns]);
 }

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
@@ -131,7 +131,7 @@ describe("useAgentChatTurnStaging", () => {
     await harness.unmount();
   });
 
-  test("does not stage turns when switching to another session", async () => {
+  test("stages turns again when switching back to another session", async () => {
     const turns = buildTurns(6);
     const harness = createHookHarness(
       ({ activeSessionId, windowStart, nextTurns }) =>
@@ -168,10 +168,8 @@ describe("useAgentChatTurnStaging", () => {
       nextTurns: builderTurns,
     });
 
-    expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual(
-      builderTurns.map((turn) => turn.key),
-    );
-    expect(animationFrameCallbacks.size).toBe(0);
+    expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual(["turn-7"]);
+    expect(animationFrameCallbacks.size).toBeGreaterThan(0);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
@@ -15,7 +15,6 @@ const buildTurns = (count: number): AgentChatWindowTurn[] =>
     key: `turn-${index}`,
     start: index * 2,
     end: index * 2 + 1,
-    rows: [],
   }));
 
 const flush = async (): Promise<void> => {
@@ -170,6 +169,62 @@ describe("useAgentChatTurnStaging", () => {
 
     expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual(["turn-7"]);
     expect(animationFrameCallbacks.size).toBeGreaterThan(0);
+
+    await harness.unmount();
+  });
+
+  test("resumes staging when turns grow for the active session", async () => {
+    const harness = createHookHarness(
+      ({ activeSessionId, windowStart, nextTurns }) =>
+        useAgentChatTurnStaging({
+          activeSessionId,
+          windowStart,
+          turns: nextTurns,
+          disabled: false,
+        }),
+      {
+        activeSessionId: "session-1",
+        windowStart: 10,
+        nextTurns: buildTurns(6),
+      },
+    );
+
+    await harness.mount();
+
+    await act(async () => {
+      const callback = animationFrameCallbacks.values().next().value;
+      animationFrameCallbacks.clear();
+      callback?.(16);
+      await flush();
+    });
+
+    expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual([
+      "turn-2",
+      "turn-3",
+      "turn-4",
+      "turn-5",
+    ]);
+
+    await harness.update({
+      activeSessionId: "session-1",
+      windowStart: 12,
+      nextTurns: buildTurns(8),
+    });
+
+    await act(async () => {
+      while (animationFrameCallbacks.size > 0) {
+        const queuedCallbacks = Array.from(animationFrameCallbacks.values());
+        animationFrameCallbacks.clear();
+        for (const callback of queuedCallbacks) {
+          callback(16);
+        }
+        await flush();
+      }
+    });
+
+    expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual(
+      buildTurns(8).map((turn) => turn.key),
+    );
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
@@ -18,12 +18,18 @@ export function useAgentChatTurnStaging({
   disabled = false,
 }: UseAgentChatTurnStagingArgs): AgentChatWindowTurn[] {
   const [count, setCount] = useState(turns.length);
+  const countRef = useRef(count);
   const frameRef = useRef<number | null>(null);
   const activeSessionRef = useRef<string | null>(null);
   const completedSessionIdsRef = useRef<Set<string>>(new Set());
   const previousSessionIdRef = useRef<string | null>(activeSessionId);
 
   useEffect(() => {
+    const updateCount = (nextCount: number): void => {
+      countRef.current = nextCount;
+      setCount((current) => (current === nextCount ? current : nextCount));
+    };
+
     if (frameRef.current !== null) {
       globalThis.cancelAnimationFrame(frameRef.current);
       frameRef.current = null;
@@ -49,18 +55,24 @@ export function useAgentChatTurnStaging({
 
     if (!shouldStage) {
       activeSessionRef.current = null;
-      setCount((current) => (current === turns.length ? current : turns.length));
-      return;
-    }
-
-    if (activeSessionRef.current === activeSessionId) {
+      updateCount(turns.length);
       return;
     }
 
     const sessionId = activeSessionId;
+    const isContinuingActiveSession = activeSessionRef.current === activeSessionId;
     activeSessionRef.current = sessionId;
-    let nextCount = Math.min(turns.length, STAGE_INIT);
-    setCount((current) => (current === nextCount ? current : nextCount));
+    let nextCount = Math.min(
+      turns.length,
+      isContinuingActiveSession ? countRef.current : STAGE_INIT,
+    );
+    updateCount(nextCount);
+
+    if (nextCount >= turns.length) {
+      activeSessionRef.current = null;
+      completedSessionIdsRef.current.add(sessionId);
+      return;
+    }
 
     const step = () => {
       if (activeSessionRef.current !== sessionId) {
@@ -69,7 +81,7 @@ export function useAgentChatTurnStaging({
       }
 
       nextCount = Math.min(turns.length, nextCount + STAGE_BATCH);
-      setCount((current) => (current === nextCount ? current : nextCount));
+      updateCount(nextCount);
 
       if (nextCount >= turns.length) {
         frameRef.current = null;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -7,6 +7,7 @@ import {
   CHAT_TURN_WINDOW_BATCH,
   CHAT_TURN_WINDOW_INIT,
 } from "./agent-chat-thread-windowing";
+import { resolveAgentChatEffectiveTurnStart } from "./use-agent-chat-history-window";
 import { useAgentChatWindow } from "./use-agent-chat-window";
 
 (
@@ -79,11 +80,11 @@ const triggerResizeObservers = (): void => {
   }
 };
 
-const createTurnRows = (turnCount: number): AgentChatWindowRow[] =>
+const createTurnRows = (turnCount: number, sessionId = "session-1"): AgentChatWindowRow[] =>
   Array.from({ length: turnCount }, (_, turnIndex) => [
     {
       kind: "message" as const,
-      key: `session-1:user-${turnIndex}`,
+      key: `${sessionId}:user-${turnIndex}`,
       message: {
         id: `user-${turnIndex}`,
         role: "user" as const,
@@ -93,7 +94,7 @@ const createTurnRows = (turnCount: number): AgentChatWindowRow[] =>
     },
     {
       kind: "message" as const,
-      key: `session-1:assistant-${turnIndex}`,
+      key: `${sessionId}:assistant-${turnIndex}`,
       message: {
         id: `assistant-${turnIndex}`,
         role: "assistant" as const,
@@ -502,6 +503,52 @@ describe("useAgentChatWindow", () => {
 
     expect(harness.getLatestResult().windowStart).toBe(
       buildAgentChatWindowTurns(rows)[2]?.start ?? 0,
+    );
+
+    await harness.unmount();
+  });
+
+  test("resolves the latest turn window immediately when the active session changes", () => {
+    expect(
+      resolveAgentChatEffectiveTurnStart({
+        activeSessionId: "session-2",
+        previousSessionId: "session-1",
+        turnStart: 0,
+        latestTurnStart: 12,
+        rowsLength: 40,
+        pendingLatestReset: false,
+      }),
+    ).toBe(12);
+  });
+
+  test("switching sessions after revealing all history resets the next session to its latest turns", async () => {
+    const firstSessionRows = createTurnRows(12, "session-1");
+    const secondSessionRows = createTurnRows(12, "session-2");
+    const harness = await mountHarness(
+      {
+        rows: firstSessionRows,
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+      },
+      { attachDom: true },
+    );
+
+    await act(async () => {
+      harness.getLatestResult().scrollToTop();
+      await flush();
+    });
+    await flushAnimationFrames();
+
+    expect(harness.getLatestResult().windowStart).toBe(0);
+
+    await harness.update({
+      rows: secondSessionRows,
+      activeSessionId: "session-2",
+      isSessionViewLoading: false,
+    });
+
+    expect(harness.getLatestResult().windowStart).toBe(
+      buildAgentChatWindowTurns(secondSessionRows)[2]?.start ?? 0,
     );
 
     await harness.unmount();

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -64,6 +64,7 @@ export function useAgentChatWindow({
   } = useAgentChatHistoryWindow({
     rows,
     isSessionViewLoading,
+    activeSessionId,
     messagesContainerRef,
     userScrolledRef,
     ...(turns ? { turns } : {}),

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
-import {
-  canEnsureWorkspaceRuntimeForHydration,
-  canUseWorkspaceRuntimeForHydration,
-} from "./hydration-runtime-policy";
+import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 
 const createRecord = (
   role: AgentSessionRecord["role"],
@@ -26,16 +23,19 @@ describe("canUseWorkspaceRuntimeForHydration", () => {
     ).toBe(true);
   });
 
-  test("allows worktree build sessions", () => {
+  test("allows non-root build sessions", () => {
     expect(
-      canUseWorkspaceRuntimeForHydration(createRecord("build", "/tmp/repo/worktree"), "/tmp/repo"),
+      canUseWorkspaceRuntimeForHydration(
+        createRecord("build", "/tmp/openducktor-worktrees/task-1"),
+        "/tmp/repo",
+      ),
     ).toBe(true);
   });
 
-  test("rejects build sessions outside the repo worktree base", () => {
+  test("allows build sessions outside the repo root", () => {
     expect(
-      canUseWorkspaceRuntimeForHydration(createRecord("build", "/tmp/other"), "/tmp/repo"),
-    ).toBe(false);
+      canUseWorkspaceRuntimeForHydration(createRecord("build", "/tmp/other-worktree"), "/tmp/repo"),
+    ).toBe(true);
   });
 
   test("rejects worktree planner sessions", () => {
@@ -51,19 +51,5 @@ describe("canUseWorkspaceRuntimeForHydration", () => {
     expect(canUseWorkspaceRuntimeForHydration(createRecord("qa", "/tmp/repo"), "/tmp/repo")).toBe(
       false,
     );
-  });
-});
-
-describe("canEnsureWorkspaceRuntimeForHydration", () => {
-  test("allows repo-root roles to ensure a workspace runtime", () => {
-    expect(canEnsureWorkspaceRuntimeForHydration(createRecord("spec", "/tmp/repo"))).toBe(true);
-    expect(canEnsureWorkspaceRuntimeForHydration(createRecord("planner", "/tmp/repo"))).toBe(true);
-  });
-
-  test("rejects build and qa roles for ensured workspace hydration", () => {
-    expect(canEnsureWorkspaceRuntimeForHydration(createRecord("build", "/tmp/repo/task"))).toBe(
-      false,
-    );
-    expect(canEnsureWorkspaceRuntimeForHydration(createRecord("qa", "/tmp/repo/task"))).toBe(false);
   });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
-import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
+import {
+  canEnsureWorkspaceRuntimeForHydration,
+  canUseWorkspaceRuntimeForHydration,
+} from "./hydration-runtime-policy";
 
 const createRecord = (
   role: AgentSessionRecord["role"],
@@ -29,6 +32,12 @@ describe("canUseWorkspaceRuntimeForHydration", () => {
     ).toBe(true);
   });
 
+  test("rejects build sessions outside the repo worktree base", () => {
+    expect(
+      canUseWorkspaceRuntimeForHydration(createRecord("build", "/tmp/other"), "/tmp/repo"),
+    ).toBe(false);
+  });
+
   test("rejects worktree planner sessions", () => {
     expect(
       canUseWorkspaceRuntimeForHydration(
@@ -42,5 +51,19 @@ describe("canUseWorkspaceRuntimeForHydration", () => {
     expect(canUseWorkspaceRuntimeForHydration(createRecord("qa", "/tmp/repo"), "/tmp/repo")).toBe(
       false,
     );
+  });
+});
+
+describe("canEnsureWorkspaceRuntimeForHydration", () => {
+  test("allows repo-root roles to ensure a workspace runtime", () => {
+    expect(canEnsureWorkspaceRuntimeForHydration(createRecord("spec", "/tmp/repo"))).toBe(true);
+    expect(canEnsureWorkspaceRuntimeForHydration(createRecord("planner", "/tmp/repo"))).toBe(true);
+  });
+
+  test("rejects build and qa roles for ensured workspace hydration", () => {
+    expect(canEnsureWorkspaceRuntimeForHydration(createRecord("build", "/tmp/repo/task"))).toBe(
+      false,
+    );
+    expect(canEnsureWorkspaceRuntimeForHydration(createRecord("qa", "/tmp/repo/task"))).toBe(false);
   });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
-import { canUseRepoRootWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
+import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 
 const createRecord = (
   role: AgentSessionRecord["role"],
@@ -10,34 +10,37 @@ const createRecord = (
   workingDirectory,
 });
 
-describe("canUseRepoRootWorkspaceRuntimeForHydration", () => {
+describe("canUseWorkspaceRuntimeForHydration", () => {
   test("allows repo-root spec sessions", () => {
-    expect(
-      canUseRepoRootWorkspaceRuntimeForHydration(createRecord("spec", "/tmp/repo"), "/tmp/repo"),
-    ).toBe(true);
+    expect(canUseWorkspaceRuntimeForHydration(createRecord("spec", "/tmp/repo"), "/tmp/repo")).toBe(
+      true,
+    );
   });
 
   test("allows normalized-equivalent repo-root planner sessions", () => {
     expect(
-      canUseRepoRootWorkspaceRuntimeForHydration(
-        createRecord("planner", "/tmp/repo/"),
-        "/tmp/repo",
-      ),
+      canUseWorkspaceRuntimeForHydration(createRecord("planner", "/tmp/repo/"), "/tmp/repo"),
     ).toBe(true);
   });
 
-  test("rejects repo-root build sessions", () => {
+  test("allows worktree build sessions", () => {
     expect(
-      canUseRepoRootWorkspaceRuntimeForHydration(createRecord("build", "/tmp/repo"), "/tmp/repo"),
-    ).toBe(false);
+      canUseWorkspaceRuntimeForHydration(createRecord("build", "/tmp/repo/worktree"), "/tmp/repo"),
+    ).toBe(true);
   });
 
   test("rejects worktree planner sessions", () => {
     expect(
-      canUseRepoRootWorkspaceRuntimeForHydration(
+      canUseWorkspaceRuntimeForHydration(
         createRecord("planner", "/tmp/repo/worktree"),
         "/tmp/repo",
       ),
     ).toBe(false);
+  });
+
+  test("rejects repo-root qa sessions", () => {
+    expect(canUseWorkspaceRuntimeForHydration(createRecord("qa", "/tmp/repo"), "/tmp/repo")).toBe(
+      false,
+    );
   });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
@@ -4,12 +4,6 @@ import { normalizeWorkingDirectory } from "../support/core";
 const REPO_ROOT_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["spec", "planner"]);
 const WORKTREE_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["build", "qa"]);
 
-export const canEnsureWorkspaceRuntimeForHydration = (
-  record: Pick<AgentSessionRecord, "role">,
-): boolean => {
-  return REPO_ROOT_WORKSPACE_RUNTIME_ROLES.has(record.role);
-};
-
 export const canUseWorkspaceRuntimeForHydration = (
   record: Pick<AgentSessionRecord, "role" | "workingDirectory">,
   repoPath: string,
@@ -23,10 +17,7 @@ export const canUseWorkspaceRuntimeForHydration = (
 
   if (WORKTREE_WORKSPACE_RUNTIME_ROLES.has(record.role)) {
     return (
-      normalizedWorkingDirectory.length > 0 &&
-      normalizedWorkingDirectory !== normalizedRepoPath &&
-      (normalizedWorkingDirectory.startsWith(`${normalizedRepoPath}/`) ||
-        normalizedWorkingDirectory.startsWith(`${normalizedRepoPath}\\`))
+      normalizedWorkingDirectory.length > 0 && normalizedWorkingDirectory !== normalizedRepoPath
     );
   }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
@@ -1,15 +1,25 @@
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import { normalizeWorkingDirectory } from "../support/core";
 
-const HYDRATION_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["spec", "planner"]);
+const REPO_ROOT_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["spec", "planner"]);
+const WORKTREE_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["build", "qa"]);
 
-export const canUseRepoRootWorkspaceRuntimeForHydration = (
+export const canUseWorkspaceRuntimeForHydration = (
   record: Pick<AgentSessionRecord, "role" | "workingDirectory">,
   repoPath: string,
 ): boolean => {
-  if (!HYDRATION_WORKSPACE_RUNTIME_ROLES.has(record.role)) {
-    return false;
+  const normalizedWorkingDirectory = normalizeWorkingDirectory(record.workingDirectory);
+  const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
+
+  if (REPO_ROOT_WORKSPACE_RUNTIME_ROLES.has(record.role)) {
+    return normalizedWorkingDirectory === normalizedRepoPath;
   }
 
-  return normalizeWorkingDirectory(record.workingDirectory) === normalizeWorkingDirectory(repoPath);
+  if (WORKTREE_WORKSPACE_RUNTIME_ROLES.has(record.role)) {
+    return (
+      normalizedWorkingDirectory.length > 0 && normalizedWorkingDirectory !== normalizedRepoPath
+    );
+  }
+
+  return false;
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
@@ -4,6 +4,12 @@ import { normalizeWorkingDirectory } from "../support/core";
 const REPO_ROOT_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["spec", "planner"]);
 const WORKTREE_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["build", "qa"]);
 
+export const canEnsureWorkspaceRuntimeForHydration = (
+  record: Pick<AgentSessionRecord, "role">,
+): boolean => {
+  return REPO_ROOT_WORKSPACE_RUNTIME_ROLES.has(record.role);
+};
+
 export const canUseWorkspaceRuntimeForHydration = (
   record: Pick<AgentSessionRecord, "role" | "workingDirectory">,
   repoPath: string,
@@ -17,7 +23,10 @@ export const canUseWorkspaceRuntimeForHydration = (
 
   if (WORKTREE_WORKSPACE_RUNTIME_ROLES.has(record.role)) {
     return (
-      normalizedWorkingDirectory.length > 0 && normalizedWorkingDirectory !== normalizedRepoPath
+      normalizedWorkingDirectory.length > 0 &&
+      normalizedWorkingDirectory !== normalizedRepoPath &&
+      (normalizedWorkingDirectory.startsWith(`${normalizedRepoPath}/`) ||
+        normalizedWorkingDirectory.startsWith(`${normalizedRepoPath}\\`))
     );
   }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -86,7 +86,9 @@ describe("createHydrationRuntimeResolver", () => {
       },
     });
 
-    const result = await resolveHydrationRuntime(createRecord("build", "/tmp/repo/worktree"));
+    const result = await resolveHydrationRuntime(
+      createRecord("build", "/tmp/openducktor-worktrees/task-1"),
+    );
     if (!result.ok) {
       throw new Error("Expected runtime resolution to succeed");
     }
@@ -99,35 +101,12 @@ describe("createHydrationRuntimeResolver", () => {
     expect(result.runtimeConnection).toEqual({
       type: "local_http",
       endpoint: "http://127.0.0.1:4555",
-      workingDirectory: "/tmp/repo/worktree",
+      workingDirectory: "/tmp/openducktor-worktrees/task-1",
     });
     expect(ensureCalls).toBe(0);
   });
 
-  test("fails fast for build sessions outside the repo worktree base", async () => {
-    let ensureCalls = 0;
-    const resolveHydrationRuntime = createHydrationRuntimeResolver({
-      repoPath: "/tmp/repo",
-      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
-        ["opencode", [createRuntime("/tmp/repo")]],
-      ]),
-      ensureWorkspaceRuntime: async () => {
-        ensureCalls += 1;
-        return createRuntime("/tmp/repo");
-      },
-    });
-
-    const result = await resolveHydrationRuntime(createRecord("build", "/tmp/other"));
-
-    expect(result).toEqual({
-      ok: false,
-      runtimeKind: "opencode",
-      reason: "No live runtime found for working directory /tmp/other.",
-    });
-    expect(ensureCalls).toBe(0);
-  });
-
-  test("does not ensure a repo-root runtime for build sessions when no live runtime exists", async () => {
+  test("fails fast for repo-root build sessions when no live runtime exists", async () => {
     let ensureCalls = 0;
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
@@ -138,14 +117,42 @@ describe("createHydrationRuntimeResolver", () => {
       },
     });
 
-    const result = await resolveHydrationRuntime(createRecord("build", "/tmp/repo/worktree"));
+    const result = await resolveHydrationRuntime(createRecord("build", "/tmp/repo"));
 
     expect(result).toEqual({
       ok: false,
       runtimeKind: "opencode",
-      reason: "No live runtime found for working directory /tmp/repo/worktree.",
+      reason: "No live runtime found for working directory /tmp/repo.",
     });
     expect(ensureCalls).toBe(0);
+  });
+
+  test("ensures a shared workspace runtime for build sessions on non-root directories", async () => {
+    let ensureCalls = 0;
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return createRuntime("/tmp/repo");
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("build", "/tmp/other"));
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4555",
+    });
+    expect(result.runtimeConnection).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4555",
+      workingDirectory: "/tmp/other",
+    });
+    expect(ensureCalls).toBe(1);
   });
 
   test("falls back to preloaded runtime connection when no run or runtime exists", async () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -73,7 +73,7 @@ describe("createHydrationRuntimeResolver", () => {
     });
   });
 
-  test("fails build session hydration when only a shared workspace runtime exists", async () => {
+  test("hydrates build sessions through a shared workspace runtime", async () => {
     let ensureCalls = 0;
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
@@ -87,10 +87,19 @@ describe("createHydrationRuntimeResolver", () => {
     });
 
     const result = await resolveHydrationRuntime(createRecord("build", "/tmp/repo/worktree"));
-    expect(result).toEqual({
-      ok: false,
-      runtimeKind: "opencode",
-      reason: "No live runtime found for working directory /tmp/repo/worktree.",
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeId).toBe("runtime-1");
+    expect(result.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4555",
+    });
+    expect(result.runtimeConnection).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4555",
+      workingDirectory: "/tmp/repo/worktree",
     });
     expect(ensureCalls).toBe(0);
   });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -104,6 +104,50 @@ describe("createHydrationRuntimeResolver", () => {
     expect(ensureCalls).toBe(0);
   });
 
+  test("fails fast for build sessions outside the repo worktree base", async () => {
+    let ensureCalls = 0;
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+        ["opencode", [createRuntime("/tmp/repo")]],
+      ]),
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return createRuntime("/tmp/repo");
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("build", "/tmp/other"));
+
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/other.",
+    });
+    expect(ensureCalls).toBe(0);
+  });
+
+  test("does not ensure a repo-root runtime for build sessions when no live runtime exists", async () => {
+    let ensureCalls = 0;
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return createRuntime("/tmp/repo");
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("build", "/tmp/repo/worktree"));
+
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/repo/worktree.",
+    });
+    expect(ensureCalls).toBe(0);
+  });
+
   test("falls back to preloaded runtime connection when no run or runtime exists", async () => {
     const workingDirectory = "/tmp/repo";
     const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -8,10 +8,7 @@ import type { AgentRuntimeConnection } from "@openducktor/core";
 import { resolveRuntimeRouteConnection, runtimeConnectionToRoute } from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
-import {
-  canEnsureWorkspaceRuntimeForHydration,
-  canUseWorkspaceRuntimeForHydration,
-} from "./hydration-runtime-policy";
+import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 import { runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
 
 export type ResolvedHydrationRuntime =
@@ -101,10 +98,7 @@ export const createHydrationRuntimeResolver = ({
       };
     }
 
-    if (
-      !canUseWorkspaceRuntimeForHydration(record, repoPath) ||
-      !canEnsureWorkspaceRuntimeForHydration(record)
-    ) {
+    if (!canUseWorkspaceRuntimeForHydration(record, repoPath)) {
       return {
         ok: false,
         runtimeKind,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -8,7 +8,10 @@ import type { AgentRuntimeConnection } from "@openducktor/core";
 import { resolveRuntimeRouteConnection, runtimeConnectionToRoute } from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
-import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
+import {
+  canEnsureWorkspaceRuntimeForHydration,
+  canUseWorkspaceRuntimeForHydration,
+} from "./hydration-runtime-policy";
 import { runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
 
 export type ResolvedHydrationRuntime =
@@ -98,7 +101,10 @@ export const createHydrationRuntimeResolver = ({
       };
     }
 
-    if (!canUseWorkspaceRuntimeForHydration(record, repoPath)) {
+    if (
+      !canUseWorkspaceRuntimeForHydration(record, repoPath) ||
+      !canEnsureWorkspaceRuntimeForHydration(record)
+    ) {
       return {
         ok: false,
         runtimeKind,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -8,7 +8,7 @@ import type { AgentRuntimeConnection } from "@openducktor/core";
 import { resolveRuntimeRouteConnection, runtimeConnectionToRoute } from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
-import { canUseRepoRootWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
+import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 import { runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
 
 export type ResolvedHydrationRuntime =
@@ -36,6 +36,8 @@ export const createHydrationRuntimeResolver = ({
   preloadedRuntimeConnectionsByKey?: Map<string, AgentRuntimeConnection>;
   ensureWorkspaceRuntime: (runtimeKind: RuntimeKind) => Promise<RuntimeInstanceSummary | null>;
 }): ((record: AgentSessionRecord) => Promise<ResolvedHydrationRuntime>) => {
+  const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
+
   const findRuntimeByWorkingDirectory = (
     runtimeKind: RuntimeKind,
     workingDirectory: string,
@@ -49,11 +51,26 @@ export const createHydrationRuntimeResolver = ({
     );
   };
 
+  const findWorkspaceRuntime = (runtimeKind: RuntimeKind): RuntimeInstanceSummary | null => {
+    const runtimes = runtimesByKind.get(runtimeKind) ?? [];
+    return (
+      runtimes.find(
+        (runtime) =>
+          runtime.role === "workspace" &&
+          normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath,
+      ) ?? null
+    );
+  };
+
   return async (record: AgentSessionRecord): Promise<ResolvedHydrationRuntime> => {
     const runtimeKind = readPersistedRuntimeKind(record);
     const workingDirectory = record.workingDirectory;
 
-    const runtime = findRuntimeByWorkingDirectory(runtimeKind, workingDirectory);
+    const runtime =
+      findRuntimeByWorkingDirectory(runtimeKind, workingDirectory) ??
+      (canUseWorkspaceRuntimeForHydration(record, repoPath)
+        ? findWorkspaceRuntime(runtimeKind)
+        : null);
     if (runtime) {
       const { runtimeConnection } = resolveRuntimeRouteConnection(
         runtime.runtimeRoute,
@@ -81,7 +98,7 @@ export const createHydrationRuntimeResolver = ({
       };
     }
 
-    if (!canUseRepoRootWorkspaceRuntimeForHydration(record, repoPath)) {
+    if (!canUseWorkspaceRuntimeForHydration(record, repoPath)) {
       return {
         ok: false,
         runtimeKind,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -2728,7 +2728,7 @@ describe("agent-orchestrator-load-sessions", () => {
     }
   });
 
-  test("fails fast for qa sessions when only a shared workspace runtime exists", async () => {
+  test("hydrates qa sessions through the shared workspace runtime when only a shared workspace runtime exists", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     let observedRuntimeEndpoint: string | null = null;
@@ -2811,24 +2811,24 @@ describe("agent-orchestrator-load-sessions", () => {
     ];
 
     try {
-      await expect(
-        loadAgentSessions("task-1", {
-          mode: "requested_history",
-          targetSessionId: "session-qa-1",
-          historyPolicy: "requested_only",
-        }),
-      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktree.");
+      await loadAgentSessions("task-1", {
+        mode: "requested_history",
+        targetSessionId: "session-qa-1",
+        historyPolicy: "requested_only",
+      });
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
     }
 
-    expect(observedRuntimeEndpoint).toBeNull();
-    expect(state["session-qa-1"]?.runtimeId).toBeNull();
-    expect(state["session-qa-1"]?.messages ?? []).toEqual([]);
+    expect(String(observedRuntimeEndpoint)).toBe("http://127.0.0.1:4444");
+    expect(state["session-qa-1"]?.runtimeId).toBe("runtime-1");
+    expect(sessionMessageAt(getSession(state, "session-qa-1"), 0)?.id).toBe(
+      "history:session-start:session-qa-1",
+    );
   });
 
-  test("does not ensure a workspace runtime for qa sessions when repo root paths only differ by trailing slash", async () => {
+  test("does not ensure a shared workspace runtime for qa sessions when repo root paths only differ by trailing slash", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3036,7 +3036,7 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(appQueryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
   });
 
-  test("fails fast instead of ensuring a workspace runtime for build sessions on worktree directories", async () => {
+  test("hydrates build sessions through the shared workspace runtime on worktree directories", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3108,7 +3108,7 @@ describe("agent-orchestrator-load-sessions", () => {
         repoPath: "/tmp/repo",
         taskId: null,
         role: "workspace",
-        workingDirectory: "/tmp/repo/shared",
+        workingDirectory: "/tmp/repo",
         runtimeRoute: {
           type: "local_http",
           endpoint: "http://127.0.0.1:4666",
@@ -3126,7 +3126,7 @@ describe("agent-orchestrator-load-sessions", () => {
         repoPath: "/tmp/repo",
         taskId: null,
         role: "workspace",
-        workingDirectory: "/tmp/repo/shared",
+        workingDirectory: "/tmp/repo",
         runtimeRoute: {
           type: "local_http" as const,
           endpoint: "http://127.0.0.1:4666",
@@ -3137,13 +3137,11 @@ describe("agent-orchestrator-load-sessions", () => {
     };
 
     try {
-      await expect(
-        loadAgentSessions("task-1", {
-          mode: "requested_history",
-          targetSessionId: "session-1",
-          historyPolicy: "requested_only",
-        }),
-      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/conflict-worktree.");
+      await loadAgentSessions("task-1", {
+        mode: "requested_history",
+        targetSessionId: "session-1",
+        historyPolicy: "requested_only",
+      });
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
@@ -3152,10 +3150,16 @@ describe("agent-orchestrator-load-sessions", () => {
     }
 
     expect(ensuredRuntimeKinds).toEqual([]);
-    expect(state["session-1"] ? sessionMessagesToArray(state["session-1"]) : undefined).toEqual([]);
+    expect(state["session-1"]?.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4666",
+    });
+    expect(sessionMessageAt(getSession(state, "session-1"), 0)?.id).toBe(
+      "history:session-start:session-1",
+    );
   });
 
-  test("fails fast instead of ensuring a workspace runtime for qa sessions on worktree directories", async () => {
+  test("ensures a shared workspace runtime for qa sessions on worktree directories", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3240,13 +3244,11 @@ describe("agent-orchestrator-load-sessions", () => {
     };
 
     try {
-      await expect(
-        loadAgentSessions("task-1", {
-          mode: "requested_history",
-          targetSessionId: "session-qa-worktree",
-          historyPolicy: "requested_only",
-        }),
-      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktrees/task-1.");
+      await loadAgentSessions("task-1", {
+        mode: "requested_history",
+        targetSessionId: "session-qa-worktree",
+        historyPolicy: "requested_only",
+      });
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
@@ -3254,12 +3256,14 @@ describe("agent-orchestrator-load-sessions", () => {
       hostModule.host.runtimeEnsure = originalEnsure;
     }
 
-    expect(ensuredRuntimeKinds).toEqual([]);
-    expect(
-      state["session-qa-worktree"]
-        ? sessionMessagesToArray(state["session-qa-worktree"])
-        : undefined,
-    ).toEqual([]);
+    expect(ensuredRuntimeKinds).toEqual(["opencode"]);
+    expect(state["session-qa-worktree"]?.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4777",
+    });
+    expect(sessionMessageAt(getSession(state, "session-qa-worktree"), 0)?.id).toBe(
+      "history:session-start:session-qa-worktree",
+    );
   });
 
   test("resumes live persisted sessions without eagerly hydrating transcript history", async () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -45,16 +45,31 @@ const persistedSessionRecord = (
     runtimeKind?: AgentSessionRecord["runtimeKind"];
     selectedModel?: AgentSessionRecord["selectedModel"];
   } & Record<string, unknown>,
-): AgentSessionRecord => ({
-  runtimeKind: input.runtimeKind ?? "opencode",
-  sessionId: input.sessionId,
-  externalSessionId: input.externalSessionId,
-  role: input.role,
-  scenario: input.scenario,
-  startedAt: input.startedAt,
-  workingDirectory: input.workingDirectory,
-  selectedModel: input.selectedModel ?? null,
-});
+): AgentSessionRecord => {
+  const {
+    runtimeKind,
+    sessionId,
+    externalSessionId,
+    role,
+    scenario,
+    startedAt,
+    workingDirectory,
+    selectedModel,
+    ...rest
+  } = input;
+
+  return {
+    runtimeKind: runtimeKind ?? "opencode",
+    sessionId,
+    externalSessionId,
+    role,
+    scenario,
+    startedAt,
+    workingDirectory,
+    selectedModel: selectedModel ?? null,
+    ...rest,
+  };
+};
 
 const createAdapter = (
   overrides: Partial<Parameters<typeof createLoadAgentSessions>[0]["adapter"]> = {},
@@ -3159,7 +3174,7 @@ describe("agent-orchestrator-load-sessions", () => {
     );
   });
 
-  test("does not ensure a shared workspace runtime for qa sessions on worktree directories", async () => {
+  test("ensures a shared workspace runtime for qa sessions on non-root working directories", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3244,13 +3259,11 @@ describe("agent-orchestrator-load-sessions", () => {
     };
 
     try {
-      await expect(
-        loadAgentSessions("task-1", {
-          mode: "requested_history",
-          targetSessionId: "session-qa-worktree",
-          historyPolicy: "requested_only",
-        }),
-      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktrees/task-1.");
+      await loadAgentSessions("task-1", {
+        mode: "requested_history",
+        targetSessionId: "session-qa-worktree",
+        historyPolicy: "requested_only",
+      });
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
@@ -3258,12 +3271,14 @@ describe("agent-orchestrator-load-sessions", () => {
       hostModule.host.runtimeEnsure = originalEnsure;
     }
 
-    expect(ensuredRuntimeKinds).toEqual([]);
-    expect(
-      state["session-qa-worktree"]
-        ? sessionMessagesToArray(state["session-qa-worktree"])
-        : undefined,
-    ).toEqual([]);
+    expect(ensuredRuntimeKinds).toEqual(["opencode"]);
+    expect(state["session-qa-worktree"]?.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4777",
+    });
+    expect(sessionMessageAt(getSession(state, "session-qa-worktree"), 0)?.id).toBe(
+      "history:session-start:session-qa-worktree",
+    );
   });
 
   test("resumes live persisted sessions without eagerly hydrating transcript history", async () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -3159,7 +3159,7 @@ describe("agent-orchestrator-load-sessions", () => {
     );
   });
 
-  test("ensures a shared workspace runtime for qa sessions on worktree directories", async () => {
+  test("does not ensure a shared workspace runtime for qa sessions on worktree directories", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3244,11 +3244,13 @@ describe("agent-orchestrator-load-sessions", () => {
     };
 
     try {
-      await loadAgentSessions("task-1", {
-        mode: "requested_history",
-        targetSessionId: "session-qa-worktree",
-        historyPolicy: "requested_only",
-      });
+      await expect(
+        loadAgentSessions("task-1", {
+          mode: "requested_history",
+          targetSessionId: "session-qa-worktree",
+          historyPolicy: "requested_only",
+        }),
+      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktrees/task-1.");
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
@@ -3256,14 +3258,12 @@ describe("agent-orchestrator-load-sessions", () => {
       hostModule.host.runtimeEnsure = originalEnsure;
     }
 
-    expect(ensuredRuntimeKinds).toEqual(["opencode"]);
-    expect(state["session-qa-worktree"]?.runtimeRoute).toEqual({
-      type: "local_http",
-      endpoint: "http://127.0.0.1:4777",
-    });
-    expect(sessionMessageAt(getSession(state, "session-qa-worktree"), 0)?.id).toBe(
-      "history:session-start:session-qa-worktree",
-    );
+    expect(ensuredRuntimeKinds).toEqual([]);
+    expect(
+      state["session-qa-worktree"]
+        ? sessionMessagesToArray(state["session-qa-worktree"])
+        : undefined,
+    ).toEqual([]);
   });
 
   test("resumes live persisted sessions without eagerly hydrating transcript history", async () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -101,6 +101,21 @@ const plannerTaskWithSessionAt = (
   return task;
 };
 
+const qaTaskWithSessionAt = (
+  taskId: string,
+  externalSessionId: string,
+  workingDirectory: string,
+): TaskCard => {
+  const task = taskWithSessionAt(taskId, externalSessionId, workingDirectory);
+  const session = task.agentSessions?.[0];
+  if (!session) {
+    throw new Error("Expected seeded task session");
+  }
+
+  task.agentSessions = [{ ...session, role: "qa", scenario: "qa_review" }];
+  return task;
+};
+
 const createRuntimeInstance = ({
   runtimeId = "runtime-1",
   workingDirectory = worktreePath,
@@ -683,6 +698,48 @@ describe("repo-session-hydration-service", () => {
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([
       {
         directories: [repoPath],
+      },
+    ]);
+    expect(reconcileCalls).toEqual(["task-1"]);
+    service.dispose();
+  });
+
+  test("reconcile still hydrates worktree sessions when the runtime is resolvable but no live snapshots remain", async () => {
+    const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
+    const reconcileCalls: string[] = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    host.runtimeList = async () => [createRuntimeInstance({ workingDirectory: repoPath })];
+
+    const service = createRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async (input) => {
+          listLiveAgentSessionSnapshotsCalls.push(
+            input.directories ? { directories: [...input.directories].sort() } : {},
+          );
+          return [];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId }) => {
+          reconcileCalls.push(taskId);
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [qaTaskWithSessionAt("task-1", "external-1", worktreePath)],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([
+      {
+        directories: [worktreePath],
       },
     ]);
     expect(reconcileCalls).toEqual(["task-1"]);

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -19,7 +19,7 @@ import {
   isSessionRuntimeMetadataError,
   readPersistedRuntimeKind,
 } from "../support/session-runtime-metadata";
-import { canUseRepoRootWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
+import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 import {
   getLiveAgentSessionCacheKey,
   LiveAgentSessionCache,
@@ -51,6 +51,7 @@ type ReconcilePreloadMetadata = {
   persistedTaskIdsByLiveSessionKey: Map<string, Set<string>>;
   runtimeKinds: Set<RuntimeKind>;
   desiredDirectoriesByRuntimeKind: Map<RuntimeKind, Set<string>>;
+  workspaceDerivedDirectoriesByRuntimeKind: Map<RuntimeKind, Set<string>>;
   runtimeKindsAllowedToEnsureRepoRoot: Set<RuntimeKind>;
   skippedTaskErrors: Map<string, unknown>;
 };
@@ -104,6 +105,7 @@ const collectReconcilePreloadMetadata = ({
   const persistedTaskIdsByLiveSessionKey = new Map<string, Set<string>>();
   const runtimeKinds = new Set<RuntimeKind>();
   const desiredDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
+  const workspaceDerivedDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
   const runtimeKindsAllowedToEnsureRepoRoot = new Set<RuntimeKind>();
   const skippedTaskErrors = new Map<string, unknown>();
 
@@ -126,8 +128,16 @@ const collectReconcilePreloadMetadata = ({
         getOrCreateMapSet(taskDesiredDirectoriesByRuntimeKind, runtimeKind).add(
           normalizeWorkingDirectory(record.workingDirectory),
         );
-        if (canUseRepoRootWorkspaceRuntimeForHydration(record, repoPath)) {
-          taskRuntimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
+        if (canUseWorkspaceRuntimeForHydration(record, repoPath)) {
+          getOrCreateMapSet(workspaceDerivedDirectoriesByRuntimeKind, runtimeKind).add(
+            normalizeWorkingDirectory(record.workingDirectory),
+          );
+          if (
+            normalizeWorkingDirectory(record.workingDirectory) ===
+            normalizeWorkingDirectory(repoPath)
+          ) {
+            taskRuntimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
+          }
         }
       }
     } catch (error) {
@@ -168,6 +178,7 @@ const collectReconcilePreloadMetadata = ({
     persistedTaskIdsByLiveSessionKey,
     runtimeKinds,
     desiredDirectoriesByRuntimeKind,
+    workspaceDerivedDirectoriesByRuntimeKind,
     runtimeKindsAllowedToEnsureRepoRoot,
     skippedTaskErrors,
   };
@@ -239,6 +250,7 @@ export const createRepoSessionHydrationService = ({
       persistedTaskIdsByLiveSessionKey,
       runtimeKinds,
       desiredDirectoriesByRuntimeKind,
+      workspaceDerivedDirectoriesByRuntimeKind,
       runtimeKindsAllowedToEnsureRepoRoot,
       skippedTaskErrors,
     } = collectReconcilePreloadMetadata({ tasks, repoPath });
@@ -289,6 +301,9 @@ export const createRepoSessionHydrationService = ({
       }
 
       preloadedRuntimeLists.set(runtimeKind, runtimeEntries);
+      const coveredDirectories = new Set(
+        runtimeEntries.map((runtime) => normalizeWorkingDirectory(runtime.workingDirectory)),
+      );
 
       for (const runtime of runtimeEntries) {
         const { runtimeConnection } = resolveRuntimeRouteConnection(
@@ -313,9 +328,90 @@ export const createRepoSessionHydrationService = ({
         }
         runtimeConnections.get(scanKey)?.directories.add(runtime.workingDirectory);
       }
+
+      const derivedDirectories =
+        workspaceDerivedDirectoriesByRuntimeKind.get(runtimeKind) ?? new Set();
+      const missingDerivedDirectories = Array.from(desiredDirectories).filter(
+        (workingDirectory) => {
+          const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+          return (
+            derivedDirectories.has(normalizedWorkingDirectory) &&
+            !coveredDirectories.has(normalizedWorkingDirectory)
+          );
+        },
+      );
+      if (missingDerivedDirectories.length === 0) {
+        continue;
+      }
+
+      const routeSourceRuntime =
+        runtimeEntries.find(
+          (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey,
+        ) ??
+        (runtimeKindsAllowedToEnsureRepoRoot.has(runtimeKind)
+          ? await ensureRuntimeAndInvalidateReadinessQueries({
+              repoPath,
+              runtimeKind,
+              ensureRuntime: (nextRepoPath, nextRuntimeKind) =>
+                host.runtimeEnsure(nextRepoPath, nextRuntimeKind),
+            })
+          : null);
+      if (!routeSourceRuntime) {
+        continue;
+      }
+
+      if (!runtimeEntries.includes(routeSourceRuntime)) {
+        await invalidateRuntimeList(runtimeKind, repoPath);
+        if (isCancelled()) {
+          return {
+            persistedByTask,
+            taskIdsToReconcile: new Set<string>(),
+            preloadedRuntimeLists,
+            preloadedRuntimeConnectionsByKey,
+            preloadedLiveAgentSessionsByKey: new Map<string, LiveAgentSessionSnapshot[]>(),
+            skippedTaskErrors,
+          };
+        }
+        runtimeEntries.push(routeSourceRuntime);
+      }
+
+      for (const workingDirectory of missingDerivedDirectories) {
+        const { runtimeConnection } = resolveRuntimeRouteConnection(
+          routeSourceRuntime.runtimeRoute,
+          workingDirectory,
+        );
+        preloadedRuntimeConnectionsByKey.set(
+          runtimeWorkingDirectoryKey(runtimeKind, workingDirectory),
+          runtimeConnection,
+        );
+        const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
+        if (!runtimeConnections.has(scanKey)) {
+          runtimeConnections.set(scanKey, {
+            runtimeKind,
+            runtimeConnection,
+            directories: new Set<string>(),
+          });
+        }
+        runtimeConnections.get(scanKey)?.directories.add(workingDirectory);
+      }
     }
 
     const taskIdsToReconcile = new Set<string>();
+    for (const { taskId, records } of persistedByTask) {
+      if (skippedTaskErrors.has(taskId)) {
+        continue;
+      }
+
+      const hasResolvableHydrationRuntime = records.some((record) =>
+        preloadedRuntimeConnectionsByKey.has(
+          runtimeWorkingDirectoryKey(readPersistedRuntimeKind(record), record.workingDirectory),
+        ),
+      );
+      if (hasResolvableHydrationRuntime) {
+        taskIdsToReconcile.add(taskId);
+      }
+    }
+
     const preloadedLiveAgentSessionsByKey = new Map<string, LiveAgentSessionSnapshot[]>();
     const runtimeSessionScanCache = new LiveAgentSessionCache(agentEngine);
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -2072,7 +2072,7 @@ describe("use-agent-orchestrator-operations", () => {
 
       expect(
         harness.getLatest().sessionStore.getSessionSnapshot("session-1")?.runtimeRecoveryState,
-      ).toBe("idle");
+      ).toBe("waiting_for_runtime");
 
       host.runtimeList = async () => [
         {

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -2072,7 +2072,7 @@ describe("use-agent-orchestrator-operations", () => {
 
       expect(
         harness.getLatest().sessionStore.getSessionSnapshot("session-1")?.runtimeRecoveryState,
-      ).toBe("waiting_for_runtime");
+      ).toBe("idle");
 
       host.runtimeList = async () => [
         {


### PR DESCRIPTION
## Summary
This PR reduces the latency when switching back to agent sessions with long transcripts that are already in memory.

## Goal
Switching from Builder to QA and back to a long Builder session was still taking more than a second because the UI was doing too much synchronous transcript work on the return path. The first async load case already behaved correctly; the problem was re-displaying large in-memory transcripts.

## What Changed
- added an O(1) unchanged-session fast path for transcript window cache reuse
- moved transcript-wide derived metadata into the same cached windowing state so revisiting a session does not rescan the full message list
- reset the visible history window during render on session changes so the next session does not inherit an oversized first paint
- re-enabled staging when revisiting a session instead of permanently treating a previously expanded session as fully materialized
- added row-level staging on top of turn/history windowing so large single-turn transcripts do not mount their full visible row set in one commit
- extended chat regression coverage for session switching, revisit staging, and large single-turn transcript staging

## Technical Choices
The fix stays inside the transcript presentation pipeline rather than adding fallback loaders or masking the problem elsewhere. The main thread cost came from transcript-wide derivation and a large one-shot mount on session revisit, so the implementation focuses on making the revisit path incremental:
- cache hits now reuse stable session-message containers directly
- per-session metadata needed by the thread is computed once with the cached transcript state
- both turn-level and row-level staging progressively reveal long transcripts while preserving the existing bottom-pinned chat behavior

## Verification
- `rtk bun run lint`
- `rtk bun run typecheck`
- `rtk bun run test`
- `rtk bun run build`
- `rtk cargo fmt --all --check`
- `rtk cargo clippy --workspace --all-targets -- -D warnings`
- `rtk bun run check:rust`
- `rtk bun run test:rust`
- `rtk cargo build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Progressive staging for chat history with per-session incremental windowing and caching for faster, smoother transcript rendering
  * Improved session-aware history/window start logic and more robust handling when switching sessions
  * Updated hydration runtime policy to better support non-root build and QA sessions

* **Tests**
  * Expanded coverage for chat staging/windowing, multi-session switching, and session hydration/resolution scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->