### PR TITLE
fix(frontend): quiet background task sync noise

### DIFF
--- a/packages/frontend/src/components/features/task-details/task-document-query-data.ts
+++ b/packages/frontend/src/components/features/task-details/task-document-query-data.ts
@@ -1,0 +1,11 @@
+import type { EnsureQueryDataOptions, QueryClient, QueryKey } from "@tanstack/react-query";
+import type { TaskDocumentPayload } from "@/types/task-documents";
+
+export const ensureTaskDocumentQueryData = <TQueryKey extends QueryKey>(
+  queryClient: QueryClient,
+  options: EnsureQueryDataOptions<TaskDocumentPayload, Error, TaskDocumentPayload, TQueryKey>,
+): Promise<TaskDocumentPayload> =>
+  queryClient.ensureQueryData({
+    ...options,
+    revalidateIfStale: true,
+  });

--- a/packages/frontend/src/components/features/task-details/use-task-documents.test.ts
+++ b/packages/frontend/src/components/features/task-details/use-task-documents.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+import { QueryClient, queryOptions } from "@tanstack/react-query";
+import { resolveLatestDocumentPayload } from "@/state/queries/document-utils";
+import { documentQueryKeys } from "@/state/queries/documents";
 import type { TaskDocumentPayload } from "@/types/task-documents";
+import { ensureTaskDocumentQueryData } from "./task-document-query-data";
 import { resolveLoadedDocumentState } from "./task-document-state";
 import type { TaskDocumentState } from "./use-task-documents";
 
@@ -19,6 +23,27 @@ const createDocumentPayload = (
   updatedAt: null,
   ...overrides,
 });
+
+const waitForCachedPlanMarkdown = async (
+  queryClient: QueryClient,
+  expectedMarkdown: string,
+): Promise<void> => {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 1000) {
+    const document = queryClient.getQueryData<TaskDocumentPayload>(
+      documentQueryKeys.plan("/repo", "task-1"),
+    );
+
+    if (document?.markdown === expectedMarkdown) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Expected cached plan markdown to be ${expectedMarkdown}`);
+};
 
 describe("resolveLoadedDocumentState", () => {
   test("applies the incoming payload when the incoming document has no timestamp", () => {
@@ -144,5 +169,59 @@ describe("resolveLoadedDocumentState", () => {
       error: "Failed to decode openducktor.documents.spec[0]: invalid base64 payload",
       loaded: true,
     });
+  });
+});
+
+describe("useTaskDocuments", () => {
+  test("document query ensure revalidates stale cached documents on demand", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    queryClient.setQueryData(documentQueryKeys.plan("/repo", "task-1"), {
+      markdown: "# Cached plan",
+      updatedAt: "2026-05-07T20:00:00.000Z",
+    });
+
+    const loadPlanDocument = mock(async (): Promise<TaskDocumentPayload> => {
+      return {
+        markdown: "# Fresh plan",
+        updatedAt: "2026-05-07T20:05:00.000Z",
+      };
+    });
+
+    try {
+      await queryClient.invalidateQueries({
+        queryKey: documentQueryKeys.plan("/repo", "task-1"),
+        exact: true,
+        refetchType: "none",
+      });
+      loadPlanDocument.mockClear();
+
+      const options = queryOptions({
+        queryKey: documentQueryKeys.plan("/repo", "task-1"),
+        queryFn: async (): Promise<TaskDocumentPayload> => {
+          const incoming = await loadPlanDocument();
+          const current = queryClient.getQueryData<TaskDocumentPayload>(
+            documentQueryKeys.plan("/repo", "task-1"),
+          );
+          return resolveLatestDocumentPayload(current, incoming);
+        },
+      });
+
+      await ensureTaskDocumentQueryData(queryClient, options);
+      await waitForCachedPlanMarkdown(queryClient, "# Fresh plan");
+
+      expect(loadPlanDocument).toHaveBeenCalledTimes(1);
+      expect(
+        queryClient.getQueryData<TaskDocumentPayload>(documentQueryKeys.plan("/repo", "task-1")),
+      ).toEqual({
+        markdown: "# Fresh plan",
+        updatedAt: "2026-05-07T20:05:00.000Z",
+      });
+    } finally {
+      queryClient.clear();
+    }
   });
 });

--- a/packages/frontend/src/components/features/task-details/use-task-documents.test.ts
+++ b/packages/frontend/src/components/features/task-details/use-task-documents.test.ts
@@ -29,11 +29,13 @@ const waitForCachedPlanMarkdown = async (
   expectedMarkdown: string,
 ): Promise<void> => {
   const startedAt = Date.now();
+  let lastDocument: TaskDocumentPayload | undefined;
 
   while (Date.now() - startedAt < 1000) {
     const document = queryClient.getQueryData<TaskDocumentPayload>(
       documentQueryKeys.plan("/repo", "task-1"),
     );
+    lastDocument = document;
 
     if (document?.markdown === expectedMarkdown) {
       return;
@@ -42,7 +44,8 @@ const waitForCachedPlanMarkdown = async (
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
 
-  throw new Error(`Expected cached plan markdown to be ${expectedMarkdown}`);
+  const actual = lastDocument ? lastDocument.markdown : JSON.stringify(lastDocument);
+  throw new Error(`Expected cached plan markdown to be ${expectedMarkdown}, got ${actual}`);
 };
 
 describe("resolveLoadedDocumentState", () => {
@@ -210,6 +213,8 @@ describe("useTaskDocuments", () => {
         },
       });
 
+      // ensureTaskDocumentQueryData returns cached stale data immediately; its
+      // revalidation runs in the background, so waitForCachedPlanMarkdown waits for it to land.
       await ensureTaskDocumentQueryData(queryClient, options);
       await waitForCachedPlanMarkdown(queryClient, "# Fresh plan");
 

--- a/packages/frontend/src/components/features/task-details/use-task-documents.ts
+++ b/packages/frontend/src/components/features/task-details/use-task-documents.ts
@@ -8,6 +8,7 @@ import {
   TASK_DOCUMENT_STALE_TIME_MS,
 } from "@/state/queries/documents";
 import type { TaskDocumentPayload } from "@/types/task-documents";
+import { ensureTaskDocumentQueryData } from "./task-document-query-data";
 
 export type DocumentSectionKey = "spec" | "plan" | "qa";
 
@@ -203,7 +204,9 @@ export function useTaskDocuments(
         return false;
       }
 
-      void queryClient.ensureQueryData(queryOptionsBySection[section]).catch(() => undefined);
+      void ensureTaskDocumentQueryData(queryClient, queryOptionsBySection[section]).catch(
+        () => undefined,
+      );
       return true;
     },
     [enabled, queryClient, queryOptionsBySection],

--- a/packages/frontend/src/state/app-state-contexts.ts
+++ b/packages/frontend/src/state/app-state-contexts.ts
@@ -85,11 +85,16 @@ export type TaskRefreshOptions = {
   trigger?: "manual" | "scheduled";
 };
 
+export type TaskDataRefreshOptions = {
+  forceFreshTaskList?: boolean;
+  source?: "external-sync";
+};
+
 export type TaskControlContextValue = {
   refreshTaskData: (
     repoPath: string,
     taskIdOrIds?: string | string[],
-    options?: { forceFreshTaskList?: boolean },
+    options?: TaskDataRefreshOptions,
   ) => Promise<void>;
   refreshTasksWithOptions: (options?: TaskRefreshOptions) => Promise<void>;
   clearTaskData: () => void;

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -828,6 +828,75 @@ describe("useAppLifecycle", () => {
     }
   });
 
+  test("resets external task sync failure dedupe when the active repo changes", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const refreshTaskData = mock(async () => {
+      throw new Error("sync failed");
+    });
+
+    const baseArgs = {
+      activeRepo: "/repo-a",
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => {}),
+      refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+      refreshBeadsCheckForRepo: mock(async () =>
+        makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+      ),
+      refreshTaskData,
+      clearBranchData: mock(() => {}),
+    } satisfies HookArgs;
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+    await harness.mount();
+    try {
+      if (!subscribedTaskListener) {
+        throw new Error("Expected task event listener to be registered");
+      }
+
+      await harness.run(async () => {
+        subscribedTaskListener?.({
+          eventId: "event-5",
+          kind: "tasks_updated",
+          repoPath: "/repo-a",
+          taskIds: ["task-1"],
+          emittedAt: "2026-04-10T13:10:00.000Z",
+        });
+        await Promise.resolve();
+      });
+      expect(
+        toastError.mock.calls.filter(([title]) => title === "Failed to sync task updates"),
+      ).toHaveLength(1);
+
+      await harness.update({ args: { ...baseArgs, activeRepo: "/repo-b" } });
+      await harness.update({ args: baseArgs });
+
+      await harness.run(async () => {
+        subscribedTaskListener?.({
+          eventId: "event-6",
+          kind: "tasks_updated",
+          repoPath: "/repo-a",
+          taskIds: ["task-1"],
+          emittedAt: "2026-04-10T13:10:01.000Z",
+        });
+        await Promise.resolve();
+      });
+
+      expect(
+        toastError.mock.calls.filter(([title]) => title === "Failed to sync task updates"),
+      ).toHaveLength(2);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("does not block repo diagnostics load on branch refresh completion", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = LegacyUseAppLifecycleArgs;

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -1224,6 +1224,84 @@ describe("useAppLifecycle", () => {
     }
   });
 
+  test("refreshes Beads diagnostics even when startup task loading is cancelled", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const branchesDeferred = createDeferred<void>();
+    const refreshBeadsCheckForRepo = mock(
+      async (_repoPath: string, force = false): Promise<BeadsCheck> =>
+        force
+          ? makeBeadsCheck({ beadsPath: null })
+          : makeBeadsCheck({
+              beadsOk: false,
+              beadsPath: "/repo/.beads",
+              beadsError: null,
+              repoStoreHealth: {
+                category: "initializing",
+                status: "initializing",
+                isReady: false,
+                detail: "Beads store initialization is in progress.",
+                attachment: {
+                  path: "/repo/.beads",
+                  databaseName: "repo_db",
+                },
+                sharedServer: {
+                  host: "127.0.0.1",
+                  port: 38240,
+                  ownershipState: "owned_by_current_process",
+                },
+              },
+            }),
+    );
+
+    const baseArgs: HookArgs = {
+      activeRepo: null,
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => branchesDeferred.promise),
+      refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+      refreshBeadsCheckForRepo,
+      refreshTaskData: mock(async () => {
+        throw new CancelledError();
+      }),
+      clearBranchData: mock(() => {}),
+      beadsPreparationToastDelayMs: 5,
+    } satisfies HookArgs;
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+
+    try {
+      await harness.mount();
+      await harness.update({
+        args: {
+          ...baseArgs,
+          activeRepo: "/repo",
+        },
+      });
+
+      await harness.run(async () => {
+        branchesDeferred.resolve();
+      });
+
+      expect(refreshBeadsCheckForRepo).toHaveBeenNthCalledWith(1, "/repo", false);
+      expect(refreshBeadsCheckForRepo).toHaveBeenNthCalledWith(2, "/repo", true);
+      expect(toastError).not.toHaveBeenCalledWith(
+        "Repository tasks unavailable",
+        expect.anything(),
+      );
+    } finally {
+      branchesDeferred.resolve();
+      await harness.unmount();
+    }
+  });
+
   test("does not force a second Beads refresh when the first check is already ready", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = LegacyUseAppLifecycleArgs;

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -186,7 +186,9 @@ describe("useAppLifecycle", () => {
         });
       });
 
-      expect(refreshTaskData).toHaveBeenCalledWith("/repo", "task-1");
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", "task-1", {
+        source: "external-sync",
+      });
     } finally {
       await harness.unmount();
     }
@@ -336,7 +338,9 @@ describe("useAppLifecycle", () => {
       });
 
       expect(refreshTaskData).toHaveBeenCalledTimes(1);
-      expect(refreshTaskData).toHaveBeenCalledWith("/repo", "task-1");
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", "task-1", {
+        source: "external-sync",
+      });
     } finally {
       await harness.unmount();
     }
@@ -389,7 +393,7 @@ describe("useAppLifecycle", () => {
       });
 
       expect(toastError).toHaveBeenCalledWith("Failed to sync external task changes", {
-        description: "Task store unavailable. sync failed",
+        description: "sync failed",
       });
     } finally {
       await harness.unmount();
@@ -436,7 +440,9 @@ describe("useAppLifecycle", () => {
         await Promise.resolve();
       });
 
-      expect(refreshTaskData).toHaveBeenCalledWith("/repo");
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", undefined, {
+        source: "external-sync",
+      });
       expect(toastError).not.toHaveBeenCalledWith("Task sync stream degraded", expect.anything());
     } finally {
       await harness.unmount();
@@ -487,7 +493,9 @@ describe("useAppLifecycle", () => {
       expect(toastError).toHaveBeenCalledWith("Task sync stream degraded", {
         description: "Task stream skipped 2 events; reconnect will replay buffered events.",
       });
-      expect(refreshTaskData).toHaveBeenCalledWith("/repo");
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", undefined, {
+        source: "external-sync",
+      });
     } finally {
       await harness.unmount();
     }
@@ -640,7 +648,9 @@ describe("useAppLifecycle", () => {
       });
 
       expect(refreshTaskData).toHaveBeenCalledTimes(1);
-      expect(refreshTaskData).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", ["task-1", "task-2"], {
+        source: "external-sync",
+      });
     } finally {
       await harness.unmount();
     }
@@ -696,7 +706,9 @@ describe("useAppLifecycle", () => {
       });
 
       expect(refreshTaskData).toHaveBeenCalledTimes(1);
-      expect(refreshTaskData).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", ["task-1", "task-2"], {
+        source: "external-sync",
+      });
     } finally {
       await harness.unmount();
     }
@@ -749,8 +761,68 @@ describe("useAppLifecycle", () => {
       });
 
       expect(toastError).toHaveBeenCalledWith("Failed to sync task updates", {
-        description: "Task store unavailable. sync failed",
+        description: "sync failed",
       });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("deduplicates repeated batched task update refresh failures", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const refreshTaskData = mock(async () => {
+      throw new Error("sync failed");
+    });
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () =>
+          makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+        ),
+        refreshTaskData,
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+    await harness.mount();
+    try {
+      if (!subscribedTaskListener) {
+        throw new Error("Expected task event listener to be registered");
+      }
+
+      await harness.run(async () => {
+        subscribedTaskListener?.({
+          eventId: "event-3",
+          kind: "tasks_updated",
+          repoPath: "/repo",
+          taskIds: ["task-1"],
+          emittedAt: "2026-04-10T13:10:00.000Z",
+        });
+        subscribedTaskListener?.({
+          eventId: "event-4",
+          kind: "tasks_updated",
+          repoPath: "/repo",
+          taskIds: ["task-1"],
+          emittedAt: "2026-04-10T13:10:01.000Z",
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(
+        toastError.mock.calls.filter(([title]) => title === "Failed to sync task updates"),
+      ).toHaveLength(1);
     } finally {
       await harness.unmount();
     }
@@ -1203,7 +1275,7 @@ describe("useAppLifecycle", () => {
       expect(toastLoading).not.toHaveBeenCalled();
       expect(toastDismiss).not.toHaveBeenCalled();
       expect(toastError).toHaveBeenCalledWith("Repository tasks unavailable", {
-        description: "Task store unavailable. init failed",
+        description: "init failed",
       });
     } finally {
       beadsDeferred.resolve(makeBeadsCheck({ beadsPath: null }));
@@ -1268,7 +1340,7 @@ describe("useAppLifecycle", () => {
       expect(toastDismiss).toHaveBeenCalledWith("toast-id");
       expect(toastSuccess).not.toHaveBeenCalled();
       expect(toastError).toHaveBeenCalledWith("Repository tasks unavailable", {
-        description: "Task store unavailable. store failed",
+        description: "store failed",
       });
     } finally {
       beadsDeferred.resolve(makeBeadsCheck({ beadsPath: null }));
@@ -1409,7 +1481,7 @@ describe("useAppLifecycle", () => {
       expect(toastDismiss).toHaveBeenCalledWith("toast-id");
       expect(toastSuccess).not.toHaveBeenCalled();
       expect(toastError).toHaveBeenCalledWith("Repository tasks unavailable", {
-        description: "Task store unavailable. gh auth expired",
+        description: "gh auth expired",
       });
     } finally {
       beadsDeferred.resolve(makeBeadsCheck({ beadsPath: null }));

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createTauriHostClient } from "@openducktor/adapters-tauri-host";
 import type { BeadsCheck } from "@openducktor/contracts";
+import { CancelledError } from "@tanstack/react-query";
 import { act } from "react";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
@@ -892,6 +893,46 @@ describe("useAppLifecycle", () => {
       expect(
         toastError.mock.calls.filter(([title]) => title === "Failed to sync task updates"),
       ).toHaveLength(2);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("does not show repository tasks unavailable when startup task load is cancelled", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const baseArgs = {
+      activeRepo: "/repo",
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => {}),
+      refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+      refreshBeadsCheckForRepo: mock(async () =>
+        makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+      ),
+      refreshTaskData: mock(async () => {
+        throw new CancelledError();
+      }),
+      clearBranchData: mock(() => {}),
+    } satisfies HookArgs;
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+
+    try {
+      await harness.mount();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toastError).not.toHaveBeenCalledWith("Repository tasks unavailable", {
+        description: "CancelledError",
+      });
     } finally {
       await harness.unmount();
     }

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
@@ -9,6 +9,7 @@ import { BROWSER_LIVE_STREAM_WARNING_EVENT_KIND } from "@/lib/browser-live/const
 import { isBrowserLiveControlEvent } from "@/lib/browser-live-control-events";
 import { errorMessage } from "@/lib/errors";
 import { hostBridge } from "@/lib/host-client";
+import type { TaskDataRefreshOptions } from "@/state/app-state-contexts";
 import { getBlockingRepoStoreHealth, summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
 import type { ActiveWorkspace } from "@/types/state-slices";
 
@@ -45,7 +46,7 @@ type UseAppLifecycleArgs = {
   refreshTaskData: (
     repoPath: string,
     taskIdOrIds?: string | string[],
-    options?: { forceFreshTaskList?: boolean },
+    options?: TaskDataRefreshOptions,
   ) => Promise<void>;
   clearBranchData: () => void;
   beadsPreparationToastDelayMs?: number;
@@ -66,6 +67,11 @@ export function useAppLifecycle({
   const refreshTaskDataRef = useRef(refreshTaskData);
   const processedTaskEventIdsRef = useRef(new Set<string>());
   const processedTaskEventOrderRef = useRef<string[]>([]);
+  const lastExternalTaskSyncFailureToastRef = useRef<{
+    repoPath: string;
+    title: string;
+    description: string;
+  } | null>(null);
 
   useLayoutEffect(() => {
     activeWorkspaceRef.current = activeWorkspace;
@@ -103,11 +109,13 @@ export function useAppLifecycle({
             });
           }
 
-          void refreshTaskDataRef.current(activeRepoPath).catch((error: unknown) => {
-            toast.error("Failed to resync tasks after task stream reconnect", {
-              description: summarizeTaskLoadError({ error }),
+          void refreshTaskDataRef
+            .current(activeRepoPath, undefined, { source: "external-sync" })
+            .catch((error: unknown) => {
+              toast.error("Failed to resync tasks after task stream reconnect", {
+                description: summarizeTaskLoadError({ error }),
+              });
             });
-          });
           return;
         }
 
@@ -136,15 +144,35 @@ export function useAppLifecycle({
         const taskIds =
           parsed.data.kind === "tasks_updated" ? parsed.data.taskIds : parsed.data.taskId;
 
-        void refreshTaskDataRef.current(parsed.data.repoPath, taskIds).catch((error: unknown) => {
-          const title =
-            parsed.data.kind === "tasks_updated"
-              ? "Failed to sync task updates"
-              : "Failed to sync external task changes";
-          toast.error(title, {
-            description: summarizeTaskLoadError({ error }),
+        void refreshTaskDataRef
+          .current(parsed.data.repoPath, taskIds, { source: "external-sync" })
+          .then(() => {
+            if (lastExternalTaskSyncFailureToastRef.current?.repoPath === parsed.data.repoPath) {
+              lastExternalTaskSyncFailureToastRef.current = null;
+            }
+          })
+          .catch((error: unknown) => {
+            const title =
+              parsed.data.kind === "tasks_updated"
+                ? "Failed to sync task updates"
+                : "Failed to sync external task changes";
+            const description = summarizeTaskLoadError({ error });
+            const lastToast = lastExternalTaskSyncFailureToastRef.current;
+            if (
+              lastToast?.repoPath === parsed.data.repoPath &&
+              lastToast.title === title &&
+              lastToast.description === description
+            ) {
+              return;
+            }
+
+            lastExternalTaskSyncFailureToastRef.current = {
+              repoPath: parsed.data.repoPath,
+              title,
+              description,
+            };
+            toast.error(title, { description });
           });
-        });
       })
       .then((cleanup) => {
         if (disposed) {

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
@@ -3,6 +3,7 @@ import {
   externalTaskSyncEventSchema,
   type RepoStoreHealth,
 } from "@openducktor/contracts";
+import { isCancelledError } from "@tanstack/react-query";
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { toast } from "sonner";
 import { BROWSER_LIVE_STREAM_WARNING_EVENT_KIND } from "@/lib/browser-live/constants";
@@ -302,7 +303,7 @@ export function useAppLifecycle({
           return;
         }
 
-        if (tasksResult.status === "rejected") {
+        if (tasksResult.status === "rejected" && !isCancelledError(tasksResult.reason)) {
           toast.error("Repository tasks unavailable", {
             description: summarizeTaskLoadError({
               error: tasksResult.reason,

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
@@ -3,7 +3,7 @@ import {
   externalTaskSyncEventSchema,
   type RepoStoreHealth,
 } from "@openducktor/contracts";
-import { isCancelledError } from "@tanstack/react-query";
+import { CancelledError } from "@tanstack/react-query";
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { toast } from "sonner";
 import { BROWSER_LIVE_STREAM_WARNING_EVENT_KIND } from "@/lib/browser-live/constants";
@@ -260,6 +260,8 @@ export function useAppLifecycle({
         let taskLoadFailed = false;
         let taskLoadError: unknown;
         try {
+          // Initial repo load may use warm task data while Beads finishes preparing; manual
+          // refresh and mutation paths remain strict and force fresh task reads.
           await refreshTaskData(activeRepoPath, undefined, { forceFreshTaskList: false });
         } catch (error) {
           taskLoadFailed = true;
@@ -315,7 +317,7 @@ export function useAppLifecycle({
           return;
         }
 
-        if (tasksResult.status === "rejected" && !isCancelledError(tasksResult.reason)) {
+        if (tasksResult.status === "rejected" && !(tasksResult.reason instanceof CancelledError)) {
           toast.error("Repository tasks unavailable", {
             description: summarizeTaskLoadError({
               error: tasksResult.reason,

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
@@ -74,6 +74,11 @@ export function useAppLifecycle({
   } | null>(null);
 
   useLayoutEffect(() => {
+    const previousRepoPath = activeWorkspaceRef.current?.repoPath ?? null;
+    const nextRepoPath = activeWorkspace?.repoPath ?? null;
+    if (previousRepoPath !== nextRepoPath) {
+      lastExternalTaskSyncFailureToastRef.current = null;
+    }
     activeWorkspaceRef.current = activeWorkspace;
     refreshTaskDataRef.current = refreshTaskData;
   }, [activeWorkspace, refreshTaskData]);

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
@@ -257,7 +257,15 @@ export function useAppLifecycle({
           }
         }
 
-        await refreshTaskData(activeRepoPath, undefined, { forceFreshTaskList: false });
+        let taskLoadFailed = false;
+        let taskLoadError: unknown;
+        try {
+          await refreshTaskData(activeRepoPath, undefined, { forceFreshTaskList: false });
+        } catch (error) {
+          taskLoadFailed = true;
+          taskLoadError = error;
+        }
+
         if (!beadsCheck.repoStoreHealth.isReady) {
           try {
             const refreshedBeadsCheck = await refreshBeadsCheckForRepo(activeRepoPath, true);
@@ -265,6 +273,10 @@ export function useAppLifecycle({
           } catch {
             // Preserve the main repo-load outcome if the follow-up diagnostics refresh fails.
           }
+        }
+
+        if (taskLoadFailed) {
+          throw taskLoadError;
         }
 
         if (

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -589,7 +589,7 @@ describe("use-task-operations", () => {
       expect(tasksList).not.toHaveBeenCalled();
       expect(getLatest().tasks[0]?.id).toBe("cached");
       expect(toastError).toHaveBeenCalledWith("Failed to load tasks", {
-        description: "Task store unavailable. settings unavailable",
+        description: "settings unavailable",
       });
     } finally {
       await harness.unmount();
@@ -938,7 +938,7 @@ describe("use-task-operations", () => {
       expect(tasksList).not.toHaveBeenCalled();
       expect(runsList).not.toHaveBeenCalled();
       expect(toastError).toHaveBeenCalledWith("Failed to refresh tasks", {
-        description: "Task store unavailable. gh auth expired",
+        description: "gh auth expired",
       });
     } finally {
       await harness.unmount();
@@ -1128,13 +1128,13 @@ describe("use-task-operations", () => {
 
       expect(toastError).toHaveBeenCalledTimes(1);
       expect(toastError).toHaveBeenCalledWith("Failed to refresh tasks", {
-        description: "Task store unavailable. gh auth expired",
+        description: "gh auth expired",
       });
       expect(consoleWarn).toHaveBeenCalledTimes(1);
       expect(consoleWarn).toHaveBeenCalledWith(TASK_REFRESH_WARNING, {
         repoPath: "/repo",
         trigger: "scheduled",
-        description: "Task store unavailable. gh auth expired",
+        description: "gh auth expired",
         error: "gh auth expired",
       });
     } finally {
@@ -1201,12 +1201,12 @@ describe("use-task-operations", () => {
       });
 
       expect(toastError).toHaveBeenCalledWith("Failed to refresh tasks", {
-        description: "Task store unavailable. gh auth expired",
+        description: "gh auth expired",
       });
       expect(consoleWarn).toHaveBeenCalledWith(TASK_REFRESH_WARNING, {
         repoPath: "/repo",
         trigger: "manual",
-        description: "Task store unavailable. gh auth expired",
+        description: "gh auth expired",
         error: "gh auth expired",
       });
     } finally {
@@ -1419,7 +1419,7 @@ describe("use-task-operations", () => {
 
       expect(toastError).toHaveBeenCalledTimes(1);
       expect(toastError).toHaveBeenCalledWith("Failed to refresh tasks", {
-        description: "Task store unavailable. gh auth expired",
+        description: "gh auth expired",
       });
       expect(consoleWarn).toHaveBeenCalledTimes(2);
 
@@ -1702,6 +1702,71 @@ describe("use-task-operations", () => {
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
+    }
+  });
+
+  test("external refreshTaskData invalidates cached task detail documents without fetching them", async () => {
+    const tasksList = mock(async () => [makeTask("A", "in_progress")]);
+    const taskDocumentGetFresh = mock(async () => {
+      throw new Error("document fetch should not run");
+    });
+
+    const original = {
+      tasksList: host.tasksList,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
+    };
+    host.tasksList = tasksList;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
+
+    const queryClient = createQueryClient();
+    let latest: ReturnType<typeof useTaskOperations> | null = null;
+    const getLatestOperations = () => {
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useTaskOperations(args);
+      return null;
+    };
+
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const harness = createSharedHookHarness(
+      Harness,
+      {
+        args: {
+          activeWorkspace: createActiveWorkspace("/repo"),
+          refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => makeBeadsCheck(),
+        },
+      },
+      { wrapper },
+    );
+
+    try {
+      queryClient.setQueryData(documentQueryKeys.plan("/repo", "A"), {
+        markdown: "# Cached plan",
+        updatedAt: null,
+      });
+      await harness.mount();
+
+      await harness.run(async () => {
+        await getLatestOperations().refreshTaskData("/repo", "A", { source: "external-sync" });
+      });
+
+      expect(taskDocumentGetFresh).not.toHaveBeenCalled();
+      expect(queryClient.getQueryState(documentQueryKeys.plan("/repo", "A"))?.isInvalidated).toBe(
+        true,
+      );
+      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
+    } finally {
+      await harness.unmount();
+      host.tasksList = original.tasksList;
       host.taskDocumentGetFresh = original.taskDocumentGetFresh;
     }
   });

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.ts
@@ -205,6 +205,7 @@ export function useTaskOperations({
         await refreshRepoTaskViewsFromQuery(queryClient, repoPath, {
           forceFreshTaskList: true,
           ancillaryFailureMode: "best-effort",
+          ignorePrimaryCancellation: true,
           refreshInactiveViews: false,
           ...(taskIds
             ? { taskDocumentStrategy: "invalidate", taskIds }

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.ts
@@ -12,7 +12,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import type { TaskRefreshOptions } from "@/state/app-state-contexts";
+import type { TaskDataRefreshOptions, TaskRefreshOptions } from "@/state/app-state-contexts";
 import { documentQueryKeys } from "@/state/queries/documents";
 import { refreshRepoTaskViewsFromQuery } from "@/state/queries/task-view-sync";
 import { getBlockingRepoStoreHealth, summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
@@ -47,7 +47,7 @@ type UseTaskOperationsResult = {
   refreshTaskData: (
     repoPath: string,
     taskIdOrIds?: string | string[],
-    options?: { forceFreshTaskList?: boolean },
+    options?: TaskDataRefreshOptions,
   ) => Promise<void>;
   refreshTasksWithOptions: (options?: TaskRefreshOptions) => Promise<void>;
   refreshTasks: () => Promise<void>;
@@ -193,7 +193,7 @@ export function useTaskOperations({
     async (
       repoPath: string,
       taskIdOrIds?: string | string[],
-      options?: { forceFreshTaskList?: boolean },
+      options?: TaskDataRefreshOptions,
     ): Promise<void> => {
       const taskIds =
         typeof taskIdOrIds === "string"
@@ -201,6 +201,18 @@ export function useTaskOperations({
           : Array.isArray(taskIdOrIds)
             ? taskIdOrIds
             : null;
+      if (options?.source === "external-sync") {
+        await refreshRepoTaskViewsFromQuery(queryClient, repoPath, {
+          forceFreshTaskList: true,
+          ancillaryFailureMode: "best-effort",
+          refreshInactiveViews: false,
+          ...(taskIds
+            ? { taskDocumentStrategy: "invalidate", taskIds }
+            : { taskDocumentStrategy: "none" }),
+        });
+        return;
+      }
+
       await refreshRepoTaskViewsFromQuery(
         queryClient,
         repoPath,

--- a/packages/frontend/src/state/queries/documents.ts
+++ b/packages/frontend/src/state/queries/documents.ts
@@ -152,6 +152,38 @@ export const removeCachedTaskDocumentQueries = (
   }
 };
 
+export const invalidateCachedTaskDocumentQueries = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskIds: string[],
+): Promise<void> => {
+  const taskIdSet = new Set(taskIds);
+  const matchingQueries = queryClient.getQueryCache().findAll({
+    queryKey: documentQueryKeys.all,
+    exact: false,
+  });
+
+  await Promise.all(
+    matchingQueries.map((query) => {
+      const [scope, _section, cachedRepoPath, cachedTaskId] = query.queryKey;
+      if (
+        scope !== documentQueryKeys.all[0] ||
+        cachedRepoPath !== repoPath ||
+        typeof cachedTaskId !== "string" ||
+        !taskIdSet.has(cachedTaskId)
+      ) {
+        return Promise.resolve();
+      }
+
+      return queryClient.invalidateQueries({
+        queryKey: query.queryKey,
+        exact: true,
+        refetchType: "none",
+      });
+    }),
+  );
+};
+
 export const refreshCachedTaskDocumentQueries = async (
   queryClient: QueryClient,
   repoPath: string,

--- a/packages/frontend/src/state/queries/documents.ts
+++ b/packages/frontend/src/state/queries/documents.ts
@@ -158,30 +158,20 @@ export const invalidateCachedTaskDocumentQueries = async (
   taskIds: string[],
 ): Promise<void> => {
   const taskIdSet = new Set(taskIds);
-  const matchingQueries = queryClient.getQueryCache().findAll({
+  await queryClient.invalidateQueries({
     queryKey: documentQueryKeys.all,
     exact: false,
-  });
-
-  await Promise.all(
-    matchingQueries.map((query) => {
+    predicate: (query) => {
       const [scope, _section, cachedRepoPath, cachedTaskId] = query.queryKey;
-      if (
-        scope !== documentQueryKeys.all[0] ||
-        cachedRepoPath !== repoPath ||
-        typeof cachedTaskId !== "string" ||
-        !taskIdSet.has(cachedTaskId)
-      ) {
-        return Promise.resolve();
-      }
-
-      return queryClient.invalidateQueries({
-        queryKey: query.queryKey,
-        exact: true,
-        refetchType: "none",
-      });
-    }),
-  );
+      return (
+        scope === documentQueryKeys.all[0] &&
+        cachedRepoPath === repoPath &&
+        typeof cachedTaskId === "string" &&
+        taskIdSet.has(cachedTaskId)
+      );
+    },
+    refetchType: "none",
+  });
 };
 
 export const refreshCachedTaskDocumentQueries = async (

--- a/packages/frontend/src/state/queries/task-view-sync.ts
+++ b/packages/frontend/src/state/queries/task-view-sync.ts
@@ -17,6 +17,7 @@ import { settingsSnapshotQueryOptions, workspaceQueryKeys } from "./workspace";
 type BaseRepoTaskViewRefreshOptions = {
   forceFreshTaskList?: boolean;
   ancillaryFailureMode?: "reject" | "best-effort";
+  ignorePrimaryCancellation?: boolean;
   refreshInactiveViews?: boolean;
 };
 
@@ -78,6 +79,7 @@ export const refreshRepoTaskViewsFromQuery = async (
         });
   const doneVisibleDays = settings.kanban.doneVisibleDays;
   const ancillaryFailureMode = options?.ancillaryFailureMode ?? "reject";
+  const ignorePrimaryCancellation = options?.ignorePrimaryCancellation ?? false;
   const refreshInactiveViews = options?.refreshInactiveViews ?? true;
 
   if (
@@ -132,7 +134,14 @@ export const refreshRepoTaskViewsFromQuery = async (
     }
   }
   await invalidateRepoTaskQueries(queryClient, repoPath);
-  await loadRepoTaskDataFromQuery(queryClient, repoPath, doneVisibleDays);
+  try {
+    await loadRepoTaskDataFromQuery(queryClient, repoPath, doneVisibleDays);
+  } catch (error) {
+    if (ignorePrimaryCancellation && isCancelledQueryError(error)) {
+      return;
+    }
+    throw error;
+  }
 
   const ancillaryRefreshes: Promise<unknown>[] = [taskDocumentRefresh()];
   if (refreshInactiveViews) {

--- a/packages/frontend/src/state/queries/task-view-sync.ts
+++ b/packages/frontend/src/state/queries/task-view-sync.ts
@@ -1,6 +1,10 @@
 import type { SettingsSnapshot } from "@openducktor/contracts";
 import { isCancelledError, type QueryClient } from "@tanstack/react-query";
-import { refreshCachedTaskDocumentQueries, removeCachedTaskDocumentQueries } from "./documents";
+import {
+  invalidateCachedTaskDocumentQueries,
+  refreshCachedTaskDocumentQueries,
+  removeCachedTaskDocumentQueries,
+} from "./documents";
 import {
   invalidateRepoTaskQueries,
   loadRepoTaskDataFromQuery,
@@ -12,6 +16,8 @@ import { settingsSnapshotQueryOptions, workspaceQueryKeys } from "./workspace";
 
 type BaseRepoTaskViewRefreshOptions = {
   forceFreshTaskList?: boolean;
+  ancillaryFailureMode?: "reject" | "best-effort";
+  refreshInactiveViews?: boolean;
 };
 
 const isCancelledQueryError = (error: unknown): boolean => isCancelledError(error);
@@ -26,10 +32,31 @@ export type RepoTaskViewRefreshOptions = BaseRepoTaskViewRefreshOptions &
         taskIds: string[];
       }
     | {
+        taskDocumentStrategy: "invalidate";
+        taskIds: string[];
+      }
+    | {
         taskDocumentStrategy: "remove";
         taskIds: string[];
       }
   );
+
+const runAncillaryRefresh = async (
+  promises: Promise<unknown>[],
+  mode: "reject" | "best-effort",
+): Promise<void> => {
+  if (mode === "reject") {
+    await Promise.all(promises);
+    return;
+  }
+
+  const results = await Promise.allSettled(promises);
+  for (const settled of results) {
+    if (settled.status === "rejected") {
+      console.warn("Background task cache refresh failed", { error: settled.reason });
+    }
+  }
+};
 
 export const refreshRepoTaskViewsFromQuery = async (
   queryClient: QueryClient,
@@ -50,6 +77,8 @@ export const refreshRepoTaskViewsFromQuery = async (
           staleTime: 0,
         });
   const doneVisibleDays = settings.kanban.doneVisibleDays;
+  const ancillaryFailureMode = options?.ancillaryFailureMode ?? "reject";
+  const refreshInactiveViews = options?.refreshInactiveViews ?? true;
 
   if (
     options?.forceFreshTaskList !== true &&
@@ -67,10 +96,16 @@ export const refreshRepoTaskViewsFromQuery = async (
     return;
   }
 
-  const taskDocumentRefresh =
-    options?.taskDocumentStrategy === "refresh"
-      ? refreshCachedTaskDocumentQueries(queryClient, repoPath, options.taskIds)
-      : Promise.resolve();
+  const taskDocumentRefresh = async (): Promise<void> => {
+    if (options?.taskDocumentStrategy === "refresh") {
+      await refreshCachedTaskDocumentQueries(queryClient, repoPath, options.taskIds);
+      return;
+    }
+
+    if (options?.taskDocumentStrategy === "invalidate") {
+      await invalidateCachedTaskDocumentQueries(queryClient, repoPath, options.taskIds);
+    }
+  };
 
   if (options?.taskDocumentStrategy === "remove") {
     removeCachedTaskDocumentQueries(queryClient, repoPath, options.taskIds);
@@ -79,6 +114,7 @@ export const refreshRepoTaskViewsFromQuery = async (
   if (
     options?.forceFreshTaskList === true ||
     options?.taskDocumentStrategy === "refresh" ||
+    options?.taskDocumentStrategy === "invalidate" ||
     options?.taskDocumentStrategy === "remove"
   ) {
     try {
@@ -96,9 +132,16 @@ export const refreshRepoTaskViewsFromQuery = async (
     }
   }
   await invalidateRepoTaskQueries(queryClient, repoPath);
-  await Promise.all([
-    loadRepoTaskDataFromQuery(queryClient, repoPath, doneVisibleDays),
-    refreshCachedKanbanQueries(queryClient, repoPath, { excludeDoneVisibleDays: doneVisibleDays }),
-    taskDocumentRefresh,
-  ]);
+  await loadRepoTaskDataFromQuery(queryClient, repoPath, doneVisibleDays);
+
+  const ancillaryRefreshes: Promise<unknown>[] = [taskDocumentRefresh()];
+  if (refreshInactiveViews) {
+    ancillaryRefreshes.push(
+      refreshCachedKanbanQueries(queryClient, repoPath, {
+        excludeDoneVisibleDays: doneVisibleDays,
+      }),
+    );
+  }
+
+  await runAncillaryRefresh(ancillaryRefreshes, ancillaryFailureMode);
 };

--- a/packages/frontend/src/state/queries/task-view-sync.ts
+++ b/packages/frontend/src/state/queries/task-view-sync.ts
@@ -138,6 +138,9 @@ export const refreshRepoTaskViewsFromQuery = async (
     await loadRepoTaskDataFromQuery(queryClient, repoPath, doneVisibleDays);
   } catch (error) {
     if (ignorePrimaryCancellation && isCancelledQueryError(error)) {
+      if (options?.taskDocumentStrategy === "invalidate") {
+        await runAncillaryRefresh([taskDocumentRefresh()], ancillaryFailureMode);
+      }
       return;
     }
     throw error;

--- a/packages/frontend/src/state/queries/tasks.test.ts
+++ b/packages/frontend/src/state/queries/tasks.test.ts
@@ -636,6 +636,65 @@ describe("tasks query cache helpers", () => {
     ).toBe("fresh");
   });
 
+  test("cancelled external targeted refresh still invalidates affected task documents", async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), settingsSnapshotFixture);
+    queryClient.setQueryData(documentQueryKeys.spec("/repo", "task-1"), {
+      markdown: "task 1 spec",
+      updatedAt: null,
+    });
+    queryClient.setQueryData(documentQueryKeys.spec("/repo", "task-2"), {
+      markdown: "task 2 spec",
+      updatedAt: null,
+    });
+    const firstRead = createDeferred<TaskCard[]>();
+    const tasksList = mock(async (): Promise<TaskCard[]> => {
+      if (tasksList.mock.calls.length === 1) {
+        return firstRead.promise;
+      }
+      return [{ ...taskFixture, id: "fresh" }];
+    });
+    host.tasksList = tasksList;
+
+    const firstRefresh = refreshRepoTaskViewsFromQuery(queryClient, "/repo", {
+      forceFreshTaskList: true,
+      ancillaryFailureMode: "best-effort",
+      ignorePrimaryCancellation: true,
+      refreshInactiveViews: false,
+      taskDocumentStrategy: "invalidate",
+      taskIds: ["task-1"],
+    });
+    for (let attempts = 0; tasksList.mock.calls.length === 0 && attempts < 10; attempts += 1) {
+      await Promise.resolve();
+    }
+    expect(tasksList).toHaveBeenCalledTimes(1);
+
+    const secondRefresh = refreshRepoTaskViewsFromQuery(queryClient, "/repo", {
+      forceFreshTaskList: true,
+      ancillaryFailureMode: "best-effort",
+      ignorePrimaryCancellation: true,
+      refreshInactiveViews: false,
+      taskDocumentStrategy: "invalidate",
+      taskIds: ["task-2"],
+    });
+
+    await expect(firstRefresh).resolves.toBeUndefined();
+    await expect(secondRefresh).resolves.toBeUndefined();
+    firstRead.resolve([{ ...taskFixture, id: "stale" }]);
+
+    expect(
+      queryClient.getQueryState(documentQueryKeys.spec("/repo", "task-1"))?.isInvalidated,
+    ).toBe(true);
+    expect(
+      queryClient.getQueryState(documentQueryKeys.spec("/repo", "task-2"))?.isInvalidated,
+    ).toBe(true);
+    expect(
+      queryClient.getQueryData<{ tasks: TaskCard[] }>(
+        taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS),
+      )?.tasks[0]?.id,
+    ).toBe("fresh");
+  });
+
   test("external repo task view refresh skips inactive done-visible variants", async () => {
     const queryClient = new QueryClient();
     queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), settingsSnapshotFixture);

--- a/packages/frontend/src/state/queries/tasks.test.ts
+++ b/packages/frontend/src/state/queries/tasks.test.ts
@@ -85,10 +85,12 @@ const sessionFixture: AgentSessionRecord = {
 describe("tasks query cache helpers", () => {
   const originalTasksList = host.tasksList;
   const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
+  const originalTaskDocumentGetFresh = host.taskDocumentGetFresh;
 
   afterEach(() => {
     host.tasksList = originalTasksList;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+    host.taskDocumentGetFresh = originalTaskDocumentGetFresh;
   });
 
   test("upsertAgentSessionInRepoTaskData inserts a persisted session into the repo task cache", () => {
@@ -541,5 +543,83 @@ describe("tasks query cache helpers", () => {
       queryClient.getQueryData<{ tasks: TaskCard[] }>(taskQueryKeys.repoData("/repo", 7))?.tasks[0]
         ?.id,
     ).toBe("fresh-7");
+  });
+
+  test("external repo task view refresh invalidates cached documents without fetching them", async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), settingsSnapshotFixture);
+    queryClient.setQueryData(documentQueryKeys.spec("/repo", "task-1"), {
+      markdown: "cached spec",
+      updatedAt: null,
+    });
+    const tasksList = mock(async (): Promise<TaskCard[]> => [{ ...taskFixture, id: "fresh" }]);
+    const taskDocumentGetFresh = mock(async () => {
+      throw new Error("document fetch should not run");
+    });
+    host.tasksList = tasksList;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
+
+    await refreshRepoTaskViewsFromQuery(queryClient, "/repo", {
+      forceFreshTaskList: true,
+      ancillaryFailureMode: "best-effort",
+      refreshInactiveViews: false,
+      taskDocumentStrategy: "invalidate",
+      taskIds: ["task-1"],
+    });
+
+    expect(tasksList).toHaveBeenCalledTimes(1);
+    expect(tasksList).toHaveBeenCalledWith("/repo", DONE_VISIBLE_DAYS);
+    expect(taskDocumentGetFresh).not.toHaveBeenCalled();
+    expect(
+      queryClient.getQueryState(documentQueryKeys.spec("/repo", "task-1"))?.isInvalidated,
+    ).toBe(true);
+  });
+
+  test("external repo task view refresh rejects when the primary task list fails", async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), settingsSnapshotFixture);
+    host.tasksList = mock(async (): Promise<TaskCard[]> => {
+      throw new Error("current board failed");
+    });
+
+    await expect(
+      refreshRepoTaskViewsFromQuery(queryClient, "/repo", {
+        forceFreshTaskList: true,
+        ancillaryFailureMode: "best-effort",
+        refreshInactiveViews: false,
+        taskDocumentStrategy: "none",
+      }),
+    ).rejects.toThrow("current board failed");
+  });
+
+  test("external repo task view refresh skips inactive done-visible variants", async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), settingsSnapshotFixture);
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo", 7), {
+      tasks: [{ ...taskFixture, id: "cached-7" }],
+    });
+    const tasksList = mock(
+      async (_repoPath: string, doneVisibleDays?: number): Promise<TaskCard[]> => {
+        if (doneVisibleDays === 7) {
+          throw new Error("inactive variant should not refresh");
+        }
+        return [{ ...taskFixture, id: `fresh-${doneVisibleDays}` }];
+      },
+    );
+    host.tasksList = tasksList;
+
+    await refreshRepoTaskViewsFromQuery(queryClient, "/repo", {
+      forceFreshTaskList: true,
+      ancillaryFailureMode: "best-effort",
+      refreshInactiveViews: false,
+      taskDocumentStrategy: "none",
+    });
+
+    expect(tasksList).toHaveBeenCalledTimes(1);
+    expect(tasksList).toHaveBeenCalledWith("/repo", DONE_VISIBLE_DAYS);
+    expect(
+      queryClient.getQueryData<{ tasks: TaskCard[] }>(taskQueryKeys.repoData("/repo", 7))?.tasks[0]
+        ?.id,
+    ).toBe("cached-7");
   });
 });

--- a/packages/frontend/src/state/queries/tasks.test.ts
+++ b/packages/frontend/src/state/queries/tasks.test.ts
@@ -592,6 +592,50 @@ describe("tasks query cache helpers", () => {
     ).rejects.toThrow("current board failed");
   });
 
+  test("external repo task view refresh treats overlapping primary cancellation as non-fatal", async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), settingsSnapshotFixture);
+    const firstRead = createDeferred<TaskCard[]>();
+    const tasksList = mock(async (): Promise<TaskCard[]> => {
+      if (tasksList.mock.calls.length === 1) {
+        return firstRead.promise;
+      }
+      return [{ ...taskFixture, id: "fresh" }];
+    });
+    host.tasksList = tasksList;
+
+    const firstRefresh = refreshRepoTaskViewsFromQuery(queryClient, "/repo", {
+      forceFreshTaskList: true,
+      ancillaryFailureMode: "best-effort",
+      ignorePrimaryCancellation: true,
+      refreshInactiveViews: false,
+      taskDocumentStrategy: "none",
+    });
+    for (let attempts = 0; tasksList.mock.calls.length === 0 && attempts < 10; attempts += 1) {
+      await Promise.resolve();
+    }
+    expect(tasksList).toHaveBeenCalledTimes(1);
+
+    const secondRefresh = refreshRepoTaskViewsFromQuery(queryClient, "/repo", {
+      forceFreshTaskList: true,
+      ancillaryFailureMode: "best-effort",
+      ignorePrimaryCancellation: true,
+      refreshInactiveViews: false,
+      taskDocumentStrategy: "none",
+    });
+
+    await expect(firstRefresh).resolves.toBeUndefined();
+    await expect(secondRefresh).resolves.toBeUndefined();
+    firstRead.resolve([{ ...taskFixture, id: "stale" }]);
+
+    expect(tasksList).toHaveBeenCalledTimes(2);
+    expect(
+      queryClient.getQueryData<{ tasks: TaskCard[] }>(
+        taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS),
+      )?.tasks[0]?.id,
+    ).toBe("fresh");
+  });
+
   test("external repo task view refresh skips inactive done-visible variants", async () => {
     const queryClient = new QueryClient();
     queryClient.setQueryData(workspaceQueryKeys.settingsSnapshot(), settingsSnapshotFixture);

--- a/packages/frontend/src/state/tasks/task-load-errors.test.ts
+++ b/packages/frontend/src/state/tasks/task-load-errors.test.ts
@@ -70,12 +70,19 @@ describe("summarizeTaskLoadError", () => {
       },
     });
 
-    expect(message).toBe("Task store unavailable. gh auth expired");
+    expect(message).toBe("gh auth expired");
   });
 
   test("falls back to raw error text when no structured repo-store context exists", () => {
     const message = summarizeTaskLoadError({ error: new Error("gh auth expired") });
 
-    expect(message).toBe("Task store unavailable. gh auth expired");
+    expect(message).toBe("gh auth expired");
+  });
+
+  test("keeps task-store wording for store failures without structured context", () => {
+    const message = summarizeTaskLoadError({ error: new Error("beads_dir missing") });
+
+    expect(message).toContain("Task store unavailable.");
+    expect(message).toContain("OpenDucktor uses centralized Beads");
   });
 });

--- a/packages/frontend/src/state/tasks/task-load-errors.ts
+++ b/packages/frontend/src/state/tasks/task-load-errors.ts
@@ -41,5 +41,5 @@ export const summarizeTaskLoadError = ({
     return `Task store unavailable. ${message} ${TASK_STORE_HINT}`;
   }
 
-  return `Task store unavailable. ${message}`;
+  return message;
 };


### PR DESCRIPTION
## Summary
- Add an external/background task sync mode that keeps the current task list refresh strict while treating inactive Kanban and document cache maintenance as ancillary.
- Invalidate affected cached task documents instead of eagerly fetching them during task-event sync, including cancelled overlapping external refreshes.
- Keep misleading non-store failures from being labeled as task-store outages and dedupe repeated background sync toasts.
- During initial repo load, intentionally allow warm cached task data (`forceFreshTaskList: false`) while Beads diagnostics finish preparing; manual refresh and mutation paths remain strict.

## Goal
Agent Studio could show `Failed to sync task updates` with `Task store unavailable` while agents were actively updating tasks, even when Kanban could refresh successfully. The noisy toast came from background task-event cache refresh work where secondary document or inactive-view refresh failures were treated like a primary task-list failure.

This PR makes external task-event sync quieter and more accurate: users should only see sync failure toasts when the primary/current task-list refresh truly fails, while ancillary cache work is invalidated or handled best-effort.

## Technical choices
- Added a `source: "external-sync"` refresh option at the task operation boundary and translated it into query-layer behavior options.
- Kept manual and mutation refresh paths strict by default, preserving existing user-visible failure behavior.
- Split primary task-list refresh from ancillary cache work in `refreshRepoTaskViewsFromQuery`.
- Skipped inactive cached Kanban refetches for external sync and invalidated matching cached task documents with `refetchType: "none"` so panels refetch on demand.
- Treated TanStack `CancelledError` from overlapping external primary refreshes as non-fatal only for external sync, while still invalidating targeted task documents before returning.
- Updated task-load error summaries so unrelated errors such as auth/query failures no longer receive `Task store unavailable` wording.
- Kept initial repo loads able to serve cached task data while a forced Beads diagnostic refresh corrects stale `Preparing` status; lifecycle tests cover the cached initial-load and cancelled startup-refresh paths.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`

Branch is up to date with `origin/main` (`0 3` from `git rev-list --left-right --count origin/main...HEAD`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-warm and revalidate task document cache to ensure stale plan documents refresh on demand.
  * Support invalidating cached task documents without refetching during external syncs.

* **Bug Fixes**
  * Improved deduplication of sync failure notifications.
  * Clearer task-store and auth failure messages.
  * Better handling of external reconnects to avoid duplicate toasts.

* **Refactor**
  * Task refresh API accepts richer options to distinguish external-sync flows.

* **Tests**
  * Expanded coverage for document cache, refresh strategies, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->