### PR TITLE
fix(frontend): deduplicate hydrated chat parts

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -1,8 +1,9 @@
 import type { MutableRefObject, RefObject } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { CHAT_SCROLL_EDGE_THRESHOLD_PX } from "./agent-chat-window-shared";
 
 type UseAgentChatScrollControllerInput = {
+  activeSessionId: string | null;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   messagesContentRef: RefObject<HTMLDivElement | null>;
   isSessionWorking: boolean;
@@ -20,6 +21,7 @@ type UseAgentChatScrollControllerResult = {
 const AUTO_SCROLL_MARK_TTL_MS = 1500;
 
 export function useAgentChatScrollController({
+  activeSessionId,
   messagesContainerRef,
   messagesContentRef,
   isSessionWorking,
@@ -34,6 +36,7 @@ export function useAgentChatScrollController({
   const userScrollIntentVersionRef = useRef(0);
   const autoScrollRef = useRef<{ time: number; top: number } | null>(null);
   const autoScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeSessionIdRef = useRef<string | null>(activeSessionId);
 
   const updateNearEdges = useCallback((nearBottom: boolean, nearTop: boolean) => {
     const changed = nearBottomRef.current !== nearBottom || nearTopRef.current !== nearTop;
@@ -104,6 +107,28 @@ export function useAgentChatScrollController({
 
     return Math.abs(element.scrollTop - autoScroll.top) < 2;
   }, []);
+
+  useLayoutEffect(() => {
+    if (activeSessionIdRef.current === activeSessionId) {
+      return;
+    }
+
+    activeSessionIdRef.current = activeSessionId;
+    userScrollIntentVersionRef.current = 0;
+    autoScrollRef.current = null;
+    if (autoScrollTimerRef.current !== null) {
+      clearTimeout(autoScrollTimerRef.current);
+      autoScrollTimerRef.current = null;
+    }
+
+    setUserScrolledState(false);
+    updateNearEdges(true, true);
+
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.style.overflowAnchor = "none";
+    }
+  }, [activeSessionId, messagesContainerRef, setUserScrolledState, updateNearEdges]);
 
   const scrollToBottomNow = useCallback(
     (force: boolean) => {

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -554,6 +554,106 @@ describe("useAgentChatWindow", () => {
     await harness.unmount();
   });
 
+  test("switching sessions clears manual scroll state so late-rendered content stays pinned", async () => {
+    const firstSessionRows = createTurnRows(12, "session-1");
+    const secondSessionRows = createTurnRows(12, "session-2");
+    const extraContentHeightPx = { current: 0 };
+    const harness = await mountHarness(
+      {
+        rows: firstSessionRows,
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+      },
+      { attachDom: true, extraContentHeightPx },
+    );
+
+    const container = harness.messagesContainerRef.current;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+
+    container.scrollTop = 120;
+    await act(async () => {
+      await dispatchWheelUp(container);
+      await dispatchScroll(container);
+    });
+    await flushAnimationFrames();
+
+    expect(harness.getLatestResult().isNearBottom).toBe(false);
+
+    await harness.update({
+      rows: secondSessionRows,
+      activeSessionId: "session-2",
+      isSessionViewLoading: false,
+    });
+
+    extraContentHeightPx.current = 200;
+    await act(async () => {
+      triggerResizeObservers();
+      await flush();
+    });
+    await flushAnimationFrames();
+
+    expect(harness.getLatestResult().isNearBottom).toBe(true);
+    expect(container.style.overflowAnchor).toBe("none");
+    expect(container.scrollTop).toBe(getMaxScrollTop(container));
+
+    await harness.unmount();
+  });
+
+  test("deferred session hydration after a switch stays pinned through late content growth", async () => {
+    const firstSessionRows = createTurnRows(12, "session-1");
+    const secondSessionRows = createTurnRows(12, "session-2");
+    const extraContentHeightPx = { current: 0 };
+    const harness = await mountHarness(
+      {
+        rows: firstSessionRows,
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+      },
+      { attachDom: true, extraContentHeightPx },
+    );
+
+    const container = harness.messagesContainerRef.current;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+
+    container.scrollTop = 120;
+    await act(async () => {
+      await dispatchWheelUp(container);
+      await dispatchScroll(container);
+    });
+    await flushAnimationFrames();
+
+    expect(harness.getLatestResult().isNearBottom).toBe(false);
+
+    await harness.update({
+      rows: [],
+      activeSessionId: "session-2",
+      isSessionViewLoading: true,
+    });
+
+    await harness.update({
+      rows: secondSessionRows,
+      activeSessionId: "session-2",
+      isSessionViewLoading: false,
+    });
+
+    extraContentHeightPx.current = 200;
+    await act(async () => {
+      triggerResizeObservers();
+      await flush();
+    });
+    await flushAnimationFrames();
+
+    expect(harness.getLatestResult().isNearBottom).toBe(true);
+    expect(container.style.overflowAnchor).toBe("none");
+    expect(container.scrollTop).toBe(getMaxScrollTop(container));
+
+    await harness.unmount();
+  });
+
   test("scrollToBottom collapses back to the latest turns and jumps to bottom", async () => {
     const rows = createTurnRows(12);
     const harness = await mountHarness(

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -49,6 +49,7 @@ export function useAgentChatWindow({
     forceScrollToBottom,
     refreshScrollState,
   } = useAgentChatScrollController({
+    activeSessionId,
     messagesContainerRef,
     messagesContentRef,
     isSessionWorking,
@@ -85,7 +86,7 @@ export function useAgentChatWindow({
     resetToLatestTurns();
   }, [forceScrollToBottom, latestTurnStart, resetToLatestTurns, turnStart]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (prevSessionIdRef.current === activeSessionId) {
       return;
     }
@@ -94,7 +95,7 @@ export function useAgentChatWindow({
     resetLatestTurnsAndPinBottom();
   }, [activeSessionId, resetLatestTurnsAndPinBottom]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const finishedLoading = prevIsSessionViewLoadingRef.current && !isSessionViewLoading;
     prevIsSessionViewLoadingRef.current = isSessionViewLoading;
     if (!finishedLoading) {

--- a/packages/frontend/src/pages/agents/use-agent-studio-repo-settings.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-repo-settings.test.tsx
@@ -1,74 +1,66 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { RepoConfig } from "@openducktor/contracts";
-import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+import { describe, expect, mock, test } from "bun:test";
+import type { RepoConfig, WorkspaceRecord } from "@openducktor/contracts";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
-
-const actualHostOperationsModule = await import("@/state/operations/host");
-
-const hostMock = {
-  workspaceGetRepoConfig: mock(
-    async (_workspaceId: string): Promise<RepoConfig> => ({
-      workspaceId: "repo",
-      workspaceName: "Repo",
-      repoPath: "/repo",
-      defaultRuntimeKind: "opencode",
-      worktreeBasePath: "/worktrees",
-      branchPrefix: "codex/",
-      defaultTargetBranch: { remote: "origin", branch: "main" },
-      git: { providers: {} },
-      hooks: { preStart: [], postComplete: [] },
-      devServers: [],
-      worktreeFileCopies: [],
-      promptOverrides: {},
-      agentDefaults: {},
-    }),
-  ),
-};
-
-let useAgentStudioRepoSettings: typeof import("./use-agent-studio-repo-settings").useAgentStudioRepoSettings;
-
-beforeEach(async () => {
-  mock.module("@/state/operations/host", () => ({
-    host: hostMock,
-  }));
-  ({ useAgentStudioRepoSettings } = await import("./use-agent-studio-repo-settings"));
-});
-
-afterEach(async () => {
-  await restoreMockedModules([["@/state/operations/host", async () => actualHostOperationsModule]]);
-});
+import { useAgentStudioRepoSettings } from "./use-agent-studio-repo-settings";
 
 enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioRepoSettings>[0];
+type RepoConfigHost = NonNullable<HookArgs["hostClient"]>;
+
+const createWorkspace = (overrides: Partial<WorkspaceRecord> = {}): WorkspaceRecord => ({
+  workspaceId: "workspace-repo",
+  workspaceName: "Repo",
+  repoPath: "/repo",
+  isActive: true,
+  hasConfig: true,
+  configuredWorktreeBasePath: null,
+  defaultWorktreeBasePath: "/worktrees/default",
+  effectiveWorktreeBasePath: "/worktrees/default",
+  ...overrides,
+});
+
+const createRepoConfig = (overrides: Partial<RepoConfig> = {}): RepoConfig => ({
+  workspaceId: "repo",
+  workspaceName: "Repo",
+  repoPath: "/repo",
+  defaultRuntimeKind: "opencode",
+  worktreeBasePath: "/worktrees",
+  branchPrefix: "codex/",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  git: { providers: {} },
+  hooks: { preStart: [], postComplete: [] },
+  devServers: [],
+  worktreeFileCopies: [],
+  promptOverrides: {},
+  agentDefaults: {},
+  ...overrides,
+});
+
+const createRepoConfigHost = (
+  loadRepoConfig: (workspaceId: string) => Promise<RepoConfig> = async () => createRepoConfig(),
+): RepoConfigHost => ({
+  workspaceGetRepoConfig: mock(loadRepoConfig),
+});
 
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioRepoSettings, initialProps);
 
 describe("useAgentStudioRepoSettings", () => {
   test("loads repo settings from the canonical repo config query", async () => {
-    hostMock.workspaceGetRepoConfig.mockClear();
-
+    const hostClient = createRepoConfigHost();
     const harness = createHookHarness({
-      activeWorkspace: {
-        workspaceId: "workspace-repo",
-        workspaceName: "Repo",
-        repoPath: "/repo",
-        isActive: true,
-        hasConfig: true,
-        configuredWorktreeBasePath: null,
-        defaultWorktreeBasePath: "/worktrees/default",
-        effectiveWorktreeBasePath: "/worktrees/default",
-      },
+      activeWorkspace: createWorkspace(),
+      hostClient,
     });
 
     await harness.mount();
     await harness.waitFor((state) => state.repoSettings !== null);
 
-    expect(hostMock.workspaceGetRepoConfig).toHaveBeenCalledWith("workspace-repo");
+    expect(hostClient.workspaceGetRepoConfig).toHaveBeenCalledWith("workspace-repo");
     expect(harness.getLatest().repoSettings).toEqual({
       defaultRuntimeKind: "opencode",
       worktreeBasePath: "/worktrees",
@@ -90,25 +82,16 @@ describe("useAgentStudioRepoSettings", () => {
   });
 
   test("resets settings when active repo becomes null", async () => {
-    hostMock.workspaceGetRepoConfig.mockClear();
-
+    const hostClient = createRepoConfigHost();
     const harness = createHookHarness({
-      activeWorkspace: {
-        workspaceId: "workspace-repo",
-        workspaceName: "Repo",
-        repoPath: "/repo",
-        isActive: true,
-        hasConfig: true,
-        configuredWorktreeBasePath: null,
-        defaultWorktreeBasePath: "/worktrees/default",
-        effectiveWorktreeBasePath: "/worktrees/default",
-      },
+      activeWorkspace: createWorkspace(),
+      hostClient,
     });
 
     await harness.mount();
     await harness.waitFor((state) => state.repoSettings !== null);
 
-    await harness.update({ activeWorkspace: null });
+    await harness.update({ activeWorkspace: null, hostClient });
 
     expect(harness.getLatest().repoSettings).toBeNull();
 
@@ -116,57 +99,44 @@ describe("useAgentStudioRepoSettings", () => {
   });
 
   test("switches to the next repository key instead of reusing stale derived state", async () => {
-    hostMock.workspaceGetRepoConfig.mockClear();
-    hostMock.workspaceGetRepoConfig.mockImplementation(
-      async (workspaceId: string): Promise<RepoConfig> => ({
+    const hostClient = createRepoConfigHost(async (workspaceId) =>
+      createRepoConfig({
         workspaceId,
         workspaceName: workspaceId === "workspace-a" ? "Repo A" : "Repo B",
         repoPath: workspaceId === "workspace-a" ? "/repo-a" : "/repo-b",
-        defaultRuntimeKind: "opencode",
         worktreeBasePath: workspaceId === "workspace-a" ? "/worktrees/a" : "/worktrees/b",
         branchPrefix: workspaceId === "workspace-a" ? "feature-a/" : "feature-b/",
-        defaultTargetBranch: { remote: "origin", branch: "main" },
-        git: { providers: {} },
-        hooks: { preStart: [], postComplete: [] },
-        devServers: [],
-        worktreeFileCopies: [],
-        promptOverrides: {},
-        agentDefaults: {},
       }),
     );
 
     const harness = createHookHarness({
-      activeWorkspace: {
+      activeWorkspace: createWorkspace({
         workspaceId: "workspace-a",
         workspaceName: "Repo A",
         repoPath: "/repo-a",
-        isActive: true,
-        hasConfig: true,
-        configuredWorktreeBasePath: null,
         defaultWorktreeBasePath: "/worktrees/a",
         effectiveWorktreeBasePath: "/worktrees/a",
-      },
+      }),
+      hostClient,
     });
 
     await harness.mount();
     await harness.waitFor((state) => state.repoSettings?.branchPrefix === "feature-a/");
 
     await harness.update({
-      activeWorkspace: {
+      activeWorkspace: createWorkspace({
         workspaceId: "workspace-b",
         workspaceName: "Repo B",
         repoPath: "/repo-b",
-        isActive: true,
-        hasConfig: true,
-        configuredWorktreeBasePath: null,
         defaultWorktreeBasePath: "/worktrees/b",
         effectiveWorktreeBasePath: "/worktrees/b",
-      },
+      }),
+      hostClient,
     });
     await harness.waitFor((state) => state.repoSettings?.branchPrefix === "feature-b/");
 
-    expect(hostMock.workspaceGetRepoConfig).toHaveBeenCalledWith("workspace-a");
-    expect(hostMock.workspaceGetRepoConfig).toHaveBeenCalledWith("workspace-b");
+    expect(hostClient.workspaceGetRepoConfig).toHaveBeenCalledWith("workspace-a");
+    expect(hostClient.workspaceGetRepoConfig).toHaveBeenCalledWith("workspace-b");
     expect(harness.getLatest().repoSettings?.worktreeBasePath).toBe("/worktrees/b");
 
     await harness.unmount();

--- a/packages/frontend/src/pages/agents/use-agent-studio-repo-settings.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-repo-settings.ts
@@ -1,16 +1,22 @@
 import type { WorkspaceRecord } from "@openducktor/contracts";
 import { useQuery } from "@tanstack/react-query";
+import type { host } from "@/state/operations/host";
 import { repoConfigQueryOptions, toRepoSettingsInput } from "@/state/queries/workspace";
 import type { RepoSettingsInput } from "@/types/state-slices";
 
-export function useAgentStudioRepoSettings(args: { activeWorkspace: WorkspaceRecord | null }): {
+type RepoConfigQueryHost = Pick<typeof host, "workspaceGetRepoConfig">;
+
+export function useAgentStudioRepoSettings(args: {
+  activeWorkspace: WorkspaceRecord | null;
+  hostClient?: RepoConfigQueryHost;
+}): {
   repoSettings: RepoSettingsInput | null;
 } {
-  const { activeWorkspace } = args;
+  const { activeWorkspace, hostClient } = args;
   const { data: repoSettings } = useQuery({
     ...(activeWorkspace
-      ? repoConfigQueryOptions(activeWorkspace.workspaceId)
-      : repoConfigQueryOptions("")),
+      ? repoConfigQueryOptions(activeWorkspace.workspaceId, hostClient)
+      : repoConfigQueryOptions("", hostClient)),
     enabled: activeWorkspace !== null,
     select: toRepoSettingsInput,
   });

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -635,7 +635,7 @@ describe("KanbanPage session start modal flow", () => {
       ["./kanban-session-start-modal", () => import("./kanban-session-start-modal")],
       [
         "../agents/use-agent-studio-repo-settings",
-        () => import("../agents/use-agent-studio-repo-settings"),
+        () => import("../../pages/agents/use-agent-studio-repo-settings"),
       ],
       [
         "@/components/features/pull-requests/merged-pull-request-confirm-dialog",

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-helpers.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-helpers.ts
@@ -144,13 +144,6 @@ export const settleDraftToIdle = (
   return shouldClear;
 };
 
-export const toPartStreamKey = (part: SessionPart): string => {
-  if (part.kind === "tool") {
-    return `${part.messageId}:${part.callId || part.partId}`;
-  }
-  return `${part.messageId}:${part.partId}`;
-};
-
 export const createPrePartTodoSettlement = (
   part: SessionPart,
   timestamp: string,

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
@@ -1,5 +1,6 @@
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { toAssistantMessageMeta, toSessionContextUsage } from "../support/assistant-meta";
+import { toReasoningMessageId } from "../support/chat-message-ids";
 import { sanitizeStreamingText } from "../support/core";
 import {
   findLastSessionMessageByRole,
@@ -24,7 +25,6 @@ import {
   createPrePartTodoSettlement,
   eventTimestampMs,
   scheduleDraftFlush,
-  toPartStreamKey,
 } from "./session-helpers";
 import { handleToolPart } from "./session-tool-parts";
 
@@ -118,9 +118,6 @@ const clearDraftChannelBuffer = (
           };
   }
 };
-
-const toReasoningMessageId = (messageId: string, partId: string): string =>
-  `thinking:${messageId}:${partId}`;
 
 const resolvePartModelSelection = (
   context: SessionPartEventContext,
@@ -494,7 +491,6 @@ export const handleAssistantPart = (
         : event.timestamp;
     context.turn.recordTurnActivityTimestamp?.(context.store.sessionId, activityTimestamp);
   }
-  const streamMessageKey = toPartStreamKey(part);
   const prepareCurrent = createPrePartTodoSettlement(part, event.timestamp);
 
   switch (part.kind) {
@@ -505,7 +501,7 @@ export const handleAssistantPart = (
       handleReasoningPart(context, event, part, prepareCurrent);
       return;
     case "tool":
-      handleToolPart(context, event, part, streamMessageKey, prepareCurrent);
+      handleToolPart(context, event, part, prepareCurrent);
       return;
     case "subagent":
       handleSubagentPart(context, event, part, prepareCurrent);

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
@@ -2,6 +2,7 @@ import { isOdtWorkflowMutationToolName } from "@openducktor/core";
 import type { AgentChatMessageMeta, AgentSessionState } from "@/types/agent-orchestrator";
 import { formatToolContent, isTodoToolName } from "../agent-tool-messages";
 import { runOrchestratorSideEffect } from "../support/async-side-effects";
+import { toToolMessageId } from "../support/chat-message-ids";
 import { findSessionMessageById, upsertSessionMessage } from "../support/messages";
 import {
   mergeTodoListPreservingOrder,
@@ -129,7 +130,6 @@ const composeToolPartSessionUpdate = ({
   current,
   prepareCurrent,
   part,
-  streamMessageKey,
   status,
   observedEventTimestampMs,
   input,
@@ -142,7 +142,6 @@ const composeToolPartSessionUpdate = ({
   current: AgentSessionState;
   prepareCurrent: PrepareCurrent;
   part: ToolPart;
-  streamMessageKey: string;
   status: ToolPartStatus;
   observedEventTimestampMs: number;
   input: Record<string, unknown> | undefined;
@@ -153,7 +152,7 @@ const composeToolPartSessionUpdate = ({
   workflowToolAliasesByCanonical?: Parameters<typeof isOdtWorkflowMutationToolName>[1];
 }): ToolPartSessionUpdate => {
   const prepared = prepareCurrent(current);
-  const fallbackMessageId = `tool:${streamMessageKey}`;
+  const fallbackMessageId = toToolMessageId(part);
   const messageId = resolveToolMessageId(
     prepared,
     {
@@ -208,7 +207,6 @@ export const handleToolPart = (
   context: SessionToolPartEventContext,
   event: SessionPartEvent,
   part: ToolPart,
-  streamMessageKey: string,
   prepareCurrent: PrepareCurrent,
 ): void => {
   const input = normalizeToolInput(part.input);
@@ -233,7 +231,6 @@ export const handleToolPart = (
         current,
         prepareCurrent,
         part,
-        streamMessageKey,
         status: resolvedStatus,
         observedEventTimestampMs,
         input,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -359,6 +359,176 @@ describe("load-sessions-stages", () => {
     });
   });
 
+  test("preserves newer live reasoning rows when hydrated history is still non-terminal", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "thinking:assistant-1:thinking-1",
+          role: "thinking",
+          content: "Hydrated partial reasoning",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "thinking-1",
+            completed: false,
+          },
+        },
+      ],
+      [
+        {
+          id: "thinking:assistant-1:thinking-1",
+          role: "thinking",
+          content: "Live reasoning has continued",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "thinking-1",
+            completed: false,
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(1);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)).toMatchObject({
+      role: "thinking",
+      content: "Live reasoning has continued",
+      meta: { kind: "reasoning", completed: false },
+    });
+  });
+
+  test("keeps cross-id reasoning rows separate under canonical ids", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "thinking:assistant-1:thinking-1",
+          role: "thinking",
+          content: "Hydrated reasoning",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "thinking-1",
+            completed: false,
+          },
+        },
+      ],
+      [
+        {
+          id: "thinking:assistant-1:alternate-thinking-key",
+          role: "thinking",
+          content: "Different live reasoning row",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "thinking-1",
+            completed: false,
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(2);
+  });
+
+  test("does not downgrade live running tool rows to stale hydrated pending rows", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "pending",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "pending",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "running output",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "running",
+            output: "newer output",
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(1);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)).toMatchObject({
+      role: "tool",
+      content: "running output",
+      meta: {
+        kind: "tool",
+        status: "running",
+        output: "newer output",
+      },
+    });
+  });
+
+  test("preserves live running tool output over stale hydrated running rows", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "older running output",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "running",
+            output: "older output",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "newer running output",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "running",
+            output: "newer output",
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(1);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)).toMatchObject({
+      role: "tool",
+      content: "newer running output",
+      meta: {
+        kind: "tool",
+        status: "running",
+        output: "newer output",
+      },
+    });
+  });
+
   test("keeps separate same-tool rows with different call ids", () => {
     const merged = mergeHydratedMessages(
       "session-1",
@@ -495,6 +665,56 @@ describe("load-sessions-stages", () => {
         callId: "call-1",
         status: "completed",
         observedStartedAtMs: 100,
+      },
+    });
+  });
+
+  test("matches tool rows with missing call ids without throwing", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "tool:assistant-1:hydrated-part-key",
+          role: "tool",
+          content: "completed output",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: undefined as unknown as string,
+            tool: "bash",
+            status: "completed",
+            output: "done",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:current-part-key",
+          role: "tool",
+          content: "still running",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: undefined as unknown as string,
+            tool: "bash",
+            status: "running",
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(1);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)).toMatchObject({
+      id: "tool:assistant-1:hydrated-part-key",
+      role: "tool",
+      content: "completed output",
+      meta: {
+        kind: "tool",
+        partId: "tool-part-1",
+        status: "completed",
+        output: "done",
       },
     });
   });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -253,6 +253,252 @@ describe("load-sessions-stages", () => {
     });
   });
 
+  test("absorbs live reasoning and tool rows that duplicate hydrated history rows", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "thinking:assistant-1:thinking-1",
+          role: "thinking",
+          content: "Hydrated reasoning",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "thinking-1",
+            completed: true,
+          },
+        },
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "bash completed",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "completed",
+            output: "done",
+          },
+        },
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Final answer",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+          },
+        },
+      ],
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Final answer",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+          },
+        },
+        {
+          id: "thinking:assistant-1:thinking-1",
+          role: "thinking",
+          content: "Live reasoning",
+          timestamp: "2026-03-01T09:00:04.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "thinking-1",
+            completed: false,
+          },
+        },
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "bash running",
+          timestamp: "2026-03-01T09:00:05.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "running",
+            observedStartedAtMs: 100,
+            inputReadyAtMs: 120,
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(3);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)).toMatchObject({
+      role: "thinking",
+      content: "Hydrated reasoning",
+      meta: { kind: "reasoning", completed: true },
+    });
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 1)).toMatchObject({
+      role: "tool",
+      content: "bash completed",
+      meta: {
+        kind: "tool",
+        status: "completed",
+        output: "done",
+        observedStartedAtMs: 100,
+        inputReadyAtMs: 120,
+      },
+    });
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 2)).toMatchObject({
+      id: "assistant-1",
+      role: "assistant",
+      content: "Final answer",
+    });
+  });
+
+  test("keeps separate same-tool rows with different call ids", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "first",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "completed",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:call-2",
+          role: "tool",
+          content: "second",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-2",
+            callId: "call-2",
+            tool: "bash",
+            status: "completed",
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(2);
+  });
+
+  test("prefers hydrated completed tool rows over same-id live running rows", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "completed output",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "completed",
+            output: "done",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "still running",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "running",
+            observedStartedAtMs: 100,
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(1);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)).toMatchObject({
+      role: "tool",
+      content: "completed output",
+      meta: {
+        kind: "tool",
+        status: "completed",
+        output: "done",
+        observedStartedAtMs: 100,
+      },
+    });
+  });
+
+  test("absorbs live tool rows created before a call id is available", () => {
+    const merged = mergeHydratedMessages(
+      "session-1",
+      [
+        {
+          id: "tool:assistant-1:call-1",
+          role: "tool",
+          content: "completed output",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-1",
+            tool: "bash",
+            status: "completed",
+            output: "done",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:tool-part-1",
+          role: "tool",
+          content: "still running",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "",
+            tool: "bash",
+            status: "running",
+            observedStartedAtMs: 100,
+          },
+        },
+      ],
+    );
+
+    expect(getSessionMessageCount({ sessionId: "session-1", messages: merged })).toBe(1);
+    expect(sessionMessageAt({ sessionId: "session-1", messages: merged }, 0)).toMatchObject({
+      id: "tool:assistant-1:call-1",
+      role: "tool",
+      content: "completed output",
+      meta: {
+        kind: "tool",
+        partId: "tool-part-1",
+        callId: "call-1",
+        status: "completed",
+        observedStartedAtMs: 100,
+      },
+    });
+  });
+
   test("absorbs current subagent rows when hydrated history has the same child session id", () => {
     const merged = mergeHydratedMessages(
       "session-1",

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -15,7 +15,6 @@ import { errorMessage } from "@/lib/errors";
 import { appQueryClient } from "@/lib/query-client";
 import { loadRuntimeListFromQuery } from "@/state/queries/runtime";
 import type {
-  AgentChatMessage,
   AgentSessionHistoryHydrationPolicy,
   AgentSessionHistoryPreludeMode,
   AgentSessionLoadMode,
@@ -28,13 +27,11 @@ import { ensureRuntimeAndInvalidateReadinessQueries } from "../../shared/runtime
 import { requireRuntimeConnectionSupport, runtimeRouteToConnection } from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
 import { DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE } from "../support/history-hydration";
+import { mergeHydratedMessages } from "../support/hydrated-message-merge";
 import {
-  appendSessionMessage,
   createSessionMessagesState,
-  findSessionMessageById,
   forEachSessionMessage,
   getSessionMessagesSlice,
-  isFinalAssistantChatMessage,
 } from "../support/messages";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
 import {
@@ -50,12 +47,7 @@ import {
 } from "../support/session-purpose";
 import { requiresLiveWorktreeRuntime } from "../support/session-runtime-attachment";
 import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
-import {
-  formatSubagentContent,
-  isSubagentMessage,
-  mergeSubagentMeta,
-  type SubagentMessage,
-} from "../support/subagent-messages";
+import { isSubagentMessage } from "../support/subagent-messages";
 import {
   EMPTY_SUBAGENT_PENDING_PERMISSIONS_BY_SESSION_ID,
   mergeSubagentPendingPermissionOverlay,
@@ -97,6 +89,8 @@ export type SessionLoadIntent = {
   shouldReconcileLiveSessions: boolean;
   historyPolicy: AgentSessionHistoryHydrationPolicy;
 };
+
+export { mergeHydratedMessages };
 
 export type PersistedSessionMergeStageInput = {
   intent: SessionLoadIntent;
@@ -455,209 +449,6 @@ const mergePersistedSessionRecord = (
     runtimeRecoveryState: current.runtimeRecoveryState ?? persisted.runtimeRecoveryState ?? "idle",
     promptOverrides,
   };
-};
-
-export const mergeHydratedMessages = (
-  sessionId: string,
-  hydratedMessages: AgentSessionState["messages"],
-  currentMessages: AgentSessionState["messages"],
-): AgentSessionState["messages"] => {
-  const currentOwner = { sessionId, messages: currentMessages };
-  const mergeSubagentMessages = (
-    hydratedMessage: SubagentMessage,
-    currentMessage: SubagentMessage,
-  ): AgentChatMessage => {
-    const hydratedMeta = hydratedMessage.meta;
-    const currentMeta = currentMessage.meta;
-    const prefersCurrentTerminalState =
-      (currentMeta.status === "completed" ||
-        currentMeta.status === "cancelled" ||
-        currentMeta.status === "error") &&
-      hydratedMeta.status !== "completed" &&
-      hydratedMeta.status !== "cancelled" &&
-      hydratedMeta.status !== "error";
-    const description = prefersCurrentTerminalState
-      ? (currentMeta.description ?? hydratedMeta.description)
-      : (hydratedMeta.description ?? currentMeta.description);
-    const nextMeta = mergeSubagentMeta(hydratedMeta, {
-      ...currentMeta,
-      partId: hydratedMeta.partId,
-      correlationKey: hydratedMeta.correlationKey,
-      ...(typeof description === "string" ? { description } : {}),
-    });
-
-    return {
-      ...hydratedMessage,
-      content: formatSubagentContent(nextMeta),
-      meta: nextMeta,
-    };
-  };
-  const matchesHydratedSubagent = (
-    hydratedMessage: AgentChatMessage,
-    candidate: AgentChatMessage,
-  ): boolean => {
-    if (!isSubagentMessage(hydratedMessage) || !isSubagentMessage(candidate)) {
-      return false;
-    }
-    if (candidate.id === hydratedMessage.id) {
-      return false;
-    }
-
-    const hydratedSessionId = hydratedMessage.meta.sessionId;
-    if (hydratedSessionId) {
-      return candidate.meta.sessionId === hydratedSessionId;
-    }
-
-    return false;
-  };
-  const canAbsorbHydratedPartSubagentIntoCurrentSessionRow = (
-    hydratedMessage: AgentChatMessage,
-    candidate: AgentChatMessage,
-  ): boolean => {
-    if (!isSubagentMessage(hydratedMessage) || !isSubagentMessage(candidate)) {
-      return false;
-    }
-    if (hydratedMessage.meta.sessionId || !candidate.meta.sessionId) {
-      return false;
-    }
-    if (!hydratedMessage.meta.correlationKey.startsWith("part:")) {
-      return false;
-    }
-    if (!candidate.meta.correlationKey.startsWith("session:")) {
-      return false;
-    }
-
-    const hydratedAgent = hydratedMessage.meta.agent?.trim();
-    const candidateAgent = candidate.meta.agent?.trim();
-    const hydratedPrompt = hydratedMessage.meta.prompt?.trim();
-    const candidatePrompt = candidate.meta.prompt?.trim();
-
-    if (!hydratedAgent || !candidateAgent || !hydratedPrompt || !candidatePrompt) {
-      return false;
-    }
-
-    return hydratedAgent === candidateAgent && hydratedPrompt === candidatePrompt;
-  };
-  const findMatchingCurrentSubagents = (
-    hydratedMessage: AgentChatMessage,
-    sameIdCurrentMessage: AgentChatMessage | undefined,
-  ): AgentChatMessage[] => {
-    if (!isSubagentMessage(hydratedMessage)) {
-      return sameIdCurrentMessage ? [sameIdCurrentMessage] : [];
-    }
-
-    const matches: AgentChatMessage[] = [];
-    const seenIds = new Set<string>();
-    if (sameIdCurrentMessage) {
-      matches.push(sameIdCurrentMessage);
-      seenIds.add(sameIdCurrentMessage.id);
-    }
-
-    const currentSlice = getSessionMessagesSlice(currentOwner, 0);
-    const fallbackCandidates: AgentChatMessage[] = [];
-    for (let index = currentSlice.length - 1; index >= 0; index -= 1) {
-      const candidate = currentSlice[index];
-      if (!candidate || seenIds.has(candidate.id)) {
-        continue;
-      }
-      if (matchesHydratedSubagent(hydratedMessage, candidate)) {
-        matches.push(candidate);
-        seenIds.add(candidate.id);
-        continue;
-      }
-      if (canAbsorbHydratedPartSubagentIntoCurrentSessionRow(hydratedMessage, candidate)) {
-        fallbackCandidates.push(candidate);
-      }
-    }
-
-    if (matches.length === 0 && fallbackCandidates.length === 1) {
-      const [fallbackCandidate] = fallbackCandidates;
-      if (fallbackCandidate) {
-        matches.push(fallbackCandidate);
-      }
-    }
-
-    return matches;
-  };
-  const mergeSameMessageId = (
-    hydratedMessage: AgentChatMessage,
-    currentMessage: AgentChatMessage | undefined,
-  ) => {
-    if (!currentMessage) {
-      return hydratedMessage;
-    }
-
-    const hydratedIsQueuedUser =
-      hydratedMessage.role === "user" &&
-      hydratedMessage.meta?.kind === "user" &&
-      hydratedMessage.meta.state === "queued";
-    const currentIsQueuedUser =
-      currentMessage.role === "user" &&
-      currentMessage.meta?.kind === "user" &&
-      currentMessage.meta.state === "queued";
-
-    if (currentIsQueuedUser && !hydratedIsQueuedUser) {
-      const mergedMeta =
-        currentMessage.meta && hydratedMessage.meta
-          ? { ...currentMessage.meta, ...hydratedMessage.meta }
-          : (hydratedMessage.meta ?? currentMessage.meta);
-      return {
-        ...currentMessage,
-        ...hydratedMessage,
-        ...(mergedMeta ? { meta: mergedMeta } : {}),
-      };
-    }
-
-    if (
-      isFinalAssistantChatMessage(hydratedMessage) &&
-      currentMessage.role === "assistant" &&
-      !isFinalAssistantChatMessage(currentMessage)
-    ) {
-      const mergedMeta =
-        currentMessage.meta && hydratedMessage.meta
-          ? { ...currentMessage.meta, ...hydratedMessage.meta }
-          : (hydratedMessage.meta ?? currentMessage.meta);
-      return {
-        ...currentMessage,
-        ...hydratedMessage,
-        ...(mergedMeta ? { meta: mergedMeta } : {}),
-      };
-    }
-
-    if (isSubagentMessage(hydratedMessage) && isSubagentMessage(currentMessage)) {
-      return mergeSubagentMessages(hydratedMessage, currentMessage);
-    }
-
-    return currentMessage;
-  };
-  const hydratedOwner = { sessionId, messages: hydratedMessages };
-  const hydratedMessageIds = new Set<string>();
-  const absorbedCurrentMessageIds = new Set<string>();
-  let mergedMessages = createSessionMessagesState(sessionId);
-
-  forEachSessionMessage(hydratedOwner, (message) => {
-    const sameIdCurrentMessage = findSessionMessageById(currentOwner, message.id);
-    const matchingCurrentMessages = findMatchingCurrentSubagents(message, sameIdCurrentMessage);
-    hydratedMessageIds.add(message.id);
-    for (const matchingCurrentMessage of matchingCurrentMessages) {
-      absorbedCurrentMessageIds.add(matchingCurrentMessage.id);
-    }
-    const mergedMessage = matchingCurrentMessages.reduce<AgentChatMessage>(
-      (currentMerged, matchingCurrentMessage) =>
-        mergeSameMessageId(currentMerged, matchingCurrentMessage),
-      message,
-    );
-    mergedMessages = appendSessionMessage({ sessionId, messages: mergedMessages }, mergedMessage);
-  });
-
-  forEachSessionMessage(currentOwner, (message) => {
-    if (hydratedMessageIds.has(message.id) || absorbedCurrentMessageIds.has(message.id)) {
-      return;
-    }
-    mergedMessages = appendSessionMessage({ sessionId, messages: mergedMessages }, message);
-  });
-
-  return mergedMessages;
 };
 
 const toRequestedHistoryRecordFromSession = (

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/chat-message-ids.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/chat-message-ids.ts
@@ -1,3 +1,5 @@
+// User and final assistant rows use their runtime-provided message ids directly.
+// These helpers only build stable chat row ids for assistant part-derived rows.
 export const toReasoningMessageId = (messageId: string, partId: string): string =>
   `thinking:${messageId}:${partId}`;
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/chat-message-ids.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/chat-message-ids.ts
@@ -1,0 +1,12 @@
+export const toReasoningMessageId = (messageId: string, partId: string): string =>
+  `thinking:${messageId}:${partId}`;
+
+export const toToolMessageId = ({
+  messageId,
+  partId,
+  callId,
+}: {
+  messageId: string;
+  partId: string;
+  callId?: string;
+}): string => `tool:${messageId}:${callId?.trim() || partId}`;

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.test.ts
@@ -1,0 +1,571 @@
+import { describe, expect, test } from "bun:test";
+import { sessionMessagesToArray } from "@/test-utils/session-message-test-helpers";
+import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
+import { mergeHydratedMessages } from "./hydrated-message-merge";
+
+const SESSION_ID = "session-1";
+
+const createSession = (messages: AgentSessionState["messages"]) => ({
+  sessionId: SESSION_ID,
+  messages,
+});
+
+const mergedMessages = (
+  hydratedMessages: AgentChatMessage[],
+  currentMessages: AgentChatMessage[],
+): AgentChatMessage[] => {
+  return sessionMessagesToArray(
+    createSession(mergeHydratedMessages(SESSION_ID, hydratedMessages, currentMessages)),
+  );
+};
+
+describe("agent-orchestrator/support/hydrated-message-merge", () => {
+  test("prefers hydrated final assistant messages while preserving current metadata", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Final answer",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+            modelId: "gpt-5",
+            totalTokens: 120,
+          },
+        },
+      ],
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Still streaming",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: false,
+            providerId: "anthropic",
+            variant: "sonnet-stream",
+            durationMs: 44,
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      id: "assistant-1",
+      role: "assistant",
+      content: "Final answer",
+      meta: {
+        kind: "assistant",
+        agentRole: "build",
+        isFinal: true,
+        providerId: "anthropic",
+        modelId: "gpt-5",
+        variant: "sonnet-stream",
+        durationMs: 44,
+        totalTokens: 120,
+      },
+    });
+  });
+
+  test("keeps completed current reasoning when hydrated reasoning is still incomplete", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "thinking:assistant-1:reasoning-1",
+          role: "thinking",
+          content: "Hydrated reasoning",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "reasoning-1",
+            completed: false,
+          },
+        },
+      ],
+      [
+        {
+          id: "thinking:assistant-1:reasoning-1",
+          role: "thinking",
+          content: "Current completed reasoning",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "reasoning-1",
+            completed: true,
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      id: "thinking:assistant-1:reasoning-1",
+      role: "thinking",
+      content: "Current completed reasoning",
+      meta: {
+        kind: "reasoning",
+        partId: "reasoning-1",
+        completed: true,
+      },
+    });
+  });
+
+  test("preserves a current terminal tool row and hydrates identity from the hydrated row", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "tool:assistant-1:hydrated-tool",
+          role: "tool",
+          content: "Hydrated running output",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-123",
+            tool: "bash",
+            status: "running",
+            observedStartedAtMs: 100,
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:current-tool",
+          role: "tool",
+          content: "Current completed output",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "",
+            tool: "bash",
+            status: "completed",
+            output: "done",
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      id: "tool:assistant-1:hydrated-tool",
+      role: "tool",
+      content: "Current completed output",
+      meta: {
+        kind: "tool",
+        partId: "tool-part-1",
+        callId: "call-123",
+        tool: "bash",
+        status: "completed",
+        output: "done",
+      },
+    });
+  });
+
+  test("matches tool rows without call ids by scoped part and avoids duplicate current rows", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "tool:assistant-1:hydrated-part",
+          role: "tool",
+          content: "Hydrated completed output",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "",
+            tool: "bash",
+            status: "completed",
+            output: "done",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:current-part",
+          role: "tool",
+          content: "Current running output",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: " ",
+            tool: "bash",
+            status: "running",
+            observedStartedAtMs: 101,
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      id: "tool:assistant-1:hydrated-part",
+      role: "tool",
+      content: "Hydrated completed output",
+      meta: {
+        kind: "tool",
+        partId: "tool-part-1",
+        status: "completed",
+        output: "done",
+        observedStartedAtMs: 101,
+      },
+    });
+  });
+
+  test("appends unmatched current messages after hydrated history", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Hydrated history",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+          },
+        },
+      ],
+      [
+        {
+          id: "assistant-2",
+          role: "assistant",
+          content: "Unmatched current row",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: false,
+          },
+        },
+      ],
+    );
+
+    expect(merged.map((message) => message.id)).toEqual(["assistant-1", "assistant-2"]);
+  });
+
+  test("keeps subagent terminal status and description consistent", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "subagent:part:msg-200:child-a",
+          role: "system",
+          content: "Subagent (build): Finished A",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "part-a-completed",
+            correlationKey: "part:msg-200:child-a",
+            status: "completed",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Finished A",
+            sessionId: "child-a",
+            startedAtMs: 100,
+            endedAtMs: 300,
+          },
+        },
+      ],
+      [
+        {
+          id: "subagent:session:msg-200:child-a",
+          role: "system",
+          content: "Subagent (build): Error A",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "session-a-error",
+            correlationKey: "session:msg-200:child-a",
+            status: "error",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Error A",
+            sessionId: "child-a",
+            startedAtMs: 95,
+            endedAtMs: 320,
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      id: "subagent:part:msg-200:child-a",
+      role: "system",
+      content: "Subagent (build): Error A",
+      meta: {
+        kind: "subagent",
+        correlationKey: "part:msg-200:child-a",
+        status: "error",
+        agent: "build",
+        prompt: "Inspect repo",
+        description: "Error A",
+        sessionId: "child-a",
+        startedAtMs: 95,
+        endedAtMs: 320,
+      },
+    });
+  });
+
+  test("absorbs a current subagent session row into only one hydrated part row", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "subagent:part:msg-200:child-a-1",
+          role: "system",
+          content: "Subagent (build): Part one",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "part-a-1",
+            correlationKey: "part:msg-200:child-a-1",
+            status: "completed",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Part one",
+            sessionId: "child-a",
+            startedAtMs: 100,
+            endedAtMs: 300,
+          },
+        },
+        {
+          id: "subagent:part:msg-200:child-a-2",
+          role: "system",
+          content: "Subagent (build): Part two",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "part-a-2",
+            correlationKey: "part:msg-200:child-a-2",
+            status: "completed",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Part two",
+            sessionId: "child-a",
+            startedAtMs: 110,
+            endedAtMs: 310,
+          },
+        },
+      ],
+      [
+        {
+          id: "subagent:session:msg-200:child-a",
+          role: "system",
+          content: "Subagent (build): Current session row",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "session-a",
+            correlationKey: "session:msg-200:child-a",
+            status: "running",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Current session row",
+            sessionId: "child-a",
+            startedAtMs: 90,
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged.map((message) => message.id)).toEqual([
+      "subagent:part:msg-200:child-a-1",
+      "subagent:part:msg-200:child-a-2",
+    ]);
+    expect(merged.every((message) => message.meta?.kind === "subagent")).toBe(true);
+    expect(merged[0]?.meta?.kind === "subagent" ? merged[0].meta.startedAtMs : null).toBe(90);
+    expect(merged[1]?.meta?.kind === "subagent" ? merged[1].meta.startedAtMs : null).toBe(110);
+  });
+
+  test("absorbs a fallback-matched subagent session row only once", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "subagent:part:msg-200:child-a-1",
+          role: "system",
+          content: "Subagent (build): Part one",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "part-a-1",
+            correlationKey: "part:msg-200:child-a-1",
+            status: "completed",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Part one",
+            startedAtMs: 100,
+            endedAtMs: 300,
+          },
+        },
+        {
+          id: "subagent:part:msg-200:child-a-2",
+          role: "system",
+          content: "Subagent (build): Part two",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "part-a-2",
+            correlationKey: "part:msg-200:child-a-2",
+            status: "completed",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Part two",
+            startedAtMs: 110,
+            endedAtMs: 310,
+          },
+        },
+      ],
+      [
+        {
+          id: "subagent:session:msg-200:child-a",
+          role: "system",
+          content: "Subagent (build): Current session row",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "session-a",
+            correlationKey: "session:msg-200:child-a",
+            status: "running",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Current session row",
+            sessionId: "child-a",
+            startedAtMs: 90,
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0]?.meta?.kind === "subagent" ? merged[0].meta.sessionId : null).toBe("child-a");
+    expect(merged[1]?.meta?.kind === "subagent" ? merged[1].meta.sessionId : null).toBeUndefined();
+    expect(merged[0]?.meta?.kind === "subagent" ? merged[0].meta.startedAtMs : null).toBe(90);
+    expect(merged[1]?.meta?.kind === "subagent" ? merged[1].meta.startedAtMs : null).toBe(110);
+  });
+
+  test("absorbs a matching current tool row only once", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "tool:assistant-1:hydrated-tool-a",
+          role: "tool",
+          content: "Hydrated running A",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "",
+            tool: "bash",
+            status: "running",
+          },
+        },
+        {
+          id: "tool:assistant-1:hydrated-tool-b",
+          role: "tool",
+          content: "Hydrated running B",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "",
+            tool: "bash",
+            status: "running",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:current-tool",
+          role: "tool",
+          content: "Current completed output",
+          timestamp: "2026-03-01T09:00:04.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "",
+            tool: "bash",
+            status: "completed",
+            output: "done",
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toMatchObject({
+      id: "tool:assistant-1:current-tool",
+      content: "Current completed output",
+      meta: { kind: "tool", status: "completed", output: "done" },
+    });
+    expect(merged[1]).toMatchObject({
+      id: "tool:assistant-1:hydrated-tool-b",
+      content: "Hydrated running B",
+      meta: { kind: "tool", status: "running" },
+    });
+  });
+
+  test("keeps hydrated terminal subagent status and description over stale current state", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "subagent:part:msg-200:child-a",
+          role: "system",
+          content: "Subagent (build): Failed A",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "part-a-error",
+            correlationKey: "part:msg-200:child-a",
+            status: "error",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Failed A",
+            sessionId: "child-a",
+            startedAtMs: 100,
+            endedAtMs: 300,
+          },
+        },
+      ],
+      [
+        {
+          id: "subagent:session:msg-200:child-a",
+          role: "system",
+          content: "Subagent (build): Still running A",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "subagent",
+            partId: "session-a-running",
+            correlationKey: "session:msg-200:child-a",
+            status: "running",
+            agent: "build",
+            prompt: "Inspect repo",
+            description: "Still running A",
+            sessionId: "child-a",
+            startedAtMs: 95,
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      content: "Subagent (build): Failed A",
+      meta: {
+        kind: "subagent",
+        status: "error",
+        description: "Failed A",
+        startedAtMs: 95,
+        endedAtMs: 300,
+      },
+    });
+  });
+});

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.test.ts
@@ -154,7 +154,7 @@ describe("agent-orchestrator/support/hydrated-message-merge", () => {
 
     expect(merged).toHaveLength(1);
     expect(merged[0]).toMatchObject({
-      id: "tool:assistant-1:hydrated-tool",
+      id: "tool:assistant-1:call-123",
       role: "tool",
       content: "Current completed output",
       meta: {
@@ -162,6 +162,55 @@ describe("agent-orchestrator/support/hydrated-message-merge", () => {
         partId: "tool-part-1",
         callId: "call-123",
         tool: "bash",
+        status: "completed",
+        output: "done",
+      },
+    });
+  });
+
+  test("canonicalizes a preserved terminal tool row that already learned its call id", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "tool:assistant-1:call-123",
+          role: "tool",
+          content: "Hydrated running output",
+          timestamp: "2026-03-01T09:00:02.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-123",
+            tool: "bash",
+            status: "running",
+          },
+        },
+      ],
+      [
+        {
+          id: "tool:assistant-1:tool-part-1",
+          role: "tool",
+          content: "Current completed output",
+          timestamp: "2026-03-01T09:00:03.000Z",
+          meta: {
+            kind: "tool",
+            partId: "tool-part-1",
+            callId: "call-123",
+            tool: "bash",
+            status: "completed",
+            output: "done",
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      id: "tool:assistant-1:call-123",
+      content: "Current completed output",
+      meta: {
+        kind: "tool",
+        partId: "tool-part-1",
+        callId: "call-123",
         status: "completed",
         output: "done",
       },
@@ -502,7 +551,7 @@ describe("agent-orchestrator/support/hydrated-message-merge", () => {
 
     expect(merged).toHaveLength(2);
     expect(merged[0]).toMatchObject({
-      id: "tool:assistant-1:current-tool",
+      id: "tool:assistant-1:tool-part-1",
       content: "Current completed output",
       meta: { kind: "tool", status: "completed", output: "done" },
     });

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.ts
@@ -19,6 +19,8 @@ type ScopedPartId = {
   partKey: string;
 };
 
+type ToolStatus = "pending" | "running" | "completed" | "error";
+
 const parseScopedPartId = (id: string, prefix: string): ScopedPartId | null => {
   if (!id.startsWith(prefix)) {
     return null;
@@ -36,12 +38,65 @@ const parseScopedPartId = (id: string, prefix: string): ScopedPartId | null => {
   };
 };
 
-const parseReasoningScopedPartId = (id: string) => parseScopedPartId(id, "thinking:");
-
 const parseToolScopedPartId = (id: string) => parseScopedPartId(id, "tool:");
 
-const isTerminalToolStatus = (status: "pending" | "running" | "completed" | "error") =>
-  status === "completed" || status === "error";
+const isTerminalToolStatus = (status: ToolStatus) => status === "completed" || status === "error";
+
+const toolStatusRank = (status: ToolStatus): number => {
+  switch (status) {
+    case "pending":
+      return 0;
+    case "running":
+      return 1;
+    case "completed":
+    case "error":
+      return 2;
+  }
+};
+
+const trimToolCallId = (callId: string | undefined): string =>
+  typeof callId === "string" ? callId.trim() : "";
+
+const shouldPreserveCurrentToolMessage = (
+  hydratedStatus: ToolStatus,
+  currentStatus: ToolStatus,
+): boolean => {
+  const hydratedTerminal = isTerminalToolStatus(hydratedStatus);
+  const currentTerminal = isTerminalToolStatus(currentStatus);
+
+  if (hydratedTerminal !== currentTerminal) {
+    return currentTerminal;
+  }
+  if (!hydratedTerminal && !currentTerminal) {
+    return toolStatusRank(currentStatus) >= toolStatusRank(hydratedStatus);
+  }
+
+  return false;
+};
+
+const preserveCurrentToolWithHydratedIdentity = (
+  hydratedMessage: AgentChatMessage,
+  currentMessage: AgentChatMessage,
+): AgentChatMessage => {
+  if (hydratedMessage.meta?.kind !== "tool" || currentMessage.meta?.kind !== "tool") {
+    return currentMessage;
+  }
+
+  const hydratedCallId = trimToolCallId(hydratedMessage.meta.callId);
+  const currentCallId = trimToolCallId(currentMessage.meta.callId);
+  if (hydratedCallId.length === 0 || currentCallId.length > 0) {
+    return currentMessage;
+  }
+
+  return {
+    ...currentMessage,
+    id: hydratedMessage.id,
+    meta: {
+      ...currentMessage.meta,
+      callId: hydratedCallId,
+    },
+  };
+};
 
 const isTerminalSubagentStatus = (status: SubagentMessage["meta"]["status"]): boolean =>
   status === "completed" || status === "cancelled" || status === "error";
@@ -56,6 +111,9 @@ const mergeReasoningMessages = (
   if (currentMessage.meta.completed && !hydratedMessage.meta.completed) {
     return currentMessage;
   }
+  if (!currentMessage.meta.completed && !hydratedMessage.meta.completed) {
+    return currentMessage;
+  }
 
   return hydratedMessage;
 };
@@ -68,11 +126,8 @@ const mergeToolMessages = (
     return currentMessage;
   }
 
-  if (
-    isTerminalToolStatus(currentMessage.meta.status) &&
-    !isTerminalToolStatus(hydratedMessage.meta.status)
-  ) {
-    return currentMessage;
+  if (shouldPreserveCurrentToolMessage(hydratedMessage.meta.status, currentMessage.meta.status)) {
+    return preserveCurrentToolWithHydratedIdentity(hydratedMessage, currentMessage);
   }
 
   const nextMeta = {
@@ -122,29 +177,6 @@ const mergeSubagentMessages = (
   };
 };
 
-const matchesHydratedReasoning = (
-  hydratedMessage: AgentChatMessage,
-  candidate: AgentChatMessage,
-): boolean => {
-  if (hydratedMessage.meta?.kind !== "reasoning" || candidate.meta?.kind !== "reasoning") {
-    return false;
-  }
-  if (candidate.id === hydratedMessage.id) {
-    return false;
-  }
-  if (hydratedMessage.meta.partId !== candidate.meta.partId) {
-    return false;
-  }
-
-  const hydratedScopedId = parseReasoningScopedPartId(hydratedMessage.id);
-  const candidateScopedId = parseReasoningScopedPartId(candidate.id);
-  return (
-    hydratedScopedId !== null &&
-    candidateScopedId !== null &&
-    hydratedScopedId.messageId === candidateScopedId.messageId
-  );
-};
-
 const matchesHydratedTool = (
   hydratedMessage: AgentChatMessage,
   candidate: AgentChatMessage,
@@ -169,8 +201,8 @@ const matchesHydratedTool = (
     return false;
   }
 
-  const hydratedCallId = hydratedMessage.meta.callId.trim();
-  const candidateCallId = candidate.meta.callId.trim();
+  const hydratedCallId = trimToolCallId(hydratedMessage.meta.callId);
+  const candidateCallId = trimToolCallId(candidate.meta.callId);
   if (hydratedCallId.length > 0 && candidateCallId.length > 0) {
     return hydratedCallId === candidateCallId;
   }
@@ -243,10 +275,7 @@ const findMatchingCurrentNonSubagentMessages = ({
     if (!candidate || seenIds.has(candidate.id)) {
       continue;
     }
-    if (
-      matchesHydratedReasoning(hydratedMessage, candidate) ||
-      matchesHydratedTool(hydratedMessage, candidate)
-    ) {
+    if (matchesHydratedTool(hydratedMessage, candidate)) {
       matches.push(candidate);
       seenIds.add(candidate.id);
     }

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.ts
@@ -98,8 +98,23 @@ const preserveCurrentToolWithHydratedIdentity = (
   };
 };
 
-const isTerminalSubagentStatus = (status: SubagentMessage["meta"]["status"]): boolean =>
-  status === "completed" || status === "cancelled" || status === "error";
+const chooseSubagentDescription = (
+  hydratedMeta: SubagentMessage["meta"],
+  currentMeta: SubagentMessage["meta"],
+  resolvedStatus: SubagentMessage["meta"]["status"],
+): string | undefined => {
+  const currentMatchesResolvedStatus = currentMeta.status === resolvedStatus;
+  const hydratedMatchesResolvedStatus = hydratedMeta.status === resolvedStatus;
+
+  if (currentMatchesResolvedStatus && !hydratedMatchesResolvedStatus) {
+    return currentMeta.description ?? hydratedMeta.description;
+  }
+  if (hydratedMatchesResolvedStatus && !currentMatchesResolvedStatus) {
+    return hydratedMeta.description ?? currentMeta.description;
+  }
+
+  return hydratedMeta.description ?? currentMeta.description;
+};
 
 const mergeReasoningMessages = (
   hydratedMessage: AgentChatMessage,
@@ -158,22 +173,21 @@ const mergeSubagentMessages = (
 ): AgentChatMessage => {
   const hydratedMeta = hydratedMessage.meta;
   const currentMeta = currentMessage.meta;
-  const prefersCurrentTerminalState =
-    isTerminalSubagentStatus(currentMeta.status) && !isTerminalSubagentStatus(hydratedMeta.status);
-  const description = prefersCurrentTerminalState
-    ? (currentMeta.description ?? hydratedMeta.description)
-    : (hydratedMeta.description ?? currentMeta.description);
   const nextMeta = mergeSubagentMeta(hydratedMeta, {
     ...currentMeta,
     partId: hydratedMeta.partId,
     correlationKey: hydratedMeta.correlationKey,
-    ...(typeof description === "string" ? { description } : {}),
   });
+  const description = chooseSubagentDescription(hydratedMeta, currentMeta, nextMeta.status);
+  const resolvedMeta = {
+    ...nextMeta,
+    ...(typeof description === "string" ? { description } : {}),
+  };
 
   return {
     ...hydratedMessage,
-    content: formatSubagentContent(nextMeta),
-    meta: nextMeta,
+    content: formatSubagentContent(resolvedMeta),
+    meta: resolvedMeta,
   };
 };
 
@@ -262,17 +276,22 @@ const findMatchingCurrentNonSubagentMessages = ({
   currentOwner,
   hydratedMessage,
   sameIdCurrentMessage,
+  absorbedCurrentMessageIds,
 }: {
   currentOwner: Pick<AgentSessionState, "sessionId" | "messages">;
   hydratedMessage: AgentChatMessage;
   sameIdCurrentMessage: AgentChatMessage | undefined;
+  absorbedCurrentMessageIds: ReadonlySet<string>;
 }): AgentChatMessage[] => {
-  const matches = sameIdCurrentMessage ? [sameIdCurrentMessage] : [];
+  const matches =
+    sameIdCurrentMessage && !absorbedCurrentMessageIds.has(sameIdCurrentMessage.id)
+      ? [sameIdCurrentMessage]
+      : [];
   const seenIds = new Set(matches.map((message) => message.id));
   const currentSlice = getSessionMessagesSlice(currentOwner, 0);
   for (let index = currentSlice.length - 1; index >= 0; index -= 1) {
     const candidate = currentSlice[index];
-    if (!candidate || seenIds.has(candidate.id)) {
+    if (!candidate || seenIds.has(candidate.id) || absorbedCurrentMessageIds.has(candidate.id)) {
       continue;
     }
     if (matchesHydratedTool(hydratedMessage, candidate)) {
@@ -287,14 +306,16 @@ const findMatchingCurrentSubagentMessages = ({
   currentOwner,
   hydratedMessage,
   sameIdCurrentMessage,
+  absorbedCurrentMessageIds,
 }: {
   currentOwner: Pick<AgentSessionState, "sessionId" | "messages">;
   hydratedMessage: AgentChatMessage;
   sameIdCurrentMessage: AgentChatMessage | undefined;
+  absorbedCurrentMessageIds: ReadonlySet<string>;
 }): AgentChatMessage[] => {
   const matches: AgentChatMessage[] = [];
   const seenIds = new Set<string>();
-  if (sameIdCurrentMessage) {
+  if (sameIdCurrentMessage && !absorbedCurrentMessageIds.has(sameIdCurrentMessage.id)) {
     matches.push(sameIdCurrentMessage);
     seenIds.add(sameIdCurrentMessage.id);
   }
@@ -303,7 +324,7 @@ const findMatchingCurrentSubagentMessages = ({
   const fallbackCandidates: AgentChatMessage[] = [];
   for (let index = currentSlice.length - 1; index >= 0; index -= 1) {
     const candidate = currentSlice[index];
-    if (!candidate || seenIds.has(candidate.id)) {
+    if (!candidate || seenIds.has(candidate.id) || absorbedCurrentMessageIds.has(candidate.id)) {
       continue;
     }
     if (matchesHydratedSubagent(hydratedMessage, candidate)) {
@@ -330,16 +351,19 @@ const findMatchingCurrentMessages = ({
   currentOwner,
   hydratedMessage,
   sameIdCurrentMessage,
+  absorbedCurrentMessageIds,
 }: {
   currentOwner: Pick<AgentSessionState, "sessionId" | "messages">;
   hydratedMessage: AgentChatMessage;
   sameIdCurrentMessage: AgentChatMessage | undefined;
+  absorbedCurrentMessageIds: ReadonlySet<string>;
 }): AgentChatMessage[] => {
   if (isSubagentMessage(hydratedMessage)) {
     return findMatchingCurrentSubagentMessages({
       currentOwner,
       hydratedMessage,
       sameIdCurrentMessage,
+      absorbedCurrentMessageIds,
     });
   }
 
@@ -347,6 +371,7 @@ const findMatchingCurrentMessages = ({
     currentOwner,
     hydratedMessage,
     sameIdCurrentMessage,
+    absorbedCurrentMessageIds,
   });
 };
 
@@ -427,6 +452,7 @@ export const mergeHydratedMessages = (
       currentOwner,
       hydratedMessage: message,
       sameIdCurrentMessage,
+      absorbedCurrentMessageIds,
     });
     hydratedMessageIds.add(message.id);
     for (const matchingCurrentMessage of matchingCurrentMessages) {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.ts
@@ -1,4 +1,5 @@
 import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
+import { toToolMessageId } from "./chat-message-ids";
 import {
   appendSessionMessage,
   createSessionMessagesState,
@@ -82,18 +83,26 @@ const preserveCurrentToolWithHydratedIdentity = (
     return currentMessage;
   }
 
-  const hydratedCallId = trimToolCallId(hydratedMessage.meta.callId);
-  const currentCallId = trimToolCallId(currentMessage.meta.callId);
-  if (hydratedCallId.length === 0 || currentCallId.length > 0) {
+  const scopedId = parseToolScopedPartId(hydratedMessage.id);
+  if (scopedId === null) {
     return currentMessage;
   }
 
+  const hydratedCallId = trimToolCallId(hydratedMessage.meta.callId);
+  const currentCallId = trimToolCallId(currentMessage.meta.callId);
+  const canonicalCallId = hydratedCallId || currentCallId;
+  const canonicalId = toToolMessageId({
+    messageId: scopedId.messageId,
+    partId: hydratedMessage.meta.partId,
+    ...(canonicalCallId ? { callId: canonicalCallId } : {}),
+  });
+
   return {
     ...currentMessage,
-    id: hydratedMessage.id,
+    id: canonicalId,
     meta: {
       ...currentMessage.meta,
-      callId: hydratedCallId,
+      callId: canonicalCallId,
     },
   };
 };

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/hydrated-message-merge.ts
@@ -1,0 +1,422 @@
+import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
+import {
+  appendSessionMessage,
+  createSessionMessagesState,
+  findSessionMessageById,
+  forEachSessionMessage,
+  getSessionMessagesSlice,
+  isFinalAssistantChatMessage,
+} from "./messages";
+import {
+  formatSubagentContent,
+  isSubagentMessage,
+  mergeSubagentMeta,
+  type SubagentMessage,
+} from "./subagent-messages";
+
+type ScopedPartId = {
+  messageId: string;
+  partKey: string;
+};
+
+const parseScopedPartId = (id: string, prefix: string): ScopedPartId | null => {
+  if (!id.startsWith(prefix)) {
+    return null;
+  }
+
+  const scopedId = id.slice(prefix.length);
+  const separatorIndex = scopedId.lastIndexOf(":");
+  if (separatorIndex <= 0 || separatorIndex >= scopedId.length - 1) {
+    return null;
+  }
+
+  return {
+    messageId: scopedId.slice(0, separatorIndex),
+    partKey: scopedId.slice(separatorIndex + 1),
+  };
+};
+
+const parseReasoningScopedPartId = (id: string) => parseScopedPartId(id, "thinking:");
+
+const parseToolScopedPartId = (id: string) => parseScopedPartId(id, "tool:");
+
+const isTerminalToolStatus = (status: "pending" | "running" | "completed" | "error") =>
+  status === "completed" || status === "error";
+
+const isTerminalSubagentStatus = (status: SubagentMessage["meta"]["status"]): boolean =>
+  status === "completed" || status === "cancelled" || status === "error";
+
+const mergeReasoningMessages = (
+  hydratedMessage: AgentChatMessage,
+  currentMessage: AgentChatMessage,
+): AgentChatMessage => {
+  if (hydratedMessage.meta?.kind !== "reasoning" || currentMessage.meta?.kind !== "reasoning") {
+    return currentMessage;
+  }
+  if (currentMessage.meta.completed && !hydratedMessage.meta.completed) {
+    return currentMessage;
+  }
+
+  return hydratedMessage;
+};
+
+const mergeToolMessages = (
+  hydratedMessage: AgentChatMessage,
+  currentMessage: AgentChatMessage,
+): AgentChatMessage => {
+  if (hydratedMessage.meta?.kind !== "tool" || currentMessage.meta?.kind !== "tool") {
+    return currentMessage;
+  }
+
+  if (
+    isTerminalToolStatus(currentMessage.meta.status) &&
+    !isTerminalToolStatus(hydratedMessage.meta.status)
+  ) {
+    return currentMessage;
+  }
+
+  const nextMeta = {
+    ...hydratedMessage.meta,
+    ...(hydratedMessage.meta.observedStartedAtMs === undefined &&
+    currentMessage.meta.observedStartedAtMs !== undefined
+      ? { observedStartedAtMs: currentMessage.meta.observedStartedAtMs }
+      : {}),
+    ...(hydratedMessage.meta.observedEndedAtMs === undefined &&
+    currentMessage.meta.observedEndedAtMs !== undefined
+      ? { observedEndedAtMs: currentMessage.meta.observedEndedAtMs }
+      : {}),
+    ...(hydratedMessage.meta.inputReadyAtMs === undefined &&
+    currentMessage.meta.inputReadyAtMs !== undefined
+      ? { inputReadyAtMs: currentMessage.meta.inputReadyAtMs }
+      : {}),
+  };
+
+  return {
+    ...hydratedMessage,
+    meta: nextMeta,
+  };
+};
+
+const mergeSubagentMessages = (
+  hydratedMessage: SubagentMessage,
+  currentMessage: SubagentMessage,
+): AgentChatMessage => {
+  const hydratedMeta = hydratedMessage.meta;
+  const currentMeta = currentMessage.meta;
+  const prefersCurrentTerminalState =
+    isTerminalSubagentStatus(currentMeta.status) && !isTerminalSubagentStatus(hydratedMeta.status);
+  const description = prefersCurrentTerminalState
+    ? (currentMeta.description ?? hydratedMeta.description)
+    : (hydratedMeta.description ?? currentMeta.description);
+  const nextMeta = mergeSubagentMeta(hydratedMeta, {
+    ...currentMeta,
+    partId: hydratedMeta.partId,
+    correlationKey: hydratedMeta.correlationKey,
+    ...(typeof description === "string" ? { description } : {}),
+  });
+
+  return {
+    ...hydratedMessage,
+    content: formatSubagentContent(nextMeta),
+    meta: nextMeta,
+  };
+};
+
+const matchesHydratedReasoning = (
+  hydratedMessage: AgentChatMessage,
+  candidate: AgentChatMessage,
+): boolean => {
+  if (hydratedMessage.meta?.kind !== "reasoning" || candidate.meta?.kind !== "reasoning") {
+    return false;
+  }
+  if (candidate.id === hydratedMessage.id) {
+    return false;
+  }
+  if (hydratedMessage.meta.partId !== candidate.meta.partId) {
+    return false;
+  }
+
+  const hydratedScopedId = parseReasoningScopedPartId(hydratedMessage.id);
+  const candidateScopedId = parseReasoningScopedPartId(candidate.id);
+  return (
+    hydratedScopedId !== null &&
+    candidateScopedId !== null &&
+    hydratedScopedId.messageId === candidateScopedId.messageId
+  );
+};
+
+const matchesHydratedTool = (
+  hydratedMessage: AgentChatMessage,
+  candidate: AgentChatMessage,
+): boolean => {
+  if (hydratedMessage.meta?.kind !== "tool" || candidate.meta?.kind !== "tool") {
+    return false;
+  }
+  if (candidate.id === hydratedMessage.id) {
+    return false;
+  }
+  if (hydratedMessage.meta.tool !== candidate.meta.tool) {
+    return false;
+  }
+
+  const hydratedScopedId = parseToolScopedPartId(hydratedMessage.id);
+  const candidateScopedId = parseToolScopedPartId(candidate.id);
+  if (
+    hydratedScopedId === null ||
+    candidateScopedId === null ||
+    hydratedScopedId.messageId !== candidateScopedId.messageId
+  ) {
+    return false;
+  }
+
+  const hydratedCallId = hydratedMessage.meta.callId.trim();
+  const candidateCallId = candidate.meta.callId.trim();
+  if (hydratedCallId.length > 0 && candidateCallId.length > 0) {
+    return hydratedCallId === candidateCallId;
+  }
+
+  return hydratedMessage.meta.partId === candidate.meta.partId;
+};
+
+const matchesHydratedSubagent = (
+  hydratedMessage: AgentChatMessage,
+  candidate: AgentChatMessage,
+): boolean => {
+  if (!isSubagentMessage(hydratedMessage) || !isSubagentMessage(candidate)) {
+    return false;
+  }
+  if (candidate.id === hydratedMessage.id) {
+    return false;
+  }
+
+  const hydratedSessionId = hydratedMessage.meta.sessionId;
+  if (hydratedSessionId) {
+    return candidate.meta.sessionId === hydratedSessionId;
+  }
+
+  return false;
+};
+
+const canAbsorbHydratedPartSubagentIntoCurrentSessionRow = (
+  hydratedMessage: AgentChatMessage,
+  candidate: AgentChatMessage,
+): boolean => {
+  if (!isSubagentMessage(hydratedMessage) || !isSubagentMessage(candidate)) {
+    return false;
+  }
+  if (hydratedMessage.meta.sessionId || !candidate.meta.sessionId) {
+    return false;
+  }
+  if (!hydratedMessage.meta.correlationKey.startsWith("part:")) {
+    return false;
+  }
+  if (!candidate.meta.correlationKey.startsWith("session:")) {
+    return false;
+  }
+
+  const hydratedAgent = hydratedMessage.meta.agent?.trim();
+  const candidateAgent = candidate.meta.agent?.trim();
+  const hydratedPrompt = hydratedMessage.meta.prompt?.trim();
+  const candidatePrompt = candidate.meta.prompt?.trim();
+
+  if (!hydratedAgent || !candidateAgent || !hydratedPrompt || !candidatePrompt) {
+    return false;
+  }
+
+  return hydratedAgent === candidateAgent && hydratedPrompt === candidatePrompt;
+};
+
+const findMatchingCurrentNonSubagentMessages = ({
+  currentOwner,
+  hydratedMessage,
+  sameIdCurrentMessage,
+}: {
+  currentOwner: Pick<AgentSessionState, "sessionId" | "messages">;
+  hydratedMessage: AgentChatMessage;
+  sameIdCurrentMessage: AgentChatMessage | undefined;
+}): AgentChatMessage[] => {
+  const matches = sameIdCurrentMessage ? [sameIdCurrentMessage] : [];
+  const seenIds = new Set(matches.map((message) => message.id));
+  const currentSlice = getSessionMessagesSlice(currentOwner, 0);
+  for (let index = currentSlice.length - 1; index >= 0; index -= 1) {
+    const candidate = currentSlice[index];
+    if (!candidate || seenIds.has(candidate.id)) {
+      continue;
+    }
+    if (
+      matchesHydratedReasoning(hydratedMessage, candidate) ||
+      matchesHydratedTool(hydratedMessage, candidate)
+    ) {
+      matches.push(candidate);
+      seenIds.add(candidate.id);
+    }
+  }
+  return matches;
+};
+
+const findMatchingCurrentSubagentMessages = ({
+  currentOwner,
+  hydratedMessage,
+  sameIdCurrentMessage,
+}: {
+  currentOwner: Pick<AgentSessionState, "sessionId" | "messages">;
+  hydratedMessage: AgentChatMessage;
+  sameIdCurrentMessage: AgentChatMessage | undefined;
+}): AgentChatMessage[] => {
+  const matches: AgentChatMessage[] = [];
+  const seenIds = new Set<string>();
+  if (sameIdCurrentMessage) {
+    matches.push(sameIdCurrentMessage);
+    seenIds.add(sameIdCurrentMessage.id);
+  }
+
+  const currentSlice = getSessionMessagesSlice(currentOwner, 0);
+  const fallbackCandidates: AgentChatMessage[] = [];
+  for (let index = currentSlice.length - 1; index >= 0; index -= 1) {
+    const candidate = currentSlice[index];
+    if (!candidate || seenIds.has(candidate.id)) {
+      continue;
+    }
+    if (matchesHydratedSubagent(hydratedMessage, candidate)) {
+      matches.push(candidate);
+      seenIds.add(candidate.id);
+      continue;
+    }
+    if (canAbsorbHydratedPartSubagentIntoCurrentSessionRow(hydratedMessage, candidate)) {
+      fallbackCandidates.push(candidate);
+    }
+  }
+
+  if (matches.length === 0 && fallbackCandidates.length === 1) {
+    const [fallbackCandidate] = fallbackCandidates;
+    if (fallbackCandidate) {
+      matches.push(fallbackCandidate);
+    }
+  }
+
+  return matches;
+};
+
+const findMatchingCurrentMessages = ({
+  currentOwner,
+  hydratedMessage,
+  sameIdCurrentMessage,
+}: {
+  currentOwner: Pick<AgentSessionState, "sessionId" | "messages">;
+  hydratedMessage: AgentChatMessage;
+  sameIdCurrentMessage: AgentChatMessage | undefined;
+}): AgentChatMessage[] => {
+  if (isSubagentMessage(hydratedMessage)) {
+    return findMatchingCurrentSubagentMessages({
+      currentOwner,
+      hydratedMessage,
+      sameIdCurrentMessage,
+    });
+  }
+
+  return findMatchingCurrentNonSubagentMessages({
+    currentOwner,
+    hydratedMessage,
+    sameIdCurrentMessage,
+  });
+};
+
+const mergeSameMessageId = (
+  hydratedMessage: AgentChatMessage,
+  currentMessage: AgentChatMessage | undefined,
+): AgentChatMessage => {
+  if (!currentMessage) {
+    return hydratedMessage;
+  }
+
+  const hydratedIsQueuedUser =
+    hydratedMessage.role === "user" &&
+    hydratedMessage.meta?.kind === "user" &&
+    hydratedMessage.meta.state === "queued";
+  const currentIsQueuedUser =
+    currentMessage.role === "user" &&
+    currentMessage.meta?.kind === "user" &&
+    currentMessage.meta.state === "queued";
+
+  if (currentIsQueuedUser && !hydratedIsQueuedUser) {
+    const mergedMeta =
+      currentMessage.meta && hydratedMessage.meta
+        ? { ...currentMessage.meta, ...hydratedMessage.meta }
+        : (hydratedMessage.meta ?? currentMessage.meta);
+    return {
+      ...currentMessage,
+      ...hydratedMessage,
+      ...(mergedMeta ? { meta: mergedMeta } : {}),
+    };
+  }
+
+  if (
+    isFinalAssistantChatMessage(hydratedMessage) &&
+    currentMessage.role === "assistant" &&
+    !isFinalAssistantChatMessage(currentMessage)
+  ) {
+    const mergedMeta =
+      currentMessage.meta && hydratedMessage.meta
+        ? { ...currentMessage.meta, ...hydratedMessage.meta }
+        : (hydratedMessage.meta ?? currentMessage.meta);
+    return {
+      ...currentMessage,
+      ...hydratedMessage,
+      ...(mergedMeta ? { meta: mergedMeta } : {}),
+    };
+  }
+
+  if (isSubagentMessage(hydratedMessage) && isSubagentMessage(currentMessage)) {
+    return mergeSubagentMessages(hydratedMessage, currentMessage);
+  }
+
+  if (hydratedMessage.meta?.kind === "reasoning" && currentMessage.meta?.kind === "reasoning") {
+    return mergeReasoningMessages(hydratedMessage, currentMessage);
+  }
+
+  if (hydratedMessage.meta?.kind === "tool" && currentMessage.meta?.kind === "tool") {
+    return mergeToolMessages(hydratedMessage, currentMessage);
+  }
+
+  return currentMessage;
+};
+
+export const mergeHydratedMessages = (
+  sessionId: string,
+  hydratedMessages: AgentSessionState["messages"],
+  currentMessages: AgentSessionState["messages"],
+): AgentSessionState["messages"] => {
+  const currentOwner = { sessionId, messages: currentMessages };
+  const hydratedOwner = { sessionId, messages: hydratedMessages };
+  const hydratedMessageIds = new Set<string>();
+  const absorbedCurrentMessageIds = new Set<string>();
+  let mergedMessages = createSessionMessagesState(sessionId);
+
+  forEachSessionMessage(hydratedOwner, (message) => {
+    const sameIdCurrentMessage = findSessionMessageById(currentOwner, message.id);
+    const matchingCurrentMessages = findMatchingCurrentMessages({
+      currentOwner,
+      hydratedMessage: message,
+      sameIdCurrentMessage,
+    });
+    hydratedMessageIds.add(message.id);
+    for (const matchingCurrentMessage of matchingCurrentMessages) {
+      absorbedCurrentMessageIds.add(matchingCurrentMessage.id);
+    }
+    const mergedMessage = matchingCurrentMessages.reduce<AgentChatMessage>(
+      (currentMerged, matchingCurrentMessage) =>
+        mergeSameMessageId(currentMerged, matchingCurrentMessage),
+      message,
+    );
+    mergedMessages = appendSessionMessage({ sessionId, messages: mergedMessages }, mergedMessage);
+  });
+
+  forEachSessionMessage(currentOwner, (message) => {
+    if (hydratedMessageIds.has(message.id) || absorbedCurrentMessageIds.has(message.id)) {
+      return;
+    }
+    mergedMessages = appendSessionMessage({ sessionId, messages: mergedMessages }, message);
+  });
+
+  return mergedMessages;
+};

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -410,8 +410,10 @@ describe("agent-orchestrator/support/persistence", () => {
       },
     );
 
-    expect(messages.some((entry) => entry.role === "thinking")).toBe(true);
-    expect(messages.some((entry) => entry.role === "tool")).toBe(true);
+    const thinking = messages.find((entry) => entry.role === "thinking");
+    const tool = messages.find((entry) => entry.role === "tool");
+    expect(thinking?.id).toBe("thinking:m-assistant:p-thinking");
+    expect(tool?.id).toBe("tool:m-assistant:call-1");
     expect(
       messages.some(
         (entry) => entry.role === "system" && entry.content.includes("Subagent (build)"),
@@ -457,6 +459,35 @@ describe("agent-orchestrator/support/persistence", () => {
         text: "Please implement this",
       },
     ]);
+  });
+
+  test("uses part ids for hydrated tool messages without call ids", () => {
+    const messages = historyToChatMessages(
+      [
+        {
+          messageId: "m-assistant",
+          role: "assistant",
+          timestamp: "2026-02-22T08:00:02.000Z",
+          text: "",
+          parts: [
+            {
+              kind: "tool",
+              messageId: "m-assistant",
+              partId: "p-tool",
+              callId: "",
+              tool: "bash",
+              status: "completed",
+            },
+          ],
+        },
+      ],
+      {
+        role: "build",
+        selectedModel: null,
+      },
+    );
+
+    expect(messages.find((entry) => entry.role === "tool")?.id).toBe("tool:m-assistant:p-tool");
   });
 
   test("merges hydrated subagent history parts that share a correlation key", () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -20,6 +20,7 @@ import {
   readAssistantActivityStartedAtMsFromParts,
   resolveAssistantTurnDurationMs,
 } from "./assistant-turn-duration";
+import { toReasoningMessageId, toToolMessageId } from "./chat-message-ids";
 import { mergeModelSelection, normalizePersistedSelection } from "./models";
 import {
   readPersistedRuntimeKind,
@@ -190,7 +191,7 @@ const historyPartToChatMessage = (
         return null;
       }
       return {
-        id: `history:thinking:${message.messageId}:${part.partId}`,
+        id: toReasoningMessageId(message.messageId, part.partId),
         role: "thinking",
         content: part.text,
         timestamp: message.timestamp,
@@ -206,7 +207,11 @@ const historyPartToChatMessage = (
       const output = normalizeToolText(part.output);
       const error = normalizeToolText(part.error);
       return {
-        id: `history:tool:${message.messageId}:${part.partId}`,
+        id: toToolMessageId({
+          messageId: message.messageId,
+          partId: part.partId,
+          callId: part.callId,
+        }),
         role: "tool",
         content: formatToolContent(part),
         timestamp: message.timestamp,


### PR DESCRIPTION
## Summary
- Canonicalizes live and hydrated reasoning/tool chat-part IDs so the same runtime part has one transcript identity.
- Extracts hydration merge logic and absorbs matching live part rows instead of appending stale duplicates after the final assistant message.
- Adds regression coverage for reasoning/tool dedupe, including tool rows created before a call ID is available.

## Goal
Agent Studio could show duplicate tool/activity rows after switching roles or task tabs because live in-memory rows and hydrated history rows represented the same reasoning/tool parts with different IDs. The hydration merge kept the hydrated transcript order, then appended unmatched live rows after the final assistant response. Reloading looked correct because those in-memory live rows were gone.

This PR fixes that root identity mismatch so tab/role switches hydrate to the same ordered transcript users see after a reload.

## Technical choices
- Added shared chat message ID helpers for canonical part IDs: `thinking:<messageId>:<partId>` and `tool:<messageId>:<callId || partId>`.
- Updated history conversion and live tool fallback ID generation to use the same helpers.
- Moved `mergeHydratedMessages` into `support/hydrated-message-merge.ts` while preserving the lifecycle module re-export for existing callers/tests.
- Added deterministic merge absorption for reasoning rows by `messageId + partId`, and tool rows by scoped message ID plus tool name, requiring equal call IDs when both exist and otherwise using part ID.
- Preserved useful live timing metadata during hydration while preferring persisted completed history over stale running live rows.
- Removed legacy `history:*` ID handling rather than keeping fallback compatibility, so the app fails cleanly on incompatible old formats instead of masking the issue.

## Verification
- `bun run typecheck`
- `bun run lint` (passes; existing info-level `noExtraBooleanCast` note remains unrelated)
- `bun run test`
- `bun run build` (passes; existing Vite chunk-size warnings remain unrelated)
- `rtk cargo fmt --all --check`
- `rtk cargo check --workspace`
- `rtk cargo test --workspace`
- `rtk cargo clippy --workspace --all-targets -- -D warnings`
- `rtk cargo build --workspace --all-targets`
- Confirmed branch is up to date with `origin/main` before creating the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive tests for session transcript reconciliation and message merging to improve timeline correctness and robustness.

* **Refactor**
  * Centralized message-merge logic and consolidated deterministic ID generation for reasoning and tool entries, including handling of missing/blank tool call IDs.
  * Scroll/synchronization logic updated to use layout-phase effects and session-aware scrolling for more reliable session switches.

* **Bug Fixes**
  * Improved repo-settings loading to avoid stale derived state when workspaces change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->