### PR TITLE
refactor(agent-orchestrator): delegate OpenCode transport policy

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -1,6 +1,7 @@
 use super::super::{
     AppService, RuntimeInstanceSummary, RuntimeStartupReadinessPolicy, RuntimeStartupWaitReport,
-    StartupEventContext, StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
+    StartupEventContext, StartupEventCorrelation, StartupEventPayload,
+    STARTUP_CONFIG_INVALID_REASON,
 };
 use super::build_runtime_setup::{BuildPrerequisites, PreparedBuildWorktree};
 use anyhow::{anyhow, Context, Result};
@@ -118,11 +119,11 @@ impl AppService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_service::runtime_registry::{AppRuntime, AppRuntimeRegistry};
     use crate::app_service::test_support::{
         build_service_with_runtime_registry, build_service_with_state,
         builtin_opencode_runtime_descriptor, make_task,
     };
-    use crate::app_service::runtime_registry::{AppRuntime, AppRuntimeRegistry};
     use anyhow::anyhow;
     use host_domain::{GitTargetBranch, RuntimeHealth, RuntimeRole, RuntimeRoute, TaskStatus};
     use std::sync::Arc;
@@ -217,9 +218,7 @@ mod tests {
             .expect_err("opencode build startup should reject stdio routes before task transition");
 
         assert!(
-            error
-                .to_string()
-                .contains("OpenCode build session startup"),
+            error.to_string().contains("OpenCode build session startup"),
             "error should come from the OpenCode runtime boundary: {error}"
         );
         let updated_patches = &task_state
@@ -294,7 +293,10 @@ mod tests {
             })
             .expect("non-OpenCode runtimes should accept stdio build bootstrap routes");
 
-        assert!(matches!(bootstrap.runtime_route, RuntimeRoute::Stdio { .. }));
+        assert!(matches!(
+            bootstrap.runtime_route,
+            RuntimeRoute::Stdio { .. }
+        ));
         let updated_patches = &task_state
             .lock()
             .expect("task store lock poisoned")

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -1,7 +1,6 @@
 use super::super::{
-    require_local_http_endpoint, AppService, RuntimeInstanceSummary, RuntimeStartupReadinessPolicy,
-    RuntimeStartupWaitReport, StartupEventContext, StartupEventCorrelation, StartupEventPayload,
-    STARTUP_CONFIG_INVALID_REASON,
+    AppService, RuntimeInstanceSummary, RuntimeStartupReadinessPolicy, RuntimeStartupWaitReport,
+    StartupEventContext, StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
 };
 use super::build_runtime_setup::{BuildPrerequisites, PreparedBuildWorktree};
 use anyhow::{anyhow, Context, Result};
@@ -93,9 +92,9 @@ impl AppService {
             task_id,
         } = input;
 
-        if runtime_kind == AgentRuntimeKind::opencode() {
-            require_local_http_endpoint(&runtime_summary.runtime_route, "build session startup")?;
-        }
+        self.runtime_registry
+            .runtime(&runtime_kind)?
+            .validate_build_session_bootstrap(&runtime_summary)?;
 
         self.task_transition_to_in_progress_without_related_tasks(
             prerequisites.repo_path.as_str(),
@@ -120,13 +119,57 @@ impl AppService {
 mod tests {
     use super::*;
     use crate::app_service::test_support::{
-        build_service_with_state, builtin_opencode_runtime_descriptor, make_task,
+        build_service_with_runtime_registry, build_service_with_state,
+        builtin_opencode_runtime_descriptor, make_task,
     };
-    use host_domain::{GitTargetBranch, RuntimeRole, RuntimeRoute, TaskStatus};
+    use crate::app_service::runtime_registry::{AppRuntime, AppRuntimeRegistry};
+    use anyhow::anyhow;
+    use host_domain::{GitTargetBranch, RuntimeHealth, RuntimeRole, RuntimeRoute, TaskStatus};
+    use std::sync::Arc;
 
-    fn make_runtime_summary(runtime_route: RuntimeRoute) -> RuntimeInstanceSummary {
+    #[derive(Clone)]
+    struct TestRuntimeAdapter;
+
+    impl AppRuntime for TestRuntimeAdapter {
+        fn definition(&self) -> host_domain::RuntimeDefinition {
+            let mut descriptor = builtin_opencode_runtime_descriptor();
+            descriptor.kind = AgentRuntimeKind::from("test-runtime");
+            descriptor.label = "Test Runtime".to_string();
+            descriptor.description = "Test Runtime runtime".to_string();
+            host_domain::RuntimeDefinition::new(descriptor, Default::default())
+        }
+
+        fn runtime_health(&self) -> RuntimeHealth {
+            RuntimeHealth {
+                kind: "test-runtime".to_string(),
+                ok: true,
+                version: Some("1.0.0".to_string()),
+                error: None,
+            }
+        }
+
+        fn stop_session(
+            &self,
+            _runtime_route: &RuntimeRoute,
+            _external_session_id: &str,
+            _working_directory: &str,
+        ) -> Result<()> {
+            Err(anyhow!("stop_session should not be used in this test"))
+        }
+    }
+
+    fn test_runtime_definition() -> host_domain::RuntimeDefinition {
+        let adapter = TestRuntimeAdapter;
+        <TestRuntimeAdapter as AppRuntime>::definition(&adapter)
+    }
+
+    fn make_runtime_summary(
+        kind: AgentRuntimeKind,
+        runtime_route: RuntimeRoute,
+        descriptor: host_domain::RuntimeDescriptor,
+    ) -> RuntimeInstanceSummary {
         RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
+            kind,
             runtime_id: "runtime-1".to_string(),
             repo_path: "/tmp/repo".to_string(),
             task_id: None,
@@ -134,7 +177,7 @@ mod tests {
             working_directory: "/tmp/repo".to_string(),
             runtime_route,
             started_at: "2026-04-13T00:00:00Z".to_string(),
-            descriptor: builtin_opencode_runtime_descriptor(),
+            descriptor,
         }
     }
 
@@ -165,15 +208,19 @@ mod tests {
                     worktree_dir: PathBuf::from("/tmp/worktrees/task-1"),
                 },
                 runtime_summary: make_runtime_summary(
+                    AgentRuntimeKind::opencode(),
                     RuntimeRoute::stdio("runtime-stdio").expect("stdio route"),
+                    builtin_opencode_runtime_descriptor(),
                 ),
                 task_id: "task-1",
             })
             .expect_err("opencode build startup should reject stdio routes before task transition");
 
-        assert_eq!(
-            error.to_string(),
-            "Runtime build session startup requires a local_http runtime route"
+        assert!(
+            error
+                .to_string()
+                .contains("OpenCode build session startup"),
+            "error should come from the OpenCode runtime boundary: {error}"
         );
         let updated_patches = &task_state
             .lock()
@@ -194,9 +241,13 @@ mod tests {
                 prepared_worktree: PreparedBuildWorktree {
                     worktree_dir: PathBuf::from("/tmp/worktrees/task-1"),
                 },
-                runtime_summary: make_runtime_summary(RuntimeRoute::LocalHttp {
-                    endpoint: "http://127.0.0.1".to_string(),
-                }),
+                runtime_summary: make_runtime_summary(
+                    AgentRuntimeKind::opencode(),
+                    RuntimeRoute::LocalHttp {
+                        endpoint: "http://127.0.0.1".to_string(),
+                    },
+                    builtin_opencode_runtime_descriptor(),
+                ),
                 task_id: "task-1",
             })
             .expect("local_http routes should remain bootstrap-compatible without explicit ports");
@@ -212,6 +263,43 @@ mod tests {
             .updated_patches;
         assert_eq!(updated_patches.len(), 1);
         assert_eq!(updated_patches[0].0, "task-1");
+        assert_eq!(updated_patches[0].1.status, Some(TaskStatus::InProgress));
+    }
+
+    #[test]
+    fn initiate_build_mode_accepts_stdio_routes_for_non_opencode_runtimes() {
+        let runtime_registry = AppRuntimeRegistry::new(
+            vec![Arc::new(TestRuntimeAdapter)],
+            host_domain::AgentRuntimeKind::from("test-runtime"),
+        )
+        .expect("test runtime registry");
+        let (service, task_state, _git_state) = build_service_with_runtime_registry(
+            vec![make_task("task-1", "task", TaskStatus::Open)],
+            runtime_registry,
+        );
+
+        let bootstrap = service
+            .initiate_build_mode(BuildModeStartInput {
+                runtime_kind: host_domain::AgentRuntimeKind::from("test-runtime"),
+                prerequisites: make_build_prerequisites(),
+                prepared_worktree: PreparedBuildWorktree {
+                    worktree_dir: PathBuf::from("/tmp/worktrees/task-1"),
+                },
+                runtime_summary: make_runtime_summary(
+                    host_domain::AgentRuntimeKind::from("test-runtime"),
+                    RuntimeRoute::stdio("runtime-stdio").expect("stdio route"),
+                    test_runtime_definition().descriptor().clone(),
+                ),
+                task_id: "task-1",
+            })
+            .expect("non-OpenCode runtimes should accept stdio build bootstrap routes");
+
+        assert!(matches!(bootstrap.runtime_route, RuntimeRoute::Stdio { .. }));
+        let updated_patches = &task_state
+            .lock()
+            .expect("task store lock poisoned")
+            .updated_patches;
+        assert_eq!(updated_patches.len(), 1);
         assert_eq!(updated_patches[0].1.status, Some(TaskStatus::InProgress));
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
@@ -97,10 +97,7 @@ pub(crate) trait AppRuntime: Send + Sync {
         ))
     }
 
-    fn validate_build_session_bootstrap(
-        &self,
-        _runtime: &RuntimeInstanceSummary,
-    ) -> Result<()> {
+    fn validate_build_session_bootstrap(&self, _runtime: &RuntimeInstanceSummary) -> Result<()> {
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/mod.rs
@@ -97,6 +97,13 @@ pub(crate) trait AppRuntime: Send + Sync {
         ))
     }
 
+    fn validate_build_session_bootstrap(
+        &self,
+        _runtime: &RuntimeInstanceSummary,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     fn connect_mcp_server(
         &self,
         _runtime: &RuntimeInstanceSummary,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -474,6 +474,11 @@ impl AppRuntime for OpenCodeRuntime {
         AgentRuntimeKind::opencode()
     }
 
+    fn validate_build_session_bootstrap(&self, runtime: &RuntimeInstanceSummary) -> Result<()> {
+        require_local_http_endpoint(&runtime.runtime_route, "OpenCode build session startup")?;
+        Ok(())
+    }
+
     fn start_host_managed(
         &self,
         service: &AppService,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-session-runtime.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-session-runtime.ts
@@ -1,9 +1,6 @@
 import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentRuntimeConnection } from "@openducktor/core";
-import {
-  getRuntimeConnectionSupportError,
-  runtimeRouteToConnection,
-} from "@/state/operations/agent-orchestrator/runtime/runtime";
+import { runtimeRouteToConnection } from "@/state/operations/agent-orchestrator/runtime/runtime";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
 type SessionRuntimeAccessState = {
@@ -42,23 +39,17 @@ export const getAttachedSessionRuntimeConnectionError = (
     | { runtimeRoute: AgentSessionState["runtimeRoute"]; workingDirectory: string }
     | null
     | undefined,
-  runtimeKind: RuntimeKind | null | undefined,
-  action = "attached session runtime access",
 ): string | null => {
   if (!session?.runtimeRoute) {
     return null;
   }
 
-  return getRuntimeConnectionSupportError(
-    runtimeKind,
-    runtimeRouteToConnection(session.runtimeRoute, session.workingDirectory),
-    action,
-  );
+  runtimeRouteToConnection(session.runtimeRoute, session.workingDirectory);
+  return null;
 };
 
 export const resolveAttachedSessionRuntimeQueryState = (
   session: SessionRuntimeAccessState | null | undefined,
-  action = "attached session runtime access",
 ): AgentChatSessionRuntimeQueryState => {
   const runtimeConnection = toAttachedSessionRuntimeConnection(session);
   const runtimeKind = session?.runtimeKind ?? null;
@@ -71,6 +62,6 @@ export const resolveAttachedSessionRuntimeQueryState = (
             runtimeConnection,
           }
         : null,
-    runtimeQueryError: getAttachedSessionRuntimeConnectionError(session, runtimeKind, action),
+    runtimeQueryError: getAttachedSessionRuntimeConnectionError(session),
   };
 };

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-session-runtime.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-session-runtime.ts
@@ -34,17 +34,12 @@ export const toAttachedSessionRuntimeConnection = (
 };
 
 export const getAttachedSessionRuntimeConnectionError = (
-  session:
+  _session:
     | Pick<AgentSessionState, "runtimeRoute" | "workingDirectory">
     | { runtimeRoute: AgentSessionState["runtimeRoute"]; workingDirectory: string }
     | null
     | undefined,
 ): string | null => {
-  if (!session?.runtimeRoute) {
-    return null;
-  }
-
-  runtimeRouteToConnection(session.runtimeRoute, session.workingDirectory);
   return null;
 };
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -612,8 +612,7 @@ describe("AgentChatThread", () => {
             todos: [],
             selectedModel: null,
           }),
-          sessionRuntimeDataError:
-            "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
+          sessionRuntimeDataError: "todos unavailable",
         },
       }),
     );
@@ -621,9 +620,9 @@ describe("AgentChatThread", () => {
 
     const bottomStack = rendered.container.querySelector(".agent-chat-bottom-stack");
     expect(bottomStack).not.toBeNull();
-    expect(bottomStack?.textContent).toContain("active session runtime data access");
+    expect(bottomStack?.textContent).toContain("todos unavailable");
     expect(bottomStack?.className).toContain("pb-3");
-    const runtimeError = screen.getByText(/active session runtime data access/);
+    const runtimeError = screen.getByText(/todos unavailable/);
     expect(runtimeError.className).toContain("border-destructive-border");
     expect(runtimeError.className).toContain("bg-destructive-surface");
     expect(runtimeError.className).toContain("text-destructive-surface-foreground");

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -186,14 +186,13 @@ describe("AgentChat", () => {
               status: "idle",
               todos: [buildTodoItem({ content: "Keep todo anchored", status: "in_progress" })],
             }),
-            sessionRuntimeDataError:
-              "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
+            sessionRuntimeDataError: "todos unavailable",
           },
         },
       }),
     );
 
-    expect(html).toContain("active session runtime data access");
-    expect(html.indexOf("active session runtime data access")).toBeLessThan(html.indexOf("<form"));
+    expect(html).toContain("todos unavailable");
+    expect(html.indexOf("todos unavailable")).toBeLessThan(html.indexOf("<form"));
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-session-runtime-data.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-session-runtime-data.ts
@@ -46,7 +46,7 @@ export const useAgentChatSessionRuntimeData = ({
   readSessionTodos,
 }: UseAgentChatSessionRuntimeDataArgs): AgentChatSessionRuntimeDataState => {
   const { runtimeQueryInput, runtimeQueryError: runtimeDataSupportError } = useMemo(
-    () => resolveAttachedSessionRuntimeQueryState(session, "active session runtime data access"),
+    () => resolveAttachedSessionRuntimeQueryState(session),
     [session],
   );
   const sessionViewLifecycle = useMemo(

--- a/packages/frontend/src/pages/agents/agent-studio-session-runtime.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-session-runtime.ts
@@ -1,9 +1,6 @@
 import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentRuntimeConnection } from "@openducktor/core";
-import {
-  getRuntimeConnectionSupportError,
-  runtimeRouteToConnection,
-} from "@/state/operations/agent-orchestrator/runtime/runtime";
+import { runtimeRouteToConnection } from "@/state/operations/agent-orchestrator/runtime/runtime";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
 type SessionRuntimeAccessState = {
@@ -42,23 +39,17 @@ export const getAttachedSessionRuntimeConnectionError = (
     | { runtimeRoute: AgentSessionState["runtimeRoute"]; workingDirectory: string }
     | null
     | undefined,
-  runtimeKind: RuntimeKind | null | undefined,
-  action = "attached session runtime access",
 ): string | null => {
   if (!session?.runtimeRoute) {
     return null;
   }
 
-  return getRuntimeConnectionSupportError(
-    runtimeKind,
-    runtimeRouteToConnection(session.runtimeRoute, session.workingDirectory),
-    action,
-  );
+  runtimeRouteToConnection(session.runtimeRoute, session.workingDirectory);
+  return null;
 };
 
 export const resolveAttachedSessionRuntimeQueryState = (
   session: SessionRuntimeAccessState | null | undefined,
-  action = "attached session runtime access",
 ): AgentStudioSessionRuntimeQueryState => {
   const runtimeConnection = toAttachedSessionRuntimeConnection(session);
   const runtimeKind = session?.runtimeKind ?? null;
@@ -71,6 +62,6 @@ export const resolveAttachedSessionRuntimeQueryState = (
             runtimeConnection,
           }
         : null,
-    runtimeQueryError: getAttachedSessionRuntimeConnectionError(session, runtimeKind, action),
+    runtimeQueryError: getAttachedSessionRuntimeConnectionError(session),
   };
 };

--- a/packages/frontend/src/pages/agents/agent-studio-session-runtime.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-session-runtime.ts
@@ -34,17 +34,12 @@ export const toAttachedSessionRuntimeConnection = (
 };
 
 export const getAttachedSessionRuntimeConnectionError = (
-  session:
+  _session:
     | Pick<AgentSessionState, "runtimeRoute" | "workingDirectory">
     | { runtimeRoute: AgentSessionState["runtimeRoute"]; workingDirectory: string }
     | null
     | undefined,
 ): string | null => {
-  if (!session?.runtimeRoute) {
-    return null;
-  }
-
-  runtimeRouteToConnection(session.runtimeRoute, session.workingDirectory);
   return null;
 };
 

--- a/packages/frontend/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
@@ -145,9 +145,11 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
     }
   });
 
-  test("surfaces an explicit error for unsupported stdio OpenCode session runtime data", async () => {
+  test("propagates adapter errors for stdio OpenCode session runtime data", async () => {
     const readSessionModelCatalog = mock(async () => CATALOG);
-    const readSessionTodos = mock(async () => []);
+    const readSessionTodos = mock(async () => {
+      throw new Error("todos unavailable");
+    });
     const harness = createHookHarness(useAgentStudioActiveSessionRuntimeData, {
       session: createAgentSessionFixture({
         sessionId: "session-1",
@@ -166,10 +168,16 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
     try {
       await harness.mount();
 
-      expect(readSessionModelCatalog).not.toHaveBeenCalled();
-      expect(readSessionTodos).not.toHaveBeenCalled();
+      expect(readSessionModelCatalog).toHaveBeenCalledTimes(1);
+      expect(readSessionTodos).toHaveBeenCalledTimes(1);
+      await harness.waitFor(
+        (state) =>
+          state.session?.isLoadingModelCatalog === false &&
+          state.runtimeDataError === "todos unavailable",
+      );
+      expect(harness.getLatest()?.session?.modelCatalog).toEqual(CATALOG);
       expect(harness.getLatest()?.session?.isLoadingModelCatalog).toBe(false);
-      expect(harness.getLatest()?.runtimeDataError).toContain("local_http is required");
+      expect(harness.getLatest()?.runtimeDataError).toBe("todos unavailable");
     } finally {
       await harness.unmount();
     }

--- a/packages/frontend/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
@@ -46,7 +46,7 @@ export const useAgentStudioActiveSessionRuntimeData = ({
   readSessionTodos,
 }: UseAgentStudioActiveSessionRuntimeDataArgs): AgentStudioSessionRuntimeDataState => {
   const { runtimeQueryInput, runtimeQueryError: runtimeDataSupportError } = useMemo(
-    () => resolveAttachedSessionRuntimeQueryState(session, "active session runtime data access"),
+    () => resolveAttachedSessionRuntimeQueryState(session),
     [session],
   );
   const sessionViewLifecycle = useMemo(

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -171,10 +171,11 @@ const createHookHarness = (
     createElement(
       QueryProvider,
       { useIsolatedClient: true },
-      createElement(RuntimeDefinitionsContext.Provider, {
-        value: runtimeDefinitionsContext,
+      createElement(
+        RuntimeDefinitionsContext.Provider,
+        { value: runtimeDefinitionsContext },
         children,
-      }),
+      ),
     );
 
   return createSharedHookHarness(

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -541,7 +541,7 @@ describe("useAgentStudioModelSelection", () => {
     }
   });
 
-  test("does not query session slash commands for unsupported stdio OpenCode sessions", async () => {
+  test("queries session slash commands for stdio OpenCode sessions", async () => {
     const readSessionSlashCommands = mock(async () => ({
       commands: [{ id: "review", trigger: "review", title: "review", hints: [] }],
     }));
@@ -563,7 +563,12 @@ describe("useAgentStudioModelSelection", () => {
       await harness.mount();
       await harness.waitFor((state) => state.isSlashCommandsLoading === false);
 
-      expect(readSessionSlashCommands).not.toHaveBeenCalled();
+      expect(readSessionSlashCommands).toHaveBeenCalledTimes(1);
+      expect(readSessionSlashCommands).toHaveBeenCalledWith("opencode", {
+        type: "stdio",
+        identity: "runtime-stdio",
+        workingDirectory: "/repo/session-worktree",
+      });
       expect(harness.getLatest().slashCommandsError).toBeNull();
     } finally {
       await harness.unmount();
@@ -602,8 +607,10 @@ describe("useAgentStudioModelSelection", () => {
     }
   });
 
-  test("fails fast when active session file search uses an unsupported stdio OpenCode session", async () => {
-    const readSessionFileSearch = mock(async () => FILE_SEARCH_RESULTS);
+  test("propagates adapter errors when active session file search uses stdio OpenCode session", async () => {
+    const readSessionFileSearch = mock(async () => {
+      throw new Error("file search unavailable");
+    });
     const harness = createHookHarness(
       createBaseProps({
         activeSession: createActiveSession({
@@ -621,9 +628,18 @@ describe("useAgentStudioModelSelection", () => {
     try {
       await harness.mount();
       await expect(harness.getLatest().searchFiles("src")).rejects.toThrow(
-        "local_http is required",
+        "file search unavailable",
       );
-      expect(readSessionFileSearch).not.toHaveBeenCalled();
+      expect(readSessionFileSearch).toHaveBeenCalledTimes(1);
+      expect(readSessionFileSearch).toHaveBeenCalledWith(
+        "opencode",
+        {
+          type: "stdio",
+          identity: "runtime-stdio",
+          workingDirectory: "/repo/session-worktree",
+        },
+        "src",
+      );
     } finally {
       await harness.unmount();
     }

--- a/packages/frontend/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-model-selection.ts
@@ -237,7 +237,6 @@ export function useAgentStudioModelSelection({
               workingDirectory: activeSessionWorkingDirectory,
             }
           : null,
-        "active session runtime queries",
       ),
     [
       activeSessionRuntimeKind,

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -262,8 +262,7 @@ describe("useAgentStudioPageModels", () => {
     const harness = createHookHarness(
       createHookArgs({
         core: {
-          sessionRuntimeDataError:
-            "Runtime connection type 'stdio' is unsupported for active session runtime data access in runtime 'opencode'; local_http is required.",
+          sessionRuntimeDataError: "todos unavailable",
         },
       }),
     );
@@ -271,7 +270,7 @@ describe("useAgentStudioPageModels", () => {
     await harness.mount();
 
     expect(harness.getLatest().agentChatModel.thread.sessionRuntimeDataError).toContain(
-      "local_http is required",
+      "todos unavailable",
     );
 
     await harness.unmount();

--- a/packages/frontend/src/pages/agents/use-agent-studio-repo-settings.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-repo-settings.ts
@@ -6,6 +6,8 @@ import type { RepoSettingsInput } from "@/types/state-slices";
 
 type RepoConfigQueryHost = Pick<typeof host, "workspaceGetRepoConfig">;
 
+const INACTIVE_WORKSPACE_REPO_CONFIG_QUERY_KEY = "__inactive_workspace__";
+
 export function useAgentStudioRepoSettings(args: {
   activeWorkspace: WorkspaceRecord | null;
   hostClient?: RepoConfigQueryHost;
@@ -13,15 +15,17 @@ export function useAgentStudioRepoSettings(args: {
   repoSettings: RepoSettingsInput | null;
 } {
   const { activeWorkspace, hostClient } = args;
+  const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
   const { data: repoSettings } = useQuery({
-    ...(activeWorkspace
-      ? repoConfigQueryOptions(activeWorkspace.workspaceId, hostClient)
-      : repoConfigQueryOptions("", hostClient)),
-    enabled: activeWorkspace !== null,
+    ...repoConfigQueryOptions(
+      activeWorkspaceId ?? INACTIVE_WORKSPACE_REPO_CONFIG_QUERY_KEY,
+      hostClient,
+    ),
+    enabled: activeWorkspaceId !== null,
     select: toRepoSettingsInput,
   });
 
   return {
-    repoSettings: repoSettings ?? null,
+    repoSettings: activeWorkspaceId !== null ? (repoSettings ?? null) : null,
   };
 }

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-fork-strategy.ts
@@ -1,7 +1,7 @@
 import type { AgentRuntimeConnection } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RuntimeInfo } from "../runtime/runtime";
-import { requireRuntimeConnectionSupport, resolveRuntimeConnection } from "../runtime/runtime";
+import { resolveRuntimeConnection } from "../runtime/runtime";
 import { throwIfRepoStale } from "../support/core";
 import { createSessionMessagesState, getSessionMessagesSlice } from "../support/messages";
 import { historyToChatMessages } from "../support/persistence";
@@ -101,16 +101,11 @@ export const executeForkStart = async ({
   });
 
   const runtimeKind = sourceRuntimeKind;
-  const supportedRuntimeConnection = requireRuntimeConnectionSupport(
-    runtimeKind,
-    sourceRuntimeConnection,
-    "fork session",
-  );
 
   const summary = await deps.runtime.adapter.forkSession({
     repoPath: ctx.repoPath,
     runtimeKind,
-    runtimeConnection: supportedRuntimeConnection,
+    runtimeConnection: sourceRuntimeConnection,
     workingDirectory: sourceSession.workingDirectory,
     taskId: ctx.taskId,
     role: ctx.role,
@@ -138,7 +133,7 @@ export const executeForkStart = async ({
   const forkHistory = await deps.runtime.adapter
     .loadSessionHistory({
       runtimeKind,
-      runtimeConnection: supportedRuntimeConnection,
+      runtimeConnection: sourceRuntimeConnection,
       externalSessionId: summary.externalSessionId,
       limit: FORK_START_HISTORY_LIMIT,
     })
@@ -188,7 +183,7 @@ export const executeForkStart = async ({
     runtimeKind,
     runtimeId: sourceSession.runtimeId,
     runtimeRoute: sourceSession.runtimeRoute,
-    runtimeConnection: supportedRuntimeConnection,
+    runtimeConnection: sourceRuntimeConnection,
     workingDirectory: sourceSession.workingDirectory,
   };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -6,7 +6,6 @@ import type { ActiveWorkspace } from "@/types/state-slices";
 import { requireActiveRepo } from "../../tasks/task-operations-model";
 import {
   type RuntimeInfo,
-  requireRuntimeConnectionSupport,
   resolveRuntimeConnection,
   runtimeRouteToConnection,
 } from "../runtime/runtime";
@@ -277,11 +276,7 @@ export const createEnsureSessionReady = ({
       requestedRuntimeKind,
       ensuredRuntimeKind: runtime.runtimeKind,
     });
-    const runtimeConnection = requireRuntimeConnectionSupport(
-      resolvedRuntimeKind,
-      resolveRuntimeConnection(runtime),
-      "resume session",
-    );
+    const runtimeConnection = resolveRuntimeConnection(runtime);
     await adapter.resumeSession({
       sessionId: session.sessionId,
       externalSessionId: session.externalSessionId,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -6,6 +6,7 @@ import type {
   TaskCard,
 } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import type { LoadAgentSessionHistoryInput } from "@openducktor/core";
 import { getSessionMessageCount } from "@/state/operations/agent-orchestrator/support/messages";
 import { sessionMessageAt } from "@/test-utils/session-message-test-helpers";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -1239,18 +1240,20 @@ describe("load-sessions-stages", () => {
     expect(updateCalls).toBe(0);
   });
 
-  test("fails requested-history hydration before adapter history loads for unsupported stdio OpenCode runtimes", async () => {
+  test("loads requested-history hydration through the adapter for stdio OpenCode runtimes", async () => {
     const stateHarness = createStateHarness({ "session-1": createSession() });
     let historyLoads = 0;
+    const historyInputs: LoadAgentSessionHistoryInput[] = [];
 
     await expect(
       hydrateSessionRecordsStage({
         adapter: {
           hasSession: () => false,
           listLiveAgentSessionSnapshots: async () => [],
-          loadSessionHistory: async () => {
+          loadSessionHistory: async (input) => {
             historyLoads += 1;
-            return [];
+            historyInputs.push(input);
+            throw new Error("Adapter rejected stdio runtime connections.");
           },
           attachSession: async (input) => ({
             sessionId: input.sessionId,
@@ -1297,11 +1300,21 @@ describe("load-sessions-stages", () => {
         },
         getRepoPromptOverrides: async () => ({}),
       }),
-    ).rejects.toThrow(
-      "Runtime connection type 'stdio' is unsupported for load session history in runtime 'opencode'; local_http is required.",
-    );
+    ).rejects.toThrow("Adapter rejected stdio runtime connections.");
 
-    expect(historyLoads).toBe(0);
+    expect(historyLoads).toBe(1);
+    expect(historyInputs).toEqual([
+      {
+        runtimeKind: "opencode",
+        runtimeConnection: {
+          type: "stdio",
+          identity: "runtime-stdio",
+          workingDirectory: "/tmp/repo/worktree",
+        },
+        externalSessionId: "external-1",
+        limit: 600,
+      },
+    ]);
     expect(stateHarness.getState()["session-1"]?.historyHydrationState).toBe("failed");
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -24,7 +24,7 @@ import type {
 } from "@/types/agent-orchestrator";
 import { host } from "../../shared/host";
 import { ensureRuntimeAndInvalidateReadinessQueries } from "../../shared/runtime-readiness-publication";
-import { requireRuntimeConnectionSupport, runtimeRouteToConnection } from "../runtime/runtime";
+import { runtimeRouteToConnection } from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
 import { DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE } from "../support/history-hydration";
 import { mergeHydratedMessages } from "../support/hydrated-message-merge";
@@ -865,11 +865,6 @@ export const reconcileLiveSessionsStage = async ({
         directories,
       }),
     attachMissingLiveSession: async ({ record, runtimeKind, runtimeConnection }) => {
-      const supportedRuntimeConnection = requireRuntimeConnectionSupport(
-        runtimeKind,
-        runtimeConnection,
-        "resume session",
-      );
       const promptOverrides = await getRepoPromptOverrides();
       if (isStaleRepoOperation()) {
         return;
@@ -890,8 +885,8 @@ export const reconcileLiveSessionsStage = async ({
         externalSessionId: record.externalSessionId ?? record.sessionId,
         repoPath: intent.repoPath,
         runtimeKind,
-        runtimeConnection: supportedRuntimeConnection,
-        workingDirectory: supportedRuntimeConnection.workingDirectory,
+        runtimeConnection,
+        workingDirectory: runtimeConnection.workingDirectory,
         taskId: intent.taskId,
         role: record.role,
         scenario: resolvedScenario,
@@ -1050,14 +1045,9 @@ export const hydrateSessionRecordsStage = async ({
       resolvedScenario,
       promptOverrides,
     });
-    const supportedRuntimeConnection = requireRuntimeConnectionSupport(
-      runtimeKind,
-      runtimeConnection,
-      "load session history",
-    );
     const history = await adapter.loadSessionHistory({
       runtimeKind,
-      runtimeConnection: supportedRuntimeConnection,
+      runtimeConnection,
       externalSessionId: record.externalSessionId ?? record.sessionId,
       limit: INITIAL_SESSION_HISTORY_LIMIT,
     });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -331,7 +331,7 @@ describe("reattach-live-session", () => {
     expect(resumeCalls).toBe(0);
   });
 
-  test("skips live reattachment for unsupported stdio OpenCode runtimes", async () => {
+  test("attempts live discovery for stdio OpenCode runtimes", async () => {
     let liveLookupCalls = 0;
     let resumeCalls = 0;
 
@@ -372,7 +372,42 @@ describe("reattach-live-session", () => {
     const reattached = await reattachLiveSession(sessionRecordFixture);
 
     expect(reattached).toBe(false);
-    expect(liveLookupCalls).toBe(0);
+    expect(liveLookupCalls).toBe(1);
     expect(resumeCalls).toBe(0);
+  });
+
+  test("propagates live lookup failures for stdio OpenCode runtimes", async () => {
+    const reattachLiveSession = createReattachLiveSession({
+      adapter: {
+        hasSession: () => false,
+      },
+      repoPath: "/tmp/repo",
+      updateSession: () => {
+        throw new Error("should not update failed session");
+      },
+      attachSessionListener: () => {
+        throw new Error("should not attach failed session");
+      },
+      promptOverrides: {},
+      resolveHydrationRuntime: async () => ({
+        ok: true,
+        runtimeKind: "opencode",
+        runtimeId: "runtime-stdio",
+        runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
+        runtimeConnection: {
+          type: "stdio",
+          identity: "runtime-stdio",
+          workingDirectory: "/tmp/repo/worktree",
+        },
+      }),
+      attachMissingLiveSession: async () => {},
+      listLiveAgentSessions: async () => {
+        throw new Error("live lookup failed");
+      },
+      isStaleRepoOperation: () => false,
+      toLiveSessionState: () => "idle",
+    });
+
+    await expect(reattachLiveSession(sessionRecordFixture)).rejects.toThrow("live lookup failed");
   });
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
@@ -1,7 +1,6 @@
 import type { AgentSessionRecord, RuntimeKind } from "@openducktor/contracts";
 import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { getRuntimeConnectionSupportError } from "../runtime/runtime";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
 import type { ResolvedHydrationRuntime } from "./hydration-runtime-resolution";
 
@@ -77,15 +76,6 @@ export const createReattachLiveSession = ({
       return false;
     }
     if (!runtimeResolution.ok) {
-      return false;
-    }
-    if (
-      getRuntimeConnectionSupportError(
-        runtimeResolution.runtimeKind,
-        runtimeResolution.runtimeConnection,
-        "live session discovery",
-      )
-    ) {
       return false;
     }
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -126,32 +126,6 @@ export const runtimeConnectionTransportKey = (
   }
 };
 
-export const getRuntimeConnectionSupportError = (
-  runtimeKind: RuntimeKind | null | undefined,
-  runtimeConnection: AgentRuntimeConnection | null | undefined,
-  action: string,
-): string | null => {
-  if (!runtimeKind || !runtimeConnection) {
-    return null;
-  }
-  if (runtimeKind !== "opencode" || runtimeConnection.type === "local_http") {
-    return null;
-  }
-  return `Runtime connection type '${runtimeConnection.type}' is unsupported for ${action} in runtime '${runtimeKind}'; local_http is required.`;
-};
-
-export const requireRuntimeConnectionSupport = (
-  runtimeKind: RuntimeKind | null | undefined,
-  runtimeConnection: AgentRuntimeConnection,
-  action: string,
-): AgentRuntimeConnection => {
-  const error = getRuntimeConnectionSupportError(runtimeKind, runtimeConnection, action);
-  if (error) {
-    throw new Error(error);
-  }
-  return runtimeConnection;
-};
-
 export const describeRuntimeRoute = (runtimeRoute: RuntimeRoute | null | undefined): string => {
   if (!runtimeRoute) {
     return "unavailable";
@@ -349,11 +323,7 @@ export const createEnsureRuntime = ({
       runtimeKind,
       runtimeId: input.runtimeId,
       runtimeRoute: input.runtimeRoute,
-      runtimeConnection: requireRuntimeConnectionSupport(
-        runtimeKind,
-        input.runtimeConnection,
-        `${role} sessions`,
-      ),
+      runtimeConnection: input.runtimeConnection,
       workingDirectory: input.workingDirectory,
     });
 


### PR DESCRIPTION
## Summary
- Move OpenCode transport compatibility checks out of shared frontend orchestration and into adapter/runtime-owned boundaries.
- Delegate host build bootstrap route validation through `AppRuntime`, with OpenCode enforcing `local_http` in `OpenCodeRuntime`.
- Update frontend and Rust tests to cover adapter-owned rejection, OpenCode build validation, and non-OpenCode stdio build bootstrap support.

## Goal
OpenCode-specific `local_http` policy was still leaking into shared session/build orchestration. That made generic code responsible for knowing OpenCode transport rules and would force future runtimes to add more branching in shared paths.

This PR keeps shared orchestration transport-neutral while preserving OpenCode's fail-fast `local_http` requirements at the runtime/adapter boundary where that policy belongs.

## Technical choices
- Removed shared frontend helpers that rejected `stdio` for `runtimeKind === "opencode"`; shared code now only resolves generic runtime routes/connections and lets adapter/query calls surface runtime-specific failures.
- Kept OpenCode SDK rejection in the adapter path via its runtime connection conversion before client creation.
- Added `AppRuntime::validate_build_session_bootstrap` as a default no-op hook so generic host build orchestration asks the runtime whether a bootstrap route is valid.
- Implemented OpenCode's hook with the existing `require_local_http_endpoint` check, so OpenCode stdio build bootstrap still fails before task transition while generic/test runtimes can accept stdio.
- Updated tests around session hydration, live reattachment, model/runtime data queries, adapter-owned errors, and host build lifecycle behavior.
- Applied Rust formatting and a small React test style polish so React Doctor reports no issues.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check`
- `cargo test`
- `bunx react-doctor@latest . --verbose --diff` → 100 / 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime bootstrap validation by delegating checks to specific runtime implementations instead of enforcing generic restrictions.
  * Simplified error handling for runtime operations, allowing adapters to attempt execution rather than failing upfront.

* **Tests**
  * Updated test cases to verify adapter invocation and error propagation instead of pre-flight validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->