### PR TITLE
fix: add stable stdio runtime identity

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -164,7 +164,9 @@ mod tests {
                 prepared_worktree: PreparedBuildWorktree {
                     worktree_dir: PathBuf::from("/tmp/worktrees/task-1"),
                 },
-                runtime_summary: make_runtime_summary(RuntimeRoute::Stdio),
+                runtime_summary: make_runtime_summary(
+                    RuntimeRoute::stdio("runtime-stdio").expect("stdio route"),
+                ),
                 task_id: "task-1",
             })
             .expect_err("opencode build startup should reject stdio routes before task transition");

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/session_stop.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/session_stop.rs
@@ -315,7 +315,7 @@ mod tests {
             .runtime(&AgentRuntimeKind::opencode())
             .expect("opencode runtime should be registered")
             .stop_session(
-                &RuntimeRoute::Stdio,
+                &RuntimeRoute::stdio("runtime-stdio").expect("stdio route"),
                 "external-session-1",
                 "/tmp/repo/worktree",
             )

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -119,7 +119,7 @@ pub(crate) fn require_local_http_endpoint<'a>(
 ) -> Result<&'a str> {
     match runtime_route {
         RuntimeRoute::LocalHttp { endpoint } => Ok(endpoint.as_str()),
-        RuntimeRoute::Stdio => Err(anyhow!(
+        RuntimeRoute::Stdio { .. } => Err(anyhow!(
             "Runtime {action} requires a local_http runtime route"
         )),
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -617,7 +617,7 @@ mod tests {
             task_id: None,
             role: host_domain::RuntimeRole::Workspace,
             working_directory: "/tmp/repo-health-stdio".to_string(),
-            runtime_route: RuntimeRoute::Stdio,
+            runtime_route: RuntimeRoute::stdio("runtime-stdio-health")?,
             started_at: "2026-04-04T16:00:00Z".to_string(),
             descriptor: builtin_opencode_runtime_descriptor(),
         };

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -698,7 +698,9 @@ impl AppRuntime for OpenCodeRuntime {
                     ),
                 ))
             }
-            RuntimeRoute::Stdio => Ok(RuntimeSessionStatusProbeTargetResolution::Unsupported),
+            RuntimeRoute::Stdio { .. } => {
+                Ok(RuntimeSessionStatusProbeTargetResolution::Unsupported)
+            }
         }
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_session_status.rs
@@ -692,7 +692,7 @@ mod tests {
     #[test]
     fn opencode_runtime_marks_stdio_session_probe_as_unsupported() -> Result<()> {
         let resolution = OpenCodeRuntime::default()
-            .session_status_probe_target(&RuntimeRoute::Stdio, "/tmp/repo")?;
+            .session_status_probe_target(&RuntimeRoute::stdio("runtime-stdio")?, "/tmp/repo")?;
 
         assert!(matches!(
             resolution,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
@@ -142,9 +142,7 @@ fn runtime_ensure_registers_host_managed_stdio_routes_without_reconstructing_por
     assert_eq!(runtime.kind, AgentRuntimeKind::from("test-runtime"));
     assert_eq!(
         runtime.runtime_route,
-        host_domain::RuntimeRoute::Stdio {
-            identity: runtime.runtime_id.clone()
-        }
+        host_domain::RuntimeRoute::stdio(runtime.runtime_id.clone())?
     );
     assert_eq!(
         service

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
@@ -16,13 +16,13 @@ impl AppRuntime for HostManagedStdioRuntimeAdapter {
         &self,
         _service: &AppService,
         _input: &crate::app_service::runtime_orchestrator::RuntimeStartInput<'_>,
-        _runtime_id: &str,
+        runtime_id: &str,
         _startup_policy: crate::app_service::RuntimeStartupReadinessPolicy,
     ) -> Result<HostManagedRuntimeStart> {
         Ok(HostManagedRuntimeStart {
             child: spawn_sleep_process(30),
             runtime_process_guard: RuntimeProcessGuard::new(()),
-            runtime_route: host_domain::RuntimeRoute::Stdio,
+            runtime_route: host_domain::RuntimeRoute::stdio(runtime_id)?,
             startup_report: crate::app_service::RuntimeStartupWaitReport::zero(),
         })
     }
@@ -140,7 +140,12 @@ fn runtime_ensure_registers_host_managed_stdio_routes_without_reconstructing_por
     let runtime = service.runtime_ensure("test-runtime", repo_path.to_string_lossy().as_ref())?;
 
     assert_eq!(runtime.kind, AgentRuntimeKind::from("test-runtime"));
-    assert!(matches!(runtime.runtime_route, host_domain::RuntimeRoute::Stdio));
+    assert_eq!(
+        runtime.runtime_route,
+        host_domain::RuntimeRoute::Stdio {
+            identity: runtime.runtime_id.clone()
+        }
+    );
     assert_eq!(
         service
             .runtime_list("test-runtime", Some(repo_path.to_string_lossy().as_ref()))?
@@ -155,7 +160,7 @@ fn runtime_ensure_registers_host_managed_stdio_routes_without_reconstructing_por
     let registered = runtimes
         .get(runtime.runtime_id.as_str())
         .expect("host-managed runtime should be registered");
-    assert!(matches!(registered.summary.runtime_route, host_domain::RuntimeRoute::Stdio));
+    assert_eq!(registered.summary.runtime_route, runtime.runtime_route);
     assert!(registered.child.is_some());
     drop(runtimes);
 
@@ -371,7 +376,7 @@ fn runs_list_consults_registered_runtime_delegate_for_stdio_probe_paths() -> Res
                 summary: host_domain::RunSummary {
                     run_id: "run-1".to_string(),
                     runtime_kind: AgentRuntimeKind::from("test-runtime"),
-                    runtime_route: host_domain::RuntimeRoute::Stdio,
+                    runtime_route: host_domain::RuntimeRoute::stdio("run-stdio")?,
                     repo_path: "/tmp/repo".to_string(),
                     task_id: "task-1".to_string(),
                     branch: "odt/task-1".to_string(),
@@ -468,7 +473,7 @@ fn task_delete_blocks_custom_runtime_sessions_via_service_runtime_registry() -> 
         RuntimeRole::Build,
         repo_path_string.as_str(),
         repo_path_string.as_str(),
-        host_domain::RuntimeRoute::Stdio,
+        host_domain::RuntimeRoute::stdio("task-runtime-build-block")?,
     )?;
 
     let error = service
@@ -550,7 +555,7 @@ fn task_delete_uses_task_runtime_route_for_matching_runtime_kind_and_worktree() 
         RuntimeRole::Build,
         repo_path_string.as_str(),
         repo_path_string.as_str(),
-        host_domain::RuntimeRoute::Stdio,
+        host_domain::RuntimeRoute::stdio("task-runtime-build-match")?,
     )?;
 
     let error = service
@@ -632,7 +637,7 @@ fn task_delete_uses_task_runtime_route_for_non_build_roles_sharing_a_worktree() 
         RuntimeRole::Qa,
         repo_path_string.as_str(),
         repo_path_string.as_str(),
-        host_domain::RuntimeRoute::Stdio,
+        host_domain::RuntimeRoute::stdio("task-runtime-qa-match")?,
     )?;
 
     let error = service

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
@@ -400,7 +400,9 @@ fn wait_for_local_server_with_process_honors_cancellation_epoch() {
 fn build_start_accepts_stdio_routes_from_runtime_adapter() -> Result<()> {
     let harness = build_external_runtime_build_start_harness(
         "build-start-stdio-runtime-route",
-        ExternalStartBehavior::ReturnRoute(host_domain::RuntimeRoute::Stdio),
+        ExternalStartBehavior::ReturnRoute(host_domain::RuntimeRoute::stdio(
+            "runtime-build-start-stdio",
+        )?),
     )?;
 
     let bootstrap =
@@ -412,7 +414,10 @@ fn build_start_accepts_stdio_routes_from_runtime_adapter() -> Result<()> {
         bootstrap.runtime_kind,
         AgentRuntimeKind::from("test-runtime")
     );
-    assert_eq!(bootstrap.runtime_route, host_domain::RuntimeRoute::Stdio);
+    assert_eq!(
+        bootstrap.runtime_route,
+        host_domain::RuntimeRoute::stdio("runtime-build-start-stdio")?
+    );
     assert_eq!(
         bootstrap.working_directory,
         harness.expected_worktree_dir("task-1")
@@ -429,7 +434,7 @@ fn build_start_accepts_stdio_routes_from_runtime_adapter() -> Result<()> {
         "test-runtime",
         harness.repo_path_string.as_str(),
         harness.repo_path.as_path(),
-        host_domain::RuntimeRoute::Stdio,
+        host_domain::RuntimeRoute::stdio("runtime-build-start-stdio")?,
     )?;
 
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -341,7 +341,7 @@ impl AppRuntime for TestRuntimeAdapter {
                         ),
                     ))
                 }
-                host_domain::RuntimeRoute::Stdio => {
+                host_domain::RuntimeRoute::Stdio { .. } => {
                     Ok(RuntimeSessionStatusProbeTargetResolution::Unsupported)
                 }
             },

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime/route.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime/route.rs
@@ -5,8 +5,13 @@ use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RuntimeRoute {
-    LocalHttp { endpoint: String },
-    Stdio { identity: String },
+    LocalHttp {
+        endpoint: String,
+    },
+    #[non_exhaustive]
+    Stdio {
+        identity: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime/route.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime/route.rs
@@ -1,19 +1,102 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
 use url::Url;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RuntimeRoute {
     LocalHttp { endpoint: String },
-    Stdio,
+    Stdio { identity: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+enum RuntimeRouteWire {
+    LocalHttp { endpoint: String },
+    Stdio { identity: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeRouteError {
+    message: String,
+}
+
+impl RuntimeRouteError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl Display for RuntimeRouteError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for RuntimeRouteError {}
+
+impl Serialize for RuntimeRoute {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        RuntimeRouteWire::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for RuntimeRoute {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = RuntimeRouteWire::deserialize(deserializer)?;
+        Self::try_from(wire).map_err(serde::de::Error::custom)
+    }
+}
+
+impl From<&RuntimeRoute> for RuntimeRouteWire {
+    fn from(route: &RuntimeRoute) -> Self {
+        match route {
+            RuntimeRoute::LocalHttp { endpoint } => RuntimeRouteWire::LocalHttp {
+                endpoint: endpoint.clone(),
+            },
+            RuntimeRoute::Stdio { identity } => RuntimeRouteWire::Stdio {
+                identity: identity.clone(),
+            },
+        }
+    }
+}
+
+impl TryFrom<RuntimeRouteWire> for RuntimeRoute {
+    type Error = RuntimeRouteError;
+
+    fn try_from(route: RuntimeRouteWire) -> Result<Self, Self::Error> {
+        match route {
+            RuntimeRouteWire::LocalHttp { endpoint } => Ok(Self::LocalHttp { endpoint }),
+            RuntimeRouteWire::Stdio { identity } => Self::stdio(identity),
+        }
+    }
 }
 
 impl RuntimeRoute {
+    pub fn stdio(identity: impl Into<String>) -> Result<Self, RuntimeRouteError> {
+        let identity = identity.into().trim().to_string();
+        if identity.is_empty() {
+            return Err(RuntimeRouteError::new(
+                "Runtime stdio route identity is required.",
+            ));
+        }
+
+        Ok(Self::Stdio { identity })
+    }
+
     pub fn local_http_port(&self) -> Option<u16> {
         match self {
             Self::LocalHttp { endpoint } => Url::parse(endpoint).ok()?.port(),
-            Self::Stdio => None,
+            Self::Stdio { .. } => None,
         }
     }
 }
@@ -42,14 +125,54 @@ mod tests {
 
     #[test]
     fn stdio_route_serializes_without_endpoint_fields() {
-        let json = serde_json::to_value(RuntimeRoute::Stdio).expect("route should serialize");
+        let json = serde_json::to_value(RuntimeRoute::stdio("runtime-stdio").unwrap())
+            .expect("route should serialize");
 
         assert_eq!(json["type"], "stdio");
+        assert_eq!(json["identity"], "runtime-stdio");
         assert!(json.get("endpoint").is_none());
+        assert!(json.get("port").is_none());
+    }
+
+    #[test]
+    fn stdio_route_deserializes_and_trims_identity() {
+        let route: RuntimeRoute = serde_json::from_value(serde_json::json!({
+            "type": "stdio",
+            "identity": " runtime-stdio "
+        }))
+        .expect("stdio route should deserialize");
+
+        assert_eq!(
+            route,
+            RuntimeRoute::Stdio {
+                identity: "runtime-stdio".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn stdio_route_rejects_missing_blank_and_unknown_fields() {
+        for payload in [
+            serde_json::json!({ "type": "stdio" }),
+            serde_json::json!({ "type": "stdio", "identity": "   " }),
+            serde_json::json!({
+                "type": "stdio",
+                "identity": "runtime-stdio",
+                "endpoint": "http://127.0.0.1:4444"
+            }),
+        ] {
+            let result = serde_json::from_value::<RuntimeRoute>(payload);
+            assert!(result.is_err(), "invalid stdio route should fail");
+        }
     }
 
     #[test]
     fn stdio_route_has_no_http_port() {
-        assert_eq!(RuntimeRoute::Stdio.local_http_port(), None);
+        assert_eq!(
+            RuntimeRoute::stdio("runtime-stdio")
+                .unwrap()
+                .local_http_port(),
+            None
+        );
     }
 }

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime/route.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime/route.rs
@@ -155,11 +155,13 @@ mod tests {
         for payload in [
             serde_json::json!({ "type": "stdio" }),
             serde_json::json!({ "type": "stdio", "identity": "   " }),
+            serde_json::json!({ "type": "stdio", "identity": "runtime-stdio", "unexpected": true }),
             serde_json::json!({
                 "type": "stdio",
                 "identity": "runtime-stdio",
                 "endpoint": "http://127.0.0.1:4444"
             }),
+            serde_json::json!({ "type": "websocket", "identity": "runtime-stdio" }),
         ] {
             let result = serde_json::from_value::<RuntimeRoute>(payload);
             assert!(result.is_err(), "invalid stdio route should fail");

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -340,6 +340,7 @@ describe("opencode-sdk-adapter", () => {
         runtimeKind: "opencode",
         runtimeConnection: {
           type: "stdio",
+          identity: "runtime-stdio",
           workingDirectory: "/repo",
         },
       }),

--- a/packages/contracts/src/agent-runtime-schemas.ts
+++ b/packages/contracts/src/agent-runtime-schemas.ts
@@ -164,6 +164,9 @@ export const runtimeRefSchema = z.object({
 });
 export type RuntimeRef = z.infer<typeof runtimeRefSchema>;
 
+export const stdioRuntimeIdentitySchema = z.string().trim().min(1);
+export type StdioRuntimeIdentity = z.infer<typeof stdioRuntimeIdentitySchema>;
+
 const runtimeToolIdSchema = z.string().trim().min(1);
 const runtimeReadOnlyRoleBlockedToolsSchema = z
   .array(runtimeToolIdSchema)
@@ -239,6 +242,7 @@ export const runtimeTransportSchema = z.discriminatedUnion("type", [
   z
     .object({
       type: z.literal("stdio"),
+      identity: stdioRuntimeIdentitySchema,
       workingDirectory: z.string().trim().min(1),
     })
     .strict(),

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -299,6 +299,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "repoRuntimeStartupStageSchema",
   "repoRuntimeStartupStatusSchema",
   "runtimeRouteSchema",
+  "stdioRuntimeIdentitySchema",
   "runtimeProvisioningModeSchema",
   "getMissingRequiredRuntimeSupportedScopes",
   "runtimeRequiredScopesByRole",

--- a/packages/contracts/src/run-schemas.ts
+++ b/packages/contracts/src/run-schemas.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { runtimeDescriptorSchema, runtimeKindSchema } from "./agent-runtime-schemas";
+import {
+  runtimeDescriptorSchema,
+  runtimeKindSchema,
+  stdioRuntimeIdentitySchema,
+} from "./agent-runtime-schemas";
 import { failureKindSchema } from "./failure-schemas";
 
 export const runtimeHealthSchema = z.object({
@@ -112,6 +116,7 @@ export const runtimeRouteSchema = z.discriminatedUnion("type", [
   z
     .object({
       type: z.literal("stdio"),
+      identity: stdioRuntimeIdentitySchema,
     })
     .strict(),
 ]);

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -895,6 +895,13 @@ describe("runtime schemas", () => {
     expect(() =>
       runtimeTransportSchema.parse({
         type: "stdio",
+        identity: "runtime-stdio",
+      }),
+    ).toThrow();
+
+    expect(() =>
+      runtimeTransportSchema.parse({
+        type: "stdio",
         identity: "   ",
         workingDirectory: "/repo",
       }),

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -167,12 +167,12 @@ describe("runtime schemas", () => {
   test("build session bootstrap preserves runtime route and working directory", () => {
     const parsed = buildSessionBootstrapSchema.parse({
       runtimeKind: "opencode",
-      runtimeRoute: { type: "stdio" },
+      runtimeRoute: { type: "stdio", identity: " runtime-build-1 " },
       workingDirectory: "/repo/.worktrees/task-1",
     });
 
     expect(parsed.runtimeKind).toBe("opencode");
-    expect(parsed.runtimeRoute).toEqual({ type: "stdio" });
+    expect(parsed.runtimeRoute).toEqual({ type: "stdio", identity: "runtime-build-1" });
     expect(parsed.workingDirectory).toBe("/repo/.worktrees/task-1");
   });
 
@@ -798,21 +798,62 @@ describe("runtime schemas", () => {
         workingDirectory: "/repo",
         runtimeRoute: {
           type: "stdio",
+          identity: " runtime-stdio ",
         },
         startedAt: "2026-01-01T00:00:00.000Z",
         descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       }).runtimeRoute,
-    ).toEqual({ type: "stdio" });
+    ).toEqual({ type: "stdio", identity: "runtime-stdio" });
 
     expect(
       runtimeTransportSchema.parse({
         type: "stdio",
+        identity: " runtime-stdio ",
         workingDirectory: "/repo",
       }),
     ).toEqual({
       type: "stdio",
+      identity: "runtime-stdio",
       workingDirectory: "/repo",
     });
+  });
+
+  test("runtime route schema rejects malformed stdio payloads", () => {
+    const baseSummary = {
+      kind: "opencode",
+      runtimeId: "runtime-stdio",
+      repoPath: "/repo",
+      taskId: null,
+      role: "workspace",
+      workingDirectory: "/repo",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+    } as const;
+
+    expect(() =>
+      runtimeInstanceSummarySchema.parse({
+        ...baseSummary,
+        runtimeRoute: { type: "stdio" },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      runtimeInstanceSummarySchema.parse({
+        ...baseSummary,
+        runtimeRoute: { type: "stdio", identity: "   " },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      runtimeInstanceSummarySchema.parse({
+        ...baseSummary,
+        runtimeRoute: {
+          type: "stdio",
+          identity: "runtime-stdio",
+          endpoint: "http://127.0.0.1:4444",
+        },
+      }),
+    ).toThrow();
   });
 
   test("runtime capabilities require execution modes only when subagents are supported", () => {
@@ -847,6 +888,22 @@ describe("runtime schemas", () => {
     expect(() =>
       runtimeTransportSchema.parse({
         type: "stdio",
+        workingDirectory: "/repo",
+      }),
+    ).toThrow();
+
+    expect(() =>
+      runtimeTransportSchema.parse({
+        type: "stdio",
+        identity: "   ",
+        workingDirectory: "/repo",
+      }),
+    ).toThrow();
+
+    expect(() =>
+      runtimeTransportSchema.parse({
+        type: "stdio",
+        identity: "runtime-stdio",
         endpoint: "http://127.0.0.1:4444",
         workingDirectory: "/repo",
       }),

--- a/packages/core/src/services/runtime-connections.test.ts
+++ b/packages/core/src/services/runtime-connections.test.ts
@@ -9,6 +9,7 @@ describe("runtime-connections", () => {
   test("requireRuntimeConnection returns the provided connection", () => {
     const connection = {
       type: "stdio",
+      identity: "runtime-stdio",
       workingDirectory: "/repo",
     } as const;
 
@@ -26,6 +27,7 @@ describe("runtime-connections", () => {
       requireRuntimeWorkingDirectory(
         {
           type: "stdio",
+          identity: "runtime-stdio",
           workingDirectory: " /repo ",
         },
         "list models",
@@ -55,6 +57,7 @@ describe("runtime-connections", () => {
       requireLocalHttpRuntimeConnection(
         {
           type: "stdio",
+          identity: "runtime-stdio",
           workingDirectory: "/repo",
         },
         "list models",

--- a/packages/frontend/src/pages/agents/agent-studio-task-hydration-state.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-task-hydration-state.test.ts
@@ -127,7 +127,7 @@ describe("deriveAgentStudioTaskHydrationState", () => {
         startedAt: "2026-02-22T08:00:00.000Z",
         runtimeKind: "opencode",
         runtimeId: null,
-        runtimeRoute: { type: "stdio" },
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
         workingDirectory: "/repo-a/worktree",
         messages: [],
         draftAssistantText: "",

--- a/packages/frontend/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
@@ -153,7 +153,7 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
         sessionId: "session-1",
         externalSessionId: "external-1",
         runtimeKind: "opencode",
-        runtimeRoute: { type: "stdio" },
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
         workingDirectory: "/repo",
         modelCatalog: null,
         isLoadingModelCatalog: false,

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -547,7 +547,7 @@ describe("useAgentStudioModelSelection", () => {
       createBaseProps({
         activeSession: createActiveSession({
           runtimeKind: "opencode",
-          runtimeRoute: { type: "stdio" },
+          runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
           workingDirectory: "/repo/session-worktree",
         }),
         readSessionSlashCommands,
@@ -606,7 +606,7 @@ describe("useAgentStudioModelSelection", () => {
       createBaseProps({
         activeSession: createActiveSession({
           runtimeKind: "opencode",
-          runtimeRoute: { type: "stdio" },
+          runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
           workingDirectory: "/repo/session-worktree",
         }),
         readSessionFileSearch,

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/public-operations.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/public-operations.ts
@@ -20,6 +20,7 @@ import type {
   AgentSessionHistoryPreludeMode,
   AgentSessionLoadOptions,
   AgentSessionState,
+  RuntimeConnectionPreloadIndex,
 } from "@/types/agent-orchestrator";
 import type { AgentOperationsContextValue } from "@/types/state-slices";
 import type { StartAgentSessionInput } from "./start-session";
@@ -60,7 +61,7 @@ type CreatePublicOperationsArgs = {
     taskId: string;
     persistedRecords?: AgentSessionRecord[];
     preloadedRuntimeLists?: Map<RuntimeKind, RuntimeInstanceSummary[]>;
-    preloadedRuntimeConnectionsByKey?: Map<string, AgentRuntimeConnection>;
+    preloadedRuntimeConnections?: RuntimeConnectionPreloadIndex;
     preloadedLiveAgentSessionsByKey?: Map<string, LiveAgentSessionSnapshot[]>;
     allowRuntimeEnsure?: boolean;
   }) => Promise<void>;

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -38,6 +38,18 @@ const createRuntime = (workingDirectory: string): RuntimeInstanceSummary => ({
   descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
 });
 
+const createStdioRuntime = (
+  runtimeId: string,
+  workingDirectory: string,
+): RuntimeInstanceSummary => ({
+  ...createRuntime(workingDirectory),
+  runtimeId,
+  runtimeRoute: {
+    type: "stdio",
+    identity: runtimeId,
+  },
+});
+
 describe("createHydrationRuntimeResolver", () => {
   test("prefers live runtime resolution over preloaded runtime connections", async () => {
     const workingDirectory = "/tmp/repo/worktree";
@@ -199,6 +211,7 @@ describe("createHydrationRuntimeResolver", () => {
         runtimeWorkingDirectoryKey("opencode", workingDirectory),
         {
           type: "stdio",
+          identity: "runtime-stdio",
           workingDirectory,
         },
       ],
@@ -219,10 +232,37 @@ describe("createHydrationRuntimeResolver", () => {
     expect(result.runtimeId).toBeNull();
     expect(result.runtimeConnection).toEqual({
       type: "stdio",
+      identity: "runtime-stdio",
       workingDirectory,
     });
     expect(result.runtimeRoute).toEqual({
       type: "stdio",
+      identity: "runtime-stdio",
+    });
+  });
+
+  test("fails fast when multiple stdio runtimes match the same working directory", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+        [
+          "opencode",
+          [
+            createStdioRuntime("runtime-stdio-a", workingDirectory),
+            createStdioRuntime("runtime-stdio-b", workingDirectory),
+          ],
+        ],
+      ]),
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    await expect(
+      resolveHydrationRuntime(createRecord("planner", workingDirectory)),
+    ).resolves.toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: `Multiple live stdio runtimes found for working directory ${workingDirectory}.`,
     });
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -376,6 +376,54 @@ describe("createHydrationRuntimeResolver", () => {
     expect(result.runtimeRoute).toEqual({ type: "stdio", identity: "runtime-stdio-b" });
   });
 
+  test("fails fast when duplicate live stdio runtimes share the same transport identity", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const runtimeConnection: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnections = createPreloadIndex([runtimeConnection]);
+    const preloadedLiveAgentSessionsByKey = new Map([
+      [
+        liveAgentSessionLookupKey("opencode", runtimeConnection, workingDirectory),
+        [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "external-1",
+            workingDirectory,
+          }),
+        ],
+      ],
+    ]);
+
+    const runtimeA = {
+      ...createStdioRuntime("runtime-a", workingDirectory),
+      runtimeRoute: { type: "stdio", identity: "runtime-stdio" } as const,
+    };
+    const runtimeB = {
+      ...createStdioRuntime("runtime-b", workingDirectory),
+      runtimeRoute: { type: "stdio", identity: "runtime-stdio" } as const,
+    };
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+        ["opencode", [runtimeA, runtimeB]],
+      ]),
+      preloadedRuntimeConnections,
+      preloadedLiveAgentSessionsByKey,
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    await expect(
+      resolveHydrationRuntime(createRecord("planner", workingDirectory)),
+    ).resolves.toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: `Multiple live stdio runtimes share transport identity stdio:runtime-stdio for working directory ${workingDirectory}.`,
+    });
+  });
+
   test("fails fast when multiple preloaded stdio connections match the same working directory", async () => {
     const workingDirectory = "/tmp/repo";
     const preloadedRuntimeConnectionA: AgentRuntimeConnection = {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@openducktor/contracts";
 import type { AgentRuntimeConnection } from "@openducktor/core";
 import { createHydrationRuntimeResolver } from "./hydration-runtime-resolution";
-import { runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
+import { runtimeConnectionPreloadKey } from "./live-agent-session-cache";
 
 const createRecord = (
   role: AgentSessionRecord["role"],
@@ -53,14 +53,15 @@ const createStdioRuntime = (
 describe("createHydrationRuntimeResolver", () => {
   test("prefers live runtime resolution over preloaded runtime connections", async () => {
     const workingDirectory = "/tmp/repo/worktree";
+    const preloadedRuntimeConnection: AgentRuntimeConnection = {
+      type: "local_http",
+      endpoint: "http://127.0.0.1:9999",
+      workingDirectory,
+    };
     const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
       [
-        runtimeWorkingDirectoryKey("opencode", workingDirectory),
-        {
-          type: "local_http",
-          endpoint: "http://127.0.0.1:9999",
-          workingDirectory,
-        },
+        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnection),
+        preloadedRuntimeConnection,
       ],
     ]);
 
@@ -169,14 +170,15 @@ describe("createHydrationRuntimeResolver", () => {
 
   test("falls back to preloaded runtime connection when no run or runtime exists", async () => {
     const workingDirectory = "/tmp/repo";
+    const preloadedRuntimeConnection: AgentRuntimeConnection = {
+      type: "local_http",
+      endpoint: "http://127.0.0.1:9999",
+      workingDirectory,
+    };
     const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
       [
-        runtimeWorkingDirectoryKey("opencode", workingDirectory),
-        {
-          type: "local_http",
-          endpoint: "http://127.0.0.1:9999",
-          workingDirectory,
-        },
+        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnection),
+        preloadedRuntimeConnection,
       ],
     ]);
     let ensureCalls = 0;
@@ -206,14 +208,15 @@ describe("createHydrationRuntimeResolver", () => {
 
   test("preserves stdio preloaded runtime connections during hydration fallback", async () => {
     const workingDirectory = "/tmp/repo";
+    const preloadedRuntimeConnection: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio",
+      workingDirectory,
+    };
     const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
       [
-        runtimeWorkingDirectoryKey("opencode", workingDirectory),
-        {
-          type: "stdio",
-          identity: "runtime-stdio",
-          workingDirectory,
-        },
+        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnection),
+        preloadedRuntimeConnection,
       ],
     ]);
 
@@ -263,6 +266,45 @@ describe("createHydrationRuntimeResolver", () => {
       ok: false,
       runtimeKind: "opencode",
       reason: `Multiple live stdio runtimes found for working directory ${workingDirectory}.`,
+    });
+  });
+
+  test("fails fast when multiple preloaded stdio connections match the same working directory", async () => {
+    const workingDirectory = "/tmp/repo";
+    const preloadedRuntimeConnectionA: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio-a",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnectionB: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio-b",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
+      [
+        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnectionA),
+        preloadedRuntimeConnectionA,
+      ],
+      [
+        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnectionB),
+        preloadedRuntimeConnectionB,
+      ],
+    ]);
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      preloadedRuntimeConnectionsByKey,
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    await expect(
+      resolveHydrationRuntime(createRecord("planner", workingDirectory)),
+    ).resolves.toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: `Multiple preloaded runtime connections found for working directory ${workingDirectory}.`,
     });
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -6,8 +6,12 @@ import {
   type RuntimeKind,
 } from "@openducktor/contracts";
 import type { AgentRuntimeConnection } from "@openducktor/core";
+import { createLiveAgentSessionSnapshotFixture } from "../test-utils";
 import { createHydrationRuntimeResolver } from "./hydration-runtime-resolution";
-import { RuntimeConnectionPreloadIndex } from "./live-agent-session-cache";
+import {
+  liveAgentSessionLookupKey,
+  RuntimeConnectionPreloadIndex,
+} from "./live-agent-session-cache";
 
 const createRecord = (
   role: AgentSessionRecord["role"],
@@ -122,6 +126,60 @@ describe("createHydrationRuntimeResolver", () => {
       workingDirectory: "/tmp/openducktor-worktrees/task-1",
     });
     expect(ensureCalls).toBe(0);
+  });
+
+  test("uses preloaded snapshots to disambiguate same-repo workspace stdio runtimes", async () => {
+    const workingDirectory = "/tmp/openducktor-worktrees/task-1";
+    const runtimeConnectionA: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio-a",
+      workingDirectory,
+    };
+    const runtimeConnectionB: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio-b",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnections = createPreloadIndex([
+      runtimeConnectionA,
+      runtimeConnectionB,
+    ]);
+    const preloadedLiveAgentSessionsByKey = new Map([
+      [
+        liveAgentSessionLookupKey("opencode", runtimeConnectionB, workingDirectory),
+        [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "external-1",
+            workingDirectory,
+          }),
+        ],
+      ],
+    ]);
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+        [
+          "opencode",
+          [
+            createStdioRuntime("runtime-stdio-a", "/tmp/repo"),
+            createStdioRuntime("runtime-stdio-b", "/tmp/repo"),
+          ],
+        ],
+      ]),
+      preloadedRuntimeConnections,
+      preloadedLiveAgentSessionsByKey,
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("build", workingDirectory));
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeId).toBe("runtime-stdio-b");
+    expect(result.runtimeConnection).toEqual(runtimeConnectionB);
+    expect(result.runtimeRoute).toEqual({ type: "stdio", identity: "runtime-stdio-b" });
   });
 
   test("fails fast for repo-root build sessions when no live runtime exists", async () => {
@@ -264,6 +322,60 @@ describe("createHydrationRuntimeResolver", () => {
     });
   });
 
+  test("uses preloaded snapshots to disambiguate same-directory live stdio runtimes", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const runtimeConnectionA: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio-a",
+      workingDirectory,
+    };
+    const runtimeConnectionB: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio-b",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnections = createPreloadIndex([
+      runtimeConnectionA,
+      runtimeConnectionB,
+    ]);
+    const preloadedLiveAgentSessionsByKey = new Map([
+      [
+        liveAgentSessionLookupKey("opencode", runtimeConnectionB, workingDirectory),
+        [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "external-1",
+            workingDirectory,
+          }),
+        ],
+      ],
+    ]);
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+        [
+          "opencode",
+          [
+            createStdioRuntime("runtime-stdio-a", workingDirectory),
+            createStdioRuntime("runtime-stdio-b", workingDirectory),
+          ],
+        ],
+      ]),
+      preloadedRuntimeConnections,
+      preloadedLiveAgentSessionsByKey,
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("planner", workingDirectory));
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeId).toBe("runtime-stdio-b");
+    expect(result.runtimeConnection).toEqual(runtimeConnectionB);
+    expect(result.runtimeRoute).toEqual({ type: "stdio", identity: "runtime-stdio-b" });
+  });
+
   test("fails fast when multiple preloaded stdio connections match the same working directory", async () => {
     const workingDirectory = "/tmp/repo";
     const preloadedRuntimeConnectionA: AgentRuntimeConnection = {
@@ -295,6 +407,52 @@ describe("createHydrationRuntimeResolver", () => {
       runtimeKind: "opencode",
       reason: `Multiple preloaded runtime connections found for working directory ${workingDirectory}.`,
     });
+  });
+
+  test("uses preloaded snapshots to disambiguate same-directory preloaded stdio connections", async () => {
+    const workingDirectory = "/tmp/repo";
+    const preloadedRuntimeConnectionA: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio-a",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnectionB: AgentRuntimeConnection = {
+      type: "stdio",
+      identity: "runtime-stdio-b",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnections = createPreloadIndex([
+      preloadedRuntimeConnectionA,
+      preloadedRuntimeConnectionB,
+    ]);
+    const preloadedLiveAgentSessionsByKey = new Map([
+      [
+        liveAgentSessionLookupKey("opencode", preloadedRuntimeConnectionB, workingDirectory),
+        [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "external-1",
+            workingDirectory,
+          }),
+        ],
+      ],
+    ]);
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      preloadedRuntimeConnections,
+      preloadedLiveAgentSessionsByKey,
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("planner", workingDirectory));
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeId).toBeNull();
+    expect(result.runtimeConnection).toEqual(preloadedRuntimeConnectionB);
+    expect(result.runtimeRoute).toEqual({ type: "stdio", identity: "runtime-stdio-b" });
   });
 
   test("includes the missing working directory when repo-root planner ensure cannot provide a runtime", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@openducktor/contracts";
 import type { AgentRuntimeConnection } from "@openducktor/core";
 import { createHydrationRuntimeResolver } from "./hydration-runtime-resolution";
-import { runtimeConnectionPreloadKey } from "./live-agent-session-cache";
+import { RuntimeConnectionPreloadIndex } from "./live-agent-session-cache";
 
 const createRecord = (
   role: AgentSessionRecord["role"],
@@ -50,6 +50,16 @@ const createStdioRuntime = (
   },
 });
 
+const createPreloadIndex = (
+  connections: AgentRuntimeConnection[],
+): RuntimeConnectionPreloadIndex => {
+  const preloadIndex = new RuntimeConnectionPreloadIndex();
+  for (const runtimeConnection of connections) {
+    preloadIndex.add("opencode", runtimeConnection);
+  }
+  return preloadIndex;
+};
+
 describe("createHydrationRuntimeResolver", () => {
   test("prefers live runtime resolution over preloaded runtime connections", async () => {
     const workingDirectory = "/tmp/repo/worktree";
@@ -58,19 +68,14 @@ describe("createHydrationRuntimeResolver", () => {
       endpoint: "http://127.0.0.1:9999",
       workingDirectory,
     };
-    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
-      [
-        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnection),
-        preloadedRuntimeConnection,
-      ],
-    ]);
+    const preloadedRuntimeConnections = createPreloadIndex([preloadedRuntimeConnection]);
 
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
       runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
         ["opencode", [createRuntime(workingDirectory)]],
       ]),
-      preloadedRuntimeConnectionsByKey,
+      preloadedRuntimeConnections,
       ensureWorkspaceRuntime: async () => null,
     });
 
@@ -175,18 +180,13 @@ describe("createHydrationRuntimeResolver", () => {
       endpoint: "http://127.0.0.1:9999",
       workingDirectory,
     };
-    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
-      [
-        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnection),
-        preloadedRuntimeConnection,
-      ],
-    ]);
+    const preloadedRuntimeConnections = createPreloadIndex([preloadedRuntimeConnection]);
     let ensureCalls = 0;
 
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
       runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
-      preloadedRuntimeConnectionsByKey,
+      preloadedRuntimeConnections,
       ensureWorkspaceRuntime: async () => {
         ensureCalls += 1;
         return null;
@@ -213,17 +213,12 @@ describe("createHydrationRuntimeResolver", () => {
       identity: "runtime-stdio",
       workingDirectory,
     };
-    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
-      [
-        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnection),
-        preloadedRuntimeConnection,
-      ],
-    ]);
+    const preloadedRuntimeConnections = createPreloadIndex([preloadedRuntimeConnection]);
 
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
       runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
-      preloadedRuntimeConnectionsByKey,
+      preloadedRuntimeConnections,
       ensureWorkspaceRuntime: async () => null,
     });
 
@@ -281,21 +276,15 @@ describe("createHydrationRuntimeResolver", () => {
       identity: "runtime-stdio-b",
       workingDirectory,
     };
-    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
-      [
-        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnectionA),
-        preloadedRuntimeConnectionA,
-      ],
-      [
-        runtimeConnectionPreloadKey("opencode", preloadedRuntimeConnectionB),
-        preloadedRuntimeConnectionB,
-      ],
+    const preloadedRuntimeConnections = createPreloadIndex([
+      preloadedRuntimeConnectionA,
+      preloadedRuntimeConnectionB,
     ]);
 
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
       runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
-      preloadedRuntimeConnectionsByKey,
+      preloadedRuntimeConnections,
       ensureWorkspaceRuntime: async () => null,
     });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -4,7 +4,7 @@ import type {
   RuntimeKind,
   RuntimeRoute,
 } from "@openducktor/contracts";
-import type { AgentRuntimeConnection } from "@openducktor/core";
+import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
 import {
   resolveRuntimeRouteConnection,
   runtimeConnectionToRoute,
@@ -13,7 +13,10 @@ import {
 import { normalizeWorkingDirectory } from "../support/core";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
 import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
-import type { RuntimeConnectionPreloadIndex } from "./live-agent-session-cache";
+import {
+  liveAgentSessionLookupKey,
+  type RuntimeConnectionPreloadIndex,
+} from "./live-agent-session-cache";
 
 export type ResolvedHydrationRuntime =
   | {
@@ -37,6 +40,15 @@ type PreloadedRuntimeConnectionLookupResult =
   | { ok: true; runtimeConnection: AgentRuntimeConnection | null }
   | { ok: false; reason: string };
 
+type RuntimeSnapshotCandidate = {
+  runtime: RuntimeInstanceSummary;
+  runtimeConnection: AgentRuntimeConnection;
+};
+
+type SnapshotConnectionMatchResult =
+  | { ok: true; runtimeConnection: AgentRuntimeConnection | null }
+  | { ok: false; reason: string };
+
 const hasAmbiguousStdioRoutes = (runtimes: RuntimeInstanceSummary[]): boolean => {
   const identities = new Set(
     runtimes
@@ -52,18 +64,58 @@ export const createHydrationRuntimeResolver = ({
   repoPath,
   runtimesByKind,
   preloadedRuntimeConnections,
+  preloadedLiveAgentSessionsByKey,
   ensureWorkspaceRuntime,
 }: {
   repoPath: string;
   runtimesByKind: Map<RuntimeKind, RuntimeInstanceSummary[]>;
   preloadedRuntimeConnections?: RuntimeConnectionPreloadIndex;
+  preloadedLiveAgentSessionsByKey?: Map<string, LiveAgentSessionSnapshot[]>;
   ensureWorkspaceRuntime: (runtimeKind: RuntimeKind) => Promise<RuntimeInstanceSummary | null>;
 }): ((record: AgentSessionRecord) => Promise<ResolvedHydrationRuntime>) => {
   const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
 
+  const findPreloadedSnapshotConnection = (
+    runtimeKind: RuntimeKind,
+    workingDirectory: string,
+    externalSessionId: string,
+    runtimeConnections: AgentRuntimeConnection[],
+  ): SnapshotConnectionMatchResult => {
+    if (!preloadedLiveAgentSessionsByKey) {
+      return { ok: true, runtimeConnection: null };
+    }
+
+    const matchesByTransportKey = new Map<string, AgentRuntimeConnection>();
+    for (const runtimeConnection of runtimeConnections) {
+      const snapshots = preloadedLiveAgentSessionsByKey.get(
+        liveAgentSessionLookupKey(runtimeKind, runtimeConnection, workingDirectory),
+      );
+      if (!snapshots?.some((snapshot) => snapshot.externalSessionId === externalSessionId)) {
+        continue;
+      }
+      matchesByTransportKey.set(
+        runtimeConnectionTransportKey(runtimeConnection),
+        runtimeConnection,
+      );
+    }
+
+    if (matchesByTransportKey.size > 1) {
+      return {
+        ok: false,
+        reason: `Multiple preloaded live sessions found for external session ${externalSessionId} in working directory ${workingDirectory}.`,
+      };
+    }
+
+    return {
+      ok: true,
+      runtimeConnection: Array.from(matchesByTransportKey.values())[0] ?? null,
+    };
+  };
+
   const findRuntimeByWorkingDirectory = (
     runtimeKind: RuntimeKind,
     workingDirectory: string,
+    externalSessionId: string,
   ): RuntimeLookupResult => {
     const runtimes = runtimesByKind.get(runtimeKind) ?? [];
     const normalizedDirectory = normalizeWorkingDirectory(workingDirectory);
@@ -71,6 +123,30 @@ export const createHydrationRuntimeResolver = ({
       (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === normalizedDirectory,
     );
     if (hasAmbiguousStdioRoutes(matches)) {
+      const candidates: RuntimeSnapshotCandidate[] = matches.map((runtime) => ({
+        runtime,
+        runtimeConnection: resolveRuntimeRouteConnection(runtime.runtimeRoute, workingDirectory)
+          .runtimeConnection,
+      }));
+      const snapshotMatch = findPreloadedSnapshotConnection(
+        runtimeKind,
+        workingDirectory,
+        externalSessionId,
+        candidates.map((candidate) => candidate.runtimeConnection),
+      );
+      if (!snapshotMatch.ok) {
+        return { ok: false, reason: snapshotMatch.reason };
+      }
+      if (snapshotMatch.runtimeConnection) {
+        const matchedTransportKey = runtimeConnectionTransportKey(snapshotMatch.runtimeConnection);
+        const matchedRuntime = candidates.find(
+          (candidate) =>
+            runtimeConnectionTransportKey(candidate.runtimeConnection) === matchedTransportKey,
+        )?.runtime;
+        if (matchedRuntime) {
+          return { ok: true, runtime: matchedRuntime };
+        }
+      }
       return {
         ok: false,
         reason: `Multiple live stdio runtimes found for working directory ${workingDirectory}.`,
@@ -80,7 +156,11 @@ export const createHydrationRuntimeResolver = ({
     return { ok: true, runtime: matches[0] ?? null };
   };
 
-  const findWorkspaceRuntime = (runtimeKind: RuntimeKind): RuntimeLookupResult => {
+  const findWorkspaceRuntime = (
+    runtimeKind: RuntimeKind,
+    workingDirectory: string,
+    externalSessionId: string,
+  ): RuntimeLookupResult => {
     const runtimes = runtimesByKind.get(runtimeKind) ?? [];
     const matches = runtimes.filter(
       (runtime) =>
@@ -88,6 +168,30 @@ export const createHydrationRuntimeResolver = ({
         normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath,
     );
     if (hasAmbiguousStdioRoutes(matches)) {
+      const candidates: RuntimeSnapshotCandidate[] = matches.map((runtime) => ({
+        runtime,
+        runtimeConnection: resolveRuntimeRouteConnection(runtime.runtimeRoute, workingDirectory)
+          .runtimeConnection,
+      }));
+      const snapshotMatch = findPreloadedSnapshotConnection(
+        runtimeKind,
+        workingDirectory,
+        externalSessionId,
+        candidates.map((candidate) => candidate.runtimeConnection),
+      );
+      if (!snapshotMatch.ok) {
+        return { ok: false, reason: snapshotMatch.reason };
+      }
+      if (snapshotMatch.runtimeConnection) {
+        const matchedTransportKey = runtimeConnectionTransportKey(snapshotMatch.runtimeConnection);
+        const matchedRuntime = candidates.find(
+          (candidate) =>
+            runtimeConnectionTransportKey(candidate.runtimeConnection) === matchedTransportKey,
+        )?.runtime;
+        if (matchedRuntime) {
+          return { ok: true, runtime: matchedRuntime };
+        }
+      }
       return {
         ok: false,
         reason: `Multiple live stdio workspace runtimes found for repo ${repoPath}.`,
@@ -100,6 +204,7 @@ export const createHydrationRuntimeResolver = ({
   const findPreloadedRuntimeConnection = (
     runtimeKind: RuntimeKind,
     workingDirectory: string,
+    externalSessionId: string,
   ): PreloadedRuntimeConnectionLookupResult => {
     if (!preloadedRuntimeConnections) {
       return { ok: true, runtimeConnection: null };
@@ -113,6 +218,18 @@ export const createHydrationRuntimeResolver = ({
       ]),
     );
     if (candidatesByTransportKey.size > 1) {
+      const snapshotMatch = findPreloadedSnapshotConnection(
+        runtimeKind,
+        workingDirectory,
+        externalSessionId,
+        Array.from(candidatesByTransportKey.values()),
+      );
+      if (!snapshotMatch.ok) {
+        return { ok: false, reason: snapshotMatch.reason };
+      }
+      if (snapshotMatch.runtimeConnection) {
+        return { ok: true, runtimeConnection: snapshotMatch.runtimeConnection };
+      }
       return {
         ok: false,
         reason: `Multiple preloaded runtime connections found for working directory ${workingDirectory}.`,
@@ -128,8 +245,13 @@ export const createHydrationRuntimeResolver = ({
   return async (record: AgentSessionRecord): Promise<ResolvedHydrationRuntime> => {
     const runtimeKind = readPersistedRuntimeKind(record);
     const workingDirectory = record.workingDirectory;
+    const externalSessionId = record.externalSessionId ?? record.sessionId;
 
-    const runtimeForDirectory = findRuntimeByWorkingDirectory(runtimeKind, workingDirectory);
+    const runtimeForDirectory = findRuntimeByWorkingDirectory(
+      runtimeKind,
+      workingDirectory,
+      externalSessionId,
+    );
     if (!runtimeForDirectory.ok) {
       return {
         ok: false,
@@ -140,7 +262,11 @@ export const createHydrationRuntimeResolver = ({
 
     let runtime = runtimeForDirectory.runtime;
     if (!runtime && canUseWorkspaceRuntimeForHydration(record, repoPath)) {
-      const workspaceRuntime = findWorkspaceRuntime(runtimeKind);
+      const workspaceRuntime = findWorkspaceRuntime(
+        runtimeKind,
+        workingDirectory,
+        externalSessionId,
+      );
       if (!workspaceRuntime.ok) {
         return {
           ok: false,
@@ -167,6 +293,7 @@ export const createHydrationRuntimeResolver = ({
     const preloadedRuntimeConnection = findPreloadedRuntimeConnection(
       runtimeKind,
       workingDirectory,
+      externalSessionId,
     );
     if (!preloadedRuntimeConnection.ok) {
       return {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -25,6 +25,21 @@ export type ResolvedHydrationRuntime =
       reason: string;
     };
 
+type RuntimeLookupResult =
+  | { ok: true; runtime: RuntimeInstanceSummary | null }
+  | { ok: false; reason: string };
+
+const hasAmbiguousStdioRoutes = (runtimes: RuntimeInstanceSummary[]): boolean => {
+  const identities = new Set(
+    runtimes
+      .map((runtime) => runtime.runtimeRoute)
+      .filter((route): route is Extract<RuntimeRoute, { type: "stdio" }> => route.type === "stdio")
+      .map((route) => route.identity.trim()),
+  );
+
+  return identities.size > 1;
+};
+
 export const createHydrationRuntimeResolver = ({
   repoPath,
   runtimesByKind,
@@ -41,36 +56,64 @@ export const createHydrationRuntimeResolver = ({
   const findRuntimeByWorkingDirectory = (
     runtimeKind: RuntimeKind,
     workingDirectory: string,
-  ): RuntimeInstanceSummary | null => {
+  ): RuntimeLookupResult => {
     const runtimes = runtimesByKind.get(runtimeKind) ?? [];
     const normalizedDirectory = normalizeWorkingDirectory(workingDirectory);
-    return (
-      runtimes.find(
-        (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === normalizedDirectory,
-      ) ?? null
+    const matches = runtimes.filter(
+      (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === normalizedDirectory,
     );
+    if (hasAmbiguousStdioRoutes(matches)) {
+      return {
+        ok: false,
+        reason: `Multiple live stdio runtimes found for working directory ${workingDirectory}.`,
+      };
+    }
+
+    return { ok: true, runtime: matches[0] ?? null };
   };
 
-  const findWorkspaceRuntime = (runtimeKind: RuntimeKind): RuntimeInstanceSummary | null => {
+  const findWorkspaceRuntime = (runtimeKind: RuntimeKind): RuntimeLookupResult => {
     const runtimes = runtimesByKind.get(runtimeKind) ?? [];
-    return (
-      runtimes.find(
-        (runtime) =>
-          runtime.role === "workspace" &&
-          normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath,
-      ) ?? null
+    const matches = runtimes.filter(
+      (runtime) =>
+        runtime.role === "workspace" &&
+        normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath,
     );
+    if (hasAmbiguousStdioRoutes(matches)) {
+      return {
+        ok: false,
+        reason: `Multiple live stdio workspace runtimes found for repo ${repoPath}.`,
+      };
+    }
+
+    return { ok: true, runtime: matches[0] ?? null };
   };
 
   return async (record: AgentSessionRecord): Promise<ResolvedHydrationRuntime> => {
     const runtimeKind = readPersistedRuntimeKind(record);
     const workingDirectory = record.workingDirectory;
 
-    const runtime =
-      findRuntimeByWorkingDirectory(runtimeKind, workingDirectory) ??
-      (canUseWorkspaceRuntimeForHydration(record, repoPath)
-        ? findWorkspaceRuntime(runtimeKind)
-        : null);
+    const runtimeForDirectory = findRuntimeByWorkingDirectory(runtimeKind, workingDirectory);
+    if (!runtimeForDirectory.ok) {
+      return {
+        ok: false,
+        runtimeKind,
+        reason: runtimeForDirectory.reason,
+      };
+    }
+
+    let runtime = runtimeForDirectory.runtime;
+    if (!runtime && canUseWorkspaceRuntimeForHydration(record, repoPath)) {
+      const workspaceRuntime = findWorkspaceRuntime(runtimeKind);
+      if (!workspaceRuntime.ok) {
+        return {
+          ok: false,
+          runtimeKind,
+          reason: workspaceRuntime.reason,
+        };
+      }
+      runtime = workspaceRuntime.runtime;
+    }
     if (runtime) {
       const { runtimeConnection } = resolveRuntimeRouteConnection(
         runtime.runtimeRoute,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -49,16 +49,8 @@ type SnapshotConnectionMatchResult =
   | { ok: true; runtimeConnection: AgentRuntimeConnection | null }
   | { ok: false; reason: string };
 
-const hasAmbiguousStdioRoutes = (runtimes: RuntimeInstanceSummary[]): boolean => {
-  const identities = new Set(
-    runtimes
-      .map((runtime) => runtime.runtimeRoute)
-      .filter((route): route is Extract<RuntimeRoute, { type: "stdio" }> => route.type === "stdio")
-      .map((route) => route.identity.trim()),
-  );
-
-  return identities.size > 1;
-};
+const hasAmbiguousStdioRoutes = (runtimes: RuntimeInstanceSummary[]): boolean =>
+  runtimes.length > 1 && runtimes.some((runtime) => runtime.runtimeRoute.type === "stdio");
 
 export const createHydrationRuntimeResolver = ({
   repoPath,
@@ -112,6 +104,49 @@ export const createHydrationRuntimeResolver = ({
     };
   };
 
+  const disambiguateAmbiguousStdioMatches = (
+    runtimeKind: RuntimeKind,
+    workingDirectory: string,
+    externalSessionId: string,
+    matches: RuntimeInstanceSummary[],
+  ): RuntimeLookupResult | null => {
+    if (!hasAmbiguousStdioRoutes(matches)) {
+      return null;
+    }
+
+    const candidates: RuntimeSnapshotCandidate[] = matches.map((runtime) => ({
+      runtime,
+      runtimeConnection: resolveRuntimeRouteConnection(runtime.runtimeRoute, workingDirectory)
+        .runtimeConnection,
+    }));
+    const snapshotMatch = findPreloadedSnapshotConnection(
+      runtimeKind,
+      workingDirectory,
+      externalSessionId,
+      candidates.map((candidate) => candidate.runtimeConnection),
+    );
+    if (!snapshotMatch.ok) {
+      return { ok: false, reason: snapshotMatch.reason };
+    }
+    if (!snapshotMatch.runtimeConnection) {
+      return { ok: true, runtime: null };
+    }
+
+    const matchedTransportKey = runtimeConnectionTransportKey(snapshotMatch.runtimeConnection);
+    const matchedCandidates = candidates.filter(
+      (candidate) =>
+        runtimeConnectionTransportKey(candidate.runtimeConnection) === matchedTransportKey,
+    );
+    const [matchedCandidate] = matchedCandidates;
+    if (matchedCandidates.length === 1 && matchedCandidate) {
+      return { ok: true, runtime: matchedCandidate.runtime };
+    }
+    return {
+      ok: false,
+      reason: `Multiple live stdio runtimes share transport identity ${matchedTransportKey} for working directory ${workingDirectory}.`,
+    };
+  };
+
   const findRuntimeByWorkingDirectory = (
     runtimeKind: RuntimeKind,
     workingDirectory: string,
@@ -122,30 +157,15 @@ export const createHydrationRuntimeResolver = ({
     const matches = runtimes.filter(
       (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === normalizedDirectory,
     );
-    if (hasAmbiguousStdioRoutes(matches)) {
-      const candidates: RuntimeSnapshotCandidate[] = matches.map((runtime) => ({
-        runtime,
-        runtimeConnection: resolveRuntimeRouteConnection(runtime.runtimeRoute, workingDirectory)
-          .runtimeConnection,
-      }));
-      const snapshotMatch = findPreloadedSnapshotConnection(
-        runtimeKind,
-        workingDirectory,
-        externalSessionId,
-        candidates.map((candidate) => candidate.runtimeConnection),
-      );
-      if (!snapshotMatch.ok) {
-        return { ok: false, reason: snapshotMatch.reason };
-      }
-      if (snapshotMatch.runtimeConnection) {
-        const matchedTransportKey = runtimeConnectionTransportKey(snapshotMatch.runtimeConnection);
-        const matchedRuntime = candidates.find(
-          (candidate) =>
-            runtimeConnectionTransportKey(candidate.runtimeConnection) === matchedTransportKey,
-        )?.runtime;
-        if (matchedRuntime) {
-          return { ok: true, runtime: matchedRuntime };
-        }
+    const ambiguousMatch = disambiguateAmbiguousStdioMatches(
+      runtimeKind,
+      workingDirectory,
+      externalSessionId,
+      matches,
+    );
+    if (ambiguousMatch) {
+      if (!ambiguousMatch.ok || ambiguousMatch.runtime) {
+        return ambiguousMatch;
       }
       return {
         ok: false,
@@ -167,30 +187,15 @@ export const createHydrationRuntimeResolver = ({
         runtime.role === "workspace" &&
         normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath,
     );
-    if (hasAmbiguousStdioRoutes(matches)) {
-      const candidates: RuntimeSnapshotCandidate[] = matches.map((runtime) => ({
-        runtime,
-        runtimeConnection: resolveRuntimeRouteConnection(runtime.runtimeRoute, workingDirectory)
-          .runtimeConnection,
-      }));
-      const snapshotMatch = findPreloadedSnapshotConnection(
-        runtimeKind,
-        workingDirectory,
-        externalSessionId,
-        candidates.map((candidate) => candidate.runtimeConnection),
-      );
-      if (!snapshotMatch.ok) {
-        return { ok: false, reason: snapshotMatch.reason };
-      }
-      if (snapshotMatch.runtimeConnection) {
-        const matchedTransportKey = runtimeConnectionTransportKey(snapshotMatch.runtimeConnection);
-        const matchedRuntime = candidates.find(
-          (candidate) =>
-            runtimeConnectionTransportKey(candidate.runtimeConnection) === matchedTransportKey,
-        )?.runtime;
-        if (matchedRuntime) {
-          return { ok: true, runtime: matchedRuntime };
-        }
+    const ambiguousMatch = disambiguateAmbiguousStdioMatches(
+      runtimeKind,
+      workingDirectory,
+      externalSessionId,
+      matches,
+    );
+    if (ambiguousMatch) {
+      if (!ambiguousMatch.ok || ambiguousMatch.runtime) {
+        return ambiguousMatch;
       }
       return {
         ok: false,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -13,7 +13,7 @@ import {
 import { normalizeWorkingDirectory } from "../support/core";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
 import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
-import { findRuntimeConnectionPreloadCandidates } from "./live-agent-session-cache";
+import type { RuntimeConnectionPreloadIndex } from "./live-agent-session-cache";
 
 export type ResolvedHydrationRuntime =
   | {
@@ -51,12 +51,12 @@ const hasAmbiguousStdioRoutes = (runtimes: RuntimeInstanceSummary[]): boolean =>
 export const createHydrationRuntimeResolver = ({
   repoPath,
   runtimesByKind,
-  preloadedRuntimeConnectionsByKey,
+  preloadedRuntimeConnections,
   ensureWorkspaceRuntime,
 }: {
   repoPath: string;
   runtimesByKind: Map<RuntimeKind, RuntimeInstanceSummary[]>;
-  preloadedRuntimeConnectionsByKey?: Map<string, AgentRuntimeConnection>;
+  preloadedRuntimeConnections?: RuntimeConnectionPreloadIndex;
   ensureWorkspaceRuntime: (runtimeKind: RuntimeKind) => Promise<RuntimeInstanceSummary | null>;
 }): ((record: AgentSessionRecord) => Promise<ResolvedHydrationRuntime>) => {
   const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
@@ -101,15 +101,11 @@ export const createHydrationRuntimeResolver = ({
     runtimeKind: RuntimeKind,
     workingDirectory: string,
   ): PreloadedRuntimeConnectionLookupResult => {
-    if (!preloadedRuntimeConnectionsByKey) {
+    if (!preloadedRuntimeConnections) {
       return { ok: true, runtimeConnection: null };
     }
 
-    const candidates = findRuntimeConnectionPreloadCandidates(
-      preloadedRuntimeConnectionsByKey,
-      runtimeKind,
-      workingDirectory,
-    );
+    const candidates = preloadedRuntimeConnections.findCandidates(runtimeKind, workingDirectory);
     const candidatesByTransportKey = new Map(
       candidates.map((runtimeConnection) => [
         runtimeConnectionTransportKey(runtimeConnection),

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -5,11 +5,15 @@ import type {
   RuntimeRoute,
 } from "@openducktor/contracts";
 import type { AgentRuntimeConnection } from "@openducktor/core";
-import { resolveRuntimeRouteConnection, runtimeConnectionToRoute } from "../runtime/runtime";
+import {
+  resolveRuntimeRouteConnection,
+  runtimeConnectionToRoute,
+  runtimeConnectionTransportKey,
+} from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
 import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
-import { runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
+import { findRuntimeConnectionPreloadCandidates } from "./live-agent-session-cache";
 
 export type ResolvedHydrationRuntime =
   | {
@@ -27,6 +31,10 @@ export type ResolvedHydrationRuntime =
 
 type RuntimeLookupResult =
   | { ok: true; runtime: RuntimeInstanceSummary | null }
+  | { ok: false; reason: string };
+
+type PreloadedRuntimeConnectionLookupResult =
+  | { ok: true; runtimeConnection: AgentRuntimeConnection | null }
   | { ok: false; reason: string };
 
 const hasAmbiguousStdioRoutes = (runtimes: RuntimeInstanceSummary[]): boolean => {
@@ -89,6 +97,38 @@ export const createHydrationRuntimeResolver = ({
     return { ok: true, runtime: matches[0] ?? null };
   };
 
+  const findPreloadedRuntimeConnection = (
+    runtimeKind: RuntimeKind,
+    workingDirectory: string,
+  ): PreloadedRuntimeConnectionLookupResult => {
+    if (!preloadedRuntimeConnectionsByKey) {
+      return { ok: true, runtimeConnection: null };
+    }
+
+    const candidates = findRuntimeConnectionPreloadCandidates(
+      preloadedRuntimeConnectionsByKey,
+      runtimeKind,
+      workingDirectory,
+    );
+    const candidatesByTransportKey = new Map(
+      candidates.map((runtimeConnection) => [
+        runtimeConnectionTransportKey(runtimeConnection),
+        runtimeConnection,
+      ]),
+    );
+    if (candidatesByTransportKey.size > 1) {
+      return {
+        ok: false,
+        reason: `Multiple preloaded runtime connections found for working directory ${workingDirectory}.`,
+      };
+    }
+
+    return {
+      ok: true,
+      runtimeConnection: Array.from(candidatesByTransportKey.values())[0] ?? null,
+    };
+  };
+
   return async (record: AgentSessionRecord): Promise<ResolvedHydrationRuntime> => {
     const runtimeKind = readPersistedRuntimeKind(record);
     const workingDirectory = record.workingDirectory;
@@ -128,16 +168,24 @@ export const createHydrationRuntimeResolver = ({
       };
     }
 
-    const preloadedRuntimeConnection = preloadedRuntimeConnectionsByKey?.get(
-      runtimeWorkingDirectoryKey(runtimeKind, workingDirectory),
+    const preloadedRuntimeConnection = findPreloadedRuntimeConnection(
+      runtimeKind,
+      workingDirectory,
     );
-    if (preloadedRuntimeConnection) {
+    if (!preloadedRuntimeConnection.ok) {
+      return {
+        ok: false,
+        runtimeKind,
+        reason: preloadedRuntimeConnection.reason,
+      };
+    }
+    if (preloadedRuntimeConnection.runtimeConnection) {
       return {
         ok: true,
         runtimeKind,
         runtimeId: null,
-        runtimeRoute: runtimeConnectionToRoute(preloadedRuntimeConnection),
-        runtimeConnection: preloadedRuntimeConnection,
+        runtimeRoute: runtimeConnectionToRoute(preloadedRuntimeConnection.runtimeConnection),
+        runtimeConnection: preloadedRuntimeConnection.runtimeConnection,
       };
     }
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
@@ -29,14 +29,14 @@ describe("live-agent-session-cache", () => {
       "opencode::local_http:http://127.0.0.1:4444",
     );
     expect(getLiveAgentSessionCacheKey("opencode", stdioRuntimeConnection)).toBe(
-      "opencode::stdio::/tmp/runtime-root",
+      "opencode::stdio:runtime-stdio::/tmp/runtime-root",
     );
     expect(runtimeWorkingDirectoryKey("opencode", "/tmp/repo/worktree/")).toBe(
       "opencode::/tmp/repo/worktree",
     );
     expect(
       liveAgentSessionLookupKey("opencode", stdioRuntimeConnection, "/tmp/repo/worktree/"),
-    ).toBe("opencode::stdio::/tmp/runtime-root::/tmp/repo/worktree");
+    ).toBe("opencode::stdio:runtime-stdio::/tmp/runtime-root::/tmp/repo/worktree");
   });
 
   test("reuses preloaded single-directory snapshots without scanning", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
@@ -9,6 +9,7 @@ import {
   getLiveAgentSessionCacheKey,
   LiveAgentSessionCache,
   liveAgentSessionLookupKey,
+  runtimeConnectionPreloadKey,
   runtimeWorkingDirectoryKey,
 } from "./live-agent-session-cache";
 
@@ -34,9 +35,28 @@ describe("live-agent-session-cache", () => {
     expect(runtimeWorkingDirectoryKey("opencode", "/tmp/repo/worktree/")).toBe(
       "opencode::/tmp/repo/worktree",
     );
+    expect(runtimeConnectionPreloadKey("opencode", stdioRuntimeConnection)).toBe(
+      "opencode::stdio:runtime-stdio::/tmp/runtime-root",
+    );
     expect(
       liveAgentSessionLookupKey("opencode", stdioRuntimeConnection, "/tmp/repo/worktree/"),
     ).toBe("opencode::stdio:runtime-stdio::/tmp/runtime-root::/tmp/repo/worktree");
+  });
+
+  test("builds distinct preload keys for stdio runtimes sharing a working directory", () => {
+    const runtimeConnectionA = createStdioRuntimeConnection("/tmp/runtime-root", {
+      identity: "runtime-stdio-a",
+    });
+    const runtimeConnectionB = createStdioRuntimeConnection("/tmp/runtime-root", {
+      identity: "runtime-stdio-b",
+    });
+
+    expect(runtimeConnectionPreloadKey("opencode", runtimeConnectionA)).toBe(
+      "opencode::stdio:runtime-stdio-a::/tmp/runtime-root",
+    );
+    expect(runtimeConnectionPreloadKey("opencode", runtimeConnectionB)).toBe(
+      "opencode::stdio:runtime-stdio-b::/tmp/runtime-root",
+    );
   });
 
   test("reuses preloaded single-directory snapshots without scanning", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
@@ -37,6 +37,8 @@ describe("live-agent-session-cache", () => {
     );
     const preloadIndex = new RuntimeConnectionPreloadIndex();
     preloadIndex.add("opencode", stdioRuntimeConnection);
+    expect(preloadIndex.hasAny("opencode", "/tmp/runtime-root/")).toBe(true);
+    expect(preloadIndex.hasAny("opencode", "/tmp/other")).toBe(false);
     expect(preloadIndex.findCandidates("opencode", "/tmp/runtime-root/")).toEqual([
       stdioRuntimeConnection,
     ]);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.test.ts
@@ -9,7 +9,7 @@ import {
   getLiveAgentSessionCacheKey,
   LiveAgentSessionCache,
   liveAgentSessionLookupKey,
-  runtimeConnectionPreloadKey,
+  RuntimeConnectionPreloadIndex,
   runtimeWorkingDirectoryKey,
 } from "./live-agent-session-cache";
 
@@ -35,15 +35,17 @@ describe("live-agent-session-cache", () => {
     expect(runtimeWorkingDirectoryKey("opencode", "/tmp/repo/worktree/")).toBe(
       "opencode::/tmp/repo/worktree",
     );
-    expect(runtimeConnectionPreloadKey("opencode", stdioRuntimeConnection)).toBe(
-      "opencode::stdio:runtime-stdio::/tmp/runtime-root",
-    );
+    const preloadIndex = new RuntimeConnectionPreloadIndex();
+    preloadIndex.add("opencode", stdioRuntimeConnection);
+    expect(preloadIndex.findCandidates("opencode", "/tmp/runtime-root/")).toEqual([
+      stdioRuntimeConnection,
+    ]);
     expect(
       liveAgentSessionLookupKey("opencode", stdioRuntimeConnection, "/tmp/repo/worktree/"),
     ).toBe("opencode::stdio:runtime-stdio::/tmp/runtime-root::/tmp/repo/worktree");
   });
 
-  test("builds distinct preload keys for stdio runtimes sharing a working directory", () => {
+  test("indexes distinct stdio runtimes sharing a working directory", () => {
     const runtimeConnectionA = createStdioRuntimeConnection("/tmp/runtime-root", {
       identity: "runtime-stdio-a",
     });
@@ -51,12 +53,15 @@ describe("live-agent-session-cache", () => {
       identity: "runtime-stdio-b",
     });
 
-    expect(runtimeConnectionPreloadKey("opencode", runtimeConnectionA)).toBe(
-      "opencode::stdio:runtime-stdio-a::/tmp/runtime-root",
-    );
-    expect(runtimeConnectionPreloadKey("opencode", runtimeConnectionB)).toBe(
-      "opencode::stdio:runtime-stdio-b::/tmp/runtime-root",
-    );
+    const preloadIndex = new RuntimeConnectionPreloadIndex();
+    preloadIndex.add("opencode", runtimeConnectionA);
+    preloadIndex.add("opencode", runtimeConnectionB);
+
+    expect(preloadIndex.size).toBe(2);
+    expect(preloadIndex.findCandidates("opencode", "/tmp/runtime-root/")).toEqual([
+      runtimeConnectionA,
+      runtimeConnectionB,
+    ]);
   });
 
   test("reuses preloaded single-directory snapshots without scanning", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.ts
@@ -21,7 +21,7 @@ export const getLiveAgentSessionCacheKey = (
 export const runtimeWorkingDirectoryKey = (runtimeKind: string, workingDirectory: string): string =>
   `${runtimeKind}::${normalizeWorkingDirectory(workingDirectory)}`;
 
-export const runtimeConnectionPreloadKey = (
+const runtimeConnectionPreloadKey = (
   runtimeKind: string,
   runtimeConnection: AgentRuntimeConnection,
 ): string =>
@@ -29,23 +29,38 @@ export const runtimeConnectionPreloadKey = (
     runtimeConnection.workingDirectory,
   )}`;
 
-export const findRuntimeConnectionPreloadCandidates = (
-  preloadedRuntimeConnectionsByKey: Map<string, AgentRuntimeConnection>,
-  runtimeKind: string,
-  workingDirectory: string,
-): AgentRuntimeConnection[] => {
-  const runtimeKindPrefix = `${runtimeKind}::`;
-  const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+export class RuntimeConnectionPreloadIndex {
+  private readonly connectionsByKey = new Map<string, AgentRuntimeConnection>();
 
-  return Array.from(preloadedRuntimeConnectionsByKey.entries())
-    .filter(
-      ([key, runtimeConnection]) =>
-        key.startsWith(runtimeKindPrefix) &&
-        normalizeWorkingDirectory(runtimeConnection.workingDirectory) ===
-          normalizedWorkingDirectory,
-    )
-    .map(([, runtimeConnection]) => runtimeConnection);
-};
+  get size(): number {
+    return this.connectionsByKey.size;
+  }
+
+  add(runtimeKind: RuntimeKind, runtimeConnection: AgentRuntimeConnection): void {
+    this.connectionsByKey.set(
+      runtimeConnectionPreloadKey(runtimeKind, runtimeConnection),
+      runtimeConnection,
+    );
+  }
+
+  hasAny(runtimeKind: RuntimeKind, workingDirectory: string): boolean {
+    return this.findCandidates(runtimeKind, workingDirectory).length > 0;
+  }
+
+  findCandidates(runtimeKind: RuntimeKind, workingDirectory: string): AgentRuntimeConnection[] {
+    const runtimeKindPrefix = `${runtimeKind}::`;
+    const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+
+    return Array.from(this.connectionsByKey.entries())
+      .filter(
+        ([key, runtimeConnection]) =>
+          key.startsWith(runtimeKindPrefix) &&
+          normalizeWorkingDirectory(runtimeConnection.workingDirectory) ===
+            normalizedWorkingDirectory,
+      )
+      .map(([, runtimeConnection]) => runtimeConnection);
+  }
+}
 
 export const liveAgentSessionLookupKey = (
   runtimeKind: string,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.ts
@@ -21,6 +21,32 @@ export const getLiveAgentSessionCacheKey = (
 export const runtimeWorkingDirectoryKey = (runtimeKind: string, workingDirectory: string): string =>
   `${runtimeKind}::${normalizeWorkingDirectory(workingDirectory)}`;
 
+export const runtimeConnectionPreloadKey = (
+  runtimeKind: string,
+  runtimeConnection: AgentRuntimeConnection,
+): string =>
+  `${runtimeKind}::${runtimeConnectionTransportKey(runtimeConnection)}::${normalizeWorkingDirectory(
+    runtimeConnection.workingDirectory,
+  )}`;
+
+export const findRuntimeConnectionPreloadCandidates = (
+  preloadedRuntimeConnectionsByKey: Map<string, AgentRuntimeConnection>,
+  runtimeKind: string,
+  workingDirectory: string,
+): AgentRuntimeConnection[] => {
+  const runtimeKindPrefix = `${runtimeKind}::`;
+  const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+
+  return Array.from(preloadedRuntimeConnectionsByKey.entries())
+    .filter(
+      ([key, runtimeConnection]) =>
+        key.startsWith(runtimeKindPrefix) &&
+        normalizeWorkingDirectory(runtimeConnection.workingDirectory) ===
+          normalizedWorkingDirectory,
+    )
+    .map(([, runtimeConnection]) => runtimeConnection);
+};
+
 export const liveAgentSessionLookupKey = (
   runtimeKind: string,
   runtimeConnection: AgentRuntimeConnection,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache.ts
@@ -29,36 +29,48 @@ const runtimeConnectionPreloadKey = (
     runtimeConnection.workingDirectory,
   )}`;
 
+const runtimeConnectionPreloadDirectoryKey = (
+  runtimeKind: RuntimeKind,
+  workingDirectory: string,
+): string => `${runtimeKind}::${normalizeWorkingDirectory(workingDirectory)}`;
+
 export class RuntimeConnectionPreloadIndex {
   private readonly connectionsByKey = new Map<string, AgentRuntimeConnection>();
+  private readonly connectionsByDirectoryKey = new Map<
+    string,
+    Map<string, AgentRuntimeConnection>
+  >();
 
   get size(): number {
     return this.connectionsByKey.size;
   }
 
   add(runtimeKind: RuntimeKind, runtimeConnection: AgentRuntimeConnection): void {
-    this.connectionsByKey.set(
-      runtimeConnectionPreloadKey(runtimeKind, runtimeConnection),
-      runtimeConnection,
+    const connectionKey = runtimeConnectionPreloadKey(runtimeKind, runtimeConnection);
+    this.connectionsByKey.set(connectionKey, runtimeConnection);
+
+    const directoryKey = runtimeConnectionPreloadDirectoryKey(
+      runtimeKind,
+      runtimeConnection.workingDirectory,
     );
+    const connectionsForDirectory =
+      this.connectionsByDirectoryKey.get(directoryKey) ?? new Map<string, AgentRuntimeConnection>();
+    connectionsForDirectory.set(connectionKey, runtimeConnection);
+    this.connectionsByDirectoryKey.set(directoryKey, connectionsForDirectory);
   }
 
   hasAny(runtimeKind: RuntimeKind, workingDirectory: string): boolean {
-    return this.findCandidates(runtimeKind, workingDirectory).length > 0;
+    return this.connectionsByDirectoryKey.has(
+      runtimeConnectionPreloadDirectoryKey(runtimeKind, workingDirectory),
+    );
   }
 
   findCandidates(runtimeKind: RuntimeKind, workingDirectory: string): AgentRuntimeConnection[] {
-    const runtimeKindPrefix = `${runtimeKind}::`;
-    const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
-
-    return Array.from(this.connectionsByKey.entries())
-      .filter(
-        ([key, runtimeConnection]) =>
-          key.startsWith(runtimeKindPrefix) &&
-          normalizeWorkingDirectory(runtimeConnection.workingDirectory) ===
-            normalizedWorkingDirectory,
-      )
-      .map(([, runtimeConnection]) => runtimeConnection);
+    return Array.from(
+      this.connectionsByDirectoryKey
+        .get(runtimeConnectionPreloadDirectoryKey(runtimeKind, workingDirectory))
+        ?.values() ?? [],
+    );
   }
 }
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -699,6 +699,63 @@ describe("load-sessions-stages", () => {
     expect(stateHarness.getState()["session-1"]?.historyHydrationState).toBe("failed");
   });
 
+  test("throws runtime resolution failures for reconcile hydration without marking the task reconciled", async () => {
+    const initialSession = createSession();
+    const stateHarness = createStateHarness({ "session-1": initialSession });
+
+    await expect(
+      hydrateSessionRecordsStage({
+        adapter: {
+          hasSession: () => false,
+          listLiveAgentSessionSnapshots: async () => [],
+          loadSessionHistory: async () => [],
+          attachSession: async (input) => ({
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-03-01T09:00:00.000Z",
+            status: "idle",
+            runtimeKind: input.runtimeKind,
+          }),
+          resumeSession: async (input) => ({
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-03-01T09:00:00.000Z",
+            status: "idle",
+            runtimeKind: input.runtimeKind,
+          }),
+        },
+        setSessionsById: stateHarness.setSessionsById,
+        updateSession: stateHarness.updateSession,
+        isStaleRepoOperation: () => false,
+        recordsToHydrate: [createRecord()],
+        historyHydrationSessionIds: new Set(),
+        failOnRuntimeResolutionError: true,
+        runtimePlanner: {
+          readCurrentHydratedRuntimeResolution: () => null,
+          resolveHydrationRuntime: async () => ({
+            ok: false,
+            runtimeKind: "opencode",
+            reason: "Multiple live stdio runtimes found for working directory /tmp/repo/worktree.",
+          }),
+          loadLiveAgentSessionSnapshot: async () => null,
+        },
+        promptAssembler: {
+          buildHydrationPreludeMessages: async () => [],
+          buildHydrationSystemPrompt: async () => "",
+        },
+        getRepoPromptOverrides: async () => ({}),
+      }),
+    ).rejects.toThrow(
+      "Multiple live stdio runtimes found for working directory /tmp/repo/worktree.",
+    );
+
+    expect(stateHarness.getState()["session-1"]).toEqual(initialSession);
+  });
+
   test("fails requested-history hydration before adapter history loads for unsupported stdio OpenCode runtimes", async () => {
     const stateHarness = createStateHarness({ "session-1": createSession() });
     let historyLoads = 0;

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -152,6 +152,15 @@ const createRuntime = (
   descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
 });
 
+const createStdioRuntime = (
+  runtimeId: string,
+  workingDirectory: string,
+): RuntimeInstanceSummary => ({
+  ...createRuntime(workingDirectory),
+  runtimeId,
+  runtimeRoute: { type: "stdio", identity: runtimeId },
+});
+
 describe("load-sessions-stages", () => {
   test("prefers hydrated final assistant messages over stale local streamed rows with the same id", () => {
     const merged = mergeHydratedMessages(
@@ -1133,6 +1142,92 @@ describe("load-sessions-stages", () => {
 
     expect(snapshot).toEqual(liveSnapshot);
     expect(snapshotLoads).toBe(0);
+  });
+
+  test("runtime planner uses preloaded snapshots to disambiguate same-directory stdio runtimes", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const runtimeConnectionA = {
+      type: "stdio" as const,
+      identity: "runtime-stdio-a",
+      workingDirectory,
+    };
+    const runtimeConnectionB = {
+      type: "stdio" as const,
+      identity: "runtime-stdio-b",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnections = new RuntimeConnectionPreloadIndex();
+    preloadedRuntimeConnections.add("opencode", runtimeConnectionA);
+    preloadedRuntimeConnections.add("opencode", runtimeConnectionB);
+
+    const planner = await createRuntimeResolutionPlannerStage({
+      intent: createIntent(),
+      options: {
+        preloadedRuntimeLists: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+          [
+            "opencode",
+            [
+              createStdioRuntime("runtime-stdio-a", workingDirectory),
+              createStdioRuntime("runtime-stdio-b", workingDirectory),
+            ],
+          ],
+        ]),
+        preloadedRuntimeConnections,
+        preloadedLiveAgentSessionsByKey: new Map([
+          [
+            liveAgentSessionLookupKey("opencode", runtimeConnectionB, workingDirectory),
+            [
+              {
+                externalSessionId: "external-1",
+                title: "Builder Session",
+                startedAt: "2026-03-01T09:00:00.000Z",
+                status: { type: "busy" as const },
+                pendingPermissions: [],
+                pendingQuestions: [],
+                workingDirectory,
+              },
+            ],
+          ],
+        ]),
+        allowRuntimeEnsure: false,
+      },
+      adapter: {
+        hasSession: () => false,
+        loadSessionHistory: async () => [],
+        attachSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+        resumeSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+      },
+      sessionsRef: createStateHarness({}).sessionsRef,
+      recordsToHydrate: [createRecord({ role: "planner", workingDirectory })],
+      historyHydrationSessionIds: new Set(),
+    });
+
+    const result = await planner.resolveHydrationRuntime(
+      createRecord({ role: "planner", workingDirectory }),
+    );
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeId).toBe("runtime-stdio-b");
+    expect(result.runtimeRoute).toEqual({ type: "stdio", identity: "runtime-stdio-b" });
+    expect(result.runtimeConnection).toEqual(runtimeConnectionB);
   });
 
   test("prompt assembler omits system prompt when the task is unavailable", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -9,7 +9,10 @@ import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { getSessionMessageCount } from "@/state/operations/agent-orchestrator/support/messages";
 import { sessionMessageAt } from "@/test-utils/session-message-test-helpers";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { liveAgentSessionLookupKey, runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
+import {
+  liveAgentSessionLookupKey,
+  RuntimeConnectionPreloadIndex,
+} from "./live-agent-session-cache";
 import {
   createHydrationPromptAssemblerStage,
   createRuntimeResolutionPlannerStage,
@@ -1034,6 +1037,12 @@ describe("load-sessions-stages", () => {
       workingDirectory,
     };
     let snapshotLoads = 0;
+    const preloadedRuntimeConnections = new RuntimeConnectionPreloadIndex();
+    preloadedRuntimeConnections.add("opencode", {
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4444",
+      workingDirectory,
+    });
 
     const planner = await createRuntimeResolutionPlannerStage({
       intent: createIntent({
@@ -1047,12 +1056,7 @@ describe("load-sessions-stages", () => {
         preloadedRuntimeLists: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
           ["opencode", [createRuntime(workingDirectory)]],
         ]),
-        preloadedRuntimeConnectionsByKey: new Map([
-          [
-            runtimeWorkingDirectoryKey("opencode", workingDirectory),
-            { type: "local_http", endpoint: "http://127.0.0.1:4444", workingDirectory },
-          ],
-        ]),
+        preloadedRuntimeConnections,
         preloadedLiveAgentSessionsByKey: new Map([
           [
             liveAgentSessionLookupKey(

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -742,9 +742,10 @@ describe("load-sessions-stages", () => {
             ok: true,
             runtimeKind: "opencode",
             runtimeId: "runtime-stdio",
-            runtimeRoute: { type: "stdio" },
+            runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
             runtimeConnection: {
               type: "stdio",
+              identity: "runtime-stdio",
               workingDirectory: "/tmp/repo/worktree",
             },
           }),

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -714,6 +714,7 @@ describe("load-sessions-stages", () => {
   test("throws runtime resolution failures for reconcile hydration without marking the task reconciled", async () => {
     const initialSession = createSession();
     const stateHarness = createStateHarness({ "session-1": initialSession });
+    let updateCalls = 0;
 
     await expect(
       hydrateSessionRecordsStage({
@@ -741,7 +742,10 @@ describe("load-sessions-stages", () => {
           }),
         },
         setSessionsById: stateHarness.setSessionsById,
-        updateSession: stateHarness.updateSession,
+        updateSession: (sessionId, updater) => {
+          updateCalls += 1;
+          stateHarness.updateSession(sessionId, updater);
+        },
         isStaleRepoOperation: () => false,
         recordsToHydrate: [createRecord()],
         historyHydrationSessionIds: new Set(),
@@ -766,6 +770,7 @@ describe("load-sessions-stages", () => {
     );
 
     expect(stateHarness.getState()["session-1"]).toEqual(initialSession);
+    expect(updateCalls).toBe(0);
   });
 
   test("fails requested-history hydration before adapter history loads for unsupported stdio OpenCode runtimes", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -640,8 +640,8 @@ export const createRuntimeResolutionPlannerStage = async ({
   const resolveHydrationRuntime = createHydrationRuntimeResolver({
     repoPath: intent.repoPath,
     runtimesByKind,
-    ...(options?.preloadedRuntimeConnectionsByKey
-      ? { preloadedRuntimeConnectionsByKey: options.preloadedRuntimeConnectionsByKey }
+    ...(options?.preloadedRuntimeConnections
+      ? { preloadedRuntimeConnections: options.preloadedRuntimeConnections }
       : {}),
     ensureWorkspaceRuntime,
   });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -643,6 +643,9 @@ export const createRuntimeResolutionPlannerStage = async ({
     ...(options?.preloadedRuntimeConnections
       ? { preloadedRuntimeConnections: options.preloadedRuntimeConnections }
       : {}),
+    ...(options?.preloadedLiveAgentSessionsByKey
+      ? { preloadedLiveAgentSessionsByKey: options.preloadedLiveAgentSessionsByKey }
+      : {}),
     ensureWorkspaceRuntime,
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -950,18 +950,18 @@ export const hydrateSessionRecordsStage = async ({
       return;
     }
     if (!runtimeResolution.ok) {
-      if (shouldHydrateHistory || failOnRuntimeResolutionError) {
+      if (shouldHydrateHistory) {
         updateSession(
           record.sessionId,
-          (current) =>
-            shouldHydrateHistory
-              ? {
-                  ...current,
-                  historyHydrationState: "failed",
-                }
-              : current,
+          (current) => ({
+            ...current,
+            historyHydrationState: "failed",
+          }),
           { persist: false },
         );
+        throw new Error(runtimeResolution.reason);
+      }
+      if (failOnRuntimeResolutionError) {
         throw new Error(runtimeResolution.reason);
       }
       updateSession(

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -163,6 +163,7 @@ export type HistoryHydrationStageInput = {
   isStaleRepoOperation: () => boolean;
   recordsToHydrate: AgentSessionRecord[];
   historyHydrationSessionIds: Set<string>;
+  failOnRuntimeResolutionError?: boolean;
   runtimePlanner: HydrationRuntimePlanner;
   promptAssembler: HydrationPromptAssembler;
   getRepoPromptOverrides: () => Promise<RepoPromptOverrides>;
@@ -907,6 +908,7 @@ export const hydrateSessionRecordsStage = async ({
   isStaleRepoOperation,
   recordsToHydrate,
   historyHydrationSessionIds,
+  failOnRuntimeResolutionError = false,
   runtimePlanner,
   promptAssembler,
   getRepoPromptOverrides,
@@ -945,13 +947,16 @@ export const hydrateSessionRecordsStage = async ({
       return;
     }
     if (!runtimeResolution.ok) {
-      if (shouldHydrateHistory) {
+      if (shouldHydrateHistory || failOnRuntimeResolutionError) {
         updateSession(
           record.sessionId,
-          (current) => ({
-            ...current,
-            historyHydrationState: "failed",
-          }),
+          (current) =>
+            shouldHydrateHistory
+              ? {
+                  ...current,
+                  historyHydrationState: "failed",
+                }
+              : current,
           { persist: false },
         );
         throw new Error(runtimeResolution.reason);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -244,6 +244,7 @@ export const createLoadAgentSessions = ({
         isStaleRepoOperation,
         recordsToHydrate,
         historyHydrationSessionIds: effectiveHistoryHydrationSessionIds,
+        failOnRuntimeResolutionError: intent.mode === "reconcile_live",
         runtimePlanner,
         promptAssembler,
         getRepoPromptOverrides,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -351,9 +351,10 @@ describe("reattach-live-session", () => {
         ok: true,
         runtimeKind: "opencode",
         runtimeId: "runtime-stdio",
-        runtimeRoute: { type: "stdio" },
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
         runtimeConnection: {
           type: "stdio",
+          identity: "runtime-stdio",
           workingDirectory: "/tmp/repo/worktree",
         },
       }),

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -139,9 +139,10 @@ const createRuntimeInstance = ({
   descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
 });
 
-const stdioRuntimeConnection = (workingDirectory: string) =>
+const stdioRuntimeConnection = (workingDirectory: string, identity = "runtime-stdio") =>
   ({
     type: "stdio",
+    identity,
     workingDirectory,
   }) as const;
 
@@ -455,12 +456,12 @@ describe("repo-session-hydration-service", () => {
       createRuntimeInstance({
         runtimeId: "runtime-stdio-a",
         workingDirectory: worktreeA,
-        runtimeRoute: { type: "stdio" },
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio-a" },
       }),
       createRuntimeInstance({
         runtimeId: "runtime-stdio-b",
         workingDirectory: worktreeB,
-        runtimeRoute: { type: "stdio" },
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio-b" },
       }),
     ];
 
@@ -505,13 +506,16 @@ describe("repo-session-hydration-service", () => {
       isCurrentRepo: () => true,
     });
 
+    const runtimeConnectionA = stdioRuntimeConnection(worktreeA, "runtime-stdio-a");
+    const runtimeConnectionB = stdioRuntimeConnection(worktreeB, "runtime-stdio-b");
+
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([
       {
-        runtimeConnection: stdioRuntimeConnection(worktreeA),
+        runtimeConnection: runtimeConnectionA,
         directories: [worktreeA],
       },
       {
-        runtimeConnection: stdioRuntimeConnection(worktreeB),
+        runtimeConnection: runtimeConnectionB,
         directories: [worktreeB],
       },
     ]);
@@ -519,7 +523,7 @@ describe("repo-session-hydration-service", () => {
       liveAgentSessionStore.readSnapshot({
         repoPath,
         runtimeKind: "opencode",
-        runtimeConnection: stdioRuntimeConnection(worktreeA),
+        runtimeConnection: runtimeConnectionA,
         workingDirectory: worktreeA,
         externalSessionId: "external-1",
       })?.externalSessionId,
@@ -528,7 +532,7 @@ describe("repo-session-hydration-service", () => {
       liveAgentSessionStore.readSnapshot({
         repoPath,
         runtimeKind: "opencode",
-        runtimeConnection: stdioRuntimeConnection(worktreeB),
+        runtimeConnection: runtimeConnectionB,
         workingDirectory: worktreeB,
         externalSessionId: "external-2",
       })?.externalSessionId,
@@ -544,7 +548,10 @@ describe("repo-session-hydration-service", () => {
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
     host.runtimeList = async () => [
-      createRuntimeInstance({ runtimeId: "runtime-stdio", runtimeRoute: { type: "stdio" } }),
+      createRuntimeInstance({
+        runtimeId: "runtime-stdio",
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
+      }),
     ];
 
     const service = createRepoSessionHydrationService({
@@ -769,7 +776,7 @@ describe("repo-session-hydration-service", () => {
       return createRuntimeInstance({
         runtimeId: "runtime-stdio-root",
         workingDirectory: repoPath,
-        runtimeRoute: { type: "stdio" },
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio-root" },
       });
     };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@/state/operations/agent-orchestrator/test-utils";
 import { runtimeQueryKeys } from "@/state/queries/runtime";
 import { host } from "../../shared/host";
+import { runtimeConnectionPreloadKey } from "./live-agent-session-cache";
 import { LiveAgentSessionStore } from "./live-agent-session-store";
 import { createRuntimeResolutionPlannerStage } from "./load-sessions-stages";
 import { createRepoSessionHydrationService } from "./repo-session-hydration-service";
@@ -537,6 +538,112 @@ describe("repo-session-hydration-service", () => {
         externalSessionId: "external-2",
       })?.externalSessionId,
     ).toBe("external-2");
+    service.dispose();
+  });
+
+  test("reconcile keeps same-directory stdio runtimes under identity-aware preload keys", async () => {
+    const listLiveAgentSessionSnapshotsCalls: Array<{
+      runtimeConnection: unknown;
+      directories?: string[];
+    }> = [];
+    const reconcilePreloadKeys: string[][] = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+    const runtimeConnectionA = stdioRuntimeConnection(worktreePath, "runtime-stdio-a");
+    const runtimeConnectionB = stdioRuntimeConnection(worktreePath, "runtime-stdio-b");
+
+    host.runtimeList = async () => [
+      createRuntimeInstance({
+        runtimeId: "runtime-stdio-a",
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio-a" },
+      }),
+      createRuntimeInstance({
+        runtimeId: "runtime-stdio-b",
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio-b" },
+      }),
+    ];
+
+    const service = createRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async (input) => {
+          listLiveAgentSessionSnapshotsCalls.push({
+            runtimeConnection: input.runtimeConnection,
+            ...(input.directories ? { directories: input.directories } : {}),
+          });
+          return [
+            {
+              externalSessionId:
+                input.runtimeConnection.type === "stdio" &&
+                input.runtimeConnection.identity === "runtime-stdio-a"
+                  ? "external-a"
+                  : "external-b",
+              title: "Task",
+              workingDirectory: input.runtimeConnection.workingDirectory,
+              startedAt: "2026-02-22T08:00:00.000Z",
+              status: { type: "busy" },
+              pendingPermissions: [],
+              pendingQuestions: [],
+            },
+          ];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ preloadedRuntimeConnectionsByKey }) => {
+          reconcilePreloadKeys.push(Array.from(preloadedRuntimeConnectionsByKey?.keys() ?? []));
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-a", worktreePath),
+        taskWithSessionAt("task-b", "external-b", worktreePath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([
+      {
+        runtimeConnection: runtimeConnectionA,
+        directories: [worktreePath],
+      },
+      {
+        runtimeConnection: runtimeConnectionB,
+        directories: [worktreePath],
+      },
+    ]);
+    expect(reconcilePreloadKeys).toEqual([
+      [
+        runtimeConnectionPreloadKey("opencode", runtimeConnectionA),
+        runtimeConnectionPreloadKey("opencode", runtimeConnectionB),
+      ],
+      [
+        runtimeConnectionPreloadKey("opencode", runtimeConnectionA),
+        runtimeConnectionPreloadKey("opencode", runtimeConnectionB),
+      ],
+    ]);
+    expect(
+      liveAgentSessionStore.readSnapshot({
+        repoPath,
+        runtimeKind: "opencode",
+        runtimeConnection: runtimeConnectionA,
+        workingDirectory: worktreePath,
+        externalSessionId: "external-a",
+      })?.externalSessionId,
+    ).toBe("external-a");
+    expect(
+      liveAgentSessionStore.readSnapshot({
+        repoPath,
+        runtimeKind: "opencode",
+        runtimeConnection: runtimeConnectionB,
+        workingDirectory: worktreePath,
+        externalSessionId: "external-b",
+      })?.externalSessionId,
+    ).toBe("external-b");
     service.dispose();
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -3,15 +3,16 @@ import {
   type AgentSessionRecord,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type RuntimeInstanceSummary,
+  type RuntimeKind,
   type TaskCard,
 } from "@openducktor/contracts";
-import { appQueryClient, clearAppQueryClient } from "@/lib/query-client";
+import type { QueryClient } from "@tanstack/react-query";
+import { createQueryClient } from "@/lib/query-client";
 import {
   createLiveAgentSessionSnapshotFixture,
   createLocalHttpRuntimeConnection,
 } from "@/state/operations/agent-orchestrator/test-utils";
 import { runtimeQueryKeys } from "@/state/queries/runtime";
-import { host } from "../../shared/host";
 import { runtimeConnectionPreloadKey } from "./live-agent-session-cache";
 import { LiveAgentSessionStore } from "./live-agent-session-store";
 import { createRuntimeResolutionPlannerStage } from "./load-sessions-stages";
@@ -147,14 +148,35 @@ const stdioRuntimeConnection = (workingDirectory: string, identity = "runtime-st
     workingDirectory,
   }) as const;
 
-describe("repo-session-hydration-service", () => {
-  const originalRuntimeList = host.runtimeList;
-  const originalRuntimeEnsure = host.runtimeEnsure;
+type RuntimeEnsure = (
+  nextRepoPath: string,
+  nextRuntimeKind: RuntimeKind,
+) => Promise<RuntimeInstanceSummary>;
 
-  beforeEach(async () => {
-    await clearAppQueryClient();
-    host.runtimeList = async () => [];
-    host.runtimeEnsure = async () => {
+describe("repo-session-hydration-service", () => {
+  let queryClient: QueryClient;
+  let runtimeEnsure: RuntimeEnsure;
+
+  const setRuntimeList = (runtimes: RuntimeInstanceSummary[]) => {
+    queryClient.setQueryData(runtimeQueryKeys.list("opencode", repoPath), runtimes);
+  };
+
+  const createTestRepoSessionHydrationService = (
+    options: Omit<
+      Parameters<typeof createRepoSessionHydrationService>[0],
+      "queryClient" | "runtimeEnsure"
+    >,
+  ) =>
+    createRepoSessionHydrationService({
+      ...options,
+      queryClient,
+      runtimeEnsure,
+    });
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    setRuntimeList([]);
+    runtimeEnsure = async () => {
       throw new Error("runtimeEnsure should not be called in this test");
     };
   });
@@ -165,7 +187,7 @@ describe("repo-session-hydration-service", () => {
     let retryRequests = 0;
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async () => [],
       },
@@ -209,9 +231,9 @@ describe("repo-session-hydration-service", () => {
     const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [createRuntimeInstance()];
+    setRuntimeList([createRuntimeInstance()]);
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async (input) => {
           listLiveAgentSessionSnapshotsCalls.push(
@@ -297,9 +319,9 @@ describe("repo-session-hydration-service", () => {
     let reusedPreloadedSnapshot: string | null = null;
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [createRuntimeInstance()];
+    setRuntimeList([createRuntimeInstance()]);
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async () => {
           preloadScanCalls += 1;
@@ -453,7 +475,7 @@ describe("repo-session-hydration-service", () => {
     }> = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [
+    setRuntimeList([
       createRuntimeInstance({
         runtimeId: "runtime-stdio-a",
         workingDirectory: worktreeA,
@@ -464,12 +486,12 @@ describe("repo-session-hydration-service", () => {
         workingDirectory: worktreeB,
         runtimeRoute: { type: "stdio", identity: "runtime-stdio-b" },
       }),
-    ];
+    ]);
 
     const taskOne = taskWithSessionAt("task-1", "external-1", worktreeA);
     const taskTwo = taskWithSessionAt("task-2", "external-2", worktreeB);
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async (input) => {
           listLiveAgentSessionSnapshotsCalls.push({
@@ -551,7 +573,7 @@ describe("repo-session-hydration-service", () => {
     const runtimeConnectionA = stdioRuntimeConnection(worktreePath, "runtime-stdio-a");
     const runtimeConnectionB = stdioRuntimeConnection(worktreePath, "runtime-stdio-b");
 
-    host.runtimeList = async () => [
+    setRuntimeList([
       createRuntimeInstance({
         runtimeId: "runtime-stdio-a",
         runtimeRoute: { type: "stdio", identity: "runtime-stdio-a" },
@@ -560,9 +582,9 @@ describe("repo-session-hydration-service", () => {
         runtimeId: "runtime-stdio-b",
         runtimeRoute: { type: "stdio", identity: "runtime-stdio-b" },
       }),
-    ];
+    ]);
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async (input) => {
           listLiveAgentSessionSnapshotsCalls.push({
@@ -654,14 +676,14 @@ describe("repo-session-hydration-service", () => {
     }> = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [
+    setRuntimeList([
       createRuntimeInstance({
         runtimeId: "runtime-stdio",
         runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
       }),
-    ];
+    ]);
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async (input) => {
           listLiveAgentSessionSnapshotsCalls.push({
@@ -719,8 +741,8 @@ describe("repo-session-hydration-service", () => {
     const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [];
-    host.runtimeEnsure = async () => {
+    setRuntimeList([]);
+    runtimeEnsure = async () => {
       runtimeEnsureCalls += 1;
       return {
         kind: "opencode",
@@ -741,7 +763,7 @@ describe("repo-session-hydration-service", () => {
     const taskOne = plannerTaskWithSessionAt("task-1", "external-1", repoPath);
     const taskTwo = plannerTaskWithSessionAt("task-2", "external-2", repoPath);
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async (input) => {
           listLiveAgentSessionSnapshotsCalls.push(
@@ -780,13 +802,13 @@ describe("repo-session-hydration-service", () => {
     const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [createRuntimeInstance({ workingDirectory: repoPath })];
-    host.runtimeEnsure = async () => {
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+    runtimeEnsure = async () => {
       runtimeEnsureCalls += 1;
       return createRuntimeInstance({ workingDirectory: repoPath });
     };
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async (input) => {
           listLiveAgentSessionSnapshotsCalls.push(
@@ -832,9 +854,9 @@ describe("repo-session-hydration-service", () => {
     const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [createRuntimeInstance({ workingDirectory: repoPath })];
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async (input) => {
           listLiveAgentSessionSnapshotsCalls.push(
@@ -877,8 +899,8 @@ describe("repo-session-hydration-service", () => {
     }> = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [];
-    host.runtimeEnsure = async () => {
+    setRuntimeList([]);
+    runtimeEnsure = async () => {
       runtimeEnsureCalls += 1;
       return createRuntimeInstance({
         runtimeId: "runtime-stdio-root",
@@ -887,7 +909,7 @@ describe("repo-session-hydration-service", () => {
       });
     };
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async (input) => {
           listLiveAgentSessionSnapshotsCalls.push({
@@ -922,8 +944,8 @@ describe("repo-session-hydration-service", () => {
 
   test("reconcile invalidates runtime list queries after ensuring a missing runtime", async () => {
     const liveAgentSessionStore = new LiveAgentSessionStore();
-    host.runtimeList = async () => [];
-    host.runtimeEnsure = async () => ({
+    setRuntimeList([]);
+    runtimeEnsure = async () => ({
       kind: "opencode",
       runtimeId: "runtime-1",
       repoPath,
@@ -937,9 +959,9 @@ describe("repo-session-hydration-service", () => {
       startedAt: "2026-02-22T08:00:00.000Z",
       descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
     });
-    appQueryClient.setQueryData(runtimeQueryKeys.list("opencode", repoPath), []);
+    queryClient.setQueryData(runtimeQueryKeys.list("opencode", repoPath), []);
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async () => [],
       },
@@ -959,7 +981,7 @@ describe("repo-session-hydration-service", () => {
     });
 
     expect(
-      appQueryClient.getQueryState(runtimeQueryKeys.list("opencode", repoPath))?.isInvalidated,
+      queryClient.getQueryState(runtimeQueryKeys.list("opencode", repoPath))?.isInvalidated,
     ).toBe(true);
     service.dispose();
   });
@@ -970,7 +992,7 @@ describe("repo-session-hydration-service", () => {
     const liveAgentSessionStore = new LiveAgentSessionStore();
     const retryTriggered = createDeferred<void>();
 
-    host.runtimeList = async () => [createRuntimeInstance()];
+    setRuntimeList([createRuntimeInstance()]);
 
     const invalidTask = taskWithSession("task-invalid", "external-invalid");
     const invalidSession = invalidTask.agentSessions?.[0];
@@ -984,7 +1006,7 @@ describe("repo-session-hydration-service", () => {
       },
     ];
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async () => [
           {
@@ -1033,7 +1055,7 @@ describe("repo-session-hydration-service", () => {
     const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    host.runtimeList = async () => [createRuntimeInstance()];
+    setRuntimeList([createRuntimeInstance()]);
 
     const partiallyInvalidTask = taskWithSession("task-invalid", "external-partial");
     const partiallyInvalidSession = partiallyInvalidTask.agentSessions?.[0];
@@ -1050,7 +1072,7 @@ describe("repo-session-hydration-service", () => {
       },
     ];
 
-    const service = createRepoSessionHydrationService({
+    const service = createTestRepoSessionHydrationService({
       agentEngine: {
         listLiveAgentSessionSnapshots: async () => [
           {
@@ -1095,7 +1117,6 @@ describe("repo-session-hydration-service", () => {
   });
 
   afterEach(() => {
-    host.runtimeList = originalRuntimeList;
-    host.runtimeEnsure = originalRuntimeEnsure;
+    queryClient.clear();
   });
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -669,6 +669,78 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
+  test("reconcile scans workspace-derived directories for every repo-root stdio runtime", async () => {
+    const listLiveAgentSessionSnapshotsCalls: Array<{
+      runtimeConnection: unknown;
+      directories?: string[];
+    }> = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+    const runtimeConnectionA = stdioRuntimeConnection(worktreePath, "runtime-stdio-a");
+    const runtimeConnectionB = stdioRuntimeConnection(worktreePath, "runtime-stdio-b");
+
+    setRuntimeList([
+      createRuntimeInstance({
+        runtimeId: "runtime-stdio-a",
+        workingDirectory: repoPath,
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio-a" },
+      }),
+      createRuntimeInstance({
+        runtimeId: "runtime-stdio-b",
+        workingDirectory: repoPath,
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio-b" },
+      }),
+    ]);
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async (input) => {
+          listLiveAgentSessionSnapshotsCalls.push({
+            runtimeConnection: input.runtimeConnection,
+            ...(input.directories ? { directories: input.directories } : {}),
+          });
+          return [
+            createLiveAgentSessionSnapshotFixture({
+              externalSessionId:
+                input.runtimeConnection.type === "stdio" &&
+                input.runtimeConnection.identity === "runtime-stdio-a"
+                  ? "external-a"
+                  : "external-b",
+              workingDirectory: worktreePath,
+            }),
+          ];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async () => {},
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-a", worktreePath),
+        taskWithSessionAt("task-b", "external-b", worktreePath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([
+      {
+        runtimeConnection: runtimeConnectionA,
+        directories: [worktreePath],
+      },
+      {
+        runtimeConnection: runtimeConnectionB,
+        directories: [worktreePath],
+      },
+    ]);
+    service.dispose();
+  });
+
   test("reconcile preloads stdio runtime snapshots into the live session store", async () => {
     const listLiveAgentSessionSnapshotsCalls: Array<{
       runtimeConnection: unknown;

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -13,7 +13,6 @@ import {
   createLocalHttpRuntimeConnection,
 } from "@/state/operations/agent-orchestrator/test-utils";
 import { runtimeQueryKeys } from "@/state/queries/runtime";
-import { runtimeConnectionPreloadKey } from "./live-agent-session-cache";
 import { LiveAgentSessionStore } from "./live-agent-session-store";
 import { createRuntimeResolutionPlannerStage } from "./load-sessions-stages";
 import { createRepoSessionHydrationService } from "./repo-session-hydration-service";
@@ -334,7 +333,7 @@ describe("repo-session-hydration-service", () => {
           taskId,
           persistedRecords,
           preloadedRuntimeLists,
-          preloadedRuntimeConnectionsByKey,
+          preloadedRuntimeConnections,
           preloadedLiveAgentSessionsByKey,
           allowRuntimeEnsure,
         }) => {
@@ -346,7 +345,7 @@ describe("repo-session-hydration-service", () => {
           const plannerOptions = {
             ...(persistedRecords ? { persistedRecords } : {}),
             ...(preloadedRuntimeLists ? { preloadedRuntimeLists } : {}),
-            ...(preloadedRuntimeConnectionsByKey ? { preloadedRuntimeConnectionsByKey } : {}),
+            ...(preloadedRuntimeConnections ? { preloadedRuntimeConnections } : {}),
             ...(preloadedLiveAgentSessionsByKey ? { preloadedLiveAgentSessionsByKey } : {}),
             ...(allowRuntimeEnsure !== undefined ? { allowRuntimeEnsure } : {}),
           };
@@ -568,7 +567,7 @@ describe("repo-session-hydration-service", () => {
       runtimeConnection: unknown;
       directories?: string[];
     }> = [];
-    const reconcilePreloadKeys: string[][] = [];
+    const reconcilePreloadIdentities: string[][] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
     const runtimeConnectionA = stdioRuntimeConnection(worktreePath, "runtime-stdio-a");
     const runtimeConnectionB = stdioRuntimeConnection(worktreePath, "runtime-stdio-b");
@@ -610,8 +609,15 @@ describe("repo-session-hydration-service", () => {
       },
       sessionHydration: {
         bootstrapTaskSessions: async () => {},
-        reconcileLiveTaskSessions: async ({ preloadedRuntimeConnectionsByKey }) => {
-          reconcilePreloadKeys.push(Array.from(preloadedRuntimeConnectionsByKey?.keys() ?? []));
+        reconcileLiveTaskSessions: async ({ preloadedRuntimeConnections }) => {
+          reconcilePreloadIdentities.push(
+            preloadedRuntimeConnections
+              ?.findCandidates("opencode", worktreePath)
+              .map((runtimeConnection) =>
+                runtimeConnection.type === "stdio" ? runtimeConnection.identity : "local_http",
+              )
+              .sort() ?? [],
+          );
         },
       },
       liveAgentSessionStore,
@@ -638,15 +644,9 @@ describe("repo-session-hydration-service", () => {
         directories: [worktreePath],
       },
     ]);
-    expect(reconcilePreloadKeys).toEqual([
-      [
-        runtimeConnectionPreloadKey("opencode", runtimeConnectionA),
-        runtimeConnectionPreloadKey("opencode", runtimeConnectionB),
-      ],
-      [
-        runtimeConnectionPreloadKey("opencode", runtimeConnectionA),
-        runtimeConnectionPreloadKey("opencode", runtimeConnectionB),
-      ],
+    expect(reconcilePreloadIdentities).toEqual([
+      ["runtime-stdio-a", "runtime-stdio-b"],
+      ["runtime-stdio-a", "runtime-stdio-b"],
     ]);
     expect(
       liveAgentSessionStore.readSnapshot({

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -353,22 +353,30 @@ export const createRepoSessionHydrationService = ({
         continue;
       }
 
-      const routeSourceRuntime =
-        runtimeEntries.find(
-          (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey,
-        ) ??
-        (runtimeKindsAllowedToEnsureRepoRoot.has(runtimeKind)
-          ? await ensureRuntimeAndInvalidateReadinessQueries({
-              repoPath,
-              runtimeKind,
-              ensureRuntime: runtimeEnsure,
-            })
-          : null);
-      if (!routeSourceRuntime) {
+      const routeSourceRuntimes = runtimeEntries.filter(
+        (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey,
+      );
+      if (
+        routeSourceRuntimes.length === 0 &&
+        runtimeKindsAllowedToEnsureRepoRoot.has(runtimeKind)
+      ) {
+        routeSourceRuntimes.push(
+          await ensureRuntimeAndInvalidateReadinessQueries({
+            repoPath,
+            runtimeKind,
+            ensureRuntime: runtimeEnsure,
+          }),
+        );
+      }
+      if (routeSourceRuntimes.length === 0) {
         continue;
       }
 
-      if (!runtimeEntries.includes(routeSourceRuntime)) {
+      if (
+        routeSourceRuntimes.some(
+          (routeSourceRuntime) => !runtimeEntries.includes(routeSourceRuntime),
+        )
+      ) {
         await invalidateRuntimeList(queryClient, runtimeKind, repoPath);
         if (isCancelled()) {
           return {
@@ -380,24 +388,30 @@ export const createRepoSessionHydrationService = ({
             skippedTaskErrors,
           };
         }
-        runtimeEntries.push(routeSourceRuntime);
+        for (const routeSourceRuntime of routeSourceRuntimes) {
+          if (!runtimeEntries.includes(routeSourceRuntime)) {
+            runtimeEntries.push(routeSourceRuntime);
+          }
+        }
       }
 
       for (const workingDirectory of missingDerivedDirectories) {
-        const { runtimeConnection } = resolveRuntimeRouteConnection(
-          routeSourceRuntime.runtimeRoute,
-          workingDirectory,
-        );
-        preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
-        const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
-        if (!runtimeConnections.has(scanKey)) {
-          runtimeConnections.set(scanKey, {
-            runtimeKind,
-            runtimeConnection,
-            directories: new Set<string>(),
-          });
+        for (const routeSourceRuntime of routeSourceRuntimes) {
+          const { runtimeConnection } = resolveRuntimeRouteConnection(
+            routeSourceRuntime.runtimeRoute,
+            workingDirectory,
+          );
+          preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
+          const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
+          if (!runtimeConnections.has(scanKey)) {
+            runtimeConnections.set(scanKey, {
+              runtimeKind,
+              runtimeConnection,
+              directories: new Set<string>(),
+            });
+          }
+          runtimeConnections.get(scanKey)?.directories.add(workingDirectory);
         }
-        runtimeConnections.get(scanKey)?.directories.add(workingDirectory);
       }
     }
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -21,10 +21,11 @@ import {
 } from "../support/session-runtime-metadata";
 import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 import {
+  findRuntimeConnectionPreloadCandidates,
   getLiveAgentSessionCacheKey,
   LiveAgentSessionCache,
   liveAgentSessionLookupKey,
-  runtimeWorkingDirectoryKey,
+  runtimeConnectionPreloadKey,
 } from "./live-agent-session-cache";
 import type { LiveAgentSessionStore } from "./live-agent-session-store";
 import type { SessionHydrationOperations } from "./session-hydration-operations";
@@ -311,7 +312,7 @@ export const createRepoSessionHydrationService = ({
           runtime.workingDirectory,
         );
         preloadedRuntimeConnectionsByKey.set(
-          runtimeWorkingDirectoryKey(runtimeKind, runtime.workingDirectory),
+          runtimeConnectionPreloadKey(runtimeKind, runtimeConnection),
           runtimeConnection,
         );
         if (!desiredDirectories.has(normalizeWorkingDirectory(runtime.workingDirectory))) {
@@ -381,7 +382,7 @@ export const createRepoSessionHydrationService = ({
           workingDirectory,
         );
         preloadedRuntimeConnectionsByKey.set(
-          runtimeWorkingDirectoryKey(runtimeKind, workingDirectory),
+          runtimeConnectionPreloadKey(runtimeKind, runtimeConnection),
           runtimeConnection,
         );
         const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
@@ -402,10 +403,13 @@ export const createRepoSessionHydrationService = ({
         continue;
       }
 
-      const hasResolvableHydrationRuntime = records.some((record) =>
-        preloadedRuntimeConnectionsByKey.has(
-          runtimeWorkingDirectoryKey(readPersistedRuntimeKind(record), record.workingDirectory),
-        ),
+      const hasResolvableHydrationRuntime = records.some(
+        (record) =>
+          findRuntimeConnectionPreloadCandidates(
+            preloadedRuntimeConnectionsByKey,
+            readPersistedRuntimeKind(record),
+            record.workingDirectory,
+          ).length > 0,
       );
       if (hasResolvableHydrationRuntime) {
         taskIdsToReconcile.add(taskId);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -372,6 +372,9 @@ export const createRepoSessionHydrationService = ({
         continue;
       }
 
+      // A repo-root runtime can be produced by the ensure call above when the
+      // runtime list did not already contain one. Keep both the query cache and
+      // this local list aligned before deriving worktree routes from it.
       if (
         routeSourceRuntimes.some(
           (routeSourceRuntime) => !runtimeEntries.includes(routeSourceRuntime),

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -22,11 +22,10 @@ import {
 } from "../support/session-runtime-metadata";
 import { canUseWorkspaceRuntimeForHydration } from "./hydration-runtime-policy";
 import {
-  findRuntimeConnectionPreloadCandidates,
   getLiveAgentSessionCacheKey,
   LiveAgentSessionCache,
   liveAgentSessionLookupKey,
-  runtimeConnectionPreloadKey,
+  RuntimeConnectionPreloadIndex,
 } from "./live-agent-session-cache";
 import type { LiveAgentSessionStore } from "./live-agent-session-store";
 import type { SessionHydrationOperations } from "./session-hydration-operations";
@@ -43,7 +42,7 @@ type ReconcilePreloadPlan = {
   persistedByTask: Array<{ taskId: string; records: AgentSessionRecord[] }>;
   taskIdsToReconcile: Set<string>;
   preloadedRuntimeLists: Map<RuntimeKind, RuntimeInstanceSummary[]>;
-  preloadedRuntimeConnectionsByKey: Map<string, AgentRuntimeConnection>;
+  preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedLiveAgentSessionsByKey: Map<string, LiveAgentSessionSnapshot[]>;
   skippedTaskErrors: Map<string, unknown>;
 };
@@ -271,7 +270,7 @@ export const createRepoSessionHydrationService = ({
 
     const runtimeConnections = new Map<string, RuntimeConnectionScan>();
     const preloadedRuntimeLists = new Map<RuntimeKind, RuntimeInstanceSummary[]>();
-    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>();
+    const preloadedRuntimeConnections = new RuntimeConnectionPreloadIndex();
     for (const runtimeKind of runtimeKinds) {
       const runtimes = await loadRuntimeListFromQuery(queryClient, runtimeKind, repoPath);
       if (isCancelled()) {
@@ -279,7 +278,7 @@ export const createRepoSessionHydrationService = ({
           persistedByTask,
           taskIdsToReconcile: new Set<string>(),
           preloadedRuntimeLists,
-          preloadedRuntimeConnectionsByKey,
+          preloadedRuntimeConnections,
           preloadedLiveAgentSessionsByKey: new Map<string, LiveAgentSessionSnapshot[]>(),
           skippedTaskErrors,
         };
@@ -305,7 +304,7 @@ export const createRepoSessionHydrationService = ({
             persistedByTask,
             taskIdsToReconcile: new Set<string>(),
             preloadedRuntimeLists,
-            preloadedRuntimeConnectionsByKey,
+            preloadedRuntimeConnections,
             preloadedLiveAgentSessionsByKey: new Map<string, LiveAgentSessionSnapshot[]>(),
             skippedTaskErrors,
           };
@@ -323,10 +322,7 @@ export const createRepoSessionHydrationService = ({
           runtime.runtimeRoute,
           runtime.workingDirectory,
         );
-        preloadedRuntimeConnectionsByKey.set(
-          runtimeConnectionPreloadKey(runtimeKind, runtimeConnection),
-          runtimeConnection,
-        );
+        preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
         if (!desiredDirectories.has(normalizeWorkingDirectory(runtime.workingDirectory))) {
           continue;
         }
@@ -379,7 +375,7 @@ export const createRepoSessionHydrationService = ({
             persistedByTask,
             taskIdsToReconcile: new Set<string>(),
             preloadedRuntimeLists,
-            preloadedRuntimeConnectionsByKey,
+            preloadedRuntimeConnections,
             preloadedLiveAgentSessionsByKey: new Map<string, LiveAgentSessionSnapshot[]>(),
             skippedTaskErrors,
           };
@@ -392,10 +388,7 @@ export const createRepoSessionHydrationService = ({
           routeSourceRuntime.runtimeRoute,
           workingDirectory,
         );
-        preloadedRuntimeConnectionsByKey.set(
-          runtimeConnectionPreloadKey(runtimeKind, runtimeConnection),
-          runtimeConnection,
-        );
+        preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
         const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
         if (!runtimeConnections.has(scanKey)) {
           runtimeConnections.set(scanKey, {
@@ -414,13 +407,11 @@ export const createRepoSessionHydrationService = ({
         continue;
       }
 
-      const hasResolvableHydrationRuntime = records.some(
-        (record) =>
-          findRuntimeConnectionPreloadCandidates(
-            preloadedRuntimeConnectionsByKey,
-            readPersistedRuntimeKind(record),
-            record.workingDirectory,
-          ).length > 0,
+      const hasResolvableHydrationRuntime = records.some((record) =>
+        preloadedRuntimeConnections.hasAny(
+          readPersistedRuntimeKind(record),
+          record.workingDirectory,
+        ),
       );
       if (hasResolvableHydrationRuntime) {
         taskIdsToReconcile.add(taskId);
@@ -441,7 +432,7 @@ export const createRepoSessionHydrationService = ({
           persistedByTask,
           taskIdsToReconcile: new Set<string>(),
           preloadedRuntimeLists,
-          preloadedRuntimeConnectionsByKey,
+          preloadedRuntimeConnections,
           preloadedLiveAgentSessionsByKey,
           skippedTaskErrors,
         };
@@ -478,7 +469,7 @@ export const createRepoSessionHydrationService = ({
       persistedByTask,
       taskIdsToReconcile,
       preloadedRuntimeLists,
-      preloadedRuntimeConnectionsByKey,
+      preloadedRuntimeConnections,
       preloadedLiveAgentSessionsByKey,
       skippedTaskErrors,
     };
@@ -615,7 +606,7 @@ export const createRepoSessionHydrationService = ({
               taskId,
               persistedRecords: records,
               preloadedRuntimeLists: plan.preloadedRuntimeLists,
-              preloadedRuntimeConnectionsByKey: plan.preloadedRuntimeConnectionsByKey,
+              preloadedRuntimeConnections: plan.preloadedRuntimeConnections,
               preloadedLiveAgentSessionsByKey: plan.preloadedLiveAgentSessionsByKey,
               allowRuntimeEnsure: false,
             });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -9,6 +9,7 @@ import type {
   AgentRuntimeConnection,
   LiveAgentSessionSnapshot,
 } from "@openducktor/core";
+import type { QueryClient } from "@tanstack/react-query";
 import { appQueryClient } from "@/lib/query-client";
 import { loadRuntimeListFromQuery, runtimeQueryKeys } from "@/state/queries/runtime";
 import { host } from "../../shared/host";
@@ -59,8 +60,12 @@ type ReconcilePreloadMetadata = {
 
 const nextSessionRetryDelayMs = (attempt: number): number => Math.min(5_000, 500 * 2 ** attempt);
 
-const invalidateRuntimeList = async (runtimeKind: RuntimeKind, repoPath: string): Promise<void> => {
-  await appQueryClient.invalidateQueries({
+const invalidateRuntimeList = async (
+  queryClient: QueryClient,
+  runtimeKind: RuntimeKind,
+  repoPath: string,
+): Promise<void> => {
+  await queryClient.invalidateQueries({
     queryKey: runtimeQueryKeys.list(runtimeKind, repoPath),
     exact: true,
     refetchType: "none",
@@ -190,6 +195,9 @@ export const createRepoSessionHydrationService = ({
   sessionHydration,
   liveAgentSessionStore,
   onRetryRequested,
+  queryClient = appQueryClient,
+  runtimeEnsure = (nextRepoPath, nextRuntimeKind) =>
+    host.runtimeEnsure(nextRepoPath, nextRuntimeKind),
 }: {
   agentEngine: Pick<AgentEnginePort, "listLiveAgentSessionSnapshots">;
   sessionHydration: Pick<
@@ -198,6 +206,11 @@ export const createRepoSessionHydrationService = ({
   >;
   liveAgentSessionStore: LiveAgentSessionStore;
   onRetryRequested: () => void;
+  queryClient?: QueryClient;
+  runtimeEnsure?: (
+    nextRepoPath: string,
+    nextRuntimeKind: RuntimeKind,
+  ) => Promise<RuntimeInstanceSummary>;
 }) => {
   const bootstrappedTasksByRepo: Record<string, Set<string>> = {};
   const reconciledTasksByRepo: Record<string, Set<string>> = {};
@@ -260,7 +273,7 @@ export const createRepoSessionHydrationService = ({
     const preloadedRuntimeLists = new Map<RuntimeKind, RuntimeInstanceSummary[]>();
     const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>();
     for (const runtimeKind of runtimeKinds) {
-      const runtimes = await loadRuntimeListFromQuery(appQueryClient, runtimeKind, repoPath);
+      const runtimes = await loadRuntimeListFromQuery(queryClient, runtimeKind, repoPath);
       if (isCancelled()) {
         return {
           persistedByTask,
@@ -284,10 +297,9 @@ export const createRepoSessionHydrationService = ({
         const ensuredRuntime = await ensureRuntimeAndInvalidateReadinessQueries({
           repoPath,
           runtimeKind,
-          ensureRuntime: (nextRepoPath, nextRuntimeKind) =>
-            host.runtimeEnsure(nextRepoPath, nextRuntimeKind),
+          ensureRuntime: runtimeEnsure,
         });
-        await invalidateRuntimeList(runtimeKind, repoPath);
+        await invalidateRuntimeList(queryClient, runtimeKind, repoPath);
         if (isCancelled()) {
           return {
             persistedByTask,
@@ -353,8 +365,7 @@ export const createRepoSessionHydrationService = ({
           ? await ensureRuntimeAndInvalidateReadinessQueries({
               repoPath,
               runtimeKind,
-              ensureRuntime: (nextRepoPath, nextRuntimeKind) =>
-                host.runtimeEnsure(nextRepoPath, nextRuntimeKind),
+              ensureRuntime: runtimeEnsure,
             })
           : null);
       if (!routeSourceRuntime) {
@@ -362,7 +373,7 @@ export const createRepoSessionHydrationService = ({
       }
 
       if (!runtimeEntries.includes(routeSourceRuntime)) {
-        await invalidateRuntimeList(runtimeKind, repoPath);
+        await invalidateRuntimeList(queryClient, runtimeKind, repoPath);
         if (isCancelled()) {
           return {
             persistedByTask,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-hydration-operations.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-hydration-operations.ts
@@ -3,11 +3,12 @@ import type {
   RuntimeInstanceSummary,
   RuntimeKind,
 } from "@openducktor/contracts";
-import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
+import type { LiveAgentSessionSnapshot } from "@openducktor/core";
 import type {
   AgentSessionHistoryPreludeMode,
   AgentSessionLoadOptions,
   AgentSessionState,
+  RuntimeConnectionPreloadIndex,
 } from "@/types/agent-orchestrator";
 import {
   getAgentSessionHistoryHydrationState,
@@ -46,7 +47,7 @@ export type SessionHydrationOperations = {
     taskId: string;
     persistedRecords?: AgentSessionRecord[];
     preloadedRuntimeLists?: Map<RuntimeKind, RuntimeInstanceSummary[]>;
-    preloadedRuntimeConnectionsByKey?: Map<string, AgentRuntimeConnection>;
+    preloadedRuntimeConnections?: RuntimeConnectionPreloadIndex;
     preloadedLiveAgentSessionsByKey?: Map<string, LiveAgentSessionSnapshot[]>;
     allowRuntimeEnsure?: boolean;
   }) => Promise<void>;
@@ -166,7 +167,7 @@ export const createSessionHydrationOperations = ({
       taskId,
       persistedRecords,
       preloadedRuntimeLists,
-      preloadedRuntimeConnectionsByKey,
+      preloadedRuntimeConnections,
       preloadedLiveAgentSessionsByKey,
       allowRuntimeEnsure,
     }) =>
@@ -177,7 +178,7 @@ export const createSessionHydrationOperations = ({
             mode: "reconcile_live",
             historyPolicy: "none",
             ...(preloadedRuntimeLists ? { preloadedRuntimeLists } : {}),
-            ...(preloadedRuntimeConnectionsByKey ? { preloadedRuntimeConnectionsByKey } : {}),
+            ...(preloadedRuntimeConnections ? { preloadedRuntimeConnections } : {}),
             ...(preloadedLiveAgentSessionsByKey ? { preloadedLiveAgentSessionsByKey } : {}),
             ...(allowRuntimeEnsure !== undefined ? { allowRuntimeEnsure } : {}),
           },

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-loaders.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-loaders.test.ts
@@ -202,7 +202,9 @@ describe("agent-orchestrator/lifecycle/session-loaders", () => {
   });
 
   test("accepts stdio model catalog connections without forcing an endpoint", async () => {
-    const harness = createStateHarness(createSession({ runtimeRoute: { type: "stdio" } }));
+    const harness = createStateHarness(
+      createSession({ runtimeRoute: { type: "stdio", identity: "runtime-stdio" } }),
+    );
     let receivedConnection: unknown = null;
     const loadSessionModelCatalog = createLoadSessionModelCatalog({
       adapter: {
@@ -217,11 +219,13 @@ describe("agent-orchestrator/lifecycle/session-loaders", () => {
 
     await loadSessionModelCatalog("session-1", "opencode", {
       type: "stdio",
+      identity: " runtime-stdio ",
       workingDirectory: "/tmp/repo",
     });
 
     expect(receivedConnection).toEqual({
       type: "stdio",
+      identity: "runtime-stdio",
       workingDirectory: "/tmp/repo",
     });
     expect(harness.getState()["session-1"]?.modelCatalog).toEqual(catalogFixture);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts
@@ -6,7 +6,7 @@ import type {
   AgentSessionTodoItem,
 } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { runtimeConnectionTransportKey } from "../runtime/runtime";
+import { normalizeStdioRuntimeIdentity, runtimeConnectionTransportKey } from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
 import {
   coerceSessionSelectionToCatalog,
@@ -35,15 +35,6 @@ const validateLocalHttpRuntimeEndpoint = (runtimeEndpoint: string): string => {
   }
 
   return trimmedEndpoint;
-};
-
-const validateStdioRuntimeIdentity = (identity: string): string => {
-  const trimmedIdentity = identity.trim();
-  if (trimmedIdentity.length === 0) {
-    throw new Error("Session runtime stdio identity is required.");
-  }
-
-  return trimmedIdentity;
 };
 
 const validateWorkingDirectory = (workingDirectory: string): string => {
@@ -85,7 +76,10 @@ const validateRuntimeConnection = (
     case "stdio":
       return {
         type: "stdio",
-        identity: validateStdioRuntimeIdentity(runtimeConnection.identity),
+        identity: normalizeStdioRuntimeIdentity(
+          runtimeConnection.identity,
+          "Session runtime stdio identity",
+        ),
         workingDirectory,
       };
   }

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts
@@ -37,6 +37,15 @@ const validateLocalHttpRuntimeEndpoint = (runtimeEndpoint: string): string => {
   return trimmedEndpoint;
 };
 
+const validateStdioRuntimeIdentity = (identity: string): string => {
+  const trimmedIdentity = identity.trim();
+  if (trimmedIdentity.length === 0) {
+    throw new Error("Session runtime stdio identity is required.");
+  }
+
+  return trimmedIdentity;
+};
+
 const validateWorkingDirectory = (workingDirectory: string): string => {
   const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
   if (normalizedWorkingDirectory.length === 0) {
@@ -76,6 +85,7 @@ const validateRuntimeConnection = (
     case "stdio":
       return {
         type: "stdio",
+        identity: validateStdioRuntimeIdentity(runtimeConnection.identity),
         workingDirectory,
       };
   }

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -111,6 +111,22 @@ describe("agent-orchestrator-runtime", () => {
         workingDirectory: "/tmp/repo/worktree",
       },
     });
+
+    expect(
+      resolveRuntimeRouteConnection(
+        {
+          type: "stdio",
+          identity: "runtime-stdio",
+        },
+        "/tmp/repo/worktree",
+      ),
+    ).toEqual({
+      runtimeConnection: {
+        type: "stdio",
+        identity: "runtime-stdio",
+        workingDirectory: "/tmp/repo/worktree",
+      },
+    });
   });
 
   test("starts build bootstrap and refreshes task data when no target worktree is provided", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -12,9 +12,14 @@ import { clearAppQueryClient } from "@/lib/query-client";
 import { createDeferred, withTimeout } from "../test-utils";
 import {
   createEnsureRuntime,
+  describeRuntimeRoute,
   loadRepoDefaultModel,
   loadRepoPromptOverrides,
   resolveRuntimeRouteConnection,
+  runtimeConnectionToRoute,
+  runtimeConnectionTransportKey,
+  runtimeRouteToConnection,
+  runtimeRouteTransportKey,
 } from "./runtime";
 
 const buildBootstrapFixture: BuildSessionBootstrap = {
@@ -127,6 +132,73 @@ describe("agent-orchestrator-runtime", () => {
         workingDirectory: "/tmp/repo/worktree",
       },
     });
+  });
+
+  test("preserves and normalizes stdio identity across route and connection helpers", () => {
+    expect(
+      runtimeConnectionToRoute({
+        type: "stdio",
+        identity: " runtime-stdio ",
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+    ).toEqual({ type: "stdio", identity: "runtime-stdio" });
+    expect(
+      runtimeRouteToConnection(
+        {
+          type: "stdio",
+          identity: " runtime-stdio ",
+        },
+        "/tmp/repo/worktree",
+      ),
+    ).toEqual({
+      type: "stdio",
+      identity: "runtime-stdio",
+      workingDirectory: "/tmp/repo/worktree",
+    });
+    expect(
+      runtimeConnectionTransportKey({
+        type: "stdio",
+        identity: "runtime-stdio-a",
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+    ).toBe("stdio:runtime-stdio-a");
+    expect(runtimeRouteTransportKey({ type: "stdio", identity: "runtime-stdio-b" })).toBe(
+      "stdio:runtime-stdio-b",
+    );
+    expect(describeRuntimeRoute({ type: "stdio", identity: " runtime-stdio " })).toBe(
+      "stdio:runtime-stdio",
+    );
+  });
+
+  test("rejects missing or blank stdio identity before building route descriptions or keys", () => {
+    const blankRoute = { type: "stdio", identity: " " } as const;
+    const missingRoute = { type: "stdio" } as unknown as Parameters<
+      typeof runtimeRouteTransportKey
+    >[0];
+    const blankConnection = {
+      type: "stdio",
+      identity: "",
+      workingDirectory: "/tmp/repo/worktree",
+    } as const;
+
+    expect(() => runtimeRouteTransportKey(blankRoute)).toThrow(
+      "Runtime route stdio identity is required.",
+    );
+    expect(() => runtimeRouteTransportKey(missingRoute)).toThrow(
+      "Runtime route stdio identity is required.",
+    );
+    expect(() => describeRuntimeRoute(blankRoute)).toThrow(
+      "Runtime route stdio identity is required.",
+    );
+    expect(() => runtimeConnectionTransportKey(blankConnection)).toThrow(
+      "Runtime connection stdio identity is required.",
+    );
+    expect(() => runtimeConnectionToRoute(blankConnection)).toThrow(
+      "Runtime connection stdio identity is required.",
+    );
+    expect(() => runtimeRouteToConnection(blankRoute, "/tmp/repo/worktree")).toThrow(
+      "Runtime route stdio identity is required.",
+    );
   });
 
   test("starts build bootstrap and refreshes task data when no target worktree is provided", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -32,6 +32,18 @@ export type RuntimeInfo = {
   workingDirectory: string;
 };
 
+export const normalizeStdioRuntimeIdentity = (
+  identity: string | null | undefined,
+  context = "Runtime stdio identity",
+): string => {
+  const trimmedIdentity = typeof identity === "string" ? identity.trim() : "";
+  if (trimmedIdentity.length === 0) {
+    throw new Error(`${context} is required.`);
+  }
+
+  return trimmedIdentity;
+};
+
 export const runtimeConnectionToRoute = (
   runtimeConnection: AgentRuntimeConnection,
 ): RuntimeRoute => {
@@ -44,7 +56,10 @@ export const runtimeConnectionToRoute = (
     case "stdio":
       return {
         type: "stdio",
-        identity: runtimeConnection.identity,
+        identity: normalizeStdioRuntimeIdentity(
+          runtimeConnection.identity,
+          "Runtime connection stdio identity",
+        ),
       };
   }
 };
@@ -63,7 +78,10 @@ export const runtimeRouteToConnection = (
     case "stdio":
       return {
         type: "stdio",
-        identity: runtimeRoute.identity,
+        identity: normalizeStdioRuntimeIdentity(
+          runtimeRoute.identity,
+          "Runtime route stdio identity",
+        ),
         workingDirectory,
       };
   }
@@ -87,7 +105,10 @@ export const runtimeRouteTransportKey = (runtimeRoute: RuntimeRoute | null | und
     case "local_http":
       return `local_http:${runtimeRoute.endpoint.trim()}`;
     case "stdio":
-      return `stdio:${runtimeRoute.identity.trim()}`;
+      return `stdio:${normalizeStdioRuntimeIdentity(
+        runtimeRoute.identity,
+        "Runtime route stdio identity",
+      )}`;
   }
 };
 
@@ -98,7 +119,10 @@ export const runtimeConnectionTransportKey = (
     case "local_http":
       return `local_http:${runtimeConnection.endpoint.trim()}`;
     case "stdio":
-      return `stdio:${runtimeConnection.identity.trim()}`;
+      return `stdio:${normalizeStdioRuntimeIdentity(
+        runtimeConnection.identity,
+        "Runtime connection stdio identity",
+      )}`;
   }
 };
 
@@ -137,7 +161,10 @@ export const describeRuntimeRoute = (runtimeRoute: RuntimeRoute | null | undefin
     case "local_http":
       return runtimeRoute.endpoint;
     case "stdio":
-      return `stdio:${runtimeRoute.identity.trim()}`;
+      return `stdio:${normalizeStdioRuntimeIdentity(
+        runtimeRoute.identity,
+        "Runtime route stdio identity",
+      )}`;
   }
 };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -44,6 +44,7 @@ export const runtimeConnectionToRoute = (
     case "stdio":
       return {
         type: "stdio",
+        identity: runtimeConnection.identity,
       };
   }
 };
@@ -62,6 +63,7 @@ export const runtimeRouteToConnection = (
     case "stdio":
       return {
         type: "stdio",
+        identity: runtimeRoute.identity,
         workingDirectory,
       };
   }
@@ -85,7 +87,7 @@ export const runtimeRouteTransportKey = (runtimeRoute: RuntimeRoute | null | und
     case "local_http":
       return `local_http:${runtimeRoute.endpoint.trim()}`;
     case "stdio":
-      return "stdio";
+      return `stdio:${runtimeRoute.identity.trim()}`;
   }
 };
 
@@ -96,7 +98,7 @@ export const runtimeConnectionTransportKey = (
     case "local_http":
       return `local_http:${runtimeConnection.endpoint.trim()}`;
     case "stdio":
-      return "stdio";
+      return `stdio:${runtimeConnection.identity.trim()}`;
   }
 };
 
@@ -135,7 +137,7 @@ export const describeRuntimeRoute = (runtimeRoute: RuntimeRoute | null | undefin
     case "local_http":
       return runtimeRoute.endpoint;
     case "stdio":
-      return "stdio";
+      return `stdio:${runtimeRoute.identity.trim()}`;
   }
 };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/test-utils.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/test-utils.ts
@@ -42,9 +42,10 @@ export const createLocalHttpRuntimeConnection = ({
 
 export const createStdioRuntimeConnection = (
   workingDirectory = "/tmp/runtime-root",
+  { identity = "runtime-stdio" }: { identity?: string } = {},
 ): AgentRuntimeConnection => ({
   type: "stdio",
-  identity: "runtime-stdio",
+  identity,
   workingDirectory,
 });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/test-utils.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/test-utils.ts
@@ -44,6 +44,7 @@ export const createStdioRuntimeConnection = (
   workingDirectory = "/tmp/runtime-root",
 ): AgentRuntimeConnection => ({
   type: "stdio",
+  identity: "runtime-stdio",
   workingDirectory,
 });
 

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -27,7 +27,7 @@ import { useTaskOperations } from "./use-task-operations";
 type LegacyRunSummary = {
   runId: string;
   runtimeKind: string;
-  runtimeRoute: { type: "local_http"; endpoint: string } | { type: "stdio" };
+  runtimeRoute: { type: "local_http"; endpoint: string } | { type: "stdio"; identity: string };
   repoPath: string;
   taskId: string;
   branch: string;

--- a/packages/frontend/src/types/agent-orchestrator.ts
+++ b/packages/frontend/src/types/agent-orchestrator.ts
@@ -10,6 +10,9 @@ import type {
   AgentUserMessageDisplayPart,
   AgentUserMessageState,
 } from "@openducktor/core";
+import type { RuntimeConnectionPreloadIndex } from "@/state/operations/agent-orchestrator/lifecycle/live-agent-session-cache";
+
+export type { RuntimeConnectionPreloadIndex };
 
 export type AgentChatMessageMeta =
   | {
@@ -203,10 +206,7 @@ export type AgentSessionLoadOptions = {
     import("@openducktor/contracts").RuntimeKind,
     import("@openducktor/contracts").RuntimeInstanceSummary[]
   >;
-  preloadedRuntimeConnectionsByKey?: Map<
-    string,
-    import("@openducktor/core").AgentRuntimeConnection
-  >;
+  preloadedRuntimeConnections?: RuntimeConnectionPreloadIndex;
   preloadedLiveAgentSessionsByKey?: Map<
     string,
     import("@openducktor/core").LiveAgentSessionSnapshot[]

--- a/packages/frontend/src/types/state-slices.ts
+++ b/packages/frontend/src/types/state-slices.ts
@@ -28,7 +28,11 @@ import type {
   AgentUserMessagePart,
 } from "@openducktor/core";
 import type { SessionRepoReadinessState } from "@/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle";
-import type { AgentSessionLoadOptions, AgentSessionState } from "./agent-orchestrator";
+import type {
+  AgentSessionLoadOptions,
+  AgentSessionState,
+  RuntimeConnectionPreloadIndex,
+} from "./agent-orchestrator";
 import type { RepoRuntimeFailureKind, RepoRuntimeHealthMap } from "./diagnostics";
 
 export type WorkspaceSelectionOperationsInput = {
@@ -188,10 +192,7 @@ export type AgentStateContextValue = {
       import("@openducktor/contracts").RuntimeKind,
       import("@openducktor/contracts").RuntimeInstanceSummary[]
     >;
-    preloadedRuntimeConnectionsByKey?: Map<
-      string,
-      import("@openducktor/core").AgentRuntimeConnection
-    >;
+    preloadedRuntimeConnections?: RuntimeConnectionPreloadIndex;
     preloadedLiveAgentSessionsByKey?: Map<
       string,
       import("@openducktor/core").LiveAgentSessionSnapshot[]


### PR DESCRIPTION
## Summary
- Add a required stable `identity` to stdio runtime routes and runtime connections so distinct stdio runtimes no longer collapse into the same cache/transport key.
- Propagate stdio identity through Rust host-domain routes, TS contracts, frontend runtime conversion, live-session preload indexes, hydration, and reconciliation.
- Add regression coverage for same-kind/same-working-directory stdio runtimes, including snapshot-based disambiguation during session hydration.

## Goal
Stdio runtime routes previously looked identical (`{ type: "stdio" }`) regardless of which runtime process they represented. That made caches, hydration, live-session scans, and reconciliation vulnerable to collisions when multiple stdio runtimes of the same kind were active for the same repo or worktree.

This PR makes stdio identity explicit and stable while keeping live runtime routing out of durable task/session persistence.

## Technical choices
- Use an opaque required `identity` field for stdio `RuntimeRoute` and `RuntimeTransport`/`AgentRuntimeConnection`, trimming and rejecting missing or blank values.
- Keep `local_http` behavior endpoint-based and unchanged.
- Use host-managed runtime IDs as the stdio route identity for host-managed runtime publication.
- Hide preload key formatting behind `RuntimeConnectionPreloadIndex` so same-kind stdio runtimes with the same working directory remain distinct without exposing raw key construction.
- During hydration/reconciliation, use preloaded live snapshots plus the persisted external session ID to disambiguate multiple matching stdio runtimes rather than selecting by working directory alone.
- Preserve the no-live-route-persistence rule: identity is used in live runtime route/connection objects and in-memory lookup keys, not written into durable Beads/session documents.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check`
- `cargo test`
- `cargo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved disambiguation of multiple stdio runtimes operating in the same workspace directory by adding unique identity tracking.
  * Enhanced runtime connection validation to detect and reject invalid or malformed stdio configuration earlier.

* **Refactor**
  * Strengthened internal validation of stdio runtime identities with consistent normalization and trimming across serialization boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->