### PR TITLE
fix: configure builder worktree upstream

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -6,7 +6,7 @@ use crate::app_service::task_workflow::builder_branch_service::BuilderBranchServ
 use anyhow::{anyhow, Context, Result};
 use host_domain::{GitTargetBranch, TaskStatus};
 use host_infra_system::{
-    build_branch_name, copy_configured_worktree_files, remove_worktree,
+    build_branch_name, copy_configured_worktree_files,
     resolve_effective_worktree_base_dir_for_workspace, run_command, RepoConfig,
 };
 use std::fs;
@@ -102,7 +102,6 @@ fn configure_build_worktree_upstream(
 
     let branch_remote_key = format!("branch.{branch}.remote");
     let branch_merge_key = format!("branch.{branch}.merge");
-    let branch_merge_ref = format!("refs/heads/{branch}");
     let local_branch_ref = format!("refs/heads/{branch}");
     let tracking_ref = format!("refs/remotes/{remote}/{branch}");
     let expected_upstream = format!("{remote}/{branch}");
@@ -112,15 +111,21 @@ fn configure_build_worktree_upstream(
         &["config", branch_remote_key.as_str(), remote],
         Some(repo_path_ref),
     )?;
-    run_command(
+    if let Err(error) = run_command(
         "git",
         &[
             "config",
             branch_merge_key.as_str(),
-            branch_merge_ref.as_str(),
+            local_branch_ref.as_str(),
         ],
         Some(repo_path_ref),
-    )?;
+    ) {
+        let cleanup_error =
+            cleanup_failed_upstream_branch_config(repo_path_ref, branch_remote_key.as_str(), None);
+        return Err(anyhow!(
+            "Failed configuring upstream merge for build worktree branch {branch}: {error}{cleanup_error}"
+        ));
+    }
 
     let tracking_ref_already_exists = git_reference_exists(repo_path_ref, tracking_ref.as_str())?;
     let created_tracking_ref = !tracking_ref_already_exists;
@@ -128,7 +133,7 @@ fn configure_build_worktree_upstream(
         // Git stores upstream config independently, but `@{upstream}` only resolves
         // when the matching tracking ref exists. Seed the local tracking ref without
         // publishing remote state so later generic push flows target the task branch.
-        run_command(
+        if let Err(error) = run_command(
             "git",
             &[
                 "update-ref",
@@ -136,7 +141,17 @@ fn configure_build_worktree_upstream(
                 local_branch_ref.as_str(),
             ],
             Some(repo_path_ref),
-        )?;
+        ) {
+            let cleanup_error = cleanup_failed_upstream_setup(
+                repo_path_ref,
+                branch_remote_key.as_str(),
+                branch_merge_key.as_str(),
+                None,
+            );
+            return Err(anyhow!(
+                "Failed creating upstream tracking ref {tracking_ref} for build worktree branch {branch}: {error}{cleanup_error}"
+            ));
+        }
     }
 
     let resolved_upstream = match run_command(
@@ -151,34 +166,100 @@ fn configure_build_worktree_upstream(
     ) {
         Ok(upstream) => upstream,
         Err(error) => {
-            if created_tracking_ref {
-                let _ = run_command(
-                    "git",
-                    &["update-ref", "-d", tracking_ref.as_str()],
-                    Some(repo_path_ref),
-                );
-            }
-            return Err(error).with_context(|| {
-                format!("Failed verifying upstream tracking for build worktree branch {branch}")
-            });
+            let cleanup_error = cleanup_failed_upstream_setup(
+                repo_path_ref,
+                branch_remote_key.as_str(),
+                branch_merge_key.as_str(),
+                created_tracking_ref.then_some(tracking_ref.as_str()),
+            );
+            return Err(anyhow!(
+                "Failed verifying upstream tracking for build worktree branch {branch}: {error}{cleanup_error}"
+            ));
         }
     };
     if resolved_upstream != expected_upstream {
-        if created_tracking_ref {
-            let _ = run_command(
-                "git",
-                &["update-ref", "-d", tracking_ref.as_str()],
-                Some(repo_path_ref),
-            );
-        }
+        let cleanup_error = cleanup_failed_upstream_setup(
+            repo_path_ref,
+            branch_remote_key.as_str(),
+            branch_merge_key.as_str(),
+            created_tracking_ref.then_some(tracking_ref.as_str()),
+        );
         return Err(anyhow!(
-            "configured upstream resolved to {resolved_upstream}, expected {expected_upstream}"
+            "configured upstream resolved to {resolved_upstream}, expected {expected_upstream}{cleanup_error}"
         ));
     }
 
     Ok(BuildUpstreamSetup {
         created_tracking_ref: created_tracking_ref.then_some(tracking_ref),
     })
+}
+
+fn cleanup_failed_upstream_setup(
+    repo_path_ref: &Path,
+    branch_remote_key: &str,
+    branch_merge_key: &str,
+    created_tracking_ref: Option<&str>,
+) -> String {
+    let mut cleanup_errors = Vec::new();
+    if let Some(tracking_ref) = created_tracking_ref {
+        if let Err(error) = run_command(
+            "git",
+            &["update-ref", "-d", tracking_ref],
+            Some(repo_path_ref),
+        ) {
+            cleanup_errors.push(format!(
+                "Also failed to delete created upstream tracking ref {tracking_ref}: {error}"
+            ));
+        }
+    }
+
+    collect_failed_upstream_branch_config_cleanup(
+        repo_path_ref,
+        branch_remote_key,
+        Some(branch_merge_key),
+        &mut cleanup_errors,
+    );
+    format_cleanup_errors(cleanup_errors)
+}
+
+fn cleanup_failed_upstream_branch_config(
+    repo_path_ref: &Path,
+    branch_remote_key: &str,
+    branch_merge_key: Option<&str>,
+) -> String {
+    let mut cleanup_errors = Vec::new();
+    collect_failed_upstream_branch_config_cleanup(
+        repo_path_ref,
+        branch_remote_key,
+        branch_merge_key,
+        &mut cleanup_errors,
+    );
+    format_cleanup_errors(cleanup_errors)
+}
+
+fn collect_failed_upstream_branch_config_cleanup(
+    repo_path_ref: &Path,
+    branch_remote_key: &str,
+    branch_merge_key: Option<&str>,
+    cleanup_errors: &mut Vec<String>,
+) {
+    for key in [Some(branch_remote_key), branch_merge_key]
+        .into_iter()
+        .flatten()
+    {
+        if let Err(error) = run_command("git", &["config", "--unset-all", key], Some(repo_path_ref))
+        {
+            cleanup_errors.push(format!("Also failed to unset git config {key}: {error}"));
+        }
+    }
+}
+
+fn format_cleanup_errors(cleanup_errors: Vec<String>) -> String {
+    if cleanup_errors.is_empty() {
+        String::new()
+    } else {
+        format!("\n{}", cleanup_errors.join("\n"))
+    }
 }
 
 impl AppService {
@@ -286,6 +367,8 @@ impl AppService {
         ) {
             Ok(setup) => setup,
             Err(error) => {
+                // Upstream setup removes any tracking ref and branch config it creates before
+                // returning an error, so rollback only needs to remove the worktree and branch.
                 let cleanup_error = self.rollback_failed_build_worktree(
                     repo_path_ref,
                     worktree_dir.as_path(),
@@ -374,8 +457,30 @@ impl AppService {
                 ));
             }
         }
-        if let Err(error) = remove_worktree(repo_path_ref, worktree_dir) {
-            cleanup_errors.push(format!("Also failed to remove worktree: {error}"));
+        let worktree_dir_string = match worktree_dir.to_str() {
+            Some(value) => value,
+            None => {
+                cleanup_errors.push(format!(
+                    "Also failed to remove worktree: path contains non-UTF-8 data ({})",
+                    worktree_dir.display()
+                ));
+                ""
+            }
+        };
+        if !worktree_dir_string.is_empty() {
+            if let Err(error) = run_command(
+                "git",
+                &[
+                    "worktree",
+                    "remove",
+                    "--force",
+                    "--end-of-options",
+                    worktree_dir_string,
+                ],
+                Some(repo_path_ref),
+            ) {
+                cleanup_errors.push(format!("Also failed to remove worktree: {error}"));
+            }
         }
         if let Err(error) = run_command(
             "git",
@@ -394,11 +499,7 @@ impl AppService {
             ));
         }
 
-        if cleanup_errors.is_empty() {
-            String::new()
-        } else {
-            format!("\n{}", cleanup_errors.join("\n"))
-        }
+        format_cleanup_errors(cleanup_errors)
     }
 }
 
@@ -680,7 +781,8 @@ mod tests {
 
         assert!(error_message
             .contains("Failed configuring upstream tracking for build worktree branch odt/task-1"));
-        assert!(error_message.contains("upstream"));
+        assert!(error_message
+            .contains("Failed verifying upstream tracking for build worktree branch odt/task-1"));
         assert!(!worktree_base.join("task-1").exists());
         assert!(!git_reference_exists(
             repo.as_path(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -405,7 +405,11 @@ impl AppService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_service::test_support::{init_git_repo, unique_temp_path};
+    use crate::app_service::test_support::{
+        build_service_with_store, init_git_repo, make_task, unique_temp_path,
+    };
+    use host_domain::GitCurrentBranch;
+    use host_infra_system::AppConfigStore;
 
     fn run_git(repo_path: &Path, args: &[&str]) -> Result<String> {
         let output = Command::new("git")
@@ -616,6 +620,76 @@ mod tests {
 
         assert_eq!(setup.created_tracking_ref, None);
         assert!(current_upstream(worktree.as_path()).is_err());
+        assert_eq!(
+            git_config_value(repo.as_path(), "branch.odt/task-1.remote")?,
+            None
+        );
+        assert_eq!(
+            git_config_value(repo.as_path(), "branch.odt/task-1.merge")?,
+            None
+        );
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn prepare_build_worktree_rolls_back_when_required_upstream_setup_fails() -> Result<()> {
+        let root = unique_temp_path("build-upstream-failure-cleanup");
+        let repo = root.join("repo");
+        let worktree_base = root.join("worktrees");
+        init_git_repo(repo.as_path())?;
+        create_branch_with_commit(repo.as_path(), "release", "release.txt")?;
+        run_git_success(
+            repo.as_path(),
+            &["update-ref", "refs/remotes/upstream/release", "release"],
+        )?;
+
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let (service, _task_state, _git_state) = build_service_with_store(
+            vec![make_task("task-1", "bug", TaskStatus::Open)],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+                revision: None,
+            },
+            config_store,
+        );
+        let prerequisites = BuildPrerequisites {
+            repo_path: repo.to_string_lossy().to_string(),
+            repo_config: RepoConfig::default(),
+            target_branch: GitTargetBranch {
+                remote: Some("upstream".to_string()),
+                branch: "release".to_string(),
+            },
+            allow_local_branch_fallback: false,
+            branch: "odt/task-1".to_string(),
+            worktree_base: worktree_base.to_string_lossy().to_string(),
+        };
+
+        let error = match service.prepare_build_worktree(&prerequisites, "task-1") {
+            Ok(_) => {
+                return Err(anyhow!(
+                    "missing remote config should fail upstream verification"
+                ))
+            }
+            Err(error) => error,
+        };
+        let error_message = error.to_string();
+
+        assert!(error_message
+            .contains("Failed configuring upstream tracking for build worktree branch odt/task-1"));
+        assert!(error_message.contains("upstream"));
+        assert!(!worktree_base.join("task-1").exists());
+        assert!(!git_reference_exists(
+            repo.as_path(),
+            "refs/heads/odt/task-1"
+        )?);
+        assert!(!git_reference_exists(
+            repo.as_path(),
+            "refs/remotes/upstream/odt/task-1"
+        )?);
         assert_eq!(
             git_config_value(repo.as_path(), "branch.odt/task-1.remote")?,
             None

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -35,6 +35,16 @@ pub(super) struct PreparedBuildWorktree {
     pub(super) worktree_dir: PathBuf,
 }
 
+struct BuildStartPoint {
+    reference: String,
+    upstream_remote: Option<String>,
+}
+
+#[derive(Default)]
+struct BuildUpstreamSetup {
+    created_tracking_ref: Option<String>,
+}
+
 fn git_reference_exists(repo_path_ref: &Path, reference: &str) -> Result<bool> {
     let status = Command::new("git")
         .args(["rev-parse", "--verify", "--quiet", reference])
@@ -52,17 +62,24 @@ fn git_reference_exists(repo_path_ref: &Path, reference: &str) -> Result<bool> {
 
 fn resolve_build_start_point(
     repo_path_ref: &Path,
-    configured_target_branch: &str,
+    target_branch: &GitTargetBranch,
     allow_local_branch_fallback: bool,
-) -> Result<String> {
-    if git_reference_exists(repo_path_ref, configured_target_branch)? {
-        return Ok(configured_target_branch.to_string());
+) -> Result<BuildStartPoint> {
+    let configured_target_branch = target_branch.canonical();
+    if git_reference_exists(repo_path_ref, configured_target_branch.as_str())? {
+        return Ok(BuildStartPoint {
+            reference: configured_target_branch,
+            upstream_remote: target_branch.remote.clone(),
+        });
     }
 
     if allow_local_branch_fallback {
         if let Some(local_branch) = configured_target_branch.strip_prefix("origin/") {
             if git_reference_exists(repo_path_ref, local_branch)? {
-                return Ok(local_branch.to_string());
+                return Ok(BuildStartPoint {
+                    reference: local_branch.to_string(),
+                    upstream_remote: None,
+                });
             }
         }
     }
@@ -71,6 +88,97 @@ fn resolve_build_start_point(
         "Configured target branch is unavailable for build worktree creation: {}",
         configured_target_branch
     ))
+}
+
+fn configure_build_worktree_upstream(
+    repo_path_ref: &Path,
+    worktree_dir: &Path,
+    branch: &str,
+    upstream_remote: Option<&str>,
+) -> Result<BuildUpstreamSetup> {
+    let Some(remote) = upstream_remote else {
+        return Ok(BuildUpstreamSetup::default());
+    };
+
+    let branch_remote_key = format!("branch.{branch}.remote");
+    let branch_merge_key = format!("branch.{branch}.merge");
+    let branch_merge_ref = format!("refs/heads/{branch}");
+    let local_branch_ref = format!("refs/heads/{branch}");
+    let tracking_ref = format!("refs/remotes/{remote}/{branch}");
+    let expected_upstream = format!("{remote}/{branch}");
+
+    run_command(
+        "git",
+        &["config", branch_remote_key.as_str(), remote],
+        Some(repo_path_ref),
+    )?;
+    run_command(
+        "git",
+        &[
+            "config",
+            branch_merge_key.as_str(),
+            branch_merge_ref.as_str(),
+        ],
+        Some(repo_path_ref),
+    )?;
+
+    let tracking_ref_already_exists = git_reference_exists(repo_path_ref, tracking_ref.as_str())?;
+    let created_tracking_ref = !tracking_ref_already_exists;
+    if created_tracking_ref {
+        // Git stores upstream config independently, but `@{upstream}` only resolves
+        // when the matching tracking ref exists. Seed the local tracking ref without
+        // publishing remote state so later generic push flows target the task branch.
+        run_command(
+            "git",
+            &[
+                "update-ref",
+                tracking_ref.as_str(),
+                local_branch_ref.as_str(),
+            ],
+            Some(repo_path_ref),
+        )?;
+    }
+
+    let resolved_upstream = match run_command(
+        "git",
+        &[
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ],
+        Some(worktree_dir),
+    ) {
+        Ok(upstream) => upstream,
+        Err(error) => {
+            if created_tracking_ref {
+                let _ = run_command(
+                    "git",
+                    &["update-ref", "-d", tracking_ref.as_str()],
+                    Some(repo_path_ref),
+                );
+            }
+            return Err(error).with_context(|| {
+                format!("Failed verifying upstream tracking for build worktree branch {branch}")
+            });
+        }
+    };
+    if resolved_upstream != expected_upstream {
+        if created_tracking_ref {
+            let _ = run_command(
+                "git",
+                &["update-ref", "-d", tracking_ref.as_str()],
+                Some(repo_path_ref),
+            );
+        }
+        return Err(anyhow!(
+            "configured upstream resolved to {resolved_upstream}, expected {expected_upstream}"
+        ));
+    }
+
+    Ok(BuildUpstreamSetup {
+        created_tracking_ref: created_tracking_ref.then_some(tracking_ref),
+    })
 }
 
 impl AppService {
@@ -152,7 +260,7 @@ impl AppService {
         let repo_path_ref = Path::new(prerequisites.repo_path.as_str());
         let start_point = resolve_build_start_point(
             repo_path_ref,
-            prerequisites.target_branch.canonical().as_str(),
+            &prerequisites.target_branch,
             prerequisites.allow_local_branch_fallback,
         )?;
         host_infra_system::run_command(
@@ -165,10 +273,32 @@ impl AppService {
                 worktree_dir
                     .to_str()
                     .ok_or_else(|| anyhow!("Invalid worktree path"))?,
-                start_point.as_str(),
+                start_point.reference.as_str(),
             ],
             Some(repo_path_ref),
         )?;
+
+        let upstream_setup = match configure_build_worktree_upstream(
+            repo_path_ref,
+            worktree_dir.as_path(),
+            prerequisites.branch.as_str(),
+            start_point.upstream_remote.as_deref(),
+        ) {
+            Ok(setup) => setup,
+            Err(error) => {
+                let cleanup_error = self.rollback_failed_build_worktree(
+                    repo_path_ref,
+                    worktree_dir.as_path(),
+                    prerequisites.branch.as_str(),
+                    None,
+                );
+                return Err(anyhow!(
+                    "Failed configuring upstream tracking for build worktree branch {}: {error}{}",
+                    prerequisites.branch,
+                    cleanup_error
+                ));
+            }
+        };
 
         if let Err(error) = copy_configured_worktree_files(
             repo_path_ref,
@@ -179,6 +309,7 @@ impl AppService {
                 repo_path_ref,
                 worktree_dir.as_path(),
                 prerequisites.branch.as_str(),
+                upstream_setup.created_tracking_ref.as_deref(),
             );
             return Err(anyhow!(
                 "Configured worktree file copy failed: {error}{}",
@@ -190,6 +321,7 @@ impl AppService {
             prerequisites,
             repo_path_ref,
             worktree_dir.as_path(),
+            upstream_setup.created_tracking_ref.as_deref(),
             task_id,
         )?;
 
@@ -201,6 +333,7 @@ impl AppService {
         prerequisites: &BuildPrerequisites,
         repo_path_ref: &Path,
         worktree_dir: &Path,
+        created_tracking_ref: Option<&str>,
         _task_id: &str,
     ) -> Result<()> {
         for hook in &prerequisites.repo_config.hooks.pre_start {
@@ -210,6 +343,7 @@ impl AppService {
                     repo_path_ref,
                     worktree_dir,
                     prerequisites.branch.as_str(),
+                    created_tracking_ref,
                 );
                 return Err(anyhow!(
                     "Worktree setup script command failed: {hook}\n{stderr}{}",
@@ -225,9 +359,21 @@ impl AppService {
         repo_path_ref: &Path,
         worktree_dir: &Path,
         branch: &str,
+        created_tracking_ref: Option<&str>,
     ) -> String {
         let mut cleanup_errors = Vec::new();
 
+        if let Some(tracking_ref) = created_tracking_ref {
+            if let Err(error) = run_command(
+                "git",
+                &["update-ref", "-d", tracking_ref],
+                Some(repo_path_ref),
+            ) {
+                cleanup_errors.push(format!(
+                    "Also failed to delete created upstream tracking ref {tracking_ref}: {error}"
+                ));
+            }
+        }
         if let Err(error) = remove_worktree(repo_path_ref, worktree_dir) {
             cleanup_errors.push(format!("Also failed to remove worktree: {error}"));
         }
@@ -253,5 +399,233 @@ impl AppService {
         } else {
             format!("\n{}", cleanup_errors.join("\n"))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_service::test_support::{init_git_repo, unique_temp_path};
+
+    fn run_git(repo_path: &Path, args: &[&str]) -> Result<String> {
+        let output = Command::new("git")
+            .current_dir(repo_path)
+            .args(args)
+            .output()
+            .with_context(|| {
+                format!(
+                    "failed running git in {} with args {:?}",
+                    repo_path.display(),
+                    args
+                )
+            })?;
+        if output.status.success() {
+            return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+        }
+
+        Err(anyhow!(
+            "git {:?} failed in {} with status {}\n{}",
+            args,
+            repo_path.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+
+    fn run_git_success(repo_path: &Path, args: &[&str]) -> Result<()> {
+        run_git(repo_path, args).map(|_| ())
+    }
+
+    fn add_bare_remote(root: &Path, repo_path: &Path, remote_name: &str) -> Result<()> {
+        fs::create_dir_all(root)?;
+        let remote_dir = root.join(format!("{remote_name}.git"));
+        let remote_dir_string = remote_dir.to_string_lossy().to_string();
+        run_git_success(root, &["init", "--bare", remote_dir_string.as_str()])?;
+        run_git_success(
+            repo_path,
+            &["remote", "add", remote_name, remote_dir_string.as_str()],
+        )
+    }
+
+    fn git_config_value(repo_path: &Path, key: &str) -> Result<Option<String>> {
+        let output = Command::new("git")
+            .current_dir(repo_path)
+            .args(["config", "--get", key])
+            .output()
+            .with_context(|| {
+                format!("failed reading git config {key} in {}", repo_path.display())
+            })?;
+        if output.status.success() {
+            return Ok(Some(
+                String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            ));
+        }
+        Ok(None)
+    }
+
+    fn current_upstream(worktree_path: &Path) -> Result<String> {
+        run_git(
+            worktree_path,
+            &[
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{upstream}",
+            ],
+        )
+    }
+
+    fn create_branch_with_commit(repo_path: &Path, branch: &str, file_name: &str) -> Result<()> {
+        run_git_success(repo_path, &["checkout", "-b", branch])?;
+        fs::write(repo_path.join(file_name), format!("{branch}\n"))?;
+        run_git_success(repo_path, &["add", file_name])?;
+        run_git_success(repo_path, &["commit", "-m", branch])
+    }
+
+    #[test]
+    fn resolve_start_point_preserves_remote_for_available_remote_target() -> Result<()> {
+        let root = unique_temp_path("build-start-remote-target");
+        let repo = root.join("repo");
+        init_git_repo(repo.as_path())?;
+        add_bare_remote(root.as_path(), repo.as_path(), "upstream")?;
+        create_branch_with_commit(repo.as_path(), "release", "release.txt")?;
+        run_git_success(
+            repo.as_path(),
+            &["update-ref", "refs/remotes/upstream/release", "release"],
+        )?;
+
+        let start_point = resolve_build_start_point(
+            repo.as_path(),
+            &GitTargetBranch {
+                remote: Some("upstream".to_string()),
+                branch: "release".to_string(),
+            },
+            false,
+        )?;
+
+        assert_eq!(start_point.reference, "upstream/release");
+        assert_eq!(start_point.upstream_remote.as_deref(), Some("upstream"));
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_start_point_does_not_guess_upstream_when_default_origin_falls_back_to_local_branch(
+    ) -> Result<()> {
+        let root = unique_temp_path("build-start-local-fallback");
+        let repo = root.join("repo");
+        init_git_repo(repo.as_path())?;
+        create_branch_with_commit(repo.as_path(), "develop", "develop.txt")?;
+
+        let start_point = resolve_build_start_point(
+            repo.as_path(),
+            &GitTargetBranch {
+                remote: Some("origin".to_string()),
+                branch: "develop".to_string(),
+            },
+            true,
+        )?;
+
+        assert_eq!(start_point.reference, "develop");
+        assert_eq!(start_point.upstream_remote, None);
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn configure_build_worktree_upstream_tracks_same_task_branch_on_target_remote() -> Result<()> {
+        let root = unique_temp_path("build-upstream-remote-task-branch");
+        let repo = root.join("repo");
+        let worktree = root.join("worktree");
+        init_git_repo(repo.as_path())?;
+        add_bare_remote(root.as_path(), repo.as_path(), "upstream")?;
+        create_branch_with_commit(repo.as_path(), "release", "release.txt")?;
+        run_git_success(
+            repo.as_path(),
+            &["update-ref", "refs/remotes/upstream/release", "release"],
+        )?;
+        run_git_success(
+            repo.as_path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "odt/task-1",
+                worktree
+                    .to_str()
+                    .ok_or_else(|| anyhow!("Invalid worktree path"))?,
+                "upstream/release",
+            ],
+        )?;
+
+        let setup = configure_build_worktree_upstream(
+            repo.as_path(),
+            worktree.as_path(),
+            "odt/task-1",
+            Some("upstream"),
+        )?;
+
+        assert_eq!(current_upstream(worktree.as_path())?, "upstream/odt/task-1");
+        assert_eq!(
+            setup.created_tracking_ref.as_deref(),
+            Some("refs/remotes/upstream/odt/task-1")
+        );
+        assert_eq!(
+            git_config_value(repo.as_path(), "branch.odt/task-1.remote")?.as_deref(),
+            Some("upstream")
+        );
+        assert_eq!(
+            git_config_value(repo.as_path(), "branch.odt/task-1.merge")?.as_deref(),
+            Some("refs/heads/odt/task-1")
+        );
+        assert_ne!(current_upstream(worktree.as_path())?, "upstream/release");
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn configure_build_worktree_upstream_leaves_local_only_target_without_upstream() -> Result<()> {
+        let root = unique_temp_path("build-upstream-local-only");
+        let repo = root.join("repo");
+        let worktree = root.join("worktree");
+        init_git_repo(repo.as_path())?;
+        create_branch_with_commit(repo.as_path(), "develop", "develop.txt")?;
+        run_git_success(
+            repo.as_path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "odt/task-1",
+                worktree
+                    .to_str()
+                    .ok_or_else(|| anyhow!("Invalid worktree path"))?,
+                "develop",
+            ],
+        )?;
+
+        let setup = configure_build_worktree_upstream(
+            repo.as_path(),
+            worktree.as_path(),
+            "odt/task-1",
+            None,
+        )?;
+
+        assert_eq!(setup.created_tracking_ref, None);
+        assert!(current_upstream(worktree.as_path()).is_err());
+        assert_eq!(
+            git_config_value(repo.as_path(), "branch.odt/task-1.remote")?,
+            None
+        );
+        assert_eq!(
+            git_config_value(repo.as_path(), "branch.odt/task-1.merge")?,
+            None
+        );
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_worktree_upstream.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_worktree_upstream.rs
@@ -1,0 +1,228 @@
+use anyhow::{anyhow, Context, Result};
+use host_domain::{GitTargetBranch as TaskGitTargetBranch, TaskCard, TaskStatus};
+use host_infra_system::{AppConfigStore, GitTargetBranch as RepoGitTargetBranch, RepoConfig};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::support::{
+    test_git_current_branch, test_repo_config, TEST_BRANCH_PREFIX, TEST_MAIN_BRANCH,
+    TEST_RUNTIME_KIND, TEST_TASK_ID,
+};
+use crate::app_service::test_support::{
+    build_service_with_store, create_fake_opencode, init_git_repo, install_fake_dolt, lock_env,
+    make_task, set_fake_opencode_and_bridge_binaries, unique_temp_path,
+    workspace_update_repo_config_by_repo_path,
+};
+use crate::app_service::AppService;
+
+fn run_git(repo_path: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(args)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed running git in {} with args {:?}",
+                repo_path.display(),
+                args
+            )
+        })?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+    }
+
+    Err(anyhow!(
+        "git {:?} failed in {} with status {}\n{}",
+        args,
+        repo_path.display(),
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    ))
+}
+
+fn run_git_success(repo_path: &Path, args: &[&str]) -> Result<()> {
+    run_git(repo_path, args).map(|_| ())
+}
+
+fn add_bare_remote(root: &Path, repo_path: &Path, remote_name: &str) -> Result<()> {
+    fs::create_dir_all(root)?;
+    let remote_dir = root.join(format!("{remote_name}.git"));
+    let remote_dir_string = remote_dir.to_string_lossy().to_string();
+    run_git_success(root, &["init", "--bare", remote_dir_string.as_str()])?;
+    run_git_success(
+        repo_path,
+        &["remote", "add", remote_name, remote_dir_string.as_str()],
+    )
+}
+
+fn create_branch_with_commit(repo_path: &Path, branch: &str, file_name: &str) -> Result<()> {
+    run_git_success(repo_path, &["checkout", "-b", branch])?;
+    commit_file_on_current_branch(repo_path, file_name, branch, branch)
+}
+
+fn commit_file_on_current_branch(
+    repo_path: &Path,
+    file_name: &str,
+    contents: &str,
+    message: &str,
+) -> Result<()> {
+    fs::write(repo_path.join(file_name), format!("{contents}\n"))?;
+    run_git_success(repo_path, &["add", file_name])?;
+    run_git_success(repo_path, &["commit", "-m", message])
+}
+
+fn push_branch(repo_path: &Path, remote: &str, branch: &str) -> Result<()> {
+    let refspec = format!("{branch}:{branch}");
+    run_git_success(repo_path, &["push", remote, refspec.as_str()])
+}
+
+fn current_upstream(worktree_path: &Path) -> Result<String> {
+    run_git(
+        worktree_path,
+        &[
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ],
+    )
+}
+
+fn current_branch(worktree_path: &Path) -> Result<String> {
+    run_git(worktree_path, &["branch", "--show-current"])
+}
+
+fn make_repo_config(
+    worktree_base: &Path,
+    target_remote: Option<&str>,
+    target_branch: &str,
+) -> RepoConfig {
+    let mut repo_config = test_repo_config(Some(worktree_base));
+    repo_config.default_target_branch = RepoGitTargetBranch {
+        remote: target_remote.map(str::to_string),
+        branch: target_branch.to_string(),
+    };
+    repo_config
+}
+
+fn create_build_service(
+    root: &Path,
+    repo: &Path,
+    task: TaskCard,
+    target_remote: Option<&str>,
+    target_branch: &str,
+) -> Result<(AppService, String)> {
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let worktree_base = root.join("builder-worktrees");
+    let repo_path = repo.to_string_lossy().to_string();
+    let (service, _task_state, _git_state) =
+        build_service_with_store(vec![task], vec![], test_git_current_branch(), config_store);
+    service.workspace_add(repo_path.as_str())?;
+    workspace_update_repo_config_by_repo_path(
+        &service,
+        repo_path.as_str(),
+        make_repo_config(worktree_base.as_path(), target_remote, target_branch),
+    )?;
+    Ok((service, repo_path))
+}
+
+fn stop_runtime_if_started(service: &AppService, repo_path: &str) -> Result<()> {
+    let runtimes = service.runtime_list(TEST_RUNTIME_KIND, Some(repo_path))?;
+    for runtime in runtimes {
+        service.runtime_stop(runtime.runtime_id.as_str())?;
+    }
+    Ok(())
+}
+
+#[test]
+fn build_start_tracks_task_branch_on_default_remote_target() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-start-default-remote-upstream");
+    let result = (|| -> Result<()> {
+        let repo = root.join("repo");
+        init_git_repo(repo.as_path())?;
+        let fake_opencode = root.join("opencode");
+        create_fake_opencode(fake_opencode.as_path())?;
+        let _dolt_guard = install_fake_dolt(root.as_path())?;
+        let _runtime_binary_guards = set_fake_opencode_and_bridge_binaries(fake_opencode.as_path());
+
+        add_bare_remote(root.as_path(), repo.as_path(), "origin")?;
+        create_branch_with_commit(repo.as_path(), "develop", "develop-only.txt")?;
+        push_branch(repo.as_path(), "origin", "develop")?;
+        run_git_success(repo.as_path(), &["checkout", TEST_MAIN_BRANCH])?;
+        commit_file_on_current_branch(repo.as_path(), "main-only.txt", "main", "main-only")?;
+
+        let task = make_task(TEST_TASK_ID, "bug", TaskStatus::Open);
+        let (service, repo_path) = create_build_service(
+            root.as_path(),
+            repo.as_path(),
+            task,
+            Some("origin"),
+            "develop",
+        )?;
+
+        let bootstrap = service.build_start(repo_path.as_str(), TEST_TASK_ID, TEST_RUNTIME_KIND)?;
+        let worktree_path = PathBuf::from(bootstrap.working_directory.as_str());
+        let branch = current_branch(worktree_path.as_path())?;
+        let upstream = current_upstream(worktree_path.as_path())?;
+
+        assert!(worktree_path.join("develop-only.txt").exists());
+        assert!(!worktree_path.join("main-only.txt").exists());
+        assert!(branch.starts_with(format!("{TEST_BRANCH_PREFIX}/{TEST_TASK_ID}").as_str()));
+        assert!(upstream.starts_with("origin/odt/"));
+        assert_eq!(upstream, format!("origin/{branch}"));
+        assert_ne!(upstream, "origin/develop");
+        assert_ne!(upstream, "origin/main");
+
+        stop_runtime_if_started(&service, repo_path.as_str())
+    })();
+
+    let _ = fs::remove_dir_all(root.as_path());
+    result
+}
+
+#[test]
+fn build_start_tracks_task_branch_on_task_target_override_remote() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-start-task-override-upstream");
+    let result = (|| -> Result<()> {
+        let repo = root.join("repo");
+        init_git_repo(repo.as_path())?;
+        let fake_opencode = root.join("opencode");
+        create_fake_opencode(fake_opencode.as_path())?;
+        let _dolt_guard = install_fake_dolt(root.as_path())?;
+        let _runtime_binary_guards = set_fake_opencode_and_bridge_binaries(fake_opencode.as_path());
+
+        add_bare_remote(root.as_path(), repo.as_path(), "upstream")?;
+        create_branch_with_commit(repo.as_path(), "release", "release-only.txt")?;
+        push_branch(repo.as_path(), "upstream", "release")?;
+        run_git_success(repo.as_path(), &["checkout", TEST_MAIN_BRANCH])?;
+        commit_file_on_current_branch(repo.as_path(), "main-only.txt", "main", "main-only")?;
+
+        let mut task = make_task(TEST_TASK_ID, "bug", TaskStatus::Open);
+        task.target_branch = Some(TaskGitTargetBranch {
+            remote: Some("upstream".to_string()),
+            branch: "release".to_string(),
+        });
+        let (service, repo_path) =
+            create_build_service(root.as_path(), repo.as_path(), task, None, TEST_MAIN_BRANCH)?;
+
+        let bootstrap = service.build_start(repo_path.as_str(), TEST_TASK_ID, TEST_RUNTIME_KIND)?;
+        let worktree_path = PathBuf::from(bootstrap.working_directory.as_str());
+        let branch = current_branch(worktree_path.as_path())?;
+        let upstream = current_upstream(worktree_path.as_path())?;
+
+        assert!(worktree_path.join("release-only.txt").exists());
+        assert!(!worktree_path.join("main-only.txt").exists());
+        assert!(branch.starts_with(format!("{TEST_BRANCH_PREFIX}/{TEST_TASK_ID}").as_str()));
+        assert!(upstream.starts_with("upstream/odt/"));
+        assert_eq!(upstream, format!("upstream/{branch}"));
+        assert_ne!(upstream, "upstream/release");
+
+        stop_runtime_if_started(&service, repo_path.as_str())
+    })();
+
+    let _ = fs::remove_dir_all(root.as_path());
+    result
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 mod approval_workflow;
+mod build_worktree_upstream;
 mod opencode_runtime;
 mod session_stop;
 mod support;


### PR DESCRIPTION
## Summary
- Configure Builder-created worktree branches to track the same task branch on the resolved target remote.
- Add compiled Builder integration coverage for default remote targets, task target override remotes, and upstream setup failure cleanup.

## Goal
This fixes task branches created for Builder worktrees so later generic push flows target the task branch instead of accidentally using the base branch upstream. The issue mattered when worktrees were created from a remote target such as `origin/main` or an override like `upstream/release`: the new task branch needs to track `<remote>/<task-branch>`, not `<remote>/<base-branch>`.

## Technical choices
- Kept the generic worktree creation API unchanged because it does not have reliable target-remote context.
- Resolved Builder start points with explicit remote awareness, preserving the existing local fallback behavior without guessing an upstream for local-only targets.
- After `git worktree add`, configured `branch.<task-branch>.remote` and `branch.<task-branch>.merge`, then seeded the local remote-tracking ref when needed so `@{upstream}` resolves before any push publishes remote state.
- Verified the upstream from inside the created worktree before file-copy hooks run, and rolled back the worktree, branch, config, and seeded tracking ref on failure.

## Verification
- `cargo fmt --all --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced build worktree preparation with improved upstream branch tracking configuration
  * Extended rollback behavior to ensure comprehensive cleanup of build-related references and artifacts
  * Better handling of remote branch resolution during build initialization

* **Tests**
  * Added integration tests for upstream branch tracking configuration and failure recovery scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->