### PR TITLE
fix: restrict auto-open errors to ODT MCP tool cards only

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
@@ -339,7 +339,7 @@ export const RegularToolMessage = ({
   return (
     <div className="space-y-1 px-1 py-0.5">
       {hasExpandableDetails ? (
-        <details className="group" open={lifecyclePhase === "failed"}>
+        <details className="group">
           <summary className="list-none [&::-webkit-details-marker]:hidden">{summaryRow}</summary>
           <div className="ml-5 mt-1 space-y-2">
             {hasInput && meta.input ? (
@@ -363,10 +363,7 @@ export const RegularToolMessage = ({
               </details>
             ) : null}
             {hasError && meta.error ? (
-              <details
-                className="rounded border border-destructive-border bg-destructive-surface"
-                open={lifecyclePhase === "failed"}
-              >
+              <details className="rounded border border-destructive-border bg-destructive-surface">
                 <summary className="cursor-pointer px-2 py-1 text-xs font-medium text-destructive-muted">
                   Error
                 </summary>

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -132,6 +132,60 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain(">Activity<");
   });
 
+  test("auto-opens failed ODT workflow tool error details", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-wf-failed",
+          role: "tool",
+          content: "Tool openducktor_odt_set_spec failed",
+          timestamp: "2026-02-22T10:20:36.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-wf-failed",
+            callId: "call-wf-failed",
+            tool: "openducktor_odt_set_spec",
+            status: "error",
+            input: { taskId: "task-x" },
+            error: "Task already has a spec",
+          },
+        },
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toMatch(/<details\b[^>]*\bopen\b/);
+    expect(html).toContain("Task already has a spec");
+  });
+
+  test("keeps regular failed tool errors collapsed", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-regular-failed",
+          role: "tool",
+          content: "Tool bash failed",
+          timestamp: "2026-02-22T10:20:37.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-regular-failed",
+            callId: "call-regular-failed",
+            tool: "bash",
+            status: "error",
+            input: { command: "invalid-cmd" },
+            error: "command not found",
+          },
+        },
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).not.toMatch(/<details\b[^>]*\bopen\b/);
+    expect(html).toContain("command not found");
+  });
+
   test("renders expandable details for regular read_task tool rows", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {


### PR DESCRIPTION
## Summary

Fix a UI behavior where all failed tool calls in the agent chat auto-expanded their error details. Only OpenDucktor MCP workflow tools (displayed as special colored cards) should auto-open on failure.

## Goal

A recent change added auto-open behavior for tool call errors, but it applied to every tool card — including regular tools like `bash`, `read`, etc. These normal tool calls should stay collapsed by default, matching the pre-existing behavior.

## Implementation

Two targeted changes in `agent-chat-message-card-tool-presenters.tsx`:

1. **Removed `open={lifecyclePhase === "failed"}` from `RegularToolMessage`** — both the outer `<details>` wrapper and the inner error `<details>` no longer auto-expand. Regular tools stay collapsed on failure.

2. **`WorkflowToolMessage` unchanged** — ODT MCP workflow tools already use `open={isFailure}` and continue to auto-open their error details.

### Tests

Two focused regression tests in `agent-chat-message-card.test.ts`:
- `auto-opens failed ODT workflow tool error details` — asserts `<details open>` present for `openducktor_odt_set_spec` with error
- `keeps regular failed tool errors collapsed` — asserts no `<details open>` for `bash` with error

## Verification

- Typecheck: ✅ all workspaces
- Lint: ✅ all workspaces  
- Tests: ✅ 2414 Bun tests + 182 Cargo tests, 0 failures
- Cargo fmt/clippy: ✅ clean