### PR TITLE
fix: portal composer file chip tooltip to document.body to escape CSS containment

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
@@ -1,5 +1,6 @@
 import type { AgentFileSearchResult, AgentSlashCommand } from "@openducktor/core";
 import { type ReactElement, useLayoutEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { badgeVariants } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import {
@@ -325,30 +326,33 @@ export function AgentChatComposerEditor({
 
   return (
     <div className="relative">
-      {composerFileReferenceTooltip ? (
-        <div
-          className={cn(
-            "pointer-events-none fixed z-50 max-w-80 rounded-md bg-foreground px-3 py-1.5 text-xs text-background text-balance shadow-sm",
-            composerFileReferenceTooltip.side === "top"
-              ? "-translate-x-1/2 -translate-y-full"
-              : "-translate-x-1/2",
-          )}
-          style={{
-            left: `${composerFileReferenceTooltip.left}px`,
-            top: `${composerFileReferenceTooltip.top}px`,
-          }}
-        >
-          <div>{composerFileReferenceTooltip.path}</div>
-          <div
-            className={cn(
-              "absolute left-1/2 size-2.5 -translate-x-1/2 rotate-45 bg-foreground",
-              composerFileReferenceTooltip.side === "top"
-                ? "bottom-0 translate-y-1/2"
-                : "top-0 -translate-y-1/2",
-            )}
-          />
-        </div>
-      ) : null}
+      {composerFileReferenceTooltip
+        ? createPortal(
+            <div
+              className={cn(
+                "pointer-events-none fixed z-50 max-w-80 rounded-md bg-foreground px-3 py-1.5 text-xs text-background text-balance shadow-sm",
+                composerFileReferenceTooltip.side === "top"
+                  ? "-translate-x-1/2 -translate-y-full"
+                  : "-translate-x-1/2",
+              )}
+              style={{
+                left: `${composerFileReferenceTooltip.left}px`,
+                top: `${composerFileReferenceTooltip.top}px`,
+              }}
+            >
+              <div>{composerFileReferenceTooltip.path}</div>
+              <div
+                className={cn(
+                  "absolute left-1/2 size-2.5 -translate-x-1/2 rotate-45 bg-foreground",
+                  composerFileReferenceTooltip.side === "top"
+                    ? "bottom-0 translate-y-1/2"
+                    : "top-0 -translate-y-1/2",
+                )}
+              />
+            </div>,
+            document.body,
+          )
+        : null}
       {showFileMenu ? (
         <AgentChatComposerFileMenu
           results={fileSearchResults}


### PR DESCRIPTION
## Summary

Fixes incorrect tooltip placement on file reference chips in the chat composer.

## The Bug

When hovering a file reference chip (e.g., `@path/to/file.ts`) in the chat composer, a tooltip with the full file path was supposed to appear directly above the chip. Instead, it appeared offset — shifted away from the chip.

## Root Cause

The resizable panel wrapper in `agents-page-layout.tsx` applies `contain: layout paint` as a CSS optimization (`PANEL_CONTAINMENT_STYLE`). Per the CSS Containment Module Level 2 spec, `contain: layout` creates a new CSS containing block for `position: fixed` descendants.

The tooltip uses `position: fixed` with viewport-relative coordinates from `getBoundingClientRect()`. Because of the containment on the ancestor panel, `position: fixed` was resolved relative to the panel wrapper instead of the viewport, shifting the tooltip away from the chip.

**Parent DOM chain:**
```
AgentsPageWorkspace → ResizablePanel → div[contain:layout paint] → AgentChat → composer → tooltip
```

## Fix

Portal the tooltip to `document.body` via React's `createPortal()`. This escapes the CSS containment context. The position calculation remains unchanged — the viewport coordinates from `getBoundingClientRect()` are correct when rendered at the document root level.

**Changes in `agent-chat-composer-editor.tsx`:**
- Added `import { createPortal } from "react-dom"`
- Wrapped tooltip JSX in `createPortal(..., document.body)` instead of inline rendering

**Why this approach:**
- Surgical: only the tooltip rendering path changes; no panel layout modification
- Standard: portal-to-body is the canonical React pattern for overlays that must escape overflow/containment
- Safe: React cleans up portal DOM nodes on unmount automatically

## Verification

All checks green:

| Check | Status |
|-------|--------|
| Bun tests (7 workspaces) | 0 failures |
| Bun typecheck (8 workspaces) | 0 errors |
| Bun lint (all workspaces) | 0 fixes |
| Rust tests (197 tests) | 0 failures |
| Rust clippy | 0 issues |
| Rust fmt | clean |