### PR TITLE
feat: add fullscreen markdown document preview modal

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
 import { AgentStudioWorkspaceSidebar } from "./agent-studio-workspace-sidebar";
+
+enableReactActEnvironment();
 
 const emptyDoc = {
   markdown: "",
@@ -34,6 +37,7 @@ describe("AgentStudioWorkspaceSidebar", () => {
     expect(html).toContain("Current specification document for this task.");
     expect(html).toContain("Spec");
     expect(html).toContain('data-testid="copy-agent-studio-document-content"');
+    expect(html).toContain('data-testid="expand-agent-studio-document"');
     expect(html).toMatch(/Feb 21(?:, \d{1,2}:\d{2}\s?[AP]M| at)/u);
   });
 
@@ -56,6 +60,7 @@ describe("AgentStudioWorkspaceSidebar", () => {
     expect(html).toContain("No QA report yet.");
     expect(html).toContain("Not set");
     expect(html).not.toContain('data-testid="copy-agent-studio-document-content"');
+    expect(html).not.toContain('data-testid="expand-agent-studio-document"');
   });
 
   test("renders empty sidebar for Builder role documents", () => {

--- a/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.test.tsx
@@ -74,4 +74,24 @@ describe("AgentStudioWorkspaceSidebar", () => {
 
     expect(html).not.toContain("Specification");
   });
+
+  test("expand button is hidden when document markdown is empty", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioWorkspaceSidebar, {
+        model: {
+          activeDocument: {
+            title: "Specification",
+            description: "Current specification document.",
+            emptyState: "No spec document yet.",
+            document: {
+              ...emptyDoc,
+              markdown: "",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(html).not.toContain('data-testid="expand-agent-studio-document"');
+  });
 });

--- a/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.test.tsx
@@ -1,7 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { replaceNavigatorClipboard } from "@/test-utils/mock-clipboard";
+import { withMockedToast } from "@/test-utils/mock-toast";
 import { AgentStudioWorkspaceSidebar } from "./agent-studio-workspace-sidebar";
 
 enableReactActEnvironment();
@@ -93,5 +96,78 @@ describe("AgentStudioWorkspaceSidebar", () => {
     );
 
     expect(html).not.toContain('data-testid="expand-agent-studio-document"');
+  });
+});
+
+describe("AgentStudioWorkspaceSidebar snapshot persistence", () => {
+  const writeClipboardMock = mock(async (_value: string) => {});
+  let restoreClipboard: (() => void) | null = null;
+
+  beforeEach(() => {
+    writeClipboardMock.mockClear();
+    writeClipboardMock.mockImplementation(async () => {});
+    restoreClipboard = replaceNavigatorClipboard(writeClipboardMock);
+  });
+
+  afterEach(() => {
+    restoreClipboard?.();
+    restoreClipboard = null;
+  });
+
+  const activeDoc = {
+    title: "Specification",
+    description: "Current specification document.",
+    emptyState: "No spec document yet.",
+    document: {
+      markdown: "# Active spec content",
+      updatedAt: "2026-02-21T10:00:00.000Z",
+      isLoading: false,
+      error: null,
+      loaded: true,
+    },
+  };
+
+  test("modal retains original content when activeDocument becomes null", () => {
+    const { rerender } = render(
+      createElement(AgentStudioWorkspaceSidebar, {
+        model: { activeDocument: activeDoc },
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId("expand-agent-studio-document"));
+
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+
+    rerender(
+      createElement(AgentStudioWorkspaceSidebar, {
+        model: { activeDocument: null },
+      }),
+    );
+
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+    // After sidebar becomes null, only the modal snapshot has the content (sidebar is empty)
+    const matching = screen.getAllByText((c) => c.includes("Active spec content"));
+    expect(matching.length).toBe(1);
+  });
+
+  test("copy button in modal copies snapshot markdown after activeDocument becomes null", async () => {
+    await withMockedToast(async () => {
+      const { rerender } = render(
+        createElement(AgentStudioWorkspaceSidebar, {
+          model: { activeDocument: activeDoc },
+        }),
+      );
+
+      fireEvent.click(screen.getByTestId("expand-agent-studio-document"));
+
+      rerender(
+        createElement(AgentStudioWorkspaceSidebar, {
+          model: { activeDocument: null },
+        }),
+      );
+
+      fireEvent.click(screen.getByTestId("markdown-preview-modal-copy"));
+      expect(writeClipboardMock).toHaveBeenCalledWith("# Active spec content");
+    });
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
@@ -1,12 +1,12 @@
 import { Maximize2 } from "lucide-react";
-import { type MouseEvent, type ReactElement, useCallback, useState } from "react";
+import type { ReactElement } from "react";
+import { useCallback, useState } from "react";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
 import { Button } from "@/components/ui/button";
-import { CopyIconButton } from "@/components/ui/copy-icon-button";
+import { DocumentCopyButton } from "@/components/ui/document-copy-button";
 import { MarkdownPreviewModal } from "@/components/ui/markdown-preview-modal";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
-import { buildCopyPreview } from "@/lib/copy-preview";
-import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
+import { hasLabeledCodeFence } from "@/lib/markdown-utils";
 
 export type AgentStudioWorkspaceDocument = {
   title: string;
@@ -31,10 +31,6 @@ const formatDocumentUpdatedAt = (iso: string | null): string | null => {
   }).format(value);
 };
 
-const hasLabeledCodeFence = (markdown: string): boolean => {
-  return markdown.includes("```") && /```[a-z0-9_-]+/i.test(markdown);
-};
-
 export type AgentStudioWorkspaceSidebarModel = {
   activeDocument: AgentStudioWorkspaceDocument | null;
 };
@@ -43,32 +39,6 @@ type DocumentSectionProps = {
   emptyState: string;
   document: TaskDocumentState;
 };
-
-function AgentStudioDocumentCopyButton({ markdown }: { markdown: string }): ReactElement {
-  const { copied, copyToClipboard } = useCopyToClipboard({
-    getSuccessDescription: buildCopyPreview,
-    errorLogContext: "AgentStudioWorkspaceSidebar",
-  });
-
-  const handleCopy = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      event.stopPropagation();
-      event.preventDefault();
-      void copyToClipboard(markdown);
-    },
-    [copyToClipboard, markdown],
-  );
-
-  return (
-    <CopyIconButton
-      copied={copied}
-      ariaLabel="Copy document content"
-      dataTestId="copy-agent-studio-document-content"
-      className="absolute top-2 right-2 z-10"
-      onClick={handleCopy}
-    />
-  );
-}
 
 function DocumentSection({ emptyState, document }: DocumentSectionProps): ReactElement {
   return (
@@ -80,7 +50,12 @@ function DocumentSection({ emptyState, document }: DocumentSectionProps): ReactE
             variant="document"
             premiumCodeBlocks={hasLabeledCodeFence(document.markdown)}
           />
-          <AgentStudioDocumentCopyButton markdown={document.markdown} />
+          <DocumentCopyButton
+            markdown={document.markdown}
+            dataTestId="copy-agent-studio-document-content"
+            errorLogContext="AgentStudioWorkspaceSidebar"
+            className="absolute top-2 right-2 z-10"
+          />
         </>
       ) : (
         <p className="text-sm text-muted-foreground">{emptyState}</p>

--- a/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
@@ -1,6 +1,9 @@
-import { type MouseEvent, type ReactElement, useCallback } from "react";
+import { Maximize2 } from "lucide-react";
+import { type MouseEvent, type ReactElement, useCallback, useState } from "react";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
+import { Button } from "@/components/ui/button";
 import { CopyIconButton } from "@/components/ui/copy-icon-button";
+import { MarkdownPreviewModal } from "@/components/ui/markdown-preview-modal";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { buildCopyPreview } from "@/lib/copy-preview";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
@@ -91,29 +94,59 @@ export function AgentStudioWorkspaceSidebar({
 }: {
   model: AgentStudioWorkspaceSidebarModel;
 }): ReactElement {
+  const [modalOpen, setModalOpen] = useState(false);
+  const openModal = useCallback(() => {
+    setModalOpen(true);
+  }, []);
+
   if (!model.activeDocument) {
     return <div className="h-full min-h-0" />;
   }
+
+  const { activeDocument } = model;
+  const canExpand = activeDocument.document.markdown.trim().length > 0;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
       <div className="space-y-1 border-b border-border p-4">
         <div className="flex items-start justify-between gap-4">
-          <h2 className="text-lg font-semibold leading-none tracking-tight">
-            {model.activeDocument.title}
-          </h2>
+          <div className="flex items-start gap-2">
+            <h2 className="text-lg font-semibold leading-none tracking-tight">
+              {activeDocument.title}
+            </h2>
+            {canExpand ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 shrink-0"
+                aria-label={`Open ${activeDocument.title} in fullscreen`}
+                data-testid="expand-agent-studio-document"
+                onClick={openModal}
+              >
+                <Maximize2 className="size-3.5" />
+              </Button>
+            ) : null}
+          </div>
           <p className="shrink-0 text-right text-xs text-muted-foreground">
-            {formatDocumentUpdatedAt(model.activeDocument.document.updatedAt) ?? "Not set"}
+            {formatDocumentUpdatedAt(activeDocument.document.updatedAt) ?? "Not set"}
           </p>
         </div>
-        <p className="text-sm text-muted-foreground">{model.activeDocument.description}</p>
+        <p className="text-sm text-muted-foreground">{activeDocument.description}</p>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto">
         <DocumentSection
-          emptyState={model.activeDocument.emptyState}
-          document={model.activeDocument.document}
+          emptyState={activeDocument.emptyState}
+          document={activeDocument.document}
         />
       </div>
+      {canExpand ? (
+        <MarkdownPreviewModal
+          open={modalOpen}
+          onOpenChange={setModalOpen}
+          markdown={activeDocument.document.markdown}
+          title={activeDocument.title}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
@@ -94,9 +94,23 @@ export function AgentStudioWorkspaceSidebar({
 }: {
   model: AgentStudioWorkspaceSidebarModel;
 }): ReactElement {
-  const [modalOpen, setModalOpen] = useState(false);
+  const [modalSnapshot, setModalSnapshot] = useState<{
+    markdown: string;
+    title: string;
+  } | null>(null);
+
   const openModal = useCallback(() => {
-    setModalOpen(true);
+    if (!model.activeDocument) {
+      return;
+    }
+    setModalSnapshot({
+      markdown: model.activeDocument.document.markdown,
+      title: model.activeDocument.title,
+    });
+  }, [model.activeDocument]);
+
+  const closeModal = useCallback(() => {
+    setModalSnapshot(null);
   }, []);
 
   if (!model.activeDocument) {
@@ -139,12 +153,16 @@ export function AgentStudioWorkspaceSidebar({
           document={activeDocument.document}
         />
       </div>
-      {canExpand ? (
+      {modalSnapshot ? (
         <MarkdownPreviewModal
-          open={modalOpen}
-          onOpenChange={setModalOpen}
-          markdown={activeDocument.document.markdown}
-          title={activeDocument.title}
+          open
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) {
+              closeModal();
+            }
+          }}
+          markdown={modalSnapshot.markdown}
+          title={modalSnapshot.title}
         />
       ) : null}
     </div>

--- a/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Maximize2 } from "lucide-react";
+import { Expand } from "lucide-react";
 import type { ReactElement } from "react";
 import { useCallback, useState } from "react";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
@@ -115,30 +115,30 @@ export function AgentStudioWorkspaceSidebar({
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
-      <div className="space-y-1 border-b border-border p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-start gap-2">
-            <h2 className="text-lg font-semibold leading-none tracking-tight">
-              {activeDocument.title}
-            </h2>
-            {canExpand ? (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-7 shrink-0"
-                aria-label={`Open ${activeDocument.title} in fullscreen`}
-                data-testid="expand-agent-studio-document"
-                onClick={openModal}
-              >
-                <Maximize2 className="size-3.5" />
-              </Button>
-            ) : null}
-          </div>
+      <div className="space-y-2 border-b border-border px-4 py-3">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-lg font-semibold leading-none tracking-tight">
+            {activeDocument.title}
+          </h2>
+          {canExpand ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0"
+              aria-label={`Open ${activeDocument.title} in fullscreen`}
+              data-testid="expand-agent-studio-document"
+              onClick={openModal}
+            >
+              <Expand className="size-3.5" />
+            </Button>
+          ) : null}
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-muted-foreground">{activeDocument.description}</p>
           <p className="shrink-0 text-right text-xs text-muted-foreground">
             {formatDocumentUpdatedAt(activeDocument.document.updatedAt) ?? "Not set"}
           </p>
         </div>
-        <p className="text-sm text-muted-foreground">{activeDocument.description}</p>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto">
         <DocumentSection

--- a/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-workspace-sidebar.tsx
@@ -113,8 +113,26 @@ export function AgentStudioWorkspaceSidebar({
     setModalSnapshot(null);
   }, []);
 
+  const snapshotModal = modalSnapshot ? (
+    <MarkdownPreviewModal
+      open
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          closeModal();
+        }
+      }}
+      markdown={modalSnapshot.markdown}
+      title={modalSnapshot.title}
+    />
+  ) : null;
+
   if (!model.activeDocument) {
-    return <div className="h-full min-h-0" />;
+    return (
+      <>
+        <div className="h-full min-h-0" />
+        {snapshotModal}
+      </>
+    );
   }
 
   const { activeDocument } = model;
@@ -153,18 +171,7 @@ export function AgentStudioWorkspaceSidebar({
           document={activeDocument.document}
         />
       </div>
-      {modalSnapshot ? (
-        <MarkdownPreviewModal
-          open
-          onOpenChange={(nextOpen) => {
-            if (!nextOpen) {
-              closeModal();
-            }
-          }}
-          markdown={modalSnapshot.markdown}
-          title={modalSnapshot.title}
-        />
-      ) : null}
+      {snapshotModal}
     </div>
   );
 }

--- a/packages/frontend/src/components/features/task-details/task-details-async-document-section.test.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-async-document-section.test.tsx
@@ -2,8 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { FileCode } from "lucide-react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
 import { TaskDetailsAsyncDocumentSection } from "./task-details-async-document-section";
 import type { TaskDocumentState } from "./use-task-documents";
+
+enableReactActEnvironment();
 
 const EMPTY_LABEL = "No implementation plan yet.";
 

--- a/packages/frontend/src/components/features/task-details/task-details-async-document-section.test.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-async-document-section.test.tsx
@@ -1,8 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { FileCode } from "lucide-react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { replaceNavigatorClipboard } from "@/test-utils/mock-clipboard";
+import { withMockedToast } from "@/test-utils/mock-toast";
 import { TaskDetailsAsyncDocumentSection } from "./task-details-async-document-section";
 import type { TaskDocumentState } from "./use-task-documents";
 
@@ -90,5 +93,109 @@ describe("TaskDetailsAsyncDocumentSection", () => {
 
     expect(html).toContain('data-testid="expand-implementation-plan"');
     expect(html).not.toContain(EMPTY_LABEL);
+  });
+});
+
+describe("TaskDetailsAsyncDocumentSection snapshot persistence", () => {
+  const writeClipboardMock = mock(async (_value: string) => {});
+  let restoreClipboard: (() => void) | null = null;
+
+  beforeEach(() => {
+    writeClipboardMock.mockClear();
+    writeClipboardMock.mockImplementation(async () => {});
+    restoreClipboard = replaceNavigatorClipboard(writeClipboardMock);
+  });
+
+  afterEach(() => {
+    restoreClipboard?.();
+    restoreClipboard = null;
+  });
+
+  const ICON = createElement(FileCode, { className: "size-3.5" });
+  const TITLE = "Implementation Plan";
+  const TEST_ID = "expand-implementation-plan";
+  const ORIGINAL_MARKDOWN = "# Original plan content";
+
+  const loadedDoc: TaskDocumentState = {
+    markdown: ORIGINAL_MARKDOWN,
+    updatedAt: "2026-01-01T00:00:00Z",
+    isLoading: false,
+    error: null,
+    loaded: true,
+  };
+
+  const baseProps = {
+    title: TITLE,
+    icon: ICON,
+    empty: EMPTY_LABEL,
+    hasDocument: true,
+    defaultExpanded: true,
+    onLoad: () => {},
+  };
+
+  const renderSection = (document: TaskDocumentState) =>
+    render(
+      createElement(TaskDetailsAsyncDocumentSection, {
+        ...baseProps,
+        document,
+      }),
+    );
+
+  test("modal retains original content when document starts loading", () => {
+    const { rerender } = renderSection(loadedDoc);
+
+    fireEvent.click(screen.getByTestId(TEST_ID));
+
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+
+    rerender(
+      createElement(TaskDetailsAsyncDocumentSection, {
+        ...baseProps,
+        document: { ...loadedDoc, isLoading: true },
+      }),
+    );
+
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+    expect(
+      screen.getAllByText((c) => c.includes("Original plan content")).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  test("modal retains original content when document becomes empty", () => {
+    const { rerender } = renderSection(loadedDoc);
+
+    fireEvent.click(screen.getByTestId(TEST_ID));
+
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+
+    rerender(
+      createElement(TaskDetailsAsyncDocumentSection, {
+        ...baseProps,
+        document: { ...loadedDoc, markdown: "" },
+      }),
+    );
+
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+    // After source becomes empty, only the modal snapshot has the content (card is empty)
+    const matching = screen.getAllByText((c) => c.includes("Original plan content"));
+    expect(matching.length).toBe(1);
+  });
+
+  test("copy button in modal copies snapshot markdown after document becomes empty", async () => {
+    await withMockedToast(async () => {
+      const { rerender } = renderSection(loadedDoc);
+
+      fireEvent.click(screen.getByTestId(TEST_ID));
+
+      rerender(
+        createElement(TaskDetailsAsyncDocumentSection, {
+          ...baseProps,
+          document: { ...loadedDoc, markdown: "" },
+        }),
+      );
+
+      fireEvent.click(screen.getByTestId("markdown-preview-modal-copy"));
+      expect(writeClipboardMock).toHaveBeenCalledWith(ORIGINAL_MARKDOWN);
+    });
   });
 });

--- a/packages/frontend/src/components/features/task-details/task-details-async-document-section.test.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-async-document-section.test.tsx
@@ -32,6 +32,7 @@ describe("TaskDetailsAsyncDocumentSection", () => {
 
     expect(html).toContain("animate-pulse");
     expect(html).not.toContain(EMPTY_LABEL);
+    expect(html).not.toContain('data-testid="expand-implementation-plan"');
   });
 
   test("shows empty-state copy only after load completes with empty markdown", () => {
@@ -49,6 +50,7 @@ describe("TaskDetailsAsyncDocumentSection", () => {
 
     expect(html).toContain(EMPTY_LABEL);
     expect(html).not.toContain("animate-pulse");
+    expect(html).not.toContain('data-testid="expand-implementation-plan"');
   });
 
   test("shows empty-state copy immediately when section has no document", () => {
@@ -67,5 +69,23 @@ describe("TaskDetailsAsyncDocumentSection", () => {
     expect(html).toContain(EMPTY_LABEL);
     expect(html).toContain("No document");
     expect(html).not.toContain("animate-pulse");
+    expect(html).not.toContain('data-testid="expand-implementation-plan"');
+  });
+
+  test("renders expand button when document is loaded and non-empty", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskDetailsAsyncDocumentSection, {
+        title: "Implementation Plan",
+        icon: createElement(FileCode, { className: "size-3.5" }),
+        empty: EMPTY_LABEL,
+        document: buildDocument({ loaded: true, markdown: "# My Plan" }),
+        hasDocument: true,
+        defaultExpanded: true,
+        onLoad: () => {},
+      }),
+    );
+
+    expect(html).toContain('data-testid="expand-implementation-plan"');
+    expect(html).not.toContain(EMPTY_LABEL);
   });
 });

--- a/packages/frontend/src/components/features/task-details/task-details-async-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-async-document-section.tsx
@@ -21,6 +21,8 @@ type TaskDetailsAsyncDocumentSectionProps = {
   summaryUpdatedAt?: string | null;
   defaultExpanded?: boolean;
   onLoad: () => void;
+  /** Task ID used to enrich the fullscreen modal title. */
+  taskId?: string;
 };
 
 export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDocumentSection({
@@ -32,6 +34,7 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
   summaryUpdatedAt = null,
   defaultExpanded = false,
   onLoad,
+  taskId,
 }: TaskDetailsAsyncDocumentSectionProps): ReactElement {
   const [modalSnapshot, setModalSnapshot] = useState<{
     markdown: string;
@@ -49,8 +52,9 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
   );
 
   const openModal = useCallback(() => {
-    setModalSnapshot({ markdown: document.markdown, title });
-  }, [document.markdown, title]);
+    const modalTitle = taskId ? `${taskId} - ${title}` : title;
+    setModalSnapshot({ markdown: document.markdown, title: modalTitle });
+  }, [document.markdown, title, taskId]);
 
   const closeModal = useCallback(() => {
     setModalSnapshot(null);

--- a/packages/frontend/src/components/features/task-details/task-details-async-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-async-document-section.tsx
@@ -1,4 +1,8 @@
-import { lazy, memo, type ReactElement, Suspense, useCallback } from "react";
+import { Maximize2 } from "lucide-react";
+import { lazy, memo, type ReactElement, Suspense, useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { MarkdownPreviewModal } from "@/components/ui/markdown-preview-modal";
 
 import { TaskDetailsCollapsibleCard } from "./task-details-collapsible-card";
 import type { TaskDocumentState } from "./use-task-documents";
@@ -29,6 +33,8 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
   defaultExpanded = false,
   onLoad,
 }: TaskDetailsAsyncDocumentSectionProps): ReactElement {
+  const [modalOpen, setModalOpen] = useState(false);
+
   const handleExpandedChange = useCallback(
     (expanded: boolean): void => {
       if (!expanded || !hasDocument) {
@@ -39,63 +45,105 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
     [hasDocument, onLoad],
   );
 
+  const openModal = useCallback(() => {
+    setModalOpen(true);
+  }, []);
+
+  const canExpand =
+    hasDocument &&
+    !document.error &&
+    document.loaded &&
+    !document.isLoading &&
+    document.markdown.trim().length > 0;
+
+  const markdownFallback = (
+    <div className="space-y-2 rounded-lg border border-border bg-muted p-3">
+      <div className="h-3 w-2/5 animate-pulse rounded bg-card" />
+      <div className="h-3 w-full animate-pulse rounded bg-card" />
+      <div className="h-3 w-4/5 animate-pulse rounded bg-card" />
+    </div>
+  );
+
+  const children = ({ isExpanded }: { isExpanded: boolean }) => {
+    if (!hasDocument) {
+      return (
+        <p className="rounded-lg border border-dashed border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
+          {empty}
+        </p>
+      );
+    }
+
+    if (document.error) {
+      return (
+        <p className="rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2 text-sm text-destructive-muted">
+          {document.error}
+        </p>
+      );
+    }
+
+    if (!document.loaded || document.isLoading) {
+      return markdownFallback;
+    }
+
+    if (document.markdown.trim().length === 0) {
+      return (
+        <p className="rounded-lg border border-dashed border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
+          {empty}
+        </p>
+      );
+    }
+
+    return (
+      <Suspense fallback={markdownFallback}>
+        <TaskDetailsMarkdownContent
+          active={isExpanded}
+          markdown={document.markdown}
+          empty={empty}
+          copyableMarkdown={document.markdown}
+        />
+      </Suspense>
+    );
+  };
+
+  const commonProps = {
+    title,
+    icon,
+    updatedAt: document.updatedAt ?? summaryUpdatedAt,
+    statusLabel: hasDocument ? null : ("No document" as const),
+    defaultExpanded,
+    onExpandedChange: handleExpandedChange,
+    children,
+  };
+
   return (
-    <TaskDetailsCollapsibleCard
-      title={title}
-      icon={icon}
-      updatedAt={document.updatedAt ?? summaryUpdatedAt}
-      statusLabel={hasDocument ? null : "No document"}
-      defaultExpanded={defaultExpanded}
-      onExpandedChange={handleExpandedChange}
-    >
-      {({ isExpanded }) => {
-        const markdownFallback = (
-          <div className="space-y-2 rounded-lg border border-border bg-muted p-3">
-            <div className="h-3 w-2/5 animate-pulse rounded bg-card" />
-            <div className="h-3 w-full animate-pulse rounded bg-card" />
-            <div className="h-3 w-4/5 animate-pulse rounded bg-card" />
-          </div>
-        );
-
-        if (!hasDocument) {
-          return (
-            <p className="rounded-lg border border-dashed border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
-              {empty}
-            </p>
-          );
-        }
-
-        if (document.error) {
-          return (
-            <p className="rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2 text-sm text-destructive-muted">
-              {document.error}
-            </p>
-          );
-        }
-
-        if (!document.loaded || document.isLoading) {
-          return markdownFallback;
-        }
-
-        if (document.markdown.trim().length === 0) {
-          return (
-            <p className="rounded-lg border border-dashed border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
-              {empty}
-            </p>
-          );
-        }
-
-        return (
-          <Suspense fallback={markdownFallback}>
-            <TaskDetailsMarkdownContent
-              active={isExpanded}
-              markdown={document.markdown}
-              empty={empty}
-              copyableMarkdown={document.markdown}
-            />
-          </Suspense>
-        );
-      }}
-    </TaskDetailsCollapsibleCard>
+    <>
+      {canExpand ? (
+        <TaskDetailsCollapsibleCard
+          {...commonProps}
+          headerAction={
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0"
+              aria-label={`Open ${title} in fullscreen`}
+              data-testid={`expand-${title.toLowerCase().replace(/\s+/g, "-")}`}
+              onClick={openModal}
+            >
+              <Maximize2 className="size-3.5" />
+            </Button>
+          }
+        />
+      ) : (
+        <TaskDetailsCollapsibleCard {...commonProps} />
+      )}
+      {canExpand ? (
+        <MarkdownPreviewModal
+          open={modalOpen}
+          onOpenChange={setModalOpen}
+          markdown={document.markdown}
+          title={title}
+        />
+      ) : null}
+    </>
   );
 });

--- a/packages/frontend/src/components/features/task-details/task-details-async-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-async-document-section.tsx
@@ -33,7 +33,10 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
   defaultExpanded = false,
   onLoad,
 }: TaskDetailsAsyncDocumentSectionProps): ReactElement {
-  const [modalOpen, setModalOpen] = useState(false);
+  const [modalSnapshot, setModalSnapshot] = useState<{
+    markdown: string;
+    title: string;
+  } | null>(null);
 
   const handleExpandedChange = useCallback(
     (expanded: boolean): void => {
@@ -46,7 +49,11 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
   );
 
   const openModal = useCallback(() => {
-    setModalOpen(true);
+    setModalSnapshot({ markdown: document.markdown, title });
+  }, [document.markdown, title]);
+
+  const closeModal = useCallback(() => {
+    setModalSnapshot(null);
   }, []);
 
   const canExpand =
@@ -136,12 +143,16 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
       ) : (
         <TaskDetailsCollapsibleCard {...commonProps} />
       )}
-      {canExpand ? (
+      {modalSnapshot ? (
         <MarkdownPreviewModal
-          open={modalOpen}
-          onOpenChange={setModalOpen}
-          markdown={document.markdown}
-          title={title}
+          open
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) {
+              closeModal();
+            }
+          }}
+          markdown={modalSnapshot.markdown}
+          title={modalSnapshot.title}
         />
       ) : null}
     </>

--- a/packages/frontend/src/components/features/task-details/task-details-async-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-async-document-section.tsx
@@ -1,4 +1,4 @@
-import { Maximize2 } from "lucide-react";
+import { Expand } from "lucide-react";
 import { lazy, memo, type ReactElement, Suspense, useCallback, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -140,7 +140,7 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
               data-testid={`expand-${title.toLowerCase().replace(/\s+/g, "-")}`}
               onClick={openModal}
             >
-              <Maximize2 className="size-3.5" />
+              <Expand className="size-3.5" />
             </Button>
           }
         />

--- a/packages/frontend/src/components/features/task-details/task-details-collapsible-card.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-collapsible-card.tsx
@@ -11,6 +11,7 @@ type TaskDetailsCollapsibleCardProps = {
   statusLabel?: string | null;
   defaultExpanded?: boolean;
   onExpandedChange?: (expanded: boolean) => void;
+  headerAction?: ReactElement;
   children: ReactNode | ((context: { isExpanded: boolean }) => ReactNode);
 };
 
@@ -21,6 +22,7 @@ export function TaskDetailsCollapsibleCard({
   statusLabel = null,
   defaultExpanded = false,
   onExpandedChange,
+  headerAction,
   children,
 }: TaskDetailsCollapsibleCardProps): ReactElement {
   const [expandedOverride, setExpandedOverride] = useState<boolean | null>(null);
@@ -38,30 +40,42 @@ export function TaskDetailsCollapsibleCard({
       }}
       className="rounded-xl border border-border/90 bg-card shadow-sm"
     >
-      <CollapsibleTrigger asChild>
-        <button
-          type="button"
-          className="group flex w-full min-w-0 cursor-pointer items-center justify-between gap-2 rounded-md p-4 text-left outline-none transition hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/40"
-        >
-          <h4 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            {icon}
-            {title}
-          </h4>
-          <span className="inline-flex items-center gap-2">
-            {summaryLabel ? (
-              <span className="rounded-full border border-border bg-muted px-2.5 py-1 text-[11px] text-muted-foreground">
-                {summaryLabel}
-              </span>
-            ) : null}
-            <ChevronDown
-              className={cn(
-                "size-3.5 text-muted-foreground transition-transform duration-150",
-                isExpanded ? "rotate-180" : "rotate-0",
-              )}
-            />
-          </span>
-        </button>
-      </CollapsibleTrigger>
+      <div className="group flex w-full items-center rounded-md p-4 transition hover:bg-muted focus-within:ring-2 focus-within:ring-ring/40">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-2 text-left outline-none"
+          >
+            <h4 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {icon}
+              {title}
+            </h4>
+            <span className="inline-flex items-center gap-2">
+              {summaryLabel ? (
+                <span className="rounded-full border border-border bg-muted px-2.5 py-1 text-[11px] text-muted-foreground">
+                  {summaryLabel}
+                </span>
+              ) : null}
+            </span>
+          </button>
+        </CollapsibleTrigger>
+        <span className="inline-flex items-center gap-2 pl-2">
+          {headerAction}
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <ChevronDown
+                className={cn(
+                  "size-3.5 transition-transform duration-150",
+                  isExpanded ? "rotate-180" : "rotate-0",
+                )}
+              />
+            </button>
+          </CollapsibleTrigger>
+        </span>
+      </div>
 
       <CollapsibleContent
         forceMount

--- a/packages/frontend/src/components/features/task-details/task-details-collapsible-card.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-collapsible-card.tsx
@@ -64,6 +64,7 @@ export function TaskDetailsCollapsibleCard({
           <CollapsibleTrigger asChild>
             <button
               type="button"
+              aria-label={isExpanded ? "Collapse section" : "Expand section"}
               className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
               <ChevronDown

--- a/packages/frontend/src/components/features/task-details/task-details-document-section.test.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-document-section.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FileText } from "lucide-react";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { replaceNavigatorClipboard } from "@/test-utils/mock-clipboard";
+import { withMockedToast } from "@/test-utils/mock-toast";
+import { TaskDetailsDocumentSection } from "./task-details-document-section";
+
+enableReactActEnvironment();
+
+const ICON = createElement(FileText, { className: "size-3.5" });
+const TITLE = "Description";
+const EMPTY = "No description.";
+const UPDATED_AT = "2026-01-01T00:00:00Z";
+
+describe("TaskDetailsDocumentSection", () => {
+  test("renders expand button when document has content", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskDetailsDocumentSection, {
+        title: TITLE,
+        icon: ICON,
+        markdown: "# Content",
+        updatedAt: UPDATED_AT,
+        empty: EMPTY,
+        defaultExpanded: true,
+      }),
+    );
+    expect(html).toContain('data-testid="expand-description"');
+  });
+
+  test("does not render expand button when document is empty", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskDetailsDocumentSection, {
+        title: TITLE,
+        icon: ICON,
+        markdown: "",
+        updatedAt: UPDATED_AT,
+        empty: EMPTY,
+        defaultExpanded: true,
+      }),
+    );
+    expect(html).not.toContain('data-testid="expand-description"');
+    expect(html).toContain(EMPTY);
+  });
+});
+
+describe("TaskDetailsDocumentSection snapshot persistence", () => {
+  const writeClipboardMock = mock(async (_value: string) => {});
+  let restoreClipboard: (() => void) | null = null;
+
+  beforeEach(() => {
+    writeClipboardMock.mockClear();
+    writeClipboardMock.mockImplementation(async () => {});
+    restoreClipboard = replaceNavigatorClipboard(writeClipboardMock);
+  });
+
+  afterEach(() => {
+    restoreClipboard?.();
+    restoreClipboard = null;
+  });
+
+  const renderSection = (markdown: string) =>
+    render(
+      createElement(TaskDetailsDocumentSection, {
+        title: TITLE,
+        icon: ICON,
+        markdown,
+        updatedAt: UPDATED_AT,
+        empty: EMPTY,
+        defaultExpanded: true,
+      }),
+    );
+
+  test("modal retains original content after source becomes empty", () => {
+    const originalMarkdown = "# Original description content";
+    const { rerender } = renderSection(originalMarkdown);
+
+    fireEvent.click(screen.getByTestId("expand-description"));
+
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+
+    rerender(
+      createElement(TaskDetailsDocumentSection, {
+        title: TITLE,
+        icon: ICON,
+        markdown: "",
+        updatedAt: UPDATED_AT,
+        empty: EMPTY,
+        defaultExpanded: true,
+      }),
+    );
+
+    // Expand button gone, modal still open with original content
+    expect(screen.queryByTestId("expand-description")).toBeNull();
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+    // After source becomes empty, only the modal snapshot has the content (card is empty)
+    const matching = screen.getAllByText((c) => c.includes("Original description content"));
+    expect(matching.length).toBe(1);
+  });
+
+  test("copy button in modal copies snapshot markdown after source becomes empty", async () => {
+    await withMockedToast(async () => {
+      const originalMarkdown = "# Copy this description";
+      const { rerender } = renderSection(originalMarkdown);
+
+      fireEvent.click(screen.getByTestId("expand-description"));
+
+      rerender(
+        createElement(TaskDetailsDocumentSection, {
+          title: TITLE,
+          icon: ICON,
+          markdown: "",
+          updatedAt: UPDATED_AT,
+          empty: EMPTY,
+          defaultExpanded: true,
+        }),
+      );
+
+      fireEvent.click(screen.getByTestId("markdown-preview-modal-copy"));
+      expect(writeClipboardMock).toHaveBeenCalledWith("# Copy this description");
+    });
+  });
+});

--- a/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
@@ -18,6 +18,8 @@ type TaskDetailsDocumentSectionProps = {
   updatedAt: string | null;
   empty: string;
   defaultExpanded?: boolean;
+  /** Task ID used to enrich the fullscreen modal title. */
+  taskId?: string;
 };
 
 export const TaskDetailsDocumentSection = memo(
@@ -28,6 +30,7 @@ export const TaskDetailsDocumentSection = memo(
     updatedAt,
     empty,
     defaultExpanded = false,
+    taskId,
   }: TaskDetailsDocumentSectionProps): ReactElement {
     const [modalSnapshot, setModalSnapshot] = useState<{
       markdown: string;
@@ -35,8 +38,9 @@ export const TaskDetailsDocumentSection = memo(
     } | null>(null);
 
     const openModal = useCallback(() => {
-      setModalSnapshot({ markdown, title });
-    }, [markdown, title]);
+      const modalTitle = taskId ? `${taskId} - ${title}` : title;
+      setModalSnapshot({ markdown, title: modalTitle });
+    }, [markdown, title, taskId]);
 
     const closeModal = useCallback(() => {
       setModalSnapshot(null);
@@ -116,5 +120,6 @@ export const TaskDetailsDocumentSection = memo(
     previous.markdown === next.markdown &&
     previous.updatedAt === next.updatedAt &&
     previous.empty === next.empty &&
-    previous.defaultExpanded === next.defaultExpanded,
+    previous.defaultExpanded === next.defaultExpanded &&
+    previous.taskId === next.taskId,
 );

--- a/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
@@ -44,62 +44,58 @@ export const TaskDetailsDocumentSection = memo(
 
     const hasContent = markdown.trim().length > 0;
 
-    if (!hasContent) {
-      return (
-        <TaskDetailsCollapsibleCard
-          title={title}
-          icon={icon}
-          updatedAt={updatedAt}
-          defaultExpanded={defaultExpanded}
-        >
-          <p className="rounded-lg border border-dashed border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
-            {empty}
-          </p>
-        </TaskDetailsCollapsibleCard>
-      );
-    }
-
-    const expandButton = (
-      <Button
-        variant="ghost"
-        size="icon"
-        className="size-7 shrink-0"
-        aria-label={`Open ${title} in fullscreen`}
-        data-testid={`expand-${title.toLowerCase().replace(/\s+/g, "-")}`}
-        onClick={openModal}
-      >
-        <Maximize2 className="size-3.5" />
-      </Button>
-    );
-
     return (
       <>
-        <TaskDetailsCollapsibleCard
-          title={title}
-          icon={icon}
-          updatedAt={updatedAt}
-          defaultExpanded={defaultExpanded}
-          headerAction={expandButton}
-        >
-          {({ isExpanded }) => (
-            <Suspense
-              fallback={
-                <div className="space-y-2 rounded-lg border border-border bg-muted p-3">
-                  <div className="h-3 w-4/5 animate-pulse rounded bg-card" />
-                  <div className="h-3 w-full animate-pulse rounded bg-card" />
-                  <div className="h-3 w-3/4 animate-pulse rounded bg-card" />
-                </div>
-              }
-            >
-              <TaskDetailsMarkdownContent
-                active={isExpanded}
-                markdown={markdown}
-                empty={empty}
-                copyableMarkdown={markdown}
-              />
-            </Suspense>
-          )}
-        </TaskDetailsCollapsibleCard>
+        {hasContent ? (
+          <TaskDetailsCollapsibleCard
+            title={title}
+            icon={icon}
+            updatedAt={updatedAt}
+            defaultExpanded={defaultExpanded}
+            headerAction={
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 shrink-0"
+                aria-label={`Open ${title} in fullscreen`}
+                data-testid={`expand-${title.toLowerCase().replace(/\s+/g, "-")}`}
+                onClick={openModal}
+              >
+                <Maximize2 className="size-3.5" />
+              </Button>
+            }
+          >
+            {({ isExpanded }) => (
+              <Suspense
+                fallback={
+                  <div className="space-y-2 rounded-lg border border-border bg-muted p-3">
+                    <div className="h-3 w-4/5 animate-pulse rounded bg-card" />
+                    <div className="h-3 w-full animate-pulse rounded bg-card" />
+                    <div className="h-3 w-3/4 animate-pulse rounded bg-card" />
+                  </div>
+                }
+              >
+                <TaskDetailsMarkdownContent
+                  active={isExpanded}
+                  markdown={markdown}
+                  empty={empty}
+                  copyableMarkdown={markdown}
+                />
+              </Suspense>
+            )}
+          </TaskDetailsCollapsibleCard>
+        ) : (
+          <TaskDetailsCollapsibleCard
+            title={title}
+            icon={icon}
+            updatedAt={updatedAt}
+            defaultExpanded={defaultExpanded}
+          >
+            <p className="rounded-lg border border-dashed border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
+              {empty}
+            </p>
+          </TaskDetailsCollapsibleCard>
+        )}
         {modalSnapshot ? (
           <MarkdownPreviewModal
             open

--- a/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
@@ -29,10 +29,17 @@ export const TaskDetailsDocumentSection = memo(
     empty,
     defaultExpanded = false,
   }: TaskDetailsDocumentSectionProps): ReactElement {
-    const [modalOpen, setModalOpen] = useState(false);
+    const [modalSnapshot, setModalSnapshot] = useState<{
+      markdown: string;
+      title: string;
+    } | null>(null);
 
     const openModal = useCallback(() => {
-      setModalOpen(true);
+      setModalSnapshot({ markdown, title });
+    }, [markdown, title]);
+
+    const closeModal = useCallback(() => {
+      setModalSnapshot(null);
     }, []);
 
     const hasContent = markdown.trim().length > 0;
@@ -93,12 +100,18 @@ export const TaskDetailsDocumentSection = memo(
             </Suspense>
           )}
         </TaskDetailsCollapsibleCard>
-        <MarkdownPreviewModal
-          open={modalOpen}
-          onOpenChange={setModalOpen}
-          markdown={markdown}
-          title={title}
-        />
+        {modalSnapshot ? (
+          <MarkdownPreviewModal
+            open
+            onOpenChange={(nextOpen) => {
+              if (!nextOpen) {
+                closeModal();
+              }
+            }}
+            markdown={modalSnapshot.markdown}
+            title={modalSnapshot.title}
+          />
+        ) : null}
       </>
     );
   },

--- a/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
@@ -116,6 +116,5 @@ export const TaskDetailsDocumentSection = memo(
     previous.markdown === next.markdown &&
     previous.updatedAt === next.updatedAt &&
     previous.empty === next.empty &&
-    previous.defaultExpanded === next.defaultExpanded &&
-    previous.icon === next.icon,
+    previous.defaultExpanded === next.defaultExpanded,
 );

--- a/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
@@ -1,4 +1,8 @@
-import { lazy, memo, type ReactElement, Suspense } from "react";
+import { Maximize2 } from "lucide-react";
+import { lazy, memo, type ReactElement, Suspense, useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { MarkdownPreviewModal } from "@/components/ui/markdown-preview-modal";
 
 import { TaskDetailsCollapsibleCard } from "./task-details-collapsible-card";
 
@@ -25,7 +29,15 @@ export const TaskDetailsDocumentSection = memo(
     empty,
     defaultExpanded = false,
   }: TaskDetailsDocumentSectionProps): ReactElement {
-    if (markdown.trim().length === 0) {
+    const [modalOpen, setModalOpen] = useState(false);
+
+    const openModal = useCallback(() => {
+      setModalOpen(true);
+    }, []);
+
+    const hasContent = markdown.trim().length > 0;
+
+    if (!hasContent) {
       return (
         <TaskDetailsCollapsibleCard
           title={title}
@@ -40,32 +52,54 @@ export const TaskDetailsDocumentSection = memo(
       );
     }
 
-    return (
-      <TaskDetailsCollapsibleCard
-        title={title}
-        icon={icon}
-        updatedAt={updatedAt}
-        defaultExpanded={defaultExpanded}
+    const expandButton = (
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-7 shrink-0"
+        aria-label={`Open ${title} in fullscreen`}
+        data-testid={`expand-${title.toLowerCase().replace(/\s+/g, "-")}`}
+        onClick={openModal}
       >
-        {({ isExpanded }) => (
-          <Suspense
-            fallback={
-              <div className="space-y-2 rounded-lg border border-border bg-muted p-3">
-                <div className="h-3 w-4/5 animate-pulse rounded bg-card" />
-                <div className="h-3 w-full animate-pulse rounded bg-card" />
-                <div className="h-3 w-3/4 animate-pulse rounded bg-card" />
-              </div>
-            }
-          >
-            <TaskDetailsMarkdownContent
-              active={isExpanded}
-              markdown={markdown}
-              empty={empty}
-              copyableMarkdown={markdown}
-            />
-          </Suspense>
-        )}
-      </TaskDetailsCollapsibleCard>
+        <Maximize2 className="size-3.5" />
+      </Button>
+    );
+
+    return (
+      <>
+        <TaskDetailsCollapsibleCard
+          title={title}
+          icon={icon}
+          updatedAt={updatedAt}
+          defaultExpanded={defaultExpanded}
+          headerAction={expandButton}
+        >
+          {({ isExpanded }) => (
+            <Suspense
+              fallback={
+                <div className="space-y-2 rounded-lg border border-border bg-muted p-3">
+                  <div className="h-3 w-4/5 animate-pulse rounded bg-card" />
+                  <div className="h-3 w-full animate-pulse rounded bg-card" />
+                  <div className="h-3 w-3/4 animate-pulse rounded bg-card" />
+                </div>
+              }
+            >
+              <TaskDetailsMarkdownContent
+                active={isExpanded}
+                markdown={markdown}
+                empty={empty}
+                copyableMarkdown={markdown}
+              />
+            </Suspense>
+          )}
+        </TaskDetailsCollapsibleCard>
+        <MarkdownPreviewModal
+          open={modalOpen}
+          onOpenChange={setModalOpen}
+          markdown={markdown}
+          title={title}
+        />
+      </>
     );
   },
   (previous, next) =>

--- a/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-document-section.tsx
@@ -1,4 +1,4 @@
-import { Maximize2 } from "lucide-react";
+import { Expand } from "lucide-react";
 import { lazy, memo, type ReactElement, Suspense, useCallback, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -65,7 +65,7 @@ export const TaskDetailsDocumentSection = memo(
                 data-testid={`expand-${title.toLowerCase().replace(/\s+/g, "-")}`}
                 onClick={openModal}
               >
-                <Maximize2 className="size-3.5" />
+                <Expand className="size-3.5" />
               </Button>
             }
           >

--- a/packages/frontend/src/components/features/task-details/task-details-sheet-body.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-sheet-body.tsx
@@ -56,6 +56,7 @@ export function TaskDetailsSheetBody({
         updatedAt={null}
         empty="No description yet."
         defaultExpanded
+        taskId={task.id}
       />
       <TaskDetailsAsyncDocumentSection
         key={`${task.id}:spec`}
@@ -66,6 +67,7 @@ export function TaskDetailsSheetBody({
         hasDocument={hasSpecDocument}
         summaryUpdatedAt={specSummaryUpdatedAt}
         onLoad={loadSpecDocumentSection}
+        taskId={task.id}
       />
 
       <TaskDetailsAsyncDocumentSection
@@ -77,6 +79,7 @@ export function TaskDetailsSheetBody({
         hasDocument={hasPlanDocument}
         summaryUpdatedAt={planSummaryUpdatedAt}
         onLoad={loadPlanDocumentSection}
+        taskId={task.id}
       />
 
       <TaskDetailsAsyncDocumentSection
@@ -88,6 +91,7 @@ export function TaskDetailsSheetBody({
         hasDocument={hasQaDocument}
         summaryUpdatedAt={qaSummaryUpdatedAt}
         onLoad={loadQaDocumentSection}
+        taskId={task.id}
       />
       <TaskDetailsMetadata key={`${task.id}:metadata`} task={task} />
       {shouldRenderSubtasks ? <TaskDetailsSubtasks subtasks={subtasks} /> : null}

--- a/packages/frontend/src/components/ui/document-copy-button.tsx
+++ b/packages/frontend/src/components/ui/document-copy-button.tsx
@@ -1,0 +1,42 @@
+import { type MouseEvent, type ReactElement, useCallback } from "react";
+import { CopyIconButton } from "@/components/ui/copy-icon-button";
+import { buildCopyPreview } from "@/lib/copy-preview";
+import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
+
+type DocumentCopyButtonProps = {
+  markdown: string;
+  dataTestId: string;
+  errorLogContext: string;
+  className?: string;
+};
+
+export function DocumentCopyButton({
+  markdown,
+  dataTestId,
+  errorLogContext,
+  className,
+}: DocumentCopyButtonProps): ReactElement {
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    getSuccessDescription: buildCopyPreview,
+    errorLogContext,
+  });
+
+  const handleCopy = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      void copyToClipboard(markdown);
+    },
+    [copyToClipboard, markdown],
+  );
+
+  return (
+    <CopyIconButton
+      copied={copied}
+      ariaLabel="Copy document content"
+      dataTestId={dataTestId}
+      onClick={handleCopy}
+      {...(className ? { className } : {})}
+    />
+  );
+}

--- a/packages/frontend/src/components/ui/document-copy-button.tsx
+++ b/packages/frontend/src/components/ui/document-copy-button.tsx
@@ -36,7 +36,7 @@ export function DocumentCopyButton({
       ariaLabel="Copy document content"
       dataTestId={dataTestId}
       onClick={handleCopy}
-      {...(className ? { className } : {})}
+      {...(className && { className })}
     />
   );
 }

--- a/packages/frontend/src/components/ui/markdown-preview-modal.test.tsx
+++ b/packages/frontend/src/components/ui/markdown-preview-modal.test.tsx
@@ -55,6 +55,14 @@ describe("MarkdownPreviewModal", () => {
     expect(screen.getByText("Specification")).toBeDefined();
   });
 
+  test("renders sr-only default title when no title prop is provided", () => {
+    render(<MarkdownPreviewModal open onOpenChange={() => {}} markdown="# Content" />);
+
+    const title = screen.getByText("Document Preview");
+    expect(title).toBeDefined();
+    expect(title.className).toContain("sr-only");
+  });
+
   test("renders copy button with expected test id", () => {
     render(<MarkdownPreviewModal open onOpenChange={() => {}} markdown="# Content" />);
 

--- a/packages/frontend/src/components/ui/markdown-preview-modal.test.tsx
+++ b/packages/frontend/src/components/ui/markdown-preview-modal.test.tsx
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { replaceNavigatorClipboard } from "@/test-utils/mock-clipboard";
+import { withMockedToast } from "@/test-utils/mock-toast";
+import { MarkdownPreviewModal } from "./markdown-preview-modal";
+
+enableReactActEnvironment();
+
+const writeClipboardMock = mock(async (_value: string) => {});
+let restoreClipboard: (() => void) | null = null;
+
+describe("MarkdownPreviewModal", () => {
+  beforeEach(() => {
+    writeClipboardMock.mockClear();
+    writeClipboardMock.mockImplementation(async () => {});
+    restoreClipboard = replaceNavigatorClipboard(writeClipboardMock);
+  });
+
+  afterEach(() => {
+    restoreClipboard?.();
+    restoreClipboard = null;
+  });
+
+  test("does not render dialog content when closed", () => {
+    render(
+      <MarkdownPreviewModal
+        open={false}
+        onOpenChange={() => {}}
+        markdown="# Hello"
+        title="Specification"
+      />,
+    );
+
+    expect(screen.queryByText("Hello")).toBeNull();
+    expect(screen.queryByText("Specification")).toBeNull();
+  });
+
+  test("renders markdown content when open", () => {
+    render(<MarkdownPreviewModal open onOpenChange={() => {}} markdown="# Hello World" />);
+
+    expect(screen.getByText("Hello World")).toBeDefined();
+  });
+
+  test("renders title when provided", () => {
+    render(
+      <MarkdownPreviewModal
+        open
+        onOpenChange={() => {}}
+        markdown="# Content"
+        title="Specification"
+      />,
+    );
+
+    expect(screen.getByText("Specification")).toBeDefined();
+  });
+
+  test("renders copy button with expected test id", () => {
+    render(<MarkdownPreviewModal open onOpenChange={() => {}} markdown="# Content" />);
+
+    expect(screen.getByTestId("markdown-preview-modal-copy")).toBeDefined();
+  });
+
+  test("copies raw markdown to clipboard on copy button click", async () => {
+    await withMockedToast(async () => {
+      render(<MarkdownPreviewModal open onOpenChange={() => {}} markdown="# Raw Markdown" />);
+
+      const copyButton = screen.getByTestId("markdown-preview-modal-copy");
+      fireEvent.click(copyButton);
+
+      expect(writeClipboardMock).toHaveBeenCalledWith("# Raw Markdown");
+    });
+  });
+});

--- a/packages/frontend/src/components/ui/markdown-preview-modal.test.tsx
+++ b/packages/frontend/src/components/ui/markdown-preview-modal.test.tsx
@@ -32,14 +32,14 @@ describe("MarkdownPreviewModal", () => {
       />,
     );
 
-    expect(screen.queryByText("Hello")).toBeNull();
+    expect(screen.queryByText((c) => c.includes("Hello"))).toBeNull();
     expect(screen.queryByText("Specification")).toBeNull();
   });
 
   test("renders markdown content when open", () => {
     render(<MarkdownPreviewModal open onOpenChange={() => {}} markdown="# Hello World" />);
 
-    expect(screen.getByText("Hello World")).toBeDefined();
+    expect(screen.getByText((c) => c.includes("Hello World"))).toBeDefined();
   });
 
   test("renders title when provided", () => {

--- a/packages/frontend/src/components/ui/markdown-preview-modal.tsx
+++ b/packages/frontend/src/components/ui/markdown-preview-modal.tsx
@@ -1,5 +1,4 @@
-import { type MouseEvent, type ReactElement, useCallback } from "react";
-import { CopyIconButton } from "@/components/ui/copy-icon-button";
+import type { ReactElement } from "react";
 import {
   Dialog,
   DialogBody,
@@ -8,9 +7,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { DocumentCopyButton } from "@/components/ui/document-copy-button";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
-import { buildCopyPreview } from "@/lib/copy-preview";
-import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
+import { hasLabeledCodeFence } from "@/lib/markdown-utils";
 
 export type MarkdownPreviewModalProps = {
   markdown: string;
@@ -18,36 +17,6 @@ export type MarkdownPreviewModalProps = {
   onOpenChange: (open: boolean) => void;
   title?: string;
 };
-
-const hasLabeledCodeFence = (markdown: string): boolean => {
-  return markdown.includes("```") && /```[a-z0-9_-]+/i.test(markdown);
-};
-
-function MarkdownPreviewModalCopyButton({ markdown }: { markdown: string }): ReactElement {
-  const { copied, copyToClipboard } = useCopyToClipboard({
-    getSuccessDescription: buildCopyPreview,
-    errorLogContext: "MarkdownPreviewModal",
-  });
-
-  const handleCopy = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      event.stopPropagation();
-      event.preventDefault();
-      void copyToClipboard(markdown);
-    },
-    [copyToClipboard, markdown],
-  );
-
-  return (
-    <CopyIconButton
-      copied={copied}
-      ariaLabel="Copy document content"
-      dataTestId="markdown-preview-modal-copy"
-      className="absolute top-2 right-2 z-10"
-      onClick={handleCopy}
-    />
-  );
-}
 
 export function MarkdownPreviewModal({
   markdown,
@@ -73,7 +42,12 @@ export function MarkdownPreviewModal({
               variant="document"
               premiumCodeBlocks={hasLabeledCodeFence(markdown)}
             />
-            <MarkdownPreviewModalCopyButton markdown={markdown} />
+            <DocumentCopyButton
+              markdown={markdown}
+              dataTestId="markdown-preview-modal-copy"
+              errorLogContext="MarkdownPreviewModal"
+              className="absolute top-2 right-2 z-10"
+            />
           </div>
         </DialogBody>
       </DialogContent>

--- a/packages/frontend/src/components/ui/markdown-preview-modal.tsx
+++ b/packages/frontend/src/components/ui/markdown-preview-modal.tsx
@@ -37,7 +37,7 @@ export function MarkdownPreviewModal({
           </DialogDescription>
         </DialogHeader>
         <DialogBody className="min-h-0 flex-1 overflow-hidden">
-          <div className="relative h-full overflow-y-auto px-6 pt-4 pb-6">
+          <div className="relative max-h-[calc(100dvh-12rem)] overflow-y-auto px-6 pt-4 pb-6">
             <MarkdownRenderer
               markdown={markdown}
               variant="document"

--- a/packages/frontend/src/components/ui/markdown-preview-modal.tsx
+++ b/packages/frontend/src/components/ui/markdown-preview-modal.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogBody,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -57,7 +58,14 @@ export function MarkdownPreviewModal({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <DialogHeader>{title ? <DialogTitle>{title}</DialogTitle> : null}</DialogHeader>
+        <DialogHeader>
+          <DialogTitle className={title ? undefined : "sr-only"}>
+            {title ?? "Document Preview"}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Fullscreen markdown document preview.
+          </DialogDescription>
+        </DialogHeader>
         <DialogBody>
           <div className="relative">
             <MarkdownRenderer

--- a/packages/frontend/src/components/ui/markdown-preview-modal.tsx
+++ b/packages/frontend/src/components/ui/markdown-preview-modal.tsx
@@ -15,6 +15,7 @@ export type MarkdownPreviewModalProps = {
   markdown: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Display title shown in the modal header. Enrichted with task context by callers. */
   title?: string;
 };
 
@@ -26,17 +27,17 @@ export function MarkdownPreviewModal({
 }: MarkdownPreviewModalProps): ReactElement {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle className={title ? undefined : "sr-only"}>
+      <DialogContent className="flex flex-col overflow-hidden p-0">
+        <DialogHeader className="shrink-0 border-b border-border px-6 py-4">
+          <DialogTitle className={title ? "text-xl font-semibold" : "sr-only"}>
             {title ?? "Document Preview"}
           </DialogTitle>
           <DialogDescription className="sr-only">
             Fullscreen markdown document preview.
           </DialogDescription>
         </DialogHeader>
-        <DialogBody>
-          <div className="relative">
+        <DialogBody className="min-h-0 flex-1 overflow-hidden">
+          <div className="relative h-full overflow-y-auto px-6 pt-4 pb-6">
             <MarkdownRenderer
               markdown={markdown}
               variant="document"
@@ -46,7 +47,7 @@ export function MarkdownPreviewModal({
               markdown={markdown}
               dataTestId="markdown-preview-modal-copy"
               errorLogContext="MarkdownPreviewModal"
-              className="absolute top-2 right-2 z-10"
+              className="absolute top-4 right-6 z-10"
             />
           </div>
         </DialogBody>

--- a/packages/frontend/src/components/ui/markdown-preview-modal.tsx
+++ b/packages/frontend/src/components/ui/markdown-preview-modal.tsx
@@ -1,0 +1,74 @@
+import { type MouseEvent, type ReactElement, useCallback } from "react";
+import { CopyIconButton } from "@/components/ui/copy-icon-button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
+import { buildCopyPreview } from "@/lib/copy-preview";
+import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
+
+export type MarkdownPreviewModalProps = {
+  markdown: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+};
+
+const hasLabeledCodeFence = (markdown: string): boolean => {
+  return markdown.includes("```") && /```[a-z0-9_-]+/i.test(markdown);
+};
+
+function MarkdownPreviewModalCopyButton({ markdown }: { markdown: string }): ReactElement {
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    getSuccessDescription: buildCopyPreview,
+    errorLogContext: "MarkdownPreviewModal",
+  });
+
+  const handleCopy = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      void copyToClipboard(markdown);
+    },
+    [copyToClipboard, markdown],
+  );
+
+  return (
+    <CopyIconButton
+      copied={copied}
+      ariaLabel="Copy document content"
+      dataTestId="markdown-preview-modal-copy"
+      className="absolute top-2 right-2 z-10"
+      onClick={handleCopy}
+    />
+  );
+}
+
+export function MarkdownPreviewModal({
+  markdown,
+  open,
+  onOpenChange,
+  title,
+}: MarkdownPreviewModalProps): ReactElement {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>{title ? <DialogTitle>{title}</DialogTitle> : null}</DialogHeader>
+        <DialogBody>
+          <div className="relative">
+            <MarkdownRenderer
+              markdown={markdown}
+              variant="document"
+              premiumCodeBlocks={hasLabeledCodeFence(markdown)}
+            />
+            <MarkdownPreviewModalCopyButton markdown={markdown} />
+          </div>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/frontend/src/lib/markdown-utils.ts
+++ b/packages/frontend/src/lib/markdown-utils.ts
@@ -1,0 +1,3 @@
+export const hasLabeledCodeFence = (markdown: string): boolean => {
+  return markdown.includes("```") && /```[a-z0-9_-]+/i.test(markdown);
+};


### PR DESCRIPTION
## Summary

Adds a reusable `MarkdownPreviewModal` component and integrates "Expand" buttons into task detail sheets and the Agent Studio sidebar, allowing users to preview markdown documents (spec, plan, QA reports) in a fullscreen dialog. Includes 7 snapshot regression tests and a follow-up refactor to deduplicate shared utilities.

## What this does

Users can now click a Maximize2 icon button in document section headers and the Agent Studio sidebar to open spec/plan/QA report content in a fullscreen markdown preview modal. The modal:

- Captures content at open time (snapshot), so later changes to the source document do not affect the open modal
- Includes a Copy button to copy raw markdown to clipboard
- Renders content with the same `MarkdownRenderer` used throughout the app (code highlighting, prose styling)
- Is fully accessible (always renders `DialogTitle`/`DialogDescription`)

## Implementation

### Wave 1 — Initial feature (1 commit)
- **`MarkdownPreviewModal`** — generic, task-agnostic `Dialog`-based viewer taking only `markdown`, `open`, `onOpenChange`, and optional `title`
- **`TaskDetailsCollapsibleCard`** — added `headerAction` prop to inject expand buttons into section headers
- Integrated expand buttons into `TaskDetailsDocumentSection`, `TaskDetailsAsyncDocumentSection`, and `AgentStudioWorkspaceSidebar`

### Wave 2 — QA fixes (3 commits)
- **Accessibility**: always render `DialogTitle` (sr-only "Document Preview" fallback) and `DialogDescription`
- **Snapshot at open time**: modal copies `{ markdown, title }` into React state on expand click so it doesn't reflect subsequent source changes
- **Modal survival**: modal persists even when source document becomes empty/null (early returns were bypassing the snapshot's render)

### Wave 3 — Regression tests (1 commit)
- 7 new snapshot persistence tests across 4 test files covering:
  - Modal retains content when source becomes empty/loading/null
  - Copy button copies the snapshot, not live content
- Fixed test resilience against `react-markdown` mock leaks from `markdown-renderer-premium.test.tsx` (pre-existing bug)
- Worked around happy-dom's missing `role="dialog"` support by using `getByTestId`

### Wave 4 — Refactor (1 commit)
- Extracted duplicate `hasLabeledCodeFence` into shared `lib/markdown-utils.ts`
- Created shared `DocumentCopyButton` component replacing 2 identical ~20-line internal components
- Fixed `memo` comparison in `TaskDetailsDocumentSection` (ReactElement `===` always false, removed `icon` from guard)
- Net: −7 lines despite adding new file

## Verification

| Check | Result |
|---|---|
| Typecheck (8 packages) | ✅ Pass |
| Lint (8 packages + boundary guards) | ✅ Pass |
| Bun tests | ✅ 2445 pass, 0 fail |
| Cargo fmt | ✅ Clean |
| Cargo clippy | ✅ No issues |
| Cargo check | ✅ All crates compile |
| Rust tests | ✅ 182 pass, 0 fail |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fullscreen markdown preview modal for document sections with expand buttons shown only when content exists.
  * Reusable copy-to-clipboard button used across previews; modal title can include task identifier.
  * Modal snapshot preserves original content while previewing even if source changes.

* **Tests**
  * Expanded coverage for expand controls, modal persistence, and clipboard interactions (with mocked clipboard/toast).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->