### PR TITLE
fix(agent-studio): align odt workflow tool selection

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp.rs
@@ -147,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn get_workspaces_result_serializes_as_object_payload() {
+    fn odt_get_workspaces_result_serializes_as_object_payload() {
         let payload = types::OdtGetWorkspacesResult {
             workspaces: vec![WorkspaceRecord {
                 workspace_id: "repo".to_string(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp/service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/odt_mcp/service.rs
@@ -17,7 +17,7 @@ use super::types::{
 use crate::app_service::workflow_rules::normalize_title_key;
 
 pub(super) const ODT_MCP_TOOL_NAMES: [&str; 13] = [
-    "get_workspaces",
+    "odt_get_workspaces",
     "odt_create_task",
     "odt_search_tasks",
     "odt_read_task",

--- a/apps/desktop/src-tauri/src/headless/odt_mcp_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/odt_mcp_commands.rs
@@ -97,8 +97,8 @@ pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), St
     registry.register("odt_mcp_ready", |state, args| {
         Box::pin(handle_odt_mcp_ready(state, args))
     })?;
-    registry.register("get_workspaces", |state, args| {
-        Box::pin(handle_get_workspaces(state, args))
+    registry.register("odt_get_workspaces", |state, args| {
+        Box::pin(handle_odt_get_workspaces(state, args))
     })?;
     registry.register("odt_read_task", |state, args| {
         Box::pin(handle_odt_read_task(state, args))
@@ -152,11 +152,11 @@ async fn handle_odt_mcp_ready(state: &HeadlessState, args: Value) -> CommandResu
     )
 }
 
-async fn handle_get_workspaces(state: &HeadlessState, args: Value) -> CommandResult {
+async fn handle_odt_get_workspaces(state: &HeadlessState, args: Value) -> CommandResult {
     let _: GetWorkspacesArgs = deserialize_args(args)?;
     let service = state.service.clone();
     serialize_value(
-        super::command_support::run_headless_blocking("get_workspaces", move || {
+        super::command_support::run_headless_blocking("odt_get_workspaces", move || {
             service.odt_get_workspaces()
         })
         .await?,
@@ -426,7 +426,7 @@ mod tests {
     }
 
     #[test]
-    fn get_workspaces_args_reject_workspace_id() {
+    fn odt_get_workspaces_args_reject_workspace_id() {
         let parsed = serde_json::from_value::<GetWorkspacesArgs>(serde_json::json!({
             "workspaceId": "repo"
         }));

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -1014,12 +1014,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invoke_handler_lists_workspaces_through_get_workspaces() {
+    async fn invoke_handler_lists_workspaces_through_odt_get_workspaces() {
         let (fixture, _task_state, repo_path, workspace_id) =
             test_state_fixture_with_task_store(Vec::new());
 
         let response = invoke_handler(
-            Path("get_workspaces".to_string()),
+            Path("odt_get_workspaces".to_string()),
             State(fixture.state.clone()),
             Ok(Json(json!({}))),
         )

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -623,9 +623,10 @@ describe("AgentChatThread", () => {
     expect(bottomStack).not.toBeNull();
     expect(bottomStack?.textContent).toContain("active session runtime data access");
     expect(bottomStack?.className).toContain("pb-3");
-    expect(screen.getByText(/active session runtime data access/).className).toContain(
-      "border-l border-input",
-    );
+    const runtimeError = screen.getByText(/active session runtime data access/);
+    expect(runtimeError.className).toContain("border-destructive-border");
+    expect(runtimeError.className).toContain("bg-destructive-surface");
+    expect(runtimeError.className).toContain("text-destructive-surface-foreground");
 
     rendered.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -398,16 +398,8 @@ const AgentChatBottomStack = memo(function AgentChatBottomStack({
       ))}
 
       {sessionRuntimeDataError ? (
-        <div className="border border-input border-b-0 border-l-0 bg-card">
-          <div
-            className={cn(
-              "px-3 py-2 text-sm text-destructive",
-              sessionAccentColor ? "border-l-4" : "border-l border-input",
-            )}
-            style={sessionAccentColor ? { borderLeftColor: sessionAccentColor } : undefined}
-          >
-            {sessionRuntimeDataError}
-          </div>
+        <div className="rounded-md border border-destructive-border bg-destructive-surface px-3 py-2 text-sm text-destructive-surface-foreground">
+          {sessionRuntimeDataError}
         </div>
       ) : null}
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -100,6 +100,12 @@ const CATALOG_WITHOUT_PROFILES: AgentModelCatalog = {
   profiles: [],
 };
 
+const EMPTY_CATALOG: AgentModelCatalog = {
+  models: [],
+  defaultModelsByProvider: {},
+  profiles: [],
+};
+
 const FILE_SEARCH_RESULTS: AgentFileSearchResult[] = [
   {
     id: "src/main.ts",
@@ -680,6 +686,34 @@ describe("useAgentStudioModelSelection", () => {
       variant: "high",
       profileId: "spec-agent",
     });
+
+    await harness.unmount();
+  });
+
+  test("preserves active session model when catalog cannot produce a replacement", async () => {
+    const updateAgentSessionModel = mock(() => {});
+    const activeSession = createActiveSession({
+      modelCatalog: EMPTY_CATALOG,
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+        updateAgentSessionModel,
+      }),
+    );
+
+    await harness.mount();
+    await harness.waitFor((state) => state.selectedModelSelection?.modelId === "gpt-5");
+
+    expect(harness.getLatest().selectedModelSelection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      profileId: "spec-agent",
+    });
+    expect(updateAgentSessionModel).toHaveBeenCalledTimes(0);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -394,7 +394,7 @@ export function useAgentStudioModelSelection({
       selectedModel: activeSessionSelectedModel,
       roleDefaultSelection,
     });
-    if (!preferredSelection || isSameSelection(activeSessionSelectedModel, preferredSelection)) {
+    if (isSameSelection(activeSessionSelectedModel, preferredSelection)) {
       return;
     }
     updateAgentSessionModel(activeSessionId, preferredSelection);

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -394,7 +394,7 @@ export function useAgentStudioModelSelection({
       selectedModel: activeSessionSelectedModel,
       roleDefaultSelection,
     });
-    if (isSameSelection(activeSessionSelectedModel, preferredSelection)) {
+    if (!preferredSelection || isSameSelection(activeSessionSelectedModel, preferredSelection)) {
       return;
     }
     updateAgentSessionModel(activeSessionId, preferredSelection);

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -6,7 +6,6 @@ import {
   lastSessionMessageForTest,
   sessionMessageAt,
   sessionMessagesToArray,
-  someSessionMessageForTest,
 } from "@/test-utils/session-message-test-helpers";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { attachAgentSessionListener } from "../events/session-events";
@@ -1910,11 +1909,16 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     try {
       await actions.sendAgentMessage("session-1", [{ kind: "text", text: "hello" }]);
       expect(sessionsRef.current["session-1"]?.status).toBe("error");
-      expect(
-        someSessionMessageForTest(getSession(sessionsRef), (message) =>
-          message.content.includes("Failed to send message:"),
-        ),
-      ).toBe(true);
+      const failureMessage = findSessionMessageForTest(getSession(sessionsRef), (message) =>
+        message.content.includes("Failed to send message:"),
+      );
+      expect(failureMessage?.content).toContain("Failed to send message:");
+      expect(failureMessage?.meta).toEqual({
+        kind: "session_notice",
+        tone: "error",
+        reason: "session_error",
+        title: "Error",
+      });
       expect(clearCalls).toBe(1);
     } finally {
       adapter.hasSession = originalHasSession;
@@ -2103,11 +2107,16 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       expect(sessionsRef.current["session-1"]?.status).toBe("running");
       expect(sessionsRef.current["session-1"]?.draftAssistantText).toBe("Still working");
       expect(sessionsRef.current["session-1"]?.draftReasoningText).toBe("Thinking");
-      expect(
-        someSessionMessageForTest(getSession(sessionsRef), (message) =>
-          message.content.includes("Failed to send message:"),
-        ),
-      ).toBe(true);
+      const failureMessage = findSessionMessageForTest(getSession(sessionsRef), (message) =>
+        message.content.includes("Failed to send message:"),
+      );
+      expect(failureMessage?.content).toContain("Failed to send message:");
+      expect(failureMessage?.meta).toEqual({
+        kind: "session_notice",
+        tone: "error",
+        reason: "session_error",
+        title: "Error",
+      });
       expect(clearCalls).toBe(0);
       expect(turnStartedAtBySessionRef.current["session-1"]).toBe(1234);
       expect(turnModelBySessionRef.current["session-1"]?.modelId).toBe("gpt-5");

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -243,6 +243,12 @@ export const createAgentSessionActions = ({
             role: "system",
             content: `Failed to send message: ${errorMessage(error)}`,
             timestamp: now(),
+            meta: {
+              kind: "session_notice",
+              tone: "error",
+              reason: "session_error",
+              title: "Error",
+            },
           }),
         }),
         { persist: false },
@@ -412,6 +418,7 @@ export const createAgentSessionActions = ({
         model: selection,
       });
     }
+
     updateSession(
       sessionId,
       (current) => ({

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
@@ -59,7 +59,7 @@ export const executeFreshStart = async ({
     role: ctx.role,
     scenario: resolved.resolvedScenario,
     systemPrompt: resolved.systemPrompt,
-    ...(selectedModel ? { model: selectedModel } : {}),
+    model: selectedModel,
   });
 
   const startedCtx = {

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
@@ -52,7 +52,7 @@ export const executeFreshStart = async ({
 
   const summary = await deps.runtime.adapter.startSession({
     repoPath: ctx.repoPath,
-    runtimeKind: resolved.runtime.runtimeKind ?? selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+    runtimeKind: resolved.runtime.runtimeKind ?? selectedModel.runtimeKind ?? DEFAULT_RUNTIME_KIND,
     runtimeConnection: resolveRuntimeConnection(resolved.runtime),
     workingDirectory: resolved.runtime.workingDirectory,
     taskId: ctx.taskId,

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -89,7 +89,7 @@ Desktop-managed and standalone MCP clients intentionally use this same host-brid
 
 Public external tools:
 
-- `get_workspaces`
+- `odt_get_workspaces`
 - `odt_create_task`
 - `odt_search_tasks`
 - `odt_read_task`
@@ -106,27 +106,29 @@ Internal workflow tools remain on the same MCP server:
 - `odt_qa_approved`
 - `odt_qa_rejected`
 
-Current OpenDucktor Spec/Planner/Builder/QA agents must not receive `odt_create_task` or `odt_search_tasks` in their tool selection.
+Current OpenDucktor Spec/Planner/Builder/QA agents must not receive `odt_create_task`, `odt_search_tasks`, or `odt_get_workspaces` in their tool selection.
 
 ## Workspace Discovery And Scoping
 
-Use `get_workspaces` when you start the MCP without a default workspace and need to discover the canonical `workspaceId` values known to the host.
+Use `odt_get_workspaces` when you start the MCP without a default workspace and need to discover the canonical `workspaceId` values known to the host.
 
-`get_workspaces` takes no input and returns the existing shared workspace record shape:
+`odt_get_workspaces` takes no input and returns the existing shared workspace record shape:
 
 ```json
-[
-  {
-    "workspaceId": "my-workspace",
-    "workspaceName": "My Workspace",
-    "repoPath": "/Users/maxsky5/code/my-repo",
-    "isActive": true,
-    "hasConfig": true,
-    "configuredWorktreeBasePath": null,
-    "defaultWorktreeBasePath": null,
-    "effectiveWorktreeBasePath": null
-  }
-]
+{
+  "workspaces": [
+    {
+      "workspaceId": "my-workspace",
+      "workspaceName": "My Workspace",
+      "repoPath": "/Users/maxsky5/code/my-repo",
+      "isActive": true,
+      "hasConfig": true,
+      "configuredWorktreeBasePath": null,
+      "defaultWorktreeBasePath": null,
+      "effectiveWorktreeBasePath": null
+    }
+  ]
+}
 ```
 
 Workspace resolution for workspace-scoped tools is deterministic:

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -647,6 +647,16 @@ describe("OpencodeSdkAdapter", () => {
       action: "deny",
     });
     expect(permissionRules).toContainEqual({
+      permission: "odt_search_tasks",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
+      permission: "odt_get_workspaces",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
       permission: "odt_read_task",
       pattern: "*",
       action: "allow",
@@ -899,6 +909,9 @@ describe("OpencodeSdkAdapter", () => {
         apply_patch: false,
         ast_grep_replace: false,
         lsp_rename: false,
+        odt_create_task: false,
+        odt_search_tasks: false,
+        odt_get_workspaces: false,
         openducktor_odt_read_task: true,
         openducktor_odt_read_task_documents: true,
         openducktor_odt_set_spec: true,
@@ -1329,14 +1342,9 @@ describe("OpencodeSdkAdapter", () => {
     expect(mock.session.promptAsyncCalls).toHaveLength(2);
   });
 
-  test("sendUserMessage falls back to the session model for model-scoped tool discovery", async () => {
+  test("sendUserMessage uses global workflow tool discovery even when the session has a selected model", async () => {
     const mock = makeMockClient({
       toolIdsResponse: ["bash", "read", "glob"],
-      modelToolsResponse: [
-        { id: "openducktor_odt_read_task" },
-        { id: "openducktor_odt_read_task_documents" },
-        { id: "openducktor_odt_set_spec" },
-      ],
     });
     const adapter = new OpencodeSdkAdapter({
       createClient: () => mock.client,
@@ -1354,25 +1362,21 @@ describe("OpencodeSdkAdapter", () => {
       parts: [{ kind: "text", text: "Use the saved model" }],
     });
 
-    expect(mock.tool.listCalls).toEqual([
-      {
-        directory: "/repo",
-        provider: "openai",
-        model: "gpt-5",
-      },
-    ]);
+    expect(mock.tool.listCalls).toEqual([]);
     expect(mock.session.promptCalls).toHaveLength(0);
-    expect(mock.session.promptAsyncCalls[0]).toMatchObject({
-      tools: {
-        edit: false,
-        write: false,
-        apply_patch: false,
-        ast_grep_replace: false,
-        lsp_rename: false,
-        openducktor_odt_read_task: true,
-        openducktor_odt_read_task_documents: true,
-        openducktor_odt_set_spec: true,
-      },
+    expect(mock.session.promptAsyncCalls[0]?.tools).toMatchObject({
+      edit: false,
+      write: false,
+      apply_patch: false,
+      ast_grep_replace: false,
+      lsp_rename: false,
+      odt_create_task: false,
+      odt_search_tasks: false,
+      odt_get_workspaces: false,
+      odt_read_task: true,
+      odt_read_task_documents: true,
+      odt_set_spec: true,
+      odt_set_plan: false,
     });
   });
 

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -626,7 +626,7 @@ export class OpencodeSdkAdapter
 
   async sendUserMessage(input: SendAgentUserMessageInput): Promise<void> {
     const session = requireSession(this.sessions, input.sessionId);
-    const tools = await this.resolveSessionToolSelection(session, input.model);
+    const tools = await this.resolveSessionToolSelection(session);
     this.emit(input.sessionId, {
       type: "session_status",
       sessionId: input.sessionId,
@@ -661,7 +661,6 @@ export class OpencodeSdkAdapter
     }
     delete session.workflowToolSelectionCache;
     delete session.workflowToolSelectionCachedAt;
-    delete session.workflowToolSelectionCacheModelKey;
   }
 
   async replyPermission(input: ReplyPermissionInput): Promise<void> {
@@ -715,18 +714,12 @@ export class OpencodeSdkAdapter
 
   private async resolveSessionToolSelection(
     session: SessionRecord,
-    model: SendAgentUserMessageInput["model"],
   ): Promise<Record<string, boolean>> {
-    const effectiveModel = model ?? session.input.model;
-    const providerId = effectiveModel?.providerId?.trim() ?? "";
-    const modelId = effectiveModel?.modelId?.trim() ?? "";
-    const modelKey = providerId && modelId ? `${providerId}/${modelId}` : "";
     const nowMs = Date.now();
     if (
       session.workflowToolSelectionCache &&
       typeof session.workflowToolSelectionCachedAt === "number" &&
-      nowMs - session.workflowToolSelectionCachedAt < WORKFLOW_TOOL_CACHE_TTL_MS &&
-      (session.workflowToolSelectionCacheModelKey ?? "") === modelKey
+      nowMs - session.workflowToolSelectionCachedAt < WORKFLOW_TOOL_CACHE_TTL_MS
     ) {
       return session.workflowToolSelectionCache;
     }
@@ -736,12 +729,10 @@ export class OpencodeSdkAdapter
       role: session.input.role,
       runtimeDescriptor: this.getRuntimeDefinition(),
       workingDirectory: session.input.workingDirectory,
-      ...(providerId && modelId ? { model: { providerId, modelId } } : {}),
     });
 
     session.workflowToolSelectionCache = selection;
     session.workflowToolSelectionCachedAt = nowMs;
-    session.workflowToolSelectionCacheModelKey = modelKey;
     return selection;
   }
 }

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -225,7 +225,6 @@ export const clearWorkflowToolCacheForDirectory = (
     if (session.input.workingDirectory === workingDirectory) {
       delete session.workflowToolSelectionCache;
       delete session.workflowToolSelectionCachedAt;
-      delete session.workflowToolSelectionCacheModelKey;
     }
   }
 };

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -64,8 +64,6 @@ export type SessionRecord = {
   workflowToolSelectionCache?: Record<string, boolean>;
   /** Timestamp when cache was last populated. */
   workflowToolSelectionCachedAt?: number;
-  /** Model key used to compute the cached workflow tool selection. */
-  workflowToolSelectionCacheModelKey?: string;
 };
 
 export type EventStreamSubscriber = {

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
@@ -32,6 +32,11 @@ describe("workflow-tool-permissions", () => {
     });
     expect(rules).toContainEqual({ permission: "odt_create_task", pattern: "*", action: "deny" });
     expect(rules).toContainEqual({ permission: "odt_search_tasks", pattern: "*", action: "deny" });
+    expect(rules).toContainEqual({
+      permission: "odt_get_workspaces",
+      pattern: "*",
+      action: "deny",
+    });
     expect(rules).toContainEqual({ permission: "odt_read_task", pattern: "*", action: "allow" });
     expect(rules).toContainEqual({
       permission: "odt_read_task_documents",

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
@@ -1,4 +1,4 @@
-import type { RuntimeDescriptor } from "@openducktor/contracts";
+import { ODT_TOOL_NAMES, type RuntimeDescriptor } from "@openducktor/contracts";
 import { AGENT_ROLE_TOOL_POLICY, type AgentRole, ODT_WORKFLOW_TOOL_NAMES } from "@openducktor/core";
 import { isReadOnlyRole } from "./read-only-roles";
 
@@ -11,11 +11,7 @@ export type OpencodePermissionRule = {
 };
 
 const ODT_MCP_PERMISSION_WILDCARDS = ["openducktor_*", "functions.openducktor_*"] as const;
-const TRUSTED_ODT_CANONICAL_DENY_PERMISSIONS = [
-  ...ODT_WORKFLOW_TOOL_NAMES,
-  "odt_create_task",
-  "odt_search_tasks",
-] as const;
+const CANONICAL_ODT_TOOL_DENY_PERMISSIONS = ODT_TOOL_NAMES;
 
 export const buildRoleScopedPermissionRules = (input: {
   role: AgentRole;
@@ -42,7 +38,7 @@ export const buildRoleScopedPermissionRules = (input: {
       action: "deny",
     });
   }
-  for (const permission of TRUSTED_ODT_CANONICAL_DENY_PERMISSIONS) {
+  for (const permission of CANONICAL_ODT_TOOL_DENY_PERMISSIONS) {
     rules.push({
       permission,
       pattern: "*",

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
@@ -8,6 +8,7 @@ const makeClient = (input: {
   modelTools?: unknown;
   throwOnIds?: boolean;
   throwOnList?: boolean;
+  onList?: () => void;
   mcpStatusResponse?: unknown;
   throwOnMcpStatus?: boolean;
 }): OpencodeClient => {
@@ -23,6 +24,7 @@ const makeClient = (input: {
         };
       },
       list: async () => {
+        input.onList?.();
         if (input.throwOnList) {
           throw new Error("list-boom");
         }
@@ -113,34 +115,23 @@ describe("workflow-tool-selection", () => {
     expect(selection.odt_set_plan).toBe(false);
   });
 
-  test("uses model-scoped tool ids when global ids miss ODT tools", async () => {
+  test("keeps canonical trusted role tools when global ids miss ODT tools", async () => {
     const selection = await resolveWorkflowToolSelection({
       client: makeClient({
         toolIds: ["bash", "read", "glob"],
-        modelTools: [
-          { id: "openducktor_odt_read_task" },
-          { id: "openducktor_odt_read_task_documents" },
-          { id: "openducktor_odt_set_spec" },
-          { id: "openducktor_odt_set_plan" },
-        ],
       }),
       role: "spec",
       runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
-      model: {
-        providerId: "openai",
-        modelId: "gpt-5",
-      },
     });
 
-    expect(selection.openducktor_odt_read_task).toBe(true);
-    expect(selection.openducktor_odt_read_task_documents).toBe(true);
-    expect(selection.openducktor_odt_set_spec).toBe(true);
-    expect(selection.openducktor_odt_set_plan).toBe(false);
     expect(selection.odt_read_task).toBe(true);
     expect(selection.odt_read_task_documents).toBe(true);
     expect(selection.odt_set_spec).toBe(true);
     expect(selection.odt_set_plan).toBe(false);
+    expect(selection.odt_create_task).toBe(false);
+    expect(selection.odt_search_tasks).toBe(false);
+    expect(selection.odt_get_workspaces).toBe(false);
   });
 
   test("propagates tool discovery errors", async () => {
@@ -153,25 +144,6 @@ describe("workflow-tool-selection", () => {
 
     expect(selection).toBeInstanceOf(Error);
     expect((selection as Error).message).toBe("boom");
-  });
-
-  test("propagates model-scoped tool discovery errors", async () => {
-    const selectionError = await resolveWorkflowToolSelection({
-      client: makeClient({
-        toolIds: ["bash", "read", "glob"],
-        throwOnList: true,
-      }),
-      role: "spec",
-      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
-      workingDirectory: "/repo",
-      model: {
-        providerId: "openai",
-        modelId: "gpt-5",
-      },
-    }).catch((error: unknown) => error);
-
-    expect(selectionError).toBeInstanceOf(Error);
-    expect((selectionError as Error).message).toBe("list-boom");
   });
 
   test("throws actionable error when trusted MCP server is disconnected", async () => {
@@ -256,7 +228,9 @@ describe("workflow-tool-selection", () => {
           "openducktor_odt_read_task",
           "openducktor_odt_read_task_documents",
           "openducktor_odt_create_task",
+          "openducktor_odt_get_workspaces",
           "functions.openducktor_odt_search_tasks",
+          "functions.openducktor_odt_get_workspaces",
         ],
       }),
       role: "spec",
@@ -267,7 +241,9 @@ describe("workflow-tool-selection", () => {
     expect(selection.openducktor_odt_read_task).toBe(true);
     expect(selection.openducktor_odt_read_task_documents).toBe(true);
     expect(selection.openducktor_odt_create_task).toBe(false);
+    expect(selection.openducktor_odt_get_workspaces).toBe(false);
     expect(selection["functions.openducktor_odt_search_tasks"]).toBe(false);
+    expect(selection["functions.openducktor_odt_get_workspaces"]).toBe(false);
   });
 
   test("denies canonical public tool ids when discovery exposes them without a server prefix", async () => {
@@ -276,6 +252,7 @@ describe("workflow-tool-selection", () => {
         toolIds: [
           "odt_create_task",
           "odt_search_tasks",
+          "odt_get_workspaces",
           "odt_read_task",
           "odt_read_task_documents",
         ],
@@ -287,6 +264,7 @@ describe("workflow-tool-selection", () => {
 
     expect(selection.odt_create_task).toBe(false);
     expect(selection.odt_search_tasks).toBe(false);
+    expect(selection.odt_get_workspaces).toBe(false);
     expect(selection.odt_read_task).toBe(true);
     expect(selection.odt_read_task_documents).toBe(true);
   });

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
@@ -1,5 +1,5 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
-import type { RuntimeDescriptor } from "@openducktor/contracts";
+import { ODT_NON_WORKFLOW_TOOL_NAMES, type RuntimeDescriptor } from "@openducktor/contracts";
 import { type AgentRole, buildRoleScopedOdtToolSelection } from "@openducktor/core";
 import { unwrapData } from "./data-utils";
 import { asUnknownRecord, readStringProp } from "./guards";
@@ -9,12 +9,7 @@ import { isReadOnlyRole } from "./read-only-roles";
 const TRUSTED_ODT_MCP_SERVER_NAME = "openducktor";
 const CONNECTED_MCP_SERVER_STATUSES = new Set(["connected"]);
 const TRUSTED_ODT_MCP_TOOL_PREFIXES = ["openducktor_", "functions.openducktor_"] as const;
-const TRUSTED_ODT_MCP_CANONICAL_TOOL_IDS = new Set(["odt_create_task", "odt_search_tasks"]);
-
-type ModelScopedToolInput = {
-  providerId: string;
-  modelId: string;
-};
+const NON_WORKFLOW_ODT_TOOL_IDS = new Set<string>(ODT_NON_WORKFLOW_TOOL_NAMES);
 
 const assertTrustedOdtMcpServerConnected = async (input: {
   client: OpencodeClient;
@@ -61,69 +56,11 @@ const assertTrustedOdtMcpServerConnected = async (input: {
   );
 };
 
-const toModelScopedToolIds = (payload: unknown): string[] => {
-  if (!Array.isArray(payload)) {
-    return [];
-  }
-
-  const toolIds: string[] = [];
-  for (const entry of payload) {
-    const toolId = readStringProp(entry, ["id"]);
-    if (!toolId) {
-      continue;
-    }
-    const trimmedToolId = toolId.trim();
-    if (trimmedToolId.length === 0 || trimmedToolId === "invalid") {
-      continue;
-    }
-    toolIds.push(trimmedToolId);
-  }
-
-  return toolIds;
-};
-
-const listModelScopedToolIds = async (input: {
-  client: OpencodeClient;
-  workingDirectory: string;
-  model?: ModelScopedToolInput;
-}): Promise<string[]> => {
-  const providerId = input.model?.providerId.trim();
-  const modelId = input.model?.modelId.trim();
-  if (!providerId || !modelId) {
-    return [];
-  }
-
-  const toolApi = (input.client as { tool?: { list?: unknown } }).tool;
-  if (!toolApi || typeof toolApi.list !== "function") {
-    return [];
-  }
-
-  const response = await (
-    toolApi.list as (args: {
-      directory: string;
-      provider: string;
-      model: string;
-    }) => Promise<unknown>
-  )({
-    directory: input.workingDirectory,
-    provider: providerId,
-    model: modelId,
-  });
-
-  return toModelScopedToolIds(
-    unwrapData(
-      response as { data?: unknown; error?: { message?: string } | unknown },
-      "list model-scoped tool ids for role policy",
-    ),
-  );
-};
-
 export const resolveWorkflowToolSelection = async (input: {
   client: OpencodeClient;
   role: AgentRole;
   runtimeDescriptor: RuntimeDescriptor;
   workingDirectory: string;
-  model?: ModelScopedToolInput;
 }): Promise<Record<string, boolean>> => {
   await assertTrustedOdtMcpServerConnected({
     client: input.client,
@@ -133,23 +70,17 @@ export const resolveWorkflowToolSelection = async (input: {
   const response = await input.client.tool.ids({
     directory: input.workingDirectory,
   });
-  const runtimeToolIdsFromDiscovery = toToolIdList(
-    unwrapData(response, "list global tool ids for role policy"),
-  );
-  const runtimeToolIdsFromModelScope = await listModelScopedToolIds({
-    client: input.client,
-    workingDirectory: input.workingDirectory,
-    ...(input.model ? { model: input.model } : {}),
-  });
-  const runtimeToolIds = Array.from(
-    new Set([...runtimeToolIdsFromDiscovery, ...runtimeToolIdsFromModelScope]),
-  );
+  const runtimeToolIds = toToolIdList(unwrapData(response, "list global tool ids for role policy"));
 
   const selection = buildRoleScopedOdtToolSelection(input.role, {
     includeCanonicalDefaults: true,
     runtimeToolIds,
     workflowToolAliasesByCanonical: input.runtimeDescriptor.workflowToolAliasesByCanonical,
   });
+
+  for (const toolId of NON_WORKFLOW_ODT_TOOL_IDS) {
+    selection[toolId] = false;
+  }
 
   if (isReadOnlyRole(input.role)) {
     for (const toolId of input.runtimeDescriptor.readOnlyRoleBlockedTools) {
@@ -163,7 +94,7 @@ export const resolveWorkflowToolSelection = async (input: {
       continue;
     }
     if (!TRUSTED_ODT_MCP_TOOL_PREFIXES.some((prefix) => trimmedToolId.startsWith(prefix))) {
-      if (!TRUSTED_ODT_MCP_CANONICAL_TOOL_IDS.has(trimmedToolId)) {
+      if (!NON_WORKFLOW_ODT_TOOL_IDS.has(trimmedToolId)) {
         continue;
       }
     }

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -240,7 +240,10 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "odtHostBridgeReadySchema",
   "odtPersistedDocumentSchema",
   "ODT_HOST_BRIDGE_RESPONSE_SCHEMAS",
+  "ODT_NON_WORKFLOW_TOOL_NAMES",
   "ODT_TOOL_SCHEMAS",
+  "ODT_TOOL_NAMES",
+  "ODT_WORKFLOW_TOOL_SCHEMAS",
   "ODT_WORKSPACE_SCOPED_TOOL_NAMES",
   "ODT_WORKSPACE_SCOPED_TOOL_SCHEMAS",
   "OPENCODE_RUNTIME_CAPABILITIES",
@@ -519,7 +522,7 @@ describe("contracts exports contract", () => {
     ).toThrow();
   });
 
-  test("keeps get_workspaces workspace-free and workspace-scoped tool inputs overrideable", () => {
+  test("keeps odt_get_workspaces workspace-free and workspace-scoped tool inputs overrideable", () => {
     expect(contracts.GetWorkspacesInputSchema.parse({})).toEqual({});
     expect(contracts.ReadTaskInputSchema.parse({ workspaceId: "repo", taskId: "task-1" })).toEqual({
       workspaceId: "repo",

--- a/packages/contracts/src/odt-mcp-schemas.test.ts
+++ b/packages/contracts/src/odt-mcp-schemas.test.ts
@@ -63,7 +63,7 @@ describe("odt mcp public task schemas", () => {
     });
   });
 
-  test("workspace-scoped tool names stay explicit and exclude get_workspaces", () => {
+  test("workspace-scoped tool names stay explicit and exclude odt_get_workspaces", () => {
     expect([...ODT_WORKSPACE_SCOPED_TOOL_NAMES].sort()).toEqual(
       [
         "odt_build_blocked",

--- a/packages/contracts/src/odt-mcp-schemas.ts
+++ b/packages/contracts/src/odt-mcp-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { agentToolNameValues } from "./agent-workflow-schemas";
 import {
   gitTargetBranchSchema,
   knownGitProviderIdSchema,
@@ -257,7 +258,23 @@ export type SearchTasksInput = z.infer<typeof SearchTasksInputSchema>;
 export const GetWorkspacesInputSchema = z.object({}).strict();
 export type GetWorkspacesInput = z.infer<typeof GetWorkspacesInputSchema>;
 
-const ODT_WORKFLOW_TOOL_SCHEMAS = {
+const pickToolSchemas = <
+  TSchemas extends Record<string, unknown>,
+  const TNames extends readonly (keyof TSchemas)[],
+>(
+  schemas: TSchemas,
+  toolNames: TNames,
+): Pick<TSchemas, TNames[number]> => {
+  return Object.fromEntries(toolNames.map((toolName) => [toolName, schemas[toolName]])) as Pick<
+    TSchemas,
+    TNames[number]
+  >;
+};
+
+export const ODT_TOOL_SCHEMAS = {
+  odt_get_workspaces: GetWorkspacesInputSchema,
+  odt_create_task: CreateTaskInputSchema,
+  odt_search_tasks: SearchTasksInputSchema,
   odt_read_task: ReadTaskInputSchema,
   odt_read_task_documents: ReadTaskDocumentsInputSchema,
   odt_set_spec: SetSpecInputSchema,
@@ -270,23 +287,40 @@ const ODT_WORKFLOW_TOOL_SCHEMAS = {
   odt_qa_rejected: QaRejectedInputSchema,
 } as const;
 
+export type OdtToolName = keyof typeof ODT_TOOL_SCHEMAS;
+
+export const ODT_WORKFLOW_TOOL_SCHEMAS = pickToolSchemas(ODT_TOOL_SCHEMAS, agentToolNameValues);
+
 export type OdtWorkflowToolName = keyof typeof ODT_WORKFLOW_TOOL_SCHEMAS;
 
-export const ODT_WORKSPACE_SCOPED_TOOL_SCHEMAS = {
-  ...ODT_WORKFLOW_TOOL_SCHEMAS,
-  odt_create_task: CreateTaskInputSchema,
-  odt_search_tasks: SearchTasksInputSchema,
-} as const;
-export type WorkspaceScopedOdtToolName = keyof typeof ODT_WORKSPACE_SCOPED_TOOL_SCHEMAS;
-export const ODT_WORKSPACE_SCOPED_TOOL_NAMES = Object.keys(
-  ODT_WORKSPACE_SCOPED_TOOL_SCHEMAS,
-) as WorkspaceScopedOdtToolName[];
+export const ODT_TOOL_NAMES = Object.keys(ODT_TOOL_SCHEMAS) as OdtToolName[];
 
-export const ODT_TOOL_SCHEMAS = {
-  get_workspaces: GetWorkspacesInputSchema,
-  ...ODT_WORKSPACE_SCOPED_TOOL_SCHEMAS,
-} as const;
-export type OdtToolName = keyof typeof ODT_TOOL_SCHEMAS;
+const ODT_WORKFLOW_TOOL_NAME_SET = new Set<OdtToolName>(
+  Object.keys(ODT_WORKFLOW_TOOL_SCHEMAS) as OdtToolName[],
+);
+
+export type NonWorkflowOdtToolName = Exclude<OdtToolName, OdtWorkflowToolName>;
+
+export const ODT_NON_WORKFLOW_TOOL_NAMES = ODT_TOOL_NAMES.filter(
+  (toolName): toolName is NonWorkflowOdtToolName => !ODT_WORKFLOW_TOOL_NAME_SET.has(toolName),
+);
+
+const ODT_WORKSPACE_DISCOVERY_TOOL_NAME = "odt_get_workspaces" as const;
+
+export type WorkspaceScopedOdtToolName = Exclude<
+  OdtToolName,
+  typeof ODT_WORKSPACE_DISCOVERY_TOOL_NAME
+>;
+
+export const ODT_WORKSPACE_SCOPED_TOOL_NAMES = ODT_TOOL_NAMES.filter(
+  (toolName): toolName is WorkspaceScopedOdtToolName =>
+    toolName !== ODT_WORKSPACE_DISCOVERY_TOOL_NAME,
+);
+
+export const ODT_WORKSPACE_SCOPED_TOOL_SCHEMAS = pickToolSchemas(
+  ODT_TOOL_SCHEMAS,
+  ODT_WORKSPACE_SCOPED_TOOL_NAMES,
+);
 
 export const odtPersistedDocumentSchema = z
   .object({
@@ -388,7 +422,7 @@ export const odtHostBridgeReadySchema = z
 export type OdtHostBridgeReady = z.infer<typeof odtHostBridgeReadySchema>;
 
 export const ODT_HOST_BRIDGE_RESPONSE_SCHEMAS = {
-  get_workspaces: getWorkspacesResultSchema,
+  odt_get_workspaces: getWorkspacesResultSchema,
   odt_create_task: createTaskResultSchema,
   odt_search_tasks: searchTasksResultSchema,
   odt_read_task: taskSummarySchema,

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -79,7 +79,7 @@ The Rust host owns Beads attachment verification, shared Dolt lifecycle, workflo
 
 ## Public Tools
 
-- `get_workspaces`
+- `odt_get_workspaces`
 - `odt_create_task`
 - `odt_search_tasks`
 - `odt_read_task`
@@ -87,7 +87,7 @@ The Rust host owns Beads attachment verification, shared Dolt lifecycle, workflo
 
 The `odt_*` mutation tools are intended for OpenDucktor workflow automation and remain available on the same server.
 
-## `get_workspaces`
+## `odt_get_workspaces`
 
 Lists the workspaces currently known to the running OpenDucktor host.
 
@@ -114,7 +114,7 @@ Example response:
 }
 ```
 
-Use `get_workspaces` first when you start the MCP without a default workspace and need to discover the `workspaceId` for later calls.
+Use `odt_get_workspaces` first when you start the MCP without a default workspace and need to discover the `workspaceId` for later calls.
 
 ## `odt_create_task`
 

--- a/packages/openducktor-mcp/src/host-bridge-client.test.ts
+++ b/packages/openducktor-mcp/src/host-bridge-client.test.ts
@@ -118,7 +118,7 @@ describe("OdtHostBridgeClient", () => {
 
     expect(requests).toEqual([
       {
-        url: "http://127.0.0.1:14327/invoke/get_workspaces",
+        url: "http://127.0.0.1:14327/invoke/odt_get_workspaces",
         body: {},
       },
     ]);

--- a/packages/openducktor-mcp/src/host-bridge-client.ts
+++ b/packages/openducktor-mcp/src/host-bridge-client.ts
@@ -5,6 +5,7 @@ import {
   type OdtHostBridgeReady,
   type OdtToolName,
   odtHostBridgeReadySchema,
+  type WorkspaceScopedOdtToolName,
 } from "@openducktor/contracts";
 import type { z } from "zod";
 import { normalizeBaseUrl } from "./path-utils";
@@ -13,7 +14,7 @@ type ToolInput<Name extends OdtToolName> = z.infer<(typeof ODT_TOOL_SCHEMAS)[Nam
 type ToolOutput<Name extends OdtToolName> = z.infer<
   (typeof ODT_HOST_BRIDGE_RESPONSE_SCHEMAS)[Name]
 >;
-type WorkspaceScopedToolName = Exclude<OdtToolName, "get_workspaces">;
+type WorkspaceScopedToolName = WorkspaceScopedOdtToolName;
 
 export type OdtHostBridgeClientPort = {
   ready(): Promise<OdtHostBridgeReady>;
@@ -76,8 +77,8 @@ export class OdtHostBridgeClient implements OdtHostBridgeClientPort {
   }
 
   async getWorkspaces(): Promise<GetWorkspacesResult> {
-    const payload = await this.invokeJson("get_workspaces", {});
-    return ODT_HOST_BRIDGE_RESPONSE_SCHEMAS.get_workspaces.parse(payload);
+    const payload = await this.invokeJson("odt_get_workspaces", {});
+    return ODT_HOST_BRIDGE_RESPONSE_SCHEMAS.odt_get_workspaces.parse(payload);
   }
 
   async call<Name extends WorkspaceScopedToolName>(

--- a/packages/openducktor-mcp/src/index.test.ts
+++ b/packages/openducktor-mcp/src/index.test.ts
@@ -94,7 +94,7 @@ const startMockBridge = async (): Promise<{ url: string; requests: RecordedReque
       writeJson(response, {
         bridgeVersion: 1,
         toolNames: [
-          "get_workspaces",
+          "odt_get_workspaces",
           "odt_create_task",
           "odt_search_tasks",
           "odt_read_task",
@@ -112,7 +112,7 @@ const startMockBridge = async (): Promise<{ url: string; requests: RecordedReque
       return;
     }
 
-    if (url === "/invoke/get_workspaces") {
+    if (url === "/invoke/odt_get_workspaces") {
       requests.push({ url, body: await readJsonBody(request) });
       writeJson(response, {
         workspaces: [
@@ -190,14 +190,14 @@ afterEach(async () => {
 });
 
 describe("MCP server tool results", () => {
-  test("get_workspaces keeps structuredContent for workspace discovery payloads", async () => {
+  test("odt_get_workspaces keeps structuredContent for workspace discovery payloads", async () => {
     const bridge = await startMockBridge();
     const transport = createTransport(bridge.url);
     const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
 
     try {
       await client.connect(transport);
-      const result = await client.callTool({ name: "get_workspaces", arguments: {} });
+      const result = await client.callTool({ name: "odt_get_workspaces", arguments: {} });
       const contentResult = requireContentToolResult(result);
 
       expect(contentResult.structuredContent).toEqual({
@@ -230,7 +230,7 @@ describe("MCP server tool results", () => {
       });
       expect(bridge.requests).toEqual([
         { url: "/invoke/odt_mcp_ready", body: {} },
-        { url: "/invoke/get_workspaces", body: {} },
+        { url: "/invoke/odt_get_workspaces", body: {} },
       ]);
     } finally {
       await client.close();

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -141,7 +141,7 @@ const registerOdtTool = <Name extends RegisteredToolName>(
 };
 
 const ODT_REGISTERED_TOOL_SPECS: Readonly<RegisteredToolSpecs> = {
-  get_workspaces: {
+  odt_get_workspaces: {
     description:
       "List the workspaces currently known to OpenDucktor. Use the returned workspaceId values to scope later workspace-bound tool calls.",
     execute: (store, input) => store.getWorkspaces(input),
@@ -232,7 +232,7 @@ const createMcpServer = async (context: OdtStoreContext = {}): Promise<McpServer
     },
     {
       instructions:
-        "OpenDucktor workflow server. Use get_workspaces to discover available workspaces when no startup --workspace-id default is configured. Public task access uses odt_create_task, odt_search_tasks, odt_read_task, and odt_read_task_documents. Workspace-scoped tools accept an optional top-level workspaceId that overrides the startup default when provided. Use odt_read_task first for the single task summary object, including task state, nested qaVerdict, and nested document presence booleans, then odt_read_task_documents only for needed document bodies. Internal workflow mutations use odt_* tools. For odt_set_plan subtasks, priority must be an integer 0..4 (default 2).",
+        "OpenDucktor workflow server. Use odt_get_workspaces to discover available workspaces when no startup --workspace-id default is configured. Public task access uses odt_create_task, odt_search_tasks, odt_read_task, and odt_read_task_documents. Workspace-scoped tools accept an optional top-level workspaceId that overrides the startup default when provided. Use odt_read_task first for the single task summary object, including task state, nested qaVerdict, and nested document presence booleans, then odt_read_task_documents only for needed document bodies. Internal workflow mutations use odt_* tools. For odt_set_plan subtasks, priority must be an integer 0..4 (default 2).",
     },
   );
 

--- a/packages/openducktor-mcp/src/odt-task-store.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.test.ts
@@ -24,11 +24,13 @@ const summaryPayload = {
 };
 
 describe("OdtTaskStore", () => {
+  const workspacesPayload = { workspaces: [] };
+
   test("delegates workspace-scoped execution using the startup workspace default", async () => {
     const calls: Array<{ toolName: string; workspaceId: string; input: unknown }> = [];
     const client = {
       ready: async () => ({ bridgeVersion: 1, toolNames: [] }),
-      getWorkspaces: async () => [],
+      getWorkspaces: async () => workspacesPayload,
       call: async (toolName, workspaceId, input) => {
         calls.push({ toolName, workspaceId, input });
         return summaryPayload;
@@ -50,7 +52,7 @@ describe("OdtTaskStore", () => {
     const calls: Array<{ toolName: string; workspaceId: string; input: unknown }> = [];
     const client = {
       ready: async () => ({ bridgeVersion: 1, toolNames: [] }),
-      getWorkspaces: async () => [],
+      getWorkspaces: async () => workspacesPayload,
       call: async (toolName, workspaceId, input) => {
         calls.push({ toolName, workspaceId, input });
         return summaryPayload;
@@ -79,7 +81,7 @@ describe("OdtTaskStore", () => {
     const calls: Array<{ toolName: string; workspaceId: string; input: unknown }> = [];
     const client = {
       ready: async () => ({ bridgeVersion: 1, toolNames: [] }),
-      getWorkspaces: async () => [],
+      getWorkspaces: async () => workspacesPayload,
       call: async (toolName, workspaceId, input) => {
         calls.push({ toolName, workspaceId, input });
         return summaryPayload;
@@ -114,7 +116,7 @@ describe("OdtTaskStore", () => {
   test("keeps MCP-side input validation before delegation", async () => {
     const client = {
       ready: async () => ({ bridgeVersion: 1, toolNames: [] }),
-      getWorkspaces: async () => [],
+      getWorkspaces: async () => workspacesPayload,
       call: async () => summaryPayload,
     } as OdtHostBridgeClientPort;
 
@@ -129,7 +131,7 @@ describe("OdtTaskStore", () => {
   test("fails before delegation when no workspace can be resolved", async () => {
     const client = {
       ready: async () => ({ bridgeVersion: 1, toolNames: [] }),
-      getWorkspaces: async () => [],
+      getWorkspaces: async () => workspacesPayload,
       call: async () => summaryPayload,
     } as OdtHostBridgeClientPort;
 
@@ -186,7 +188,7 @@ describe("OdtTaskStore", () => {
   test("accepts document-level decode errors on odt_read_task_documents", async () => {
     const client = {
       ready: async () => ({ bridgeVersion: 1, toolNames: [] }),
-      getWorkspaces: async () => [],
+      getWorkspaces: async () => workspacesPayload,
       call: async () => ({
         documents: {
           spec: {

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -47,7 +47,7 @@ export class OdtTaskStore {
   }
 
   async getWorkspaces(rawInput: unknown) {
-    ODT_TOOL_SCHEMAS.get_workspaces.parse(rawInput);
+    ODT_TOOL_SCHEMAS.odt_get_workspaces.parse(rawInput);
     return this.client.getWorkspaces();
   }
 

--- a/packages/openducktor-mcp/src/store-context.test.ts
+++ b/packages/openducktor-mcp/src/store-context.test.ts
@@ -53,7 +53,7 @@ describe("resolveStoreContext", () => {
           toolNames: Object.keys(ODT_TOOL_SCHEMAS),
         });
       }
-      if (url.endsWith("/invoke/get_workspaces")) {
+      if (url.endsWith("/invoke/odt_get_workspaces")) {
         return jsonResponse({
           workspaces: [
             {
@@ -147,7 +147,7 @@ describe("resolveStoreContext", () => {
           toolNames: Object.keys(ODT_TOOL_SCHEMAS),
         });
       }
-      if (url === "http://127.0.0.1:14327/invoke/get_workspaces") {
+      if (url === "http://127.0.0.1:14327/invoke/odt_get_workspaces") {
         return jsonResponse({
           workspaces: [
             {
@@ -194,7 +194,7 @@ describe("resolveStoreContext", () => {
           toolNames: Object.keys(ODT_TOOL_SCHEMAS),
         });
       }
-      if (url === "http://127.0.0.1:14328/invoke/get_workspaces") {
+      if (url === "http://127.0.0.1:14328/invoke/odt_get_workspaces") {
         return jsonResponse({
           workspaces: [
             {
@@ -238,7 +238,7 @@ describe("resolveStoreContext", () => {
           toolNames: Object.keys(ODT_TOOL_SCHEMAS),
         });
       }
-      if (url === "http://127.0.0.1:14327/invoke/get_workspaces") {
+      if (url === "http://127.0.0.1:14327/invoke/odt_get_workspaces") {
         return jsonResponse({
           workspaces: [
             {
@@ -254,7 +254,7 @@ describe("resolveStoreContext", () => {
           ],
         });
       }
-      if (url === "http://127.0.0.1:14328/invoke/get_workspaces") {
+      if (url === "http://127.0.0.1:14328/invoke/odt_get_workspaces") {
         return jsonResponse({
           workspaces: [
             {
@@ -311,7 +311,7 @@ describe("resolveStoreContext", () => {
           toolNames: Object.keys(ODT_TOOL_SCHEMAS),
         });
       }
-      if (url.endsWith("/invoke/get_workspaces")) {
+      if (url.endsWith("/invoke/odt_get_workspaces")) {
         return jsonResponse({
           workspaces: [
             {


### PR DESCRIPTION
## Summary

- Fix the session-start root cause by removing model-scoped workflow tool fallback and using global workflow discovery for current workflow roles.
- Rename public workspace discovery from `get_workspaces` to `odt_get_workspaces` and derive ODT workflow vs non-workflow tool boundaries from shared contracts.
- Out of scope: reducing the public `odt_get_workspaces` payload or changing the existing external MCP response contract.

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run check:rust`
- [x] `bun run test:rust`
- [ ] Not applicable

## Checklist

- [x] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [ ] I linked related issues or context below

## Related Issues

Closes #

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional Context

Goal: make the ODT public/workflow tool contract consistent across contracts, MCP transport, Rust host/headless, and workflow-role selection while fixing the session-start error at the source.

Technical choices:
- add shared canonical ODT tool buckets in `packages/contracts` (`ODT_TOOL_NAMES`, `ODT_NON_WORKFLOW_TOOL_NAMES`, workflow/workspace-scoped derivations) so downstream selection and permission rules stop drifting.
- keep `odt_get_workspaces`, `odt_create_task`, and `odt_search_tasks` out of current spec/planner/build/qa role tool sets while still exposing them for external MCP/public usage.
- remove stale model-scoped workflow tool cache plumbing in the Opencode adapter so the implementation matches the new global discovery behavior.
- align MCP docs, bridge calls, and Rust registration/tests with the renamed `odt_get_workspaces` tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for failed message sends with improved error messaging and metadata.
  * Improved visibility of runtime session data errors with updated error styling.

* **Improvements**
  * Streamlined agent session model selection workflow.
  * Standardized internal tool naming conventions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->