### PR TITLE
fix: improve agent studio dev server unavailable UX

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -4,7 +4,6 @@ import type { DevServerScriptState } from "@openducktor/contracts";
 import { render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import {
   AgentStudioDevServerPanel,
@@ -111,11 +110,7 @@ const failedScript: DevServerScriptState = {
 
 describe("AgentStudioDevServerPanel", () => {
   test("renders compact start row while stopped", () => {
-    const view = render(
-      <TooltipProvider>
-        <AgentStudioDevServerPanel model={baseModel()} />
-      </TooltipProvider>,
-    );
+    const view = render(<AgentStudioDevServerPanel model={baseModel()} />);
 
     try {
       expect(screen.getByTestId("agent-studio-dev-server-start-button").textContent).toContain(
@@ -134,16 +129,14 @@ describe("AgentStudioDevServerPanel", () => {
 
   test("renders disabled compact row when no worktree is available", () => {
     const view = render(
-      <TooltipProvider>
-        <AgentStudioDevServerPanel
-          model={baseModel({
-            mode: "disabled",
-            disabledReason:
-              "Create or resume a Builder worktree before starting repository dev servers.",
-            worktreePath: null,
-          })}
-        />
-      </TooltipProvider>,
+      <AgentStudioDevServerPanel
+        model={baseModel({
+          mode: "disabled",
+          disabledReason:
+            "Create or resume a Builder worktree before starting repository dev servers.",
+          worktreePath: null,
+        })}
+      />,
     );
 
     try {
@@ -167,16 +160,14 @@ describe("AgentStudioDevServerPanel", () => {
 
   test("renders empty compact row with a tooltip instead of inline copy", () => {
     const view = render(
-      <TooltipProvider>
-        <AgentStudioDevServerPanel
-          model={baseModel({
-            mode: "empty",
-            disabledReason:
-              "Configure one or more builder dev server commands in repository settings to stream them here.",
-            worktreePath: null,
-          })}
-        />
-      </TooltipProvider>,
+      <AgentStudioDevServerPanel
+        model={baseModel({
+          mode: "empty",
+          disabledReason:
+            "Configure one or more builder dev server commands in repository settings to stream them here.",
+          worktreePath: null,
+        })}
+      />,
     );
 
     try {

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -143,10 +143,16 @@ describe("AgentStudioDevServerPanel", () => {
       const button = screen.getByTestId(
         "agent-studio-dev-server-start-button",
       ) as HTMLButtonElement;
-      expect(button.disabled).toBe(true);
-      expect(screen.getByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeTruthy();
-      expect(screen.queryByTestId("agent-studio-dev-server-compact-message")).toBeNull();
 
+      expect(button.disabled).toBe(false);
+      expect(button.getAttribute("aria-disabled")).toBe("true");
+      expect(button.getAttribute("aria-describedby")).toBe(
+        "agent-studio-dev-server-disabled-reason",
+      );
+      expect(button.getAttribute("class")).toContain("cursor-not-allowed");
+      expect(button.getAttribute("class")).toContain("opacity-50");
+      expect(screen.queryByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeNull();
+      expect(screen.queryByTestId("agent-studio-dev-server-compact-message")).toBeNull();
       expect(
         screen.getByText(
           "Create or resume a Builder worktree before starting repository dev servers.",
@@ -175,10 +181,15 @@ describe("AgentStudioDevServerPanel", () => {
         "agent-studio-dev-server-start-button",
       ) as HTMLButtonElement;
 
-      expect(button.disabled).toBe(true);
-      expect(screen.getByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeTruthy();
+      expect(button.disabled).toBe(false);
+      expect(button.getAttribute("aria-disabled")).toBe("true");
+      expect(button.getAttribute("aria-describedby")).toBe(
+        "agent-studio-dev-server-disabled-reason",
+      );
+      expect(button.getAttribute("class")).toContain("cursor-not-allowed");
+      expect(button.getAttribute("class")).toContain("opacity-50");
+      expect(screen.queryByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeNull();
       expect(screen.queryByTestId("agent-studio-dev-server-compact-message")).toBeNull();
-
       expect(
         screen.getByText(
           "Configure one or more builder dev server commands in repository settings to stream them here.",

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -1,12 +1,19 @@
 import { describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { DevServerScriptState } from "@openducktor/contracts";
+import { render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import {
   AgentStudioDevServerPanel,
   type AgentStudioDevServerPanelModel,
 } from "./agent-studio-dev-server-panel";
+
+if (typeof document === "undefined") {
+  GlobalRegistrator.register();
+}
 
 const buildTerminalBuffer = (script: DevServerScriptState): AgentStudioDevServerTerminalBuffer => ({
   entries: script.bufferedTerminalChunks,
@@ -20,6 +27,7 @@ const baseModel = (
   mode: "stopped",
   isExpanded: false,
   isLoading: false,
+  disabledReason: null,
   repoPath: "/repo",
   taskId: "task-7",
   worktreePath: "/tmp/worktree/task-7",
@@ -103,29 +111,94 @@ const failedScript: DevServerScriptState = {
 
 describe("AgentStudioDevServerPanel", () => {
   test("renders compact start row while stopped", () => {
-    const html = renderToStaticMarkup(
-      createElement(AgentStudioDevServerPanel, { model: baseModel() }),
+    const view = render(
+      <TooltipProvider>
+        <AgentStudioDevServerPanel model={baseModel()} />
+      </TooltipProvider>,
     );
 
-    expect(html).toContain("Start dev servers");
-    expect(html).not.toContain("Start the configured builder dev servers for this task worktree.");
-    expect(html).not.toContain("Restart");
+    try {
+      expect(screen.getByTestId("agent-studio-dev-server-start-button").textContent).toContain(
+        "Start dev servers",
+      );
+      expect(screen.queryByTestId("agent-studio-dev-server-compact-message")).toBeNull();
+      expect(screen.queryByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeNull();
+      expect(
+        screen.queryByText("Start the configured builder dev servers for this task worktree."),
+      ).toBeNull();
+      expect(screen.queryByText("Restart")).toBeNull();
+    } finally {
+      view.unmount();
+    }
   });
 
   test("renders disabled compact row when no worktree is available", () => {
-    const html = renderToStaticMarkup(
-      createElement(AgentStudioDevServerPanel, {
-        model: baseModel({
-          mode: "disabled",
-          worktreePath: null,
-        }),
-      }),
+    const view = render(
+      <TooltipProvider>
+        <AgentStudioDevServerPanel
+          model={baseModel({
+            mode: "disabled",
+            disabledReason:
+              "Create or resume a Builder worktree before starting repository dev servers.",
+            worktreePath: null,
+          })}
+        />
+      </TooltipProvider>,
     );
 
-    expect(html).toContain(
-      "Create or resume a Builder worktree before starting repository dev servers.",
+    try {
+      const button = screen.getByTestId(
+        "agent-studio-dev-server-start-button",
+      ) as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
+      expect(screen.getByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeTruthy();
+      expect(screen.queryByTestId("agent-studio-dev-server-compact-message")).toBeNull();
+
+      expect(
+        screen.getByText(
+          "Create or resume a Builder worktree before starting repository dev servers.",
+          { selector: "span.sr-only" },
+        ).textContent,
+      ).toContain("Create or resume a Builder worktree before starting repository dev servers.");
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test("renders empty compact row with a tooltip instead of inline copy", () => {
+    const view = render(
+      <TooltipProvider>
+        <AgentStudioDevServerPanel
+          model={baseModel({
+            mode: "empty",
+            disabledReason:
+              "Configure one or more builder dev server commands in repository settings to stream them here.",
+            worktreePath: null,
+          })}
+        />
+      </TooltipProvider>,
     );
-    expect(html).toContain("disabled");
+
+    try {
+      const button = screen.getByTestId(
+        "agent-studio-dev-server-start-button",
+      ) as HTMLButtonElement;
+
+      expect(button.disabled).toBe(true);
+      expect(screen.getByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeTruthy();
+      expect(screen.queryByTestId("agent-studio-dev-server-compact-message")).toBeNull();
+
+      expect(
+        screen.getByText(
+          "Configure one or more builder dev server commands in repository settings to stream them here.",
+          { selector: "span.sr-only" },
+        ).textContent,
+      ).toContain(
+        "Configure one or more builder dev server commands in repository settings to stream them here.",
+      );
+    } finally {
+      view.unmount();
+    }
   });
 
   test("renders expanded terminal tabs and terminal surface while active", () => {

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -8,6 +8,8 @@ import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio
 import {
   AgentStudioDevServerPanel,
   type AgentStudioDevServerPanelModel,
+  DEV_SERVER_DISABLED_REASON,
+  DEV_SERVER_EMPTY_REASON,
 } from "./agent-studio-dev-server-panel";
 
 if (typeof document === "undefined") {
@@ -132,8 +134,7 @@ describe("AgentStudioDevServerPanel", () => {
       <AgentStudioDevServerPanel
         model={baseModel({
           mode: "disabled",
-          disabledReason:
-            "Create or resume a Builder worktree before starting repository dev servers.",
+          disabledReason: DEV_SERVER_DISABLED_REASON,
           worktreePath: null,
         })}
       />,
@@ -146,19 +147,15 @@ describe("AgentStudioDevServerPanel", () => {
 
       expect(button.disabled).toBe(false);
       expect(button.getAttribute("aria-disabled")).toBe("true");
-      expect(button.getAttribute("aria-describedby")).toBe(
-        "agent-studio-dev-server-disabled-reason",
-      );
+      const disabledReasonId = button.getAttribute("aria-describedby");
+      expect(disabledReasonId).toBeTruthy();
       expect(button.getAttribute("class")).toContain("cursor-not-allowed");
       expect(button.getAttribute("class")).toContain("opacity-50");
       expect(screen.queryByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeNull();
       expect(screen.queryByTestId("agent-studio-dev-server-compact-message")).toBeNull();
-      expect(
-        screen.getByText(
-          "Create or resume a Builder worktree before starting repository dev servers.",
-          { selector: "span.sr-only" },
-        ).textContent,
-      ).toContain("Create or resume a Builder worktree before starting repository dev servers.");
+      expect(document.getElementById(disabledReasonId ?? "")?.textContent).toContain(
+        DEV_SERVER_DISABLED_REASON,
+      );
     } finally {
       view.unmount();
     }
@@ -169,8 +166,7 @@ describe("AgentStudioDevServerPanel", () => {
       <AgentStudioDevServerPanel
         model={baseModel({
           mode: "empty",
-          disabledReason:
-            "Configure one or more builder dev server commands in repository settings to stream them here.",
+          disabledReason: DEV_SERVER_EMPTY_REASON,
           worktreePath: null,
         })}
       />,
@@ -183,20 +179,14 @@ describe("AgentStudioDevServerPanel", () => {
 
       expect(button.disabled).toBe(false);
       expect(button.getAttribute("aria-disabled")).toBe("true");
-      expect(button.getAttribute("aria-describedby")).toBe(
-        "agent-studio-dev-server-disabled-reason",
-      );
+      const disabledReasonId = button.getAttribute("aria-describedby");
+      expect(disabledReasonId).toBeTruthy();
       expect(button.getAttribute("class")).toContain("cursor-not-allowed");
       expect(button.getAttribute("class")).toContain("opacity-50");
       expect(screen.queryByTestId("agent-studio-dev-server-disabled-start-trigger")).toBeNull();
       expect(screen.queryByTestId("agent-studio-dev-server-compact-message")).toBeNull();
-      expect(
-        screen.getByText(
-          "Configure one or more builder dev server commands in repository settings to stream them here.",
-          { selector: "span.sr-only" },
-        ).textContent,
-      ).toContain(
-        "Configure one or more builder dev server commands in repository settings to stream them here.",
+      expect(document.getElementById(disabledReasonId ?? "")?.textContent).toContain(
+        DEV_SERVER_EMPTY_REASON,
       );
     } finally {
       view.unmount();

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -1,6 +1,6 @@
 import type { DevServerScriptState } from "@openducktor/contracts";
 import { Check, Copy, Play, RefreshCw, Square } from "lucide-react";
-import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
+import { cloneElement, memo, type ReactElement, useCallback, useMemo, useState } from "react";
 import { AgentStudioDevServerTerminal } from "@/components/features/agents/agent-studio-dev-server-terminal";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -77,25 +77,34 @@ const renderCompactStartButton = ({
   button,
   disabledReason,
 }: {
-  button: ReactElement;
+  button: ReactElement<{
+    className?: string;
+    onClick?: (() => void) | undefined;
+    disabled?: boolean | undefined;
+    [key: string]: unknown;
+  }>;
   disabledReason: string | null;
 }): ReactElement => {
   if (!disabledReason) {
     return button;
   }
 
+  const disabledReasonId = "agent-studio-dev-server-disabled-reason";
+  const tooltipTriggerButton = cloneElement(button, {
+    disabled: undefined,
+    onClick: undefined,
+    className: cn(button.props.className, "cursor-not-allowed opacity-50"),
+    "aria-disabled": "true",
+    "aria-describedby": disabledReasonId,
+  });
+
   return (
     <TooltipProvider>
+      <span id={disabledReasonId} className="sr-only">
+        {disabledReason}
+      </span>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className="inline-flex w-full cursor-not-allowed"
-            data-testid="agent-studio-dev-server-disabled-start-trigger"
-          >
-            {button}
-            <span className="sr-only">{disabledReason}</span>
-          </span>
-        </TooltipTrigger>
+        <TooltipTrigger asChild>{tooltipTriggerButton}</TooltipTrigger>
         <TooltipContent side="top">
           <p>{disabledReason}</p>
         </TooltipContent>

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -4,6 +4,7 @@ import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
 import { AgentStudioDevServerTerminal } from "@/components/features/agents/agent-studio-dev-server-terminal";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
@@ -14,6 +15,7 @@ export type AgentStudioDevServerPanelModel = {
   mode: AgentStudioDevServerPanelMode;
   isExpanded: boolean;
   isLoading: boolean;
+  disabledReason: string | null;
   repoPath: string | null;
   taskId: string | null;
   worktreePath: string | null;
@@ -133,8 +135,20 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
     const isDisabled = model.mode === "disabled";
     const isLoading = model.mode === "loading";
     const startDisabled = isEmpty || isDisabled || isLoading || isActionPending;
-    const showCompactMessage = model.mode !== "stopped";
     const startLabel = getStartLabel(isLoading, model.isStartPending);
+    const startButton = (
+      <Button
+        type="button"
+        size="sm"
+        className="w-full justify-center rounded-lg"
+        disabled={startDisabled}
+        onClick={model.onStart}
+        data-testid="agent-studio-dev-server-start-button"
+      >
+        <Play className="size-4" />
+        {startLabel}
+      </Button>
+    );
 
     return (
       <div
@@ -142,26 +156,25 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
         data-testid="agent-studio-dev-server-compact-panel"
       >
         <div className="flex items-center">
-          <Button
-            type="button"
-            size="sm"
-            className="w-full justify-center rounded-lg"
-            disabled={startDisabled}
-            onClick={model.onStart}
-            data-testid="agent-studio-dev-server-start-button"
-          >
-            <Play className="size-4" />
-            {startLabel}
-          </Button>
+          {model.disabledReason ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="inline-flex w-full cursor-not-allowed"
+                  data-testid="agent-studio-dev-server-disabled-start-trigger"
+                >
+                  {startButton}
+                  <span className="sr-only">{model.disabledReason}</span>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                <p>{model.disabledReason}</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            startButton
+          )}
         </div>
-        {showCompactMessage ? (
-          <div
-            className="mt-3 text-sm text-muted-foreground"
-            data-testid="agent-studio-dev-server-compact-message"
-          >
-            {headerSummary}
-          </div>
-        ) : null}
         {panelError ? (
           <div
             className="mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -4,7 +4,7 @@ import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
 import { AgentStudioDevServerTerminal } from "@/components/features/agents/agent-studio-dev-server-terminal";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
@@ -157,20 +157,22 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
       >
         <div className="flex items-center">
           {model.disabledReason ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="inline-flex w-full cursor-not-allowed"
-                  data-testid="agent-studio-dev-server-disabled-start-trigger"
-                >
-                  {startButton}
-                  <span className="sr-only">{model.disabledReason}</span>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                <p>{model.disabledReason}</p>
-              </TooltipContent>
-            </Tooltip>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex w-full cursor-not-allowed"
+                    data-testid="agent-studio-dev-server-disabled-start-trigger"
+                  >
+                    {startButton}
+                    <span className="sr-only">{model.disabledReason}</span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p>{model.disabledReason}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           ) : (
             startButton
           )}

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -73,6 +73,37 @@ const getEmptyTerminalMessage = (script: DevServerScriptState): string => {
   return "Terminal output will appear here once this dev server writes output. Drag to select logs, then press Cmd/Ctrl+C to copy.";
 };
 
+const renderCompactStartButton = ({
+  button,
+  disabledReason,
+}: {
+  button: ReactElement;
+  disabledReason: string | null;
+}): ReactElement => {
+  if (!disabledReason) {
+    return button;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex w-full cursor-not-allowed"
+            data-testid="agent-studio-dev-server-disabled-start-trigger"
+          >
+            {button}
+            <span className="sr-only">{disabledReason}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p>{disabledReason}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
 export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel({
   model,
 }: {
@@ -156,26 +187,7 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
         data-testid="agent-studio-dev-server-compact-panel"
       >
         <div className="flex items-center">
-          {model.disabledReason ? (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className="inline-flex w-full cursor-not-allowed"
-                    data-testid="agent-studio-dev-server-disabled-start-trigger"
-                  >
-                    {startButton}
-                    <span className="sr-only">{model.disabledReason}</span>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  <p>{model.disabledReason}</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : (
-            startButton
-          )}
+          {renderCompactStartButton({ button: startButton, disabledReason: model.disabledReason })}
         </div>
         {panelError ? (
           <div

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -1,6 +1,14 @@
 import type { DevServerScriptState } from "@openducktor/contracts";
 import { Check, Copy, Play, RefreshCw, Square } from "lucide-react";
-import { cloneElement, memo, type ReactElement, useCallback, useMemo, useState } from "react";
+import {
+  cloneElement,
+  memo,
+  type ReactElement,
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+} from "react";
 import { AgentStudioDevServerTerminal } from "@/components/features/agents/agent-studio-dev-server-terminal";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -32,6 +40,11 @@ export type AgentStudioDevServerPanelModel = {
   onStop: () => void;
   onRestart: () => void;
 };
+
+export const DEV_SERVER_DISABLED_REASON =
+  "Create or resume a Builder worktree before starting repository dev servers.";
+export const DEV_SERVER_EMPTY_REASON =
+  "Configure one or more builder dev server commands in repository settings to stream them here.";
 
 const statusIndicatorClassName = (status: DevServerScriptState["status"]): string => {
   if (status === "running") {
@@ -76,6 +89,7 @@ const getEmptyTerminalMessage = (script: DevServerScriptState): string => {
 const renderCompactStartButton = ({
   button,
   disabledReason,
+  disabledReasonId,
 }: {
   button: ReactElement<{
     className?: string;
@@ -84,12 +98,12 @@ const renderCompactStartButton = ({
     [key: string]: unknown;
   }>;
   disabledReason: string | null;
+  disabledReasonId: string;
 }): ReactElement => {
   if (!disabledReason) {
     return button;
   }
 
-  const disabledReasonId = "agent-studio-dev-server-disabled-reason";
   const tooltipTriggerButton = cloneElement(button, {
     disabled: undefined,
     onClick: undefined,
@@ -135,6 +149,7 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
       : null);
   const selectedScriptTerminalChunkCount = selectedScriptTerminalBuffer?.entries.length ?? 0;
   const panelError = model.error ?? rendererError;
+  const disabledReasonId = useId();
   const { copied: copiedWorktreePath, copyToClipboard: copyWorktreePath } = useCopyToClipboard({
     getSuccessDescription: (value) => value,
     errorLogContext: "AgentStudioDevServerPanel",
@@ -142,11 +157,11 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
 
   const headerSummary = useMemo(() => {
     if (model.mode === "empty") {
-      return "Configure one or more builder dev server commands in repository settings to stream them here.";
+      return DEV_SERVER_EMPTY_REASON;
     }
 
     if (model.mode === "disabled") {
-      return "Create or resume a Builder worktree before starting repository dev servers.";
+      return DEV_SERVER_DISABLED_REASON;
     }
 
     if (model.mode === "loading") {
@@ -189,6 +204,8 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
         {startLabel}
       </Button>
     );
+    // `disabledReason` is only produced for the stable `empty`/`disabled` modes.
+    // It cannot overlap with the transient loading/start-pending button labels.
 
     return (
       <div
@@ -196,7 +213,11 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
         data-testid="agent-studio-dev-server-compact-panel"
       >
         <div className="flex items-center">
-          {renderCompactStartButton({ button: startButton, disabledReason: model.disabledReason })}
+          {renderCompactStartButton({
+            button: startButton,
+            disabledReason: model.disabledReason,
+            disabledReasonId,
+          })}
         </div>
         {panelError ? (
           <div

--- a/packages/frontend/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -124,6 +124,7 @@ const devServerModel: AgentStudioDevServerPanelModel = {
   mode: "active",
   isExpanded: true,
   isLoading: false,
+  disabledReason: null,
   repoPath: "/repo",
   taskId: "task-12",
   worktreePath: "/tmp/worktree/task-12",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -194,8 +194,59 @@ describe("useAgentStudioDevServerPanel", () => {
       await waitFor(() => {
         expect(getLatest().mode).toBe("empty");
       });
+      expect(getLatest().disabledReason).toBe(
+        "Configure one or more builder dev server commands in repository settings to stream them here.",
+      );
       expect(getStateCalls).toBe(0);
       expect(devServerEventListener).toBeNull();
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test("returns a disabled reason when a builder worktree is unavailable", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    devServerGetState = async () =>
+      buildState({
+        worktreePath: null,
+      });
+
+    let latest: HookResult | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().mode).toBe("disabled");
+      });
+      expect(getLatest().disabledReason).toBe(
+        "Create or resume a Builder worktree before starting repository dev servers.",
+      );
     } finally {
       view.unmount();
     }

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -2,9 +2,11 @@ import type { DevServerEvent, DevServerGroupState } from "@openducktor/contracts
 import { devServerEventSchema } from "@openducktor/contracts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type {
-  AgentStudioDevServerPanelMode,
-  AgentStudioDevServerPanelModel,
+import {
+  type AgentStudioDevServerPanelMode,
+  type AgentStudioDevServerPanelModel,
+  DEV_SERVER_DISABLED_REASON,
+  DEV_SERVER_EMPTY_REASON,
 } from "@/components/features/agents/agent-studio-dev-server-panel";
 import { errorMessage } from "@/lib/errors";
 import { hostClient, subscribeDevServerEvents } from "@/lib/host-client";
@@ -436,10 +438,9 @@ export function useAgentStudioDevServerPanel({
   let disabledReason: string | null = null;
 
   if (mode === "disabled") {
-    disabledReason = "Create or resume a Builder worktree before starting repository dev servers.";
+    disabledReason = DEV_SERVER_DISABLED_REASON;
   } else if (mode === "empty") {
-    disabledReason =
-      "Configure one or more builder dev server commands in repository settings to stream them here.";
+    disabledReason = DEV_SERVER_EMPTY_REASON;
   }
 
   return {

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -433,11 +433,18 @@ export function useAgentStudioDevServerPanel({
 
   const error =
     actionError ?? subscriptionError ?? (stateQuery.error ? errorMessage(stateQuery.error) : null);
+  const disabledReason =
+    mode === "disabled"
+      ? "Create or resume a Builder worktree before starting repository dev servers."
+      : mode === "empty"
+        ? "Configure one or more builder dev server commands in repository settings to stream them here."
+        : null;
 
   return {
     mode,
     isExpanded,
     isLoading: isAwaitingFreshState || stateQuery.isLoading,
+    disabledReason,
     repoPath,
     taskId,
     worktreePath: effectiveState?.worktreePath ?? null,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -433,12 +433,14 @@ export function useAgentStudioDevServerPanel({
 
   const error =
     actionError ?? subscriptionError ?? (stateQuery.error ? errorMessage(stateQuery.error) : null);
-  const disabledReason =
-    mode === "disabled"
-      ? "Create or resume a Builder worktree before starting repository dev servers."
-      : mode === "empty"
-        ? "Configure one or more builder dev server commands in repository settings to stream them here."
-        : null;
+  let disabledReason: string | null = null;
+
+  if (mode === "disabled") {
+    disabledReason = "Create or resume a Builder worktree before starting repository dev servers.";
+  } else if (mode === "empty") {
+    disabledReason =
+      "Configure one or more builder dev server commands in repository settings to stream them here.";
+  }
 
   return {
     mode,

--- a/packages/frontend/src/pages/agents/use-agent-studio-right-panel.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-right-panel.test.tsx
@@ -119,6 +119,7 @@ const devServerModel: AgentStudioDevServerPanelModel = {
   mode: "stopped",
   isExpanded: false,
   isLoading: false,
+  disabledReason: null,
   repoPath: "/repo",
   taskId: "task-12",
   worktreePath: "/tmp/worktree/task-12",


### PR DESCRIPTION
## Summary
- replace compact dev-server unavailable inline messages with disabled-button tooltips in Agent Studio
- keep the tooltip path self-contained and keyboard accessible in disabled and empty states
- add focused component and hook coverage for disabled reasons and compact-panel behavior

## Goal
This PR improves the Agent Studio build-tools UX when repository dev servers cannot be started. The previous compact panel rendered full inline warning text, which took too much vertical space and added noise to the panel.

## Why
The goal is to keep the compact panel small while still explaining why the start action is unavailable. Reviewers should be able to see that the change preserves the existing dev-server state logic and only improves how unavailable states are presented.

## Implementation
I kept the existing mode derivation in `use-agent-studio-dev-server-panel` and added a model-level `disabledReason` so the view stays presentational.

In `agent-studio-dev-server-panel.tsx`, the compact start action now renders through a small local helper that wraps unavailable states with a tooltip and owns its `TooltipProvider`, which avoids relying on sibling panel composition.

For accessibility, the unavailable state uses a focusable tooltip trigger with `aria-disabled` and `aria-describedby` so keyboard-only users can still discover the disabled reason without triggering the start action.

The test updates cover:
- disabled compact state
- empty compact state
- stopped compact state remaining clean
- hook-derived disabled reasons for `empty` and `disabled`

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `rtk cargo fmt --all --check`
- `rtk cargo clippy --workspace --all-targets -- -D warnings`
- `bun run check:rust`
- `bun run test:rust`
- `rtk cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Developer server panel now displays contextual explanatory messages when disabled, guiding users to resolve issues (e.g., create or resume a Builder worktree, or configure dev server commands in settings).

* **Improvements**
  * Enhanced accessibility with proper aria attributes for disabled button states.
  * Improved visual design for disabled states with enhanced styling indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->