### PR TITLE
fix: stabilize early chat transcript rendering

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.test.ts
@@ -29,7 +29,7 @@ describe("getAgentChatThreadState", () => {
     });
 
     expect(state.isTranscriptLoading).toBe(true);
-    expect(state.hideTranscriptWhileHydrating).toBe(true);
+    expect(state.hideTranscriptWhileHydrating).toBe(false);
     expect(state.statusOverlay?.kind).toBe("session_loading");
     expect(state.statusOverlay?.description).toBe("Loading the selected conversation.");
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.test.ts
@@ -14,7 +14,7 @@ describe("getAgentChatThreadState", () => {
 
     expect(state.statusOverlay?.kind).toBe("runtime_waiting");
     expect(state.statusOverlay?.title).toBe("Runtime is starting");
-    expect(state.hideTranscriptWhileHydrating).toBe(false);
+    expect(state.hideTranscriptWhileDeferred).toBe(false);
     expect(state.isTranscriptLoading).toBe(false);
   });
 
@@ -29,7 +29,7 @@ describe("getAgentChatThreadState", () => {
     });
 
     expect(state.isTranscriptLoading).toBe(true);
-    expect(state.hideTranscriptWhileHydrating).toBe(false);
+    expect(state.hideTranscriptWhileDeferred).toBe(false);
     expect(state.statusOverlay?.kind).toBe("session_loading");
     expect(state.statusOverlay?.description).toBe("Loading the selected conversation.");
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
@@ -32,7 +32,7 @@ export const getAgentChatThreadState = ({
 }: BuildAgentChatThreadStateArgs): AgentChatThreadState => {
   const isTranscriptLoading =
     isSessionViewLoading || isSessionHistoryLoading || isTranscriptRenderDeferred;
-  const hideTranscriptWhileHydrating = isSessionHistoryLoading || isTranscriptRenderDeferred;
+  const hideTranscriptWhileHydrating = isTranscriptRenderDeferred;
   const statusOverlay = (() => {
     if (
       isWaitingForRuntimeReadiness &&
@@ -56,9 +56,10 @@ export const getAgentChatThreadState = ({
     return {
       kind: "session_loading" as const,
       title: "Loading session",
-      description: hideTranscriptWhileHydrating
-        ? "Loading the selected conversation."
-        : "Preparing the selected session view.",
+      description:
+        isSessionHistoryLoading || isTranscriptRenderDeferred
+          ? "Loading the selected conversation."
+          : "Preparing the selected session view.",
     };
   })();
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
@@ -13,7 +13,7 @@ type BuildAgentChatThreadStateArgs = Pick<
 
 export type AgentChatThreadState = {
   isTranscriptLoading: boolean;
-  hideTranscriptWhileHydrating: boolean;
+  hideTranscriptWhileDeferred: boolean;
   statusOverlay: {
     kind: "runtime_waiting" | "session_loading";
     title: string;
@@ -32,7 +32,7 @@ export const getAgentChatThreadState = ({
 }: BuildAgentChatThreadStateArgs): AgentChatThreadState => {
   const isTranscriptLoading =
     isSessionViewLoading || isSessionHistoryLoading || isTranscriptRenderDeferred;
-  const hideTranscriptWhileHydrating = isTranscriptRenderDeferred;
+  const hideTranscriptWhileDeferred = isTranscriptRenderDeferred;
   const statusOverlay = (() => {
     if (
       isWaitingForRuntimeReadiness &&
@@ -65,7 +65,7 @@ export const getAgentChatThreadState = ({
 
   return {
     isTranscriptLoading,
-    hideTranscriptWhileHydrating,
+    hideTranscriptWhileDeferred,
     statusOverlay,
     showRuntimeBlockedCard: readinessState === "blocked" && Boolean(blockedReason),
   };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -724,7 +724,7 @@ describe("AgentChatThread", () => {
     expect(html).toContain("Preparing the selected session view.");
   });
 
-  test("hides transcript rows while session history is hydrating", () => {
+  test("keeps transcript rows visible while the same session history is hydrating", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatThread, {
         model: {
@@ -740,7 +740,69 @@ describe("AgentChatThread", () => {
 
     expect(html).toContain("Loading session");
     expect(html).toContain("Loading the selected conversation.");
-    expect(html).not.toContain("Old cached message");
+    expect(html).toContain("Old cached message");
+  });
+
+  test("preserves expanded tool details while same-session history hydration appends messages", async () => {
+    const messages = [
+      buildMessage("tool", "Tool read_task completed", {
+        id: "tool-1",
+        meta: {
+          kind: "tool",
+          partId: "part-1",
+          callId: "call-1",
+          tool: "read_task",
+          status: "completed",
+          input: { taskId: "openducktor-d4li" },
+          output: '{"task":{"id":"openducktor-d4li","title":"Fix chat flicker"}}',
+        },
+      }),
+    ];
+    const session = buildSession({
+      sessionId: "session-tool-hydrating",
+      messages,
+    });
+    const model = {
+      ...buildBaseModel(),
+      isSessionHistoryLoading: true,
+      session,
+    };
+
+    const rendered = render(
+      createElement(AgentChatThread, {
+        model,
+      }),
+    );
+    await act(flush);
+
+    const toolDetails = rendered.container.querySelector(
+      "details.group",
+    ) as HTMLDetailsElement | null;
+    if (!toolDetails) {
+      throw new Error("Expected expandable tool details");
+    }
+    toolDetails.open = true;
+
+    rendered.rerender(
+      createElement(AgentChatThread, {
+        model: {
+          ...model,
+          session: buildSession({
+            ...session,
+            messages: [
+              ...messages,
+              buildMessage("assistant", "Next streamed response", { id: "assistant-2" }),
+            ],
+          }),
+        },
+      }),
+    );
+    await act(flush);
+
+    expect(toolDetails.isConnected).toBe(true);
+    expect(toolDetails.open).toBe(true);
+
+    rendered.unmount();
   });
 
   test("renders native scroll controls for top and bottom navigation", async () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -452,7 +452,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   });
   const {
     isTranscriptLoading,
-    hideTranscriptWhileHydrating,
+    hideTranscriptWhileDeferred,
     statusOverlay,
     showRuntimeBlockedCard,
   } = getAgentChatThreadState({
@@ -466,7 +466,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const rowsCacheRef = useRef<Map<string, AgentChatWindowRowsCacheEntry>>(new Map());
 
   const transcriptState = useMemo(() => {
-    if (!session || hideTranscriptWhileHydrating) {
+    if (!session || hideTranscriptWhileDeferred) {
       return {
         rows: EMPTY_ROWS,
         turns: [] as AgentChatWindowTurn[],
@@ -481,7 +481,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
       showThinkingMessages,
       cache: rowsCacheRef.current,
     });
-  }, [hideTranscriptWhileHydrating, session, showThinkingMessages]);
+  }, [hideTranscriptWhileDeferred, session, showThinkingMessages]);
   const rows = transcriptState.rows;
   const transcriptTurns = transcriptState.turns;
   const hasAttachmentMessages = transcriptState.hasAttachmentMessages;
@@ -653,7 +653,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
         sessionRuntimeKind={sessionRuntimeKind}
         messagesContainerRef={messagesContainerRef}
         messagesContentRef={messagesContentRef}
-        renderedTurns={rows.length > 0 && !hideTranscriptWhileHydrating ? renderedTurns : []}
+        renderedTurns={rows.length > 0 && !hideTranscriptWhileDeferred ? renderedTurns : []}
         allowTurnContainment={allowTurnContainment}
         resolveRowRef={resolveRowRef}
         statusOverlay={statusOverlay}

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
@@ -182,4 +182,36 @@ describe("useAgentChatRowStaging", () => {
 
     await harness.unmount();
   });
+
+  test("returns all rows immediately when a small active transcript grows", async () => {
+    const harness = createHookHarness(
+      ({ activeSessionId, nextRows, nextTurns }) =>
+        useAgentChatRowStaging({
+          activeSessionId,
+          rows: nextRows,
+          turns: nextTurns,
+          disabled: false,
+        }),
+      {
+        activeSessionId: "session-1",
+        nextRows: buildRows(1),
+        nextTurns: [{ key: "turn-0", start: 0, end: 0 }],
+      },
+    );
+
+    await harness.mount();
+    await harness.update({
+      activeSessionId: "session-1",
+      nextRows: buildRows(2),
+      nextTurns: [{ key: "turn-0", start: 0, end: 1 }],
+    });
+
+    expect(harness.getLatest().rows.map((row: AgentChatWindowRow) => row.key)).toEqual([
+      "session-1:row-0",
+      "session-1:row-1",
+    ]);
+    expect(animationFrameCallbacks.size).toBe(0);
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
@@ -4,6 +4,20 @@ import type { AgentChatWindowRow, AgentChatWindowTurn } from "./agent-chat-threa
 const ROW_STAGE_INIT = 24;
 const ROW_STAGE_BATCH = 32;
 
+const shouldStageRows = ({
+  activeSessionId,
+  completedSessionIds,
+  disabled,
+  rowCount,
+}: {
+  activeSessionId: string;
+  completedSessionIds: Set<string>;
+  disabled: boolean;
+  rowCount: number;
+}): boolean => {
+  return !disabled && rowCount > ROW_STAGE_INIT && !completedSessionIds.has(activeSessionId);
+};
+
 type UseAgentChatRowStagingArgs = {
   activeSessionId: string | null;
   rows: AgentChatWindowRow[];
@@ -51,11 +65,18 @@ export function useAgentChatRowStaging({
       completedSessionIdsRef.current.delete(activeSessionId);
     }
 
-    const shouldStage =
-      !disabled &&
-      activeSessionId !== null &&
-      rows.length > ROW_STAGE_INIT &&
-      !completedSessionIdsRef.current.has(activeSessionId);
+    if (activeSessionId === null) {
+      activeSessionRef.current = null;
+      updateRowCount(rows.length);
+      return;
+    }
+
+    const shouldStage = shouldStageRows({
+      activeSessionId,
+      completedSessionIds: completedSessionIdsRef.current,
+      disabled,
+      rowCount: rows.length,
+    });
 
     if (!shouldStage) {
       activeSessionRef.current = null;
@@ -107,12 +128,15 @@ export function useAgentChatRowStaging({
   }, [activeSessionId, disabled, rows.length]);
 
   return useMemo(() => {
-    const shouldStage =
-      !disabled &&
-      activeSessionId !== null &&
-      rows.length > ROW_STAGE_INIT &&
-      !completedSessionIdsRef.current.has(activeSessionId);
-    if (!shouldStage) {
+    if (
+      activeSessionId === null ||
+      !shouldStageRows({
+        activeSessionId,
+        completedSessionIds: completedSessionIdsRef.current,
+        disabled,
+        rowCount: rows.length,
+      })
+    ) {
       return { rows, turns };
     }
 

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
@@ -107,6 +107,15 @@ export function useAgentChatRowStaging({
   }, [activeSessionId, disabled, rows.length]);
 
   return useMemo(() => {
+    const shouldStage =
+      !disabled &&
+      activeSessionId !== null &&
+      rows.length > ROW_STAGE_INIT &&
+      !completedSessionIdsRef.current.has(activeSessionId);
+    if (!shouldStage) {
+      return { rows, turns };
+    }
+
     if (rowCount >= rows.length) {
       return { rows, turns };
     }
@@ -122,5 +131,5 @@ export function useAgentChatRowStaging({
           end: turn.end - rowStart,
         })),
     };
-  }, [rowCount, rows, turns]);
+  }, [activeSessionId, disabled, rowCount, rows, turns]);
 }

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
@@ -229,6 +229,38 @@ describe("useAgentChatTurnStaging", () => {
     await harness.unmount();
   });
 
+  test("returns all turns immediately when an unwindowed active transcript grows", async () => {
+    const harness = createHookHarness(
+      ({ activeSessionId, windowStart, nextTurns }) =>
+        useAgentChatTurnStaging({
+          activeSessionId,
+          windowStart,
+          turns: nextTurns,
+          disabled: false,
+        }),
+      {
+        activeSessionId: "session-1",
+        windowStart: 0,
+        nextTurns: buildTurns(1),
+      },
+    );
+
+    await harness.mount();
+    await harness.update({
+      activeSessionId: "session-1",
+      windowStart: 0,
+      nextTurns: buildTurns(2),
+    });
+
+    expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual([
+      "turn-0",
+      "turn-1",
+    ]);
+    expect(animationFrameCallbacks.size).toBe(0);
+
+    await harness.unmount();
+  });
+
   test("returns all turns immediately when staging is disabled", async () => {
     const turns = buildTurns(6);
     const harness = createHookHarness(

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
@@ -103,10 +103,20 @@ export function useAgentChatTurnStaging({
   }, [activeSessionId, disabled, turns.length, windowStart]);
 
   return useMemo(() => {
+    const shouldStage =
+      !disabled &&
+      activeSessionId !== null &&
+      windowStart > 0 &&
+      turns.length > STAGE_INIT &&
+      !completedSessionIdsRef.current.has(activeSessionId);
+    if (!shouldStage) {
+      return turns;
+    }
+
     if (count >= turns.length) {
       return turns;
     }
 
     return turns.slice(Math.max(0, turns.length - count));
-  }, [count, turns]);
+  }, [activeSessionId, count, disabled, turns, windowStart]);
 }

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
@@ -4,6 +4,27 @@ import type { AgentChatWindowTurn } from "./agent-chat-thread-windowing";
 const STAGE_INIT = 1;
 const STAGE_BATCH = 3;
 
+const shouldStageTurns = ({
+  activeSessionId,
+  completedSessionIds,
+  disabled,
+  turnCount,
+  windowStart,
+}: {
+  activeSessionId: string;
+  completedSessionIds: Set<string>;
+  disabled: boolean;
+  turnCount: number;
+  windowStart: number;
+}): boolean => {
+  return (
+    !disabled &&
+    windowStart > 0 &&
+    turnCount > STAGE_INIT &&
+    !completedSessionIds.has(activeSessionId)
+  );
+};
+
 type UseAgentChatTurnStagingArgs = {
   activeSessionId: string | null;
   windowStart: number;
@@ -46,12 +67,19 @@ export function useAgentChatTurnStaging({
       completedSessionIdsRef.current.delete(activeSessionId);
     }
 
-    const shouldStage =
-      !disabled &&
-      activeSessionId !== null &&
-      windowStart > 0 &&
-      turns.length > STAGE_INIT &&
-      !completedSessionIdsRef.current.has(activeSessionId);
+    if (activeSessionId === null) {
+      activeSessionRef.current = null;
+      updateCount(turns.length);
+      return;
+    }
+
+    const shouldStage = shouldStageTurns({
+      activeSessionId,
+      completedSessionIds: completedSessionIdsRef.current,
+      disabled,
+      turnCount: turns.length,
+      windowStart,
+    });
 
     if (!shouldStage) {
       activeSessionRef.current = null;
@@ -103,13 +131,16 @@ export function useAgentChatTurnStaging({
   }, [activeSessionId, disabled, turns.length, windowStart]);
 
   return useMemo(() => {
-    const shouldStage =
-      !disabled &&
-      activeSessionId !== null &&
-      windowStart > 0 &&
-      turns.length > STAGE_INIT &&
-      !completedSessionIdsRef.current.has(activeSessionId);
-    if (!shouldStage) {
+    if (
+      activeSessionId === null ||
+      !shouldStageTurns({
+        activeSessionId,
+        completedSessionIds: completedSessionIdsRef.current,
+        disabled,
+        turnCount: turns.length,
+        windowStart,
+      })
+    ) {
       return turns;
     }
 


### PR DESCRIPTION
## Summary
- Keep same-session chat transcript rows mounted while history hydration is loading, so existing tool expansion state is preserved.
- Make early row/turn staging return complete small transcripts immediately instead of briefly slicing from stale staging counts.
- Add regression coverage for transcript visibility, expanded tool details, and small transcript growth.

## Goal
This fixes early-session chat flicker where the transcript appeared to re-render on each new message and expanded/collapsed tool call details reset. The issue was most visible at the start of a new session while the transcript had only a few messages.

## Technical Choices
- `isSessionHistoryLoading` still drives the loading overlay, but no longer hides renderable same-session transcript rows.
- `isTranscriptRenderDeferred` remains the condition that hides transcript content, preserving the existing protection against showing stale rows during cross-session deferred rendering.
- Row and turn staging now short-circuit to full data for non-staged cases, avoiding a transient render where early transcripts briefly drop previously mounted rows before effects update the staging count.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached message content now remains visible while loading session history instead of being hidden.
  * Expandable message details remain open and mounted when the chat session updates.
  * Messages and conversation turns now display immediately when available, eliminating unnecessary animation delays in smaller active transcripts.
  * Improved status messaging clarity during session and transcript loading states.
  * More reliable conversation loading and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->