### PR TITLE
test(host): validate Windows tool discovery

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -65,9 +65,9 @@ pub(crate) type OpencodeStartupWaitReport = RuntimeStartupWaitReport;
 #[cfg(test)]
 pub(crate) use opencode_runtime::wait_for_local_server_with_process;
 pub(crate) use opencode_runtime::{
-    opencode_server_parent_pid, process_exists, read_opencode_version,
-    resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
-    wait_for_local_server_with_process as wait_for_runtime_with_process,
+    opencode_binary_not_found_message, opencode_server_parent_pid, process_exists,
+    read_opencode_version, resolve_opencode_binary_path, terminate_child_process,
+    terminate_process_by_pid, wait_for_local_server_with_process as wait_for_runtime_with_process,
     wait_for_process_exit_by_pid, StartupCancelEpoch,
 };
 pub(crate) type RuntimeSessionStatusMap = runtime_session_status::RuntimeSessionStatusMap;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -63,11 +63,13 @@ pub(crate) type OpencodeStartupReadinessPolicy = RuntimeStartupReadinessPolicy;
 #[cfg(test)]
 pub(crate) type OpencodeStartupWaitReport = RuntimeStartupWaitReport;
 #[cfg(test)]
+pub(crate) use opencode_runtime::resolve_opencode_binary_path;
+#[cfg(test)]
 pub(crate) use opencode_runtime::wait_for_local_server_with_process;
 pub(crate) use opencode_runtime::{
-    opencode_binary_not_found_message, opencode_server_parent_pid, process_exists,
-    read_opencode_version, resolve_opencode_binary_path, terminate_child_process,
-    terminate_process_by_pid, wait_for_local_server_with_process as wait_for_runtime_with_process,
+    opencode_server_parent_pid, process_exists, read_opencode_version, resolve_opencode_binary,
+    terminate_child_process, terminate_process_by_pid,
+    wait_for_local_server_with_process as wait_for_runtime_with_process,
     wait_for_process_exit_by_pid, StartupCancelEpoch,
 };
 pub(crate) type RuntimeSessionStatusMap = runtime_session_status::RuntimeSessionStatusMap;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -11,9 +11,9 @@ use std::path::Path;
 use std::process::Child;
 
 pub(crate) use process_lifecycle::{
-    opencode_server_parent_pid, process_exists, read_opencode_version,
-    resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
-    wait_for_process_exit_by_pid,
+    opencode_binary_not_found_message, opencode_server_parent_pid, process_exists,
+    read_opencode_version, resolve_opencode_binary_path, terminate_child_process,
+    terminate_process_by_pid, wait_for_process_exit_by_pid,
 };
 pub(crate) use process_registry::{
     opencode_process_registry_path, reconcile_opencode_process_registry_on_startup,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -10,10 +10,11 @@ use anyhow::Result;
 use std::path::Path;
 use std::process::Child;
 
+#[cfg(test)]
+pub(crate) use process_lifecycle::resolve_opencode_binary_path;
 pub(crate) use process_lifecycle::{
-    opencode_binary_not_found_message, opencode_server_parent_pid, process_exists,
-    read_opencode_version, resolve_opencode_binary_path, terminate_child_process,
-    terminate_process_by_pid, wait_for_process_exit_by_pid,
+    opencode_server_parent_pid, process_exists, read_opencode_version, resolve_opencode_binary,
+    terminate_child_process, terminate_process_by_pid, wait_for_process_exit_by_pid,
 };
 pub(crate) use process_registry::{
     opencode_process_registry_path, reconcile_opencode_process_registry_on_startup,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
@@ -1,6 +1,7 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use host_infra_system::{
-    bundled_command, parse_user_path, resolve_command_path, subprocess_path_env,
+    bundled_command, is_executable_file, parse_user_path_os, resolve_command_path,
+    subprocess_path_env,
 };
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -45,43 +46,39 @@ pub(crate) fn read_opencode_version(binary: &str) -> Option<String> {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn resolve_opencode_binary_path() -> Option<String> {
-    if let Ok(override_binary) = std::env::var("OPENDUCKTOR_OPENCODE_BINARY") {
-        if override_binary.trim().is_empty() {
-            return resolve_opencode_binary_path_without_override();
-        }
-        if let Ok(path) = parse_user_path(override_binary.as_str()) {
-            return (path.is_file() && is_executable_path(path.as_path()))
-                .then(|| path.to_string_lossy().to_string());
-        }
-        return None;
-    }
-
-    resolve_opencode_binary_path_without_override()
+    resolve_opencode_binary().ok()
 }
 
-pub(crate) fn opencode_binary_not_found_message() -> String {
-    if let Ok(override_binary) = std::env::var("OPENDUCKTOR_OPENCODE_BINARY") {
-        if !override_binary.trim().is_empty() {
-            return match parse_user_path(override_binary.as_str()) {
-                Ok(path) => format!(
+pub(crate) fn resolve_opencode_binary() -> std::result::Result<String, String> {
+    if let Some(override_binary) = std::env::var_os("OPENDUCKTOR_OPENCODE_BINARY") {
+        if override_binary
+            .to_str()
+            .is_some_and(|value| value.trim().is_empty())
+        {
+            return Err(
+                "Configured OpenCode override OPENDUCKTOR_OPENCODE_BINARY is empty".to_string(),
+            );
+        }
+        return match parse_user_path_os(override_binary.as_os_str()) {
+            Ok(path) if is_executable_file(path.as_path()) => Ok(path.to_string_lossy().to_string()),
+            Ok(path) => Err(format!(
                     "Configured OpenCode override OPENDUCKTOR_OPENCODE_BINARY points to a missing or non-executable file: {}",
                     path.display()
-                ),
-                Err(error) => format!(
+                )),
+            Err(error) => Err(format!(
                     "Configured OpenCode override OPENDUCKTOR_OPENCODE_BINARY is invalid: {error:#}"
-                ),
-            };
-        }
+                )),
+        };
     }
 
-    "opencode not found in bundled locations, standard install locations, PATH, or ~/.opencode/bin"
-        .to_string()
+    resolve_opencode_binary_without_override()
 }
 
-fn resolve_opencode_binary_path_without_override() -> Option<String> {
+fn resolve_opencode_binary_without_override() -> std::result::Result<String, String> {
     if let Some(resolved) = bundled_command("opencode") {
-        return Some(resolved);
+        return Ok(resolved);
     }
 
     if let Some(home) = std::env::var_os("HOME") {
@@ -89,26 +86,19 @@ fn resolve_opencode_binary_path_without_override() -> Option<String> {
             .join(".opencode")
             .join("bin")
             .join("opencode");
-        if candidate.is_file() && is_executable_path(candidate.as_path()) {
-            return candidate.to_str().map(|value| value.to_string());
+        if is_executable_file(candidate.as_path()) {
+            return Ok(candidate.to_string_lossy().to_string());
         }
     }
 
-    resolve_command_path("opencode").ok().flatten()
-}
-
-#[cfg(unix)]
-fn is_executable_path(path: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-
-    path.metadata()
-        .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
-}
-
-#[cfg(not(unix))]
-fn is_executable_path(path: &Path) -> bool {
-    path.is_file()
+    match resolve_command_path("opencode") {
+        Ok(Some(path)) => Ok(path),
+        Ok(None) => Err(
+            "opencode not found in bundled locations, standard install locations, PATH, or ~/.opencode/bin"
+                .to_string(),
+        ),
+        Err(error) => Err(error.to_string()),
+    }
 }
 
 #[cfg(unix)]
@@ -284,8 +274,7 @@ pub(super) fn spawn_opencode_server_with_config(
     config_content: &str,
     port: u16,
 ) -> Result<Child> {
-    let opencode_binary = resolve_opencode_binary_path()
-        .ok_or_else(|| anyhow!(opencode_binary_not_found_message()))?;
+    let opencode_binary = resolve_opencode_binary().map_err(anyhow::Error::msg)?;
     spawn_opencode_server_with_binary(
         opencode_binary.as_str(),
         working_directory,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
@@ -47,11 +47,39 @@ pub(crate) fn read_opencode_version(binary: &str) -> Option<String> {
 
 pub(crate) fn resolve_opencode_binary_path() -> Option<String> {
     if let Ok(override_binary) = std::env::var("OPENDUCKTOR_OPENCODE_BINARY") {
+        if override_binary.trim().is_empty() {
+            return resolve_opencode_binary_path_without_override();
+        }
         if let Ok(path) = parse_user_path(override_binary.as_str()) {
-            return Some(path.to_string_lossy().to_string());
+            return (path.is_file() && is_executable_path(path.as_path()))
+                .then(|| path.to_string_lossy().to_string());
+        }
+        return None;
+    }
+
+    resolve_opencode_binary_path_without_override()
+}
+
+pub(crate) fn opencode_binary_not_found_message() -> String {
+    if let Ok(override_binary) = std::env::var("OPENDUCKTOR_OPENCODE_BINARY") {
+        if !override_binary.trim().is_empty() {
+            return match parse_user_path(override_binary.as_str()) {
+                Ok(path) => format!(
+                    "Configured OpenCode override OPENDUCKTOR_OPENCODE_BINARY points to a missing or non-executable file: {}",
+                    path.display()
+                ),
+                Err(error) => format!(
+                    "Configured OpenCode override OPENDUCKTOR_OPENCODE_BINARY is invalid: {error:#}"
+                ),
+            };
         }
     }
 
+    "opencode not found in bundled locations, standard install locations, PATH, or ~/.opencode/bin"
+        .to_string()
+}
+
+fn resolve_opencode_binary_path_without_override() -> Option<String> {
     if let Some(resolved) = bundled_command("opencode") {
         return Some(resolved);
     }
@@ -79,8 +107,8 @@ fn is_executable_path(path: &Path) -> bool {
 }
 
 #[cfg(not(unix))]
-fn is_executable_path(_path: &Path) -> bool {
-    true
+fn is_executable_path(path: &Path) -> bool {
+    path.is_file()
 }
 
 #[cfg(unix)]
@@ -257,7 +285,7 @@ pub(super) fn spawn_opencode_server_with_config(
     port: u16,
 ) -> Result<Child> {
     let opencode_binary = resolve_opencode_binary_path()
-        .ok_or_else(|| anyhow!("opencode binary not found in bundled locations, standard install locations, PATH, or ~/.opencode/bin"))?;
+        .ok_or_else(|| anyhow!(opencode_binary_not_found_message()))?;
     spawn_opencode_server_with_binary(
         opencode_binary.as_str(),
         working_directory,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -7,13 +7,13 @@ use crate::app_service::opencode_runtime::{
     OpenCodeProcessTracker,
 };
 use crate::app_service::{
-    opencode_binary_not_found_message, read_opencode_version, require_local_http_endpoint,
-    require_local_http_port, resolve_opencode_binary_path, wait_for_runtime_with_process,
-    AppService, RuntimeProcessGuard, RuntimeRoute, RuntimeSessionStatusMap,
-    RuntimeSessionStatusProbeError, RuntimeSessionStatusProbeOutcome,
-    RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeTargetResolution,
-    RuntimeSessionStatusSnapshot, RuntimeStartupReadinessPolicy, StartupEventContext,
-    StartupEventCorrelation, StartupEventPayload,
+    read_opencode_version, require_local_http_endpoint, require_local_http_port,
+    resolve_opencode_binary, wait_for_runtime_with_process, AppService, RuntimeProcessGuard,
+    RuntimeRoute, RuntimeSessionStatusMap, RuntimeSessionStatusProbeError,
+    RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
+    RuntimeSessionStatusProbeTargetResolution, RuntimeSessionStatusSnapshot,
+    RuntimeStartupReadinessPolicy, StartupEventContext, StartupEventCorrelation,
+    StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{AgentRuntimeKind, RuntimeDefinition, RuntimeHealth, RuntimeInstanceSummary};
@@ -594,19 +594,19 @@ impl AppRuntime for OpenCodeRuntime {
     }
 
     fn runtime_health(&self) -> RuntimeHealth {
-        let opencode_binary = resolve_opencode_binary_path();
-        let opencode_ok = opencode_binary.is_some();
+        let opencode_binary = resolve_opencode_binary();
+        let opencode_ok = opencode_binary.is_ok();
         RuntimeHealth {
             kind: "opencode".to_string(),
             ok: opencode_ok,
-            version: opencode_binary.as_ref().map(|binary| {
+            version: opencode_binary.as_ref().ok().map(|binary| {
                 if let Some(version) = read_opencode_version(binary.as_str()) {
                     format!("{version} ({binary})")
                 } else {
                     format!("installed ({binary})")
                 }
             }),
-            error: (!opencode_ok).then(opencode_binary_not_found_message),
+            error: opencode_binary.err(),
         }
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_registry/open_code.rs
@@ -7,13 +7,13 @@ use crate::app_service::opencode_runtime::{
     OpenCodeProcessTracker,
 };
 use crate::app_service::{
-    read_opencode_version, require_local_http_endpoint, require_local_http_port,
-    resolve_opencode_binary_path, wait_for_runtime_with_process, AppService, RuntimeProcessGuard,
-    RuntimeRoute, RuntimeSessionStatusMap, RuntimeSessionStatusProbeError,
-    RuntimeSessionStatusProbeOutcome, RuntimeSessionStatusProbeTarget,
-    RuntimeSessionStatusProbeTargetResolution, RuntimeSessionStatusSnapshot,
-    RuntimeStartupReadinessPolicy, StartupEventContext, StartupEventCorrelation,
-    StartupEventPayload,
+    opencode_binary_not_found_message, read_opencode_version, require_local_http_endpoint,
+    require_local_http_port, resolve_opencode_binary_path, wait_for_runtime_with_process,
+    AppService, RuntimeProcessGuard, RuntimeRoute, RuntimeSessionStatusMap,
+    RuntimeSessionStatusProbeError, RuntimeSessionStatusProbeOutcome,
+    RuntimeSessionStatusProbeTarget, RuntimeSessionStatusProbeTargetResolution,
+    RuntimeSessionStatusSnapshot, RuntimeStartupReadinessPolicy, StartupEventContext,
+    StartupEventCorrelation, StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{AgentRuntimeKind, RuntimeDefinition, RuntimeHealth, RuntimeInstanceSummary};
@@ -606,10 +606,7 @@ impl AppRuntime for OpenCodeRuntime {
                     format!("installed ({binary})")
                 }
             }),
-            error: (!opencode_ok).then(|| {
-                "opencode not found in bundled locations, standard install locations, PATH, or ~/.opencode/bin"
-                    .to_string()
-            }),
+            error: (!opencode_ok).then(opencode_binary_not_found_message),
         }
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_checks.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_checks.rs
@@ -4,7 +4,9 @@ use host_domain::{
     RepoStoreHealthStatus, RepoStoreSharedServerHealth, RepoStoreSharedServerOwnershipState,
     RuntimeCheck, SystemCheck,
 };
-use host_infra_system::{command_exists, run_command_allow_failure_with_env, version_command};
+use host_infra_system::{
+    command_exists, resolve_command_path, run_command_allow_failure_with_env, version_command,
+};
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -31,14 +33,12 @@ fn build_beads_check(repo_store_health: RepoStoreHealth) -> BeadsCheck {
     }
 }
 
-fn missing_bd_repo_store_health() -> RepoStoreHealth {
+fn missing_bd_repo_store_health(detail: String) -> RepoStoreHealth {
     RepoStoreHealth {
         category: RepoStoreHealthCategory::AttachmentVerificationFailed,
         status: RepoStoreHealthStatus::Blocking,
         is_ready: false,
-        detail: Some(
-            "bd not found in bundled locations, standard install locations, or PATH".to_string(),
-        ),
+        detail: Some(detail),
         attachment: RepoStoreAttachmentHealth {
             path: None,
             database_name: None,
@@ -204,8 +204,19 @@ impl AppService {
     }
 
     pub fn beads_check(&self, repo_path: &str) -> Result<BeadsCheck> {
-        if !command_exists("bd") {
-            return Ok(build_beads_check(missing_bd_repo_store_health()));
+        match resolve_command_path("bd") {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return Ok(build_beads_check(missing_bd_repo_store_health(
+                    "bd not found in bundled locations, standard install locations, or PATH"
+                        .to_string(),
+                )));
+            }
+            Err(error) => {
+                return Ok(build_beads_check(missing_bd_repo_store_health(
+                    error.to_string(),
+                )));
+            }
         }
 
         let repo = Path::new(repo_path);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_checks.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_checks.rs
@@ -5,7 +5,7 @@ use host_domain::{
     RuntimeCheck, SystemCheck,
 };
 use host_infra_system::{
-    command_exists, resolve_command_path, run_command_allow_failure_with_env, version_command,
+    required_command_error, run_command_allow_failure_with_env, version_command,
 };
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -121,19 +121,14 @@ impl AppService {
     }
 
     fn probe_runtime_check(&self) -> Result<RuntimeCheck> {
-        let git_ok = command_exists("git");
-        let gh_ok = command_exists("gh");
+        let git_error = required_command_error("git");
+        let gh_error = required_command_error("gh");
+        let git_ok = git_error.is_none();
+        let gh_ok = gh_error.is_none();
         let (gh_auth_ok, gh_auth_login, gh_auth_error) = if gh_ok {
             probe_github_auth_status()
         } else {
-            (
-                false,
-                None,
-                Some(
-                    "gh not found in bundled locations, standard install locations, or PATH"
-                        .to_string(),
-                ),
-            )
+            (false, None, gh_error.clone())
         };
         let runtimes = self
             .runtime_registry
@@ -147,17 +142,11 @@ impl AppService {
             .collect::<Result<Vec<_>>>()?;
 
         let mut errors = Vec::new();
-        if !git_ok {
-            errors.push(
-                "git not found in bundled locations, standard install locations, or PATH"
-                    .to_string(),
-            );
+        if let Some(error) = git_error {
+            errors.push(error);
         }
-        if !gh_ok {
-            errors.push(
-                "gh not found in bundled locations, standard install locations, or PATH"
-                    .to_string(),
-            );
+        if let Some(error) = gh_error {
+            errors.push(error);
         }
         for runtime in &runtimes {
             if let Some(error) = runtime.error.as_ref() {
@@ -204,19 +193,8 @@ impl AppService {
     }
 
     pub fn beads_check(&self, repo_path: &str) -> Result<BeadsCheck> {
-        match resolve_command_path("bd") {
-            Ok(Some(_)) => {}
-            Ok(None) => {
-                return Ok(build_beads_check(missing_bd_repo_store_health(
-                    "bd not found in bundled locations, standard install locations, or PATH"
-                        .to_string(),
-                )));
-            }
-            Err(error) => {
-                return Ok(build_beads_check(missing_bd_repo_store_health(
-                    error.to_string(),
-                )));
-            }
+        if let Some(error) = required_command_error("bd") {
+            return Ok(build_beads_check(missing_bd_repo_store_health(error)));
         }
 
         let repo = Path::new(repo_path);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -1,7 +1,11 @@
 use anyhow::Result;
 use host_domain::{AgentRuntimeKind, GitCurrentBranch, RuntimeInstanceSummary, RuntimeRole};
 use host_infra_system::AppConfigStore;
+#[cfg(unix)]
+use host_test_support::EnvVarGuard;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
@@ -12,10 +16,13 @@ use crate::app_service::opencode_runtime::test_support::{
 use crate::app_service::test_support::{
     add_workspace_with_repo_config, build_service_with_store, builtin_opencode_runtime_descriptor,
     builtin_opencode_runtime_route, create_fake_opencode, init_git_repo, install_fake_dolt,
-    lock_env, make_session, make_task, set_env_var, set_fake_opencode_and_bridge_binaries,
-    unique_temp_path, wait_for_path_exists, wait_for_process_exit,
+    lock_env, make_session, make_task, prepend_path, remove_env_var, set_env_var,
+    set_fake_opencode_and_bridge_binaries, unique_temp_path, wait_for_path_exists,
+    wait_for_process_exit,
 };
-use crate::app_service::AgentRuntimeProcess;
+use crate::app_service::{
+    resolve_opencode_binary, resolve_opencode_binary_path, AgentRuntimeProcess,
+};
 
 fn runtime_summary_fixture(
     runtime_id: &str,
@@ -36,6 +43,104 @@ fn runtime_summary_fixture(
         started_at: "2026-02-20T12:00:00Z".to_string(),
         descriptor: builtin_opencode_runtime_descriptor(),
     }
+}
+
+#[test]
+fn resolve_opencode_binary_path_supports_home_shorthand_override() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("opencode-tilde-override");
+    let home = root.join("home");
+    let override_dir = home.join("custom-bin");
+    fs::create_dir_all(&override_dir)?;
+    let override_binary = override_dir.join("opencode");
+    create_fake_opencode(&override_binary)?;
+
+    let _home_guard = set_env_var("HOME", home.to_string_lossy().as_ref());
+    let _override_guard = set_env_var("OPENDUCKTOR_OPENCODE_BINARY", "~/custom-bin/opencode");
+
+    let resolved = resolve_opencode_binary_path();
+    assert_eq!(
+        resolved.as_deref(),
+        Some(override_binary.to_string_lossy().as_ref())
+    );
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn resolve_opencode_binary_path_rejects_invalid_override_without_path_fallback() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("opencode-invalid-override");
+    let path_bin = root.join("path-bin");
+    fs::create_dir_all(&path_bin)?;
+    let path_opencode = path_bin.join("opencode");
+    create_fake_opencode(&path_opencode)?;
+
+    let _override_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        root.join("missing-opencode").to_string_lossy().as_ref(),
+    );
+    let _home_guard = remove_env_var("HOME");
+    let _path_guard = prepend_path(&path_bin);
+
+    assert!(resolve_opencode_binary_path().is_none());
+    let error = resolve_opencode_binary().expect_err("invalid override should fail fast");
+    assert!(error.contains("OPENDUCKTOR_OPENCODE_BINARY"));
+    assert!(error.contains("missing or non-executable file"));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn resolve_opencode_binary_path_rejects_empty_override_without_fallback() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("opencode-empty-override");
+    let home_bin = root.join(".opencode").join("bin");
+    fs::create_dir_all(&home_bin)?;
+    create_fake_opencode(&home_bin.join("opencode"))?;
+    let empty_bin = root.join("empty-bin");
+    fs::create_dir_all(&empty_bin)?;
+    let fallback_path = format!("{}:/usr/bin:/bin", empty_bin.to_string_lossy());
+
+    let _override_guard = set_env_var("OPENDUCKTOR_OPENCODE_BINARY", "   ");
+    let _home_guard = set_env_var("HOME", root.to_string_lossy().as_ref());
+    let _path_guard = set_env_var("PATH", fallback_path.as_str());
+
+    assert!(resolve_opencode_binary_path().is_none());
+    let error = resolve_opencode_binary().expect_err("empty override should fail fast");
+    assert!(error.contains("OPENDUCKTOR_OPENCODE_BINARY is empty"));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn resolve_opencode_binary_path_rejects_non_utf8_override_without_fallback() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("opencode-non-utf8-override");
+    let path_bin = root.join("path-bin");
+    fs::create_dir_all(&path_bin)?;
+    create_fake_opencode(&path_bin.join("opencode"))?;
+
+    let mut override_bytes = root.join("missing-opencode").into_os_string().into_vec();
+    override_bytes.push(0xff);
+    let _override_guard = EnvVarGuard::set_os(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        std::ffi::OsString::from_vec(override_bytes),
+    );
+    let _home_guard = remove_env_var("HOME");
+    let _path_guard = prepend_path(&path_bin);
+
+    assert!(resolve_opencode_binary_path().is_none());
+    let error = resolve_opencode_binary().expect_err("non-utf8 override should fail fast");
+    assert!(error.contains("OPENDUCKTOR_OPENCODE_BINARY"));
+    assert!(error.contains("missing or non-executable file"));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
@@ -257,6 +257,12 @@ fn beads_and_system_checks_report_missing_bd_binary() -> Result<()> {
         beads.repo_store_health.category,
         RepoStoreHealthCategory::AttachmentVerificationFailed
     );
+    assert_eq!(
+        beads.repo_store_health.status,
+        RepoStoreHealthStatus::Blocking
+    );
+    assert!(!beads.repo_store_health.is_ready);
+    assert!(beads.repo_store_health.attachment.path.is_none());
     assert!(beads
         .beads_error
         .as_deref()
@@ -267,6 +273,53 @@ fn beads_and_system_checks_report_missing_bd_binary() -> Result<()> {
     assert!(system.errors.iter().any(|entry| entry.contains(
         "beads: bd not found in bundled locations, standard install locations, or PATH"
     )));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn runtime_check_reports_invalid_opencode_override_as_missing() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("opencode-invalid-override-health");
+    let path_bin = root.join("path-bin");
+    fs::create_dir_all(&path_bin)?;
+    let path_opencode = path_bin.join("opencode");
+    create_fake_opencode(&path_opencode)?;
+    let missing_opencode = root.join("missing-opencode");
+    let _override_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        missing_opencode.to_string_lossy().as_ref(),
+    );
+    let _home_guard = remove_env_var("HOME");
+    let _path_guard = prepend_path(&path_bin);
+
+    let (service, _task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let runtime = service.runtime_check()?;
+    let opencode_runtime = runtime
+        .runtimes
+        .iter()
+        .find(|entry| entry.kind == "opencode")
+        .expect("opencode runtime should be present");
+    assert!(!opencode_runtime.ok);
+    assert!(opencode_runtime
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("OPENDUCKTOR_OPENCODE_BINARY"));
+    assert!(runtime
+        .errors
+        .iter()
+        .any(|entry| entry.contains("OPENDUCKTOR_OPENCODE_BINARY")));
 
     let _ = fs::remove_dir_all(root);
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
@@ -237,8 +237,9 @@ fn beads_check_reports_structured_restore_needed_health() -> Result<()> {
 fn beads_and_system_checks_report_missing_bd_binary() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("beads-missing-binary");
-    let _path_guard = set_env_var("PATH", "/usr/bin:/bin");
-    let _override_guard = set_env_var("OPENDUCKTOR_BD_PATH", "/tmp/odt-missing-bd-binary");
+    let empty_bin = root.join("empty-bin");
+    fs::create_dir_all(&empty_bin)?;
+    let _path_guard = set_env_var("PATH", empty_bin.to_string_lossy().as_ref());
 
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
@@ -273,6 +274,45 @@ fn beads_and_system_checks_report_missing_bd_binary() -> Result<()> {
     assert!(system.errors.iter().any(|entry| entry.contains(
         "beads: bd not found in bundled locations, standard install locations, or PATH"
     )));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn beads_and_system_checks_report_invalid_bd_override() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("beads-invalid-bd-override");
+    let path_bin = root.join("path-bin");
+    fs::create_dir_all(&path_bin)?;
+    create_fake_bd(&path_bin.join("bd"))?;
+    let missing_bd = root.join("missing-bd");
+
+    let _path_guard = prepend_path(&path_bin);
+    let _override_guard = set_env_var("OPENDUCKTOR_BD_PATH", missing_bd.to_string_lossy().as_ref());
+
+    let (service, _task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let beads = service.beads_check("/tmp/does-not-matter")?;
+    let beads_error = beads.beads_error.as_deref().unwrap_or_default();
+    assert!(!beads.beads_ok);
+    assert!(beads_error.contains("OPENDUCKTOR_BD_PATH"));
+    assert!(beads_error.contains("missing or non-executable file"));
+    assert!(beads_error.contains(missing_bd.to_string_lossy().as_ref()));
+
+    let system = service.system_check("/tmp/does-not-matter")?;
+    assert!(system.errors.iter().any(|entry| {
+        entry.contains("beads: Configured command override OPENDUCKTOR_BD_PATH")
+            && entry.contains(missing_bd.to_string_lossy().as_ref())
+    }));
 
     let _ = fs::remove_dir_all(root);
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -35,7 +35,7 @@ use crate::app_service::test_support::{
 use crate::app_service::{
     build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
     find_openducktor_workspace_root, parse_mcp_command_json, read_opencode_version,
-    resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
+    resolve_mcp_command, resolve_opencode_binary, resolve_opencode_binary_path, terminate_child_process,
     terminate_process_by_pid,
     validate_parent_relationships_for_update, AgentRuntimeProcess,
     DevServerGroupRuntime, RunProcess, RuntimeCleanupTarget,
@@ -736,19 +736,21 @@ fn resolve_opencode_binary_path_rejects_invalid_override_without_path_fallback()
     let _path_guard = prepend_path(&path_bin);
 
     assert!(resolve_opencode_binary_path().is_none());
+    let error = resolve_opencode_binary().expect_err("invalid override should fail fast");
+    assert!(error.contains("OPENDUCKTOR_OPENCODE_BINARY"));
+    assert!(error.contains("missing or non-executable file"));
 
     let _ = fs::remove_dir_all(root);
     Ok(())
 }
 
 #[test]
-fn resolve_opencode_binary_path_uses_home_fallback_when_override_and_path_missing() -> Result<()> {
+fn resolve_opencode_binary_path_rejects_empty_override_without_fallback() -> Result<()> {
     let _env_lock = lock_env();
-    let root = unique_temp_path("opencode-home-fallback");
+    let root = unique_temp_path("opencode-empty-override");
     let home_bin = root.join(".opencode").join("bin");
     fs::create_dir_all(&home_bin)?;
-    let home_opencode = home_bin.join("opencode");
-    create_fake_opencode(&home_opencode)?;
+    create_fake_opencode(&home_bin.join("opencode"))?;
     let empty_bin = root.join("empty-bin");
     fs::create_dir_all(&empty_bin)?;
     let fallback_path = format!("{}:/usr/bin:/bin", empty_bin.to_string_lossy());
@@ -757,11 +759,10 @@ fn resolve_opencode_binary_path_uses_home_fallback_when_override_and_path_missin
     let _home_guard = set_env_var("HOME", root.to_string_lossy().as_ref());
     let _path_guard = set_env_var("PATH", fallback_path.as_str());
 
-    let resolved = resolve_opencode_binary_path();
-    assert_eq!(
-        resolved.as_deref(),
-        Some(home_opencode.to_string_lossy().as_ref())
-    );
+    assert!(resolve_opencode_binary_path().is_none());
+    let error = resolve_opencode_binary().expect_err("empty override should fail fast");
+    assert!(error.contains("OPENDUCKTOR_OPENCODE_BINARY is empty"));
+
     let _ = fs::remove_dir_all(root);
     Ok(())
 }
@@ -911,7 +912,7 @@ fn resolve_mcp_command_prefers_workspace_entrypoint_and_preserves_fallbacks() ->
         let error = resolve_mcp_command().expect_err("missing mcp + bun should fail");
         assert!(error
             .to_string()
-            .contains("Configured command override OPENDUCKTOR_BUN_PATH points to a missing file"));
+            .contains("Configured command override OPENDUCKTOR_BUN_PATH points to a missing or non-executable file"));
     }
 
     {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -720,6 +720,28 @@ fn resolve_opencode_binary_path_supports_home_shorthand_override() -> Result<()>
 }
 
 #[test]
+fn resolve_opencode_binary_path_rejects_invalid_override_without_path_fallback() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("opencode-invalid-override");
+    let path_bin = root.join("path-bin");
+    fs::create_dir_all(&path_bin)?;
+    let path_opencode = path_bin.join("opencode");
+    create_fake_opencode(&path_opencode)?;
+
+    let _override_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        root.join("missing-opencode").to_string_lossy().as_ref(),
+    );
+    let _home_guard = remove_env_var("HOME");
+    let _path_guard = prepend_path(&path_bin);
+
+    assert!(resolve_opencode_binary_path().is_none());
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn resolve_opencode_binary_path_uses_home_fallback_when_override_and_path_missing() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("opencode-home-fallback");

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
@@ -28,6 +28,7 @@ fn temp_config_root(label: &str) -> PathBuf {
 }
 
 fn skip_if_dolt_unavailable() -> bool {
+    let _env_lock = lock_env();
     crate::resolve_command_path("dolt")
         .expect("dolt resolution should not fail")
         .is_none()

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
@@ -136,6 +136,29 @@ fn shared_beads_helpers_use_expected_layouts() {
 }
 
 #[test]
+fn shared_dolt_server_reports_invalid_dolt_override() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = temp_config_root("invalid-dolt-override");
+    let empty_bin = root.join("empty-bin");
+    fs::create_dir_all(&empty_bin)?;
+    let _config_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", root.to_string_lossy().as_ref());
+    let _path_guard = EnvVarGuard::set("PATH", empty_bin.to_string_lossy().as_ref());
+    let _dolt_guard = EnvVarGuard::set(
+        "OPENDUCKTOR_DOLT_PATH",
+        root.join("missing-dolt").to_string_lossy().as_ref(),
+    );
+
+    let error = ensure_shared_dolt_server_running(4242)
+        .expect_err("invalid dolt override should prevent shared server startup");
+    let message = error.to_string();
+    assert!(message.contains("OPENDUCKTOR_DOLT_PATH"));
+    assert!(message.contains("missing or non-executable file"));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn repo_attachment_helpers_use_expected_layouts() {
     let _env_lock = lock_env();
     let _override_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "/tmp/odt-config-root");

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -35,9 +35,9 @@ pub use filesystem::{list_directory, FilesystemListDirectoryError};
 pub use git::GitCliPort;
 pub use open_in::{discover_open_in_tools, open_directory_in_tool};
 pub use process::{
-    bundled_command, command_exists, command_path, required_command_error, resolve_command_path,
-    run_command, run_command_allow_failure, run_command_allow_failure_with_env,
-    run_command_with_env, subprocess_path_env, version_command,
+    bundled_command, command_exists, command_path, is_executable_file, required_command_error,
+    resolve_command_path, run_command, run_command_allow_failure,
+    run_command_allow_failure_with_env, run_command_with_env, subprocess_path_env, version_command,
 };
 pub use user_paths::{normalize_user_path, parse_user_path, parse_user_path_os};
 pub use worktree::{

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -35,9 +35,9 @@ pub use filesystem::{list_directory, FilesystemListDirectoryError};
 pub use git::GitCliPort;
 pub use open_in::{discover_open_in_tools, open_directory_in_tool};
 pub use process::{
-    bundled_command, command_exists, command_path, resolve_command_path, run_command,
-    run_command_allow_failure, run_command_allow_failure_with_env, run_command_with_env,
-    subprocess_path_env, version_command,
+    bundled_command, command_exists, command_path, required_command_error, resolve_command_path,
+    run_command, run_command_allow_failure, run_command_allow_failure_with_env,
+    run_command_with_env, subprocess_path_env, version_command,
 };
 pub use user_paths::{normalize_user_path, parse_user_path, parse_user_path_os};
 pub use worktree::{

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -1367,10 +1367,11 @@ mod tests {
 
     #[test]
     fn required_command_error_reports_plain_missing_command() {
-        let program = format!(
-            "odt-missing-command-{}",
-            unique_temp_path("nonce").display()
-        );
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let program = format!("odt-missing-command-{nonce}");
 
         let error = required_command_error(program.as_str())
             .expect("missing command should produce an error message");

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -64,12 +64,12 @@ fn explicit_command_override(program: &str) -> Result<Option<String>> {
     let explicit_path = parse_user_path_os(&raw_path)
         .with_context(|| format!("Invalid {override_name} path override"))?;
 
-    if explicit_path.is_file() {
+    if is_executable_file(explicit_path.as_path()) {
         return Ok(Some(explicit_path.to_string_lossy().to_string()));
     }
 
     Err(anyhow!(
-        "Configured command override {override_name} points to a missing file: {}",
+        "Configured command override {override_name} points to a missing or non-executable file: {}",
         explicit_path.display()
     ))
 }
@@ -657,6 +657,8 @@ pub fn version_command(program: &str, args: &[&str]) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use super::command_file_names;
     use super::{
         bundled_command_path_from_executable, command_env_override_name, command_exists,
         command_path, command_path_from_directories, compose_process_path_entries,
@@ -689,6 +691,18 @@ mod tests {
             .permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(path, permissions).expect("script should be executable");
+    }
+
+    #[cfg(not(unix))]
+    fn write_executable(path: &Path, body: &str) {
+        fs::write(path, body).expect("command file should be writable");
+    }
+
+    fn path_list(entries: &[PathBuf]) -> String {
+        env::join_paths(entries)
+            .expect("test PATH should be joinable")
+            .to_string_lossy()
+            .to_string()
     }
 
     #[cfg(unix)]
@@ -768,6 +782,107 @@ mod tests {
     fn command_path_treats_metacharacters_as_literal_program_name() {
         let payload = "definitely_not_real_$(echo injected)`uname`;touch /tmp/odt";
         assert!(command_path(payload).is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_command_lookup_resolves_exe_from_extensionless_name() {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("odt-windows-exe-lookup");
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).expect("bin dir should be created");
+        let fake_bd = bin.join("bd.exe");
+        fs::write(&fake_bd, "").expect("fake exe should be writable");
+
+        let _path_guard = EnvVarGuard::set("PATH", path_list(&[bin.clone()]).as_str());
+        let _pathext_guard = EnvVarGuard::set("PATHEXT", ".EXE;.CMD");
+
+        assert!(command_exists("bd"));
+        assert_eq!(
+            command_path("bd").as_deref(),
+            Some(fake_bd.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            resolve_command_path("bd")
+                .expect("resolution should succeed")
+                .as_deref(),
+            Some(fake_bd.to_string_lossy().as_ref())
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_command_lookup_honors_pathext_and_version_command() {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("odt-windows-cmd-lookup");
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).expect("bin dir should be created");
+        let fake_bd = bin.join("bd.cmd");
+        fs::write(&fake_bd, "@echo off\r\necho bd-fake 1.2.3\r\n")
+            .expect("fake cmd should be writable");
+
+        let _path_guard = EnvVarGuard::set("PATH", path_list(&[bin.clone()]).as_str());
+        let _pathext_guard = EnvVarGuard::set("PATHEXT", ".CMD");
+
+        assert_eq!(
+            command_path("bd").as_deref(),
+            Some(fake_bd.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            version_command("bd", &["--version"]).as_deref(),
+            Some("bd-fake 1.2.3")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_command_file_names_normalize_pathext_and_default_when_empty() {
+        let _env_lock = lock_env();
+        let _pathext_guard = EnvVarGuard::set("PATHEXT", "EXE;.Cmd;; ");
+        let names = command_file_names("bd");
+        assert_eq!(
+            names,
+            vec![
+                std::ffi::OsString::from("bd"),
+                std::ffi::OsString::from("bd.exe"),
+                std::ffi::OsString::from("bd.cmd"),
+            ]
+        );
+
+        drop(_pathext_guard);
+        let _empty_pathext_guard = EnvVarGuard::set("PATHEXT", " ");
+        let default_names = command_file_names("bd");
+        assert!(default_names.contains(&std::ffi::OsString::from("bd.exe")));
+        assert!(default_names.contains(&std::ffi::OsString::from("bd.cmd")));
+        assert!(default_names.contains(&std::ffi::OsString::from("bd.bat")));
+        assert!(default_names.contains(&std::ffi::OsString::from("bd.com")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_command_lookup_resolves_explicit_extension_literally() {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("odt-windows-literal-extension");
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).expect("bin dir should be created");
+        let fake_cmd = bin.join("bd.cmd");
+        let fake_exe = bin.join("bd.cmd.exe");
+        fs::write(&fake_cmd, "").expect("fake cmd should be writable");
+        fs::write(&fake_exe, "").expect("fake exe should be writable");
+
+        let _path_guard = EnvVarGuard::set("PATH", path_list(&[bin.clone()]).as_str());
+        let _pathext_guard = EnvVarGuard::set("PATHEXT", ".EXE");
+
+        assert_eq!(
+            command_path("bd.cmd").as_deref(),
+            Some(fake_cmd.to_string_lossy().as_ref())
+        );
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -1173,6 +1288,87 @@ mod tests {
             explicit_command_override(program.as_str()).expect_err("invalid override should fail");
 
         assert!(error.to_string().contains("Configured command override"));
+    }
+
+    #[test]
+    fn valid_bd_and_dolt_overrides_win_over_path_lookup() {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("odt-tool-overrides-win");
+        let override_dir = root.join("override-bin");
+        let path_dir = root.join("path-bin");
+        fs::create_dir_all(&override_dir).expect("override dir should exist");
+        fs::create_dir_all(&path_dir).expect("path dir should exist");
+
+        let bd_override = override_dir.join("custom-bd");
+        let dolt_override = override_dir.join("custom-dolt");
+        write_executable(&bd_override, "#!/bin/sh\nprintf 'bd-override'\n");
+        write_executable(&dolt_override, "#!/bin/sh\nprintf 'dolt-override'\n");
+        write_executable(&path_dir.join("bd"), "#!/bin/sh\nprintf 'bd-path'\n");
+        write_executable(&path_dir.join("dolt"), "#!/bin/sh\nprintf 'dolt-path'\n");
+
+        let _path_guard = EnvVarGuard::set("PATH", path_list(&[path_dir]).as_str());
+        let _bd_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_BD_PATH",
+            bd_override.to_string_lossy().as_ref(),
+        );
+        let _dolt_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_DOLT_PATH",
+            dolt_override.to_string_lossy().as_ref(),
+        );
+
+        assert_eq!(
+            command_path("bd").as_deref(),
+            Some(bd_override.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            command_path("dolt").as_deref(),
+            Some(dolt_override.to_string_lossy().as_ref())
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn invalid_generic_override_is_not_bypassed_by_path_lookup() {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("odt-invalid-override-no-bypass");
+        let path_dir = root.join("path-bin");
+        fs::create_dir_all(&path_dir).expect("path dir should exist");
+        write_executable(&path_dir.join("bd"), "#!/bin/sh\nprintf 'bd-path'\n");
+
+        let missing_override = root.join("missing-bd");
+        let _path_guard = EnvVarGuard::set("PATH", path_list(&[path_dir]).as_str());
+        let _bd_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_BD_PATH",
+            missing_override.to_string_lossy().as_ref(),
+        );
+
+        let error = resolve_command_path("bd").expect_err("invalid override should error");
+        assert!(error.to_string().contains("OPENDUCKTOR_BD_PATH"));
+        assert!(command_path("bd").is_none());
+        assert!(!command_exists("bd"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_executable_generic_override_is_rejected() {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("odt-non-executable-override");
+        fs::create_dir_all(&root).expect("temp dir should exist");
+        let override_path = root.join("bd");
+        fs::write(&override_path, "#!/bin/sh\nprintf 'bd'\n").expect("override file should exist");
+
+        let _bd_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_BD_PATH",
+            override_path.to_string_lossy().as_ref(),
+        );
+
+        let error = resolve_command_path("bd").expect_err("non-executable override should error");
+        assert!(error.to_string().contains("non-executable file"));
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -148,14 +148,14 @@ fn existing_file_path(path: PathBuf) -> Option<String> {
 }
 
 #[cfg(unix)]
-fn is_executable_file(path: &Path) -> bool {
+pub fn is_executable_file(path: &Path) -> bool {
     path.metadata()
         .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
         .unwrap_or(false)
 }
 
 #[cfg(not(unix))]
-fn is_executable_file(path: &Path) -> bool {
+pub fn is_executable_file(path: &Path) -> bool {
     path.is_file()
 }
 
@@ -240,7 +240,7 @@ fn explicit_command_override_directories() -> Vec<PathBuf> {
             }
 
             let path = parse_user_path_os(&value).ok()?;
-            if !path.is_file() {
+            if !is_executable_file(path.as_path()) {
                 return None;
             }
 
@@ -1266,7 +1266,7 @@ mod tests {
         let override_dir = root.join("override-bin");
         let override_path = override_dir.join("custom-bun");
         fs::create_dir_all(&override_dir).expect("override dir should exist");
-        fs::write(&override_path, "").expect("override file should exist");
+        write_executable(&override_path, "#!/bin/sh\nprintf 'override'\n");
 
         let _shell_guard = EnvVarGuard::set("SHELL", "/tmp/odt-missing-shell");
         let _path_guard = EnvVarGuard::set("PATH", "/usr/bin:/bin");
@@ -1283,6 +1283,37 @@ mod tests {
         assert!(
             entries.iter().any(|entry| entry == &override_dir),
             "explicit override directory should be included in subprocess PATH"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn subprocess_path_env_excludes_non_executable_override_directories() {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("odt-subprocess-path-non-executable-override");
+        let override_dir = root.join("override-bin");
+        let override_path = override_dir.join("custom-bun");
+        fs::create_dir_all(&override_dir).expect("override dir should exist");
+        fs::write(&override_path, "#!/bin/sh\nprintf 'override'\n")
+            .expect("override file should exist");
+
+        let _shell_guard = EnvVarGuard::set("SHELL", "/tmp/odt-missing-shell");
+        let _path_guard = EnvVarGuard::set("PATH", "/usr/bin:/bin");
+        let _home_guard = EnvVarGuard::set("HOME", root.to_string_lossy().as_ref());
+        let _user_guard = EnvVarGuard::set("USER", "odt-test");
+        let _logname_guard = EnvVarGuard::set("LOGNAME", "odt-test");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_BUN_PATH",
+            override_path.to_string_lossy().as_ref(),
+        );
+
+        let entries = path_entries_from_value(subprocess_path_env());
+
+        assert!(
+            !entries.iter().any(|entry| entry == &override_dir),
+            "non-executable override directory should not be included in subprocess PATH"
         );
 
         let _ = fs::remove_dir_all(root);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -645,6 +645,16 @@ pub fn command_exists(program: &str) -> bool {
     command_path(program).is_some()
 }
 
+pub fn required_command_error(program: &str) -> Option<String> {
+    match resolve_command_path(program) {
+        Ok(Some(_)) => None,
+        Ok(None) => Some(format!(
+            "{program} not found in bundled locations, standard install locations, or PATH"
+        )),
+        Err(error) => Some(error.to_string()),
+    }
+}
+
 pub fn version_command(program: &str, args: &[&str]) -> Option<String> {
     let resolved = resolve_command_path(program).ok().flatten()?;
     run_command(&resolved, args, None).ok().and_then(|output| {
@@ -662,9 +672,10 @@ mod tests {
     use super::{
         bundled_command_path_from_executable, command_env_override_name, command_exists,
         command_path, command_path_from_directories, compose_process_path_entries,
-        explicit_command_override, path_entries_from_value, resolve_command_path, run_command,
-        run_command_allow_failure, run_command_allow_failure_with_env, run_command_with_env,
-        subprocess_path_env, version_command,
+        explicit_command_override, path_entries_from_value, required_command_error,
+        resolve_command_path, run_command, run_command_allow_failure,
+        run_command_allow_failure_with_env, run_command_with_env, subprocess_path_env,
+        version_command,
     };
     use host_test_support::{lock_env, EnvVarGuard};
     use std::{
@@ -1347,8 +1358,27 @@ mod tests {
         assert!(error.to_string().contains("OPENDUCKTOR_BD_PATH"));
         assert!(command_path("bd").is_none());
         assert!(!command_exists("bd"));
+        assert!(required_command_error("bd")
+            .unwrap_or_default()
+            .contains("OPENDUCKTOR_BD_PATH"));
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn required_command_error_reports_plain_missing_command() {
+        let program = format!(
+            "odt-missing-command-{}",
+            unique_temp_path("nonce").display()
+        );
+
+        let error = required_command_error(program.as_str())
+            .expect("missing command should produce an error message");
+
+        assert!(error.contains(program.as_str()));
+        assert!(
+            error.contains("not found in bundled locations, standard install locations, or PATH")
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Adds Windows-focused coverage for required external tool discovery, including extensionless `.exe`/`PATHEXT` lookup and `version_command` behavior.
- Preserves fail-fast diagnostics for configured `bd`, `dolt`, and `opencode` overrides instead of silently falling back to PATH.
- Centralizes required-command diagnostic handling so system checks can surface actionable resolver errors consistently.

## Goal
The Windows web runner should rely on installed external tools (`bd`, `dolt`, and `opencode`) in the same way the host does on macOS, without bundling binaries or adding hidden fallback storage. This PR validates the existing resolver behavior on Windows and tightens diagnostics where configured overrides were previously easy to mask.

## Technical choices
- Kept discovery logic in `host-infra-system`, where command resolution already lives.
- Added Windows-gated Rust tests for `.exe`, `.cmd`, mixed-case/no-dot `PATHEXT`, default extension behavior, literal explicit extensions, and resolver agreement across `command_exists`, `command_path`, `resolve_command_path`, and `version_command`.
- Added generic override tests for `OPENDUCKTOR_BD_PATH` and `OPENDUCKTOR_DOLT_PATH`, including invalid and non-executable override behavior.
- Tightened `OPENDUCKTOR_OPENCODE_BINARY` resolution so non-empty invalid overrides report an override-specific runtime health/startup error rather than false success or PATH fallback.
- Added `required_command_error` in `host-infra-system` and refactored system checks to use it for `git`, `gh`, and `bd`, preserving actionable override errors while keeping generic not-found messages for plain missing tools.

## Verification
- `rtk bun run lint`
- `rtk bun run typecheck`
- `rtk bun run test`
- `rtk bun run build`
- `rtk cargo fmt --all --check`
- `rtk cargo clippy --workspace --all-targets -- -D warnings`
- `rtk cargo test --workspace`
- `rtk cargo build --workspace`

Note: Windows-gated tests were added but not executed on this macOS host.