### PR TITLE
fix: allow active workflow document revisions

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/document_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/document_service.rs
@@ -2,8 +2,8 @@ use super::task_context::LoadedTaskContext;
 use crate::app_service::service_core::AppService;
 use crate::app_service::workflow_rules::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
-    normalize_required_markdown, normalize_subtask_plan_inputs, normalize_title_key,
-    validate_parent_relationships_for_create, validate_plan_subtask_rules,
+    is_active_or_review_status, normalize_required_markdown, normalize_subtask_plan_inputs,
+    normalize_title_key, validate_parent_relationships_for_create, validate_plan_subtask_rules,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{CreateTaskInput, IssueType, PlanSubtaskInput, SpecDocument, TaskStatus};
@@ -20,7 +20,7 @@ impl AppService {
         let context = self.load_task_context_from_resolved(repo_path, task_id)?;
         if !can_set_spec_from_status(&context.task.status) {
             return Err(anyhow!(
-                "set_spec is only allowed from open/spec_ready/ready_for_dev (current: {})",
+                "set_spec is only allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review (current: {})",
                 context.task.status.as_cli_value()
             ));
         }
@@ -73,17 +73,24 @@ impl AppService {
         let mut context = self.load_task_context_from_resolved(repo_path, task_id)?;
         if !can_set_plan(&context.task) {
             return Err(anyhow!(
-                "set_plan is not allowed for issue type {} from status {}",
+                "set_plan is not allowed for issue type {} from status {}. feature/epic allow spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review; task/bug also allow open.",
                 context.task.issue_type.as_cli_value(),
                 context.task.status.as_cli_value()
             ));
         }
 
         let issue_type = context.task.issue_type.clone();
+        let has_explicit_subtasks = subtasks.is_some();
         let mut subtask_creates = normalize_subtask_plan_inputs(subtasks.unwrap_or_default())?;
         validate_plan_subtask_rules(&context.task, &context.repo.tasks, &subtask_creates)?;
         if issue_type != IssueType::Epic {
             subtask_creates.clear();
+        }
+
+        let should_replace_epic_subtasks = issue_type == IssueType::Epic
+            && (!is_active_or_review_status(&context.task.status) || has_explicit_subtasks);
+        if should_replace_epic_subtasks {
+            self.validate_epic_subtasks_replaceable(&context)?;
         }
 
         let plan = self
@@ -91,16 +98,21 @@ impl AppService {
             .set_plan(context.repo_dir(), task_id, &markdown)
             .with_context(|| format!("Failed to persist implementation plan for {task_id}"))?;
 
-        if issue_type == IssueType::Epic {
+        if should_replace_epic_subtasks {
             self.replace_epic_plan_subtasks(&mut context, subtask_creates)?;
         }
 
-        self.task_transition(
-            context.repo.repo_path.as_str(),
-            task_id,
-            TaskStatus::ReadyForDev,
-            Some("Implementation plan ready"),
-        )?;
+        if matches!(
+            context.task.status,
+            TaskStatus::Open | TaskStatus::SpecReady
+        ) {
+            self.task_transition(
+                context.repo.repo_path.as_str(),
+                task_id,
+                TaskStatus::ReadyForDev,
+                Some("Implementation plan ready"),
+            )?;
+        }
 
         Ok(plan)
     }
@@ -126,6 +138,7 @@ impl AppService {
         subtask_creates: Vec<CreateTaskInput>,
     ) -> Result<()> {
         let task_id = context.task.id.clone();
+        self.validate_epic_subtasks_replaceable(context)?;
 
         let existing_direct_subtasks = context
             .repo
@@ -134,19 +147,6 @@ impl AppService {
             .filter(|entry| entry.parent_id.as_deref() == Some(task_id.as_str()))
             .cloned()
             .collect::<Vec<_>>();
-        let blocked_subtasks = existing_direct_subtasks
-            .iter()
-            .filter(|entry| !can_replace_epic_subtask_status(&entry.status))
-            .map(|entry| format!("{} ({})", entry.id, entry.status.as_cli_value()))
-            .collect::<Vec<_>>();
-        if !blocked_subtasks.is_empty() {
-            return Err(anyhow!(
-                "Cannot replace epic subtasks while active work exists. \
-Move subtasks to open/spec_ready/ready_for_dev first: {}",
-                blocked_subtasks.join(", ")
-            ));
-        }
-
         let existing_direct_subtask_ids = existing_direct_subtasks
             .iter()
             .map(|entry| entry.id.clone())
@@ -183,6 +183,27 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
                 .task_store
                 .create_task(context.repo_dir(), create_input)?;
             context.repo.tasks.push(created);
+        }
+
+        Ok(())
+    }
+
+    fn validate_epic_subtasks_replaceable(&self, context: &LoadedTaskContext) -> Result<()> {
+        let task_id = context.task.id.as_str();
+        let blocked_subtasks = context
+            .repo
+            .tasks
+            .iter()
+            .filter(|entry| entry.parent_id.as_deref() == Some(task_id))
+            .filter(|entry| !can_replace_epic_subtask_status(&entry.status))
+            .map(|entry| format!("{} ({})", entry.id, entry.status.as_cli_value()))
+            .collect::<Vec<_>>();
+        if !blocked_subtasks.is_empty() {
+            return Err(anyhow!(
+                "Cannot replace epic subtasks while active work exists. \
+Move subtasks to open/spec_ready/ready_for_dev first: {}",
+                blocked_subtasks.join(", ")
+            ));
         }
 
         Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/document_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/document_service.rs
@@ -82,13 +82,18 @@ impl AppService {
         let issue_type = context.task.issue_type.clone();
         let has_explicit_subtasks = subtasks.is_some();
         let mut subtask_creates = normalize_subtask_plan_inputs(subtasks.unwrap_or_default())?;
-        validate_plan_subtask_rules(&context.task, &context.repo.tasks, &subtask_creates)?;
+        let is_active_or_review = is_active_or_review_status(&context.task.status);
+        let should_validate_subtask_rules =
+            issue_type != IssueType::Epic || !is_active_or_review || has_explicit_subtasks;
+        if should_validate_subtask_rules {
+            validate_plan_subtask_rules(&context.task, &context.repo.tasks, &subtask_creates)?;
+        }
         if issue_type != IssueType::Epic {
             subtask_creates.clear();
         }
 
-        let should_replace_epic_subtasks = issue_type == IssueType::Epic
-            && (!is_active_or_review_status(&context.task.status) || has_explicit_subtasks);
+        let should_replace_epic_subtasks =
+            issue_type == IssueType::Epic && (!is_active_or_review || has_explicit_subtasks);
         if should_replace_epic_subtasks {
             self.validate_epic_subtasks_replaceable(&context)?;
         }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/document_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/document_service.rs
@@ -92,8 +92,7 @@ impl AppService {
             subtask_creates.clear();
         }
 
-        let should_replace_epic_subtasks =
-            issue_type == IssueType::Epic && (!is_active_or_review || has_explicit_subtasks);
+        let should_replace_epic_subtasks = issue_type == IssueType::Epic && has_explicit_subtasks;
         if should_replace_epic_subtasks {
             self.validate_epic_subtasks_replaceable(&context)?;
         }
@@ -143,7 +142,6 @@ impl AppService {
         subtask_creates: Vec<CreateTaskInput>,
     ) -> Result<()> {
         let task_id = context.task.id.clone();
-        self.validate_epic_subtasks_replaceable(context)?;
 
         let existing_direct_subtasks = context
             .repo

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/mod.rs
@@ -2,3 +2,4 @@ mod approval_workflow;
 mod opencode_runtime;
 mod session_stop;
 mod support;
+mod workflow_document_revisions;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1520,22 +1520,66 @@ fn set_spec_persists_trimmed_markdown_and_transitions_open_task() -> Result<()> 
 }
 
 #[test]
-fn set_spec_rejects_invalid_status() {
-    let repo_path = "/tmp/odt-repo-spec-invalid";
-    let (service, _task_state, _git_state) = build_service_with_git_state(
-        vec![make_task("task-1", "task", TaskStatus::InProgress)],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-    );
+fn set_spec_allows_active_and_review_statuses_without_status_transition() -> Result<()> {
+    for status in [
+        TaskStatus::Blocked,
+        TaskStatus::InProgress,
+        TaskStatus::AiReview,
+        TaskStatus::HumanReview,
+    ] {
+        let repo_path = format!("/tmp/odt-repo-spec-active-{}", status.as_cli_value());
+        let (service, task_state, _git_state) = build_service_with_git_state(
+            vec![make_task("task-1", "task", status.clone())],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+                revision: None,
+            },
+        );
 
-    let error = service
-        .set_spec(repo_path, "task-1", "# Spec")
-        .expect_err("set_spec should be blocked in in_progress");
-    assert!(error.to_string().contains("set_spec is only allowed"));
+        let spec = service.set_spec(repo_path.as_str(), "task-1", "  # Revised Spec  ")?;
+        assert_eq!(spec.markdown, "# Revised Spec");
+
+        let task_state = task_state.lock().expect("task lock poisoned");
+        assert_eq!(
+            task_state.spec_set_calls,
+            vec![("task-1".to_string(), "# Revised Spec".to_string())]
+        );
+        assert!(
+            !task_state
+                .updated_patches
+                .iter()
+                .any(|(_, patch)| patch.status.is_some()),
+            "status update should be skipped for {}",
+            status.as_cli_value()
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn set_spec_rejects_deferred_and_closed_statuses() {
+    for status in [TaskStatus::Deferred, TaskStatus::Closed] {
+        let repo_path = format!("/tmp/odt-repo-spec-invalid-{}", status.as_cli_value());
+        let (service, task_state, _git_state) = build_service_with_git_state(
+            vec![make_task("task-1", "task", status.clone())],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+                revision: None,
+            },
+        );
+
+        let error = service
+            .set_spec(repo_path.as_str(), "task-1", "# Spec")
+            .expect_err("set_spec should be blocked in deferred/closed");
+        assert!(error.to_string().contains("set_spec is only allowed"));
+        let task_state = task_state.lock().expect("task lock poisoned");
+        assert!(task_state.spec_set_calls.is_empty());
+    }
 }
 
 #[test]
@@ -1627,6 +1671,53 @@ fn set_plan_allows_feature_from_ready_for_dev_without_status_transition() -> Res
 }
 
 #[test]
+fn set_plan_allows_active_and_review_statuses_without_status_transition() -> Result<()> {
+    for issue_type in ["task", "bug", "feature", "epic"] {
+        for status in [
+            TaskStatus::Blocked,
+            TaskStatus::InProgress,
+            TaskStatus::AiReview,
+            TaskStatus::HumanReview,
+        ] {
+            let repo_path = format!(
+                "/tmp/odt-repo-plan-active-{issue_type}-{}",
+                status.as_cli_value()
+            );
+            let (service, task_state, _git_state) = build_service_with_git_state(
+                vec![make_task("task-1", issue_type, status.clone())],
+                vec![],
+                GitCurrentBranch {
+                    name: Some("main".to_string()),
+                    detached: false,
+                    revision: None,
+                },
+            );
+
+            let plan = service.set_plan(repo_path.as_str(), "task-1", "  # Revised Plan  ", None)?;
+            assert_eq!(plan.markdown, "# Revised Plan");
+
+            let task_state = task_state.lock().expect("task lock poisoned");
+            assert_eq!(
+                task_state.plan_set_calls,
+                vec![("task-1".to_string(), "# Revised Plan".to_string())]
+            );
+            assert!(task_state.created_inputs.is_empty());
+            assert!(task_state.delete_calls.is_empty());
+            assert!(
+                !task_state
+                    .updated_patches
+                    .iter()
+                    .any(|(_, patch)| patch.status.is_some()),
+                "status update should be skipped for {issue_type} {}",
+                status.as_cli_value()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
 fn set_plan_rejects_invalid_status_for_feature() {
     let repo_path = "/tmp/odt-repo-plan-invalid";
     let (service, _task_state, _git_state) = build_service_with_git_state(
@@ -1643,6 +1734,34 @@ fn set_plan_rejects_invalid_status_for_feature() {
         .set_plan(repo_path, "task-1", "# Plan", None)
         .expect_err("feature/open should not allow plan");
     assert!(error.to_string().contains("set_plan is not allowed"));
+}
+
+#[test]
+fn set_plan_rejects_deferred_and_closed_statuses() {
+    for issue_type in ["task", "bug", "feature", "epic"] {
+        for status in [TaskStatus::Deferred, TaskStatus::Closed] {
+            let repo_path = format!(
+                "/tmp/odt-repo-plan-invalid-{issue_type}-{}",
+                status.as_cli_value()
+            );
+            let (service, task_state, _git_state) = build_service_with_git_state(
+                vec![make_task("task-1", issue_type, status.clone())],
+                vec![],
+                GitCurrentBranch {
+                    name: Some("main".to_string()),
+                    detached: false,
+                    revision: None,
+                },
+            );
+
+            let error = service
+                .set_plan(repo_path.as_str(), "task-1", "# Plan", None)
+                .expect_err("set_plan should be blocked in deferred/closed");
+            assert!(error.to_string().contains("set_plan is not allowed"));
+            let task_state = task_state.lock().expect("task lock poisoned");
+            assert!(task_state.plan_set_calls.is_empty());
+        }
+    }
 }
 
 #[test]
@@ -1747,6 +1866,43 @@ fn set_plan_for_epic_without_subtasks_clears_existing_direct_subtasks() -> Resul
 }
 
 #[test]
+fn set_plan_for_active_epic_without_subtasks_preserves_existing_direct_subtasks() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-plan-active-epic-preserve";
+    let epic = make_task("epic-1", "epic", TaskStatus::InProgress);
+    let mut existing_child = make_task("child-1", "task", TaskStatus::Open);
+    existing_child.parent_id = Some("epic-1".to_string());
+
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![epic, existing_child],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let plan = service.set_plan(repo_path, "epic-1", "# Revised Epic Plan", None)?;
+    assert_eq!(plan.markdown, "# Revised Epic Plan");
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(
+        task_state.plan_set_calls,
+        vec![("epic-1".to_string(), "# Revised Epic Plan".to_string())]
+    );
+    assert!(task_state.delete_calls.is_empty());
+    assert!(task_state.created_inputs.is_empty());
+    assert!(
+        !task_state
+            .updated_patches
+            .iter()
+            .any(|(_, patch)| patch.status.is_some()),
+        "status update should be skipped for active epic revisions"
+    );
+    Ok(())
+}
+
+#[test]
 fn set_plan_for_epic_rejects_subtask_replacement_when_existing_subtask_is_active() {
     let repo_path = "/tmp/odt-repo-plan-epic-active-subtask";
     let epic = make_task("epic-1", "epic", TaskStatus::SpecReady);
@@ -1784,6 +1940,50 @@ fn set_plan_for_epic_rejects_subtask_replacement_when_existing_subtask_is_active
     );
 
     let task_state = task_state.lock().expect("task lock poisoned");
+    assert!(task_state.plan_set_calls.is_empty());
+    assert!(task_state.delete_calls.is_empty());
+    assert!(task_state.created_inputs.is_empty());
+}
+
+#[test]
+fn set_plan_for_active_epic_rejects_explicit_subtask_replacement_before_persisting_plan() {
+    let repo_path = "/tmp/odt-repo-plan-active-epic-active-subtask";
+    let epic = make_task("epic-1", "epic", TaskStatus::InProgress);
+    let mut active_child = make_task("child-1", "task", TaskStatus::InProgress);
+    active_child.parent_id = Some("epic-1".to_string());
+
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![epic, active_child],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let error = service
+        .set_plan(
+            repo_path,
+            "epic-1",
+            "# Epic Plan",
+            Some(vec![PlanSubtaskInput {
+                title: "Build API".to_string(),
+                issue_type: Some(IssueType::Task),
+                priority: Some(2),
+                description: None,
+            }]),
+        )
+        .expect_err("active direct subtasks must block explicit replacement");
+    assert!(
+        error
+            .to_string()
+            .contains("Cannot replace epic subtasks while active work exists"),
+        "unexpected error: {error}"
+    );
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert!(task_state.plan_set_calls.is_empty());
     assert!(task_state.delete_calls.is_empty());
     assert!(task_state.created_inputs.is_empty());
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1520,69 +1520,6 @@ fn set_spec_persists_trimmed_markdown_and_transitions_open_task() -> Result<()> 
 }
 
 #[test]
-fn set_spec_allows_active_and_review_statuses_without_status_transition() -> Result<()> {
-    for status in [
-        TaskStatus::Blocked,
-        TaskStatus::InProgress,
-        TaskStatus::AiReview,
-        TaskStatus::HumanReview,
-    ] {
-        let repo_path = format!("/tmp/odt-repo-spec-active-{}", status.as_cli_value());
-        let (service, task_state, _git_state) = build_service_with_git_state(
-            vec![make_task("task-1", "task", status.clone())],
-            vec![],
-            GitCurrentBranch {
-                name: Some("main".to_string()),
-                detached: false,
-                revision: None,
-            },
-        );
-
-        let spec = service.set_spec(repo_path.as_str(), "task-1", "  # Revised Spec  ")?;
-        assert_eq!(spec.markdown, "# Revised Spec");
-
-        let task_state = task_state.lock().expect("task lock poisoned");
-        assert_eq!(
-            task_state.spec_set_calls,
-            vec![("task-1".to_string(), "# Revised Spec".to_string())]
-        );
-        assert!(
-            !task_state
-                .updated_patches
-                .iter()
-                .any(|(_, patch)| patch.status.is_some()),
-            "status update should be skipped for {}",
-            status.as_cli_value()
-        );
-    }
-
-    Ok(())
-}
-
-#[test]
-fn set_spec_rejects_deferred_and_closed_statuses() {
-    for status in [TaskStatus::Deferred, TaskStatus::Closed] {
-        let repo_path = format!("/tmp/odt-repo-spec-invalid-{}", status.as_cli_value());
-        let (service, task_state, _git_state) = build_service_with_git_state(
-            vec![make_task("task-1", "task", status.clone())],
-            vec![],
-            GitCurrentBranch {
-                name: Some("main".to_string()),
-                detached: false,
-                revision: None,
-            },
-        );
-
-        let error = service
-            .set_spec(repo_path.as_str(), "task-1", "# Spec")
-            .expect_err("set_spec should be blocked in deferred/closed");
-        assert!(error.to_string().contains("set_spec is only allowed"));
-        let task_state = task_state.lock().expect("task lock poisoned");
-        assert!(task_state.spec_set_calls.is_empty());
-    }
-}
-
-#[test]
 fn set_spec_allows_ready_for_dev_without_status_transition() -> Result<()> {
     let repo_path = "/tmp/odt-repo-spec-ready";
     let (service, task_state, _git_state) = build_service_with_git_state(
@@ -1671,53 +1608,6 @@ fn set_plan_allows_feature_from_ready_for_dev_without_status_transition() -> Res
 }
 
 #[test]
-fn set_plan_allows_active_and_review_statuses_without_status_transition() -> Result<()> {
-    for issue_type in ["task", "bug", "feature", "epic"] {
-        for status in [
-            TaskStatus::Blocked,
-            TaskStatus::InProgress,
-            TaskStatus::AiReview,
-            TaskStatus::HumanReview,
-        ] {
-            let repo_path = format!(
-                "/tmp/odt-repo-plan-active-{issue_type}-{}",
-                status.as_cli_value()
-            );
-            let (service, task_state, _git_state) = build_service_with_git_state(
-                vec![make_task("task-1", issue_type, status.clone())],
-                vec![],
-                GitCurrentBranch {
-                    name: Some("main".to_string()),
-                    detached: false,
-                    revision: None,
-                },
-            );
-
-            let plan = service.set_plan(repo_path.as_str(), "task-1", "  # Revised Plan  ", None)?;
-            assert_eq!(plan.markdown, "# Revised Plan");
-
-            let task_state = task_state.lock().expect("task lock poisoned");
-            assert_eq!(
-                task_state.plan_set_calls,
-                vec![("task-1".to_string(), "# Revised Plan".to_string())]
-            );
-            assert!(task_state.created_inputs.is_empty());
-            assert!(task_state.delete_calls.is_empty());
-            assert!(
-                !task_state
-                    .updated_patches
-                    .iter()
-                    .any(|(_, patch)| patch.status.is_some()),
-                "status update should be skipped for {issue_type} {}",
-                status.as_cli_value()
-            );
-        }
-    }
-
-    Ok(())
-}
-
-#[test]
 fn set_plan_rejects_invalid_status_for_feature() {
     let repo_path = "/tmp/odt-repo-plan-invalid";
     let (service, _task_state, _git_state) = build_service_with_git_state(
@@ -1734,34 +1624,6 @@ fn set_plan_rejects_invalid_status_for_feature() {
         .set_plan(repo_path, "task-1", "# Plan", None)
         .expect_err("feature/open should not allow plan");
     assert!(error.to_string().contains("set_plan is not allowed"));
-}
-
-#[test]
-fn set_plan_rejects_deferred_and_closed_statuses() {
-    for issue_type in ["task", "bug", "feature", "epic"] {
-        for status in [TaskStatus::Deferred, TaskStatus::Closed] {
-            let repo_path = format!(
-                "/tmp/odt-repo-plan-invalid-{issue_type}-{}",
-                status.as_cli_value()
-            );
-            let (service, task_state, _git_state) = build_service_with_git_state(
-                vec![make_task("task-1", issue_type, status.clone())],
-                vec![],
-                GitCurrentBranch {
-                    name: Some("main".to_string()),
-                    detached: false,
-                    revision: None,
-                },
-            );
-
-            let error = service
-                .set_plan(repo_path.as_str(), "task-1", "# Plan", None)
-                .expect_err("set_plan should be blocked in deferred/closed");
-            assert!(error.to_string().contains("set_plan is not allowed"));
-            let task_state = task_state.lock().expect("task lock poisoned");
-            assert!(task_state.plan_set_calls.is_empty());
-        }
-    }
 }
 
 #[test]
@@ -1833,8 +1695,8 @@ fn set_plan_for_epic_replaces_existing_subtasks_with_new_plan_proposals() -> Res
 }
 
 #[test]
-fn set_plan_for_epic_without_subtasks_clears_existing_direct_subtasks() -> Result<()> {
-    let repo_path = "/tmp/odt-repo-plan-epic-clear";
+fn set_plan_for_epic_without_subtasks_preserves_existing_direct_subtasks() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-plan-epic-preserve";
     let epic = make_task("epic-1", "epic", TaskStatus::SpecReady);
     let mut existing_child = make_task("child-1", "task", TaskStatus::Open);
     existing_child.parent_id = Some("epic-1".to_string());
@@ -1853,52 +1715,12 @@ fn set_plan_for_epic_without_subtasks_clears_existing_direct_subtasks() -> Resul
     assert_eq!(plan.markdown, "# Epic Plan");
 
     let task_state = task_state.lock().expect("task lock poisoned");
-    assert_eq!(
-        task_state.delete_calls,
-        vec![("child-1".to_string(), false)]
-    );
+    assert!(task_state.delete_calls.is_empty());
     assert!(task_state.created_inputs.is_empty());
     assert!(task_state
         .updated_patches
         .iter()
         .any(|(_, patch)| patch.status == Some(TaskStatus::ReadyForDev)));
-    Ok(())
-}
-
-#[test]
-fn set_plan_for_active_epic_without_subtasks_preserves_existing_direct_subtasks() -> Result<()> {
-    let repo_path = "/tmp/odt-repo-plan-active-epic-preserve";
-    let epic = make_task("epic-1", "epic", TaskStatus::InProgress);
-    let mut existing_child = make_task("child-1", "task", TaskStatus::Open);
-    existing_child.parent_id = Some("epic-1".to_string());
-
-    let (service, task_state, _git_state) = build_service_with_git_state(
-        vec![epic, existing_child],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-    );
-
-    let plan = service.set_plan(repo_path, "epic-1", "# Revised Epic Plan", None)?;
-    assert_eq!(plan.markdown, "# Revised Epic Plan");
-
-    let task_state = task_state.lock().expect("task lock poisoned");
-    assert_eq!(
-        task_state.plan_set_calls,
-        vec![("epic-1".to_string(), "# Revised Epic Plan".to_string())]
-    );
-    assert!(task_state.delete_calls.is_empty());
-    assert!(task_state.created_inputs.is_empty());
-    assert!(
-        !task_state
-            .updated_patches
-            .iter()
-            .any(|(_, patch)| patch.status.is_some()),
-        "status update should be skipped for active epic revisions"
-    );
     Ok(())
 }
 
@@ -1932,49 +1754,6 @@ fn set_plan_for_epic_rejects_subtask_replacement_when_existing_subtask_is_active
             }]),
         )
         .expect_err("active direct subtasks must block replacement");
-    assert!(
-        error
-            .to_string()
-            .contains("Cannot replace epic subtasks while active work exists"),
-        "unexpected error: {error}"
-    );
-
-    let task_state = task_state.lock().expect("task lock poisoned");
-    assert!(task_state.plan_set_calls.is_empty());
-    assert!(task_state.delete_calls.is_empty());
-    assert!(task_state.created_inputs.is_empty());
-}
-
-#[test]
-fn set_plan_for_active_epic_rejects_explicit_subtask_replacement_before_persisting_plan() {
-    let repo_path = "/tmp/odt-repo-plan-active-epic-active-subtask";
-    let epic = make_task("epic-1", "epic", TaskStatus::InProgress);
-    let mut active_child = make_task("child-1", "task", TaskStatus::InProgress);
-    active_child.parent_id = Some("epic-1".to_string());
-
-    let (service, task_state, _git_state) = build_service_with_git_state(
-        vec![epic, active_child],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-    );
-
-    let error = service
-        .set_plan(
-            repo_path,
-            "epic-1",
-            "# Epic Plan",
-            Some(vec![PlanSubtaskInput {
-                title: "Build API".to_string(),
-                issue_type: Some(IssueType::Task),
-                priority: Some(2),
-                description: None,
-            }]),
-        )
-        .expect_err("active direct subtasks must block explicit replacement");
     assert!(
         error
             .to_string()

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_document_revisions.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_document_revisions.rs
@@ -1,0 +1,220 @@
+use anyhow::Result;
+use host_domain::{GitCurrentBranch, IssueType, PlanSubtaskInput, TaskStatus};
+
+use crate::app_service::test_support::{build_service_with_git_state, make_task};
+
+fn main_branch() -> GitCurrentBranch {
+    GitCurrentBranch {
+        name: Some("main".to_string()),
+        detached: false,
+        revision: None,
+    }
+}
+
+#[test]
+fn set_spec_allows_active_and_review_statuses_without_status_transition() -> Result<()> {
+    for status in [
+        TaskStatus::Blocked,
+        TaskStatus::InProgress,
+        TaskStatus::AiReview,
+        TaskStatus::HumanReview,
+    ] {
+        let repo_path = format!("/tmp/odt-repo-spec-active-{}", status.as_cli_value());
+        let (service, task_state, _git_state) = build_service_with_git_state(
+            vec![make_task("task-1", "task", status.clone())],
+            vec![],
+            main_branch(),
+        );
+
+        let spec = service.set_spec(repo_path.as_str(), "task-1", "  # Revised Spec  ")?;
+        assert_eq!(spec.markdown, "# Revised Spec");
+
+        let task_state = task_state.lock().expect("task lock poisoned");
+        assert_eq!(
+            task_state.spec_set_calls,
+            vec![("task-1".to_string(), "# Revised Spec".to_string())]
+        );
+        assert!(
+            !task_state
+                .updated_patches
+                .iter()
+                .any(|(_, patch)| patch.status.is_some()),
+            "status update should be skipped for {}",
+            status.as_cli_value()
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn set_spec_rejects_deferred_and_closed_statuses() {
+    for status in [TaskStatus::Deferred, TaskStatus::Closed] {
+        let repo_path = format!("/tmp/odt-repo-spec-invalid-{}", status.as_cli_value());
+        let (service, task_state, _git_state) = build_service_with_git_state(
+            vec![make_task("task-1", "task", status)],
+            vec![],
+            main_branch(),
+        );
+
+        let error = service
+            .set_spec(repo_path.as_str(), "task-1", "# Spec")
+            .expect_err("set_spec should be blocked in deferred/closed");
+        assert!(error.to_string().contains("set_spec is only allowed"));
+        let task_state = task_state.lock().expect("task lock poisoned");
+        assert!(task_state.spec_set_calls.is_empty());
+    }
+}
+
+#[test]
+fn set_plan_allows_active_and_review_statuses_without_status_transition() -> Result<()> {
+    for issue_type in ["task", "bug", "feature", "epic"] {
+        for status in [
+            TaskStatus::Blocked,
+            TaskStatus::InProgress,
+            TaskStatus::AiReview,
+            TaskStatus::HumanReview,
+        ] {
+            let repo_path = format!(
+                "/tmp/odt-repo-plan-active-{issue_type}-{}",
+                status.as_cli_value()
+            );
+            let (service, task_state, _git_state) = build_service_with_git_state(
+                vec![make_task("task-1", issue_type, status.clone())],
+                vec![],
+                main_branch(),
+            );
+
+            let plan =
+                service.set_plan(repo_path.as_str(), "task-1", "  # Revised Plan  ", None)?;
+            assert_eq!(plan.markdown, "# Revised Plan");
+
+            let task_state = task_state.lock().expect("task lock poisoned");
+            assert_eq!(
+                task_state.plan_set_calls,
+                vec![("task-1".to_string(), "# Revised Plan".to_string())]
+            );
+            assert!(task_state.created_inputs.is_empty());
+            assert!(task_state.delete_calls.is_empty());
+            assert!(
+                !task_state
+                    .updated_patches
+                    .iter()
+                    .any(|(_, patch)| patch.status.is_some()),
+                "status update should be skipped for {issue_type} {}",
+                status.as_cli_value()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn set_plan_rejects_deferred_and_closed_statuses() {
+    for issue_type in ["task", "bug", "feature", "epic"] {
+        for status in [TaskStatus::Deferred, TaskStatus::Closed] {
+            let repo_path = format!(
+                "/tmp/odt-repo-plan-invalid-{issue_type}-{}",
+                status.as_cli_value()
+            );
+            let (service, task_state, _git_state) = build_service_with_git_state(
+                vec![make_task("task-1", issue_type, status)],
+                vec![],
+                main_branch(),
+            );
+
+            let error = service
+                .set_plan(repo_path.as_str(), "task-1", "# Plan", None)
+                .expect_err("set_plan should be blocked in deferred/closed");
+            assert!(error.to_string().contains("set_plan is not allowed"));
+            let task_state = task_state.lock().expect("task lock poisoned");
+            assert!(task_state.plan_set_calls.is_empty());
+        }
+    }
+}
+
+#[test]
+fn set_plan_rejects_feature_and_epic_open_statuses() {
+    for issue_type in ["feature", "epic"] {
+        let repo_path = format!("/tmp/odt-repo-plan-invalid-{issue_type}-open");
+        let (service, task_state, _git_state) = build_service_with_git_state(
+            vec![make_task("task-1", issue_type, TaskStatus::Open)],
+            vec![],
+            main_branch(),
+        );
+
+        let error = service
+            .set_plan(repo_path.as_str(), "task-1", "# Plan", None)
+            .expect_err("feature/epic open should not allow plan");
+        assert!(error.to_string().contains("set_plan is not allowed"));
+        let task_state = task_state.lock().expect("task lock poisoned");
+        assert!(task_state.plan_set_calls.is_empty());
+    }
+}
+
+#[test]
+fn set_plan_for_active_epic_without_subtasks_preserves_existing_direct_subtasks() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-plan-active-epic-preserve";
+    let epic = make_task("epic-1", "epic", TaskStatus::InProgress);
+    let mut existing_child = make_task("child-1", "task", TaskStatus::Open);
+    existing_child.parent_id = Some("epic-1".to_string());
+
+    let (service, task_state, _git_state) =
+        build_service_with_git_state(vec![epic, existing_child], vec![], main_branch());
+
+    let plan = service.set_plan(repo_path, "epic-1", "# Revised Epic Plan", None)?;
+    assert_eq!(plan.markdown, "# Revised Epic Plan");
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(
+        task_state.plan_set_calls,
+        vec![("epic-1".to_string(), "# Revised Epic Plan".to_string())]
+    );
+    assert!(task_state.delete_calls.is_empty());
+    assert!(task_state.created_inputs.is_empty());
+    assert!(
+        !task_state
+            .updated_patches
+            .iter()
+            .any(|(_, patch)| patch.status.is_some()),
+        "status update should be skipped for active epic revisions"
+    );
+    Ok(())
+}
+
+#[test]
+fn set_plan_for_active_epic_rejects_explicit_subtask_replacement_before_persisting_plan() {
+    let repo_path = "/tmp/odt-repo-plan-active-epic-active-subtask";
+    let epic = make_task("epic-1", "epic", TaskStatus::InProgress);
+    let mut active_child = make_task("child-1", "task", TaskStatus::InProgress);
+    active_child.parent_id = Some("epic-1".to_string());
+
+    let (service, task_state, _git_state) =
+        build_service_with_git_state(vec![epic, active_child], vec![], main_branch());
+
+    let error = service
+        .set_plan(
+            repo_path,
+            "epic-1",
+            "# Epic Plan",
+            Some(vec![PlanSubtaskInput {
+                title: "Build API".to_string(),
+                issue_type: Some(IssueType::Task),
+                priority: Some(2),
+                description: None,
+            }]),
+        )
+        .expect_err("active direct subtasks must block explicit replacement");
+    assert!(
+        error
+            .to_string()
+            .contains("Cannot replace epic subtasks while active work exists"),
+        "unexpected error: {error}"
+    );
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert!(task_state.plan_set_calls.is_empty());
+    assert!(task_state.delete_calls.is_empty());
+    assert!(task_state.created_inputs.is_empty());
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_document_revisions.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_document_revisions.rs
@@ -184,6 +184,36 @@ fn set_plan_for_active_epic_without_subtasks_preserves_existing_direct_subtasks(
 }
 
 #[test]
+fn set_plan_for_ready_epic_without_subtasks_preserves_existing_direct_subtasks() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-plan-ready-epic-preserve";
+    let epic = make_task("epic-1", "epic", TaskStatus::ReadyForDev);
+    let mut existing_child = make_task("child-1", "task", TaskStatus::Open);
+    existing_child.parent_id = Some("epic-1".to_string());
+
+    let (service, task_state, _git_state) =
+        build_service_with_git_state(vec![epic, existing_child], vec![], main_branch());
+
+    let plan = service.set_plan(repo_path, "epic-1", "# Revised Epic Plan", None)?;
+    assert_eq!(plan.markdown, "# Revised Epic Plan");
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(
+        task_state.plan_set_calls,
+        vec![("epic-1".to_string(), "# Revised Epic Plan".to_string())]
+    );
+    assert!(task_state.delete_calls.is_empty());
+    assert!(task_state.created_inputs.is_empty());
+    assert!(
+        !task_state
+            .updated_patches
+            .iter()
+            .any(|(_, patch)| patch.status.is_some()),
+        "status update should be skipped for ready_for_dev epic revisions"
+    );
+    Ok(())
+}
+
+#[test]
 fn set_plan_for_active_epic_rejects_explicit_subtask_replacement_before_persisting_plan() {
     let repo_path = "/tmp/odt-repo-plan-active-epic-active-subtask";
     let epic = make_task("epic-1", "epic", TaskStatus::InProgress);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/workflow_rules.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/workflow_rules.rs
@@ -158,7 +158,12 @@ fn spec_and_plan_write_status_guards_follow_matrix() {
     assert!(can_set_spec_from_status(&TaskStatus::Open));
     assert!(can_set_spec_from_status(&TaskStatus::SpecReady));
     assert!(can_set_spec_from_status(&TaskStatus::ReadyForDev));
-    assert!(!can_set_spec_from_status(&TaskStatus::InProgress));
+    assert!(can_set_spec_from_status(&TaskStatus::InProgress));
+    assert!(can_set_spec_from_status(&TaskStatus::Blocked));
+    assert!(can_set_spec_from_status(&TaskStatus::AiReview));
+    assert!(can_set_spec_from_status(&TaskStatus::HumanReview));
+    assert!(!can_set_spec_from_status(&TaskStatus::Deferred));
+    assert!(!can_set_spec_from_status(&TaskStatus::Closed));
 
     let epic_open = make_task("epic-open", "epic", TaskStatus::Open);
     let epic_spec_ready = make_task("epic-spec", "epic", TaskStatus::SpecReady);
@@ -170,6 +175,13 @@ fn spec_and_plan_write_status_guards_follow_matrix() {
     let bug_open = make_task("bug-open", "bug", TaskStatus::Open);
     let bug_ready_for_dev = make_task("bug-ready", "bug", TaskStatus::ReadyForDev);
     let feature_in_progress = make_task("feature-progress", "feature", TaskStatus::InProgress);
+    let task_in_progress = make_task("task-progress", "task", TaskStatus::InProgress);
+    let bug_blocked = make_task("bug-blocked", "bug", TaskStatus::Blocked);
+    let epic_ai_review = make_task("epic-ai-review", "epic", TaskStatus::AiReview);
+    let feature_human_review =
+        make_task("feature-human-review", "feature", TaskStatus::HumanReview);
+    let task_deferred = make_task("task-deferred", "task", TaskStatus::Deferred);
+    let task_closed = make_task("task-closed", "task", TaskStatus::Closed);
 
     assert!(!can_set_plan(&epic_open));
     assert!(can_set_plan(&epic_spec_ready));
@@ -180,7 +192,13 @@ fn spec_and_plan_write_status_guards_follow_matrix() {
     assert!(can_set_plan(&task_ready_for_dev));
     assert!(can_set_plan(&bug_open));
     assert!(can_set_plan(&bug_ready_for_dev));
-    assert!(!can_set_plan(&feature_in_progress));
+    assert!(can_set_plan(&feature_in_progress));
+    assert!(can_set_plan(&task_in_progress));
+    assert!(can_set_plan(&bug_blocked));
+    assert!(can_set_plan(&epic_ai_review));
+    assert!(can_set_plan(&feature_human_review));
+    assert!(!can_set_plan(&task_deferred));
+    assert!(!can_set_plan(&task_closed));
 }
 
 #[test]
@@ -247,15 +265,15 @@ fn bug_in_open_can_start_build_directly() {
 }
 
 #[test]
-fn in_progress_tasks_expose_builder_action_and_no_plan_actions() {
+fn in_progress_tasks_expose_builder_action_and_document_revision_actions() {
     let task = make_task("task-1", "task", TaskStatus::InProgress);
     let actions = derive_available_actions(&task, std::slice::from_ref(&task));
     assert!(actions.contains(&TaskAction::OpenBuilder));
     assert!(actions.contains(&TaskAction::ResetImplementation));
     assert!(!actions.contains(&TaskAction::BuildStart));
     assert!(!actions.contains(&TaskAction::OpenQa));
-    assert!(!actions.contains(&TaskAction::SetSpec));
-    assert!(!actions.contains(&TaskAction::SetPlan));
+    assert!(actions.contains(&TaskAction::SetSpec));
+    assert!(actions.contains(&TaskAction::SetPlan));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/mod.rs
@@ -3,7 +3,8 @@ mod validators;
 
 pub(crate) use transitions::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
-    default_qa_required_for_issue_type, derive_agent_workflows, is_open_state,
+    default_qa_required_for_issue_type, derive_agent_workflows, is_active_or_review_status,
+    is_open_state,
 };
 pub(crate) use validators::{
     can_reset_implementation_from_status, can_reset_task_from_status, derive_available_actions,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
@@ -61,6 +61,47 @@ fn module_derive_available_actions_exposes_qa_start_for_review_states() {
 }
 
 #[test]
+fn module_derive_available_actions_exposes_document_updates_for_active_and_review_states() {
+    for issue_type in ["epic", "feature", "task", "bug"] {
+        for status in [
+            TaskStatus::InProgress,
+            TaskStatus::Blocked,
+            TaskStatus::AiReview,
+            TaskStatus::HumanReview,
+        ] {
+            let task = make_task("task-1", issue_type, status);
+
+            let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+
+            assert!(
+                actions.contains(&TaskAction::SetSpec),
+                "set_spec missing for {issue_type} {}",
+                task.status.as_cli_value()
+            );
+            assert!(
+                actions.contains(&TaskAction::SetPlan),
+                "set_plan missing for {issue_type} {}",
+                task.status.as_cli_value()
+            );
+        }
+    }
+}
+
+#[test]
+fn module_derive_available_actions_hides_document_updates_for_terminal_or_deferred_states() {
+    for issue_type in ["epic", "feature", "task", "bug"] {
+        for status in [TaskStatus::Deferred, TaskStatus::Closed] {
+            let task = make_task("task-1", issue_type, status);
+
+            let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+
+            assert!(!actions.contains(&TaskAction::SetSpec));
+            assert!(!actions.contains(&TaskAction::SetPlan));
+        }
+    }
+}
+
+#[test]
 fn module_derive_available_actions_exposes_rework_and_open_qa_for_qa_rejected_tasks() {
     let mut task = make_task("task-1", "task", TaskStatus::InProgress);
     task.document_summary.qa_report.has = true;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/transitions.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/transitions.rs
@@ -161,7 +161,23 @@ pub(crate) fn allows_transition(task: &TaskCard, from: &TaskStatus, to: &TaskSta
 pub(crate) fn can_set_spec_from_status(status: &TaskStatus) -> bool {
     matches!(
         status,
-        TaskStatus::Open | TaskStatus::SpecReady | TaskStatus::ReadyForDev
+        TaskStatus::Open
+            | TaskStatus::SpecReady
+            | TaskStatus::ReadyForDev
+            | TaskStatus::InProgress
+            | TaskStatus::Blocked
+            | TaskStatus::AiReview
+            | TaskStatus::HumanReview
+    )
+}
+
+pub(crate) fn is_active_or_review_status(status: &TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::InProgress
+            | TaskStatus::Blocked
+            | TaskStatus::AiReview
+            | TaskStatus::HumanReview
     )
 }
 
@@ -169,11 +185,14 @@ pub(crate) fn can_set_plan(task: &TaskCard) -> bool {
     match task.issue_type {
         IssueType::Epic | IssueType::Feature => {
             matches!(task.status, TaskStatus::SpecReady | TaskStatus::ReadyForDev)
+                || is_active_or_review_status(&task.status)
         }
-        IssueType::Task | IssueType::Bug => matches!(
-            task.status,
-            TaskStatus::Open | TaskStatus::SpecReady | TaskStatus::ReadyForDev
-        ),
+        IssueType::Task | IssueType::Bug => {
+            matches!(
+                task.status,
+                TaskStatus::Open | TaskStatus::SpecReady | TaskStatus::ReadyForDev
+            ) || is_active_or_review_status(&task.status)
+        }
     }
 }
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -373,7 +373,7 @@ describe("AgentChatMessageCard tool duration", () => {
             status: "error",
             input: { taskId: "fairnest-99z" },
             error:
-              "set_spec is only allowed from open/spec_ready/ready_for_dev (current: in_progress)",
+              "set_spec is only allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review (current: deferred)",
           },
         },
         sessionRole: "spec",

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -2200,7 +2200,8 @@ describe("agent-orchestrator-session-events", () => {
         callId: "call-guard",
         tool: "odt_set_spec",
         status: "error",
-        error: "set_spec is only allowed from open/spec_ready/ready_for_dev (current: in_progress)",
+        error:
+          "set_spec is only allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review (current: deferred)",
       },
     });
 

--- a/docs/contracts/workflow-contract-fixture.json
+++ b/docs/contracts/workflow-contract-fixture.json
@@ -81,12 +81,20 @@
       "closed": []
     }
   },
-  "setSpecAllowedStatuses": ["open", "spec_ready", "ready_for_dev"],
+  "setSpecAllowedStatuses": [
+    "open",
+    "spec_ready",
+    "ready_for_dev",
+    "in_progress",
+    "blocked",
+    "ai_review",
+    "human_review"
+  ],
   "setPlanAllowedStatuses": {
-    "epic": ["spec_ready", "ready_for_dev"],
-    "feature": ["spec_ready", "ready_for_dev"],
-    "task": ["open", "spec_ready", "ready_for_dev"],
-    "bug": ["open", "spec_ready", "ready_for_dev"]
+    "epic": ["spec_ready", "ready_for_dev", "in_progress", "blocked", "ai_review", "human_review"],
+    "feature": ["spec_ready", "ready_for_dev", "in_progress", "blocked", "ai_review", "human_review"],
+    "task": ["open", "spec_ready", "ready_for_dev", "in_progress", "blocked", "ai_review", "human_review"],
+    "bug": ["open", "spec_ready", "ready_for_dev", "in_progress", "blocked", "ai_review", "human_review"]
   },
   "resetImplementationAllowedStatuses": ["in_progress", "blocked", "ai_review", "human_review"],
   "resetTaskAllowedStatuses": [

--- a/docs/task-workflow-actions.md
+++ b/docs/task-workflow-actions.md
@@ -36,13 +36,16 @@ The backend is the single source of truth for which actions are currently allowe
 
 ### `set_spec`
 - Purpose: author or revise the specification markdown.
-- Transition: `open -> spec_ready`, or stays in place when already `spec_ready` or `ready_for_dev`.
+- Allowed from `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review`.
+- Transition: `open -> spec_ready`; all other allowed statuses stay in place as document-only revisions.
 
 ### `set_plan`
 - Purpose: author or revise implementation plan markdown.
-- Transition:
-  - `feature/epic`: allowed from `spec_ready` and `ready_for_dev` (`ready_for_dev` remains `ready_for_dev`).
-  - `task/bug`: allowed from `open`, `spec_ready`, and `ready_for_dev` (`ready_for_dev` remains `ready_for_dev`).
+- Allowed statuses:
+  - `feature/epic`: `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review`.
+  - `task/bug`: `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review`.
+- Transition: valid pre-build planning moves to `ready_for_dev`; `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review` stay in place as document-only revisions.
+- Epic subtask proposals are replacement intent; replacing existing direct subtasks is allowed only when those subtasks are still `open`, `spec_ready`, or `ready_for_dev`. Omitting `subtasks` during active/review epic revisions preserves existing direct subtasks.
 
 ### `build_start`
 - Purpose: start build execution for this task.

--- a/docs/task-workflow-actions.md
+++ b/docs/task-workflow-actions.md
@@ -45,7 +45,7 @@ The backend is the single source of truth for which actions are currently allowe
   - `feature/epic`: `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review`.
   - `task/bug`: `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review`.
 - Transition: valid pre-build planning moves to `ready_for_dev`; `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, and `human_review` stay in place as document-only revisions.
-- Epic subtask proposals are replacement intent; replacing existing direct subtasks is allowed only when those subtasks are still `open`, `spec_ready`, or `ready_for_dev`. Omitting `subtasks` during active/review epic revisions preserves existing direct subtasks.
+- Epic subtask proposals are replacement intent; replacing existing direct subtasks is allowed only when those subtasks are still `open`, `spec_ready`, or `ready_for_dev`. Omitting `subtasks` preserves existing direct subtasks.
 
 ### `build_start`
 - Purpose: start build execution for this task.

--- a/docs/task-workflow-status-model.md
+++ b/docs/task-workflow-status-model.md
@@ -54,9 +54,10 @@ Removed from OpenDucktor UI scope:
 ## Type-Specific Flow Rules
 - `feature` and `epic` follow the standard path:
   `open -> spec_ready -> ready_for_dev -> in_progress -> ai_review/human_review -> closed`
-- `feature` and `epic` cannot start planning directly from `open`; `set_plan` is allowed from `spec_ready` and `ready_for_dev`.
+- `feature` and `epic` cannot start planning directly from `open`; `set_plan` is allowed from `spec_ready`, `ready_for_dev`, and later active/review states as document revisions.
 - `task` and `bug` may skip spec/planning:
   `open -> in_progress`
+- Spec and plan documents can be revised during `in_progress`, `blocked`, `ai_review`, and `human_review` without changing task status.
 
 ## QA Requirement Defaults
 `qaRequired` defaults by issue type:

--- a/docs/task-workflow-transition-matrix.md
+++ b/docs/task-workflow-transition-matrix.md
@@ -46,10 +46,10 @@ Native task actions:
 | Trigger | From | Guards | To |
 |---|---|---|---|
 | `task_create` | n/a | always | `open` |
-| `odt_set_spec` | `open`, `spec_ready`, `ready_for_dev` | non-empty markdown | `spec_ready` when starting from `open`, otherwise unchanged |
-| `odt_set_plan` (feature/epic) | `spec_ready`, `ready_for_dev` | non-empty markdown | `ready_for_dev` |
-| `odt_set_plan` (task/bug) | `open`, `spec_ready`, `ready_for_dev` | non-empty markdown | `ready_for_dev` |
-| `odt_set_plan` (epic with subtasks) | `spec_ready`, `ready_for_dev` | plan includes subtask proposals | `ready_for_dev` |
+| `odt_set_spec` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | non-empty markdown | `spec_ready` when starting from `open`, otherwise unchanged |
+| `odt_set_plan` (feature/epic) | `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | non-empty markdown | `ready_for_dev` when starting from `spec_ready`, otherwise unchanged |
+| `odt_set_plan` (task/bug) | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | non-empty markdown | `ready_for_dev` when starting from `open` or `spec_ready`, otherwise unchanged |
+| `odt_set_plan` (epic with subtasks) | `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | plan includes subtask proposals; replacing existing direct subtasks requires all direct subtasks to be `open`, `spec_ready`, or `ready_for_dev` | `ready_for_dev` when starting from `spec_ready`, otherwise unchanged |
 | `odt_build_resumed` | `ready_for_dev` | feature/epic standard flow | `in_progress` |
 | `odt_build_resumed` | `open`, `spec_ready`, `ready_for_dev`, `blocked` | task/bug optional flow + blocked resume | `in_progress` |
 | `odt_build_blocked` | `in_progress` | reason required | `blocked` |

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -435,7 +435,7 @@ describe("stream-part-mapper", () => {
           error: {
             code: "ODT_TOOL_EXECUTION_ERROR",
             message:
-              "set_spec is only allowed from open/spec_ready/ready_for_dev (current: in_progress)",
+              "set_spec is only allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review (current: deferred)",
           },
         },
       },
@@ -451,14 +451,15 @@ describe("stream-part-mapper", () => {
       status: "error",
       input: { taskId: "task-1" },
       preview: "task-1",
-      error: "set_spec is only allowed from open/spec_ready/ready_for_dev (current: in_progress)",
+      error:
+        "set_spec is only allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review (current: deferred)",
       metadata: {
         structuredContent: {
           ok: false,
           error: {
             code: "ODT_TOOL_EXECUTION_ERROR",
             message:
-              "set_spec is only allowed from open/spec_ready/ready_for_dev (current: in_progress)",
+              "set_spec is only allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review (current: deferred)",
           },
         },
       },

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -56,6 +56,10 @@ describe("buildAgentSystemPrompt", () => {
       "governing constitution for the current task",
       "higher-trust inputs than conversational summaries",
       "Treat the odt_read_task response as the latest persisted workflow summary",
+      "odt_set_spec allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review",
+      "odt_set_plan for feature/epic allowed from spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review.",
+      "odt_set_plan for task/bug allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review.",
+      "document-only revisions",
     ]);
     expect(prompt).not.toContain("Existing documents:");
     expect(prompt).not.toContain("- spec: # Purpose");

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -149,9 +149,10 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
       bulletSection("Lifecycle contract", [
         "Feature/epic flow: open -> spec_ready -> ready_for_dev -> in_progress -> ai_review/human_review -> closed.",
         "Task/bug may skip planning and go open -> in_progress.",
-        "odt_set_spec allowed from open/spec_ready/ready_for_dev.",
-        "odt_set_plan for feature/epic allowed from spec_ready/ready_for_dev.",
-        "odt_set_plan for task/bug allowed from open/spec_ready/ready_for_dev.",
+        "odt_set_spec allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review; only open -> spec_ready changes status, all other allowed statuses are document-only revisions.",
+        "odt_set_plan for feature/epic allowed from spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review.",
+        "odt_set_plan for task/bug allowed from open/spec_ready/ready_for_dev/in_progress/blocked/ai_review/human_review.",
+        "odt_set_plan changes status only for valid pre-build progression to ready_for_dev; in_progress/blocked/ai_review/human_review calls are document-only revisions.",
         "For odt_set_plan subtasks, priority must be an integer 0..4 (default 2).",
         "odt_build_completed from in_progress transitions to ai_review only when qaRequired=true and the latest QA verdict is not approved; otherwise it transitions to human_review.",
         "odt_qa_rejected transitions ai_review/human_review -> in_progress.",

--- a/packages/core/src/types/workflow-docs.contract.test.ts
+++ b/packages/core/src/types/workflow-docs.contract.test.ts
@@ -40,10 +40,10 @@ describe("workflow docs contract", () => {
     );
 
     expect(transitionDoc).toMatch(
-      /\| `odt_set_plan` \(feature\/epic\) \| `spec_ready`, `ready_for_dev` \|/,
+      /\| `odt_set_plan` \(feature\/epic\) \| `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` \|/,
     );
     expect(transitionDoc).toMatch(
-      /\| `odt_set_plan` \(task\/bug\) \| `open`, `spec_ready`, `ready_for_dev` \|/,
+      /\| `odt_set_plan` \(task\/bug\) \| `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` \|/,
     );
   });
 

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -168,12 +168,12 @@ const ODT_REGISTERED_TOOL_SPECS: Readonly<RegisteredToolSpecs> = {
   },
   odt_set_spec: {
     description:
-      "Persist specification markdown for a task and transition open->spec_ready when needed.",
+      "Persist specification markdown for a task. Transitions open->spec_ready only when starting from open; allowed revisions from later active/review states leave status unchanged.",
     execute: (store, input) => store.setSpec(input),
   },
   odt_set_plan: {
     description:
-      "Persist implementation plan markdown and transition task to ready_for_dev (with optional epic subtask proposals). Subtask priority values must be integers in [0, 4], default 2.",
+      "Persist implementation plan markdown. Valid pre-build planning transitions to ready_for_dev; allowed revisions from active/review states leave status unchanged. Optional epic subtask proposal priority values must be integers in [0, 4], default 2.",
     execute: (store, input) => store.setPlan(input),
   },
   odt_build_blocked: {


### PR DESCRIPTION
## Summary
- Allow spec and plan document revisions from active/review workflow statuses without changing task status.
- Keep closed/deferred rejection and pre-build lifecycle transitions intact.
- Add registered Rust coverage, contract/docs updates, and prompt/MCP wording for the revised workflow rules.

## Goal and context
Spec and planner roles need to revise task documents after work has already moved into `in_progress`, `blocked`, `ai_review`, or `human_review`. Previously those document updates were rejected even though the operation only needed to update task metadata, which blocked legitimate workflow corrections during build and review cycles.

The PR preserves the existing lifecycle model: `open` spec creation still moves to `spec_ready`, valid pre-build planning still moves tasks to `ready_for_dev`, and `closed`/`deferred` remain invalid for document edits.

## Technical choices and implementation
- Expanded backend workflow guards so `odt_set_spec` and `odt_set_plan` allow active/review statuses while keeping issue-type-specific planning rules for `open` feature/epic tasks.
- Made document service transitions status-preserving outside the pre-build progression path.
- Treated active/review epic plan calls with omitted `subtasks` as document-only revisions, while explicit subtask replacement still validates safety before persisting the plan.
- Updated contract fixtures, workflow docs, MCP descriptions, agent prompts, and UI/adapter test fixtures to reflect the new allowed statuses and error messages.
- Added compiled integration coverage for active/review spec and plan revisions, terminal/deferred rejection, feature/epic open rejection, and active epic subtask replacement behavior.

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spec and plan operations now allowed during active and review task statuses.
  * Document-only revisions supported for in-progress and review states without status transitions.
  * Conditional epic subtask replacement based on task state.

* **Bug Fixes**
  * ReadyForDev transitions now restricted to `Open` or `SpecReady` statuses.
  * Epic subtask replacement validation tightened.

* **Documentation**
  * Updated workflow rules and transition matrix documentation.
  * Clarified allowed statuses for spec and plan operations.

* **Tests**
  * Expanded integration and unit test coverage for new workflow states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->