### PR TITLE
refactor: unify Beads delivery metadata setters

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -1,11 +1,9 @@
 use super::*;
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Map;
 use std::collections::HashSet;
 
-fn parse_pull_request_record(value: &Value) -> Option<PullRequestRecord> {
-    serde_json::from_value(value.clone()).ok()
-}
-
-fn parse_direct_merge_record(value: &Value) -> Option<DirectMergeRecord> {
+fn parse_record<T: DeserializeOwned>(value: &Value) -> Option<T> {
     serde_json::from_value(value.clone()).ok()
 }
 
@@ -41,23 +39,23 @@ impl BeadsTaskStore {
 
         let pull_request = namespace
             .and_then(|ns| ns.get("pullRequest"))
-            .and_then(parse_pull_request_record)
+            .and_then(parse_record::<PullRequestRecord>)
             .or_else(|| {
                 namespace
                     .and_then(|ns| ns.get("delivery"))
                     .and_then(Value::as_object)
                     .and_then(|delivery| delivery.get("linkedPullRequest"))
-                    .and_then(parse_pull_request_record)
+                    .and_then(parse_record::<PullRequestRecord>)
             });
         let direct_merge = namespace
             .and_then(|ns| ns.get("directMerge"))
-            .and_then(parse_direct_merge_record)
+            .and_then(parse_record::<DirectMergeRecord>)
             .or_else(|| {
                 namespace
                     .and_then(|ns| ns.get("delivery"))
                     .and_then(Value::as_object)
                     .and_then(|delivery| delivery.get("directMerge"))
-                    .and_then(parse_direct_merge_record)
+                    .and_then(parse_record::<DirectMergeRecord>)
             });
         let target_branch = namespace.and_then(crate::metadata::metadata_target_branch);
 
@@ -217,6 +215,34 @@ impl BeadsTaskStore {
         Ok(())
     }
 
+    fn set_namespace_value<T: Serialize>(
+        namespace_map: &mut Map<String, Value>,
+        key: &str,
+        value: Option<T>,
+    ) -> Result<()> {
+        match value {
+            Some(value) => {
+                namespace_map.insert(key.to_string(), serde_json::to_value(value)?);
+            }
+            None => {
+                namespace_map.remove(key);
+            }
+        }
+        Ok(())
+    }
+
+    fn persist_namespace_with_delivery_cleanup(
+        &self,
+        repo_path: &Path,
+        task_id: &str,
+        namespace_key: &str,
+        root: &mut Map<String, Value>,
+        mut namespace_map: Map<String, Value>,
+    ) -> Result<()> {
+        namespace_map.remove("delivery");
+        self.persist_namespace(repo_path, task_id, namespace_key, root, namespace_map)
+    }
+
     pub(super) fn set_pull_request_impl(
         &self,
         repo_path: &Path,
@@ -226,17 +252,15 @@ impl BeadsTaskStore {
         let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
 
-        match pull_request {
-            Some(value) => {
-                namespace_map.insert("pullRequest".to_string(), serde_json::to_value(value)?);
-            }
-            None => {
-                namespace_map.remove("pullRequest");
-            }
-        }
+        Self::set_namespace_value(&mut namespace_map, "pullRequest", pull_request)?;
 
-        namespace_map.remove("delivery");
-        self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
+        self.persist_namespace_with_delivery_cleanup(
+            repo_path,
+            task_id,
+            &namespace_key,
+            &mut root,
+            namespace_map,
+        )?;
         self.refresh_cached_pull_request_sync_candidate_from_store(repo_path, task_id)?;
         Ok(())
     }
@@ -251,26 +275,16 @@ impl BeadsTaskStore {
         let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
 
-        match pull_request {
-            Some(value) => {
-                namespace_map.insert("pullRequest".to_string(), serde_json::to_value(value)?);
-            }
-            None => {
-                namespace_map.remove("pullRequest");
-            }
-        }
+        Self::set_namespace_value(&mut namespace_map, "pullRequest", pull_request)?;
+        Self::set_namespace_value(&mut namespace_map, "directMerge", direct_merge)?;
 
-        match direct_merge {
-            Some(value) => {
-                namespace_map.insert("directMerge".to_string(), serde_json::to_value(value)?);
-            }
-            None => {
-                namespace_map.remove("directMerge");
-            }
-        }
-
-        namespace_map.remove("delivery");
-        self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
+        self.persist_namespace_with_delivery_cleanup(
+            repo_path,
+            task_id,
+            &namespace_key,
+            &mut root,
+            namespace_map,
+        )?;
         self.refresh_cached_pull_request_sync_candidate_from_store(repo_path, task_id)?;
         Ok(())
     }
@@ -284,17 +298,15 @@ impl BeadsTaskStore {
         let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
 
-        match direct_merge {
-            Some(value) => {
-                namespace_map.insert("directMerge".to_string(), serde_json::to_value(value)?);
-            }
-            None => {
-                namespace_map.remove("directMerge");
-            }
-        }
+        Self::set_namespace_value(&mut namespace_map, "directMerge", direct_merge)?;
 
-        namespace_map.remove("delivery");
-        self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
+        self.persist_namespace_with_delivery_cleanup(
+            repo_path,
+            task_id,
+            &namespace_key,
+            &mut root,
+            namespace_map,
+        )?;
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -7,6 +7,11 @@ fn parse_record<T: DeserializeOwned>(value: &Value) -> Option<T> {
     serde_json::from_value(value.clone()).ok()
 }
 
+enum PullRequestSyncRefresh {
+    Refresh,
+    Skip,
+}
+
 impl BeadsTaskStore {
     pub(super) fn parse_task_metadata_from_issue(&self, issue: &RawIssue) -> Result<TaskMetadata> {
         let metadata_root = parse_metadata_root(issue.metadata.clone());
@@ -235,7 +240,7 @@ impl BeadsTaskStore {
         &self,
         repo_path: &Path,
         task_id: &str,
-        refresh_pull_request_cache: bool,
+        pull_request_sync_refresh: PullRequestSyncRefresh,
         update_namespace: impl FnOnce(&mut Map<String, Value>) -> Result<()>,
     ) -> Result<()> {
         let (mut root, namespace_key, mut namespace_map) =
@@ -245,8 +250,11 @@ impl BeadsTaskStore {
         namespace_map.remove("delivery");
         self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
 
-        if refresh_pull_request_cache {
-            self.refresh_cached_pull_request_sync_candidate_from_store(repo_path, task_id)?;
+        match pull_request_sync_refresh {
+            PullRequestSyncRefresh::Refresh => {
+                self.refresh_cached_pull_request_sync_candidate_from_store(repo_path, task_id)?;
+            }
+            PullRequestSyncRefresh::Skip => {}
         }
 
         Ok(())
@@ -258,9 +266,12 @@ impl BeadsTaskStore {
         task_id: &str,
         pull_request: Option<PullRequestRecord>,
     ) -> Result<()> {
-        self.update_delivery_namespace(repo_path, task_id, true, |namespace_map| {
-            Self::set_namespace_value(namespace_map, "pullRequest", pull_request)
-        })
+        self.update_delivery_namespace(
+            repo_path,
+            task_id,
+            PullRequestSyncRefresh::Refresh,
+            |namespace_map| Self::set_namespace_value(namespace_map, "pullRequest", pull_request),
+        )
     }
 
     pub(super) fn set_delivery_metadata_impl(
@@ -270,10 +281,15 @@ impl BeadsTaskStore {
         pull_request: Option<PullRequestRecord>,
         direct_merge: Option<DirectMergeRecord>,
     ) -> Result<()> {
-        self.update_delivery_namespace(repo_path, task_id, true, |namespace_map| {
-            Self::set_namespace_value(namespace_map, "pullRequest", pull_request)?;
-            Self::set_namespace_value(namespace_map, "directMerge", direct_merge)
-        })
+        self.update_delivery_namespace(
+            repo_path,
+            task_id,
+            PullRequestSyncRefresh::Refresh,
+            |namespace_map| {
+                Self::set_namespace_value(namespace_map, "pullRequest", pull_request)?;
+                Self::set_namespace_value(namespace_map, "directMerge", direct_merge)
+            },
+        )
     }
 
     pub(super) fn set_direct_merge_record_impl(
@@ -282,9 +298,12 @@ impl BeadsTaskStore {
         task_id: &str,
         direct_merge: Option<DirectMergeRecord>,
     ) -> Result<()> {
-        self.update_delivery_namespace(repo_path, task_id, false, |namespace_map| {
-            Self::set_namespace_value(namespace_map, "directMerge", direct_merge)
-        })
+        self.update_delivery_namespace(
+            repo_path,
+            task_id,
+            PullRequestSyncRefresh::Skip,
+            |namespace_map| Self::set_namespace_value(namespace_map, "directMerge", direct_merge),
+        )
     }
 
     pub(super) fn get_task_metadata_impl(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -231,16 +231,25 @@ impl BeadsTaskStore {
         Ok(())
     }
 
-    fn persist_namespace_with_delivery_cleanup(
+    fn update_delivery_namespace(
         &self,
         repo_path: &Path,
         task_id: &str,
-        namespace_key: &str,
-        root: &mut Map<String, Value>,
-        mut namespace_map: Map<String, Value>,
+        refresh_pull_request_cache: bool,
+        update_namespace: impl FnOnce(&mut Map<String, Value>) -> Result<()>,
     ) -> Result<()> {
+        let (mut root, namespace_key, mut namespace_map) =
+            self.load_namespace(repo_path, task_id)?;
+
+        update_namespace(&mut namespace_map)?;
         namespace_map.remove("delivery");
-        self.persist_namespace(repo_path, task_id, namespace_key, root, namespace_map)
+        self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
+
+        if refresh_pull_request_cache {
+            self.refresh_cached_pull_request_sync_candidate_from_store(repo_path, task_id)?;
+        }
+
+        Ok(())
     }
 
     pub(super) fn set_pull_request_impl(
@@ -249,20 +258,9 @@ impl BeadsTaskStore {
         task_id: &str,
         pull_request: Option<PullRequestRecord>,
     ) -> Result<()> {
-        let (mut root, namespace_key, mut namespace_map) =
-            self.load_namespace(repo_path, task_id)?;
-
-        Self::set_namespace_value(&mut namespace_map, "pullRequest", pull_request)?;
-
-        self.persist_namespace_with_delivery_cleanup(
-            repo_path,
-            task_id,
-            &namespace_key,
-            &mut root,
-            namespace_map,
-        )?;
-        self.refresh_cached_pull_request_sync_candidate_from_store(repo_path, task_id)?;
-        Ok(())
+        self.update_delivery_namespace(repo_path, task_id, true, |namespace_map| {
+            Self::set_namespace_value(namespace_map, "pullRequest", pull_request)
+        })
     }
 
     pub(super) fn set_delivery_metadata_impl(
@@ -272,21 +270,10 @@ impl BeadsTaskStore {
         pull_request: Option<PullRequestRecord>,
         direct_merge: Option<DirectMergeRecord>,
     ) -> Result<()> {
-        let (mut root, namespace_key, mut namespace_map) =
-            self.load_namespace(repo_path, task_id)?;
-
-        Self::set_namespace_value(&mut namespace_map, "pullRequest", pull_request)?;
-        Self::set_namespace_value(&mut namespace_map, "directMerge", direct_merge)?;
-
-        self.persist_namespace_with_delivery_cleanup(
-            repo_path,
-            task_id,
-            &namespace_key,
-            &mut root,
-            namespace_map,
-        )?;
-        self.refresh_cached_pull_request_sync_candidate_from_store(repo_path, task_id)?;
-        Ok(())
+        self.update_delivery_namespace(repo_path, task_id, true, |namespace_map| {
+            Self::set_namespace_value(namespace_map, "pullRequest", pull_request)?;
+            Self::set_namespace_value(namespace_map, "directMerge", direct_merge)
+        })
     }
 
     pub(super) fn set_direct_merge_record_impl(
@@ -295,19 +282,9 @@ impl BeadsTaskStore {
         task_id: &str,
         direct_merge: Option<DirectMergeRecord>,
     ) -> Result<()> {
-        let (mut root, namespace_key, mut namespace_map) =
-            self.load_namespace(repo_path, task_id)?;
-
-        Self::set_namespace_value(&mut namespace_map, "directMerge", direct_merge)?;
-
-        self.persist_namespace_with_delivery_cleanup(
-            repo_path,
-            task_id,
-            &namespace_key,
-            &mut root,
-            namespace_map,
-        )?;
-        Ok(())
+        self.update_delivery_namespace(repo_path, task_id, false, |namespace_map| {
+            Self::set_namespace_value(namespace_map, "directMerge", direct_merge)
+        })
     }
 
     pub(super) fn get_task_metadata_impl(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -9,10 +9,10 @@ use super::{
 use anyhow::{anyhow, Result};
 use chrono::{Duration as ChronoDuration, Utc};
 use host_domain::{
-    AgentSessionDocument, AgentWorkflows, CreateTaskInput, IssueType, PullRequestRecord, QaVerdict,
-    QaWorkflowVerdict, TaskCard, TaskDocumentSummary, TaskStatus, TaskStore, UpdateTaskPatch,
-    ODT_QA_APPROVED_SOURCE_TOOL, ODT_QA_REJECTED_SOURCE_TOOL, ODT_SET_PLAN_SOURCE_TOOL,
-    ODT_SET_SPEC_SOURCE_TOOL,
+    AgentSessionDocument, AgentWorkflows, CreateTaskInput, DirectMergeRecord, GitMergeMethod,
+    GitTargetBranch, IssueType, PullRequestRecord, QaVerdict, QaWorkflowVerdict, TaskCard,
+    TaskDocumentSummary, TaskStatus, TaskStore, UpdateTaskPatch, ODT_QA_APPROVED_SOURCE_TOOL,
+    ODT_QA_REJECTED_SOURCE_TOOL, ODT_SET_PLAN_SOURCE_TOOL, ODT_SET_SPEC_SOURCE_TOOL,
 };
 use host_infra_system::{
     compute_beads_database_name, read_shared_dolt_server_state, resolve_repo_beads_attachment_dir,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_sessions.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_sessions.rs
@@ -1,5 +1,313 @@
 use super::*;
 
+fn make_pull_request_record() -> PullRequestRecord {
+    PullRequestRecord {
+        provider_id: "github".to_string(),
+        number: 42,
+        url: "https://github.com/example/repo/pull/42".to_string(),
+        state: "open".to_string(),
+        created_at: "2026-02-20T11:00:00Z".to_string(),
+        updated_at: "2026-02-20T12:00:00Z".to_string(),
+        last_synced_at: None,
+        merged_at: None,
+        closed_at: None,
+    }
+}
+
+fn make_direct_merge_record() -> DirectMergeRecord {
+    DirectMergeRecord {
+        method: GitMergeMethod::Squash,
+        source_branch: "feature/x".to_string(),
+        target_branch: GitTargetBranch {
+            remote: Some("origin".to_string()),
+            branch: "main".to_string(),
+        },
+        merged_at: "2026-02-20T13:00:00Z".to_string(),
+    }
+}
+
+fn make_pull_request_sync_candidate_task(task_id: &str) -> TaskCard {
+    TaskCard {
+        id: task_id.to_string(),
+        title: format!("Task {task_id}"),
+        description: String::new(),
+        notes: String::new(),
+        status: TaskStatus::Open,
+        priority: 2,
+        issue_type: IssueType::Task,
+        ai_review_enabled: true,
+        available_actions: Vec::new(),
+        labels: Vec::new(),
+        assignee: None,
+        parent_id: None,
+        subtask_ids: Vec::new(),
+        agent_sessions: Vec::new(),
+        target_branch: None,
+        target_branch_error: None,
+        pull_request: Some(make_pull_request_record()),
+        document_summary: TaskDocumentSummary::default(),
+        agent_workflows: AgentWorkflows::default(),
+        updated_at: "2026-02-20T12:00:00Z".to_string(),
+        created_at: "2026-02-20T11:00:00Z".to_string(),
+    }
+}
+
+fn seed_pull_request_sync_candidate_cache(
+    store: &BeadsTaskStore,
+    repo: &RepoFixture,
+) -> Result<u64> {
+    let generation = store.pull_request_sync_candidate_cache_generation_for_repo(repo.path())?;
+    store.cache_pull_request_sync_candidates_for_repo_if_generation(
+        repo.path(),
+        "openducktor",
+        generation,
+        &[make_pull_request_sync_candidate_task("task-1")],
+    )?;
+    Ok(generation)
+}
+
+#[test]
+fn set_pull_request_writes_key_and_removes_legacy_delivery() -> Result<()> {
+    let repo = RepoFixture::new("set-pull-request-some");
+    let current = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {"delivery": {"linkedPullRequest": {"number": 1}}}})),
+    );
+    let refreshed = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "pullRequest": make_pull_request_record(),
+                "directMerge": make_direct_merge_record()
+            }
+        })),
+    );
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([current]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(json!([refreshed]).to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+    let generation = seed_pull_request_sync_candidate_cache(&store, &repo)?;
+
+    store.set_pull_request(repo.path(), "task-1", Some(make_pull_request_record()))?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 3);
+    let metadata_root = metadata_from_call(&calls[1]);
+    assert_eq!(metadata_root["openducktor"]["pullRequest"]["number"], 42);
+    assert!(metadata_root["openducktor"].get("delivery").is_none());
+    let refreshed_generation =
+        store.pull_request_sync_candidate_cache_generation_for_repo(repo.path())?;
+    assert!(refreshed_generation > generation);
+    Ok(())
+}
+
+#[test]
+fn set_pull_request_none_removes_key_and_legacy_delivery() -> Result<()> {
+    let repo = RepoFixture::new("set-pull-request-none");
+    let current = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "pullRequest": make_pull_request_record(),
+                "delivery": {"linkedPullRequest": {"number": 1}}
+            }
+        })),
+    );
+    let refreshed = issue_value("task-1", "open", "task", None, json!([]), None);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([current]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(json!([refreshed]).to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+    let generation = seed_pull_request_sync_candidate_cache(&store, &repo)?;
+
+    store.set_pull_request(repo.path(), "task-1", None)?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 3);
+    let metadata_root = metadata_from_call(&calls[1]);
+    assert!(metadata_root["openducktor"].get("pullRequest").is_none());
+    assert!(metadata_root["openducktor"].get("delivery").is_none());
+    let refreshed_generation =
+        store.pull_request_sync_candidate_cache_generation_for_repo(repo.path())?;
+    assert!(refreshed_generation > generation);
+    Ok(())
+}
+
+#[test]
+fn set_delivery_metadata_writes_both_keys_and_removes_legacy_delivery() -> Result<()> {
+    let repo = RepoFixture::new("set-delivery-metadata-some");
+    let current = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {"delivery": {"directMerge": {"sourceBranch": "old"}}}})),
+    );
+    let refreshed = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {"pullRequest": make_pull_request_record()}})),
+    );
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([current]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(json!([refreshed]).to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+    let generation = seed_pull_request_sync_candidate_cache(&store, &repo)?;
+
+    store.set_delivery_metadata(
+        repo.path(),
+        "task-1",
+        Some(make_pull_request_record()),
+        Some(make_direct_merge_record()),
+    )?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 3);
+    let metadata_root = metadata_from_call(&calls[1]);
+    assert_eq!(metadata_root["openducktor"]["pullRequest"]["number"], 42);
+    assert_eq!(
+        metadata_root["openducktor"]["directMerge"]["sourceBranch"],
+        "feature/x"
+    );
+    assert!(metadata_root["openducktor"].get("delivery").is_none());
+    let refreshed_generation =
+        store.pull_request_sync_candidate_cache_generation_for_repo(repo.path())?;
+    assert!(refreshed_generation > generation);
+    Ok(())
+}
+
+#[test]
+fn set_delivery_metadata_none_removes_both_keys_and_legacy_delivery() -> Result<()> {
+    let repo = RepoFixture::new("set-delivery-metadata-none");
+    let current = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "pullRequest": make_pull_request_record(),
+                "directMerge": make_direct_merge_record(),
+                "delivery": {"directMerge": {"sourceBranch": "old"}}
+            }
+        })),
+    );
+    let refreshed = issue_value("task-1", "open", "task", None, json!([]), None);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([current]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(json!([refreshed]).to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+    let generation = seed_pull_request_sync_candidate_cache(&store, &repo)?;
+
+    store.set_delivery_metadata(repo.path(), "task-1", None, None)?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 3);
+    let metadata_root = metadata_from_call(&calls[1]);
+    assert!(metadata_root["openducktor"].get("pullRequest").is_none());
+    assert!(metadata_root["openducktor"].get("directMerge").is_none());
+    assert!(metadata_root["openducktor"].get("delivery").is_none());
+    let refreshed_generation =
+        store.pull_request_sync_candidate_cache_generation_for_repo(repo.path())?;
+    assert!(refreshed_generation > generation);
+    Ok(())
+}
+
+#[test]
+fn set_direct_merge_record_writes_key_and_removes_legacy_delivery_without_refresh() -> Result<()> {
+    let repo = RepoFixture::new("set-direct-merge-some");
+    let current = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {"delivery": {"directMerge": {"sourceBranch": "old"}}}})),
+    );
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([current]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+    let generation = seed_pull_request_sync_candidate_cache(&store, &repo)?;
+
+    store.set_direct_merge_record(repo.path(), "task-1", Some(make_direct_merge_record()))?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 2);
+    let metadata_root = metadata_from_call(&calls[1]);
+    assert_eq!(
+        metadata_root["openducktor"]["directMerge"]["sourceBranch"],
+        "feature/x"
+    );
+    assert!(metadata_root["openducktor"].get("delivery").is_none());
+    let refreshed_generation =
+        store.pull_request_sync_candidate_cache_generation_for_repo(repo.path())?;
+    assert_eq!(refreshed_generation, generation);
+    Ok(())
+}
+
+#[test]
+fn set_direct_merge_record_none_removes_key_and_legacy_delivery_without_refresh() -> Result<()> {
+    let repo = RepoFixture::new("set-direct-merge-none");
+    let current = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "directMerge": make_direct_merge_record(),
+                "delivery": {"directMerge": {"sourceBranch": "old"}}
+            }
+        })),
+    );
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([current]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+    let generation = seed_pull_request_sync_candidate_cache(&store, &repo)?;
+
+    store.set_direct_merge_record(repo.path(), "task-1", None)?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 2);
+    let metadata_root = metadata_from_call(&calls[1]);
+    assert!(metadata_root["openducktor"].get("directMerge").is_none());
+    assert!(metadata_root["openducktor"].get("delivery").is_none());
+    let refreshed_generation =
+        store.pull_request_sync_candidate_cache_generation_for_repo(repo.path())?;
+    assert_eq!(refreshed_generation, generation);
+    Ok(())
+}
+
 #[test]
 fn list_tasks_parses_agent_sessions_for_multiple_tasks_in_single_list_call() -> Result<()> {
     let repo = RepoFixture::new("list-task-sessions");
@@ -239,6 +547,39 @@ fn get_task_metadata_fetches_all_fields_in_single_call() -> Result<()> {
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].program, "bd");
     assert!(calls[0].args.contains(&"show".to_string()));
+    Ok(())
+}
+
+#[test]
+fn get_task_metadata_ignores_malformed_delivery_records() -> Result<()> {
+    let repo = RepoFixture::new("get-task-metadata-malformed-delivery-records");
+    let issue = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "pullRequest": {"providerId": "github", "number": "not-a-number"},
+                "directMerge": {"method": "not-a-merge-method"},
+                "delivery": {
+                    "linkedPullRequest": {"providerId": "github", "number": "also-invalid"},
+                    "directMerge": {"method": "also-invalid"}
+                }
+            }
+        })),
+    );
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([issue]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let metadata = store.get_task_metadata(repo.path(), "task-1")?;
+    assert!(metadata.pull_request.is_none());
+    assert!(metadata.direct_merge.is_none());
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Unifies Beads delivery metadata parsing and namespace write behavior for pull-request and direct-merge records.
- Centralizes legacy `delivery` cleanup, namespace persistence, and PR sync cache refresh policy in one internal write path.
- Adds focused persistence coverage for stored payload shape, cleanup, refresh/no-refresh behavior, and malformed metadata parsing.

## Goal
This PR reduces duplication in `host-infra-beads` delivery metadata persistence. The previous code had duplicate parse wrappers and three setter implementations that repeated the same durable-write shape: load metadata namespace, set or remove delivery keys, remove legacy `delivery`, persist the namespace, and optionally refresh the pull-request sync cache.

That duplication made future changes easy to apply inconsistently across `pullRequest` and `directMerge` paths, especially around legacy metadata cleanup and cache refresh behavior.

## Technical choices
- Replaced the identical pull-request/direct-merge parse wrappers with a generic `parse_record<T: DeserializeOwned>` helper while preserving parse-failure-to-`None` behavior.
- Added `set_namespace_value<T: Serialize>` to keep insert/remove JSON serialization behavior consistent by metadata key.
- Introduced `update_delivery_namespace` as the single durable-write path for delivery metadata updates. It owns load, mutation, legacy `delivery` removal, persistence, and optional PR sync cache refresh ordering.
- Used a private `PullRequestSyncRefresh::{Refresh, Skip}` enum instead of a boolean flag so each setter states its cache refresh policy explicitly.
- Kept public store/trait APIs unchanged and preserved the existing behavior where pull-request-related setters refresh the sync candidate cache while direct-merge-only updates do not.

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo build --workspace`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of session and task delivery metadata persistence with streamlined namespace management and consolidated setter logic.

* **Tests**
  * Added comprehensive test coverage for metadata persistence and update behavior, including validation of malformed record handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->