### PR TITLE
fix(release): sign macOS CEF helper before bundling

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -248,6 +248,37 @@ jobs:
           uploadUpdaterSignatures: false
           retryAttempts: 2
 
+      - name: Verify signed CEF helper in app bundle
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          helper="apps/desktop/src-tauri/target/$TARGET/release/bundle/macos/OpenDucktor.app/Contents/MacOS/openducktor-desktop-helper"
+
+          if [[ ! -f "$helper" ]]; then
+            echo "Bundled CEF helper was not found at $helper" >&2
+            exit 1
+          fi
+
+          codesign --verify --verbose=4 "$helper"
+          codesign -dvvv "$helper"
+          entitlements_file="$(mktemp)"
+          codesign -d --entitlements :- "$helper" > "$entitlements_file"
+
+          require_entitlement() {
+            local entitlement="$1"
+            local value
+
+            value="$(/usr/libexec/PlistBuddy -c "Print :$entitlement" "$entitlements_file")"
+            if [[ "$value" != "true" ]]; then
+              echo "Expected entitlement $entitlement=true on bundled CEF helper, got: $value" >&2
+              exit 1
+            fi
+          }
+
+          require_entitlement "com.apple.security.cs.allow-jit"
+          require_entitlement "com.apple.security.cs.allow-unsigned-executable-memory"
+
   finalize-release:
     name: Summarize release draft
     if: ${{ always() }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -232,6 +232,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           CEF_PATH: ${{ steps.cef.outputs.cef_path }}
+          OPENDUCKTOR_TAURI_TARGET: ${{ matrix.target }}
           OPENDUCKTOR_PREPARE_SIDECARS: "1"
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -269,7 +269,11 @@ jobs:
             local entitlement="$1"
             local value
 
-            value="$(/usr/libexec/PlistBuddy -c "Print :$entitlement" "$entitlements_file")"
+            if ! value="$(/usr/libexec/PlistBuddy -c "Print :$entitlement" "$entitlements_file" 2>&1)"; then
+              echo "Expected entitlement $entitlement=true on bundled CEF helper, but PlistBuddy failed: $value" >&2
+              exit 1
+            fi
+
             if [[ "$value" != "true" ]]; then
               echo "Expected entitlement $entitlement=true on bundled CEF helper, got: $value" >&2
               exit 1

--- a/apps/desktop/scripts/sign-macos-cef-helper.sh
+++ b/apps/desktop/scripts/sign-macos-cef-helper.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
 if [[ -z "${CEF_PATH:-}" || -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
   exit 0
 fi
 
-helper_path="src-tauri/target/release/openducktor-desktop-helper"
+target_root="${CARGO_TARGET_DIR:-src-tauri/target}"
+helper_path="${target_root}/release/openducktor-desktop-helper"
+entitlements_path="src-tauri/entitlements/macos-cef-helper.plist"
 
 if [[ -n "${OPENDUCKTOR_TAURI_TARGET:-}" ]]; then
-  helper_path="src-tauri/target/${OPENDUCKTOR_TAURI_TARGET}/release/openducktor-desktop-helper"
+  helper_path="${target_root}/${OPENDUCKTOR_TAURI_TARGET}/release/openducktor-desktop-helper"
 fi
 
 if [[ ! -f "$helper_path" ]]; then
@@ -17,5 +23,10 @@ if [[ ! -f "$helper_path" ]]; then
   exit 1
 fi
 
-codesign --force --sign "$APPLE_SIGNING_IDENTITY" --options runtime --timestamp "$helper_path"
+if [[ ! -f "$entitlements_path" ]]; then
+  echo "macOS CEF helper entitlements file was not found at $entitlements_path" >&2
+  exit 1
+fi
+
+codesign --force --sign "$APPLE_SIGNING_IDENTITY" --options runtime --timestamp --entitlements "$entitlements_path" "$helper_path"
 codesign --verify --verbose=4 "$helper_path"

--- a/apps/desktop/scripts/sign-macos-cef-helper.sh
+++ b/apps/desktop/scripts/sign-macos-cef-helper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${CEF_PATH:-}" || -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
+  exit 0
+fi
+
+helper_path="src-tauri/target/release/openducktor-desktop-helper"
+
+if [[ -n "${OPENDUCKTOR_TAURI_TARGET:-}" ]]; then
+  helper_path="src-tauri/target/${OPENDUCKTOR_TAURI_TARGET}/release/openducktor-desktop-helper"
+fi
+
+if [[ ! -f "$helper_path" ]]; then
+  echo "macOS CEF helper signing is active, but openducktor-desktop-helper was not found at $helper_path" >&2
+  echo "Build the app first, or set OPENDUCKTOR_TAURI_TARGET to the Cargo target triple used by Tauri build." >&2
+  exit 1
+fi
+
+codesign --force --sign "$APPLE_SIGNING_IDENTITY" --options runtime --timestamp "$helper_path"
+codesign --verify --verbose=4 "$helper_path"

--- a/apps/desktop/scripts/sign-macos-cef-helper.sh
+++ b/apps/desktop/scripts/sign-macos-cef-helper.sh
@@ -9,6 +9,7 @@ if [[ -z "${CEF_PATH:-}" || -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
   exit 0
 fi
 
+# Expects CWD = apps/desktop, set by tauri.conf.json beforeBundleCommand.
 target_root="${CARGO_TARGET_DIR:-src-tauri/target}"
 helper_path="${target_root}/release/openducktor-desktop-helper"
 entitlements_path="src-tauri/entitlements/macos-cef-helper.plist"

--- a/apps/desktop/scripts/sign-macos-cef-helper.ts
+++ b/apps/desktop/scripts/sign-macos-cef-helper.ts
@@ -1,10 +1,18 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 const platform = process.env.TAURI_ENV_PLATFORM ?? process.platform;
 
 if (platform !== "darwin") {
   process.exit(0);
 }
 
-const signing = Bun.spawnSync(["bash", "scripts/sign-macos-cef-helper.sh"], {
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const desktopRoot = dirname(scriptDir);
+const scriptPath = join(scriptDir, "sign-macos-cef-helper.sh");
+
+const signing = Bun.spawnSync(["bash", scriptPath], {
+  cwd: desktopRoot,
   stdin: "inherit",
   stdout: "inherit",
   stderr: "inherit",

--- a/apps/desktop/scripts/sign-macos-cef-helper.ts
+++ b/apps/desktop/scripts/sign-macos-cef-helper.ts
@@ -1,0 +1,13 @@
+const platform = process.env.TAURI_ENV_PLATFORM ?? process.platform;
+
+if (platform !== "darwin") {
+  process.exit(0);
+}
+
+const signing = Bun.spawnSync(["bash", "scripts/sign-macos-cef-helper.sh"], {
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+process.exit(signing.exitCode ?? 1);

--- a/apps/desktop/src-tauri/entitlements/macos-cef-helper.plist
+++ b/apps/desktop/src-tauri/entitlements/macos-cef-helper.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "beforeDevCommand": "cd .. && bun run dev",
     "beforeBuildCommand": "cd .. && bun run build",
-    "beforeBundleCommand": "cd .. && bash scripts/sign-macos-cef-helper.sh",
+    "beforeBundleCommand": "cd .. && bun -e \"const isDarwin = (process.env.TAURI_ENV_PLATFORM ?? process.platform) === 'darwin'; if (isDarwin) { const p = Bun.spawnSync(['bash', 'scripts/sign-macos-cef-helper.sh'], { stdin: 'inherit', stdout: 'inherit', stderr: 'inherit' }); process.exit(p.exitCode ?? 1); }\"",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../dist"
   },

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "beforeDevCommand": "cd .. && bun run dev",
     "beforeBuildCommand": "cd .. && bun run build",
-    "beforeBundleCommand": "cd .. && bun -e \"const isDarwin = (process.env.TAURI_ENV_PLATFORM ?? process.platform) === 'darwin'; if (isDarwin) { const p = Bun.spawnSync(['bash', 'scripts/sign-macos-cef-helper.sh'], { stdin: 'inherit', stdout: 'inherit', stderr: 'inherit' }); process.exit(p.exitCode ?? 1); }\"",
+    "beforeBundleCommand": "cd .. && bun run scripts/sign-macos-cef-helper.ts",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../dist"
   },

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,6 +6,7 @@
   "build": {
     "beforeDevCommand": "cd .. && bun run dev",
     "beforeBuildCommand": "cd .. && bun run build",
+    "beforeBundleCommand": "cd .. && bash scripts/sign-macos-cef-helper.sh",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../dist"
   },


### PR DESCRIPTION
## Summary
- Sign the macOS CEF helper during Tauri's pre-bundle hook so it is already hardened before app bundling/signing.
- Add helper-specific CEF/V8 entitlements and verify the final bundled helper keeps the expected signature and entitlements in release CI.
- Keep non-macOS builds safe by only invoking the shell signer from the Tauri hook on Darwin.

## Testing
- [x] bun run lint
- [x] bun run typecheck
- [x] bun run test
- [x] bun run build
- [x] bun run check:rust
- [x] bun run test:rust
- [x] bash -n apps/desktop/scripts/sign-macos-cef-helper.sh
- [x] plutil -lint apps/desktop/src-tauri/entitlements/macos-cef-helper.plist
- [x] rtk git diff --check

## Checklist
- [x] macOS signing path remains fail-fast when expected files are missing.
- [x] Non-macOS Tauri builds skip the macOS-only signing script before requiring Bash/codesign.
- [x] Release CI verifies the final bundled helper signature and required entitlements.

## Related Issues
- None.

## Breaking Changes
- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS build and release processes with improved code signing and verification for the desktop helper component. Added automated checks during bundling to validate proper configuration and system capabilities on macOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->