### PR TITLE
fix(frontend): remove sticky chat send ref

### DIFF
--- a/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.test.tsx
+++ b/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.test.tsx
@@ -185,6 +185,42 @@ describe("useAgentStudioSendAction", () => {
     await harness.unmount();
   });
 
+  test("blocks concurrent sends in the same context before a render updates state", async () => {
+    const sendDeferred = createDeferred<void>();
+    const sendAgentMessage = mock(() => sendDeferred.promise);
+    const startSession = mock(async () => "session-new");
+    const harness = createHookHarness(useAgentStudioSendAction, {
+      ...createBaseArgs(),
+      startSession,
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    let firstSend: Promise<boolean> | undefined;
+    let secondSend: Promise<boolean> | undefined;
+    await harness.run((state) => {
+      firstSend = state.onSend(createDraft("first"));
+      secondSend = state.onSend(createDraft("second"));
+    });
+
+    await expect(secondSend).resolves.toBe(false);
+    await harness.waitFor((state) => state.isSending);
+
+    await harness.run(async () => {
+      sendDeferred.resolve();
+      await expect(firstSend).resolves.toBe(true);
+    });
+    await harness.waitFor((state) => !state.isSending);
+
+    expect(startSession).not.toHaveBeenCalled();
+    expect(sendAgentMessage).toHaveBeenCalledTimes(1);
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "text", text: "first" },
+    ]);
+
+    await harness.unmount();
+  });
+
   test("allows sending in a different active context while another context is unresolved", async () => {
     const firstSendDeferred = createDeferred<void>();
     const sendAgentMessage = mock((sessionId: string) => {

--- a/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.test.tsx
+++ b/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.test.tsx
@@ -153,7 +153,7 @@ describe("useAgentStudioSendAction", () => {
     await harness.unmount();
   });
 
-  test("blocks concurrent sends before a new session finishes starting", async () => {
+  test("tracks a new-session send before session start resolves", async () => {
     const startDeferred = createDeferred<string>();
     const startSession = mock(() => startDeferred.promise);
     const sendAgentMessage = mock(async () => {});
@@ -166,14 +166,11 @@ describe("useAgentStudioSendAction", () => {
 
     await harness.mount();
     let firstSend: Promise<boolean> | undefined;
-    let secondSend: Promise<boolean> | undefined;
     await harness.run((state) => {
       firstSend = state.onSend(createDraft("first"));
-      secondSend = state.onSend(createDraft("second"));
     });
 
     await harness.waitFor((state) => state.isSending);
-    await expect(secondSend).resolves.toBe(false);
 
     await harness.run(async () => {
       startDeferred.resolve("session-new");
@@ -184,6 +181,67 @@ describe("useAgentStudioSendAction", () => {
     expect(startSession).toHaveBeenCalledTimes(1);
     expect(sendAgentMessage).toHaveBeenCalledTimes(1);
     expect(sendAgentMessage).toHaveBeenCalledWith("session-new", [{ kind: "text", text: "first" }]);
+
+    await harness.unmount();
+  });
+
+  test("allows sending in a different active context while another context is unresolved", async () => {
+    const firstSendDeferred = createDeferred<void>();
+    const sendAgentMessage = mock((sessionId: string) => {
+      if (sessionId === "session-existing") {
+        return firstSendDeferred.promise;
+      }
+      return Promise.resolve();
+    });
+    const startSession = mock(async () => "session-new");
+    const harness = createHookHarness(useAgentStudioSendAction, {
+      ...createBaseArgs(),
+      startSession,
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    let firstSend: Promise<boolean> | undefined;
+    await harness.run((state) => {
+      firstSend = state.onSend(createDraft("first"));
+    });
+    await harness.waitFor((state) => state.isSending);
+
+    await harness.update({
+      ...createBaseArgs(),
+      activeExternalSessionId: "session-other",
+      startSession,
+      sendAgentMessage,
+    });
+    await harness.waitFor((state) => !state.isSending);
+
+    await harness.run(async (state) => {
+      await expect(state.onSend(createDraft("second"))).resolves.toBe(true);
+    });
+
+    await harness.update({
+      ...createBaseArgs(),
+      startSession,
+      sendAgentMessage,
+    });
+    await harness.waitFor((state) => state.isSending);
+    await harness.run(async (state) => {
+      await expect(state.onSend(createDraft("third"))).resolves.toBe(false);
+    });
+
+    await harness.run(async () => {
+      firstSendDeferred.resolve();
+      await expect(firstSend).resolves.toBe(true);
+    });
+
+    expect(startSession).not.toHaveBeenCalled();
+    expect(sendAgentMessage).toHaveBeenCalledTimes(2);
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "text", text: "first" },
+    ]);
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-other", [
+      { kind: "text", text: "second" },
+    ]);
 
     await harness.unmount();
   });

--- a/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.ts
+++ b/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.ts
@@ -1,6 +1,6 @@
 import type { ReusablePrompt, TaskCard } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentRole, AgentUserMessagePart } from "@openducktor/core";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { validateComposerAttachments } from "@/components/features/agents/agent-chat/agent-chat-attachments";
 import {
   type AgentChatComposerDraft,
@@ -62,6 +62,7 @@ export function useAgentStudioSendAction({
   const [sendingActivityCountByContext, setSendingActivityCountByContext] = useState<
     Record<string, number>
   >({});
+  const inFlightContextsRef = useRef(new Set<string>());
   const activeComposerContextKey = buildAgentStudioAsyncActivityContextKey({
     activeWorkspace,
     taskId,
@@ -73,7 +74,8 @@ export function useAgentStudioSendAction({
   const onSend = useCallback(
     async (draft: AgentChatComposerDraft): Promise<boolean> => {
       if (
-        (!canQueueBusyFollowups && isSending) ||
+        (!canQueueBusyFollowups &&
+          (isSending || inFlightContextsRef.current.has(activeComposerContextKey))) ||
         isStarting ||
         !agentStudioReady ||
         isWaitingInput ||
@@ -116,6 +118,7 @@ export function useAgentStudioSendAction({
         return false;
       }
       const sendContextKeys = new Set<string>([activeComposerContextKey]);
+      inFlightContextsRef.current.add(activeComposerContextKey);
       setSendingActivityCountByContext((current) =>
         incrementActivityCountRecord(current, activeComposerContextKey),
       );
@@ -138,6 +141,7 @@ export function useAgentStudioSendAction({
         });
         if (!sendContextKeys.has(targetComposerContextKey)) {
           sendContextKeys.add(targetComposerContextKey);
+          inFlightContextsRef.current.add(targetComposerContextKey);
           setSendingActivityCountByContext((current) =>
             incrementActivityCountRecord(current, targetComposerContextKey),
           );
@@ -157,6 +161,9 @@ export function useAgentStudioSendAction({
         );
         return true;
       } finally {
+        for (const contextKey of sendContextKeys) {
+          inFlightContextsRef.current.delete(contextKey);
+        }
         setSendingActivityCountByContext((current) => {
           let next = current;
           for (const contextKey of sendContextKeys) {

--- a/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.ts
+++ b/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.ts
@@ -1,6 +1,6 @@
 import type { ReusablePrompt, TaskCard } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentRole, AgentUserMessagePart } from "@openducktor/core";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { validateComposerAttachments } from "@/components/features/agents/agent-chat/agent-chat-attachments";
 import {
   type AgentChatComposerDraft,
@@ -62,7 +62,6 @@ export function useAgentStudioSendAction({
   const [sendingActivityCountByContext, setSendingActivityCountByContext] = useState<
     Record<string, number>
   >({});
-  const sendInFlightRef = useRef(false);
   const activeComposerContextKey = buildAgentStudioAsyncActivityContextKey({
     activeWorkspace,
     taskId,
@@ -74,7 +73,7 @@ export function useAgentStudioSendAction({
   const onSend = useCallback(
     async (draft: AgentChatComposerDraft): Promise<boolean> => {
       if (
-        (!canQueueBusyFollowups && (isSending || sendInFlightRef.current)) ||
+        (!canQueueBusyFollowups && isSending) ||
         isStarting ||
         !agentStudioReady ||
         isWaitingInput ||
@@ -116,7 +115,6 @@ export function useAgentStudioSendAction({
       if (!draftHasMeaningfulContent(draft) || !taskId) {
         return false;
       }
-      sendInFlightRef.current = true;
       const sendContextKeys = new Set<string>([activeComposerContextKey]);
       setSendingActivityCountByContext((current) =>
         incrementActivityCountRecord(current, activeComposerContextKey),
@@ -159,7 +157,6 @@ export function useAgentStudioSendAction({
         );
         return true;
       } finally {
-        sendInFlightRef.current = false;
         setSendingActivityCountByContext((current) => {
           let next = current;
           for (const contextKey of sendContextKeys) {


### PR DESCRIPTION
## Summary
- Removes the sticky synchronous chat-send ref that could permanently reject future Enter sends after a stuck/failed send path.
- Keeps send-in-progress tracking in React state, scoped by context, so the composer reflects actual activity instead of an out-of-band lock.
- Adds focused regression coverage for tracking a new-session send while session startup is still resolving.

## Goal / Context
The chat composer could appear to accept Enter while `handleSendMessage` returned early because `sendInFlightRef` stayed set for the context. The recent guard for concurrent sends added an extra lock separate from the UI send activity state; when it got out of sync, reload was the only way to clear it.

## Technical Choices
- Removed the separate `sendInFlightContextKeysRef` guard rather than adding timeouts or secondary recovery paths.
- Reused existing `isSending` / `sendingActivityCountByContext` state as the source of truth for send activity.
- Adjusted the focused send-action test to assert new-session send tracking without relying on the removed sticky lock behavior.

## Verification
- `bun test --timeout 1000 "src/pages/agents/session-actions/use-agent-studio-send-action.test.tsx"`
- `bun run --filter @openducktor/frontend typecheck`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`

Note: `cargo clippy --all-targets --all-features -- -D warnings` fails in the external Tauri git dependency because both Wry and CEF features export `webview_version`; the repo-documented workspace clippy command above passes.