### PR TITLE
fix(web): make launcher shutdown cross-platform

### DIFF
--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -111,6 +111,24 @@ describe("launcher internals", () => {
     ]);
   });
 
+  test("detects when the host exits during the graceful shutdown wait", async () => {
+    const hostExited = await __launcherTestInternals.waitForGracefulHostExit(
+      createHostProcess(Promise.resolve(0)),
+      async () => new Promise(() => {}),
+    );
+
+    expect(hostExited).toBe(true);
+  });
+
+  test("detects when the host needs force termination after graceful shutdown wait", async () => {
+    const hostExited = await __launcherTestInternals.waitForGracefulHostExit(
+      createHostProcess(new Promise<number>(() => {})),
+      async () => {},
+    );
+
+    expect(hostExited).toBe(false);
+  });
+
   test("uses process-group signals on non-Windows platforms", async () => {
     const { child, killCalls } = createTerminableHostProcess(1234);
     const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -5,11 +5,11 @@ const createHostProcess = (exited: Promise<number>): Bun.Subprocess => {
   return { exited } as Bun.Subprocess;
 };
 
-const createTerminableHostProcess = (pid?: number) => {
+const createTerminableHostProcess = (pid?: number, exited = new Promise<number>(() => {})) => {
   const killCalls: Array<number | NodeJS.Signals | undefined> = [];
   const child = {
     pid,
-    exited: new Promise<number>(() => {}),
+    exited,
     kill(signal?: number | NodeJS.Signals) {
       killCalls.push(signal);
       return true;
@@ -18,6 +18,8 @@ const createTerminableHostProcess = (pid?: number) => {
 
   return { child, killCalls };
 };
+
+const noopWindowsProcessTreeTerminator = async () => {};
 
 describe("launcher internals", () => {
   test("waits for the fake host health and token-authenticated session endpoints", async () => {
@@ -139,6 +141,7 @@ describe("launcher internals", () => {
         processKillCalls.push({ pid, signal });
         return true;
       },
+      terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
       sleep: async () => {},
     });
 
@@ -150,9 +153,59 @@ describe("launcher internals", () => {
     expect(killCalls).toEqual([undefined, 9]);
   });
 
-  test("does not use negative process-group signals on Windows", async () => {
+  test("waits the full process-group grace window before Unix escalation", async () => {
+    const { child } = createTerminableHostProcess(1234, Promise.resolve(0));
+    const calls: string[] = [];
+
+    await __launcherTestInternals.terminateHostProcess(child, {
+      platform: "linux",
+      killProcess(_pid, signal) {
+        calls.push(`process:${signal}`);
+        return true;
+      },
+      terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
+      sleep: async (durationMs) => {
+        calls.push(`sleep:${durationMs}`);
+      },
+    });
+
+    expect(calls).toEqual([
+      "process:SIGTERM",
+      "sleep:3000",
+      "process:0",
+      "process:SIGKILL",
+      "sleep:1000",
+    ]);
+  });
+
+  test("skips Unix SIGKILL when the process group is already gone", async () => {
     const { child, killCalls } = createTerminableHostProcess(1234);
     const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
+
+    await __launcherTestInternals.terminateHostProcess(child, {
+      platform: "linux",
+      killProcess(pid, signal) {
+        processKillCalls.push({ pid, signal });
+        if (signal === 0) {
+          throw new Error("process group is gone");
+        }
+        return true;
+      },
+      terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
+      sleep: async () => {},
+    });
+
+    expect(processKillCalls).toEqual([
+      { pid: -1234, signal: "SIGTERM" },
+      { pid: -1234, signal: 0 },
+    ]);
+    expect(killCalls).toEqual([undefined, 9]);
+  });
+
+  test("terminates the Windows process tree without negative process-group signals", async () => {
+    const { child, killCalls } = createTerminableHostProcess(1234);
+    const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
+    const processTreeKills: number[] = [];
 
     await __launcherTestInternals.terminateHostProcess(child, {
       platform: "win32",
@@ -163,11 +216,16 @@ describe("launcher internals", () => {
         }
         return true;
       },
+      terminateWindowsProcessTree(pid) {
+        processTreeKills.push(pid);
+        return Promise.resolve();
+      },
       sleep: async () => {},
     });
 
     expect(processKillCalls).toEqual([]);
-    expect(killCalls).toEqual([undefined, 9]);
+    expect(processTreeKills).toEqual([1234]);
+    expect(killCalls).toEqual([]);
   });
 
   test("skips process-group signals when the host PID is invalid", async () => {
@@ -180,6 +238,7 @@ describe("launcher internals", () => {
         processKillCalls.push({ pid, signal });
         return true;
       },
+      terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
       sleep: async () => {},
     });
 

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -5,6 +5,20 @@ const createHostProcess = (exited: Promise<number>): Bun.Subprocess => {
   return { exited } as Bun.Subprocess;
 };
 
+const createTerminableHostProcess = (pid?: number) => {
+  const killCalls: Array<number | NodeJS.Signals | undefined> = [];
+  const child = {
+    pid,
+    exited: new Promise<number>(() => {}),
+    kill(signal?: number | NodeJS.Signals) {
+      killCalls.push(signal);
+      return true;
+    },
+  } as unknown as Bun.Subprocess;
+
+  return { child, killCalls };
+};
+
 describe("launcher internals", () => {
   test("waits for the fake host health and token-authenticated session endpoints", async () => {
     const requests: Array<{ url: string; method: string | undefined; token: string | null }> = [];
@@ -95,6 +109,64 @@ describe("launcher internals", () => {
         token: "control-token",
       },
     ]);
+  });
+
+  test("uses process-group signals on non-Windows platforms", async () => {
+    const { child, killCalls } = createTerminableHostProcess(1234);
+    const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
+
+    await __launcherTestInternals.terminateHostProcess(child, {
+      platform: "linux",
+      killProcess(pid, signal) {
+        processKillCalls.push({ pid, signal });
+        return true;
+      },
+      sleep: async () => {},
+    });
+
+    expect(processKillCalls).toEqual([
+      { pid: -1234, signal: "SIGTERM" },
+      { pid: -1234, signal: 0 },
+      { pid: -1234, signal: "SIGKILL" },
+    ]);
+    expect(killCalls).toEqual([undefined, 9]);
+  });
+
+  test("does not use negative process-group signals on Windows", async () => {
+    const { child, killCalls } = createTerminableHostProcess(1234);
+    const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
+
+    await __launcherTestInternals.terminateHostProcess(child, {
+      platform: "win32",
+      killProcess(pid, signal) {
+        processKillCalls.push({ pid, signal });
+        if (pid < 0) {
+          throw new Error("Windows termination must not use negative PIDs.");
+        }
+        return true;
+      },
+      sleep: async () => {},
+    });
+
+    expect(processKillCalls).toEqual([]);
+    expect(killCalls).toEqual([undefined, 9]);
+  });
+
+  test("skips process-group signals when the host PID is invalid", async () => {
+    const { child, killCalls } = createTerminableHostProcess(0);
+    const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
+
+    await __launcherTestInternals.terminateHostProcess(child, {
+      platform: "darwin",
+      killProcess(pid, signal) {
+        processKillCalls.push({ pid, signal });
+        return true;
+      },
+      sleep: async () => {},
+    });
+
+    expect(processKillCalls).toEqual([]);
+    expect(killCalls).toEqual([undefined, 9]);
   });
 
   test("builds runtime config JSON for the browser shell", () => {

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -160,6 +160,16 @@ const waitForHostExit = async (
   await Promise.race([child.exited, sleep(durationMs)]);
 };
 
+const waitForGracefulHostExit = async (
+  child: ManagedProcess,
+  sleep: HostTerminationDependencies["sleep"] = Bun.sleep,
+): Promise<boolean> => {
+  return Promise.race([
+    child.exited.then(() => true),
+    sleep(HOST_GRACEFUL_EXIT_TIMEOUT_MS).then(() => false),
+  ]);
+};
+
 const terminateHostProcess = async (
   child: ManagedProcess | null,
   dependencies: HostTerminationDependencies = defaultHostTerminationDependencies,
@@ -310,6 +320,7 @@ export const __launcherTestInternals = {
   terminateHostProcess,
   verifyBackendReadiness,
   waitForBackend,
+  waitForGracefulHostExit,
 };
 
 const startViteServer = async (
@@ -467,9 +478,11 @@ export const runLauncher = async (options: LauncherOptions): Promise<number> => 
         );
       }
 
-      await Promise.race([hostProcess.exited, Bun.sleep(HOST_GRACEFUL_EXIT_TIMEOUT_MS)]);
-      logInfo("Ensuring OpenDucktor host process has exited...");
-      await terminateHostProcess(hostProcess);
+      const hostExited = await waitForGracefulHostExit(hostProcess);
+      if (!hostExited) {
+        logInfo("Ensuring OpenDucktor host process has exited...");
+        await terminateHostProcess(hostProcess);
+      }
       logSuccess("OpenDucktor web stopped.");
     })();
 

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -21,6 +21,11 @@ type BackendReadinessDependencies = {
   fetch: typeof fetch;
   sleep: (durationMs: number) => Promise<unknown>;
 };
+type HostTerminationDependencies = {
+  platform: NodeJS.Platform;
+  killProcess: typeof process.kill;
+  sleep: (durationMs: number) => Promise<unknown>;
+};
 type FrontendServer = {
   close(): Promise<void>;
 };
@@ -141,32 +146,60 @@ const verifyBackendReadiness = async (
   }
 };
 
-const terminateProcessGroup = async (child: ManagedProcess | null): Promise<void> => {
+const defaultHostTerminationDependencies: HostTerminationDependencies = {
+  platform: process.platform,
+  killProcess: process.kill,
+  sleep: Bun.sleep,
+};
+
+const waitForHostExit = async (
+  child: ManagedProcess,
+  durationMs: number,
+  sleep: HostTerminationDependencies["sleep"],
+): Promise<void> => {
+  await Promise.race([child.exited, sleep(durationMs)]);
+};
+
+const terminateHostProcess = async (
+  child: ManagedProcess | null,
+  dependencies: HostTerminationDependencies = defaultHostTerminationDependencies,
+): Promise<void> => {
   if (!child) {
     return;
   }
 
   const pid = child.pid;
-  if (typeof pid === "number" && pid > 0) {
+  const hasProcessGroupPid = typeof pid === "number" && pid > 0;
+
+  if (dependencies.platform === "win32") {
+    child.kill();
+    await waitForHostExit(child, 3_000, dependencies.sleep);
+
+    child.kill(9);
+    await waitForHostExit(child, 1_000, dependencies.sleep);
+    return;
+  }
+
+  if (hasProcessGroupPid) {
     try {
-      process.kill(-pid, "SIGTERM");
+      dependencies.killProcess(-pid, "SIGTERM");
     } catch {}
   }
 
   child.kill();
-  await Promise.race([child.exited, Bun.sleep(3_000)]);
+  await waitForHostExit(child, 3_000, dependencies.sleep);
 
-  if (typeof pid === "number" && pid > 0) {
+  if (hasProcessGroupPid) {
     try {
-      process.kill(-pid, 0);
+      dependencies.killProcess(-pid, 0);
       try {
-        process.kill(-pid, "SIGKILL");
+        dependencies.killProcess(-pid, "SIGKILL");
       } catch {}
     } catch {}
   }
 
   child.kill(9);
-  await Promise.race([child.exited, Bun.sleep(1_000)]);
+  await waitForHostExit(child, 1_000, dependencies.sleep);
 };
 
 const closeFrontendServer = async (server: FrontendServer | null): Promise<void> => {
@@ -274,6 +307,7 @@ export const __launcherTestInternals = {
   resolveStaticAssetPath,
   requestHostShutdown,
   shouldForceExitForRepeatedSignal,
+  terminateHostProcess,
   verifyBackendReadiness,
   waitForBackend,
 };
@@ -435,7 +469,7 @@ export const runLauncher = async (options: LauncherOptions): Promise<number> => 
 
       await Promise.race([hostProcess.exited, Bun.sleep(HOST_GRACEFUL_EXIT_TIMEOUT_MS)]);
       logInfo("Ensuring OpenDucktor host process has exited...");
-      await terminateProcessGroup(hostProcess);
+      await terminateHostProcess(hostProcess);
       logSuccess("OpenDucktor web stopped.");
     })();
 

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -24,6 +24,7 @@ type BackendReadinessDependencies = {
 type HostTerminationDependencies = {
   platform: NodeJS.Platform;
   killProcess: typeof process.kill;
+  terminateWindowsProcessTree: (pid: number) => Promise<void>;
   sleep: (durationMs: number) => Promise<unknown>;
 };
 type FrontendServer = {
@@ -37,6 +38,8 @@ const VITE_CLOSE_TIMEOUT_MS = 3_000;
 const HOST_GRACEFUL_EXIT_TIMEOUT_MS = 2_000;
 const FORCE_EXIT_SIGNAL_GRACE_MS = 1_500;
 const MCP_SIDECAR_PATH_ENV = "OPENDUCKTOR_OPENDUCKTOR_MCP_PATH";
+const HOST_FORCE_TERMINATION_GRACE_MS = 3_000;
+const HOST_FORCE_KILL_WAIT_MS = 1_000;
 
 const buildFrontendUrl = (port: number): string => `http://${LOCALHOST}:${port}`;
 const buildBackendUrl = (port: number): string => `http://${LOCALHOST}:${port}`;
@@ -149,6 +152,14 @@ const verifyBackendReadiness = async (
 const defaultHostTerminationDependencies: HostTerminationDependencies = {
   platform: process.platform,
   killProcess: process.kill,
+  terminateWindowsProcessTree: async (pid: number) => {
+    const taskkill = Bun.spawn({
+      cmd: ["taskkill", "/PID", String(pid), "/T", "/F"],
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await Promise.race([taskkill.exited, Bun.sleep(HOST_FORCE_TERMINATION_GRACE_MS)]);
+  },
   sleep: Bun.sleep,
 };
 
@@ -182,11 +193,14 @@ const terminateHostProcess = async (
   const hasProcessGroupPid = typeof pid === "number" && pid > 0;
 
   if (dependencies.platform === "win32") {
-    child.kill();
-    await waitForHostExit(child, 3_000, dependencies.sleep);
-
-    child.kill(9);
-    await waitForHostExit(child, 1_000, dependencies.sleep);
+    if (hasProcessGroupPid) {
+      try {
+        await dependencies.terminateWindowsProcessTree(pid);
+      } catch {}
+    } else {
+      child.kill();
+    }
+    await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
     return;
   }
 
@@ -197,7 +211,7 @@ const terminateHostProcess = async (
   }
 
   child.kill();
-  await waitForHostExit(child, 3_000, dependencies.sleep);
+  await dependencies.sleep(HOST_FORCE_TERMINATION_GRACE_MS);
 
   if (hasProcessGroupPid) {
     try {
@@ -209,7 +223,7 @@ const terminateHostProcess = async (
   }
 
   child.kill(9);
-  await waitForHostExit(child, 1_000, dependencies.sleep);
+  await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
 };
 
 const closeFrontendServer = async (server: FrontendServer | null): Promise<void> => {


### PR DESCRIPTION
## Summary
- Make the `@openducktor/web` launcher host force-stop path platform-aware.
- Preserve Unix/macOS process-group cleanup while avoiding negative-PID signaling on Windows.
- Add unit coverage for Unix, Windows, invalid PID, and graceful-exit shutdown behavior.

## Goal
`bunx @openducktor/web` starts a detached Rust web host and is responsible for shutting it down when the launcher exits or receives Ctrl+C. The previous force cleanup always used negative-PID process-group signals such as `process.kill(-pid, "SIGTERM")`, which are Unix-specific and unsafe for Windows.

This PR fixes that shutdown path without changing the frontend/backend protocol. The launcher still asks the host to shut down through `POST /shutdown` with `x-openducktor-control-token`, closes the frontend server, waits for the host to exit gracefully, and only force-stops the process if that wait times out.

## Technical choices
- Kept the process-management logic local to `packages/openducktor-web/src/launcher.ts` to avoid introducing a broader abstraction for a single launcher-specific need.
- Added a deterministic `terminateHostProcess` helper with injectable `platform`, `killProcess`, and `sleep` dependencies so platform behavior can be tested on any OS.
- Preserved the existing non-Windows behavior: negative-PID `SIGTERM`, child kill, bounded wait, process-group liveness probe, negative-PID `SIGKILL`, final child kill, and bounded wait.
- Added a Windows branch that uses only Bun child-process termination and bounded waits, never negative PID signaling.
- Added `waitForGracefulHostExit` so the force-stop helper is only called when the host does not exit during the graceful shutdown window.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check` from `apps/desktop/src-tauri`
- `cargo clippy --workspace --all-targets -- -D warnings` from `apps/desktop/src-tauri`
- `cargo build` from `apps/desktop/src-tauri`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More deterministic, cross-platform host shutdown with staged graceful wait before escalation to stronger termination methods.
  * Improved handling for Windows vs. non-Windows termination flows and edge cases where process groups are absent.

* **Tests**
  * Expanded tests covering graceful-exit outcomes, escalation timing, and platform-specific termination behaviors.

* **Chores**
  * No public API changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/565)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->