### PR TITLE
refactor(frontend): consolidate task workflow dispatch

### DIFF
--- a/packages/frontend/src/components/features/task-details/task-details-sheet-model.test.ts
+++ b/packages/frontend/src/components/features/task-details/task-details-sheet-model.test.ts
@@ -38,6 +38,23 @@ const makeTask = (id: string, overrides: Partial<TaskCard> = {}): TaskCard => ({
   ...overrides,
 });
 
+type WorkflowCallbacks = Parameters<typeof runTaskWorkflowAction>[2];
+
+const makeWorkflowCallbacks = (overrides: Partial<WorkflowCallbacks> = {}): WorkflowCallbacks => ({
+  onPlan: undefined,
+  onQaStart: undefined,
+  onQaOpen: undefined,
+  onBuild: undefined,
+  onOpenSession: undefined,
+  onDelegate: undefined,
+  onDefer: undefined,
+  onResumeDeferred: undefined,
+  onHumanApprove: undefined,
+  onHumanRequestChanges: undefined,
+  onResetImplementation: undefined,
+  ...overrides,
+});
+
 describe("task-details-sheet-model", () => {
   test("derives subtasks only for existing ids", () => {
     const subtask = makeTask("T-2");
@@ -208,6 +225,26 @@ describe("task-details-sheet-model", () => {
     expect(shouldLoadDocumentSection(true)).toBe(true);
     expect(shouldLoadDocumentSection(false)).toBe(false);
     expect(shouldLoadDocumentSection(undefined)).toBe(false);
+  });
+
+  test("falls back to opening QA when no shared session opener exists", () => {
+    const onQaOpen = mock(() => {});
+    const onBuild = mock(() => {});
+
+    runTaskWorkflowAction("open_qa", "T-1", makeWorkflowCallbacks({ onQaOpen, onBuild }));
+
+    expect(onQaOpen).toHaveBeenCalledWith("T-1");
+    expect(onBuild).not.toHaveBeenCalled();
+  });
+
+  test("falls back to starting builder when no shared session opener exists", () => {
+    const onQaOpen = mock(() => {});
+    const onBuild = mock(() => {});
+
+    runTaskWorkflowAction("open_builder", "T-1", makeWorkflowCallbacks({ onQaOpen, onBuild }));
+
+    expect(onBuild).toHaveBeenCalledWith("T-1");
+    expect(onQaOpen).not.toHaveBeenCalled();
   });
 
   test("forwards role-specific session options to onOpenSession", () => {

--- a/packages/frontend/src/components/features/task-details/task-details-sheet-model.ts
+++ b/packages/frontend/src/components/features/task-details/task-details-sheet-model.ts
@@ -48,7 +48,7 @@ const roleSessionActions: Record<OpenSessionWorkflowAction, RoleSessionActionCon
     role: "build",
     fallback: (callbacks, taskId) => callbacks.onBuild?.(taskId),
   },
-} satisfies Record<OpenSessionWorkflowAction, RoleSessionActionConfig>;
+};
 
 const openRoleSession = (
   action: OpenSessionWorkflowAction,

--- a/packages/frontend/src/components/features/task-details/task-details-sheet-model.ts
+++ b/packages/frontend/src/components/features/task-details/task-details-sheet-model.ts
@@ -27,6 +27,49 @@ type TaskWorkflowActionContext = {
     | undefined;
 };
 
+type OpenSessionWorkflowAction = Extract<
+  TaskWorkflowAction,
+  "open_spec" | "open_planner" | "open_qa" | "open_builder"
+>;
+
+type RoleSessionActionConfig = {
+  role: AgentRole;
+  fallback?: (callbacks: TaskWorkflowCallbacks, taskId: string) => void;
+};
+
+const roleSessionActions: Record<OpenSessionWorkflowAction, RoleSessionActionConfig> = {
+  open_spec: { role: "spec" },
+  open_planner: { role: "planner" },
+  open_qa: {
+    role: "qa",
+    fallback: (callbacks, taskId) => callbacks.onQaOpen?.(taskId),
+  },
+  open_builder: {
+    role: "build",
+    fallback: (callbacks, taskId) => callbacks.onBuild?.(taskId),
+  },
+} satisfies Record<OpenSessionWorkflowAction, RoleSessionActionConfig>;
+
+const openRoleSession = (
+  action: OpenSessionWorkflowAction,
+  taskId: string,
+  callbacks: TaskWorkflowCallbacks,
+  context: TaskWorkflowActionContext | undefined,
+): void => {
+  const actionConfig = roleSessionActions[action];
+
+  if (callbacks.onOpenSession) {
+    callbacks.onOpenSession(
+      taskId,
+      actionConfig.role,
+      context?.resolveSessionOptions?.(actionConfig.role),
+    );
+    return;
+  }
+
+  actionConfig.fallback?.(callbacks, taskId);
+};
+
 export const toTaskLabels = toDisplayTaskLabels;
 
 export const toSubtasks = (task: TaskCard | null, taskById: Map<string, TaskCard>): TaskCard[] => {
@@ -95,8 +138,6 @@ export const runTaskWorkflowAction = (
 
   switch (action) {
     case "set_spec":
-      callbacks.onPlan?.(taskId, action);
-      return;
     case "set_plan":
       callbacks.onPlan?.(taskId, action);
       return;
@@ -104,24 +145,10 @@ export const runTaskWorkflowAction = (
       callbacks.onQaStart?.(taskId);
       return;
     case "open_spec":
-      callbacks.onOpenSession?.(taskId, "spec", context?.resolveSessionOptions?.("spec"));
-      return;
     case "open_planner":
-      callbacks.onOpenSession?.(taskId, "planner", context?.resolveSessionOptions?.("planner"));
-      return;
     case "open_qa":
-      if (callbacks.onOpenSession) {
-        callbacks.onOpenSession(taskId, "qa", context?.resolveSessionOptions?.("qa"));
-      } else {
-        callbacks.onQaOpen?.(taskId);
-      }
-      return;
     case "open_builder":
-      if (callbacks.onOpenSession) {
-        callbacks.onOpenSession(taskId, "build", context?.resolveSessionOptions?.("build"));
-      } else {
-        callbacks.onBuild?.(taskId);
-      }
+      openRoleSession(action, taskId, callbacks, context);
       return;
     case "build_start":
       callbacks.onDelegate?.(taskId);


### PR DESCRIPTION
## Summary
- Consolidates duplicated task workflow action dispatch for planning and role-session actions.
- Adds explicit QA/build fallback tests so session-opening behavior stays regression-resistant.
- Keeps the task-details action router behavior-preserving with no UI, backend, or contract changes.

## Goal
This PR simplifies `runTaskWorkflowAction` in the task-details sheet model. The previous router had repeated almost-identical branches for `set_spec`/`set_plan` and for QA/build session opening. Because this function maps UI workflow actions to workflow callbacks, consolidating those patterns makes role/action parity easier to review and lowers the risk of future routing regressions.

## Technical choices
- Kept the existing switch for single-callback workflow actions so the router remains explicit and easy to scan.
- Merged `set_spec` and `set_plan` into one shared branch that still forwards the original action to `onPlan`.
- Added a small typed role-session action map for `open_spec`, `open_planner`, `open_qa`, and `open_builder`, plus one helper that resolves role-specific session options and preserves the existing QA/build fallback callbacks only when `onOpenSession` is absent.
- Added focused tests for the QA and builder fallback paths, while existing tests continue to cover preferred `onOpenSession` behavior and role-specific options.
- Removed redundant map typing in a follow-up cleanup so the helper remains simple and readable.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo build --workspace`

Target branch check: branch is up-to-date with `origin/main`; no rebase was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for session fallback behavior, validating proper fallback routing when primary session options are unavailable.

* **Refactor**
  * Improved internal session management workflow to streamline session-opening operations with enhanced fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->