### PR TITLE
fix(web): display app version in browser shell

### DIFF
--- a/packages/openducktor-web/src/vite-config.test.ts
+++ b/packages/openducktor-web/src/vite-config.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import packageJson from "../package.json";
+import { resolveAppVersion } from "../vite.config";
+
+describe("resolveAppVersion", () => {
+  test("uses ODT_APP_VERSION when provided", () => {
+    expect(resolveAppVersion({ ODT_APP_VERSION: "9.8.7" })).toBe("9.8.7");
+  });
+
+  test("uses the web package version when ODT_APP_VERSION is absent", () => {
+    expect(resolveAppVersion({})).toBe(packageJson.version);
+  });
+});

--- a/packages/openducktor-web/src/vite-config.test.ts
+++ b/packages/openducktor-web/src/vite-config.test.ts
@@ -10,4 +10,12 @@ describe("resolveAppVersion", () => {
   test("uses the web package version when ODT_APP_VERSION is absent", () => {
     expect(resolveAppVersion({})).toBe(packageJson.version);
   });
+
+  test("uses the web package version when ODT_APP_VERSION is empty", () => {
+    expect(resolveAppVersion({ ODT_APP_VERSION: "" })).toBe(packageJson.version);
+  });
+
+  test("uses the web package version when ODT_APP_VERSION is blank", () => {
+    expect(resolveAppVersion({ ODT_APP_VERSION: "   " })).toBe(packageJson.version);
+  });
 });

--- a/packages/openducktor-web/vite.config.ts
+++ b/packages/openducktor-web/vite.config.ts
@@ -18,7 +18,8 @@ function readPackageVersion(packageJsonPath = path.resolve(__dirname, "package.j
 }
 
 export function resolveAppVersion(env: NodeJS.ProcessEnv = process.env): string {
-  return env.ODT_APP_VERSION ?? readPackageVersion();
+  const versionOverride = env.ODT_APP_VERSION?.trim();
+  return versionOverride || readPackageVersion();
 }
 
 export default defineConfig({

--- a/packages/openducktor-web/vite.config.ts
+++ b/packages/openducktor-web/vite.config.ts
@@ -1,5 +1,6 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
@@ -7,6 +8,18 @@ import { defineConfig } from "vite";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const frontendSrc = path.resolve(__dirname, "../frontend/src");
+
+function readPackageVersion(packageJsonPath = path.resolve(__dirname, "package.json")): string {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+    throw new Error(`Missing package version in ${packageJsonPath}`);
+  }
+  return packageJson.version;
+}
+
+export function resolveAppVersion(env: NodeJS.ProcessEnv = process.env): string {
+  return env.ODT_APP_VERSION ?? readPackageVersion();
+}
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
@@ -25,7 +38,7 @@ export default defineConfig({
     ],
   },
   define: {
-    "import.meta.env.VITE_ODT_APP_VERSION": JSON.stringify(process.env.ODT_APP_VERSION ?? ""),
+    "import.meta.env.VITE_ODT_APP_VERSION": JSON.stringify(resolveAppVersion()),
   },
   clearScreen: false,
   server: {


### PR DESCRIPTION
## Summary
- Inject the web shell app version from `ODT_APP_VERSION` when it is explicitly provided.
- Fall back to the `@openducktor/web` package version when no override is provided.
- Treat empty or whitespace-only overrides as unset so the sidebar still displays a version.

## Goal
When OpenDucktor runs in browser/web mode through `bun run browser:dev` or `bunx @openducktor/web`, the shared sidebar reads `VITE_ODT_APP_VERSION` to decide whether to render the version label. The web Vite config previously defined that value as an empty string unless `ODT_APP_VERSION` was set, so normal web-mode launches hid the version entirely.

This PR fixes that by making the web shell provide a real version by default, matching the desktop shell behavior and keeping the sidebar version visible in web mode.

## Technical choices
- Added `resolveAppVersion()` in `packages/openducktor-web/vite.config.ts` so version resolution is explicit and testable at the web shell boundary.
- Kept `ODT_APP_VERSION` as the highest-priority override for release or custom build flows.
- Read `packages/openducktor-web/package.json` as the default source because the web package owns the browser shell build being served.
- Trimmed the override before use so accidentally blank environment values do not mask the package version.
- Added focused Bun tests for explicit override, absent override, empty override, and whitespace-only override cases.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check` from `apps/desktop/src-tauri`
- `cargo clippy --workspace --all-targets -- -D warnings` from `apps/desktop/src-tauri`
- `cargo build --workspace` from `apps/desktop/src-tauri`