### PR TITLE
docs(runtime): align build_start bootstrap contract

### DIFF
--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -77,7 +77,7 @@ It is live runtime-instance metadata only:
 
 `runtimeInstanceSummaryRoleSchema` is currently `workspace` only, so this payload describes shared workspace runtime instances rather than every startup path in the system.
 
-The host returns this payload after listing or ensuring a workspace runtime. It tells the frontend which runtime instance is running, which repo scope it belongs to, where its working directory is, how to reach it through `runtimeRoute`, and which static runtime definition it comes from through `descriptor`. Build startup returns `RunSummary` instead.
+The host returns this payload after listing or ensuring a workspace runtime. It tells the frontend which runtime instance is running, which repo scope it belongs to, where its working directory is, how to reach it through `runtimeRoute`, and which static runtime definition it comes from through `descriptor`. Build startup returns `BuildSessionBootstrap` instead, because the build path only needs the runtime kind, live route, and working directory needed to bootstrap the Builder session.
 
 ### `RuntimeRoute`
 
@@ -353,7 +353,7 @@ Current startup routing is split like this:
 
 - `runtime_ensure(runtime_kind, repo)` is the workspace-runtime path used by `spec` and `planner`,
 - `qa` still requires `task` scope, but current orchestration resolves it against the build continuation working directory and either reuses the running build session for that directory or ensures the selected runtime for that working directory,
-- `build_start(repo, task, runtimeKind)` is the build-specific path and returns `RunSummary`, not `RuntimeInstanceSummary`.
+- `build_start(repo, task, runtimeKind)` is the build-specific path and returns `BuildSessionBootstrap`, not `RuntimeInstanceSummary`.
 
 Role-to-scope requirements come from `runtimeRequiredScopesByRole` in `packages/contracts/src/agent-runtime-schemas.ts`, while scenario start-mode compatibility comes from `agentScenarioDefinitionByScenario` in `packages/contracts/src/agent-workflow-schemas.ts`.
 

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -77,7 +77,7 @@ It is live runtime-instance metadata only:
 
 `runtimeInstanceSummaryRoleSchema` is currently `workspace` only, so this payload describes shared workspace runtime instances rather than every startup path in the system.
 
-The host returns this payload after listing or ensuring a workspace runtime. It tells the frontend which runtime instance is running, which repo scope it belongs to, where its working directory is, how to reach it through `runtimeRoute`, and which static runtime definition it comes from through `descriptor`. Build startup returns `BuildSessionBootstrap` instead, because the build path only needs the runtime kind, live route, and working directory needed to bootstrap the Builder session.
+The host returns this payload after listing or ensuring a workspace runtime. It tells the frontend which runtime instance is running, which repo scope it belongs to, where its working directory is, how to reach it through `runtimeRoute`, and which static runtime definition it comes from through `descriptor`. Build startup returns `BuildSessionBootstrap` instead, because the build path requires `runtimeKind`, `runtimeRoute`, and `workingDirectory` to bootstrap the Builder session.
 
 ### `RuntimeRoute`
 


### PR DESCRIPTION
## Summary
Align the runtime integration guide with the live `build_start` contract.

## Goal
The guide previously said `build_start(repo, task, runtimeKind)` returns `RunSummary`, which no longer matches the contracts or host/frontend integration. This PR corrects that drift so runtime implementers follow the real bootstrap payload shape.

## Implementation
- Update the `RuntimeInstanceSummary` note to say build startup returns `BuildSessionBootstrap`.
- Update the build runtime rules section to say `build_start` returns `BuildSessionBootstrap`, not `RuntimeInstanceSummary`.
- Keep the change focused on documentation only; no runtime behavior changed.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the runtime integration guide to clarify the expected response format returned by build session startup.
  * Documented the required configuration fields needed to bootstrap the builder session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->