### PR TITLE
fix(frontend): type readonly transcript defaults

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-session-approval-actions.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-session-approval-actions.ts
@@ -4,7 +4,7 @@ import type { AgentApprovalRequest } from "@/types/agent-orchestrator";
 
 type UseAgentSessionApprovalActionsParams = {
   activeExternalSessionId: string | null;
-  pendingApprovals: AgentApprovalRequest[];
+  pendingApprovals: ReadonlyArray<AgentApprovalRequest>;
   agentStudioReady: boolean;
   replyAgentApproval: (
     externalSessionId: string,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-session-approval-actions.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-session-approval-actions.ts
@@ -4,7 +4,7 @@ import type { AgentApprovalRequest } from "@/types/agent-orchestrator";
 
 type UseAgentSessionApprovalActionsParams = {
   activeExternalSessionId: string | null;
-  pendingApprovals: ReadonlyArray<AgentApprovalRequest>;
+  pendingApprovals: readonly AgentApprovalRequest[];
   agentStudioReady: boolean;
   replyAgentApproval: (
     externalSessionId: string,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-readonly-session-transcript-surface-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-readonly-session-transcript-surface-model.ts
@@ -20,8 +20,8 @@ import { useAgentSessionApprovalActions } from "./use-agent-session-approval-act
 import { useRepoRuntimeReadiness } from "./use-repo-runtime-readiness";
 
 const DEFAULT_SHOW_THINKING_MESSAGES = false;
-const EMPTY_PENDING_APPROVALS: ReadonlyArray<AgentApprovalRequest> = Object.freeze([]);
-const EMPTY_PENDING_QUESTIONS: ReadonlyArray<AgentQuestionRequest> = Object.freeze([]);
+const EMPTY_PENDING_APPROVALS: readonly AgentApprovalRequest[] = Object.freeze([]);
+const EMPTY_PENDING_QUESTIONS: readonly AgentQuestionRequest[] = Object.freeze([]);
 
 type UseReadonlySessionTranscriptSurfaceModelArgs = {
   isOpen: boolean;
@@ -429,10 +429,12 @@ export function useReadonlySessionTranscriptSurfaceModel({
   }, [activeWorkspace, isResolvingTranscript, loadError, externalSessionId]);
   const approvalSession = runtimeData.session;
   const activeApprovalSessionId = approvalSession?.externalSessionId ?? null;
-  const pendingApprovalRequests = approvalSession?.pendingApprovals ?? EMPTY_PENDING_APPROVALS;
+  const pendingApprovalRequests: readonly AgentApprovalRequest[] =
+    approvalSession?.pendingApprovals ?? EMPTY_PENDING_APPROVALS;
   const questionSession = runtimeData.session;
   const activeQuestionSessionId = questionSession?.externalSessionId ?? null;
-  const pendingQuestionRequests = questionSession?.pendingQuestions ?? EMPTY_PENDING_QUESTIONS;
+  const pendingQuestionRequests: readonly AgentQuestionRequest[] =
+    questionSession?.pendingQuestions ?? EMPTY_PENDING_QUESTIONS;
   const replyTranscriptApproval = useCallback(
     async (
       targetExternalSessionId: string,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-readonly-session-transcript-surface-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-readonly-session-transcript-surface-model.ts
@@ -20,8 +20,8 @@ import { useAgentSessionApprovalActions } from "./use-agent-session-approval-act
 import { useRepoRuntimeReadiness } from "./use-repo-runtime-readiness";
 
 const DEFAULT_SHOW_THINKING_MESSAGES = false;
-const EMPTY_PENDING_APPROVALS = Object.freeze([]) as unknown as AgentApprovalRequest[];
-const EMPTY_PENDING_QUESTIONS = Object.freeze([]) as unknown as AgentQuestionRequest[];
+const EMPTY_PENDING_APPROVALS: ReadonlyArray<AgentApprovalRequest> = Object.freeze([]);
+const EMPTY_PENDING_QUESTIONS: ReadonlyArray<AgentQuestionRequest> = Object.freeze([]);
 
 type UseReadonlySessionTranscriptSurfaceModelArgs = {
   isOpen: boolean;


### PR DESCRIPTION
## Summary
- Replace readonly transcript fallback arrays that used `Object.freeze([]) as unknown as ...` with typed frozen readonly constants.
- Preserve readonly intent through derived pending approval/question variables and the approval action hook input.

## Goal
The readonly transcript surface model previously used double-casts for empty pending approval and question defaults. That bypassed TypeScript's checks in a transcript view model that handles runtime approvals and questions. This PR removes that compiler escape hatch so future type mismatches surface at compile time instead of being hidden by `unknown` casts.

## Technical choices
- Used typed frozen empty constants (`readonly AgentApprovalRequest[]` and `readonly AgentQuestionRequest[]`) to keep the stable fallback-array behavior without weakening type safety.
- Explicitly typed the derived pending request variables as readonly arrays so the readonly contract is visible where the defaults are consumed.
- Widened `useAgentSessionApprovalActions` to accept `readonly AgentApprovalRequest[]` because the hook only reads pending approvals and should not require mutable input.
- Kept the change scoped to the transcript pending-request boundary rather than broadening array readonly changes across unrelated chat state.

## Verification
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check`
- `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for approval and question request handling with stricter immutability constraints on internal data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->