### PR TITLE
fix(agent-studio): avoid useless polling and switch flicker

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-surface-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-surface-model.ts
@@ -150,6 +150,7 @@ type UseAgentChatSurfaceModelArgs = {
   mode: AgentChatMode;
   session: AgentSessionState | null;
   isTaskHydrating: boolean;
+  isSessionHistoryHydrated: boolean;
   contextSwitchVersion: number;
   showThinkingMessages: boolean;
   isSessionWorking: boolean;
@@ -169,6 +170,7 @@ export function useAgentChatSurfaceModel({
   mode,
   session,
   isTaskHydrating,
+  isSessionHistoryHydrated,
   contextSwitchVersion,
   showThinkingMessages,
   isSessionWorking,
@@ -189,6 +191,7 @@ export function useAgentChatSurfaceModel({
   const { threadSession, activeSessionId, isContextSwitching } = useAgentChatThreadContext({
     activeSession: session,
     isTaskHydrating,
+    isSessionHistoryHydrated,
     contextSwitchVersion,
   });
   const syncBottomAfterComposerLayoutRef = useRef<(() => void) | null>(null);

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-thread-context.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-thread-context.test.tsx
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  createAgentSessionFixture,
+  createHookHarness,
+  enableReactActEnvironment,
+} from "@/pages/agents/agent-studio-test-utils";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { useAgentChatThreadContext } from "./use-agent-chat-thread-context";
+
+type HookArgs = Parameters<typeof useAgentChatThreadContext>[0];
+
+type TestWindow = Window &
+  typeof globalThis & {
+    requestAnimationFrame: (callback: FrameRequestCallback) => number;
+    cancelAnimationFrame: (handle: number) => void;
+  };
+
+type GlobalWithWindow = {
+  window?: TestWindow;
+};
+
+const globalWithWindow = globalThis as unknown as GlobalWithWindow;
+
+let originalWindow: TestWindow | undefined;
+let originalRequestAnimationFrame: TestWindow["requestAnimationFrame"] | undefined;
+let originalCancelAnimationFrame: TestWindow["cancelAnimationFrame"] | undefined;
+let rafCallbacks = new Map<number, FrameRequestCallback>();
+let nextRafId = 1;
+
+const flushRafFrames = (frameCount = 1): void => {
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+    const callbacks = [...rafCallbacks.values()];
+    rafCallbacks.clear();
+    callbacks.forEach((callback) => {
+      callback(frameIndex * 16);
+    });
+  }
+};
+
+const createSession = (overrides: Partial<AgentSessionState> = {}): AgentSessionState =>
+  createAgentSessionFixture({
+    status: "idle",
+    runtimeKind: "opencode",
+    ...overrides,
+  });
+
+const createHookArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  activeSession: createSession({
+    sessionId: "session-a",
+    externalSessionId: "external-a",
+    role: "spec",
+    scenario: "spec_initial",
+  }),
+  isTaskHydrating: false,
+  isSessionHistoryHydrated: true,
+  contextSwitchVersion: 0,
+  ...overrides,
+});
+
+describe("useAgentChatThreadContext", () => {
+  beforeEach(() => {
+    enableReactActEnvironment();
+    rafCallbacks = new Map<number, FrameRequestCallback>();
+    nextRafId = 1;
+
+    originalWindow = globalWithWindow.window;
+    if (!globalWithWindow.window) {
+      globalWithWindow.window = globalThis as unknown as TestWindow;
+    }
+    const windowRef = globalWithWindow.window;
+    originalRequestAnimationFrame = windowRef.requestAnimationFrame;
+    originalCancelAnimationFrame = windowRef.cancelAnimationFrame;
+
+    windowRef.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+      const requestId = nextRafId;
+      nextRafId += 1;
+      rafCallbacks.set(requestId, callback);
+      return requestId;
+    };
+    windowRef.cancelAnimationFrame = (handle: number): void => {
+      rafCallbacks.delete(handle);
+    };
+  });
+
+  afterEach(() => {
+    if (!globalWithWindow.window) {
+      return;
+    }
+    const windowRef = globalWithWindow.window;
+    if (originalRequestAnimationFrame) {
+      windowRef.requestAnimationFrame = originalRequestAnimationFrame;
+    }
+    if (originalCancelAnimationFrame) {
+      windowRef.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+    if (originalWindow) {
+      globalWithWindow.window = originalWindow;
+    } else {
+      Reflect.deleteProperty(globalWithWindow, "window");
+    }
+  });
+
+  test("displays an already hydrated existing session without a switch flicker", async () => {
+    const sessionA = createSession({
+      sessionId: "session-a",
+      externalSessionId: "external-a",
+      role: "spec",
+      scenario: "spec_initial",
+    });
+    const sessionB = createSession({
+      sessionId: "session-b",
+      externalSessionId: "external-b",
+      role: "planner",
+      scenario: "planner_initial",
+    });
+    const harness = createHookHarness(
+      useAgentChatThreadContext,
+      createHookArgs({ activeSession: sessionA }),
+    );
+
+    await harness.mount();
+    expect(harness.getLatest().threadSession?.sessionId).toBe("session-a");
+    expect(harness.getLatest().isContextSwitching).toBe(false);
+
+    await harness.update(createHookArgs({ activeSession: sessionB, contextSwitchVersion: 1 }));
+    expect(harness.getLatest().threadSession?.sessionId).toBe("session-b");
+    expect(harness.getLatest().activeSessionId).toBe("session-b");
+    expect(harness.getLatest().isContextSwitching).toBe(false);
+    await harness.unmount();
+  });
+
+  test("clears the visible thread immediately when the target session cannot render yet", async () => {
+    const sessionA = createSession({
+      sessionId: "session-a",
+      externalSessionId: "external-a",
+      role: "spec",
+      scenario: "spec_initial",
+    });
+    const sessionB = createSession({
+      sessionId: "session-b",
+      externalSessionId: "external-b",
+      role: "planner",
+      scenario: "planner_initial",
+      historyHydrationState: "not_requested",
+    });
+    const harness = createHookHarness(
+      useAgentChatThreadContext,
+      createHookArgs({ activeSession: sessionA }),
+    );
+
+    await harness.mount();
+    await harness.update(
+      createHookArgs({
+        activeSession: sessionB,
+        isSessionHistoryHydrated: false,
+        contextSwitchVersion: 1,
+      }),
+    );
+    expect(harness.getLatest().threadSession).toBeNull();
+    expect(harness.getLatest().activeSessionId).toBeNull();
+    expect(harness.getLatest().isContextSwitching).toBe(true);
+    await harness.unmount();
+  });
+
+  test("keeps the thread cleared while task hydration is running", async () => {
+    const session = createSession({
+      sessionId: "session-a",
+      externalSessionId: "external-a",
+      role: "spec",
+      scenario: "spec_initial",
+    });
+    const harness = createHookHarness(
+      useAgentChatThreadContext,
+      createHookArgs({ activeSession: session }),
+    );
+
+    await harness.mount();
+    await harness.update(
+      createHookArgs({
+        activeSession: session,
+        contextSwitchVersion: 1,
+        isTaskHydrating: true,
+      }),
+    );
+    expect(harness.getLatest().threadSession).toBeNull();
+    expect(harness.getLatest().isContextSwitching).toBe(true);
+
+    await harness.run(() => {
+      flushRafFrames(1);
+    });
+    expect(harness.getLatest().threadSession).toBeNull();
+    expect(harness.getLatest().isContextSwitching).toBe(true);
+
+    await harness.update(
+      createHookArgs({
+        activeSession: session,
+        contextSwitchVersion: 1,
+        isTaskHydrating: false,
+      }),
+    );
+    await harness.run(() => {
+      flushRafFrames(1);
+    });
+    expect(harness.getLatest().threadSession?.sessionId).toBe("session-a");
+    expect(harness.getLatest().isContextSwitching).toBe(false);
+    await harness.unmount();
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-thread-context.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-thread-context.test.tsx
@@ -89,9 +89,13 @@ describe("useAgentChatThreadContext", () => {
     const windowRef = globalWithWindow.window;
     if (originalRequestAnimationFrame) {
       windowRef.requestAnimationFrame = originalRequestAnimationFrame;
+    } else {
+      Reflect.deleteProperty(windowRef, "requestAnimationFrame");
     }
     if (originalCancelAnimationFrame) {
       windowRef.cancelAnimationFrame = originalCancelAnimationFrame;
+    } else {
+      Reflect.deleteProperty(windowRef, "cancelAnimationFrame");
     }
     if (originalWindow) {
       globalWithWindow.window = originalWindow;

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-thread-context.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-thread-context.ts
@@ -4,6 +4,7 @@ import type { AgentSessionState } from "@/types/agent-orchestrator";
 type UseAgentChatThreadContextArgs = {
   activeSession: AgentSessionState | null;
   isTaskHydrating: boolean;
+  isSessionHistoryHydrated: boolean;
   contextSwitchVersion: number;
 };
 
@@ -16,12 +17,18 @@ type AgentChatThreadContext = {
 export const useAgentChatThreadContext = ({
   activeSession,
   isTaskHydrating,
+  isSessionHistoryHydrated,
   contextSwitchVersion,
 }: UseAgentChatThreadContextArgs): AgentChatThreadContext => {
   const [isContextSwitchIntentActive, setIsContextSwitchIntentActive] = useState(false);
   const contextSwitchVersionRef = useRef(contextSwitchVersion);
   const clearIntentRafRef = useRef<number | null>(null);
   const activeSessionId = activeSession?.sessionId ?? null;
+  const hasPendingContextSwitchVersion = contextSwitchVersionRef.current !== contextSwitchVersion;
+  const canRenderActiveSession = activeSession !== null && isSessionHistoryHydrated;
+  const shouldClearThread =
+    isTaskHydrating ||
+    (!canRenderActiveSession && (hasPendingContextSwitchVersion || isContextSwitchIntentActive));
 
   useEffect(() => {
     if (contextSwitchVersionRef.current === contextSwitchVersion) {
@@ -78,9 +85,8 @@ export const useAgentChatThreadContext = ({
   }, []);
 
   return {
-    threadSession: activeSession,
-    activeSessionId,
-    isContextSwitching:
-      isTaskHydrating || (isContextSwitchIntentActive && activeSessionId === null),
+    threadSession: shouldClearThread ? null : activeSession,
+    activeSessionId: shouldClearThread ? null : activeSessionId,
+    isContextSwitching: shouldClearThread,
   };
 };

--- a/packages/frontend/src/components/features/agents/agent-chat/use-readonly-session-transcript-surface-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-readonly-session-transcript-surface-model.ts
@@ -313,6 +313,7 @@ export function useReadonlySessionTranscriptSurfaceModel({
     mode: "non_interactive",
     session: runtimeData.session,
     isTaskHydrating: shouldShowPendingSessionResolution,
+    isSessionHistoryHydrated: hydration.isActiveSessionHistoryHydrated,
     contextSwitchVersion: 0,
     showThinkingMessages: activeWorkspace ? showThinkingMessages : DEFAULT_SHOW_THINKING_MESSAGES,
     isSessionWorking,

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -36,6 +36,7 @@ const baseArgs: BuildArgs = {
     contextSwitchVersion: 4,
     isActiveTaskHydrated: true,
     isActiveTaskHydrationFailed: false,
+    isViewSessionHistoryHydrated: true,
     isViewSessionHistoryHydrationFailed: false,
     isViewSessionHistoryHydrating: false,
     isViewSessionWaitingForRuntimeReadiness: false,
@@ -126,6 +127,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
 
     expect(mapped.core.role).toBe("planner");
     expect(mapped.core.contextSwitchVersion).toBe(4);
+    expect(mapped.core.isSessionHistoryHydrated).toBe(true);
     expect(mapped.core.isSessionHistoryHydrationFailed).toBe(false);
     expect(mapped.core.isWaitingForRuntimeReadiness).toBe(false);
     expect(mapped.taskTabs.onSelectTab).toBe(onSelectTab);

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -91,6 +91,7 @@ type AgentStudioPageModelsViewContext = Pick<
   | "contextSwitchVersion"
   | "isActiveTaskHydrated"
   | "isActiveTaskHydrationFailed"
+  | "isViewSessionHistoryHydrated"
   | "isViewSessionHistoryHydrationFailed"
   | "isViewSessionHistoryHydrating"
   | "isViewSessionWaitingForRuntimeReadiness"
@@ -200,6 +201,7 @@ export const buildAgentStudioPageModelsArgs = ({
       isTaskHydrating: Boolean(
         view.viewTaskId && !view.isActiveTaskHydrated && !view.isActiveTaskHydrationFailed,
       ),
+      isSessionHistoryHydrated: view.isViewSessionHistoryHydrated,
       isSessionHistoryHydrating: view.isViewSessionHistoryHydrating,
       isWaitingForRuntimeReadiness: view.isViewSessionWaitingForRuntimeReadiness,
       isSessionHistoryHydrationFailed: view.isViewSessionHistoryHydrationFailed,
@@ -381,6 +383,7 @@ export function useAgentStudioOrchestrationController({
       contextSwitchVersion,
       isActiveTaskHydrated,
       isActiveTaskHydrationFailed: selection.isActiveTaskHydrationFailed,
+      isViewSessionHistoryHydrated: selection.isViewSessionHistoryHydrated,
       isViewSessionHistoryHydrationFailed: selection.isViewSessionHistoryHydrationFailed,
       isViewSessionHistoryHydrating: selection.isViewSessionHistoryHydrating,
       isViewSessionWaitingForRuntimeReadiness: selection.isViewSessionWaitingForRuntimeReadiness,

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -86,6 +86,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     selectedTask: createTask(),
     sessionRuntimeDataError: null,
     isTaskHydrating: false,
+    isSessionHistoryHydrated: true,
     isSessionHistoryHydrating: false,
     isWaitingForRuntimeReadiness: false,
     isSessionHistoryHydrationFailed: false,

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
@@ -36,6 +36,7 @@ type AgentStudioCoreContext = {
   activeSession: AgentSessionState | null;
   sessionRuntimeDataError: string | null;
   isTaskHydrating: boolean;
+  isSessionHistoryHydrated: boolean;
   isSessionHistoryHydrating: boolean;
   isWaitingForRuntimeReadiness: boolean;
   isSessionHistoryHydrationFailed: boolean;
@@ -505,6 +506,7 @@ export function useAgentStudioPageModels({
     mode: "interactive",
     session: core.activeSession,
     isTaskHydrating: core.isTaskHydrating,
+    isSessionHistoryHydrated: core.isSessionHistoryHydrated,
     contextSwitchVersion: core.contextSwitchVersion,
     showThinkingMessages: chatSettings.showThinkingMessages,
     isSessionWorking: sessionActions.isSessionWorking,

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -274,6 +274,8 @@ const renderPage = async (options?: { waitForKanbanReady?: boolean }): Promise<R
     });
   }
 
+  await waitForMockCall(workspaceGetRepoConfigMock);
+
   return renderer;
 };
 
@@ -414,10 +416,6 @@ describe("KanbanPage session start modal flow", () => {
         latestSessionStartModalModel = model;
         return null;
       },
-    }));
-
-    mock.module("../agents/use-agent-studio-repo-settings", () => ({
-      useAgentStudioRepoSettings: () => ({ repoSettings: createRepoSettingsFixture() }),
     }));
 
     mock.module("@/components/features/pull-requests/merged-pull-request-confirm-dialog", () => ({
@@ -633,10 +631,6 @@ describe("KanbanPage session start modal flow", () => {
         () => import("@/components/features/kanban/kanban-column"),
       ],
       ["./kanban-session-start-modal", () => import("./kanban-session-start-modal")],
-      [
-        "../agents/use-agent-studio-repo-settings",
-        () => import("../../pages/agents/use-agent-studio-repo-settings"),
-      ],
       [
         "@/components/features/pull-requests/merged-pull-request-confirm-dialog",
         () => import("@/components/features/pull-requests/merged-pull-request-confirm-dialog"),

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -13,9 +13,12 @@ import {
   createLocalHttpRuntimeConnection,
 } from "@/state/operations/agent-orchestrator/test-utils";
 import { runtimeQueryKeys } from "@/state/queries/runtime";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { LiveAgentSessionStore } from "./live-agent-session-store";
+import { createLoadAgentSessions } from "./load-sessions";
 import { createRuntimeResolutionPlannerStage } from "./load-sessions-stages";
 import { createRepoSessionHydrationService } from "./repo-session-hydration-service";
+import { createSessionHydrationOperations } from "./session-hydration-operations";
 
 const createDeferred = <T>() => {
   let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
@@ -147,17 +150,6 @@ const stdioRuntimeConnection = (workingDirectory: string, identity = "runtime-st
     workingDirectory,
   }) as const;
 
-const isExpectedReconcileRetryLog = (args: Parameters<typeof console.error>): boolean => {
-  const [message, error] = args;
-  return (
-    typeof message === "string" &&
-    message.startsWith("Failed to reconcile agent sessions for task") &&
-    message.includes("Retrying in") &&
-    error instanceof Error &&
-    error.message.startsWith("No live runtime found for working directory ")
-  );
-};
-
 const isExpectedRuntimeMetadataLog = (args: Parameters<typeof console.error>): boolean => {
   const [message, error] = args;
   return (
@@ -195,16 +187,6 @@ const withSuppressedExpectedConsoleErrors = async ({
     console.error = originalError;
   }
 };
-
-const withSuppressedExpectedReconcileRetryLogs = (
-  expectedCount: number,
-  run: () => Promise<void>,
-): Promise<void> =>
-  withSuppressedExpectedConsoleErrors({
-    expectedCount,
-    isExpected: isExpectedReconcileRetryLog,
-    run,
-  });
 
 const withSuppressedExpectedRuntimeMetadataLogs = (
   expectedCount: number,
@@ -738,7 +720,7 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
-  test("reconcile does not synthesize worktree scans from repo-root stdio runtimes", async () => {
+  test("reconcile skips worktree sessions instead of retrying when only repo-root stdio runtimes exist", async () => {
     const listLiveAgentSessionSnapshotsCalls: Array<{
       runtimeConnection: unknown;
       directories?: string[];
@@ -802,24 +784,22 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await withSuppressedExpectedReconcileRetryLogs(2, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [
-          taskWithSessionAt("task-a", "external-a", worktreePath),
-          taskWithSessionAt("task-b", "external-b", worktreePath),
-        ],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-a", worktreePath),
+        taskWithSessionAt("task-b", "external-b", worktreePath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([]);
-    expect(reconcileCalls.sort()).toEqual(["task-a", "task-b"]);
+    expect(reconcileCalls).toEqual([]);
     service.dispose();
   });
 
-  test("reconcile does not preload repo-root workspace runtimes for build sessions", async () => {
+  test("reconcile uses repo-root workspace runtimes only for matching repo-root workspace sessions", async () => {
     const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
     const reconcileCalls: string[] = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
@@ -858,28 +838,291 @@ describe("repo-session-hydration-service", () => {
             throw new Error("Expected persisted session record");
           }
           expect(record.workingDirectory).toBe(repoPath);
-          expect(preloadedRuntimeConnections?.hasAny("opencode", repoPath)).toBe(false);
-          throw new Error(`No live runtime found for working directory ${repoPath}.`);
+          expect(preloadedRuntimeConnections?.hasAny("opencode", repoPath)).toBe(true);
         },
       },
       liveAgentSessionStore,
       onRetryRequested: () => {},
     });
 
-    await withSuppressedExpectedReconcileRetryLogs(2, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [
-          taskWithSessionAt("task-root-build", "external-build-root", repoPath),
-          plannerTaskWithSessionAt("task-root-planner", "external-planner-root", repoPath),
-        ],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-root-build", "external-build-root", repoPath),
+        plannerTaskWithSessionAt("task-root-planner", "external-planner-root", repoPath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([{ directories: [repoPath] }]);
-    expect(reconcileCalls.sort()).toEqual(["task-root-build", "task-root-planner"]);
+    expect(reconcileCalls).toEqual(["task-root-planner"]);
+    service.dispose();
+  });
+
+  test("reconcile filters missing worktree records from mixed tasks so live records do not trigger retries", async () => {
+    const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
+    let retryRequests = 0;
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+
+    const mixedTask = plannerTaskWithSessionAt("task-mixed", "external-planner", repoPath);
+    const plannerSession = mixedTask.agentSessions?.[0];
+    if (!plannerSession) {
+      throw new Error("Expected planner session fixture");
+    }
+    mixedTask.agentSessions = [
+      plannerSession,
+      {
+        ...plannerSession,
+        sessionId: "session-task-mixed-build",
+        externalSessionId: "external-missing-build",
+        role: "build",
+        scenario: "build_implementation_start",
+        workingDirectory: worktreePath,
+      },
+    ];
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async () => [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "external-planner",
+            workingDirectory: repoPath,
+          }),
+        ],
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId, persistedRecords }) => {
+          reconcileCalls.push({ taskId, records: persistedRecords ?? [] });
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {
+        retryRequests += 1;
+      },
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [mixedTask],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(reconcileCalls).toHaveLength(1);
+    expect(reconcileCalls[0]?.taskId).toBe("task-mixed");
+    expect(reconcileCalls[0]?.records.map((record) => record.externalSessionId)).toEqual([
+      "external-planner",
+    ]);
+    expect(retryRequests).toBe(0);
+    service.dispose();
+  });
+
+  test("reconcile can pick up a mixed-task worktree record after it becomes live later", async () => {
+    const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
+    let retryRequests = 0;
+    let liveSnapshots = [
+      createLiveAgentSessionSnapshotFixture({
+        externalSessionId: "external-planner",
+        workingDirectory: repoPath,
+      }),
+    ];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+
+    const mixedTask = plannerTaskWithSessionAt("task-mixed", "external-planner", repoPath);
+    const plannerSession = mixedTask.agentSessions?.[0];
+    if (!plannerSession) {
+      throw new Error("Expected planner session fixture");
+    }
+    mixedTask.agentSessions = [
+      plannerSession,
+      {
+        ...plannerSession,
+        sessionId: "session-task-mixed-build",
+        externalSessionId: "external-build",
+        role: "build",
+        scenario: "build_implementation_start",
+        workingDirectory: worktreePath,
+      },
+    ];
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async () => liveSnapshots,
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId, persistedRecords }) => {
+          reconcileCalls.push({ taskId, records: persistedRecords ?? [] });
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {
+        retryRequests += 1;
+      },
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [mixedTask],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+    liveSnapshots = [
+      createLiveAgentSessionSnapshotFixture({
+        externalSessionId: "external-build",
+        workingDirectory: worktreePath,
+      }),
+    ];
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [mixedTask],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(
+      reconcileCalls.map((call) => call.records.map((record) => record.externalSessionId)),
+    ).toEqual([["external-planner"], ["external-build"]]);
+    expect(retryRequests).toBe(0);
+    service.dispose();
+  });
+
+  test("reconcile filters mixed tasks before the real hydration path resolves runtimes", async () => {
+    let retryRequests = 0;
+    let resumeCalls = 0;
+    let liveSnapshotScans = 0;
+    let attachedListeners = 0;
+    let state: Record<string, AgentSessionState> = {};
+    const sessionsRef = { current: state };
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+
+    const mixedTask = plannerTaskWithSessionAt("task-mixed", "external-planner", repoPath);
+    const plannerSession = mixedTask.agentSessions?.[0];
+    if (!plannerSession) {
+      throw new Error("Expected planner session fixture");
+    }
+    mixedTask.agentSessions = [
+      plannerSession,
+      {
+        ...plannerSession,
+        sessionId: "session-task-mixed-build",
+        externalSessionId: "external-missing-build",
+        role: "build",
+        scenario: "build_implementation_start",
+        workingDirectory: worktreePath,
+      },
+    ];
+
+    const setSessionsById: Parameters<typeof createLoadAgentSessions>[0]["setSessionsById"] = (
+      updater,
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const updateSession: Parameters<typeof createLoadAgentSessions>[0]["updateSession"] = (
+      sessionId,
+      updater,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = { ...state, [sessionId]: updater(current) };
+      sessionsRef.current = state;
+    };
+    const adapter: Parameters<typeof createLoadAgentSessions>[0]["adapter"] = {
+      hasSession: () => false,
+      loadSessionHistory: async () => [],
+      listLiveAgentSessionSnapshots: async () => {
+        liveSnapshotScans += 1;
+        return [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "external-planner",
+            workingDirectory: repoPath,
+          }),
+        ];
+      },
+      resumeSession: async (input) => {
+        resumeCalls += 1;
+        return {
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-02-22T08:00:00.000Z",
+          status: "running",
+          runtimeKind: input.runtimeKind,
+        };
+      },
+      attachSession: async (input) => ({
+        sessionId: input.sessionId,
+        externalSessionId: input.externalSessionId,
+        role: input.role,
+        scenario: input.scenario,
+        startedAt: "2026-02-22T08:00:00.000Z",
+        status: "running",
+        runtimeKind: input.runtimeKind,
+      }),
+    };
+    const loadAgentSessions = createLoadAgentSessions({
+      activeWorkspace: {
+        repoPath,
+        workspaceId: "workspace-1",
+        workspaceName: "Test Workspace",
+      },
+      adapter,
+      repoEpochRef: { current: 0 },
+      currentWorkspaceRepoPathRef: { current: repoPath },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [mixedTask] },
+      updateSession,
+      attachSessionListener: () => {
+        attachedListeners += 1;
+      },
+      loadRepoPromptOverrides: async () => ({}),
+    });
+    const sessionHydration = createSessionHydrationOperations({
+      loadAgentSessions,
+      getSessionSnapshot: (sessionId) => sessionsRef.current[sessionId],
+    });
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async (input) => {
+          if (!adapter.listLiveAgentSessionSnapshots) {
+            throw new Error("Expected live snapshot scanner");
+          }
+          return adapter.listLiveAgentSessionSnapshots(input);
+        },
+      },
+      sessionHydration,
+      liveAgentSessionStore,
+      onRetryRequested: () => {
+        retryRequests += 1;
+      },
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [mixedTask],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(liveSnapshotScans).toBe(1);
+    expect(resumeCalls).toBe(1);
+    expect(attachedListeners).toBe(1);
+    expect(retryRequests).toBe(0);
+    expect(state["session-task-mixed"]?.status).toBe("running");
+    expect(state["session-task-mixed-build"]).toBeUndefined();
     service.dispose();
   });
 
@@ -1105,6 +1348,143 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
+  test("reconcile scans repo-root http runtimes for worktree sessions once without retrying missing live sessions", async () => {
+    const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
+    const reconcileCalls: string[] = [];
+    let retryRequests = 0;
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async (input) => {
+          listLiveAgentSessionSnapshotsCalls.push(
+            input.directories ? { directories: [...input.directories].sort() } : {},
+          );
+          return [];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId }) => {
+          reconcileCalls.push(taskId);
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {
+        retryRequests += 1;
+      },
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-a", "/tmp/repo/worktree-a"),
+        taskWithSessionAt("task-b", "external-b", "/tmp/repo/worktree-b"),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([
+      {
+        directories: ["/tmp/repo/worktree-a", "/tmp/repo/worktree-b"],
+      },
+    ]);
+    expect(reconcileCalls).toEqual([]);
+    expect(retryRequests).toBe(0);
+    service.dispose();
+  });
+
+  test("reconcile only targets matching live worktree sessions discovered through repo-root http runtimes", async () => {
+    const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async () => [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "external-a",
+            workingDirectory: worktreePath,
+          }),
+        ],
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId, persistedRecords }) => {
+          reconcileCalls.push({ taskId, records: persistedRecords ?? [] });
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-a", worktreePath),
+        taskWithSessionAt("task-b", "external-b", worktreePath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(reconcileCalls).toHaveLength(1);
+    expect(reconcileCalls[0]?.taskId).toBe("task-a");
+    expect(reconcileCalls[0]?.records.map((record) => record.externalSessionId)).toEqual([
+      "external-a",
+    ]);
+    service.dispose();
+  });
+
+  test("reconcile does not match duplicate external session ids from other scanned worktree directories", async () => {
+    const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+    const worktreeA = "/tmp/repo/worktree-a";
+    const worktreeB = "/tmp/repo/worktree-b";
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async () => [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "external-shared",
+            workingDirectory: worktreeA,
+          }),
+        ],
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId, persistedRecords }) => {
+          reconcileCalls.push({ taskId, records: persistedRecords ?? [] });
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-shared", worktreeA),
+        taskWithSessionAt("task-b", "external-shared", worktreeB),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(reconcileCalls).toHaveLength(1);
+    expect(reconcileCalls[0]?.taskId).toBe("task-a");
+    expect(reconcileCalls[0]?.records.map((record) => record.workingDirectory)).toEqual([
+      worktreeA,
+    ]);
+    service.dispose();
+  });
+
   test("reconcile does not ensure missing stdio worktree runtimes", async () => {
     let runtimeEnsureCalls = 0;
     const listLiveAgentSessionSnapshotsCalls: Array<{
@@ -1148,21 +1528,19 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await withSuppressedExpectedReconcileRetryLogs(2, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [
-          taskWithSessionAt("task-1", "external-1", "/tmp/repo/worktree-a"),
-          taskWithSessionAt("task-2", "external-2", "/tmp/repo/worktree-b"),
-        ],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-a", worktreePath),
+        taskWithSessionAt("task-b", "external-b", worktreePath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     expect(runtimeEnsureCalls).toBe(0);
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([]);
-    expect(reconcileCalls.sort()).toEqual(["task-1", "task-2"]);
+    expect(reconcileCalls).toEqual([]);
     service.dispose();
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -160,6 +160,16 @@ const isExpectedRuntimeMetadataLog = (args: Parameters<typeof console.error>): b
   );
 };
 
+const isExpectedRetryableUnmatchedLog = (args: Parameters<typeof console.error>): boolean => {
+  const [message, error] = args;
+  return (
+    typeof message === "string" &&
+    message.startsWith("Failed to reconcile agent sessions") &&
+    error instanceof Error &&
+    error.message.startsWith("No matching live agent session was found")
+  );
+};
+
 const withSuppressedExpectedConsoleErrors = async ({
   expectedCount,
   isExpected,
@@ -195,6 +205,16 @@ const withSuppressedExpectedRuntimeMetadataLogs = (
   withSuppressedExpectedConsoleErrors({
     expectedCount,
     isExpected: isExpectedRuntimeMetadataLog,
+    run,
+  });
+
+const withSuppressedExpectedRetryableUnmatchedLogs = (
+  expectedCount: number,
+  run: () => Promise<void>,
+): Promise<void> =>
+  withSuppressedExpectedConsoleErrors({
+    expectedCount,
+    isExpected: isExpectedRetryableUnmatchedLog,
     run,
   });
 
@@ -860,7 +880,7 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
-  test("reconcile filters missing worktree records from mixed tasks so live records do not trigger retries", async () => {
+  test("reconcile schedules retry for unmatched worktree records while reconciling live records", async () => {
     const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
     let retryRequests = 0;
     const liveAgentSessionStore = new LiveAgentSessionStore();
@@ -905,11 +925,15 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [mixedTask],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [mixedTask],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
+
+      await Bun.sleep(600);
     });
 
     expect(reconcileCalls).toHaveLength(1);
@@ -917,7 +941,7 @@ describe("repo-session-hydration-service", () => {
     expect(reconcileCalls[0]?.records.map((record) => record.externalSessionId)).toEqual([
       "external-planner",
     ]);
-    expect(retryRequests).toBe(0);
+    expect(retryRequests).toBe(1);
     service.dispose();
   });
 
@@ -967,11 +991,13 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [mixedTask],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [mixedTask],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
     liveSnapshots = [
       createLiveAgentSessionSnapshotFixture({
@@ -989,6 +1015,82 @@ describe("repo-session-hydration-service", () => {
     expect(
       reconcileCalls.map((call) => call.records.map((record) => record.externalSessionId)),
     ).toEqual([["external-planner"], ["external-build"]]);
+    expect(retryRequests).toBe(0);
+    service.dispose();
+  });
+
+  test("reconcile record tracking distinguishes ids that contain key delimiters", async () => {
+    const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
+    let retryRequests = 0;
+    let liveSnapshots = [
+      createLiveAgentSessionSnapshotFixture({
+        externalSessionId: "external",
+        workingDirectory: worktreePath,
+      }),
+    ];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+
+    const task = taskWithSessionAt("task-key", "external", worktreePath);
+    const firstSession = task.agentSessions?.[0];
+    if (!firstSession) {
+      throw new Error("Expected seeded task session");
+    }
+    task.agentSessions = [
+      {
+        ...firstSession,
+        sessionId: "session::shared",
+        externalSessionId: "external",
+      },
+      {
+        ...firstSession,
+        sessionId: "session",
+        externalSessionId: "shared::external",
+      },
+    ];
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async () => liveSnapshots,
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId, persistedRecords }) => {
+          reconcileCalls.push({ taskId, records: persistedRecords ?? [] });
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {
+        retryRequests += 1;
+      },
+    });
+
+    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [task],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
+    });
+
+    liveSnapshots = [
+      createLiveAgentSessionSnapshotFixture({
+        externalSessionId: "shared::external",
+        workingDirectory: worktreePath,
+      }),
+    ];
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [task],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(
+      reconcileCalls.map((call) => call.records.map((record) => record.externalSessionId)),
+    ).toEqual([["external"], ["shared::external"]]);
     expect(retryRequests).toBe(0);
     service.dispose();
   });
@@ -1110,11 +1212,13 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [mixedTask],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [mixedTask],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(liveSnapshotScans).toBe(1);
@@ -1237,11 +1341,13 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [taskOne, taskTwo],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRetryableUnmatchedLogs(2, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [taskOne, taskTwo],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(runtimeEnsureCalls).toBe(1);
@@ -1348,12 +1454,11 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
-  test("reconcile scans repo-root http runtimes for worktree sessions once without retrying missing live sessions", async () => {
+  test("reconcile retries unmatched worktree sessions after scanning compatible repo-root http runtimes", async () => {
     const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
     const reconcileCalls: string[] = [];
     let retryRequests = 0;
     const liveAgentSessionStore = new LiveAgentSessionStore();
-
     setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
 
     const service = createTestRepoSessionHydrationService({
@@ -1377,14 +1482,18 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [
-        taskWithSessionAt("task-a", "external-a", "/tmp/repo/worktree-a"),
-        taskWithSessionAt("task-b", "external-b", "/tmp/repo/worktree-b"),
-      ],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRetryableUnmatchedLogs(2, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [
+          taskWithSessionAt("task-a", "external-a", "/tmp/repo/worktree-a"),
+          taskWithSessionAt("task-b", "external-b", "/tmp/repo/worktree-b"),
+        ],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
+
+      await Bun.sleep(600);
     });
 
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([
@@ -1393,7 +1502,7 @@ describe("repo-session-hydration-service", () => {
       },
     ]);
     expect(reconcileCalls).toEqual([]);
-    expect(retryRequests).toBe(0);
+    expect(retryRequests).toBe(2);
     service.dispose();
   });
 
@@ -1422,14 +1531,16 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [
-        taskWithSessionAt("task-a", "external-a", worktreePath),
-        taskWithSessionAt("task-b", "external-b", worktreePath),
-      ],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [
+          taskWithSessionAt("task-a", "external-a", worktreePath),
+          taskWithSessionAt("task-b", "external-b", worktreePath),
+        ],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(reconcileCalls).toHaveLength(1);
@@ -1467,14 +1578,16 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [
-        taskWithSessionAt("task-a", "external-shared", worktreeA),
-        taskWithSessionAt("task-b", "external-shared", worktreeB),
-      ],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [
+          taskWithSessionAt("task-a", "external-shared", worktreeA),
+          taskWithSessionAt("task-b", "external-shared", worktreeB),
+        ],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(reconcileCalls).toHaveLength(1);
@@ -1575,11 +1688,13 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await service.reconcilePendingTasks({
-      repoPath,
-      tasks: [plannerTaskWithSessionAt("task-1", "external-1", repoPath)],
-      isCancelled: () => false,
-      isCurrentRepo: () => true,
+    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [plannerTaskWithSessionAt("task-1", "external-1", repoPath)],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+      });
     });
 
     expect(

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -16,6 +16,7 @@ import { host } from "../../shared/host";
 import { ensureRuntimeAndInvalidateReadinessQueries } from "../../shared/runtime-readiness-publication";
 import { resolveRuntimeRouteConnection } from "../runtime/runtime";
 import { normalizeWorkingDirectory } from "../support/core";
+import { requiresLiveWorktreeRuntime } from "../support/session-runtime-attachment";
 import {
   isSessionRuntimeMetadataError,
   readPersistedRuntimeKind,
@@ -36,11 +37,17 @@ type RuntimeConnectionScan = {
   runtimeKind: RuntimeKind;
   runtimeConnection: AgentRuntimeConnection;
   directories: Set<string>;
+  runtimeConnectionsByDirectory: Map<string, AgentRuntimeConnection>;
+};
+
+type ReconcileTarget = {
+  taskId: string;
+  records: AgentSessionRecord[];
 };
 
 type ReconcilePreloadPlan = {
   persistedByTask: Array<{ taskId: string; records: AgentSessionRecord[] }>;
-  taskIdsToReconcile: Set<string>;
+  reconcileTargets: ReconcileTarget[];
   preloadedRuntimeLists: Map<RuntimeKind, RuntimeInstanceSummary[]>;
   preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedLiveAgentSessionsByKey: Map<string, LiveAgentSessionSnapshot[]>;
@@ -49,7 +56,7 @@ type ReconcilePreloadPlan = {
 
 type ReconcilePreloadMetadata = {
   persistedByTask: Array<{ taskId: string; records: AgentSessionRecord[] }>;
-  persistedTaskIdsByLiveSessionKey: Map<string, Set<string>>;
+  persistedLiveSessionKeys: Set<string>;
   runtimeKinds: Set<RuntimeKind>;
   desiredDirectoriesByRuntimeKind: Map<RuntimeKind, Set<string>>;
   runtimeKindsAllowedToEnsureRepoRoot: Set<RuntimeKind>;
@@ -83,6 +90,27 @@ const getOrCreateRepoTaskSet = (
   return created;
 };
 
+const persistedSessionRecordKey = (taskId: string, record: AgentSessionRecord): string =>
+  `${taskId}::${readPersistedRuntimeKind(record)}::${record.sessionId}::${record.externalSessionId ?? record.sessionId}::${normalizeWorkingDirectory(record.workingDirectory)}`;
+
+const toTaskWithUnreconciledRecords = (
+  task: TaskCard,
+  reconciledRecordKeys: Set<string>,
+): TaskCard | null => {
+  const unreconciledRecords = (task.agentSessions ?? []).filter((record) => {
+    try {
+      return !reconciledRecordKeys.has(persistedSessionRecordKey(task.id, record));
+    } catch (error) {
+      if (isSessionRuntimeMetadataError(error)) {
+        return true;
+      }
+      throw error;
+    }
+  });
+
+  return unreconciledRecords.length > 0 ? { ...task, agentSessions: unreconciledRecords } : null;
+};
+
 const getOrCreateMapSet = <K>(map: Map<K, Set<string>>, key: K): Set<string> => {
   const existing = map.get(key);
   if (existing) {
@@ -92,6 +120,168 @@ const getOrCreateMapSet = <K>(map: Map<K, Set<string>>, key: K): Set<string> => 
   const created = new Set<string>();
   map.set(key, created);
   return created;
+};
+
+const liveAgentSessionMatchKey = (
+  runtimeKind: RuntimeKind,
+  runtimeConnection: AgentRuntimeConnection,
+  workingDirectory: string,
+  externalSessionId: string,
+): string =>
+  `${liveAgentSessionLookupKey(runtimeKind, runtimeConnection, workingDirectory)}::${externalSessionId}`;
+
+const createCancelledReconcilePreloadPlan = ({
+  persistedByTask,
+  preloadedRuntimeLists,
+  preloadedRuntimeConnections,
+  preloadedLiveAgentSessionsByKey = new Map<string, LiveAgentSessionSnapshot[]>(),
+  skippedTaskErrors,
+}: {
+  persistedByTask: ReconcilePreloadPlan["persistedByTask"];
+  preloadedRuntimeLists: Map<RuntimeKind, RuntimeInstanceSummary[]>;
+  preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
+  preloadedLiveAgentSessionsByKey?: Map<string, LiveAgentSessionSnapshot[]>;
+  skippedTaskErrors: Map<string, unknown>;
+}): ReconcilePreloadPlan => ({
+  persistedByTask,
+  reconcileTargets: [],
+  preloadedRuntimeLists,
+  preloadedRuntimeConnections,
+  preloadedLiveAgentSessionsByKey,
+  skippedTaskErrors,
+});
+
+const hasMatchingPreloadedLiveSession = ({
+  record,
+  runtimeKind,
+  runtimeConnections,
+  preloadedLiveSessionKeys,
+}: {
+  record: AgentSessionRecord;
+  runtimeKind: RuntimeKind;
+  runtimeConnections: RuntimeConnectionPreloadIndex;
+  preloadedLiveSessionKeys: Set<string>;
+}): boolean => {
+  const externalSessionId = record.externalSessionId ?? record.sessionId;
+  if (!externalSessionId) {
+    return false;
+  }
+
+  const candidateRuntimeConnections = runtimeConnections.findCandidates(
+    runtimeKind,
+    record.workingDirectory,
+  );
+  return candidateRuntimeConnections.some((runtimeConnection) =>
+    preloadedLiveSessionKeys.has(
+      liveAgentSessionMatchKey(
+        runtimeKind,
+        runtimeConnection,
+        record.workingDirectory,
+        externalSessionId,
+      ),
+    ),
+  );
+};
+
+const buildReconcileTargets = ({
+  persistedByTask,
+  skippedTaskErrors,
+  repoPath,
+  exactResolvableRuntimeConnections,
+  preloadedRuntimeConnections,
+  preloadedLiveSessionKeys,
+}: {
+  persistedByTask: ReconcilePreloadPlan["persistedByTask"];
+  skippedTaskErrors: Map<string, unknown>;
+  repoPath: string;
+  exactResolvableRuntimeConnections: RuntimeConnectionPreloadIndex;
+  preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
+  preloadedLiveSessionKeys: Set<string>;
+}): ReconcileTarget[] => {
+  const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
+
+  return persistedByTask.flatMap<ReconcileTarget>(({ taskId, records }) => {
+    if (skippedTaskErrors.has(taskId)) {
+      return [];
+    }
+
+    const recordsToReconcile = records.filter((record) => {
+      const externalSessionId = record.externalSessionId ?? record.sessionId;
+      if (!externalSessionId) {
+        return false;
+      }
+      if (
+        !canUseWorkspaceRuntimeForHydration(record, repoPath) &&
+        normalizeWorkingDirectory(record.workingDirectory) === normalizedRepoPath
+      ) {
+        return false;
+      }
+
+      const runtimeKind = readPersistedRuntimeKind(record);
+      return (
+        hasMatchingPreloadedLiveSession({
+          record,
+          runtimeKind,
+          runtimeConnections: preloadedRuntimeConnections,
+          preloadedLiveSessionKeys,
+        }) || exactResolvableRuntimeConnections.hasAny(runtimeKind, record.workingDirectory)
+      );
+    });
+
+    return recordsToReconcile.length > 0 ? [{ taskId, records: recordsToReconcile }] : [];
+  });
+};
+
+const isRepoRootWorkspaceRuntime = (
+  runtime: RuntimeInstanceSummary,
+  normalizedRepoPath: string,
+): boolean =>
+  runtime.role === "workspace" &&
+  normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath;
+
+const hasExactNonRepoRootRuntime = (
+  runtimes: RuntimeInstanceSummary[],
+  workingDirectory: string,
+  normalizedRepoPath: string,
+): boolean => {
+  const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+  return runtimes.some(
+    (runtime) =>
+      normalizeWorkingDirectory(runtime.workingDirectory) === normalizedWorkingDirectory &&
+      !isRepoRootWorkspaceRuntime(runtime, normalizedRepoPath),
+  );
+};
+
+const collectRepoRootWorktreeScanDirectories = ({
+  records,
+  runtimeKind,
+  runtimeEntries,
+  repoPathKey,
+}: {
+  records: AgentSessionRecord[];
+  runtimeKind: RuntimeKind;
+  runtimeEntries: RuntimeInstanceSummary[];
+  repoPathKey: string;
+}): string[] => {
+  const directories = new Set<string>();
+
+  for (const record of records) {
+    const externalSessionId = record.externalSessionId ?? record.sessionId;
+    const workingDirectory = normalizeWorkingDirectory(record.workingDirectory);
+    if (
+      !externalSessionId ||
+      !requiresLiveWorktreeRuntime(record) ||
+      workingDirectory === repoPathKey ||
+      readPersistedRuntimeKind(record) !== runtimeKind ||
+      hasExactNonRepoRootRuntime(runtimeEntries, workingDirectory, repoPathKey)
+    ) {
+      continue;
+    }
+
+    directories.add(workingDirectory);
+  }
+
+  return Array.from(directories);
 };
 
 const collectReconcilePreloadMetadata = ({
@@ -106,7 +296,7 @@ const collectReconcilePreloadMetadata = ({
     records: task.agentSessions ?? [],
   }));
 
-  const persistedTaskIdsByLiveSessionKey = new Map<string, Set<string>>();
+  const persistedLiveSessionKeys = new Set<string>();
   const runtimeKinds = new Set<RuntimeKind>();
   const desiredDirectoriesByRuntimeKind = new Map<RuntimeKind, Set<string>>();
   const runtimeKindsAllowedToEnsureRepoRoot = new Set<RuntimeKind>();
@@ -153,7 +343,7 @@ const collectReconcilePreloadMetadata = ({
     }
 
     for (const liveSessionKey of taskLiveSessionKeys) {
-      getOrCreateMapSet(persistedTaskIdsByLiveSessionKey, liveSessionKey).add(taskId);
+      persistedLiveSessionKeys.add(liveSessionKey);
     }
 
     for (const [runtimeKind, workingDirectories] of taskDesiredDirectoriesByRuntimeKind) {
@@ -170,7 +360,7 @@ const collectReconcilePreloadMetadata = ({
 
   return {
     persistedByTask,
-    persistedTaskIdsByLiveSessionKey,
+    persistedLiveSessionKeys,
     runtimeKinds,
     desiredDirectoriesByRuntimeKind,
     runtimeKindsAllowedToEnsureRepoRoot,
@@ -201,7 +391,8 @@ export const createRepoSessionHydrationService = ({
   ) => Promise<RuntimeInstanceSummary>;
 }) => {
   const bootstrappedTasksByRepo: Record<string, Set<string>> = {};
-  const reconciledTasksByRepo: Record<string, Set<string>> = {};
+  const reconciledRecordKeysByRepo: Record<string, Set<string>> = {};
+  const inFlightReconcileTasksByRepo: Record<string, Set<string>> = {};
   const retryAttemptsByKey: Record<string, number> = {};
   const retryTimeoutsByKey: Record<string, ReturnType<typeof setTimeout>> = {};
 
@@ -249,7 +440,7 @@ export const createRepoSessionHydrationService = ({
   }): Promise<ReconcilePreloadPlan> => {
     const {
       persistedByTask,
-      persistedTaskIdsByLiveSessionKey,
+      persistedLiveSessionKeys,
       runtimeKinds,
       desiredDirectoriesByRuntimeKind,
       runtimeKindsAllowedToEnsureRepoRoot,
@@ -257,19 +448,35 @@ export const createRepoSessionHydrationService = ({
     } = collectReconcilePreloadMetadata({ tasks, repoPath });
 
     const runtimeConnections = new Map<string, RuntimeConnectionScan>();
+    const addRuntimeConnectionScan = (
+      runtimeKind: RuntimeKind,
+      runtimeConnection: AgentRuntimeConnection,
+      workingDirectory: string,
+    ): void => {
+      const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
+      const scan = runtimeConnections.get(scanKey) ?? {
+        runtimeKind,
+        runtimeConnection,
+        directories: new Set<string>(),
+        runtimeConnectionsByDirectory: new Map<string, AgentRuntimeConnection>(),
+      };
+      const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+      scan.directories.add(workingDirectory);
+      scan.runtimeConnectionsByDirectory.set(normalizedWorkingDirectory, runtimeConnection);
+      runtimeConnections.set(scanKey, scan);
+    };
     const preloadedRuntimeLists = new Map<RuntimeKind, RuntimeInstanceSummary[]>();
     const preloadedRuntimeConnections = new RuntimeConnectionPreloadIndex();
+    const exactResolvableRuntimeConnections = new RuntimeConnectionPreloadIndex();
     for (const runtimeKind of runtimeKinds) {
       const runtimes = await loadRuntimeListFromQuery(queryClient, runtimeKind, repoPath);
       if (isCancelled()) {
-        return {
+        return createCancelledReconcilePreloadPlan({
           persistedByTask,
-          taskIdsToReconcile: new Set<string>(),
           preloadedRuntimeLists,
           preloadedRuntimeConnections,
-          preloadedLiveAgentSessionsByKey: new Map<string, LiveAgentSessionSnapshot[]>(),
           skippedTaskErrors,
-        };
+        });
       }
 
       const runtimeEntries = [...runtimes];
@@ -288,14 +495,12 @@ export const createRepoSessionHydrationService = ({
         });
         await invalidateRuntimeList(queryClient, runtimeKind, repoPath);
         if (isCancelled()) {
-          return {
+          return createCancelledReconcilePreloadPlan({
             persistedByTask,
-            taskIdsToReconcile: new Set<string>(),
             preloadedRuntimeLists,
             preloadedRuntimeConnections,
-            preloadedLiveAgentSessionsByKey: new Map<string, LiveAgentSessionSnapshot[]>(),
             skippedTaskErrors,
-          };
+          });
         }
         runtimeEntries.push(ensuredRuntime);
       }
@@ -326,11 +531,25 @@ export const createRepoSessionHydrationService = ({
         );
       };
 
+      const repoRootWorktreeScanDirectories = collectRepoRootWorktreeScanDirectories({
+        records: persistedByTask.flatMap(({ taskId, records }) =>
+          skippedTaskErrors.has(taskId) ? [] : records,
+        ),
+        runtimeKind,
+        runtimeEntries,
+        repoPathKey,
+      });
+
       for (const runtime of runtimeEntries) {
         const isRepoRootWorkspaceRuntime =
           runtime.role === "workspace" &&
           normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey;
-        if (!canScanRepoRootWorkspaceRuntime(runtime)) {
+        const canScanRepoRootRuntime = canScanRepoRootWorkspaceRuntime(runtime);
+        if (
+          isRepoRootWorkspaceRuntime &&
+          !canScanRepoRootRuntime &&
+          repoRootWorktreeScanDirectories.length === 0
+        ) {
           continue;
         }
 
@@ -339,48 +558,31 @@ export const createRepoSessionHydrationService = ({
           runtime.workingDirectory,
         );
         if (!isRepoRootWorkspaceRuntime) {
-          preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
-        }
-        if (!desiredDirectories.has(normalizeWorkingDirectory(runtime.workingDirectory))) {
+          if (desiredDirectories.has(normalizeWorkingDirectory(runtime.workingDirectory))) {
+            preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
+            exactResolvableRuntimeConnections.add(runtimeKind, runtimeConnection);
+            addRuntimeConnectionScan(runtimeKind, runtimeConnection, runtime.workingDirectory);
+          }
           continue;
         }
 
-        const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
-        if (!runtimeConnections.has(scanKey)) {
-          runtimeConnections.set(scanKey, {
-            runtimeKind,
-            runtimeConnection,
-            directories: new Set<string>(),
-          });
+        if (desiredDirectories.has(repoPathKey) && canScanRepoRootRuntime) {
+          addRuntimeConnectionScan(runtimeKind, runtimeConnection, runtime.workingDirectory);
         }
-        runtimeConnections.get(scanKey)?.directories.add(runtime.workingDirectory);
-      }
-    }
-
-    const taskIdsToReconcile = new Set<string>();
-    for (const { taskId, records } of persistedByTask) {
-      if (skippedTaskErrors.has(taskId)) {
-        continue;
-      }
-
-      const shouldAttemptReconcile = records.some((record) => {
-        const externalSessionId = record.externalSessionId ?? record.sessionId;
-        if (!externalSessionId) {
-          return false;
+        if (runtime.runtimeRoute.type !== "stdio") {
+          for (const workingDirectory of repoRootWorktreeScanDirectories) {
+            const { runtimeConnection: worktreeRuntimeConnection } = resolveRuntimeRouteConnection(
+              runtime.runtimeRoute,
+              workingDirectory,
+            );
+            addRuntimeConnectionScan(runtimeKind, worktreeRuntimeConnection, workingDirectory);
+          }
         }
-
-        const runtimeKind = readPersistedRuntimeKind(record);
-        return (
-          preloadedRuntimeConnections.hasAny(runtimeKind, record.workingDirectory) ||
-          !canUseWorkspaceRuntimeForHydration(record, repoPath)
-        );
-      });
-      if (shouldAttemptReconcile) {
-        taskIdsToReconcile.add(taskId);
       }
     }
 
     const preloadedLiveAgentSessionsByKey = new Map<string, LiveAgentSessionSnapshot[]>();
+    const preloadedLiveSessionKeys = new Set<string>();
     const runtimeSessionScanCache = new LiveAgentSessionCache(agentEngine);
 
     for (const input of runtimeConnections.values()) {
@@ -390,14 +592,13 @@ export const createRepoSessionHydrationService = ({
         directories: Array.from(input.directories),
       });
       if (isCancelled()) {
-        return {
+        return createCancelledReconcilePreloadPlan({
           persistedByTask,
-          taskIdsToReconcile: new Set<string>(),
           preloadedRuntimeLists,
           preloadedRuntimeConnections,
           preloadedLiveAgentSessionsByKey,
           skippedTaskErrors,
-        };
+        });
       }
 
       const sessionsByWorkingDirectory = new Map<string, LiveAgentSessionSnapshot[]>();
@@ -409,27 +610,49 @@ export const createRepoSessionHydrationService = ({
       }
 
       for (const [workingDirectory, sessionsForDirectory] of sessionsByWorkingDirectory) {
+        const runtimeConnectionForDirectory =
+          input.runtimeConnectionsByDirectory.get(workingDirectory) ?? input.runtimeConnection;
+        preloadedRuntimeConnections.add(input.runtimeKind, runtimeConnectionForDirectory);
         preloadedLiveAgentSessionsByKey.set(
-          liveAgentSessionLookupKey(input.runtimeKind, input.runtimeConnection, workingDirectory),
+          liveAgentSessionLookupKey(
+            input.runtimeKind,
+            runtimeConnectionForDirectory,
+            workingDirectory,
+          ),
           sessionsForDirectory,
         );
       }
 
       for (const runtimeSession of runtimeSessions) {
-        const liveSessionKey = `${input.runtimeKind}::${runtimeSession.externalSessionId}`;
-        const taskIds = persistedTaskIdsByLiveSessionKey.get(liveSessionKey);
-        if (!taskIds) {
-          continue;
-        }
-        for (const taskId of taskIds) {
-          taskIdsToReconcile.add(taskId);
+        const workingDirectory = normalizeWorkingDirectory(runtimeSession.workingDirectory);
+        const runtimeConnectionForDirectory =
+          input.runtimeConnectionsByDirectory.get(workingDirectory) ?? input.runtimeConnection;
+        const liveSessionKey = liveAgentSessionMatchKey(
+          input.runtimeKind,
+          runtimeConnectionForDirectory,
+          workingDirectory,
+          runtimeSession.externalSessionId,
+        );
+        if (
+          persistedLiveSessionKeys.has(`${input.runtimeKind}::${runtimeSession.externalSessionId}`)
+        ) {
+          preloadedLiveSessionKeys.add(liveSessionKey);
         }
       }
     }
 
+    const reconcileTargets = buildReconcileTargets({
+      persistedByTask,
+      skippedTaskErrors,
+      repoPath,
+      exactResolvableRuntimeConnections,
+      preloadedRuntimeConnections,
+      preloadedLiveSessionKeys,
+    });
+
     return {
       persistedByTask,
-      taskIdsToReconcile,
+      reconcileTargets,
       preloadedRuntimeLists,
       preloadedRuntimeConnections,
       preloadedLiveAgentSessionsByKey,
@@ -441,7 +664,8 @@ export const createRepoSessionHydrationService = ({
     resetRepo(repoPath: string): void {
       liveAgentSessionStore.clearRepo(repoPath);
       getOrCreateRepoTaskSet(bootstrappedTasksByRepo, repoPath);
-      getOrCreateRepoTaskSet(reconciledTasksByRepo, repoPath);
+      getOrCreateRepoTaskSet(reconciledRecordKeysByRepo, repoPath).clear();
+      getOrCreateRepoTaskSet(inFlightReconcileTasksByRepo, repoPath).clear();
     },
 
     dispose(): void {
@@ -525,14 +749,25 @@ export const createRepoSessionHydrationService = ({
       isCancelled: () => boolean;
       isCurrentRepo: (repoPath: string) => boolean;
     }): Promise<void> {
-      const reconciledTaskIds = getOrCreateRepoTaskSet(reconciledTasksByRepo, repoPath);
-      const pendingTasks = tasks.filter((task) => !reconciledTaskIds.has(task.id));
+      const reconciledRecordKeys = getOrCreateRepoTaskSet(reconciledRecordKeysByRepo, repoPath);
+      const inFlightReconcileTasks = getOrCreateRepoTaskSet(inFlightReconcileTasksByRepo, repoPath);
+      const pendingTasks = tasks.flatMap((task) => {
+        if (inFlightReconcileTasks.has(task.id)) {
+          return [];
+        }
+
+        const taskWithUnreconciledRecords = toTaskWithUnreconciledRecords(
+          task,
+          reconciledRecordKeys,
+        );
+        return taskWithUnreconciledRecords ? [taskWithUnreconciledRecords] : [];
+      });
       if (pendingTasks.length === 0) {
         return;
       }
 
       for (const task of pendingTasks) {
-        reconciledTaskIds.add(task.id);
+        inFlightReconcileTasks.add(task.id);
       }
 
       try {
@@ -547,10 +782,9 @@ export const createRepoSessionHydrationService = ({
 
         liveAgentSessionStore.replaceRepoSnapshots(repoPath, plan.preloadedLiveAgentSessionsByKey);
 
-        if (plan.taskIdsToReconcile.size === 0) {
+        if (plan.reconcileTargets.length === 0) {
           for (const { taskId } of plan.persistedByTask) {
             if (plan.skippedTaskErrors.has(taskId)) {
-              reconciledTaskIds.delete(taskId);
               clearRetry("reconcile", repoPath, taskId);
               continue;
             }
@@ -559,11 +793,8 @@ export const createRepoSessionHydrationService = ({
           return;
         }
 
-        const reconcileTaskIds = Array.from(plan.taskIdsToReconcile);
         const results = await Promise.allSettled(
-          reconcileTaskIds.map(async (taskId) => {
-            const records =
-              plan.persistedByTask.find((entry) => entry.taskId === taskId)?.records ?? [];
+          plan.reconcileTargets.map(async ({ taskId, records }) => {
             await sessionHydration.reconcileLiveTaskSessions({
               taskId,
               persistedRecords: records,
@@ -572,7 +803,7 @@ export const createRepoSessionHydrationService = ({
               preloadedLiveAgentSessionsByKey: plan.preloadedLiveAgentSessionsByKey,
               allowRuntimeEnsure: false,
             });
-            return taskId;
+            return { taskId, records };
           }),
         );
         if (isCancelled()) {
@@ -582,9 +813,12 @@ export const createRepoSessionHydrationService = ({
         const failedTaskErrors = new Map<string, unknown>();
         for (const [index, result] of results.entries()) {
           if (result.status === "fulfilled") {
+            for (const record of result.value.records) {
+              reconciledRecordKeys.add(persistedSessionRecordKey(result.value.taskId, record));
+            }
             continue;
           }
-          const taskId = reconcileTaskIds[index];
+          const taskId = plan.reconcileTargets[index]?.taskId;
           if (taskId) {
             failedTaskErrors.set(taskId, result.reason);
           }
@@ -592,7 +826,6 @@ export const createRepoSessionHydrationService = ({
 
         for (const { taskId } of plan.persistedByTask) {
           if (plan.skippedTaskErrors.has(taskId)) {
-            reconciledTaskIds.delete(taskId);
             clearRetry("reconcile", repoPath, taskId);
             continue;
           }
@@ -603,7 +836,6 @@ export const createRepoSessionHydrationService = ({
         }
 
         for (const [taskId, error] of failedTaskErrors) {
-          reconciledTasksByRepo[repoPath]?.delete(taskId);
           scheduleRetry("reconcile", repoPath, taskId, error);
         }
       } catch (error) {
@@ -611,8 +843,11 @@ export const createRepoSessionHydrationService = ({
           return;
         }
         for (const task of pendingTasks) {
-          reconciledTasksByRepo[repoPath]?.delete(task.id);
           scheduleRetry("reconcile", repoPath, task.id, error);
+        }
+      } finally {
+        for (const task of pendingTasks) {
+          inFlightReconcileTasks.delete(task.id);
         }
       }
     },

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -48,6 +48,7 @@ type ReconcileTarget = {
 type ReconcilePreloadPlan = {
   persistedByTask: Array<{ taskId: string; records: AgentSessionRecord[] }>;
   reconcileTargets: ReconcileTarget[];
+  retryableUnmatchedTaskIds: Set<string>;
   preloadedRuntimeLists: Map<RuntimeKind, RuntimeInstanceSummary[]>;
   preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedLiveAgentSessionsByKey: Map<string, LiveAgentSessionSnapshot[]>;
@@ -77,7 +78,7 @@ const invalidateRuntimeList = async (
   });
 };
 
-const getOrCreateRepoTaskSet = (
+const getOrCreateRepoStringSet = (
   store: Record<string, Set<string>>,
   repoPath: string,
 ): Set<string> => {
@@ -90,8 +91,21 @@ const getOrCreateRepoTaskSet = (
   return created;
 };
 
+const tupleKey = (parts: string[]): string => JSON.stringify(parts);
+
 const persistedSessionRecordKey = (taskId: string, record: AgentSessionRecord): string =>
-  `${taskId}::${readPersistedRuntimeKind(record)}::${record.sessionId}::${record.externalSessionId ?? record.sessionId}::${normalizeWorkingDirectory(record.workingDirectory)}`;
+  tupleKey([
+    taskId,
+    readPersistedRuntimeKind(record),
+    record.sessionId,
+    record.externalSessionId ?? record.sessionId,
+    normalizeWorkingDirectory(record.workingDirectory),
+  ]);
+
+const createRetryableUnmatchedReconcileError = (taskId: string, repoPath: string): Error =>
+  new Error(
+    `No matching live agent session was found for task '${taskId}' in repo '${repoPath}' after scanning a compatible runtime.`,
+  );
 
 const toTaskWithUnreconciledRecords = (
   task: TaskCard,
@@ -145,6 +159,7 @@ const createCancelledReconcilePreloadPlan = ({
 }): ReconcilePreloadPlan => ({
   persistedByTask,
   reconcileTargets: [],
+  retryableUnmatchedTaskIds: new Set<string>(),
   preloadedRuntimeLists,
   preloadedRuntimeConnections,
   preloadedLiveAgentSessionsByKey,
@@ -189,6 +204,7 @@ const buildReconcileTargets = ({
   repoPath,
   exactResolvableRuntimeConnections,
   preloadedRuntimeConnections,
+  scannedRuntimeConnections,
   preloadedLiveSessionKeys,
 }: {
   persistedByTask: ReconcilePreloadPlan["persistedByTask"];
@@ -196,11 +212,13 @@ const buildReconcileTargets = ({
   repoPath: string;
   exactResolvableRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
+  scannedRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedLiveSessionKeys: Set<string>;
-}): ReconcileTarget[] => {
+}): { reconcileTargets: ReconcileTarget[]; retryableUnmatchedTaskIds: Set<string> } => {
   const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
+  const retryableUnmatchedTaskIds = new Set<string>();
 
-  return persistedByTask.flatMap<ReconcileTarget>(({ taskId, records }) => {
+  const reconcileTargets = persistedByTask.flatMap<ReconcileTarget>(({ taskId, records }) => {
     if (skippedTaskErrors.has(taskId)) {
       return [];
     }
@@ -218,18 +236,27 @@ const buildReconcileTargets = ({
       }
 
       const runtimeKind = readPersistedRuntimeKind(record);
-      return (
+      const canReconcile =
         hasMatchingPreloadedLiveSession({
           record,
           runtimeKind,
           runtimeConnections: preloadedRuntimeConnections,
           preloadedLiveSessionKeys,
-        }) || exactResolvableRuntimeConnections.hasAny(runtimeKind, record.workingDirectory)
-      );
+        }) || exactResolvableRuntimeConnections.hasAny(runtimeKind, record.workingDirectory);
+      if (canReconcile) {
+        return true;
+      }
+
+      if (scannedRuntimeConnections.hasAny(runtimeKind, record.workingDirectory)) {
+        retryableUnmatchedTaskIds.add(taskId);
+      }
+      return false;
     });
 
     return recordsToReconcile.length > 0 ? [{ taskId, records: recordsToReconcile }] : [];
   });
+
+  return { reconcileTargets, retryableUnmatchedTaskIds };
 };
 
 const isRepoRootWorkspaceRuntime = (
@@ -317,7 +344,7 @@ const collectReconcilePreloadMetadata = ({
         }
 
         taskRuntimeKinds.add(runtimeKind);
-        taskLiveSessionKeys.add(`${runtimeKind}::${externalSessionId}`);
+        taskLiveSessionKeys.add(tupleKey([runtimeKind, externalSessionId]));
         getOrCreateMapSet(taskDesiredDirectoriesByRuntimeKind, runtimeKind).add(
           normalizeWorkingDirectory(record.workingDirectory),
         );
@@ -448,6 +475,7 @@ export const createRepoSessionHydrationService = ({
     } = collectReconcilePreloadMetadata({ tasks, repoPath });
 
     const runtimeConnections = new Map<string, RuntimeConnectionScan>();
+    const scannedRuntimeConnections = new RuntimeConnectionPreloadIndex();
     const addRuntimeConnectionScan = (
       runtimeKind: RuntimeKind,
       runtimeConnection: AgentRuntimeConnection,
@@ -461,9 +489,10 @@ export const createRepoSessionHydrationService = ({
         runtimeConnectionsByDirectory: new Map<string, AgentRuntimeConnection>(),
       };
       const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
-      scan.directories.add(workingDirectory);
+      scan.directories.add(normalizedWorkingDirectory);
       scan.runtimeConnectionsByDirectory.set(normalizedWorkingDirectory, runtimeConnection);
       runtimeConnections.set(scanKey, scan);
+      scannedRuntimeConnections.add(runtimeKind, runtimeConnection);
     };
     const preloadedRuntimeLists = new Map<RuntimeKind, RuntimeInstanceSummary[]>();
     const preloadedRuntimeConnections = new RuntimeConnectionPreloadIndex();
@@ -634,25 +663,29 @@ export const createRepoSessionHydrationService = ({
           runtimeSession.externalSessionId,
         );
         if (
-          persistedLiveSessionKeys.has(`${input.runtimeKind}::${runtimeSession.externalSessionId}`)
+          persistedLiveSessionKeys.has(
+            tupleKey([input.runtimeKind, runtimeSession.externalSessionId]),
+          )
         ) {
           preloadedLiveSessionKeys.add(liveSessionKey);
         }
       }
     }
 
-    const reconcileTargets = buildReconcileTargets({
+    const { reconcileTargets, retryableUnmatchedTaskIds } = buildReconcileTargets({
       persistedByTask,
       skippedTaskErrors,
       repoPath,
       exactResolvableRuntimeConnections,
       preloadedRuntimeConnections,
+      scannedRuntimeConnections,
       preloadedLiveSessionKeys,
     });
 
     return {
       persistedByTask,
       reconcileTargets,
+      retryableUnmatchedTaskIds,
       preloadedRuntimeLists,
       preloadedRuntimeConnections,
       preloadedLiveAgentSessionsByKey,
@@ -663,9 +696,9 @@ export const createRepoSessionHydrationService = ({
   return {
     resetRepo(repoPath: string): void {
       liveAgentSessionStore.clearRepo(repoPath);
-      getOrCreateRepoTaskSet(bootstrappedTasksByRepo, repoPath);
-      getOrCreateRepoTaskSet(reconciledRecordKeysByRepo, repoPath).clear();
-      getOrCreateRepoTaskSet(inFlightReconcileTasksByRepo, repoPath).clear();
+      getOrCreateRepoStringSet(bootstrappedTasksByRepo, repoPath);
+      getOrCreateRepoStringSet(reconciledRecordKeysByRepo, repoPath).clear();
+      getOrCreateRepoStringSet(inFlightReconcileTasksByRepo, repoPath).clear();
     },
 
     dispose(): void {
@@ -691,7 +724,7 @@ export const createRepoSessionHydrationService = ({
       isCancelled: () => boolean;
       isCurrentRepo: (repoPath: string) => boolean;
     }): Promise<void> {
-      const bootstrappedTasks = getOrCreateRepoTaskSet(bootstrappedTasksByRepo, repoPath);
+      const bootstrappedTasks = getOrCreateRepoStringSet(bootstrappedTasksByRepo, repoPath);
       const pendingTasks = tasks.filter((task) => !bootstrappedTasks.has(task.id));
       if (pendingTasks.length === 0) {
         return;
@@ -749,8 +782,11 @@ export const createRepoSessionHydrationService = ({
       isCancelled: () => boolean;
       isCurrentRepo: (repoPath: string) => boolean;
     }): Promise<void> {
-      const reconciledRecordKeys = getOrCreateRepoTaskSet(reconciledRecordKeysByRepo, repoPath);
-      const inFlightReconcileTasks = getOrCreateRepoTaskSet(inFlightReconcileTasksByRepo, repoPath);
+      const reconciledRecordKeys = getOrCreateRepoStringSet(reconciledRecordKeysByRepo, repoPath);
+      const inFlightReconcileTasks = getOrCreateRepoStringSet(
+        inFlightReconcileTasksByRepo,
+        repoPath,
+      );
       const pendingTasks = tasks.flatMap((task) => {
         if (inFlightReconcileTasks.has(task.id)) {
           return [];
@@ -786,6 +822,15 @@ export const createRepoSessionHydrationService = ({
           for (const { taskId } of plan.persistedByTask) {
             if (plan.skippedTaskErrors.has(taskId)) {
               clearRetry("reconcile", repoPath, taskId);
+              continue;
+            }
+            if (plan.retryableUnmatchedTaskIds.has(taskId)) {
+              scheduleRetry(
+                "reconcile",
+                repoPath,
+                taskId,
+                createRetryableUnmatchedReconcileError(taskId, repoPath),
+              );
               continue;
             }
             clearRetry("reconcile", repoPath, taskId);
@@ -830,6 +875,15 @@ export const createRepoSessionHydrationService = ({
             continue;
           }
           if (failedTaskErrors.has(taskId)) {
+            continue;
+          }
+          if (plan.retryableUnmatchedTaskIds.has(taskId)) {
+            scheduleRetry(
+              "reconcile",
+              repoPath,
+              taskId,
+              createRetryableUnmatchedReconcileError(taskId, repoPath),
+            );
             continue;
           }
           clearRetry("reconcile", repoPath, taskId);


### PR DESCRIPTION
## Summary
- Stops Agent Studio session reconciliation from permanently skipping unresolved persisted sessions after a partial load.
- Keeps Agent Studio tab/role switches responsive while avoiding a blank flicker when the target transcript is already available.
- Adds focused regression coverage for both session reconciliation and chat thread switch behavior.

## Goal
This PR fixes two related Agent Studio responsiveness issues. First, persisted session reconciliation could mark a task as processed before all matching sessions were available, causing later polling passes to skip sessions that still needed hydration. Second, making session switches feel immediate initially cleared the chat every time, which caused an unnecessary flicker when switching to an idle session whose transcript was already loaded in memory.

The intended behavior is that Agent Studio keeps loading missing session data asynchronously without blocking navigation, while already-ready transcripts render directly during tab or role switches.

## Technical Choices
- Reworked session reconciliation tracking to operate on stable record-level targets instead of task-level skip state, so partially resolved tasks can continue polling only for the missing records.
- Matched live sessions with a runtime-aware key that includes runtime kind, runtime connection, working directory, and external session id, avoiding accidental cross-runtime matches.
- Threaded `isViewSessionHistoryHydrated` through the Agent Studio page model into the chat surface and thread context.
- Updated the chat thread clearing rule to blank the transcript only when the selected task/session cannot render yet, while directly displaying already-hydrated target sessions to avoid flicker.
- Added focused tests for partial reconciliation, hydrated session switches, and unready session switches.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session history hydration tracking to improve session switching behavior and prevent UI flicker when navigating between pre-loaded sessions.

* **Bug Fixes**
  * Improved session reconciliation logic to reduce unnecessary retries and correctly filter persisted sessions against live runtimes, ensuring more reliable session recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->