### PR TITLE
fix(mcp): reject workflow workspace id input

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
@@ -146,6 +146,7 @@ pub(crate) fn build_opencode_config_content(workspace_id: &str, host_url: &str) 
                 "environment": {
                     "ODT_WORKSPACE_ID": workspace_id,
                     "ODT_HOST_URL": host_url,
+                    "ODT_FORBID_WORKSPACE_ID_INPUT": "true",
                 }
             }
         }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -1095,4 +1095,5 @@ fn build_opencode_config_content_embeds_mcp_command_and_env() {
     let env = &parsed["mcp"]["openducktor"]["environment"];
     assert_eq!(env["ODT_WORKSPACE_ID"].as_str(), Some("repo"));
     assert_eq!(env["ODT_HOST_URL"].as_str(), Some("http://127.0.0.1:14327"));
+    assert_eq!(env["ODT_FORBID_WORKSPACE_ID_INPUT"].as_str(), Some("true"));
 }

--- a/packages/openducktor-mcp/src/index.test.ts
+++ b/packages/openducktor-mcp/src/index.test.ts
@@ -158,7 +158,10 @@ const startMockBridge = async (): Promise<{ url: string; requests: RecordedReque
   };
 };
 
-const createTransport = (hostUrl: string) => {
+const createTransport = (
+  hostUrl: string,
+  options: { workspaceId?: string; forbidWorkspaceIdInput?: boolean } = {},
+) => {
   return new StdioClientTransport({
     command: process.execPath,
     args: ["src/index.ts"],
@@ -166,6 +169,8 @@ const createTransport = (hostUrl: string) => {
     env: {
       ...inheritedEnv,
       ODT_HOST_URL: hostUrl,
+      ...(options.workspaceId ? { ODT_WORKSPACE_ID: options.workspaceId } : {}),
+      ...(options.forbidWorkspaceIdInput ? { ODT_FORBID_WORKSPACE_ID_INPUT: "true" } : {}),
     },
     stderr: "pipe",
   });
@@ -180,6 +185,20 @@ const requireContentToolResult = (result: unknown): ContentToolResult => {
   return result as ContentToolResult;
 };
 
+const readToolInputProperties = (
+  toolsResult: unknown,
+  toolName: string,
+): Record<string, unknown> => {
+  const tools = (toolsResult as { tools?: Array<{ name?: string; inputSchema?: unknown }> }).tools;
+  const tool = tools?.find((entry) => entry.name === toolName);
+  const properties = (tool?.inputSchema as { properties?: Record<string, unknown> } | undefined)
+    ?.properties;
+  if (!properties) {
+    throw new Error(`Expected ${toolName} to expose input schema properties.`);
+  }
+  return properties;
+};
+
 afterEach(async () => {
   await Promise.all(
     Array.from(activeServers, async (server) => {
@@ -190,6 +209,91 @@ afterEach(async () => {
 });
 
 describe("MCP server tool results", () => {
+  test("workspaceId-forbidden mode rejects workspaceId for advertised workspace-scoped tools", async () => {
+    const bridge = await startMockBridge();
+    const transport = createTransport(bridge.url, {
+      workspaceId: "repo",
+      forbidWorkspaceIdInput: true,
+    });
+    const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+
+      expect(readToolInputProperties(tools, "odt_read_task")).toMatchObject({
+        taskId: expect.any(Object),
+        workspaceId: expect.any(Object),
+      });
+      expect(readToolInputProperties(tools, "odt_set_plan")).toHaveProperty("workspaceId");
+      expect(readToolInputProperties(tools, "odt_get_workspaces")).not.toHaveProperty(
+        "workspaceId",
+      );
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("workspaceId-forbidden mode rejects explicit workspaceId instead of dropping it", async () => {
+    const bridge = await startMockBridge();
+    const transport = createTransport(bridge.url, {
+      workspaceId: "repo",
+      forbidWorkspaceIdInput: true,
+    });
+    const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+      const result = await client.callTool({
+        name: "odt_read_task",
+        arguments: {
+          workspaceId: "tool-repo",
+          taskId: "task-1",
+        },
+      });
+      const contentResult = requireContentToolResult(result);
+
+      expect(contentResult.structuredContent).toBeUndefined();
+      expect(contentResult.content[0]?.text ?? "").toContain("Invalid arguments");
+      expect(bridge.requests).toEqual([
+        { url: "/invoke/odt_mcp_ready", body: {} },
+        { url: "/invoke/odt_get_workspaces", body: {} },
+      ]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("workspaceId stays advertised for public MCP clients with a startup workspace", async () => {
+    const bridge = await startMockBridge();
+    const transport = createTransport(bridge.url, { workspaceId: "repo" });
+    const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+
+      expect(readToolInputProperties(tools, "odt_read_task")).toHaveProperty("workspaceId");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("workspaceId stays advertised when no startup workspace is configured", async () => {
+    const bridge = await startMockBridge();
+    const transport = createTransport(bridge.url);
+    const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+
+      expect(readToolInputProperties(tools, "odt_read_task")).toHaveProperty("workspaceId");
+    } finally {
+      await client.close();
+    }
+  });
+
   test("odt_get_workspaces keeps structuredContent for workspace discovery payloads", async () => {
     const bridge = await startMockBridge();
     const transport = createTransport(bridge.url);
@@ -261,6 +365,39 @@ describe("MCP server tool results", () => {
           url: "/invoke/odt_read_task",
           body: {
             workspaceId: "repo",
+            taskId: "task-1",
+          },
+        },
+      ]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("startup workspace still lets explicit tool input workspaceId override execution", async () => {
+    const bridge = await startMockBridge();
+    const transport = createTransport(bridge.url, { workspaceId: "repo" });
+    const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+      const result = await client.callTool({
+        name: "odt_read_task",
+        arguments: {
+          workspaceId: "tool-repo",
+          taskId: "task-1",
+        },
+      });
+      const contentResult = requireContentToolResult(result);
+
+      expect(contentResult.structuredContent).toEqual(taskSummaryPayload);
+      expect(bridge.requests).toEqual([
+        { url: "/invoke/odt_mcp_ready", body: {} },
+        { url: "/invoke/odt_get_workspaces", body: {} },
+        {
+          url: "/invoke/odt_read_task",
+          body: {
+            workspaceId: "tool-repo",
             taskId: "task-1",
           },
         },

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -99,6 +99,24 @@ const createServerInstructions = (options: { forbidWorkspaceIdInput: boolean }):
   return `OpenDucktor workflow server. ${workspaceInstruction} ${SHARED_SERVER_INSTRUCTIONS}`;
 };
 
+const hasOwnWorkspaceIdInput = (input: unknown): boolean => {
+  return typeof input === "object" && input !== null && Object.hasOwn(input, "workspaceId");
+};
+
+const rejectForbiddenWorkspaceIdInput = (
+  toolName: RegisteredToolName,
+  input: unknown,
+  options: { forbidWorkspaceIdInput: boolean },
+): void => {
+  if (
+    options.forbidWorkspaceIdInput &&
+    WORKSPACE_SCOPED_TOOL_NAMES.has(toolName) &&
+    hasOwnWorkspaceIdInput(input)
+  ) {
+    throw new Error("workspaceId is not allowed in workflow-scoped tool calls.");
+  }
+};
+
 const isSchemaLike = (value: unknown): value is ZodRawShapeCompat[string] => {
   if (!value || typeof value !== "object") {
     return false;
@@ -161,6 +179,7 @@ const registerOdtTool = <Name extends RegisteredToolName>(
     },
     async (input: unknown) => {
       try {
+        rejectForbiddenWorkspaceIdInput(tool.name, input, options);
         const parsedInput = schema.parse(input) as ToolInputByName<Name>;
         const result = await tool.execute(store, parsedInput);
         return toToolResult(result);

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import { z } from "zod";
 import packageJson from "../package.json" with { type: "json" };
-import { ODT_MCP_TOOL_NAMES, ODT_TOOL_SCHEMAS } from "./lib";
+import { ODT_MCP_TOOL_NAMES, ODT_TOOL_SCHEMAS, ODT_WORKSPACE_SCOPED_TOOL_NAMES } from "./lib";
 import { OdtTaskStore } from "./odt-task-store";
 import { type OdtStoreContext, resolveStoreContext } from "./store-context";
 import { toErrorMessage, toToolError, toToolResult } from "./tool-results";
@@ -85,6 +86,19 @@ type RegisteredToolSpecs = {
   };
 };
 
+const WORKSPACE_SCOPED_TOOL_NAMES = new Set<RegisteredToolName>(ODT_WORKSPACE_SCOPED_TOOL_NAMES);
+const FORBIDDEN_WORKSPACE_ID_SCHEMA = z.never().optional().describe("Do not provide.");
+const SHARED_SERVER_INSTRUCTIONS =
+  "Public task access uses odt_create_task, odt_search_tasks, odt_read_task, and odt_read_task_documents. Use odt_read_task first for the single task summary object, including task state, nested qaVerdict, and nested document presence booleans, then odt_read_task_documents only for needed document bodies. Internal workflow mutations use odt_* tools. For odt_set_plan subtasks, priority must be an integer 0..4 (default 2).";
+
+const createServerInstructions = (options: { forbidWorkspaceIdInput: boolean }): string => {
+  const workspaceInstruction = options.forbidWorkspaceIdInput
+    ? "This MCP is already scoped to its startup workspace. Do not provide workspaceId in tool calls."
+    : "Use odt_get_workspaces to discover available workspaces only when no startup workspace is configured. Workspace-scoped tools accept optional top-level workspaceId; when provided, it overrides the startup workspace.";
+
+  return `OpenDucktor workflow server. ${workspaceInstruction} ${SHARED_SERVER_INSTRUCTIONS}`;
+};
+
 const isSchemaLike = (value: unknown): value is ZodRawShapeCompat[string] => {
   if (!value || typeof value !== "object") {
     return false;
@@ -113,14 +127,31 @@ const assertRegisterToolInputSchema: (
   }
 };
 
+const toVisibleInputSchema = (
+  toolName: RegisteredToolName,
+  options: { forbidWorkspaceIdInput: boolean },
+): ZodRawShapeCompat => {
+  const inputSchema: unknown = ODT_TOOL_SCHEMAS[toolName].shape;
+  assertRegisterToolInputSchema(toolName, inputSchema);
+
+  if (!options.forbidWorkspaceIdInput || !WORKSPACE_SCOPED_TOOL_NAMES.has(toolName)) {
+    return inputSchema;
+  }
+
+  return {
+    ...inputSchema,
+    workspaceId: FORBIDDEN_WORKSPACE_ID_SCHEMA,
+  };
+};
+
 const registerOdtTool = <Name extends RegisteredToolName>(
   server: McpServer,
   store: OdtTaskStore,
   tool: RegisteredTool<Name>,
+  options: { forbidWorkspaceIdInput: boolean },
 ): void => {
   const schema = ODT_TOOL_SCHEMAS[tool.name];
-  const inputSchema: unknown = schema.shape;
-  assertRegisterToolInputSchema(tool.name, inputSchema);
+  const inputSchema = toVisibleInputSchema(tool.name, options);
 
   server.registerTool(
     tool.name,
@@ -203,7 +234,11 @@ const ODT_REGISTERED_TOOL_SPECS: Readonly<RegisteredToolSpecs> = {
   },
 };
 
-const registerTools = (server: McpServer, store: OdtTaskStore): void => {
+const registerTools = (
+  server: McpServer,
+  store: OdtTaskStore,
+  options: { forbidWorkspaceIdInput: boolean },
+): void => {
   const registerOneTool = <Name extends RegisteredToolName>(toolName: Name): void => {
     const spec = ODT_REGISTERED_TOOL_SPECS[toolName];
     const tool: RegisteredTool<Name> = {
@@ -211,7 +246,7 @@ const registerTools = (server: McpServer, store: OdtTaskStore): void => {
       description: spec.description,
       execute: spec.execute,
     };
-    registerOdtTool(server, store, tool);
+    registerOdtTool(server, store, tool, options);
   };
 
   for (const toolName of ODT_MCP_TOOL_NAMES) {
@@ -222,6 +257,8 @@ const registerTools = (server: McpServer, store: OdtTaskStore): void => {
 const createMcpServer = async (context: OdtStoreContext = {}): Promise<McpServer> => {
   const resolved = await resolveStoreContext(context);
   const store = new OdtTaskStore(resolved);
+  const forbidWorkspaceIdInput =
+    resolved.forbidWorkspaceIdInput === true && resolved.workspaceId !== undefined;
 
   const server = new McpServer(
     {
@@ -229,12 +266,11 @@ const createMcpServer = async (context: OdtStoreContext = {}): Promise<McpServer
       version: packageJson.version,
     },
     {
-      instructions:
-        "OpenDucktor workflow server. Use odt_get_workspaces to discover available workspaces only when no startup workspace is configured. Public task access uses odt_create_task, odt_search_tasks, odt_read_task, and odt_read_task_documents. Workspace-scoped tools accept optional top-level workspaceId: it overrides the startup workspace when provided; workflow agents should omit it. Use odt_read_task first for the single task summary object, including task state, nested qaVerdict, and nested document presence booleans, then odt_read_task_documents only for needed document bodies. Internal workflow mutations use odt_* tools. For odt_set_plan subtasks, priority must be an integer 0..4 (default 2).",
+      instructions: createServerInstructions({ forbidWorkspaceIdInput }),
     },
   );
 
-  registerTools(server, store);
+  registerTools(server, store, { forbidWorkspaceIdInput });
   return server;
 };
 

--- a/packages/openducktor-mcp/src/lib.ts
+++ b/packages/openducktor-mcp/src/lib.ts
@@ -18,6 +18,7 @@ export {
   ODT_HOST_BRIDGE_RESPONSE_SCHEMAS,
   ODT_MCP_TOOL_NAMES,
   ODT_TOOL_SCHEMAS,
+  ODT_WORKSPACE_SCOPED_TOOL_NAMES,
   odtHostBridgeReadySchema,
   type PublicTask,
   publicTaskSchema,

--- a/packages/openducktor-mcp/src/store-context.test.ts
+++ b/packages/openducktor-mcp/src/store-context.test.ts
@@ -146,6 +146,30 @@ describe("resolveStoreContext", () => {
     });
   });
 
+  test("preserves explicit false for workspaceId-forbidden mode", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      if (url.endsWith("/health")) {
+        return jsonResponse({ ok: true });
+      }
+      if (url.endsWith("/invoke/odt_mcp_ready")) {
+        return jsonResponse({
+          bridgeVersion: 1,
+          toolNames: Object.keys(ODT_TOOL_SCHEMAS),
+        });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as typeof fetch;
+
+    process.env.ODT_HOST_URL = "http://127.0.0.1:14327";
+    process.env.ODT_FORBID_WORKSPACE_ID_INPUT = "0";
+
+    await expect(resolveStoreContext({})).resolves.toEqual({
+      hostUrl: "http://127.0.0.1:14327",
+      forbidWorkspaceIdInput: false,
+    });
+  });
+
   test("rejects invalid workspaceId-forbidden mode values", async () => {
     process.env.ODT_HOST_URL = "http://127.0.0.1:14327";
     process.env.ODT_FORBID_WORKSPACE_ID_INPUT = "yes";

--- a/packages/openducktor-mcp/src/store-context.test.ts
+++ b/packages/openducktor-mcp/src/store-context.test.ts
@@ -31,6 +31,7 @@ afterEach(async () => {
   globalThis.fetch = originalFetch;
   delete process.env.ODT_WORKSPACE_ID;
   delete process.env.ODT_HOST_URL;
+  delete process.env.ODT_FORBID_WORKSPACE_ID_INPUT;
   delete process.env.ODT_METADATA_NAMESPACE;
   delete process.env.OPENDUCKTOR_CONFIG_DIR;
   delete process.env.ODT_BEADS_ATTACHMENT_DIR;
@@ -101,6 +102,57 @@ describe("resolveStoreContext", () => {
     await expect(resolveStoreContext({})).resolves.toEqual({
       hostUrl: "http://127.0.0.1:14327",
     });
+  });
+
+  test("reads workspaceId-forbidden mode from the environment", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      if (url.endsWith("/health")) {
+        return jsonResponse({ ok: true });
+      }
+      if (url.endsWith("/invoke/odt_mcp_ready")) {
+        return jsonResponse({
+          bridgeVersion: 1,
+          toolNames: Object.keys(ODT_TOOL_SCHEMAS),
+        });
+      }
+      if (url.endsWith("/invoke/odt_get_workspaces")) {
+        return jsonResponse({
+          workspaces: [
+            {
+              workspaceId: "repo",
+              workspaceName: "Repo",
+              repoPath: "/repo",
+              isActive: true,
+              hasConfig: true,
+              configuredWorktreeBasePath: null,
+              defaultWorktreeBasePath: null,
+              effectiveWorktreeBasePath: null,
+            },
+          ],
+        });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as typeof fetch;
+
+    process.env.ODT_WORKSPACE_ID = "repo";
+    process.env.ODT_HOST_URL = "http://127.0.0.1:14327";
+    process.env.ODT_FORBID_WORKSPACE_ID_INPUT = "true";
+
+    await expect(resolveStoreContext({})).resolves.toEqual({
+      workspaceId: "repo",
+      hostUrl: "http://127.0.0.1:14327",
+      forbidWorkspaceIdInput: true,
+    });
+  });
+
+  test("rejects invalid workspaceId-forbidden mode values", async () => {
+    process.env.ODT_HOST_URL = "http://127.0.0.1:14327";
+    process.env.ODT_FORBID_WORKSPACE_ID_INPUT = "yes";
+
+    await expect(resolveStoreContext({})).rejects.toThrow(
+      "ODT_FORBID_WORKSPACE_ID_INPUT must be true, false, 1, or 0.",
+    );
   });
 
   test("rejects legacy direct Beads/Dolt startup contract", async () => {

--- a/packages/openducktor-mcp/src/store-context.ts
+++ b/packages/openducktor-mcp/src/store-context.ts
@@ -203,11 +203,13 @@ export const resolveStoreContext = async (context: OdtStoreContext): Promise<Odt
   const hostUrl = explicitHostUrl
     ? await validateExplicitHostUrl(explicitHostUrl)
     : await discoverHostUrl(workspaceId);
+  const workspaceIdInputMode =
+    forbidWorkspaceIdInput !== undefined ? { forbidWorkspaceIdInput } : {};
 
   if (!workspaceId) {
     return {
       hostUrl,
-      ...(forbidWorkspaceIdInput ? { forbidWorkspaceIdInput } : {}),
+      ...workspaceIdInputMode,
     };
   }
 
@@ -218,6 +220,6 @@ export const resolveStoreContext = async (context: OdtStoreContext): Promise<Odt
   return {
     workspaceId,
     hostUrl,
-    ...(forbidWorkspaceIdInput ? { forbidWorkspaceIdInput } : {}),
+    ...workspaceIdInputMode,
   };
 };

--- a/packages/openducktor-mcp/src/store-context.ts
+++ b/packages/openducktor-mcp/src/store-context.ts
@@ -2,14 +2,18 @@ import { readFile } from "node:fs/promises";
 import { OdtHostBridgeClient } from "./host-bridge-client";
 import { normalizeOptionalInput, resolveMcpBridgeRegistryPath } from "./path-utils";
 
+const FORBID_WORKSPACE_ID_INPUT_ENV = "ODT_FORBID_WORKSPACE_ID_INPUT";
+
 export type OdtStoreOptions = {
   workspaceId?: string;
   hostUrl: string;
+  forbidWorkspaceIdInput?: boolean;
 };
 
 export type OdtStoreContext = {
   workspaceId?: string;
   hostUrl?: string;
+  forbidWorkspaceIdInput?: boolean;
   beadsAttachmentDir?: string;
   doltHost?: string;
   doltPort?: string;
@@ -61,6 +65,21 @@ const validateExplicitHostUrl = async (hostUrl: string): Promise<string> => {
 
   await new OdtHostBridgeClient({ baseUrl: hostUrl }).ready();
   return hostUrl;
+};
+
+const readBooleanEnv = (name: string): boolean | undefined => {
+  const value = normalizeOptionalInput(process.env[name]);
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalized = value.toLowerCase();
+  if (normalized === "true" || normalized === "1") {
+    return true;
+  }
+  if (normalized === "false" || normalized === "0") {
+    return false;
+  }
+  throw new Error(`${name} must be true, false, 1, or 0.`);
 };
 
 const validateConfiguredWorkspace = async (hostUrl: string, workspaceId: string): Promise<void> => {
@@ -176,6 +195,8 @@ export const resolveStoreContext = async (context: OdtStoreContext): Promise<Odt
   const workspaceId =
     normalizeOptionalInput(context.workspaceId) ??
     normalizeOptionalInput(process.env.ODT_WORKSPACE_ID);
+  const forbidWorkspaceIdInput =
+    context.forbidWorkspaceIdInput ?? readBooleanEnv(FORBID_WORKSPACE_ID_INPUT_ENV);
 
   const explicitHostUrl =
     normalizeOptionalInput(context.hostUrl) ?? normalizeOptionalInput(process.env.ODT_HOST_URL);
@@ -184,7 +205,10 @@ export const resolveStoreContext = async (context: OdtStoreContext): Promise<Odt
     : await discoverHostUrl(workspaceId);
 
   if (!workspaceId) {
-    return { hostUrl };
+    return {
+      hostUrl,
+      ...(forbidWorkspaceIdInput ? { forbidWorkspaceIdInput } : {}),
+    };
   }
 
   if (explicitHostUrl) {
@@ -194,5 +218,6 @@ export const resolveStoreContext = async (context: OdtStoreContext): Promise<Odt
   return {
     workspaceId,
     hostUrl,
+    ...(forbidWorkspaceIdInput ? { forbidWorkspaceIdInput } : {}),
   };
 };


### PR DESCRIPTION
Summary: prevent workflow-scoped OpenDucktor MCP sessions from silently accepting or dropping a `workspaceId` argument while preserving the public MCP override contract.

Goal

Workflow agents are launched with a startup workspace already injected by OpenDucktor. They should not pass `workspaceId` to workflow tools, but the previous hidden-schema approach could let the MCP SDK strip an explicit `workspaceId` before the handler ran. That created a correctness risk: an explicit override could be silently discarded and the operation could run against the startup workspace instead.

Technical choices

- Added `ODT_FORBID_WORKSPACE_ID_INPUT=true` to the OpenCode MCP environment generated for workflow agents.
- Kept the canonical workspace-scoped tool schemas intact for public/default MCP clients so explicit `workspaceId` still has priority when that mode is used.
- In workflow-forbidden mode, register workspace-scoped MCP tools with a visible `workspaceId` property typed as `z.never().optional()` and described as `Do not provide.`. This makes accidental or explicit `workspaceId` input fail fast during MCP argument validation instead of being stripped or delegated to the host.
- Made MCP server instructions mode-aware so workflow-scoped sessions tell agents not to provide `workspaceId`, while public sessions still document the override behavior.
- Added tests for advertised schemas, explicit rejection without host delegation, environment parsing, invalid env values, and preservation of the public override behavior.

Verification

- `bun test packages/openducktor-mcp/src/index.test.ts packages/openducktor-mcp/src/store-context.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `bun run check:rust`
- `bun run test:rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build`
- `git diff --check`