### PR TITLE
refactor(runtime): resolve startup config by runtime kind

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
@@ -26,9 +26,12 @@ pub(crate) use open_code::OpenCodeRuntime;
 pub(crate) trait AppRuntime: Send + Sync {
     fn definition(&self) -> RuntimeDefinition;
 
+    fn kind(&self) -> AgentRuntimeKind {
+        self.definition().kind().clone()
+    }
+
     fn startup_config(&self, service: &AppService) -> Result<RuntimeStartupReadinessConfig> {
-        let definition = self.definition();
-        let runtime_kind = definition.kind();
+        let runtime_kind = self.kind();
         let config_path = service.runtime_config_store.path();
         let config = service.runtime_config_store.load().with_context(|| {
             format!(
@@ -38,7 +41,7 @@ pub(crate) trait AppRuntime: Send + Sync {
             )
         })?;
 
-        select_startup_config(&config, runtime_kind, config_path)
+        select_startup_config(&config, &runtime_kind, config_path)
     }
 
     fn startup_policy(&self, service: &AppService) -> Result<RuntimeStartupReadinessPolicy> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
@@ -5,11 +5,14 @@ use super::{
     RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeTargetResolution,
     RuntimeStartupReadinessPolicy, RuntimeStartupWaitReport,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeKind, RuntimeDefinition, RuntimeHealth, RuntimeInstanceSummary, RuntimeRegistry,
+    RuntimeStartupReadinessConfig,
 };
+use host_infra_system::RuntimeConfig;
 use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
 use std::process::Child;
 use std::sync::Arc;
 
@@ -23,7 +26,26 @@ pub(crate) use open_code::OpenCodeRuntime;
 pub(crate) trait AppRuntime: Send + Sync {
     fn definition(&self) -> RuntimeDefinition;
 
-    fn startup_policy(&self, service: &AppService) -> Result<RuntimeStartupReadinessPolicy>;
+    fn startup_config(&self, service: &AppService) -> Result<RuntimeStartupReadinessConfig> {
+        let definition = self.definition();
+        let runtime_kind = definition.kind();
+        let config_path = service.runtime_config_store.path();
+        let config = service.runtime_config_store.load().with_context(|| {
+            format!(
+                "Failed loading startup readiness config for runtime '{}' from {}. Fix invalid JSON in this file or delete it so OpenDucktor can recreate defaults.",
+                runtime_kind.as_str(),
+                config_path.display()
+            )
+        })?;
+
+        select_startup_config(&config, runtime_kind, config_path)
+    }
+
+    fn startup_policy(&self, service: &AppService) -> Result<RuntimeStartupReadinessPolicy> {
+        Ok(RuntimeStartupReadinessPolicy::from_config(
+            self.startup_config(service)?,
+        ))
+    }
 
     fn start_external(
         &self,
@@ -142,6 +164,25 @@ pub(crate) trait AppRuntime: Send + Sync {
     }
 }
 
+fn select_startup_config(
+    config: &RuntimeConfig,
+    runtime_kind: &AgentRuntimeKind,
+    config_path: &Path,
+) -> Result<RuntimeStartupReadinessConfig> {
+    config
+        .runtimes
+        .get(runtime_kind.as_str())
+        .cloned()
+        .ok_or_else(|| {
+            anyhow!(
+                "Runtime config {} is missing startup readiness settings for runtime '{}'. Add a runtimes.{} entry or delete the file so OpenDucktor can recreate registry defaults.",
+                config_path.display(),
+                runtime_kind.as_str(),
+                runtime_kind.as_str()
+            )
+        })
+}
+
 pub(crate) struct ExternalRuntimeStart {
     pub(crate) runtime_route: RuntimeRoute,
     pub(crate) startup_report: RuntimeStartupWaitReport,
@@ -255,6 +296,32 @@ impl AppRuntimeRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn select_startup_config_errors_when_runtime_entry_is_missing() {
+        let config = RuntimeConfig {
+            runtimes: BTreeMap::new(),
+            ..RuntimeConfig::default()
+        };
+        let config_path = Path::new("/tmp/runtime-config.json");
+
+        let error = select_startup_config(
+            &config,
+            &AgentRuntimeKind::from("test-runtime"),
+            config_path,
+        )
+        .expect_err("missing runtime startup config should fail");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("runtime 'test-runtime'"),
+            "error should name requested runtime kind: {message}"
+        );
+        assert!(
+            message.contains(config_path.to_string_lossy().as_ref()),
+            "error should include runtime config path: {message}"
+        );
+    }
 
     #[test]
     fn builtin_for_service_creates_distinct_runtime_instances() {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -16,10 +16,7 @@ use crate::app_service::{
     StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
-use host_domain::{
-    AgentRuntimeKind, RuntimeDefinition, RuntimeHealth, RuntimeInstanceSummary,
-    RuntimeStartupReadinessConfig,
-};
+use host_domain::{AgentRuntimeKind, RuntimeDefinition, RuntimeHealth, RuntimeInstanceSummary};
 use host_infra_system::pick_free_port;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -373,18 +370,6 @@ impl OpenCodeRuntime {
         ))
     }
 
-    fn startup_config(service: &AppService) -> Result<RuntimeStartupReadinessConfig> {
-        let config = service.runtime_config_store.load().with_context(|| {
-            format!(
-                "Failed loading OpenCode startup readiness config from {}. Fix invalid JSON in this file or delete it so OpenDucktor can recreate defaults.",
-                service.runtime_config_store.path().display()
-            )
-        })?;
-        config.runtimes.get("opencode").cloned().ok_or_else(|| {
-            anyhow!("Runtime config is missing startup readiness settings for opencode")
-        })
-    }
-
     fn abort_session(
         runtime_route: &RuntimeRoute,
         external_session_id: &str,
@@ -483,12 +468,6 @@ impl AppRuntime for OpenCodeRuntime {
             .definition_by_str("opencode")
             .expect("builtin runtime registry should include opencode")
             .clone()
-    }
-
-    fn startup_policy(&self, service: &AppService) -> Result<RuntimeStartupReadinessPolicy> {
-        Ok(RuntimeStartupReadinessPolicy::from_config(
-            Self::startup_config(service)?,
-        ))
     }
 
     fn start_host_managed(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -470,6 +470,10 @@ impl AppRuntime for OpenCodeRuntime {
             .clone()
     }
 
+    fn kind(&self) -> AgentRuntimeKind {
+        AgentRuntimeKind::opencode()
+    }
+
     fn start_host_managed(
         &self,
         service: &AppService,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
@@ -8,6 +8,10 @@ impl AppRuntime for HostManagedStdioRuntimeAdapter {
         test_runtime_definition("test-runtime", "Test Runtime")
     }
 
+    fn kind(&self) -> AgentRuntimeKind {
+        AgentRuntimeKind::from("test-runtime")
+    }
+
     fn start_host_managed(
         &self,
         _service: &AppService,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
@@ -24,12 +24,7 @@ impl AppRuntime for HostManagedStdioRuntimeAdapter {
     }
 
     fn runtime_health(&self) -> RuntimeHealth {
-        RuntimeHealth {
-            kind: "test-runtime".to_string(),
-            ok: true,
-            version: None,
-            error: None,
-        }
+        runtime_health_ok("test-runtime")
     }
 
     fn stop_session(
@@ -50,32 +45,14 @@ fn runtime_ensure_registers_external_runtimes_without_local_child_processes() ->
     fs::create_dir_all(repo_path.join(".git"))?;
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition_with_provisioning(
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(
+                TestRuntimeAdapter::for_kind_with_provisioning(
                     "test-runtime",
                     "Test Runtime",
                     RuntimeProvisioningMode::External,
                 ),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            ),
         ],
         AgentRuntimeKind::opencode(),
     )?;
@@ -117,17 +94,7 @@ fn runtime_ensure_registers_host_managed_stdio_routes_without_reconstructing_por
 
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
             Arc::new(HostManagedStdioRuntimeAdapter),
         ],
         AgentRuntimeKind::opencode(),
@@ -170,28 +137,13 @@ fn runtime_ensure_registers_host_managed_stdio_routes_without_reconstructing_por
 fn runtime_check_lists_all_registered_runtimes_from_the_registry() -> Result<()> {
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: Some("1.0.0".to_string()),
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: Some("0.1.0".to_string()),
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(
+                TestRuntimeAdapter::opencode().with_health_version("1.0.0"),
+            ),
+            Arc::new(
+                TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")
+                    .with_health_version("0.1.0"),
+            ),
         ],
         AgentRuntimeKind::opencode(),
     )?;
@@ -215,28 +167,8 @@ fn runtime_check_lists_all_registered_runtimes_from_the_registry() -> Result<()>
 fn runtime_definitions_list_uses_registered_runtime_definitions() -> Result<()> {
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")),
         ],
         AgentRuntimeKind::opencode(),
     )?;
@@ -257,28 +189,8 @@ fn runtime_definitions_list_uses_registered_runtime_definitions() -> Result<()> 
 fn injected_runtime_registry_drives_runtime_config_defaults() -> Result<()> {
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")),
         ],
         AgentRuntimeKind::opencode(),
     )?;
@@ -327,30 +239,13 @@ fn runtime_apis_fail_fast_for_unsupported_runtime_kinds() {
 fn runs_list_consults_registered_runtime_delegate_for_stdio_probe_paths() -> Result<()> {
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::ReturnError(
-                    "custom runtime probe hook invoked",
-                ),
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(
+                TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")
+                    .with_session_probe_behavior(SessionProbeBehavior::ReturnError(
+                        "custom runtime probe hook invoked",
+                    )),
+            ),
         ],
         AgentRuntimeKind::opencode(),
     )?;
@@ -418,28 +313,11 @@ fn task_delete_blocks_custom_runtime_sessions_via_service_runtime_registry() -> 
 
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::ReturnUnsupported,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(
+                TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")
+                    .with_session_probe_behavior(SessionProbeBehavior::ReturnUnsupported),
+            ),
         ],
         AgentRuntimeKind::opencode(),
     )?;
@@ -501,28 +379,8 @@ fn task_delete_uses_task_runtime_route_for_matching_runtime_kind_and_worktree() 
 
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")),
         ],
         AgentRuntimeKind::opencode(),
     )?;
@@ -585,28 +443,8 @@ fn task_delete_uses_task_runtime_route_for_non_build_roles_sharing_a_worktree() 
 
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")),
         ],
         AgentRuntimeKind::opencode(),
     )?;
@@ -665,30 +503,13 @@ fn task_delete_uses_task_runtime_route_for_non_build_roles_sharing_a_worktree() 
 fn runs_list_hides_runs_when_runtime_probe_returns_actionable_failure() -> Result<()> {
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::ProbeFailure(
-                    "probe failed for test runtime",
-                ),
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(
+                TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")
+                    .with_session_probe_behavior(SessionProbeBehavior::ProbeFailure(
+                        "probe failed for test runtime",
+                    )),
+            ),
         ],
         AgentRuntimeKind::opencode(),
     )?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/runtime.rs
@@ -8,10 +8,6 @@ impl AppRuntime for HostManagedStdioRuntimeAdapter {
         test_runtime_definition("test-runtime", "Test Runtime")
     }
 
-    fn startup_policy(&self, _service: &AppService) -> Result<OpencodeStartupReadinessPolicy> {
-        Ok(OpencodeStartupReadinessPolicy::default())
-    }
-
     fn start_host_managed(
         &self,
         _service: &AppService,
@@ -63,6 +59,7 @@ fn runtime_ensure_registers_external_runtimes_without_local_child_processes() ->
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition_with_provisioning(
@@ -77,6 +74,7 @@ fn runtime_ensure_registers_external_runtimes_without_local_child_processes() ->
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -128,6 +126,7 @@ fn runtime_ensure_registers_host_managed_stdio_routes_without_reconstructing_por
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(HostManagedStdioRuntimeAdapter),
         ],
@@ -180,6 +179,7 @@ fn runtime_check_lists_all_registered_runtimes_from_the_registry() -> Result<()>
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition("test-runtime", "Test Runtime"),
@@ -190,6 +190,7 @@ fn runtime_check_lists_all_registered_runtimes_from_the_registry() -> Result<()>
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -223,6 +224,7 @@ fn runtime_definitions_list_uses_registered_runtime_definitions() -> Result<()> 
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition("test-runtime", "Test Runtime"),
@@ -233,6 +235,7 @@ fn runtime_definitions_list_uses_registered_runtime_definitions() -> Result<()> 
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -263,6 +266,7 @@ fn injected_runtime_registry_drives_runtime_config_defaults() -> Result<()> {
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition("test-runtime", "Test Runtime"),
@@ -273,6 +277,7 @@ fn injected_runtime_registry_drives_runtime_config_defaults() -> Result<()> {
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -331,6 +336,7 @@ fn runs_list_consults_registered_runtime_delegate_for_stdio_probe_paths() -> Res
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition("test-runtime", "Test Runtime"),
@@ -343,6 +349,7 @@ fn runs_list_consults_registered_runtime_delegate_for_stdio_probe_paths() -> Res
                 session_probe_behavior: SessionProbeBehavior::ReturnError(
                     "custom runtime probe hook invoked",
                 ),
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -420,6 +427,7 @@ fn task_delete_blocks_custom_runtime_sessions_via_service_runtime_registry() -> 
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition("test-runtime", "Test Runtime"),
@@ -430,6 +438,7 @@ fn task_delete_blocks_custom_runtime_sessions_via_service_runtime_registry() -> 
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::ReturnUnsupported,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -501,6 +510,7 @@ fn task_delete_uses_task_runtime_route_for_matching_runtime_kind_and_worktree() 
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition("test-runtime", "Test Runtime"),
@@ -511,6 +521,7 @@ fn task_delete_uses_task_runtime_route_for_matching_runtime_kind_and_worktree() 
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -583,6 +594,7 @@ fn task_delete_uses_task_runtime_route_for_non_build_roles_sharing_a_worktree() 
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition("test-runtime", "Test Runtime"),
@@ -593,6 +605,7 @@ fn task_delete_uses_task_runtime_route_for_non_build_roles_sharing_a_worktree() 
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),
@@ -661,6 +674,7 @@ fn runs_list_hides_runs_when_runtime_probe_returns_actionable_failure() -> Resul
                     error: None,
                 },
                 session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
             Arc::new(TestRuntimeAdapter {
                 definition: test_runtime_definition("test-runtime", "Test Runtime"),
@@ -673,6 +687,7 @@ fn runs_list_hides_runs_when_runtime_probe_returns_actionable_failure() -> Resul
                 session_probe_behavior: SessionProbeBehavior::ProbeFailure(
                     "probe failed for test runtime",
                 ),
+                external_start_behavior: ExternalStartBehavior::default(),
             }),
         ],
         AgentRuntimeKind::opencode(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
@@ -150,28 +150,8 @@ fn opencode_startup_readiness_policy_uses_config_overrides() -> Result<()> {
 fn startup_readiness_policy_uses_config_for_registered_runtime_kind() -> Result<()> {
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition("test-runtime", "Test Runtime"),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(TestRuntimeAdapter::for_kind("test-runtime", "Test Runtime")),
         ],
         AgentRuntimeKind::opencode(),
     )?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/startup.rs
@@ -147,6 +147,69 @@ fn opencode_startup_readiness_policy_uses_config_overrides() -> Result<()> {
 }
 
 #[test]
+fn startup_readiness_policy_uses_config_for_registered_runtime_kind() -> Result<()> {
+    let runtime_registry = AppRuntimeRegistry::new(
+        vec![
+            Arc::new(TestRuntimeAdapter {
+                definition: builtin_opencode_runtime_definition(),
+                health: RuntimeHealth {
+                    kind: "opencode".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
+            }),
+            Arc::new(TestRuntimeAdapter {
+                definition: test_runtime_definition("test-runtime", "Test Runtime"),
+                health: RuntimeHealth {
+                    kind: "test-runtime".to_string(),
+                    ok: true,
+                    version: None,
+                    error: None,
+                },
+                session_probe_behavior: SessionProbeBehavior::Default,
+                external_start_behavior: ExternalStartBehavior::default(),
+            }),
+        ],
+        AgentRuntimeKind::opencode(),
+    )?;
+    let (service, _task_state, _git_state) =
+        build_service_with_runtime_registry(vec![], runtime_registry);
+    let config = RuntimeConfig {
+        runtimes: BTreeMap::from([(
+            "test-runtime".to_string(),
+            OpencodeStartupReadinessConfig {
+                timeout_ms: 45_678,
+                connect_timeout_ms: 678,
+                initial_retry_delay_ms: 44,
+                max_retry_delay_ms: 222,
+                child_check_interval_ms: 88,
+            },
+        )]),
+        ..RuntimeConfig::default()
+    };
+    service.runtime_config_store.save(&config)?;
+
+    let policy = service.resolve_runtime_startup_policy(
+        &AgentRuntimeKind::from("test-runtime"),
+        "agent_runtime",
+        "/tmp/repo",
+        "task-42",
+        RuntimeRole::Qa,
+        "test runtime failed to start for task task-42",
+    )?;
+
+    assert_eq!(policy.timeout, Duration::from_millis(45_678));
+    assert_eq!(policy.connect_timeout, Duration::from_millis(678));
+    assert_eq!(policy.initial_retry_delay, Duration::from_millis(44));
+    assert_eq!(policy.max_retry_delay, Duration::from_millis(222));
+    assert_eq!(policy.child_state_check_interval, Duration::from_millis(88));
+    Ok(())
+}
+
+#[test]
 fn opencode_startup_readiness_policy_returns_actionable_error_on_invalid_config() -> Result<()> {
     let root = unique_temp_path("startup-policy-invalid-config");
     let config_path = root.join("runtime-config.json");
@@ -164,7 +227,7 @@ fn opencode_startup_readiness_policy_returns_actionable_error_on_invalid_config(
     let message = format!("{error:#}");
     assert!(
         message.contains(&format!(
-            "Failed loading OpenCode startup readiness config from {}",
+            "Failed loading startup readiness config for runtime 'opencode' from {}",
             config_path.display()
         )),
         "error should include startup context and config path: {message}"
@@ -201,7 +264,7 @@ fn resolve_build_startup_policy_emits_config_failure_metrics() -> Result<()> {
         .expect_err("invalid config should fail build startup policy resolution");
     let message = format!("{error:#}");
     assert!(message.contains("opencode build runtime failed before worktree preparation"));
-    assert!(message.contains("Failed loading OpenCode startup readiness config"));
+    assert!(message.contains("Failed loading startup readiness config for runtime 'opencode'"));
 
     let metrics = service.startup_metrics_snapshot()?;
     assert_eq!(
@@ -235,7 +298,7 @@ fn resolve_runtime_startup_policy_emits_config_failure_metrics() -> Result<()> {
         .expect_err("invalid config should fail runtime startup policy resolution");
     let message = format!("{error:#}");
     assert!(message.contains("opencode runtime failed to start for task task-42"));
-    assert!(message.contains("Failed loading OpenCode startup readiness config"));
+    assert!(message.contains("Failed loading startup readiness config for runtime 'opencode'"));
 
     let metrics = service.startup_metrics_snapshot()?;
     assert_eq!(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -317,6 +317,10 @@ impl AppRuntime for TestRuntimeAdapter {
         self.definition.clone()
     }
 
+    fn kind(&self) -> AgentRuntimeKind {
+        self.definition.kind().clone()
+    }
+
     fn start_external(
         &self,
         _service: &AppService,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -140,6 +140,15 @@ pub(super) struct TestRuntimeAdapter {
     pub(super) external_start_behavior: ExternalStartBehavior,
 }
 
+pub(super) fn runtime_health_ok(kind: &str) -> RuntimeHealth {
+    RuntimeHealth {
+        kind: kind.to_string(),
+        ok: true,
+        version: None,
+        error: None,
+    }
+}
+
 #[derive(Clone)]
 pub(super) enum ExternalStartBehavior {
     ReturnRoute(host_domain::RuntimeRoute),
@@ -151,6 +160,53 @@ impl Default for ExternalStartBehavior {
         Self::ReturnRoute(host_domain::RuntimeRoute::LocalHttp {
             endpoint: "http://127.0.0.1:43123".to_string(),
         })
+    }
+}
+
+impl TestRuntimeAdapter {
+    pub(super) fn new(definition: RuntimeDefinition) -> Self {
+        let health = runtime_health_ok(definition.kind().as_str());
+        Self {
+            health,
+            definition,
+            session_probe_behavior: SessionProbeBehavior::Default,
+            external_start_behavior: ExternalStartBehavior::default(),
+        }
+    }
+
+    pub(super) fn opencode() -> Self {
+        Self::new(builtin_opencode_runtime_definition())
+    }
+
+    pub(super) fn for_kind(kind: &str, label: &str) -> Self {
+        Self::new(test_runtime_definition(kind, label))
+    }
+
+    pub(super) fn for_kind_with_provisioning(
+        kind: &str,
+        label: &str,
+        provisioning_mode: RuntimeProvisioningMode,
+    ) -> Self {
+        Self::new(test_runtime_definition_with_provisioning(
+            kind,
+            label,
+            provisioning_mode,
+        ))
+    }
+
+    pub(super) fn with_health_version(mut self, version: impl Into<String>) -> Self {
+        self.health.version = Some(version.into());
+        self
+    }
+
+    pub(super) fn with_session_probe_behavior(mut self, behavior: SessionProbeBehavior) -> Self {
+        self.session_probe_behavior = behavior;
+        self
+    }
+
+    pub(super) fn with_external_start_behavior(mut self, behavior: ExternalStartBehavior) -> Self {
+        self.external_start_behavior = behavior;
+        self
     }
 }
 
@@ -182,32 +238,15 @@ pub(super) fn build_external_runtime_build_start_harness(
 
     let runtime_registry = AppRuntimeRegistry::new(
         vec![
-            Arc::new(TestRuntimeAdapter {
-                definition: builtin_opencode_runtime_definition(),
-                health: RuntimeHealth {
-                    kind: "opencode".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior: ExternalStartBehavior::default(),
-            }),
-            Arc::new(TestRuntimeAdapter {
-                definition: test_runtime_definition_with_provisioning(
+            Arc::new(TestRuntimeAdapter::opencode()),
+            Arc::new(
+                TestRuntimeAdapter::for_kind_with_provisioning(
                     "test-runtime",
                     "Test Runtime",
                     RuntimeProvisioningMode::External,
-                ),
-                health: RuntimeHealth {
-                    kind: "test-runtime".to_string(),
-                    ok: true,
-                    version: None,
-                    error: None,
-                },
-                session_probe_behavior: SessionProbeBehavior::Default,
-                external_start_behavior,
-            }),
+                )
+                .with_external_start_behavior(external_start_behavior),
+            ),
         ],
         AgentRuntimeKind::opencode(),
     )?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit/support.rs
@@ -278,10 +278,6 @@ impl AppRuntime for TestRuntimeAdapter {
         self.definition.clone()
     }
 
-    fn startup_policy(&self, _service: &AppService) -> Result<OpencodeStartupReadinessPolicy> {
-        Ok(OpencodeStartupReadinessPolicy::default())
-    }
-
     fn start_external(
         &self,
         _service: &AppService,


### PR DESCRIPTION
## Summary
- Move startup readiness config resolution into the runtime registry boundary so adapters resolve settings by their registered runtime kind.
- Remove OpenCode's hardcoded `runtimes.get("opencode")` startup config path while preserving existing OpenCode defaults, overrides, and error handling.
- Simplify runtime test fixtures with reusable `TestRuntimeAdapter` builders.

## Goal
OpenDucktor is moving toward multiple agent runtimes, but startup readiness config lookup still had one OpenCode-specific path. This PR makes that lookup runtime-kind driven so future registered runtimes can use the same normalized `runtime-config.json` path without copying OpenCode-specific key lookups or falling back to OpenCode defaults.

## Technical approach
- Added default `AppRuntime::startup_config` and `startup_policy` implementations that derive the runtime kind from `definition().kind()`, load the normalized `RuntimeConfigStore`, and select the matching `runtimes.<kind>` entry.
- Added an explicit fail-fast selector error that names the requested runtime kind and runtime config path when the normalized entry is unexpectedly missing.
- Let `OpenCodeRuntime` inherit the generic startup policy path by deleting its private hardcoded config helper.
- Added focused coverage for a registered non-built-in runtime resolving custom startup readiness values, and for the missing-entry invariant breach.
- Added test-only `TestRuntimeAdapter` constructors/builders to keep runtime test setup readable after adopting the generic startup policy default.

## Verification
- `cargo fmt --all --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `cargo build`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`