### PR TITLE
refactor(opencode): share parent session parsing

### DIFF
--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   type EventStreamRuntime,
   flushPendingSubagentInputEventsForSession,
+  readParentExternalSessionId,
   type SubagentSessionLink,
 } from "./event-stream/shared";
 import type { SessionInput, SessionRecord } from "./types";
@@ -133,6 +134,19 @@ const runEventStreamWithSession = async (
 const runEventStream = async (events: Event[]): Promise<AgentEvent[]> => {
   return (await runEventStreamWithSession(events)).emitted;
 };
+
+test("readParentExternalSessionId accepts OpenCode parent id spellings", () => {
+  for (const key of ["parentID", "parentId", "parent_id"] as const) {
+    expect(readParentExternalSessionId({ [key]: "external-parent-session" })).toBe(
+      "external-parent-session",
+    );
+  }
+
+  expect(readParentExternalSessionId({ parentID: "" })).toBeUndefined();
+  expect(readParentExternalSessionId({ parentID: "   " })).toBeUndefined();
+  expect(readParentExternalSessionId({ parentID: 123 })).toBeUndefined();
+  expect(readParentExternalSessionId(undefined)).toBeUndefined();
+});
 
 test("flushPendingSubagentInputEventsForSession preserves original timestamps", () => {
   const emitted: AgentEvent[] = [];

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -3,7 +3,12 @@ import type { AgentEvent } from "@openducktor/core";
 import { handleMessageEvent } from "./event-stream/message-events";
 import { handleSessionEvent } from "./event-stream/session-events";
 import type { SubagentSessionLink } from "./event-stream/shared";
-import { isRelevantEvent, readEventDirectory, readEventSessionId } from "./event-stream/shared";
+import {
+  isRelevantEvent,
+  readEventDirectory,
+  readEventSessionId,
+  readParentExternalSessionId,
+} from "./event-stream/shared";
 import type {
   EventStreamSubscriber,
   OpencodeEventLogger,
@@ -177,19 +182,7 @@ export const isRelevantSubscriberEvent = (
       properties && typeof properties === "object" && properties !== null && "info" in properties
         ? (properties as { info?: unknown }).info
         : undefined;
-    const parentExternalSessionId =
-      info && typeof info === "object" && info !== null
-        ? (["parentID", "parentId", "parent_id"] as const).reduce<string | undefined>(
-            (found, key) => {
-              if (found) {
-                return found;
-              }
-              const value = (info as Record<string, unknown>)[key];
-              return typeof value === "string" && value.trim().length > 0 ? value : undefined;
-            },
-            undefined,
-          )
-        : undefined;
+    const parentExternalSessionId = readParentExternalSessionId(info);
 
     if (event.type === "question.asked" && parentExternalSessionId) {
       return parentExternalSessionId === subscriber.externalSessionId;

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -23,23 +23,9 @@ import {
   markSessionActive,
   markSessionIdle,
   readEventSessionId,
+  readParentExternalSessionId,
   removePendingSubagentCorrelationKey,
 } from "./shared";
-
-const readParentExternalSessionId = (info: unknown): string | undefined => {
-  if (!info || typeof info !== "object") {
-    return undefined;
-  }
-
-  for (const key of ["parentID", "parentId", "parent_id"] as const) {
-    const value = (info as Record<string, unknown>)[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value;
-    }
-  }
-
-  return undefined;
-};
 
 type PendingInputEvent = Extract<AgentEvent, { type: "approval_required" | "question_required" }>;
 

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -54,13 +54,15 @@ export type EventStreamState = {
 
 export type EventStreamRuntime = EventStreamContext & EventStreamState;
 
+const PARENT_EXTERNAL_SESSION_ID_KEYS = ["parentID", "parentId", "parent_id"] as const;
+
 export const readParentExternalSessionId = (info: unknown): string | undefined => {
   const record = asUnknownRecord(info);
   if (!record) {
     return undefined;
   }
 
-  for (const key of ["parentID", "parentId", "parent_id"] as const) {
+  for (const key of PARENT_EXTERNAL_SESSION_ID_KEYS) {
     const value = record[key];
     if (typeof value === "string" && value.trim().length > 0) {
       return value;

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -54,6 +54,22 @@ export type EventStreamState = {
 
 export type EventStreamRuntime = EventStreamContext & EventStreamState;
 
+export const readParentExternalSessionId = (info: unknown): string | undefined => {
+  const record = asUnknownRecord(info);
+  if (!record) {
+    return undefined;
+  }
+
+  for (const key of ["parentID", "parentId", "parent_id"] as const) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
 export const flushPendingSubagentInputEventsForSession = (
   runtime: EventStreamRuntime,
   childExternalSessionId: string,


### PR DESCRIPTION
Summary: Share OpenCode parent session ID parsing across subscriber relevance filtering and session event handling.

## Goal
This PR removes duplicated parsing of OpenCode parent session IDs from the event-stream code. Both subscriber relevance checks and session event handling need to understand the same OpenCode payload spellings (`parentID`, `parentId`, and `parent_id`) so subagent permission/question routing and child-session correlation do not drift over time.

## Technical choices
- Moved parent session ID extraction into `packages/adapters-opencode-sdk/src/event-stream/shared.ts` as `readParentExternalSessionId`.
- Added a named `PARENT_EXTERNAL_SESSION_ID_KEYS` constant so the supported OpenCode compatibility surface is explicit in one place.
- Reused the shared parser from both `event-stream.ts` and `event-stream/session-events.ts`.
- Preserved existing behavior: accepts all three parent ID spellings, returns non-empty string values as-is, and ignores missing, blank, or non-string values.
- Added focused coverage in `event-stream.test.ts` for all accepted spellings and ignored invalid values.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run check:rust`
- `bun run test:rust`
- `cargo build --workspace`