### PR TITLE
fix(release): correct macOS CEF signing order

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -157,9 +157,9 @@ jobs:
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.cef_cache.outputs.cargo_tauri_root }}
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-${{ steps.cef_cache.outputs.tauri_revision_short }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-${{ steps.cef_cache.outputs.tauri_revision_short }}-${{ steps.cef_cache.outputs.tauri_toolchain_patch }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-${{ steps.cef_cache.outputs.tauri_revision_short }}-${{ steps.cef_cache.outputs.tauri_toolchain_patch }}
 
       - name: Restore export-cef-dir tool cache
         id: export_cef_tool_cache
@@ -293,6 +293,27 @@ jobs:
           codesign -dvvv "$helper"
           codesign --verify --verbose=4 "$web_host"
           codesign -dvvv "$web_host"
+          app_bundle="apps/desktop/src-tauri/target/$TARGET/release/bundle/macos/OpenDucktor.app"
+          codesign --verify --verbose=4 "$app_bundle"
+
+          helper_app_count=0
+          while IFS= read -r -d '' helper_app; do
+            helper_app_count=$((helper_app_count + 1))
+            codesign --verify --verbose=4 "$helper_app"
+          done < <(find "$app_bundle/Contents/Frameworks" -maxdepth 1 -type d -name 'openducktor-desktop Helper*.app' -print0)
+
+          if [[ "$helper_app_count" -eq 0 ]]; then
+            echo "No bundled CEF helper apps were found under $app_bundle/Contents/Frameworks" >&2
+            exit 1
+          fi
+
+          plugin_helper_app="$app_bundle/Contents/Frameworks/openducktor-desktop Helper (Plugin).app"
+          if [[ ! -d "$plugin_helper_app" ]]; then
+            echo "Bundled CEF plugin helper app was not found at $plugin_helper_app" >&2
+            exit 1
+          fi
+          codesign --verify --verbose=4 "$plugin_helper_app"
+
           entitlements_file="$(mktemp)"
           codesign -d --entitlements :- "$helper" > "$entitlements_file"
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -158,8 +158,6 @@ jobs:
         with:
           path: ${{ steps.cef_cache.outputs.cargo_tauri_root }}
           key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-${{ steps.cef_cache.outputs.tauri_revision_short }}-${{ steps.cef_cache.outputs.tauri_toolchain_patch }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-tauri-${{ steps.cef_cache.outputs.tauri_revision_short }}-${{ steps.cef_cache.outputs.tauri_toolchain_patch }}
 
       - name: Restore export-cef-dir tool cache
         id: export_cef_tool_cache
@@ -312,7 +310,6 @@ jobs:
             echo "Bundled CEF plugin helper app was not found at $plugin_helper_app" >&2
             exit 1
           fi
-          codesign --verify --verbose=4 "$plugin_helper_app"
 
           entitlements_file="$(mktemp)"
           codesign -d --entitlements :- "$helper" > "$entitlements_file"

--- a/apps/desktop/scripts/cef-paths.test.ts
+++ b/apps/desktop/scripts/cef-paths.test.ts
@@ -4,6 +4,7 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import {
+  CARGO_TAURI_CEF_TOOLCHAIN_PATCH,
   readCefVersion,
   readTauriCefRevision,
   resolveCargoTauriToolsRoot,
@@ -54,7 +55,7 @@ afterEach(() => {
 describe("cef-paths", () => {
   test("reads the cef crate version from Cargo.lock", () => {
     const tauriRoot = withTempTauriRoot(
-      '[package]\nname = "root"\n\n[[package]]\nname = "serde"\nversion = "1.0.0"\n\n[[package]]\nname = "cef"\nversion = "135.0.0"\n\n[[package]]\nname = "tauri"\nversion = "2.10.3"\nsource = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#1234567890abcdef1234567890abcdef12345678"\n',
+      '[[package]]\nname = "serde"\nversion = "1.0.0"\n\n[[package]]\nname = "cef"\nversion = "135.0.0"\n\n[[package]]\nname = "tauri"\nversion = "2.10.3"\nsource = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#1234567890abcdef1234567890abcdef12345678"\n',
     );
 
     try {
@@ -78,7 +79,7 @@ describe("cef-paths", () => {
           "cache",
           "cargo-tools",
           "tauri-feat-cef",
-          "1234567890ab",
+          `1234567890ab-${CARGO_TAURI_CEF_TOOLCHAIN_PATCH}`,
         ),
       );
       expect(resolveCargoTauriToolsRoot(tauriRoot)).toBe(
@@ -88,7 +89,7 @@ describe("cef-paths", () => {
           "cache",
           "cargo-tools",
           "tauri-feat-cef",
-          "1234567890ab",
+          `1234567890ab-${CARGO_TAURI_CEF_TOOLCHAIN_PATCH}`,
         ),
       );
       expect(resolveExportCefToolsRoot(tauriRoot)).toBe(

--- a/apps/desktop/scripts/cef-paths.ts
+++ b/apps/desktop/scripts/cef-paths.ts
@@ -7,6 +7,9 @@ const OPENDUCKTOR_CARGO_TOOLS_ROOT_ENV = "OPENDUCKTOR_CARGO_TOOLS_ROOT";
 const OPENDUCKTOR_CEF_PATH_ENV = "OPENDUCKTOR_CEF_PATH";
 const UPSTREAM_CEF_PATH_ENV = "CEF_PATH";
 
+// Bump this whenever setup-cef.ts changes the local Tauri bundler patch.
+export const CARGO_TAURI_CEF_TOOLCHAIN_PATCH = "cef-helper-sign-order-v2";
+
 function readTauriRevisionPrefix(tauriRoot: string): string {
   return readTauriCefRevision(tauriRoot).slice(0, 12);
 }
@@ -120,7 +123,7 @@ export function resolveCargoTauriToolsRoot(tauriRoot: string): string {
       "cache",
       "cargo-tools",
       "tauri-feat-cef",
-      readTauriRevisionPrefix(tauriRoot),
+      `${readTauriRevisionPrefix(tauriRoot)}-${CARGO_TAURI_CEF_TOOLCHAIN_PATCH}`,
     )
   );
 }

--- a/apps/desktop/scripts/codemap.md
+++ b/apps/desktop/scripts/codemap.md
@@ -10,4 +10,4 @@ Small Node/Bun entry points that spawn the real command or prepare build inputs.
 Scripts read the current workspace state, prepare sidecar or CEF metadata, and then hand control to `bun run tauri ...` or other child processes.
 
 ## Integration Points
-`package.json` script entries, `src-tauri` build config, CEF cache/release helpers, and `git-hooks.integration.test.ts`.
+`package.json` script entries, `src-tauri` build config, patched CEF/Tauri toolchain cache helpers, and `git-hooks.integration.test.ts`.

--- a/apps/desktop/scripts/resolve-cef-cache-metadata.ts
+++ b/apps/desktop/scripts/resolve-cef-cache-metadata.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 
 import {
+  CARGO_TAURI_CEF_TOOLCHAIN_PATCH,
   readCefVersion,
   readTauriCefRevision,
   resolveCargoTauriToolsRoot,
@@ -18,6 +19,7 @@ const exportCefToolRoot = resolveExportCefToolsRoot(tauriRoot);
 
 console.log(`tauri_revision=${tauriRevision}`);
 console.log(`tauri_revision_short=${tauriRevision.slice(0, 12)}`);
+console.log(`tauri_toolchain_patch=${CARGO_TAURI_CEF_TOOLCHAIN_PATCH}`);
 console.log(`cef_version=${cefVersion}`);
 console.log(`cargo_tauri_root=${cargoTauriRoot}`);
 console.log(`cargo_tauri_path=${resolve(cargoTauriRoot, "bin", `cargo-tauri${binaryExtension}`)}`);

--- a/apps/desktop/scripts/setup-cef.ts
+++ b/apps/desktop/scripts/setup-cef.ts
@@ -1,9 +1,10 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, rmSync, statSync } from "node:fs";
-import { homedir } from "node:os";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 
 import {
+  CARGO_TAURI_CEF_TOOLCHAIN_PATCH,
   readCefVersion,
   readTauriCefRevision,
   resolveCargoTauriToolsRoot,
@@ -23,6 +24,11 @@ const binaryExtension = process.platform === "win32" ? ".exe" : "";
 const cargoTauriPath = resolve(cargoTauriBinRoot, `cargo-tauri${binaryExtension}`);
 const exportCefDirPath = resolve(exportCefToolBinRoot, `export-cef-dir${binaryExtension}`);
 const cefVersion = readCefVersion(tauriRoot);
+const cargoTauriPatchMarkerPath = resolve(cargoTauriRoot, ".openducktor-toolchain-patch");
+
+function expectedCargoTauriPatchMarker(): string {
+  return `${CARGO_TAURI_CEF_TOOLCHAIN_PATCH}\n${tauriRevision}`;
+}
 
 function cargoHomeBinPath(): string {
   return resolve(process.env.CARGO_HOME ?? join(homedir(), ".cargo"), "bin");
@@ -38,10 +44,15 @@ function commandEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   };
 }
 
-function run(command: string, args: string[], env = commandEnv()): Promise<void> {
+function run(
+  command: string,
+  args: string[],
+  env = commandEnv(),
+  cwd = desktopRoot,
+): Promise<void> {
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(command, args, {
-      cwd: desktopRoot,
+      cwd,
       env,
       stdio: "inherit",
     });
@@ -70,6 +81,77 @@ function run(command: string, args: string[], env = commandEnv()): Promise<void>
       rejectPromise(new Error(`${command} ${args.join(" ")} exited with code ${code ?? 1}`));
     });
   });
+}
+
+function hasExpectedCargoTauriToolchain(): boolean {
+  if (!isRunnableBinary(cargoTauriPath, ["--version"])) {
+    return false;
+  }
+
+  try {
+    return (
+      readFileSync(cargoTauriPatchMarkerPath, "utf8").trim() === expectedCargoTauriPatchMarker()
+    );
+  } catch {
+    return false;
+  }
+}
+
+function patchTauriBundlerSignOrder(sourceRoot: string): void {
+  const bundlerAppPath = resolve(sourceRoot, "crates/tauri-bundler/src/bundle/macos/app.rs");
+  const source = readFileSync(bundlerAppPath, "utf8");
+  const mainBinarySignBlock = `  let bin_paths = copy_binaries_to_bundle(&bundle_directory, settings)?;\n  sign_paths.extend(bin_paths.into_iter().map(|path| SignTarget {\n    path,\n    is_an_executable: true,\n  }));\n\n  copy_custom_files_to_bundle(&bundle_directory, settings)?;`;
+  const deferredMainBinarySignBlock = `  let app_binary_paths = copy_binaries_to_bundle(&bundle_directory, settings)?;\n\n  copy_custom_files_to_bundle(&bundle_directory, settings)?;`;
+  const cefHelperSignBlock = `  // Handle CEF support if cef_path is set\n  if let Some(cef_path) = settings.bundle_settings().cef_path.as_ref() {\n    let helper_paths = create_cef_helpers(&bundle_directory, settings, cef_path)?;\n    // Add helper apps to sign paths\n    sign_paths.extend(helper_paths.into_iter().map(|path| SignTarget {\n      path,\n      is_an_executable: true,\n    }));`;
+  const beforeSigningBlock = `  }\n\n  if settings.no_sign() {`;
+  const signMainAfterCefBlock = `  }\n\n  // The CEF helper .app bundles must be signed before the containing app's\n  // main executable. On macOS Intel, codesign rejects the main executable when\n  // unsigned CEF helper apps are already present under Contents/Frameworks.\n  sign_paths.extend(app_binary_paths.into_iter().map(|path| SignTarget {\n    path,\n    is_an_executable: true,\n  }));\n\n  if settings.no_sign() {`;
+  const cefHelperSignBoundaryBlock = `${cefHelperSignBlock}${beforeSigningBlock}`;
+  const cefHelperThenMainSignBlock = `${cefHelperSignBlock}${signMainAfterCefBlock}`;
+
+  if (!source.includes(mainBinarySignBlock)) {
+    throw new Error("Unable to patch Tauri bundler: main binary signing block was not found.");
+  }
+  if (!source.includes(cefHelperSignBoundaryBlock)) {
+    throw new Error("Unable to patch Tauri bundler: CEF helper signing boundary was not found.");
+  }
+
+  writeFileSync(
+    bundlerAppPath,
+    source
+      .replace(mainBinarySignBlock, deferredMainBinarySignBlock)
+      .replace(cefHelperSignBoundaryBlock, cefHelperThenMainSignBlock),
+  );
+}
+
+async function installPatchedCargoTauri(): Promise<void> {
+  const sourceRoot = mkdtempSync(join(tmpdir(), "openducktor-tauri-cli-"));
+
+  try {
+    await run("git", ["init"], commandEnv(), sourceRoot);
+    await run(
+      "git",
+      ["remote", "add", "origin", "https://github.com/tauri-apps/tauri"],
+      commandEnv(),
+      sourceRoot,
+    );
+    await run("git", ["fetch", "--depth", "1", "origin", tauriRevision], commandEnv(), sourceRoot);
+    await run("git", ["checkout", "--detach", "FETCH_HEAD"], commandEnv(), sourceRoot);
+    patchTauriBundlerSignOrder(sourceRoot);
+    await run("rustup", [
+      "run",
+      "stable",
+      "cargo",
+      "install",
+      "--locked",
+      "--root",
+      cargoTauriRoot,
+      "--path",
+      resolve(sourceRoot, "crates/tauri-cli"),
+    ]);
+    writeFileSync(cargoTauriPatchMarkerPath, `${expectedCargoTauriPatchMarker()}\n`);
+  } finally {
+    rmSync(sourceRoot, { force: true, recursive: true });
+  }
 }
 
 function isRunnableBinary(binaryPath: string, args: string[]): boolean {
@@ -117,22 +199,9 @@ await (async () => {
     await run("rustup", ["target", "add", "x86_64-apple-darwin", "aarch64-apple-darwin"]);
   }
 
-  if (!isRunnableBinary(cargoTauriPath, ["--version"])) {
+  if (!hasExpectedCargoTauriToolchain()) {
     rmSync(cargoTauriRoot, { force: true, recursive: true });
-    await run("rustup", [
-      "run",
-      "stable",
-      "cargo",
-      "install",
-      "--locked",
-      "--root",
-      cargoTauriRoot,
-      "tauri-cli",
-      "--git",
-      "https://github.com/tauri-apps/tauri",
-      "--rev",
-      tauriRevision,
-    ]);
+    await installPatchedCargoTauri();
   }
 
   if (!isRunnableBinary(exportCefDirPath, ["--help"])) {

--- a/apps/desktop/scripts/setup-cef.ts
+++ b/apps/desktop/scripts/setup-cef.ts
@@ -20,6 +20,7 @@ const exportCefToolRoot = resolveExportCefToolsRoot(tauriRoot);
 const exportCefToolBinRoot = resolve(exportCefToolRoot, "bin");
 const cefPath = resolveCefPath(tauriRoot);
 const tauriRevision = readTauriCefRevision(tauriRoot);
+const SUPPORTED_TAURI_CEF_PATCH_REVISION = "a94e1b8595d9bb49328451dfe151d8499c712d44";
 const binaryExtension = process.platform === "win32" ? ".exe" : "";
 const cargoTauriPath = resolve(cargoTauriBinRoot, `cargo-tauri${binaryExtension}`);
 const exportCefDirPath = resolve(exportCefToolBinRoot, `export-cef-dir${binaryExtension}`);
@@ -28,6 +29,10 @@ const cargoTauriPatchMarkerPath = resolve(cargoTauriRoot, ".openducktor-toolchai
 
 function expectedCargoTauriPatchMarker(): string {
   return `${CARGO_TAURI_CEF_TOOLCHAIN_PATCH}\n${tauriRevision}`;
+}
+
+function tauriBundlerPatchContext(): string {
+  return `patch=${CARGO_TAURI_CEF_TOOLCHAIN_PATCH}, expected tauri=${SUPPORTED_TAURI_CEF_PATCH_REVISION}, actual tauri=${tauriRevision}`;
 }
 
 function cargoHomeBinPath(): string {
@@ -98,28 +103,35 @@ function hasExpectedCargoTauriToolchain(): boolean {
 }
 
 function patchTauriBundlerSignOrder(sourceRoot: string): void {
+  if (tauriRevision !== SUPPORTED_TAURI_CEF_PATCH_REVISION) {
+    throw new Error(
+      `Unable to patch Tauri bundler: unsupported pinned revision (${tauriBundlerPatchContext()}).`,
+    );
+  }
+
   const bundlerAppPath = resolve(sourceRoot, "crates/tauri-bundler/src/bundle/macos/app.rs");
   const source = readFileSync(bundlerAppPath, "utf8");
   const mainBinarySignBlock = `  let bin_paths = copy_binaries_to_bundle(&bundle_directory, settings)?;\n  sign_paths.extend(bin_paths.into_iter().map(|path| SignTarget {\n    path,\n    is_an_executable: true,\n  }));\n\n  copy_custom_files_to_bundle(&bundle_directory, settings)?;`;
   const deferredMainBinarySignBlock = `  let app_binary_paths = copy_binaries_to_bundle(&bundle_directory, settings)?;\n\n  copy_custom_files_to_bundle(&bundle_directory, settings)?;`;
-  const cefHelperSignBlock = `  // Handle CEF support if cef_path is set\n  if let Some(cef_path) = settings.bundle_settings().cef_path.as_ref() {\n    let helper_paths = create_cef_helpers(&bundle_directory, settings, cef_path)?;\n    // Add helper apps to sign paths\n    sign_paths.extend(helper_paths.into_iter().map(|path| SignTarget {\n      path,\n      is_an_executable: true,\n    }));`;
-  const beforeSigningBlock = `  }\n\n  if settings.no_sign() {`;
-  const signMainAfterCefBlock = `  }\n\n  // The CEF helper .app bundles must be signed before the containing app's\n  // main executable. On macOS Intel, codesign rejects the main executable when\n  // unsigned CEF helper apps are already present under Contents/Frameworks.\n  sign_paths.extend(app_binary_paths.into_iter().map(|path| SignTarget {\n    path,\n    is_an_executable: true,\n  }));\n\n  if settings.no_sign() {`;
-  const cefHelperSignBoundaryBlock = `${cefHelperSignBlock}${beforeSigningBlock}`;
-  const cefHelperThenMainSignBlock = `${cefHelperSignBlock}${signMainAfterCefBlock}`;
+  const cefSignBlock = `  // Handle CEF support if cef_path is set\n  if let Some(cef_path) = settings.bundle_settings().cef_path.as_ref() {\n    let helper_paths = create_cef_helpers(&bundle_directory, settings, cef_path)?;\n    // Add helper apps to sign paths\n    sign_paths.extend(helper_paths.into_iter().map(|path| SignTarget {\n      path,\n      is_an_executable: true,\n    }));\n    let cef_framework_path = copy_cef_framework(&bundle_directory, cef_path)?;\n    // Add CEF framework to sign paths\n    add_framework_sign_path(\n      &cef_path.join(CEF_FRAMEWORK),\n      &cef_framework_path,\n      &mut sign_paths,\n    );\n  }`;
+  const cefThenMainSignBlock = `${cefSignBlock}\n\n  // The CEF helper .app bundles must be signed before the containing app's\n  // main executable. On macOS Intel, codesign rejects the main executable when\n  // unsigned CEF helper apps are already present under Contents/Frameworks.\n  sign_paths.extend(app_binary_paths.into_iter().map(|path| SignTarget {\n    path,\n    is_an_executable: true,\n  }));`;
 
   if (!source.includes(mainBinarySignBlock)) {
-    throw new Error("Unable to patch Tauri bundler: main binary signing block was not found.");
+    throw new Error(
+      `Unable to patch Tauri bundler: main binary signing block was not found (${tauriBundlerPatchContext()}).`,
+    );
   }
-  if (!source.includes(cefHelperSignBoundaryBlock)) {
-    throw new Error("Unable to patch Tauri bundler: CEF helper signing boundary was not found.");
+  if (!source.includes(cefSignBlock)) {
+    throw new Error(
+      `Unable to patch Tauri bundler: CEF signing block was not found (${tauriBundlerPatchContext()}).`,
+    );
   }
 
   writeFileSync(
     bundlerAppPath,
     source
       .replace(mainBinarySignBlock, deferredMainBinarySignBlock)
-      .replace(cefHelperSignBoundaryBlock, cefHelperThenMainSignBlock),
+      .replace(cefSignBlock, cefThenMainSignBlock),
   );
 }
 


### PR DESCRIPTION
## Summary

- Patch the pinned Tauri CEF CLI during `tauri:setup:cef` so CEF helper `.app` bundles are signed before the containing app executable.
- Add a patch-aware cargo-tauri cache key and marker so CI cannot reuse an unpatched signing toolchain.
- Extend release verification to check the final `OpenDucktor.app` and nested CEF helper apps, including `openducktor-desktop Helper (Plugin).app`.

## Why

The macOS Intel desktop release failed because Tauri's CEF bundler created nested helper `.app` bundles under `Contents/Frameworks`, then attempted to sign the main executable before those nested apps were signed. Intel `codesign` rejected that bundle state with `code object is not signed at all` for the plugin helper app. The Apple Silicon job happened to tolerate the ordering, but the ordering was still incorrect for macOS' inside-out signing model.

This fixes the issue at the bundler/toolchain layer instead of adding another post-processing signing fallback.

## Verification

- `bun test apps/desktop/scripts/cef-paths.test.ts`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `rtk git diff --check`
- release workflow YAML parse check
- `bun run --cwd apps/desktop scripts/resolve-cef-cache-metadata.ts`
- `bun run --cwd apps/desktop scripts/setup-cef.ts`
- repeated `setup-cef` run to confirm idempotency after installing the patched toolchain