### PR TITLE
fix(frontend): allow messages to existing sessions

### DIFF
--- a/packages/frontend/src/pages/agents/selected-session/selected-session-context.test.ts
+++ b/packages/frontend/src/pages/agents/selected-session/selected-session-context.test.ts
@@ -159,6 +159,32 @@ describe("buildAgentStudioSelectedSessionContext", () => {
     expect(context.chat.emptyState?.actionLabel).toBeUndefined();
   });
 
+  test("keeps existing session composer writable when selected role is unavailable", () => {
+    const unavailableQaTask = createTaskCardFixture({
+      agentWorkflows: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        builder: { required: true, canSkip: false, available: true, completed: true },
+        qa: { required: true, canSkip: false, available: false, completed: false },
+      },
+    });
+    const qaSession = createSession({ role: "qa" });
+
+    const context = buildAgentStudioSelectedSessionContext(
+      createInput({
+        role: "qa",
+        selectedTask: unavailableQaTask,
+        activeSession: qaSession,
+        sessionsForTask: [toAgentSessionSummary(qaSession)],
+        allSessionSummaries: [toAgentSessionSummary(qaSession)],
+      }),
+    );
+
+    expect(context.workflow.selectedRoleAvailable).toBe(false);
+    expect(context.chat.composerReadOnly).toBe(false);
+    expect(context.chat.composerReadOnlyReason).toBeNull();
+  });
+
   test("projects kickoff and starting empty-state affordances without stale pending flags", () => {
     const startLaunchKickoff = mock(async () => {});
     const readyContext = buildAgentStudioSelectedSessionContext(

--- a/packages/frontend/src/pages/agents/selected-session/selected-session-context.ts
+++ b/packages/frontend/src/pages/agents/selected-session/selected-session-context.ts
@@ -282,6 +282,7 @@ export const buildAgentStudioSelectedSessionContext = ({
       })
     : null;
   const canKickoff = sessionActions.canKickoffNewSession && workflow.selectedRoleAvailable;
+  const composerReadOnly = !activeSession && !workflow.selectedRoleAvailable;
   const emptyState = buildSelectedSessionChatEmptyState({
     taskId,
     isStarting: sessionActions.isStarting,
@@ -323,8 +324,8 @@ export const buildAgentStudioSelectedSessionContext = ({
             pendingQuestions: activeSession.pendingQuestions,
           }
         : null,
-      composerReadOnly: !workflow.selectedRoleAvailable,
-      composerReadOnlyReason: workflow.selectedRoleReadOnlyReason,
+      composerReadOnly,
+      composerReadOnlyReason: composerReadOnly ? workflow.selectedRoleReadOnlyReason : null,
     },
     runtime: {
       runtimeDefinitions,

--- a/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.test.tsx
+++ b/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.test.tsx
@@ -114,6 +114,54 @@ describe("useAgentStudioSendAction", () => {
     await harness.unmount();
   });
 
+  test("blocks unavailable roles only when a new session would be started", async () => {
+    const startSession = mock(async () => "session-new");
+    const sendAgentMessage = mock(async () => {});
+    const unavailableQaTask = createTaskCardFixture({
+      agentWorkflows: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        builder: { required: true, canSkip: false, available: true, completed: true },
+        qa: { required: true, canSkip: false, available: false, completed: false },
+      },
+    });
+    const harness = createHookHarness(useAgentStudioSendAction, {
+      ...createBaseArgs(),
+      role: "qa",
+      activeExternalSessionId: null,
+      selectedTask: unavailableQaTask,
+      startSession,
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await expect(state.onSend(createDraft("start qa"))).resolves.toBe(false);
+    });
+
+    expect(startSession).not.toHaveBeenCalled();
+    expect(sendAgentMessage).not.toHaveBeenCalled();
+
+    await harness.update({
+      ...createBaseArgs(),
+      role: "qa",
+      activeExternalSessionId: "session-existing",
+      selectedTask: unavailableQaTask,
+      startSession,
+      sendAgentMessage,
+    });
+    await harness.run(async (state) => {
+      await expect(state.onSend(createDraft("follow up"))).resolves.toBe(true);
+    });
+
+    expect(startSession).not.toHaveBeenCalled();
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "text", text: "follow up" },
+    ]);
+
+    await harness.unmount();
+  });
+
   test("tracks a new-session send across draft and target session contexts", async () => {
     const sendDeferred = createDeferred<void>();
     const startSession = mock(async () => "session-new");

--- a/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.ts
+++ b/packages/frontend/src/pages/agents/session-actions/use-agent-studio-send-action.ts
@@ -83,7 +83,7 @@ export function useAgentStudioSendAction({
       ) {
         return false;
       }
-      if (!canStartSessionForRole(selectedTask, role)) {
+      if (!activeExternalSessionId && !canStartSessionForRole(selectedTask, role)) {
         return false;
       }
       if (activeSessionIsLoadingModelCatalog && !activeSessionSelectedModel) {

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -1320,7 +1320,7 @@ describe("useAgentStudioPageModels", () => {
     await harness.unmount();
   });
 
-  test("keeps stop control enabled for running session even when role is unavailable", async () => {
+  test("keeps existing session composer and stop control enabled when role is unavailable", async () => {
     const unavailablePlannerTask = createTaskCardFixture({
       status: "open",
       agentWorkflows: {
@@ -1353,7 +1353,8 @@ describe("useAgentStudioPageModels", () => {
     await harness.mount();
 
     const state = harness.getLatest();
-    expect(state.agentChatModel.composer.isReadOnly).toBe(true);
+    expect(state.agentChatModel.composer.isReadOnly).toBe(false);
+    expect(state.agentChatModel.composer.readOnlyReason).toBeNull();
     expect(state.agentChatModel.composer.canStopSession).toBe(true);
 
     await harness.unmount();


### PR DESCRIPTION
## Summary
- Allows the Agent Studio chat composer to stay writable when an existing session is selected, even if the task workflow currently marks that role unavailable.
- Keeps new-session kickoff gates unchanged by only applying the role-availability read-only state when there is no active session.
- Adds regression coverage for selected-session context and Agent Studio page model behavior.

## Goal
This fixes a bug where existing QA sessions could be visible but impossible to message because the composer inherited the task status gate used for starting new sessions. Existing sessions should remain interactive regardless of the task's current workflow status, while the workflow gates should still decide whether a new session may be started.

## Technical choices
The change is scoped to selected-session chat model construction. Instead of using `!workflow.selectedRoleAvailable` directly for `composerReadOnly`, the composer now becomes read-only from workflow availability only when there is no `activeSession`. When an active existing session is selected, the read-only reason is cleared so the composer can accept follow-up messages.

Tests cover both the lower-level selected-session context and the page model that feeds the chat surface, including the existing running-session stop-control case.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the composer was incorrectly locked when a role became unavailable. The composer now remains usable in existing sessions, only becoming read-only when attempting to start new sessions with unavailable roles.

* **Tests**
  * Added test coverage for role-availability behavior with active sessions to ensure correct composer and action permissions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/569)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->