### PR TITLE
fix: require explicit runtime selection

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-runtime-combobox.tsx
+++ b/packages/frontend/src/components/features/agents/agent-runtime-combobox.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from "react";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
 
 type AgentRuntimeComboboxProps = {
-  value: RuntimeKind;
+  value: RuntimeKind | "";
   onValueChange: (value: RuntimeKind) => void;
   runtimeOptions: ComboboxOption[];
   placeholder?: string;

--- a/packages/frontend/src/components/features/agents/session-start-modal.tsx
+++ b/packages/frontend/src/components/features/agents/session-start-modal.tsx
@@ -34,7 +34,7 @@ export type SessionStartModalModel = {
   backgroundConfirmLabel?: string;
   cancelLabel?: string;
   selectedModelSelection: AgentModelSelection | null;
-  selectedRuntimeKind: RuntimeKind;
+  selectedRuntimeKind: RuntimeKind | null;
   runtimeOptions: ComboboxOption[];
   supportsProfiles: boolean;
   supportsVariants: boolean;
@@ -114,7 +114,8 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
   );
   const confirmDisabled =
     isStarting ||
-    (!isReuseMode && (isSelectionCatalogLoading || !selectedModelSelection)) ||
+    (!isReuseMode &&
+      (isSelectionCatalogLoading || !selectedRuntimeKind || !selectedModelSelection)) ||
     (requiresExistingSession && !hasExistingSessionSelection);
   const runtimeDisabled = isSelectionCatalogLoading || isReuseMode;
   const agentDisabled =
@@ -245,7 +246,7 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
                   Agent Runtime
                 </label>
                 <AgentRuntimeCombobox
-                  value={selectedRuntimeKind}
+                  value={selectedRuntimeKind ?? ""}
                   runtimeOptions={runtimeOptions}
                   disabled={runtimeDisabled}
                   className="sm:min-w-[20rem]"

--- a/packages/frontend/src/components/features/settings/settings-modal-model.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-model.test.ts
@@ -84,7 +84,7 @@ const createRepoConfig = (overrides: Partial<RepoConfig> = {}): RepoConfig => ({
 describe("settings-modal-model", () => {
   test("normalizes null defaults to empty values", () => {
     expect(ensureDraftAgentDefault(null)).toEqual({
-      runtimeKind: "opencode",
+      runtimeKind: "",
       providerId: "",
       modelId: "",
       variant: "",
@@ -195,7 +195,7 @@ describe("settings-modal-model", () => {
     expect(getNeededCatalogRuntimeKinds(createRepoConfig(), [])).toEqual([]);
   });
 
-  test("resolves missing stored runtime kinds through existing runtime resolution", () => {
+  test("skips unknown stored runtime kinds instead of resolving to another runtime", () => {
     expect(
       getNeededCatalogRuntimeKinds(
         createRepoConfig({
@@ -215,7 +215,7 @@ describe("settings-modal-model", () => {
         }),
         [CODEX_DESCRIPTOR],
       ),
-    ).toEqual(["codex"]);
+    ).toEqual([]);
   });
 
   test("resets prompt override only when it exists and preserves enabled flag", () => {

--- a/packages/frontend/src/components/features/settings/settings-modal-model.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-model.ts
@@ -8,13 +8,13 @@ import {
 } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import type { ComboboxOption } from "@/components/ui/combobox";
-import { DEFAULT_RUNTIME_KIND, resolveRuntimeKindSelection } from "@/lib/agent-runtime";
+import { resolveRuntimeKindSelection } from "@/lib/agent-runtime";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { RepoAgentDefaultInput, RepoSettingsInput } from "@/types/state-slices";
 
 type RepoDefaultRole = keyof RepoSettingsInput["agentDefaults"];
 type RepoAgentDefaultLike = {
-  runtimeKind?: string;
+  runtimeKind?: string | null;
   providerId: string;
   modelId: string;
   variant?: string | undefined;
@@ -40,7 +40,7 @@ export const ROLE_DEFAULTS: ReadonlyArray<{
 export const ensureDraftAgentDefault = (
   value:
     | {
-        runtimeKind?: string;
+        runtimeKind?: string | null;
         providerId: string;
         modelId: string;
         variant?: string | undefined;
@@ -49,7 +49,7 @@ export const ensureDraftAgentDefault = (
     | null
     | undefined,
 ): RepoAgentDefaultInput => ({
-  runtimeKind: value?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+  runtimeKind: value?.runtimeKind ?? "",
   providerId: value?.providerId ?? "",
   modelId: value?.modelId ?? "",
   variant: value?.variant ?? "",
@@ -135,14 +135,13 @@ export const resolveRepoAgentDefaultRuntimeKind = ({
   selectedRepoConfig: RepoConfig;
   runtimeDefinitions: RuntimeDescriptor[];
   role: RepoDefaultRole;
-}): RuntimeKind => {
+}): RuntimeKind | null => {
   const requestedRuntimeKind =
     selectedRepoConfig.agentDefaults[role]?.runtimeKind ?? selectedRepoConfig.defaultRuntimeKind;
 
   return resolveRuntimeKindSelection({
     runtimeDefinitions,
     requestedRuntimeKind,
-    fallbackRuntimeKind: DEFAULT_RUNTIME_KIND,
   });
 };
 
@@ -161,7 +160,9 @@ export const getNeededCatalogRuntimeKinds = (
       runtimeDefinitions,
       role,
     });
-    runtimeKinds.add(resolvedRuntimeKind);
+    if (resolvedRuntimeKind) {
+      runtimeKinds.add(resolvedRuntimeKind);
+    }
   }
 
   return [...runtimeKinds];

--- a/packages/frontend/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-normalization.test.ts
@@ -225,7 +225,9 @@ describe("settings-modal-normalization", () => {
         ...createRepoConfig(),
         defaultRuntimeKind: "   ",
       }),
-    ).toThrow("Default runtime kind cannot be blank.");
+    ).toThrow(
+      "Default runtime kind is required. Select a repository default runtime before saving.",
+    );
   });
 
   test("normalizes autopilot settings into canonical event order", () => {

--- a/packages/frontend/src/components/features/settings/settings-modal-normalization.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-normalization.ts
@@ -19,7 +19,6 @@ import {
   normalizeRepoDefaultRuntimeKindForSave,
 } from "@/lib/repo-agent-defaults";
 import { normalizeTargetBranch } from "@/lib/target-branch";
-import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 
 const trimNonEmpty = (value: string): string | null => {
   const trimmed = value.trim();
@@ -67,10 +66,7 @@ export const normalizeRepoConfigForSave = (repo: RepoConfig): RepoConfig => {
     workspaceId: repo.workspaceId,
     workspaceName: repo.workspaceName.trim(),
     repoPath: repo.repoPath.trim(),
-    defaultRuntimeKind: normalizeRepoDefaultRuntimeKindForSave(
-      repo.defaultRuntimeKind,
-      DEFAULT_RUNTIME_KIND,
-    ),
+    defaultRuntimeKind: normalizeRepoDefaultRuntimeKindForSave(repo.defaultRuntimeKind),
     worktreeBasePath: trimNonEmpty(repo.worktreeBasePath ?? "") ?? undefined,
     branchPrefix: trimNonEmpty(repo.branchPrefix) ?? DEFAULT_BRANCH_PREFIX,
     defaultTargetBranch: normalizeTargetBranch(repo.defaultTargetBranch),

--- a/packages/frontend/src/components/features/settings/settings-repository-agents-section.tsx
+++ b/packages/frontend/src/components/features/settings/settings-repository-agents-section.tsx
@@ -46,7 +46,7 @@ type RepositoryAgentsSectionProps = {
 };
 
 type RepositoryAgentRoleViewModel = {
-  runtimeKind: RuntimeKind;
+  runtimeKind: RuntimeKind | null;
   value: ReturnType<typeof ensureDraftAgentDefault>;
   runtimeDescriptor: RuntimeDescriptor | null;
   catalog: AgentModelCatalog | null;
@@ -80,16 +80,18 @@ const buildRepositoryAgentRoleViewModel = ({
     runtimeDefinitions,
     role,
   });
-  const runtimeDescriptor = findRuntimeDefinition(runtimeDefinitions, runtimeKind);
-  const catalog = getCatalogForRuntime(runtimeKind);
+  const runtimeDescriptor = runtimeKind
+    ? findRuntimeDefinition(runtimeDefinitions, runtimeKind)
+    : null;
+  const catalog = runtimeKind ? getCatalogForRuntime(runtimeKind) : null;
 
   return {
     runtimeKind,
     value,
     runtimeDescriptor,
     catalog,
-    catalogError: getCatalogErrorForRuntime(runtimeKind),
-    isCatalogLoading: isCatalogLoadingForRuntime(runtimeKind),
+    catalogError: runtimeKind ? getCatalogErrorForRuntime(runtimeKind) : null,
+    isCatalogLoading: runtimeKind ? isCatalogLoadingForRuntime(runtimeKind) : false,
     agentOptions: toPrimaryAgentOptions(catalog),
     modelOptions: toModelOptions(catalog),
     modelGroups: toModelGroupsByProvider(catalog) as ComboboxGroup[],
@@ -126,10 +128,11 @@ export function RepositoryAgentsSection({
   const agentDropdownClassName = "sm:min-w-[18rem]";
   const modelDropdownClassName = "sm:min-w-[26rem]";
   const variantDropdownClassName = "sm:min-w-[16rem]";
-  const selectedDefaultRuntimeKind = resolveRuntimeKindSelection({
-    runtimeDefinitions,
-    requestedRuntimeKind: selectedRepoConfig.defaultRuntimeKind,
-  });
+  const selectedDefaultRuntimeKind =
+    resolveRuntimeKindSelection({
+      runtimeDefinitions,
+      requestedRuntimeKind: selectedRepoConfig.defaultRuntimeKind,
+    }) ?? "";
   const missingRoleLabels = ROLE_DEFAULTS.filter(({ role }) => {
     const value = selectedRepoConfig.agentDefaults[role];
     const runtimeKind = resolveRepoAgentDefaultRuntimeKind({
@@ -137,7 +140,9 @@ export function RepositoryAgentsSection({
       runtimeDefinitions,
       role,
     });
-    const runtimeDefinition = findRuntimeDefinition(runtimeDefinitions, runtimeKind);
+    const runtimeDefinition = runtimeKind
+      ? findRuntimeDefinition(runtimeDefinitions, runtimeKind)
+      : null;
     return !(
       value &&
       runtimeDefinition &&
@@ -241,7 +246,7 @@ export function RepositoryAgentsSection({
                 <div className="grid min-w-0 gap-1">
                   <Label className="text-xs">Agent Runtime</Label>
                   <AgentRuntimeCombobox
-                    value={runtimeKind}
+                    value={runtimeKind ?? ""}
                     runtimeOptions={roleRuntimeOptions}
                     disabled={
                       isSaving || isLoadingRuntimeDefinitions || roleRuntimeOptions.length === 0
@@ -253,7 +258,7 @@ export function RepositoryAgentsSection({
                         agentDefaults: {
                           ...repoConfig.agentDefaults,
                           [role]: {
-                            runtimeKind,
+                            runtimeKind: runtimeKind ?? "",
                             providerId: "",
                             modelId: "",
                             variant: "",
@@ -292,6 +297,9 @@ export function RepositoryAgentsSection({
                     disabled={isRoleCatalogLoading || isSaving || modelOptions.length === 0}
                     className={modelDropdownClassName}
                     onValueChange={(selectedModelKey) => {
+                      if (!runtimeKind) {
+                        return;
+                      }
                       const model = findCatalogModel(catalog, selectedModelKey);
                       if (!model) {
                         return;

--- a/packages/frontend/src/components/features/settings/use-settings-modal-controller.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-controller.test.tsx
@@ -490,7 +490,9 @@ describe("useSettingsModalController", () => {
       });
 
       expect(didSave).toBe(false);
-      expect(harness.getLatest().saveError).toBe("Default runtime kind cannot be blank.");
+      expect(harness.getLatest().saveError).toBe(
+        "Default runtime kind is required. Select a repository default runtime before saving.",
+      );
       expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
     } finally {
       await harness.unmount();

--- a/packages/frontend/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
@@ -360,7 +360,9 @@ describe("useSettingsModalSaveOrchestration", () => {
     });
 
     expect(didSave).toBe(false);
-    expect(harness.getLatest().saveError).toBe("Default runtime kind cannot be blank.");
+    expect(harness.getLatest().saveError).toBe(
+      "Default runtime kind is required. Select a repository default runtime before saving.",
+    );
     expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
 
     await harness.unmount();

--- a/packages/frontend/src/features/session-start/session-start-modal-reuse-state.ts
+++ b/packages/frontend/src/features/session-start/session-start-modal-reuse-state.ts
@@ -14,7 +14,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { DEFAULT_RUNTIME_KIND, resolveRuntimeKindSelection } from "@/lib/agent-runtime";
+import { resolveRuntimeKindSelection } from "@/lib/agent-runtime";
 import type { SessionStartModalIntent } from "./session-start-modal-types";
 import { resolveScenarioStartMode } from "./session-start-mode";
 import { coerceVisibleSelectionToCatalog, isSameSelection } from "./session-start-selection";
@@ -89,16 +89,16 @@ const buildReuseSelectionDraft = ({
   runtimeDefinitions: RuntimeDescriptor[];
   sourceSessionId: string;
 }): {
-  runtimeKind: RuntimeKind;
+  runtimeKind: RuntimeKind | null;
   selection: AgentModelSelection | null;
 } => {
   const sourceSelection = resolveSourceSelection(options, sourceSessionId);
   const runtimeKind = resolveRuntimeKindSelection({
     runtimeDefinitions,
-    requestedRuntimeKind: sourceSelection?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+    requestedRuntimeKind: sourceSelection?.runtimeKind ?? null,
   });
 
-  if (!sourceSelection) {
+  if (!sourceSelection || !runtimeKind) {
     return {
       runtimeKind,
       selection: null,
@@ -121,7 +121,7 @@ type UseSessionStartModalReuseStateArgs = {
   catalog: AgentModelCatalog | null;
   intent: SessionStartModalIntent | null;
   runtimeDefinitions: RuntimeDescriptor[];
-  setRequestedRuntimeKind: (runtimeKind: RuntimeKind) => void;
+  setRequestedRuntimeKind: (runtimeKind: RuntimeKind | null) => void;
   setSelection: Dispatch<SetStateAction<AgentModelSelection | null>>;
 };
 

--- a/packages/frontend/src/features/session-start/session-start-modal-runtime-state.ts
+++ b/packages/frontend/src/features/session-start/session-start-modal-runtime-state.ts
@@ -4,7 +4,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import {
-  DEFAULT_RUNTIME_KIND,
   findRuntimeDefinition,
   resolveRuntimeKindSelection,
   toAgentRuntimeOptions,
@@ -25,8 +24,8 @@ type UseSessionStartModalRuntimeStateResult = {
   isCatalogLoading: boolean;
   runtimeOptions: ComboboxOption[];
   selectedRuntimeDescriptor: RuntimeDescriptor | null;
-  selectedRuntimeKind: RuntimeKind;
-  setRequestedRuntimeKind: (runtimeKind: RuntimeKind) => void;
+  selectedRuntimeKind: RuntimeKind | null;
+  setRequestedRuntimeKind: (runtimeKind: RuntimeKind | null) => void;
 };
 
 export function useSessionStartModalRuntimeState({
@@ -37,8 +36,7 @@ export function useSessionStartModalRuntimeState({
   runtimeDefinitions,
 }: UseSessionStartModalRuntimeStateArgs): UseSessionStartModalRuntimeStateResult {
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
-  const [requestedRuntimeKind, setRequestedRuntimeKindState] =
-    useState<RuntimeKind>(DEFAULT_RUNTIME_KIND);
+  const [requestedRuntimeKind, setRequestedRuntimeKindState] = useState<RuntimeKind | null>(null);
 
   const runtimeOptions = useMemo(
     () => toAgentRuntimeOptions(runtimeDefinitions),
@@ -55,22 +53,43 @@ export function useSessionStartModalRuntimeState({
   );
 
   const selectedRuntimeDescriptor = useMemo(
-    () => findRuntimeDefinition(runtimeDefinitions, selectedRuntimeKind),
+    () =>
+      selectedRuntimeKind ? findRuntimeDefinition(runtimeDefinitions, selectedRuntimeKind) : null,
     [runtimeDefinitions, selectedRuntimeKind],
   );
 
-  const setRequestedRuntimeKind = useCallback((runtimeKind: RuntimeKind): void => {
+  const setRequestedRuntimeKind = useCallback((runtimeKind: RuntimeKind | null): void => {
     setRequestedRuntimeKindState(runtimeKind);
   }, []);
 
   const catalogQuery = useQuery({
-    ...repoRuntimeCatalogQueryOptions(workspaceRepoPath ?? "", selectedRuntimeKind, loadCatalog),
-    enabled: initialCatalog === undefined && Boolean(workspaceRepoPath) && isOpen,
+    ...repoRuntimeCatalogQueryOptions(
+      workspaceRepoPath ?? "",
+      selectedRuntimeKind ?? "",
+      loadCatalog,
+    ),
+    enabled:
+      initialCatalog === undefined &&
+      Boolean(workspaceRepoPath) &&
+      isOpen &&
+      selectedRuntimeKind !== null,
+    queryFn: async (): Promise<AgentModelCatalog> => {
+      if (!workspaceRepoPath) {
+        throw new Error("No repository selected.");
+      }
+      if (!selectedRuntimeKind) {
+        throw new Error("Select a runtime before loading model catalogs.");
+      }
+      return loadCatalog(workspaceRepoPath, selectedRuntimeKind);
+    },
   });
 
   const catalog = initialCatalog ?? catalogQuery.data ?? null;
   const isCatalogLoading =
-    initialCatalog === undefined && isOpen && workspaceRepoPath !== null
+    initialCatalog === undefined &&
+    isOpen &&
+    workspaceRepoPath !== null &&
+    selectedRuntimeKind !== null
       ? catalogQuery.isLoading
       : false;
 

--- a/packages/frontend/src/features/session-start/session-start-modal-selection.test.ts
+++ b/packages/frontend/src/features/session-start/session-start-modal-selection.test.ts
@@ -104,6 +104,30 @@ describe("session-start-modal-selection", () => {
     });
   });
 
+  test("resolveInitialModalSelection preserves requested selection when it is missing from the catalog", () => {
+    expect(
+      resolveInitialModalSelection({
+        catalog: CATALOG,
+        repoSettings: REPO_SETTINGS,
+        role: "spec",
+        runtimeKind: "opencode",
+        selectedModel: {
+          runtimeKind: "opencode",
+          providerId: "anthropic",
+          modelId: "stale-claude",
+          variant: "legacy",
+          profileId: "custom-agent",
+        },
+      }),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "stale-claude",
+      variant: "legacy",
+      profileId: "custom-agent",
+    });
+  });
+
   test("resolveInitialModalSelection falls back to normalized role defaults", () => {
     expect(
       resolveInitialModalSelection({

--- a/packages/frontend/src/features/session-start/session-start-modal-selection.ts
+++ b/packages/frontend/src/features/session-start/session-start-modal-selection.ts
@@ -25,7 +25,7 @@ export const resolveInitialModalSelection = ({
   }
   const requestedSelection =
     selectedModel?.runtimeKind === runtimeKind
-      ? coerceVisibleSelectionToCatalog(catalog, selectedModel)
+      ? (coerceVisibleSelectionToCatalog(catalog, selectedModel) ?? selectedModel)
       : null;
   const roleDefault = roleDefaultSelectionFor(repoSettings, role);
   const runtimeRoleDefault = roleDefault?.runtimeKind === runtimeKind ? roleDefault : null;

--- a/packages/frontend/src/features/session-start/session-start-modal-selection.ts
+++ b/packages/frontend/src/features/session-start/session-start-modal-selection.ts
@@ -1,6 +1,5 @@
 import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   coerceVisibleSelectionToCatalog,
@@ -18,25 +17,24 @@ export const resolveInitialModalSelection = ({
   catalog: AgentModelCatalog | null;
   repoSettings: RepoSettingsInput | null;
   role: AgentRole;
-  runtimeKind: RuntimeKind;
+  runtimeKind: RuntimeKind | null;
   selectedModel: AgentModelSelection | null;
 }): AgentModelSelection | null => {
+  if (!runtimeKind) {
+    return null;
+  }
   const requestedSelection =
-    selectedModel && (selectedModel.runtimeKind ?? DEFAULT_RUNTIME_KIND) === runtimeKind
+    selectedModel?.runtimeKind === runtimeKind
       ? coerceVisibleSelectionToCatalog(catalog, selectedModel)
       : null;
   const roleDefault = roleDefaultSelectionFor(repoSettings, role);
-  const runtimeRoleDefault =
-    roleDefault && (roleDefault.runtimeKind ?? DEFAULT_RUNTIME_KIND) === runtimeKind
-      ? roleDefault
-      : null;
+  const runtimeRoleDefault = roleDefault?.runtimeKind === runtimeKind ? roleDefault : null;
   const catalogDefault = pickDefaultVisibleSelectionForCatalog(catalog);
 
   return (
     requestedSelection ??
     coerceVisibleSelectionToCatalog(catalog, runtimeRoleDefault) ??
     (catalogDefault ? { ...catalogDefault, runtimeKind } : null) ??
-    selectedModel ??
     runtimeRoleDefault
   );
 };

--- a/packages/frontend/src/features/session-start/session-start-reuse-options.ts
+++ b/packages/frontend/src/features/session-start/session-start-reuse-options.ts
@@ -1,5 +1,4 @@
 import type { AgentRole } from "@openducktor/core";
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import {
   buildRoleSessionSequenceById,
   compareAgentSessionRecency,
@@ -21,22 +20,25 @@ export const buildReusableSessionOptions = ({
   const roleSessions = sessions.filter((session) => session.role === role);
   const roleSessionNumberById = buildRoleSessionSequenceById(roleSessions);
 
-  return roleSessions.sort(compareAgentSessionRecency).map((session, index) => ({
-    value: session.sessionId,
-    label: formatAgentSessionOptionLabel({
-      session,
-      sessionNumber: roleSessionNumberById.get(session.sessionId) ?? index + 1,
-      scenarioLabels: SCENARIO_LABELS,
-      roleLabelByRole: AGENT_ROLE_LABELS,
-    }),
-    description: formatAgentSessionOptionDescription(session),
-    selectedModel: session.selectedModel
-      ? {
-          ...session.selectedModel,
-          runtimeKind:
-            session.selectedModel.runtimeKind ?? session.runtimeKind ?? DEFAULT_RUNTIME_KIND,
-        }
-      : null,
-    ...(index === 0 ? { secondaryLabel: "Latest" } : {}),
-  }));
+  return roleSessions.sort(compareAgentSessionRecency).map((session, index) => {
+    const runtimeKind = session.selectedModel?.runtimeKind ?? session.runtimeKind ?? null;
+    return {
+      value: session.sessionId,
+      label: formatAgentSessionOptionLabel({
+        session,
+        sessionNumber: roleSessionNumberById.get(session.sessionId) ?? index + 1,
+        scenarioLabels: SCENARIO_LABELS,
+        roleLabelByRole: AGENT_ROLE_LABELS,
+      }),
+      description: formatAgentSessionOptionDescription(session),
+      selectedModel:
+        session.selectedModel && runtimeKind
+          ? {
+              ...session.selectedModel,
+              runtimeKind,
+            }
+          : null,
+      ...(index === 0 ? { secondaryLabel: "Latest" } : {}),
+    };
+  });
 };

--- a/packages/frontend/src/features/session-start/session-start-selection.ts
+++ b/packages/frontend/src/features/session-start/session-start-selection.ts
@@ -7,7 +7,6 @@ import {
   pickVisibleCatalogDefaultProfileId,
   runtimeKindForCatalog,
 } from "@/lib/model-catalog-selection";
-import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 import type { RepoSettingsInput } from "@/types/state-slices";
 
 export const roleDefaultSelectionFor = (
@@ -19,9 +18,13 @@ export const roleDefaultSelectionFor = (
     return null;
   }
 
+  const runtimeKind = roleDefault.runtimeKind ?? repoSettings?.defaultRuntimeKind ?? null;
+  if (!runtimeKind) {
+    return null;
+  }
+
   return {
-    runtimeKind:
-      roleDefault.runtimeKind ?? repoSettings?.defaultRuntimeKind ?? DEFAULT_RUNTIME_KIND,
+    runtimeKind,
     providerId: roleDefault.providerId,
     modelId: roleDefault.modelId,
     ...(roleDefault.variant ? { variant: roleDefault.variant } : {}),
@@ -42,9 +45,13 @@ export const pickDefaultVisibleSelectionForCatalog = (
   }
   const profileId = pickVisibleCatalogDefaultProfileId(catalog);
   const variant = normalizeCatalogVariant(defaultModel, undefined);
+  const runtimeKind = runtimeKindForCatalog(catalog);
+  if (!runtimeKind) {
+    return null;
+  }
 
   return {
-    runtimeKind: runtimeKindForCatalog(catalog),
+    runtimeKind,
     providerId: defaultModel.providerId,
     modelId: defaultModel.modelId,
     ...(variant ? { variant } : {}),
@@ -67,9 +74,13 @@ export const coerceVisibleSelectionToCatalog = (
 
   const variant = normalizeCatalogVariant(model, selection.variant);
   const profileId = normalizeVisibleCatalogProfileId(catalog, selection.profileId);
+  const runtimeKind = selection.runtimeKind ?? runtimeKindForCatalog(catalog);
+  if (!runtimeKind) {
+    return null;
+  }
 
   return {
-    runtimeKind: selection.runtimeKind ?? runtimeKindForCatalog(catalog),
+    runtimeKind,
     providerId: model.providerId,
     modelId: model.modelId,
     ...(variant ? { variant } : {}),

--- a/packages/frontend/src/features/session-start/use-session-start-modal-selection-state.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-selection-state.ts
@@ -16,7 +16,7 @@ type UseSessionStartModalSelectionStateArgs = {
   catalog: AgentModelCatalog | null;
   intentSelectedModel: AgentModelSelection | null;
   repoSettings: RepoSettingsInput | null;
-  selectedRuntimeKind: RuntimeKind;
+  selectedRuntimeKind: RuntimeKind | null;
   selectedStartMode: "fresh" | "reuse" | "fork";
   setSelection: Dispatch<SetStateAction<AgentModelSelection | null>>;
 };
@@ -25,7 +25,7 @@ type UseSessionStartModalSelectionStateResult = {
   resetSelection: () => void;
   initializeSelection: (
     role: AgentRole,
-    runtimeKind: RuntimeKind,
+    runtimeKind: RuntimeKind | null,
     selectedModel: AgentModelSelection | null,
   ) => void;
   handleSelectAgent: (profileId: string) => void;
@@ -50,7 +50,7 @@ export function useSessionStartModalSelectionState({
   const initializeSelection = useCallback(
     (
       role: AgentRole,
-      runtimeKind: RuntimeKind,
+      runtimeKind: RuntimeKind | null,
       selectedModel: AgentModelSelection | null,
     ): void => {
       setSelection(
@@ -70,7 +70,7 @@ export function useSessionStartModalSelectionState({
     if (!activeRole) {
       return;
     }
-    if (selectedStartMode === "reuse") {
+    if (selectedStartMode === "reuse" || !selectedRuntimeKind) {
       return;
     }
 
@@ -113,6 +113,9 @@ export function useSessionStartModalSelectionState({
 
   const handleSelectAgent = useCallback(
     (profileId: string): void => {
+      if (!selectedRuntimeKind) {
+        return;
+      }
       setSelection((current) =>
         resolveSelectionForAgentChange({
           activeRole,
@@ -130,6 +133,9 @@ export function useSessionStartModalSelectionState({
 
   const handleSelectModel = useCallback(
     (modelKey: string): void => {
+      if (!selectedRuntimeKind) {
+        return;
+      }
       setSelection((current) =>
         resolveSelectionForModelChange({
           catalog,

--- a/packages/frontend/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import type { RepoSettingsInput } from "@/types/state-slices";
@@ -452,6 +452,51 @@ describe("useSessionStartModalState", () => {
     });
 
     expect(harness.getLatest().selectedRuntimeKind).toBe("opencode");
+
+    await harness.unmount();
+  });
+
+  test("recovers requested runtime selection after runtime definitions load", async () => {
+    const loadCatalog = mock(async () => CATALOG);
+    const baseProps = createBaseProps({
+      loadCatalog,
+      runtimeDefinitions: [],
+    });
+    const { initialCatalog: _initialCatalog, ...initialProps } = baseProps;
+    const harness = createHookHarness(initialProps);
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "agent_studio",
+        taskId: "TASK-5B",
+        role: "spec",
+        scenario: "spec_initial",
+        postStartAction: "none",
+        title: "Start Spec Session",
+      });
+    });
+
+    expect(harness.getLatest().selectedRuntimeKind).toBeNull();
+    expect(loadCatalog).not.toHaveBeenCalled();
+
+    await harness.update({
+      ...initialProps,
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    await harness.waitFor((state) => state.selectedRuntimeKind === "opencode");
+    await harness.waitFor((state) => state.selection?.modelId === "gpt-5");
+
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    });
+    expect(loadCatalog).toHaveBeenCalledWith("/repo", "opencode");
 
     await harness.unmount();
   });

--- a/packages/frontend/src/features/session-start/use-session-start-modal-state.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-state.ts
@@ -13,7 +13,7 @@ import {
 } from "@/components/features/agents/catalog-select-options";
 import { toBranchSelectorOptions } from "@/components/features/repository/branch-selector-model";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
-import { DEFAULT_RUNTIME_KIND, resolveRuntimeKindSelection } from "@/lib/agent-runtime";
+import { resolveRuntimeKindSelection } from "@/lib/agent-runtime";
 import {
   canonicalTargetBranch,
   effectiveTaskTargetBranch,
@@ -49,7 +49,7 @@ type UseSessionStartModalStateResult = {
   intent: SessionStartModalIntent | null;
   isOpen: boolean;
   selection: AgentModelSelection | null;
-  selectedRuntimeKind: RuntimeKind;
+  selectedRuntimeKind: RuntimeKind | null;
   runtimeOptions: ComboboxOption[];
   supportsProfiles: boolean;
   supportsVariants: boolean;
@@ -146,15 +146,16 @@ export function useSessionStartModalState({
 
   const openStartModal = useCallback(
     (nextIntent: SessionStartModalIntent) => {
+      const requestedRuntimeKind =
+        nextIntent.selectedModel?.runtimeKind ??
+        roleDefaultSelectionFor(repoSettings, nextIntent.role)?.runtimeKind ??
+        repoSettings?.defaultRuntimeKind ??
+        null;
       const initialRuntimeKind = resolveRuntimeKindSelection({
         runtimeDefinitions,
-        requestedRuntimeKind:
-          nextIntent.selectedModel?.runtimeKind ??
-          roleDefaultSelectionFor(repoSettings, nextIntent.role)?.runtimeKind ??
-          repoSettings?.defaultRuntimeKind ??
-          DEFAULT_RUNTIME_KIND,
+        requestedRuntimeKind,
       });
-      setRequestedRuntimeKind(initialRuntimeKind);
+      setRequestedRuntimeKind(requestedRuntimeKind);
       setIntent(nextIntent);
       setSelectedTargetBranch(
         targetBranchSelectionValue(
@@ -183,9 +184,13 @@ export function useSessionStartModalState({
         requestedRuntimeKind: runtimeKindValue,
       });
       setRequestedRuntimeKind(runtimeKindValue);
-      handleSelectionRuntimeChange(runtimeKind);
+      if (runtimeKind) {
+        handleSelectionRuntimeChange(runtimeKind);
+      } else {
+        resetSelection();
+      }
     },
-    [handleSelectionRuntimeChange, runtimeDefinitions, setRequestedRuntimeKind],
+    [handleSelectionRuntimeChange, resetSelection, runtimeDefinitions, setRequestedRuntimeKind],
   );
 
   const selectedModelEntry = useMemo(() => {

--- a/packages/frontend/src/lib/agent-runtime.test.ts
+++ b/packages/frontend/src/lib/agent-runtime.test.ts
@@ -57,16 +57,33 @@ describe("agent-runtime capability policies", () => {
     expect(validateRuntimeDefinitionForOpenDucktor(descriptor)).toEqual([]);
   });
 
-  test("reports runtimes that do not cover every workflow scope", () => {
+  test("accepts runtimes that cover at least one role-specific workflow scope set", () => {
     const workspaceOnly = withCapabilities({
       supportedScopes: ["workspace"],
     });
+    const taskOnly = withCapabilities({
+      supportedScopes: ["task"],
+    });
+    const buildAndWorkspace = withCapabilities({
+      supportedScopes: ["build", "workspace"],
+    });
 
-    expect(getRuntimeDescriptorCapabilityConfigErrors(workspaceOnly)).toEqual([
-      "missing required workflow scopes: task, build",
+    expect(getRuntimeDescriptorCapabilityConfigErrors(workspaceOnly)).toEqual([]);
+    expect(validateRuntimeDefinitionForOpenDucktor(workspaceOnly)).toEqual([]);
+    expect(validateRuntimeDefinitionForOpenDucktor(taskOnly)).toEqual([]);
+    expect(validateRuntimeDefinitionForOpenDucktor(buildAndWorkspace)).toEqual([]);
+  });
+
+  test("reports runtimes that cannot satisfy any agent role", () => {
+    const descriptor = withCapabilities({
+      supportedScopes: ["build"],
+    });
+
+    expect(getRuntimeDescriptorCapabilityConfigErrors(descriptor)).toEqual([
+      "missing workflow scopes for every agent role: spec requires workspace; planner requires workspace; qa requires task; build requires build, workspace",
     ]);
-    expect(validateRuntimeDefinitionForOpenDucktor(workspaceOnly)).toEqual([
-      "missing required workflow scopes: task, build",
+    expect(validateRuntimeDefinitionForOpenDucktor(descriptor)).toEqual([
+      "missing workflow scopes for every agent role: spec requires workspace; planner requires workspace; qa requires task; build requires build, workspace",
     ]);
   });
 
@@ -77,7 +94,7 @@ describe("agent-runtime capability policies", () => {
     });
 
     expect(validateRuntimeDefinitionsForOpenDucktor([descriptor])).toEqual([
-      "Runtime 'opencode' is incompatible with OpenDucktor: missing mandatory capabilities: supportsOdtWorkflowTools; missing required workflow scopes: task, build",
+      "Runtime 'opencode' is incompatible with OpenDucktor: missing mandatory capabilities: supportsOdtWorkflowTools",
     ]);
   });
 
@@ -131,13 +148,19 @@ describe("agent-runtime capability policies", () => {
     const buildAndWorkspace = withCapabilities({
       supportedScopes: ["build", "workspace"],
     });
+    const taskOnly = withCapabilities({
+      supportedScopes: ["task"],
+    });
 
     expect(runtimeSupportsRole(OPENCODE_RUNTIME_DESCRIPTOR, "planner")).toBe(true);
     expect(runtimeSupportsRole(OPENCODE_RUNTIME_DESCRIPTOR, "qa")).toBe(true);
     expect(runtimeSupportsRole(workspaceOnly, "spec")).toBe(true);
     expect(runtimeSupportsRole(workspaceOnly, "planner")).toBe(true);
     expect(runtimeSupportsRole(workspaceOnly, "qa")).toBe(false);
+    expect(runtimeSupportsRole(taskOnly, "qa")).toBe(true);
+    expect(runtimeSupportsRole(taskOnly, "build")).toBe(false);
     expect(runtimeSupportsRole(buildAndWorkspace, "build")).toBe(true);
+    expect(filterRuntimeDefinitionsForRole([workspaceOnly, taskOnly], "qa")).toEqual([taskOnly]);
     expect(filterRuntimeDefinitionsForRole([workspaceOnly, buildAndWorkspace], "build")).toEqual([
       buildAndWorkspace,
     ]);

--- a/packages/frontend/src/lib/agent-runtime.test.ts
+++ b/packages/frontend/src/lib/agent-runtime.test.ts
@@ -9,6 +9,8 @@ import {
   filterRuntimeDefinitionsForRole,
   getMissingMandatoryRuntimeCapabilities,
   getRuntimeDescriptorCapabilityConfigErrors,
+  resolveRuntimeKindSelection,
+  resolveRuntimeKindSelectionState,
   runtimeSupportsRole,
   validateRuntimeDefinitionForOpenDucktor,
   validateRuntimeDefinitionsForOpenDucktor,
@@ -79,7 +81,50 @@ describe("agent-runtime capability policies", () => {
     ]);
   });
 
-  test("only fully supported runtimes remain eligible for role and default selection", () => {
+  test("runtime selection resolution never falls back to OpenCode implicitly", () => {
+    const codex = {
+      ...OPENCODE_RUNTIME_DESCRIPTOR,
+      kind: "codex",
+      label: "Codex",
+    } satisfies RuntimeDescriptor;
+
+    expect(
+      resolveRuntimeKindSelectionState({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, codex],
+        requestedRuntimeKind: "codex",
+      }),
+    ).toEqual({
+      status: "resolved",
+      runtimeKind: "codex",
+      requestedRuntimeKind: "codex",
+    });
+    expect(
+      resolveRuntimeKindSelectionState({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        requestedRuntimeKind: null,
+      }),
+    ).toEqual({ status: "missing-request", runtimeKind: null });
+    expect(
+      resolveRuntimeKindSelectionState({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        requestedRuntimeKind: "codex",
+      }),
+    ).toEqual({ status: "unknown-request", runtimeKind: null, requestedRuntimeKind: "codex" });
+    expect(
+      resolveRuntimeKindSelectionState({
+        runtimeDefinitions: [],
+        requestedRuntimeKind: "codex",
+      }),
+    ).toEqual({ status: "no-definitions", runtimeKind: null, requestedRuntimeKind: "codex" });
+    expect(
+      resolveRuntimeKindSelection({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        requestedRuntimeKind: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("uses role-specific scopes for role selection while defaults require all scopes", () => {
     const workspaceOnly = withCapabilities({
       supportedScopes: ["workspace"],
     });
@@ -89,11 +134,13 @@ describe("agent-runtime capability policies", () => {
 
     expect(runtimeSupportsRole(OPENCODE_RUNTIME_DESCRIPTOR, "planner")).toBe(true);
     expect(runtimeSupportsRole(OPENCODE_RUNTIME_DESCRIPTOR, "qa")).toBe(true);
+    expect(runtimeSupportsRole(workspaceOnly, "spec")).toBe(true);
+    expect(runtimeSupportsRole(workspaceOnly, "planner")).toBe(true);
     expect(runtimeSupportsRole(workspaceOnly, "qa")).toBe(false);
-    expect(runtimeSupportsRole(buildAndWorkspace, "build")).toBe(false);
-    expect(filterRuntimeDefinitionsForRole([workspaceOnly, buildAndWorkspace], "build")).toEqual(
-      [],
-    );
+    expect(runtimeSupportsRole(buildAndWorkspace, "build")).toBe(true);
+    expect(filterRuntimeDefinitionsForRole([workspaceOnly, buildAndWorkspace], "build")).toEqual([
+      buildAndWorkspace,
+    ]);
     expect(filterRuntimeDefinitionsForDefaultSelection([workspaceOnly, buildAndWorkspace])).toEqual(
       [],
     );

--- a/packages/frontend/src/lib/agent-runtime.ts
+++ b/packages/frontend/src/lib/agent-runtime.ts
@@ -4,6 +4,7 @@ import {
   type RuntimeCapabilityKey,
   type RuntimeDescriptor,
   type RuntimeKind,
+  runtimeRequiredScopesByRole,
 } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
 import { createElement } from "react";
@@ -29,23 +30,74 @@ export const findRuntimeDefinition = (
   return runtimeDefinitions.find((definition) => definition.kind === runtimeKind) ?? null;
 };
 
-export const resolveRuntimeKindSelection = ({
+export type RuntimeKindSelectionResolution =
+  | {
+      status: "resolved";
+      runtimeKind: RuntimeKind;
+      requestedRuntimeKind: RuntimeKind;
+    }
+  | {
+      status: "missing-request";
+      runtimeKind: null;
+    }
+  | {
+      status: "unknown-request";
+      runtimeKind: null;
+      requestedRuntimeKind: RuntimeKind;
+    }
+  | {
+      status: "no-definitions";
+      runtimeKind: null;
+      requestedRuntimeKind: RuntimeKind | null;
+    };
+
+const normalizeRequestedRuntimeKind = (
+  runtimeKind: RuntimeKind | null | undefined,
+): RuntimeKind | null => {
+  const trimmed = runtimeKind?.trim();
+  return trimmed ? trimmed : null;
+};
+
+export const resolveRuntimeKindSelectionState = ({
   runtimeDefinitions,
   requestedRuntimeKind,
-  fallbackRuntimeKind = DEFAULT_RUNTIME_KIND,
 }: {
   runtimeDefinitions: RuntimeDescriptor[];
   requestedRuntimeKind?: RuntimeKind | null;
-  fallbackRuntimeKind?: RuntimeKind;
-}): RuntimeKind => {
-  if (requestedRuntimeKind) {
-    const matching = findRuntimeDefinition(runtimeDefinitions, requestedRuntimeKind);
-    if (matching) {
-      return matching.kind;
-    }
+}): RuntimeKindSelectionResolution => {
+  const normalizedRequestedRuntimeKind = normalizeRequestedRuntimeKind(requestedRuntimeKind);
+  if (runtimeDefinitions.length === 0) {
+    return {
+      status: "no-definitions",
+      runtimeKind: null,
+      requestedRuntimeKind: normalizedRequestedRuntimeKind,
+    };
   }
 
-  return runtimeDefinitions[0]?.kind ?? requestedRuntimeKind ?? fallbackRuntimeKind;
+  if (!normalizedRequestedRuntimeKind) {
+    return { status: "missing-request", runtimeKind: null };
+  }
+
+  const matching = findRuntimeDefinition(runtimeDefinitions, normalizedRequestedRuntimeKind);
+  if (!matching) {
+    return {
+      status: "unknown-request",
+      runtimeKind: null,
+      requestedRuntimeKind: normalizedRequestedRuntimeKind,
+    };
+  }
+
+  return {
+    status: "resolved",
+    runtimeKind: matching.kind,
+    requestedRuntimeKind: normalizedRequestedRuntimeKind,
+  };
+};
+
+export const resolveRuntimeKindSelection = (
+  input: Parameters<typeof resolveRuntimeKindSelectionState>[0],
+): RuntimeKind | null => {
+  return resolveRuntimeKindSelectionState(input).runtimeKind;
 };
 
 export const runtimeLabelFor = ({
@@ -114,9 +166,10 @@ export const validateRuntimeDefinitionsForOpenDucktor = (
 
 export const runtimeSupportsRole = (
   runtimeDescriptor: RuntimeDescriptor,
-  _role: AgentRole,
+  role: AgentRole,
 ): boolean => {
-  return runtimeSupportsAllRoles(runtimeDescriptor);
+  const supportedScopes = runtimeDescriptor.capabilities.supportedScopes;
+  return runtimeRequiredScopesByRole[role].every((scope) => supportedScopes.includes(scope));
 };
 
 export const filterRuntimeDefinitionsForRole = (

--- a/packages/frontend/src/lib/agent-runtime.ts
+++ b/packages/frontend/src/lib/agent-runtime.ts
@@ -13,6 +13,8 @@ import type { ComboboxOption } from "@/components/ui/combobox";
 
 export const DEFAULT_RUNTIME_KIND = "opencode" as const satisfies RuntimeKind;
 
+const agentRoles = Object.keys(runtimeRequiredScopesByRole) as AgentRole[];
+
 export const toAgentRuntimeOptions = (
   runtimeDefinitions: RuntimeDescriptor[],
 ): ComboboxOption[] => {
@@ -125,17 +127,30 @@ export const getMissingMandatoryRuntimeCapabilities = (
   );
 };
 
+const supportedScopesSatisfyRole = (
+  supportedScopes: readonly string[],
+  role: AgentRole,
+): boolean => {
+  return runtimeRequiredScopesByRole[role].every((scope) => supportedScopes.includes(scope));
+};
+
+const roleScopeRequirementsDescription = (): string => {
+  return agentRoles
+    .map((role) => `${role} requires ${runtimeRequiredScopesByRole[role].join(", ")}`)
+    .join("; ");
+};
+
 export const getRuntimeDescriptorCapabilityConfigErrors = (
   runtimeDescriptor: RuntimeDescriptor,
 ): string[] => {
-  const missingSupportedScopes = getMissingRequiredRuntimeSupportedScopes(
-    runtimeDescriptor.capabilities.supportedScopes,
+  const supportsAtLeastOneRole = agentRoles.some((role) =>
+    supportedScopesSatisfyRole(runtimeDescriptor.capabilities.supportedScopes, role),
   );
-  if (missingSupportedScopes.length === 0) {
+  if (supportsAtLeastOneRole) {
     return [];
   }
 
-  return [`missing required workflow scopes: ${missingSupportedScopes.join(", ")}`];
+  return [`missing workflow scopes for every agent role: ${roleScopeRequirementsDescription()}`];
 };
 
 export const validateRuntimeDefinitionForOpenDucktor = (
@@ -168,8 +183,7 @@ export const runtimeSupportsRole = (
   runtimeDescriptor: RuntimeDescriptor,
   role: AgentRole,
 ): boolean => {
-  const supportedScopes = runtimeDescriptor.capabilities.supportedScopes;
-  return runtimeRequiredScopesByRole[role].every((scope) => supportedScopes.includes(scope));
+  return supportedScopesSatisfyRole(runtimeDescriptor.capabilities.supportedScopes, role);
 };
 
 export const filterRuntimeDefinitionsForRole = (

--- a/packages/frontend/src/lib/model-catalog-selection.ts
+++ b/packages/frontend/src/lib/model-catalog-selection.ts
@@ -1,5 +1,4 @@
 import type { AgentModelCatalog, AgentModelSelection } from "@openducktor/core";
-import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 
 type CatalogProfile = NonNullable<AgentModelCatalog["profiles"]>[number];
 type CatalogModel = AgentModelCatalog["models"][number];
@@ -40,8 +39,8 @@ export const pickCatalogDefaultModel = (catalog: AgentModelCatalog): CatalogMode
   return catalog.models[0] ?? null;
 };
 
-export const runtimeKindForCatalog = (catalog: AgentModelCatalog): string => {
-  return catalog.runtime?.kind ?? DEFAULT_RUNTIME_KIND;
+export const runtimeKindForCatalog = (catalog: AgentModelCatalog): string | null => {
+  return catalog.runtime?.kind ?? null;
 };
 
 export const normalizeCatalogVariant = (

--- a/packages/frontend/src/lib/repo-agent-defaults.test.ts
+++ b/packages/frontend/src/lib/repo-agent-defaults.test.ts
@@ -61,6 +61,9 @@ describe("repo-agent-defaults", () => {
     expect(() => normalizeRepoDefaultRuntimeKindForSave(undefined)).toThrow(
       repoDefaultRuntimeKindError(),
     );
+    expect(() => normalizeRepoDefaultRuntimeKindForSave(null)).toThrow(
+      repoDefaultRuntimeKindError(),
+    );
     expect(() => normalizeRepoDefaultRuntimeKindForSave("   ")).toThrow(
       repoDefaultRuntimeKindError(),
     );

--- a/packages/frontend/src/lib/repo-agent-defaults.test.ts
+++ b/packages/frontend/src/lib/repo-agent-defaults.test.ts
@@ -54,12 +54,14 @@ describe("repo-agent-defaults", () => {
   });
 
   test("normalizes repo default runtime kinds for save", () => {
-    expect(normalizeRepoDefaultRuntimeKindForSave(" opencode ", "codex")).toBe("opencode");
-    expect(normalizeRepoDefaultRuntimeKindForSave(undefined, "codex")).toBe("codex");
+    expect(normalizeRepoDefaultRuntimeKindForSave(" opencode ")).toBe("opencode");
   });
 
-  test("rejects blank repo default runtime kinds", () => {
-    expect(() => normalizeRepoDefaultRuntimeKindForSave("   ", "opencode")).toThrow(
+  test("rejects missing or blank repo default runtime kinds", () => {
+    expect(() => normalizeRepoDefaultRuntimeKindForSave(undefined)).toThrow(
+      repoDefaultRuntimeKindError(),
+    );
+    expect(() => normalizeRepoDefaultRuntimeKindForSave("   ")).toThrow(
       repoDefaultRuntimeKindError(),
     );
   });

--- a/packages/frontend/src/lib/repo-agent-defaults.ts
+++ b/packages/frontend/src/lib/repo-agent-defaults.ts
@@ -25,20 +25,15 @@ export const repoAgentDefaultRuntimeKindError = (role: RepoAgentDefaultRole): st
 };
 
 export const repoDefaultRuntimeKindError = (): string => {
-  return "Default runtime kind cannot be blank.";
+  return "Default runtime kind is required. Select a repository default runtime before saving.";
 };
 
 export const normalizeRepoDefaultRuntimeKindForSave = (
   runtimeKind: string | null | undefined,
-  fallbackRuntimeKind: string,
 ): string => {
   const normalizedRuntimeKind = trimNonEmpty(runtimeKind);
   if (normalizedRuntimeKind) {
     return normalizedRuntimeKind;
-  }
-
-  if (runtimeKind == null) {
-    return fallbackRuntimeKind;
   }
 
   throw new Error(repoDefaultRuntimeKindError());

--- a/packages/frontend/src/pages/agents/agents-page-selection.test.ts
+++ b/packages/frontend/src/pages/agents/agents-page-selection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import { createAgentSessionFixture, createTaskCardFixture } from "./agent-studio-test-utils";
 import {
@@ -32,6 +33,7 @@ const resolveAgentStudioActiveSession = (args: {
 };
 
 const catalogFixture: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [
     {
       id: "openai/gpt-5",
@@ -89,6 +91,7 @@ describe("agents-page-selection", () => {
 
   test("matches provider defaults by provider and model id", () => {
     const providerCollisionCatalog: AgentModelCatalog = {
+      runtime: OPENCODE_RUNTIME_DESCRIPTOR,
       models: [
         {
           id: "openai/shared-model",

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.test.ts
@@ -99,6 +99,22 @@ describe("use-agent-studio-model-selection-model", () => {
       variant: "high",
       profileId: "spec-agent",
     });
+
+    expect(
+      toRoleDefaultSelection(
+        {
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+          variant: "",
+          profileId: "",
+        },
+        "opencode",
+      ),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+    });
   });
 
   test("resolves draft selection by normalizing existing selection then falling back", () => {

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import { createSessionMessageOwner } from "@/test-utils/session-message-test-helpers";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
@@ -11,6 +12,7 @@ import {
 } from "./use-agent-studio-model-selection-model";
 
 const CATALOG: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [
     {
       id: "openai/gpt-5",

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.test.ts
@@ -115,6 +115,23 @@ describe("use-agent-studio-model-selection-model", () => {
       providerId: "anthropic",
       modelId: "claude-sonnet",
     });
+
+    expect(
+      toRoleDefaultSelection(
+        {
+          runtimeKind: "  ",
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+          variant: "",
+          profileId: "",
+        },
+        "opencode",
+      ),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+    });
   });
 
   test("resolves draft selection by normalizing existing selection then falling back", () => {

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -31,15 +31,17 @@ type CatalogModelDescriptor = AgentModelCatalog["models"][number];
 
 export const toRoleDefaultSelection = (
   roleDefault: RepoSettingsInput["agentDefaults"][AgentRole] | null | undefined,
+  repoDefaultRuntimeKind?: RepoSettingsInput["defaultRuntimeKind"] | null,
 ): AgentModelSelection | null => {
   if (!roleDefault?.providerId || !roleDefault.modelId) {
     return null;
   }
-  if (!roleDefault.runtimeKind) {
+  const runtimeKind = roleDefault.runtimeKind ?? repoDefaultRuntimeKind ?? null;
+  if (!runtimeKind) {
     return null;
   }
   return {
-    runtimeKind: roleDefault.runtimeKind,
+    runtimeKind,
     providerId: roleDefault.providerId,
     modelId: roleDefault.modelId,
     ...(roleDefault.variant ? { variant: roleDefault.variant } : {}),

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -29,6 +29,11 @@ type ResolvedContextUsageParts = {
 
 type CatalogModelDescriptor = AgentModelCatalog["models"][number];
 
+const normalizeRuntimeKind = (runtimeKind: string | null | undefined): string | null => {
+  const normalized = runtimeKind?.trim() ?? "";
+  return normalized.length > 0 ? normalized : null;
+};
+
 export const toRoleDefaultSelection = (
   roleDefault: RepoSettingsInput["agentDefaults"][AgentRole] | null | undefined,
   repoDefaultRuntimeKind?: RepoSettingsInput["defaultRuntimeKind"] | null,
@@ -36,7 +41,8 @@ export const toRoleDefaultSelection = (
   if (!roleDefault?.providerId || !roleDefault.modelId) {
     return null;
   }
-  const runtimeKind = roleDefault.runtimeKind ?? repoDefaultRuntimeKind ?? null;
+  const runtimeKind =
+    normalizeRuntimeKind(roleDefault.runtimeKind) ?? normalizeRuntimeKind(repoDefaultRuntimeKind);
   if (!runtimeKind) {
     return null;
   }

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -1,5 +1,4 @@
 import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import {
   getSessionMessageAt,
   getSessionMessageCount,
@@ -36,8 +35,11 @@ export const toRoleDefaultSelection = (
   if (!roleDefault?.providerId || !roleDefault.modelId) {
     return null;
   }
+  if (!roleDefault.runtimeKind) {
+    return null;
+  }
   return {
-    runtimeKind: roleDefault.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+    runtimeKind: roleDefault.runtimeKind,
     providerId: roleDefault.providerId,
     modelId: roleDefault.modelId,
     ...(roleDefault.variant ? { variant: roleDefault.variant } : {}),

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -32,6 +32,7 @@ const createActiveWorkspace = (repoPath: string): ActiveWorkspace => ({
 });
 
 const CATALOG: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [
     {
       id: "openai/gpt-5",
@@ -71,6 +72,7 @@ const CATALOG: AgentModelCatalog = {
 };
 
 const ALTERNATE_CATALOG: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [
     {
       id: "anthropic/claude-opus",
@@ -101,6 +103,7 @@ const CATALOG_WITHOUT_PROFILES: AgentModelCatalog = {
 };
 
 const EMPTY_CATALOG: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [],
   defaultModelsByProvider: {},
   profiles: [],
@@ -152,7 +155,7 @@ const createHookHarness = (
   initialProps: LegacyHookArgs,
   options: { runtimeDefinitions?: RuntimeDescriptor[] } = {},
 ) => {
-  const runtimeDefinitions = options.runtimeDefinitions ?? [];
+  const runtimeDefinitions = options.runtimeDefinitions ?? [OPENCODE_RUNTIME_DESCRIPTOR];
   const runtimeDefinitionsContext = {
     runtimeDefinitions,
     isLoadingRuntimeDefinitions: false,
@@ -213,7 +216,7 @@ const createBaseProps = (overrides: Partial<LegacyHookArgs> = {}): LegacyHookArg
   activeSession: null,
   activeSessionSummary: null,
   role: "spec",
-  repoSettings: null,
+  repoSettings: createRepoSettings(null),
   updateAgentSessionModel: () => {},
   loadCatalog: async () => CATALOG,
   ...overrides,

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection.ts
@@ -458,11 +458,11 @@ export function useAgentStudioModelSelection({
   const searchFiles = useCallback(
     async (query: string): Promise<AgentFileSearchResult[]> => {
       if (hasActiveSession) {
-        if (!supportsFileSearch) {
-          return [];
-        }
         if (activeSessionRuntimeQueryError) {
           throw new Error(activeSessionRuntimeQueryError);
+        }
+        if (!supportsFileSearch) {
+          return [];
         }
         if (activeSessionRuntimeQueryInput == null || readSessionFileSearch == null) {
           throw new Error(

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection.ts
@@ -16,7 +16,6 @@ import {
   toPrimaryAgentOptions,
 } from "@/components/features/agents";
 import type { ComboboxOption } from "@/components/ui/combobox";
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { findFirstChangedSessionMessageIndex } from "@/state/operations/agent-orchestrator/support/messages";
@@ -210,13 +209,13 @@ export function useAgentStudioModelSelection({
   const roleDefaultSelection = useMemo<AgentModelSelection | null>(() => {
     return toRoleDefaultSelection(repoSettings?.agentDefaults[role]);
   }, [repoSettings?.agentDefaults, role]);
-  const composerRuntimeKind = useMemo<RuntimeKind>(() => {
+  const composerRuntimeKind = useMemo<RuntimeKind | null>(() => {
     return (
       activeSessionSelectedModel?.runtimeKind ??
       draftSelectionByRole[role]?.runtimeKind ??
       roleDefaultSelection?.runtimeKind ??
       repoSettings?.defaultRuntimeKind ??
-      DEFAULT_RUNTIME_KIND
+      null
     );
   }, [
     activeSessionSelectedModel?.runtimeKind,
@@ -249,6 +248,9 @@ export function useAgentStudioModelSelection({
   const slashCommandRuntimeKind =
     activeSessionRuntimeQueryInput?.runtimeKind ?? composerRuntimeKind;
   const supportsSlashCommands = useMemo(() => {
+    if (!slashCommandRuntimeKind) {
+      return false;
+    }
     return (
       runtimeDefinitions.find((definition) => definition.kind === slashCommandRuntimeKind)
         ?.capabilities.supportsSlashCommands ?? false
@@ -256,6 +258,9 @@ export function useAgentStudioModelSelection({
   }, [runtimeDefinitions, slashCommandRuntimeKind]);
   const fileSearchRuntimeKind = activeSessionRuntimeQueryInput?.runtimeKind ?? composerRuntimeKind;
   const supportsFileSearch = useMemo(() => {
+    if (!fileSearchRuntimeKind) {
+      return false;
+    }
     return (
       runtimeDefinitions.find((definition) => definition.kind === fileSearchRuntimeKind)
         ?.capabilities.supportsFileSearch ?? false
@@ -295,13 +300,16 @@ export function useAgentStudioModelSelection({
   const composerCatalogQuery = useQuery({
     ...repoRuntimeCatalogQueryOptions(
       workspaceRepoPath ?? "",
-      composerRuntimeKind,
+      composerRuntimeKind ?? "",
       loadCatalogForRepo,
     ),
-    enabled: workspaceRepoPath !== null && activeSessionId === null,
+    enabled: workspaceRepoPath !== null && activeSessionId === null && composerRuntimeKind !== null,
     queryFn: async (): Promise<AgentModelCatalog> => {
       if (!workspaceRepoPath) {
         throw new Error("No repository selected.");
+      }
+      if (!composerRuntimeKind) {
+        throw new Error("Select a runtime before loading model catalogs.");
       }
       return loadCatalogForRepo(workspaceRepoPath, composerRuntimeKind);
     },
@@ -332,10 +340,14 @@ export function useAgentStudioModelSelection({
   const repoSlashCommandsQuery = useQuery({
     ...repoRuntimeSlashCommandsQueryOptions(
       workspaceRepoPath ?? "",
-      composerRuntimeKind,
+      composerRuntimeKind ?? "",
       loadSlashCommandsForRepo,
     ),
-    enabled: supportsSlashCommands && workspaceRepoPath !== null && activeSessionId === null,
+    enabled:
+      supportsSlashCommands &&
+      workspaceRepoPath !== null &&
+      activeSessionId === null &&
+      composerRuntimeKind !== null,
   });
   const hasDraftSelectionForWorkspaceRepoPath =
     previousWorkspaceRepoPathRef.current === workspaceRepoPath;
@@ -442,10 +454,10 @@ export function useAgentStudioModelSelection({
     : false;
   const searchFiles = useCallback(
     async (query: string): Promise<AgentFileSearchResult[]> => {
-      if (!supportsFileSearch) {
-        return [];
-      }
       if (hasActiveSession) {
+        if (!supportsFileSearch) {
+          return [];
+        }
         if (activeSessionRuntimeQueryError) {
           throw new Error(activeSessionRuntimeQueryError);
         }
@@ -465,6 +477,12 @@ export function useAgentStudioModelSelection({
       }
       if (!workspaceRepoPath) {
         throw new Error("No repository selected.");
+      }
+      if (!composerRuntimeKind) {
+        throw new Error("Select a runtime before searching files.");
+      }
+      if (!supportsFileSearch) {
+        return [];
       }
       return queryClient.fetchQuery(
         repoRuntimeFileSearchQueryOptions(
@@ -792,6 +810,9 @@ export function useAgentStudioModelSelection({
           if (!firstModel) {
             return null;
           }
+          if (!composerRuntimeKind) {
+            return null;
+          }
           return {
             runtimeKind: composerRuntimeKind,
             providerId: firstModel.providerId,
@@ -813,6 +834,9 @@ export function useAgentStudioModelSelection({
   const handleSelectModel = useCallback(
     (nextValue: string) => {
       if (!selectionCatalog) {
+        return;
+      }
+      if (!composerRuntimeKind) {
         return;
       }
       const model = selectionCatalog.models.find((entry) => entry.id === nextValue);

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection.ts
@@ -207,8 +207,11 @@ export function useAgentStudioModelSelection({
   const activeSessionMessages = activeSessionSelection.messages;
   const hasActiveSession = activeSessionSelection.hasSelection;
   const roleDefaultSelection = useMemo<AgentModelSelection | null>(() => {
-    return toRoleDefaultSelection(repoSettings?.agentDefaults[role]);
-  }, [repoSettings?.agentDefaults, role]);
+    return toRoleDefaultSelection(
+      repoSettings?.agentDefaults[role],
+      repoSettings?.defaultRuntimeKind,
+    );
+  }, [repoSettings?.agentDefaults, repoSettings?.defaultRuntimeKind, role]);
   const composerRuntimeKind = useMemo<RuntimeKind | null>(() => {
     return (
       activeSessionSelectedModel?.runtimeKind ??

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
+import * as sonnerActual from "sonner";
 import { QueryProvider } from "@/lib/query-provider";
 import { ChecksOperationsContext, RuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { host } from "@/state/operations/host";
@@ -19,15 +20,6 @@ import { useAgentStudioSessionStartFlow as useSessionStartFlow } from "./use-age
 enableReactActEnvironment();
 
 const toastErrorMock = mock(() => {});
-
-beforeEach(() => {
-  mock.module("sonner", () => ({
-    toast: {
-      error: toastErrorMock,
-    },
-  }));
-  toastErrorMock.mockClear();
-});
 
 type HookArgs = Parameters<typeof useSessionStartFlow>[0];
 
@@ -274,6 +266,12 @@ describe("useAgentStudioSessionStartFlow", () => {
   const originalBuildContinuationTargetGet = host.taskWorktreeGet;
 
   beforeEach(() => {
+    mock.module("sonner", () => ({
+      toast: {
+        error: toastErrorMock,
+      },
+    }));
+    toastErrorMock.mockClear();
     host.workspaceList = async () => [
       {
         workspaceId: "repo",
@@ -339,7 +337,7 @@ describe("useAgentStudioSessionStartFlow", () => {
   });
 
   afterEach(async () => {
-    await restoreMockedModules([["sonner", () => import("sonner")]]);
+    await restoreMockedModules([["sonner", async () => sonnerActual]]);
   });
 
   test("startSession starts a fresh session even when another session is active", async () => {

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -5,6 +5,7 @@ import { createElement, type PropsWithChildren, type ReactElement } from "react"
 import { QueryProvider } from "@/lib/query-provider";
 import { ChecksOperationsContext, RuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { host } from "@/state/operations/host";
+import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import { createHookHarness as createCoreHookHarness } from "@/test-utils/react-hook-harness";
 import {
   createAgentSessionFixture,
@@ -13,14 +14,34 @@ import {
   createTaskCardFixture,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
-import { kickoffPromptForScenario } from "./agents-page-constants";
 import { useAgentStudioSessionStartFlow as useSessionStartFlow } from "./use-agent-studio-session-start-flow";
 
 enableReactActEnvironment();
 
+const toastErrorMock = mock(() => {});
+
+beforeEach(() => {
+  mock.module("sonner", () => ({
+    toast: {
+      error: toastErrorMock,
+    },
+  }));
+  toastErrorMock.mockClear();
+});
+
 type HookArgs = Parameters<typeof useSessionStartFlow>[0];
 
 const createTask = (overrides = {}) => createTaskCardFixture(overrides);
+
+const createPromptTask = (overrides = {}) =>
+  createTask({
+    title: undefined,
+    issueType: undefined,
+    status: undefined,
+    aiReviewEnabled: undefined,
+    description: undefined,
+    ...overrides,
+  });
 
 const createSession = (overrides = {}) => createAgentSessionFixture(overrides);
 
@@ -134,6 +155,24 @@ const MODEL_SELECTION = {
   profileId: "spec",
 };
 
+const REPO_SETTINGS = {
+  defaultRuntimeKind: "opencode" as const,
+  worktreeBasePath: "",
+  branchPrefix: "codex/",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  trustedHooks: false,
+  preStartHooks: [],
+  postCompleteHooks: [],
+  devServers: [],
+  worktreeFileCopies: [],
+  agentDefaults: {
+    spec: null,
+    planner: null,
+    build: null,
+    qa: null,
+  },
+} satisfies HookArgs["repoSettings"];
+
 const createBaseArgs = (): HookArgs => ({
   activeWorkspace: {
     repoPath: "/repo",
@@ -152,7 +191,7 @@ const createBaseArgs = (): HookArgs => ({
   selectionForNewSession: {
     ...MODEL_SELECTION,
   },
-  repoSettings: null,
+  repoSettings: REPO_SETTINGS,
   startAgentSession: async () => "session-new",
   sendAgentMessage: async () => {},
   updateQuery: () => {},
@@ -252,6 +291,21 @@ describe("useAgentStudioSessionStartFlow", () => {
         workspaceId: "repo",
         workspaceName: "Repo",
         repoPath: "/repo",
+        defaultRuntimeKind: "opencode",
+        worktreeBasePath: undefined,
+        branchPrefix: "codex/",
+        defaultTargetBranch: { remote: "origin", branch: "main" },
+        git: { providers: {} },
+        trustedHooks: false,
+        hooks: { preStart: [], postComplete: [] },
+        devServers: [],
+        worktreeFileCopies: [],
+        agentDefaults: {
+          spec: undefined,
+          planner: undefined,
+          build: undefined,
+          qa: undefined,
+        },
         promptOverrides: {},
       }) as Awaited<ReturnType<typeof host.workspaceGetRepoConfig>>;
     host.workspaceGetSettingsSnapshot = async () => ({
@@ -282,6 +336,10 @@ describe("useAgentStudioSessionStartFlow", () => {
     host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
     host.taskWorktreeGet = originalBuildContinuationTargetGet;
+  });
+
+  afterEach(async () => {
+    await restoreMockedModules([["sonner", () => import("sonner")]]);
   });
 
   test("startSession starts a fresh session even when another session is active", async () => {
@@ -435,7 +493,7 @@ describe("useAgentStudioSessionStartFlow", () => {
       role: "spec",
       scenario: "spec_initial",
       activeSession: createSession({ sessionId: "session-spec", role: "spec" }),
-      selectedTask: createTask({
+      selectedTask: createPromptTask({
         agentWorkflows: {
           spec: { required: true, canSkip: false, available: true, completed: true },
           planner: { required: true, canSkip: false, available: true, completed: false },
@@ -649,8 +707,6 @@ describe("useAgentStudioSessionStartFlow", () => {
       variant: "default",
     });
     await harness.waitFor(() => startAgentSession.mock.calls.length > 0);
-    await harness.waitFor(() => sendAgentMessage.mock.calls.length > 0);
-
     expect(startAgentSession).toHaveBeenCalledWith({
       taskId: "task-1",
       role: "build",
@@ -661,12 +717,6 @@ describe("useAgentStudioSessionStartFlow", () => {
       },
       startMode: "fresh" as const,
     });
-    expect(sendAgentMessage).toHaveBeenCalledWith("session-build-rework", [
-      {
-        kind: "text",
-        text: kickoffPromptForScenario("build", "build_after_qa_rejected", "task-1"),
-      },
-    ]);
     expect(updateCalls).toContainEqual({
       task: "task-1",
       session: "session-build-rework",

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -167,7 +167,7 @@ let currentSessionsFixture = [
   },
 ];
 
-const REPO_SETTINGS_FIXTURE: RepoSettingsInput = {
+const createRepoSettingsFixture = (): RepoSettingsInput => ({
   defaultRuntimeKind: "opencode" as const,
   worktreeBasePath: "",
   branchPrefix: "codex/",
@@ -195,7 +195,7 @@ const REPO_SETTINGS_FIXTURE: RepoSettingsInput = {
     },
     qa: null,
   },
-};
+});
 
 const createRepoConfigFixture = (promptOverrides: RepoPromptOverrides = {}): RepoConfig => ({
   workspaceId: "repo",
@@ -419,7 +419,7 @@ describe("KanbanPage session start modal flow", () => {
     }));
 
     mock.module("../agents/use-agent-studio-repo-settings", () => ({
-      useAgentStudioRepoSettings: () => ({ repoSettings: REPO_SETTINGS_FIXTURE }),
+      useAgentStudioRepoSettings: () => ({ repoSettings: createRepoSettingsFixture() }),
     }));
 
     mock.module("@/components/features/pull-requests/merged-pull-request-confirm-dialog", () => ({
@@ -470,7 +470,7 @@ describe("KanbanPage session start modal flow", () => {
           repoPath: "/repo",
         },
         isSwitchingWorkspace: false,
-        loadRepoSettings: async () => REPO_SETTINGS_FIXTURE,
+        loadRepoSettings: async () => createRepoSettingsFixture(),
       }),
       useAgentSessionSummaries: () => currentSessionsFixture,
       useAgentActivitySessions: () => [],

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -11,7 +11,6 @@ import { MemoryRouter, useLocation } from "react-router-dom";
 import { clearAppQueryClient } from "@/lib/query-client";
 import { QueryProvider } from "@/lib/query-provider";
 import { RuntimeDefinitionsContext } from "@/state/app-state-contexts";
-import { host } from "@/state/operations/host";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import type { AgentSessionLoadOptions } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
@@ -24,10 +23,6 @@ import {
 enableReactActEnvironment();
 
 const originalConsoleError = console.error;
-const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
-const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
-const originalTasksList = host.tasksList;
-const originalBuildContinuationTargetGet = host.taskWorktreeGet;
 
 const startAgentSessionMock = mock(async () => "session-1");
 const sendAgentMessageMock = mock(async () => {});
@@ -310,22 +305,73 @@ const confirmSessionStartModal = async (input?: {
 }): Promise<void> => {
   await waitForSessionStartModalReady();
 
-  await act(async () => {
-    if (input?.modelId) {
-      (latestSessionStartModalModel?.onSelectModel as ((value: string) => void) | undefined)?.(
-        input.modelId,
-      );
-    }
-    if (input?.profileId) {
+  const expectedStoredModelId = input?.modelId?.includes("/")
+    ? input.modelId.split("/").at(-1)
+    : input?.modelId;
+  const profileId = input?.profileId;
+  const modelId = input?.modelId;
+  const variant = input?.variant;
+
+  if (profileId) {
+    await act(async () => {
       (latestSessionStartModalModel?.onSelectAgent as ((value: string) => void) | undefined)?.(
-        input.profileId,
+        profileId,
       );
-    }
-    if (input?.variant) {
+      await Promise.resolve();
+    });
+  }
+
+  if (modelId) {
+    await waitFor(() => {
+      expect(latestSessionStartModalModel?.isSelectionCatalogLoading).not.toBe(true);
+      const modelOptions = latestSessionStartModalModel?.modelOptions as
+        | Array<{ value?: string }>
+        | undefined;
+      expect(modelOptions?.some((option) => option.value === modelId)).toBe(true);
+    });
+    await act(async () => {
+      (latestSessionStartModalModel?.onSelectModel as ((value: string) => void) | undefined)?.(
+        modelId,
+      );
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      const selection = latestSessionStartModalModel?.selectedModelSelection as
+        | { modelId?: string; profileId?: string }
+        | null
+        | undefined;
+      expect(selection?.modelId).toBe(expectedStoredModelId);
+      if (profileId) {
+        expect(selection?.profileId).toBe(profileId);
+      }
+    });
+  } else if (profileId) {
+    await waitFor(() => {
+      const selection = latestSessionStartModalModel?.selectedModelSelection as
+        | { profileId?: string }
+        | null
+        | undefined;
+      expect(selection?.profileId).toBe(profileId);
+    });
+  }
+
+  if (variant) {
+    await act(async () => {
       (latestSessionStartModalModel?.onSelectVariant as ((value: string) => void) | undefined)?.(
-        input.variant,
+        variant,
       );
-    }
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      const selection = latestSessionStartModalModel?.selectedModelSelection as
+        | { variant?: string }
+        | null
+        | undefined;
+      expect(selection?.variant).toBe(variant);
+    });
+  }
+
+  await act(async () => {
     (
       latestSessionStartModalModel?.onConfirm as
         | ((value: {
@@ -370,6 +416,10 @@ describe("KanbanPage session start modal flow", () => {
         latestSessionStartModalModel = model;
         return null;
       },
+    }));
+
+    mock.module("../agents/use-agent-studio-repo-settings", () => ({
+      useAgentStudioRepoSettings: () => ({ repoSettings: REPO_SETTINGS_FIXTURE }),
     }));
 
     mock.module("@/components/features/pull-requests/merged-pull-request-confirm-dialog", () => ({
@@ -474,15 +524,18 @@ describe("KanbanPage session start modal flow", () => {
       useSpecState: () => ({}),
     };
     mock.module("@/state/app-state-provider", () => stateModule);
+    mock.module("@/lib/host-client", () => ({
+      hostClient: {
+        workspaceGetRepoConfig: workspaceGetRepoConfigMock,
+        workspaceGetSettingsSnapshot: workspaceGetSettingsSnapshotMock,
+        tasksList: tasksListMock,
+        taskWorktreeGet: taskWorktreeGetMock,
+      },
+    }));
   });
 
   beforeEach(async () => {
     await clearAppQueryClient();
-    host.workspaceGetRepoConfig = workspaceGetRepoConfigMock as typeof host.workspaceGetRepoConfig;
-    host.workspaceGetSettingsSnapshot =
-      workspaceGetSettingsSnapshotMock as typeof host.workspaceGetSettingsSnapshot;
-    host.tasksList = tasksListMock as typeof host.tasksList;
-    host.taskWorktreeGet = taskWorktreeGetMock as typeof host.taskWorktreeGet;
     currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "open" });
     currentSessionsFixture = [
       {
@@ -574,10 +627,6 @@ describe("KanbanPage session start modal flow", () => {
   });
 
   afterEach(async () => {
-    host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
-    host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
-    host.tasksList = originalTasksList;
-    host.taskWorktreeGet = originalBuildContinuationTargetGet;
     await restoreMockedModules([
       ["sonner", () => import("sonner")],
       [
@@ -585,6 +634,10 @@ describe("KanbanPage session start modal flow", () => {
         () => import("@/components/features/kanban/kanban-column"),
       ],
       ["./kanban-session-start-modal", () => import("./kanban-session-start-modal")],
+      [
+        "../agents/use-agent-studio-repo-settings",
+        () => import("../agents/use-agent-studio-repo-settings"),
+      ],
       [
         "@/components/features/pull-requests/merged-pull-request-confirm-dialog",
         () => import("@/components/features/pull-requests/merged-pull-request-confirm-dialog"),
@@ -594,6 +647,7 @@ describe("KanbanPage session start modal flow", () => {
         "@/features/human-review-feedback/human-review-feedback-modal",
         () => import("@/features/human-review-feedback/human-review-feedback-modal"),
       ],
+      ["@/lib/host-client", () => import("@/lib/host-client")],
       ["@/state/app-state-provider", () => import("../../state/app-state-provider")],
     ]);
   });

--- a/packages/frontend/src/state/agent-runtime-registry.test.ts
+++ b/packages/frontend/src/state/agent-runtime-registry.test.ts
@@ -23,4 +23,21 @@ describe("agent-runtime-registry", () => {
       "Unsupported agent runtime 'test-runtime'.",
     );
   });
+
+  test("requires an explicit runtime for adapter selection", async () => {
+    const engine = createAgentRuntimeRegistry().createAgentEngine();
+
+    const missingRuntimeInput = {
+      repoPath: "/repo",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "spec",
+      scenario: "spec_initial",
+      systemPrompt: "Prompt",
+    } as unknown as Parameters<typeof engine.startSession>[0];
+
+    await expect(engine.startSession(missingRuntimeInput)).rejects.toThrow(
+      "Runtime kind is required to select an agent runtime adapter.",
+    );
+  });
 });

--- a/packages/frontend/src/state/agent-runtime-registry.ts
+++ b/packages/frontend/src/state/agent-runtime-registry.ts
@@ -60,8 +60,7 @@ export const createAgentRuntimeRegistry = (): AgentRuntimeRegistry => {
     registeredRuntimeKinds,
     getAdapter,
     getRuntimeDefinition,
-    createAgentEngine: () =>
-      new RuntimeRegistryAgentEngine(getAdapter, registeredRuntimeKinds, DEFAULT_RUNTIME_KIND),
+    createAgentEngine: () => new RuntimeRegistryAgentEngine(getAdapter, registeredRuntimeKinds),
   };
 };
 
@@ -71,7 +70,6 @@ class RuntimeRegistryAgentEngine implements AgentEnginePort {
   constructor(
     private readonly getAdapter: (runtimeKind: RuntimeKind) => RegisteredRuntimeAdapter,
     private readonly registeredRuntimeKinds: RuntimeKind[],
-    private readonly defaultRuntimeKind: RuntimeKind,
   ) {}
 
   async startSession(input: Parameters<AgentEnginePort["startSession"]>[0]) {
@@ -240,12 +238,16 @@ class RuntimeRegistryAgentEngine implements AgentEnginePort {
     model: AgentModelSelection | undefined,
     sessionId?: string,
   ): RuntimeKind {
-    return (
-      runtimeKind ??
-      model?.runtimeKind ??
-      (sessionId ? this.runtimeKindsBySessionId.get(sessionId) : undefined) ??
-      this.defaultRuntimeKind
-    );
+    if (runtimeKind) {
+      return runtimeKind;
+    }
+    if (model?.runtimeKind) {
+      return model.runtimeKind;
+    }
+    if (sessionId) {
+      return this.requireSessionRuntimeKind(sessionId);
+    }
+    throw new Error("Runtime kind is required to select an agent runtime adapter.");
   }
 
   private requireSessionRuntimeKind(sessionId: string): RuntimeKind {

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -72,6 +72,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -113,6 +114,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -201,6 +203,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -308,6 +311,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -380,6 +384,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -505,6 +510,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => unsubscribe,
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -605,6 +611,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -684,6 +691,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -773,6 +781,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -868,6 +877,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -1141,6 +1151,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -1238,6 +1249,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",
@@ -1355,6 +1367,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo",

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
@@ -26,6 +26,14 @@ export const executeFreshStart = async ({
 }: FreshStrategyInput): Promise<Extract<StartOrReuseResult, { kind: "started" }>> => {
   const taskCard = resolveStartTask({ ctx, task: deps.task });
   const selectedModel = input.selectedModel;
+  const selectedModelRuntimeKind = requireConfiguredRuntimeKind(
+    selectedModel.runtimeKind,
+    `Runtime kind is required to start ${ctx.role} sessions. Select an explicit runtime before starting a session.`,
+  );
+  const selectedModelWithRuntime = {
+    ...selectedModel,
+    runtimeKind: selectedModelRuntimeKind,
+  };
   const targetWorkingDirectory =
     input.targetWorkingDirectory !== undefined
       ? input.targetWorkingDirectory
@@ -37,7 +45,7 @@ export const executeFreshStart = async ({
   const resolved = await resolveRuntimeAndModel({
     ctx,
     scenario: input.scenario,
-    requestedRuntimeKind: selectedModel.runtimeKind,
+    requestedRuntimeKind: selectedModelRuntimeKind,
     ...(targetWorkingDirectory !== undefined ? { targetWorkingDirectory } : {}),
     taskCard,
     deps,
@@ -48,10 +56,12 @@ export const executeFreshStart = async ({
     scenario: resolved.resolvedScenario,
     startMode: input.startMode,
   });
-  const runtimeKind = requireConfiguredRuntimeKind(
-    resolved.runtime.runtimeKind ?? selectedModel.runtimeKind,
-    `Runtime kind is required to start ${ctx.role} sessions. Select an explicit runtime before starting a session.`,
-  );
+  if (resolved.runtime.runtimeKind && resolved.runtime.runtimeKind !== selectedModelRuntimeKind) {
+    throw new Error(
+      `Selected model runtime kind '${selectedModelRuntimeKind}' does not match ensured runtime kind '${resolved.runtime.runtimeKind}'.`,
+    );
+  }
+  const runtimeKind = resolved.runtime.runtimeKind ?? selectedModelRuntimeKind;
 
   const summary = await deps.runtime.adapter.startSession({
     repoPath: ctx.repoPath,
@@ -62,7 +72,7 @@ export const executeFreshStart = async ({
     role: ctx.role,
     scenario: resolved.resolvedScenario,
     systemPrompt: resolved.systemPrompt,
-    model: selectedModel,
+    model: selectedModelWithRuntime,
   });
 
   const startedCtx = {
@@ -85,7 +95,7 @@ export const executeFreshStart = async ({
     runtimeInfo: resolved.runtime,
     systemPrompt: resolved.systemPrompt,
     promptOverrides: resolved.promptOverrides,
-    selectedModel,
+    selectedModel: selectedModelWithRuntime,
     deps,
     taskCard: resolved.taskCard,
   });

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
@@ -1,5 +1,4 @@
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
-import { resolveRuntimeConnection } from "../runtime/runtime";
+import { requireConfiguredRuntimeKind, resolveRuntimeConnection } from "../runtime/runtime";
 import type {
   StartOrReuseResult,
   StartSessionContext,
@@ -49,10 +48,14 @@ export const executeFreshStart = async ({
     scenario: resolved.resolvedScenario,
     startMode: input.startMode,
   });
+  const runtimeKind = requireConfiguredRuntimeKind(
+    resolved.runtime.runtimeKind ?? selectedModel.runtimeKind,
+    `Runtime kind is required to start ${ctx.role} sessions. Select an explicit runtime before starting a session.`,
+  );
 
   const summary = await deps.runtime.adapter.startSession({
     repoPath: ctx.repoPath,
-    runtimeKind: resolved.runtime.runtimeKind ?? selectedModel.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+    runtimeKind,
     runtimeConnection: resolveRuntimeConnection(resolved.runtime),
     workingDirectory: resolved.runtime.workingDirectory,
     taskId: ctx.taskId,

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
@@ -1,4 +1,8 @@
-import { requireConfiguredRuntimeKind, resolveRuntimeConnection } from "../runtime/runtime";
+import { resolveRuntimeConnection } from "../runtime/runtime";
+import {
+  assertSelectedModelRuntimeKindMatchesEnsuredRuntime,
+  requireSelectedModelRuntimeKindForStart,
+} from "../support/session-runtime-metadata";
 import type {
   StartOrReuseResult,
   StartSessionContext,
@@ -26,10 +30,7 @@ export const executeFreshStart = async ({
 }: FreshStrategyInput): Promise<Extract<StartOrReuseResult, { kind: "started" }>> => {
   const taskCard = resolveStartTask({ ctx, task: deps.task });
   const selectedModel = input.selectedModel;
-  const selectedModelRuntimeKind = requireConfiguredRuntimeKind(
-    selectedModel.runtimeKind,
-    `Runtime kind is required to start ${ctx.role} sessions. Select an explicit runtime before starting a session.`,
-  );
+  const selectedModelRuntimeKind = requireSelectedModelRuntimeKindForStart(ctx.role, selectedModel);
   const selectedModelWithRuntime = {
     ...selectedModel,
     runtimeKind: selectedModelRuntimeKind,
@@ -56,11 +57,10 @@ export const executeFreshStart = async ({
     scenario: resolved.resolvedScenario,
     startMode: input.startMode,
   });
-  if (resolved.runtime.runtimeKind && resolved.runtime.runtimeKind !== selectedModelRuntimeKind) {
-    throw new Error(
-      `Selected model runtime kind '${selectedModelRuntimeKind}' does not match ensured runtime kind '${resolved.runtime.runtimeKind}'.`,
-    );
-  }
+  assertSelectedModelRuntimeKindMatchesEnsuredRuntime({
+    selectedModelRuntimeKind,
+    ensuredRuntimeKind: resolved.runtime.runtimeKind,
+  });
   const runtimeKind = resolved.runtime.runtimeKind ?? selectedModelRuntimeKind;
 
   const summary = await deps.runtime.adapter.startSession({

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fresh-strategy.ts
@@ -57,11 +57,10 @@ export const executeFreshStart = async ({
     scenario: resolved.resolvedScenario,
     startMode: input.startMode,
   });
-  assertSelectedModelRuntimeKindMatchesEnsuredRuntime({
+  const runtimeKind = assertSelectedModelRuntimeKindMatchesEnsuredRuntime({
     selectedModelRuntimeKind,
     ensuredRuntimeKind: resolved.runtime.runtimeKind,
   });
-  const runtimeKind = resolved.runtime.runtimeKind ?? selectedModelRuntimeKind;
 
   const summary = await deps.runtime.adapter.startSession({
     repoPath: ctx.repoPath,

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-local-state.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-local-state.ts
@@ -1,7 +1,7 @@
 import type { AgentModelSelection } from "@openducktor/core";
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import { createRepoScopedAgentSessionState } from "@/state/repo-scoped-agent-session";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { requireConfiguredRuntimeKind } from "../runtime/runtime";
 import { runOrchestratorTask } from "../support/async-side-effects";
 import { toPersistedSessionRecord } from "../support/persistence";
 import { buildSessionHeaderMessages } from "../support/session-prompt";
@@ -32,7 +32,10 @@ export const buildInitialSession = ({
       sessionId: startedCtx.summary.sessionId,
       externalSessionId: startedCtx.summary.externalSessionId,
       taskId: startedCtx.taskId,
-      runtimeKind: runtime.runtimeKind ?? selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+      runtimeKind: requireConfiguredRuntimeKind(
+        runtime.runtimeKind ?? selectedModel?.runtimeKind,
+        `Runtime kind is required to initialize ${startedCtx.role} sessions.`,
+      ),
       role: startedCtx.role,
       scenario: startedCtx.resolvedScenario,
       status: "starting",

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.test-helpers.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.test-helpers.ts
@@ -1,4 +1,32 @@
+import type { RuntimeInfo } from "../runtime/runtime";
 import type { StartSessionDependencies } from "./start-session";
+
+const ensureRuntimeWithKind = async (
+  ...args: Parameters<StartSessionDependencies["runtime"]["ensureRuntime"]>
+): Promise<RuntimeInfo> => {
+  const [, , , options] = args;
+  const runtimeKind = options?.runtimeKind ?? "opencode";
+  const workingDirectory = options?.targetWorkingDirectory ?? "/tmp/repo";
+
+  return {
+    kind: runtimeKind,
+    runtimeKind,
+    runtimeId: "runtime-1",
+    runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+    workingDirectory,
+  };
+};
+
+const withRuntimeKind = async (
+  ensureRuntime: StartSessionDependencies["runtime"]["ensureRuntime"],
+  ...args: Parameters<StartSessionDependencies["runtime"]["ensureRuntime"]>
+): Promise<RuntimeInfo> => {
+  const [, , , options] = args;
+  const runtime = await ensureRuntime(...args);
+  const runtimeKind = runtime.runtimeKind ?? options?.runtimeKind ?? runtime.kind;
+
+  return runtimeKind ? { ...runtime, runtimeKind } : runtime;
+};
 
 export type FlatStartSessionDependencies = Omit<
   StartSessionDependencies["repo"],
@@ -49,7 +77,8 @@ export const toStartSessionDependencies = (
           workingDirectory: "/tmp/repo/worktree",
           source: "active_build_run",
         })),
-      ensureRuntime: deps.ensureRuntime,
+      ensureRuntime: (...args) =>
+        withRuntimeKind(deps.ensureRuntime ?? ensureRuntimeWithKind, ...args),
     },
     task: {
       taskRef: deps.taskRef,

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentModelSelection } from "@openducktor/core";
-import { clearAppQueryClient } from "@/lib/query-client";
+import { appQueryClient, clearAppQueryClient } from "@/lib/query-client";
+import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
 import {
   sessionMessageAt,
   sessionMessagesToArray,
@@ -65,6 +66,14 @@ const withCapturedConsoleError = async (
   } finally {
     console.error = originalError;
   }
+};
+
+const setPersistedSessionListFixture = (
+  repoPath: string,
+  taskId: string,
+  sessions: AgentSessionRecord[],
+): void => {
+  appQueryClient.setQueryData(agentSessionQueryKeys.list(repoPath, taskId), sessions);
 };
 
 const taskFixture = createTaskCardFixture({
@@ -1437,8 +1446,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
   test("returns the requested persisted session for the same role and hydrates when missing from memory", async () => {
     let loadAgentSessionsCalls = 0;
 
-    const originalAgentSessionsList = host.agentSessionsList;
-    host.agentSessionsList = async () => [
+    setPersistedSessionListFixture("/tmp/repo", "task-1", [
       persistedSessionRecord({
         runtimeKind: "opencode",
         sessionId: "persisted-2",
@@ -1484,7 +1492,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
       }),
-    ];
+    ]);
 
     const sessionsRef = { current: {} };
     const start = createStartAgentSessionWithFlatDeps({
@@ -1542,19 +1550,15 @@ describe("agent-orchestrator/handlers/start-session", () => {
       sendAgentMessage: async () => {},
     });
 
-    try {
-      const sessionId = await start({
-        taskId: "task-1",
-        role: "build",
-        scenario: "build_after_human_request_changes",
-        startMode: "reuse",
-        sourceSessionId: "persisted-build-newer",
-      });
-      expect(sessionId).toBe("persisted-build-newer");
-      expect(loadAgentSessionsCalls).toBe(1);
-    } finally {
-      host.agentSessionsList = originalAgentSessionsList;
-    }
+    const sessionId = await start({
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_after_human_request_changes",
+      startMode: "reuse",
+      sourceSessionId: "persisted-build-newer",
+    });
+    expect(sessionId).toBe("persisted-build-newer");
+    expect(loadAgentSessionsCalls).toBe(1);
   });
 
   test("forks from the selected source session for pull request generation", async () => {
@@ -2416,8 +2420,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       };
     };
 
-    const originalAgentSessionsList = host.agentSessionsList;
-    host.agentSessionsList = async () => [
+    setPersistedSessionListFixture("/tmp/repo", "task-1", [
       persistedSessionRecord({
         runtimeKind: "opencode",
         sessionId: "persisted-opencode",
@@ -2439,7 +2442,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
           profileId: "Ares",
         },
       }),
-    ];
+    ]);
 
     const sessionsRef = { current: {} };
     const start = createStartAgentSessionWithFlatDeps({
@@ -2516,7 +2519,6 @@ describe("agent-orchestrator/handlers/start-session", () => {
       expect(startCalls).toBe(0);
     } finally {
       adapter.startSession = originalStartSession;
-      host.agentSessionsList = originalAgentSessionsList;
     }
   });
 
@@ -2539,29 +2541,27 @@ describe("agent-orchestrator/handlers/start-session", () => {
       };
     };
 
-    const originalAgentSessionsList = host.agentSessionsList;
-    host.agentSessionsList = async () =>
-      [
-        {
-          sessionId: "persisted-claude",
-          externalSessionId: "external-claude",
-          taskId: "task-1",
-          role: "build",
-          scenario: "build_after_human_request_changes",
-          status: "idle",
-          startedAt: "2026-02-22T08:20:00.000Z",
-          updatedAt: "2026-02-22T08:20:00.000Z",
-          runtimeId: "runtime-1",
-          runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
-          workingDirectory: "/tmp/repo/worktree",
-          selectedModel: {
-            runtimeKind: "claude-code",
-            providerId: "anthropic",
-            modelId: "claude-3-7-sonnet",
-            profileId: "Hephaestus",
-          },
+    setPersistedSessionListFixture("/tmp/repo", "task-1", [
+      {
+        sessionId: "persisted-claude",
+        externalSessionId: "external-claude",
+        taskId: "task-1",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        status: "idle",
+        startedAt: "2026-02-22T08:20:00.000Z",
+        updatedAt: "2026-02-22T08:20:00.000Z",
+        runtimeId: "runtime-1",
+        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+        workingDirectory: "/tmp/repo/worktree",
+        selectedModel: {
+          runtimeKind: "claude-code",
+          providerId: "anthropic",
+          modelId: "claude-3-7-sonnet",
+          profileId: "Hephaestus",
         },
-      ] as unknown as Awaited<ReturnType<typeof host.agentSessionsList>>;
+      } as unknown as AgentSessionRecord,
+    ]);
 
     const sessionsRef = { current: {} };
     const start = createStartAgentSessionWithFlatDeps({
@@ -2637,7 +2637,6 @@ describe("agent-orchestrator/handlers/start-session", () => {
       expect(startCalls).toBe(0);
     } finally {
       adapter.startSession = originalStartSession;
-      host.agentSessionsList = originalAgentSessionsList;
     }
   });
 
@@ -3381,6 +3380,83 @@ describe("agent-orchestrator/handlers/start-session", () => {
       host.agentSessionsList = originalAgentSessionsList;
     }
   });
+
+  for (const runtimeKind of [undefined, "", "  "] as const) {
+    const caseLabel = runtimeKind === undefined ? "missing" : "blank";
+
+    test(`does not start a fresh session when selected model runtime kind is ${caseLabel}`, async () => {
+      let runtimeCalls = 0;
+      let startCalls = 0;
+      let persistCalls = 0;
+
+      const adapter = new OpencodeSdkAdapter();
+      const originalStartSession = adapter.startSession;
+      adapter.startSession = async () => {
+        startCalls += 1;
+        throw new Error("startSession should not be reached");
+      };
+
+      const selectedModel = (() => {
+        if (runtimeKind === undefined) {
+          const { runtimeKind: _runtimeKind, ...selectionWithoutRuntime } = BUILD_SELECTION;
+          return selectionWithoutRuntime as AgentModelSelection;
+        }
+        return { ...BUILD_SELECTION, runtimeKind } as AgentModelSelection;
+      })();
+
+      const start = createStartAgentSessionWithFlatDeps({
+        activeRepo: "/tmp/repo",
+        adapter,
+        setSessionsById: () => {},
+        sessionsRef: { current: {} },
+        taskRef: { current: [taskFixture] },
+        repoEpochRef: { current: 1 },
+        currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+        inFlightStartsByWorkspaceTaskRef: { current: new Map() },
+        attachSessionListener: () => {},
+        resolveTaskWorktree: async () => ({
+          workingDirectory: "/tmp/repo/worktree",
+          source: "active_build_run",
+        }),
+        ensureRuntime: async () => {
+          runtimeCalls += 1;
+          return {
+            kind: "opencode",
+            runtimeId: null,
+            runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+            workingDirectory: "/tmp/repo/worktree",
+          };
+        },
+        loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+        loadRepoDefaultModel: async () => null,
+        loadRepoPromptOverrides: async () => ({}),
+        loadAgentSessions: async () => {},
+        refreshTaskData: async () => {},
+        persistSessionRecord: async () => {
+          persistCalls += 1;
+        },
+        sendAgentMessage: async () => {},
+      });
+
+      try {
+        await expect(
+          start({
+            taskId: "task-1",
+            role: "build",
+            startMode: "fresh",
+            selectedModel,
+          }),
+        ).rejects.toThrow(
+          "Runtime kind is required to start build sessions. Select an explicit runtime before starting a session.",
+        );
+        expect(runtimeCalls).toBe(0);
+        expect(startCalls).toBe(0);
+        expect(persistCalls).toBe(0);
+      } finally {
+        adapter.startSession = originalStartSession;
+      }
+    });
+  }
 
   test("does not block start completion on kickoff refresh", async () => {
     const refreshDeferred = createDeferred<void>();

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -314,6 +314,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       resolveTaskWorktree: async () => continuationTarget("/tmp/repo/worktree"),
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: "runtime-1",
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -908,6 +909,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       resolveTaskWorktree: async () => continuationTarget("/tmp/repo/worktree/"),
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: "runtime-1",
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -1455,9 +1457,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
         repoPath: "/tmp/repo",
         role: "build",
         scenario: "build_after_human_request_changes",
-        status: "idle",
         startedAt: "2026-02-22T08:20:00.000Z",
-        updatedAt: "2026-02-22T08:20:00.000Z",
         runtimeId: "runtime-1",
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -2429,9 +2429,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
         repoPath: "/tmp/repo",
         role: "build",
         scenario: "build_implementation_start",
-        status: "idle",
         startedAt: "2026-02-22T08:20:00.000Z",
-        updatedAt: "2026-02-22T08:20:00.000Z",
         runtimeId: "runtime-1",
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -2545,14 +2543,10 @@ describe("agent-orchestrator/handlers/start-session", () => {
       {
         sessionId: "persisted-claude",
         externalSessionId: "external-claude",
-        taskId: "task-1",
+        runtimeKind: "claude-code",
         role: "build",
         scenario: "build_after_human_request_changes",
-        status: "idle",
         startedAt: "2026-02-22T08:20:00.000Z",
-        updatedAt: "2026-02-22T08:20:00.000Z",
-        runtimeId: "runtime-1",
-        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
         selectedModel: {
           runtimeKind: "claude-code",
@@ -2560,7 +2554,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
           modelId: "claude-3-7-sonnet",
           profileId: "Hephaestus",
         },
-      } as unknown as AgentSessionRecord,
+      },
     ]);
 
     const sessionsRef = { current: {} };

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -226,7 +226,7 @@ export const createStartAgentSession = ({
       resolveStartTask({ ctx: startCtx, task });
     }
     if (input.startMode === "fresh") {
-      requireSelectedModelRuntimeKindForStart(role, input.selectedModel);
+      void requireSelectedModelRuntimeKindForStart(role, input.selectedModel);
     }
 
     const normalizedSourceSessionId =

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -6,6 +6,7 @@ import {
 } from "@openducktor/core";
 import { canonicalTargetBranch, effectiveTaskTargetBranch } from "@/lib/target-branch";
 import { requireActiveRepo } from "../../tasks/task-operations-model";
+import { requireConfiguredRuntimeKind } from "../runtime/runtime";
 import { runOrchestratorSideEffect } from "../support/async-side-effects";
 import { createRepoStaleGuard, throwIfRepoStale } from "../support/core";
 import { kickoffPromptWithTaskContext } from "../support/scenario";
@@ -223,6 +224,12 @@ export const createStartAgentSession = ({
 
     if (input.startMode === "fresh" && role === "qa") {
       resolveStartTask({ ctx: startCtx, task });
+    }
+    if (input.startMode === "fresh") {
+      requireConfiguredRuntimeKind(
+        input.selectedModel.runtimeKind,
+        `Runtime kind is required to start ${role} sessions. Select an explicit runtime before starting a session.`,
+      );
     }
 
     const normalizedSourceSessionId =

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -6,10 +6,10 @@ import {
 } from "@openducktor/core";
 import { canonicalTargetBranch, effectiveTaskTargetBranch } from "@/lib/target-branch";
 import { requireActiveRepo } from "../../tasks/task-operations-model";
-import { requireConfiguredRuntimeKind } from "../runtime/runtime";
 import { runOrchestratorSideEffect } from "../support/async-side-effects";
 import { createRepoStaleGuard, throwIfRepoStale } from "../support/core";
 import { kickoffPromptWithTaskContext } from "../support/scenario";
+import { requireSelectedModelRuntimeKindForStart } from "../support/session-runtime-metadata";
 import type {
   ResolvedRuntimeAndModel,
   RuntimeDependencies,
@@ -226,10 +226,7 @@ export const createStartAgentSession = ({
       resolveStartTask({ ctx: startCtx, task });
     }
     if (input.startMode === "fresh") {
-      requireConfiguredRuntimeKind(
-        input.selectedModel.runtimeKind,
-        `Runtime kind is required to start ${role} sessions. Select an explicit runtime before starting a session.`,
-      );
+      requireSelectedModelRuntimeKindForStart(role, input.selectedModel);
     }
 
     const normalizedSourceSessionId =

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.test.ts
@@ -191,6 +191,118 @@ describe("agent-orchestrator-ensure-ready", () => {
     }
   });
 
+  test("uses top-level session runtime metadata when refreshing an attached session", async () => {
+    let capturedRuntimeKind: string | null | undefined = null;
+
+    const adapter = createAdapter();
+    const originalHasSession = adapter.hasSession;
+    adapter.hasSession = () => true;
+
+    const sessionsRef = {
+      current: {
+        "session-1": buildSession({
+          runtimeKind: "claude-code",
+          runtimeRoute: null,
+          selectedModel: null,
+          status: "idle",
+        }),
+      },
+    };
+
+    const ensureReady = createEnsureSessionReady({
+      activeWorkspace: {
+        repoPath: "/tmp/repo",
+        workspaceId: "workspace-1",
+        workspaceName: "Active Workspace",
+      },
+      adapter,
+      repoEpochRef: { current: 1 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      sessionsRef,
+      taskRef: { current: [taskFixture] },
+      unsubscribersRef: { current: new Map() },
+      updateSession: (_sessionId, updater) => {
+        const current = sessionsRef.current["session-1"];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current["session-1"] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async (_repoPath, _taskId, _role, options) => {
+        capturedRuntimeKind = options?.runtimeKind;
+        return {
+          kind: "claude-code",
+          runtimeKind: "claude-code",
+          runtimeId: "runtime-claude",
+          runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:5555" },
+          workingDirectory: "/tmp/repo/worktree",
+        };
+      },
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    try {
+      await ensureReady("session-1");
+
+      expect(String(capturedRuntimeKind)).toBe("claude-code");
+      expect(sessionsRef.current["session-1"]?.runtimeKind).toBe("claude-code");
+      expect(sessionsRef.current["session-1"]?.runtimeRoute).toEqual({
+        type: "local_http",
+        endpoint: "http://127.0.0.1:5555",
+      });
+    } finally {
+      adapter.hasSession = originalHasSession;
+    }
+  });
+
+  test("rejects attached session runtime mismatches instead of using repo defaults", async () => {
+    const adapter = createAdapter();
+    const originalHasSession = adapter.hasSession;
+    adapter.hasSession = () => true;
+
+    const ensureReady = createEnsureSessionReady({
+      activeWorkspace: {
+        repoPath: "/tmp/repo",
+        workspaceId: "workspace-1",
+        workspaceName: "Active Workspace",
+      },
+      adapter,
+      repoEpochRef: { current: 1 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      sessionsRef: {
+        current: {
+          "session-1": buildSession({
+            runtimeKind: "claude-code",
+            runtimeRoute: null,
+            selectedModel: null,
+            status: "idle",
+          }),
+        },
+      },
+      taskRef: { current: [taskFixture] },
+      unsubscribersRef: { current: new Map() },
+      updateSession: () => {},
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeKind: "opencode",
+        runtimeId: null,
+        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    try {
+      await expect(ensureReady("session-1")).rejects.toThrow(
+        "Session 'session-1' runtime kind metadata 'claude-code' does not match ensured runtime kind 'opencode'.",
+      );
+    } finally {
+      adapter.hasSession = originalHasSession;
+    }
+  });
+
   test("blocks readiness when attached runtime snapshot reports pending input", async () => {
     let attachCalls = 0;
     let resumeCalls = 0;
@@ -726,6 +838,88 @@ describe("agent-orchestrator-ensure-ready", () => {
       adapter.hasSession = originalHasSession;
       adapter.resumeSession = originalResumeSession;
       adapter.listLiveAgentSessionSnapshots = originalListLiveAgentSessionSnapshots;
+    }
+  });
+
+  test("passes top-level session runtime metadata when resuming a detached session", async () => {
+    let ensuredRuntimeKind: string | null | undefined = null;
+    let resumedInput:
+      | Parameters<InstanceType<typeof OpencodeSdkAdapter>["resumeSession"]>[0]
+      | null = null;
+
+    const adapter = createAdapter();
+    const originalHasSession = adapter.hasSession;
+    const originalResumeSession = adapter.resumeSession;
+    adapter.hasSession = () => false;
+    adapter.resumeSession = async (input) => {
+      resumedInput = input;
+      return {
+        runtimeKind: "claude-code",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        role: "build",
+        scenario: "build_implementation_start",
+        status: "idle",
+      };
+    };
+
+    const sessionsRef = {
+      current: {
+        "session-1": buildSession({
+          runtimeKind: "claude-code",
+          runtimeRoute: null,
+          selectedModel: null,
+          status: "idle",
+        }),
+      },
+    };
+
+    const ensureReady = createEnsureSessionReady({
+      activeWorkspace: {
+        repoPath: "/tmp/repo",
+        workspaceId: "workspace-1",
+        workspaceName: "Active Workspace",
+      },
+      adapter,
+      repoEpochRef: { current: 1 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      sessionsRef,
+      taskRef: { current: [taskFixture] },
+      unsubscribersRef: { current: new Map() },
+      updateSession: (_sessionId, updater) => {
+        const current = sessionsRef.current["session-1"];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current["session-1"] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async (_repoPath, _taskId, _role, options) => {
+        ensuredRuntimeKind = options?.runtimeKind;
+        return {
+          kind: "claude-code",
+          runtimeKind: "claude-code",
+          runtimeId: "runtime-claude",
+          runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:5555" },
+          workingDirectory: "/tmp/repo/worktree",
+        };
+      },
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    try {
+      await ensureReady("session-1");
+
+      expect(String(ensuredRuntimeKind)).toBe("claude-code");
+      expect(resumedInput).toMatchObject({
+        runtimeKind: "claude-code",
+        runtimeConnection: { type: "local_http", endpoint: "http://127.0.0.1:5555" },
+      });
+      expect(sessionsRef.current["session-1"]?.runtimeKind).toBe("claude-code");
+    } finally {
+      adapter.hasSession = originalHasSession;
+      adapter.resumeSession = originalResumeSession;
     }
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.test.ts
@@ -102,6 +102,7 @@ describe("agent-orchestrator-ensure-ready", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -172,6 +173,7 @@ describe("agent-orchestrator-ensure-ready", () => {
       },
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -376,6 +378,7 @@ describe("agent-orchestrator-ensure-ready", () => {
       },
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -485,6 +488,7 @@ describe("agent-orchestrator-ensure-ready", () => {
       },
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -572,6 +576,7 @@ describe("agent-orchestrator-ensure-ready", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -650,6 +655,7 @@ describe("agent-orchestrator-ensure-ready", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -721,6 +727,7 @@ describe("agent-orchestrator-ensure-ready", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -814,6 +821,7 @@ describe("agent-orchestrator-ensure-ready", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => ({
         kind: "opencode",
+        runtimeKind: "opencode",
         runtimeId: null,
         runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
         workingDirectory: "/tmp/repo/worktree",
@@ -952,6 +960,7 @@ describe("agent-orchestrator-ensure-ready", () => {
         runtimeCalls += 1;
         return {
           kind: "opencode",
+          runtimeKind: "opencode",
           runtimeId: null,
           runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
           workingDirectory: "/tmp/repo/worktree",
@@ -1002,6 +1011,7 @@ describe("agent-orchestrator-ensure-ready", () => {
         runtimeCalls += 1;
         return {
           kind: "opencode",
+          runtimeKind: "opencode",
           runtimeId: null,
           runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
           workingDirectory: "/tmp/repo/worktree",

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -6,7 +6,6 @@ import type { ActiveWorkspace } from "@/types/state-slices";
 import { requireActiveRepo } from "../../tasks/task-operations-model";
 import {
   type RuntimeInfo,
-  requireConfiguredRuntimeKind,
   requireRuntimeConnectionSupport,
   resolveRuntimeConnection,
   runtimeRouteToConnection,
@@ -14,6 +13,10 @@ import {
 import { runOrchestratorTask } from "../support/async-side-effects";
 import { shouldReattachListenerForAttachedSession, throwIfRepoStale } from "../support/core";
 import { loadSessionPromptContext } from "../support/session-prompt";
+import {
+  assertSessionRuntimeKindMatchesEnsuredRuntime,
+  requireSessionRuntimeKind,
+} from "../support/session-runtime-metadata";
 
 type EnsureSessionReadyDependencies = {
   activeWorkspace: ActiveWorkspace | null;
@@ -67,32 +70,6 @@ const hasPendingInput = (
   session: Pick<AgentSessionState, "pendingPermissions" | "pendingQuestions">,
 ) => {
   return session.pendingPermissions.length > 0 || session.pendingQuestions.length > 0;
-};
-
-const requireSessionRuntimeKind = (
-  session: AgentSessionState,
-): NonNullable<AgentSessionState["runtimeKind"]> => {
-  return requireConfiguredRuntimeKind(
-    session.runtimeKind ?? session.selectedModel?.runtimeKind,
-    `Session '${session.sessionId}' is missing runtime kind metadata.`,
-  );
-};
-
-const assertEnsuredRuntimeKindMatchesSession = ({
-  session,
-  requestedRuntimeKind,
-  runtime,
-}: {
-  session: AgentSessionState;
-  requestedRuntimeKind: AgentSessionState["runtimeKind"];
-  runtime: RuntimeInfo;
-}): void => {
-  if (!runtime.runtimeKind || runtime.runtimeKind === requestedRuntimeKind) {
-    return;
-  }
-  throw new Error(
-    `Session '${session.sessionId}' runtime kind metadata '${requestedRuntimeKind}' does not match ensured runtime kind '${runtime.runtimeKind}'.`,
-  );
 };
 
 export const createEnsureSessionReady = ({
@@ -203,7 +180,11 @@ export const createEnsureSessionReady = ({
             runtimeKind: requestedRuntimeKind,
           });
           assertNotStale();
-          assertEnsuredRuntimeKindMatchesSession({ session, requestedRuntimeKind, runtime });
+          assertSessionRuntimeKindMatchesEnsuredRuntime({
+            sessionId: session.sessionId,
+            requestedRuntimeKind,
+            ensuredRuntimeKind: runtime.runtimeKind,
+          });
 
           attachedRuntimeKind = runtime.runtimeKind ?? requestedRuntimeKind;
           attachedRuntimeId = runtime.runtimeId;
@@ -291,7 +272,11 @@ export const createEnsureSessionReady = ({
       runtimeKind: requestedRuntimeKind,
     });
     assertNotStale();
-    assertEnsuredRuntimeKindMatchesSession({ session, requestedRuntimeKind, runtime });
+    assertSessionRuntimeKindMatchesEnsuredRuntime({
+      sessionId: session.sessionId,
+      requestedRuntimeKind,
+      ensuredRuntimeKind: runtime.runtimeKind,
+    });
     const resolvedRuntimeKind = runtime.runtimeKind ?? requestedRuntimeKind;
     const runtimeConnection = requireRuntimeConnectionSupport(
       resolvedRuntimeKind,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -167,7 +167,8 @@ export const createEnsureSessionReady = ({
         attachSessionListener(repoPath, sessionId);
       }
       if (session.status !== "error") {
-        let attachedRuntimeKind = session.runtimeKind;
+        let attachedRuntimeKind: NonNullable<AgentSessionState["runtimeKind"]> =
+          session.runtimeKind ?? requireSessionRuntimeKind(session);
         let attachedRuntimeId = session.runtimeId;
         let attachedRuntimeRoute = session.runtimeRoute;
         let attachedWorkingDirectory = session.workingDirectory;
@@ -180,13 +181,12 @@ export const createEnsureSessionReady = ({
             runtimeKind: requestedRuntimeKind,
           });
           assertNotStale();
-          assertSessionRuntimeKindMatchesEnsuredRuntime({
+          attachedRuntimeKind = assertSessionRuntimeKindMatchesEnsuredRuntime({
             sessionId: session.sessionId,
             requestedRuntimeKind,
             ensuredRuntimeKind: runtime.runtimeKind,
           });
 
-          attachedRuntimeKind = runtime.runtimeKind ?? requestedRuntimeKind;
           attachedRuntimeId = runtime.runtimeId;
           attachedRuntimeRoute = runtime.runtimeRoute;
           attachedWorkingDirectory = runtime.workingDirectory;
@@ -198,7 +198,7 @@ export const createEnsureSessionReady = ({
               runtimeId: attachedRuntimeId,
               runtimeRoute: attachedRuntimeRoute,
               workingDirectory: attachedWorkingDirectory,
-              ...(attachedRuntimeKind ? { runtimeKind: attachedRuntimeKind } : {}),
+              runtimeKind: attachedRuntimeKind,
             }),
             { persist: false },
           );
@@ -228,7 +228,7 @@ export const createEnsureSessionReady = ({
             ...(liveSessionTitle ? { title: liveSessionTitle } : {}),
             pendingPermissions,
             pendingQuestions,
-            ...(attachedRuntimeKind ? { runtimeKind: attachedRuntimeKind } : {}),
+            runtimeKind: attachedRuntimeKind,
           }),
           { persist: false },
         );
@@ -272,12 +272,11 @@ export const createEnsureSessionReady = ({
       runtimeKind: requestedRuntimeKind,
     });
     assertNotStale();
-    assertSessionRuntimeKindMatchesEnsuredRuntime({
+    const resolvedRuntimeKind = assertSessionRuntimeKindMatchesEnsuredRuntime({
       sessionId: session.sessionId,
       requestedRuntimeKind,
       ensuredRuntimeKind: runtime.runtimeKind,
     });
-    const resolvedRuntimeKind = runtime.runtimeKind ?? requestedRuntimeKind;
     const runtimeConnection = requireRuntimeConnectionSupport(
       resolvedRuntimeKind,
       resolveRuntimeConnection(runtime),

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -6,6 +6,7 @@ import type { ActiveWorkspace } from "@/types/state-slices";
 import { requireActiveRepo } from "../../tasks/task-operations-model";
 import {
   type RuntimeInfo,
+  requireConfiguredRuntimeKind,
   requireRuntimeConnectionSupport,
   resolveRuntimeConnection,
   runtimeRouteToConnection,
@@ -66,6 +67,32 @@ const hasPendingInput = (
   session: Pick<AgentSessionState, "pendingPermissions" | "pendingQuestions">,
 ) => {
   return session.pendingPermissions.length > 0 || session.pendingQuestions.length > 0;
+};
+
+const requireSessionRuntimeKind = (
+  session: AgentSessionState,
+): NonNullable<AgentSessionState["runtimeKind"]> => {
+  return requireConfiguredRuntimeKind(
+    session.runtimeKind ?? session.selectedModel?.runtimeKind,
+    `Session '${session.sessionId}' is missing runtime kind metadata.`,
+  );
+};
+
+const assertEnsuredRuntimeKindMatchesSession = ({
+  session,
+  requestedRuntimeKind,
+  runtime,
+}: {
+  session: AgentSessionState;
+  requestedRuntimeKind: AgentSessionState["runtimeKind"];
+  runtime: RuntimeInfo;
+}): void => {
+  if (!runtime.runtimeKind || runtime.runtimeKind === requestedRuntimeKind) {
+    return;
+  }
+  throw new Error(
+    `Session '${session.sessionId}' runtime kind metadata '${requestedRuntimeKind}' does not match ensured runtime kind '${runtime.runtimeKind}'.`,
+  );
 };
 
 export const createEnsureSessionReady = ({
@@ -169,18 +196,14 @@ export const createEnsureSessionReady = ({
         let attachedWorkingDirectory = session.workingDirectory;
 
         if (!attachedRuntimeKind || attachedRuntimeRoute === null) {
-          const requestedRuntimeKind = session.runtimeKind ?? session.selectedModel?.runtimeKind;
-          if (!requestedRuntimeKind) {
-            throw new Error(`Session '${session.sessionId}' is missing runtime kind metadata.`);
-          }
+          const requestedRuntimeKind = requireSessionRuntimeKind(session);
           const runtime = await ensureRuntime(repoPath, session.taskId, session.role, {
             workspaceId,
             targetWorkingDirectory: session.workingDirectory,
-            ...(session.selectedModel?.runtimeKind
-              ? { runtimeKind: session.selectedModel.runtimeKind }
-              : {}),
+            runtimeKind: requestedRuntimeKind,
           });
           assertNotStale();
+          assertEnsuredRuntimeKindMatchesSession({ session, requestedRuntimeKind, runtime });
 
           attachedRuntimeKind = runtime.runtimeKind ?? requestedRuntimeKind;
           attachedRuntimeId = runtime.runtimeId;
@@ -261,22 +284,15 @@ export const createEnsureSessionReady = ({
       loadRepoPromptOverrides,
     });
     assertNotStale();
+    const requestedRuntimeKind = requireSessionRuntimeKind(session);
     const runtime = await ensureRuntime(repoPath, session.taskId, session.role, {
       workspaceId,
       targetWorkingDirectory: session.workingDirectory,
-      ...(session.selectedModel?.runtimeKind
-        ? { runtimeKind: session.selectedModel.runtimeKind }
-        : {}),
+      runtimeKind: requestedRuntimeKind,
     });
     assertNotStale();
-    const requestedRuntimeKind = session.runtimeKind ?? session.selectedModel?.runtimeKind;
-    let resolvedRuntimeKind = runtime.runtimeKind;
-    if (!resolvedRuntimeKind) {
-      if (!requestedRuntimeKind) {
-        throw new Error(`Session '${session.sessionId}' is missing runtime kind metadata.`);
-      }
-      resolvedRuntimeKind = requestedRuntimeKind;
-    }
+    assertEnsuredRuntimeKindMatchesSession({ session, requestedRuntimeKind, runtime });
+    const resolvedRuntimeKind = runtime.runtimeKind ?? requestedRuntimeKind;
     const runtimeConnection = requireRuntimeConnectionSupport(
       resolvedRuntimeKind,
       resolveRuntimeConnection(runtime),

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-loaders.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-loaders.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentSessionTodoItem } from "@openducktor/core";
 import { getSessionMessageCount } from "@/state/operations/agent-orchestrator/support/messages";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -19,6 +20,7 @@ const createDeferred = <T>() => {
 };
 
 const catalogFixture: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [
     {
       id: "openai/gpt-5",

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   agentPromptTemplateIdValues,
   type BuildSessionBootstrap,
@@ -15,7 +15,6 @@ import {
   loadRepoDefaultModel,
   loadRepoPromptOverrides,
   resolveRuntimeRouteConnection,
-  setRuntimeRepoConfigLoaderForTest,
 } from "./runtime";
 
 const buildBootstrapFixture: BuildSessionBootstrap = {
@@ -83,25 +82,17 @@ const createPromptOverrideSettingsSnapshot = (
 });
 
 describe("agent-orchestrator-runtime", () => {
-  let restoreRuntimeRepoConfigLoader: (() => void) | null = null;
   let runtimeHost: NonNullable<Parameters<typeof createEnsureRuntime>[0]["hostClient"]>;
+  let repoConfigLoader: NonNullable<Parameters<typeof createEnsureRuntime>[0]["repoConfigLoader"]>;
 
   beforeEach(async () => {
-    restoreRuntimeRepoConfigLoader?.();
     await clearAppQueryClient();
-    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
-      createRepoConfig(),
-    );
+    repoConfigLoader = async () => createRepoConfig();
     runtimeHost = {
       runtimeEnsure: async () => sharedRuntimeFixture,
       buildStart: async () => buildBootstrapFixture,
       taskWorktreeGet: async () => taskWorktreeFixture,
     };
-  });
-
-  afterEach(() => {
-    restoreRuntimeRepoConfigLoader?.();
-    restoreRuntimeRepoConfigLoader = null;
   });
 
   test("resolves runtime route connections through one shared boundary helper", () => {
@@ -133,6 +124,7 @@ describe("agent-orchestrator-runtime", () => {
 
     const ensureRuntime = createEnsureRuntime({
       hostClient: runtimeHost,
+      repoConfigLoader,
       refreshTaskData: async () => {
         refreshCalls += 1;
       },
@@ -162,6 +154,7 @@ describe("agent-orchestrator-runtime", () => {
 
     const ensureRuntime = createEnsureRuntime({
       hostClient: runtimeHost,
+      repoConfigLoader,
       refreshTaskData: async () => refreshDeferred.promise,
     });
 
@@ -195,6 +188,7 @@ describe("agent-orchestrator-runtime", () => {
 
     const ensureRuntime = createEnsureRuntime({
       hostClient: runtimeHost,
+      repoConfigLoader,
       refreshTaskData: async () => {},
     });
 
@@ -206,19 +200,18 @@ describe("agent-orchestrator-runtime", () => {
   });
 
   test("fails before build start when repo and role runtime defaults are missing", async () => {
-    restoreRuntimeRepoConfigLoader?.();
-    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
+    repoConfigLoader = async () =>
       createRepoConfig({
         defaultRuntimeKind: undefined as never,
         agentDefaults: {},
-      }),
-    );
+      });
     runtimeHost.buildStart = mock(async () => buildBootstrapFixture);
     runtimeHost.runtimeEnsure = mock(async () => sharedRuntimeFixture);
     runtimeHost.taskWorktreeGet = mock(async () => taskWorktreeFixture);
 
     const ensureRuntime = createEnsureRuntime({
       hostClient: runtimeHost,
+      repoConfigLoader,
       refreshTaskData: async () => {},
     });
 
@@ -235,19 +228,18 @@ describe("agent-orchestrator-runtime", () => {
   });
 
   test("fails before runtime ensure when repo default runtime is blank", async () => {
-    restoreRuntimeRepoConfigLoader?.();
-    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
+    repoConfigLoader = async () =>
       createRepoConfig({
         defaultRuntimeKind: " " as never,
         agentDefaults: {},
-      }),
-    );
+      });
     runtimeHost.buildStart = mock(async () => buildBootstrapFixture);
     runtimeHost.runtimeEnsure = mock(async () => sharedRuntimeFixture);
     runtimeHost.taskWorktreeGet = mock(async () => taskWorktreeFixture);
 
     const ensureRuntime = createEnsureRuntime({
       hostClient: runtimeHost,
+      repoConfigLoader,
       refreshTaskData: async () => {},
     });
 
@@ -278,6 +270,7 @@ describe("agent-orchestrator-runtime", () => {
 
     const ensureRuntime = createEnsureRuntime({
       hostClient: runtimeHost,
+      repoConfigLoader,
       refreshTaskData: async () => {},
     });
 
@@ -316,6 +309,7 @@ describe("agent-orchestrator-runtime", () => {
 
     const ensureRuntime = createEnsureRuntime({
       hostClient: runtimeHost,
+      repoConfigLoader,
       refreshTaskData: async () => {},
     });
 
@@ -343,6 +337,7 @@ describe("agent-orchestrator-runtime", () => {
 
     const ensureRuntime = createEnsureRuntime({
       hostClient: runtimeHost,
+      repoConfigLoader,
       refreshTaskData: async () => {},
     });
 
@@ -354,17 +349,17 @@ describe("agent-orchestrator-runtime", () => {
   });
 
   test("propagates repo config loading errors when default model lookup fails", async () => {
-    restoreRuntimeRepoConfigLoader?.();
-    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () => {
+    const failingRepoConfigLoader = async () => {
       throw new Error("missing config");
-    });
+    };
 
-    await expect(loadRepoDefaultModel("/tmp/repo", "build")).rejects.toThrow("missing config");
+    await expect(
+      loadRepoDefaultModel("/tmp/repo", "build", failingRepoConfigLoader),
+    ).rejects.toThrow("missing config");
   });
 
   test("maps repo role defaults into model selection", async () => {
-    restoreRuntimeRepoConfigLoader?.();
-    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
+    const selection = await loadRepoDefaultModel("/tmp/repo", "build", async () =>
       createRepoConfig({
         agentDefaults: {
           build: {
@@ -377,8 +372,6 @@ describe("agent-orchestrator-runtime", () => {
         },
       }),
     );
-
-    const selection = await loadRepoDefaultModel("/tmp/repo", "build");
     expect(selection).toEqual({
       runtimeKind: "opencode",
       providerId: "openai",

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   agentPromptTemplateIdValues,
   type BuildSessionBootstrap,
@@ -47,9 +47,7 @@ const taskWorktreeFixture: TaskWorktreeSummary = {
   workingDirectory: "/tmp/repo/worktree",
 };
 
-const createPromptOverrideRepoConfig = (
-  promptOverrides: RepoConfig["promptOverrides"],
-): RepoConfig => ({
+const createRepoConfig = (overrides: Partial<RepoConfig> = {}): RepoConfig => ({
   workspaceId: "repo",
   workspaceName: "Repo",
   repoPath: "/tmp/repo",
@@ -61,9 +59,17 @@ const createPromptOverrideRepoConfig = (
   hooks: { preStart: [], postComplete: [] },
   devServers: [],
   worktreeFileCopies: [],
-  promptOverrides,
+  promptOverrides: {},
   agentDefaults: {},
+  ...overrides,
 });
+
+const createPromptOverrideRepoConfig = (
+  promptOverrides: RepoConfig["promptOverrides"],
+): RepoConfig =>
+  createRepoConfig({
+    promptOverrides,
+  });
 
 const createPromptOverrideSettingsSnapshot = (
   globalPromptOverrides: SettingsSnapshot["globalPromptOverrides"],
@@ -84,21 +90,9 @@ describe("agent-orchestrator-runtime", () => {
   beforeEach(async () => {
     restoreRuntimeRepoConfigLoader?.();
     await clearAppQueryClient();
-    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () => ({
-      workspaceId: "repo",
-      workspaceName: "Repo",
-      repoPath: "/tmp/repo",
-      defaultRuntimeKind: "opencode",
-      branchPrefix: "obp",
-      defaultTargetBranch: { remote: "origin", branch: "main" },
-      git: { providers: {} },
-      trustedHooks: false,
-      hooks: { preStart: [], postComplete: [] },
-      devServers: [],
-      worktreeFileCopies: [],
-      promptOverrides: {},
-      agentDefaults: {},
-    }));
+    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
+      createRepoConfig(),
+    );
     host.workspaceList = async () => [
       {
         workspaceId: "repo",
@@ -111,21 +105,7 @@ describe("agent-orchestrator-runtime", () => {
         effectiveWorktreeBasePath: "/tmp/worktrees/repo",
       },
     ];
-    host.workspaceGetRepoConfig = async () => ({
-      workspaceId: "repo",
-      workspaceName: "Repo",
-      repoPath: "/tmp/repo",
-      defaultRuntimeKind: "opencode",
-      branchPrefix: "obp",
-      defaultTargetBranch: { remote: "origin", branch: "main" },
-      git: { providers: {} },
-      trustedHooks: false,
-      hooks: { preStart: [], postComplete: [] },
-      devServers: [],
-      worktreeFileCopies: [],
-      promptOverrides: {},
-      agentDefaults: {},
-    });
+    host.workspaceGetRepoConfig = async () => createRepoConfig();
     runtimeHost = {
       runtimeEnsure: async () => sharedRuntimeFixture,
       buildStart: async () => buildBootstrapFixture,
@@ -239,6 +219,64 @@ describe("agent-orchestrator-runtime", () => {
     ).rejects.toThrow("Runtime build session startup requires a local_http runtime route");
   });
 
+  test("fails before build start when repo and role runtime defaults are missing", async () => {
+    restoreRuntimeRepoConfigLoader?.();
+    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
+      createRepoConfig({
+        defaultRuntimeKind: undefined as never,
+        agentDefaults: {},
+      }),
+    );
+    runtimeHost.buildStart = mock(async () => buildBootstrapFixture);
+    runtimeHost.runtimeEnsure = mock(async () => sharedRuntimeFixture);
+    runtimeHost.taskWorktreeGet = mock(async () => taskWorktreeFixture);
+
+    const ensureRuntime = createEnsureRuntime({
+      hostClient: runtimeHost,
+      refreshTaskData: async () => {},
+    });
+
+    await expect(
+      ensureRuntime("/tmp/repo", "task-1", "build", {
+        workspaceId: "workspace-1",
+      }),
+    ).rejects.toThrow(
+      "Runtime kind is not configured for build sessions. Select a build agent runtime or repository default runtime before starting a session.",
+    );
+    expect(runtimeHost.buildStart).not.toHaveBeenCalled();
+    expect(runtimeHost.runtimeEnsure).not.toHaveBeenCalled();
+    expect(runtimeHost.taskWorktreeGet).not.toHaveBeenCalled();
+  });
+
+  test("fails before runtime ensure when repo default runtime is blank", async () => {
+    restoreRuntimeRepoConfigLoader?.();
+    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
+      createRepoConfig({
+        defaultRuntimeKind: " " as never,
+        agentDefaults: {},
+      }),
+    );
+    runtimeHost.buildStart = mock(async () => buildBootstrapFixture);
+    runtimeHost.runtimeEnsure = mock(async () => sharedRuntimeFixture);
+    runtimeHost.taskWorktreeGet = mock(async () => taskWorktreeFixture);
+
+    const ensureRuntime = createEnsureRuntime({
+      hostClient: runtimeHost,
+      refreshTaskData: async () => {},
+    });
+
+    await expect(
+      ensureRuntime("/tmp/repo", "task-1", "spec", {
+        workspaceId: "workspace-1",
+      }),
+    ).rejects.toThrow(
+      "Runtime kind is not configured for spec sessions. Select a spec agent runtime or repository default runtime before starting a session.",
+    );
+    expect(runtimeHost.buildStart).not.toHaveBeenCalled();
+    expect(runtimeHost.runtimeEnsure).not.toHaveBeenCalled();
+    expect(runtimeHost.taskWorktreeGet).not.toHaveBeenCalled();
+  });
+
   test("uses shared repo runtime for build role when a target working directory is provided", async () => {
     let buildStartCalls = 0;
     let repoRuntimeEnsureCalls = 0;
@@ -340,29 +378,19 @@ describe("agent-orchestrator-runtime", () => {
 
   test("maps repo role defaults into model selection", async () => {
     restoreRuntimeRepoConfigLoader?.();
-    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () => ({
-      workspaceId: "repo",
-      workspaceName: "Repo",
-      repoPath: "/tmp/repo",
-      defaultRuntimeKind: "opencode" as const,
-      branchPrefix: "obp",
-      defaultTargetBranch: { remote: "origin", branch: "main" },
-      git: { providers: {} },
-      trustedHooks: false,
-      hooks: { preStart: [], postComplete: [] },
-      devServers: [],
-      worktreeFileCopies: [],
-      promptOverrides: {},
-      agentDefaults: {
-        build: {
-          runtimeKind: "opencode",
-          providerId: "openai",
-          modelId: "gpt-5",
-          variant: "high",
-          profileId: "builder",
+    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
+      createRepoConfig({
+        agentDefaults: {
+          build: {
+            runtimeKind: "opencode",
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "high",
+            profileId: "builder",
+          },
         },
-      },
-    }));
+      }),
+    );
 
     const selection = await loadRepoDefaultModel("/tmp/repo", "build");
     expect(selection).toEqual({

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -9,7 +9,6 @@ import {
   type TaskWorktreeSummary,
 } from "@openducktor/contracts";
 import { clearAppQueryClient } from "@/lib/query-client";
-import { host } from "../../shared/host";
 import { createDeferred, withTimeout } from "../test-utils";
 import {
   createEnsureRuntime,
@@ -93,19 +92,6 @@ describe("agent-orchestrator-runtime", () => {
     restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () =>
       createRepoConfig(),
     );
-    host.workspaceList = async () => [
-      {
-        workspaceId: "repo",
-        workspaceName: "Repo",
-        repoPath: "/tmp/repo",
-        isActive: true,
-        hasConfig: true,
-        configuredWorktreeBasePath: null,
-        defaultWorktreeBasePath: "/tmp/worktrees/repo",
-        effectiveWorktreeBasePath: "/tmp/worktrees/repo",
-      },
-    ];
-    host.workspaceGetRepoConfig = async () => createRepoConfig();
     runtimeHost = {
       runtimeEnsure: async () => sharedRuntimeFixture,
       buildStart: async () => buildBootstrapFixture,

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   agentPromptTemplateIdValues,
   type BuildSessionBootstrap,
@@ -16,6 +16,7 @@ import {
   loadRepoDefaultModel,
   loadRepoPromptOverrides,
   resolveRuntimeRouteConnection,
+  setRuntimeRepoConfigLoaderForTest,
 } from "./runtime";
 
 const buildBootstrapFixture: BuildSessionBootstrap = {
@@ -77,8 +78,27 @@ const createPromptOverrideSettingsSnapshot = (
 });
 
 describe("agent-orchestrator-runtime", () => {
+  let restoreRuntimeRepoConfigLoader: (() => void) | null = null;
+  let runtimeHost: NonNullable<Parameters<typeof createEnsureRuntime>[0]["hostClient"]>;
+
   beforeEach(async () => {
+    restoreRuntimeRepoConfigLoader?.();
     await clearAppQueryClient();
+    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () => ({
+      workspaceId: "repo",
+      workspaceName: "Repo",
+      repoPath: "/tmp/repo",
+      defaultRuntimeKind: "opencode",
+      branchPrefix: "obp",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: { providers: {} },
+      trustedHooks: false,
+      hooks: { preStart: [], postComplete: [] },
+      devServers: [],
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    }));
     host.workspaceList = async () => [
       {
         workspaceId: "repo",
@@ -106,9 +126,16 @@ describe("agent-orchestrator-runtime", () => {
       promptOverrides: {},
       agentDefaults: {},
     });
-    host.runtimeEnsure = async () => sharedRuntimeFixture;
-    host.buildStart = async () => buildBootstrapFixture;
-    host.taskWorktreeGet = async () => taskWorktreeFixture;
+    runtimeHost = {
+      runtimeEnsure: async () => sharedRuntimeFixture,
+      buildStart: async () => buildBootstrapFixture,
+      taskWorktreeGet: async () => taskWorktreeFixture,
+    };
+  });
+
+  afterEach(() => {
+    restoreRuntimeRepoConfigLoader?.();
+    restoreRuntimeRepoConfigLoader = null;
   });
 
   test("resolves runtime route connections through one shared boundary helper", () => {
@@ -133,45 +160,42 @@ describe("agent-orchestrator-runtime", () => {
     let refreshCalls = 0;
     let buildStartCalls = 0;
 
-    const originalBuildStart = host.buildStart;
-    host.buildStart = async () => {
+    runtimeHost.buildStart = async () => {
       buildStartCalls += 1;
       return buildBootstrapFixture;
     };
 
-    try {
-      const ensureRuntime = createEnsureRuntime({
-        refreshTaskData: async () => {
-          refreshCalls += 1;
-        },
-      });
+    const ensureRuntime = createEnsureRuntime({
+      hostClient: runtimeHost,
+      refreshTaskData: async () => {
+        refreshCalls += 1;
+      },
+    });
 
-      const runtime = await ensureRuntime("/tmp/repo", "task-1", "build", {
-        workspaceId: "workspace-1",
-      });
+    const runtime = await ensureRuntime("/tmp/repo", "task-1", "build", {
+      workspaceId: "workspace-1",
+    });
 
-      expect(runtime).toEqual({
-        runtimeKind: "opencode",
-        runtimeId: null,
-        runtimeConnection: {
-          type: "local_http",
-          endpoint: "http://127.0.0.1:4444",
-          workingDirectory: "/tmp/repo/worktree",
-        },
-        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+    expect(runtime).toEqual({
+      runtimeKind: "opencode",
+      runtimeId: null,
+      runtimeConnection: {
+        type: "local_http",
+        endpoint: "http://127.0.0.1:4444",
         workingDirectory: "/tmp/repo/worktree",
-      });
-      expect(buildStartCalls).toBe(1);
-      expect(refreshCalls).toBe(1);
-    } finally {
-      host.buildStart = originalBuildStart;
-    }
+      },
+      runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+      workingDirectory: "/tmp/repo/worktree",
+    });
+    expect(buildStartCalls).toBe(1);
+    expect(refreshCalls).toBe(1);
   });
 
   test("returns build runtime without waiting for refresh completion", async () => {
     const refreshDeferred = createDeferred<void>();
 
     const ensureRuntime = createEnsureRuntime({
+      hostClient: runtimeHost,
       refreshTaskData: async () => refreshDeferred.promise,
     });
 
@@ -199,148 +223,124 @@ describe("agent-orchestrator-runtime", () => {
   });
 
   test("propagates build startup transport errors before returning an unusable stdio runtime", async () => {
-    const originalBuildStart = host.buildStart;
-    host.buildStart = async () => {
+    runtimeHost.buildStart = async () => {
       throw new Error("Runtime build session startup requires a local_http runtime route");
     };
 
-    try {
-      const ensureRuntime = createEnsureRuntime({
-        refreshTaskData: async () => {},
-      });
+    const ensureRuntime = createEnsureRuntime({
+      hostClient: runtimeHost,
+      refreshTaskData: async () => {},
+    });
 
-      await expect(
-        ensureRuntime("/tmp/repo", "task-1", "build", {
-          workspaceId: "workspace-1",
-        }),
-      ).rejects.toThrow("Runtime build session startup requires a local_http runtime route");
-    } finally {
-      host.buildStart = originalBuildStart;
-    }
+    await expect(
+      ensureRuntime("/tmp/repo", "task-1", "build", {
+        workspaceId: "workspace-1",
+      }),
+    ).rejects.toThrow("Runtime build session startup requires a local_http runtime route");
   });
 
   test("uses shared repo runtime for build role when a target working directory is provided", async () => {
     let buildStartCalls = 0;
     let repoRuntimeEnsureCalls = 0;
 
-    const originalBuildStart = host.buildStart;
-    const originalRepoRuntimeEnsure = host.runtimeEnsure;
-    host.buildStart = async () => {
+    runtimeHost.buildStart = async () => {
       buildStartCalls += 1;
       return buildBootstrapFixture;
     };
-    host.runtimeEnsure = async () => {
+    runtimeHost.runtimeEnsure = async () => {
       repoRuntimeEnsureCalls += 1;
       return sharedRuntimeFixture;
     };
 
-    try {
-      const ensureRuntime = createEnsureRuntime({
-        refreshTaskData: async () => {},
-      });
+    const ensureRuntime = createEnsureRuntime({
+      hostClient: runtimeHost,
+      refreshTaskData: async () => {},
+    });
 
-      const runtime = await ensureRuntime("/tmp/repo", "task-1", "build", {
-        workspaceId: "workspace-1",
-        targetWorkingDirectory: "/tmp/repo/conflict-worktree",
-      });
+    const runtime = await ensureRuntime("/tmp/repo", "task-1", "build", {
+      workspaceId: "workspace-1",
+      targetWorkingDirectory: "/tmp/repo/conflict-worktree",
+    });
 
-      expect(runtime).toEqual({
-        runtimeKind: "opencode",
-        runtimeId: "runtime-shared",
-        runtimeConnection: {
-          type: "local_http",
-          endpoint: "http://127.0.0.1:4666",
-          workingDirectory: "/tmp/repo/conflict-worktree",
-        },
-        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4666" },
+    expect(runtime).toEqual({
+      runtimeKind: "opencode",
+      runtimeId: "runtime-shared",
+      runtimeConnection: {
+        type: "local_http",
+        endpoint: "http://127.0.0.1:4666",
         workingDirectory: "/tmp/repo/conflict-worktree",
-      });
-      expect(buildStartCalls).toBe(0);
-      expect(repoRuntimeEnsureCalls).toBe(1);
-    } finally {
-      host.buildStart = originalBuildStart;
-      host.runtimeEnsure = originalRepoRuntimeEnsure;
-    }
+      },
+      runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4666" },
+      workingDirectory: "/tmp/repo/conflict-worktree",
+    });
+    expect(buildStartCalls).toBe(0);
+    expect(repoRuntimeEnsureCalls).toBe(1);
   });
 
   test("uses task worktree for qa when builder worktree exists", async () => {
     let continuationCalls = 0;
     let repoRuntimeEnsureCalls = 0;
 
-    const originalContinuationTarget = host.taskWorktreeGet;
-    const originalRepoRuntimeEnsure = host.runtimeEnsure;
-    host.taskWorktreeGet = async () => {
+    runtimeHost.taskWorktreeGet = async () => {
       continuationCalls += 1;
       return taskWorktreeFixture;
     };
-    host.runtimeEnsure = async () => {
+    runtimeHost.runtimeEnsure = async () => {
       repoRuntimeEnsureCalls += 1;
       return sharedRuntimeFixture;
     };
 
-    try {
-      const ensureRuntime = createEnsureRuntime({
-        refreshTaskData: async () => {},
-      });
+    const ensureRuntime = createEnsureRuntime({
+      hostClient: runtimeHost,
+      refreshTaskData: async () => {},
+    });
 
-      const runtime = await ensureRuntime("/tmp/repo", "task-1", "qa", {
-        workspaceId: "workspace-1",
-      });
+    const runtime = await ensureRuntime("/tmp/repo", "task-1", "qa", {
+      workspaceId: "workspace-1",
+    });
 
-      expect(runtime).toEqual({
-        runtimeKind: "opencode",
-        runtimeId: "runtime-shared",
-        runtimeConnection: {
-          type: "local_http",
-          endpoint: "http://127.0.0.1:4666",
-          workingDirectory: "/tmp/repo/worktree",
-        },
-        runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4666" },
+    expect(runtime).toEqual({
+      runtimeKind: "opencode",
+      runtimeId: "runtime-shared",
+      runtimeConnection: {
+        type: "local_http",
+        endpoint: "http://127.0.0.1:4666",
         workingDirectory: "/tmp/repo/worktree",
-      });
-      expect(continuationCalls).toBe(1);
-      expect(repoRuntimeEnsureCalls).toBe(1);
-    } finally {
-      host.taskWorktreeGet = originalContinuationTarget;
-      host.runtimeEnsure = originalRepoRuntimeEnsure;
-    }
+      },
+      runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4666" },
+      workingDirectory: "/tmp/repo/worktree",
+    });
+    expect(continuationCalls).toBe(1);
+    expect(repoRuntimeEnsureCalls).toBe(1);
   });
 
   test("throws actionable error when qa has no task worktree", async () => {
-    const originalContinuationTarget = host.taskWorktreeGet;
-    host.taskWorktreeGet = async () => null;
+    runtimeHost.taskWorktreeGet = async () => null;
 
-    try {
-      const ensureRuntime = createEnsureRuntime({
-        refreshTaskData: async () => {},
-      });
+    const ensureRuntime = createEnsureRuntime({
+      hostClient: runtimeHost,
+      refreshTaskData: async () => {},
+    });
 
-      await expect(
-        ensureRuntime("/tmp/repo", "task-1", "qa", {
-          workspaceId: "workspace-1",
-        }),
-      ).rejects.toThrow("Builder continuation cannot start until a builder worktree exists");
-    } finally {
-      host.taskWorktreeGet = originalContinuationTarget;
-    }
+    await expect(
+      ensureRuntime("/tmp/repo", "task-1", "qa", {
+        workspaceId: "workspace-1",
+      }),
+    ).rejects.toThrow("Builder continuation cannot start until a builder worktree exists");
   });
 
   test("propagates repo config loading errors when default model lookup fails", async () => {
-    const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
-    host.workspaceGetRepoConfig = async () => {
+    restoreRuntimeRepoConfigLoader?.();
+    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () => {
       throw new Error("missing config");
-    };
+    });
 
-    try {
-      await expect(loadRepoDefaultModel("/tmp/repo", "build")).rejects.toThrow("missing config");
-    } finally {
-      host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
-    }
+    await expect(loadRepoDefaultModel("/tmp/repo", "build")).rejects.toThrow("missing config");
   });
 
   test("maps repo role defaults into model selection", async () => {
-    const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
-    host.workspaceGetRepoConfig = async () => ({
+    restoreRuntimeRepoConfigLoader?.();
+    restoreRuntimeRepoConfigLoader = setRuntimeRepoConfigLoaderForTest(async () => ({
       workspaceId: "repo",
       workspaceName: "Repo",
       repoPath: "/tmp/repo",
@@ -362,20 +362,16 @@ describe("agent-orchestrator-runtime", () => {
           profileId: "builder",
         },
       },
-    });
+    }));
 
-    try {
-      const selection = await loadRepoDefaultModel("/tmp/repo", "build");
-      expect(selection).toEqual({
-        runtimeKind: "opencode",
-        providerId: "openai",
-        modelId: "gpt-5",
-        variant: "high",
-        profileId: "builder",
-      });
-    } finally {
-      host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
-    }
+    const selection = await loadRepoDefaultModel("/tmp/repo", "build");
+    expect(selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "builder",
+    });
   });
 
   test("loads effective prompt overrides by merging global and repository values", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -16,7 +16,6 @@ import {
   requireRuntimeConnection,
 } from "@openducktor/core";
 import type { QueryClient } from "@tanstack/react-query";
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import { appQueryClient } from "@/lib/query-client";
 import { loadRepoConfigFromQuery, loadSettingsSnapshotFromQuery } from "@/state/queries/workspace";
 import { host } from "../../shared/host";
@@ -165,12 +164,27 @@ export type TaskDocuments = {
 
 type EnsureRuntimeDependencies = {
   refreshTaskData: (repoPath: string, taskIdOrIds?: string | string[]) => Promise<void>;
+  hostClient?: Pick<typeof host, "buildStart" | "runtimeEnsure" | "taskWorktreeGet">;
 };
 
 type RuntimeWorkspaceQueryHost = Pick<
   typeof host,
   "workspaceGetRepoConfig" | "workspaceGetSettingsSnapshot"
 >;
+
+type RepoConfigLoader = (workspaceId: string) => Promise<RepoConfig>;
+
+let repoConfigLoader: RepoConfigLoader = (workspaceId: string): Promise<RepoConfig> => {
+  return loadRepoConfigFromQuery(appQueryClient, workspaceId);
+};
+
+export const setRuntimeRepoConfigLoaderForTest = (loader: RepoConfigLoader): (() => void) => {
+  const previousLoader = repoConfigLoader;
+  repoConfigLoader = loader;
+  return () => {
+    repoConfigLoader = previousLoader;
+  };
+};
 
 export const loadTaskDocuments = async (
   repoPath: string,
@@ -189,14 +203,10 @@ export const loadTaskDocuments = async (
   };
 };
 
-const loadRepoConfig = (workspaceId: string): Promise<RepoConfig> => {
-  return loadRepoConfigFromQuery(appQueryClient, workspaceId);
-};
-
 export const loadRepoDefaultTargetBranch = async (
   workspaceId: string,
 ): Promise<GitTargetBranch | null> => {
-  const config = await loadRepoConfig(workspaceId);
+  const config = await repoConfigLoader(workspaceId);
   return config.defaultTargetBranch ?? null;
 };
 
@@ -204,7 +214,7 @@ export const loadRepoDefaultModel = async (
   workspaceId: string,
   role: AgentRole,
 ): Promise<AgentModelSelection | null> => {
-  const config = await loadRepoConfig(workspaceId);
+  const config = await repoConfigLoader(workspaceId);
   const roleDefault = config?.agentDefaults?.[role];
   if (!roleDefault) {
     return null;
@@ -256,12 +266,29 @@ export const loadRepoDefaultRuntimeKind = async (
   workspaceId: string,
   role: AgentRole,
 ): Promise<RuntimeKind> => {
-  const config = await loadRepoConfig(workspaceId);
+  const config = await repoConfigLoader(workspaceId);
   const roleDefault = config?.agentDefaults?.[role];
-  return roleDefault?.runtimeKind ?? config?.defaultRuntimeKind ?? DEFAULT_RUNTIME_KIND;
+  return requireConfiguredRuntimeKind(
+    roleDefault?.runtimeKind ?? config?.defaultRuntimeKind,
+    `Runtime kind is not configured for ${role} sessions. Select a ${role} agent runtime or repository default runtime before starting a session.`,
+  );
 };
 
-export const createEnsureRuntime = ({ refreshTaskData }: EnsureRuntimeDependencies) => {
+export const requireConfiguredRuntimeKind = (
+  runtimeKind: RuntimeKind | string | null | undefined,
+  contextMessage: string,
+): RuntimeKind => {
+  const normalized = runtimeKind?.trim() ?? "";
+  if (!normalized) {
+    throw new Error(contextMessage);
+  }
+  return normalized;
+};
+
+export const createEnsureRuntime = ({
+  refreshTaskData,
+  hostClient = host,
+}: EnsureRuntimeDependencies) => {
   return async (
     repoPath: string,
     taskId: string,
@@ -274,13 +301,18 @@ export const createEnsureRuntime = ({ refreshTaskData }: EnsureRuntimeDependenci
   ): Promise<RuntimeInfo> => {
     const targetWorkingDirectory = options?.targetWorkingDirectory?.trim() ?? "";
     const workspaceId = options?.workspaceId?.trim() ?? "";
-    const runtimeKind = options?.runtimeKind?.trim()
-      ? options.runtimeKind
-      : workspaceId
-        ? await loadRepoDefaultRuntimeKind(workspaceId, role)
-        : (() => {
-            throw new Error("Active workspace is required to resolve the default runtime.");
-          })();
+    let runtimeKind: RuntimeKind;
+    if (options?.runtimeKind?.trim()) {
+      runtimeKind = requireConfiguredRuntimeKind(
+        options.runtimeKind,
+        `Runtime kind is required to start ${role} sessions.`,
+      );
+    } else {
+      if (!workspaceId) {
+        throw new Error("Active workspace is required to resolve the default runtime.");
+      }
+      runtimeKind = await loadRepoDefaultRuntimeKind(workspaceId, role);
+    }
     const toRuntimeInfo = (input: {
       runtimeId: string | null;
       runtimeRoute: RuntimeRoute;
@@ -304,7 +336,7 @@ export const createEnsureRuntime = ({ refreshTaskData }: EnsureRuntimeDependenci
           repoPath,
           runtimeKind,
           ensureRuntime: (nextRepoPath, nextRuntimeKind) =>
-            host.runtimeEnsure(nextRepoPath, nextRuntimeKind),
+            hostClient.runtimeEnsure(nextRepoPath, nextRuntimeKind),
         });
         const { runtimeConnection } = resolveRuntimeRouteConnection(
           runtime.runtimeRoute,
@@ -318,7 +350,11 @@ export const createEnsureRuntime = ({ refreshTaskData }: EnsureRuntimeDependenci
         });
       }
 
-      const bootstrap: BuildSessionBootstrap = await host.buildStart(repoPath, taskId, runtimeKind);
+      const bootstrap: BuildSessionBootstrap = await hostClient.buildStart(
+        repoPath,
+        taskId,
+        runtimeKind,
+      );
       runOrchestratorSideEffect(
         "runtime-refresh-task-data-after-build-start",
         refreshTaskData(repoPath),
@@ -340,7 +376,9 @@ export const createEnsureRuntime = ({ refreshTaskData }: EnsureRuntimeDependenci
 
     if (role === "qa") {
       const continuationTarget =
-        targetWorkingDirectory.length === 0 ? await host.taskWorktreeGet(repoPath, taskId) : null;
+        targetWorkingDirectory.length === 0
+          ? await hostClient.taskWorktreeGet(repoPath, taskId)
+          : null;
       const workingDirectory = targetWorkingDirectory || continuationTarget?.workingDirectory;
       if (!workingDirectory) {
         throw new Error(MISSING_BUILD_TARGET_ERROR);
@@ -349,7 +387,7 @@ export const createEnsureRuntime = ({ refreshTaskData }: EnsureRuntimeDependenci
         repoPath,
         runtimeKind,
         ensureRuntime: (nextRepoPath, nextRuntimeKind) =>
-          host.runtimeEnsure(nextRepoPath, nextRuntimeKind),
+          hostClient.runtimeEnsure(nextRepoPath, nextRuntimeKind),
       });
       const { runtimeConnection } = resolveRuntimeRouteConnection(
         runtime.runtimeRoute,
@@ -367,7 +405,7 @@ export const createEnsureRuntime = ({ refreshTaskData }: EnsureRuntimeDependenci
       repoPath,
       runtimeKind,
       ensureRuntime: (nextRepoPath, nextRuntimeKind) =>
-        host.runtimeEnsure(nextRepoPath, nextRuntimeKind),
+        hostClient.runtimeEnsure(nextRepoPath, nextRuntimeKind),
     });
     const workingDirectory = targetWorkingDirectory || runtime.workingDirectory;
     const { runtimeConnection } = resolveRuntimeRouteConnection(

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -165,6 +165,7 @@ export type TaskDocuments = {
 type EnsureRuntimeDependencies = {
   refreshTaskData: (repoPath: string, taskIdOrIds?: string | string[]) => Promise<void>;
   hostClient?: Pick<typeof host, "buildStart" | "runtimeEnsure" | "taskWorktreeGet">;
+  repoConfigLoader?: RepoConfigLoader;
 };
 
 type RuntimeWorkspaceQueryHost = Pick<
@@ -172,18 +173,10 @@ type RuntimeWorkspaceQueryHost = Pick<
   "workspaceGetRepoConfig" | "workspaceGetSettingsSnapshot"
 >;
 
-type RepoConfigLoader = (workspaceId: string) => Promise<RepoConfig>;
+export type RepoConfigLoader = (workspaceId: string) => Promise<RepoConfig>;
 
-let repoConfigLoader: RepoConfigLoader = (workspaceId: string): Promise<RepoConfig> => {
+const defaultRepoConfigLoader: RepoConfigLoader = (workspaceId: string): Promise<RepoConfig> => {
   return loadRepoConfigFromQuery(appQueryClient, workspaceId);
-};
-
-export const setRuntimeRepoConfigLoaderForTest = (loader: RepoConfigLoader): (() => void) => {
-  const previousLoader = repoConfigLoader;
-  repoConfigLoader = loader;
-  return () => {
-    repoConfigLoader = previousLoader;
-  };
 };
 
 export const loadTaskDocuments = async (
@@ -205,16 +198,18 @@ export const loadTaskDocuments = async (
 
 export const loadRepoDefaultTargetBranch = async (
   workspaceId: string,
+  loadRepoConfig: RepoConfigLoader = defaultRepoConfigLoader,
 ): Promise<GitTargetBranch | null> => {
-  const config = await repoConfigLoader(workspaceId);
+  const config = await loadRepoConfig(workspaceId);
   return config.defaultTargetBranch ?? null;
 };
 
 export const loadRepoDefaultModel = async (
   workspaceId: string,
   role: AgentRole,
+  loadRepoConfig: RepoConfigLoader = defaultRepoConfigLoader,
 ): Promise<AgentModelSelection | null> => {
-  const config = await repoConfigLoader(workspaceId);
+  const config = await loadRepoConfig(workspaceId);
   const roleDefault = config?.agentDefaults?.[role];
   if (!roleDefault) {
     return null;
@@ -265,8 +260,9 @@ export const loadTaskWorktree = async (
 export const loadRepoDefaultRuntimeKind = async (
   workspaceId: string,
   role: AgentRole,
+  loadRepoConfig: RepoConfigLoader = defaultRepoConfigLoader,
 ): Promise<RuntimeKind> => {
-  const config = await repoConfigLoader(workspaceId);
+  const config = await loadRepoConfig(workspaceId);
   const roleDefault = config?.agentDefaults?.[role];
   return requireConfiguredRuntimeKind(
     roleDefault?.runtimeKind ?? config?.defaultRuntimeKind,
@@ -288,6 +284,7 @@ export const requireConfiguredRuntimeKind = (
 export const createEnsureRuntime = ({
   refreshTaskData,
   hostClient = host,
+  repoConfigLoader = defaultRepoConfigLoader,
 }: EnsureRuntimeDependencies) => {
   return async (
     repoPath: string,
@@ -301,17 +298,18 @@ export const createEnsureRuntime = ({
   ): Promise<RuntimeInfo> => {
     const targetWorkingDirectory = options?.targetWorkingDirectory?.trim() ?? "";
     const workspaceId = options?.workspaceId?.trim() ?? "";
+    const explicitRuntimeKind = options?.runtimeKind?.trim() ?? "";
     let runtimeKind: RuntimeKind;
-    if (options?.runtimeKind?.trim()) {
+    if (explicitRuntimeKind) {
       runtimeKind = requireConfiguredRuntimeKind(
-        options.runtimeKind,
+        explicitRuntimeKind,
         `Runtime kind is required to start ${role} sessions.`,
       );
     } else {
       if (!workspaceId) {
         throw new Error("Active workspace is required to resolve the default runtime.");
       }
-      runtimeKind = await loadRepoDefaultRuntimeKind(workspaceId, role);
+      runtimeKind = await loadRepoDefaultRuntimeKind(workspaceId, role, repoConfigLoader);
     }
     const toRuntimeInfo = (input: {
       runtimeId: string | null;

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/models.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/models.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import {
   coerceSessionSelectionToCatalog,
@@ -7,6 +8,7 @@ import {
 } from "./models";
 
 const catalogFixture: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [
     {
       id: "openai/gpt-5",

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/models.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/models.ts
@@ -16,9 +16,13 @@ export const pickDefaultSessionSelectionForCatalog = (
     return null;
   }
   const variant = normalizeCatalogVariant(model, undefined);
+  const runtimeKind = runtimeKindForCatalog(catalog);
+  if (!runtimeKind) {
+    return null;
+  }
 
   return {
-    runtimeKind: runtimeKindForCatalog(catalog),
+    runtimeKind,
     providerId: model.providerId,
     modelId: model.modelId,
     ...(variant ? { variant } : {}),
@@ -40,9 +44,13 @@ export const coerceSessionSelectionToCatalog = (
 
   const variant = normalizeCatalogVariant(model, selection.variant);
   const profileId = normalizeKnownCatalogProfileId(catalog, selection.profileId);
+  const runtimeKind = selection.runtimeKind ?? runtimeKindForCatalog(catalog);
+  if (!runtimeKind) {
+    return null;
+  }
 
   return {
-    runtimeKind: selection.runtimeKind ?? runtimeKindForCatalog(catalog),
+    runtimeKind,
     providerId: model.providerId,
     modelId: model.modelId,
     ...(variant ? { variant } : {}),

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -115,6 +115,17 @@ describe("agent-orchestrator/support/persistence", () => {
     ).toThrow("Persisted session 'session-1' is missing runtime kind metadata.");
   });
 
+  test("rejects persisted session records with blank top-level runtime kind", () => {
+    const invalidRecord: AgentSessionRecord = {
+      ...recordFixture,
+      runtimeKind: "  ",
+    };
+
+    expect(() => fromPersistedSessionRecord(invalidRecord, "task-1", repoPathFixture)).toThrow(
+      "Persisted session 'session-1' is missing runtime kind metadata.",
+    );
+  });
+
   test("rejects persisted selected models without a runtime kind", () => {
     const invalidRecord = {
       ...recordFixture,
@@ -122,6 +133,21 @@ describe("agent-orchestrator/support/persistence", () => {
         providerId: "openai",
         modelId: "gpt-5",
       } as unknown as NonNullable<AgentSessionRecord["selectedModel"]>,
+    };
+
+    expect(() => fromPersistedSessionRecord(invalidRecord, "task-1", repoPathFixture)).toThrow(
+      "Persisted session 'session-1' selected model is missing runtime kind metadata.",
+    );
+  });
+
+  test("rejects persisted selected models with blank runtime kind", () => {
+    const invalidRecord: AgentSessionRecord = {
+      ...recordFixture,
+      selectedModel: {
+        runtimeKind: "\t ",
+        providerId: "openai",
+        modelId: "gpt-5",
+      },
     };
 
     expect(() => fromPersistedSessionRecord(invalidRecord, "task-1", repoPathFixture)).toThrow(
@@ -159,6 +185,17 @@ describe("agent-orchestrator/support/persistence", () => {
     );
   });
 
+  test("rejects persisting sessions with blank top-level runtime kind", () => {
+    const session: AgentSessionState = {
+      ...fromPersistedSessionRecord(recordFixture, "task-1", repoPathFixture),
+      runtimeKind: "\n  ",
+    };
+
+    expect(() => toPersistedSessionRecord(session)).toThrow(
+      "Session 'session-1' is missing runtime kind metadata.",
+    );
+  });
+
   test("rejects persisting selected models without a runtime kind", () => {
     const session: AgentSessionState = {
       ...fromPersistedSessionRecord(recordFixture, "task-1", repoPathFixture),
@@ -166,6 +203,21 @@ describe("agent-orchestrator/support/persistence", () => {
         providerId: "openai",
         modelId: "gpt-5",
       } as unknown as NonNullable<AgentSessionState["selectedModel"]>,
+    };
+
+    expect(() => toPersistedSessionRecord(session)).toThrow(
+      "Session 'session-1' selected model is missing runtime kind metadata.",
+    );
+  });
+
+  test("rejects persisting selected models with blank runtime kind", () => {
+    const session: AgentSessionState = {
+      ...fromPersistedSessionRecord(recordFixture, "task-1", repoPathFixture),
+      selectedModel: {
+        runtimeKind: "  ",
+        providerId: "openai",
+        modelId: "gpt-5",
+      },
     };
 
     expect(() => toPersistedSessionRecord(session)).toThrow(

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-runtime-metadata.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-runtime-metadata.ts
@@ -33,6 +33,12 @@ const missingPersistedSelectedModelRuntimeKindMessage = (sessionId: string): str
 const missingSessionRuntimeKindMessage = (sessionId: string): string =>
   `Session '${sessionId}' is missing runtime kind metadata.`;
 
+const missingEnsuredSessionRuntimeKindMessage = (sessionId: string): string =>
+  `Session '${sessionId}' ensured runtime is missing runtime kind metadata.`;
+
+const missingEnsuredSelectedModelRuntimeKindMessage = (): string =>
+  "Selected model ensured runtime is missing runtime kind metadata.";
+
 const missingSelectedModelRuntimeKindMessage = (sessionId: string): string =>
   `Session '${sessionId}' selected model is missing runtime kind metadata.`;
 
@@ -104,14 +110,19 @@ export const assertSessionRuntimeKindMatchesEnsuredRuntime = ({
   sessionId: string;
   requestedRuntimeKind: RuntimeKind;
   ensuredRuntimeKind: RuntimeKind | string | null | undefined;
-}): void => {
-  if (!ensuredRuntimeKind || ensuredRuntimeKind === requestedRuntimeKind) {
-    return;
+}): RuntimeKind => {
+  const normalizedEnsuredRuntimeKind = requireRuntimeKindMetadata(
+    ensuredRuntimeKind,
+    missingEnsuredSessionRuntimeKindMessage(sessionId),
+  );
+  if (normalizedEnsuredRuntimeKind === requestedRuntimeKind) {
+    return normalizedEnsuredRuntimeKind;
   }
 
   throwSessionRuntimeMetadataError(
-    `Session '${sessionId}' runtime kind metadata '${requestedRuntimeKind}' does not match ensured runtime kind '${ensuredRuntimeKind}'.`,
+    `Session '${sessionId}' runtime kind metadata '${requestedRuntimeKind}' does not match ensured runtime kind '${normalizedEnsuredRuntimeKind}'.`,
   );
+  throw new Error("unreachable");
 };
 
 export const assertSelectedModelRuntimeKindMatchesEnsuredRuntime = ({
@@ -120,14 +131,19 @@ export const assertSelectedModelRuntimeKindMatchesEnsuredRuntime = ({
 }: {
   selectedModelRuntimeKind: RuntimeKind;
   ensuredRuntimeKind: RuntimeKind | string | null | undefined;
-}): void => {
-  if (!ensuredRuntimeKind || ensuredRuntimeKind === selectedModelRuntimeKind) {
-    return;
+}): RuntimeKind => {
+  const normalizedEnsuredRuntimeKind = requireRuntimeKindMetadata(
+    ensuredRuntimeKind,
+    missingEnsuredSelectedModelRuntimeKindMessage(),
+  );
+  if (normalizedEnsuredRuntimeKind === selectedModelRuntimeKind) {
+    return normalizedEnsuredRuntimeKind;
   }
 
   throwSessionRuntimeMetadataError(
-    `Selected model runtime kind '${selectedModelRuntimeKind}' does not match ensured runtime kind '${ensuredRuntimeKind}'.`,
+    `Selected model runtime kind '${selectedModelRuntimeKind}' does not match ensured runtime kind '${normalizedEnsuredRuntimeKind}'.`,
   );
+  throw new Error("unreachable");
 };
 
 export const requireSelectedModelRuntimeKindForPersistence = (

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-runtime-metadata.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-runtime-metadata.ts
@@ -12,17 +12,26 @@ const throwSessionRuntimeMetadataError = (message: string): never => {
   throw new SessionRuntimeMetadataError(message);
 };
 
+const requireRuntimeKindMetadata = (
+  runtimeKind: string | null | undefined,
+  message: string,
+): RuntimeKind => {
+  const trimmedRuntimeKind = runtimeKind?.trim();
+  if (!trimmedRuntimeKind) {
+    throwSessionRuntimeMetadataError(message);
+  }
+
+  return trimmedRuntimeKind as RuntimeKind;
+};
+
 export const readPersistedRuntimeKind = ({
   sessionId,
   runtimeKind,
 }: Pick<AgentSessionRecord, "sessionId" | "runtimeKind">): RuntimeKind => {
-  if (!runtimeKind) {
-    throwSessionRuntimeMetadataError(
-      `Persisted session '${sessionId}' is missing runtime kind metadata.`,
-    );
-  }
-
-  return runtimeKind;
+  return requireRuntimeKindMetadata(
+    runtimeKind,
+    `Persisted session '${sessionId}' is missing runtime kind metadata.`,
+  );
 };
 
 export const requirePersistedSelectedModelRuntimeKind = (
@@ -30,32 +39,27 @@ export const requirePersistedSelectedModelRuntimeKind = (
   sessionRuntimeKind: NonNullable<AgentSessionRecord["runtimeKind"]>,
   selectedModel: NonNullable<AgentSessionRecord["selectedModel"]>,
 ): NonNullable<typeof selectedModel.runtimeKind> => {
-  if (!selectedModel.runtimeKind) {
-    throwSessionRuntimeMetadataError(
-      `Persisted session '${sessionId}' selected model is missing runtime kind metadata.`,
-    );
-  }
+  const runtimeKind = requireRuntimeKindMetadata(
+    selectedModel.runtimeKind,
+    `Persisted session '${sessionId}' selected model is missing runtime kind metadata.`,
+  );
 
-  if (selectedModel.runtimeKind !== sessionRuntimeKind) {
+  if (runtimeKind !== sessionRuntimeKind) {
     throwSessionRuntimeMetadataError(
       `Persisted session '${sessionId}' selected model runtime kind does not match session runtime kind.`,
     );
   }
 
-  return selectedModel.runtimeKind as NonNullable<typeof selectedModel.runtimeKind>;
+  return runtimeKind as NonNullable<typeof selectedModel.runtimeKind>;
 };
 
 export const requireSessionRuntimeKindForPersistence = (
   session: Pick<AgentSessionState, "sessionId" | "runtimeKind">,
 ): NonNullable<AgentSessionState["runtimeKind"]> => {
-  const runtimeKind = session.runtimeKind;
-  if (!runtimeKind) {
-    throwSessionRuntimeMetadataError(
-      `Session '${session.sessionId}' is missing runtime kind metadata.`,
-    );
-  }
-
-  return runtimeKind as NonNullable<AgentSessionState["runtimeKind"]>;
+  return requireRuntimeKindMetadata(
+    session.runtimeKind,
+    `Session '${session.sessionId}' is missing runtime kind metadata.`,
+  ) as NonNullable<AgentSessionState["runtimeKind"]>;
 };
 
 export const requireSelectedModelRuntimeKindForPersistence = (
@@ -63,12 +67,10 @@ export const requireSelectedModelRuntimeKindForPersistence = (
   sessionRuntimeKind: NonNullable<AgentSessionState["runtimeKind"]>,
   selectedModel: NonNullable<AgentSessionState["selectedModel"]>,
 ): NonNullable<typeof selectedModel.runtimeKind> => {
-  const runtimeKind = selectedModel.runtimeKind;
-  if (!runtimeKind) {
-    throwSessionRuntimeMetadataError(
-      `Session '${sessionId}' selected model is missing runtime kind metadata.`,
-    );
-  }
+  const runtimeKind = requireRuntimeKindMetadata(
+    selectedModel.runtimeKind,
+    `Session '${sessionId}' selected model is missing runtime kind metadata.`,
+  );
 
   if (runtimeKind !== sessionRuntimeKind) {
     throwSessionRuntimeMetadataError(

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-runtime-metadata.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-runtime-metadata.ts
@@ -24,13 +24,28 @@ const requireRuntimeKindMetadata = (
   return trimmedRuntimeKind as RuntimeKind;
 };
 
+const missingPersistedSessionRuntimeKindMessage = (sessionId: string): string =>
+  `Persisted session '${sessionId}' is missing runtime kind metadata.`;
+
+const missingPersistedSelectedModelRuntimeKindMessage = (sessionId: string): string =>
+  `Persisted session '${sessionId}' selected model is missing runtime kind metadata.`;
+
+const missingSessionRuntimeKindMessage = (sessionId: string): string =>
+  `Session '${sessionId}' is missing runtime kind metadata.`;
+
+const missingSelectedModelRuntimeKindMessage = (sessionId: string): string =>
+  `Session '${sessionId}' selected model is missing runtime kind metadata.`;
+
+export const startSessionRuntimeKindRequiredMessage = (role: AgentSessionState["role"]): string =>
+  `Runtime kind is required to start ${role} sessions. Select an explicit runtime before starting a session.`;
+
 export const readPersistedRuntimeKind = ({
   sessionId,
   runtimeKind,
 }: Pick<AgentSessionRecord, "sessionId" | "runtimeKind">): RuntimeKind => {
   return requireRuntimeKindMetadata(
     runtimeKind,
-    `Persisted session '${sessionId}' is missing runtime kind metadata.`,
+    missingPersistedSessionRuntimeKindMessage(sessionId),
   );
 };
 
@@ -41,7 +56,7 @@ export const requirePersistedSelectedModelRuntimeKind = (
 ): NonNullable<typeof selectedModel.runtimeKind> => {
   const runtimeKind = requireRuntimeKindMetadata(
     selectedModel.runtimeKind,
-    `Persisted session '${sessionId}' selected model is missing runtime kind metadata.`,
+    missingPersistedSelectedModelRuntimeKindMessage(sessionId),
   );
 
   if (runtimeKind !== sessionRuntimeKind) {
@@ -58,8 +73,61 @@ export const requireSessionRuntimeKindForPersistence = (
 ): NonNullable<AgentSessionState["runtimeKind"]> => {
   return requireRuntimeKindMetadata(
     session.runtimeKind,
-    `Session '${session.sessionId}' is missing runtime kind metadata.`,
+    missingSessionRuntimeKindMessage(session.sessionId),
   ) as NonNullable<AgentSessionState["runtimeKind"]>;
+};
+
+export const requireSessionRuntimeKind = (
+  session: Pick<AgentSessionState, "sessionId" | "runtimeKind" | "selectedModel">,
+): NonNullable<AgentSessionState["runtimeKind"]> => {
+  return requireRuntimeKindMetadata(
+    session.runtimeKind ?? session.selectedModel?.runtimeKind,
+    missingSessionRuntimeKindMessage(session.sessionId),
+  ) as NonNullable<AgentSessionState["runtimeKind"]>;
+};
+
+export const requireSelectedModelRuntimeKindForStart = (
+  role: AgentSessionState["role"],
+  selectedModel: Pick<NonNullable<AgentSessionState["selectedModel"]>, "runtimeKind">,
+): NonNullable<NonNullable<AgentSessionState["selectedModel"]>["runtimeKind"]> => {
+  return requireRuntimeKindMetadata(
+    selectedModel.runtimeKind,
+    startSessionRuntimeKindRequiredMessage(role),
+  ) as NonNullable<NonNullable<AgentSessionState["selectedModel"]>["runtimeKind"]>;
+};
+
+export const assertSessionRuntimeKindMatchesEnsuredRuntime = ({
+  sessionId,
+  requestedRuntimeKind,
+  ensuredRuntimeKind,
+}: {
+  sessionId: string;
+  requestedRuntimeKind: RuntimeKind;
+  ensuredRuntimeKind: RuntimeKind | string | null | undefined;
+}): void => {
+  if (!ensuredRuntimeKind || ensuredRuntimeKind === requestedRuntimeKind) {
+    return;
+  }
+
+  throwSessionRuntimeMetadataError(
+    `Session '${sessionId}' runtime kind metadata '${requestedRuntimeKind}' does not match ensured runtime kind '${ensuredRuntimeKind}'.`,
+  );
+};
+
+export const assertSelectedModelRuntimeKindMatchesEnsuredRuntime = ({
+  selectedModelRuntimeKind,
+  ensuredRuntimeKind,
+}: {
+  selectedModelRuntimeKind: RuntimeKind;
+  ensuredRuntimeKind: RuntimeKind | string | null | undefined;
+}): void => {
+  if (!ensuredRuntimeKind || ensuredRuntimeKind === selectedModelRuntimeKind) {
+    return;
+  }
+
+  throwSessionRuntimeMetadataError(
+    `Selected model runtime kind '${selectedModelRuntimeKind}' does not match ensured runtime kind '${ensuredRuntimeKind}'.`,
+  );
 };
 
 export const requireSelectedModelRuntimeKindForPersistence = (
@@ -69,7 +137,7 @@ export const requireSelectedModelRuntimeKindForPersistence = (
 ): NonNullable<typeof selectedModel.runtimeKind> => {
   const runtimeKind = requireRuntimeKindMetadata(
     selectedModel.runtimeKind,
-    `Session '${sessionId}' selected model is missing runtime kind metadata.`,
+    missingSelectedModelRuntimeKindMessage(sessionId),
   );
 
   if (runtimeKind !== sessionRuntimeKind) {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/utils.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
@@ -17,6 +18,7 @@ const createSession = (messages: AgentChatMessage[]) => ({
 });
 
 const catalogFixture: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [
     {
       id: "openai/gpt-5",

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -574,7 +574,9 @@ describe("use-repo-settings-operations", () => {
           ...inputFixture,
           defaultRuntimeKind: "   " as RepoSettingsInput["defaultRuntimeKind"],
         }),
-      ).rejects.toThrow("Default runtime kind cannot be blank.");
+      ).rejects.toThrow(
+        "Default runtime kind is required. Select a repository default runtime before saving.",
+      );
       expect(workspaceSaveRepoSettings).toHaveBeenCalledTimes(0);
     } finally {
       await harness.unmount();

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.ts
@@ -87,10 +87,7 @@ export function useRepoSettingsOperations({
       const plannerDefault = toConfigDefault("planner", input.agentDefaults.planner);
       const buildDefault = toConfigDefault("build", input.agentDefaults.build);
       const qaDefault = toConfigDefault("qa", input.agentDefaults.qa);
-      const defaultRuntimeKind = normalizeRepoDefaultRuntimeKindForSave(
-        input.defaultRuntimeKind,
-        input.defaultRuntimeKind,
-      );
+      const defaultRuntimeKind = normalizeRepoDefaultRuntimeKindForSave(input.defaultRuntimeKind);
       const normalizedWorktreeBasePath = input.worktreeBasePath.trim();
       const normalizedBranchPrefix = input.branchPrefix.trim();
       const normalizedTargetBranch = normalizeTargetBranch(input.defaultTargetBranch);

--- a/packages/frontend/src/state/operations/workspace/use-workspace-selection-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-selection-operations.ts
@@ -3,7 +3,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 import type { ActiveWorkspace, WorkspaceSelectionOperationsInput } from "@/types/state-slices";
 import {
   loadRepoConfigFromQuery,
@@ -284,10 +283,15 @@ export function useWorkspaceSelectionOperations({
             if (workspaceSwitchVersionRef.current !== switchVersion) {
               return;
             }
+            if (!repoConfig?.defaultRuntimeKind?.trim()) {
+              throw new Error(
+                "Repository default runtime is not configured. Select a repository default runtime before switching repositories.",
+              );
+            }
 
             return ensureRuntimeAndInvalidateReadinessQueries({
               repoPath: selectedWorkspace.repoPath,
-              runtimeKind: repoConfig?.defaultRuntimeKind ?? DEFAULT_RUNTIME_KIND,
+              runtimeKind: repoConfig.defaultRuntimeKind,
               ensureRuntime: (repoPath, runtimeKind) =>
                 hostClient.runtimeEnsure(repoPath, runtimeKind),
               queryClient,

--- a/packages/frontend/src/state/queries/runtime-catalog.ts
+++ b/packages/frontend/src/state/queries/runtime-catalog.ts
@@ -21,7 +21,7 @@ const runtimeCatalogQueryKeys = {
 
 export const repoRuntimeCatalogQueryOptions = (
   repoPath: string,
-  runtimeKind: RuntimeKind,
+  runtimeKind: RuntimeKind | "",
   loadRepoRuntimeCatalog: (
     repoPath: string,
     runtimeKind: RuntimeKind,
@@ -29,13 +29,18 @@ export const repoRuntimeCatalogQueryOptions = (
 ) =>
   queryOptions({
     queryKey: runtimeCatalogQueryKeys.repo(repoPath, runtimeKind),
-    queryFn: (): Promise<AgentModelCatalog> => loadRepoRuntimeCatalog(repoPath, runtimeKind),
+    queryFn: (): Promise<AgentModelCatalog> => {
+      if (!runtimeKind) {
+        throw new Error("Runtime kind is required to load the model catalog.");
+      }
+      return loadRepoRuntimeCatalog(repoPath, runtimeKind);
+    },
     staleTime: RUNTIME_CATALOG_STALE_TIME_MS,
   });
 
 export const repoRuntimeSlashCommandsQueryOptions = (
   repoPath: string,
-  runtimeKind: RuntimeKind,
+  runtimeKind: RuntimeKind | "",
   loadRepoRuntimeSlashCommands: (
     repoPath: string,
     runtimeKind: RuntimeKind,
@@ -44,13 +49,15 @@ export const repoRuntimeSlashCommandsQueryOptions = (
   queryOptions({
     queryKey: runtimeCatalogQueryKeys.repoSlashCommands(repoPath, runtimeKind),
     queryFn: (): Promise<AgentSlashCommandCatalog> =>
-      loadRepoRuntimeSlashCommands(repoPath, runtimeKind),
+      runtimeKind
+        ? loadRepoRuntimeSlashCommands(repoPath, runtimeKind)
+        : Promise.reject(new Error("Runtime kind is required to load slash commands.")),
     staleTime: RUNTIME_CATALOG_STALE_TIME_MS,
   });
 
 export const repoRuntimeFileSearchQueryOptions = (
   repoPath: string,
-  runtimeKind: RuntimeKind,
+  runtimeKind: RuntimeKind | "",
   query: string,
   loadRepoRuntimeFileSearch: (
     repoPath: string,
@@ -61,6 +68,8 @@ export const repoRuntimeFileSearchQueryOptions = (
   queryOptions({
     queryKey: runtimeCatalogQueryKeys.repoFileSearch(repoPath, runtimeKind, query),
     queryFn: (): Promise<AgentFileSearchResult[]> =>
-      loadRepoRuntimeFileSearch(repoPath, runtimeKind, query),
+      runtimeKind
+        ? loadRepoRuntimeFileSearch(repoPath, runtimeKind, query)
+        : Promise.reject(new Error("Runtime kind is required to search files.")),
     staleTime: RUNTIME_FILE_SEARCH_STALE_TIME_MS,
   });

--- a/packages/frontend/src/state/queries/workspace.ts
+++ b/packages/frontend/src/state/queries/workspace.ts
@@ -1,7 +1,6 @@
 import type { RepoConfig, SettingsSnapshot, WorkspaceRecord } from "@openducktor/contracts";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { normalizeTargetBranch } from "@/lib/target-branch";
-import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import { host } from "../operations/host";
 
@@ -34,7 +33,7 @@ export const toRepoSettingsInput = (config: RepoConfig): RepoSettingsInput => ({
   agentDefaults: {
     spec: config.agentDefaults.spec
       ? {
-          runtimeKind: config.agentDefaults.spec.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+          runtimeKind: config.agentDefaults.spec.runtimeKind,
           providerId: config.agentDefaults.spec.providerId,
           modelId: config.agentDefaults.spec.modelId,
           variant: config.agentDefaults.spec.variant ?? "",
@@ -43,7 +42,7 @@ export const toRepoSettingsInput = (config: RepoConfig): RepoSettingsInput => ({
       : null,
     planner: config.agentDefaults.planner
       ? {
-          runtimeKind: config.agentDefaults.planner.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+          runtimeKind: config.agentDefaults.planner.runtimeKind,
           providerId: config.agentDefaults.planner.providerId,
           modelId: config.agentDefaults.planner.modelId,
           variant: config.agentDefaults.planner.variant ?? "",
@@ -52,7 +51,7 @@ export const toRepoSettingsInput = (config: RepoConfig): RepoSettingsInput => ({
       : null,
     build: config.agentDefaults.build
       ? {
-          runtimeKind: config.agentDefaults.build.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+          runtimeKind: config.agentDefaults.build.runtimeKind,
           providerId: config.agentDefaults.build.providerId,
           modelId: config.agentDefaults.build.modelId,
           variant: config.agentDefaults.build.variant ?? "",
@@ -61,7 +60,7 @@ export const toRepoSettingsInput = (config: RepoConfig): RepoSettingsInput => ({
       : null,
     qa: config.agentDefaults.qa
       ? {
-          runtimeKind: config.agentDefaults.qa.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+          runtimeKind: config.agentDefaults.qa.runtimeKind,
           providerId: config.agentDefaults.qa.providerId,
           modelId: config.agentDefaults.qa.modelId,
           variant: config.agentDefaults.qa.variant ?? "",

--- a/packages/frontend/src/types/state-slices.ts
+++ b/packages/frontend/src/types/state-slices.ts
@@ -40,7 +40,7 @@ export type WorkspaceSelectionOperationsInput = {
 export type ActiveWorkspace = Pick<WorkspaceRecord, "workspaceId" | "workspaceName" | "repoPath">;
 
 export type RepoAgentDefaultInput = {
-  runtimeKind?: RuntimeKind;
+  runtimeKind?: RuntimeKind | null;
   providerId: string;
   modelId: string;
   variant: string;


### PR DESCRIPTION
## Summary
Remove silent OpenCode defaulting from runtime selection so missing or incomplete runtime metadata is surfaced as actionable configuration errors instead of being treated as OpenCode.

## Goal and context
OpenDucktor is preparing for multiple agent runtimes. Several frontend paths previously treated missing runtime kind values as OpenCode, which could mask bad repo settings, stale persisted session metadata, or role-specific runtime configuration gaps. This PR makes runtime selection explicit across repo settings, session start, runtime readiness, and Agent Studio so future runtimes are not accidentally routed through OpenCode.

## Technical choices
- Added explicit runtime selection states so missing, unknown, and unavailable runtime kinds no longer collapse to a default.
- Made role filtering use `runtimeRequiredScopesByRole`, while keeping generic default selection stricter for runtimes that support every role.
- Preserved missing role runtime values during repo settings hydration, and rejected missing or blank repository default runtime values on save.
- Required session-owned runtime metadata when attaching/resuming persisted sessions, and rejected ensured runtime mismatches instead of falling back to repo defaults.
- Required selected-model runtime metadata before fresh-start side effects such as runtime ensure, adapter start, or persistence.
- Centralized runtime metadata guard/error helpers for consistency and maintainability.
- Kept explicit `runtimeKind: "opencode"` behavior valid when OpenCode is actually configured.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `bun run check:rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run test:rust`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, user-facing error when repository default runtime is missing: instructs selecting a repository default before saving.
  * Prevents saving or starting sessions when required runtime selection is missing or blank.
  * Fixed cases where missing runtime metadata could produce incorrect defaults or unexpected behavior.

* **Refactor**
  * Runtime selection is now explicit across the UI; implicit/default fallbacks removed.
  * Session start and model selection flows now respect nullable/empty runtime choices and disable actions accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->