### PR TITLE
fix(agent-orchestrator): fail fast on missing worktree runtimes

### DIFF
--- a/packages/frontend/src/lib/host-client.test.ts
+++ b/packages/frontend/src/lib/host-client.test.ts
@@ -97,4 +97,34 @@ describe("host-client", () => {
     expect(firstRuntimeEnsure).toHaveBeenCalledTimes(1);
     expect(secondRuntimeEnsure).toHaveBeenCalledTimes(1);
   });
+
+  test("hostClient allows scoped method overrides for tests", async () => {
+    const shellRuntimeEnsure = mock(async () => createRuntimeInstanceSummary("runtime-shell"));
+    const overrideRuntimeEnsure = mock(async () =>
+      createRuntimeInstanceSummary("runtime-override"),
+    );
+    configureShellBridge(
+      createTestShellBridge({
+        client: { runtimeEnsure: shellRuntimeEnsure } as unknown as TauriHostClient,
+      }),
+    );
+
+    const { hostClient } = await import("./host-client");
+    const originalRuntimeEnsure = hostClient.runtimeEnsure;
+
+    hostClient.runtimeEnsure = overrideRuntimeEnsure as TauriHostClient["runtimeEnsure"];
+    try {
+      await expect(hostClient.runtimeEnsure("/repo", "opencode")).resolves.toMatchObject({
+        runtimeId: "runtime-override",
+      });
+    } finally {
+      hostClient.runtimeEnsure = originalRuntimeEnsure;
+    }
+
+    await expect(hostClient.runtimeEnsure("/repo", "opencode")).resolves.toMatchObject({
+      runtimeId: "runtime-shell",
+    });
+    expect(overrideRuntimeEnsure).toHaveBeenCalledTimes(1);
+    expect(shellRuntimeEnsure).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/frontend/src/lib/host-client.ts
+++ b/packages/frontend/src/lib/host-client.ts
@@ -1,15 +1,54 @@
 import type { TauriHostClient } from "@openducktor/adapters-tauri-host";
 import { getShellBridge, type HostBridge } from "./shell-bridge";
 
+const hostClientOverrides = new Map<PropertyKey, { value: unknown; restoreValue: unknown }>();
+const shellClientMethodBindings = new WeakMap<object, Map<PropertyKey, unknown>>();
+
+const readShellClientValue = (propertyKey: PropertyKey): unknown => {
+  const client = getShellBridge().client;
+  const value = client[propertyKey as keyof TauriHostClient];
+  if (typeof value !== "function") {
+    return value;
+  }
+
+  const clientObject = client as object;
+  const existingBindings = shellClientMethodBindings.get(clientObject) ?? new Map();
+  if (!shellClientMethodBindings.has(clientObject)) {
+    shellClientMethodBindings.set(clientObject, existingBindings);
+  }
+  const existingBinding = existingBindings.get(propertyKey);
+  if (existingBinding) {
+    return existingBinding;
+  }
+
+  const boundValue = value.bind(client);
+  existingBindings.set(propertyKey, boundValue);
+  return boundValue;
+};
+
 const hostClientProxy = new Proxy(
   {},
   {
     get(_target, propertyKey) {
-      const value = getShellBridge().client[propertyKey as keyof TauriHostClient];
-      if (typeof value === "function") {
-        return value.bind(getShellBridge().client);
+      const override = hostClientOverrides.get(propertyKey);
+      if (override) {
+        return override.value;
       }
-      return value;
+      return readShellClientValue(propertyKey);
+    },
+    set(_target, propertyKey, value) {
+      const existingOverride = hostClientOverrides.get(propertyKey);
+      const restoreValue = existingOverride?.restoreValue ?? readShellClientValue(propertyKey);
+      if (value === restoreValue) {
+        hostClientOverrides.delete(propertyKey);
+        return true;
+      }
+      hostClientOverrides.set(propertyKey, { value, restoreValue });
+      return true;
+    },
+    deleteProperty(_target, propertyKey) {
+      hostClientOverrides.delete(propertyKey);
+      return true;
     },
   },
 ) as TauriHostClient;

--- a/packages/frontend/src/lib/host-client.ts
+++ b/packages/frontend/src/lib/host-client.ts
@@ -12,8 +12,9 @@ const readShellClientValue = (propertyKey: PropertyKey): unknown => {
   }
 
   const clientObject = client as object;
-  const existingBindings = shellClientMethodBindings.get(clientObject) ?? new Map();
-  if (!shellClientMethodBindings.has(clientObject)) {
+  let existingBindings = shellClientMethodBindings.get(clientObject);
+  if (!existingBindings) {
+    existingBindings = new Map();
     shellClientMethodBindings.set(clientObject, existingBindings);
   }
   const existingBinding = existingBindings.get(propertyKey);

--- a/packages/frontend/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
+++ b/packages/frontend/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
@@ -42,7 +42,7 @@ export const resolveRepoNavigationBoundaryPhase = ({
     return "idle";
   }
 
-  if (Boolean(lastWorkspaceId) && lastWorkspaceId !== activeWorkspaceId) {
+  if (lastWorkspaceId && lastWorkspaceId !== activeWorkspaceId) {
     return "detecting";
   }
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.test.ts
@@ -23,19 +23,19 @@ describe("canUseWorkspaceRuntimeForHydration", () => {
     ).toBe(true);
   });
 
-  test("allows non-root build sessions", () => {
+  test("rejects non-root build sessions", () => {
     expect(
       canUseWorkspaceRuntimeForHydration(
         createRecord("build", "/tmp/openducktor-worktrees/task-1"),
         "/tmp/repo",
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  test("allows build sessions outside the repo root", () => {
+  test("rejects build sessions outside the repo root", () => {
     expect(
       canUseWorkspaceRuntimeForHydration(createRecord("build", "/tmp/other-worktree"), "/tmp/repo"),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("rejects worktree planner sessions", () => {
@@ -51,5 +51,11 @@ describe("canUseWorkspaceRuntimeForHydration", () => {
     expect(canUseWorkspaceRuntimeForHydration(createRecord("qa", "/tmp/repo"), "/tmp/repo")).toBe(
       false,
     );
+  });
+
+  test("rejects worktree qa sessions", () => {
+    expect(
+      canUseWorkspaceRuntimeForHydration(createRecord("qa", "/tmp/repo/worktree"), "/tmp/repo"),
+    ).toBe(false);
   });
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-policy.ts
@@ -2,7 +2,6 @@ import type { AgentSessionRecord } from "@openducktor/contracts";
 import { normalizeWorkingDirectory } from "../support/core";
 
 const REPO_ROOT_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["spec", "planner"]);
-const WORKTREE_WORKSPACE_RUNTIME_ROLES = new Set<AgentSessionRecord["role"]>(["build", "qa"]);
 
 export const canUseWorkspaceRuntimeForHydration = (
   record: Pick<AgentSessionRecord, "role" | "workingDirectory">,
@@ -11,15 +10,12 @@ export const canUseWorkspaceRuntimeForHydration = (
   const normalizedWorkingDirectory = normalizeWorkingDirectory(record.workingDirectory);
   const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
 
-  if (REPO_ROOT_WORKSPACE_RUNTIME_ROLES.has(record.role)) {
-    return normalizedWorkingDirectory === normalizedRepoPath;
+  if (normalizedWorkingDirectory.length === 0) {
+    return false;
   }
 
-  if (WORKTREE_WORKSPACE_RUNTIME_ROLES.has(record.role)) {
-    return (
-      normalizedWorkingDirectory.length > 0 && normalizedWorkingDirectory !== normalizedRepoPath
-    );
-  }
-
-  return false;
+  return (
+    REPO_ROOT_WORKSPACE_RUNTIME_ROLES.has(record.role) &&
+    normalizedWorkingDirectory === normalizedRepoPath
+  );
 };

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -186,6 +186,112 @@ describe("createHydrationRuntimeResolver", () => {
     expect(ensureCalls).toBe(0);
   });
 
+  test("fails fast for repo-root build sessions when only the workspace runtime exists", async () => {
+    let ensureCalls = 0;
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+        ["opencode", [createRuntime("/tmp/repo")]],
+      ]),
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return null;
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("build", "/tmp/repo"));
+
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/repo.",
+    });
+    expect(ensureCalls).toBe(0);
+  });
+
+  test("fails fast for repo-root qa sessions when only the workspace runtime exists", async () => {
+    let ensureCalls = 0;
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+        ["opencode", [createRuntime("/tmp/repo")]],
+      ]),
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return null;
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("qa", "/tmp/repo"));
+
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/repo.",
+    });
+    expect(ensureCalls).toBe(0);
+  });
+
+  test("fails fast for repo-root build sessions when only a preloaded runtime connection exists", async () => {
+    const workingDirectory = "/tmp/repo";
+    const preloadedRuntimeConnections = createPreloadIndex([
+      {
+        type: "local_http",
+        endpoint: "http://127.0.0.1:9999",
+        workingDirectory,
+      },
+    ]);
+    let ensureCalls = 0;
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      preloadedRuntimeConnections,
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return null;
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("build", workingDirectory));
+
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/repo.",
+    });
+    expect(ensureCalls).toBe(0);
+  });
+
+  test("fails fast for repo-root qa sessions when only a preloaded runtime connection exists", async () => {
+    const workingDirectory = "/tmp/repo";
+    const preloadedRuntimeConnections = createPreloadIndex([
+      {
+        type: "local_http",
+        endpoint: "http://127.0.0.1:9999",
+        workingDirectory,
+      },
+    ]);
+    let ensureCalls = 0;
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      preloadedRuntimeConnections,
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return null;
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("qa", workingDirectory));
+
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/repo.",
+    });
+    expect(ensureCalls).toBe(0);
+  });
+
   test("does not ensure a shared workspace runtime for build sessions on non-root directories", async () => {
     let ensureCalls = 0;
     const resolveHydrationRuntime = createHydrationRuntimeResolver({

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -95,7 +95,7 @@ describe("createHydrationRuntimeResolver", () => {
     });
   });
 
-  test("hydrates build sessions through a shared workspace runtime", async () => {
+  test("fails fast for build worktree sessions when only the workspace runtime exists", async () => {
     let ensureCalls = 0;
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
@@ -111,24 +111,15 @@ describe("createHydrationRuntimeResolver", () => {
     const result = await resolveHydrationRuntime(
       createRecord("build", "/tmp/openducktor-worktrees/task-1"),
     );
-    if (!result.ok) {
-      throw new Error("Expected runtime resolution to succeed");
-    }
-
-    expect(result.runtimeId).toBe("runtime-1");
-    expect(result.runtimeRoute).toEqual({
-      type: "local_http",
-      endpoint: "http://127.0.0.1:4555",
-    });
-    expect(result.runtimeConnection).toEqual({
-      type: "local_http",
-      endpoint: "http://127.0.0.1:4555",
-      workingDirectory: "/tmp/openducktor-worktrees/task-1",
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/openducktor-worktrees/task-1.",
     });
     expect(ensureCalls).toBe(0);
   });
 
-  test("uses preloaded snapshots to disambiguate same-repo workspace stdio runtimes", async () => {
+  test("uses exact preloaded snapshots to disambiguate worktree stdio connections", async () => {
     const workingDirectory = "/tmp/openducktor-worktrees/task-1";
     const runtimeConnectionA: AgentRuntimeConnection = {
       type: "stdio",
@@ -158,15 +149,7 @@ describe("createHydrationRuntimeResolver", () => {
 
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
-      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
-        [
-          "opencode",
-          [
-            createStdioRuntime("runtime-stdio-a", "/tmp/repo"),
-            createStdioRuntime("runtime-stdio-b", "/tmp/repo"),
-          ],
-        ],
-      ]),
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
       preloadedRuntimeConnections,
       preloadedLiveAgentSessionsByKey,
       ensureWorkspaceRuntime: async () => null,
@@ -177,7 +160,7 @@ describe("createHydrationRuntimeResolver", () => {
       throw new Error("Expected runtime resolution to succeed");
     }
 
-    expect(result.runtimeId).toBe("runtime-stdio-b");
+    expect(result.runtimeId).toBeNull();
     expect(result.runtimeConnection).toEqual(runtimeConnectionB);
     expect(result.runtimeRoute).toEqual({ type: "stdio", identity: "runtime-stdio-b" });
   });
@@ -203,7 +186,7 @@ describe("createHydrationRuntimeResolver", () => {
     expect(ensureCalls).toBe(0);
   });
 
-  test("ensures a shared workspace runtime for build sessions on non-root directories", async () => {
+  test("does not ensure a shared workspace runtime for build sessions on non-root directories", async () => {
     let ensureCalls = 0;
     const resolveHydrationRuntime = createHydrationRuntimeResolver({
       repoPath: "/tmp/repo",
@@ -215,20 +198,12 @@ describe("createHydrationRuntimeResolver", () => {
     });
 
     const result = await resolveHydrationRuntime(createRecord("build", "/tmp/other"));
-    if (!result.ok) {
-      throw new Error("Expected runtime resolution to succeed");
-    }
-
-    expect(result.runtimeRoute).toEqual({
-      type: "local_http",
-      endpoint: "http://127.0.0.1:4555",
+    expect(result).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/other.",
     });
-    expect(result.runtimeConnection).toEqual({
-      type: "local_http",
-      endpoint: "http://127.0.0.1:4555",
-      workingDirectory: "/tmp/other",
-    });
-    expect(ensureCalls).toBe(1);
+    expect(ensureCalls).toBe(0);
   });
 
   test("falls back to preloaded runtime connection when no run or runtime exists", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -77,12 +77,19 @@ export const createHydrationRuntimeResolver = ({
       return { ok: true, runtimeConnection: null };
     }
 
+    const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
     const matchesByTransportKey = new Map<string, AgentRuntimeConnection>();
     for (const runtimeConnection of runtimeConnections) {
       const snapshots = preloadedLiveAgentSessionsByKey.get(
         liveAgentSessionLookupKey(runtimeKind, runtimeConnection, workingDirectory),
       );
-      if (!snapshots?.some((snapshot) => snapshot.externalSessionId === externalSessionId)) {
+      if (
+        !snapshots?.some(
+          (snapshot) =>
+            snapshot.externalSessionId === externalSessionId &&
+            normalizeWorkingDirectory(snapshot.workingDirectory) === normalizedWorkingDirectory,
+        )
+      ) {
         continue;
       }
       matchesByTransportKey.set(
@@ -222,18 +229,26 @@ export const createHydrationRuntimeResolver = ({
     }
 
     const candidates = preloadedRuntimeConnections.findCandidates(runtimeKind, workingDirectory);
-    const candidatesByTransportKey = new Map(
+    const candidatesByTransportKey = new Map<string, AgentRuntimeConnection>(
       candidates.map((runtimeConnection) => [
         runtimeConnectionTransportKey(runtimeConnection),
         runtimeConnection,
       ]),
     );
-    if (candidatesByTransportKey.size > 1) {
+    const candidateConnections = Array.from(candidatesByTransportKey.values());
+    const candidatesWithPreloadedSnapshots = preloadedLiveAgentSessionsByKey
+      ? candidateConnections.filter((runtimeConnection) =>
+          preloadedLiveAgentSessionsByKey.has(
+            liveAgentSessionLookupKey(runtimeKind, runtimeConnection, workingDirectory),
+          ),
+        )
+      : [];
+    if (candidatesWithPreloadedSnapshots.length > 0) {
       const snapshotMatch = findPreloadedSnapshotConnection(
         runtimeKind,
         workingDirectory,
         externalSessionId,
-        Array.from(candidatesByTransportKey.values()),
+        candidatesWithPreloadedSnapshots,
       );
       if (!snapshotMatch.ok) {
         return { ok: false, reason: snapshotMatch.reason };
@@ -241,6 +256,10 @@ export const createHydrationRuntimeResolver = ({
       if (snapshotMatch.runtimeConnection) {
         return { ok: true, runtimeConnection: snapshotMatch.runtimeConnection };
       }
+      return { ok: true, runtimeConnection: null };
+    }
+
+    if (candidatesByTransportKey.size > 1) {
       return {
         ok: false,
         reason: `Multiple preloaded runtime connections found for working directory ${workingDirectory}.`,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -307,6 +307,9 @@ export const createHydrationRuntimeResolver = ({
       !canUseWorkspaceRuntime &&
       normalizeWorkingDirectory(workingDirectory) === normalizedRepoPath
     ) {
+      // Exact non-workspace repo-root runtimes are handled above. Preloaded
+      // connections do not carry runtime role metadata, so build/QA records must
+      // fail here instead of accepting a role-less repo-root workspace route.
       return {
         ok: false,
         runtimeKind,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -151,11 +151,17 @@ export const createHydrationRuntimeResolver = ({
     runtimeKind: RuntimeKind,
     workingDirectory: string,
     externalSessionId: string,
+    includeRepoRootWorkspaceRuntimes: boolean,
   ): RuntimeLookupResult => {
     const runtimes = runtimesByKind.get(runtimeKind) ?? [];
     const normalizedDirectory = normalizeWorkingDirectory(workingDirectory);
+    const isRepoRootWorkspaceRuntime = (runtime: RuntimeInstanceSummary): boolean =>
+      runtime.role === "workspace" &&
+      normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath;
     const matches = runtimes.filter(
-      (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === normalizedDirectory,
+      (runtime) =>
+        normalizeWorkingDirectory(runtime.workingDirectory) === normalizedDirectory &&
+        (includeRepoRootWorkspaceRuntimes || !isRepoRootWorkspaceRuntime(runtime)),
     );
     const ambiguousMatch = disambiguateAmbiguousStdioMatches(
       runtimeKind,
@@ -251,11 +257,13 @@ export const createHydrationRuntimeResolver = ({
     const runtimeKind = readPersistedRuntimeKind(record);
     const workingDirectory = record.workingDirectory;
     const externalSessionId = record.externalSessionId ?? record.sessionId;
+    const canUseWorkspaceRuntime = canUseWorkspaceRuntimeForHydration(record, repoPath);
 
     const runtimeForDirectory = findRuntimeByWorkingDirectory(
       runtimeKind,
       workingDirectory,
       externalSessionId,
+      canUseWorkspaceRuntime,
     );
     if (!runtimeForDirectory.ok) {
       return {
@@ -266,7 +274,7 @@ export const createHydrationRuntimeResolver = ({
     }
 
     let runtime = runtimeForDirectory.runtime;
-    if (!runtime && canUseWorkspaceRuntimeForHydration(record, repoPath)) {
+    if (!runtime && canUseWorkspaceRuntime) {
       const workspaceRuntime = findWorkspaceRuntime(
         runtimeKind,
         workingDirectory,
@@ -295,6 +303,17 @@ export const createHydrationRuntimeResolver = ({
       };
     }
 
+    if (
+      !canUseWorkspaceRuntime &&
+      normalizeWorkingDirectory(workingDirectory) === normalizedRepoPath
+    ) {
+      return {
+        ok: false,
+        runtimeKind,
+        reason: `No live runtime found for working directory ${workingDirectory}.`,
+      };
+    }
+
     const preloadedRuntimeConnection = findPreloadedRuntimeConnection(
       runtimeKind,
       workingDirectory,
@@ -317,7 +336,7 @@ export const createHydrationRuntimeResolver = ({
       };
     }
 
-    if (!canUseWorkspaceRuntimeForHydration(record, repoPath)) {
+    if (!canUseWorkspaceRuntime) {
       return {
         ok: false,
         runtimeKind,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -5,7 +5,11 @@ import type {
   RuntimeKind,
   TaskCard,
 } from "@openducktor/contracts";
-import type { AgentEnginePort, LiveAgentSessionSnapshot } from "@openducktor/core";
+import type {
+  AgentEnginePort,
+  AgentRuntimeConnection,
+  LiveAgentSessionSnapshot,
+} from "@openducktor/core";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { errorMessage } from "@/lib/errors";
 import { appQueryClient } from "@/lib/query-client";
@@ -22,6 +26,7 @@ import type {
 import { host } from "../../shared/host";
 import { ensureRuntimeAndInvalidateReadinessQueries } from "../../shared/runtime-readiness-publication";
 import { requireRuntimeConnectionSupport, runtimeRouteToConnection } from "../runtime/runtime";
+import { normalizeWorkingDirectory } from "../support/core";
 import { DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE } from "../support/history-hydration";
 import {
   appendSessionMessage,
@@ -43,6 +48,7 @@ import {
   isTranscriptAgentSession,
   resolveAgentSessionPurposeForLoad,
 } from "../support/session-purpose";
+import { requiresLiveWorktreeRuntime } from "../support/session-runtime-attachment";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
 import {
   formatSubagentContent,
@@ -59,7 +65,11 @@ import {
   createHydrationRuntimeResolver,
   type ResolvedHydrationRuntime,
 } from "./hydration-runtime-resolution";
-import { LiveAgentSessionCache } from "./live-agent-session-cache";
+import {
+  LiveAgentSessionCache,
+  liveAgentSessionLookupKey,
+  RuntimeConnectionPreloadIndex,
+} from "./live-agent-session-cache";
 import type { LiveAgentSessionStore } from "./live-agent-session-store";
 import { createReattachLiveSession } from "./reattach-live-session";
 
@@ -178,6 +188,140 @@ export type HistoryHydrationStageInput = {
 const INITIAL_SESSION_HISTORY_LIMIT = 600;
 const SESSION_HISTORY_HYDRATION_CONCURRENCY = 3;
 const EMPTY_PROMPT_OVERRIDES: RepoPromptOverrides = {};
+
+type VerifiedWorktreeRuntimeTarget = {
+  workingDirectory: string;
+  externalSessionIds: Set<string>;
+};
+
+const isRepoRootWorkspaceRuntime = (
+  runtime: RuntimeInstanceSummary,
+  normalizedRepoPath: string,
+): boolean =>
+  runtime.role === "workspace" &&
+  normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath;
+
+const hasExactNonRepoRootWorkspaceRuntime = ({
+  runtimes,
+  workingDirectory,
+  normalizedRepoPath,
+}: {
+  runtimes: RuntimeInstanceSummary[];
+  workingDirectory: string;
+  normalizedRepoPath: string;
+}): boolean => {
+  const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+  return runtimes.some(
+    (runtime) =>
+      normalizeWorkingDirectory(runtime.workingDirectory) === normalizedWorkingDirectory &&
+      !isRepoRootWorkspaceRuntime(runtime, normalizedRepoPath),
+  );
+};
+
+const getOrCreateVerifiedWorktreeRuntimeTarget = (
+  targetsByWorkingDirectory: Map<string, VerifiedWorktreeRuntimeTarget>,
+  workingDirectory: string,
+): VerifiedWorktreeRuntimeTarget => {
+  const key = normalizeWorkingDirectory(workingDirectory);
+  const existing = targetsByWorkingDirectory.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const created = { workingDirectory: key, externalSessionIds: new Set<string>() };
+  targetsByWorkingDirectory.set(key, created);
+  return created;
+};
+
+const preloadVerifiedRepoRootRuntimeConnectionsForWorktreeSessions = async ({
+  adapter,
+  records,
+  repoPath,
+  runtimesByKind,
+  preloadedRuntimeConnections,
+  preloadedLiveAgentSessionsByKey,
+}: {
+  adapter: Pick<SessionLifecycleAdapter, "listLiveAgentSessionSnapshots">;
+  records: AgentSessionRecord[];
+  repoPath: string;
+  runtimesByKind: Map<RuntimeKind, RuntimeInstanceSummary[]>;
+  preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
+  preloadedLiveAgentSessionsByKey: Map<string, LiveAgentSessionSnapshot[]>;
+}): Promise<void> => {
+  if (!adapter.listLiveAgentSessionSnapshots) {
+    return;
+  }
+
+  const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
+  const targetsByRuntimeKind = new Map<RuntimeKind, Map<string, VerifiedWorktreeRuntimeTarget>>();
+  for (const record of records) {
+    const externalSessionId = record.externalSessionId ?? record.sessionId;
+    const normalizedWorkingDirectory = normalizeWorkingDirectory(record.workingDirectory);
+    if (
+      !externalSessionId ||
+      !requiresLiveWorktreeRuntime(record) ||
+      normalizedWorkingDirectory === normalizedRepoPath
+    ) {
+      continue;
+    }
+
+    const runtimeKind = readPersistedRuntimeKind(record);
+    const runtimes = runtimesByKind.get(runtimeKind) ?? [];
+    if (
+      hasExactNonRepoRootWorkspaceRuntime({
+        runtimes,
+        workingDirectory: record.workingDirectory,
+        normalizedRepoPath,
+      })
+    ) {
+      continue;
+    }
+
+    const targetsByWorkingDirectory =
+      targetsByRuntimeKind.get(runtimeKind) ?? new Map<string, VerifiedWorktreeRuntimeTarget>();
+    const target = getOrCreateVerifiedWorktreeRuntimeTarget(
+      targetsByWorkingDirectory,
+      record.workingDirectory,
+    );
+    target.externalSessionIds.add(externalSessionId);
+    targetsByRuntimeKind.set(runtimeKind, targetsByWorkingDirectory);
+  }
+
+  for (const [runtimeKind, targetsByWorkingDirectory] of targetsByRuntimeKind) {
+    const repoRootWorkspaceRuntimes = (runtimesByKind.get(runtimeKind) ?? []).filter((runtime) =>
+      isRepoRootWorkspaceRuntime(runtime, normalizedRepoPath),
+    );
+    for (const runtime of repoRootWorkspaceRuntimes) {
+      for (const target of targetsByWorkingDirectory.values()) {
+        const runtimeConnection: AgentRuntimeConnection = runtimeRouteToConnection(
+          runtime.runtimeRoute,
+          target.workingDirectory,
+        );
+        const liveSessions = await adapter.listLiveAgentSessionSnapshots({
+          runtimeKind,
+          runtimeConnection,
+          directories: [target.workingDirectory],
+        });
+        const liveSessionsForDirectory = liveSessions.filter(
+          (session) =>
+            normalizeWorkingDirectory(session.workingDirectory) === target.workingDirectory,
+        );
+        const hasMatchingSession = liveSessionsForDirectory.some((session) =>
+          target.externalSessionIds.has(session.externalSessionId),
+        );
+        if (!hasMatchingSession) {
+          continue;
+        }
+
+        preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
+        preloadedLiveAgentSessionsByKey.set(
+          liveAgentSessionLookupKey(runtimeKind, runtimeConnection, target.workingDirectory),
+          liveSessionsForDirectory,
+        );
+      }
+    }
+  }
+};
 const normalizeLiveSessionTitle = (title: string | undefined): string | undefined => {
   const trimmed = title?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
@@ -735,19 +879,29 @@ export const createRuntimeResolutionPlannerStage = async ({
     return runtime;
   };
 
+  const preloadedRuntimeConnections =
+    options?.preloadedRuntimeConnections ?? new RuntimeConnectionPreloadIndex();
+  const preloadedLiveAgentSessionsByKey =
+    options?.preloadedLiveAgentSessionsByKey ?? new Map<string, LiveAgentSessionSnapshot[]>();
+
+  await preloadVerifiedRepoRootRuntimeConnectionsForWorktreeSessions({
+    adapter,
+    records: recordsNeedingRuntimeResolution,
+    repoPath: intent.repoPath,
+    runtimesByKind,
+    preloadedRuntimeConnections,
+    preloadedLiveAgentSessionsByKey,
+  });
+
   const resolveHydrationRuntime = createHydrationRuntimeResolver({
     repoPath: intent.repoPath,
     runtimesByKind,
-    ...(options?.preloadedRuntimeConnections
-      ? { preloadedRuntimeConnections: options.preloadedRuntimeConnections }
-      : {}),
-    ...(options?.preloadedLiveAgentSessionsByKey
-      ? { preloadedLiveAgentSessionsByKey: options.preloadedLiveAgentSessionsByKey }
-      : {}),
+    ...(preloadedRuntimeConnections.size > 0 ? { preloadedRuntimeConnections } : {}),
+    ...(preloadedLiveAgentSessionsByKey.size > 0 ? { preloadedLiveAgentSessionsByKey } : {}),
     ensureWorkspaceRuntime,
   });
   const liveAgentSessionScanCache =
-    adapter.listLiveAgentSessionSnapshots || options?.preloadedLiveAgentSessionsByKey
+    adapter.listLiveAgentSessionSnapshots || preloadedLiveAgentSessionsByKey.size > 0
       ? new LiveAgentSessionCache(
           {
             listLiveAgentSessionSnapshots: async (input) => {
@@ -759,7 +913,7 @@ export const createRuntimeResolutionPlannerStage = async ({
               return adapter.listLiveAgentSessionSnapshots(input);
             },
           },
-          options?.preloadedLiveAgentSessionsByKey,
+          preloadedLiveAgentSessionsByKey.size > 0 ? preloadedLiveAgentSessionsByKey : undefined,
         )
       : null;
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -971,6 +971,248 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(sessionMessagesToArray(getSession(state, "session-1"))).toEqual([]);
   });
 
+  test("recovers a worktree session from a repo-root runtime after verifying the live external session", async () => {
+    const persistedRecord = persistedSessionRecord({
+      runtimeKind: "opencode",
+      sessionId: "session-1",
+      externalSessionId: "external-1",
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_implementation_start",
+      startedAt: "2026-02-22T08:00:00.000Z",
+      updatedAt: "2026-02-22T08:00:00.000Z",
+      workingDirectory: "/tmp/repo/worktree",
+    });
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": {
+          ...persistedRecord,
+          externalSessionId: "external-1",
+          runtimeKind: "opencode",
+          repoPath: "/tmp/repo",
+          taskId: "task-1",
+          status: "stopped",
+          runtimeId: null,
+          runtimeRoute: null,
+          historyHydrationState: "not_requested",
+          messages: [],
+          draftAssistantText: "",
+          draftAssistantMessageId: null,
+          draftReasoningText: "",
+          draftReasoningMessageId: null,
+          contextUsage: null,
+          pendingPermissions: [],
+          pendingQuestions: [],
+          todos: [],
+          modelCatalog: null,
+          selectedModel: null,
+          isLoadingModelCatalog: false,
+          promptOverrides: {},
+        },
+      },
+    };
+    let state = sessionsRef.current;
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const observedSnapshotDirectories: string[][] = [];
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeWorkspace: {
+        repoPath: "/tmp/repo",
+        workspaceId: "workspace-1",
+        workspaceName: "Active Workspace",
+      },
+      adapter: createAdapter({
+        listLiveAgentSessionSnapshots: async (input) => {
+          observedSnapshotDirectories.push(input.directories ?? []);
+          return [
+            {
+              externalSessionId: "external-1",
+              title: "BUILD task-1",
+              workingDirectory: "/tmp/repo/worktree",
+              startedAt: "2026-02-22T08:00:00.000Z",
+              status: { type: "busy" },
+              pendingPermissions: [],
+              pendingQuestions: [],
+            },
+          ];
+        },
+        loadSessionHistory: async () => {
+          throw new Error("recover_runtime_attachment must not hydrate transcript history");
+        },
+      }),
+      repoEpochRef: { current: 2 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession: (sessionId, updater) => {
+        const current = state[sessionId];
+        if (!current) {
+          return;
+        }
+        state = {
+          ...state,
+          [sessionId]: updater(current),
+        };
+        sessionsRef.current = state;
+      },
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    await loadAgentSessions("task-1", {
+      mode: "recover_runtime_attachment",
+      targetSessionId: "session-1",
+      historyPolicy: "none",
+      persistedRecords: [persistedRecord],
+      preloadedRuntimeLists: new Map([
+        [
+          "opencode",
+          [
+            {
+              kind: "opencode",
+              runtimeId: "runtime-root",
+              repoPath: "/tmp/repo",
+              taskId: null,
+              role: "workspace",
+              workingDirectory: "/tmp/repo",
+              runtimeRoute: {
+                type: "local_http",
+                endpoint: "http://127.0.0.1:4444",
+              },
+              startedAt: "2026-02-22T08:00:00.000Z",
+              descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+            },
+          ],
+        ],
+      ]),
+    });
+
+    expect(observedSnapshotDirectories).toEqual([["/tmp/repo/worktree"]]);
+    expect(getSession(state, "session-1").runtimeId).toBeNull();
+    expect(getSession(state, "session-1").runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4444",
+    });
+    expect(getSession(state, "session-1").workingDirectory).toBe("/tmp/repo/worktree");
+    expect(getSession(state, "session-1").historyHydrationState).toBe("not_requested");
+    expect(sessionMessagesToArray(getSession(state, "session-1"))).toEqual([]);
+  });
+
+  test("does not reuse a verified repo-root worktree recovery for another external session", async () => {
+    const firstRecord = persistedSessionRecord({
+      runtimeKind: "opencode",
+      sessionId: "session-1",
+      externalSessionId: "external-1",
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_implementation_start",
+      startedAt: "2026-02-22T08:00:00.000Z",
+      updatedAt: "2026-02-22T08:00:00.000Z",
+      workingDirectory: "/tmp/repo/worktree",
+    });
+    const secondRecord = persistedSessionRecord({
+      runtimeKind: "opencode",
+      sessionId: "session-2",
+      externalSessionId: "external-2",
+      taskId: "task-1",
+      role: "qa",
+      scenario: "qa_review",
+      startedAt: "2026-02-22T08:00:00.000Z",
+      updatedAt: "2026-02-22T08:00:00.000Z",
+      workingDirectory: "/tmp/repo/worktree",
+    });
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeWorkspace: {
+        repoPath: "/tmp/repo",
+        workspaceId: "workspace-1",
+        workspaceName: "Active Workspace",
+      },
+      adapter: createAdapter({
+        listLiveAgentSessionSnapshots: async () => [
+          {
+            externalSessionId: "external-1",
+            title: "BUILD task-1",
+            workingDirectory: "/tmp/repo/worktree",
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+            pendingPermissions: [],
+            pendingQuestions: [],
+          },
+        ],
+      }),
+      repoEpochRef: { current: 2 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession: (sessionId, updater) => {
+        const current = state[sessionId];
+        if (!current) {
+          return;
+        }
+        state = {
+          ...state,
+          [sessionId]: updater(current),
+        };
+        sessionsRef.current = state;
+      },
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    await expect(
+      loadAgentSessions("task-1", {
+        mode: "reconcile_live",
+        historyPolicy: "none",
+        persistedRecords: [firstRecord, secondRecord],
+        preloadedRuntimeLists: new Map([
+          [
+            "opencode",
+            [
+              {
+                kind: "opencode",
+                runtimeId: "runtime-root",
+                repoPath: "/tmp/repo",
+                taskId: null,
+                role: "workspace",
+                workingDirectory: "/tmp/repo",
+                runtimeRoute: {
+                  type: "local_http",
+                  endpoint: "http://127.0.0.1:4444",
+                },
+                startedAt: "2026-02-22T08:00:00.000Z",
+                descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+              },
+            ],
+          ],
+        ]),
+      }),
+    ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktree.");
+
+    expect(getSession(state, "session-1").runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4444",
+    });
+    expect(getSession(state, "session-2").runtimeRoute).toBeNull();
+  });
+
   test("composes bootstrap, requested history hydration, and live reconciliation without cross-mode regressions", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -1968,10 +1968,33 @@ describe("agent-orchestrator-load-sessions", () => {
       loadRepoPromptOverrides: async () => ({}),
     });
 
+    const preloadedRuntimeLists = new Map<"opencode", RuntimeInstanceSummary[]>([
+      [
+        "opencode",
+        [
+          {
+            kind: "opencode",
+            runtimeId: "runtime-worktree",
+            repoPath: "/tmp/repo",
+            taskId: null,
+            role: "workspace",
+            workingDirectory: "/tmp/repo/worktree",
+            runtimeRoute: {
+              type: "local_http",
+              endpoint: "http://127.0.0.1:4444",
+            },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+          },
+        ],
+      ],
+    ]);
+
     await loadAgentSessions("task-1", {
       mode: "requested_history",
       targetSessionId: "session-child-1",
       historyPolicy: "requested_only",
+      preloadedRuntimeLists,
       persistedRecords: [
         persistedSessionRecord({
           runtimeKind: "opencode",
@@ -3038,7 +3061,7 @@ describe("agent-orchestrator-load-sessions", () => {
     }
   });
 
-  test("hydrates qa sessions through the shared workspace runtime when only a shared workspace runtime exists", async () => {
+  test("fails fast for qa worktree sessions when only a shared workspace runtime exists", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     let observedRuntimeEndpoint: string | null = null;
@@ -3121,21 +3144,21 @@ describe("agent-orchestrator-load-sessions", () => {
     ];
 
     try {
-      await loadAgentSessions("task-1", {
-        mode: "requested_history",
-        targetSessionId: "session-qa-1",
-        historyPolicy: "requested_only",
-      });
+      await expect(
+        loadAgentSessions("task-1", {
+          mode: "requested_history",
+          targetSessionId: "session-qa-1",
+          historyPolicy: "requested_only",
+        }),
+      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktree.");
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
     }
 
-    expect(String(observedRuntimeEndpoint)).toBe("http://127.0.0.1:4444");
-    expect(state["session-qa-1"]?.runtimeId).toBe("runtime-1");
-    expect(sessionMessageAt(getSession(state, "session-qa-1"), 0)?.id).toBe(
-      "history:session-start:session-qa-1",
-    );
+    expect(observedRuntimeEndpoint).toBeNull();
+    expect(state["session-qa-1"]?.runtimeId).toBeNull();
+    expect(sessionMessagesToArray(getSession(state, "session-qa-1"))).toEqual([]);
   });
 
   test("does not ensure a shared workspace runtime for qa sessions when repo root paths only differ by trailing slash", async () => {
@@ -3346,7 +3369,7 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(appQueryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
   });
 
-  test("hydrates build sessions through the shared workspace runtime on worktree directories", async () => {
+  test("fails fast for build worktree sessions when only the shared workspace runtime exists", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3447,11 +3470,13 @@ describe("agent-orchestrator-load-sessions", () => {
     };
 
     try {
-      await loadAgentSessions("task-1", {
-        mode: "requested_history",
-        targetSessionId: "session-1",
-        historyPolicy: "requested_only",
-      });
+      await expect(
+        loadAgentSessions("task-1", {
+          mode: "requested_history",
+          targetSessionId: "session-1",
+          historyPolicy: "requested_only",
+        }),
+      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/conflict-worktree.");
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
@@ -3460,16 +3485,11 @@ describe("agent-orchestrator-load-sessions", () => {
     }
 
     expect(ensuredRuntimeKinds).toEqual([]);
-    expect(state["session-1"]?.runtimeRoute).toEqual({
-      type: "local_http",
-      endpoint: "http://127.0.0.1:4666",
-    });
-    expect(sessionMessageAt(getSession(state, "session-1"), 0)?.id).toBe(
-      "history:session-start:session-1",
-    );
+    expect(state["session-1"]?.runtimeRoute).toBeNull();
+    expect(sessionMessagesToArray(getSession(state, "session-1"))).toEqual([]);
   });
 
-  test("ensures a shared workspace runtime for qa sessions on non-root working directories", async () => {
+  test("does not ensure a shared workspace runtime for qa sessions on non-root working directories", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3554,11 +3574,13 @@ describe("agent-orchestrator-load-sessions", () => {
     };
 
     try {
-      await loadAgentSessions("task-1", {
-        mode: "requested_history",
-        targetSessionId: "session-qa-worktree",
-        historyPolicy: "requested_only",
-      });
+      await expect(
+        loadAgentSessions("task-1", {
+          mode: "requested_history",
+          targetSessionId: "session-qa-worktree",
+          historyPolicy: "requested_only",
+        }),
+      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktrees/task-1.");
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
@@ -3566,14 +3588,9 @@ describe("agent-orchestrator-load-sessions", () => {
       hostModule.host.runtimeEnsure = originalEnsure;
     }
 
-    expect(ensuredRuntimeKinds).toEqual(["opencode"]);
-    expect(state["session-qa-worktree"]?.runtimeRoute).toEqual({
-      type: "local_http",
-      endpoint: "http://127.0.0.1:4777",
-    });
-    expect(sessionMessageAt(getSession(state, "session-qa-worktree"), 0)?.id).toBe(
-      "history:session-start:session-qa-worktree",
-    );
+    expect(ensuredRuntimeKinds).toEqual([]);
+    expect(state["session-qa-worktree"]?.runtimeRoute).toBeNull();
+    expect(sessionMessagesToArray(getSession(state, "session-qa-worktree"))).toEqual([]);
   });
 
   test("resumes live persisted sessions without eagerly hydrating transcript history", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -98,6 +98,22 @@ const createAdapter = (
   ...overrides,
 });
 
+const waitForHistoryCallCount = async (
+  getHistoryCalls: () => number,
+  expectedCalls: number,
+): Promise<void> => {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (getHistoryCalls() >= expectedCalls) {
+      return;
+    }
+    await Promise.resolve();
+  }
+
+  throw new Error(
+    `Expected at least ${expectedCalls} history calls, received ${getHistoryCalls()}.`,
+  );
+};
+
 describe("agent-orchestrator-load-sessions", () => {
   beforeEach(async () => {
     await clearAppQueryClient();
@@ -4640,6 +4656,7 @@ describe("agent-orchestrator-load-sessions", () => {
       loadRepoPromptOverrides: async () => ({}),
     });
 
+    const workingDirectory = "/tmp/repo/worktree";
     const persistedRecords = [
       persistedSessionRecord({
         sessionId: "session-1",
@@ -4647,7 +4664,7 @@ describe("agent-orchestrator-load-sessions", () => {
         role: "build",
         scenario: "build_implementation_start",
         startedAt: "2026-02-22T08:00:00.000Z",
-        workingDirectory: "/tmp/repo",
+        workingDirectory,
       }),
     ];
     const preloadedRuntimeLists = new Map([
@@ -4660,7 +4677,7 @@ describe("agent-orchestrator-load-sessions", () => {
             repoPath: "/tmp/repo",
             taskId: null,
             role: "workspace",
-            workingDirectory: "/tmp/repo",
+            workingDirectory,
             runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
             startedAt: "2026-02-22T08:00:00.000Z",
             descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
@@ -4684,9 +4701,7 @@ describe("agent-orchestrator-load-sessions", () => {
       preloadedRuntimeLists,
     });
 
-    while (historyCalls === 0) {
-      await Promise.resolve();
-    }
+    await waitForHistoryCallCount(() => historyCalls, 1);
     expect(historyCalls).toBe(1);
     historyDeferred.resolve([
       {
@@ -4762,6 +4777,7 @@ describe("agent-orchestrator-load-sessions", () => {
       loadRepoPromptOverrides: async () => ({}),
     });
 
+    const workingDirectory = "/tmp/repo/worktree";
     const persistedRecords = [
       persistedSessionRecord({
         sessionId: "session-1",
@@ -4769,7 +4785,7 @@ describe("agent-orchestrator-load-sessions", () => {
         role: "build",
         scenario: "build_implementation_start",
         startedAt: "2026-02-22T08:00:00.000Z",
-        workingDirectory: "/tmp/repo",
+        workingDirectory,
       }),
     ];
     const preloadedRuntimeLists = new Map([
@@ -4782,7 +4798,7 @@ describe("agent-orchestrator-load-sessions", () => {
             repoPath: "/tmp/repo",
             taskId: null,
             role: "workspace",
-            workingDirectory: "/tmp/repo",
+            workingDirectory,
             runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
             startedAt: "2026-02-22T08:00:00.000Z",
             descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
@@ -4807,9 +4823,7 @@ describe("agent-orchestrator-load-sessions", () => {
       preloadedRuntimeLists,
     });
 
-    while (historyCalls < 2) {
-      await Promise.resolve();
-    }
+    await waitForHistoryCallCount(() => historyCalls, 2);
     expect(historyCalls).toBe(2);
 
     historyDeferred.resolve([

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -3161,7 +3161,7 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(sessionMessagesToArray(getSession(state, "session-qa-1"))).toEqual([]);
   });
 
-  test("does not ensure a shared workspace runtime for qa sessions when repo root paths only differ by trailing slash", async () => {
+  test("does not bind qa repo-root sessions to an existing workspace runtime", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3225,7 +3225,22 @@ describe("agent-orchestrator-load-sessions", () => {
         workingDirectory: "/tmp/repo/",
       }),
     ];
-    hostModule.host.runtimeList = async () => [];
+    hostModule.host.runtimeList = async () => [
+      {
+        kind: "opencode",
+        runtimeId: "runtime-root",
+        repoPath: "/tmp/repo",
+        taskId: null,
+        role: "workspace",
+        workingDirectory: "/tmp/repo",
+        runtimeRoute: {
+          type: "local_http",
+          endpoint: "http://127.0.0.1:4555",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      },
+    ];
     legacyHost.runsList = async () => [];
     hostModule.host.runtimeEnsure = async (_repoPath, runtimeKind) => {
       ensuredRuntimeKinds.push(runtimeKind);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -147,6 +147,76 @@ const stdioRuntimeConnection = (workingDirectory: string, identity = "runtime-st
     workingDirectory,
   }) as const;
 
+const isExpectedReconcileRetryLog = (args: Parameters<typeof console.error>): boolean => {
+  const [message, error] = args;
+  return (
+    typeof message === "string" &&
+    message.startsWith("Failed to reconcile agent sessions for task") &&
+    message.includes("Retrying in") &&
+    error instanceof Error &&
+    error.message.startsWith("No live runtime found for working directory ")
+  );
+};
+
+const isExpectedRuntimeMetadataLog = (args: Parameters<typeof console.error>): boolean => {
+  const [message, error] = args;
+  return (
+    typeof message === "string" &&
+    message.startsWith("Skipping reconcile preload for task") &&
+    error instanceof Error &&
+    error.name === "SessionRuntimeMetadataError"
+  );
+};
+
+const withSuppressedExpectedConsoleErrors = async ({
+  expectedCount,
+  isExpected,
+  run,
+}: {
+  expectedCount: number;
+  isExpected: (args: Parameters<typeof console.error>) => boolean;
+  run: () => Promise<void>;
+}): Promise<void> => {
+  const originalError = console.error;
+  let suppressedCount = 0;
+  console.error = (...args: Parameters<typeof console.error>): void => {
+    if (isExpected(args)) {
+      suppressedCount += 1;
+      return;
+    }
+
+    originalError(...args);
+  };
+
+  try {
+    await run();
+  } finally {
+    console.error = originalError;
+  }
+
+  expect(suppressedCount).toBe(expectedCount);
+};
+
+const withSuppressedExpectedReconcileRetryLogs = (
+  expectedCount: number,
+  run: () => Promise<void>,
+): Promise<void> =>
+  withSuppressedExpectedConsoleErrors({
+    expectedCount,
+    isExpected: isExpectedReconcileRetryLog,
+    run,
+  });
+
+const withSuppressedExpectedRuntimeMetadataLogs = (
+  expectedCount: number,
+  run: () => Promise<void>,
+): Promise<void> =>
+  withSuppressedExpectedConsoleErrors({
+    expectedCount,
+    isExpected: isExpectedRuntimeMetadataLog,
+    run,
+  });
+
 type RuntimeEnsure = (
   nextRepoPath: string,
   nextRuntimeKind: RuntimeKind,
@@ -733,14 +803,16 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [
-        taskWithSessionAt("task-a", "external-a", worktreePath),
-        taskWithSessionAt("task-b", "external-b", worktreePath),
-      ],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedReconcileRetryLogs(2, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [
+          taskWithSessionAt("task-a", "external-a", worktreePath),
+          taskWithSessionAt("task-b", "external-b", worktreePath),
+        ],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([]);
@@ -795,14 +867,16 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [
-        taskWithSessionAt("task-root-build", "external-build-root", repoPath),
-        plannerTaskWithSessionAt("task-root-planner", "external-planner-root", repoPath),
-      ],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedReconcileRetryLogs(2, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [
+          taskWithSessionAt("task-root-build", "external-build-root", repoPath),
+          plannerTaskWithSessionAt("task-root-planner", "external-planner-root", repoPath),
+        ],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([{ directories: [repoPath] }]);
@@ -1075,14 +1149,16 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [
-        taskWithSessionAt("task-1", "external-1", "/tmp/repo/worktree-a"),
-        taskWithSessionAt("task-2", "external-2", "/tmp/repo/worktree-b"),
-      ],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedReconcileRetryLogs(2, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [
+          taskWithSessionAt("task-1", "external-1", "/tmp/repo/worktree-a"),
+          taskWithSessionAt("task-2", "external-2", "/tmp/repo/worktree-b"),
+        ],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(runtimeEnsureCalls).toBe(0);
@@ -1182,11 +1258,13 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [taskWithSession("task-valid", "external-valid"), invalidTask],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRuntimeMetadataLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [taskWithSession("task-valid", "external-valid"), invalidTask],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     const retryResult = await Promise.race([
@@ -1254,11 +1332,13 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [taskWithSession("task-valid", "external-valid"), partiallyInvalidTask],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRuntimeMetadataLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [taskWithSession("task-valid", "external-valid"), partiallyInvalidTask],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(reconcileCalls).toEqual(["task-valid"]);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -748,6 +748,68 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
+  test("reconcile does not preload repo-root workspace runtimes for build sessions", async () => {
+    const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
+    const reconcileCalls: string[] = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([
+      createRuntimeInstance({
+        runtimeId: "runtime-root",
+        workingDirectory: repoPath,
+      }),
+    ]);
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async (input) => {
+          listLiveAgentSessionSnapshotsCalls.push({
+            ...(input.directories ? { directories: input.directories } : {}),
+          });
+          return [
+            createLiveAgentSessionSnapshotFixture({
+              externalSessionId: "external-planner-root",
+              workingDirectory: repoPath,
+            }),
+          ];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({
+          taskId,
+          persistedRecords,
+          preloadedRuntimeConnections,
+        }) => {
+          reconcileCalls.push(taskId);
+          const record = persistedRecords?.[0];
+          if (!record) {
+            throw new Error("Expected persisted session record");
+          }
+          expect(record.workingDirectory).toBe(repoPath);
+          expect(preloadedRuntimeConnections?.hasAny("opencode", repoPath)).toBe(false);
+          throw new Error(`No live runtime found for working directory ${repoPath}.`);
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-root-build", "external-build-root", repoPath),
+        plannerTaskWithSessionAt("task-root-planner", "external-planner-root", repoPath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([{ directories: [repoPath] }]);
+    expect(reconcileCalls.sort()).toEqual(["task-root-build", "task-root-planner"]);
+    service.dispose();
+  });
+
   test("reconcile preloads stdio runtime snapshots into the live session store", async () => {
     const listLiveAgentSessionSnapshotsCalls: Array<{
       runtimeConnection: unknown;

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -669,14 +669,13 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
-  test("reconcile scans workspace-derived directories for every repo-root stdio runtime", async () => {
+  test("reconcile does not synthesize worktree scans from repo-root stdio runtimes", async () => {
     const listLiveAgentSessionSnapshotsCalls: Array<{
       runtimeConnection: unknown;
       directories?: string[];
     }> = [];
+    const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
-    const runtimeConnectionA = stdioRuntimeConnection(worktreePath, "runtime-stdio-a");
-    const runtimeConnectionB = stdioRuntimeConnection(worktreePath, "runtime-stdio-b");
 
     setRuntimeList([
       createRuntimeInstance({
@@ -712,7 +711,23 @@ describe("repo-session-hydration-service", () => {
       },
       sessionHydration: {
         bootstrapTaskSessions: async () => {},
-        reconcileLiveTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({
+          taskId,
+          persistedRecords,
+          preloadedRuntimeConnections,
+        }) => {
+          reconcileCalls.push(taskId);
+          const record = persistedRecords?.[0];
+          if (!record) {
+            throw new Error("Expected persisted session record");
+          }
+          expect(preloadedRuntimeConnections?.hasAny("opencode", record.workingDirectory)).toBe(
+            false,
+          );
+          throw new Error(
+            `No live runtime found for working directory ${record.workingDirectory}.`,
+          );
+        },
       },
       liveAgentSessionStore,
       onRetryRequested: () => {},
@@ -728,16 +743,8 @@ describe("repo-session-hydration-service", () => {
       isCurrentRepo: () => true,
     });
 
-    expect(listLiveAgentSessionSnapshotsCalls).toEqual([
-      {
-        runtimeConnection: runtimeConnectionA,
-        directories: [worktreePath],
-      },
-      {
-        runtimeConnection: runtimeConnectionB,
-        directories: [worktreePath],
-      },
-    ]);
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([]);
+    expect(reconcileCalls.sort()).toEqual(["task-a", "task-b"]);
     service.dispose();
   });
 
@@ -926,7 +933,7 @@ describe("repo-session-hydration-service", () => {
     const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
-    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+    setRuntimeList([createRuntimeInstance({ workingDirectory: worktreePath })]);
 
     const service = createTestRepoSessionHydrationService({
       agentEngine: {
@@ -969,6 +976,7 @@ describe("repo-session-hydration-service", () => {
       runtimeConnection: unknown;
       directories?: string[];
     }> = [];
+    const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
     setRuntimeList([]);
@@ -993,7 +1001,13 @@ describe("repo-session-hydration-service", () => {
       },
       sessionHydration: {
         bootstrapTaskSessions: async () => {},
-        reconcileLiveTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId, persistedRecords }) => {
+          reconcileCalls.push(taskId);
+          const record = persistedRecords?.[0];
+          throw new Error(
+            `No live runtime found for working directory ${record?.workingDirectory ?? "unknown"}.`,
+          );
+        },
       },
       liveAgentSessionStore,
       onRetryRequested: () => {},
@@ -1011,6 +1025,7 @@ describe("repo-session-hydration-service", () => {
 
     expect(runtimeEnsureCalls).toBe(0);
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([]);
+    expect(reconcileCalls.sort()).toEqual(["task-1", "task-2"]);
     service.dispose();
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -190,11 +190,10 @@ const withSuppressedExpectedConsoleErrors = async ({
 
   try {
     await run();
+    expect(suppressedCount).toBe(expectedCount);
   } finally {
     console.error = originalError;
   }
-
-  expect(suppressedCount).toBe(expectedCount);
 };
 
 const withSuppressedExpectedReconcileRetryLogs = (

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -52,7 +52,6 @@ type ReconcilePreloadMetadata = {
   persistedTaskIdsByLiveSessionKey: Map<string, Set<string>>;
   runtimeKinds: Set<RuntimeKind>;
   desiredDirectoriesByRuntimeKind: Map<RuntimeKind, Set<string>>;
-  workspaceDerivedDirectoriesByRuntimeKind: Map<RuntimeKind, Set<string>>;
   runtimeKindsAllowedToEnsureRepoRoot: Set<RuntimeKind>;
   skippedTaskErrors: Map<string, unknown>;
 };
@@ -110,7 +109,6 @@ const collectReconcilePreloadMetadata = ({
   const persistedTaskIdsByLiveSessionKey = new Map<string, Set<string>>();
   const runtimeKinds = new Set<RuntimeKind>();
   const desiredDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
-  const workspaceDerivedDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
   const runtimeKindsAllowedToEnsureRepoRoot = new Set<RuntimeKind>();
   const skippedTaskErrors = new Map<string, unknown>();
 
@@ -134,15 +132,7 @@ const collectReconcilePreloadMetadata = ({
           normalizeWorkingDirectory(record.workingDirectory),
         );
         if (canUseWorkspaceRuntimeForHydration(record, repoPath)) {
-          getOrCreateMapSet(workspaceDerivedDirectoriesByRuntimeKind, runtimeKind).add(
-            normalizeWorkingDirectory(record.workingDirectory),
-          );
-          if (
-            normalizeWorkingDirectory(record.workingDirectory) ===
-            normalizeWorkingDirectory(repoPath)
-          ) {
-            taskRuntimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
-          }
+          taskRuntimeKindsAllowedToEnsureRepoRoot.add(runtimeKind);
         }
       }
     } catch (error) {
@@ -183,7 +173,6 @@ const collectReconcilePreloadMetadata = ({
     persistedTaskIdsByLiveSessionKey,
     runtimeKinds,
     desiredDirectoriesByRuntimeKind,
-    workspaceDerivedDirectoriesByRuntimeKind,
     runtimeKindsAllowedToEnsureRepoRoot,
     skippedTaskErrors,
   };
@@ -263,7 +252,6 @@ export const createRepoSessionHydrationService = ({
       persistedTaskIdsByLiveSessionKey,
       runtimeKinds,
       desiredDirectoriesByRuntimeKind,
-      workspaceDerivedDirectoriesByRuntimeKind,
       runtimeKindsAllowedToEnsureRepoRoot,
       skippedTaskErrors,
     } = collectReconcilePreloadMetadata({ tasks, repoPath });
@@ -313,9 +301,6 @@ export const createRepoSessionHydrationService = ({
       }
 
       preloadedRuntimeLists.set(runtimeKind, runtimeEntries);
-      const coveredDirectories = new Set(
-        runtimeEntries.map((runtime) => normalizeWorkingDirectory(runtime.workingDirectory)),
-      );
 
       for (const runtime of runtimeEntries) {
         const { runtimeConnection } = resolveRuntimeRouteConnection(
@@ -337,85 +322,6 @@ export const createRepoSessionHydrationService = ({
         }
         runtimeConnections.get(scanKey)?.directories.add(runtime.workingDirectory);
       }
-
-      const derivedDirectories =
-        workspaceDerivedDirectoriesByRuntimeKind.get(runtimeKind) ?? new Set();
-      const missingDerivedDirectories = Array.from(desiredDirectories).filter(
-        (workingDirectory) => {
-          const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
-          return (
-            derivedDirectories.has(normalizedWorkingDirectory) &&
-            !coveredDirectories.has(normalizedWorkingDirectory)
-          );
-        },
-      );
-      if (missingDerivedDirectories.length === 0) {
-        continue;
-      }
-
-      const routeSourceRuntimes = runtimeEntries.filter(
-        (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey,
-      );
-      if (
-        routeSourceRuntimes.length === 0 &&
-        runtimeKindsAllowedToEnsureRepoRoot.has(runtimeKind)
-      ) {
-        routeSourceRuntimes.push(
-          await ensureRuntimeAndInvalidateReadinessQueries({
-            repoPath,
-            runtimeKind,
-            ensureRuntime: runtimeEnsure,
-          }),
-        );
-      }
-      if (routeSourceRuntimes.length === 0) {
-        continue;
-      }
-
-      // A repo-root runtime can be produced by the ensure call above when the
-      // runtime list did not already contain one. Keep both the query cache and
-      // this local list aligned before deriving worktree routes from it.
-      if (
-        routeSourceRuntimes.some(
-          (routeSourceRuntime) => !runtimeEntries.includes(routeSourceRuntime),
-        )
-      ) {
-        await invalidateRuntimeList(queryClient, runtimeKind, repoPath);
-        if (isCancelled()) {
-          return {
-            persistedByTask,
-            taskIdsToReconcile: new Set<string>(),
-            preloadedRuntimeLists,
-            preloadedRuntimeConnections,
-            preloadedLiveAgentSessionsByKey: new Map<string, LiveAgentSessionSnapshot[]>(),
-            skippedTaskErrors,
-          };
-        }
-        for (const routeSourceRuntime of routeSourceRuntimes) {
-          if (!runtimeEntries.includes(routeSourceRuntime)) {
-            runtimeEntries.push(routeSourceRuntime);
-          }
-        }
-      }
-
-      for (const workingDirectory of missingDerivedDirectories) {
-        for (const routeSourceRuntime of routeSourceRuntimes) {
-          const { runtimeConnection } = resolveRuntimeRouteConnection(
-            routeSourceRuntime.runtimeRoute,
-            workingDirectory,
-          );
-          preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
-          const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
-          if (!runtimeConnections.has(scanKey)) {
-            runtimeConnections.set(scanKey, {
-              runtimeKind,
-              runtimeConnection,
-              directories: new Set<string>(),
-            });
-          }
-          runtimeConnections.get(scanKey)?.directories.add(workingDirectory);
-        }
-      }
     }
 
     const taskIdsToReconcile = new Set<string>();
@@ -424,13 +330,19 @@ export const createRepoSessionHydrationService = ({
         continue;
       }
 
-      const hasResolvableHydrationRuntime = records.some((record) =>
-        preloadedRuntimeConnections.hasAny(
-          readPersistedRuntimeKind(record),
-          record.workingDirectory,
-        ),
-      );
-      if (hasResolvableHydrationRuntime) {
+      const shouldAttemptReconcile = records.some((record) => {
+        const externalSessionId = record.externalSessionId ?? record.sessionId;
+        if (!externalSessionId) {
+          return false;
+        }
+
+        const runtimeKind = readPersistedRuntimeKind(record);
+        return (
+          preloadedRuntimeConnections.hasAny(runtimeKind, record.workingDirectory) ||
+          !canUseWorkspaceRuntimeForHydration(record, repoPath)
+        );
+      });
+      if (shouldAttemptReconcile) {
         taskIdsToReconcile.add(taskId);
       }
     }

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -302,12 +302,45 @@ export const createRepoSessionHydrationService = ({
 
       preloadedRuntimeLists.set(runtimeKind, runtimeEntries);
 
+      const canScanRepoRootWorkspaceRuntime = (runtime: RuntimeInstanceSummary): boolean => {
+        const normalizedRuntimeDirectory = normalizeWorkingDirectory(runtime.workingDirectory);
+        if (runtime.role !== "workspace" || normalizedRuntimeDirectory !== repoPathKey) {
+          return true;
+        }
+
+        return persistedByTask.some(({ records }) =>
+          records.some((record) => {
+            try {
+              return (
+                readPersistedRuntimeKind(record) === runtimeKind &&
+                normalizeWorkingDirectory(record.workingDirectory) === normalizedRuntimeDirectory &&
+                canUseWorkspaceRuntimeForHydration(record, repoPath)
+              );
+            } catch (error) {
+              if (isSessionRuntimeMetadataError(error)) {
+                return false;
+              }
+              throw error;
+            }
+          }),
+        );
+      };
+
       for (const runtime of runtimeEntries) {
+        const isRepoRootWorkspaceRuntime =
+          runtime.role === "workspace" &&
+          normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey;
+        if (!canScanRepoRootWorkspaceRuntime(runtime)) {
+          continue;
+        }
+
         const { runtimeConnection } = resolveRuntimeRouteConnection(
           runtime.runtimeRoute,
           runtime.workingDirectory,
         );
-        preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
+        if (!isRepoRootWorkspaceRuntime) {
+          preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
+        }
         if (!desiredDirectories.has(normalizeWorkingDirectory(runtime.workingDirectory))) {
           continue;
         }

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -3,6 +3,7 @@ import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import {
   type AgentSessionRecord,
   OPENCODE_RUNTIME_DESCRIPTOR,
+  type RuntimeInstanceSummary,
   type TaskCard,
 } from "@openducktor/contracts";
 import { toast } from "sonner";
@@ -104,7 +105,7 @@ const persistedSessionFixture: AgentSessionRecord = {
   role: "build",
   scenario: "build_implementation_start",
   startedAt: "2026-02-22T08:00:00.000Z",
-  workingDirectory: "/tmp/repo",
+  workingDirectory: "/tmp/repo/worktree",
   selectedModel: null,
 };
 
@@ -137,6 +138,24 @@ const buildBootstrapFixture = {
   },
   workingDirectory: "/tmp/repo/worktree",
 };
+
+const createWorktreeRuntimeFixture = (
+  overrides: Partial<RuntimeInstanceSummary> = {},
+): RuntimeInstanceSummary => ({
+  kind: "opencode",
+  runtimeId: "runtime-1",
+  repoPath: "/tmp/repo",
+  taskId: null,
+  role: "workspace",
+  workingDirectory: "/tmp/repo/worktree",
+  runtimeRoute: {
+    type: "local_http",
+    endpoint: "http://127.0.0.1:4444",
+  },
+  startedAt: "2026-02-22T08:00:00.000Z",
+  descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+  ...overrides,
+});
 
 const BUILD_SELECTION = {
   runtimeKind: "opencode" as const,
@@ -369,12 +388,7 @@ describe("use-agent-orchestrator-operations", () => {
       const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
       const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
-      host.agentSessionsList = async () => [
-        {
-          ...persistedSessionFixture,
-          workingDirectory: "/tmp/repo",
-        },
-      ];
+      host.agentSessionsList = async () => [persistedBuildSessionFixture];
       host.agentSessionUpsert = async () => {};
       host.specGet = async () => ({ markdown: "", updatedAt: null });
       host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -459,12 +473,7 @@ describe("use-agent-orchestrator-operations", () => {
       const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
       const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
 
-      host.agentSessionsList = async () => [
-        {
-          ...persistedSessionFixture,
-          workingDirectory: "/tmp/repo/worktree",
-        },
-      ];
+      host.agentSessionsList = async () => [persistedBuildSessionFixture];
       host.agentSessionUpsert = async () => {};
       host.runtimeList = async () => [
         {
@@ -473,7 +482,7 @@ describe("use-agent-orchestrator-operations", () => {
           repoPath: "/tmp/repo",
           taskId: null,
           role: "workspace",
-          workingDirectory: "/tmp/repo",
+          workingDirectory: "/tmp/repo/worktree",
           runtimeRoute: {
             type: "local_http" as const,
             endpoint: "http://127.0.0.1:4444",
@@ -522,7 +531,7 @@ describe("use-agent-orchestrator-operations", () => {
         tasks: [
           {
             ...taskFixture,
-            agentSessions: [persistedSessionFixture],
+            agentSessions: [persistedBuildSessionFixture],
           },
         ],
         refreshTaskData: async () => {},
@@ -535,7 +544,7 @@ describe("use-agent-orchestrator-operations", () => {
         await harness.run(async () => {
           await harness.getLatest().reconcileLiveTaskSessions({
             taskId: "task-1",
-            persistedRecords: [persistedSessionFixture],
+            persistedRecords: [persistedBuildSessionFixture],
           });
         });
 
@@ -943,7 +952,22 @@ describe("use-agent-orchestrator-operations", () => {
       host.specGet = async () => ({ markdown: "", updatedAt: null });
       host.planGet = async () => ({ markdown: "", updatedAt: null });
       host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
-      host.runtimeList = async () => [];
+      host.runtimeList = async () => [
+        {
+          runtimeId: "runtime-1",
+          kind: "opencode",
+          repoPath: "/tmp/repo",
+          taskId: null,
+          role: "workspace",
+          workingDirectory: "/tmp/repo/worktree",
+          runtimeRoute: {
+            type: "local_http",
+            endpoint: "http://127.0.0.1:4555",
+          },
+          startedAt: "2026-02-22T08:00:00.000Z",
+          descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+        },
+      ];
       host.runtimeEnsure = async () => ({
         runtimeId: "runtime-1",
         kind: "opencode",
@@ -1953,11 +1977,13 @@ describe("use-agent-orchestrator-operations", () => {
   test("revisit to the same repo bootstraps task sessions again", async () => {
     await withSuppressedRendererWarning(async () => {
       const originalAgentSessionsList = host.agentSessionsList;
+      const originalRuntimeList = host.runtimeList;
       let persistedListCalls = 0;
       host.agentSessionsList = async () => {
         persistedListCalls += 1;
         return [persistedBuildSessionFixture];
       };
+      host.runtimeList = async () => [createWorktreeRuntimeFixture()];
 
       const harness = createHookHarness({
         activeRepo: "/tmp/repo-a",
@@ -1981,6 +2007,7 @@ describe("use-agent-orchestrator-operations", () => {
       } finally {
         await harness.unmount();
         host.agentSessionsList = originalAgentSessionsList;
+        host.runtimeList = originalRuntimeList;
       }
     });
   });
@@ -2209,7 +2236,7 @@ describe("use-agent-orchestrator-operations", () => {
 
     const harness = createHookHarness({
       activeRepo: "/tmp/repo",
-      tasks: [taskFixtureWithPersistedBuildSession],
+      tasks: [taskFixture],
       refreshTaskData: async () => {},
     });
 
@@ -3003,8 +3030,10 @@ describe("use-agent-orchestrator-operations", () => {
     await withSuppressedRendererWarning(async () => {
       const originalAgentSessionUpsert = host.agentSessionUpsert;
       const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
+      const originalRuntimeList = host.runtimeList;
       let repoConfigCalls = 0;
       host.agentSessionUpsert = async () => {};
+      host.runtimeList = async () => [createWorktreeRuntimeFixture()];
       host.workspaceGetRepoConfig = async () => {
         repoConfigCalls += 1;
         if (repoConfigCalls === 1) {
@@ -3050,6 +3079,7 @@ describe("use-agent-orchestrator-operations", () => {
         await harness.unmount();
         host.agentSessionUpsert = originalAgentSessionUpsert;
         host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
+        host.runtimeList = originalRuntimeList;
       }
     });
   });
@@ -3057,11 +3087,13 @@ describe("use-agent-orchestrator-operations", () => {
   test("bootstraps task sessions from task list metadata without per-task persisted fetches", async () => {
     await withSuppressedRendererWarning(async () => {
       const originalAgentSessionsList = host.agentSessionsList;
+      const originalRuntimeList = host.runtimeList;
       let persistedListCalls = 0;
       host.agentSessionsList = async () => {
         persistedListCalls += 1;
         return [];
       };
+      host.runtimeList = async () => [createWorktreeRuntimeFixture()];
 
       const harness = createHookHarness({
         activeRepo: "/tmp/repo",
@@ -3082,6 +3114,7 @@ describe("use-agent-orchestrator-operations", () => {
       } finally {
         await harness.unmount();
         host.agentSessionsList = originalAgentSessionsList;
+        host.runtimeList = originalRuntimeList;
       }
     });
   });

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -2235,7 +2235,7 @@ describe("use-agent-orchestrator-operations", () => {
 
       expect(
         harness.getLatest().sessionStore.getSessionSnapshot("session-1")?.runtimeRecoveryState,
-      ).toBe("idle");
+      ).toBe("waiting_for_runtime");
 
       host.runtimeList = async () => [
         {


### PR DESCRIPTION
## Summary
- Makes build/QA session hydration require an exact live runtime for the persisted runtime kind and working directory.
- Keeps repo-root workspace runtime reuse limited to workspace-scoped spec/planner hydration.
- Adds regression coverage for missing worktree runtimes, repo-root build sessions, requested-history loads, host override seams, and expected hydration error logging.

## Goal
Session hydration could silently rebind persisted worktree sessions to a repo-root workspace runtime. That masks broken runtime routing and can cause history, todo, diff, and file-status reads to target the wrong live session. This PR makes those failures explicit so build and QA sessions fail fast when their exact runtime is unavailable.

## Technical approach
- Tightened hydration runtime policy so build/QA records cannot use repo-root workspace fallback, even when their persisted working directory normalizes to the repo root.
- Updated runtime resolution to check exact `runtimeKind + workingDirectory` live/preloaded runtime connections before returning a session connection, and to report `No live runtime found for working directory <path>.` when missing.
- Updated reconcile preloading so repo-root workspace runtime scans are only used when at least one persisted record is allowed to hydrate from that workspace runtime.
- Avoided synthesizing worktree runtime connections from repo-root routes during reconcile preloading.
- Added focused tests for strict worktree runtime resolution, repo-root build/QA rejection, requested-history dedupe behavior, and identity-aware stdio preloading.
- Added bounded test waits and scoped expected-log suppression so regressions fail as test failures instead of hangs or noisy logs.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check` from `apps/desktop/src-tauri`
- `cargo clippy --workspace --all-targets -- -D warnings` from `apps/desktop/src-tauri`
- `cargo check --workspace` from `apps/desktop/src-tauri`
- `cargo test --workspace` from `apps/desktop/src-tauri`
- `cargo build --workspace` from `apps/desktop/src-tauri`