### PR TITLE
fix: validate launch start modes as alternatives

### DIFF
--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime/registry/capabilities.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime/registry/capabilities.rs
@@ -674,6 +674,17 @@ impl RuntimeCapabilities {
     }
 
     pub(super) fn launch_config_errors(&self) -> Vec<String> {
+        let supported_modes = if self.session_lifecycle.supported_start_modes.is_empty() {
+            "none".to_string()
+        } else {
+            self.session_lifecycle
+                .supported_start_modes
+                .iter()
+                .map(|mode| mode.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
         LAUNCH_START_MODE_REQUIREMENTS
             .iter()
             .filter_map(|requirement| {
@@ -690,16 +701,6 @@ impl RuntimeCapabilities {
                     .map(|mode| mode.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
-                let supported_modes = if self.session_lifecycle.supported_start_modes.is_empty() {
-                    "none".to_string()
-                } else {
-                    self.session_lifecycle
-                        .supported_start_modes
-                        .iter()
-                        .map(|mode| mode.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                };
                 Some(format!(
                     "[launch_scoped] launch action {} has no supported start mode (allowed: {}; runtime supports: {})",
                     requirement.id,

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime/registry/capabilities.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime/registry/capabilities.rs
@@ -677,20 +677,34 @@ impl RuntimeCapabilities {
         LAUNCH_START_MODE_REQUIREMENTS
             .iter()
             .filter_map(|requirement| {
-                let missing_modes = requirement
+                let has_supported_start_mode = requirement
                     .modes
                     .iter()
-                    .copied()
-                    .filter(|mode| !self.session_lifecycle.supported_start_modes.contains(mode))
-                    .map(|mode| mode.to_string())
-                    .collect::<Vec<_>>();
-                if missing_modes.is_empty() {
+                    .any(|mode| self.session_lifecycle.supported_start_modes.contains(mode));
+                if has_supported_start_mode {
                     return None;
                 }
+                let allowed_modes = requirement
+                    .modes
+                    .iter()
+                    .map(|mode| mode.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let supported_modes = if self.session_lifecycle.supported_start_modes.is_empty() {
+                    "none".to_string()
+                } else {
+                    self.session_lifecycle
+                        .supported_start_modes
+                        .iter()
+                        .map(|mode| mode.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
                 Some(format!(
-                    "[launch_scoped] launch action {} requires start modes: {}",
+                    "[launch_scoped] launch action {} has no supported start mode (allowed: {}; runtime supports: {})",
                     requirement.id,
-                    missing_modes.join(", ")
+                    allowed_modes,
+                    supported_modes
                 ))
             })
             .collect()

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime/registry/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime/registry/tests.rs
@@ -533,16 +533,36 @@ fn runtime_descriptor_validation_reports_capability_invariants() {
 }
 
 #[test]
-fn runtime_descriptor_validation_reports_launch_start_mode_gaps() {
+fn runtime_descriptor_validation_treats_launch_start_modes_as_alternatives() {
     let mut descriptor = runtime_definition("custom", "Custom").descriptor().clone();
-    let supported_start_modes = vec![
+    let session_lifecycle = &mut descriptor.capabilities.session_lifecycle;
+    session_lifecycle.supported_start_modes = vec![
         RuntimeSessionStartMode::Fresh,
         RuntimeSessionStartMode::Reuse,
     ];
+    session_lifecycle.supports_session_fork = false;
+    session_lifecycle.fork_targets.clear();
+
+    assert!(descriptor.validate_for_openducktor().is_empty());
+
+    let session_lifecycle = &mut descriptor.capabilities.session_lifecycle;
+    session_lifecycle.supported_start_modes = vec![
+        RuntimeSessionStartMode::Fresh,
+        RuntimeSessionStartMode::Fork,
+    ];
+    session_lifecycle.supports_session_fork = true;
+    session_lifecycle.fork_targets = vec![RuntimeForkTarget::Session];
+
+    assert!(descriptor.validate_for_openducktor().is_empty());
+}
+
+#[test]
+fn runtime_descriptor_validation_reports_launch_start_mode_gaps() {
+    let mut descriptor = runtime_definition("custom", "Custom").descriptor().clone();
     descriptor
         .capabilities
         .session_lifecycle
-        .supported_start_modes = supported_start_modes;
+        .supported_start_modes = vec![RuntimeSessionStartMode::Fresh];
     descriptor
         .capabilities
         .session_lifecycle
@@ -556,7 +576,7 @@ fn runtime_descriptor_validation_reports_launch_start_mode_gaps() {
     assert_eq!(
         descriptor.validate_for_openducktor(),
         vec![
-            "[launch_scoped] launch action build_pull_request_generation requires start modes: fork"
+            "[launch_scoped] launch action build_pull_request_generation has no supported start mode (allowed: reuse, fork; runtime supports: fresh)"
                 .to_string()
         ]
     );

--- a/packages/frontend/src/components/features/agents/session-start-modal.tsx
+++ b/packages/frontend/src/components/features/agents/session-start-modal.tsx
@@ -127,6 +127,10 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
     !selectedModelSelection ||
     !supportsVariants ||
     variantOptions.length === 0;
+  const runtimePlaceholder =
+    runtimeOptions.length > 0
+      ? "Select runtime"
+      : `No runtime supports ${sessionStartModeButtonLabel(selectedStartMode).toLowerCase()}`;
   const handleConfirm = (): void => {
     if (confirmDisabled) {
       return;
@@ -248,6 +252,7 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
                 <AgentRuntimeCombobox
                   value={selectedRuntimeKind ?? ""}
                   runtimeOptions={runtimeOptions}
+                  placeholder={runtimePlaceholder}
                   disabled={runtimeDisabled}
                   className="sm:min-w-[20rem]"
                   onValueChange={onSelectRuntime}

--- a/packages/frontend/src/components/features/agents/session-start-modal.tsx
+++ b/packages/frontend/src/components/features/agents/session-start-modal.tsx
@@ -25,6 +25,8 @@ type SessionStartModalConfirmInput =
       sourceExternalSessionId: string | null;
       targetBranch?: string;
     };
+type SessionStartModalConfirmPayload = Exclude<SessionStartModalConfirmInput, boolean>;
+type SessionStartModalConfirmDraft = Omit<SessionStartModalConfirmPayload, "runInBackground">;
 
 export type SessionStartModalModel = {
   open: boolean;
@@ -61,6 +63,335 @@ export type SessionStartModalModel = {
   isStarting: boolean;
   onOpenChange: (nextOpen: boolean) => void;
   onConfirm: (input?: SessionStartModalConfirmInput) => void;
+};
+
+type StartModeFieldProps = {
+  availableStartModes: AgentSessionStartMode[];
+  hasExistingSessionOptions: boolean;
+  selectedStartMode: AgentSessionStartMode;
+  onSelectStartMode: (startMode: AgentSessionStartMode) => void;
+};
+
+function StartModeField({
+  availableStartModes,
+  hasExistingSessionOptions,
+  selectedStartMode,
+  onSelectStartMode,
+}: StartModeFieldProps): ReactElement | null {
+  if (availableStartModes.length <= 1) {
+    return null;
+  }
+
+  const isStartModeDisabled = (startMode: AgentSessionStartMode): boolean => {
+    return (startMode === "reuse" || startMode === "fork") && !hasExistingSessionOptions;
+  };
+
+  return (
+    <div className="grid gap-1.5">
+      <p className="text-sm font-medium text-foreground">Session Mode</p>
+      <div className="grid grid-cols-2 gap-2">
+        {availableStartModes.map((startMode) => (
+          <Button
+            key={startMode}
+            type="button"
+            variant={selectedStartMode === startMode ? "default" : "outline"}
+            disabled={isStartModeDisabled(startMode)}
+            onClick={() => onSelectStartMode(startMode)}
+          >
+            {sessionStartModeButtonLabel(startMode)}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type ExistingSessionFieldProps = {
+  disabled: boolean;
+  existingSessionOptions: ComboboxOption[];
+  selectedSourceSessionId: string;
+  onSelectSourceSession: (externalSessionId: string) => void;
+};
+
+function ExistingSessionField({
+  disabled,
+  existingSessionOptions,
+  selectedSourceSessionId,
+  onSelectSourceSession,
+}: ExistingSessionFieldProps): ReactElement {
+  return (
+    <div className="grid gap-1.5" data-testid="session-start-source-field">
+      <label className="text-sm font-medium text-foreground" htmlFor="session-start-source">
+        Existing Session
+      </label>
+      <Combobox
+        value={selectedSourceSessionId}
+        options={existingSessionOptions}
+        placeholder="Select session"
+        searchPlaceholder="Search session..."
+        disabled={disabled}
+        className="sm:min-w-[28rem]"
+        onValueChange={onSelectSourceSession}
+      />
+    </div>
+  );
+}
+
+type TargetBranchFieldProps = {
+  disabled: boolean;
+  selectedTargetBranch: string;
+  targetBranchOptions: ComboboxOption[];
+  onSelectTargetBranch: ((branch: string) => void) | undefined;
+};
+
+function TargetBranchField({
+  disabled,
+  selectedTargetBranch,
+  targetBranchOptions,
+  onSelectTargetBranch,
+}: TargetBranchFieldProps): ReactElement {
+  return (
+    <div className="grid gap-1.5" data-testid="session-start-target-branch-field">
+      <label className="text-sm font-medium text-foreground" htmlFor="session-start-target-branch">
+        Target branch
+      </label>
+      <BranchSelector
+        value={selectedTargetBranch}
+        options={targetBranchOptions}
+        placeholder={targetBranchOptions.length > 0 ? "Select branch..." : "Branches unavailable"}
+        disabled={disabled}
+        className="sm:min-w-[28rem]"
+        onValueChange={(branch) => onSelectTargetBranch?.(branch)}
+      />
+    </div>
+  );
+}
+
+type RuntimeFieldProps = {
+  disabled: boolean;
+  runtimeOptions: ComboboxOption[];
+  selectedRuntimeKind: RuntimeKind | null;
+  selectedStartMode: AgentSessionStartMode;
+  onSelectRuntime: (runtimeKind: RuntimeKind) => void;
+};
+
+function RuntimeField({
+  disabled,
+  runtimeOptions,
+  selectedRuntimeKind,
+  selectedStartMode,
+  onSelectRuntime,
+}: RuntimeFieldProps): ReactElement {
+  const runtimePlaceholder =
+    runtimeOptions.length > 0
+      ? "Select runtime"
+      : `No runtime supports ${sessionStartModeButtonLabel(selectedStartMode).toLowerCase()}`;
+
+  return (
+    <div className="grid gap-1.5" data-testid="session-start-runtime-field">
+      <label className="text-sm font-medium text-foreground" htmlFor="session-start-runtime">
+        Agent Runtime
+      </label>
+      <AgentRuntimeCombobox
+        value={selectedRuntimeKind ?? ""}
+        runtimeOptions={runtimeOptions}
+        placeholder={runtimePlaceholder}
+        disabled={disabled}
+        className="sm:min-w-[20rem]"
+        onValueChange={onSelectRuntime}
+      />
+    </div>
+  );
+}
+
+type AgentFieldProps = {
+  agentOptions: ComboboxOption[];
+  disabled: boolean;
+  helperText: string | null;
+  selectedAgent: string;
+  supportsProfiles: boolean;
+  onSelectAgent: (agent: string) => void;
+};
+
+function AgentField({
+  agentOptions,
+  disabled,
+  helperText,
+  selectedAgent,
+  supportsProfiles,
+  onSelectAgent,
+}: AgentFieldProps): ReactElement {
+  return (
+    <div className="grid gap-1.5" data-testid="session-start-agent-field">
+      <label className="text-sm font-medium text-foreground" htmlFor="session-start-agent">
+        Agent
+      </label>
+      <Combobox
+        value={selectedAgent}
+        options={agentOptions}
+        placeholder={supportsProfiles ? "Select agent" : "Agent handled by runtime"}
+        disabled={disabled}
+        className="sm:min-w-[20rem]"
+        onValueChange={onSelectAgent}
+      />
+      {helperText ? <p className="text-xs text-muted-foreground">{helperText}</p> : null}
+    </div>
+  );
+}
+
+type ModelVariantFieldsProps = {
+  isSelectionCatalogLoading: boolean;
+  modelDisabled: boolean;
+  modelGroups: ComboboxGroup[];
+  modelOptions: ComboboxOption[];
+  selectedModel: string;
+  selectedModelSelection: AgentModelSelection | null;
+  selectedVariant: string;
+  supportsVariants: boolean;
+  variantDisabled: boolean;
+  variantOptions: ComboboxOption[];
+  onSelectModel: (model: string) => void;
+  onSelectVariant: (variant: string) => void;
+};
+
+function ModelVariantFields({
+  isSelectionCatalogLoading,
+  modelDisabled,
+  modelGroups,
+  modelOptions,
+  selectedModel,
+  selectedModelSelection,
+  selectedVariant,
+  supportsVariants,
+  variantDisabled,
+  variantOptions,
+  onSelectModel,
+  onSelectVariant,
+}: ModelVariantFieldsProps): ReactElement {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-1.5" data-testid="session-start-model-field">
+        <label className="text-sm font-medium text-foreground" htmlFor="session-start-model">
+          Model
+        </label>
+        <Combobox
+          value={selectedModel}
+          options={modelOptions}
+          groups={modelGroups}
+          matchAllSearchTerms
+          placeholder={isSelectionCatalogLoading ? "Loading models..." : "Select model"}
+          disabled={modelDisabled}
+          className="w-full"
+          onValueChange={onSelectModel}
+        />
+      </div>
+
+      <div className="grid gap-1.5" data-testid="session-start-variant-field">
+        <label className="text-sm font-medium text-foreground" htmlFor="session-start-variant">
+          Variant
+        </label>
+        <Combobox
+          value={selectedVariant}
+          options={variantOptions}
+          placeholder={
+            isSelectionCatalogLoading
+              ? "Checking compatibility..."
+              : !selectedModelSelection
+                ? "Select model first"
+                : !supportsVariants
+                  ? "Variants handled by runtime"
+                  : variantOptions.length === 0
+                    ? "This model has no variants"
+                    : "Select variant"
+          }
+          disabled={variantDisabled}
+          className="w-full"
+          onValueChange={onSelectVariant}
+        />
+      </div>
+    </div>
+  );
+}
+
+type SessionStartModalFooterProps = {
+  allowRunInBackground: boolean;
+  backgroundConfirmLabel: string;
+  cancelLabel: string;
+  confirmDisabled: boolean;
+  confirmLabel: string;
+  confirmInput: SessionStartModalConfirmDraft;
+  isStarting: boolean;
+  onConfirm: (input?: SessionStartModalConfirmInput) => void;
+  onOpenChange: (nextOpen: boolean) => void;
+};
+
+function SessionStartModalFooter({
+  allowRunInBackground,
+  backgroundConfirmLabel,
+  cancelLabel,
+  confirmDisabled,
+  confirmLabel,
+  confirmInput,
+  isStarting,
+  onConfirm,
+  onOpenChange,
+}: SessionStartModalFooterProps): ReactElement {
+  return (
+    <DialogFooter className="mt-0 flex w-full items-center justify-between border-t border-border pt-5 sm:justify-between">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => onOpenChange(false)}
+        disabled={isStarting}
+      >
+        {cancelLabel}
+      </Button>
+
+      <div className="flex items-center gap-2">
+        {allowRunInBackground ? (
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={confirmDisabled}
+            onClick={() => onConfirm({ ...confirmInput, runInBackground: true })}
+          >
+            {isStarting ? <LoaderCircle className="size-4 animate-spin" /> : null}
+            {backgroundConfirmLabel}
+          </Button>
+        ) : null}
+        <Button type="submit" disabled={confirmDisabled}>
+          {isStarting ? <LoaderCircle className="size-4 animate-spin" /> : null}
+          {confirmLabel}
+        </Button>
+      </div>
+    </DialogFooter>
+  );
+}
+
+const agentHelperTextFor = ({
+  agentOptions,
+  isReuseMode,
+  isSelectionCatalogLoading,
+  supportsProfiles,
+}: {
+  agentOptions: ComboboxOption[];
+  isReuseMode: boolean;
+  isSelectionCatalogLoading: boolean;
+  supportsProfiles: boolean;
+}): string | null => {
+  if (isReuseMode) {
+    return "Reuse mode keeps the previous session agent/model/variant.";
+  }
+  if (isSelectionCatalogLoading) {
+    return "Loading agents for the selected runtime.";
+  }
+  if (!supportsProfiles) {
+    return "This runtime manages agent selection automatically.";
+  }
+  if (agentOptions.length === 0) {
+    return "No agent profiles are available for this runtime.";
+  }
+  return null;
 };
 
 export function SessionStartModal({ model }: { model: SessionStartModalModel }): ReactElement {
@@ -117,6 +448,23 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
     (!isReuseMode &&
       (isSelectionCatalogLoading || !selectedRuntimeKind || !selectedModelSelection)) ||
     (requiresExistingSession && !hasExistingSessionSelection);
+  const confirmInput = {
+    startMode: selectedStartMode,
+    sourceExternalSessionId: requiresExistingSession ? selectedSourceSessionId : null,
+    ...(showTargetBranchSelector ? { targetBranch: selectedTargetBranch } : {}),
+  };
+  const handleConfirm = (): void => {
+    if (confirmDisabled) {
+      return;
+    }
+    onConfirm({ ...confirmInput, runInBackground: false });
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    handleConfirm();
+  };
+
   const runtimeDisabled = isSelectionCatalogLoading || isReuseMode;
   const agentDisabled =
     isReuseMode || isSelectionCatalogLoading || !supportsProfiles || agentOptions.length === 0;
@@ -127,41 +475,12 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
     !selectedModelSelection ||
     !supportsVariants ||
     variantOptions.length === 0;
-  const runtimePlaceholder =
-    runtimeOptions.length > 0
-      ? "Select runtime"
-      : `No runtime supports ${sessionStartModeButtonLabel(selectedStartMode).toLowerCase()}`;
-  const handleConfirm = (): void => {
-    if (confirmDisabled) {
-      return;
-    }
-    onConfirm({
-      runInBackground: false,
-      startMode: selectedStartMode,
-      sourceExternalSessionId: requiresExistingSession ? selectedSourceSessionId : null,
-      ...(showTargetBranchSelector ? { targetBranch: selectedTargetBranch } : {}),
-    });
-  };
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
-    event.preventDefault();
-    handleConfirm();
-  };
-
-  let agentHelperText: string | null = null;
-  if (isReuseMode) {
-    agentHelperText = "Reuse mode keeps the previous session agent/model/variant.";
-  } else if (isSelectionCatalogLoading) {
-    agentHelperText = "Loading agents for the selected runtime.";
-  } else if (!supportsProfiles) {
-    agentHelperText = "This runtime manages agent selection automatically.";
-  } else if (agentOptions.length === 0) {
-    agentHelperText = "No agent profiles are available for this runtime.";
-  }
-
-  const isStartModeDisabled = (startMode: AgentSessionStartMode): boolean => {
-    return (startMode === "reuse" || startMode === "fork") && !hasExistingSessionOptions;
-  };
+  const agentHelperText = agentHelperTextFor({
+    agentOptions,
+    isReuseMode,
+    isSelectionCatalogLoading,
+    supportsProfiles,
+  });
 
   return (
     <Dialog
@@ -182,190 +501,76 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
         <form className="flex min-h-0 flex-1 flex-col" onSubmit={handleSubmit}>
           <DialogBody className="pt-2 pb-4">
             <fieldset className="space-y-5" disabled={isStarting}>
-              {availableStartModes.length > 1 ? (
-                <div className="grid gap-1.5">
-                  <p className="text-sm font-medium text-foreground">Session Mode</p>
-                  <div className="grid grid-cols-2 gap-2">
-                    {availableStartModes.map((startMode) => (
-                      <Button
-                        key={startMode}
-                        type="button"
-                        variant={selectedStartMode === startMode ? "default" : "outline"}
-                        disabled={isStartModeDisabled(startMode)}
-                        onClick={() => onSelectStartMode(startMode)}
-                      >
-                        {sessionStartModeButtonLabel(startMode)}
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
+              <StartModeField
+                availableStartModes={availableStartModes}
+                hasExistingSessionOptions={hasExistingSessionOptions}
+                selectedStartMode={selectedStartMode}
+                onSelectStartMode={onSelectStartMode}
+              />
 
               {requiresExistingSession ? (
-                <div className="grid gap-1.5" data-testid="session-start-source-field">
-                  <label
-                    className="text-sm font-medium text-foreground"
-                    htmlFor="session-start-source"
-                  >
-                    Existing Session
-                  </label>
-                  <Combobox
-                    value={selectedSourceSessionId}
-                    options={existingSessionOptions}
-                    placeholder="Select session"
-                    searchPlaceholder="Search session..."
-                    disabled={isStarting || !hasExistingSessionOptions}
-                    className="sm:min-w-[28rem]"
-                    onValueChange={onSelectSourceSession}
-                  />
-                </div>
+                <ExistingSessionField
+                  disabled={isStarting || !hasExistingSessionOptions}
+                  existingSessionOptions={existingSessionOptions}
+                  selectedSourceSessionId={selectedSourceSessionId}
+                  onSelectSourceSession={onSelectSourceSession}
+                />
               ) : null}
 
               {showTargetBranchSelector ? (
-                <div className="grid gap-1.5" data-testid="session-start-target-branch-field">
-                  <label
-                    className="text-sm font-medium text-foreground"
-                    htmlFor="session-start-target-branch"
-                  >
-                    Target branch
-                  </label>
-                  <BranchSelector
-                    value={selectedTargetBranch}
-                    options={targetBranchOptions}
-                    placeholder={
-                      targetBranchOptions.length > 0 ? "Select branch..." : "Branches unavailable"
-                    }
-                    disabled={isStarting || targetBranchOptions.length === 0}
-                    className="sm:min-w-[28rem]"
-                    onValueChange={(branch) => onSelectTargetBranch?.(branch)}
-                  />
-                </div>
+                <TargetBranchField
+                  disabled={isStarting || targetBranchOptions.length === 0}
+                  selectedTargetBranch={selectedTargetBranch}
+                  targetBranchOptions={targetBranchOptions}
+                  onSelectTargetBranch={onSelectTargetBranch}
+                />
               ) : null}
 
-              <div className="grid gap-1.5" data-testid="session-start-runtime-field">
-                <label
-                  className="text-sm font-medium text-foreground"
-                  htmlFor="session-start-runtime"
-                >
-                  Agent Runtime
-                </label>
-                <AgentRuntimeCombobox
-                  value={selectedRuntimeKind ?? ""}
-                  runtimeOptions={runtimeOptions}
-                  placeholder={runtimePlaceholder}
-                  disabled={runtimeDisabled}
-                  className="sm:min-w-[20rem]"
-                  onValueChange={onSelectRuntime}
-                />
-              </div>
+              <RuntimeField
+                disabled={runtimeDisabled}
+                runtimeOptions={runtimeOptions}
+                selectedRuntimeKind={selectedRuntimeKind}
+                selectedStartMode={selectedStartMode}
+                onSelectRuntime={onSelectRuntime}
+              />
 
-              <div className="grid gap-1.5" data-testid="session-start-agent-field">
-                <label
-                  className="text-sm font-medium text-foreground"
-                  htmlFor="session-start-agent"
-                >
-                  Agent
-                </label>
-                <Combobox
-                  value={selectedAgent}
-                  options={agentOptions}
-                  placeholder={supportsProfiles ? "Select agent" : "Agent handled by runtime"}
-                  disabled={agentDisabled}
-                  className="sm:min-w-[20rem]"
-                  onValueChange={onSelectAgent}
-                />
-                {agentHelperText ? (
-                  <p className="text-xs text-muted-foreground">{agentHelperText}</p>
-                ) : null}
-              </div>
+              <AgentField
+                agentOptions={agentOptions}
+                disabled={agentDisabled}
+                helperText={agentHelperText}
+                selectedAgent={selectedAgent}
+                supportsProfiles={supportsProfiles}
+                onSelectAgent={onSelectAgent}
+              />
 
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="grid gap-1.5" data-testid="session-start-model-field">
-                  <label
-                    className="text-sm font-medium text-foreground"
-                    htmlFor="session-start-model"
-                  >
-                    Model
-                  </label>
-                  <Combobox
-                    value={selectedModel}
-                    options={modelOptions}
-                    groups={modelGroups}
-                    matchAllSearchTerms
-                    placeholder={isSelectionCatalogLoading ? "Loading models..." : "Select model"}
-                    disabled={modelDisabled}
-                    className="w-full"
-                    onValueChange={onSelectModel}
-                  />
-                </div>
-
-                <div className="grid gap-1.5" data-testid="session-start-variant-field">
-                  <label
-                    className="text-sm font-medium text-foreground"
-                    htmlFor="session-start-variant"
-                  >
-                    Variant
-                  </label>
-                  <Combobox
-                    value={selectedVariant}
-                    options={variantOptions}
-                    placeholder={
-                      isSelectionCatalogLoading
-                        ? "Checking compatibility..."
-                        : !selectedModelSelection
-                          ? "Select model first"
-                          : !supportsVariants
-                            ? "Variants handled by runtime"
-                            : variantOptions.length === 0
-                              ? "This model has no variants"
-                              : "Select variant"
-                    }
-                    disabled={variantDisabled}
-                    className="w-full"
-                    onValueChange={onSelectVariant}
-                  />
-                </div>
-              </div>
+              <ModelVariantFields
+                isSelectionCatalogLoading={isSelectionCatalogLoading}
+                modelDisabled={modelDisabled}
+                modelGroups={modelGroups}
+                modelOptions={modelOptions}
+                selectedModel={selectedModel}
+                selectedModelSelection={selectedModelSelection}
+                selectedVariant={selectedVariant}
+                supportsVariants={supportsVariants}
+                variantDisabled={variantDisabled}
+                variantOptions={variantOptions}
+                onSelectModel={onSelectModel}
+                onSelectVariant={onSelectVariant}
+              />
             </fieldset>
           </DialogBody>
 
-          <DialogFooter className="mt-0 flex w-full items-center justify-between border-t border-border pt-5 sm:justify-between">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isStarting}
-            >
-              {cancelLabel}
-            </Button>
-
-            <div className="flex items-center gap-2">
-              {allowRunInBackground ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  disabled={confirmDisabled}
-                  onClick={() =>
-                    onConfirm({
-                      runInBackground: true,
-                      startMode: selectedStartMode,
-                      sourceExternalSessionId: requiresExistingSession
-                        ? selectedSourceSessionId
-                        : null,
-                      ...(showTargetBranchSelector ? { targetBranch: selectedTargetBranch } : {}),
-                    })
-                  }
-                >
-                  {isStarting ? <LoaderCircle className="size-4 animate-spin" /> : null}
-                  {backgroundConfirmLabel}
-                </Button>
-              ) : null}
-              <Button type="submit" disabled={confirmDisabled}>
-                {isStarting ? <LoaderCircle className="size-4 animate-spin" /> : null}
-                {confirmLabel}
-              </Button>
-            </div>
-          </DialogFooter>
+          <SessionStartModalFooter
+            allowRunInBackground={allowRunInBackground}
+            backgroundConfirmLabel={backgroundConfirmLabel}
+            cancelLabel={cancelLabel}
+            confirmDisabled={confirmDisabled}
+            confirmLabel={confirmLabel}
+            confirmInput={confirmInput}
+            isStarting={isStarting}
+            onConfirm={onConfirm}
+            onOpenChange={onOpenChange}
+          />
         </form>
       </DialogContent>
     </Dialog>

--- a/packages/frontend/src/features/session-start/session-start-modal-reuse-state.ts
+++ b/packages/frontend/src/features/session-start/session-start-modal-reuse-state.ts
@@ -12,7 +12,10 @@ import {
   useMemo,
   useState,
 } from "react";
-import { resolveRuntimeKindSelection } from "@/lib/agent-runtime";
+import {
+  filterRuntimeDefinitionsForStartMode,
+  resolveRuntimeKindSelection,
+} from "@/lib/agent-runtime";
 import { getSessionLaunchAction, type SessionLaunchActionId } from "./session-start-launch-options";
 import type { SessionStartModalIntent } from "./session-start-modal-types";
 import { resolveLaunchStartMode } from "./session-start-mode";
@@ -93,7 +96,7 @@ const buildReuseSelectionDraft = ({
 } => {
   const sourceSelection = resolveSourceSelection(options, sourceExternalSessionId);
   const runtimeKind = resolveRuntimeKindSelection({
-    runtimeDefinitions,
+    runtimeDefinitions: filterRuntimeDefinitionsForStartMode(runtimeDefinitions, "reuse"),
     requestedRuntimeKind: sourceSelection?.runtimeKind ?? null,
   });
 
@@ -127,7 +130,7 @@ type UseSessionStartModalReuseStateArgs = {
 type UseSessionStartModalReuseStateResult = {
   availableStartModes: AgentSessionStartMode[];
   existingSessionOptions: SessionStartExistingSessionOption[];
-  initializeStartState: (intent: SessionStartModalIntent) => void;
+  initializeStartState: (intent: SessionStartModalIntent) => AgentSessionStartMode;
   resetStartState: () => void;
   selectedSourceSessionId: string;
   selectedStartMode: AgentSessionStartMode;
@@ -161,16 +164,20 @@ export function useSessionStartModalReuseState({
     setSelectedSourceSessionId("");
   }, []);
 
-  const initializeStartState = useCallback((nextIntent: SessionStartModalIntent): void => {
-    const nextState = resolveInitialStartState({
-      launchActionId: nextIntent.launchActionId,
-      existingSessionOptions: nextIntent.existingSessionOptions ?? [],
-      initialStartMode: nextIntent.initialStartMode,
-      initialSourceExternalSessionId: nextIntent.initialSourceExternalSessionId,
-    });
-    setSelectedStartMode(nextState.selectedStartMode);
-    setSelectedSourceSessionId(nextState.selectedSourceSessionId);
-  }, []);
+  const initializeStartState = useCallback(
+    (nextIntent: SessionStartModalIntent): AgentSessionStartMode => {
+      const nextState = resolveInitialStartState({
+        launchActionId: nextIntent.launchActionId,
+        existingSessionOptions: nextIntent.existingSessionOptions ?? [],
+        initialStartMode: nextIntent.initialStartMode,
+        initialSourceExternalSessionId: nextIntent.initialSourceExternalSessionId,
+      });
+      setSelectedStartMode(nextState.selectedStartMode);
+      setSelectedSourceSessionId(nextState.selectedSourceSessionId);
+      return nextState.selectedStartMode;
+    },
+    [],
+  );
 
   const applyReuseSourceSelection = useCallback(
     (sourceExternalSessionId: string): void => {

--- a/packages/frontend/src/features/session-start/session-start-modal-reuse-state.ts
+++ b/packages/frontend/src/features/session-start/session-start-modal-reuse-state.ts
@@ -63,13 +63,24 @@ const resolveInitialStartState = ({
   selectedStartMode: AgentSessionStartMode;
 } => {
   const allowedStartModes = getSessionLaunchAction(launchActionId).allowedStartModes;
-  const selectedStartMode =
-    initialStartMode && allowedStartModes.includes(initialStartMode)
-      ? initialStartMode
-      : resolveLaunchStartMode({
-          launchActionId,
-          existingSessionOptions,
-        });
+  const hasExistingSession = existingSessionOptions.length > 0;
+  let selectedStartMode: AgentSessionStartMode;
+
+  if (initialStartMode && allowedStartModes.includes(initialStartMode)) {
+    selectedStartMode = initialStartMode;
+    if (
+      (selectedStartMode === "reuse" || selectedStartMode === "fork") &&
+      !hasExistingSession &&
+      allowedStartModes.includes("fresh")
+    ) {
+      selectedStartMode = "fresh";
+    }
+  } else {
+    selectedStartMode = resolveLaunchStartMode({
+      launchActionId,
+      existingSessionOptions,
+    });
+  }
 
   return {
     selectedStartMode,

--- a/packages/frontend/src/features/session-start/session-start-modal-runtime-state.ts
+++ b/packages/frontend/src/features/session-start/session-start-modal-runtime-state.ts
@@ -1,10 +1,11 @@
 import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
-import type { AgentModelCatalog } from "@openducktor/core";
+import type { AgentModelCatalog, AgentSessionStartMode } from "@openducktor/core";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import {
   DEFAULT_RUNTIME_KIND,
+  filterRuntimeDefinitionsForStartMode,
   findRuntimeDefinition,
   resolveRuntimeKindSelection,
   toAgentRuntimeOptions,
@@ -18,11 +19,13 @@ type UseSessionStartModalRuntimeStateArgs = {
   isOpen: boolean;
   loadCatalog: (repoPath: string, runtimeKind: RuntimeKind) => Promise<AgentModelCatalog>;
   runtimeDefinitions: RuntimeDescriptor[];
+  selectedStartMode: AgentSessionStartMode;
 };
 
 type UseSessionStartModalRuntimeStateResult = {
   catalog: AgentModelCatalog | null;
   isCatalogLoading: boolean;
+  eligibleRuntimeDefinitions: RuntimeDescriptor[];
   runtimeOptions: ComboboxOption[];
   selectedRuntimeDescriptor: RuntimeDescriptor | null;
   selectedRuntimeKind: RuntimeKind | null;
@@ -35,28 +38,36 @@ export function useSessionStartModalRuntimeState({
   isOpen,
   loadCatalog,
   runtimeDefinitions,
+  selectedStartMode,
 }: UseSessionStartModalRuntimeStateArgs): UseSessionStartModalRuntimeStateResult {
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
   const [requestedRuntimeKind, setRequestedRuntimeKindState] = useState<RuntimeKind | null>(null);
 
+  const eligibleRuntimeDefinitions = useMemo(
+    () => filterRuntimeDefinitionsForStartMode(runtimeDefinitions, selectedStartMode),
+    [runtimeDefinitions, selectedStartMode],
+  );
+
   const runtimeOptions = useMemo(
-    () => toAgentRuntimeOptions(runtimeDefinitions),
-    [runtimeDefinitions],
+    () => toAgentRuntimeOptions(eligibleRuntimeDefinitions),
+    [eligibleRuntimeDefinitions],
   );
 
   const selectedRuntimeKind = useMemo(
     () =>
       resolveRuntimeKindSelection({
-        runtimeDefinitions,
+        runtimeDefinitions: eligibleRuntimeDefinitions,
         requestedRuntimeKind,
       }),
-    [requestedRuntimeKind, runtimeDefinitions],
+    [requestedRuntimeKind, eligibleRuntimeDefinitions],
   );
 
   const selectedRuntimeDescriptor = useMemo(
     () =>
-      selectedRuntimeKind ? findRuntimeDefinition(runtimeDefinitions, selectedRuntimeKind) : null,
-    [runtimeDefinitions, selectedRuntimeKind],
+      selectedRuntimeKind
+        ? findRuntimeDefinition(eligibleRuntimeDefinitions, selectedRuntimeKind)
+        : null,
+    [eligibleRuntimeDefinitions, selectedRuntimeKind],
   );
 
   const setRequestedRuntimeKind = useCallback((runtimeKind: RuntimeKind | null): void => {
@@ -97,6 +108,7 @@ export function useSessionStartModalRuntimeState({
   return {
     catalog,
     isCatalogLoading,
+    eligibleRuntimeDefinitions,
     runtimeOptions,
     selectedRuntimeDescriptor,
     selectedRuntimeKind,

--- a/packages/frontend/src/features/session-start/session-start-reuse-options.ts
+++ b/packages/frontend/src/features/session-start/session-start-reuse-options.ts
@@ -23,6 +23,7 @@ export const buildReusableSessionOptions = ({
     const runtimeKind = session.selectedModel?.runtimeKind ?? session.runtimeKind ?? null;
     return {
       value: session.externalSessionId,
+      runtimeKind: session.runtimeKind ?? null,
       label: formatAgentSessionOptionLabel({
         session,
         sessionNumber: roleSessionNumberById.get(session.externalSessionId) ?? index + 1,

--- a/packages/frontend/src/features/session-start/session-start-types.ts
+++ b/packages/frontend/src/features/session-start/session-start-types.ts
@@ -1,4 +1,4 @@
-import type { GitTargetBranch } from "@openducktor/contracts";
+import type { GitTargetBranch, RuntimeKind } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import type { SessionLaunchActionId } from "./session-start-launch-options";
 
@@ -7,6 +7,7 @@ export type SessionStartExistingSessionOption = {
   label: string;
   description: string;
   secondaryLabel?: string;
+  runtimeKind?: RuntimeKind | null;
   selectedModel?: AgentModelSelection | null;
 };
 

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { assertRuntimeSupportsSelectedStartMode } from "./use-session-start-modal-runner";
+
+const FORKLESS_RUNTIME = {
+  ...OPENCODE_RUNTIME_DESCRIPTOR,
+  label: "Reuse Runtime",
+  capabilities: {
+    ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities,
+    sessionLifecycle: {
+      ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.sessionLifecycle,
+      supportedStartModes: ["fresh", "reuse"],
+      supportsSessionFork: false,
+      forkTargets: [],
+    },
+  },
+} as RuntimeDescriptor;
+
+describe("assertRuntimeSupportsSelectedStartMode", () => {
+  test("accepts a runtime that supports the concrete selected start mode", () => {
+    expect(() =>
+      assertRuntimeSupportsSelectedStartMode({
+        launchActionId: "build_pull_request_generation",
+        role: "build",
+        runtimeDescriptor: FORKLESS_RUNTIME,
+        runtimeKind: FORKLESS_RUNTIME.kind,
+        startMode: "reuse",
+        taskId: "TASK-1",
+      }),
+    ).not.toThrow();
+  });
+
+  test("fails fast before launch when the selected runtime does not support the selected mode", () => {
+    expect(() =>
+      assertRuntimeSupportsSelectedStartMode({
+        launchActionId: "build_pull_request_generation",
+        role: "build",
+        runtimeDescriptor: FORKLESS_RUNTIME,
+        runtimeKind: FORKLESS_RUNTIME.kind,
+        startMode: "fork",
+        taskId: "TASK-1",
+      }),
+    ).toThrow(
+      'Runtime "Reuse Runtime" does not support fork session starts for build_pull_request_generation. Select a compatible runtime or start mode.',
+    );
+  });
+
+  test("requires an available runtime for concrete non-reuse starts", () => {
+    expect(() =>
+      assertRuntimeSupportsSelectedStartMode({
+        launchActionId: "build_implementation_start",
+        role: "build",
+        runtimeDescriptor: null,
+        runtimeKind: "missing-runtime" as unknown as RuntimeKind,
+        startMode: "fresh",
+        taskId: "TASK-2",
+      }),
+    ).toThrow(
+      "Starting a build build_implementation_start session for TASK-2 requires a runtime that supports fresh session starts.",
+    );
+  });
+});

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
-import { assertRuntimeSupportsSelectedStartMode } from "./use-session-start-modal-runner";
+import {
+  assertRuntimeSupportsSelectedStartMode,
+  requireSourceSessionRuntimeKind,
+} from "./use-session-start-modal-runner";
 
 const FORKLESS_RUNTIME = {
   ...OPENCODE_RUNTIME_DESCRIPTOR,
@@ -59,5 +62,28 @@ describe("assertRuntimeSupportsSelectedStartMode", () => {
     ).toThrow(
       "Starting a build build_implementation_start session for TASK-2 requires a runtime that supports fresh session starts.",
     );
+  });
+
+  test("uses the source option runtime kind before selected model runtime kind", () => {
+    expect(
+      requireSourceSessionRuntimeKind({
+        value: "session-1",
+        label: "Reusable session",
+        description: "Reusable session with runtime",
+        runtimeKind: "opencode",
+        selectedModel: null,
+      }),
+    ).toBe("opencode");
+  });
+
+  test("fails fast when a reusable session has no runtime kind", () => {
+    expect(() =>
+      requireSourceSessionRuntimeKind({
+        value: "session-2",
+        label: "Missing runtime session",
+        description: "Reusable session without runtime",
+        selectedModel: null,
+      }),
+    ).toThrow("Reusable session is missing a runtime kind.");
   });
 });

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/target-branch";
 import type { ActiveWorkspace, RepoSettingsInput } from "@/types/state-slices";
 import { supportsTaskTargetBranchSelection } from "./constants";
+import type { SessionStartExistingSessionOption } from "./session-start-types";
 import type { SessionStartModalOpenRequest } from "./use-session-start-modal-coordinator";
 import { useSessionStartModalCoordinator } from "./use-session-start-modal-coordinator";
 
@@ -80,17 +81,16 @@ const requireSourceSessionId = (
   );
 };
 
-const sourceSessionRuntimeKind = ({
-  existingSessionOptions,
-  sourceExternalSessionId,
-}: {
-  existingSessionOptions: Array<{ value: string; selectedModel?: AgentModelSelection | null }>;
-  sourceExternalSessionId: string;
-}): RuntimeKind | null => {
-  return (
-    existingSessionOptions.find((option) => option.value === sourceExternalSessionId)?.selectedModel
-      ?.runtimeKind ?? null
-  );
+export const requireSourceSessionRuntimeKind = (
+  sourceSession: SessionStartExistingSessionOption | null | undefined,
+): RuntimeKind => {
+  const runtimeKind =
+    sourceSession?.runtimeKind ?? sourceSession?.selectedModel?.runtimeKind ?? null;
+  if (runtimeKind) {
+    return runtimeKind;
+  }
+
+  throw new Error("Reusable session is missing a runtime kind.");
 };
 
 export const assertRuntimeSupportsSelectedStartMode = ({
@@ -278,22 +278,21 @@ export function useSessionStartModalRunner({
                 };
 
         if (decision.startMode === "reuse") {
-          const sourceRuntimeKind = sourceSessionRuntimeKind({
-            existingSessionOptions,
-            sourceExternalSessionId: decision.sourceExternalSessionId,
+          const sourceOption = existingSessionOptions.find(
+            (option) => option.value === decision.sourceExternalSessionId,
+          );
+          const sourceRuntimeKind = requireSourceSessionRuntimeKind(sourceOption);
+
+          const sourceRuntimeDescriptor = findRuntimeDefinition(
+            eligibleRuntimeDefinitions,
+            sourceRuntimeKind,
+          );
+          assertRuntimeSupportsSelectedStartMode({
+            ...requestContext,
+            runtimeDescriptor: sourceRuntimeDescriptor,
+            runtimeKind: sourceRuntimeKind,
+            startMode: decision.startMode,
           });
-          if (sourceRuntimeKind) {
-            const sourceRuntimeDescriptor = findRuntimeDefinition(
-              eligibleRuntimeDefinitions,
-              sourceRuntimeKind,
-            );
-            assertRuntimeSupportsSelectedStartMode({
-              ...requestContext,
-              runtimeDescriptor: sourceRuntimeDescriptor,
-              runtimeKind: sourceRuntimeKind,
-              startMode: decision.startMode,
-            });
-          }
         } else {
           assertRuntimeSupportsSelectedStartMode({
             ...requestContext,

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
@@ -1,8 +1,14 @@
-import type { GitBranch, GitTargetBranch } from "@openducktor/contracts";
-import type { AgentModelSelection } from "@openducktor/core";
+import type {
+  GitBranch,
+  GitTargetBranch,
+  RuntimeDescriptor,
+  RuntimeKind,
+} from "@openducktor/contracts";
+import type { AgentModelSelection, AgentRole, AgentSessionStartMode } from "@openducktor/core";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { SessionStartModalModel } from "@/components/features/agents";
+import { runtimeSupportsStartMode } from "@/lib/agent-runtime";
 import { errorMessage } from "@/lib/errors";
 import {
   INVALID_TASK_TARGET_BRANCH_LABEL,
@@ -74,6 +80,49 @@ const requireSourceSessionId = (
   );
 };
 
+const sourceSessionRuntimeKind = ({
+  existingSessionOptions,
+  sourceExternalSessionId,
+}: {
+  existingSessionOptions: Array<{ value: string; selectedModel?: AgentModelSelection | null }>;
+  sourceExternalSessionId: string;
+}): RuntimeKind | null => {
+  return (
+    existingSessionOptions.find((option) => option.value === sourceExternalSessionId)?.selectedModel
+      ?.runtimeKind ?? null
+  );
+};
+
+export const assertRuntimeSupportsSelectedStartMode = ({
+  launchActionId,
+  role,
+  runtimeDescriptor,
+  runtimeKind,
+  startMode,
+  taskId,
+}: {
+  launchActionId: string;
+  role: AgentRole;
+  runtimeDescriptor: RuntimeDescriptor | null;
+  runtimeKind: RuntimeKind | null;
+  startMode: AgentSessionStartMode;
+  taskId: string;
+}): void => {
+  if (!runtimeDescriptor) {
+    throw new Error(
+      `Starting a ${role} ${launchActionId} session for ${taskId} requires a runtime that supports ${startMode} session starts.`,
+    );
+  }
+  if (runtimeSupportsStartMode(runtimeDescriptor, startMode)) {
+    return;
+  }
+
+  const runtimeLabel = runtimeDescriptor.label || runtimeKind || runtimeDescriptor.kind;
+  throw new Error(
+    `Runtime "${runtimeLabel}" does not support ${startMode} session starts for ${launchActionId}. Select a compatible runtime or start mode.`,
+  );
+};
+
 export function useSessionStartModalRunner({
   activeWorkspace,
   branches = [],
@@ -97,6 +146,7 @@ export function useSessionStartModalRunner({
     intent,
     isOpen,
     selection,
+    selectedRuntimeDescriptor,
     selectedRuntimeKind,
     runtimeOptions,
     supportsProfiles,
@@ -192,22 +242,12 @@ export function useSessionStartModalRunner({
 
       const requestContext = pendingRun.request;
 
-      const decision: SessionStartModalDecision =
-        input.startMode === "reuse"
-          ? {
-              startMode: "reuse",
-              sourceExternalSessionId: requireSourceSessionId(
-                input.sourceExternalSessionId,
-                requestContext,
-              ),
-              ...(input.targetBranch
-                ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
-                : {}),
-            }
-          : input.startMode === "fork"
+      setIsStarting(true);
+      try {
+        const decision: SessionStartModalDecision =
+          input.startMode === "reuse"
             ? {
-                startMode: "fork",
-                selectedModel: requireSelectedModel(selectionRef.current, requestContext),
+                startMode: "reuse",
                 sourceExternalSessionId: requireSourceSessionId(
                   input.sourceExternalSessionId,
                   requestContext,
@@ -216,16 +256,48 @@ export function useSessionStartModalRunner({
                   ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
                   : {}),
               }
-            : {
-                startMode: "fresh",
-                selectedModel: requireSelectedModel(selectionRef.current, requestContext),
-                ...(input.targetBranch
-                  ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
-                  : {}),
-              };
+            : input.startMode === "fork"
+              ? {
+                  startMode: "fork",
+                  selectedModel: requireSelectedModel(selectionRef.current, requestContext),
+                  sourceExternalSessionId: requireSourceSessionId(
+                    input.sourceExternalSessionId,
+                    requestContext,
+                  ),
+                  ...(input.targetBranch
+                    ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
+                    : {}),
+                }
+              : {
+                  startMode: "fresh",
+                  selectedModel: requireSelectedModel(selectionRef.current, requestContext),
+                  ...(input.targetBranch
+                    ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
+                    : {}),
+                };
 
-      setIsStarting(true);
-      try {
+        if (decision.startMode === "reuse") {
+          const sourceRuntimeKind = sourceSessionRuntimeKind({
+            existingSessionOptions,
+            sourceExternalSessionId: decision.sourceExternalSessionId,
+          });
+          if (sourceRuntimeKind) {
+            assertRuntimeSupportsSelectedStartMode({
+              ...requestContext,
+              runtimeDescriptor: selectedRuntimeDescriptor,
+              runtimeKind: sourceRuntimeKind,
+              startMode: decision.startMode,
+            });
+          }
+        } else {
+          assertRuntimeSupportsSelectedStartMode({
+            ...requestContext,
+            runtimeDescriptor: selectedRuntimeDescriptor,
+            runtimeKind: decision.selectedModel.runtimeKind ?? selectedRuntimeKind,
+            startMode: decision.startMode,
+          });
+        }
+
         const value = await pendingRun.execute({
           decision,
           runInBackground: input.runInBackground ?? false,
@@ -240,7 +312,7 @@ export function useSessionStartModalRunner({
         setIsStarting(false);
       }
     },
-    [resolvePendingRun],
+    [existingSessionOptions, resolvePendingRun, selectedRuntimeDescriptor, selectedRuntimeKind],
   );
 
   const sessionStartModal = useMemo<SessionStartModalModel | null>(() => {

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
@@ -8,7 +8,7 @@ import type { AgentModelSelection, AgentRole, AgentSessionStartMode } from "@ope
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { SessionStartModalModel } from "@/components/features/agents";
-import { runtimeSupportsStartMode } from "@/lib/agent-runtime";
+import { findRuntimeDefinition, runtimeSupportsStartMode } from "@/lib/agent-runtime";
 import { errorMessage } from "@/lib/errors";
 import {
   INVALID_TASK_TARGET_BRANCH_LABEL,
@@ -146,6 +146,7 @@ export function useSessionStartModalRunner({
     intent,
     isOpen,
     selection,
+    eligibleRuntimeDefinitions,
     selectedRuntimeDescriptor,
     selectedRuntimeKind,
     runtimeOptions,
@@ -282,9 +283,13 @@ export function useSessionStartModalRunner({
             sourceExternalSessionId: decision.sourceExternalSessionId,
           });
           if (sourceRuntimeKind) {
+            const sourceRuntimeDescriptor = findRuntimeDefinition(
+              eligibleRuntimeDefinitions,
+              sourceRuntimeKind,
+            );
             assertRuntimeSupportsSelectedStartMode({
               ...requestContext,
-              runtimeDescriptor: selectedRuntimeDescriptor,
+              runtimeDescriptor: sourceRuntimeDescriptor,
               runtimeKind: sourceRuntimeKind,
               startMode: decision.startMode,
             });
@@ -312,7 +317,13 @@ export function useSessionStartModalRunner({
         setIsStarting(false);
       }
     },
-    [existingSessionOptions, resolvePendingRun, selectedRuntimeDescriptor, selectedRuntimeKind],
+    [
+      eligibleRuntimeDefinitions,
+      existingSessionOptions,
+      resolvePendingRun,
+      selectedRuntimeDescriptor,
+      selectedRuntimeKind,
+    ],
   );
 
   const sessionStartModal = useMemo<SessionStartModalModel | null>(() => {

--- a/packages/frontend/src/features/session-start/use-session-start-modal-selection-state.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-selection-state.ts
@@ -70,7 +70,11 @@ export function useSessionStartModalSelectionState({
     if (!activeRole) {
       return;
     }
-    if (selectedStartMode === "reuse" || !selectedRuntimeKind) {
+    if (selectedStartMode === "reuse") {
+      return;
+    }
+    if (!selectedRuntimeKind) {
+      setSelection((current) => (current === null ? current : null));
       return;
     }
 

--- a/packages/frontend/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -149,6 +149,42 @@ const createBaseProps = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   ...overrides,
 });
 
+const createBuildRepoSettingsForRuntime = (runtimeKind: RuntimeKind): RepoSettingsInput => ({
+  ...createRepoSettings({
+    build: {
+      runtimeKind,
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    },
+  }),
+  defaultRuntimeKind: runtimeKind,
+});
+
+const createExistingSessionWithModel = ({
+  description = "Reusable builder session",
+  label = "Builder session",
+  runtimeKind,
+  value,
+}: {
+  description?: string;
+  label?: string;
+  runtimeKind: RuntimeKind;
+  value: string;
+}) => ({
+  value,
+  label,
+  description,
+  selectedModel: {
+    runtimeKind,
+    providerId: "openai",
+    modelId: "gpt-5",
+    variant: "high",
+    profileId: "spec-agent",
+  },
+});
+
 describe("useSessionStartModalState", () => {
   test("initializes selection from repo role defaults", async () => {
     const harness = createHookHarness(createBaseProps());
@@ -878,21 +914,9 @@ describe("useSessionStartModalState", () => {
   });
 
   test("filters runtime options by the selected start mode without selecting fallbacks", async () => {
-    const repoSettings = {
-      ...createRepoSettings({
-        build: {
-          runtimeKind: REUSE_RUNTIME_KIND,
-          providerId: "openai",
-          modelId: "gpt-5",
-          variant: "high",
-          profileId: "spec-agent",
-        },
-      }),
-      defaultRuntimeKind: REUSE_RUNTIME_KIND,
-    };
     const harness = createHookHarness(
       createBaseProps({
-        repoSettings,
+        repoSettings: createBuildRepoSettingsForRuntime(REUSE_RUNTIME_KIND),
         runtimeDefinitions: [REUSE_RUNTIME_DESCRIPTOR, FORK_RUNTIME_DESCRIPTOR],
       }),
     );
@@ -906,18 +930,10 @@ describe("useSessionStartModalState", () => {
         role: "build",
         launchActionId: "build_pull_request_generation",
         existingSessionOptions: [
-          {
+          createExistingSessionWithModel({
             value: "session-pr-runtime",
-            label: "Builder session",
-            description: "Reusable builder session",
-            selectedModel: {
-              runtimeKind: REUSE_RUNTIME_KIND,
-              providerId: "openai",
-              modelId: "gpt-5",
-              variant: "high",
-              profileId: "spec-agent",
-            },
-          },
+            runtimeKind: REUSE_RUNTIME_KIND,
+          }),
         ],
         postStartAction: "kickoff",
         title: "Start PR Generation",
@@ -961,21 +977,9 @@ describe("useSessionStartModalState", () => {
   });
 
   test("clears runtime and model selection when no runtime supports the selected mode", async () => {
-    const repoSettings = {
-      ...createRepoSettings({
-        build: {
-          runtimeKind: REUSE_RUNTIME_KIND,
-          providerId: "openai",
-          modelId: "gpt-5",
-          variant: "high",
-          profileId: "spec-agent",
-        },
-      }),
-      defaultRuntimeKind: REUSE_RUNTIME_KIND,
-    };
     const harness = createHookHarness(
       createBaseProps({
-        repoSettings,
+        repoSettings: createBuildRepoSettingsForRuntime(REUSE_RUNTIME_KIND),
         runtimeDefinitions: [REUSE_RUNTIME_DESCRIPTOR],
       }),
     );
@@ -989,18 +993,10 @@ describe("useSessionStartModalState", () => {
         role: "build",
         launchActionId: "build_pull_request_generation",
         existingSessionOptions: [
-          {
+          createExistingSessionWithModel({
             value: "session-pr-no-fork",
-            label: "Builder session",
-            description: "Reusable builder session",
-            selectedModel: {
-              runtimeKind: REUSE_RUNTIME_KIND,
-              providerId: "openai",
-              modelId: "gpt-5",
-              variant: "high",
-              profileId: "spec-agent",
-            },
-          },
+            runtimeKind: REUSE_RUNTIME_KIND,
+          }),
         ],
         postStartAction: "kickoff",
         title: "Start PR Generation",
@@ -1040,18 +1036,11 @@ describe("useSessionStartModalState", () => {
         role: "build",
         launchActionId: "build_pull_request_generation",
         existingSessionOptions: [
-          {
+          createExistingSessionWithModel({
             value: "session-pr-fork-runtime",
-            label: "Builder session",
             description: "Builder session from a fork-only runtime",
-            selectedModel: {
-              runtimeKind: FORK_RUNTIME_KIND,
-              providerId: "openai",
-              modelId: "gpt-5",
-              variant: "high",
-              profileId: "spec-agent",
-            },
-          },
+            runtimeKind: FORK_RUNTIME_KIND,
+          }),
         ],
         postStartAction: "kickoff",
         title: "Start PR Generation",

--- a/packages/frontend/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
+import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
-import type { AgentModelCatalog } from "@openducktor/core";
+import type { AgentModelCatalog, AgentSessionStartMode } from "@openducktor/core";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   createHookHarness as createSharedHookHarness,
@@ -57,6 +58,44 @@ const ALTERNATE_RUNTIME_DESCRIPTOR = {
   kind: "opencode",
   label: "Alternate Runtime",
 } as const;
+
+const runtimeKind = (kind: string): RuntimeKind => kind as unknown as RuntimeKind;
+
+const createRuntimeDescriptor = ({
+  kind,
+  label,
+  supportedStartModes,
+}: {
+  kind: RuntimeKind;
+  label: string;
+  supportedStartModes: AgentSessionStartMode[];
+}): RuntimeDescriptor => ({
+  ...OPENCODE_RUNTIME_DESCRIPTOR,
+  kind,
+  label,
+  capabilities: {
+    ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities,
+    sessionLifecycle: {
+      ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.sessionLifecycle,
+      supportedStartModes,
+      supportsSessionFork: supportedStartModes.includes("fork"),
+      forkTargets: supportedStartModes.includes("fork") ? ["session"] : [],
+    },
+  },
+});
+
+const REUSE_RUNTIME_KIND = runtimeKind("reuse-runtime");
+const FORK_RUNTIME_KIND = runtimeKind("fork-runtime");
+const REUSE_RUNTIME_DESCRIPTOR = createRuntimeDescriptor({
+  kind: REUSE_RUNTIME_KIND,
+  label: "Reuse Runtime",
+  supportedStartModes: ["fresh", "reuse"],
+});
+const FORK_RUNTIME_DESCRIPTOR = createRuntimeDescriptor({
+  kind: FORK_RUNTIME_KIND,
+  label: "Fork Runtime",
+  supportedStartModes: ["fresh", "fork"],
+});
 
 const createRepoSettings = (
   overrides: Partial<RepoSettingsInput["agentDefaults"]> = {},
@@ -834,6 +873,195 @@ describe("useSessionStartModalState", () => {
       variant: "default",
       profileId: "build-agent",
     });
+
+    await harness.unmount();
+  });
+
+  test("filters runtime options by the selected start mode without selecting fallbacks", async () => {
+    const repoSettings = {
+      ...createRepoSettings({
+        build: {
+          runtimeKind: REUSE_RUNTIME_KIND,
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "high",
+          profileId: "spec-agent",
+        },
+      }),
+      defaultRuntimeKind: REUSE_RUNTIME_KIND,
+    };
+    const harness = createHookHarness(
+      createBaseProps({
+        repoSettings,
+        runtimeDefinitions: [REUSE_RUNTIME_DESCRIPTOR, FORK_RUNTIME_DESCRIPTOR],
+      }),
+    );
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-PR-RUNTIME-MODE",
+        role: "build",
+        launchActionId: "build_pull_request_generation",
+        existingSessionOptions: [
+          {
+            value: "session-pr-runtime",
+            label: "Builder session",
+            description: "Reusable builder session",
+            selectedModel: {
+              runtimeKind: REUSE_RUNTIME_KIND,
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "high",
+              profileId: "spec-agent",
+            },
+          },
+        ],
+        postStartAction: "kickoff",
+        title: "Start PR Generation",
+      });
+    });
+
+    expect(harness.getLatest().selectedStartMode).toBe("reuse");
+    expect(harness.getLatest().runtimeOptions.map((option) => option.value)).toEqual([
+      REUSE_RUNTIME_KIND,
+    ]);
+    expect(harness.getLatest().selectedRuntimeKind).toBe(REUSE_RUNTIME_KIND);
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectStartMode("fork");
+    });
+
+    expect(harness.getLatest().runtimeOptions.map((option) => option.value)).toEqual([
+      FORK_RUNTIME_KIND,
+    ]);
+    await harness.waitFor((state) => state.selectedRuntimeKind === null);
+    await harness.waitFor((state) => state.selection === null);
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectRuntime(FORK_RUNTIME_KIND);
+    });
+
+    await harness.waitFor((state) => state.selectedRuntimeKind === FORK_RUNTIME_KIND);
+    await harness.waitFor((state) => state.selection?.runtimeKind === FORK_RUNTIME_KIND);
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectStartMode("reuse");
+    });
+
+    expect(harness.getLatest().runtimeOptions.map((option) => option.value)).toEqual([
+      REUSE_RUNTIME_KIND,
+    ]);
+    await harness.waitFor((state) => state.selectedRuntimeKind === REUSE_RUNTIME_KIND);
+    await harness.waitFor((state) => state.selection?.runtimeKind === REUSE_RUNTIME_KIND);
+
+    await harness.unmount();
+  });
+
+  test("clears runtime and model selection when no runtime supports the selected mode", async () => {
+    const repoSettings = {
+      ...createRepoSettings({
+        build: {
+          runtimeKind: REUSE_RUNTIME_KIND,
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "high",
+          profileId: "spec-agent",
+        },
+      }),
+      defaultRuntimeKind: REUSE_RUNTIME_KIND,
+    };
+    const harness = createHookHarness(
+      createBaseProps({
+        repoSettings,
+        runtimeDefinitions: [REUSE_RUNTIME_DESCRIPTOR],
+      }),
+    );
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-PR-NO-FORK-RUNTIME",
+        role: "build",
+        launchActionId: "build_pull_request_generation",
+        existingSessionOptions: [
+          {
+            value: "session-pr-no-fork",
+            label: "Builder session",
+            description: "Reusable builder session",
+            selectedModel: {
+              runtimeKind: REUSE_RUNTIME_KIND,
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "high",
+              profileId: "spec-agent",
+            },
+          },
+        ],
+        postStartAction: "kickoff",
+        title: "Start PR Generation",
+      });
+    });
+
+    expect(harness.getLatest().selectedRuntimeKind).toBe(REUSE_RUNTIME_KIND);
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectStartMode("fork");
+    });
+
+    expect(harness.getLatest().runtimeOptions).toEqual([]);
+    await harness.waitFor((state) => state.selectedRuntimeKind === null);
+    await harness.waitFor((state) => state.selection === null);
+
+    await harness.unmount();
+  });
+
+  test("does not reuse a source-session runtime that lacks reuse support", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        runtimeDefinitions: [FORK_RUNTIME_DESCRIPTOR],
+        repoSettings: {
+          ...createRepoSettings(),
+          defaultRuntimeKind: FORK_RUNTIME_KIND,
+        },
+      }),
+    );
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-PR-REUSE-INCOMPATIBLE",
+        role: "build",
+        launchActionId: "build_pull_request_generation",
+        existingSessionOptions: [
+          {
+            value: "session-pr-fork-runtime",
+            label: "Builder session",
+            description: "Builder session from a fork-only runtime",
+            selectedModel: {
+              runtimeKind: FORK_RUNTIME_KIND,
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "high",
+              profileId: "spec-agent",
+            },
+          },
+        ],
+        postStartAction: "kickoff",
+        title: "Start PR Generation",
+      });
+    });
+
+    expect(harness.getLatest().selectedStartMode).toBe("reuse");
+    expect(harness.getLatest().runtimeOptions).toEqual([]);
+    await harness.waitFor((state) => state.selectedRuntimeKind === null);
+    await harness.waitFor((state) => state.selection === null);
 
     await harness.unmount();
   });

--- a/packages/frontend/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -97,6 +97,27 @@ const FORK_RUNTIME_DESCRIPTOR = createRuntimeDescriptor({
   supportedStartModes: ["fresh", "fork"],
 });
 
+const FRESH_RUNTIME_KIND = runtimeKind("fresh-runtime");
+const FRESH_RUNTIME_DESCRIPTOR = createRuntimeDescriptor({
+  kind: FRESH_RUNTIME_KIND,
+  label: "Fresh Runtime",
+  supportedStartModes: ["fresh"],
+});
+
+const REUSE_ONLY_RUNTIME_KIND = runtimeKind("reuse-only-runtime");
+const REUSE_ONLY_RUNTIME_DESCRIPTOR = createRuntimeDescriptor({
+  kind: REUSE_ONLY_RUNTIME_KIND,
+  label: "Reuse Only Runtime",
+  supportedStartModes: ["reuse"],
+});
+
+const FORK_ONLY_RUNTIME_KIND = runtimeKind("fork-only-runtime");
+const FORK_ONLY_RUNTIME_DESCRIPTOR = createRuntimeDescriptor({
+  kind: FORK_ONLY_RUNTIME_KIND,
+  label: "Fork Only Runtime",
+  supportedStartModes: ["fork"],
+});
+
 const createRepoSettings = (
   overrides: Partial<RepoSettingsInput["agentDefaults"]> = {},
 ): RepoSettingsInput => ({
@@ -176,6 +197,7 @@ const createExistingSessionWithModel = ({
   value,
   label,
   description,
+  runtimeKind,
   selectedModel: {
     runtimeKind,
     providerId: "openai",
@@ -320,6 +342,72 @@ describe("useSessionStartModalState", () => {
     });
 
     expect(harness.getLatest().selectedStartMode).toBe("fresh");
+
+    await harness.unmount();
+  });
+
+  test("demotes reuse starts without existing sessions and keeps runtime options fresh-compatible", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        runtimeDefinitions: [
+          FRESH_RUNTIME_DESCRIPTOR,
+          REUSE_ONLY_RUNTIME_DESCRIPTOR,
+          FORK_ONLY_RUNTIME_DESCRIPTOR,
+        ],
+      }),
+    );
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-4",
+        role: "build",
+        launchActionId: "build_after_human_request_changes",
+        initialStartMode: "reuse",
+        postStartAction: "kickoff",
+        title: "Resume Builder Session",
+      });
+    });
+
+    expect(harness.getLatest().selectedStartMode).toBe("fresh");
+    expect(harness.getLatest().runtimeOptions.map((option) => option.value)).toEqual([
+      FRESH_RUNTIME_KIND,
+    ]);
+
+    await harness.unmount();
+  });
+
+  test("falls back from an unavailable fork start to fresh when no sessions exist", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        runtimeDefinitions: [
+          FRESH_RUNTIME_DESCRIPTOR,
+          REUSE_ONLY_RUNTIME_DESCRIPTOR,
+          FORK_ONLY_RUNTIME_DESCRIPTOR,
+        ],
+      }),
+    );
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-4B",
+        role: "build",
+        launchActionId: "build_after_human_request_changes",
+        initialStartMode: "fork",
+        postStartAction: "kickoff",
+        title: "Resume Builder Session",
+      });
+    });
+
+    expect(harness.getLatest().selectedStartMode).toBe("fresh");
+    expect(harness.getLatest().runtimeOptions.map((option) => option.value)).toEqual([
+      FRESH_RUNTIME_KIND,
+    ]);
 
     await harness.unmount();
   });

--- a/packages/frontend/src/features/session-start/use-session-start-modal-state.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-state.ts
@@ -4,7 +4,7 @@ import type {
   AgentModelSelection,
   AgentSessionStartMode,
 } from "@openducktor/core";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { resolveAgentAccentColor } from "@/components/features/agents/agent-accent-color";
 import {
   toModelGroupsByProvider,
@@ -129,6 +129,10 @@ export function useSessionStartModalState({
     setRequestedRuntimeKind,
     setSelection,
   });
+
+  useEffect(() => {
+    setSelectedStartModeForRuntime(selectedStartMode);
+  }, [selectedStartMode]);
   const {
     resetSelection,
     initializeSelection,
@@ -215,12 +219,8 @@ export function useSessionStartModalState({
   const handleSelectedStartModeChange = useCallback(
     (startMode: AgentSessionStartMode): void => {
       handleSelectStartMode(startMode);
-      if ((startMode === "reuse" || startMode === "fork") && existingSessionOptions.length === 0) {
-        return;
-      }
-      setSelectedStartModeForRuntime(startMode);
     },
-    [existingSessionOptions.length, handleSelectStartMode],
+    [handleSelectStartMode],
   );
 
   const selectedModelEntry = useMemo(() => {

--- a/packages/frontend/src/features/session-start/use-session-start-modal-state.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-state.ts
@@ -52,6 +52,7 @@ type UseSessionStartModalStateResult = {
   intent: SessionStartModalIntent | null;
   isOpen: boolean;
   selection: AgentModelSelection | null;
+  eligibleRuntimeDefinitions: RuntimeDescriptor[];
   selectedRuntimeDescriptor: RuntimeDescriptor | null;
   selectedRuntimeKind: RuntimeKind | null;
   runtimeOptions: ComboboxOption[];
@@ -331,6 +332,7 @@ export function useSessionStartModalState({
     intent,
     isOpen: intent !== null,
     selection,
+    eligibleRuntimeDefinitions,
     selectedRuntimeDescriptor,
     selectedRuntimeKind,
     runtimeOptions,

--- a/packages/frontend/src/features/session-start/use-session-start-modal-state.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-state.ts
@@ -13,7 +13,10 @@ import {
 } from "@/components/features/agents/catalog-select-options";
 import { toBranchSelectorOptions } from "@/components/features/repository/branch-selector-model";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
-import { resolveRuntimeKindSelection } from "@/lib/agent-runtime";
+import {
+  filterRuntimeDefinitionsForStartMode,
+  resolveRuntimeKindSelection,
+} from "@/lib/agent-runtime";
 import {
   canonicalTargetBranch,
   effectiveTaskTargetBranch,
@@ -49,6 +52,7 @@ type UseSessionStartModalStateResult = {
   intent: SessionStartModalIntent | null;
   isOpen: boolean;
   selection: AgentModelSelection | null;
+  selectedRuntimeDescriptor: RuntimeDescriptor | null;
   selectedRuntimeKind: RuntimeKind | null;
   runtimeOptions: ComboboxOption[];
   supportsProfiles: boolean;
@@ -89,9 +93,12 @@ export function useSessionStartModalState({
   const [intent, setIntent] = useState<SessionStartModalIntent | null>(null);
   const [selection, setSelection] = useState<AgentModelSelection | null>(null);
   const [selectedTargetBranch, setSelectedTargetBranch] = useState("");
+  const [selectedStartModeForRuntime, setSelectedStartModeForRuntime] =
+    useState<AgentSessionStartMode>("fresh");
   const activeRole = intent?.role ?? null;
   const {
     catalog,
+    eligibleRuntimeDefinitions,
     isCatalogLoading,
     selectedRuntimeDescriptor,
     selectedRuntimeKind,
@@ -103,6 +110,7 @@ export function useSessionStartModalState({
     isOpen: intent !== null,
     loadCatalog: loadCatalogForRepo,
     runtimeDefinitions,
+    selectedStartMode: selectedStartModeForRuntime,
   });
   const {
     availableStartModes,
@@ -140,6 +148,7 @@ export function useSessionStartModalState({
   const closeStartModal = useCallback(() => {
     setIntent(null);
     setSelectedTargetBranch("");
+    setSelectedStartModeForRuntime("fresh");
     resetSelection();
     resetStartState();
   }, [resetSelection, resetStartState]);
@@ -151,11 +160,16 @@ export function useSessionStartModalState({
         roleDefaultSelectionFor(repoSettings, nextIntent.role)?.runtimeKind ??
         repoSettings?.defaultRuntimeKind ??
         null;
+      const initialStartMode = initializeStartState(nextIntent);
       const initialRuntimeKind = resolveRuntimeKindSelection({
-        runtimeDefinitions,
+        runtimeDefinitions: filterRuntimeDefinitionsForStartMode(
+          runtimeDefinitions,
+          initialStartMode,
+        ),
         requestedRuntimeKind,
       });
       setRequestedRuntimeKind(requestedRuntimeKind);
+      setSelectedStartModeForRuntime(initialStartMode);
       setIntent(nextIntent);
       setSelectedTargetBranch(
         targetBranchSelectionValue(
@@ -165,7 +179,6 @@ export function useSessionStartModalState({
           ),
         ),
       );
-      initializeStartState(nextIntent);
       initializeSelection(nextIntent.role, initialRuntimeKind, nextIntent.selectedModel ?? null);
     },
     [
@@ -180,7 +193,7 @@ export function useSessionStartModalState({
   const handleSelectRuntime = useCallback(
     (runtimeKindValue: RuntimeKind): void => {
       const runtimeKind = resolveRuntimeKindSelection({
-        runtimeDefinitions,
+        runtimeDefinitions: eligibleRuntimeDefinitions,
         requestedRuntimeKind: runtimeKindValue,
       });
       setRequestedRuntimeKind(runtimeKindValue);
@@ -190,7 +203,23 @@ export function useSessionStartModalState({
         resetSelection();
       }
     },
-    [handleSelectionRuntimeChange, resetSelection, runtimeDefinitions, setRequestedRuntimeKind],
+    [
+      eligibleRuntimeDefinitions,
+      handleSelectionRuntimeChange,
+      resetSelection,
+      setRequestedRuntimeKind,
+    ],
+  );
+
+  const handleSelectedStartModeChange = useCallback(
+    (startMode: AgentSessionStartMode): void => {
+      handleSelectStartMode(startMode);
+      if ((startMode === "reuse" || startMode === "fork") && existingSessionOptions.length === 0) {
+        return;
+      }
+      setSelectedStartModeForRuntime(startMode);
+    },
+    [existingSessionOptions.length, handleSelectStartMode],
   );
 
   const selectedModelEntry = useMemo(() => {
@@ -302,6 +331,7 @@ export function useSessionStartModalState({
     intent,
     isOpen: intent !== null,
     selection,
+    selectedRuntimeDescriptor,
     selectedRuntimeKind,
     runtimeOptions,
     supportsProfiles:
@@ -322,7 +352,7 @@ export function useSessionStartModalState({
     selectedTargetBranch,
     openStartModal,
     closeStartModal,
-    handleSelectStartMode,
+    handleSelectStartMode: handleSelectedStartModeChange,
     handleSelectSourceSession,
     handleSelectTargetBranch,
     handleSelectRuntime,

--- a/packages/frontend/src/lib/agent-runtime.test.ts
+++ b/packages/frontend/src/lib/agent-runtime.test.ts
@@ -7,11 +7,13 @@ import {
 import {
   filterRuntimeDefinitionsForDefaultSelection,
   filterRuntimeDefinitionsForRole,
+  filterRuntimeDefinitionsForStartMode,
   getMissingMandatoryRuntimeCapabilities,
   getRuntimeDescriptorCapabilityConfigErrors,
   resolveRuntimeKindSelection,
   resolveRuntimeKindSelectionState,
   runtimeSupportsRole,
+  runtimeSupportsStartMode,
   validateRuntimeDefinitionForOpenDucktor,
   validateRuntimeDefinitionsForOpenDucktor,
 } from "./agent-runtime";
@@ -257,8 +259,8 @@ describe("agent-runtime capability policies", () => {
     ]);
   });
 
-  test("reports launch-scoped start mode gaps separately from role scopes", () => {
-    const descriptor = withCapabilities({
+  test("treats multi-mode launch start modes as alternatives", () => {
+    const reuseOnlyPrRuntime = withCapabilities({
       sessionLifecycle: {
         ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.sessionLifecycle,
         supportedStartModes: ["fresh", "reuse"],
@@ -266,10 +268,68 @@ describe("agent-runtime capability policies", () => {
         forkTargets: [],
       },
     });
+    const forkOnlyPrRuntime = withCapabilities({
+      sessionLifecycle: {
+        ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.sessionLifecycle,
+        supportedStartModes: ["fresh", "fork"],
+        supportsSessionFork: true,
+        forkTargets: ["session"],
+      },
+    });
+
+    expect(getRuntimeDescriptorCapabilityConfigErrors(reuseOnlyPrRuntime)).not.toContain(
+      expect.stringContaining("build_pull_request_generation"),
+    );
+    expect(getRuntimeDescriptorCapabilityConfigErrors(forkOnlyPrRuntime)).not.toContain(
+      expect.stringContaining("build_pull_request_generation"),
+    );
+  });
+
+  test("reports launch-scoped errors only when no allowed start mode is supported", () => {
+    const descriptor = withCapabilities({
+      sessionLifecycle: {
+        ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.sessionLifecycle,
+        supportedStartModes: ["fresh"],
+        supportsSessionFork: false,
+        forkTargets: [],
+      },
+    });
 
     expect(getRuntimeDescriptorCapabilityConfigErrors(descriptor)).toContain(
-      "[launch_scoped] launch build_pull_request_generation requires start modes: fork",
+      "[launch_scoped] launch build_pull_request_generation has no supported start mode (allowed: reuse, fork; runtime supports: fresh)",
     );
+  });
+
+  test("filters runtime definitions by the selected start mode", () => {
+    const reuseRuntime = withCapabilities({
+      sessionLifecycle: {
+        ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.sessionLifecycle,
+        supportedStartModes: ["fresh", "reuse"],
+        supportsSessionFork: false,
+        forkTargets: [],
+      },
+    });
+    const forkRuntime = {
+      ...withCapabilities({
+        sessionLifecycle: {
+          ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.sessionLifecycle,
+          supportedStartModes: ["fresh", "fork"],
+          supportsSessionFork: true,
+          forkTargets: ["session"],
+        },
+      }),
+      kind: "fork-runtime" as unknown as RuntimeDescriptor["kind"],
+      label: "Fork Runtime",
+    };
+
+    expect(runtimeSupportsStartMode(reuseRuntime, "reuse")).toBe(true);
+    expect(runtimeSupportsStartMode(reuseRuntime, "fork")).toBe(false);
+    expect(filterRuntimeDefinitionsForStartMode([reuseRuntime, forkRuntime], "reuse")).toEqual([
+      reuseRuntime,
+    ]);
+    expect(filterRuntimeDefinitionsForStartMode([reuseRuntime, forkRuntime], "fork")).toEqual([
+      forkRuntime,
+    ]);
   });
 
   test("reports incompatible runtime definitions with runtime-specific context", () => {

--- a/packages/frontend/src/lib/agent-runtime.ts
+++ b/packages/frontend/src/lib/agent-runtime.ts
@@ -109,6 +109,20 @@ export const runtimeLabelFor = ({
   return findRuntimeDefinition(runtimeDefinitions, runtimeKind)?.label ?? runtimeKind;
 };
 
+export const runtimeSupportsStartMode = (
+  runtimeDescriptor: RuntimeDescriptor,
+  startMode: AgentSessionStartMode,
+): boolean => {
+  return runtimeDescriptor.capabilities.sessionLifecycle.supportedStartModes.includes(startMode);
+};
+
+export const filterRuntimeDefinitionsForStartMode = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  startMode: AgentSessionStartMode,
+): RuntimeDescriptor[] => {
+  return runtimeDefinitions.filter((definition) => runtimeSupportsStartMode(definition, startMode));
+};
+
 const runtimeSupportsCapability = (
   runtimeDescriptor: RuntimeDescriptor,
   capability: RuntimeCapabilityKey,
@@ -265,12 +279,17 @@ export const getRuntimeDescriptorCapabilityConfigErrors = (
 
 const launchStartModeRequirements = sessionLaunchActionIds.map((id) => SESSION_LAUNCH_ACTIONS[id]);
 
-const getUnsupportedLaunchStartModes = (
+const formatStartModes = (startModes: readonly AgentSessionStartMode[]): string => {
+  return startModes.length > 0 ? startModes.join(", ") : "none";
+};
+
+const runtimeSupportsAnyLaunchStartMode = (
   runtimeDescriptor: RuntimeDescriptor,
   allowedStartModes: readonly AgentSessionStartMode[],
-): AgentSessionStartMode[] => {
-  const supportedStartModes = runtimeDescriptor.capabilities.sessionLifecycle.supportedStartModes;
-  return allowedStartModes.filter((startMode) => !supportedStartModes.includes(startMode));
+): boolean => {
+  return allowedStartModes.some((startMode) =>
+    runtimeSupportsStartMode(runtimeDescriptor, startMode),
+  );
 };
 
 export const getRuntimeDescriptorLaunchConfigErrors = (
@@ -280,16 +299,13 @@ export const getRuntimeDescriptorLaunchConfigErrors = (
     if (!runtimeSupportsRole(runtimeDescriptor, launch.role)) {
       return [];
     }
-    const missingStartModes = getUnsupportedLaunchStartModes(
-      runtimeDescriptor,
-      launch.allowedStartModes,
-    );
-    if (missingStartModes.length === 0) {
+    if (runtimeSupportsAnyLaunchStartMode(runtimeDescriptor, launch.allowedStartModes)) {
       return [];
     }
 
+    const supportedStartModes = runtimeDescriptor.capabilities.sessionLifecycle.supportedStartModes;
     return [
-      `[launch_scoped] launch ${launch.id} requires start modes: ${missingStartModes.join(", ")}`,
+      `[launch_scoped] launch ${launch.id} has no supported start mode (allowed: ${formatStartModes(launch.allowedStartModes)}; runtime supports: ${formatStartModes(supportedStartModes)})`,
     ];
   });
 };

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -784,7 +784,7 @@ describe("KanbanPage session start modal flow", () => {
     });
   });
 
-  test("reuse confirm does not overwrite the reused session model", async () => {
+  test("reuse confirm fails fast when the modal has no reusable source option", async () => {
     const renderer = await renderPage();
 
     await act(async () => {
@@ -800,20 +800,16 @@ describe("KanbanPage session start modal flow", () => {
         }) => void
       )({
         startMode: "reuse",
-        sourceExternalSessionId: "session-existing",
+        sourceExternalSessionId: "session-build-latest",
       });
       await Promise.resolve();
     });
 
-    expect(startAgentSessionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId: "TASK-123",
-        role: "build",
-        startMode: "reuse",
-        sourceExternalSessionId: "session-existing",
-      }),
-    );
+    expect(startAgentSessionMock).not.toHaveBeenCalled();
     expect(updateAgentSessionModelMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith("Failed to start the session.", {
+      description: "Reusable session is missing a runtime kind.",
+    });
 
     await act(async () => {
       renderer.unmount();


### PR DESCRIPTION
## Summary
- Treat launch `allowedStartModes` as alternatives in both TypeScript and Rust runtime descriptor validation.
- Filter session-start runtime choices by the currently selected start mode and fail fast when the selected runtime cannot support that mode.
- Polish the session-start modal structure and reuse-runtime validation path so review/debugging stays focused.

## Goal and context
Launch actions can advertise multiple allowed start modes such as `fresh`, `reuse`, and `fork`. The previous descriptor validation treated that list cumulatively, which forced runtimes to support every listed mode even when any one compatible mode should be enough. That rejected valid runtime descriptors and could leave the session-start modal with incompatible runtime/model selections after mode changes.

This PR aligns validation with the intended contract: allowed modes are alternatives, fresh-only actions still require `fresh`, and fork/baseline invariants remain unchanged.

## Technical choices and implementation
- Added shared frontend helpers to check whether a runtime supports a concrete start mode and to filter runtime definitions for a selected mode.
- Updated TypeScript descriptor validation and Rust `RuntimeCapabilities::launch_config_errors` to pass when any allowed launch mode overlaps with runtime support, while returning actionable no-overlap errors.
- Scoped modal runtime options to mode-compatible definitions and cleared incompatible selections instead of silently falling back to another runtime.
- Added a submit-boundary guard that validates the concrete selected runtime/start mode before executing a run; reuse mode derives the source session runtime directly from the selected source option.
- Split the large `SessionStartModal` render tree into focused field/footer helpers without changing payload shape or disabled-state behavior.

## Verification
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `rtk cargo fmt --all --check`
- `rtk cargo check --workspace --all-targets`
- `rtk cargo clippy --workspace --all-targets -- -D warnings`
- `rtk cargo test --workspace --all-targets`
- `rtk cargo build --workspace`

Branch is up to date with `origin/main` (`0` behind, `2` ahead); no rebase was needed.