### PR TITLE
fix(frontend): route-hydrate worktree sessions

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-runtime-attachment-retry.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-runtime-attachment-retry.ts
@@ -218,5 +218,5 @@ export function useAgentChatRuntimeAttachmentRetry({
 export const refreshRuntimeAttachmentSources = async (
   refetchRuntimeLists: Array<() => Promise<unknown>>,
 ): Promise<void> => {
-  await Promise.all(refetchRuntimeLists.map((refetch) => refetch()));
+  await Promise.all(Array.from(new Set(refetchRuntimeLists)).map((refetch) => refetch()));
 };

--- a/packages/frontend/src/pages/agents/use-agent-studio-runtime-attachment-retry.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-runtime-attachment-retry.test.ts
@@ -161,4 +161,12 @@ describe("selectRuntimeAttachmentCandidates", () => {
 
     expect(refetchRuntimeList).toHaveBeenCalledTimes(1);
   });
+
+  test("deduplicates shared runtime list refetchers", async () => {
+    const refetchRuntimeList = mock(async () => []);
+
+    await refreshRuntimeAttachmentSources([refetchRuntimeList, refetchRuntimeList]);
+
+    expect(refetchRuntimeList).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/frontend/src/pages/agents/use-agent-studio-runtime-attachment-retry.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-runtime-attachment-retry.ts
@@ -203,5 +203,5 @@ export function useAgentStudioRuntimeAttachmentRetry({
 export const refreshRuntimeAttachmentSources = async (
   refetchRuntimeLists: Array<() => Promise<unknown>>,
 ): Promise<void> => {
-  await Promise.all(refetchRuntimeLists.map((refetch) => refetch()));
+  await Promise.all(Array.from(new Set(refetchRuntimeLists)).map((refetch) => refetch()));
 };

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -345,6 +345,43 @@ describe("createHydrationRuntimeResolver", () => {
     expect(ensureCalls).toBe(0);
   });
 
+  test("uses a single preloaded runtime connection when preloaded snapshots do not match the record", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const preloadedRuntimeConnection: AgentRuntimeConnection = {
+      type: "local_http",
+      endpoint: "http://127.0.0.1:9999",
+      workingDirectory,
+    };
+    const preloadedRuntimeConnections = createPreloadIndex([preloadedRuntimeConnection]);
+    const preloadedLiveAgentSessionsByKey = new Map([
+      [
+        liveAgentSessionLookupKey("opencode", preloadedRuntimeConnection, workingDirectory),
+        [
+          createLiveAgentSessionSnapshotFixture({
+            externalSessionId: "other-external-session",
+            workingDirectory,
+          }),
+        ],
+      ],
+    ]);
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      preloadedRuntimeConnections,
+      preloadedLiveAgentSessionsByKey,
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("build", workingDirectory));
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeId).toBeNull();
+    expect(result.runtimeConnection).toEqual(preloadedRuntimeConnection);
+  });
+
   test("preserves stdio preloaded runtime connections during hydration fallback", async () => {
     const workingDirectory = "/tmp/repo";
     const preloadedRuntimeConnection: AgentRuntimeConnection = {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -256,7 +256,6 @@ export const createHydrationRuntimeResolver = ({
       if (snapshotMatch.runtimeConnection) {
         return { ok: true, runtimeConnection: snapshotMatch.runtimeConnection };
       }
-      return { ok: true, runtimeConnection: null };
     }
 
     if (candidatesByTransportKey.size > 1) {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -2035,6 +2035,80 @@ describe("load-sessions-stages", () => {
     });
   });
 
+  test("runtime planner records cached route-only snapshots without re-scanning", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const runtimeConnection = {
+      type: "local_http" as const,
+      endpoint: "http://127.0.0.1:4444",
+      workingDirectory,
+    };
+    const preloadedLiveAgentSessionsByKey = new Map([
+      [liveAgentSessionLookupKey("opencode", runtimeConnection, workingDirectory), []],
+    ]);
+    const preloadedRuntimeConnections = new RuntimeConnectionPreloadIndex();
+    const snapshotRequests: Array<{ directories?: string[] }> = [];
+
+    const planner = await createRuntimeResolutionPlannerStage({
+      intent: createIntent({
+        mode: "recover_runtime_attachment",
+        requestedSessionId: "session-1",
+        shouldReconcileLiveSessions: true,
+        historyPolicy: "none",
+      }),
+      options: {
+        preloadedRuntimeLists: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+          ["opencode", [createRuntime("/tmp/repo")]],
+        ]),
+        preloadedRuntimeConnections,
+        preloadedLiveAgentSessionsByKey,
+        allowRuntimeEnsure: false,
+      },
+      adapter: {
+        hasSession: () => false,
+        loadSessionHistory: async () => [],
+        attachSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+        resumeSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+        listLiveAgentSessionSnapshots: async (input) => {
+          snapshotRequests.push(input.directories ? { directories: input.directories } : {});
+          return [];
+        },
+      },
+      sessionsRef: createStateHarness({}).sessionsRef,
+      recordsToHydrate: [createRecord({ workingDirectory })],
+      historyHydrationSessionIds: new Set(),
+    });
+
+    const resolution = await planner.resolveHydrationRuntime(createRecord({ workingDirectory }));
+
+    expect(snapshotRequests).toEqual([]);
+    expect(preloadedRuntimeConnections.findCandidates("opencode", workingDirectory)).toEqual([
+      runtimeConnection,
+    ]);
+    expect(resolution).toEqual({
+      ok: true,
+      runtimeKind: "opencode",
+      runtimeId: null,
+      runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+      runtimeConnection,
+    });
+  });
+
   test("runtime planner does not route-hydrate inactive worktree sessions through repo-root stdio runtimes", async () => {
     const workingDirectory = "/tmp/repo/worktree";
     const snapshotRequests: Array<{ directories?: string[] }> = [];

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -1971,6 +1971,128 @@ describe("load-sessions-stages", () => {
     expect(snapshotLoads).toBe(0);
   });
 
+  test("runtime planner route-hydrates inactive worktree sessions through a verified repo-root HTTP runtime", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const snapshotRequests: Array<{ directories?: string[] }> = [];
+
+    const planner = await createRuntimeResolutionPlannerStage({
+      intent: createIntent({
+        mode: "recover_runtime_attachment",
+        requestedSessionId: "session-1",
+        shouldReconcileLiveSessions: true,
+        historyPolicy: "none",
+      }),
+      options: {
+        preloadedRuntimeLists: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+          ["opencode", [createRuntime("/tmp/repo")]],
+        ]),
+        allowRuntimeEnsure: false,
+      },
+      adapter: {
+        hasSession: () => false,
+        loadSessionHistory: async () => [],
+        attachSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+        resumeSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+        listLiveAgentSessionSnapshots: async (input) => {
+          snapshotRequests.push(input.directories ? { directories: input.directories } : {});
+          return [];
+        },
+      },
+      sessionsRef: createStateHarness({}).sessionsRef,
+      recordsToHydrate: [createRecord({ workingDirectory })],
+      historyHydrationSessionIds: new Set(),
+    });
+
+    const resolution = await planner.resolveHydrationRuntime(createRecord({ workingDirectory }));
+
+    expect(snapshotRequests).toEqual([{ directories: [workingDirectory] }]);
+    expect(resolution).toEqual({
+      ok: true,
+      runtimeKind: "opencode",
+      runtimeId: null,
+      runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+      runtimeConnection: {
+        type: "local_http",
+        endpoint: "http://127.0.0.1:4444",
+        workingDirectory,
+      },
+    });
+  });
+
+  test("runtime planner does not route-hydrate inactive worktree sessions through repo-root stdio runtimes", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const snapshotRequests: Array<{ directories?: string[] }> = [];
+
+    const planner = await createRuntimeResolutionPlannerStage({
+      intent: createIntent({
+        mode: "recover_runtime_attachment",
+        requestedSessionId: "session-1",
+        shouldReconcileLiveSessions: true,
+        historyPolicy: "none",
+      }),
+      options: {
+        preloadedRuntimeLists: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+          ["opencode", [createStdioRuntime("runtime-stdio-root", "/tmp/repo")]],
+        ]),
+        allowRuntimeEnsure: false,
+      },
+      adapter: {
+        hasSession: () => false,
+        loadSessionHistory: async () => [],
+        attachSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+        resumeSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+        listLiveAgentSessionSnapshots: async (input) => {
+          snapshotRequests.push(input.directories ? { directories: input.directories } : {});
+          return [];
+        },
+      },
+      sessionsRef: createStateHarness({}).sessionsRef,
+      recordsToHydrate: [createRecord({ workingDirectory })],
+      historyHydrationSessionIds: new Set(),
+    });
+
+    const resolution = await planner.resolveHydrationRuntime(createRecord({ workingDirectory }));
+
+    expect(snapshotRequests).toEqual([]);
+    expect(resolution).toEqual({
+      ok: false,
+      runtimeKind: "opencode",
+      reason: "No live runtime found for working directory /tmp/repo/worktree.",
+    });
+  });
+
   test("runtime planner reads preloaded live snapshots without a scan adapter", async () => {
     const workingDirectory = "/tmp/repo/worktree";
     const runtimeConnection = {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -270,10 +270,16 @@ const preloadRouteProbedRepoRootRuntimeConnectionsForWorktreeSessions = async ({
           runtimeConnection,
           workingDirectory: target.workingDirectory,
         });
-        if (
-          preloadedRuntimeConnections.hasAny(runtimeKind, target.workingDirectory) &&
-          preloadedLiveAgentSessionsByKey.has(lookupKey)
-        ) {
+        const cachedLiveSessionsForDirectory = preloadedLiveAgentSessionsByKey.get(lookupKey);
+        if (cachedLiveSessionsForDirectory) {
+          recordRouteOnlyHydrationPreload({
+            runtimeKind,
+            runtimeConnection,
+            workingDirectory: target.workingDirectory,
+            preloadedRuntimeConnections,
+            preloadedLiveAgentSessionsByKey,
+            liveSessionsForDirectory: cachedLiveSessionsForDirectory,
+          });
           continue;
         }
         const result = await scanRouteOnlyHydrationDirectory({

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -5,11 +5,7 @@ import type {
   RuntimeKind,
   TaskCard,
 } from "@openducktor/contracts";
-import type {
-  AgentEnginePort,
-  AgentRuntimeConnection,
-  LiveAgentSessionSnapshot,
-} from "@openducktor/core";
+import type { AgentEnginePort, LiveAgentSessionSnapshot } from "@openducktor/core";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { errorMessage } from "@/lib/errors";
 import { appQueryClient } from "@/lib/query-client";
@@ -57,13 +53,17 @@ import {
   createHydrationRuntimeResolver,
   type ResolvedHydrationRuntime,
 } from "./hydration-runtime-resolution";
-import {
-  LiveAgentSessionCache,
-  liveAgentSessionLookupKey,
-  RuntimeConnectionPreloadIndex,
-} from "./live-agent-session-cache";
+import { LiveAgentSessionCache, RuntimeConnectionPreloadIndex } from "./live-agent-session-cache";
 import type { LiveAgentSessionStore } from "./live-agent-session-store";
 import { createReattachLiveSession } from "./reattach-live-session";
+import {
+  canUseRuntimeForRouteOnlyHydration,
+  createRouteOnlyHydrationLookupKey,
+  createRouteOnlyHydrationRuntimeConnection,
+  hasExactNonRepoRootRuntime,
+  recordRouteOnlyHydrationPreload,
+  scanRouteOnlyHydrationDirectory,
+} from "./route-only-hydration";
 
 export type UpdateSession = (
   sessionId: string,
@@ -183,51 +183,26 @@ const INITIAL_SESSION_HISTORY_LIMIT = 600;
 const SESSION_HISTORY_HYDRATION_CONCURRENCY = 3;
 const EMPTY_PROMPT_OVERRIDES: RepoPromptOverrides = {};
 
-type VerifiedWorktreeRuntimeTarget = {
+type RouteProbedWorktreeRuntimeTarget = {
   workingDirectory: string;
-  externalSessionIds: Set<string>;
 };
 
-const isRepoRootWorkspaceRuntime = (
-  runtime: RuntimeInstanceSummary,
-  normalizedRepoPath: string,
-): boolean =>
-  runtime.role === "workspace" &&
-  normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath;
-
-const hasExactNonRepoRootWorkspaceRuntime = ({
-  runtimes,
-  workingDirectory,
-  normalizedRepoPath,
-}: {
-  runtimes: RuntimeInstanceSummary[];
-  workingDirectory: string;
-  normalizedRepoPath: string;
-}): boolean => {
-  const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
-  return runtimes.some(
-    (runtime) =>
-      normalizeWorkingDirectory(runtime.workingDirectory) === normalizedWorkingDirectory &&
-      !isRepoRootWorkspaceRuntime(runtime, normalizedRepoPath),
-  );
-};
-
-const getOrCreateVerifiedWorktreeRuntimeTarget = (
-  targetsByWorkingDirectory: Map<string, VerifiedWorktreeRuntimeTarget>,
+const getOrCreateRouteProbedWorktreeRuntimeTarget = (
+  targetsByWorkingDirectory: Map<string, RouteProbedWorktreeRuntimeTarget>,
   workingDirectory: string,
-): VerifiedWorktreeRuntimeTarget => {
+): RouteProbedWorktreeRuntimeTarget => {
   const key = normalizeWorkingDirectory(workingDirectory);
   const existing = targetsByWorkingDirectory.get(key);
   if (existing) {
     return existing;
   }
 
-  const created = { workingDirectory: key, externalSessionIds: new Set<string>() };
+  const created = { workingDirectory: key };
   targetsByWorkingDirectory.set(key, created);
   return created;
 };
 
-const preloadVerifiedRepoRootRuntimeConnectionsForWorktreeSessions = async ({
+const preloadRouteProbedRepoRootRuntimeConnectionsForWorktreeSessions = async ({
   adapter,
   records,
   repoPath,
@@ -247,7 +222,10 @@ const preloadVerifiedRepoRootRuntimeConnectionsForWorktreeSessions = async ({
   }
 
   const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
-  const targetsByRuntimeKind = new Map<RuntimeKind, Map<string, VerifiedWorktreeRuntimeTarget>>();
+  const targetsByRuntimeKind = new Map<
+    RuntimeKind,
+    Map<string, RouteProbedWorktreeRuntimeTarget>
+  >();
   for (const record of records) {
     const externalSessionId = record.externalSessionId ?? record.sessionId;
     const normalizedWorkingDirectory = normalizeWorkingDirectory(record.workingDirectory);
@@ -262,56 +240,60 @@ const preloadVerifiedRepoRootRuntimeConnectionsForWorktreeSessions = async ({
     const runtimeKind = readPersistedRuntimeKind(record);
     const runtimes = runtimesByKind.get(runtimeKind) ?? [];
     if (
-      hasExactNonRepoRootWorkspaceRuntime({
+      hasExactNonRepoRootRuntime({
         runtimes,
         workingDirectory: record.workingDirectory,
-        normalizedRepoPath,
+        repoPath,
       })
     ) {
       continue;
     }
 
     const targetsByWorkingDirectory =
-      targetsByRuntimeKind.get(runtimeKind) ?? new Map<string, VerifiedWorktreeRuntimeTarget>();
-    const target = getOrCreateVerifiedWorktreeRuntimeTarget(
-      targetsByWorkingDirectory,
-      record.workingDirectory,
-    );
-    target.externalSessionIds.add(externalSessionId);
+      targetsByRuntimeKind.get(runtimeKind) ?? new Map<string, RouteProbedWorktreeRuntimeTarget>();
+    getOrCreateRouteProbedWorktreeRuntimeTarget(targetsByWorkingDirectory, record.workingDirectory);
     targetsByRuntimeKind.set(runtimeKind, targetsByWorkingDirectory);
   }
 
   for (const [runtimeKind, targetsByWorkingDirectory] of targetsByRuntimeKind) {
     const repoRootWorkspaceRuntimes = (runtimesByKind.get(runtimeKind) ?? []).filter((runtime) =>
-      isRepoRootWorkspaceRuntime(runtime, normalizedRepoPath),
+      canUseRuntimeForRouteOnlyHydration(runtime, normalizedRepoPath),
     );
     for (const runtime of repoRootWorkspaceRuntimes) {
       for (const target of targetsByWorkingDirectory.values()) {
-        const runtimeConnection: AgentRuntimeConnection = runtimeRouteToConnection(
-          runtime.runtimeRoute,
+        const runtimeConnection = createRouteOnlyHydrationRuntimeConnection(
+          runtime,
           target.workingDirectory,
         );
-        const liveSessions = await adapter.listLiveAgentSessionSnapshots({
+        const lookupKey = createRouteOnlyHydrationLookupKey({
           runtimeKind,
           runtimeConnection,
-          directories: [target.workingDirectory],
+          workingDirectory: target.workingDirectory,
         });
-        const liveSessionsForDirectory = liveSessions.filter(
-          (session) =>
-            normalizeWorkingDirectory(session.workingDirectory) === target.workingDirectory,
-        );
-        const hasMatchingSession = liveSessionsForDirectory.some((session) =>
-          target.externalSessionIds.has(session.externalSessionId),
-        );
-        if (!hasMatchingSession) {
+        if (
+          preloadedRuntimeConnections.hasAny(runtimeKind, target.workingDirectory) &&
+          preloadedLiveAgentSessionsByKey.has(lookupKey)
+        ) {
           continue;
         }
-
-        preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
-        preloadedLiveAgentSessionsByKey.set(
-          liveAgentSessionLookupKey(runtimeKind, runtimeConnection, target.workingDirectory),
-          liveSessionsForDirectory,
-        );
+        const result = await scanRouteOnlyHydrationDirectory({
+          scanner: { listLiveAgentSessionSnapshots: adapter.listLiveAgentSessionSnapshots },
+          runtimeKind,
+          runtime,
+          repoPath,
+          workingDirectory: target.workingDirectory,
+        });
+        if (!result) {
+          continue;
+        }
+        recordRouteOnlyHydrationPreload({
+          runtimeKind,
+          runtimeConnection: result.runtimeConnection,
+          workingDirectory: target.workingDirectory,
+          preloadedRuntimeConnections,
+          preloadedLiveAgentSessionsByKey,
+          liveSessionsForDirectory: result.liveSessionsForDirectory,
+        });
       }
     }
   }
@@ -675,7 +657,7 @@ export const createRuntimeResolutionPlannerStage = async ({
   const preloadedLiveAgentSessionsByKey =
     options?.preloadedLiveAgentSessionsByKey ?? new Map<string, LiveAgentSessionSnapshot[]>();
 
-  await preloadVerifiedRepoRootRuntimeConnectionsForWorktreeSessions({
+  await preloadRouteProbedRepoRootRuntimeConnectionsForWorktreeSessions({
     adapter,
     records: recordsNeedingRuntimeResolution,
     repoPath: intent.repoPath,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -1105,7 +1105,7 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(sessionMessagesToArray(getSession(state, "session-1"))).toEqual([]);
   });
 
-  test("does not reuse a verified repo-root worktree recovery for another external session", async () => {
+  test("route-hydrates unmatched records after probing a repo-root worktree route", async () => {
     const firstRecord = persistedSessionRecord({
       runtimeKind: "opencode",
       sessionId: "session-1",
@@ -1177,40 +1177,47 @@ describe("agent-orchestrator-load-sessions", () => {
       loadRepoPromptOverrides: async () => ({}),
     });
 
-    await expect(
-      loadAgentSessions("task-1", {
-        mode: "reconcile_live",
-        historyPolicy: "none",
-        persistedRecords: [firstRecord, secondRecord],
-        preloadedRuntimeLists: new Map([
+    await loadAgentSessions("task-1", {
+      mode: "reconcile_live",
+      historyPolicy: "none",
+      persistedRecords: [firstRecord, secondRecord],
+      preloadedRuntimeLists: new Map([
+        [
+          "opencode",
           [
-            "opencode",
-            [
-              {
-                kind: "opencode",
-                runtimeId: "runtime-root",
-                repoPath: "/tmp/repo",
-                taskId: null,
-                role: "workspace",
-                workingDirectory: "/tmp/repo",
-                runtimeRoute: {
-                  type: "local_http",
-                  endpoint: "http://127.0.0.1:4444",
-                },
-                startedAt: "2026-02-22T08:00:00.000Z",
-                descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+            {
+              kind: "opencode",
+              runtimeId: "runtime-root",
+              repoPath: "/tmp/repo",
+              taskId: null,
+              role: "workspace",
+              workingDirectory: "/tmp/repo",
+              runtimeRoute: {
+                type: "local_http",
+                endpoint: "http://127.0.0.1:4444",
               },
-            ],
+              startedAt: "2026-02-22T08:00:00.000Z",
+              descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+            },
           ],
-        ]),
-      }),
-    ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktree.");
+        ],
+      ]),
+    });
 
+    expect(getSession(state, "session-1").runtimeId).toBeNull();
     expect(getSession(state, "session-1").runtimeRoute).toEqual({
       type: "local_http",
       endpoint: "http://127.0.0.1:4444",
     });
-    expect(getSession(state, "session-2").runtimeRoute).toBeNull();
+    expect(getSession(state, "session-1").workingDirectory).toBe("/tmp/repo/worktree");
+    expect(getSession(state, "session-2").runtimeId).toBeNull();
+    expect(getSession(state, "session-2").runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4444",
+    });
+    expect(getSession(state, "session-2").workingDirectory).toBe("/tmp/repo/worktree");
+    expect(sessionMessagesToArray(getSession(state, "session-1"))).toEqual([]);
+    expect(sessionMessagesToArray(getSession(state, "session-2"))).toEqual([]);
   });
 
   test("composes bootstrap, requested history hydration, and live reconciliation without cross-mode regressions", async () => {
@@ -3319,7 +3326,7 @@ describe("agent-orchestrator-load-sessions", () => {
     }
   });
 
-  test("fails fast for qa worktree sessions when only a shared workspace runtime exists", async () => {
+  test("route-hydrates qa worktree sessions through a probed shared HTTP workspace runtime", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     let observedRuntimeEndpoint: string | null = null;
@@ -3402,21 +3409,24 @@ describe("agent-orchestrator-load-sessions", () => {
     ];
 
     try {
-      await expect(
-        loadAgentSessions("task-1", {
-          mode: "requested_history",
-          targetSessionId: "session-qa-1",
-          historyPolicy: "requested_only",
-        }),
-      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktree.");
+      await loadAgentSessions("task-1", {
+        mode: "requested_history",
+        targetSessionId: "session-qa-1",
+        historyPolicy: "requested_only",
+      });
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
     }
 
-    expect(observedRuntimeEndpoint).toBeNull();
+    expect(observedRuntimeEndpoint as string | null).toBe("http://127.0.0.1:4444");
     expect(state["session-qa-1"]?.runtimeId).toBeNull();
-    expect(sessionMessagesToArray(getSession(state, "session-qa-1"))).toEqual([]);
+    expect(state["session-qa-1"]?.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4444",
+    });
+    expect(state["session-qa-1"]?.workingDirectory).toBe("/tmp/repo/worktree");
+    expect(sessionMessagesToArray(getSession(state, "session-qa-1")).length).toBeGreaterThan(0);
   });
 
   test("does not bind qa repo-root sessions to an existing workspace runtime", async () => {
@@ -3642,7 +3652,7 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(appQueryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
   });
 
-  test("fails fast for build worktree sessions when only the shared workspace runtime exists", async () => {
+  test("route-hydrates build worktree sessions through a probed shared HTTP workspace runtime", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     const ensuredRuntimeKinds: string[] = [];
@@ -3743,13 +3753,11 @@ describe("agent-orchestrator-load-sessions", () => {
     };
 
     try {
-      await expect(
-        loadAgentSessions("task-1", {
-          mode: "requested_history",
-          targetSessionId: "session-1",
-          historyPolicy: "requested_only",
-        }),
-      ).rejects.toThrow("No live runtime found for working directory /tmp/repo/conflict-worktree.");
+      await loadAgentSessions("task-1", {
+        mode: "requested_history",
+        targetSessionId: "session-1",
+        historyPolicy: "requested_only",
+      });
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.runtimeList = originalRuntimeList;
@@ -3758,8 +3766,13 @@ describe("agent-orchestrator-load-sessions", () => {
     }
 
     expect(ensuredRuntimeKinds).toEqual([]);
-    expect(state["session-1"]?.runtimeRoute).toBeNull();
-    expect(sessionMessagesToArray(getSession(state, "session-1"))).toEqual([]);
+    expect(state["session-1"]?.runtimeId).toBeNull();
+    expect(state["session-1"]?.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4666",
+    });
+    expect(state["session-1"]?.workingDirectory).toBe("/tmp/repo/conflict-worktree");
+    expect(sessionMessagesToArray(getSession(state, "session-1")).length).toBeGreaterThan(0);
   });
 
   test("does not ensure a shared workspace runtime for qa sessions on non-root working directories", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -1658,6 +1658,52 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
+  test("reconcile marks exact-runtime sessions without live snapshots as reconciled", async () => {
+    let snapshotLoads = 0;
+    const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: worktreePath })]);
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async () => {
+          snapshotLoads += 1;
+          return [];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId, persistedRecords }) => {
+          reconcileCalls.push({ taskId, records: persistedRecords ?? [] });
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {},
+    });
+    const tasks = [taskWithSession("task-1", "external-1")];
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks,
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks,
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(snapshotLoads).toBe(1);
+    expect(reconcileCalls).toHaveLength(1);
+    expect(reconcileCalls[0]?.records.map((record) => record.sessionId)).toEqual([
+      "session-task-1",
+    ]);
+    service.dispose();
+  });
+
   test("reconcile does not ensure missing stdio worktree runtimes", async () => {
     let runtimeEnsureCalls = 0;
     const listLiveAgentSessionSnapshotsCalls: Array<{

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -160,16 +160,6 @@ const isExpectedRuntimeMetadataLog = (args: Parameters<typeof console.error>): b
   );
 };
 
-const isExpectedRetryableUnmatchedLog = (args: Parameters<typeof console.error>): boolean => {
-  const [message, error] = args;
-  return (
-    typeof message === "string" &&
-    message.startsWith("Failed to reconcile agent sessions") &&
-    error instanceof Error &&
-    error.message.startsWith("No matching live agent session was found")
-  );
-};
-
 const withSuppressedExpectedConsoleErrors = async ({
   expectedCount,
   isExpected,
@@ -205,16 +195,6 @@ const withSuppressedExpectedRuntimeMetadataLogs = (
   withSuppressedExpectedConsoleErrors({
     expectedCount,
     isExpected: isExpectedRuntimeMetadataLog,
-    run,
-  });
-
-const withSuppressedExpectedRetryableUnmatchedLogs = (
-  expectedCount: number,
-  run: () => Promise<void>,
-): Promise<void> =>
-  withSuppressedExpectedConsoleErrors({
-    expectedCount,
-    isExpected: isExpectedRetryableUnmatchedLog,
     run,
   });
 
@@ -880,7 +860,7 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
-  test("reconcile schedules retry for unmatched worktree records while reconciling live records", async () => {
+  test("reconcile route-hydrates inactive worktree records while reconciling live records", async () => {
     const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
     let retryRequests = 0;
     const liveAgentSessionStore = new LiveAgentSessionStore();
@@ -925,27 +905,24 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [mixedTask],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
-
-      await Bun.sleep(600);
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [mixedTask],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     expect(reconcileCalls).toHaveLength(1);
     expect(reconcileCalls[0]?.taskId).toBe("task-mixed");
     expect(reconcileCalls[0]?.records.map((record) => record.externalSessionId)).toEqual([
       "external-planner",
+      "external-missing-build",
     ]);
-    expect(retryRequests).toBe(1);
+    expect(retryRequests).toBe(0);
     service.dispose();
   });
 
-  test("reconcile can pick up a mixed-task worktree record after it becomes live later", async () => {
+  test("reconcile records route-hydrated worktree sessions once even if they become live later", async () => {
     const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
     let retryRequests = 0;
     let liveSnapshots = [
@@ -991,13 +968,11 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [mixedTask],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [mixedTask],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
     liveSnapshots = [
       createLiveAgentSessionSnapshotFixture({
@@ -1014,7 +989,7 @@ describe("repo-session-hydration-service", () => {
 
     expect(
       reconcileCalls.map((call) => call.records.map((record) => record.externalSessionId)),
-    ).toEqual([["external-planner"], ["external-build"]]);
+    ).toEqual([["external-planner", "external-build"], ["external-build"]]);
     expect(retryRequests).toBe(0);
     service.dispose();
   });
@@ -1066,13 +1041,11 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [task],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [task],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     liveSnapshots = [
@@ -1090,7 +1063,7 @@ describe("repo-session-hydration-service", () => {
 
     expect(
       reconcileCalls.map((call) => call.records.map((record) => record.externalSessionId)),
-    ).toEqual([["external"], ["shared::external"]]);
+    ).toEqual([["external", "shared::external"], ["shared::external"]]);
     expect(retryRequests).toBe(0);
     service.dispose();
   });
@@ -1212,13 +1185,11 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [mixedTask],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [mixedTask],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     expect(liveSnapshotScans).toBe(1);
@@ -1226,7 +1197,11 @@ describe("repo-session-hydration-service", () => {
     expect(attachedListeners).toBe(1);
     expect(retryRequests).toBe(0);
     expect(state["session-task-mixed"]?.status).toBe("running");
-    expect(state["session-task-mixed-build"]).toBeUndefined();
+    expect(state["session-task-mixed-build"]?.runtimeRoute).toEqual({
+      type: "local_http",
+      endpoint: "http://127.0.0.1:4555",
+    });
+    expect(state["session-task-mixed-build"]?.status).toBe("stopped");
     service.dispose();
   });
 
@@ -1341,13 +1316,11 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(2, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [taskOne, taskTwo],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [taskOne, taskTwo],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     expect(runtimeEnsureCalls).toBe(1);
@@ -1356,6 +1329,70 @@ describe("repo-session-hydration-service", () => {
         directories: [repoPath],
       },
     ]);
+    service.dispose();
+  });
+
+  test("reconcile route-hydrates inactive repo-root workspace sessions after a verified workspace scan", async () => {
+    const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
+    const reconcileCalls: Array<{ taskId: string; hasPreloadedRuntimeConnection: boolean }> = [];
+    let retryRequests = 0;
+    const liveAgentSessionStore = new LiveAgentSessionStore();
+
+    setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
+
+    const service = createTestRepoSessionHydrationService({
+      agentEngine: {
+        listLiveAgentSessionSnapshots: async (input) => {
+          listLiveAgentSessionSnapshotsCalls.push(
+            input.directories ? { directories: [...input.directories].sort() } : {},
+          );
+          return [];
+        },
+      },
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({
+          taskId,
+          persistedRecords,
+          preloadedRuntimeConnections,
+        }) => {
+          const record = persistedRecords?.[0];
+          if (!record) {
+            throw new Error("Expected persisted session record");
+          }
+          reconcileCalls.push({
+            taskId,
+            hasPreloadedRuntimeConnection:
+              preloadedRuntimeConnections?.hasAny("opencode", record.workingDirectory) ?? false,
+          });
+        },
+      },
+      liveAgentSessionStore,
+      onRetryRequested: () => {
+        retryRequests += 1;
+      },
+    });
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        plannerTaskWithSessionAt("task-1", "external-1", repoPath),
+        plannerTaskWithSessionAt("task-2", "external-2", repoPath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(listLiveAgentSessionSnapshotsCalls).toEqual([
+      {
+        directories: [repoPath],
+      },
+    ]);
+    expect(reconcileCalls).toEqual([
+      { taskId: "task-1", hasPreloadedRuntimeConnection: true },
+      { taskId: "task-2", hasPreloadedRuntimeConnection: true },
+    ]);
+    expect(retryRequests).toBe(0);
     service.dispose();
   });
 
@@ -1454,9 +1491,9 @@ describe("repo-session-hydration-service", () => {
     service.dispose();
   });
 
-  test("reconcile retries unmatched worktree sessions after scanning compatible repo-root http runtimes", async () => {
+  test("reconcile hydrates inactive worktree sessions through compatible repo-root http runtimes", async () => {
     const listLiveAgentSessionSnapshotsCalls: Array<{ directories?: string[] }> = [];
-    const reconcileCalls: string[] = [];
+    const reconcileCalls: Array<{ taskId: string; hasPreloadedRuntimeConnection: boolean }> = [];
     let retryRequests = 0;
     const liveAgentSessionStore = new LiveAgentSessionStore();
     setRuntimeList([createRuntimeInstance({ workingDirectory: repoPath })]);
@@ -1472,8 +1509,20 @@ describe("repo-session-hydration-service", () => {
       },
       sessionHydration: {
         bootstrapTaskSessions: async () => {},
-        reconcileLiveTaskSessions: async ({ taskId }) => {
-          reconcileCalls.push(taskId);
+        reconcileLiveTaskSessions: async ({
+          taskId,
+          persistedRecords,
+          preloadedRuntimeConnections,
+        }) => {
+          const record = persistedRecords?.[0];
+          if (!record) {
+            throw new Error("Expected persisted session record");
+          }
+          reconcileCalls.push({
+            taskId,
+            hasPreloadedRuntimeConnection:
+              preloadedRuntimeConnections?.hasAny("opencode", record.workingDirectory) ?? false,
+          });
         },
       },
       liveAgentSessionStore,
@@ -1482,18 +1531,14 @@ describe("repo-session-hydration-service", () => {
       },
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(2, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [
-          taskWithSessionAt("task-a", "external-a", "/tmp/repo/worktree-a"),
-          taskWithSessionAt("task-b", "external-b", "/tmp/repo/worktree-b"),
-        ],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
-
-      await Bun.sleep(600);
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-a", "/tmp/repo/worktree-a"),
+        taskWithSessionAt("task-b", "external-b", "/tmp/repo/worktree-b"),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     expect(listLiveAgentSessionSnapshotsCalls).toEqual([
@@ -1501,12 +1546,15 @@ describe("repo-session-hydration-service", () => {
         directories: ["/tmp/repo/worktree-a", "/tmp/repo/worktree-b"],
       },
     ]);
-    expect(reconcileCalls).toEqual([]);
-    expect(retryRequests).toBe(2);
+    expect(reconcileCalls).toEqual([
+      { taskId: "task-a", hasPreloadedRuntimeConnection: true },
+      { taskId: "task-b", hasPreloadedRuntimeConnection: true },
+    ]);
+    expect(retryRequests).toBe(0);
     service.dispose();
   });
 
-  test("reconcile only targets matching live worktree sessions discovered through repo-root http runtimes", async () => {
+  test("reconcile route-hydrates unmatched worktree sessions discovered through repo-root http runtimes", async () => {
     const reconcileCalls: Array<{ taskId: string; records: AgentSessionRecord[] }> = [];
     const liveAgentSessionStore = new LiveAgentSessionStore();
 
@@ -1531,23 +1579,23 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [
-          taskWithSessionAt("task-a", "external-a", worktreePath),
-          taskWithSessionAt("task-b", "external-b", worktreePath),
-        ],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-a", worktreePath),
+        taskWithSessionAt("task-b", "external-b", worktreePath),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
-    expect(reconcileCalls).toHaveLength(1);
-    expect(reconcileCalls[0]?.taskId).toBe("task-a");
-    expect(reconcileCalls[0]?.records.map((record) => record.externalSessionId)).toEqual([
-      "external-a",
-    ]);
+    expect(reconcileCalls).toHaveLength(2);
+    expect(reconcileCalls.map((call) => call.taskId).sort()).toEqual(["task-a", "task-b"]);
+    expect(
+      reconcileCalls
+        .flatMap((call) => call.records.map((record) => record.externalSessionId))
+        .sort(),
+    ).toEqual(["external-a", "external-b"]);
     service.dispose();
   });
 
@@ -1578,23 +1626,35 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [
-          taskWithSessionAt("task-a", "external-shared", worktreeA),
-          taskWithSessionAt("task-b", "external-shared", worktreeB),
-        ],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [
+        taskWithSessionAt("task-a", "external-shared", worktreeA),
+        taskWithSessionAt("task-b", "external-shared", worktreeB),
+      ],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
-    expect(reconcileCalls).toHaveLength(1);
-    expect(reconcileCalls[0]?.taskId).toBe("task-a");
-    expect(reconcileCalls[0]?.records.map((record) => record.workingDirectory)).toEqual([
-      worktreeA,
-    ]);
+    expect(reconcileCalls).toHaveLength(2);
+    expect(reconcileCalls.map((call) => call.taskId).sort()).toEqual(["task-a", "task-b"]);
+    expect(
+      reconcileCalls
+        .flatMap((call) => call.records.map((record) => record.workingDirectory))
+        .sort(),
+    ).toEqual([worktreeA, worktreeB]);
+    expect(
+      liveAgentSessionStore.readSnapshot({
+        repoPath,
+        runtimeKind: "opencode",
+        runtimeConnection: createLocalHttpRuntimeConnection({
+          endpoint: "http://127.0.0.1:4555",
+          workingDirectory: worktreeB,
+        }),
+        workingDirectory: worktreeB,
+        externalSessionId: "external-shared",
+      }),
+    ).toBeNull();
     service.dispose();
   });
 
@@ -1688,13 +1748,11 @@ describe("repo-session-hydration-service", () => {
       onRetryRequested: () => {},
     });
 
-    await withSuppressedExpectedRetryableUnmatchedLogs(1, async () => {
-      await service.reconcilePendingTasks({
-        repoPath,
-        tasks: [plannerTaskWithSessionAt("task-1", "external-1", repoPath)],
-        isCancelled: () => false,
-        isCurrentRepo: () => true,
-      });
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [plannerTaskWithSessionAt("task-1", "external-1", repoPath)],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
     });
 
     expect(

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -260,13 +260,17 @@ const buildReconcileTargets = ({
         runtimeConnections: preloadedRuntimeConnections,
         preloadedLiveSessionKeys,
       });
-      const canHydrateThroughRouteProbedConnection = routeProbedHydrationRuntimeConnections.hasAny(
+      const canHydrateThroughResolvableConnection = preloadedRuntimeConnections.hasAny(
         runtimeKind,
         record.workingDirectory,
       );
-      const canReconcile = hasMatchingLiveSession || canHydrateThroughRouteProbedConnection;
+      const canHydrateThroughRouteOnlyConnection = routeProbedHydrationRuntimeConnections.hasAny(
+        runtimeKind,
+        record.workingDirectory,
+      );
+      const canReconcile = hasMatchingLiveSession || canHydrateThroughResolvableConnection;
       if (canReconcile) {
-        if (!hasMatchingLiveSession) {
+        if (!hasMatchingLiveSession && canHydrateThroughRouteOnlyConnection) {
           routeOnlyHydrationRecordKeys.add(persistedSessionRecordKey(taskId, record));
         }
         return true;
@@ -601,7 +605,6 @@ export const createRepoSessionHydrationService = ({
         if (!isRepoRootWorkspaceRuntimeForRepo) {
           if (desiredDirectories.has(normalizeWorkingDirectory(runtime.workingDirectory))) {
             preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
-            routeProbedHydrationRuntimeConnections.add(runtimeKind, runtimeConnection);
             addRuntimeConnectionScan(runtimeKind, runtimeConnection, runtime.workingDirectory);
           }
           continue;
@@ -610,7 +613,6 @@ export const createRepoSessionHydrationService = ({
         if (desiredDirectories.has(repoPathKey) && canScanRepoRootRuntime) {
           addRuntimeConnectionScan(runtimeKind, runtimeConnection, runtime.workingDirectory);
           preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
-          routeProbedHydrationRuntimeConnections.add(runtimeKind, runtimeConnection);
         }
         if (canUseRuntimeForRouteOnlyHydration(runtime, repoPathKey)) {
           for (const workingDirectory of repoRootWorktreeScanDirectories) {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -29,6 +29,14 @@ import {
   RuntimeConnectionPreloadIndex,
 } from "./live-agent-session-cache";
 import type { LiveAgentSessionStore } from "./live-agent-session-store";
+import {
+  canUseRuntimeForRouteOnlyHydration,
+  createRouteOnlyHydrationLookupKey,
+  createRouteOnlyHydrationRuntimeConnection,
+  hasExactNonRepoRootRuntime,
+  isRepoRootWorkspaceRuntime,
+  recordRouteOnlyHydrationPreload,
+} from "./route-only-hydration";
 import type { SessionHydrationOperations } from "./session-hydration-operations";
 
 type HydrationScope = "bootstrap" | "reconcile";
@@ -37,6 +45,7 @@ type RuntimeConnectionScan = {
   runtimeKind: RuntimeKind;
   runtimeConnection: AgentRuntimeConnection;
   directories: Set<string>;
+  routeOnlyHydrationDirectories: Set<string>;
   runtimeConnectionsByDirectory: Map<string, AgentRuntimeConnection>;
 };
 
@@ -49,6 +58,7 @@ type ReconcilePreloadPlan = {
   persistedByTask: Array<{ taskId: string; records: AgentSessionRecord[] }>;
   reconcileTargets: ReconcileTarget[];
   retryableUnmatchedTaskIds: Set<string>;
+  routeOnlyHydrationRecordKeys: Set<string>;
   preloadedRuntimeLists: Map<RuntimeKind, RuntimeInstanceSummary[]>;
   preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedLiveAgentSessionsByKey: Map<string, LiveAgentSessionSnapshot[]>;
@@ -149,17 +159,20 @@ const createCancelledReconcilePreloadPlan = ({
   preloadedRuntimeLists,
   preloadedRuntimeConnections,
   preloadedLiveAgentSessionsByKey = new Map<string, LiveAgentSessionSnapshot[]>(),
+  routeOnlyHydrationRecordKeys = new Set<string>(),
   skippedTaskErrors,
 }: {
   persistedByTask: ReconcilePreloadPlan["persistedByTask"];
   preloadedRuntimeLists: Map<RuntimeKind, RuntimeInstanceSummary[]>;
   preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedLiveAgentSessionsByKey?: Map<string, LiveAgentSessionSnapshot[]>;
+  routeOnlyHydrationRecordKeys?: Set<string>;
   skippedTaskErrors: Map<string, unknown>;
 }): ReconcilePreloadPlan => ({
   persistedByTask,
   reconcileTargets: [],
   retryableUnmatchedTaskIds: new Set<string>(),
+  routeOnlyHydrationRecordKeys,
   preloadedRuntimeLists,
   preloadedRuntimeConnections,
   preloadedLiveAgentSessionsByKey,
@@ -202,7 +215,7 @@ const buildReconcileTargets = ({
   persistedByTask,
   skippedTaskErrors,
   repoPath,
-  exactResolvableRuntimeConnections,
+  routeProbedHydrationRuntimeConnections,
   preloadedRuntimeConnections,
   scannedRuntimeConnections,
   preloadedLiveSessionKeys,
@@ -210,13 +223,18 @@ const buildReconcileTargets = ({
   persistedByTask: ReconcilePreloadPlan["persistedByTask"];
   skippedTaskErrors: Map<string, unknown>;
   repoPath: string;
-  exactResolvableRuntimeConnections: RuntimeConnectionPreloadIndex;
+  routeProbedHydrationRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
   scannedRuntimeConnections: RuntimeConnectionPreloadIndex;
   preloadedLiveSessionKeys: Set<string>;
-}): { reconcileTargets: ReconcileTarget[]; retryableUnmatchedTaskIds: Set<string> } => {
+}): {
+  reconcileTargets: ReconcileTarget[];
+  retryableUnmatchedTaskIds: Set<string>;
+  routeOnlyHydrationRecordKeys: Set<string>;
+} => {
   const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
   const retryableUnmatchedTaskIds = new Set<string>();
+  const routeOnlyHydrationRecordKeys = new Set<string>();
 
   const reconcileTargets = persistedByTask.flatMap<ReconcileTarget>(({ taskId, records }) => {
     if (skippedTaskErrors.has(taskId)) {
@@ -236,14 +254,21 @@ const buildReconcileTargets = ({
       }
 
       const runtimeKind = readPersistedRuntimeKind(record);
-      const canReconcile =
-        hasMatchingPreloadedLiveSession({
-          record,
-          runtimeKind,
-          runtimeConnections: preloadedRuntimeConnections,
-          preloadedLiveSessionKeys,
-        }) || exactResolvableRuntimeConnections.hasAny(runtimeKind, record.workingDirectory);
+      const hasMatchingLiveSession = hasMatchingPreloadedLiveSession({
+        record,
+        runtimeKind,
+        runtimeConnections: preloadedRuntimeConnections,
+        preloadedLiveSessionKeys,
+      });
+      const canHydrateThroughRouteProbedConnection = routeProbedHydrationRuntimeConnections.hasAny(
+        runtimeKind,
+        record.workingDirectory,
+      );
+      const canReconcile = hasMatchingLiveSession || canHydrateThroughRouteProbedConnection;
       if (canReconcile) {
+        if (!hasMatchingLiveSession) {
+          routeOnlyHydrationRecordKeys.add(persistedSessionRecordKey(taskId, record));
+        }
         return true;
       }
 
@@ -256,27 +281,7 @@ const buildReconcileTargets = ({
     return recordsToReconcile.length > 0 ? [{ taskId, records: recordsToReconcile }] : [];
   });
 
-  return { reconcileTargets, retryableUnmatchedTaskIds };
-};
-
-const isRepoRootWorkspaceRuntime = (
-  runtime: RuntimeInstanceSummary,
-  normalizedRepoPath: string,
-): boolean =>
-  runtime.role === "workspace" &&
-  normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath;
-
-const hasExactNonRepoRootRuntime = (
-  runtimes: RuntimeInstanceSummary[],
-  workingDirectory: string,
-  normalizedRepoPath: string,
-): boolean => {
-  const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
-  return runtimes.some(
-    (runtime) =>
-      normalizeWorkingDirectory(runtime.workingDirectory) === normalizedWorkingDirectory &&
-      !isRepoRootWorkspaceRuntime(runtime, normalizedRepoPath),
-  );
+  return { reconcileTargets, retryableUnmatchedTaskIds, routeOnlyHydrationRecordKeys };
 };
 
 const collectRepoRootWorktreeScanDirectories = ({
@@ -300,7 +305,11 @@ const collectRepoRootWorktreeScanDirectories = ({
       !requiresLiveWorktreeRuntime(record) ||
       workingDirectory === repoPathKey ||
       readPersistedRuntimeKind(record) !== runtimeKind ||
-      hasExactNonRepoRootRuntime(runtimeEntries, workingDirectory, repoPathKey)
+      hasExactNonRepoRootRuntime({
+        runtimes: runtimeEntries,
+        workingDirectory,
+        repoPath: repoPathKey,
+      })
     ) {
       continue;
     }
@@ -480,23 +489,28 @@ export const createRepoSessionHydrationService = ({
       runtimeKind: RuntimeKind,
       runtimeConnection: AgentRuntimeConnection,
       workingDirectory: string,
+      allowRouteOnlyHydration = false,
     ): void => {
       const scanKey = getLiveAgentSessionCacheKey(runtimeKind, runtimeConnection);
       const scan = runtimeConnections.get(scanKey) ?? {
         runtimeKind,
         runtimeConnection,
         directories: new Set<string>(),
+        routeOnlyHydrationDirectories: new Set<string>(),
         runtimeConnectionsByDirectory: new Map<string, AgentRuntimeConnection>(),
       };
       const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
       scan.directories.add(normalizedWorkingDirectory);
+      if (allowRouteOnlyHydration) {
+        scan.routeOnlyHydrationDirectories.add(normalizedWorkingDirectory);
+      }
       scan.runtimeConnectionsByDirectory.set(normalizedWorkingDirectory, runtimeConnection);
       runtimeConnections.set(scanKey, scan);
       scannedRuntimeConnections.add(runtimeKind, runtimeConnection);
     };
     const preloadedRuntimeLists = new Map<RuntimeKind, RuntimeInstanceSummary[]>();
     const preloadedRuntimeConnections = new RuntimeConnectionPreloadIndex();
-    const exactResolvableRuntimeConnections = new RuntimeConnectionPreloadIndex();
+    const routeProbedHydrationRuntimeConnections = new RuntimeConnectionPreloadIndex();
     for (const runtimeKind of runtimeKinds) {
       const runtimes = await loadRuntimeListFromQuery(queryClient, runtimeKind, repoPath);
       if (isCancelled()) {
@@ -570,12 +584,10 @@ export const createRepoSessionHydrationService = ({
       });
 
       for (const runtime of runtimeEntries) {
-        const isRepoRootWorkspaceRuntime =
-          runtime.role === "workspace" &&
-          normalizeWorkingDirectory(runtime.workingDirectory) === repoPathKey;
+        const isRepoRootWorkspaceRuntimeForRepo = isRepoRootWorkspaceRuntime(runtime, repoPathKey);
         const canScanRepoRootRuntime = canScanRepoRootWorkspaceRuntime(runtime);
         if (
-          isRepoRootWorkspaceRuntime &&
+          isRepoRootWorkspaceRuntimeForRepo &&
           !canScanRepoRootRuntime &&
           repoRootWorktreeScanDirectories.length === 0
         ) {
@@ -586,10 +598,10 @@ export const createRepoSessionHydrationService = ({
           runtime.runtimeRoute,
           runtime.workingDirectory,
         );
-        if (!isRepoRootWorkspaceRuntime) {
+        if (!isRepoRootWorkspaceRuntimeForRepo) {
           if (desiredDirectories.has(normalizeWorkingDirectory(runtime.workingDirectory))) {
             preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
-            exactResolvableRuntimeConnections.add(runtimeKind, runtimeConnection);
+            routeProbedHydrationRuntimeConnections.add(runtimeKind, runtimeConnection);
             addRuntimeConnectionScan(runtimeKind, runtimeConnection, runtime.workingDirectory);
           }
           continue;
@@ -597,14 +609,21 @@ export const createRepoSessionHydrationService = ({
 
         if (desiredDirectories.has(repoPathKey) && canScanRepoRootRuntime) {
           addRuntimeConnectionScan(runtimeKind, runtimeConnection, runtime.workingDirectory);
+          preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
+          routeProbedHydrationRuntimeConnections.add(runtimeKind, runtimeConnection);
         }
-        if (runtime.runtimeRoute.type !== "stdio") {
+        if (canUseRuntimeForRouteOnlyHydration(runtime, repoPathKey)) {
           for (const workingDirectory of repoRootWorktreeScanDirectories) {
-            const { runtimeConnection: worktreeRuntimeConnection } = resolveRuntimeRouteConnection(
-              runtime.runtimeRoute,
+            const worktreeRuntimeConnection = createRouteOnlyHydrationRuntimeConnection(
+              runtime,
               workingDirectory,
             );
-            addRuntimeConnectionScan(runtimeKind, worktreeRuntimeConnection, workingDirectory);
+            addRuntimeConnectionScan(
+              runtimeKind,
+              worktreeRuntimeConnection,
+              workingDirectory,
+              true,
+            );
           }
         }
       }
@@ -652,6 +671,31 @@ export const createRepoSessionHydrationService = ({
         );
       }
 
+      for (const workingDirectory of input.routeOnlyHydrationDirectories) {
+        const runtimeConnectionForDirectory =
+          input.runtimeConnectionsByDirectory.get(workingDirectory) ?? input.runtimeConnection;
+        const lookupKey = createRouteOnlyHydrationLookupKey({
+          runtimeKind: input.runtimeKind,
+          runtimeConnection: runtimeConnectionForDirectory,
+          workingDirectory,
+        });
+        const liveSessionsForRouteOnlyDirectory =
+          preloadedLiveAgentSessionsByKey.get(lookupKey) ?? [];
+        // A successful directory-scoped scan through a repo-root HTTP runtime proves that
+        // this transport can address the worktree directory. Preserve the worktree
+        // directory in the request-scoped connection; do not substitute or persist the
+        // repo-root runtime as the session's durable runtime.
+        recordRouteOnlyHydrationPreload({
+          runtimeKind: input.runtimeKind,
+          runtimeConnection: runtimeConnectionForDirectory,
+          workingDirectory,
+          preloadedRuntimeConnections,
+          routeProbedHydrationRuntimeConnections,
+          preloadedLiveAgentSessionsByKey,
+          liveSessionsForDirectory: liveSessionsForRouteOnlyDirectory,
+        });
+      }
+
       for (const runtimeSession of runtimeSessions) {
         const workingDirectory = normalizeWorkingDirectory(runtimeSession.workingDirectory);
         const runtimeConnectionForDirectory =
@@ -672,20 +716,22 @@ export const createRepoSessionHydrationService = ({
       }
     }
 
-    const { reconcileTargets, retryableUnmatchedTaskIds } = buildReconcileTargets({
-      persistedByTask,
-      skippedTaskErrors,
-      repoPath,
-      exactResolvableRuntimeConnections,
-      preloadedRuntimeConnections,
-      scannedRuntimeConnections,
-      preloadedLiveSessionKeys,
-    });
+    const { reconcileTargets, retryableUnmatchedTaskIds, routeOnlyHydrationRecordKeys } =
+      buildReconcileTargets({
+        persistedByTask,
+        skippedTaskErrors,
+        repoPath,
+        routeProbedHydrationRuntimeConnections,
+        preloadedRuntimeConnections,
+        scannedRuntimeConnections,
+        preloadedLiveSessionKeys,
+      });
 
     return {
       persistedByTask,
       reconcileTargets,
       retryableUnmatchedTaskIds,
+      routeOnlyHydrationRecordKeys,
       preloadedRuntimeLists,
       preloadedRuntimeConnections,
       preloadedLiveAgentSessionsByKey,
@@ -859,7 +905,10 @@ export const createRepoSessionHydrationService = ({
         for (const [index, result] of results.entries()) {
           if (result.status === "fulfilled") {
             for (const record of result.value.records) {
-              reconciledRecordKeys.add(persistedSessionRecordKey(result.value.taskId, record));
+              const recordKey = persistedSessionRecordKey(result.value.taskId, record);
+              if (!plan.routeOnlyHydrationRecordKeys.has(recordKey)) {
+                reconciledRecordKeys.add(recordKey);
+              }
             }
             continue;
           }

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/route-only-hydration.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/route-only-hydration.ts
@@ -1,0 +1,135 @@
+import type { RuntimeInstanceSummary, RuntimeKind } from "@openducktor/contracts";
+import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
+import { runtimeRouteToConnection } from "../runtime/runtime";
+import { normalizeWorkingDirectory } from "../support/core";
+import {
+  liveAgentSessionLookupKey,
+  type RuntimeConnectionPreloadIndex,
+} from "./live-agent-session-cache";
+
+type LiveAgentSessionScanner = {
+  listLiveAgentSessionSnapshots: (input: {
+    runtimeKind: RuntimeKind;
+    runtimeConnection: AgentRuntimeConnection;
+    directories?: string[];
+  }) => Promise<LiveAgentSessionSnapshot[]>;
+};
+
+export type RouteOnlyHydrationPreloadResult = {
+  runtimeConnection: AgentRuntimeConnection;
+  liveSessionsForDirectory: LiveAgentSessionSnapshot[];
+};
+
+export const isRepoRootWorkspaceRuntime = (
+  runtime: RuntimeInstanceSummary,
+  repoPath: string,
+): boolean => {
+  const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
+  return (
+    runtime.role === "workspace" &&
+    normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath
+  );
+};
+
+export const hasExactNonRepoRootRuntime = ({
+  runtimes,
+  workingDirectory,
+  repoPath,
+}: {
+  runtimes: RuntimeInstanceSummary[];
+  workingDirectory: string;
+  repoPath: string;
+}): boolean => {
+  const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
+  const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+  return runtimes.some(
+    (runtime) =>
+      normalizeWorkingDirectory(runtime.workingDirectory) === normalizedWorkingDirectory &&
+      !isRepoRootWorkspaceRuntime(runtime, normalizedRepoPath),
+  );
+};
+
+export const canUseRuntimeForRouteOnlyHydration = (
+  runtime: RuntimeInstanceSummary,
+  repoPath: string,
+): boolean =>
+  isRepoRootWorkspaceRuntime(runtime, repoPath) && runtime.runtimeRoute.type !== "stdio";
+
+export const createRouteOnlyHydrationRuntimeConnection = (
+  runtime: RuntimeInstanceSummary,
+  workingDirectory: string,
+): AgentRuntimeConnection =>
+  runtimeRouteToConnection(runtime.runtimeRoute, normalizeWorkingDirectory(workingDirectory));
+
+export const createRouteOnlyHydrationLookupKey = ({
+  runtimeKind,
+  runtimeConnection,
+  workingDirectory,
+}: {
+  runtimeKind: RuntimeKind;
+  runtimeConnection: AgentRuntimeConnection;
+  workingDirectory: string;
+}): string => liveAgentSessionLookupKey(runtimeKind, runtimeConnection, workingDirectory);
+
+export const scanRouteOnlyHydrationDirectory = async ({
+  scanner,
+  runtimeKind,
+  runtime,
+  repoPath,
+  workingDirectory,
+}: {
+  scanner: LiveAgentSessionScanner;
+  runtimeKind: RuntimeKind;
+  runtime: RuntimeInstanceSummary;
+  repoPath: string;
+  workingDirectory: string;
+}): Promise<RouteOnlyHydrationPreloadResult | null> => {
+  const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+  if (!canUseRuntimeForRouteOnlyHydration(runtime, repoPath)) {
+    return null;
+  }
+
+  const runtimeConnection = createRouteOnlyHydrationRuntimeConnection(
+    runtime,
+    normalizedWorkingDirectory,
+  );
+  const liveSessions = await scanner.listLiveAgentSessionSnapshots({
+    runtimeKind,
+    runtimeConnection,
+    directories: [normalizedWorkingDirectory],
+  });
+  const liveSessionsForDirectory = liveSessions.filter(
+    (session) => normalizeWorkingDirectory(session.workingDirectory) === normalizedWorkingDirectory,
+  );
+  return {
+    runtimeConnection,
+    liveSessionsForDirectory,
+  };
+};
+
+export const recordRouteOnlyHydrationPreload = ({
+  runtimeKind,
+  runtimeConnection,
+  workingDirectory,
+  preloadedRuntimeConnections,
+  routeProbedHydrationRuntimeConnections,
+  preloadedLiveAgentSessionsByKey,
+  liveSessionsForDirectory,
+}: {
+  runtimeKind: RuntimeKind;
+  runtimeConnection: AgentRuntimeConnection;
+  workingDirectory: string;
+  preloadedRuntimeConnections: RuntimeConnectionPreloadIndex;
+  routeProbedHydrationRuntimeConnections?: RuntimeConnectionPreloadIndex;
+  preloadedLiveAgentSessionsByKey: Map<string, LiveAgentSessionSnapshot[]>;
+  liveSessionsForDirectory: LiveAgentSessionSnapshot[];
+}): void => {
+  preloadedRuntimeConnections.add(runtimeKind, runtimeConnection);
+  routeProbedHydrationRuntimeConnections?.add(runtimeKind, runtimeConnection);
+  const lookupKey = createRouteOnlyHydrationLookupKey({
+    runtimeKind,
+    runtimeConnection,
+    workingDirectory,
+  });
+  preloadedLiveAgentSessionsByKey.set(lookupKey, liveSessionsForDirectory);
+};

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/route-only-hydration.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/route-only-hydration.ts
@@ -20,16 +20,18 @@ export type RouteOnlyHydrationPreloadResult = {
   liveSessionsForDirectory: LiveAgentSessionSnapshot[];
 };
 
+const isRepoRootWorkspaceRuntimeForNormalizedRepoPath = (
+  runtime: RuntimeInstanceSummary,
+  normalizedRepoPath: string,
+): boolean =>
+  runtime.role === "workspace" &&
+  normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath;
+
 export const isRepoRootWorkspaceRuntime = (
   runtime: RuntimeInstanceSummary,
   repoPath: string,
-): boolean => {
-  const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
-  return (
-    runtime.role === "workspace" &&
-    normalizeWorkingDirectory(runtime.workingDirectory) === normalizedRepoPath
-  );
-};
+): boolean =>
+  isRepoRootWorkspaceRuntimeForNormalizedRepoPath(runtime, normalizeWorkingDirectory(repoPath));
 
 export const hasExactNonRepoRootRuntime = ({
   runtimes,
@@ -45,7 +47,7 @@ export const hasExactNonRepoRootRuntime = ({
   return runtimes.some(
     (runtime) =>
       normalizeWorkingDirectory(runtime.workingDirectory) === normalizedWorkingDirectory &&
-      !isRepoRootWorkspaceRuntime(runtime, normalizedRepoPath),
+      !isRepoRootWorkspaceRuntimeForNormalizedRepoPath(runtime, normalizedRepoPath),
   );
 };
 


### PR DESCRIPTION
## Summary
- Route-hydrates build/QA worktree sessions through a probed repo-root HTTP workspace runtime when no exact worktree runtime is available.
- Extracts shared route-only hydration helpers so repo-session reconciliation and requested-history hydration use the same policy.
- Dedupe runtime-list refetch callbacks during runtime attachment retry.

## Goal
This fixes hydration/reconnect behavior for persisted worktree sessions that only have a repo-root HTTP OpenCode runtime available. Previously, these sessions could fail with a missing live runtime even though the runtime route was usable for directory-scoped session lookup, which could leave Agent Studio in a reconnecting state or unable to hydrate the requested session.

## Technical choices
- Added `route-only-hydration.ts` to centralize route-only policy, runtime connection creation, lookup-key generation, directory-scoped scans, and preload recording.
- Kept fail-fast semantics for unsupported route-only cases: stdio repo-root runtimes are not used for route-only worktree hydration.
- Preserve durable/runtime separation by setting route-probed hydrated sessions to `runtimeId: null` while carrying the adapter-local `runtimeConnection` with the target worktree directory.
- Cache empty directory-scoped snapshot results by lookup key so reconciliation and requested-history hydration do not repeat the same scan unnecessarily.
- Updated full-suite expectations to assert successful route hydration for repo-root HTTP workspace runtimes and retained explicit stdio/no-route coverage.
- Dedupe shared runtime list refetchers with `Set` before retrying runtime attachment source refreshes.

## Verification
- `bun run lint && bun run typecheck && bun run test && bun run build`
- `rtk cargo fmt --all --check && rtk cargo check --workspace && rtk cargo test --workspace && rtk cargo clippy --workspace --all-targets -- -D warnings && rtk cargo build --workspace`
- Focused hydration tests were also run during development, including `load-sessions.test.ts` after updating stale expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized runtime attachment refresh calls by eliminating duplicate function invocations.

* **Bug Fixes**
  * Enhanced runtime resolution for agent sessions with improved worktree handling and session hydration logic.
  * Fixed session recovery to properly identify and utilize available runtime connections.

* **Tests**
  * Added test coverage for runtime deduplication behavior and session hydration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->