### PR TITLE
fix(frontend): stabilize agent session switching

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -559,6 +559,88 @@ describe("AgentChatThread", () => {
     rendered.unmount();
   });
 
+  test("stages a large attachment transcript on session switch", async () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    const animationFrameCallbacks = new Map<number, FrameRequestCallback>();
+    let nextAnimationFrameId = 1;
+
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      const frameId = nextAnimationFrameId;
+      nextAnimationFrameId += 1;
+      animationFrameCallbacks.set(frameId, callback);
+      return frameId;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((frameId: number) => {
+      animationFrameCallbacks.delete(frameId);
+    }) as typeof cancelAnimationFrame;
+
+    try {
+      const attachmentMessages = Array.from({ length: 80 }, (_, index) =>
+        buildMessage(
+          "user",
+          `Attachment message ${index + 1}`,
+          index === 0
+            ? {
+                id: `attachment-message-${index + 1}`,
+                meta: {
+                  kind: "user",
+                  state: "read",
+                  parts: [
+                    {
+                      kind: "attachment",
+                      attachment: {
+                        id: "attachment-1",
+                        name: "spec.md",
+                        kind: "pdf",
+                        path: "/tmp/spec.md",
+                      },
+                    },
+                  ],
+                },
+              }
+            : {
+                id: `attachment-message-${index + 1}`,
+              },
+        ),
+      );
+
+      const rendered = render(
+        createElement(AgentChatThread, {
+          model: {
+            ...buildBaseModel(),
+            session: buildSession({
+              sessionId: "session-normal",
+              messages: [buildMessage("assistant", "Baseline transcript", { id: "assistant-1" })],
+            }),
+          },
+        }),
+      );
+
+      rendered.rerender(
+        createElement(AgentChatThread, {
+          model: {
+            ...buildBaseModel(),
+            session: buildSession({
+              sessionId: "session-attachments",
+              messages: attachmentMessages,
+            }),
+          },
+        }),
+      );
+
+      expect(rendered.container.querySelectorAll("[data-row-key]")).toHaveLength(1);
+      expect(rendered.queryByText("Attachment message 1")).toBeNull();
+      expect(rendered.queryByText("Attachment message 80")).not.toBeNull();
+      expect(rendered.container.querySelector('[style*="content-visibility"]')).toBeNull();
+
+      rendered.unmount();
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
   test("adds bottom spacing before the composer when the last bottom-stack item is a question", async () => {
     const rendered = render(
       createElement(AgentChatThread, {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -524,6 +524,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     scrollToBottom,
     scrollToTop,
     scrollToBottomOnSend,
+    preserveScrollBeforeStagedPrepend,
   } = useAgentChatWindow({
     rows,
     turns: transcriptTurns,
@@ -556,19 +557,20 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     return resolveAgentAccentColor(profileId, sessionAgentColors[profileId]);
   }, [sessionAgentColors, sessionSelectedModel?.profileId]);
   const sessionWorkingDirectory = session?.workingDirectory ?? null;
-  // Attachment-bearing sessions are kept fully materialized because staged turn reveal and
-  // containment can under-measure transcript height during hydration and break bottom pinning.
+  // Attachment-bearing sessions keep containment disabled because intrinsic-size estimates can
+  // under-measure rich attachment rows and break bottom pinning. Row/turn staging still applies so
+  // cached large transcripts do not remount hundreds of rows in one synchronous session switch.
   const stagedTurns = useAgentChatTurnStaging({
     activeSessionId,
     windowStart,
     turns: windowedTurns,
-    disabled: hasAttachmentMessages,
+    onBeforePrepend: preserveScrollBeforeStagedPrepend,
   });
   const stagedTranscript = useAgentChatRowStaging({
     activeSessionId,
     rows: windowedRows,
     turns: stagedTurns,
-    disabled: hasAttachmentMessages,
+    onBeforePrepend: preserveScrollBeforeStagedPrepend,
   });
   const stagedRows = stagedTranscript.rows;
   const stagedWindowTurns = stagedTranscript.turns;

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-row-staging.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act } from "react";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
 import type { AgentChatWindowRow, AgentChatWindowTurn } from "./agent-chat-thread-windowing";
@@ -78,8 +78,8 @@ describe("useAgentChatRowStaging", () => {
 
     await harness.mount();
 
-    expect(harness.getLatest().rows).toHaveLength(24);
-    expect(harness.getLatest().turns).toEqual([{ key: "turn-0", start: 0, end: 23 }]);
+    expect(harness.getLatest().rows).toHaveLength(8);
+    expect(harness.getLatest().turns).toEqual([{ key: "turn-0", start: 0, end: 7 }]);
 
     await harness.unmount();
   });
@@ -127,13 +127,14 @@ describe("useAgentChatRowStaging", () => {
       nextTurns: turns,
     });
 
-    expect(harness.getLatest().rows).toHaveLength(24);
+    expect(harness.getLatest().rows).toHaveLength(8);
     expect(animationFrameCallbacks.size).toBeGreaterThan(0);
 
     await harness.unmount();
   });
 
   test("resumes staging when rows grow for the active session", async () => {
+    const onBeforePrepend = mock(() => {});
     const harness = createHookHarness(
       ({ activeSessionId, nextRows, nextTurns }) =>
         useAgentChatRowStaging({
@@ -141,6 +142,7 @@ describe("useAgentChatRowStaging", () => {
           rows: nextRows,
           turns: nextTurns,
           disabled: false,
+          onBeforePrepend,
         }),
       {
         activeSessionId: "session-1",
@@ -158,7 +160,8 @@ describe("useAgentChatRowStaging", () => {
       await flush();
     });
 
-    expect(harness.getLatest().rows).toHaveLength(56);
+    expect(harness.getLatest().rows).toHaveLength(16);
+    expect(onBeforePrepend).toHaveBeenCalledTimes(1);
 
     await harness.update({
       activeSessionId: "session-1",

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
@@ -55,7 +55,7 @@ export function useAgentChatRowStaging({
   const completedSessionIdsRef = useRef<Set<string>>(new Set());
   const previousSessionIdRef = useRef<string | null>(activeSessionId);
   const previousSessionId = previousSessionIdRef.current;
-  const switchedSessions =
+  const renderSwitchedSessions =
     previousSessionId !== null && activeSessionId !== null && previousSessionId !== activeSessionId;
 
   useEffect(() => {
@@ -69,9 +69,14 @@ export function useAgentChatRowStaging({
       frameRef.current = null;
     }
 
+    const effectPreviousSessionId = previousSessionIdRef.current;
+    const effectSwitchedSessions =
+      effectPreviousSessionId !== null &&
+      activeSessionId !== null &&
+      effectPreviousSessionId !== activeSessionId;
     previousSessionIdRef.current = activeSessionId;
 
-    if (switchedSessions && activeSessionId !== null) {
+    if (effectSwitchedSessions && activeSessionId !== null) {
       completedSessionIdsRef.current.delete(activeSessionId);
     }
 
@@ -85,7 +90,7 @@ export function useAgentChatRowStaging({
       activeSessionId,
       completedSessionIds: completedSessionIdsRef.current,
       disabled,
-      forceStage: switchedSessions,
+      forceStage: effectSwitchedSessions,
       rowCount: rows.length,
     });
 
@@ -137,7 +142,7 @@ export function useAgentChatRowStaging({
         frameRef.current = null;
       }
     };
-  }, [activeSessionId, disabled, onBeforePrepend, rows.length, switchedSessions]);
+  }, [activeSessionId, disabled, onBeforePrepend, rows.length]);
 
   return useMemo(() => {
     if (
@@ -146,7 +151,7 @@ export function useAgentChatRowStaging({
         activeSessionId,
         completedSessionIds: completedSessionIdsRef.current,
         disabled,
-        forceStage: switchedSessions,
+        forceStage: renderSwitchedSessions,
         rowCount: rows.length,
       })
     ) {
@@ -154,7 +159,7 @@ export function useAgentChatRowStaging({
     }
 
     const effectiveRowCount =
-      switchedSessions && activeSessionRef.current !== activeSessionId
+      renderSwitchedSessions && activeSessionRef.current !== activeSessionId
         ? Math.min(rows.length, ROW_STAGE_INIT)
         : rowCount;
 
@@ -173,5 +178,5 @@ export function useAgentChatRowStaging({
           end: turn.end - rowStart,
         })),
     };
-  }, [activeSessionId, disabled, rowCount, rows, switchedSessions, turns]);
+  }, [activeSessionId, disabled, rowCount, rows, renderSwitchedSessions, turns]);
 }

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-row-staging.ts
@@ -1,21 +1,27 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { AgentChatWindowRow, AgentChatWindowTurn } from "./agent-chat-thread-windowing";
 
-const ROW_STAGE_INIT = 24;
-const ROW_STAGE_BATCH = 32;
+const ROW_STAGE_INIT = 8;
+const ROW_STAGE_BATCH = 8;
 
 const shouldStageRows = ({
   activeSessionId,
   completedSessionIds,
   disabled,
+  forceStage,
   rowCount,
 }: {
   activeSessionId: string;
   completedSessionIds: Set<string>;
   disabled: boolean;
+  forceStage?: boolean;
   rowCount: number;
 }): boolean => {
-  return !disabled && rowCount > ROW_STAGE_INIT && !completedSessionIds.has(activeSessionId);
+  return (
+    !disabled &&
+    rowCount > ROW_STAGE_INIT &&
+    (forceStage === true || !completedSessionIds.has(activeSessionId))
+  );
 };
 
 type UseAgentChatRowStagingArgs = {
@@ -23,6 +29,7 @@ type UseAgentChatRowStagingArgs = {
   rows: AgentChatWindowRow[];
   turns: AgentChatWindowTurn[];
   disabled?: boolean;
+  onBeforePrepend?: () => void;
 };
 
 type UseAgentChatRowStagingResult = {
@@ -35,13 +42,21 @@ export function useAgentChatRowStaging({
   rows,
   turns,
   disabled = false,
+  onBeforePrepend,
 }: UseAgentChatRowStagingArgs): UseAgentChatRowStagingResult {
-  const [rowCount, setRowCount] = useState(rows.length);
+  const [rowCount, setRowCount] = useState(() =>
+    activeSessionId !== null && !disabled && rows.length > ROW_STAGE_INIT
+      ? ROW_STAGE_INIT
+      : rows.length,
+  );
   const rowCountRef = useRef(rowCount);
   const frameRef = useRef<number | null>(null);
   const activeSessionRef = useRef<string | null>(null);
   const completedSessionIdsRef = useRef<Set<string>>(new Set());
   const previousSessionIdRef = useRef<string | null>(activeSessionId);
+  const previousSessionId = previousSessionIdRef.current;
+  const switchedSessions =
+    previousSessionId !== null && activeSessionId !== null && previousSessionId !== activeSessionId;
 
   useEffect(() => {
     const updateRowCount = (nextRowCount: number): void => {
@@ -54,11 +69,6 @@ export function useAgentChatRowStaging({
       frameRef.current = null;
     }
 
-    const previousSessionId = previousSessionIdRef.current;
-    const switchedSessions =
-      previousSessionId !== null &&
-      activeSessionId !== null &&
-      previousSessionId !== activeSessionId;
     previousSessionIdRef.current = activeSessionId;
 
     if (switchedSessions && activeSessionId !== null) {
@@ -75,6 +85,7 @@ export function useAgentChatRowStaging({
       activeSessionId,
       completedSessionIds: completedSessionIdsRef.current,
       disabled,
+      forceStage: switchedSessions,
       rowCount: rows.length,
     });
 
@@ -106,6 +117,7 @@ export function useAgentChatRowStaging({
       }
 
       nextRowCount = Math.min(rows.length, nextRowCount + ROW_STAGE_BATCH);
+      onBeforePrepend?.();
       updateRowCount(nextRowCount);
 
       if (nextRowCount >= rows.length) {
@@ -125,7 +137,7 @@ export function useAgentChatRowStaging({
         frameRef.current = null;
       }
     };
-  }, [activeSessionId, disabled, rows.length]);
+  }, [activeSessionId, disabled, onBeforePrepend, rows.length, switchedSessions]);
 
   return useMemo(() => {
     if (
@@ -134,17 +146,23 @@ export function useAgentChatRowStaging({
         activeSessionId,
         completedSessionIds: completedSessionIdsRef.current,
         disabled,
+        forceStage: switchedSessions,
         rowCount: rows.length,
       })
     ) {
       return { rows, turns };
     }
 
-    if (rowCount >= rows.length) {
+    const effectiveRowCount =
+      switchedSessions && activeSessionRef.current !== activeSessionId
+        ? Math.min(rows.length, ROW_STAGE_INIT)
+        : rowCount;
+
+    if (effectiveRowCount >= rows.length) {
       return { rows, turns };
     }
 
-    const rowStart = Math.max(0, rows.length - rowCount);
+    const rowStart = Math.max(0, rows.length - effectiveRowCount);
     return {
       rows: rows.slice(rowStart),
       turns: turns
@@ -155,5 +173,5 @@ export function useAgentChatRowStaging({
           end: turn.end - rowStart,
         })),
     };
-  }, [activeSessionId, disabled, rowCount, rows, turns]);
+  }, [activeSessionId, disabled, rowCount, rows, switchedSessions, turns]);
 }

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
@@ -1,14 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act } from "react";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
 import type { AgentChatWindowTurn } from "./agent-chat-thread-windowing";
 import { useAgentChatTurnStaging } from "./use-agent-chat-turn-staging";
 
-(
-  globalThis as typeof globalThis & {
-    IS_REACT_ACT_ENVIRONMENT?: boolean;
-  }
-).IS_REACT_ACT_ENVIRONMENT = true;
+const reactActGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
 
 const buildTurns = (count: number): AgentChatWindowTurn[] =>
   Array.from({ length: count }, (_, index) => ({
@@ -27,8 +25,11 @@ describe("useAgentChatTurnStaging", () => {
   const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
   const animationFrameCallbacks = new Map<number, FrameRequestCallback>();
   let nextAnimationFrameId = 1;
+  let originalIsReactActEnvironment: boolean | undefined;
 
   beforeEach(() => {
+    originalIsReactActEnvironment = reactActGlobal.IS_REACT_ACT_ENVIRONMENT;
+    reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true;
     animationFrameCallbacks.clear();
     nextAnimationFrameId = 1;
     globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
@@ -43,6 +44,11 @@ describe("useAgentChatTurnStaging", () => {
   });
 
   afterEach(() => {
+    if (typeof originalIsReactActEnvironment === "undefined") {
+      delete reactActGlobal.IS_REACT_ACT_ENVIRONMENT;
+    } else {
+      reactActGlobal.IS_REACT_ACT_ENVIRONMENT = originalIsReactActEnvironment;
+    }
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;
     globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
   });
@@ -174,6 +180,7 @@ describe("useAgentChatTurnStaging", () => {
   });
 
   test("resumes staging when turns grow for the active session", async () => {
+    const onBeforePrepend = mock(() => {});
     const harness = createHookHarness(
       ({ activeSessionId, windowStart, nextTurns }) =>
         useAgentChatTurnStaging({
@@ -181,6 +188,7 @@ describe("useAgentChatTurnStaging", () => {
           windowStart,
           turns: nextTurns,
           disabled: false,
+          onBeforePrepend,
         }),
       {
         activeSessionId: "session-1",
@@ -199,11 +207,10 @@ describe("useAgentChatTurnStaging", () => {
     });
 
     expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual([
-      "turn-2",
-      "turn-3",
       "turn-4",
       "turn-5",
     ]);
+    expect(onBeforePrepend).toHaveBeenCalledTimes(1);
 
     await harness.update({
       activeSessionId: "session-1",

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
@@ -53,7 +53,7 @@ export function useAgentChatTurnStaging({
   const completedSessionIdsRef = useRef<Set<string>>(new Set());
   const previousSessionIdRef = useRef<string | null>(activeSessionId);
   const previousSessionId = previousSessionIdRef.current;
-  const switchedSessions =
+  const renderSwitchedSessions =
     previousSessionId !== null && activeSessionId !== null && previousSessionId !== activeSessionId;
 
   useEffect(() => {
@@ -67,9 +67,14 @@ export function useAgentChatTurnStaging({
       frameRef.current = null;
     }
 
+    const effectPreviousSessionId = previousSessionIdRef.current;
+    const effectSwitchedSessions =
+      effectPreviousSessionId !== null &&
+      activeSessionId !== null &&
+      effectPreviousSessionId !== activeSessionId;
     previousSessionIdRef.current = activeSessionId;
 
-    if (switchedSessions && activeSessionId !== null) {
+    if (effectSwitchedSessions && activeSessionId !== null) {
       completedSessionIdsRef.current.delete(activeSessionId);
     }
 
@@ -83,7 +88,7 @@ export function useAgentChatTurnStaging({
       activeSessionId,
       completedSessionIds: completedSessionIdsRef.current,
       disabled,
-      forceStage: switchedSessions,
+      forceStage: effectSwitchedSessions,
       turnCount: turns.length,
       windowStart,
     });
@@ -136,7 +141,7 @@ export function useAgentChatTurnStaging({
         frameRef.current = null;
       }
     };
-  }, [activeSessionId, disabled, onBeforePrepend, switchedSessions, turns.length, windowStart]);
+  }, [activeSessionId, disabled, onBeforePrepend, turns.length, windowStart]);
 
   return useMemo(() => {
     if (
@@ -145,7 +150,7 @@ export function useAgentChatTurnStaging({
         activeSessionId,
         completedSessionIds: completedSessionIdsRef.current,
         disabled,
-        forceStage: switchedSessions,
+        forceStage: renderSwitchedSessions,
         turnCount: turns.length,
         windowStart,
       })
@@ -154,7 +159,7 @@ export function useAgentChatTurnStaging({
     }
 
     const effectiveCount =
-      switchedSessions && activeSessionRef.current !== activeSessionId
+      renderSwitchedSessions && activeSessionRef.current !== activeSessionId
         ? Math.min(turns.length, STAGE_INIT)
         : count;
 
@@ -163,5 +168,5 @@ export function useAgentChatTurnStaging({
     }
 
     return turns.slice(Math.max(0, turns.length - effectiveCount));
-  }, [activeSessionId, count, disabled, switchedSessions, turns, windowStart]);
+  }, [activeSessionId, count, disabled, renderSwitchedSessions, turns, windowStart]);
 }

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
@@ -2,18 +2,20 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { AgentChatWindowTurn } from "./agent-chat-thread-windowing";
 
 const STAGE_INIT = 1;
-const STAGE_BATCH = 3;
+const STAGE_BATCH = 1;
 
 const shouldStageTurns = ({
   activeSessionId,
   completedSessionIds,
   disabled,
+  forceStage,
   turnCount,
   windowStart,
 }: {
   activeSessionId: string;
   completedSessionIds: Set<string>;
   disabled: boolean;
+  forceStage?: boolean;
   turnCount: number;
   windowStart: number;
 }): boolean => {
@@ -21,7 +23,7 @@ const shouldStageTurns = ({
     !disabled &&
     windowStart > 0 &&
     turnCount > STAGE_INIT &&
-    !completedSessionIds.has(activeSessionId)
+    (forceStage === true || !completedSessionIds.has(activeSessionId))
   );
 };
 
@@ -30,6 +32,7 @@ type UseAgentChatTurnStagingArgs = {
   windowStart: number;
   turns: AgentChatWindowTurn[];
   disabled?: boolean;
+  onBeforePrepend?: () => void;
 };
 
 export function useAgentChatTurnStaging({
@@ -37,13 +40,21 @@ export function useAgentChatTurnStaging({
   windowStart,
   turns,
   disabled = false,
+  onBeforePrepend,
 }: UseAgentChatTurnStagingArgs): AgentChatWindowTurn[] {
-  const [count, setCount] = useState(turns.length);
+  const [count, setCount] = useState(() =>
+    activeSessionId !== null && !disabled && windowStart > 0 && turns.length > STAGE_INIT
+      ? STAGE_INIT
+      : turns.length,
+  );
   const countRef = useRef(count);
   const frameRef = useRef<number | null>(null);
   const activeSessionRef = useRef<string | null>(null);
   const completedSessionIdsRef = useRef<Set<string>>(new Set());
   const previousSessionIdRef = useRef<string | null>(activeSessionId);
+  const previousSessionId = previousSessionIdRef.current;
+  const switchedSessions =
+    previousSessionId !== null && activeSessionId !== null && previousSessionId !== activeSessionId;
 
   useEffect(() => {
     const updateCount = (nextCount: number): void => {
@@ -56,11 +67,6 @@ export function useAgentChatTurnStaging({
       frameRef.current = null;
     }
 
-    const previousSessionId = previousSessionIdRef.current;
-    const switchedSessions =
-      previousSessionId !== null &&
-      activeSessionId !== null &&
-      previousSessionId !== activeSessionId;
     previousSessionIdRef.current = activeSessionId;
 
     if (switchedSessions && activeSessionId !== null) {
@@ -77,6 +83,7 @@ export function useAgentChatTurnStaging({
       activeSessionId,
       completedSessionIds: completedSessionIdsRef.current,
       disabled,
+      forceStage: switchedSessions,
       turnCount: turns.length,
       windowStart,
     });
@@ -109,6 +116,7 @@ export function useAgentChatTurnStaging({
       }
 
       nextCount = Math.min(turns.length, nextCount + STAGE_BATCH);
+      onBeforePrepend?.();
       updateCount(nextCount);
 
       if (nextCount >= turns.length) {
@@ -128,7 +136,7 @@ export function useAgentChatTurnStaging({
         frameRef.current = null;
       }
     };
-  }, [activeSessionId, disabled, turns.length, windowStart]);
+  }, [activeSessionId, disabled, onBeforePrepend, switchedSessions, turns.length, windowStart]);
 
   return useMemo(() => {
     if (
@@ -137,6 +145,7 @@ export function useAgentChatTurnStaging({
         activeSessionId,
         completedSessionIds: completedSessionIdsRef.current,
         disabled,
+        forceStage: switchedSessions,
         turnCount: turns.length,
         windowStart,
       })
@@ -144,10 +153,15 @@ export function useAgentChatTurnStaging({
       return turns;
     }
 
-    if (count >= turns.length) {
+    const effectiveCount =
+      switchedSessions && activeSessionRef.current !== activeSessionId
+        ? Math.min(turns.length, STAGE_INIT)
+        : count;
+
+    if (effectiveCount >= turns.length) {
       return turns;
     }
 
-    return turns.slice(Math.max(0, turns.length - count));
-  }, [activeSessionId, count, disabled, turns, windowStart]);
+    return turns.slice(Math.max(0, turns.length - effectiveCount));
+  }, [activeSessionId, count, disabled, switchedSessions, turns, windowStart]);
 }

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -755,6 +755,83 @@ describe("useAgentChatWindow", () => {
     await harness.unmount();
   });
 
+  test("preserves the visible anchor when staged history prepends while scrolled", async () => {
+    const rows = createTurnRows(8);
+    const extraContentHeightPx = { current: 0 };
+    const harness = await mountHarness(
+      {
+        rows,
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+        isSessionWorking: false,
+      },
+      { attachDom: true, extraContentHeightPx },
+    );
+
+    const container = harness.messagesContainerRef.current;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+
+    container.scrollTop = 120;
+    await act(async () => {
+      await dispatchWheelUp(container);
+      await dispatchScroll(container);
+    });
+    await flushAnimationFrames();
+
+    harness.getLatestResult().preserveScrollBeforeStagedPrepend();
+    extraContentHeightPx.current = 200;
+    await harness.update({
+      rows,
+      activeSessionId: "session-1",
+      isSessionViewLoading: false,
+      isSessionWorking: false,
+    });
+
+    expect(container.scrollTop).toBe(320);
+    expect(harness.getLatestResult().isNearBottom).toBe(false);
+
+    await harness.unmount();
+  });
+
+  test("does not delta-preserve staged prepends while following the transcript", async () => {
+    const rows = createTurnRows(8);
+    const extraContentHeightPx = { current: 0 };
+    const harness = await mountHarness(
+      {
+        rows,
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+        isSessionWorking: false,
+      },
+      { attachDom: true, extraContentHeightPx },
+    );
+
+    const container = harness.messagesContainerRef.current;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+
+    container.scrollTop = getMaxScrollTop(container);
+    await act(async () => {
+      await dispatchScroll(container);
+    });
+
+    harness.getLatestResult().preserveScrollBeforeStagedPrepend();
+    extraContentHeightPx.current = 200;
+    await harness.update({
+      rows,
+      activeSessionId: "session-1",
+      isSessionViewLoading: false,
+      isSessionWorking: false,
+    });
+
+    expect(container.scrollTop).toBe(getMaxScrollTop(container) - 200);
+
+    await harness.unmount();
+  });
+
   test("keeps the bottom locked while streaming when the user stays pinned", async () => {
     const rows = createTurnRows(4);
     const extraContentHeightPx = { current: 0 };

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -21,9 +21,16 @@ type UseAgentChatWindowResult = {
   windowStart: number;
   isNearBottom: boolean;
   isNearTop: boolean;
+  preserveScrollBeforeStagedPrepend: () => void;
   scrollToBottom: () => void;
   scrollToTop: () => void;
   scrollToBottomOnSend: () => void;
+};
+
+type StagedPrependScrollSnapshot = {
+  sessionId: string | null;
+  beforeScrollHeight: number;
+  beforeScrollTop: number;
 };
 
 export function useAgentChatWindow({
@@ -41,6 +48,7 @@ export function useAgentChatWindow({
   const composerLayoutSyncTokenRef = useRef(0);
   const prevSessionIdRef = useRef<string | null>(null);
   const prevIsSessionViewLoadingRef = useRef(isSessionViewLoading);
+  const stagedPrependScrollSnapshotRef = useRef<StagedPrependScrollSnapshot | null>(null);
   const {
     isNearBottom,
     isNearTop,
@@ -76,6 +84,23 @@ export function useAgentChatWindow({
     return !userScrolledRef.current;
   }, [userScrolledRef]);
 
+  const preserveScrollBeforeStagedPrepend = useCallback(() => {
+    if (!userScrolledRef.current || stagedPrependScrollSnapshotRef.current !== null) {
+      return;
+    }
+
+    const container = messagesContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    stagedPrependScrollSnapshotRef.current = {
+      sessionId: activeSessionId,
+      beforeScrollHeight: container.scrollHeight,
+      beforeScrollTop: container.scrollTop,
+    };
+  }, [activeSessionId, messagesContainerRef, userScrolledRef]);
+
   const resetLatestTurnsAndPinBottom = useCallback(() => {
     if (turnStart === latestTurnStart) {
       forceScrollToBottom();
@@ -92,6 +117,7 @@ export function useAgentChatWindow({
     }
 
     prevSessionIdRef.current = activeSessionId;
+    stagedPrependScrollSnapshotRef.current = null;
     resetLatestTurnsAndPinBottom();
   }, [activeSessionId, resetLatestTurnsAndPinBottom]);
 
@@ -167,6 +193,9 @@ export function useAgentChatWindow({
     userScrollIntentVersionRef,
   ]);
 
+  // Intentionally runs after every commit: staged transcript prepends happen in sibling hooks
+  // after this hook has already computed its window, so the window key can remain unchanged while
+  // the rendered DOM grows above the viewport.
   useLayoutEffect(() => {
     void visibleWindowKey;
 
@@ -180,8 +209,21 @@ export function useAgentChatWindow({
 
   useLayoutEffect(() => {
     void visibleWindowKey;
+
+    const pendingStagedPrepend = stagedPrependScrollSnapshotRef.current;
+    const container = messagesContainerRef.current;
+    if (pendingStagedPrepend && pendingStagedPrepend.sessionId === activeSessionId && container) {
+      stagedPrependScrollSnapshotRef.current = null;
+      const scrollHeightDelta = container.scrollHeight - pendingStagedPrepend.beforeScrollHeight;
+      if (scrollHeightDelta !== 0) {
+        container.scrollTop = pendingStagedPrepend.beforeScrollTop + scrollHeightDelta;
+      }
+    } else if (pendingStagedPrepend) {
+      stagedPrependScrollSnapshotRef.current = null;
+    }
+
     refreshScrollState();
-  }, [refreshScrollState, visibleWindowKey]);
+  });
 
   return {
     windowedRows,
@@ -189,6 +231,7 @@ export function useAgentChatWindow({
     windowStart,
     isNearBottom,
     isNearTop: isNearTop && turnStart === 0,
+    preserveScrollBeforeStagedPrepend,
     scrollToBottom: () => {
       resetLatestTurnsAndPinBottom();
     },

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -193,9 +193,6 @@ export function useAgentChatWindow({
     userScrollIntentVersionRef,
   ]);
 
-  // Intentionally runs after every commit: staged transcript prepends happen in sibling hooks
-  // after this hook has already computed its window, so the window key can remain unchanged while
-  // the rendered DOM grows above the viewport.
   useLayoutEffect(() => {
     void visibleWindowKey;
 
@@ -207,23 +204,34 @@ export function useAgentChatWindow({
     forceScrollToBottom();
   }, [forceScrollToBottom, visibleWindowKey]);
 
+  // Intentionally checks staged prepends after every commit: staging happens in sibling hooks after
+  // this hook computes its window, so the window key can remain unchanged while the DOM grows above
+  // the viewport. The expensive scroll-state refresh stays gated in the next effect.
   useLayoutEffect(() => {
-    void visibleWindowKey;
-
     const pendingStagedPrepend = stagedPrependScrollSnapshotRef.current;
     const container = messagesContainerRef.current;
+    let restoredStagedPrepend = false;
     if (pendingStagedPrepend && pendingStagedPrepend.sessionId === activeSessionId && container) {
       stagedPrependScrollSnapshotRef.current = null;
       const scrollHeightDelta = container.scrollHeight - pendingStagedPrepend.beforeScrollHeight;
       if (scrollHeightDelta !== 0) {
         container.scrollTop = pendingStagedPrepend.beforeScrollTop + scrollHeightDelta;
+        restoredStagedPrepend = true;
       }
     } else if (pendingStagedPrepend) {
       stagedPrependScrollSnapshotRef.current = null;
     }
 
-    refreshScrollState();
+    if (restoredStagedPrepend) {
+      refreshScrollState();
+    }
   });
+
+  useLayoutEffect(() => {
+    void visibleWindowKey;
+
+    refreshScrollState();
+  }, [refreshScrollState, visibleWindowKey]);
 
   return {
     windowedRows,

--- a/packages/frontend/src/state/agent-runtime-registry.test.ts
+++ b/packages/frontend/src/state/agent-runtime-registry.test.ts
@@ -54,13 +54,12 @@ describe("agent-runtime-registry", () => {
     const loadSessionTodos = mock(async () => []);
     const listLiveAgentSessionSnapshots = mock(async () => []);
 
-    OpencodeSdkAdapter.prototype.listAvailableModels = listAvailableModels;
-    OpencodeSdkAdapter.prototype.loadSessionTodos = loadSessionTodos;
-    OpencodeSdkAdapter.prototype.listLiveAgentSessionSnapshots = listLiveAgentSessionSnapshots;
-
-    const engine = createAgentRuntimeRegistry().createAgentEngine();
-
     try {
+      OpencodeSdkAdapter.prototype.listAvailableModels = listAvailableModels;
+      OpencodeSdkAdapter.prototype.loadSessionTodos = loadSessionTodos;
+      OpencodeSdkAdapter.prototype.listLiveAgentSessionSnapshots = listLiveAgentSessionSnapshots;
+
+      const engine = createAgentRuntimeRegistry().createAgentEngine();
       const {
         listAvailableModels: readModels,
         loadSessionTodos: readTodos,

--- a/packages/frontend/src/state/agent-runtime-registry.test.ts
+++ b/packages/frontend/src/state/agent-runtime-registry.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import { createAgentRuntimeRegistry, DEFAULT_RUNTIME_KIND } from "./agent-runtime-registry";
 
 describe("agent-runtime-registry", () => {
@@ -39,5 +40,70 @@ describe("agent-runtime-registry", () => {
     await expect(engine.startSession(missingRuntimeInput)).rejects.toThrow(
       "Runtime kind is required to select an agent runtime adapter.",
     );
+  });
+
+  test("keeps runtime engine methods bound when passed as callbacks", async () => {
+    const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+    const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+    const originalListLiveAgentSessionSnapshots =
+      OpencodeSdkAdapter.prototype.listLiveAgentSessionSnapshots;
+    const listAvailableModels = mock(async () => ({
+      models: [],
+      defaultModelsByProvider: {},
+    }));
+    const loadSessionTodos = mock(async () => []);
+    const listLiveAgentSessionSnapshots = mock(async () => []);
+
+    OpencodeSdkAdapter.prototype.listAvailableModels = listAvailableModels;
+    OpencodeSdkAdapter.prototype.loadSessionTodos = loadSessionTodos;
+    OpencodeSdkAdapter.prototype.listLiveAgentSessionSnapshots = listLiveAgentSessionSnapshots;
+
+    const engine = createAgentRuntimeRegistry().createAgentEngine();
+
+    try {
+      const {
+        listAvailableModels: readModels,
+        loadSessionTodos: readTodos,
+        listLiveAgentSessionSnapshots: readSnapshots,
+      } = engine;
+
+      await readModels({
+        runtimeKind: "opencode",
+        runtimeConnection: {
+          type: "local_http",
+          endpoint: "http://127.0.0.1:1",
+          workingDirectory: "/tmp/repo",
+        },
+      });
+
+      await readTodos({
+        runtimeKind: "opencode",
+        runtimeConnection: {
+          type: "local_http",
+          endpoint: "http://127.0.0.1:1",
+          workingDirectory: "/tmp/repo",
+        },
+        externalSessionId: "external-1",
+      });
+
+      await readSnapshots({
+        runtimeKind: "opencode",
+        runtimeConnection: {
+          type: "local_http",
+          endpoint: "http://127.0.0.1:1",
+          workingDirectory: "/tmp/repo",
+        },
+        directories: ["/tmp/repo"],
+      });
+
+      expect(listAvailableModels).toHaveBeenCalledTimes(1);
+      expect(loadSessionTodos).toHaveBeenCalledTimes(1);
+      expect(listLiveAgentSessionSnapshots).toHaveBeenCalledTimes(1);
+    } finally {
+      OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+      OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+      OpencodeSdkAdapter.prototype.listLiveAgentSessionSnapshots =
+        originalListLiveAgentSessionSnapshots;
+    }
   });
 });

--- a/packages/frontend/src/state/agent-runtime-registry.ts
+++ b/packages/frontend/src/state/agent-runtime-registry.ts
@@ -70,7 +70,31 @@ class RuntimeRegistryAgentEngine implements AgentEnginePort {
   constructor(
     private readonly getAdapter: (runtimeKind: RuntimeKind) => RegisteredRuntimeAdapter,
     private readonly registeredRuntimeKinds: RuntimeKind[],
-  ) {}
+  ) {
+    this.startSession = this.startSession.bind(this);
+    this.resumeSession = this.resumeSession.bind(this);
+    this.attachSession = this.attachSession.bind(this);
+    this.detachSession = this.detachSession.bind(this);
+    this.forkSession = this.forkSession.bind(this);
+    this.listRuntimeDefinitions = this.listRuntimeDefinitions.bind(this);
+    this.listAvailableModels = this.listAvailableModels.bind(this);
+    this.listAvailableSlashCommands = this.listAvailableSlashCommands.bind(this);
+    this.searchFiles = this.searchFiles.bind(this);
+    this.listLiveAgentSessions = this.listLiveAgentSessions.bind(this);
+    this.listLiveAgentSessionSnapshots = this.listLiveAgentSessionSnapshots.bind(this);
+    this.hasSession = this.hasSession.bind(this);
+    this.loadSessionHistory = this.loadSessionHistory.bind(this);
+    this.loadSessionTodos = this.loadSessionTodos.bind(this);
+    this.listLiveAgentSessionPendingInput = this.listLiveAgentSessionPendingInput.bind(this);
+    this.updateSessionModel = this.updateSessionModel.bind(this);
+    this.sendUserMessage = this.sendUserMessage.bind(this);
+    this.replyPermission = this.replyPermission.bind(this);
+    this.replyQuestion = this.replyQuestion.bind(this);
+    this.subscribeEvents = this.subscribeEvents.bind(this);
+    this.stopSession = this.stopSession.bind(this);
+    this.loadSessionDiff = this.loadSessionDiff.bind(this);
+    this.loadFileStatus = this.loadFileStatus.bind(this);
+  }
 
   async startSession(input: Parameters<AgentEnginePort["startSession"]>[0]) {
     const runtimeKind = this.resolveRuntimeKind(input.runtimeKind, input.model);


### PR DESCRIPTION
## Summary
- Stage cached Agent Studio transcripts during session switches so large histories do not synchronously remount hundreds of rows.
- Preserve the visible scroll anchor while staged history prepends above a manually scrolled viewport.
- Bind runtime registry agent-engine methods so callback usage keeps runtime resolution context.

## Goal / Context
Switching into sessions with large cached transcripts could block the UI, attachment-heavy transcripts bypassed the staging path, and staged prepends could make the viewport jump when the user scrolled into history. Separately, runtime engine methods passed as callbacks could lose `this` and surface `this.requireInputRuntimeKind is not a function` during session preparation.

## Technical choices
- Keep attachment transcript containment disabled to avoid rich-row height under-measurement, but still stage row/turn rendering.
- Capture `scrollTop` and `scrollHeight` before staged prepends and restore by the height delta only for user-scrolled views.
- Bind the public `RuntimeRegistryAgentEngine` methods in the constructor rather than relying on call-site binding.
- Add focused regressions for attachment staging, row/turn staging, scroll preservation, and unbound callback usage.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run check:rust`
- `bun run test:rust`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scroll position jumping when switching chat sessions with large attachments
  * Resolved method binding issues affecting session runtime operations

* **Improvements**
  * Enhanced message staging for better performance with large attachment transcripts
  * Improved scroll anchoring during incremental message loading in chat threads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->