### PR TITLE
refactor(opencode): share user message display resolution

### DIFF
--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
@@ -39,14 +39,19 @@ const resolveUserMessageDisplay = (input: {
     initialVisibleUserMessage.displayParts,
     input.model,
   );
-  const { displayParts, visible } = buildVisibleUserMessage({
+
+  if (!matchedQueuedSend) {
+    return { ...initialVisibleUserMessage, matchedQueuedSend: null };
+  }
+
+  const finalVisibleUserMessage = buildVisibleUserMessage({
     fallbackText: input.fallbackText,
     normalizedDisplayParts: input.normalizedDisplayParts,
     ...(input.metadata ? { metadata: input.metadata } : {}),
-    ...(matchedQueuedSend ? { matchedQueuedSend } : {}),
+    matchedQueuedSend,
   });
 
-  return { displayParts, matchedQueuedSend, visible };
+  return { ...finalVisibleUserMessage, matchedQueuedSend };
 };
 
 export const reconcileUserMessageQueuedStates = (runtime: EventStreamRuntime): void => {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
@@ -1,9 +1,11 @@
 import type { Part } from "@opencode-ai/sdk/v2/client";
+import type { AgentUserMessageDisplayPart } from "@openducktor/core";
 import {
   normalizeUserMessageDisplayParts,
   type readMessageModelSelection,
   readTextFromMessageInfo,
 } from "../../message-normalizers";
+import type { QueuedUserMessageSend, SessionMessageMetadata } from "../../types";
 import type { EventStreamRuntime } from "../shared";
 import { getKnownMessageParts } from "./helpers";
 import { buildVisibleUserMessage } from "./user-display";
@@ -14,6 +16,39 @@ import {
   resolveUserMessageStateFromPendingAssistant,
   takeQueuedUserSendMatch,
 } from "./user-state";
+
+const resolveUserMessageDisplay = (input: {
+  fallbackText: string;
+  normalizedDisplayParts: AgentUserMessageDisplayPart[];
+  metadata?: SessionMessageMetadata;
+  runtime: EventStreamRuntime;
+  messageId: string;
+  model?: ReturnType<typeof readMessageModelSelection>;
+}): {
+  displayParts: AgentUserMessageDisplayPart[];
+  matchedQueuedSend: QueuedUserMessageSend | null;
+  visible: string;
+} => {
+  const initialVisibleUserMessage = buildVisibleUserMessage({
+    fallbackText: input.fallbackText,
+    normalizedDisplayParts: input.normalizedDisplayParts,
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+  });
+  const matchedQueuedSend = takeQueuedUserSendMatch(
+    input.runtime,
+    initialVisibleUserMessage.visible,
+    initialVisibleUserMessage.displayParts,
+    input.model,
+  );
+  const { displayParts, visible } = buildVisibleUserMessage({
+    fallbackText: input.fallbackText,
+    normalizedDisplayParts: input.normalizedDisplayParts,
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+    ...(matchedQueuedSend ? { matchedQueuedSend } : {}),
+  });
+
+  return { displayParts, matchedQueuedSend, visible };
+};
 
 export const reconcileUserMessageQueuedStates = (runtime: EventStreamRuntime): void => {
   const session = runtime.getSession(runtime.externalSessionId);
@@ -60,22 +95,13 @@ export const handleUserMessageUpdated = (
   const currentMetadata = session?.messageMetadataById.get(input.messageId);
   const normalizedDisplayParts = normalizeUserMessageDisplayParts(userParts);
   const fallbackText = currentMetadata?.text ?? readTextFromMessageInfo(input.infoRecord);
-  const initialVisibleUserMessage = buildVisibleUserMessage({
+  const { displayParts, matchedQueuedSend, visible } = resolveUserMessageDisplay({
     fallbackText,
     normalizedDisplayParts,
-    ...(currentMetadata ? { metadata: currentMetadata } : {}),
-  });
-  const matchedQueuedSend = takeQueuedUserSendMatch(
     runtime,
-    initialVisibleUserMessage.visible,
-    initialVisibleUserMessage.displayParts,
-    input.messageModel,
-  );
-  const { displayParts, visible } = buildVisibleUserMessage({
-    fallbackText,
-    normalizedDisplayParts,
+    messageId: input.messageId,
     ...(currentMetadata ? { metadata: currentMetadata } : {}),
-    ...(matchedQueuedSend ? { matchedQueuedSend } : {}),
+    ...(input.messageModel ? { model: input.messageModel } : {}),
   });
   if (visible.trim().length === 0 && displayParts.length === 0) {
     return true;
@@ -113,22 +139,13 @@ export const handleUserPartUpdated = (runtime: EventStreamRuntime, messageId: st
     getKnownMessageParts(runtime, messageId),
   );
   const fallbackText = metadata?.text ?? "";
-  const initialVisibleUserMessage = buildVisibleUserMessage({
+  const { displayParts, matchedQueuedSend, visible } = resolveUserMessageDisplay({
     fallbackText,
     normalizedDisplayParts,
-    ...(metadata ? { metadata } : {}),
-  });
-  const matchedQueuedSend = takeQueuedUserSendMatch(
     runtime,
-    initialVisibleUserMessage.visible,
-    initialVisibleUserMessage.displayParts,
-    metadata?.model,
-  );
-  const { displayParts, visible } = buildVisibleUserMessage({
-    fallbackText,
-    normalizedDisplayParts,
+    messageId,
     ...(metadata ? { metadata } : {}),
-    ...(matchedQueuedSend ? { matchedQueuedSend } : {}),
+    ...(metadata?.model ? { model: metadata.model } : {}),
   });
   if (visible.trim().length > 0 || displayParts.length > 0) {
     persistUserMessageMetadata({

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
@@ -22,7 +22,6 @@ const resolveUserMessageDisplay = (input: {
   normalizedDisplayParts: AgentUserMessageDisplayPart[];
   metadata?: SessionMessageMetadata;
   runtime: EventStreamRuntime;
-  messageId: string;
   model?: ReturnType<typeof readMessageModelSelection>;
 }): {
   displayParts: AgentUserMessageDisplayPart[];
@@ -99,7 +98,6 @@ export const handleUserMessageUpdated = (
     fallbackText,
     normalizedDisplayParts,
     runtime,
-    messageId: input.messageId,
     ...(currentMetadata ? { metadata: currentMetadata } : {}),
     ...(input.messageModel ? { model: input.messageModel } : {}),
   });
@@ -143,7 +141,6 @@ export const handleUserPartUpdated = (runtime: EventStreamRuntime, messageId: st
     fallbackText,
     normalizedDisplayParts,
     runtime,
-    messageId,
     ...(metadata ? { metadata } : {}),
     ...(metadata?.model ? { model: metadata.model } : {}),
   });


### PR DESCRIPTION
## Summary
- Extracts shared user-message display resolution for OpenCode message and part updates.
- Keeps persistence and emission decisions in the existing handlers while centralizing visible text, display parts, and queued-send matching.
- Preserves current queued-send, attachment, slash-command, and model behavior covered by existing adapter tests.

## Goal
`handleUserMessageUpdated` and `handleUserPartUpdated` were performing the same display-resolution sequence independently: normalize display parts, build an initial visible message, match a queued send, then rebuild the visible message with queued-send metadata. This PR reduces that duplicated "almost helper" logic so future OpenCode event handling changes only need to update the shared display-resolution path.

## Technical choices
- Added a local `resolveUserMessageDisplay` helper in `packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts` because the extracted behavior is specific to user message event handling.
- The helper accepts only the data it actually needs: fallback text, normalized display parts, optional current metadata, runtime, and optional model selection.
- It performs the existing two-pass `buildVisibleUserMessage` flow unchanged so queued-send matching still uses the pre-match visible message and display parts, then attachment/model metadata can be merged into the final display result.
- Existing handlers still own empty-message suppression, metadata persistence, explicit/live state resolution, and event emission, preserving their current responsibility boundaries.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check` from `apps/desktop/src-tauri`
- `cargo clippy --workspace --all-targets -- -D warnings` from `apps/desktop/src-tauri`
- `cargo build --workspace` from `apps/desktop/src-tauri`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code maintainability by consolidating duplicate message-handling logic into a shared utility function, reducing code duplication and enhancing consistency across message processing workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/570)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->