### PR TITLE
fix: recover failed OpenCode MCP clients

### DIFF
--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1293,7 +1293,7 @@ describe("OpencodeSdkAdapter", () => {
     });
   });
 
-  test("sendUserMessage caches workflow tool discovery across prompts for the same model", async () => {
+  test("sendUserMessage caches workflow tool discovery but checks MCP health for each prompt", async () => {
     const mock = makeMockClient({});
     const adapter = new OpencodeSdkAdapter({
       createClient: () => mock.client,
@@ -1320,7 +1320,7 @@ describe("OpencodeSdkAdapter", () => {
     });
 
     expect(mock.tool.idsCalls).toEqual([{ directory: "/repo" }]);
-    expect(mock.mcp.statusCalls).toEqual([{ directory: "/repo" }]);
+    expect(mock.mcp.statusCalls).toEqual([{ directory: "/repo" }, { directory: "/repo" }]);
     expect(mock.session.promptCalls).toHaveLength(0);
     expect(mock.session.promptAsyncCalls).toHaveLength(2);
   });

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -3,7 +3,7 @@ import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { OPENCODE_RUNTIME_DESCRIPTOR, type RuntimeInstanceSummary } from "@openducktor/contracts";
 import type { AgentEvent, RuntimeKind } from "@openducktor/core";
 import { OpencodeSdkAdapter as BaseOpencodeSdkAdapter } from "./opencode-sdk-adapter";
-import type { OpencodeSdkAdapterOptions } from "./types";
+import type { OpencodeSdkAdapterOptions, SessionRecord } from "./types";
 
 type TestAdapterInternals = {
   sessions: Map<
@@ -474,6 +474,93 @@ describe("opencode-sdk-adapter", () => {
       }),
     ).rejects.toThrow("client.global.event()");
     expect(adapter.hasSession("external-session-1")).toBe(false);
+  });
+
+  test("checks same-directory MCP health before returning cached workflow tool selection", async () => {
+    const mock = makeMockClient();
+    const statusCalls: Array<{ directory: string }> = [];
+    const connectCalls: Array<{ directory: string; name: string }> = [];
+    const toolIdCalls: Array<{ directory: string }> = [];
+    const statusResponses = [
+      { openducktor: { status: "connected" } },
+      { openducktor: { status: "failed", error: "MCP error -32000: Connection closed" } },
+      { openducktor: { status: "connected" } },
+    ];
+    let statusResponseIndex = 0;
+    const client = {
+      ...mock.client,
+      mcp: {
+        status: async (input: { directory: string }) => {
+          statusCalls.push(input);
+          const response = statusResponses[statusResponseIndex] ?? statusResponses.at(-1);
+          statusResponseIndex += 1;
+          return { data: response, error: undefined };
+        },
+        connect: async (input: { directory: string; name: string }) => {
+          connectCalls.push(input);
+          return { data: true, error: undefined };
+        },
+      },
+      tool: {
+        ids: async (input: { directory: string }) => {
+          toolIdCalls.push(input);
+          return { data: ["odt_read_task"], error: undefined };
+        },
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => client,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: "/repo",
+      workingDirectory: "/repo/.openducktor/worktrees/task-1",
+      taskId: "task-1",
+      runtimeKind: "opencode",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    const adapterInternals = adapter as unknown as {
+      sessions: Map<string, SessionRecord>;
+      resolveSessionToolSelection: (session: SessionRecord) => Promise<Record<string, boolean>>;
+    };
+    const session = adapterInternals.sessions.get("external-session-1");
+    if (!session) {
+      throw new Error("Expected test session to be registered.");
+    }
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("external-session-1", (event) => {
+      events.push(event);
+    });
+
+    await adapterInternals.resolveSessionToolSelection(session);
+    await adapterInternals.resolveSessionToolSelection(session);
+
+    expect(statusCalls).toEqual([
+      { directory: "/repo/.openducktor/worktrees/task-1" },
+      { directory: "/repo/.openducktor/worktrees/task-1" },
+      { directory: "/repo/.openducktor/worktrees/task-1" },
+    ]);
+    expect(connectCalls).toEqual([
+      {
+        directory: "/repo/.openducktor/worktrees/task-1",
+        name: "openducktor",
+      },
+    ]);
+    expect(toolIdCalls).toEqual([{ directory: "/repo/.openducktor/worktrees/task-1" }]);
+    expect(events).toEqual([
+      {
+        type: "mcp_reconnect_started",
+        externalSessionId: "external-session-1",
+        timestamp: "2026-02-22T12:00:00.000Z",
+        serverName: "openducktor",
+        workingDirectory: "/repo/.openducktor/worktrees/task-1",
+        status: "failed",
+        errorDetails: "MCP error -32000: Connection closed",
+      },
+    ]);
   });
 
   test("listLiveAgentSessions maps server sessions and statuses", async () => {

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -84,7 +84,10 @@ import type {
 } from "./types";
 import { WORKFLOW_TOOL_CACHE_TTL_MS } from "./types";
 import { buildRoleScopedPermissionRules } from "./workflow-tool-permissions";
-import { resolveWorkflowToolSelection } from "./workflow-tool-selection";
+import {
+  ensureTrustedOdtMcpServerConnected,
+  resolveWorkflowToolSelection,
+} from "./workflow-tool-selection";
 
 const toLiveAgentSessionStatus = (status: unknown): LiveAgentSessionSummary["status"] => {
   if (status === undefined || status === null) {
@@ -770,6 +773,22 @@ export class OpencodeSdkAdapter
     session: SessionRecord,
   ): Promise<Record<string, boolean>> {
     const nowMs = Date.now();
+    await ensureTrustedOdtMcpServerConnected({
+      client: session.client,
+      workingDirectory: session.input.workingDirectory,
+      onReconnectStart: (event) => {
+        this.emit(session.summary.externalSessionId, {
+          type: "mcp_reconnect_started",
+          externalSessionId: session.summary.externalSessionId,
+          timestamp: this.now(),
+          serverName: event.serverName,
+          workingDirectory: event.workingDirectory,
+          status: event.status,
+          ...(event.errorDetails ? { errorDetails: event.errorDetails } : {}),
+        });
+      },
+    });
+
     if (
       session.workflowToolSelectionCache &&
       typeof session.workflowToolSelectionCachedAt === "number" &&
@@ -783,6 +802,7 @@ export class OpencodeSdkAdapter
       role: requireWorkflowRole(session),
       runtimeDescriptor: this.getRuntimeDefinition(),
       workingDirectory: session.input.workingDirectory,
+      skipMcpConnectionCheck: true,
     });
 
     session.workflowToolSelectionCache = selection;

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
@@ -10,8 +10,13 @@ const makeClient = (input: {
   throwOnList?: boolean;
   onList?: () => void;
   mcpStatusResponse?: unknown;
+  mcpStatusResponses?: unknown[];
   throwOnMcpStatus?: boolean;
+  throwOnMcpConnect?: boolean;
+  onMcpStatus?: (args: { directory: string }) => void;
+  onMcpConnect?: (args: { directory: string; name: string }) => void;
 }): OpencodeClient => {
+  let statusResponseIndex = 0;
   return {
     tool: {
       ids: async () => {
@@ -35,12 +40,31 @@ const makeClient = (input: {
       },
     },
     mcp: {
-      status: async () => {
+      status: async (args: { directory: string }) => {
+        input.onMcpStatus?.(args);
         if (input.throwOnMcpStatus) {
           throw new Error("mcp-down");
         }
+        if (input.mcpStatusResponses) {
+          const response = input.mcpStatusResponses[statusResponseIndex];
+          statusResponseIndex += 1;
+          return {
+            data: response,
+            error: undefined,
+          };
+        }
         return {
           data: input.mcpStatusResponse ?? { openducktor: { status: "connected" } },
+          error: undefined,
+        };
+      },
+      connect: async (args: { directory: string; name: string }) => {
+        input.onMcpConnect?.(args);
+        if (input.throwOnMcpConnect) {
+          throw new Error("mcp-connect-down");
+        }
+        return {
+          data: true,
           error: undefined,
         };
       },
@@ -170,8 +194,77 @@ describe("workflow-tool-selection", () => {
     }).catch((error: unknown) => error);
 
     expect(selectionError).toBeInstanceOf(Error);
-    expect((selectionError as Error).message).toContain('MCP server "openducktor" is "failed"');
+    expect((selectionError as Error).message).toContain('unavailable for "/repo"');
+    expect((selectionError as Error).message).toContain(
+      'MCP server "openducktor" stayed unavailable after reconnect',
+    );
     expect((selectionError as Error).message).toContain("connection closed");
+  });
+
+  test("reconnects a failed trusted MCP server for the same worktree before tool selection", async () => {
+    const mcpStatusDirectories: string[] = [];
+    const mcpConnectCalls: Array<{ directory: string; name: string }> = [];
+    const reconnectEvents: Array<{
+      serverName: string;
+      workingDirectory: string;
+      status: string;
+      errorDetails: string | undefined;
+    }> = [];
+
+    const selection = await resolveWorkflowToolSelection({
+      client: makeClient({
+        toolIds: ["odt_read_task", "odt_set_plan"],
+        mcpStatusResponses: [
+          { openducktor: { status: "failed", error: "MCP error -32000: Connection closed" } },
+          { openducktor: { status: "connected" } },
+        ],
+        onMcpStatus: (args) => mcpStatusDirectories.push(args.directory),
+        onMcpConnect: (args) => mcpConnectCalls.push(args),
+      }),
+      role: "build",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      workingDirectory: "/repo/.openducktor/worktrees/task-1",
+      onReconnectStart: (event) => reconnectEvents.push(event),
+    });
+
+    expect(mcpStatusDirectories).toEqual([
+      "/repo/.openducktor/worktrees/task-1",
+      "/repo/.openducktor/worktrees/task-1",
+    ]);
+    expect(mcpConnectCalls).toEqual([
+      {
+        directory: "/repo/.openducktor/worktrees/task-1",
+        name: "openducktor",
+      },
+    ]);
+    expect(reconnectEvents).toEqual([
+      {
+        serverName: "openducktor",
+        workingDirectory: "/repo/.openducktor/worktrees/task-1",
+        status: "failed",
+        errorDetails: "MCP error -32000: Connection closed",
+      },
+    ]);
+    expect(selection.odt_read_task).toBe(true);
+    expect(selection.odt_set_plan).toBe(false);
+  });
+
+  test("propagates same-directory MCP reconnect failures", async () => {
+    const selectionError = await resolveWorkflowToolSelection({
+      client: makeClient({
+        toolIds: ["odt_read_task"],
+        mcpStatusResponse: {
+          openducktor: { status: "failed", error: "MCP error -32000: Connection closed" },
+        },
+        throwOnMcpConnect: true,
+      }),
+      role: "build",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      workingDirectory: "/repo/.openducktor/worktrees/task-1",
+    }).catch((error: unknown) => error);
+
+    expect(selectionError).toBeInstanceOf(Error);
+    expect((selectionError as Error).message).toBe("mcp-connect-down");
   });
 
   test("propagates trusted MCP status lookup failures", async () => {

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
@@ -25,18 +25,27 @@ const isToolIdControlledByOdtWorkflowSelection = (toolId: string): boolean =>
   isOpencodeExposedOdtToolAlias(toolId) ||
   OPENCODE_EXPOSED_ODT_TOOL_IDS_BLOCKED_FOR_WORKFLOW_AGENTS.has(toolId);
 
-const assertTrustedOdtMcpServerConnected = async (input: {
-  client: OpencodeClient;
+type McpApi = {
+  status?: (args: { directory: string }) => Promise<unknown>;
+  connect?: (args: { directory: string; name: string }) => Promise<unknown>;
+};
+
+type OdtMcpStatus = {
+  status: string;
+  errorDetails: string | undefined;
+};
+
+const readOdtMcpStatus = async (input: {
+  mcp: McpApi;
   workingDirectory: string;
-}): Promise<void> => {
-  const mcp = (input.client as { mcp?: { status?: unknown } }).mcp;
-  if (!mcp || typeof mcp.status !== "function") {
+}): Promise<OdtMcpStatus> => {
+  if (typeof input.mcp.status !== "function") {
     throw new Error(
       `ODT workflow tools unavailable: OpenCode MCP status API is unavailable for "${OPENDUCKTOR_MCP_SERVER_NAME}".`,
     );
   }
 
-  const response = await (mcp.status as (args: { directory: string }) => Promise<unknown>)({
+  const response = await input.mcp.status({
     directory: input.workingDirectory,
   });
   const statusPayload = unwrapData(
@@ -57,16 +66,98 @@ const assertTrustedOdtMcpServerConnected = async (input: {
       `ODT workflow tools unavailable: MCP server "${OPENDUCKTOR_MCP_SERVER_NAME}" status is missing.`,
     );
   }
-  const normalizedStatus = status.trim().toLowerCase();
+
+  return {
+    status,
+    errorDetails: readStringProp(serverStatus, ["error"]),
+  };
+};
+
+const formatOdtMcpUnavailableError = (input: {
+  workingDirectory: string;
+  status: string;
+  errorDetails: string | undefined;
+  recoveredStatus?: OdtMcpStatus;
+}): string => {
+  const initialStatus = input.status.trim();
+  const initialDetails = input.errorDetails ? ` (${input.errorDetails})` : "";
+  if (!input.recoveredStatus) {
+    return `ODT workflow tools unavailable for "${input.workingDirectory}": MCP server "${OPENDUCKTOR_MCP_SERVER_NAME}" is "${initialStatus}"${initialDetails}.`;
+  }
+
+  const recoveredDetails = input.recoveredStatus.errorDetails
+    ? ` (${input.recoveredStatus.errorDetails})`
+    : "";
+  return `ODT workflow tools unavailable for "${input.workingDirectory}": MCP server "${OPENDUCKTOR_MCP_SERVER_NAME}" stayed unavailable after reconnect. Initial status was "${initialStatus}"${initialDetails}; recovered status is "${input.recoveredStatus.status.trim()}"${recoveredDetails}.`;
+};
+
+export const ensureTrustedOdtMcpServerConnected = async (input: {
+  client: OpencodeClient;
+  workingDirectory: string;
+  onReconnectStart?: (event: {
+    serverName: string;
+    workingDirectory: string;
+    status: string;
+    errorDetails: string | undefined;
+  }) => void;
+}): Promise<void> => {
+  const mcp = (input.client as { mcp?: McpApi }).mcp;
+  if (!mcp) {
+    throw new Error(
+      `ODT workflow tools unavailable: OpenCode MCP status API is unavailable for "${OPENDUCKTOR_MCP_SERVER_NAME}".`,
+    );
+  }
+
+  const initialStatus = await readOdtMcpStatus({
+    mcp,
+    workingDirectory: input.workingDirectory,
+  });
+  const normalizedStatus = initialStatus.status.trim().toLowerCase();
   if (normalizedStatus === CONNECTED_MCP_STATUS) {
     return;
   }
 
-  const errorDetails = readStringProp(serverStatus, ["error"]);
+  if (typeof mcp.connect !== "function") {
+    throw new Error(
+      formatOdtMcpUnavailableError({
+        workingDirectory: input.workingDirectory,
+        status: initialStatus.status,
+        errorDetails: initialStatus.errorDetails,
+      }),
+    );
+  }
+
+  input.onReconnectStart?.({
+    serverName: OPENDUCKTOR_MCP_SERVER_NAME,
+    workingDirectory: input.workingDirectory,
+    status: initialStatus.status,
+    errorDetails: initialStatus.errorDetails,
+  });
+
+  const connectResponse = await mcp.connect({
+    directory: input.workingDirectory,
+    name: OPENDUCKTOR_MCP_SERVER_NAME,
+  });
+  unwrapData(
+    connectResponse as { data?: unknown; error?: { message?: string } | unknown },
+    `connect mcp server ${OPENDUCKTOR_MCP_SERVER_NAME} for role policy`,
+  );
+
+  const recoveredStatus = await readOdtMcpStatus({
+    mcp,
+    workingDirectory: input.workingDirectory,
+  });
+  if (recoveredStatus.status.trim().toLowerCase() === CONNECTED_MCP_STATUS) {
+    return;
+  }
+
   throw new Error(
-    `ODT workflow tools unavailable: MCP server "${OPENDUCKTOR_MCP_SERVER_NAME}" is "${status.trim()}"${
-      errorDetails ? ` (${errorDetails})` : ""
-    }.`,
+    formatOdtMcpUnavailableError({
+      workingDirectory: input.workingDirectory,
+      status: initialStatus.status,
+      errorDetails: initialStatus.errorDetails,
+      recoveredStatus,
+    }),
   );
 };
 
@@ -75,11 +166,21 @@ export const resolveWorkflowToolSelection = async (input: {
   role: AgentRole;
   runtimeDescriptor: RuntimeDescriptor;
   workingDirectory: string;
+  skipMcpConnectionCheck?: boolean;
+  onReconnectStart?: (event: {
+    serverName: string;
+    workingDirectory: string;
+    status: string;
+    errorDetails: string | undefined;
+  }) => void;
 }): Promise<Record<string, boolean>> => {
-  await assertTrustedOdtMcpServerConnected({
-    client: input.client,
-    workingDirectory: input.workingDirectory,
-  });
+  if (input.skipMcpConnectionCheck !== true) {
+    await ensureTrustedOdtMcpServerConnected({
+      client: input.client,
+      workingDirectory: input.workingDirectory,
+      ...(input.onReconnectStart ? { onReconnectStart: input.onReconnectStart } : {}),
+    });
+  }
 
   const response = await input.client.tool.ids({
     directory: input.workingDirectory,

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
@@ -35,6 +35,13 @@ type OdtMcpStatus = {
   errorDetails: string | undefined;
 };
 
+type OdtMcpReconnectStartHandler = (event: {
+  serverName: string;
+  workingDirectory: string;
+  status: string;
+  errorDetails: string | undefined;
+}) => void;
+
 const readOdtMcpStatus = async (input: {
   mcp: McpApi;
   workingDirectory: string;
@@ -94,12 +101,7 @@ const formatOdtMcpUnavailableError = (input: {
 export const ensureTrustedOdtMcpServerConnected = async (input: {
   client: OpencodeClient;
   workingDirectory: string;
-  onReconnectStart?: (event: {
-    serverName: string;
-    workingDirectory: string;
-    status: string;
-    errorDetails: string | undefined;
-  }) => void;
+  onReconnectStart?: OdtMcpReconnectStartHandler | undefined;
 }): Promise<void> => {
   const mcp = (input.client as { mcp?: McpApi }).mcp;
   if (!mcp) {
@@ -167,18 +169,13 @@ export const resolveWorkflowToolSelection = async (input: {
   runtimeDescriptor: RuntimeDescriptor;
   workingDirectory: string;
   skipMcpConnectionCheck?: boolean;
-  onReconnectStart?: (event: {
-    serverName: string;
-    workingDirectory: string;
-    status: string;
-    errorDetails: string | undefined;
-  }) => void;
+  onReconnectStart?: OdtMcpReconnectStartHandler | undefined;
 }): Promise<Record<string, boolean>> => {
   if (input.skipMcpConnectionCheck !== true) {
     await ensureTrustedOdtMcpServerConnected({
       client: input.client,
       workingDirectory: input.workingDirectory,
-      ...(input.onReconnectStart ? { onReconnectStart: input.onReconnectStart } : {}),
+      onReconnectStart: input.onReconnectStart,
     });
   }
 

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -461,6 +461,15 @@ export type AgentEvent =
       status: AgentSessionStatus;
     }
   | {
+      type: "mcp_reconnect_started";
+      externalSessionId: ExternalSessionId;
+      timestamp: string;
+      serverName: string;
+      workingDirectory: string;
+      status: string;
+      errorDetails?: string;
+    }
+  | {
       type: "session_error";
       externalSessionId: ExternalSessionId;
       timestamp: string;

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-event-batching.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-event-batching.ts
@@ -89,6 +89,9 @@ const SESSION_EVENT_BATCH_RULES: SessionEventBatchRules = {
   approval_required: {
     immediate: true,
   },
+  mcp_reconnect_started: {
+    immediate: true,
+  },
   question_required: {
     immediate: true,
   },
@@ -144,6 +147,8 @@ const withTypedSessionEvent = <T>(
       return callback(event, SESSION_EVENT_BATCH_RULES.session_status);
     case "approval_required":
       return callback(event, SESSION_EVENT_BATCH_RULES.approval_required);
+    case "mcp_reconnect_started":
+      return callback(event, SESSION_EVENT_BATCH_RULES.mcp_reconnect_started);
     case "question_required":
       return callback(event, SESSION_EVENT_BATCH_RULES.question_required);
     case "session_todos_updated":

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { withMockedToast } from "@/test-utils/mock-toast";
 import {
   lastSessionMessageForTest,
   sessionMessageAt,
@@ -465,6 +466,61 @@ describe("agent-orchestrator-session-events", () => {
     } finally {
       Date.now = originalDateNow;
     }
+  });
+
+  test("shows a toast when OpenDucktor starts MCP reconnect recovery", async () => {
+    await withMockedToast(async ({ toastInfoMock }) => {
+      const handlers: Array<(event: SessionEvent) => void> = [];
+      const adapter: SessionEventAdapter = {
+        subscribeEvents: (_externalSessionId, handler) => {
+          handlers.push(handler);
+          return () => {};
+        },
+        replyApproval: async () => {},
+      };
+      const sessionsRef: { current: Record<string, AgentSessionState> } = {
+        current: {
+          "session-1": buildSession({ role: "build" }),
+        },
+      };
+
+      attachAgentSessionListener({
+        adapter,
+        repoPath: "/tmp/repo",
+        externalSessionId: "session-1",
+        sessionsRef,
+        draftRawBySessionRef: { current: {} },
+        draftSourceBySessionRef: { current: {} },
+        draftMessageIdBySessionRef: { current: {} },
+        draftFlushTimeoutBySessionRef: { current: {} },
+        turnStartedAtBySessionRef: { current: {} },
+        updateSession: () => {},
+        resolveTurnDurationMs: () => undefined,
+        clearTurnDuration: () => {},
+        refreshTaskData: async () => {},
+      });
+
+      const handleEvent = handlers[0];
+      if (!handleEvent) {
+        throw new Error("Expected session event handler to be registered");
+      }
+
+      handleEvent({
+        type: "mcp_reconnect_started",
+        externalSessionId: "session-1",
+        timestamp: "2026-02-22T08:00:05.000Z",
+        serverName: "openducktor",
+        workingDirectory: "/tmp/repo/.openducktor/worktrees/task-1",
+        status: "failed",
+        errorDetails: "MCP error -32000: Connection closed",
+      });
+
+      expect(toastInfoMock).toHaveBeenCalledWith("Reconnecting OpenDucktor MCP", {
+        description:
+          "OpenDucktor MCP is failed for /tmp/repo/.openducktor/worktrees/task-1. MCP error -32000: Connection closed OpenDucktor is trying to reconnect.",
+      });
+      expect(getSessionMessages(sessionsRef)).toEqual([]);
+    });
   });
 
   test("runs completion side effects once for duplicate completed tool events", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -517,7 +517,7 @@ describe("agent-orchestrator-session-events", () => {
 
       expect(toastInfoMock).toHaveBeenCalledWith("Reconnecting OpenDucktor MCP", {
         description:
-          "OpenDucktor MCP is failed for /tmp/repo/.openducktor/worktrees/task-1. MCP error -32000: Connection closed OpenDucktor is trying to reconnect.",
+          "OpenDucktor MCP is failed for /tmp/repo/.openducktor/worktrees/task-1. MCP error -32000: Connection closed. OpenDucktor is trying to reconnect.",
       });
       expect(getSessionMessages(sessionsRef)).toEqual([]);
     });

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -1,3 +1,4 @@
+import { toast } from "sonner";
 import { createSessionEventBatcher, isImmediateSessionEvent } from "./session-event-batching";
 import type {
   AttachAgentSessionListenerParams,
@@ -31,6 +32,15 @@ const hasSessionStateChanges = (current: object, next: object): boolean => {
   return false;
 };
 
+const handleMcpReconnectStarted = (
+  event: Extract<SessionEvent, { type: "mcp_reconnect_started" }>,
+): void => {
+  const details = event.errorDetails ? ` ${event.errorDetails}` : "";
+  toast.info("Reconnecting OpenDucktor MCP", {
+    description: `OpenDucktor MCP is ${event.status} for ${event.workingDirectory}.${details} OpenDucktor is trying to reconnect.`,
+  });
+};
+
 const handleSessionEvent = (context: SessionEventHandlerContext, event: SessionEvent): void => {
   switch (event.type) {
     case "session_started":
@@ -53,6 +63,9 @@ const handleSessionEvent = (context: SessionEventHandlerContext, event: SessionE
       return;
     case "approval_required":
       handlePermissionRequired(context.lifecycle, event);
+      return;
+    case "mcp_reconnect_started":
+      handleMcpReconnectStarted(event);
       return;
     case "question_required":
       handleQuestionRequired(context.lifecycle, event);

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -35,7 +35,7 @@ const hasSessionStateChanges = (current: object, next: object): boolean => {
 const handleMcpReconnectStarted = (
   event: Extract<SessionEvent, { type: "mcp_reconnect_started" }>,
 ): void => {
-  const details = event.errorDetails ? ` ${event.errorDetails}` : "";
+  const details = event.errorDetails ? ` ${event.errorDetails}.` : "";
   toast.info("Reconnecting OpenDucktor MCP", {
     description: `OpenDucktor MCP is ${event.status} for ${event.workingDirectory}.${details} OpenDucktor is trying to reconnect.`,
   });

--- a/packages/frontend/src/test-utils/mock-toast.ts
+++ b/packages/frontend/src/test-utils/mock-toast.ts
@@ -5,24 +5,33 @@ export const withMockedToast = async (
   callback: (mocks: {
     toastSuccessMock: ReturnType<typeof mock>;
     toastErrorMock: ReturnType<typeof mock>;
+    toastInfoMock: ReturnType<typeof mock>;
   }) => Promise<void>,
 ): Promise<void> => {
   const originalSuccess = toast.success;
   const originalError = toast.error;
+  const originalInfo = toast.info;
   const toastSuccessMock = mock(() => "");
   const toastErrorMock = mock(() => "");
+  const toastInfoMock = mock(() => "");
 
   toast.success = toastSuccessMock;
   toast.error = toastErrorMock;
+  toast.info = toastInfoMock;
 
-  if (toast.success !== toastSuccessMock || toast.error !== toastErrorMock) {
+  if (
+    toast.success !== toastSuccessMock ||
+    toast.error !== toastErrorMock ||
+    toast.info !== toastInfoMock
+  ) {
     throw new Error("withMockedToast: toast properties are not writable");
   }
 
   try {
-    await callback({ toastSuccessMock, toastErrorMock });
+    await callback({ toastSuccessMock, toastErrorMock, toastInfoMock });
   } finally {
     toast.success = originalSuccess;
     toast.error = originalError;
+    toast.info = originalInfo;
   }
 };


### PR DESCRIPTION
## Summary
- Reconnects the directory-scoped `openducktor` MCP client when OpenCode reports it as failed or disconnected before workflow tool selection.
- Emits an immediate session event and toast when OpenDucktor starts MCP recovery so users can see when the issue occurs.
- Keeps workflow tool discovery cached while checking MCP health before each send, preventing stale cached tool selections from hiding a failed MCP client.

## Goal
Builder sessions can use task worktrees as their OpenCode directory, and OpenCode tracks MCP clients per directory. A worktree-scoped `openducktor` MCP client can get stuck failed with errors like `MCP error -32000: Connection closed` while the repo-root MCP client remains connected. Restarting OpenCode/OpenDucktor clears that state, but users should not need to restart the runtime or app.

This PR adds same-directory recovery at the adapter boundary so OpenDucktor repairs the affected worktree MCP client before sending workflow-agent messages.

## Technical choices
- Added `ensureTrustedOdtMcpServerConnected` in the OpenCode adapter workflow-tool path.
- When the trusted MCP server is not `connected`, the adapter calls OpenCode `mcp.connect({ directory: workingDirectory, name: "openducktor" })` for the same session directory, then re-checks status.
- The recovery path does not fall back to repo root and does not restart the OpenCode runtime.
- Reconnect failures remain fail-fast with an actionable error that includes the worktree directory and initial/recovered status details.
- Added a new `mcp_reconnect_started` agent event so the frontend can show a toast exactly when recovery starts.
- Marked the reconnect event as immediate in session event batching so the toast is not delayed behind streaming updates.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace -- --test-threads=1`
- `cargo build --workspace`