### PR TITLE
feat(settings): add empty kanban column display modes

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -542,6 +542,7 @@ impl AppService {
         config.chat = snapshot.chat;
         config.kanban = KanbanSettings {
             done_visible_days: snapshot.kanban.done_visible_days.max(0),
+            empty_column_display: snapshot.kanban.empty_column_display,
         };
         config.autopilot = snapshot.autopilot;
         config.global_prompt_overrides = snapshot.global_prompt_overrides;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -222,7 +222,8 @@ mod tests {
     use anyhow::{anyhow, Result};
     use host_domain::TaskStore;
     use host_infra_system::{
-        AppConfigStore, AutopilotSettings, GitCliPort, HookSet, PromptOverride, RepoDevServerScript,
+        AppConfigStore, AutopilotSettings, GitCliPort, HookSet, KanbanEmptyColumnDisplay,
+        PromptOverride, RepoDevServerScript,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -491,6 +492,43 @@ mod tests {
             fixture.service.workspace_get_settings_snapshot()?;
         assert!(persisted_chat.show_thinking_messages);
         assert_eq!(persisted_autopilot, AutopilotSettings::default());
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_save_settings_snapshot_preserves_kanban_empty_column_display() -> Result<()> {
+        let fixture = setup_fixture("snapshot-kanban-empty-display", HookSet::default());
+
+        let (theme, git, chat, mut kanban, autopilot, workspaces, global_prompt_overrides) =
+            fixture.service.workspace_get_settings_snapshot()?;
+        kanban.empty_column_display = KanbanEmptyColumnDisplay::Collapsed;
+
+        fixture
+            .service
+            .workspace_save_settings_snapshot(WorkspaceSettingsSnapshotUpdate {
+                theme,
+                git,
+                chat,
+                kanban,
+                autopilot,
+                workspaces,
+                global_prompt_overrides,
+            })?;
+
+        let (
+            _persisted_theme,
+            _persisted_git,
+            _persisted_chat,
+            persisted_kanban,
+            _persisted_autopilot,
+            _persisted_repos,
+            _persisted_global_prompt_overrides,
+        ) = fixture.service.workspace_get_settings_snapshot()?;
+
+        assert_eq!(
+            persisted_kanban.empty_column_display,
+            KanbanEmptyColumnDisplay::Collapsed
+        );
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -13,9 +13,10 @@ pub use normalize::{normalize_hook_set, normalize_repo_dev_servers};
 pub use persistence::resolve_openducktor_base_dir;
 pub use store::{AppConfigStore, RuntimeConfigStore};
 pub use types::{
-    AgentDefaults, AgentModelDefault, AutopilotActionId, AutopilotEventId, AutopilotRule,
-    AutopilotSettings, ChatSettings, GitMergeMethod, GitProviderConfig, GitProviderRepository,
-    GitTargetBranch, GlobalConfig, GlobalGitConfig, HookSet, KanbanSettings,
+    hook_set_fingerprint, repo_script_fingerprint, AgentDefaults, AgentModelDefault,
+    AutopilotActionId, AutopilotEventId, AutopilotRule, AutopilotSettings, ChatSettings,
+    GitMergeMethod, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
+    GlobalGitConfig, HookSet, KanbanEmptyColumnDisplay, KanbanSettings,
     OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig,
     RepoDevServerScript, RepoGitConfig, RuntimeConfig, SchedulerConfig, SoftGuardrails,
 };

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -13,11 +13,10 @@ pub use normalize::{normalize_hook_set, normalize_repo_dev_servers};
 pub use persistence::resolve_openducktor_base_dir;
 pub use store::{AppConfigStore, RuntimeConfigStore};
 pub use types::{
-    hook_set_fingerprint, repo_script_fingerprint, AgentDefaults, AgentModelDefault,
-    AutopilotActionId, AutopilotEventId, AutopilotRule, AutopilotSettings, ChatSettings,
-    GitMergeMethod, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
-    GlobalGitConfig, HookSet, KanbanEmptyColumnDisplay, KanbanSettings,
-    OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig,
+    AgentDefaults, AgentModelDefault, AutopilotActionId, AutopilotEventId, AutopilotRule,
+    AutopilotSettings, ChatSettings, GitMergeMethod, GitProviderConfig, GitProviderRepository,
+    GitTargetBranch, GlobalConfig, GlobalGitConfig, HookSet, KanbanEmptyColumnDisplay,
+    KanbanSettings, OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig,
     RepoDevServerScript, RepoGitConfig, RuntimeConfig, SchedulerConfig, SoftGuardrails,
 };
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -164,6 +164,17 @@ pub struct ChatSettings {
 pub struct KanbanSettings {
     #[serde(default = "default_done_visible_days")]
     pub done_visible_days: i32,
+    #[serde(default)]
+    pub empty_column_display: KanbanEmptyColumnDisplay,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum KanbanEmptyColumnDisplay {
+    #[default]
+    Show,
+    Hidden,
+    Collapsed,
 }
 
 const fn default_done_visible_days() -> i32 {
@@ -174,6 +185,7 @@ impl Default for KanbanSettings {
     fn default() -> Self {
         Self {
             done_visible_days: default_done_visible_days(),
+            empty_column_display: KanbanEmptyColumnDisplay::Show,
         }
     }
 }
@@ -598,11 +610,161 @@ impl RuntimeConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::RepoConfig;
+    use super::{
+        deserialize_global_config, hook_set_fingerprint, repo_script_fingerprint, GlobalConfig,
+        HookSet, KanbanEmptyColumnDisplay, KanbanSettings, RepoConfig, RepoDevServerScript,
+    };
+
+    #[test]
+    fn hook_set_fingerprint_changes_with_command_boundaries() {
+        let grouped = HookSet {
+            pre_start: vec!["echo a".to_string(), "echo b".to_string()],
+            post_complete: Vec::new(),
+        };
+        let embedded_newline = HookSet {
+            pre_start: vec!["echo a\necho b".to_string()],
+            post_complete: Vec::new(),
+        };
+
+        assert_ne!(
+            hook_set_fingerprint(&grouped),
+            hook_set_fingerprint(&embedded_newline),
+            "fingerprint must be sensitive to command boundaries"
+        );
+    }
+
+    #[test]
+    fn hook_set_fingerprint_changes_with_group_assignment() {
+        let pre_start = HookSet {
+            pre_start: vec!["echo test".to_string()],
+            post_complete: Vec::new(),
+        };
+        let post_complete = HookSet {
+            pre_start: Vec::new(),
+            post_complete: vec!["echo test".to_string()],
+        };
+
+        assert_ne!(
+            hook_set_fingerprint(&pre_start),
+            hook_set_fingerprint(&post_complete),
+            "fingerprint must include the target hook group"
+        );
+    }
 
     #[test]
     fn repo_config_default_target_branch_is_origin_main() {
         let config = RepoConfig::default();
         assert_eq!(config.default_target_branch.canonical(), "origin/main");
+    }
+
+    #[test]
+    fn kanban_settings_defaults_empty_column_display_to_show() {
+        let settings = KanbanSettings::default();
+
+        assert_eq!(settings.done_visible_days, 1);
+        assert_eq!(
+            settings.empty_column_display,
+            KanbanEmptyColumnDisplay::Show
+        );
+    }
+
+    #[test]
+    fn deserialize_global_config_defaults_missing_kanban_empty_column_display() {
+        let config = deserialize_global_config(
+            r#"{
+                "version": 2,
+                "theme": "light",
+                "kanban": { "doneVisibleDays": 4 }
+            }"#,
+        )
+        .expect("config should deserialize");
+
+        assert_eq!(config.kanban.done_visible_days, 4);
+        assert_eq!(
+            config.kanban.empty_column_display,
+            KanbanEmptyColumnDisplay::Show
+        );
+    }
+
+    #[test]
+    fn kanban_empty_column_display_serializes_roundtrip() {
+        let config = GlobalConfig {
+            kanban: KanbanSettings {
+                done_visible_days: 2,
+                empty_column_display: KanbanEmptyColumnDisplay::Collapsed,
+            },
+            ..GlobalConfig::default()
+        };
+
+        let serialized = serde_json::to_string(&config).expect("config should serialize");
+        let deserialized =
+            deserialize_global_config(&serialized).expect("config should deserialize");
+
+        assert_eq!(
+            deserialized.kanban.empty_column_display,
+            KanbanEmptyColumnDisplay::Collapsed
+        );
+    }
+
+    #[test]
+    fn deserialize_global_config_rejects_invalid_kanban_empty_column_display() {
+        let error = deserialize_global_config(
+            r#"{
+                "version": 2,
+                "theme": "light",
+                "kanban": {
+                    "doneVisibleDays": 1,
+                    "emptyColumnDisplay": "compact"
+                }
+            }"#,
+        )
+        .expect_err("invalid empty-column display should fail");
+
+        assert!(
+            error.contains("compact"),
+            "error should identify the invalid value: {error}"
+        );
+    }
+
+    #[test]
+    fn repo_script_fingerprint_ignores_dev_server_names_but_tracks_commands() {
+        let hooks = HookSet::default();
+        let renamed = vec![RepoDevServerScript {
+            id: "frontend".to_string(),
+            name: "Frontend".to_string(),
+            command: "bun run dev".to_string(),
+        }];
+        let same_command_new_name = vec![RepoDevServerScript {
+            id: "frontend".to_string(),
+            name: "Web".to_string(),
+            command: "bun run dev".to_string(),
+        }];
+        let changed_command = vec![RepoDevServerScript {
+            id: "frontend".to_string(),
+            name: "Frontend".to_string(),
+            command: "bun run start".to_string(),
+        }];
+
+        assert_eq!(
+            repo_script_fingerprint(&hooks, &renamed),
+            repo_script_fingerprint(&hooks, &same_command_new_name)
+        );
+        assert_ne!(
+            repo_script_fingerprint(&hooks, &renamed),
+            repo_script_fingerprint(&hooks, &changed_command)
+        );
+    }
+
+    #[test]
+    fn repo_script_fingerprint_matches_legacy_hook_fingerprint_without_dev_servers() {
+        let hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: vec!["echo post".to_string()],
+        };
+
+        assert_eq!(
+            hook_set_fingerprint(&hooks),
+            repo_script_fingerprint(&hooks, &[])
+        );
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -611,45 +611,9 @@ impl RuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::{
-        deserialize_global_config, hook_set_fingerprint, repo_script_fingerprint, GlobalConfig,
-        HookSet, KanbanEmptyColumnDisplay, KanbanSettings, RepoConfig, RepoDevServerScript,
+        deserialize_global_config, GlobalConfig, KanbanEmptyColumnDisplay, KanbanSettings,
+        RepoConfig,
     };
-
-    #[test]
-    fn hook_set_fingerprint_changes_with_command_boundaries() {
-        let grouped = HookSet {
-            pre_start: vec!["echo a".to_string(), "echo b".to_string()],
-            post_complete: Vec::new(),
-        };
-        let embedded_newline = HookSet {
-            pre_start: vec!["echo a\necho b".to_string()],
-            post_complete: Vec::new(),
-        };
-
-        assert_ne!(
-            hook_set_fingerprint(&grouped),
-            hook_set_fingerprint(&embedded_newline),
-            "fingerprint must be sensitive to command boundaries"
-        );
-    }
-
-    #[test]
-    fn hook_set_fingerprint_changes_with_group_assignment() {
-        let pre_start = HookSet {
-            pre_start: vec!["echo test".to_string()],
-            post_complete: Vec::new(),
-        };
-        let post_complete = HookSet {
-            pre_start: Vec::new(),
-            post_complete: vec!["echo test".to_string()],
-        };
-
-        assert_ne!(
-            hook_set_fingerprint(&pre_start),
-            hook_set_fingerprint(&post_complete),
-            "fingerprint must include the target hook group"
-        );
-    }
 
     #[test]
     fn repo_config_default_target_branch_is_origin_main() {
@@ -723,48 +687,6 @@ mod tests {
         assert!(
             error.contains("compact"),
             "error should identify the invalid value: {error}"
-        );
-    }
-
-    #[test]
-    fn repo_script_fingerprint_ignores_dev_server_names_but_tracks_commands() {
-        let hooks = HookSet::default();
-        let renamed = vec![RepoDevServerScript {
-            id: "frontend".to_string(),
-            name: "Frontend".to_string(),
-            command: "bun run dev".to_string(),
-        }];
-        let same_command_new_name = vec![RepoDevServerScript {
-            id: "frontend".to_string(),
-            name: "Web".to_string(),
-            command: "bun run dev".to_string(),
-        }];
-        let changed_command = vec![RepoDevServerScript {
-            id: "frontend".to_string(),
-            name: "Frontend".to_string(),
-            command: "bun run start".to_string(),
-        }];
-
-        assert_eq!(
-            repo_script_fingerprint(&hooks, &renamed),
-            repo_script_fingerprint(&hooks, &same_command_new_name)
-        );
-        assert_ne!(
-            repo_script_fingerprint(&hooks, &renamed),
-            repo_script_fingerprint(&hooks, &changed_command)
-        );
-    }
-
-    #[test]
-    fn repo_script_fingerprint_matches_legacy_hook_fingerprint_without_dev_servers() {
-        let hooks = HookSet {
-            pre_start: vec!["echo pre".to_string()],
-            post_complete: vec!["echo post".to_string()],
-        };
-
-        assert_eq!(
-            hook_set_fingerprint(&hooks),
-            repo_script_fingerprint(&hooks, &[])
         );
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -22,12 +22,13 @@ pub use beads::{
     SHARED_DOLT_SERVER_HOST, SHARED_DOLT_SERVER_USER,
 };
 pub use config::{
-    derive_workspace_name_from_repo_path, normalize_hook_set, normalize_repo_dev_servers,
-    propose_workspace_id, uniquify_workspace_id, AgentDefaults, AgentModelDefault, AppConfigStore,
-    AutopilotActionId, AutopilotEventId, AutopilotRule, AutopilotSettings, ChatSettings,
-    GitMergeMethod, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
-    GlobalGitConfig, HookSet, KanbanSettings, OpencodeStartupReadinessConfig, PromptOverride,
-    PromptOverrides, RepoConfig, RepoDevServerScript, RepoGitConfig, RuntimeConfig,
+    derive_workspace_name_from_repo_path, hook_set_fingerprint, normalize_hook_set,
+    normalize_repo_dev_servers, propose_workspace_id, repo_script_fingerprint,
+    uniquify_workspace_id, AgentDefaults, AgentModelDefault, AppConfigStore, AutopilotActionId,
+    AutopilotEventId, AutopilotRule, AutopilotSettings, ChatSettings, GitMergeMethod,
+    GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig, GlobalGitConfig,
+    HookSet, KanbanEmptyColumnDisplay, KanbanSettings, OpencodeStartupReadinessConfig,
+    PromptOverride, PromptOverrides, RepoConfig, RepoDevServerScript, RepoGitConfig, RuntimeConfig,
     RuntimeConfigStore, SchedulerConfig, SoftGuardrails,
 };
 pub use filesystem::{list_directory, FilesystemListDirectoryError};

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -22,14 +22,14 @@ pub use beads::{
     SHARED_DOLT_SERVER_HOST, SHARED_DOLT_SERVER_USER,
 };
 pub use config::{
-    derive_workspace_name_from_repo_path, hook_set_fingerprint, normalize_hook_set,
-    normalize_repo_dev_servers, propose_workspace_id, repo_script_fingerprint,
-    uniquify_workspace_id, AgentDefaults, AgentModelDefault, AppConfigStore, AutopilotActionId,
-    AutopilotEventId, AutopilotRule, AutopilotSettings, ChatSettings, GitMergeMethod,
-    GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig, GlobalGitConfig,
-    HookSet, KanbanEmptyColumnDisplay, KanbanSettings, OpencodeStartupReadinessConfig,
-    PromptOverride, PromptOverrides, RepoConfig, RepoDevServerScript, RepoGitConfig, RuntimeConfig,
-    RuntimeConfigStore, SchedulerConfig, SoftGuardrails,
+    derive_workspace_name_from_repo_path, normalize_hook_set, normalize_repo_dev_servers,
+    propose_workspace_id, uniquify_workspace_id, AgentDefaults, AgentModelDefault, AppConfigStore,
+    AutopilotActionId, AutopilotEventId, AutopilotRule, AutopilotSettings, ChatSettings,
+    GitMergeMethod, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
+    GlobalGitConfig, HookSet, KanbanEmptyColumnDisplay, KanbanSettings,
+    OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig,
+    RepoDevServerScript, RepoGitConfig, RuntimeConfig, RuntimeConfigStore, SchedulerConfig,
+    SoftGuardrails,
 };
 pub use filesystem::{list_directory, FilesystemListDirectoryError};
 pub use git::GitCliPort;

--- a/packages/contracts/src/config-schemas.test.ts
+++ b/packages/contracts/src/config-schemas.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { AUTOPILOT_EVENT_IDS, repoConfigSchema, settingsSnapshotSchema } from "./config-schemas";
+import {
+  AUTOPILOT_EVENT_IDS,
+  KANBAN_EMPTY_COLUMN_DISPLAY_VALUES,
+  kanbanSettingsSchema,
+  repoConfigSchema,
+  settingsSnapshotSchema,
+} from "./config-schemas";
 
 const baseRepoConfigInput = {
   workspaceId: "repo",
@@ -84,7 +90,7 @@ describe("config-schemas", () => {
     expect(() => repoConfigSchema.parse({})).toThrow();
   });
 
-  test("defaults kanban done visibility to one day", () => {
+  test("defaults kanban settings for existing snapshots", () => {
     const parsed = settingsSnapshotSchema.parse({
       theme: "light",
       git: { defaultMergeMethod: "merge_commit" },
@@ -93,6 +99,28 @@ describe("config-schemas", () => {
     });
 
     expect(parsed.kanban.doneVisibleDays).toBe(1);
+    expect(parsed.kanban.emptyColumnDisplay).toBe("show");
+  });
+
+  test("defaults missing kanban empty-column display to show", () => {
+    const parsed = kanbanSettingsSchema.parse({ doneVisibleDays: 4 });
+
+    expect(parsed).toEqual({ doneVisibleDays: 4, emptyColumnDisplay: "show" });
+  });
+
+  test("accepts every supported kanban empty-column display mode", () => {
+    for (const emptyColumnDisplay of KANBAN_EMPTY_COLUMN_DISPLAY_VALUES) {
+      expect(kanbanSettingsSchema.parse({ doneVisibleDays: 1, emptyColumnDisplay })).toEqual({
+        doneVisibleDays: 1,
+        emptyColumnDisplay,
+      });
+    }
+  });
+
+  test("rejects invalid kanban empty-column display modes", () => {
+    expect(() =>
+      kanbanSettingsSchema.parse({ doneVisibleDays: 1, emptyColumnDisplay: "compact" }),
+    ).toThrow();
   });
 
   test("defaults autopilot rules for every supported event", () => {

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -17,7 +17,9 @@ const DEFAULT_CHAT_SETTINGS = {
 } as const;
 export const DEFAULT_KANBAN_SETTINGS = {
   doneVisibleDays: 1,
+  emptyColumnDisplay: "show",
 } as const;
+export const KANBAN_EMPTY_COLUMN_DISPLAY_VALUES = ["show", "hidden", "collapsed"] as const;
 const DEFAULT_THEME = "light" as const;
 
 export const AUTOPILOT_EVENT_IDS = [
@@ -144,7 +146,12 @@ export type ChatSettings = z.infer<typeof chatSettingsSchema>;
 
 export const kanbanSettingsSchema = z.object({
   doneVisibleDays: z.number().int().min(0).default(DEFAULT_KANBAN_SETTINGS.doneVisibleDays),
+  emptyColumnDisplay: z
+    .enum(KANBAN_EMPTY_COLUMN_DISPLAY_VALUES)
+    .default(DEFAULT_KANBAN_SETTINGS.emptyColumnDisplay),
 });
+export const kanbanEmptyColumnDisplaySchema = z.enum(KANBAN_EMPTY_COLUMN_DISPLAY_VALUES);
+export type KanbanEmptyColumnDisplay = z.infer<typeof kanbanEmptyColumnDisplaySchema>;
 export type KanbanSettings = z.infer<typeof kanbanSettingsSchema>;
 
 export const autopilotEventIdSchema = z.enum(AUTOPILOT_EVENT_IDS);

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -57,6 +57,7 @@ import type {
   GitWorktreeSummary,
   GlobalConfig,
   IssueType,
+  KanbanEmptyColumnDisplay,
   KanbanSettings,
   PlanSubtaskInput,
   PlanSubtaskIssueType,
@@ -170,6 +171,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "buildResumedResultSchema",
   "CreateTaskInputSchema",
   "DEFAULT_KANBAN_SETTINGS",
+  "KANBAN_EMPTY_COLUMN_DISPLAY_VALUES",
   "devServerEventSchema",
   "devServerGroupStateSchema",
   "devServerTerminalChunkSchema",
@@ -227,6 +229,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "gitWorktreeStatusSnapshotSchema",
   "gitWorktreeSummarySchema",
   "kanbanSettingsSchema",
+  "kanbanEmptyColumnDisplaySchema",
   "globalConfigSchema",
   "globalGitConfigSchema",
   "GetWorkspacesInputSchema",
@@ -433,6 +436,7 @@ type ExportedTypeContract = {
   GitWorktreeStatusSnapshot: GitWorktreeStatusSnapshot;
   GitWorktreeSummary: GitWorktreeSummary;
   GlobalConfig: GlobalConfig;
+  KanbanEmptyColumnDisplay: KanbanEmptyColumnDisplay;
   KanbanSettings: KanbanSettings;
   IssueType: IssueType;
   PlanSubtaskInput: PlanSubtaskInput;
@@ -517,6 +521,7 @@ describe("contracts exports contract", () => {
 
     expect(parsedSnapshot.chat.showThinkingMessages).toBe(false);
     expect(parsedSnapshot.kanban.doneVisibleDays).toBe(1);
+    expect(parsedSnapshot.kanban.emptyColumnDisplay).toBe("show");
   });
 
   test("rejects settings snapshots without a theme", () => {

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.test.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.test.tsx
@@ -1,0 +1,34 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+let KanbanCollapsedColumn: typeof import("./kanban-collapsed-column").KanbanCollapsedColumn;
+
+describe("KanbanCollapsedColumn", () => {
+  beforeAll(async () => {
+    const modulePath = `./kanban-collapsed-column?test=${Date.now()}`;
+    const kanbanCollapsedColumnModule = (await import(modulePath)) as {
+      KanbanCollapsedColumn: typeof import("./kanban-collapsed-column").KanbanCollapsedColumn;
+    };
+    KanbanCollapsedColumn = kanbanCollapsedColumnModule.KanbanCollapsedColumn;
+  });
+
+  test("renders a keyboard-focusable tooltip trigger without a native title", () => {
+    const html = renderToStaticMarkup(
+      <TooltipProvider delayDuration={120}>
+        <KanbanCollapsedColumn
+          column={{
+            id: "open",
+            title: "Backlog",
+            tasks: [],
+          }}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(html).toContain('aria-label="Backlog column is empty and collapsed"');
+    expect(html).toContain('type="button"');
+    expect(html).not.toContain('title="Backlog column is empty and collapsed"');
+    expect(html).toContain("bg-muted-foreground/45");
+  });
+});

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
@@ -18,27 +18,29 @@ export function KanbanCollapsedColumn({ column }: KanbanCollapsedColumnProps): R
       aria-label={label}
       title={label}
       className={cn(
-        "flex min-h-96 flex-col items-center overflow-hidden rounded-2xl border shadow-sm",
+        "flex min-h-96 flex-col overflow-hidden rounded-2xl border shadow-sm",
         KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
         theme.boardSurfaceClass,
       )}
     >
-      <span
-        className={cn("block h-16 w-full shrink-0", theme.headerAccentClass)}
-        aria-hidden="true"
-      />
-      <div className="flex min-h-0 flex-1 flex-col items-center justify-between gap-3 px-2 py-4">
+      <div className={cn("border-b border-border/60 p-3", theme.headerSurfaceClass)}>
+        <span
+          className={cn("mb-3 block h-1.5 w-10 rounded-full", theme.headerAccentClass)}
+          aria-hidden="true"
+        />
+        <h3 className="text-sm font-semibold leading-snug text-foreground">{column.title}</h3>
+      </div>
+      <div className="flex flex-1 flex-col gap-2 p-3">
         <Badge
           variant="outline"
-          className={cn("h-6 rounded-full px-2 text-[11px] font-semibold", theme.countBadgeClass)}
+          className={cn(
+            "w-fit rounded-full px-2 py-0.5 text-[11px] font-medium",
+            theme.countBadgeClass,
+          )}
         >
-          0
+          0 tasks
         </Badge>
-        <div className="flex min-h-0 flex-1 items-center justify-center">
-          <p className="origin-center rotate-180 text-nowrap text-xs font-semibold uppercase tracking-wide text-foreground [writing-mode:vertical-rl]">
-            {column.title}
-          </p>
-        </div>
+        <p className="text-xs leading-relaxed text-muted-foreground">Empty lane</p>
         <p className="sr-only">No tasks in this lane.</p>
       </div>
     </section>

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
@@ -2,7 +2,7 @@ import type { KanbanColumn as KanbanColumnData } from "@openducktor/core";
 import type { ReactElement } from "react";
 import { KANBAN_COLLAPSED_LANE_WIDTH_CLASS } from "@/components/features/kanban/kanban-layout";
 import { laneTheme } from "@/components/features/kanban/kanban-theme";
-import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type KanbanCollapsedColumnProps = {
@@ -12,37 +12,49 @@ type KanbanCollapsedColumnProps = {
 export function KanbanCollapsedColumn({ column }: KanbanCollapsedColumnProps): ReactElement {
   const theme = laneTheme(column.id);
   const label = `${column.title} column is empty and collapsed`;
+  const accentClass = column.id === "open" ? "bg-muted-foreground/45" : theme.headerAccentClass;
 
   return (
-    <section
-      aria-label={label}
-      title={label}
-      className={cn(
-        "flex min-h-96 flex-col overflow-hidden rounded-2xl border shadow-sm",
-        KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
-        theme.boardSurfaceClass,
-      )}
-    >
-      <div className={cn("border-b border-border/60 p-3", theme.headerSurfaceClass)}>
-        <span
-          className={cn("mb-3 block h-1.5 w-10 rounded-full", theme.headerAccentClass)}
-          aria-hidden="true"
-        />
-        <h3 className="text-sm font-semibold leading-snug text-foreground">{column.title}</h3>
-      </div>
-      <div className="flex flex-1 flex-col gap-2 p-3">
-        <Badge
-          variant="outline"
-          className={cn(
-            "w-fit rounded-full px-2 py-0.5 text-[11px] font-medium",
-            theme.countBadgeClass,
-          )}
-        >
-          0 tasks
-        </Badge>
-        <p className="text-xs leading-relaxed text-muted-foreground">Empty lane</p>
-        <p className="sr-only">No tasks in this lane.</p>
-      </div>
-    </section>
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <section
+            aria-label={label}
+            title={label}
+            className={cn(
+              "group flex min-h-96 flex-col items-center rounded-full border px-1.5 py-3 shadow-sm transition-[background-color,border-color,box-shadow] hover:shadow-md",
+              KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
+              theme.boardSurfaceClass,
+            )}
+          >
+            <span
+              className={cn(
+                "flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-background shadow-sm ring-2 ring-background",
+                accentClass,
+              )}
+              aria-hidden="true"
+            >
+              0
+            </span>
+            <span
+              className={cn("mt-3 h-12 w-1 rounded-full opacity-80", accentClass)}
+              aria-hidden="true"
+            />
+            <span
+              className={cn(
+                "mt-2 w-1 flex-1 rounded-full opacity-25 transition-opacity group-hover:opacity-45",
+                accentClass,
+              )}
+              aria-hidden="true"
+            />
+            <span className="sr-only">No tasks in this lane.</span>
+          </section>
+        </TooltipTrigger>
+        <TooltipContent side="right" sideOffset={10} className="flex flex-col gap-1 px-3 py-2">
+          <p className="text-sm font-semibold text-background">{column.title}</p>
+          <p className="text-xs font-medium text-background/75">Collapsed empty lane</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
@@ -1,0 +1,46 @@
+import type { KanbanColumn as KanbanColumnData } from "@openducktor/core";
+import type { ReactElement } from "react";
+import { KANBAN_COLLAPSED_LANE_WIDTH_CLASS } from "@/components/features/kanban/kanban-layout";
+import { laneTheme } from "@/components/features/kanban/kanban-theme";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type KanbanCollapsedColumnProps = {
+  column: KanbanColumnData;
+};
+
+export function KanbanCollapsedColumn({ column }: KanbanCollapsedColumnProps): ReactElement {
+  const theme = laneTheme(column.id);
+  const label = `${column.title} column is empty and collapsed`;
+
+  return (
+    <section
+      aria-label={label}
+      title={label}
+      className={cn(
+        "flex min-h-96 flex-col items-center overflow-hidden rounded-2xl border shadow-sm",
+        KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
+        theme.boardSurfaceClass,
+      )}
+    >
+      <span
+        className={cn("block h-16 w-full shrink-0", theme.headerAccentClass)}
+        aria-hidden="true"
+      />
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-between gap-3 px-2 py-4">
+        <Badge
+          variant="outline"
+          className={cn("h-6 rounded-full px-2 text-[11px] font-semibold", theme.countBadgeClass)}
+        >
+          0
+        </Badge>
+        <div className="flex min-h-0 flex-1 items-center justify-center">
+          <p className="origin-center rotate-180 text-nowrap text-xs font-semibold uppercase tracking-wide text-foreground [writing-mode:vertical-rl]">
+            {column.title}
+          </p>
+        </div>
+        <p className="sr-only">No tasks in this lane.</p>
+      </div>
+    </section>
+  );
+}

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
@@ -5,7 +5,7 @@ import {
   KANBAN_LANE_HEADER_HEIGHT_CLASS,
 } from "@/components/features/kanban/kanban-layout";
 import { laneTheme } from "@/components/features/kanban/kanban-theme";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type KanbanCollapsedColumnProps = {
@@ -15,58 +15,56 @@ type KanbanCollapsedColumnProps = {
 export function KanbanCollapsedColumn({ column }: KanbanCollapsedColumnProps): ReactElement {
   const theme = laneTheme(column.id);
   const label = `${column.title} column is empty and collapsed`;
-  const accentClass = column.id === "open" ? "bg-muted-foreground/45" : theme.headerAccentClass;
+  const accentClass = theme.collapsedAccentClass ?? theme.headerAccentClass;
 
   return (
-    <TooltipProvider delayDuration={120}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <section
-            aria-label={label}
-            title={label}
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          className={cn(
+            "group flex min-h-96 cursor-default flex-col overflow-hidden rounded-2xl border p-0 text-left shadow-sm transition-[background-color,border-color,box-shadow] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
+            theme.boardSurfaceClass,
+          )}
+        >
+          <span
             className={cn(
-              "group flex min-h-96 flex-col overflow-hidden rounded-2xl border shadow-sm transition-[background-color,border-color,box-shadow] hover:shadow-md",
-              KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
-              theme.boardSurfaceClass,
+              "flex w-full flex-col items-center justify-between border-b border-border/80 px-1.5 pb-3 pt-4",
+              KANBAN_LANE_HEADER_HEIGHT_CLASS,
+              theme.headerSurfaceClass,
             )}
           >
-            <div
-              className={cn(
-                "flex w-full flex-col items-center justify-between border-b border-border/80 px-1.5 pb-3 pt-4",
-                KANBAN_LANE_HEADER_HEIGHT_CLASS,
-                theme.headerSurfaceClass,
-              )}
-            >
-              <span className={cn("block h-1.5 w-4 rounded-full", accentClass)} />
-              <div className="flex h-6 items-center justify-center">
-                <span
-                  className={cn(
-                    "flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-background shadow-sm ring-2 ring-background",
-                    accentClass,
-                  )}
-                  aria-hidden="true"
-                >
-                  0
-                </span>
-              </div>
-            </div>
-            <div className="flex flex-1 flex-col items-center px-1.5 py-3 w-full">
+            <span className={cn("block h-1.5 w-4 rounded-full", accentClass)} />
+            <span className="flex h-6 items-center justify-center">
               <span
                 className={cn(
-                  "mt-2 w-1 flex-1 rounded-full opacity-25 transition-opacity group-hover:opacity-45",
+                  "flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-background shadow-sm ring-2 ring-background",
                   accentClass,
                 )}
                 aria-hidden="true"
-              />
-            </div>
-            <span className="sr-only">No tasks in this lane.</span>
-          </section>
-        </TooltipTrigger>
-        <TooltipContent side="top" sideOffset={10} className="flex flex-col gap-1 px-3 py-2">
-          <p className="text-sm font-semibold text-background">{column.title}</p>
-          <p className="text-xs font-medium text-background/75">Collapsed empty lane</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+              >
+                0
+              </span>
+            </span>
+          </span>
+          <span className="flex w-full flex-1 flex-col items-center px-1.5 py-3">
+            <span
+              className={cn(
+                "mt-2 w-1 flex-1 rounded-full opacity-25 transition-opacity group-hover:opacity-45",
+                accentClass,
+              )}
+              aria-hidden="true"
+            />
+          </span>
+          <span className="sr-only">No tasks in this lane.</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={10} className="flex flex-col gap-1 px-3 py-2">
+        <p className="text-sm font-semibold text-background">{column.title}</p>
+        <p className="text-xs font-medium text-background/75">Collapsed empty lane</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
@@ -1,6 +1,9 @@
 import type { KanbanColumn as KanbanColumnData } from "@openducktor/core";
 import type { ReactElement } from "react";
-import { KANBAN_COLLAPSED_LANE_WIDTH_CLASS } from "@/components/features/kanban/kanban-layout";
+import {
+  KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
+  KANBAN_LANE_HEADER_HEIGHT_CLASS,
+} from "@/components/features/kanban/kanban-layout";
 import { laneTheme } from "@/components/features/kanban/kanban-theme";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -22,35 +25,44 @@ export function KanbanCollapsedColumn({ column }: KanbanCollapsedColumnProps): R
             aria-label={label}
             title={label}
             className={cn(
-              "group flex min-h-96 flex-col items-center rounded-full border px-1.5 py-3 shadow-sm transition-[background-color,border-color,box-shadow] hover:shadow-md",
+              "group flex min-h-96 flex-col overflow-hidden rounded-2xl border shadow-sm transition-[background-color,border-color,box-shadow] hover:shadow-md",
               KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
               theme.boardSurfaceClass,
             )}
           >
-            <span
+            <div
               className={cn(
-                "flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-background shadow-sm ring-2 ring-background",
-                accentClass,
+                "flex w-full flex-col items-center justify-between border-b border-border/80 px-1.5 pb-3 pt-4",
+                KANBAN_LANE_HEADER_HEIGHT_CLASS,
+                theme.headerSurfaceClass,
               )}
-              aria-hidden="true"
             >
-              0
-            </span>
-            <span
-              className={cn("mt-3 h-12 w-1 rounded-full opacity-80", accentClass)}
-              aria-hidden="true"
-            />
-            <span
-              className={cn(
-                "mt-2 w-1 flex-1 rounded-full opacity-25 transition-opacity group-hover:opacity-45",
-                accentClass,
-              )}
-              aria-hidden="true"
-            />
+              <span className={cn("block h-1.5 w-4 rounded-full", accentClass)} />
+              <div className="flex h-6 items-center justify-center">
+                <span
+                  className={cn(
+                    "flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-background shadow-sm ring-2 ring-background",
+                    accentClass,
+                  )}
+                  aria-hidden="true"
+                >
+                  0
+                </span>
+              </div>
+            </div>
+            <div className="flex flex-1 flex-col items-center px-1.5 py-3 w-full">
+              <span
+                className={cn(
+                  "mt-2 w-1 flex-1 rounded-full opacity-25 transition-opacity group-hover:opacity-45",
+                  accentClass,
+                )}
+                aria-hidden="true"
+              />
+            </div>
             <span className="sr-only">No tasks in this lane.</span>
           </section>
         </TooltipTrigger>
-        <TooltipContent side="right" sideOffset={10} className="flex flex-col gap-1 px-3 py-2">
+        <TooltipContent side="top" sideOffset={10} className="flex flex-col gap-1 px-3 py-2">
           <p className="text-sm font-semibold text-background">{column.title}</p>
           <p className="text-xs font-medium text-background/75">Collapsed empty lane</p>
         </TooltipContent>

--- a/packages/frontend/src/components/features/kanban/kanban-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-column.tsx
@@ -6,7 +6,10 @@ import type {
 } from "@openducktor/core";
 import { Inbox } from "lucide-react";
 import { type ComponentProps, memo, type ReactElement, useEffect, useRef } from "react";
-import { KANBAN_LANE_WIDTH_CLASS } from "@/components/features/kanban/kanban-layout";
+import {
+  KANBAN_LANE_HEADER_HEIGHT_CLASS,
+  KANBAN_LANE_WIDTH_CLASS,
+} from "@/components/features/kanban/kanban-layout";
 import type {
   ActiveTaskSessionContextByTaskId,
   KanbanTaskActivityState,
@@ -196,14 +199,23 @@ function LaneHeader({
   const theme = laneTheme(id);
   return (
     <header
-      className={cn("space-y-3 border-b border-border/80 px-4 pb-3 pt-4", theme.headerSurfaceClass)}
+      className={cn(
+        "flex flex-col justify-between border-b border-border/80 px-4 pb-3 pt-4",
+        KANBAN_LANE_HEADER_HEIGHT_CLASS,
+        theme.headerSurfaceClass,
+      )}
     >
       <span className={cn("block h-1.5 w-14 rounded-full", theme.headerAccentClass)} />
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-foreground">{title}</h3>
+        <h3 className="min-w-0 truncate text-sm font-semibold uppercase tracking-wide text-foreground">
+          {title}
+        </h3>
         <Badge
           variant="outline"
-          className={cn("h-6 rounded-full px-2 text-[11px] font-semibold", theme.countBadgeClass)}
+          className={cn(
+            "h-6 shrink-0 rounded-full px-2 text-[11px] font-semibold",
+            theme.countBadgeClass,
+          )}
         >
           {laneCountLabel(count)}
         </Badge>

--- a/packages/frontend/src/components/features/kanban/kanban-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-column.tsx
@@ -19,7 +19,6 @@ import { KanbanTaskCard } from "@/components/features/kanban/kanban-task-card";
 import { laneTheme } from "@/components/features/kanban/kanban-theme";
 import { useKanbanVirtualization } from "@/components/features/kanban/use-kanban-virtualization";
 import { Badge } from "@/components/ui/badge";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type TaskSessions = NonNullable<ComponentProps<typeof KanbanTaskCard>["taskSessions"]>;
@@ -267,77 +266,39 @@ export function KanbanColumn({
   const isVirtualized = renderModel.kind === "virtualized";
 
   return (
-    <TooltipProvider>
-      <section
-        className={cn(
-          "flex flex-col overflow-hidden rounded-2xl border shadow-sm",
-          KANBAN_LANE_WIDTH_CLASS,
-          theme.boardSurfaceClass,
-        )}
-      >
-        <LaneHeader id={column.id} title={column.title} count={column.tasks.length} />
-        <div ref={cardsViewportRef} className="flex-1 p-3">
-          {column.tasks.length === 0 ? <LaneEmptyState id={column.id} /> : null}
+    <section
+      className={cn(
+        "flex flex-col overflow-hidden rounded-2xl border shadow-sm",
+        KANBAN_LANE_WIDTH_CLASS,
+        theme.boardSurfaceClass,
+      )}
+    >
+      <LaneHeader id={column.id} title={column.title} count={column.tasks.length} />
+      <div ref={cardsViewportRef} className="flex-1 p-3">
+        {column.tasks.length === 0 ? <LaneEmptyState id={column.id} /> : null}
 
-          {column.tasks.length > 0 && isVirtualized ? (
-            <div style={{ minHeight: renderModel.totalHeight }}>
-              {renderModel.topSpacerHeight > 0 ? (
-                <div style={{ height: renderModel.topSpacerHeight }} />
-              ) : null}
-              <div className="space-y-3">
-                {renderModel.visibleTasks.map((task) => {
-                  const activeSessionContext = activeTaskSessionContextByTaskId.get(task.id);
-                  return (
-                    <MeasuredTaskCard
-                      key={task.id}
-                      task={task}
-                      taskSessions={taskSessionsByTaskId.get(task.id) ?? EMPTY_TASK_SESSIONS}
-                      hasActiveSession={Boolean(activeSessionContext)}
-                      activeSessionRole={activeSessionContext?.role}
-                      activeSessionPresentationState={activeSessionContext?.presentationState}
-                      taskActivityState={getRequiredTaskActivityState(
-                        taskActivityStateByTaskId,
-                        task.id,
-                      )}
-                      measurementVersion={measurementVersion}
-                      onMeasuredHeight={handleMeasuredHeight}
-                      onOpenDetails={onOpenDetails}
-                      onDelegate={onDelegate}
-                      onOpenSession={onOpenSession}
-                      onPlan={onPlan}
-                      onBuild={onBuild}
-                      {...(onQaStart ? { onQaStart } : {})}
-                      {...(onQaOpen ? { onQaOpen } : {})}
-                      {...(onHumanApprove ? { onHumanApprove } : {})}
-                      {...(onHumanRequestChanges ? { onHumanRequestChanges } : {})}
-                      {...(onResetImplementation ? { onResetImplementation } : {})}
-                    />
-                  );
-                })}
-              </div>
-              {renderModel.bottomSpacerHeight > 0 ? (
-                <div style={{ height: renderModel.bottomSpacerHeight }} />
-              ) : null}
-            </div>
-          ) : null}
-
-          {column.tasks.length > 0 && !isVirtualized ? (
+        {column.tasks.length > 0 && isVirtualized ? (
+          <div style={{ minHeight: renderModel.totalHeight }}>
+            {renderModel.topSpacerHeight > 0 ? (
+              <div style={{ height: renderModel.topSpacerHeight }} />
+            ) : null}
             <div className="space-y-3">
               {renderModel.visibleTasks.map((task) => {
                 const activeSessionContext = activeTaskSessionContextByTaskId.get(task.id);
                 return (
-                  <KanbanTaskCard
+                  <MeasuredTaskCard
                     key={task.id}
                     task={task}
                     taskSessions={taskSessionsByTaskId.get(task.id) ?? EMPTY_TASK_SESSIONS}
                     hasActiveSession={Boolean(activeSessionContext)}
-                    {...(activeSessionContext?.role
-                      ? { activeSessionRole: activeSessionContext.role }
-                      : {})}
+                    activeSessionRole={activeSessionContext?.role}
+                    activeSessionPresentationState={activeSessionContext?.presentationState}
                     taskActivityState={getRequiredTaskActivityState(
                       taskActivityStateByTaskId,
                       task.id,
                     )}
+                    measurementVersion={measurementVersion}
+                    onMeasuredHeight={handleMeasuredHeight}
                     onOpenDetails={onOpenDetails}
                     onDelegate={onDelegate}
                     onOpenSession={onOpenSession}
@@ -352,9 +313,45 @@ export function KanbanColumn({
                 );
               })}
             </div>
-          ) : null}
-        </div>
-      </section>
-    </TooltipProvider>
+            {renderModel.bottomSpacerHeight > 0 ? (
+              <div style={{ height: renderModel.bottomSpacerHeight }} />
+            ) : null}
+          </div>
+        ) : null}
+
+        {column.tasks.length > 0 && !isVirtualized ? (
+          <div className="space-y-3">
+            {renderModel.visibleTasks.map((task) => {
+              const activeSessionContext = activeTaskSessionContextByTaskId.get(task.id);
+              return (
+                <KanbanTaskCard
+                  key={task.id}
+                  task={task}
+                  taskSessions={taskSessionsByTaskId.get(task.id) ?? EMPTY_TASK_SESSIONS}
+                  hasActiveSession={Boolean(activeSessionContext)}
+                  {...(activeSessionContext?.role
+                    ? { activeSessionRole: activeSessionContext.role }
+                    : {})}
+                  taskActivityState={getRequiredTaskActivityState(
+                    taskActivityStateByTaskId,
+                    task.id,
+                  )}
+                  onOpenDetails={onOpenDetails}
+                  onDelegate={onDelegate}
+                  onOpenSession={onOpenSession}
+                  onPlan={onPlan}
+                  onBuild={onBuild}
+                  {...(onQaStart ? { onQaStart } : {})}
+                  {...(onQaOpen ? { onQaOpen } : {})}
+                  {...(onHumanApprove ? { onHumanApprove } : {})}
+                  {...(onHumanRequestChanges ? { onHumanRequestChanges } : {})}
+                  {...(onResetImplementation ? { onResetImplementation } : {})}
+                />
+              );
+            })}
+          </div>
+        ) : null}
+      </div>
+    </section>
   );
 }

--- a/packages/frontend/src/components/features/kanban/kanban-layout.ts
+++ b/packages/frontend/src/components/features/kanban/kanban-layout.ts
@@ -1,7 +1,7 @@
 export const KANBAN_LANE_WIDTH_PX = 328;
 export const KANBAN_LANE_WIDTH_CLASS = "w-[328px] min-w-[328px]";
-export const KANBAN_COLLAPSED_LANE_WIDTH_PX = 56;
-export const KANBAN_COLLAPSED_LANE_WIDTH_CLASS = "w-[56px] min-w-[56px]";
+export const KANBAN_COLLAPSED_LANE_WIDTH_PX = 144;
+export const KANBAN_COLLAPSED_LANE_WIDTH_CLASS = "w-[144px] min-w-[144px]";
 
 const KANBAN_LANE_BORDER_PX = 1;
 const KANBAN_LANE_HORIZONTAL_PADDING_PX = 12;

--- a/packages/frontend/src/components/features/kanban/kanban-layout.ts
+++ b/packages/frontend/src/components/features/kanban/kanban-layout.ts
@@ -1,5 +1,7 @@
 export const KANBAN_LANE_WIDTH_PX = 328;
 export const KANBAN_LANE_WIDTH_CLASS = "w-[328px] min-w-[328px]";
+export const KANBAN_LANE_HEADER_HEIGHT_PX = 72;
+export const KANBAN_LANE_HEADER_HEIGHT_CLASS = "h-[72px]";
 export const KANBAN_COLLAPSED_LANE_WIDTH_PX = 36;
 export const KANBAN_COLLAPSED_LANE_WIDTH_CLASS = "w-[36px] min-w-[36px]";
 

--- a/packages/frontend/src/components/features/kanban/kanban-layout.ts
+++ b/packages/frontend/src/components/features/kanban/kanban-layout.ts
@@ -1,7 +1,7 @@
 export const KANBAN_LANE_WIDTH_PX = 328;
 export const KANBAN_LANE_WIDTH_CLASS = "w-[328px] min-w-[328px]";
-export const KANBAN_COLLAPSED_LANE_WIDTH_PX = 144;
-export const KANBAN_COLLAPSED_LANE_WIDTH_CLASS = "w-[144px] min-w-[144px]";
+export const KANBAN_COLLAPSED_LANE_WIDTH_PX = 36;
+export const KANBAN_COLLAPSED_LANE_WIDTH_CLASS = "w-[36px] min-w-[36px]";
 
 const KANBAN_LANE_BORDER_PX = 1;
 const KANBAN_LANE_HORIZONTAL_PADDING_PX = 12;

--- a/packages/frontend/src/components/features/kanban/kanban-layout.ts
+++ b/packages/frontend/src/components/features/kanban/kanban-layout.ts
@@ -1,5 +1,7 @@
 export const KANBAN_LANE_WIDTH_PX = 328;
 export const KANBAN_LANE_WIDTH_CLASS = "w-[328px] min-w-[328px]";
+export const KANBAN_COLLAPSED_LANE_WIDTH_PX = 56;
+export const KANBAN_COLLAPSED_LANE_WIDTH_CLASS = "w-[56px] min-w-[56px]";
 
 const KANBAN_LANE_BORDER_PX = 1;
 const KANBAN_LANE_HORIZONTAL_PADDING_PX = 12;

--- a/packages/frontend/src/components/features/settings/settings-kanban-section.test.tsx
+++ b/packages/frontend/src/components/features/settings/settings-kanban-section.test.tsx
@@ -6,7 +6,7 @@ import { SettingsKanbanSection } from "./settings-kanban-section";
 
 describe("settings kanban section", () => {
   test("renders the done-task visibility setting", () => {
-    const kanban: KanbanSettings = { doneVisibleDays: 3 };
+    const kanban: KanbanSettings = { doneVisibleDays: 3, emptyColumnDisplay: "collapsed" };
 
     const html = renderToStaticMarkup(
       createElement(SettingsKanbanSection, {
@@ -18,6 +18,8 @@ describe("settings kanban section", () => {
 
     expect(html).toContain("Kanban Settings");
     expect(html).toContain("Done tasks visible for");
+    expect(html).toContain("Empty columns");
+    expect(html).toContain("Collapsed");
     expect(html).toContain('value="3"');
   });
 });

--- a/packages/frontend/src/components/features/settings/settings-kanban-section.test.tsx
+++ b/packages/frontend/src/components/features/settings/settings-kanban-section.test.tsx
@@ -19,7 +19,7 @@ describe("settings kanban section", () => {
     expect(html).toContain("Kanban Settings");
     expect(html).toContain("Done tasks visible for");
     expect(html).toContain("Empty columns");
-    expect(html).toContain("Collapsed");
+    expect(html).toContain("Choose whether empty lanes stay visible");
     expect(html).toContain('value="3"');
   });
 });

--- a/packages/frontend/src/components/features/settings/settings-kanban-section.tsx
+++ b/packages/frontend/src/components/features/settings/settings-kanban-section.tsx
@@ -90,7 +90,8 @@ export function SettingsKanbanSection({
                 return;
               }
               if (!isKanbanEmptyColumnDisplay(value)) {
-                throw new Error(`Unsupported Kanban empty-column display mode: ${value}`);
+                console.error(`Unsupported Kanban empty-column display mode: ${value}`);
+                return;
               }
 
               onUpdateKanban((current) => ({

--- a/packages/frontend/src/components/features/settings/settings-kanban-section.tsx
+++ b/packages/frontend/src/components/features/settings/settings-kanban-section.tsx
@@ -1,5 +1,10 @@
-import type { KanbanSettings } from "@openducktor/contracts";
+import {
+  KANBAN_EMPTY_COLUMN_DISPLAY_VALUES,
+  type KanbanEmptyColumnDisplay,
+  type KanbanSettings,
+} from "@openducktor/contracts";
 import type { ReactElement } from "react";
+import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
@@ -8,6 +13,27 @@ type SettingsKanbanSectionProps = {
   disabled: boolean;
   onUpdateKanban: (updater: (current: KanbanSettings) => KanbanSettings) => void;
 };
+
+const EMPTY_COLUMN_DISPLAY_OPTIONS: ComboboxOption[] = [
+  {
+    value: "show",
+    label: "Show",
+    description: "Display empty columns normally.",
+  },
+  {
+    value: "hidden",
+    label: "Hidden",
+    description: "Hide empty columns from the board.",
+  },
+  {
+    value: "collapsed",
+    label: "Collapsed",
+    description: "Show a compact themed marker for each empty column.",
+  },
+];
+
+const isKanbanEmptyColumnDisplay = (value: string): value is KanbanEmptyColumnDisplay =>
+  KANBAN_EMPTY_COLUMN_DISPLAY_VALUES.includes(value as KanbanEmptyColumnDisplay);
 
 export function SettingsKanbanSection({
   kanban,
@@ -19,7 +45,7 @@ export function SettingsKanbanSection({
       <div className="space-y-2">
         <h3 className="text-sm font-semibold text-foreground">Kanban Settings</h3>
         <p className="text-xs text-muted-foreground">
-          Control how long completed tasks stay visible on the board.
+          Control completed-task visibility and how empty columns appear on the board.
         </p>
       </div>
 
@@ -35,6 +61,10 @@ export function SettingsKanbanSection({
             value={kanban.doneVisibleDays}
             disabled={disabled}
             onChange={(event) => {
+              if (disabled) {
+                return;
+              }
+
               const parsed = Number.parseInt(event.currentTarget.value, 10);
               onUpdateKanban((current) => ({
                 ...current,
@@ -46,6 +76,33 @@ export function SettingsKanbanSection({
         <p className="text-xs text-muted-foreground">
           Set to `0` to hide Done tasks by default. Changes take effect after you save settings.
         </p>
+        <div className="grid gap-2 border-t border-border pt-3">
+          <Label id="kanban-empty-column-display-label">Empty columns</Label>
+          <Combobox
+            value={kanban.emptyColumnDisplay}
+            options={EMPTY_COLUMN_DISPLAY_OPTIONS}
+            disabled={disabled}
+            triggerAriaLabelledBy="kanban-empty-column-display-label"
+            searchPlaceholder="Search display modes..."
+            emptyText="No display mode found."
+            onValueChange={(value) => {
+              if (disabled) {
+                return;
+              }
+              if (!isKanbanEmptyColumnDisplay(value)) {
+                throw new Error(`Unsupported Kanban empty-column display mode: ${value}`);
+              }
+
+              onUpdateKanban((current) => ({
+                ...current,
+                emptyColumnDisplay: value,
+              }));
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            Choose whether empty lanes stay visible, disappear, or collapse to a themed marker.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/features/settings/settings-modal-content.test.tsx
+++ b/packages/frontend/src/components/features/settings/settings-modal-content.test.tsx
@@ -127,7 +127,7 @@ describe("settings modal content", () => {
     expect(html).toContain("Kanban Settings");
     expect(html).toContain("Done tasks visible for");
     expect(html).toContain("Empty columns");
-    expect(html).toContain("Collapsed");
+    expect(html).toContain("Choose whether empty lanes stay visible");
     expect(html).toContain('value="7"');
   });
 

--- a/packages/frontend/src/components/features/settings/settings-modal-content.test.tsx
+++ b/packages/frontend/src/components/features/settings/settings-modal-content.test.tsx
@@ -8,7 +8,7 @@ const createMockSnapshot = (overrides: Partial<SettingsSnapshot> = {}): Settings
   theme: "light",
   git: { defaultMergeMethod: "merge_commit" },
   chat: { showThinkingMessages: false },
-  kanban: { doneVisibleDays: 1 },
+  kanban: { doneVisibleDays: 1, emptyColumnDisplay: "show" },
   autopilot: { rules: [] },
   workspaces: {},
   globalPromptOverrides: {},
@@ -105,7 +105,9 @@ describe("settings modal content", () => {
   });
 
   test("renders kanban section when section is kanban", () => {
-    const snapshot = createMockSnapshot({ kanban: { doneVisibleDays: 7 } });
+    const snapshot = createMockSnapshot({
+      kanban: { doneVisibleDays: 7, emptyColumnDisplay: "collapsed" },
+    });
     const controller = createMockController(snapshot);
 
     const html = renderToStaticMarkup(
@@ -124,6 +126,8 @@ describe("settings modal content", () => {
 
     expect(html).toContain("Kanban Settings");
     expect(html).toContain("Done tasks visible for");
+    expect(html).toContain("Empty columns");
+    expect(html).toContain("Collapsed");
     expect(html).toContain('value="7"');
   });
 

--- a/packages/frontend/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-normalization.test.ts
@@ -339,6 +339,7 @@ describe("settings-modal-normalization", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+        emptyColumnDisplay: "show" as const,
       },
       autopilot: {
         rules: [],
@@ -386,6 +387,7 @@ describe("settings-modal-normalization", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+        emptyColumnDisplay: "show" as const,
       },
       autopilot: {
         rules: [],
@@ -415,6 +417,7 @@ describe("settings-modal-normalization", () => {
           },
           kanban: {
             doneVisibleDays: 1,
+            emptyColumnDisplay: "show" as const,
           },
           autopilot: {
             rules: [],

--- a/packages/frontend/src/components/features/settings/settings-modal-save-policy.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-save-policy.test.ts
@@ -19,6 +19,7 @@ const createSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],

--- a/packages/frontend/src/components/features/settings/use-settings-modal-controller.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-controller.test.tsx
@@ -39,6 +39,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: createDefaultAutopilotSettings(),
   workspaces: {

--- a/packages/frontend/src/components/features/settings/use-settings-modal-dirty-draft-actions.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-dirty-draft-actions.test.tsx
@@ -26,6 +26,7 @@ const createSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],

--- a/packages/frontend/src/components/features/settings/use-settings-modal-dirty-state.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-dirty-state.test.tsx
@@ -23,6 +23,7 @@ const createSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],

--- a/packages/frontend/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
@@ -24,6 +24,7 @@ const createInitialSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],
@@ -141,11 +142,13 @@ describe("useSettingsModalDraftActions", () => {
       state.updateGlobalKanbanSettings((kanban) => ({
         ...kanban,
         doneVisibleDays: 7,
+        emptyColumnDisplay: "collapsed",
       }));
     });
 
     const snapshot = harness.getLatest().snapshotDraft;
     expect(snapshot?.kanban.doneVisibleDays).toBe(7);
+    expect(snapshot?.kanban.emptyColumnDisplay).toBe("collapsed");
     expect(snapshot?.chat.showThinkingMessages).toBe(false);
 
     await harness.unmount();

--- a/packages/frontend/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
@@ -23,6 +23,7 @@ const createSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],

--- a/packages/frontend/src/components/features/settings/use-settings-modal-repo-script-validation.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-repo-script-validation.test.tsx
@@ -23,6 +23,7 @@ const createSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],

--- a/packages/frontend/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
@@ -25,6 +25,7 @@ const createSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],

--- a/packages/frontend/src/lib/task-status-presentation.ts
+++ b/packages/frontend/src/lib/task-status-presentation.ts
@@ -5,6 +5,7 @@ type KanbanLaneTheme = {
   boardSurfaceClass: string;
   headerSurfaceClass: string;
   headerAccentClass: string;
+  collapsedAccentClass?: string;
   countBadgeClass: string;
   emptyStateClass: string;
 };
@@ -31,6 +32,7 @@ const TASK_STATUS_PRESENTATION: Record<TaskCard["status"], TaskStatusPresentatio
       boardSurfaceClass: "border-border/90 bg-muted/60",
       headerSurfaceClass: "bg-muted/80",
       headerAccentClass: "bg-muted/0",
+      collapsedAccentClass: "bg-muted-foreground/45",
       countBadgeClass: "border-input bg-card text-foreground",
       emptyStateClass: "border-input bg-card/80 text-muted-foreground",
     },

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-settings.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-settings.test.tsx
@@ -21,6 +21,7 @@ const hostMock = {
       },
       kanban: {
         doneVisibleDays: 1,
+        emptyColumnDisplay: "show",
       },
       autopilot: {
         rules: [],
@@ -78,6 +79,7 @@ const createSettingsSnapshot = (
     },
     kanban: {
       doneVisibleDays: 1,
+      emptyColumnDisplay: "show",
     },
     autopilot: {
       rules: [],

--- a/packages/frontend/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
@@ -109,6 +109,7 @@ beforeEach(() => {
     },
     kanban: {
       doneVisibleDays: 1,
+      emptyColumnDisplay: "show",
     },
     autopilot: {
       rules: [],

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -258,6 +258,7 @@ describe("useAgentStudioSessionActions", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+        emptyColumnDisplay: "show",
       },
       autopilot: {
         rules: [],

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -314,6 +314,7 @@ describe("useAgentStudioSessionStartFlow", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+        emptyColumnDisplay: "show",
       },
       autopilot: {
         rules: [],

--- a/packages/frontend/src/pages/kanban/kanban-page-content.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page-content.test.tsx
@@ -8,6 +8,7 @@ import type { KanbanPageContentModel } from "./kanban-page-model-types";
 const model: KanbanPageContentModel = {
   isLoadingTasks: false,
   isSwitchingWorkspace: false,
+  emptyColumnDisplay: "show",
   columns: [
     {
       id: "open",
@@ -35,7 +36,16 @@ describe("KanbanPageContent", () => {
 
   beforeEach(async () => {
     mock.module("@/components/features/kanban/kanban-column", () => ({
-      KanbanColumn: (): ReactElement => <div data-testid="kanban-column" />,
+      KanbanColumn: ({ column }: { column: (typeof model.columns)[number] }): ReactElement => (
+        <div data-testid="kanban-column">{column.title}</div>
+      ),
+    }));
+    mock.module("@/components/features/kanban/kanban-collapsed-column", () => ({
+      KanbanCollapsedColumn: ({
+        column,
+      }: {
+        column: (typeof model.columns)[number];
+      }): ReactElement => <div data-testid="kanban-collapsed-column">{column.title}</div>,
     }));
 
     ({ KanbanPageContent } = await import("./kanban-page-content"));
@@ -46,6 +56,10 @@ describe("KanbanPageContent", () => {
       [
         "@/components/features/kanban/kanban-column",
         () => import("@/components/features/kanban/kanban-column"),
+      ],
+      [
+        "@/components/features/kanban/kanban-collapsed-column",
+        () => import("@/components/features/kanban/kanban-collapsed-column"),
       ],
     ]);
   });
@@ -96,5 +110,51 @@ describe("KanbanPageContent", () => {
     expect(html).not.toContain('data-testid="kanban-refresh-indicator"');
     expect(html).not.toContain("Refreshing tasks...");
     expect(html).not.toContain('data-testid="kanban-loading-overlay"');
+  });
+
+  test("shows empty columns when the display mode is show", () => {
+    const html = renderToStaticMarkup(createElement(KanbanPageContent, { model }));
+
+    expect(html.match(/data-testid="kanban-column"/g)?.length).toBe(1);
+    expect(html).toContain("Backlog");
+    expect(html).not.toContain('data-testid="kanban-collapsed-column"');
+  });
+
+  test("hides empty columns when the display mode is hidden", () => {
+    const html = renderToStaticMarkup(
+      createElement(KanbanPageContent, {
+        model: {
+          ...model,
+          emptyColumnDisplay: "hidden",
+        },
+      }),
+    );
+
+    expect(html).not.toContain('data-testid="kanban-column"');
+    expect(html).not.toContain('data-testid="kanban-collapsed-column"');
+  });
+
+  test("collapses empty columns without collapsing populated columns", () => {
+    const html = renderToStaticMarkup(
+      createElement(KanbanPageContent, {
+        model: {
+          ...model,
+          emptyColumnDisplay: "collapsed",
+          columns: [
+            ...model.columns,
+            {
+              id: "in_progress",
+              title: "In progress",
+              tasks: [{ id: "TASK-1" }] as (typeof model.columns)[number]["tasks"],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(html.match(/data-testid="kanban-collapsed-column"/g)?.length).toBe(1);
+    expect(html.match(/data-testid="kanban-column"/g)?.length).toBe(1);
+    expect(html).toContain("Backlog");
+    expect(html).toContain("In progress");
   });
 });

--- a/packages/frontend/src/pages/kanban/kanban-page-content.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page-content.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { KanbanCollapsedColumn } from "@/components/features/kanban/kanban-collapsed-column";
 import { KanbanColumn } from "@/components/features/kanban/kanban-column";
 import { cn } from "@/lib/utils";
 import { KanbanBoardLoadingShell } from "./kanban-board-loading-shell";
@@ -7,6 +8,41 @@ import type { KanbanPageContentModel } from "./kanban-page-model-types";
 type KanbanPageContentProps = {
   model: KanbanPageContentModel;
 };
+
+type KanbanPageColumn = KanbanPageContentModel["columns"][number];
+
+function renderKanbanColumn(
+  column: KanbanPageColumn,
+  model: KanbanPageContentModel,
+): ReactElement | null {
+  if (column.tasks.length === 0 && model.emptyColumnDisplay === "hidden") {
+    return null;
+  }
+
+  if (column.tasks.length === 0 && model.emptyColumnDisplay === "collapsed") {
+    return <KanbanCollapsedColumn key={column.id} column={column} />;
+  }
+
+  return (
+    <KanbanColumn
+      key={column.id}
+      column={column}
+      taskSessionsByTaskId={model.taskSessionsByTaskId}
+      activeTaskSessionContextByTaskId={model.activeTaskSessionContextByTaskId}
+      taskActivityStateByTaskId={model.taskActivityStateByTaskId}
+      onOpenDetails={model.onOpenDetails}
+      onDelegate={model.onDelegate}
+      onOpenSession={model.onOpenSession}
+      onPlan={model.onPlan}
+      onQaStart={model.onQaStart}
+      onQaOpen={model.onQaOpen}
+      onBuild={model.onBuild}
+      onHumanApprove={model.onHumanApprove}
+      onHumanRequestChanges={model.onHumanRequestChanges}
+      onResetImplementation={model.onResetImplementation}
+    />
+  );
+}
 
 export function KanbanPageContent({ model }: KanbanPageContentProps): ReactElement {
   const totalTaskCount = model.columns.reduce((count, column) => count + column.tasks.length, 0);
@@ -22,25 +58,7 @@ export function KanbanPageContent({ model }: KanbanPageContentProps): ReactEleme
         )}
       >
         <div className="flex min-h-full min-w-max items-start gap-4 pr-4">
-          {model.columns.map((column) => (
-            <KanbanColumn
-              key={column.id}
-              column={column}
-              taskSessionsByTaskId={model.taskSessionsByTaskId}
-              activeTaskSessionContextByTaskId={model.activeTaskSessionContextByTaskId}
-              taskActivityStateByTaskId={model.taskActivityStateByTaskId}
-              onOpenDetails={model.onOpenDetails}
-              onDelegate={model.onDelegate}
-              onOpenSession={model.onOpenSession}
-              onPlan={model.onPlan}
-              onQaStart={model.onQaStart}
-              onQaOpen={model.onQaOpen}
-              onBuild={model.onBuild}
-              onHumanApprove={model.onHumanApprove}
-              onHumanRequestChanges={model.onHumanRequestChanges}
-              onResetImplementation={model.onResetImplementation}
-            />
-          ))}
+          {model.columns.map((column) => renderKanbanColumn(column, model))}
         </div>
       </div>
 

--- a/packages/frontend/src/pages/kanban/kanban-page-content.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page-content.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { KanbanCollapsedColumn } from "@/components/features/kanban/kanban-collapsed-column";
 import { KanbanColumn } from "@/components/features/kanban/kanban-column";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { KanbanBoardLoadingShell } from "./kanban-board-loading-shell";
 import type { KanbanPageContentModel } from "./kanban-page-model-types";
@@ -57,9 +58,11 @@ export function KanbanPageContent({ model }: KanbanPageContentProps): ReactEleme
           showBlockingLoader ? "opacity-0" : "opacity-100",
         )}
       >
-        <div className="flex min-h-full min-w-max items-start gap-4 pr-4">
-          {model.columns.map((column) => renderKanbanColumn(column, model))}
-        </div>
+        <TooltipProvider delayDuration={120}>
+          <div className="flex min-h-full min-w-max items-start gap-4 pr-4">
+            {model.columns.map((column) => renderKanbanColumn(column, model))}
+          </div>
+        </TooltipProvider>
       </div>
 
       {showBlockingLoader ? (

--- a/packages/frontend/src/pages/kanban/kanban-page-model-types.ts
+++ b/packages/frontend/src/pages/kanban/kanban-page-model-types.ts
@@ -1,4 +1,4 @@
-import type { GitTargetBranch, TaskCard } from "@openducktor/contracts";
+import type { GitTargetBranch, KanbanEmptyColumnDisplay, TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario, KanbanColumn as KanbanColumnData } from "@openducktor/core";
 import type { SessionStartModalModel } from "@/components/features/agents";
 import type {
@@ -79,6 +79,7 @@ export type KanbanPageHeaderModel = {
 export type KanbanPageContentModel = {
   isLoadingTasks: boolean;
   isSwitchingWorkspace: boolean;
+  emptyColumnDisplay: KanbanEmptyColumnDisplay;
   columns: KanbanColumnData[];
   taskSessionsByTaskId: Map<string, KanbanTaskSession[]>;
   activeTaskSessionContextByTaskId: ActiveTaskSessionContextByTaskId;

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -57,6 +57,7 @@ const workspaceGetSettingsSnapshotMock = mock(async () => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],
@@ -613,6 +614,7 @@ describe("KanbanPage session start modal flow", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+        emptyColumnDisplay: "show",
       },
       autopilot: {
         rules: [],

--- a/packages/frontend/src/pages/kanban/use-kanban-board-model.ts
+++ b/packages/frontend/src/pages/kanban/use-kanban-board-model.ts
@@ -1,4 +1,4 @@
-import type { TaskCard } from "@openducktor/contracts";
+import type { KanbanEmptyColumnDisplay, TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario } from "@openducktor/core";
 import { mapToKanbanColumns } from "@openducktor/core";
 import { useMemo } from "react";
@@ -196,6 +196,7 @@ export const buildTaskSessionsByTaskId = (
 type UseKanbanBoardModelArgs = {
   isLoadingTasks: boolean;
   isSwitchingWorkspace: boolean;
+  emptyColumnDisplay: KanbanEmptyColumnDisplay;
   tasks: TaskCard[];
   sessions: AgentSessionSummary[];
   onOpenDetails: (taskId: string) => void;
@@ -217,6 +218,7 @@ type UseKanbanBoardModelArgs = {
 export function useKanbanBoardModel({
   isLoadingTasks,
   isSwitchingWorkspace,
+  emptyColumnDisplay,
   tasks,
   sessions,
   onOpenDetails,
@@ -256,6 +258,7 @@ export function useKanbanBoardModel({
   return {
     isLoadingTasks,
     isSwitchingWorkspace,
+    emptyColumnDisplay,
     columns: columnsWithSortedTasks,
     taskSessionsByTaskId,
     activeTaskSessionContextByTaskId,

--- a/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
+++ b/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_KANBAN_SETTINGS } from "@openducktor/contracts";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
@@ -80,6 +81,9 @@ export function useKanbanPageModels({
   const reportedKanbanTasksErrorRef = useRef<string | null>(null);
   const settingsSnapshotQuery = useQuery(settingsSnapshotQueryOptions());
   const doneVisibleDays = settingsSnapshotQuery.data?.kanban.doneVisibleDays;
+  const emptyColumnDisplay =
+    settingsSnapshotQuery.data?.kanban.emptyColumnDisplay ??
+    DEFAULT_KANBAN_SETTINGS.emptyColumnDisplay;
   const kanbanTaskListQuery = useQuery({
     ...kanbanTaskListQueryOptions(workspaceRepoPath ?? "__disabled__", doneVisibleDays ?? 0),
     enabled: workspaceRepoPath !== null && doneVisibleDays !== undefined,
@@ -262,6 +266,7 @@ export function useKanbanPageModels({
   const content = useKanbanBoardModel({
     isLoadingTasks: isLoadingKanbanTasks,
     isSwitchingWorkspace,
+    emptyColumnDisplay,
     tasks: kanbanTasks,
     sessions,
     onOpenDetails,

--- a/packages/frontend/src/state/app-state-context-values.test.ts
+++ b/packages/frontend/src/state/app-state-context-values.test.ts
@@ -66,6 +66,7 @@ describe("app-state-context-values", () => {
         },
         kanban: {
           doneVisibleDays: 1,
+          emptyColumnDisplay: "show",
         },
         autopilot: {
           rules: [],

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -79,7 +79,7 @@ const createPromptOverrideSettingsSnapshot = (
   theme: "light",
   git: { defaultMergeMethod: "merge_commit" },
   chat: { showThinkingMessages: false },
-  kanban: { doneVisibleDays: 1 },
+  kanban: { doneVisibleDays: 1, emptyColumnDisplay: "show" },
   autopilot: { rules: [] },
   workspaces: {},
   globalPromptOverrides,

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -312,6 +312,7 @@ describe("use-agent-orchestrator-operations", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+        emptyColumnDisplay: "show",
       },
       autopilot: {
         rules: [],

--- a/packages/frontend/src/state/operations/shared/prompt-overrides.test.ts
+++ b/packages/frontend/src/state/operations/shared/prompt-overrides.test.ts
@@ -36,7 +36,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
   },
   workspaces: {},
   chat: { showThinkingMessages: false },
-  kanban: { doneVisibleDays: 1 },
+  kanban: { doneVisibleDays: 1, emptyColumnDisplay: "show" },
   autopilot: { rules: [] },
   globalPromptOverrides: {
     "kickoff.spec_initial": {

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -75,6 +75,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],
@@ -720,6 +721,7 @@ describe("use-repo-settings-operations", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+        emptyColumnDisplay: "show" as const,
       },
       autopilot: {
         rules: [],

--- a/packages/frontend/src/state/operations/workspace/use-workspace-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-operations.test.tsx
@@ -280,6 +280,7 @@ const settingsSnapshot = (repoPaths: string[]): SettingsSnapshot => ({
   },
   kanban: {
     doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
   },
   autopilot: {
     rules: [],


### PR DESCRIPTION
## Summary
- Adds a global Kanban setting for empty columns with Show, Hidden, and Collapsed modes.
- Persists and validates the setting across shared contracts, Rust host config, and frontend settings UI.
- Renders collapsed empty columns as compact themed rails with accessible top tooltips and aligned header height.

## Goal
This PR gives users control over how empty Kanban lanes appear. The current always-visible empty columns can waste horizontal space, but fully hiding columns can reduce status awareness. The new collapsed mode keeps the board compact while preserving lane context through a small visual rail and tooltip.

## Technical choices
- Added `emptyColumnDisplay` to the shared Kanban settings schema with a default of `show` so existing configs keep current behavior.
- Added a Rust `KanbanEmptyColumnDisplay` enum without a fallback variant, so invalid persisted values fail deserialization instead of being silently defaulted.
- Kept `doneVisibleDays` as the only task-query input; empty-column display affects only board rendering after tasks have been grouped and filtered.
- Implemented collapsed lanes as narrow theme-aware rails using the existing lane theme accents, semantic tokens, accessible labels, and a top-positioned tooltip.
- Introduced a shared Kanban header height constant so normal and collapsed lane headers align, with normal lane titles truncating instead of wrapping.
- Updated focused contract, Rust config/persistence, settings, and Kanban rendering tests.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`