### PR TITLE
refactor(frontend): consolidate pending count hooks

### DIFF
--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -65,6 +65,17 @@ const createSession = (
   });
 };
 
+const createPendingQuestion = (requestId = "question-1") => ({
+  requestId,
+  questions: [
+    {
+      header: "Question",
+      question: "Need input",
+      options: [{ label: "Reply", description: "Provide input" }],
+    },
+  ],
+});
+
 const createDocumentState = (markdown: string): TaskDocumentState => ({
   markdown,
   updatedAt: null,
@@ -1031,6 +1042,122 @@ describe("useAgentStudioPageModels", () => {
 
     expect(
       harness.getLatest().agentChatModel.thread.subagentPendingApprovalCountByExternalSessionId,
+    ).toBe(initialCounts);
+
+    await harness.unmount();
+  });
+
+  test("derives subagent pending question counts from all live session summaries", async () => {
+    const parentSession = createSession("session-parent", "external-parent");
+    const childWithQuestion = createSession("session-child-1", "external-child-1", {
+      taskId: "other-task",
+      pendingQuestions: [createPendingQuestion("question-1"), createPendingQuestion("question-2")],
+    });
+    const childWithoutQuestion = createSession("session-child-2", "external-child-2", {
+      pendingQuestions: [],
+    });
+    const harness = createHookHarness(
+      createHookArgs({
+        core: {
+          activeSession: parentSession,
+          sessionsForTask: [toAgentSessionSummary(parentSession)],
+          allSessionSummaries: [
+            toAgentSessionSummary(parentSession),
+            toAgentSessionSummary(childWithQuestion),
+            toAgentSessionSummary(childWithoutQuestion),
+          ],
+        },
+      }),
+    );
+
+    await harness.mount();
+
+    expect(
+      harness.getLatest().agentChatModel.thread.subagentPendingQuestionCountByExternalSessionId,
+    ).toEqual({
+      "external-child-1": 2,
+    });
+
+    await harness.unmount();
+  });
+
+  test("derives subagent pending question counts from parent live event overlay", async () => {
+    const parentSession = createSession("session-parent", "external-parent", {
+      subagentPendingQuestionsByExternalSessionId: {
+        "external-child-session": [createPendingQuestion("question-1")],
+        "external-empty-child-session": [],
+      },
+    });
+    const childSummary = toAgentSessionSummary(
+      createSession("internal-child-session", "external-child-session", {
+        taskId: "other-task",
+      }),
+    );
+    const harness = createHookHarness(
+      createHookArgs({
+        core: {
+          activeSession: parentSession,
+          sessionsForTask: [toAgentSessionSummary(parentSession)],
+          allSessionSummaries: [toAgentSessionSummary(parentSession), childSummary],
+        },
+      }),
+    );
+
+    await harness.mount();
+
+    expect(
+      harness.getLatest().agentChatModel.thread.subagentPendingQuestionCountByExternalSessionId,
+    ).toEqual({
+      "external-child-session": 1,
+    });
+
+    await harness.unmount();
+  });
+
+  test("keeps subagent pending question count map stable when counts do not change", async () => {
+    const parentSession = createSession("session-parent", "external-parent");
+    const childWithQuestion = createSession("session-child-1", "external-child-1", {
+      taskId: "other-task",
+      pendingQuestions: [createPendingQuestion("question-1")],
+    });
+    const initialProps = createHookArgs({
+      core: {
+        activeSession: parentSession,
+        sessionsForTask: [toAgentSessionSummary(parentSession)],
+        allSessionSummaries: [
+          toAgentSessionSummary(parentSession),
+          toAgentSessionSummary(childWithQuestion),
+        ],
+      },
+    });
+    const harness = createHookHarness(initialProps);
+
+    await harness.mount();
+
+    const initialCounts =
+      harness.getLatest().agentChatModel.thread.subagentPendingQuestionCountByExternalSessionId;
+
+    await harness.update(
+      createHookArgs({
+        core: {
+          activeSession: parentSession,
+          sessionsForTask: [toAgentSessionSummary(parentSession)],
+          allSessionSummaries: [
+            toAgentSessionSummary(parentSession),
+            toAgentSessionSummary(childWithQuestion),
+            toAgentSessionSummary(
+              createSession("session-child-2", "external-child-2", {
+                taskId: "other-task",
+                pendingQuestions: [],
+              }),
+            ),
+          ],
+        },
+      }),
+    );
+
+    expect(
+      harness.getLatest().agentChatModel.thread.subagentPendingQuestionCountByExternalSessionId,
     ).toBe(initialCounts);
 
     await harness.unmount();

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -65,6 +65,21 @@ const createSession = (
   });
 };
 
+const createPendingApproval = (
+  requestId = "perm-1",
+  actionName = "shell",
+  affectedPaths = ["bun test"],
+) => ({
+  requestId,
+  requestType: "permission_grant" as const,
+  title: `Approve permission: ${actionName}`,
+  summary: `Approval request for ${actionName}.`,
+  affectedPaths,
+  action: { name: actionName },
+  mutation: "mutating" as const,
+  supportedReplyOutcomes: ["approve_once" as const, "approve_session" as const, "reject" as const],
+});
+
 const createPendingQuestion = (requestId = "question-1") => ({
   requestId,
   questions: [
@@ -835,34 +850,8 @@ describe("useAgentStudioPageModels", () => {
     const childWithApproval = createSession("session-child-1", "external-child-1", {
       taskId: "other-task",
       pendingApprovals: [
-        {
-          requestId: "perm-1",
-          requestType: "permission_grant" as const,
-          title: `Approve permission: ${"shell"}`,
-          summary: `Approval request for ${"shell"}.`,
-          affectedPaths: ["bun test"],
-          action: { name: "shell" },
-          mutation: "mutating" as const,
-          supportedReplyOutcomes: [
-            "approve_once" as const,
-            "approve_session" as const,
-            "reject" as const,
-          ],
-        },
-        {
-          requestId: "perm-2",
-          requestType: "permission_grant" as const,
-          title: `Approve permission: ${"shell"}`,
-          summary: `Approval request for ${"shell"}.`,
-          affectedPaths: ["git status"],
-          action: { name: "shell" },
-          mutation: "mutating" as const,
-          supportedReplyOutcomes: [
-            "approve_once" as const,
-            "approve_session" as const,
-            "reject" as const,
-          ],
-        },
+        createPendingApproval("perm-1"),
+        createPendingApproval("perm-2", "shell", ["git status"]),
       ],
     });
     const childWithoutApproval = createSession("session-child-2", "external-child-2", {
@@ -897,22 +886,7 @@ describe("useAgentStudioPageModels", () => {
     const parentSession = createSession("session-parent", "external-parent");
     const childWithApproval = createSession("session-child-internal", "session-child-runtime", {
       taskId: "other-task",
-      pendingApprovals: [
-        {
-          requestId: "perm-1",
-          requestType: "permission_grant" as const,
-          title: `Approve permission: ${"shell"}`,
-          summary: `Approval request for ${"shell"}.`,
-          affectedPaths: ["bun test"],
-          action: { name: "shell" },
-          mutation: "mutating" as const,
-          supportedReplyOutcomes: [
-            "approve_once" as const,
-            "approve_session" as const,
-            "reject" as const,
-          ],
-        },
-      ],
+      pendingApprovals: [createPendingApproval("perm-1")],
     });
     const harness = createHookHarness(
       createHookArgs({
@@ -941,20 +915,7 @@ describe("useAgentStudioPageModels", () => {
     const parentSession = createSession("session-parent", "external-parent", {
       subagentPendingApprovalsByExternalSessionId: {
         "external-child-session": [
-          {
-            requestId: "perm-1",
-            requestType: "permission_grant" as const,
-            title: `Approve permission: ${"external_directory"}`,
-            summary: `Approval request for ${"external_directory"}.`,
-            affectedPaths: ["/tmp/*"],
-            action: { name: "external_directory" },
-            mutation: "mutating" as const,
-            supportedReplyOutcomes: [
-              "approve_once" as const,
-              "approve_session" as const,
-              "reject" as const,
-            ],
-          },
+          createPendingApproval("perm-1", "external_directory", ["/tmp/*"]),
         ],
       },
     });
@@ -987,22 +948,7 @@ describe("useAgentStudioPageModels", () => {
     const parentSession = createSession("session-parent", "external-parent");
     const childWithApproval = createSession("session-child-1", "external-child-1", {
       taskId: "other-task",
-      pendingApprovals: [
-        {
-          requestId: "perm-1",
-          requestType: "permission_grant" as const,
-          title: `Approve permission: ${"shell"}`,
-          summary: `Approval request for ${"shell"}.`,
-          affectedPaths: ["bun test"],
-          action: { name: "shell" },
-          mutation: "mutating" as const,
-          supportedReplyOutcomes: [
-            "approve_once" as const,
-            "approve_session" as const,
-            "reject" as const,
-          ],
-        },
-      ],
+      pendingApprovals: [createPendingApproval("perm-1")],
     });
     const initialProps = createHookArgs({
       core: {

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
@@ -54,6 +54,8 @@ type AgentStudioCoreContext = {
 const EMPTY_SUBAGENT_PENDING_APPROVAL_COUNTS: Record<string, number> = Object.freeze({});
 const EMPTY_SUBAGENT_PENDING_QUESTION_COUNTS: Record<string, number> = Object.freeze({});
 
+type PendingInputOverlayMap = Record<string, readonly unknown[]>;
+
 const arePendingInputCountMapsEqual = (
   left: Record<string, number>,
   right: Record<string, number>,
@@ -67,34 +69,45 @@ const arePendingInputCountMapsEqual = (
   return leftKeys.every((key) => left[key] === right[key]);
 };
 
-const useStablePendingApprovalCounts = (
-  sessions: AgentSessionSummary[],
-  subagentPendingApprovalsByExternalSessionId:
-    | AgentSessionState["subagentPendingApprovalsByExternalSessionId"]
-    | undefined,
-): Record<string, number> => {
-  const previousRef = useRef<Record<string, number>>(EMPTY_SUBAGENT_PENDING_APPROVAL_COUNTS);
+const getSessionPendingApprovalCount = (session: AgentSessionSummary): number =>
+  session.pendingApprovals.length;
+
+const getSessionPendingQuestionCount = (session: AgentSessionSummary): number =>
+  session.pendingQuestions.length;
+
+const useStablePendingInputCounts = ({
+  sessions,
+  subagentPendingInputsByExternalSessionId,
+  getSessionPendingInputCount,
+  emptyCounts,
+}: {
+  sessions: AgentSessionSummary[];
+  subagentPendingInputsByExternalSessionId: PendingInputOverlayMap | undefined;
+  getSessionPendingInputCount: (session: AgentSessionSummary) => number;
+  emptyCounts: Record<string, number>;
+}): Record<string, number> => {
+  const previousRef = useRef<Record<string, number>>(emptyCounts);
   return useMemo(() => {
     const next: Record<string, number> = {};
     for (const session of sessions) {
-      const pendingApprovalCount = session.pendingApprovals.length;
-      if (pendingApprovalCount > 0) {
-        next[session.externalSessionId] = pendingApprovalCount;
+      const pendingInputCount = getSessionPendingInputCount(session);
+      if (pendingInputCount > 0) {
+        next[session.externalSessionId] = pendingInputCount;
       }
     }
 
-    if (subagentPendingApprovalsByExternalSessionId) {
-      for (const [externalSessionId, pendingApprovals] of Object.entries(
-        subagentPendingApprovalsByExternalSessionId,
+    if (subagentPendingInputsByExternalSessionId) {
+      for (const [externalSessionId, pendingInputs] of Object.entries(
+        subagentPendingInputsByExternalSessionId,
       )) {
-        const pendingApprovalCount = pendingApprovals.length;
-        if (pendingApprovalCount > 0) {
-          next[externalSessionId] = pendingApprovalCount;
+        const pendingInputCount = pendingInputs.length;
+        if (pendingInputCount > 0) {
+          next[externalSessionId] = pendingInputCount;
         }
       }
     }
 
-    const nextCounts = Object.keys(next).length > 0 ? next : EMPTY_SUBAGENT_PENDING_APPROVAL_COUNTS;
+    const nextCounts = Object.keys(next).length > 0 ? next : emptyCounts;
     const previous = previousRef.current;
     if (arePendingInputCountMapsEqual(previous, nextCounts)) {
       return previous;
@@ -102,7 +115,26 @@ const useStablePendingApprovalCounts = (
 
     previousRef.current = nextCounts;
     return nextCounts;
-  }, [sessions, subagentPendingApprovalsByExternalSessionId]);
+  }, [
+    sessions,
+    subagentPendingInputsByExternalSessionId,
+    getSessionPendingInputCount,
+    emptyCounts,
+  ]);
+};
+
+const useStablePendingApprovalCounts = (
+  sessions: AgentSessionSummary[],
+  subagentPendingApprovalsByExternalSessionId:
+    | AgentSessionState["subagentPendingApprovalsByExternalSessionId"]
+    | undefined,
+): Record<string, number> => {
+  return useStablePendingInputCounts({
+    sessions,
+    subagentPendingInputsByExternalSessionId: subagentPendingApprovalsByExternalSessionId,
+    getSessionPendingInputCount: getSessionPendingApprovalCount,
+    emptyCounts: EMPTY_SUBAGENT_PENDING_APPROVAL_COUNTS,
+  });
 };
 
 const useStablePendingQuestionCounts = (
@@ -111,36 +143,12 @@ const useStablePendingQuestionCounts = (
     | AgentSessionState["subagentPendingQuestionsByExternalSessionId"]
     | undefined,
 ): Record<string, number> => {
-  const previousRef = useRef<Record<string, number>>(EMPTY_SUBAGENT_PENDING_QUESTION_COUNTS);
-  return useMemo(() => {
-    const next: Record<string, number> = {};
-    for (const session of sessions) {
-      const pendingQuestionCount = session.pendingQuestions.length;
-      if (pendingQuestionCount > 0) {
-        next[session.externalSessionId] = pendingQuestionCount;
-      }
-    }
-
-    if (subagentPendingQuestionsByExternalSessionId) {
-      for (const [externalSessionId, pendingQuestions] of Object.entries(
-        subagentPendingQuestionsByExternalSessionId,
-      )) {
-        const pendingQuestionCount = pendingQuestions.length;
-        if (pendingQuestionCount > 0) {
-          next[externalSessionId] = pendingQuestionCount;
-        }
-      }
-    }
-
-    const nextCounts = Object.keys(next).length > 0 ? next : EMPTY_SUBAGENT_PENDING_QUESTION_COUNTS;
-    const previous = previousRef.current;
-    if (arePendingInputCountMapsEqual(previous, nextCounts)) {
-      return previous;
-    }
-
-    previousRef.current = nextCounts;
-    return nextCounts;
-  }, [sessions, subagentPendingQuestionsByExternalSessionId]);
+  return useStablePendingInputCounts({
+    sessions,
+    subagentPendingInputsByExternalSessionId: subagentPendingQuestionsByExternalSessionId,
+    getSessionPendingInputCount: getSessionPendingQuestionCount,
+    emptyCounts: EMPTY_SUBAGENT_PENDING_QUESTION_COUNTS,
+  });
 };
 
 type AgentStudioTaskTabsContext = {


### PR DESCRIPTION
## Summary
- Consolidates Agent Studio pending approval/question count derivation into one shared stable-count hook.
- Adds question-path coverage for summary counts, live overlay counts, zero omission, and stable object identity.
- Simplifies pending approval fixtures so the focused tests are easier to maintain.

## Goal
This PR removes duplicated stable-counting logic between `useStablePendingApprovalCounts` and `useStablePendingQuestionCounts`. Both hooks previously implemented the same pattern separately: derive counts by external session ID, include live subagent overlays, omit zero-count entries, and preserve object identity when counts are unchanged. Keeping that logic duplicated makes future stability or filtering changes easy to apply inconsistently.

## Technical approach
- Introduced a local `useStablePendingInputCounts` helper in `use-agent-studio-page-models.ts` that owns the shared derivation, zero filtering, empty-map reuse, and value-equality reference stability.
- Kept approval/question wrapper hooks in place so call sites still clearly show which pending input kind is being counted.
- Used small named selectors for approval and question summary counts to keep dependencies stable and readable.
- Preserved existing behavior: summary entries are written first, live overlay entries are applied second, and non-zero overlay entries keep the previous effective replacement behavior for duplicate keys.
- Added focused question tests mirroring the approval behavior, plus a `createPendingApproval` test fixture to reduce noisy literals.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cd apps/desktop/src-tauri && cargo fmt --all --check`
- `bun run check:rust`
- `cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings`
- `bun run test:rust`
- `cd apps/desktop/src-tauri && cargo build --workspace`