### PR TITLE
refactor(frontend): deepen selected session context

### DIFF
--- a/packages/frontend/src/pages/agents/agents-page-view-model.test.ts
+++ b/packages/frontend/src/pages/agents/agents-page-view-model.test.ts
@@ -199,7 +199,6 @@ describe("agents-page-view-model", () => {
       primaryQuickAction: null,
       onQuickAction,
       isStarting: true,
-      contextSessionsLength: 2,
     });
 
     expect(model.workflowSteps).toHaveLength(2);
@@ -265,7 +264,6 @@ describe("agents-page-view-model", () => {
       primaryQuickAction: null,
       onQuickAction: mock(() => {}),
       isStarting: false,
-      contextSessionsLength: 0,
     });
 
     expect(model.onOpenTaskDetails).toBeNull();

--- a/packages/frontend/src/pages/agents/agents-page-view-model.ts
+++ b/packages/frontend/src/pages/agents/agents-page-view-model.ts
@@ -66,7 +66,6 @@ export const buildAgentStudioHeaderModel = (args: {
   onQuickAction: (option: AgentStudioQuickActionOption) => void;
   onResolveGitConflictQuickAction?: (() => void) | null;
   isStarting: boolean;
-  contextSessionsLength: number;
 }): AgentStudioHeaderModel => ({
   taskTitle: args.selectedTask?.title ?? null,
   taskId: args.selectedTask?.id ?? null,

--- a/packages/frontend/src/pages/agents/selected-session/selected-session-context.test.ts
+++ b/packages/frontend/src/pages/agents/selected-session/selected-session-context.test.ts
@@ -41,7 +41,6 @@ const createInput = (
     selectedTask,
     sessionsForTask,
     allSessionSummaries: overrides.allSessionSummaries ?? sessionsForTask,
-    contextSessionsLength: overrides.contextSessionsLength ?? sessionsForTask.length,
     activeSession: null,
     runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
     sessionRuntimeDataError: null,
@@ -92,7 +91,6 @@ describe("buildAgentStudioSelectedSessionContext", () => {
         selectedTask: null,
         sessionsForTask: [],
         allSessionSummaries: [],
-        contextSessionsLength: 0,
         activeSession: null,
         sessionActions: {
           ...createInput().sessionActions,
@@ -158,7 +156,6 @@ describe("buildAgentStudioSelectedSessionContext", () => {
     expect(context.workflow.selectedRoleAvailable).toBe(false);
     expect(context.chat.composerReadOnly).toBe(true);
     expect(context.chat.composerReadOnlyReason).toContain("Planner is unavailable");
-    expect(context.sessionStart.canKickoff).toBe(false);
     expect(context.chat.emptyState?.actionLabel).toBeUndefined();
   });
 

--- a/packages/frontend/src/pages/agents/selected-session/selected-session-context.test.ts
+++ b/packages/frontend/src/pages/agents/selected-session/selected-session-context.test.ts
@@ -159,6 +159,36 @@ describe("buildAgentStudioSelectedSessionContext", () => {
     expect(context.chat.emptyState?.actionLabel).toBeUndefined();
   });
 
+  test("projects kickoff and starting empty-state affordances without stale pending flags", () => {
+    const startLaunchKickoff = mock(async () => {});
+    const readyContext = buildAgentStudioSelectedSessionContext(
+      createInput({
+        sessionActions: {
+          ...createInput().sessionActions,
+          startLaunchKickoff,
+        },
+      }),
+    );
+
+    expect(readyContext.chat.emptyState).toMatchObject({
+      title: "Send a message to start a new session automatically.",
+      actionLabel: "Start Spec",
+    });
+    expect(readyContext.chat.emptyState?.isActionPending).toBeUndefined();
+
+    const startingContext = buildAgentStudioSelectedSessionContext(
+      createInput({
+        sessionActions: {
+          ...createInput().sessionActions,
+          isStarting: true,
+          startLaunchKickoff,
+        },
+      }),
+    );
+
+    expect(startingContext.chat.emptyState).toEqual({ title: "Initializing session..." });
+  });
+
   test("projects runtime readiness and runtime-data errors without masking", () => {
     const refreshChecks = mock(async () => {});
     const context = buildAgentStudioSelectedSessionContext(
@@ -258,5 +288,26 @@ describe("buildAgentStudioSelectedSessionContext", () => {
       "session-main": 1,
       "session-sub": 1,
     });
+  });
+
+  test("disables pending input actions when the selected session has no pending items", () => {
+    const noActiveSessionContext = buildAgentStudioSelectedSessionContext(
+      createInput({ activeSession: null }),
+    );
+
+    expect(noActiveSessionContext.pendingInput.pendingQuestions.canSubmit).toBe(false);
+    expect(noActiveSessionContext.pendingInput.approvals.canReply).toBe(false);
+
+    const idleSession = createSession({ pendingApprovals: [], pendingQuestions: [] });
+    const idleContext = buildAgentStudioSelectedSessionContext(
+      createInput({
+        activeSession: idleSession,
+        sessionsForTask: [toAgentSessionSummary(idleSession)],
+        allSessionSummaries: [toAgentSessionSummary(idleSession)],
+      }),
+    );
+
+    expect(idleContext.pendingInput.pendingQuestions.canSubmit).toBe(false);
+    expect(idleContext.pendingInput.approvals.canReply).toBe(false);
   });
 });

--- a/packages/frontend/src/pages/agents/selected-session/selected-session-context.test.ts
+++ b/packages/frontend/src/pages/agents/selected-session/selected-session-context.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, mock, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import type { AgentRole } from "@openducktor/core";
+import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
+import { toAgentSessionSummary } from "@/state/agent-sessions-store";
+import { AGENT_ROLE_LABELS } from "@/types";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { createAgentSessionFixture, createTaskCardFixture } from "../agent-studio-test-utils";
+import {
+  type AgentStudioSelectedSessionContextInput,
+  buildAgentStudioSelectedSessionContext,
+} from "./selected-session-context";
+
+const createDoc = (markdown: string): TaskDocumentState => ({
+  markdown,
+  updatedAt: null,
+  isLoading: false,
+  error: null,
+  loaded: true,
+});
+
+const createSession = (overrides: Partial<AgentSessionState> = {}): AgentSessionState =>
+  createAgentSessionFixture({
+    runtimeKind: "opencode",
+    externalSessionId: "session-1",
+    taskId: "task-1",
+    role: "spec",
+    status: "idle",
+    ...overrides,
+  });
+
+const createInput = (
+  overrides: Partial<AgentStudioSelectedSessionContextInput> = {},
+): AgentStudioSelectedSessionContextInput => {
+  const selectedTask = createTaskCardFixture({ id: "task-1", title: "Task 1" });
+  const sessionsForTask = overrides.sessionsForTask ?? [];
+
+  return {
+    taskId: "task-1",
+    role: "spec",
+    selectedTask,
+    sessionsForTask,
+    allSessionSummaries: overrides.allSessionSummaries ?? sessionsForTask,
+    contextSessionsLength: overrides.contextSessionsLength ?? sessionsForTask.length,
+    activeSession: null,
+    runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    sessionRuntimeDataError: null,
+    hasActiveGitConflict: false,
+    isTaskHydrating: false,
+    isSessionHistoryHydrated: true,
+    isSessionHistoryHydrating: false,
+    isSessionSelectionResolving: false,
+    isWaitingForRuntimeReadiness: false,
+    isSessionHistoryHydrationFailed: false,
+    activeSessionContextUsage: null,
+    documents: {
+      specDoc: createDoc("spec"),
+      planDoc: createDoc("plan"),
+      qaDoc: createDoc("qa"),
+    },
+    readiness: {
+      agentStudioReadinessState: "ready",
+      agentStudioReady: true,
+      agentStudioBlockedReason: null,
+      isLoadingChecks: false,
+      refreshChecks: async () => {},
+    },
+    sessionActions: {
+      isStarting: false,
+      isSessionWorking: false,
+      canKickoffNewSession: true,
+      kickoffLabel: "Start Spec",
+      startLaunchKickoff: async () => {},
+      onSubmitQuestionAnswers: async () => {},
+      isSubmittingQuestionByRequestId: {},
+    },
+    approvals: {
+      isSubmittingApprovalByRequestId: {},
+      approvalReplyErrorByRequestId: {},
+      onReplyApproval: async () => {},
+    },
+    roleLabelByRole: AGENT_ROLE_LABELS,
+    ...overrides,
+  };
+};
+
+describe("buildAgentStudioSelectedSessionContext", () => {
+  test("projects no-task/no-session context without runtime or panel fallbacks", () => {
+    const context = buildAgentStudioSelectedSessionContext(
+      createInput({
+        taskId: "",
+        selectedTask: null,
+        sessionsForTask: [],
+        allSessionSummaries: [],
+        contextSessionsLength: 0,
+        activeSession: null,
+        sessionActions: {
+          ...createInput().sessionActions,
+          canKickoffNewSession: false,
+        },
+      }),
+    );
+
+    expect(context.documents.activeDocument).toBeNull();
+    expect(context.rightPanel.hasTaskContext).toBe(false);
+    expect(context.rightPanel.hasDocumentPanel).toBe(false);
+    expect(context.chat.emptyState?.title).toBe("Select a task to begin.");
+    expect(context.chat.emptyState?.actionLabel).toBeUndefined();
+    expect(context.runtime.sessionRuntimeDataError).toBeNull();
+  });
+
+  test("maps active document and right-panel availability from selected role semantics", () => {
+    const expectedByRole: Record<AgentRole, string | null> = {
+      spec: "Specification",
+      planner: "Implementation Plan",
+      qa: "QA Report",
+      build: null,
+    };
+
+    for (const [role, expectedTitle] of Object.entries(expectedByRole) as [
+      AgentRole,
+      string | null,
+    ][]) {
+      const session = createSession({ role });
+      const context = buildAgentStudioSelectedSessionContext(
+        createInput({
+          role,
+          activeSession: session,
+          sessionsForTask: [toAgentSessionSummary(session)],
+          allSessionSummaries: [toAgentSessionSummary(session)],
+        }),
+      );
+
+      expect(context.documents.activeDocument?.title ?? null).toBe(expectedTitle);
+      expect(context.rightPanel.hasDocumentPanel).toBe(expectedTitle !== null);
+      expect(context.rightPanel.hasBuildToolsPanel).toBe(role === "build");
+    }
+  });
+
+  test("marks unavailable selected role read-only and disables kickoff affordance", () => {
+    const unavailablePlannerTask = createTaskCardFixture({
+      agentWorkflows: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: false, completed: false },
+        builder: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: true, canSkip: false, available: false, completed: false },
+      },
+    });
+
+    const context = buildAgentStudioSelectedSessionContext(
+      createInput({
+        role: "planner",
+        selectedTask: unavailablePlannerTask,
+      }),
+    );
+
+    expect(context.workflow.selectedInteractionRole).toBe("planner");
+    expect(context.workflow.selectedRoleAvailable).toBe(false);
+    expect(context.chat.composerReadOnly).toBe(true);
+    expect(context.chat.composerReadOnlyReason).toContain("Planner is unavailable");
+    expect(context.sessionStart.canKickoff).toBe(false);
+    expect(context.chat.emptyState?.actionLabel).toBeUndefined();
+  });
+
+  test("projects runtime readiness and runtime-data errors without masking", () => {
+    const refreshChecks = mock(async () => {});
+    const context = buildAgentStudioSelectedSessionContext(
+      createInput({
+        sessionRuntimeDataError: "session todos unavailable",
+        isWaitingForRuntimeReadiness: true,
+        readiness: {
+          agentStudioReadinessState: "blocked",
+          agentStudioReady: false,
+          agentStudioBlockedReason: "Runtime unavailable",
+          isLoadingChecks: true,
+          refreshChecks,
+        },
+      }),
+    );
+
+    expect(context.runtime.sessionRuntimeDataError).toBe("session todos unavailable");
+    expect(context.runtime.isWaitingForRuntimeReadiness).toBe(true);
+    expect(context.runtime.runtimeReadiness).toMatchObject({
+      readinessState: "blocked",
+      isReady: false,
+      blockedReason: "Runtime unavailable",
+      isLoadingChecks: true,
+    });
+    expect(context.runtime.runtimeReadiness.refreshChecks).toBe(refreshChecks);
+  });
+
+  test("propagates selected-session and subagent pending input affordances", () => {
+    const approvalReply = mock(async () => {});
+    const questionReply = mock(async () => {});
+    const session = createSession({
+      externalSessionId: "session-main",
+      pendingApprovals: [
+        {
+          requestId: "approval-main",
+          requestType: "runtime_tool",
+          title: "Approve tool",
+          summary: "Approve a tool call.",
+          tool: { name: "shell" },
+          mutation: "mutating",
+          supportedReplyOutcomes: ["approve_once", "reject"],
+        },
+      ],
+      pendingQuestions: [{ requestId: "question-main", questions: [] }],
+      subagentPendingApprovalsByExternalSessionId: {
+        "session-sub": [
+          {
+            requestId: "approval-sub",
+            requestType: "runtime_tool",
+            title: "Approve subagent tool",
+            summary: "Approve a subagent tool call.",
+            tool: { name: "shell" },
+            mutation: "mutating",
+            supportedReplyOutcomes: ["approve_once", "reject"],
+          },
+        ],
+      },
+      subagentPendingQuestionsByExternalSessionId: {
+        "session-sub": [{ requestId: "question-sub", questions: [] }],
+      },
+    });
+
+    const context = buildAgentStudioSelectedSessionContext(
+      createInput({
+        activeSession: session,
+        sessionsForTask: [toAgentSessionSummary(session)],
+        allSessionSummaries: [toAgentSessionSummary(session)],
+        sessionActions: {
+          ...createInput().sessionActions,
+          onSubmitQuestionAnswers: questionReply,
+          isSubmittingQuestionByRequestId: { "question-main": true },
+        },
+        approvals: {
+          isSubmittingApprovalByRequestId: { "approval-main": true },
+          approvalReplyErrorByRequestId: { "approval-main": "failed" },
+          onReplyApproval: approvalReply,
+        },
+      }),
+    );
+
+    expect(context.pendingInput.pendingQuestions).toMatchObject({
+      canSubmit: true,
+      isSubmittingByRequestId: { "question-main": true },
+    });
+    expect(context.pendingInput.pendingQuestions.onSubmit).toBe(questionReply);
+    expect(context.pendingInput.approvals).toMatchObject({
+      canReply: true,
+      isSubmittingByRequestId: { "approval-main": true },
+      errorByRequestId: { "approval-main": "failed" },
+    });
+    expect(context.pendingInput.approvals.onReply).toBe(approvalReply);
+    expect(context.pendingInput.subagentPendingApprovalCountByExternalSessionId).toEqual({
+      "session-main": 1,
+      "session-sub": 1,
+    });
+    expect(context.pendingInput.subagentPendingQuestionCountByExternalSessionId).toEqual({
+      "session-main": 1,
+      "session-sub": 1,
+    });
+  });
+});

--- a/packages/frontend/src/pages/agents/selected-session/selected-session-context.ts
+++ b/packages/frontend/src/pages/agents/selected-session/selected-session-context.ts
@@ -70,7 +70,6 @@ export type SelectedSessionChatContext = {
   activeComposerSession: SelectedSessionComposerActiveSession;
   composerReadOnly: boolean;
   composerReadOnlyReason: string | null;
-  canKickoff: boolean;
 };
 
 export type SelectedSessionRuntimeContext = {
@@ -98,24 +97,12 @@ export type SelectedSessionPendingInputContext = {
   subagentPendingQuestionCountByExternalSessionId: Record<string, number>;
 };
 
-export type SelectedSessionStartAffordanceContext = {
-  canKickoff: boolean;
-  kickoffLabel: string;
-  isKickoffPending: boolean;
-  startLaunchKickoff: () => Promise<void>;
-  sessionCreateOptions: WorkflowModelContext["sessionCreateOptions"];
-  quickActions: WorkflowModelContext["quickActions"];
-  primaryQuickAction: WorkflowModelContext["primaryQuickAction"];
-  createSessionDisabled: boolean;
-};
-
 export type AgentStudioSelectedSessionContext = {
   taskId: string;
   role: AgentRole;
   selectedTask: TaskCard | null;
   sessionsForTask: AgentSessionSummary[];
   allSessionSummaries: AgentSessionSummary[];
-  contextSessionsLength: number;
   activeSession: AgentSessionState | null;
   workflow: WorkflowModelContext;
   documents: SelectedSessionDocumentsContext;
@@ -123,7 +110,6 @@ export type AgentStudioSelectedSessionContext = {
   chat: SelectedSessionChatContext;
   runtime: SelectedSessionRuntimeContext;
   pendingInput: SelectedSessionPendingInputContext;
-  sessionStart: SelectedSessionStartAffordanceContext;
 };
 
 export type AgentStudioSelectedSessionContextInput = {
@@ -132,7 +118,6 @@ export type AgentStudioSelectedSessionContextInput = {
   selectedTask: TaskCard | null;
   sessionsForTask: AgentSessionSummary[];
   allSessionSummaries: AgentSessionSummary[];
-  contextSessionsLength: number;
   activeSession: AgentSessionState | null;
   runtimeDefinitions: RuntimeDescriptor[];
   sessionRuntimeDataError: string | null;
@@ -255,7 +240,6 @@ export const buildAgentStudioSelectedSessionContext = ({
   selectedTask,
   sessionsForTask,
   allSessionSummaries,
-  contextSessionsLength,
   activeSession,
   runtimeDefinitions,
   sessionRuntimeDataError,
@@ -312,7 +296,6 @@ export const buildAgentStudioSelectedSessionContext = ({
     selectedTask,
     sessionsForTask,
     allSessionSummaries,
-    contextSessionsLength,
     activeSession,
     workflow,
     documents: {
@@ -340,7 +323,6 @@ export const buildAgentStudioSelectedSessionContext = ({
         : null,
       composerReadOnly: !workflow.selectedRoleAvailable,
       composerReadOnlyReason: workflow.selectedRoleReadOnlyReason,
-      canKickoff,
     },
     runtime: {
       runtimeDefinitions,
@@ -385,16 +367,6 @@ export const buildAgentStudioSelectedSessionContext = ({
           allSessionSummaries,
           activeSession?.subagentPendingQuestionsByExternalSessionId,
         ),
-    },
-    sessionStart: {
-      canKickoff,
-      kickoffLabel: sessionActions.kickoffLabel,
-      isKickoffPending: sessionActions.isStarting,
-      startLaunchKickoff: sessionActions.startLaunchKickoff,
-      sessionCreateOptions: workflow.sessionCreateOptions,
-      quickActions: workflow.quickActions,
-      primaryQuickAction: workflow.primaryQuickAction,
-      createSessionDisabled: workflow.createSessionDisabled,
     },
   };
 };

--- a/packages/frontend/src/pages/agents/selected-session/selected-session-context.ts
+++ b/packages/frontend/src/pages/agents/selected-session/selected-session-context.ts
@@ -1,0 +1,443 @@
+import type {
+  RuntimeApprovalReplyOutcome,
+  RuntimeDescriptor,
+  TaskCard,
+} from "@openducktor/contracts";
+import type { AgentRole } from "@openducktor/core";
+import type { AgentStudioWorkspaceDocument } from "@/components/features/agents";
+import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
+import type { AgentSessionSummary } from "@/state/agent-sessions-store";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentStudioReadinessState } from "../agent-studio-task-hydration-state";
+import {
+  type AgentStudioDocumentsContext,
+  type AgentStudioSessionContextUsage,
+  buildActiveDocumentForRole,
+  buildWorkflowModelContext,
+  toChatContextUsage,
+  type WorkflowModelContext,
+} from "../use-agent-studio-page-model-builders";
+
+const EMPTY_SUBAGENT_PENDING_APPROVAL_COUNTS: Record<string, number> = Object.freeze({});
+const EMPTY_SUBAGENT_PENDING_QUESTION_COUNTS: Record<string, number> = Object.freeze({});
+
+type SelectedSessionRuntimeReadinessContext = {
+  readinessState: AgentStudioReadinessState;
+  isReady: boolean;
+  blockedReason: string | null;
+  isLoadingChecks: boolean;
+  refreshChecks: () => Promise<void>;
+};
+
+type SelectedSessionComposerActiveSession = Pick<
+  AgentSessionState,
+  | "externalSessionId"
+  | "selectedModel"
+  | "isLoadingModelCatalog"
+  | "pendingApprovals"
+  | "pendingQuestions"
+> | null;
+
+type SelectedSessionPendingQuestionsContext = {
+  canSubmit: boolean;
+  isSubmittingByRequestId: Record<string, boolean>;
+  onSubmit: (requestId: string, answers: string[][]) => Promise<void>;
+};
+
+type SelectedSessionApprovalsContext = {
+  canReply: boolean;
+  isSubmittingByRequestId: Record<string, boolean>;
+  errorByRequestId: Record<string, string>;
+  onReply: (requestId: string, outcome: RuntimeApprovalReplyOutcome) => Promise<void>;
+};
+
+export type SelectedSessionDocumentsContext = {
+  activeDocumentRole: AgentRole;
+  activeDocument: AgentStudioWorkspaceDocument | null;
+  hasDocumentPanel: boolean;
+};
+
+export type SelectedSessionRightPanelContext = {
+  role: AgentRole;
+  hasTaskContext: boolean;
+  hasDocumentPanel: boolean;
+  hasBuildToolsPanel: boolean;
+};
+
+export type SelectedSessionChatContext = {
+  emptyState: NonNullable<AgentChatModel["thread"]["emptyState"]> | null;
+  contextUsage: AgentChatModel["composer"]["contextUsage"];
+  activeComposerSession: SelectedSessionComposerActiveSession;
+  composerReadOnly: boolean;
+  composerReadOnlyReason: string | null;
+  canKickoff: boolean;
+};
+
+export type SelectedSessionRuntimeContext = {
+  runtimeDefinitions: RuntimeDescriptor[];
+  runtimeReadiness: SelectedSessionRuntimeReadinessContext;
+  sessionRuntimeDataError: string | null;
+  isTaskHydrating: boolean;
+  isSessionHistoryHydrated: boolean;
+  isSessionHistoryHydrating: boolean;
+  isSessionHistoryHydrationFailed: boolean;
+  isSessionSelectionResolving: boolean;
+  isWaitingForRuntimeReadiness: boolean;
+};
+
+export type SelectedSessionPendingInputContext = {
+  pendingQuestions: SelectedSessionPendingQuestionsContext;
+  approvals: SelectedSessionApprovalsContext;
+  subagentPendingApprovalsByExternalSessionId:
+    | AgentSessionState["subagentPendingApprovalsByExternalSessionId"]
+    | undefined;
+  subagentPendingApprovalCountByExternalSessionId: Record<string, number>;
+  subagentPendingQuestionsByExternalSessionId:
+    | AgentSessionState["subagentPendingQuestionsByExternalSessionId"]
+    | undefined;
+  subagentPendingQuestionCountByExternalSessionId: Record<string, number>;
+};
+
+export type SelectedSessionStartAffordanceContext = {
+  canKickoff: boolean;
+  kickoffLabel: string;
+  isKickoffPending: boolean;
+  startLaunchKickoff: () => Promise<void>;
+  sessionCreateOptions: WorkflowModelContext["sessionCreateOptions"];
+  quickActions: WorkflowModelContext["quickActions"];
+  primaryQuickAction: WorkflowModelContext["primaryQuickAction"];
+  createSessionDisabled: boolean;
+};
+
+export type AgentStudioSelectedSessionContext = {
+  taskId: string;
+  role: AgentRole;
+  selectedTask: TaskCard | null;
+  sessionsForTask: AgentSessionSummary[];
+  allSessionSummaries: AgentSessionSummary[];
+  contextSessionsLength: number;
+  activeSession: AgentSessionState | null;
+  workflow: WorkflowModelContext;
+  documents: SelectedSessionDocumentsContext;
+  rightPanel: SelectedSessionRightPanelContext;
+  chat: SelectedSessionChatContext;
+  runtime: SelectedSessionRuntimeContext;
+  pendingInput: SelectedSessionPendingInputContext;
+  sessionStart: SelectedSessionStartAffordanceContext;
+};
+
+export type AgentStudioSelectedSessionContextInput = {
+  taskId: string;
+  role: AgentRole;
+  selectedTask: TaskCard | null;
+  sessionsForTask: AgentSessionSummary[];
+  allSessionSummaries: AgentSessionSummary[];
+  contextSessionsLength: number;
+  activeSession: AgentSessionState | null;
+  runtimeDefinitions: RuntimeDescriptor[];
+  sessionRuntimeDataError: string | null;
+  hasActiveGitConflict: boolean;
+  isTaskHydrating: boolean;
+  isSessionHistoryHydrated: boolean;
+  isSessionHistoryHydrating: boolean;
+  isSessionSelectionResolving: boolean;
+  isWaitingForRuntimeReadiness: boolean;
+  isSessionHistoryHydrationFailed: boolean;
+  activeSessionContextUsage: AgentStudioSessionContextUsage;
+  documents: AgentStudioDocumentsContext;
+  readiness: {
+    agentStudioReadinessState: AgentStudioReadinessState;
+    agentStudioReady: boolean;
+    agentStudioBlockedReason: string | null;
+    isLoadingChecks: boolean;
+    refreshChecks: () => Promise<void>;
+  };
+  sessionActions: {
+    isStarting: boolean;
+    isSessionWorking: boolean;
+    canKickoffNewSession: boolean;
+    kickoffLabel: string;
+    startLaunchKickoff: () => Promise<void>;
+    onSubmitQuestionAnswers: (requestId: string, answers: string[][]) => Promise<void>;
+    isSubmittingQuestionByRequestId: Record<string, boolean>;
+  };
+  approvals: {
+    isSubmittingApprovalByRequestId: Record<string, boolean>;
+    approvalReplyErrorByRequestId: Record<string, string>;
+    onReplyApproval: (requestId: string, outcome: RuntimeApprovalReplyOutcome) => Promise<void>;
+  };
+  roleLabelByRole: Record<AgentRole, string>;
+};
+
+const arePendingInputCountMapsEqual = (
+  left: Record<string, number>,
+  right: Record<string, number>,
+): boolean => {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+
+  return leftKeys.every((key) => left[key] === right[key]);
+};
+
+export const keepStablePendingInputCounts = (
+  previous: Record<string, number>,
+  next: Record<string, number>,
+): Record<string, number> => {
+  if (arePendingInputCountMapsEqual(previous, next)) {
+    return previous;
+  }
+
+  return next;
+};
+
+export const buildSubagentPendingApprovalCountByExternalSessionId = (
+  sessions: AgentSessionSummary[],
+  subagentPendingApprovalsByExternalSessionId:
+    | AgentSessionState["subagentPendingApprovalsByExternalSessionId"]
+    | undefined,
+): Record<string, number> => {
+  const next: Record<string, number> = {};
+  for (const session of sessions) {
+    const pendingApprovalCount = session.pendingApprovals.length;
+    if (pendingApprovalCount > 0) {
+      next[session.externalSessionId] = pendingApprovalCount;
+    }
+  }
+
+  if (subagentPendingApprovalsByExternalSessionId) {
+    for (const [externalSessionId, pendingApprovals] of Object.entries(
+      subagentPendingApprovalsByExternalSessionId,
+    )) {
+      const pendingApprovalCount = pendingApprovals.length;
+      if (pendingApprovalCount > 0) {
+        next[externalSessionId] = pendingApprovalCount;
+      }
+    }
+  }
+
+  return Object.keys(next).length > 0 ? next : EMPTY_SUBAGENT_PENDING_APPROVAL_COUNTS;
+};
+
+export const buildSubagentPendingQuestionCountByExternalSessionId = (
+  sessions: AgentSessionSummary[],
+  subagentPendingQuestionsByExternalSessionId:
+    | AgentSessionState["subagentPendingQuestionsByExternalSessionId"]
+    | undefined,
+): Record<string, number> => {
+  const next: Record<string, number> = {};
+  for (const session of sessions) {
+    const pendingQuestionCount = session.pendingQuestions.length;
+    if (pendingQuestionCount > 0) {
+      next[session.externalSessionId] = pendingQuestionCount;
+    }
+  }
+
+  if (subagentPendingQuestionsByExternalSessionId) {
+    for (const [externalSessionId, pendingQuestions] of Object.entries(
+      subagentPendingQuestionsByExternalSessionId,
+    )) {
+      const pendingQuestionCount = pendingQuestions.length;
+      if (pendingQuestionCount > 0) {
+        next[externalSessionId] = pendingQuestionCount;
+      }
+    }
+  }
+
+  return Object.keys(next).length > 0 ? next : EMPTY_SUBAGENT_PENDING_QUESTION_COUNTS;
+};
+
+export const buildAgentStudioSelectedSessionContext = ({
+  taskId,
+  role,
+  selectedTask,
+  sessionsForTask,
+  allSessionSummaries,
+  contextSessionsLength,
+  activeSession,
+  runtimeDefinitions,
+  sessionRuntimeDataError,
+  hasActiveGitConflict,
+  isTaskHydrating,
+  isSessionHistoryHydrated,
+  isSessionHistoryHydrating,
+  isSessionSelectionResolving,
+  isWaitingForRuntimeReadiness,
+  isSessionHistoryHydrationFailed,
+  activeSessionContextUsage,
+  documents,
+  readiness,
+  sessionActions,
+  approvals,
+  roleLabelByRole,
+}: AgentStudioSelectedSessionContextInput): AgentStudioSelectedSessionContext => {
+  const workflowActiveSession = activeSession
+    ? {
+        externalSessionId: activeSession.externalSessionId,
+        role: activeSession.role,
+      }
+    : null;
+  const workflow = buildWorkflowModelContext({
+    selectedTask,
+    sessionsForTask,
+    activeSession: workflowActiveSession,
+    role,
+    isSessionWorking: sessionActions.isSessionWorking,
+    hasActiveGitConflict,
+    roleLabelByRole,
+  });
+  const activeDocumentRole = activeSession?.role ?? role;
+  const activeDocument = taskId
+    ? buildActiveDocumentForRole({
+        activeRole: activeDocumentRole,
+        specDoc: documents.specDoc,
+        planDoc: documents.planDoc,
+        qaDoc: documents.qaDoc,
+      })
+    : null;
+  const canKickoff = sessionActions.canKickoffNewSession && workflow.selectedRoleAvailable;
+  const emptyState = buildSelectedSessionChatEmptyState({
+    taskId,
+    isStarting: sessionActions.isStarting,
+    canKickoff,
+    kickoffLabel: sessionActions.kickoffLabel,
+    startLaunchKickoff: sessionActions.startLaunchKickoff,
+  });
+
+  return {
+    taskId,
+    role,
+    selectedTask,
+    sessionsForTask,
+    allSessionSummaries,
+    contextSessionsLength,
+    activeSession,
+    workflow,
+    documents: {
+      activeDocumentRole,
+      activeDocument,
+      hasDocumentPanel: Boolean(activeDocument),
+    },
+    rightPanel: {
+      role,
+      hasTaskContext: Boolean(taskId),
+      hasDocumentPanel: Boolean(activeDocument),
+      hasBuildToolsPanel: role === "build",
+    },
+    chat: {
+      emptyState,
+      contextUsage: toChatContextUsage(activeSessionContextUsage),
+      activeComposerSession: activeSession
+        ? {
+            externalSessionId: activeSession.externalSessionId,
+            selectedModel: activeSession.selectedModel,
+            isLoadingModelCatalog: activeSession.isLoadingModelCatalog,
+            pendingApprovals: activeSession.pendingApprovals,
+            pendingQuestions: activeSession.pendingQuestions,
+          }
+        : null,
+      composerReadOnly: !workflow.selectedRoleAvailable,
+      composerReadOnlyReason: workflow.selectedRoleReadOnlyReason,
+      canKickoff,
+    },
+    runtime: {
+      runtimeDefinitions,
+      runtimeReadiness: {
+        readinessState: readiness.agentStudioReadinessState,
+        isReady: readiness.agentStudioReady,
+        blockedReason: readiness.agentStudioBlockedReason,
+        isLoadingChecks: readiness.isLoadingChecks,
+        refreshChecks: readiness.refreshChecks,
+      },
+      sessionRuntimeDataError,
+      isTaskHydrating,
+      isSessionHistoryHydrated,
+      isSessionHistoryHydrating,
+      isSessionSelectionResolving,
+      isWaitingForRuntimeReadiness,
+      isSessionHistoryHydrationFailed,
+    },
+    pendingInput: {
+      pendingQuestions: {
+        canSubmit: true,
+        isSubmittingByRequestId: sessionActions.isSubmittingQuestionByRequestId,
+        onSubmit: sessionActions.onSubmitQuestionAnswers,
+      },
+      approvals: {
+        canReply: true,
+        isSubmittingByRequestId: approvals.isSubmittingApprovalByRequestId,
+        errorByRequestId: approvals.approvalReplyErrorByRequestId,
+        onReply: approvals.onReplyApproval,
+      },
+      subagentPendingApprovalsByExternalSessionId:
+        activeSession?.subagentPendingApprovalsByExternalSessionId,
+      subagentPendingApprovalCountByExternalSessionId:
+        buildSubagentPendingApprovalCountByExternalSessionId(
+          allSessionSummaries,
+          activeSession?.subagentPendingApprovalsByExternalSessionId,
+        ),
+      subagentPendingQuestionsByExternalSessionId:
+        activeSession?.subagentPendingQuestionsByExternalSessionId,
+      subagentPendingQuestionCountByExternalSessionId:
+        buildSubagentPendingQuestionCountByExternalSessionId(
+          allSessionSummaries,
+          activeSession?.subagentPendingQuestionsByExternalSessionId,
+        ),
+    },
+    sessionStart: {
+      canKickoff,
+      kickoffLabel: sessionActions.kickoffLabel,
+      isKickoffPending: sessionActions.isStarting,
+      startLaunchKickoff: sessionActions.startLaunchKickoff,
+      sessionCreateOptions: workflow.sessionCreateOptions,
+      quickActions: workflow.quickActions,
+      primaryQuickAction: workflow.primaryQuickAction,
+      createSessionDisabled: workflow.createSessionDisabled,
+    },
+  };
+};
+
+const buildSelectedSessionChatEmptyState = ({
+  taskId,
+  isStarting,
+  canKickoff,
+  kickoffLabel,
+  startLaunchKickoff,
+}: {
+  taskId: string;
+  isStarting: boolean;
+  canKickoff: boolean;
+  kickoffLabel: string;
+  startLaunchKickoff: () => Promise<void>;
+}): NonNullable<AgentChatModel["thread"]["emptyState"]> | null => {
+  if (!taskId) {
+    return {
+      title: "Select a task to begin.",
+    };
+  }
+
+  if (isStarting) {
+    return {
+      title: "Initializing session...",
+    };
+  }
+
+  if (canKickoff) {
+    return {
+      title: "Send a message to start a new session automatically.",
+      actionLabel: kickoffLabel,
+      onAction: (): void => {
+        void startLaunchKickoff();
+      },
+      isActionPending: isStarting,
+    };
+  }
+
+  return {
+    title: "Send a message to start a new session automatically.",
+  };
+};
+
+export type { AgentStudioDocumentsContext };

--- a/packages/frontend/src/pages/agents/selected-session/selected-session-context.ts
+++ b/packages/frontend/src/pages/agents/selected-session/selected-session-context.ts
@@ -289,6 +289,8 @@ export const buildAgentStudioSelectedSessionContext = ({
     kickoffLabel: sessionActions.kickoffLabel,
     startLaunchKickoff: sessionActions.startLaunchKickoff,
   });
+  const hasPendingQuestions = (activeSession?.pendingQuestions ?? []).length > 0;
+  const hasPendingApprovals = (activeSession?.pendingApprovals ?? []).length > 0;
 
   return {
     taskId,
@@ -343,12 +345,12 @@ export const buildAgentStudioSelectedSessionContext = ({
     },
     pendingInput: {
       pendingQuestions: {
-        canSubmit: true,
+        canSubmit: hasPendingQuestions,
         isSubmittingByRequestId: sessionActions.isSubmittingQuestionByRequestId,
         onSubmit: sessionActions.onSubmitQuestionAnswers,
       },
       approvals: {
-        canReply: true,
+        canReply: hasPendingApprovals,
         isSubmittingByRequestId: approvals.isSubmittingApprovalByRequestId,
         errorByRequestId: approvals.approvalReplyErrorByRequestId,
         onReply: approvals.onReplyApproval,
@@ -403,7 +405,6 @@ const buildSelectedSessionChatEmptyState = ({
       onAction: (): void => {
         void startLaunchKickoff();
       },
-      isActionPending: isStarting,
     };
   }
 

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -75,7 +75,6 @@ const baseDocuments = {
 const baseArgs: BuildArgs = {
   view: {
     viewTaskId: "task-1",
-    contextSwitchVersion: 4,
   },
   selectedSession: buildAgentStudioSelectedSessionContext({
     taskId: "task-1",
@@ -83,7 +82,6 @@ const baseArgs: BuildArgs = {
     selectedTask: task,
     sessionsForTask: [session],
     allSessionSummaries: [session],
-    contextSessionsLength: 1,
     activeSession: session,
     runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
     sessionRuntimeDataError: null,
@@ -144,7 +142,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
   test("maps grouped orchestration context into page-model contracts", () => {
     const mapped = buildAgentStudioPageModelsArgs(baseArgs);
 
-    expect(mapped.core.activeTabValue).toBe("task-1");
+    expect(mapped.activeTabValue).toBe("task-1");
     expect(mapped.selectedSession.role).toBe("planner");
     expect(mapped.selectedSession.runtime.runtimeDefinitions).toEqual([
       OPENCODE_RUNTIME_DESCRIPTOR,
@@ -196,9 +194,9 @@ describe("buildAgentStudioPageModelsArgs", () => {
       },
     });
 
-    expect(withActiveTab.core.activeTabValue).toBe("task-tab-2");
-    expect(withTaskFallback.core.activeTabValue).toBe("task-1");
-    expect(withEmptyFallback.core.activeTabValue).toBe("__agent_studio_empty__");
+    expect(withActiveTab.activeTabValue).toBe("task-tab-2");
+    expect(withTaskFallback.activeTabValue).toBe("task-1");
+    expect(withEmptyFallback.activeTabValue).toBe("__agent_studio_empty__");
   });
 });
 
@@ -236,7 +234,6 @@ describe("buildAgentStudioSelectedSessionContextFromOrchestration", () => {
       roleLabelByRole: buildRoleLabelByRole(ROLE_OPTIONS),
     });
 
-    expect(context.contextSessionsLength).toBe(1);
     expect(context.runtime.isTaskHydrating).toBe(true);
     expect(context.runtime.sessionRuntimeDataError).toBe("runtime data failed");
     expect(context.runtime.runtimeReadiness.readinessState).toBe("checking");
@@ -269,25 +266,5 @@ describe("buildAgentStudioSelectedSessionContextFromOrchestration", () => {
 
     expect(failed.selectedSession.runtime.isTaskHydrating).toBe(true);
     expect(failed.selectedSession.runtime.isSessionHistoryHydrationFailed).toBe(true);
-  });
-
-  test("derives contextSessionsLength from the sessions context size", () => {
-    const secondSession = createAgentSessionFixture({
-      runtimeKind: "opencode",
-      externalSessionId: "session-2",
-      taskId: "task-1",
-      role: "planner",
-    });
-    const mapped = buildAgentStudioPageModelsArgs({
-      ...baseArgs,
-      selectedSession: {
-        ...baseArgs.selectedSession,
-        allSessionSummaries: [session, secondSession],
-        sessionsForTask: [session, secondSession],
-        contextSessionsLength: 2,
-      },
-    });
-
-    expect(mapped.selectedSession.contextSessionsLength).toBe(2);
   });
 });

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { createAgentSessionFixture, createTaskCardFixture } from "./agent-studio-test-utils";
+import { ROLE_OPTIONS } from "./agents-page-constants";
+import { buildRoleLabelByRole } from "./agents-page-view-model";
+import { buildAgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
 import { buildAgentStudioPageModelsArgs } from "./use-agent-studio-orchestration-controller";
 
 type BuildArgs = Parameters<typeof buildAgentStudioPageModelsArgs>[0];
@@ -27,28 +30,74 @@ const onReorderTab = () => {};
 const handleSelectAgentProfile = () => {};
 const handleSelectModel = () => {};
 const handleSelectVariant = () => {};
+const baseReadiness = {
+  agentStudioReadinessState: "ready" as const,
+  agentStudioReady: true,
+  agentStudioBlockedReason: "",
+  isLoadingChecks: false,
+  refreshChecks: async () => {},
+};
+const baseSessionActions = {
+  handleWorkflowStepSelect: () => {},
+  handleSessionSelectionChange: () => {},
+  handleCreateSession: () => {},
+  handlePrepareMessageFirstSession: () => {},
+  handleQuickAction: () => {},
+  openTaskDetails: () => {},
+  isStarting: false,
+  isSending: false,
+  isSessionWorking: false,
+  isWaitingInput: false,
+  busySendBlockedReason: null,
+  canKickoffNewSession: false,
+  kickoffLabel: "Kickoff",
+  canStopSession: false,
+  startLaunchKickoff: async () => {},
+  onSend: async () => true,
+  onSubmitQuestionAnswers: async () => {},
+  isSubmittingQuestionByRequestId: {},
+  stopAgentSession: async () => {},
+};
+const baseApprovals = {
+  isSubmittingApprovalByRequestId: {},
+  approvalReplyErrorByRequestId: {},
+  onReplyApproval: async () => {},
+};
+const baseDocuments = {
+  specDoc: taskDocument,
+  planDoc: taskDocument,
+  qaDoc: taskDocument,
+};
 
 const baseArgs: BuildArgs = {
   view: {
     viewTaskId: "task-1",
-    viewRole: "planner",
-    viewSelectedTask: task,
     contextSwitchVersion: 4,
-    isSessionSelectionResolving: false,
-    isActiveTaskHydrated: true,
-    isActiveTaskHydrationFailed: false,
-    isViewSessionHistoryHydrated: true,
-    isViewSessionHistoryHydrationFailed: false,
-    isViewSessionHistoryHydrating: false,
-    isViewSessionWaitingForRuntimeReadiness: false,
-    hasActiveGitConflict: false,
   },
-  sessions: {
+  selectedSession: buildAgentStudioSelectedSessionContext({
+    taskId: "task-1",
+    role: "planner",
+    selectedTask: task,
+    sessionsForTask: [session],
     allSessionSummaries: [session],
-    viewSessionsForTask: [session],
-    viewActiveSession: session,
-  },
-  runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    contextSessionsLength: 1,
+    activeSession: session,
+    runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    sessionRuntimeDataError: null,
+    hasActiveGitConflict: false,
+    isTaskHydrating: false,
+    isSessionHistoryHydrated: true,
+    isSessionHistoryHydrating: false,
+    isSessionSelectionResolving: false,
+    isWaitingForRuntimeReadiness: false,
+    isSessionHistoryHydrationFailed: false,
+    activeSessionContextUsage: null,
+    documents: baseDocuments,
+    readiness: baseReadiness,
+    sessionActions: baseSessionActions,
+    approvals: baseApprovals,
+    roleLabelByRole: buildRoleLabelByRole(ROLE_OPTIONS),
+  }),
   tabs: {
     activeTaskTabId: "task-1",
     taskTabs: [],
@@ -59,39 +108,7 @@ const baseArgs: BuildArgs = {
     handleCloseTab: onCloseTab,
     handleReorderTab: onReorderTab,
   },
-  documents: {
-    specDoc: taskDocument,
-    planDoc: taskDocument,
-    qaDoc: taskDocument,
-  },
-  readiness: {
-    agentStudioReadinessState: "ready",
-    agentStudioReady: true,
-    agentStudioBlockedReason: "",
-    isLoadingChecks: false,
-    refreshChecks: async () => {},
-  },
-  sessionActions: {
-    handleWorkflowStepSelect: () => {},
-    handleSessionSelectionChange: () => {},
-    handleCreateSession: () => {},
-    handlePrepareMessageFirstSession: () => {},
-    handleQuickAction: () => {},
-    openTaskDetails: () => {},
-    isStarting: false,
-    isSending: false,
-    isSessionWorking: false,
-    isWaitingInput: false,
-    busySendBlockedReason: null,
-    canKickoffNewSession: false,
-    kickoffLabel: "Kickoff",
-    canStopSession: false,
-    startLaunchKickoff: async () => {},
-    onSend: async () => true,
-    onSubmitQuestionAnswers: async () => {},
-    isSubmittingQuestionByRequestId: {},
-    stopAgentSession: async () => {},
-  },
+  sessionActions: baseSessionActions,
   modelSelection: {
     selectedModelSelection: null,
     selectedModelDescriptor: null,
@@ -112,11 +129,6 @@ const baseArgs: BuildArgs = {
     handleSelectVariant,
     agentAccentColorsByProfileId: {},
     activeSessionContextUsage: null,
-  },
-  approvals: {
-    isSubmittingApprovalByRequestId: {},
-    approvalReplyErrorByRequestId: {},
-    onReplyApproval: async () => {},
   },
   chatSettings: {
     showThinkingMessages: true,
@@ -140,8 +152,8 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
     expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
     expect(mapped.taskTabs.onReorderTab).toBe(onReorderTab);
-    expect(mapped.documents.planDoc.markdown).toBe("# doc");
-    expect(mapped.readiness.agentStudioReadinessState).toBe("ready");
+    expect(mapped.selectedSession.documents.activeDocument?.document.markdown).toBe("# doc");
+    expect(mapped.selectedSession.runtime.runtimeReadiness.readinessState).toBe("ready");
     expect(mapped.modelSelection.onSelectAgent).toBe(handleSelectAgentProfile);
     expect(mapped.modelSelection.onSelectModel).toBe(handleSelectModel);
     expect(mapped.modelSelection.onSelectVariant).toBe(handleSelectVariant);
@@ -166,6 +178,10 @@ describe("buildAgentStudioPageModelsArgs", () => {
     });
     const withEmptyFallback = buildAgentStudioPageModelsArgs({
       ...baseArgs,
+      selectedSession: {
+        ...baseArgs.selectedSession,
+        taskId: "",
+      },
       view: {
         ...baseArgs.view,
         viewTaskId: "",
@@ -184,18 +200,28 @@ describe("buildAgentStudioPageModelsArgs", () => {
   test("derives isTaskHydrating only when a task exists and hydration is incomplete", () => {
     const hydrating = buildAgentStudioPageModelsArgs({
       ...baseArgs,
-      view: {
-        ...baseArgs.view,
-        isActiveTaskHydrated: false,
+      selectedSession: {
+        ...baseArgs.selectedSession,
+        runtime: {
+          ...baseArgs.selectedSession.runtime,
+          isTaskHydrating: true,
+        },
       },
     });
     const hydrated = buildAgentStudioPageModelsArgs(baseArgs);
     const noTaskSelected = buildAgentStudioPageModelsArgs({
       ...baseArgs,
+      selectedSession: {
+        ...baseArgs.selectedSession,
+        taskId: "",
+        runtime: {
+          ...baseArgs.selectedSession.runtime,
+          isTaskHydrating: false,
+        },
+      },
       view: {
         ...baseArgs.view,
         viewTaskId: "",
-        isActiveTaskHydrated: false,
       },
     });
 
@@ -207,10 +233,12 @@ describe("buildAgentStudioPageModelsArgs", () => {
   test("stops reporting task hydration after hydration fails", () => {
     const failed = buildAgentStudioPageModelsArgs({
       ...baseArgs,
-      view: {
-        ...baseArgs.view,
-        isActiveTaskHydrated: false,
-        isActiveTaskHydrationFailed: true,
+      selectedSession: {
+        ...baseArgs.selectedSession,
+        runtime: {
+          ...baseArgs.selectedSession.runtime,
+          isTaskHydrating: false,
+        },
       },
     });
 
@@ -220,9 +248,12 @@ describe("buildAgentStudioPageModelsArgs", () => {
   test("forwards explicit session history hydration failures into page-model core", () => {
     const failed = buildAgentStudioPageModelsArgs({
       ...baseArgs,
-      view: {
-        ...baseArgs.view,
-        isViewSessionHistoryHydrationFailed: true,
+      selectedSession: {
+        ...baseArgs.selectedSession,
+        runtime: {
+          ...baseArgs.selectedSession.runtime,
+          isSessionHistoryHydrationFailed: true,
+        },
       },
     });
 
@@ -238,10 +269,11 @@ describe("buildAgentStudioPageModelsArgs", () => {
     });
     const mapped = buildAgentStudioPageModelsArgs({
       ...baseArgs,
-      sessions: {
-        ...baseArgs.sessions,
+      selectedSession: {
+        ...baseArgs.selectedSession,
         allSessionSummaries: [session, secondSession],
-        viewSessionsForTask: [session, secondSession],
+        sessionsForTask: [session, secondSession],
+        contextSessionsLength: 2,
       },
     });
 

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -4,7 +4,10 @@ import { createAgentSessionFixture, createTaskCardFixture } from "./agent-studio
 import { ROLE_OPTIONS } from "./agents-page-constants";
 import { buildRoleLabelByRole } from "./agents-page-view-model";
 import { buildAgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
-import { buildAgentStudioPageModelsArgs } from "./use-agent-studio-orchestration-controller";
+import {
+  buildAgentStudioPageModelsArgs,
+  buildAgentStudioSelectedSessionContextFromOrchestration,
+} from "./use-agent-studio-orchestration-controller";
 
 type BuildArgs = Parameters<typeof buildAgentStudioPageModelsArgs>[0];
 
@@ -128,7 +131,6 @@ const baseArgs: BuildArgs = {
     handleSelectModel,
     handleSelectVariant,
     agentAccentColorsByProfileId: {},
-    activeSessionContextUsage: null,
   },
   chatSettings: {
     showThinkingMessages: true,
@@ -142,12 +144,14 @@ describe("buildAgentStudioPageModelsArgs", () => {
   test("maps grouped orchestration context into page-model contracts", () => {
     const mapped = buildAgentStudioPageModelsArgs(baseArgs);
 
-    expect(mapped.core.role).toBe("planner");
-    expect(mapped.core.contextSwitchVersion).toBe(4);
-    expect(mapped.core.runtimeDefinitions).toEqual([OPENCODE_RUNTIME_DESCRIPTOR]);
-    expect(mapped.core.isSessionHistoryHydrated).toBe(true);
-    expect(mapped.core.isSessionHistoryHydrationFailed).toBe(false);
-    expect(mapped.core.isWaitingForRuntimeReadiness).toBe(false);
+    expect(mapped.core.activeTabValue).toBe("task-1");
+    expect(mapped.selectedSession.role).toBe("planner");
+    expect(mapped.selectedSession.runtime.runtimeDefinitions).toEqual([
+      OPENCODE_RUNTIME_DESCRIPTOR,
+    ]);
+    expect(mapped.selectedSession.runtime.isSessionHistoryHydrated).toBe(true);
+    expect(mapped.selectedSession.runtime.isSessionHistoryHydrationFailed).toBe(false);
+    expect(mapped.selectedSession.runtime.isWaitingForRuntimeReadiness).toBe(false);
     expect(mapped.taskTabs.onSelectTab).toBe(onSelectTab);
     expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
     expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
@@ -196,68 +200,75 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(withTaskFallback.core.activeTabValue).toBe("task-1");
     expect(withEmptyFallback.core.activeTabValue).toBe("__agent_studio_empty__");
   });
+});
 
-  test("derives isTaskHydrating only when a task exists and hydration is incomplete", () => {
-    const hydrating = buildAgentStudioPageModelsArgs({
+describe("buildAgentStudioSelectedSessionContextFromOrchestration", () => {
+  test("maps raw orchestration inputs into selected-session context", () => {
+    const context = buildAgentStudioSelectedSessionContextFromOrchestration({
+      taskId: "task-1",
+      role: "planner",
+      selectedTask: task,
+      sessionsForTask: [session],
+      allSessionSummaries: [session],
+      activeSession: session,
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+      viewSessionRuntimeDataError: "runtime data failed",
+      hasActiveGitConflict: true,
+      isActiveTaskHydrated: false,
+      isActiveTaskHydrationFailed: false,
+      isSessionHistoryHydrated: false,
+      isSessionHistoryHydrating: true,
+      isSessionSelectionResolving: true,
+      isWaitingForRuntimeReadiness: true,
+      isSessionHistoryHydrationFailed: false,
+      activeSessionContextUsage: { totalTokens: 64, contextWindow: 1024 },
+      documents: baseDocuments,
+      readiness: {
+        ...baseReadiness,
+        agentStudioReadinessState: "checking",
+        agentStudioReady: false,
+      },
+      sessionActions: {
+        ...baseSessionActions,
+        canKickoffNewSession: true,
+      },
+      approvals: baseApprovals,
+      roleLabelByRole: buildRoleLabelByRole(ROLE_OPTIONS),
+    });
+
+    expect(context.contextSessionsLength).toBe(1);
+    expect(context.runtime.isTaskHydrating).toBe(true);
+    expect(context.runtime.sessionRuntimeDataError).toBe("runtime data failed");
+    expect(context.runtime.runtimeReadiness.readinessState).toBe("checking");
+    expect(context.runtime.isSessionSelectionResolving).toBe(true);
+    expect(context.runtime.isSessionHistoryHydrating).toBe(true);
+    expect(context.runtime.isWaitingForRuntimeReadiness).toBe(true);
+    expect(context.chat.contextUsage).toEqual({ totalTokens: 64, contextWindow: 1024 });
+    expect(context.workflow.selectedInteractionRole).toBe("planner");
+    expect(context.documents.activeDocument?.title).toBe("Implementation Plan");
+    expect(context.rightPanel).toMatchObject({
+      role: "planner",
+      hasTaskContext: true,
+      hasDocumentPanel: true,
+      hasBuildToolsPanel: false,
+    });
+  });
+
+  test("forwards selected-session runtime state without recomputing it", () => {
+    const failed = buildAgentStudioPageModelsArgs({
       ...baseArgs,
       selectedSession: {
         ...baseArgs.selectedSession,
         runtime: {
           ...baseArgs.selectedSession.runtime,
           isTaskHydrating: true,
-        },
-      },
-    });
-    const hydrated = buildAgentStudioPageModelsArgs(baseArgs);
-    const noTaskSelected = buildAgentStudioPageModelsArgs({
-      ...baseArgs,
-      selectedSession: {
-        ...baseArgs.selectedSession,
-        taskId: "",
-        runtime: {
-          ...baseArgs.selectedSession.runtime,
-          isTaskHydrating: false,
-        },
-      },
-      view: {
-        ...baseArgs.view,
-        viewTaskId: "",
-      },
-    });
-
-    expect(hydrating.core.isTaskHydrating).toBe(true);
-    expect(hydrated.core.isTaskHydrating).toBe(false);
-    expect(noTaskSelected.core.isTaskHydrating).toBe(false);
-  });
-
-  test("stops reporting task hydration after hydration fails", () => {
-    const failed = buildAgentStudioPageModelsArgs({
-      ...baseArgs,
-      selectedSession: {
-        ...baseArgs.selectedSession,
-        runtime: {
-          ...baseArgs.selectedSession.runtime,
-          isTaskHydrating: false,
-        },
-      },
-    });
-
-    expect(failed.core.isTaskHydrating).toBe(false);
-  });
-
-  test("forwards explicit session history hydration failures into page-model core", () => {
-    const failed = buildAgentStudioPageModelsArgs({
-      ...baseArgs,
-      selectedSession: {
-        ...baseArgs.selectedSession,
-        runtime: {
-          ...baseArgs.selectedSession.runtime,
           isSessionHistoryHydrationFailed: true,
         },
       },
     });
 
-    expect(failed.core.isSessionHistoryHydrationFailed).toBe(true);
+    expect(failed.selectedSession.runtime.isTaskHydrating).toBe(true);
+    expect(failed.selectedSession.runtime.isSessionHistoryHydrationFailed).toBe(true);
   });
 
   test("derives contextSessionsLength from the sessions context size", () => {
@@ -277,6 +288,6 @@ describe("buildAgentStudioPageModelsArgs", () => {
       },
     });
 
-    expect(mapped.core.contextSessionsLength).toBe(2);
+    expect(mapped.selectedSession.contextSessionsLength).toBe(2);
   });
 });

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -101,7 +101,7 @@ type UseAgentStudioOrchestrationControllerResult = {
 
 type AgentStudioPageModelsViewContext = Pick<
   AgentStudioOrchestrationSelectionContext,
-  "viewTaskId" | "contextSwitchVersion"
+  "viewTaskId"
 >;
 
 type AgentStudioPageModelsTabsContext = Pick<
@@ -156,7 +156,7 @@ type BuildAgentStudioPageModelsArgsInput = {
 
 type BuildSelectedSessionContextFromOrchestrationInput = Omit<
   AgentStudioSelectedSessionContextInput,
-  "contextSessionsLength" | "isTaskHydrating" | "sessionRuntimeDataError"
+  "isTaskHydrating" | "sessionRuntimeDataError"
 > & {
   viewSessionRuntimeDataError?: string | null;
   isActiveTaskHydrated: boolean;
@@ -171,7 +171,6 @@ export const buildAgentStudioSelectedSessionContextFromOrchestration = ({
 }: BuildSelectedSessionContextFromOrchestrationInput): AgentStudioSelectedSessionContext =>
   buildAgentStudioSelectedSessionContext({
     ...input,
-    contextSessionsLength: input.sessionsForTask.length,
     sessionRuntimeDataError: viewSessionRuntimeDataError ?? null,
     isTaskHydrating: Boolean(input.taskId && !isActiveTaskHydrated && !isActiveTaskHydrationFailed),
   });
@@ -203,9 +202,7 @@ export const buildAgentStudioPageModelsArgs = ({
   } = modelSelection;
 
   return {
-    core: {
-      activeTabValue: activeTaskTabId || view.viewTaskId || "__agent_studio_empty__",
-    },
+    activeTabValue: activeTaskTabId || view.viewTaskId || "__agent_studio_empty__",
     selectedSession,
     taskTabs: {
       ...taskTabs,
@@ -250,7 +247,6 @@ export function useAgentStudioOrchestrationController({
     activeTaskTabId,
     taskTabs,
     availableTabTasks,
-    contextSwitchVersion,
     isLoadingTasks,
     isActiveTaskHydrated,
     handleSelectTab,
@@ -459,7 +455,6 @@ export function useAgentStudioOrchestrationController({
   const pageModelsArgs = buildAgentStudioPageModelsArgs({
     view: {
       viewTaskId,
-      contextSwitchVersion,
     },
     selectedSession: selectedSessionContext,
     tabs: {

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -18,7 +18,10 @@ import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-st
 import { ROLE_OPTIONS } from "./agents-page-constants";
 import { buildRoleLabelByRole } from "./agents-page-view-model";
 import { useAgentStudioChatComposer } from "./chat-composer/use-agent-studio-chat-composer";
-import type { AgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
+import type {
+  AgentStudioSelectedSessionContext,
+  AgentStudioSelectedSessionContextInput,
+} from "./selected-session/selected-session-context";
 import { buildAgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
 import { useAgentStudioChatSettings } from "./use-agent-studio-chat-settings";
 import { useAgentStudioDocuments } from "./use-agent-studio-documents";
@@ -134,7 +137,6 @@ type AgentStudioPageModelsModelSelectionContext = Pick<
   | "modelGroups"
   | "variantOptions"
   | "agentAccentColorsByProfileId"
-  | "activeSessionContextUsage"
   | "handleSelectAgentProfile"
   | "handleSelectModel"
   | "handleSelectVariant"
@@ -151,6 +153,28 @@ type BuildAgentStudioPageModelsArgsInput = {
   };
   composer: AgentStudioOrchestrationComposerContext;
 };
+
+type BuildSelectedSessionContextFromOrchestrationInput = Omit<
+  AgentStudioSelectedSessionContextInput,
+  "contextSessionsLength" | "isTaskHydrating" | "sessionRuntimeDataError"
+> & {
+  viewSessionRuntimeDataError?: string | null;
+  isActiveTaskHydrated: boolean;
+  isActiveTaskHydrationFailed: boolean;
+};
+
+export const buildAgentStudioSelectedSessionContextFromOrchestration = ({
+  viewSessionRuntimeDataError,
+  isActiveTaskHydrated,
+  isActiveTaskHydrationFailed,
+  ...input
+}: BuildSelectedSessionContextFromOrchestrationInput): AgentStudioSelectedSessionContext =>
+  buildAgentStudioSelectedSessionContext({
+    ...input,
+    contextSessionsLength: input.sessionsForTask.length,
+    sessionRuntimeDataError: viewSessionRuntimeDataError ?? null,
+    isTaskHydrating: Boolean(input.taskId && !isActiveTaskHydrated && !isActiveTaskHydrationFailed),
+  });
 
 export const buildAgentStudioPageModelsArgs = ({
   view,
@@ -181,23 +205,6 @@ export const buildAgentStudioPageModelsArgs = ({
   return {
     core: {
       activeTabValue: activeTaskTabId || view.viewTaskId || "__agent_studio_empty__",
-      taskId: selectedSession.taskId,
-      role: selectedSession.role,
-      selectedTask: selectedSession.selectedTask,
-      sessionsForTask: selectedSession.sessionsForTask,
-      allSessionSummaries: selectedSession.allSessionSummaries,
-      contextSessionsLength: selectedSession.contextSessionsLength,
-      activeSession: selectedSession.activeSession,
-      runtimeDefinitions: selectedSession.runtime.runtimeDefinitions,
-      sessionRuntimeDataError: selectedSession.runtime.sessionRuntimeDataError,
-      hasActiveGitConflict: false,
-      isTaskHydrating: selectedSession.runtime.isTaskHydrating,
-      isSessionHistoryHydrated: selectedSession.runtime.isSessionHistoryHydrated,
-      isSessionHistoryHydrating: selectedSession.runtime.isSessionHistoryHydrating,
-      isSessionSelectionResolving: selectedSession.runtime.isSessionSelectionResolving,
-      isWaitingForRuntimeReadiness: selectedSession.runtime.isWaitingForRuntimeReadiness,
-      isSessionHistoryHydrationFailed: selectedSession.runtime.isSessionHistoryHydrationFailed,
-      contextSwitchVersion: view.contextSwitchVersion,
     },
     selectedSession,
     taskTabs: {
@@ -333,7 +340,6 @@ export function useAgentStudioOrchestrationController({
     onSubmitQuestionAnswers,
     handleWorkflowStepSelect,
     handleSessionSelectionChange,
-    handleCreateSession,
     handlePrepareMessageFirstSession,
     handleQuickAction,
   } = useAgentStudioSessionActions({
@@ -374,20 +380,18 @@ export function useAgentStudioOrchestrationController({
   const roleLabelByRole = useMemo(() => buildRoleLabelByRole(ROLE_OPTIONS), []);
   const selectedSessionContext = useMemo(
     () =>
-      buildAgentStudioSelectedSessionContext({
+      buildAgentStudioSelectedSessionContextFromOrchestration({
         taskId: viewTaskId,
         role: viewRole,
         selectedTask: viewSelectedTask,
         sessionsForTask: viewSessionsForTask,
         allSessionSummaries: selection.allSessionSummaries,
-        contextSessionsLength: viewSessionsForTask.length,
         activeSession: viewActiveSession,
         runtimeDefinitions,
-        sessionRuntimeDataError: viewSessionRuntimeDataError ?? null,
+        viewSessionRuntimeDataError,
         hasActiveGitConflict,
-        isTaskHydrating: Boolean(
-          viewTaskId && !isActiveTaskHydrated && !selection.isActiveTaskHydrationFailed,
-        ),
+        isActiveTaskHydrated,
+        isActiveTaskHydrationFailed: selection.isActiveTaskHydrationFailed,
         isSessionHistoryHydrated: selection.isViewSessionHistoryHydrated,
         isSessionHistoryHydrating: selection.isViewSessionHistoryHydrating,
         isSessionSelectionResolving: selection.isSessionSelectionResolving,
@@ -472,19 +476,13 @@ export function useAgentStudioOrchestrationController({
       openTaskDetails: actions.openTaskDetails,
       isStarting,
       isSending,
-      isSubmittingQuestionByRequestId,
       isSessionWorking,
       isWaitingInput,
       busySendBlockedReason,
-      canKickoffNewSession,
-      kickoffLabel,
       canStopSession,
-      startLaunchKickoff,
       onSend,
-      onSubmitQuestionAnswers,
       handleWorkflowStepSelect,
       handleSessionSelectionChange,
-      handleCreateSession,
       handlePrepareMessageFirstSession,
       handleQuickAction,
       stopAgentSession,
@@ -505,7 +503,6 @@ export function useAgentStudioOrchestrationController({
       modelGroups,
       variantOptions,
       agentAccentColorsByProfileId,
-      activeSessionContextUsage,
       handleSelectAgentProfile,
       handleSelectModel,
       handleSelectVariant,

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -5,6 +5,7 @@ import type {
   WorkspaceRecord,
 } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
+import { useMemo } from "react";
 import type {
   AgentStudioTaskTabsModel,
   SessionStartModalModel,
@@ -14,7 +15,11 @@ import type { HumanReviewFeedbackModalModel } from "@/features/human-review-feed
 import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-slices";
 import type { AgentStudioQueryUpdate as QueryUpdate } from "./agent-studio-navigation";
 import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
+import { ROLE_OPTIONS } from "./agents-page-constants";
+import { buildRoleLabelByRole } from "./agents-page-view-model";
 import { useAgentStudioChatComposer } from "./chat-composer/use-agent-studio-chat-composer";
+import type { AgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
+import { buildAgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
 import { useAgentStudioChatSettings } from "./use-agent-studio-chat-settings";
 import { useAgentStudioDocuments } from "./use-agent-studio-documents";
 import { useAgentStudioPageModels } from "./use-agent-studio-page-models";
@@ -93,27 +98,7 @@ type UseAgentStudioOrchestrationControllerResult = {
 
 type AgentStudioPageModelsViewContext = Pick<
   AgentStudioOrchestrationSelectionContext,
-  | "viewTaskId"
-  | "viewRole"
-  | "viewSelectedTask"
-  | "contextSwitchVersion"
-  | "isSessionSelectionResolving"
-  | "isActiveTaskHydrated"
-  | "isActiveTaskHydrationFailed"
-  | "isViewSessionHistoryHydrated"
-  | "isViewSessionHistoryHydrationFailed"
-  | "isViewSessionHistoryHydrating"
-  | "isViewSessionWaitingForRuntimeReadiness"
-> & {
-  hasActiveGitConflict: boolean;
-};
-
-type AgentStudioPageModelsSessionsContext = Pick<
-  AgentStudioOrchestrationSelectionContext,
-  | "allSessionSummaries"
-  | "viewSessionsForTask"
-  | "viewActiveSession"
-  | "viewSessionRuntimeDataError"
+  "viewTaskId" | "contextSwitchVersion"
 >;
 
 type AgentStudioPageModelsTabsContext = Pick<
@@ -126,11 +111,6 @@ type AgentStudioPageModelsTabsContext = Pick<
   | "handleCreateTab"
   | "handleCloseTab"
   | "handleReorderTab"
->;
-
-type AgentStudioPageModelsDocumentsContext = Pick<
-  ReturnType<typeof useAgentStudioDocuments>,
-  "specDoc" | "planDoc" | "qaDoc"
 >;
 
 type AgentStudioPageModelsSessionActionsContext = Parameters<
@@ -162,14 +142,10 @@ type AgentStudioPageModelsModelSelectionContext = Pick<
 
 type BuildAgentStudioPageModelsArgsInput = {
   view: AgentStudioPageModelsViewContext;
-  sessions: AgentStudioPageModelsSessionsContext;
-  runtimeDefinitions: RuntimeDescriptor[];
+  selectedSession: AgentStudioSelectedSessionContext;
   tabs: AgentStudioPageModelsTabsContext;
-  documents: AgentStudioPageModelsDocumentsContext;
-  readiness: AgentStudioOrchestrationReadinessContext;
   sessionActions: AgentStudioPageModelsSessionActionsContext;
   modelSelection: AgentStudioPageModelsModelSelectionContext;
-  approvals: ReturnType<typeof useAgentSessionApprovalActions>;
   chatSettings: {
     showThinkingMessages: boolean;
   };
@@ -178,14 +154,10 @@ type BuildAgentStudioPageModelsArgsInput = {
 
 export const buildAgentStudioPageModelsArgs = ({
   view,
-  sessions,
-  runtimeDefinitions,
+  selectedSession,
   tabs,
-  documents,
-  readiness,
   sessionActions,
   modelSelection,
-  approvals,
   chatSettings,
   composer,
 }: BuildAgentStudioPageModelsArgsInput): Parameters<typeof useAgentStudioPageModels>[0] => {
@@ -209,26 +181,25 @@ export const buildAgentStudioPageModelsArgs = ({
   return {
     core: {
       activeTabValue: activeTaskTabId || view.viewTaskId || "__agent_studio_empty__",
-      taskId: view.viewTaskId,
-      role: view.viewRole,
-      selectedTask: view.viewSelectedTask,
-      sessionsForTask: sessions.viewSessionsForTask,
-      allSessionSummaries: sessions.allSessionSummaries,
-      contextSessionsLength: sessions.viewSessionsForTask.length,
-      activeSession: sessions.viewActiveSession,
-      runtimeDefinitions,
-      sessionRuntimeDataError: sessions.viewSessionRuntimeDataError ?? null,
-      hasActiveGitConflict: view.hasActiveGitConflict,
-      isTaskHydrating: Boolean(
-        view.viewTaskId && !view.isActiveTaskHydrated && !view.isActiveTaskHydrationFailed,
-      ),
-      isSessionHistoryHydrated: view.isViewSessionHistoryHydrated,
-      isSessionHistoryHydrating: view.isViewSessionHistoryHydrating,
-      isSessionSelectionResolving: view.isSessionSelectionResolving,
-      isWaitingForRuntimeReadiness: view.isViewSessionWaitingForRuntimeReadiness,
-      isSessionHistoryHydrationFailed: view.isViewSessionHistoryHydrationFailed,
+      taskId: selectedSession.taskId,
+      role: selectedSession.role,
+      selectedTask: selectedSession.selectedTask,
+      sessionsForTask: selectedSession.sessionsForTask,
+      allSessionSummaries: selectedSession.allSessionSummaries,
+      contextSessionsLength: selectedSession.contextSessionsLength,
+      activeSession: selectedSession.activeSession,
+      runtimeDefinitions: selectedSession.runtime.runtimeDefinitions,
+      sessionRuntimeDataError: selectedSession.runtime.sessionRuntimeDataError,
+      hasActiveGitConflict: false,
+      isTaskHydrating: selectedSession.runtime.isTaskHydrating,
+      isSessionHistoryHydrated: selectedSession.runtime.isSessionHistoryHydrated,
+      isSessionHistoryHydrating: selectedSession.runtime.isSessionHistoryHydrating,
+      isSessionSelectionResolving: selectedSession.runtime.isSessionSelectionResolving,
+      isWaitingForRuntimeReadiness: selectedSession.runtime.isWaitingForRuntimeReadiness,
+      isSessionHistoryHydrationFailed: selectedSession.runtime.isSessionHistoryHydrationFailed,
       contextSwitchVersion: view.contextSwitchVersion,
     },
+    selectedSession,
     taskTabs: {
       ...taskTabs,
       onSelectTab: handleSelectTab,
@@ -236,8 +207,6 @@ export const buildAgentStudioPageModelsArgs = ({
       onCloseTab: handleCloseTab,
       onReorderTab: handleReorderTab,
     },
-    documents,
-    readiness,
     sessionActions,
     chatSettings,
     modelSelection: {
@@ -248,7 +217,6 @@ export const buildAgentStudioPageModelsArgs = ({
       onSelectModel: handleSelectModel,
       onSelectVariant: handleSelectVariant,
     },
-    approvals,
     composer,
   };
 };
@@ -403,28 +371,93 @@ export function useAgentStudioOrchestrationController({
       replyAgentApproval,
     });
 
+  const roleLabelByRole = useMemo(() => buildRoleLabelByRole(ROLE_OPTIONS), []);
+  const selectedSessionContext = useMemo(
+    () =>
+      buildAgentStudioSelectedSessionContext({
+        taskId: viewTaskId,
+        role: viewRole,
+        selectedTask: viewSelectedTask,
+        sessionsForTask: viewSessionsForTask,
+        allSessionSummaries: selection.allSessionSummaries,
+        contextSessionsLength: viewSessionsForTask.length,
+        activeSession: viewActiveSession,
+        runtimeDefinitions,
+        sessionRuntimeDataError: viewSessionRuntimeDataError ?? null,
+        hasActiveGitConflict,
+        isTaskHydrating: Boolean(
+          viewTaskId && !isActiveTaskHydrated && !selection.isActiveTaskHydrationFailed,
+        ),
+        isSessionHistoryHydrated: selection.isViewSessionHistoryHydrated,
+        isSessionHistoryHydrating: selection.isViewSessionHistoryHydrating,
+        isSessionSelectionResolving: selection.isSessionSelectionResolving,
+        isWaitingForRuntimeReadiness: selection.isViewSessionWaitingForRuntimeReadiness,
+        isSessionHistoryHydrationFailed: selection.isViewSessionHistoryHydrationFailed,
+        activeSessionContextUsage,
+        documents: {
+          specDoc,
+          planDoc,
+          qaDoc,
+        },
+        readiness,
+        sessionActions: {
+          isStarting,
+          isSessionWorking,
+          canKickoffNewSession,
+          kickoffLabel,
+          startLaunchKickoff,
+          onSubmitQuestionAnswers,
+          isSubmittingQuestionByRequestId,
+        },
+        approvals: {
+          isSubmittingApprovalByRequestId,
+          approvalReplyErrorByRequestId,
+          onReplyApproval,
+        },
+        roleLabelByRole,
+      }),
+    [
+      activeSessionContextUsage,
+      approvalReplyErrorByRequestId,
+      canKickoffNewSession,
+      hasActiveGitConflict,
+      isActiveTaskHydrated,
+      isSessionWorking,
+      isStarting,
+      isSubmittingApprovalByRequestId,
+      isSubmittingQuestionByRequestId,
+      kickoffLabel,
+      onReplyApproval,
+      onSubmitQuestionAnswers,
+      planDoc,
+      qaDoc,
+      readiness,
+      roleLabelByRole,
+      runtimeDefinitions,
+      selection.allSessionSummaries,
+      selection.isActiveTaskHydrationFailed,
+      selection.isSessionSelectionResolving,
+      selection.isViewSessionHistoryHydrated,
+      selection.isViewSessionHistoryHydrationFailed,
+      selection.isViewSessionHistoryHydrating,
+      selection.isViewSessionWaitingForRuntimeReadiness,
+      specDoc,
+      startLaunchKickoff,
+      viewActiveSession,
+      viewRole,
+      viewSelectedTask,
+      viewSessionRuntimeDataError,
+      viewSessionsForTask,
+      viewTaskId,
+    ],
+  );
+
   const pageModelsArgs = buildAgentStudioPageModelsArgs({
     view: {
       viewTaskId,
-      viewRole,
-      viewSelectedTask,
       contextSwitchVersion,
-      isSessionSelectionResolving: selection.isSessionSelectionResolving,
-      isActiveTaskHydrated,
-      isActiveTaskHydrationFailed: selection.isActiveTaskHydrationFailed,
-      isViewSessionHistoryHydrated: selection.isViewSessionHistoryHydrated,
-      isViewSessionHistoryHydrationFailed: selection.isViewSessionHistoryHydrationFailed,
-      isViewSessionHistoryHydrating: selection.isViewSessionHistoryHydrating,
-      isViewSessionWaitingForRuntimeReadiness: selection.isViewSessionWaitingForRuntimeReadiness,
-      hasActiveGitConflict,
     },
-    sessions: {
-      allSessionSummaries: selection.allSessionSummaries,
-      viewSessionsForTask,
-      viewActiveSession,
-      viewSessionRuntimeDataError,
-    },
-    runtimeDefinitions,
+    selectedSession: selectedSessionContext,
     tabs: {
       activeTaskTabId,
       taskTabs,
@@ -435,12 +468,6 @@ export function useAgentStudioOrchestrationController({
       handleCloseTab,
       handleReorderTab,
     },
-    documents: {
-      specDoc,
-      planDoc,
-      qaDoc,
-    },
-    readiness,
     sessionActions: {
       openTaskDetails: actions.openTaskDetails,
       isStarting,
@@ -483,11 +510,6 @@ export function useAgentStudioOrchestrationController({
       handleSelectModel,
       handleSelectVariant,
     },
-    approvals: {
-      isSubmittingApprovalByRequestId,
-      approvalReplyErrorByRequestId,
-      onReplyApproval,
-    },
     chatSettings: {
       showThinkingMessages,
     },
@@ -505,10 +527,10 @@ export function useAgentStudioOrchestrationController({
   } = useAgentStudioPageModels(pageModelsArgs);
 
   const rightPanel = useAgentStudioRightPanel({
-    role: viewRole,
-    hasTaskContext: Boolean(viewTaskId),
-    hasDocumentPanel: Boolean(agentStudioWorkspaceSidebarModel.activeDocument),
-    hasBuildToolsPanel: viewRole === "build",
+    role: selectedSessionContext.rightPanel.role,
+    hasTaskContext: selectedSessionContext.rightPanel.hasTaskContext,
+    hasDocumentPanel: selectedSessionContext.rightPanel.hasDocumentPanel,
+    hasBuildToolsPanel: selectedSessionContext.rightPanel.hasBuildToolsPanel,
   });
 
   return {

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -1065,7 +1065,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: parentSession,
           sessionsForTask: [toAgentSessionSummary(parentSession)],
           allSessionSummaries: [
@@ -1102,7 +1102,7 @@ describe("useAgentStudioPageModels", () => {
     );
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: parentSession,
           sessionsForTask: [toAgentSessionSummary(parentSession)],
           allSessionSummaries: [toAgentSessionSummary(parentSession), childSummary],
@@ -1128,7 +1128,7 @@ describe("useAgentStudioPageModels", () => {
       pendingQuestions: [createPendingQuestion("question-1")],
     });
     const initialProps = createHookArgs({
-      core: {
+      selectedSessionCore: {
         activeSession: parentSession,
         sessionsForTask: [toAgentSessionSummary(parentSession)],
         allSessionSummaries: [
@@ -1146,7 +1146,7 @@ describe("useAgentStudioPageModels", () => {
 
     await harness.update(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: parentSession,
           sessionsForTask: [toAgentSessionSummary(parentSession)],
           allSessionSummaries: [

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -41,7 +41,7 @@ type SelectedSessionTestCore = Omit<
 };
 
 type HookArgsOverrides = {
-  core?: Partial<SelectedSessionTestCore>;
+  selectedSessionCore?: Partial<SelectedSessionTestCore>;
   taskTabs?: Partial<HookArgs["taskTabs"]>;
   documents?: Partial<AgentStudioSelectedSessionContextInput["documents"]>;
   readiness?: Partial<AgentStudioSelectedSessionContextInput["readiness"]>;
@@ -121,16 +121,14 @@ const createDocumentState = (markdown: string): TaskDocumentState => ({
 
 const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
   const defaultSession = createSession();
-  const sessionsForTask = overrides.core?.sessionsForTask ?? [
+  const sessionsForTask = overrides.selectedSessionCore?.sessionsForTask ?? [
     toAgentSessionSummary(defaultSession),
   ];
-  const allSessionSummaries = overrides.core?.allSessionSummaries ?? sessionsForTask;
+  const allSessionSummaries = overrides.selectedSessionCore?.allSessionSummaries ?? sessionsForTask;
   const activeSession =
-    overrides.core?.activeSession !== undefined ? overrides.core.activeSession : defaultSession;
-  const contextSessionsLength =
-    overrides.core?.contextSessionsLength !== undefined
-      ? overrides.core.contextSessionsLength
-      : sessionsForTask.length;
+    overrides.selectedSessionCore?.activeSession !== undefined
+      ? overrides.selectedSessionCore.activeSession
+      : defaultSession;
 
   const selectedSessionCore: SelectedSessionTestCore = {
     activeTabValue: "task-1",
@@ -146,14 +144,10 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     isWaitingForRuntimeReadiness: false,
     isSessionHistoryHydrationFailed: false,
     runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
-    ...overrides.core,
+    ...overrides.selectedSessionCore,
     allSessionSummaries,
     sessionsForTask,
     activeSession,
-    contextSessionsLength,
-  };
-  const core: HookArgs["core"] = {
-    activeTabValue: selectedSessionCore.activeTabValue,
   };
 
   const taskTabs: HookArgs["taskTabs"] = {
@@ -247,7 +241,6 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
       selectedTask: selectedSessionCore.selectedTask,
       sessionsForTask: selectedSessionCore.sessionsForTask,
       allSessionSummaries: selectedSessionCore.allSessionSummaries,
-      contextSessionsLength: selectedSessionCore.contextSessionsLength,
       activeSession: selectedSessionCore.activeSession,
       runtimeDefinitions: selectedSessionCore.runtimeDefinitions,
       sessionRuntimeDataError: selectedSessionCore.sessionRuntimeDataError,
@@ -271,7 +264,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
   };
 
   return {
-    core,
+    activeTabValue: selectedSessionCore.activeTabValue,
     selectedSession,
     taskTabs,
     sessionActions,
@@ -288,13 +281,12 @@ describe("useAgentStudioPageModels", () => {
   test("keeps the interactive composer model available before a task is selected", async () => {
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeTabValue: "",
           taskId: "",
           selectedTask: null,
           sessionsForTask: [],
           activeSession: null,
-          contextSessionsLength: 0,
         },
       }),
     );
@@ -361,7 +353,7 @@ describe("useAgentStudioPageModels", () => {
   test("forwards session runtime data errors into the composer model", async () => {
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           sessionRuntimeDataError: "todos unavailable",
         },
       }),
@@ -428,7 +420,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: cachedSession,
           sessionsForTask: [cachedSession],
           isSessionHistoryHydrating: false,
@@ -458,7 +450,7 @@ describe("useAgentStudioPageModels", () => {
     const specSession = createSession("session-spec", "external-spec", { role: "spec" });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           role: "spec",
           activeSession: specSession,
           sessionsForTask: [specSession],
@@ -481,7 +473,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const plannerHarness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           role: "planner",
           activeSession: plannerSession,
           sessionsForTask: [plannerSession],
@@ -504,7 +496,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const qaHarness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           role: "qa",
           activeSession: qaSession,
           sessionsForTask: [qaSession],
@@ -525,7 +517,7 @@ describe("useAgentStudioPageModels", () => {
     const buildSession = createSession("session-build", "external-build", { role: "build" });
     const buildHarness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           role: "build",
           activeSession: buildSession,
           sessionsForTask: [buildSession],
@@ -548,7 +540,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           role: "spec",
           activeSession: plannerSession,
           sessionsForTask: [plannerSession],
@@ -574,7 +566,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           role: "qa",
           activeSession: buildSession,
           sessionsForTask: [buildSession],
@@ -614,7 +606,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: approvalSession,
           sessionsForTask: [approvalSession],
         },
@@ -631,7 +623,7 @@ describe("useAgentStudioPageModels", () => {
 
     await harness.update(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: approvalSessionWithoutRequests,
           sessionsForTask: [approvalSessionWithoutRequests],
         },
@@ -665,7 +657,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: approvalSession,
           sessionsForTask: [approvalSession],
           runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
@@ -691,9 +683,7 @@ describe("useAgentStudioPageModels", () => {
     const sessionA = createSession("session-a", "external-a");
     const sessionB = createSession("session-b", "external-b");
     const sharedOverrides: HookArgsOverrides = {
-      core: {
-        contextSessionsLength: 2,
-      },
+      selectedSessionCore: {},
       sessionActions: {
         isSessionWorking: false,
       },
@@ -703,8 +693,8 @@ describe("useAgentStudioPageModels", () => {
     const harness = createHookHarness(
       createHookArgs({
         ...sharedOverrides,
-        core: {
-          ...sharedOverrides.core,
+        selectedSessionCore: {
+          ...sharedOverrides.selectedSessionCore,
           sessionsForTask: [sessionA, sessionB],
           activeSession: sessionA,
         },
@@ -722,8 +712,8 @@ describe("useAgentStudioPageModels", () => {
     await harness.update(
       createHookArgs({
         ...sharedOverrides,
-        core: {
-          ...sharedOverrides.core,
+        selectedSessionCore: {
+          ...sharedOverrides.selectedSessionCore,
           sessionsForTask: [sessionA, sessionB],
           activeSession: sessionB,
         },
@@ -739,8 +729,8 @@ describe("useAgentStudioPageModels", () => {
     await harness.update(
       createHookArgs({
         ...sharedOverrides,
-        core: {
-          ...sharedOverrides.core,
+        selectedSessionCore: {
+          ...sharedOverrides.selectedSessionCore,
           sessionsForTask: [sessionA, sessionB],
           activeSession: sessionA,
         },
@@ -754,7 +744,7 @@ describe("useAgentStudioPageModels", () => {
   test("keeps thread model stable for input-only composer updates", async () => {
     const session = createSession("session-1", "external-1");
     const baseProps = createHookArgs({
-      core: {
+      selectedSessionCore: {
         activeSession: session,
         sessionsForTask: [session],
       },
@@ -788,7 +778,7 @@ describe("useAgentStudioPageModels", () => {
   test("keeps composer model stable for thread-only updates", async () => {
     const session = createSession("session-1", "external-1");
     const baseProps = createHookArgs({
-      core: {
+      selectedSessionCore: {
         activeSession: session,
         sessionsForTask: [session],
       },
@@ -818,7 +808,7 @@ describe("useAgentStudioPageModels", () => {
   test("updates thread model when showThinkingMessages changes without rebuilding composer", async () => {
     const session = createSession("session-1", "external-1");
     const baseProps = createHookArgs({
-      core: {
+      selectedSessionCore: {
         activeSession: session,
         sessionsForTask: [session],
       },
@@ -854,7 +844,7 @@ describe("useAgentStudioPageModels", () => {
   test("updates thread model for pending request maps without rebuilding composer", async () => {
     const session = createSession("session-1", "external-1");
     const baseProps = createHookArgs({
-      core: {
+      selectedSessionCore: {
         activeSession: session,
         sessionsForTask: [session],
       },
@@ -930,7 +920,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: parentSession,
           sessionsForTask: [toAgentSessionSummary(parentSession)],
           allSessionSummaries: [
@@ -961,7 +951,7 @@ describe("useAgentStudioPageModels", () => {
     });
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: parentSession,
           sessionsForTask: [toAgentSessionSummary(parentSession)],
           allSessionSummaries: [
@@ -997,7 +987,7 @@ describe("useAgentStudioPageModels", () => {
     );
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: parentSession,
           sessionsForTask: [toAgentSessionSummary(parentSession)],
           allSessionSummaries: [toAgentSessionSummary(parentSession), childSummary],
@@ -1022,7 +1012,7 @@ describe("useAgentStudioPageModels", () => {
       pendingApprovals: [createPendingApproval("perm-1")],
     });
     const initialProps = createHookArgs({
-      core: {
+      selectedSessionCore: {
         activeSession: parentSession,
         sessionsForTask: [toAgentSessionSummary(parentSession)],
         allSessionSummaries: [
@@ -1040,7 +1030,7 @@ describe("useAgentStudioPageModels", () => {
 
     await harness.update(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           activeSession: parentSession,
           sessionsForTask: [toAgentSessionSummary(parentSession)],
           allSessionSummaries: [
@@ -1187,7 +1177,7 @@ describe("useAgentStudioPageModels", () => {
       isLoadingModelCatalog: false,
     });
     const baseProps = createHookArgs({
-      core: {
+      selectedSessionCore: {
         activeSession: initialSession,
         sessionsForTask: [initialSession],
       },
@@ -1211,8 +1201,7 @@ describe("useAgentStudioPageModels", () => {
     await harness.update(
       createHookArgs({
         ...baseProps,
-        core: {
-          ...baseProps.core,
+        selectedSessionCore: {
           activeSession: sameSessionIdNewRef,
           sessionsForTask: [sameSessionIdNewRef],
         },
@@ -1233,7 +1222,7 @@ describe("useAgentStudioPageModels", () => {
       isLoadingModelCatalog: false,
     });
     const baseProps = createHookArgs({
-      core: {
+      selectedSessionCore: {
         activeSession: initialSession,
         sessionsForTask: [initialSession],
       },
@@ -1271,8 +1260,7 @@ describe("useAgentStudioPageModels", () => {
     await harness.update(
       createHookArgs({
         ...baseProps,
-        core: {
-          ...baseProps.core,
+        selectedSessionCore: {
           activeSession: waitingSession,
           sessionsForTask: [waitingSession],
         },
@@ -1307,7 +1295,7 @@ describe("useAgentStudioPageModels", () => {
 
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           role: "planner",
           selectedTask: unavailablePlannerTask,
           activeSession: null,
@@ -1349,7 +1337,7 @@ describe("useAgentStudioPageModels", () => {
 
     const harness = createHookHarness(
       createHookArgs({
-        core: {
+        selectedSessionCore: {
           role: "planner",
           selectedTask: unavailablePlannerTask,
           activeSession: runningPlannerSession,

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -14,6 +14,12 @@ import {
   createTaskCardFixture,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
+import { ROLE_OPTIONS } from "./agents-page-constants";
+import { buildRoleLabelByRole } from "./agents-page-view-model";
+import {
+  type AgentStudioSelectedSessionContextInput,
+  buildAgentStudioSelectedSessionContext,
+} from "./selected-session/selected-session-context";
 
 type UseAgentStudioPageModelsHook =
   typeof import("./use-agent-studio-page-models")["useAgentStudioPageModels"];
@@ -24,12 +30,13 @@ type HookArgs = Parameters<UseAgentStudioPageModelsHook>[0];
 
 type HookArgsOverrides = {
   core?: Partial<HookArgs["core"]>;
+  selectedSession?: Partial<HookArgs["selectedSession"]>;
   taskTabs?: Partial<HookArgs["taskTabs"]>;
-  documents?: Partial<HookArgs["documents"]>;
-  readiness?: Partial<HookArgs["readiness"]>;
+  documents?: Partial<AgentStudioSelectedSessionContextInput["documents"]>;
+  readiness?: Partial<AgentStudioSelectedSessionContextInput["readiness"]>;
   sessionActions?: Partial<HookArgs["sessionActions"]>;
   modelSelection?: Partial<HookArgs["modelSelection"]>;
-  approvals?: Partial<HookArgs["approvals"]>;
+  approvals?: Partial<AgentStudioSelectedSessionContextInput["approvals"]>;
   chatSettings?: Partial<HookArgs["chatSettings"]>;
   composer?: Partial<HookArgs["composer"]>;
 };
@@ -134,89 +141,122 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     contextSessionsLength,
   };
 
+  const taskTabs: HookArgs["taskTabs"] = {
+    taskTabs: [{ taskId: "task-1", taskTitle: "Task 1", status: "idle", isActive: true }],
+    availableTabTasks: [createTask()],
+    isLoadingTasks: false,
+    onSelectTab: () => {},
+    onCreateTab: () => {},
+    onCloseTab: () => {},
+    onReorderTab: () => {},
+    ...overrides.taskTabs,
+  };
+  const documents = {
+    specDoc: createDocumentState("spec"),
+    planDoc: createDocumentState(""),
+    qaDoc: createDocumentState(""),
+    ...overrides.documents,
+  };
+  const readiness: AgentStudioSelectedSessionContextInput["readiness"] = {
+    agentStudioReadinessState: "ready",
+    agentStudioReady: true,
+    agentStudioBlockedReason: "",
+    isLoadingChecks: false,
+    refreshChecks: async () => {},
+    ...overrides.readiness,
+  };
+  const sessionActions: HookArgs["sessionActions"] = {
+    handleWorkflowStepSelect: () => {},
+    handleSessionSelectionChange: () => {},
+    handleCreateSession: () => {},
+    handlePrepareMessageFirstSession: () => {},
+    handleQuickAction: () => {},
+    openTaskDetails: () => {},
+    isStarting: false,
+    isSending: false,
+    isSessionWorking: true,
+    isWaitingInput: false,
+    busySendBlockedReason: null,
+    canKickoffNewSession: false,
+    kickoffLabel: "Start Spec",
+    canStopSession: true,
+    startLaunchKickoff: async () => {},
+    onSend: async () => true,
+    onSubmitQuestionAnswers: async () => {},
+    isSubmittingQuestionByRequestId: {},
+    stopAgentSession: async () => {},
+    ...overrides.sessionActions,
+  };
+  const modelSelection: HookArgs["modelSelection"] = {
+    selectedModelSelection: null,
+    isSelectionCatalogLoading: false,
+    supportsSlashCommands: true,
+    supportsFileSearch: true,
+    slashCommandCatalog: { commands: [] },
+    slashCommands: [],
+    slashCommandsError: null,
+    isSlashCommandsLoading: false,
+    searchFiles: async () => [],
+    agentOptions: [{ value: "spec", label: "Spec" }],
+    modelOptions: [],
+    modelGroups: [],
+    variantOptions: [],
+    onSelectAgent: () => {},
+    onSelectModel: () => {},
+    onSelectVariant: () => {},
+    activeSessionAgentColors: {},
+    activeSessionContextUsage: { totalTokens: 12, contextWindow: 100 },
+    ...overrides.modelSelection,
+  };
+  const approvals: AgentStudioSelectedSessionContextInput["approvals"] = {
+    isSubmittingApprovalByRequestId: {},
+    approvalReplyErrorByRequestId: {},
+    onReplyApproval: async () => {},
+    ...overrides.approvals,
+  };
+  const chatSettings = {
+    showThinkingMessages: false,
+    ...overrides.chatSettings,
+  };
+  const composer = {
+    draftStateKey: "draft-1",
+    ...overrides.composer,
+  };
+  const selectedSession = {
+    ...buildAgentStudioSelectedSessionContext({
+      taskId: core.taskId,
+      role: core.role,
+      selectedTask: core.selectedTask,
+      sessionsForTask: core.sessionsForTask,
+      allSessionSummaries: core.allSessionSummaries,
+      contextSessionsLength: core.contextSessionsLength,
+      activeSession: core.activeSession,
+      runtimeDefinitions: core.runtimeDefinitions,
+      sessionRuntimeDataError: core.sessionRuntimeDataError,
+      hasActiveGitConflict: core.hasActiveGitConflict,
+      isTaskHydrating: core.isTaskHydrating,
+      isSessionHistoryHydrated: core.isSessionHistoryHydrated,
+      isSessionHistoryHydrating: core.isSessionHistoryHydrating,
+      isSessionSelectionResolving: core.isSessionSelectionResolving,
+      isWaitingForRuntimeReadiness: core.isWaitingForRuntimeReadiness,
+      isSessionHistoryHydrationFailed: core.isSessionHistoryHydrationFailed,
+      activeSessionContextUsage: modelSelection.activeSessionContextUsage,
+      documents,
+      readiness,
+      sessionActions,
+      approvals,
+      roleLabelByRole: buildRoleLabelByRole(ROLE_OPTIONS),
+    }),
+  };
+
   return {
     core,
-    taskTabs: {
-      taskTabs: [{ taskId: "task-1", taskTitle: "Task 1", status: "idle", isActive: true }],
-      availableTabTasks: [createTask()],
-      isLoadingTasks: false,
-      onSelectTab: () => {},
-      onCreateTab: () => {},
-      onCloseTab: () => {},
-      onReorderTab: () => {},
-      ...overrides.taskTabs,
-    },
-    documents: {
-      specDoc: createDocumentState("spec"),
-      planDoc: createDocumentState(""),
-      qaDoc: createDocumentState(""),
-      ...overrides.documents,
-    },
-    readiness: {
-      agentStudioReadinessState: "ready",
-      agentStudioReady: true,
-      agentStudioBlockedReason: "",
-      isLoadingChecks: false,
-      refreshChecks: async () => {},
-      ...overrides.readiness,
-    },
-    sessionActions: {
-      handleWorkflowStepSelect: () => {},
-      handleSessionSelectionChange: () => {},
-      handleCreateSession: () => {},
-      handlePrepareMessageFirstSession: () => {},
-      handleQuickAction: () => {},
-      openTaskDetails: () => {},
-      isStarting: false,
-      isSending: false,
-      isSessionWorking: true,
-      isWaitingInput: false,
-      busySendBlockedReason: null,
-      canKickoffNewSession: false,
-      kickoffLabel: "Start Spec",
-      canStopSession: true,
-      startLaunchKickoff: async () => {},
-      onSend: async () => true,
-      onSubmitQuestionAnswers: async () => {},
-      isSubmittingQuestionByRequestId: {},
-      stopAgentSession: async () => {},
-      ...overrides.sessionActions,
-    },
-    modelSelection: {
-      selectedModelSelection: null,
-      isSelectionCatalogLoading: false,
-      supportsSlashCommands: true,
-      supportsFileSearch: true,
-      slashCommandCatalog: { commands: [] },
-      slashCommands: [],
-      slashCommandsError: null,
-      isSlashCommandsLoading: false,
-      searchFiles: async () => [],
-      agentOptions: [{ value: "spec", label: "Spec" }],
-      modelOptions: [],
-      modelGroups: [],
-      variantOptions: [],
-      onSelectAgent: () => {},
-      onSelectModel: () => {},
-      onSelectVariant: () => {},
-      activeSessionAgentColors: {},
-      activeSessionContextUsage: { totalTokens: 12, contextWindow: 100 },
-      ...overrides.modelSelection,
-    },
-    approvals: {
-      isSubmittingApprovalByRequestId: {},
-      approvalReplyErrorByRequestId: {},
-      onReplyApproval: async () => {},
-      ...overrides.approvals,
-    },
-    chatSettings: {
-      showThinkingMessages: false,
-      ...overrides.chatSettings,
-    },
-    composer: {
-      draftStateKey: "draft-1",
-      ...overrides.composer,
-    },
+    selectedSession,
+    taskTabs,
+    sessionActions,
+    modelSelection,
+    chatSettings,
+    composer,
   };
 };
 
@@ -812,10 +852,16 @@ describe("useAgentStudioPageModels", () => {
 
     const approvalUpdateProps = {
       ...baseProps,
-      approvals: {
-        ...baseProps.approvals,
-        isSubmittingApprovalByRequestId: {
-          "perm-1": true,
+      selectedSession: {
+        ...baseProps.selectedSession,
+        pendingInput: {
+          ...baseProps.selectedSession.pendingInput,
+          approvals: {
+            ...baseProps.selectedSession.pendingInput.approvals,
+            isSubmittingByRequestId: {
+              "perm-1": true,
+            },
+          },
         },
       },
     };
@@ -829,10 +875,16 @@ describe("useAgentStudioPageModels", () => {
 
     await harness.update({
       ...approvalUpdateProps,
-      sessionActions: {
-        ...approvalUpdateProps.sessionActions,
-        isSubmittingQuestionByRequestId: {
-          "q-1": true,
+      selectedSession: {
+        ...approvalUpdateProps.selectedSession,
+        pendingInput: {
+          ...approvalUpdateProps.selectedSession.pendingInput,
+          pendingQuestions: {
+            ...approvalUpdateProps.selectedSession.pendingInput.pendingQuestions,
+            isSubmittingByRequestId: {
+              "q-1": true,
+            },
+          },
         },
       },
     });

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -28,14 +28,27 @@ enableReactActEnvironment();
 
 type HookArgs = Parameters<UseAgentStudioPageModelsHook>[0];
 
+type SelectedSessionTestCore = Omit<
+  AgentStudioSelectedSessionContextInput,
+  | "documents"
+  | "readiness"
+  | "sessionActions"
+  | "approvals"
+  | "activeSessionContextUsage"
+  | "roleLabelByRole"
+> & {
+  activeTabValue: string;
+};
+
 type HookArgsOverrides = {
-  core?: Partial<HookArgs["core"]>;
-  selectedSession?: Partial<HookArgs["selectedSession"]>;
+  core?: Partial<SelectedSessionTestCore>;
   taskTabs?: Partial<HookArgs["taskTabs"]>;
   documents?: Partial<AgentStudioSelectedSessionContextInput["documents"]>;
   readiness?: Partial<AgentStudioSelectedSessionContextInput["readiness"]>;
   sessionActions?: Partial<HookArgs["sessionActions"]>;
+  selectedSessionActions?: Partial<AgentStudioSelectedSessionContextInput["sessionActions"]>;
   modelSelection?: Partial<HookArgs["modelSelection"]>;
+  activeSessionContextUsage?: AgentStudioSelectedSessionContextInput["activeSessionContextUsage"];
   approvals?: Partial<AgentStudioSelectedSessionContextInput["approvals"]>;
   chatSettings?: Partial<HookArgs["chatSettings"]>;
   composer?: Partial<HookArgs["composer"]>;
@@ -119,7 +132,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
       ? overrides.core.contextSessionsLength
       : sessionsForTask.length;
 
-  const core: HookArgs["core"] = {
+  const selectedSessionCore: SelectedSessionTestCore = {
     activeTabValue: "task-1",
     taskId: "task-1",
     role: "spec",
@@ -132,13 +145,15 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     isSessionSelectionResolving: false,
     isWaitingForRuntimeReadiness: false,
     isSessionHistoryHydrationFailed: false,
-    contextSwitchVersion: 0,
     runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
     ...overrides.core,
     allSessionSummaries,
     sessionsForTask,
     activeSession,
     contextSessionsLength,
+  };
+  const core: HookArgs["core"] = {
+    activeTabValue: selectedSessionCore.activeTabValue,
   };
 
   const taskTabs: HookArgs["taskTabs"] = {
@@ -168,7 +183,6 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
   const sessionActions: HookArgs["sessionActions"] = {
     handleWorkflowStepSelect: () => {},
     handleSessionSelectionChange: () => {},
-    handleCreateSession: () => {},
     handlePrepareMessageFirstSession: () => {},
     handleQuickAction: () => {},
     openTaskDetails: () => {},
@@ -177,15 +191,20 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     isSessionWorking: true,
     isWaitingInput: false,
     busySendBlockedReason: null,
-    canKickoffNewSession: false,
-    kickoffLabel: "Start Spec",
     canStopSession: true,
-    startLaunchKickoff: async () => {},
     onSend: async () => true,
-    onSubmitQuestionAnswers: async () => {},
-    isSubmittingQuestionByRequestId: {},
     stopAgentSession: async () => {},
     ...overrides.sessionActions,
+  };
+  const selectedSessionActions: AgentStudioSelectedSessionContextInput["sessionActions"] = {
+    isStarting: sessionActions.isStarting,
+    isSessionWorking: sessionActions.isSessionWorking,
+    canKickoffNewSession: false,
+    kickoffLabel: "Start Spec",
+    startLaunchKickoff: async () => {},
+    onSubmitQuestionAnswers: async () => {},
+    isSubmittingQuestionByRequestId: {},
+    ...overrides.selectedSessionActions,
   };
   const modelSelection: HookArgs["modelSelection"] = {
     selectedModelSelection: null,
@@ -205,7 +224,6 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     onSelectModel: () => {},
     onSelectVariant: () => {},
     activeSessionAgentColors: {},
-    activeSessionContextUsage: { totalTokens: 12, contextWindow: 100 },
     ...overrides.modelSelection,
   };
   const approvals: AgentStudioSelectedSessionContextInput["approvals"] = {
@@ -224,26 +242,29 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
   };
   const selectedSession = {
     ...buildAgentStudioSelectedSessionContext({
-      taskId: core.taskId,
-      role: core.role,
-      selectedTask: core.selectedTask,
-      sessionsForTask: core.sessionsForTask,
-      allSessionSummaries: core.allSessionSummaries,
-      contextSessionsLength: core.contextSessionsLength,
-      activeSession: core.activeSession,
-      runtimeDefinitions: core.runtimeDefinitions,
-      sessionRuntimeDataError: core.sessionRuntimeDataError,
-      hasActiveGitConflict: core.hasActiveGitConflict,
-      isTaskHydrating: core.isTaskHydrating,
-      isSessionHistoryHydrated: core.isSessionHistoryHydrated,
-      isSessionHistoryHydrating: core.isSessionHistoryHydrating,
-      isSessionSelectionResolving: core.isSessionSelectionResolving,
-      isWaitingForRuntimeReadiness: core.isWaitingForRuntimeReadiness,
-      isSessionHistoryHydrationFailed: core.isSessionHistoryHydrationFailed,
-      activeSessionContextUsage: modelSelection.activeSessionContextUsage,
+      taskId: selectedSessionCore.taskId,
+      role: selectedSessionCore.role,
+      selectedTask: selectedSessionCore.selectedTask,
+      sessionsForTask: selectedSessionCore.sessionsForTask,
+      allSessionSummaries: selectedSessionCore.allSessionSummaries,
+      contextSessionsLength: selectedSessionCore.contextSessionsLength,
+      activeSession: selectedSessionCore.activeSession,
+      runtimeDefinitions: selectedSessionCore.runtimeDefinitions,
+      sessionRuntimeDataError: selectedSessionCore.sessionRuntimeDataError,
+      hasActiveGitConflict: selectedSessionCore.hasActiveGitConflict,
+      isTaskHydrating: selectedSessionCore.isTaskHydrating,
+      isSessionHistoryHydrated: selectedSessionCore.isSessionHistoryHydrated,
+      isSessionHistoryHydrating: selectedSessionCore.isSessionHistoryHydrating,
+      isSessionSelectionResolving: selectedSessionCore.isSessionSelectionResolving,
+      isWaitingForRuntimeReadiness: selectedSessionCore.isWaitingForRuntimeReadiness,
+      isSessionHistoryHydrationFailed: selectedSessionCore.isSessionHistoryHydrationFailed,
+      activeSessionContextUsage: overrides.activeSessionContextUsage ?? {
+        totalTokens: 12,
+        contextWindow: 100,
+      },
       documents,
       readiness,
-      sessionActions,
+      sessionActions: selectedSessionActions,
       approvals,
       roleLabelByRole: buildRoleLabelByRole(ROLE_OPTIONS),
     }),
@@ -295,9 +316,7 @@ describe("useAgentStudioPageModels", () => {
 
     const harness = createHookHarness(
       createHookArgs({
-        modelSelection: {
-          activeSessionContextUsage: { totalTokens: 12, contextWindow: 100 },
-        },
+        activeSessionContextUsage: { totalTokens: 12, contextWindow: 100 },
         composer: {
           draftStateKey: "draft-message",
         },
@@ -306,8 +325,10 @@ describe("useAgentStudioPageModels", () => {
         },
         sessionActions: {
           onSend,
-          startLaunchKickoff: onKickoff,
           stopAgentSession: onStopSession,
+        },
+        selectedSessionActions: {
+          startLaunchKickoff: onKickoff,
         },
       }),
     );
@@ -676,9 +697,7 @@ describe("useAgentStudioPageModels", () => {
       sessionActions: {
         isSessionWorking: false,
       },
-      modelSelection: {
-        activeSessionContextUsage: null,
-      },
+      activeSessionContextUsage: null,
     };
 
     const harness = createHookHarness(
@@ -1294,8 +1313,10 @@ describe("useAgentStudioPageModels", () => {
           activeSession: null,
           sessionsForTask: [],
         },
-        sessionActions: {
+        selectedSessionActions: {
           canKickoffNewSession: true,
+        },
+        sessionActions: {
           isSessionWorking: false,
         },
       }),

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
@@ -1,8 +1,4 @@
-import type {
-  RuntimeApprovalReplyOutcome,
-  RuntimeDescriptor,
-  TaskCard,
-} from "@openducktor/contracts";
+import type { RuntimeDescriptor, TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import { useMemo, useRef } from "react";
 import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
@@ -13,21 +9,14 @@ import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStudioQuickActionOption } from "./agent-studio-quick-actions";
-import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
-import { ROLE_OPTIONS } from "./agents-page-constants";
 import type { SessionCreateOption } from "./agents-page-session-tabs";
 import {
   buildAgentStudioTaskTabsModel,
   buildAgentStudioWorkspaceSidebarModel,
-  buildRoleLabelByRole,
 } from "./agents-page-view-model";
-import {
-  type AgentStudioDocumentsContext,
-  type AgentStudioSessionContextUsage,
-  buildActiveDocumentForRole,
-  buildWorkflowModelContext,
-  toChatContextUsage,
-} from "./use-agent-studio-page-model-builders";
+import type { AgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
+import { keepStablePendingInputCounts } from "./selected-session/selected-session-context";
+import type { AgentStudioSessionContextUsage } from "./use-agent-studio-page-model-builders";
 import { useAgentStudioHeaderModel } from "./use-agent-studio-page-submodels";
 
 type AgentStudioCoreContext = {
@@ -51,104 +40,15 @@ type AgentStudioCoreContext = {
   contextSwitchVersion: number;
 };
 
-const EMPTY_SUBAGENT_PENDING_APPROVAL_COUNTS: Record<string, number> = Object.freeze({});
-const EMPTY_SUBAGENT_PENDING_QUESTION_COUNTS: Record<string, number> = Object.freeze({});
-
-type PendingInputOverlayMap = Record<string, readonly unknown[]>;
-
-const arePendingInputCountMapsEqual = (
-  left: Record<string, number>,
-  right: Record<string, number>,
-): boolean => {
-  const leftKeys = Object.keys(left);
-  const rightKeys = Object.keys(right);
-  if (leftKeys.length !== rightKeys.length) {
-    return false;
-  }
-
-  return leftKeys.every((key) => left[key] === right[key]);
-};
-
-const getSessionPendingApprovalCount = (session: AgentSessionSummary): number =>
-  session.pendingApprovals.length;
-
-const getSessionPendingQuestionCount = (session: AgentSessionSummary): number =>
-  session.pendingQuestions.length;
-
-const useStablePendingInputCounts = ({
-  sessions,
-  subagentPendingInputsByExternalSessionId,
-  getSessionPendingInputCount,
-  emptyCounts,
-}: {
-  sessions: AgentSessionSummary[];
-  subagentPendingInputsByExternalSessionId: PendingInputOverlayMap | undefined;
-  getSessionPendingInputCount: (session: AgentSessionSummary) => number;
-  emptyCounts: Record<string, number>;
-}): Record<string, number> => {
-  const previousRef = useRef<Record<string, number>>(emptyCounts);
+const useStablePendingInputCounts = (
+  nextCounts: Record<string, number>,
+): Record<string, number> => {
+  const previousRef = useRef<Record<string, number>>(nextCounts);
   return useMemo(() => {
-    const next: Record<string, number> = {};
-    for (const session of sessions) {
-      const pendingInputCount = getSessionPendingInputCount(session);
-      if (pendingInputCount > 0) {
-        next[session.externalSessionId] = pendingInputCount;
-      }
-    }
-
-    if (subagentPendingInputsByExternalSessionId) {
-      for (const [externalSessionId, pendingInputs] of Object.entries(
-        subagentPendingInputsByExternalSessionId,
-      )) {
-        const pendingInputCount = pendingInputs.length;
-        if (pendingInputCount > 0) {
-          next[externalSessionId] = pendingInputCount;
-        }
-      }
-    }
-
-    const nextCounts = Object.keys(next).length > 0 ? next : emptyCounts;
-    const previous = previousRef.current;
-    if (arePendingInputCountMapsEqual(previous, nextCounts)) {
-      return previous;
-    }
-
-    previousRef.current = nextCounts;
-    return nextCounts;
-  }, [
-    sessions,
-    subagentPendingInputsByExternalSessionId,
-    getSessionPendingInputCount,
-    emptyCounts,
-  ]);
-};
-
-const useStablePendingApprovalCounts = (
-  sessions: AgentSessionSummary[],
-  subagentPendingApprovalsByExternalSessionId:
-    | AgentSessionState["subagentPendingApprovalsByExternalSessionId"]
-    | undefined,
-): Record<string, number> => {
-  return useStablePendingInputCounts({
-    sessions,
-    subagentPendingInputsByExternalSessionId: subagentPendingApprovalsByExternalSessionId,
-    getSessionPendingInputCount: getSessionPendingApprovalCount,
-    emptyCounts: EMPTY_SUBAGENT_PENDING_APPROVAL_COUNTS,
-  });
-};
-
-const useStablePendingQuestionCounts = (
-  sessions: AgentSessionSummary[],
-  subagentPendingQuestionsByExternalSessionId:
-    | AgentSessionState["subagentPendingQuestionsByExternalSessionId"]
-    | undefined,
-): Record<string, number> => {
-  return useStablePendingInputCounts({
-    sessions,
-    subagentPendingInputsByExternalSessionId: subagentPendingQuestionsByExternalSessionId,
-    getSessionPendingInputCount: getSessionPendingQuestionCount,
-    emptyCounts: EMPTY_SUBAGENT_PENDING_QUESTION_COUNTS,
-  });
+    const stableCounts = keepStablePendingInputCounts(previousRef.current, nextCounts);
+    previousRef.current = stableCounts;
+    return stableCounts;
+  }, [nextCounts]);
 };
 
 type AgentStudioTaskTabsContext = {
@@ -183,14 +83,6 @@ type AgentStudioSessionActionsContext = {
   stopAgentSession: (externalSessionId: string) => Promise<void>;
 };
 
-type AgentStudioReadinessContext = {
-  agentStudioReadinessState: AgentStudioReadinessState;
-  agentStudioReady: boolean;
-  agentStudioBlockedReason: string | null;
-  isLoadingChecks: boolean;
-  refreshChecks: () => Promise<void>;
-};
-
 type AgentStudioModelSelectionContext = {
   selectedModelSelection: AgentModelSelection | null;
   selectedModelDescriptor?: AgentChatModel["composer"]["selectedModelDescriptor"];
@@ -213,12 +105,6 @@ type AgentStudioModelSelectionContext = {
   activeSessionContextUsage: AgentStudioSessionContextUsage;
 };
 
-type AgentStudioApprovalContext = {
-  isSubmittingApprovalByRequestId: Record<string, boolean>;
-  approvalReplyErrorByRequestId: Record<string, string>;
-  onReplyApproval: (requestId: string, outcome: RuntimeApprovalReplyOutcome) => Promise<void>;
-};
-
 type AgentStudioComposerContext = {
   draftStateKey: string;
 };
@@ -229,24 +115,20 @@ type AgentStudioChatSettingsContext = {
 
 type UseAgentStudioPageModelsArgs = {
   core: AgentStudioCoreContext;
+  selectedSession: AgentStudioSelectedSessionContext;
   taskTabs: AgentStudioTaskTabsContext;
-  documents: AgentStudioDocumentsContext;
-  readiness: AgentStudioReadinessContext;
   sessionActions: AgentStudioSessionActionsContext;
   modelSelection: AgentStudioModelSelectionContext;
-  approvals: AgentStudioApprovalContext;
   chatSettings: AgentStudioChatSettingsContext;
   composer: AgentStudioComposerContext;
 };
 
 export function useAgentStudioPageModels({
   core,
+  selectedSession,
   taskTabs,
-  documents,
-  readiness,
   sessionActions,
   modelSelection,
-  approvals,
   chatSettings,
   composer,
 }: UseAgentStudioPageModelsArgs): {
@@ -256,26 +138,11 @@ export function useAgentStudioPageModels({
   agentStudioWorkspaceSidebarModel: ReturnType<typeof buildAgentStudioWorkspaceSidebarModel>;
   agentChatModel: AgentChatModel;
 } {
-  const workflowSessionsForTask = core.sessionsForTask;
-  const subagentPendingApprovalCountByExternalSessionId = useStablePendingApprovalCounts(
-    core.allSessionSummaries,
-    core.activeSession?.subagentPendingApprovalsByExternalSessionId,
+  const subagentPendingApprovalCountByExternalSessionId = useStablePendingInputCounts(
+    selectedSession.pendingInput.subagentPendingApprovalCountByExternalSessionId,
   );
-  const subagentPendingQuestionCountByExternalSessionId = useStablePendingQuestionCounts(
-    core.allSessionSummaries,
-    core.activeSession?.subagentPendingQuestionsByExternalSessionId,
-  );
-  const workflowActiveExternalSessionId = core.activeSession?.externalSessionId ?? null;
-  const workflowActiveSessionRole = core.activeSession?.role ?? null;
-  const workflowActiveSession = useMemo(
-    () =>
-      workflowActiveExternalSessionId && workflowActiveSessionRole
-        ? {
-            externalSessionId: workflowActiveExternalSessionId,
-            role: workflowActiveSessionRole,
-          }
-        : null,
-    [workflowActiveExternalSessionId, workflowActiveSessionRole],
+  const subagentPendingQuestionCountByExternalSessionId = useStablePendingInputCounts(
+    selectedSession.pendingInput.subagentPendingQuestionCountByExternalSessionId,
   );
 
   const agentStudioTaskTabsModel = useMemo(
@@ -288,10 +155,10 @@ export function useAgentStudioPageModels({
         onCreateTab: taskTabs.onCreateTab,
         onCloseTab: taskTabs.onCloseTab,
         onReorderTab: taskTabs.onReorderTab,
-        agentStudioReady: readiness.agentStudioReady,
+        agentStudioReady: selectedSession.runtime.runtimeReadiness.isReady,
       }),
     [
-      readiness.agentStudioReady,
+      selectedSession.runtime.runtimeReadiness.isReady,
       taskTabs.availableTabTasks,
       taskTabs.isLoadingTasks,
       taskTabs.onCloseTab,
@@ -302,28 +169,6 @@ export function useAgentStudioPageModels({
     ],
   );
 
-  const roleLabelByRole = useMemo(() => buildRoleLabelByRole(ROLE_OPTIONS), []);
-  const workflowModelContext = useMemo(
-    () =>
-      buildWorkflowModelContext({
-        selectedTask: core.selectedTask,
-        sessionsForTask: workflowSessionsForTask,
-        activeSession: workflowActiveSession,
-        role: core.role,
-        isSessionWorking: sessionActions.isSessionWorking,
-        hasActiveGitConflict: core.hasActiveGitConflict,
-        roleLabelByRole,
-      }),
-    [
-      core.hasActiveGitConflict,
-      core.role,
-      core.selectedTask,
-      roleLabelByRole,
-      sessionActions.isSessionWorking,
-      workflowActiveSession,
-      workflowSessionsForTask,
-    ],
-  );
   const {
     workflowSessionByRole,
     workflowStateByRole,
@@ -334,29 +179,15 @@ export function useAgentStudioPageModels({
     quickActions,
     primaryQuickAction,
     selectedInteractionRole,
-    selectedRoleAvailable,
-    selectedRoleReadOnlyReason,
-  } = workflowModelContext;
-
-  const activeDocumentRole = core.activeSession?.role ?? core.role;
-  const activeDocument = useMemo(
-    () =>
-      buildActiveDocumentForRole({
-        activeRole: activeDocumentRole,
-        specDoc: documents.specDoc,
-        planDoc: documents.planDoc,
-        qaDoc: documents.qaDoc,
-      }),
-    [activeDocumentRole, documents.planDoc, documents.qaDoc, documents.specDoc],
-  );
+  } = selectedSession.workflow;
 
   const agentStudioHeaderModel = useAgentStudioHeaderModel({
-    selectedTask: core.selectedTask,
-    onOpenTaskDetails: core.selectedTask ? sessionActions.openTaskDetails : null,
-    activeSession: core.activeSession,
-    sessionsForTaskLength: core.sessionsForTask.length,
-    contextSessionsLength: core.contextSessionsLength,
-    agentStudioReady: readiness.agentStudioReady,
+    selectedTask: selectedSession.selectedTask,
+    onOpenTaskDetails: selectedSession.selectedTask ? sessionActions.openTaskDetails : null,
+    activeSession: selectedSession.activeSession,
+    sessionsForTaskLength: selectedSession.sessionsForTask.length,
+    contextSessionsLength: selectedSession.contextSessionsLength,
+    agentStudioReady: selectedSession.runtime.runtimeReadiness.isReady,
     isStarting: sessionActions.isStarting,
     onWorkflowStepSelect: sessionActions.handleWorkflowStepSelect,
     onSessionSelectionChange: sessionActions.handleSessionSelectionChange,
@@ -379,21 +210,18 @@ export function useAgentStudioPageModels({
   const agentStudioWorkspaceSidebarModel = useMemo(
     () =>
       buildAgentStudioWorkspaceSidebarModel({
-        activeDocument,
+        activeDocument: selectedSession.documents.activeDocument,
       }),
-    [activeDocument],
+    [selectedSession.documents.activeDocument],
   );
 
-  const chatContextUsage = useMemo(
-    () => toChatContextUsage(modelSelection.activeSessionContextUsage),
-    [modelSelection.activeSessionContextUsage],
-  );
-  const canKickoff = sessionActions.canKickoffNewSession && selectedRoleAvailable;
-  const activeComposerExternalSessionId = core.activeSession?.externalSessionId ?? null;
-  const activeComposerSelectedModel = core.activeSession?.selectedModel ?? null;
-  const activeComposerIsLoadingModelCatalog = core.activeSession?.isLoadingModelCatalog ?? false;
-  const activeComposerPendingApprovals = core.activeSession?.pendingApprovals ?? [];
-  const activeComposerPendingQuestions = core.activeSession?.pendingQuestions ?? [];
+  const selectedActiveComposerSession = selectedSession.chat.activeComposerSession;
+  const activeComposerExternalSessionId = selectedActiveComposerSession?.externalSessionId ?? null;
+  const activeComposerSelectedModel = selectedActiveComposerSession?.selectedModel ?? null;
+  const activeComposerIsLoadingModelCatalog =
+    selectedActiveComposerSession?.isLoadingModelCatalog ?? false;
+  const activeComposerPendingApprovals = selectedActiveComposerSession?.pendingApprovals ?? [];
+  const activeComposerPendingQuestions = selectedActiveComposerSession?.pendingQuestions ?? [];
   const activeComposerSession = useMemo(
     () =>
       activeComposerExternalSessionId
@@ -406,100 +234,42 @@ export function useAgentStudioPageModels({
           }
         : null,
     [
+      activeComposerExternalSessionId,
       activeComposerIsLoadingModelCatalog,
       activeComposerPendingApprovals,
       activeComposerPendingQuestions,
       activeComposerSelectedModel,
-      activeComposerExternalSessionId,
     ],
   );
-
-  const chatEmptyState = useMemo(() => {
-    if (!core.taskId) {
-      return {
-        title: "Select a task to begin.",
-      };
-    }
-
-    if (sessionActions.isStarting) {
-      return {
-        title: "Initializing session...",
-      };
-    }
-
-    if (canKickoff) {
-      return {
-        title: "Send a message to start a new session automatically.",
-        actionLabel: sessionActions.kickoffLabel,
-        onAction: (): void => {
-          void sessionActions.startLaunchKickoff();
-        },
-        isActionPending: sessionActions.isStarting,
-      };
-    }
-
-    return {
-      title: "Send a message to start a new session automatically.",
-    };
-  }, [
-    canKickoff,
-    core.taskId,
-    sessionActions.isStarting,
-    sessionActions.kickoffLabel,
-    sessionActions.startLaunchKickoff,
-  ]);
-
-  const runtimeReadiness = useMemo(
-    () => ({
-      readinessState: readiness.agentStudioReadinessState,
-      isReady: readiness.agentStudioReady,
-      blockedReason: readiness.agentStudioBlockedReason,
-      isLoadingChecks: readiness.isLoadingChecks,
-      refreshChecks: readiness.refreshChecks,
-    }),
-    [
-      readiness.agentStudioBlockedReason,
-      readiness.agentStudioReadinessState,
-      readiness.agentStudioReady,
-      readiness.isLoadingChecks,
-      readiness.refreshChecks,
-    ],
-  );
-
-  const pendingQuestions = useMemo(
-    () => ({
-      canSubmit: true,
-      isSubmittingByRequestId: sessionActions.isSubmittingQuestionByRequestId,
-      onSubmit: sessionActions.onSubmitQuestionAnswers,
-    }),
-    [sessionActions.isSubmittingQuestionByRequestId, sessionActions.onSubmitQuestionAnswers],
-  );
-
-  const approvalsModel = useMemo(
-    () => ({
-      canReply: true,
-      isSubmittingByRequestId: approvals.isSubmittingApprovalByRequestId,
-      errorByRequestId: approvals.approvalReplyErrorByRequestId,
-      onReply: approvals.onReplyApproval,
-    }),
-    [
-      approvals.isSubmittingApprovalByRequestId,
-      approvals.onReplyApproval,
-      approvals.approvalReplyErrorByRequestId,
-    ],
+  const selectedChatContextUsage = selectedSession.chat.contextUsage;
+  const contextUsageTotalTokens = selectedChatContextUsage?.totalTokens ?? null;
+  const contextUsageContextWindow = selectedChatContextUsage?.contextWindow ?? null;
+  const contextUsageOutputLimit = selectedChatContextUsage?.outputLimit;
+  const chatContextUsage = useMemo(
+    () =>
+      contextUsageTotalTokens !== null && contextUsageContextWindow !== null
+        ? {
+            totalTokens: contextUsageTotalTokens,
+            contextWindow: contextUsageContextWindow,
+            ...(typeof contextUsageOutputLimit === "number"
+              ? { outputLimit: contextUsageOutputLimit }
+              : {}),
+          }
+        : null,
+    [contextUsageContextWindow, contextUsageOutputLimit, contextUsageTotalTokens],
   );
 
   const composerConfig = useMemo(
     () => ({
-      taskId: core.taskId,
+      taskId: selectedSession.taskId,
       activeSession: activeComposerSession,
       isSessionWorking: sessionActions.isSessionWorking,
       isWaitingInput: sessionActions.isWaitingInput,
       busySendBlockedReason: sessionActions.busySendBlockedReason,
       canStopSession: sessionActions.canStopSession,
       stopAgentSession: sessionActions.stopAgentSession,
-      isReadOnly: !selectedRoleAvailable,
-      readOnlyReason: selectedRoleReadOnlyReason,
+      isReadOnly: selectedSession.chat.composerReadOnly,
+      readOnlyReason: selectedSession.chat.composerReadOnlyReason,
       draftStateKey: composer.draftStateKey,
       onSend: sessionActions.onSend,
       isSending: sessionActions.isSending,
@@ -524,10 +294,7 @@ export function useAgentStudioPageModels({
       onSelectVariant: modelSelection.onSelectVariant,
     }),
     [
-      chatContextUsage,
       composer.draftStateKey,
-      core.taskId,
-      activeComposerSession,
       modelSelection.agentOptions,
       modelSelection.isSelectionCatalogLoading,
       modelSelection.isSlashCommandsLoading,
@@ -545,8 +312,11 @@ export function useAgentStudioPageModels({
       modelSelection.supportsFileSearch,
       modelSelection.supportsSlashCommands,
       modelSelection.variantOptions,
-      selectedRoleAvailable,
-      selectedRoleReadOnlyReason,
+      activeComposerSession,
+      selectedSession.chat.composerReadOnly,
+      selectedSession.chat.composerReadOnlyReason,
+      chatContextUsage,
+      selectedSession.taskId,
       sessionActions.busySendBlockedReason,
       sessionActions.canStopSession,
       sessionActions.isSending,
@@ -560,26 +330,26 @@ export function useAgentStudioPageModels({
 
   const surfaceModel = useAgentChatSurfaceModel({
     mode: "interactive",
-    session: core.activeSession,
-    isTaskHydrating: core.isTaskHydrating,
-    isSessionSelectionResolving: core.isSessionSelectionResolving,
+    session: selectedSession.activeSession,
+    isTaskHydrating: selectedSession.runtime.isTaskHydrating,
+    isSessionSelectionResolving: selectedSession.runtime.isSessionSelectionResolving,
     showThinkingMessages: chatSettings.showThinkingMessages,
     isSessionWorking: sessionActions.isSessionWorking,
-    isSessionHistoryLoading: core.isSessionHistoryHydrating,
-    isWaitingForRuntimeReadiness: core.isWaitingForRuntimeReadiness,
-    runtimeDefinitions: core.runtimeDefinitions,
-    sessionRuntimeDataError: core.sessionRuntimeDataError,
-    runtimeReadiness,
-    emptyState: chatEmptyState,
-    pendingQuestions,
-    approvals: approvalsModel,
+    isSessionHistoryLoading: selectedSession.runtime.isSessionHistoryHydrating,
+    isWaitingForRuntimeReadiness: selectedSession.runtime.isWaitingForRuntimeReadiness,
+    runtimeDefinitions: selectedSession.runtime.runtimeDefinitions,
+    sessionRuntimeDataError: selectedSession.runtime.sessionRuntimeDataError,
+    runtimeReadiness: selectedSession.runtime.runtimeReadiness,
+    emptyState: selectedSession.chat.emptyState,
+    pendingQuestions: selectedSession.pendingInput.pendingQuestions,
+    approvals: selectedSession.pendingInput.approvals,
     composer: composerConfig,
     sessionAgentColors: modelSelection.activeSessionAgentColors,
     subagentPendingApprovalsByExternalSessionId:
-      core.activeSession?.subagentPendingApprovalsByExternalSessionId,
+      selectedSession.pendingInput.subagentPendingApprovalsByExternalSessionId,
     subagentPendingApprovalCountByExternalSessionId,
     subagentPendingQuestionsByExternalSessionId:
-      core.activeSession?.subagentPendingQuestionsByExternalSessionId,
+      selectedSession.pendingInput.subagentPendingQuestionsByExternalSessionId,
     subagentPendingQuestionCountByExternalSessionId,
   });
   const composerModel = surfaceModel.composer;

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
@@ -1,4 +1,4 @@
-import type { RuntimeDescriptor, TaskCard } from "@openducktor/contracts";
+import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import { useMemo, useRef } from "react";
 import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
@@ -6,8 +6,6 @@ import type { AgentChatComposerDraft } from "@/components/features/agents/agent-
 import { useAgentChatSurfaceModel } from "@/components/features/agents/agent-chat/use-agent-chat-surface-model";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents/agent-studio-task-tabs";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
-import type { AgentSessionSummary } from "@/state/agent-sessions-store";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStudioQuickActionOption } from "./agent-studio-quick-actions";
 import type { SessionCreateOption } from "./agents-page-session-tabs";
 import {
@@ -16,28 +14,10 @@ import {
 } from "./agents-page-view-model";
 import type { AgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
 import { keepStablePendingInputCounts } from "./selected-session/selected-session-context";
-import type { AgentStudioSessionContextUsage } from "./use-agent-studio-page-model-builders";
 import { useAgentStudioHeaderModel } from "./use-agent-studio-page-submodels";
 
 type AgentStudioCoreContext = {
   activeTabValue: string;
-  taskId: string;
-  role: AgentRole;
-  selectedTask: TaskCard | null;
-  allSessionSummaries: AgentSessionSummary[];
-  sessionsForTask: AgentSessionSummary[];
-  contextSessionsLength: number;
-  activeSession: AgentSessionState | null;
-  runtimeDefinitions: RuntimeDescriptor[];
-  sessionRuntimeDataError: string | null;
-  hasActiveGitConflict: boolean;
-  isTaskHydrating: boolean;
-  isSessionHistoryHydrated: boolean;
-  isSessionHistoryHydrating: boolean;
-  isSessionSelectionResolving: boolean;
-  isWaitingForRuntimeReadiness: boolean;
-  isSessionHistoryHydrationFailed: boolean;
-  contextSwitchVersion: number;
 };
 
 const useStablePendingInputCounts = (
@@ -64,7 +44,6 @@ type AgentStudioTaskTabsContext = {
 type AgentStudioSessionActionsContext = {
   handleWorkflowStepSelect: (role: AgentRole, externalSessionId: string | null) => void;
   handleSessionSelectionChange: (nextValue: string) => void;
-  handleCreateSession: (option: SessionCreateOption) => void;
   handlePrepareMessageFirstSession: (option: SessionCreateOption) => void;
   handleQuickAction: (option: AgentStudioQuickActionOption) => void;
   openTaskDetails: () => void;
@@ -73,13 +52,8 @@ type AgentStudioSessionActionsContext = {
   isSessionWorking: boolean;
   isWaitingInput: boolean;
   busySendBlockedReason: string | null;
-  canKickoffNewSession: boolean;
-  kickoffLabel: string;
   canStopSession: boolean;
-  startLaunchKickoff: () => Promise<void>;
   onSend: (draft: AgentChatComposerDraft) => Promise<boolean>;
-  onSubmitQuestionAnswers: (requestId: string, answers: string[][]) => Promise<void>;
-  isSubmittingQuestionByRequestId: Record<string, boolean>;
   stopAgentSession: (externalSessionId: string) => Promise<void>;
 };
 
@@ -102,7 +76,6 @@ type AgentStudioModelSelectionContext = {
   onSelectModel: (model: string) => void;
   onSelectVariant: (variant: string) => void;
   activeSessionAgentColors: Record<string, string>;
-  activeSessionContextUsage: AgentStudioSessionContextUsage;
 };
 
 type AgentStudioComposerContext = {
@@ -258,6 +231,72 @@ export function useAgentStudioPageModels({
         : null,
     [contextUsageContextWindow, contextUsageOutputLimit, contextUsageTotalTokens],
   );
+  const selectedRuntimeReadiness = selectedSession.runtime.runtimeReadiness;
+  const runtimeReadiness = useMemo(
+    () => ({
+      readinessState: selectedRuntimeReadiness.readinessState,
+      isReady: selectedRuntimeReadiness.isReady,
+      blockedReason: selectedRuntimeReadiness.blockedReason,
+      isLoadingChecks: selectedRuntimeReadiness.isLoadingChecks,
+      refreshChecks: selectedRuntimeReadiness.refreshChecks,
+    }),
+    [
+      selectedRuntimeReadiness.blockedReason,
+      selectedRuntimeReadiness.isLoadingChecks,
+      selectedRuntimeReadiness.isReady,
+      selectedRuntimeReadiness.readinessState,
+      selectedRuntimeReadiness.refreshChecks,
+    ],
+  );
+  const selectedPendingQuestions = selectedSession.pendingInput.pendingQuestions;
+  const pendingQuestions = useMemo(
+    () => ({
+      canSubmit: selectedPendingQuestions.canSubmit,
+      isSubmittingByRequestId: selectedPendingQuestions.isSubmittingByRequestId,
+      onSubmit: selectedPendingQuestions.onSubmit,
+    }),
+    [
+      selectedPendingQuestions.canSubmit,
+      selectedPendingQuestions.isSubmittingByRequestId,
+      selectedPendingQuestions.onSubmit,
+    ],
+  );
+  const selectedApprovals = selectedSession.pendingInput.approvals;
+  const approvals = useMemo(
+    () => ({
+      canReply: selectedApprovals.canReply,
+      isSubmittingByRequestId: selectedApprovals.isSubmittingByRequestId,
+      errorByRequestId: selectedApprovals.errorByRequestId,
+      onReply: selectedApprovals.onReply,
+    }),
+    [
+      selectedApprovals.canReply,
+      selectedApprovals.errorByRequestId,
+      selectedApprovals.isSubmittingByRequestId,
+      selectedApprovals.onReply,
+    ],
+  );
+  const selectedEmptyState = selectedSession.chat.emptyState;
+  const emptyStateTitle = selectedEmptyState?.title ?? null;
+  const emptyStateActionLabel = selectedEmptyState?.actionLabel;
+  const emptyStateOnAction = selectedEmptyState?.onAction;
+  const emptyStateIsActionPending = selectedEmptyState?.isActionPending;
+  const emptyState = useMemo(
+    () =>
+      emptyStateTitle
+        ? {
+            title: emptyStateTitle,
+            ...(typeof emptyStateActionLabel === "string"
+              ? { actionLabel: emptyStateActionLabel }
+              : {}),
+            ...(emptyStateOnAction ? { onAction: emptyStateOnAction } : {}),
+            ...(typeof emptyStateIsActionPending === "boolean"
+              ? { isActionPending: emptyStateIsActionPending }
+              : {}),
+          }
+        : null,
+    [emptyStateActionLabel, emptyStateIsActionPending, emptyStateOnAction, emptyStateTitle],
+  );
 
   const composerConfig = useMemo(
     () => ({
@@ -339,10 +378,10 @@ export function useAgentStudioPageModels({
     isWaitingForRuntimeReadiness: selectedSession.runtime.isWaitingForRuntimeReadiness,
     runtimeDefinitions: selectedSession.runtime.runtimeDefinitions,
     sessionRuntimeDataError: selectedSession.runtime.sessionRuntimeDataError,
-    runtimeReadiness: selectedSession.runtime.runtimeReadiness,
-    emptyState: selectedSession.chat.emptyState,
-    pendingQuestions: selectedSession.pendingInput.pendingQuestions,
-    approvals: selectedSession.pendingInput.approvals,
+    runtimeReadiness,
+    emptyState,
+    pendingQuestions,
+    approvals,
     composer: composerConfig,
     sessionAgentColors: modelSelection.activeSessionAgentColors,
     subagentPendingApprovalsByExternalSessionId:

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
@@ -16,10 +16,6 @@ import type { AgentStudioSelectedSessionContext } from "./selected-session/selec
 import { keepStablePendingInputCounts } from "./selected-session/selected-session-context";
 import { useAgentStudioHeaderModel } from "./use-agent-studio-page-submodels";
 
-type AgentStudioCoreContext = {
-  activeTabValue: string;
-};
-
 const useStablePendingInputCounts = (
   nextCounts: Record<string, number>,
 ): Record<string, number> => {
@@ -87,7 +83,7 @@ type AgentStudioChatSettingsContext = {
 };
 
 type UseAgentStudioPageModelsArgs = {
-  core: AgentStudioCoreContext;
+  activeTabValue: string;
   selectedSession: AgentStudioSelectedSessionContext;
   taskTabs: AgentStudioTaskTabsContext;
   sessionActions: AgentStudioSessionActionsContext;
@@ -97,7 +93,7 @@ type UseAgentStudioPageModelsArgs = {
 };
 
 export function useAgentStudioPageModels({
-  core,
+  activeTabValue,
   selectedSession,
   taskTabs,
   sessionActions,
@@ -159,7 +155,6 @@ export function useAgentStudioPageModels({
     onOpenTaskDetails: selectedSession.selectedTask ? sessionActions.openTaskDetails : null,
     activeSession: selectedSession.activeSession,
     sessionsForTaskLength: selectedSession.sessionsForTask.length,
-    contextSessionsLength: selectedSession.contextSessionsLength,
     agentStudioReady: selectedSession.runtime.runtimeReadiness.isReady,
     isStarting: sessionActions.isStarting,
     onWorkflowStepSelect: sessionActions.handleWorkflowStepSelect,
@@ -408,7 +403,7 @@ export function useAgentStudioPageModels({
   );
 
   return {
-    activeTabValue: core.activeTabValue,
+    activeTabValue,
     agentStudioTaskTabsModel,
     agentStudioHeaderModel,
     agentStudioWorkspaceSidebarModel,

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
@@ -1,6 +1,6 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
 import type { AgentChatComposerDraft } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
 import { useAgentChatSurfaceModel } from "@/components/features/agents/agent-chat/use-agent-chat-surface-model";
@@ -20,11 +20,16 @@ const useStablePendingInputCounts = (
   nextCounts: Record<string, number>,
 ): Record<string, number> => {
   const previousRef = useRef<Record<string, number>>(nextCounts);
-  return useMemo(() => {
-    const stableCounts = keepStablePendingInputCounts(previousRef.current, nextCounts);
+  const stableCounts = useMemo(
+    () => keepStablePendingInputCounts(previousRef.current, nextCounts),
+    [nextCounts],
+  );
+
+  useEffect(() => {
     previousRef.current = stableCounts;
-    return stableCounts;
-  }, [nextCounts]);
+  }, [stableCounts]);
+
+  return stableCounts;
 };
 
 type AgentStudioTaskTabsContext = {

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-submodels.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-submodels.test.tsx
@@ -42,7 +42,6 @@ const createHookArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   onOpenTaskDetails: mock(() => {}),
   activeSession: { status: "running" },
   sessionsForTaskLength: 1,
-  contextSessionsLength: 1,
   agentStudioReady: true,
   isStarting: false,
   onWorkflowStepSelect: mock(() => {}),

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -15,7 +15,6 @@ type UseAgentStudioHeaderModelArgs = {
   onOpenTaskDetails: (() => void) | null;
   activeSession: Pick<AgentSessionState, "status"> | null;
   sessionsForTaskLength: number;
-  contextSessionsLength: number;
   agentStudioReady: boolean;
   isStarting: boolean;
   onWorkflowStepSelect: AgentStudioWorkflowStepSelect;
@@ -31,7 +30,6 @@ export const useAgentStudioHeaderModel = ({
   onOpenTaskDetails,
   activeSession,
   sessionsForTaskLength,
-  contextSessionsLength,
   agentStudioReady,
   isStarting,
   onWorkflowStepSelect,
@@ -67,12 +65,10 @@ export const useAgentStudioHeaderModel = ({
         onQuickAction,
         onResolveGitConflictQuickAction: onResolveGitConflictQuickAction ?? null,
         isStarting,
-        contextSessionsLength,
       }),
     [
       activeSessionStatus,
       agentStudioReady,
-      contextSessionsLength,
       isStarting,
       onOpenTaskDetails,
       onPrepareMessageFirstSession,


### PR DESCRIPTION
## Summary
- Adds a focused Agent Studio selected-session context module that centralizes selected-session-derived workflow, document, chat, runtime, pending-input, and right-panel decisions.
- Simplifies page-model wiring so rendering hooks consume already-interpreted selected-session state instead of rebuilding cross-cutting decisions.
- Tightens related tests around the selected-session seam and updates page-model fixtures after rebasing onto `origin/main`.

## Goal
Agent Studio selected-session behavior was spread across page orchestration, page-model builders, runtime readiness, documents, pending permissions/questions, chat, and right-panel state. That made it hard to reason about what the current selected session means and forced broad tests to understand too much orchestration detail.

This PR introduces a narrower selected-session seam so those decisions live in one place and downstream UI model builders receive smaller, more stable inputs.

## Technical choices
- Introduced `selected-session/selected-session-context.ts` as the owner of selected-session interpretation instead of creating a broad generic orchestration module.
- Moved workflow model construction, active document selection, runtime readiness mapping, composer read-only state, chat empty state, and pending input count derivation behind the selected-session context.
- Kept pending-input count maps stable with `keepStablePendingInputCounts` so existing chat-thread memo behavior is preserved.
- Trimmed dead page-model surface after the extraction, including unused session-start/chat kickoff fields and context/session length plumbing that no longer belonged in the page model.
- Updated focused tests to assert selected-session behavior at the new seam and to use `selectedSessionCore` fixtures instead of lower-level page-model core overrides.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `cargo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Agent Studio state into a single selected-session context and simplified page models to derive the UI from that unified shape.
  * Header/session wiring updated so session-creation state is driven by an explicit starting flag; removed legacy session-count input.
  * Stabilized pending-input counts for more consistent UI updates.

* **Tests**
  * Updated and added tests to align with the new selected-session-driven interfaces and behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/564)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->