### PR TITLE
fix(beads): clear labels from tasks

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -255,20 +255,23 @@ impl BeadsTaskStore {
         task_id: &str,
         labels: Vec<String>,
         args: &mut Vec<String>,
-    ) -> Result<()> {
+    ) -> Result<Option<TaskCard>> {
         let labels = normalize_labels(labels);
         if labels.is_empty() {
             let current_task = self.show_task(repo_path, task_id)?;
+            if current_task.labels.is_empty() {
+                return Ok(Some(current_task));
+            }
             for label in current_task.labels {
                 args.push("--remove-label".to_string());
                 args.push(label);
             }
-            return Ok(());
+            return Ok(None);
         }
 
         args.push("--set-labels".to_string());
         args.push(labels.join(","));
-        Ok(())
+        Ok(None)
     }
 
     pub(super) fn update_task_impl(
@@ -278,6 +281,8 @@ impl BeadsTaskStore {
         patch: UpdateTaskPatch,
     ) -> Result<TaskCard> {
         let mut args = vec!["update".to_string()];
+        let updates_metadata = patch.ai_review_enabled.is_some() || patch.target_branch.is_some();
+        let mut current_task_after_noop_label_update = None;
 
         if let Some(title) = patch.title {
             args.push("--title".to_string());
@@ -320,7 +325,8 @@ impl BeadsTaskStore {
         }
 
         if let Some(labels) = patch.labels {
-            self.append_label_update_args(repo_path, task_id, labels, &mut args)?;
+            current_task_after_noop_label_update =
+                self.append_label_update_args(repo_path, task_id, labels, &mut args)?;
         }
 
         if args.len() > 1 {
@@ -331,7 +337,7 @@ impl BeadsTaskStore {
             self.invalidate_task_list_cache(repo_path)?;
         }
 
-        if patch.ai_review_enabled.is_some() || patch.target_branch.is_some() {
+        if updates_metadata {
             let (mut root, namespace_key, mut namespace_map) =
                 self.load_namespace(repo_path, task_id)?;
             if let Some(ai_review_enabled) = patch.ai_review_enabled {
@@ -344,6 +350,13 @@ impl BeadsTaskStore {
                 );
             }
             self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
+        }
+
+        if let Some(task) = current_task_after_noop_label_update {
+            if args.len() == 1 && !updates_metadata {
+                self.refresh_cached_pull_request_sync_candidate(repo_path, task.clone())?;
+                return Ok(task);
+            }
         }
 
         let task = self.show_task(repo_path, task_id)?;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -298,8 +298,16 @@ impl BeadsTaskStore {
         }
 
         if let Some(labels) = patch.labels {
-            args.push("--set-labels".to_string());
-            args.push(normalize_labels(labels).join(","));
+            let labels = normalize_labels(labels);
+            if labels.is_empty() {
+                for label in self.show_task(repo_path, task_id)?.labels {
+                    args.push("--remove-label".to_string());
+                    args.push(label);
+                }
+            } else {
+                args.push("--set-labels".to_string());
+                args.push(labels.join(","));
+            }
         }
 
         if args.len() > 1 {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -249,6 +249,28 @@ impl BeadsTaskStore {
         Ok(task)
     }
 
+    fn append_label_update_args(
+        &self,
+        repo_path: &Path,
+        task_id: &str,
+        labels: Vec<String>,
+        args: &mut Vec<String>,
+    ) -> Result<()> {
+        let labels = normalize_labels(labels);
+        if labels.is_empty() {
+            let current_task = self.show_task(repo_path, task_id)?;
+            for label in current_task.labels {
+                args.push("--remove-label".to_string());
+                args.push(label);
+            }
+            return Ok(());
+        }
+
+        args.push("--set-labels".to_string());
+        args.push(labels.join(","));
+        Ok(())
+    }
+
     pub(super) fn update_task_impl(
         &self,
         repo_path: &Path,
@@ -298,16 +320,7 @@ impl BeadsTaskStore {
         }
 
         if let Some(labels) = patch.labels {
-            let labels = normalize_labels(labels);
-            if labels.is_empty() {
-                for label in self.show_task(repo_path, task_id)?.labels {
-                    args.push("--remove-label".to_string());
-                    args.push(label);
-                }
-            } else {
-                args.push("--set-labels".to_string());
-                args.push(labels.join(","));
-            }
+            self.append_label_update_args(repo_path, task_id, labels, &mut args)?;
         }
 
         if args.len() > 1 {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_tasks.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_tasks.rs
@@ -959,6 +959,47 @@ fn update_task_removes_existing_labels_when_patch_labels_is_empty() -> Result<()
 }
 
 #[test]
+fn update_task_skips_write_and_second_read_when_empty_labels_are_already_clear() -> Result<()> {
+    let repo = RepoFixture::new("update-task-clear-empty-labels");
+    let mut current = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {}})),
+    );
+    current["labels"] = json!([]);
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([current]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let task = store.update_task(
+        repo.path(),
+        "task-1",
+        UpdateTaskPatch {
+            title: None,
+            description: None,
+            notes: None,
+            status: None,
+            priority: None,
+            issue_type: None,
+            ai_review_enabled: None,
+            labels: Some(Vec::new()),
+            assignee: None,
+            parent_id: None,
+            target_branch: None,
+        },
+    )?;
+
+    assert!(task.labels.is_empty());
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].args[0], "show");
+    Ok(())
+}
+
+#[test]
 fn update_task_can_update_only_ai_review_metadata() -> Result<()> {
     let repo = RepoFixture::new("update-task-metadata");
     let current = issue_value(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_tasks.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests/persistence_tasks.rs
@@ -896,6 +896,69 @@ fn update_task_updates_cli_fields_and_qa_metadata() -> Result<()> {
 }
 
 #[test]
+fn update_task_removes_existing_labels_when_patch_labels_is_empty() -> Result<()> {
+    let repo = RepoFixture::new("update-task-clear-labels");
+    let mut current = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({"openducktor": {}})),
+    );
+    current["labels"] = json!(["backend", "api"]);
+    let mut updated = current.clone();
+    updated["labels"] = json!([]);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([current]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(json!([updated]).to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let task = store.update_task(
+        repo.path(),
+        "task-1",
+        UpdateTaskPatch {
+            title: None,
+            description: None,
+            notes: None,
+            status: None,
+            priority: None,
+            issue_type: None,
+            ai_review_enabled: None,
+            labels: Some(Vec::new()),
+            assignee: None,
+            parent_id: None,
+            target_branch: None,
+        },
+    )?;
+
+    assert!(task.labels.is_empty());
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].args[0], "show");
+    assert_eq!(
+        calls[1].args,
+        vec![
+            "update",
+            "--remove-label",
+            "api",
+            "--remove-label",
+            "backend",
+            "--json",
+            "--",
+            "task-1"
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>()
+    );
+    assert_eq!(calls[2].args[0], "show");
+    Ok(())
+}
+
+#[test]
 fn update_task_can_update_only_ai_review_metadata() -> Result<()> {
     let repo = RepoFixture::new("update-task-metadata");
     let current = issue_value(


### PR DESCRIPTION
## Summary
- Fixes task updates so removing all labels actually clears existing Beads labels.
- Adds regression coverage for empty label patches in the Beads task store.
- Refactors label CLI argument construction into a focused helper for readability.

## Goal
This PR fixes a bug where editing a task to remove every label kept the previous labels instead. The UI and host contracts already represented an explicit empty label patch as `labels: []`, but the Beads adapter translated that to `bd update --set-labels ""`. Beads ignores that empty replacement value, so the persisted task labels were unchanged.

## Technical choices
The fix stays at the Beads adapter boundary, where OpenDucktor task patches are translated into `bd` CLI arguments. Non-empty label updates still use `--set-labels` with the normalized comma-separated label list. Empty label updates now load the current task and emit one `--remove-label` argument per existing label, which uses Beads' supported clearing path rather than relying on an empty `--set-labels` value.

The label argument construction is isolated in `append_label_update_args(...)` so `update_task_impl` remains focused on assembling the broader update command. The regression test verifies that `labels: Some(Vec::new())` first reads current labels, removes each existing label, and returns a task with no labels.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for label clearing functionality in task updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->