### PR TITLE
fix(chat): keep latest turn measured after completion

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread-tauri.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread-tauri.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { createElement, createRef } from "react";
 import { buildMessage, buildSession } from "./agent-chat-test-fixtures";
 import { AgentChatThread } from "./agent-chat-thread";
@@ -35,7 +35,7 @@ const buildBaseModel = () => ({
 
 const buildLongSession = (externalSessionId: string, count = 80) => {
   const messages = Array.from({ length: count }, (_, index) =>
-    buildMessage("user", `Message ${index + 1}`, {
+    buildMessage(index % 2 === 0 ? "user" : "assistant", `Message ${index + 1}`, {
       id: `message-${index + 1}`,
     }),
   );
@@ -56,7 +56,7 @@ afterEach(() => {
 });
 
 describe("AgentChatThread Tauri runtime", () => {
-  test("keeps turn containment enabled in the Tauri runtime when no attachments are present", () => {
+  test("keeps turn containment enabled in the Tauri runtime when no attachments are present", async () => {
     const runtimeWindow = globalThis.window as Window & { __TAURI_INTERNALS__?: object };
     runtimeWindow.__TAURI_INTERNALS__ = {};
 
@@ -69,7 +69,9 @@ describe("AgentChatThread Tauri runtime", () => {
       }),
     );
 
-    expect(rendered.container.querySelector('[style*="content-visibility"]')).not.toBeNull();
-    expect(rendered.container.querySelector('[style*="contain-intrinsic-size"]')).not.toBeNull();
+    await waitFor(() => {
+      expect(rendered.container.querySelector('[style*="content-visibility"]')).not.toBeNull();
+      expect(rendered.container.querySelector('[style*="contain-intrinsic-size"]')).not.toBeNull();
+    });
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -670,17 +670,19 @@ describe("AgentChatThread", () => {
     );
     await act(flush);
 
-    const getTurnStyle = (rowKey: string): string => {
+    const getTurnStyle = (rowKey: string): string | null => {
       const row = rendered.container.querySelector(`[data-row-key="${rowKey}"]`);
       const turn = row?.parentElement;
       if (!(turn instanceof HTMLDivElement)) {
-        throw new Error(`Expected turn element for ${rowKey}`);
+        return null;
       }
 
       return turn.getAttribute("style") ?? "";
     };
 
-    expect(getTurnStyle(`${externalSessionId}:user-12`)).not.toContain("content-visibility");
+    const runningLatestTurnStyle = getTurnStyle(`${externalSessionId}:user-12`);
+    expect(runningLatestTurnStyle).not.toBeNull();
+    expect(runningLatestTurnStyle).not.toContain("content-visibility");
 
     rendered.rerender(
       createElement(AgentChatThread, {
@@ -699,8 +701,12 @@ describe("AgentChatThread", () => {
     );
     await act(flush);
 
-    expect(getTurnStyle(`${externalSessionId}:user-3`)).toContain("content-visibility");
-    expect(getTurnStyle(`${externalSessionId}:user-12`)).not.toContain("content-visibility");
+    const completedOlderTurnStyle = getTurnStyle(`${externalSessionId}:user-3`);
+    const completedLatestTurnStyle = getTurnStyle(`${externalSessionId}:user-12`);
+    expect(completedOlderTurnStyle).not.toBeNull();
+    expect(completedOlderTurnStyle).toContain("content-visibility");
+    expect(completedLatestTurnStyle).not.toBeNull();
+    expect(completedLatestTurnStyle).not.toContain("content-visibility");
 
     rendered.unmount();
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -641,6 +641,70 @@ describe("AgentChatThread", () => {
     }
   });
 
+  test("keeps the latest user turn uncontained after a running session completes", async () => {
+    const externalSessionId = "session-completed-scroll";
+    const messages = Array.from({ length: 12 }, (_, index) => [
+      buildMessage("user", `Command ${index + 1}`, {
+        id: `user-${index + 1}`,
+      }),
+      buildMessage("assistant", `Result ${index + 1}`, {
+        id: `assistant-${index + 1}`,
+      }),
+    ]).flat();
+    const runningSession = buildSession({
+      externalSessionId,
+      messages,
+      pendingQuestions: [],
+      pendingPermissions: [],
+      status: "running",
+    });
+    const model = {
+      ...buildBaseModel(),
+      isSessionWorking: true,
+      session: runningSession,
+    };
+    const rendered = render(
+      createElement(AgentChatThread, {
+        model,
+      }),
+    );
+    await act(flush);
+
+    const getTurnStyle = (rowKey: string): string => {
+      const row = rendered.container.querySelector(`[data-row-key="${rowKey}"]`);
+      const turn = row?.parentElement;
+      if (!(turn instanceof HTMLDivElement)) {
+        throw new Error(`Expected turn element for ${rowKey}`);
+      }
+
+      return turn.getAttribute("style") ?? "";
+    };
+
+    expect(getTurnStyle(`${externalSessionId}:user-12`)).not.toContain("content-visibility");
+
+    rendered.rerender(
+      createElement(AgentChatThread, {
+        model: {
+          ...model,
+          isSessionWorking: false,
+          session: buildSession({
+            externalSessionId,
+            messages,
+            pendingQuestions: [],
+            pendingPermissions: [],
+            status: "idle",
+          }),
+        },
+      }),
+    );
+    await act(flush);
+
+    expect(getTurnStyle(`${externalSessionId}:user-3`)).toContain("content-visibility");
+    expect(getTurnStyle(`${externalSessionId}:user-12`)).not.toContain("content-visibility");
+
+    rendered.unmount();
+  });
+
   test("adds bottom spacing before the composer when the last bottom-stack item is a question", async () => {
     const rendered = render(
       createElement(AgentChatThread, {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -680,13 +680,15 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     },
     [registerRowElement],
   );
-  const activeTurnKey = useMemo(() => {
-    if (!session || !isSessionWorking || !transcriptState.lastUserMessageId) {
+  // Keep the newest turn measured after completion too. Re-applying content-visibility to the
+  // just-finished turn can make the browser anchor around the prompt and jump away from the bottom.
+  const latestUserTurnKey = useMemo(() => {
+    if (!session || !transcriptState.lastUserMessageId) {
       return null;
     }
 
     return `${session.externalSessionId}:${transcriptState.lastUserMessageId}`;
-  }, [isSessionWorking, session, transcriptState.lastUserMessageId]);
+  }, [session, transcriptState.lastUserMessageId]);
   const activeStreamingAssistantMessageId = transcriptState.activeStreamingAssistantMessageId;
   const showSessionLoadingOverlay = useAgentChatLoadingOverlay({
     externalSessionId: activeExternalSessionId,
@@ -696,9 +698,9 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     return stagedWindowTurns.map((turn) => ({
       key: turn.key,
       rows: stagedRows.slice(turn.start, turn.end + 1),
-      isActive: turn.key === activeTurnKey,
+      isActive: turn.key === latestUserTurnKey,
     }));
-  }, [activeTurnKey, stagedRows, stagedWindowTurns]);
+  }, [latestUserTurnKey, stagedRows, stagedWindowTurns]);
   const allowTurnContainment = !hasAttachmentMessages;
   const bottomStackRef = useRef<HTMLDivElement | null>(null);
   const bottomStackHeightRef = useRef<number | null>(null);


### PR DESCRIPTION
## Summary
- Keeps the newest user turn measured after an agent session completes so browser scroll anchoring does not jump back to the prompt or previous message.
- Adds regression coverage for the completion transition and updates the Tauri containment test to account for staged turn rendering.

## Goal
This PR fixes a chat scroll regression where sending or using a slash command could leave the transcript at the bottom while the agent was running, then jump back toward the prior user message once the agent completed. The completed turn was being re-contained immediately after `isSessionWorking` became false, which could cause the browser to re-anchor around the prompt instead of preserving the latest bottom position.

## Technical choices
The fix keeps the latest user turn exempt from `content-visibility` even after the session transitions from running to idle. Older turns still use containment, preserving the performance benefit for large transcripts while keeping the just-finished turn fully measured for stable scroll anchoring.

The regression test renders a long command/result transcript, verifies the newest user turn is uncontained while running, rerenders the same session as completed, and asserts that the newest turn remains uncontained while older turns remain contained. The Tauri runtime containment test now waits for staged older turns to render before checking that containment remains enabled when no attachments are present.

## Verification
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo build --workspace`