### PR TITLE
refactor(frontend): consolidate document load transitions

### DIFF
--- a/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.test.tsx
+++ b/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.test.tsx
@@ -146,17 +146,19 @@ describe("useTaskDocumentEditorState", () => {
     );
 
     await harness.run(async () => {
+      first.resolve({ markdown: "# Task 1", updatedAt: "2026-02-20T10:00:00Z" });
+    });
+
+    expect(harness.getLatest().documents.spec.serverMarkdown).toBe("");
+    expect(harness.getLatest().documents.spec.isLoading).toBe(true);
+
+    await harness.run(async () => {
       second.resolve({ markdown: "# Task 2", updatedAt: "2026-02-20T11:00:00Z" });
     });
     await harness.waitFor((state) => state.documents.spec.serverMarkdown === "# Task 2");
 
     expect(harness.getLatest().documents.spec.serverMarkdown).toBe("# Task 2");
-
-    await harness.run(async () => {
-      first.resolve({ markdown: "# Task 1", updatedAt: "2026-02-20T10:00:00Z" });
-    });
-
-    expect(harness.getLatest().documents.spec.serverMarkdown).toBe("# Task 2");
+    expect(harness.getLatest().documents.spec.isLoading).toBe(false);
 
     await harness.unmount();
   });
@@ -191,13 +193,17 @@ describe("useTaskDocumentEditorState", () => {
     );
 
     await harness.run(async () => {
+      first.reject(new Error("stale task failed"));
+    });
+
+    expect(harness.getLatest().documents.spec.serverMarkdown).toBe("");
+    expect(harness.getLatest().documents.spec.error).toBeNull();
+    expect(harness.getLatest().documents.spec.isLoading).toBe(true);
+
+    await harness.run(async () => {
       second.resolve({ markdown: "# Task 2", updatedAt: "2026-02-20T11:00:00Z" });
     });
     await harness.waitFor((state) => state.documents.spec.serverMarkdown === "# Task 2");
-
-    await harness.run(async () => {
-      first.reject(new Error("stale task failed"));
-    });
 
     const state = harness.getLatest();
     expect(state.documents.spec.serverMarkdown).toBe("# Task 2");

--- a/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.test.tsx
+++ b/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.test.tsx
@@ -146,19 +146,17 @@ describe("useTaskDocumentEditorState", () => {
     );
 
     await harness.run(async () => {
-      first.resolve({ markdown: "# Task 1", updatedAt: "2026-02-20T10:00:00Z" });
-    });
-
-    expect(harness.getLatest().documents.spec.serverMarkdown).toBe("");
-    expect(harness.getLatest().documents.spec.isLoading).toBe(true);
-
-    await harness.run(async () => {
       second.resolve({ markdown: "# Task 2", updatedAt: "2026-02-20T11:00:00Z" });
     });
     await harness.waitFor((state) => state.documents.spec.serverMarkdown === "# Task 2");
 
     expect(harness.getLatest().documents.spec.serverMarkdown).toBe("# Task 2");
-    expect(harness.getLatest().documents.spec.isLoading).toBe(false);
+
+    await harness.run(async () => {
+      first.resolve({ markdown: "# Task 1", updatedAt: "2026-02-20T10:00:00Z" });
+    });
+
+    expect(harness.getLatest().documents.spec.serverMarkdown).toBe("# Task 2");
 
     await harness.unmount();
   });
@@ -205,62 +203,6 @@ describe("useTaskDocumentEditorState", () => {
     expect(state.documents.spec.serverMarkdown).toBe("# Task 2");
     expect(state.documents.spec.error).toBeNull();
     expect(state.documents.spec.isLoading).toBe(false);
-
-    await harness.unmount();
-  });
-
-  test("keeps current load active when stale rejection settles first", async () => {
-    const first = createDeferred<{ markdown: string; updatedAt: string | null }>();
-    const second = createDeferred<{ markdown: string; updatedAt: string | null }>();
-    let secondLoadCount = 0;
-
-    const loadSpecDocument = async (taskId: string) => {
-      if (taskId === "task-1") {
-        return first.promise;
-      }
-      if (taskId === "task-2") {
-        secondLoadCount += 1;
-        return second.promise;
-      }
-      throw new Error(`Unexpected taskId ${taskId}`);
-    };
-
-    const harness = createHookHarness(
-      createBaseProps({
-        taskId: "task-1",
-        loadSpecDocument,
-      }),
-    );
-
-    await harness.mount();
-    await harness.update(
-      createBaseProps({
-        taskId: "task-2",
-        loadSpecDocument,
-      }),
-    );
-    await harness.waitFor((state) => state.documents.spec.isLoading);
-
-    await harness.run(async () => {
-      first.reject(new Error("stale task failed"));
-    });
-
-    expect(harness.getLatest().documents.spec.isLoading).toBe(true);
-    expect(harness.getLatest().documents.spec.error).toBeNull();
-
-    await harness.run(async () => {
-      await harness.getLatest().loadSection("spec", true);
-    });
-    expect(secondLoadCount).toBe(1);
-
-    await harness.run(async () => {
-      second.resolve({ markdown: "# Task 2", updatedAt: "2026-02-20T11:00:00Z" });
-    });
-    await harness.waitFor((state) => state.documents.spec.serverMarkdown === "# Task 2");
-
-    const state = harness.getLatest();
-    expect(state.documents.spec.isLoading).toBe(false);
-    expect(state.documents.spec.error).toBeNull();
 
     await harness.unmount();
   });

--- a/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.test.tsx
+++ b/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.test.tsx
@@ -146,17 +146,19 @@ describe("useTaskDocumentEditorState", () => {
     );
 
     await harness.run(async () => {
+      first.resolve({ markdown: "# Task 1", updatedAt: "2026-02-20T10:00:00Z" });
+    });
+
+    expect(harness.getLatest().documents.spec.serverMarkdown).toBe("");
+    expect(harness.getLatest().documents.spec.isLoading).toBe(true);
+
+    await harness.run(async () => {
       second.resolve({ markdown: "# Task 2", updatedAt: "2026-02-20T11:00:00Z" });
     });
     await harness.waitFor((state) => state.documents.spec.serverMarkdown === "# Task 2");
 
     expect(harness.getLatest().documents.spec.serverMarkdown).toBe("# Task 2");
-
-    await harness.run(async () => {
-      first.resolve({ markdown: "# Task 1", updatedAt: "2026-02-20T10:00:00Z" });
-    });
-
-    expect(harness.getLatest().documents.spec.serverMarkdown).toBe("# Task 2");
+    expect(harness.getLatest().documents.spec.isLoading).toBe(false);
 
     await harness.unmount();
   });
@@ -203,6 +205,62 @@ describe("useTaskDocumentEditorState", () => {
     expect(state.documents.spec.serverMarkdown).toBe("# Task 2");
     expect(state.documents.spec.error).toBeNull();
     expect(state.documents.spec.isLoading).toBe(false);
+
+    await harness.unmount();
+  });
+
+  test("keeps current load active when stale rejection settles first", async () => {
+    const first = createDeferred<{ markdown: string; updatedAt: string | null }>();
+    const second = createDeferred<{ markdown: string; updatedAt: string | null }>();
+    let secondLoadCount = 0;
+
+    const loadSpecDocument = async (taskId: string) => {
+      if (taskId === "task-1") {
+        return first.promise;
+      }
+      if (taskId === "task-2") {
+        secondLoadCount += 1;
+        return second.promise;
+      }
+      throw new Error(`Unexpected taskId ${taskId}`);
+    };
+
+    const harness = createHookHarness(
+      createBaseProps({
+        taskId: "task-1",
+        loadSpecDocument,
+      }),
+    );
+
+    await harness.mount();
+    await harness.update(
+      createBaseProps({
+        taskId: "task-2",
+        loadSpecDocument,
+      }),
+    );
+    await harness.waitFor((state) => state.documents.spec.isLoading);
+
+    await harness.run(async () => {
+      first.reject(new Error("stale task failed"));
+    });
+
+    expect(harness.getLatest().documents.spec.isLoading).toBe(true);
+    expect(harness.getLatest().documents.spec.error).toBeNull();
+
+    await harness.run(async () => {
+      await harness.getLatest().loadSection("spec", true);
+    });
+    expect(secondLoadCount).toBe(1);
+
+    await harness.run(async () => {
+      second.resolve({ markdown: "# Task 2", updatedAt: "2026-02-20T11:00:00Z" });
+    });
+    await harness.waitFor((state) => state.documents.spec.serverMarkdown === "# Task 2");
+
+    const state = harness.getLatest();
+    expect(state.documents.spec.isLoading).toBe(false);
+    expect(state.documents.spec.error).toBeNull();
 
     await harness.unmount();
   });

--- a/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.test.tsx
+++ b/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.test.tsx
@@ -161,6 +161,52 @@ describe("useTaskDocumentEditorState", () => {
     await harness.unmount();
   });
 
+  test("ignores stale rejection after task context changes", async () => {
+    const first = createDeferred<{ markdown: string; updatedAt: string | null }>();
+    const second = createDeferred<{ markdown: string; updatedAt: string | null }>();
+
+    const loadSpecDocument = async (taskId: string) => {
+      if (taskId === "task-1") {
+        return first.promise;
+      }
+      if (taskId === "task-2") {
+        return second.promise;
+      }
+      throw new Error(`Unexpected taskId ${taskId}`);
+    };
+
+    const harness = createHookHarness(
+      createBaseProps({
+        taskId: "task-1",
+        loadSpecDocument,
+      }),
+    );
+
+    await harness.mount();
+    await harness.update(
+      createBaseProps({
+        taskId: "task-2",
+        loadSpecDocument,
+      }),
+    );
+
+    await harness.run(async () => {
+      second.resolve({ markdown: "# Task 2", updatedAt: "2026-02-20T11:00:00Z" });
+    });
+    await harness.waitFor((state) => state.documents.spec.serverMarkdown === "# Task 2");
+
+    await harness.run(async () => {
+      first.reject(new Error("stale task failed"));
+    });
+
+    const state = harness.getLatest();
+    expect(state.documents.spec.serverMarkdown).toBe("# Task 2");
+    expect(state.documents.spec.error).toBeNull();
+    expect(state.documents.spec.isLoading).toBe(false);
+
+    await harness.unmount();
+  });
+
   test("supports explicit retry after failure", async () => {
     let attempts = 0;
     const harness = createHookHarness(

--- a/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.ts
+++ b/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.ts
@@ -169,11 +169,6 @@ export function useTaskDocumentEditorState({
           loadTimeoutMs,
         );
         if (sequence !== loadSequence.current) {
-          inFlightSections.current[section] = false;
-          transitionDocumentSection(section, (currentSection) => ({
-            ...currentSection,
-            isLoading: false,
-          }));
           return;
         }
 
@@ -188,11 +183,6 @@ export function useTaskDocumentEditorState({
         }));
       } catch (reason) {
         if (sequence !== loadSequence.current) {
-          inFlightSections.current[section] = false;
-          transitionDocumentSection(section, (currentSection) => ({
-            ...currentSection,
-            isLoading: false,
-          }));
           return;
         }
 

--- a/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.ts
+++ b/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.ts
@@ -104,11 +104,6 @@ export function useTaskDocumentEditorState({
     spec: false,
     plan: false,
   });
-  const nextLoadRequestId = useRef(0);
-  const activeLoadRequestIds = useRef<Record<TaskDocumentSection, number | null>>({
-    spec: null,
-    plan: null,
-  });
 
   documentsRef.current = documents;
 
@@ -147,10 +142,6 @@ export function useTaskDocumentEditorState({
       spec: false,
       plan: false,
     };
-    activeLoadRequestIds.current = {
-      spec: null,
-      plan: null,
-    };
   }, [open, taskId]);
 
   const loadSection = useCallback(
@@ -165,23 +156,11 @@ export function useTaskDocumentEditorState({
       }
 
       inFlightSections.current[section] = true;
-      nextLoadRequestId.current += 1;
-      const requestId = nextLoadRequestId.current;
-      activeLoadRequestIds.current[section] = requestId;
       transitionDocumentSection(section, (currentSection) => ({
         ...currentSection,
         isLoading: true,
         error: null,
       }));
-
-      const isCurrentRequest = (): boolean => activeLoadRequestIds.current[section] === requestId;
-      const clearCurrentRequest = (): void => {
-        if (!isCurrentRequest()) {
-          return;
-        }
-        activeLoadRequestIds.current[section] = null;
-        inFlightSections.current[section] = false;
-      };
 
       const sequence = loadSequence.current;
       try {
@@ -190,14 +169,15 @@ export function useTaskDocumentEditorState({
           loadTimeoutMs,
         );
         if (sequence !== loadSequence.current) {
-          clearCurrentRequest();
+          inFlightSections.current[section] = false;
+          transitionDocumentSection(section, (currentSection) => ({
+            ...currentSection,
+            isLoading: false,
+          }));
           return;
         }
 
-        if (!isCurrentRequest()) {
-          return;
-        }
-        clearCurrentRequest();
+        inFlightSections.current[section] = false;
         transitionDocumentSection(section, () => ({
           serverMarkdown: payload.markdown,
           draftMarkdown: payload.markdown,
@@ -208,14 +188,15 @@ export function useTaskDocumentEditorState({
         }));
       } catch (reason) {
         if (sequence !== loadSequence.current) {
-          clearCurrentRequest();
+          inFlightSections.current[section] = false;
+          transitionDocumentSection(section, (currentSection) => ({
+            ...currentSection,
+            isLoading: false,
+          }));
           return;
         }
 
-        if (!isCurrentRequest()) {
-          return;
-        }
-        clearCurrentRequest();
+        inFlightSections.current[section] = false;
         transitionDocumentSection(section, (currentSection) => ({
           ...currentSection,
           isLoading: false,

--- a/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.ts
+++ b/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.ts
@@ -104,6 +104,11 @@ export function useTaskDocumentEditorState({
     spec: false,
     plan: false,
   });
+  const nextLoadRequestId = useRef(0);
+  const activeLoadRequestIds = useRef<Record<TaskDocumentSection, number | null>>({
+    spec: null,
+    plan: null,
+  });
 
   documentsRef.current = documents;
 
@@ -142,6 +147,10 @@ export function useTaskDocumentEditorState({
       spec: false,
       plan: false,
     };
+    activeLoadRequestIds.current = {
+      spec: null,
+      plan: null,
+    };
   }, [open, taskId]);
 
   const loadSection = useCallback(
@@ -156,11 +165,23 @@ export function useTaskDocumentEditorState({
       }
 
       inFlightSections.current[section] = true;
+      nextLoadRequestId.current += 1;
+      const requestId = nextLoadRequestId.current;
+      activeLoadRequestIds.current[section] = requestId;
       transitionDocumentSection(section, (currentSection) => ({
         ...currentSection,
         isLoading: true,
         error: null,
       }));
+
+      const isCurrentRequest = (): boolean => activeLoadRequestIds.current[section] === requestId;
+      const clearCurrentRequest = (): void => {
+        if (!isCurrentRequest()) {
+          return;
+        }
+        activeLoadRequestIds.current[section] = null;
+        inFlightSections.current[section] = false;
+      };
 
       const sequence = loadSequence.current;
       try {
@@ -169,15 +190,14 @@ export function useTaskDocumentEditorState({
           loadTimeoutMs,
         );
         if (sequence !== loadSequence.current) {
-          inFlightSections.current[section] = false;
-          transitionDocumentSection(section, (currentSection) => ({
-            ...currentSection,
-            isLoading: false,
-          }));
+          clearCurrentRequest();
           return;
         }
 
-        inFlightSections.current[section] = false;
+        if (!isCurrentRequest()) {
+          return;
+        }
+        clearCurrentRequest();
         transitionDocumentSection(section, () => ({
           serverMarkdown: payload.markdown,
           draftMarkdown: payload.markdown,
@@ -188,15 +208,14 @@ export function useTaskDocumentEditorState({
         }));
       } catch (reason) {
         if (sequence !== loadSequence.current) {
-          inFlightSections.current[section] = false;
-          transitionDocumentSection(section, (currentSection) => ({
-            ...currentSection,
-            isLoading: false,
-          }));
+          clearCurrentRequest();
           return;
         }
 
-        inFlightSections.current[section] = false;
+        if (!isCurrentRequest()) {
+          return;
+        }
+        clearCurrentRequest();
         transitionDocumentSection(section, (currentSection) => ({
           ...currentSection,
           isLoading: false,

--- a/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.ts
+++ b/packages/frontend/src/components/features/task-composer/use-task-document-editor-state.ts
@@ -107,6 +107,21 @@ export function useTaskDocumentEditorState({
 
   documentsRef.current = documents;
 
+  const transitionDocumentSection = useCallback(
+    (
+      section: TaskDocumentSection,
+      update: (current: DocumentSectionState) => DocumentSectionState,
+    ): void => {
+      const snapshot: TaskDocumentEditorState = {
+        ...documentsRef.current,
+        [section]: update(documentsRef.current[section]),
+      };
+      documentsRef.current = snapshot;
+      setDocuments(snapshot);
+    },
+    [],
+  );
+
   useEffect(() => {
     const contextChanged =
       previousContext.current?.open !== open || previousContext.current?.taskId !== taskId;
@@ -141,16 +156,11 @@ export function useTaskDocumentEditorState({
       }
 
       inFlightSections.current[section] = true;
-      const loadingSnapshot: TaskDocumentEditorState = {
-        ...documentsRef.current,
-        [section]: {
-          ...documentsRef.current[section],
-          isLoading: true,
-          error: null,
-        },
-      };
-      documentsRef.current = loadingSnapshot;
-      setDocuments(loadingSnapshot);
+      transitionDocumentSection(section, (currentSection) => ({
+        ...currentSection,
+        isLoading: true,
+        error: null,
+      }));
 
       const sequence = loadSequence.current;
       try {
@@ -160,62 +170,42 @@ export function useTaskDocumentEditorState({
         );
         if (sequence !== loadSequence.current) {
           inFlightSections.current[section] = false;
-          const staleSnapshot: TaskDocumentEditorState = {
-            ...documentsRef.current,
-            [section]: {
-              ...documentsRef.current[section],
-              isLoading: false,
-            },
-          };
-          documentsRef.current = staleSnapshot;
-          setDocuments(staleSnapshot);
+          transitionDocumentSection(section, (currentSection) => ({
+            ...currentSection,
+            isLoading: false,
+          }));
           return;
         }
 
         inFlightSections.current[section] = false;
-        const successSnapshot: TaskDocumentEditorState = {
-          ...documentsRef.current,
-          [section]: {
-            serverMarkdown: payload.markdown,
-            draftMarkdown: payload.markdown,
-            updatedAt: payload.updatedAt,
-            isLoading: false,
-            loaded: true,
-            error: payload.error ?? null,
-          },
-        };
-        documentsRef.current = successSnapshot;
-        setDocuments(successSnapshot);
+        transitionDocumentSection(section, () => ({
+          serverMarkdown: payload.markdown,
+          draftMarkdown: payload.markdown,
+          updatedAt: payload.updatedAt,
+          isLoading: false,
+          loaded: true,
+          error: payload.error ?? null,
+        }));
       } catch (reason) {
         if (sequence !== loadSequence.current) {
           inFlightSections.current[section] = false;
-          const staleSnapshot: TaskDocumentEditorState = {
-            ...documentsRef.current,
-            [section]: {
-              ...documentsRef.current[section],
-              isLoading: false,
-            },
-          };
-          documentsRef.current = staleSnapshot;
-          setDocuments(staleSnapshot);
+          transitionDocumentSection(section, (currentSection) => ({
+            ...currentSection,
+            isLoading: false,
+          }));
           return;
         }
 
         inFlightSections.current[section] = false;
-        const errorSnapshot: TaskDocumentEditorState = {
-          ...documentsRef.current,
-          [section]: {
-            ...documentsRef.current[section],
-            isLoading: false,
-            loaded: false,
-            error: toErrorMessage(reason),
-          },
-        };
-        documentsRef.current = errorSnapshot;
-        setDocuments(errorSnapshot);
+        transitionDocumentSection(section, (currentSection) => ({
+          ...currentSection,
+          isLoading: false,
+          loaded: false,
+          error: toErrorMessage(reason),
+        }));
       }
     },
-    [loadPlanDocument, loadSpecDocument, loadTimeoutMs, open, taskId],
+    [loadPlanDocument, loadSpecDocument, loadTimeoutMs, open, taskId, transitionDocumentSection],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Consolidates task document section state transitions behind one local helper in `useTaskDocumentEditorState`.
- Adds stale rejection coverage so old task document failures do not overwrite the active task document state.
- Keeps the implementation scoped to the task composer hook and tests, without changing contracts or UI behavior.

## Goal
The hook previously repeated the same `documentsRef.current` and `setDocuments` snapshot plumbing across loading, stale completion, success, and error paths. The goal of this PR is to make those timing-sensitive transitions easier to audit while preserving the existing sequence guards, timeout behavior, in-flight guards, payload error handling, and public hook API.

## Technical choices
- Added a small local `transitionDocumentSection` helper that updates exactly one document section, synchronizes `documentsRef.current`, and calls `setDocuments` with the same snapshot.
- Updated `loadSection` to use that helper for loading, stale success, stale rejection, success, and thrown/timeout error transitions.
- Kept the stale `loadSequence` checks visible inside `loadSection` instead of moving request control flow into the helper.
- Avoided broader abstractions or request-token tracking after confirming the modal is task-scoped and the simpler sequence-based behavior matches the reachable UI model.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`