### PR TITLE
fix: centralize enabled runtime selection

### DIFF
--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -310,9 +310,7 @@ export const globalConfigSchema = z.object({
   recentWorkspaces: z.array(workspaceIdSchema).default([]),
 });
 type ParsedGlobalConfig = z.infer<typeof globalConfigSchema>;
-export type GlobalConfig = Omit<ParsedGlobalConfig, "agentRuntimes"> & {
-  agentRuntimes?: AgentRuntimes;
-};
+export type GlobalConfig = ParsedGlobalConfig;
 
 export const settingsSnapshotSchema = z.object({
   theme: themeValueSchema,
@@ -327,6 +325,4 @@ export const settingsSnapshotSchema = z.object({
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
 });
 type ParsedSettingsSnapshot = z.infer<typeof settingsSnapshotSchema>;
-export type SettingsSnapshot = Omit<ParsedSettingsSnapshot, "agentRuntimes"> & {
-  agentRuntimes?: AgentRuntimes;
-};
+export type SettingsSnapshot = ParsedSettingsSnapshot;

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { type ComponentProps, createElement as createReactElement } from "react";
 import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server";
 import { RuntimeDefinitionsContext } from "@/state/app-state-contexts";
@@ -8,6 +8,8 @@ import { buildMessage } from "./agent-chat-test-fixtures";
 
 const TEST_RUNTIME_DEFINITIONS_CONTEXT = {
   runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+  availableRuntimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   isLoadingRuntimeDefinitions: false,
   runtimeDefinitionsError: null,
   refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],

--- a/packages/frontend/src/components/features/agents/agent-runtime-icon.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-runtime-icon.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AgentRuntimeIcon } from "./agent-runtime-icon";
+
+describe("AgentRuntimeIcon", () => {
+  test("renders the OpenCode brand icon", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentRuntimeIcon, { runtimeKind: "opencode", className: "size-5" }),
+    );
+
+    expect(html).toContain('viewBox="0 0 512 512"');
+    expect(html).toContain("dark:fill-[#F1ECEC]");
+    expect(html).toContain("size-5");
+  });
+
+  test("renders the Codex brand icon", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentRuntimeIcon, { runtimeKind: "codex", className: "size-5" }),
+    );
+
+    expect(html).toContain('viewBox="0 0 256 260"');
+    expect(html).toContain("dark:fill-white");
+    expect(html).toContain("size-5");
+    expect(html).not.toContain("lucide-bot");
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-runtime-icon.tsx
+++ b/packages/frontend/src/components/features/agents/agent-runtime-icon.tsx
@@ -1,5 +1,4 @@
 import type { RuntimeKind } from "@openducktor/contracts";
-import { Bot } from "lucide-react";
 import type { ReactElement } from "react";
 import { cn } from "@/lib/utils";
 
@@ -8,7 +7,11 @@ type AgentRuntimeIconProps = {
   className?: string;
 };
 
-function OpenCodeBrandIcon({ className }: { className?: string }): ReactElement {
+type RuntimeBrandIconProps = {
+  className: string | undefined;
+};
+
+function OpenCodeBrandIcon({ className }: RuntimeBrandIconProps): ReactElement {
   return (
     <svg
       aria-hidden="true"
@@ -29,10 +32,31 @@ function OpenCodeBrandIcon({ className }: { className?: string }): ReactElement 
   );
 }
 
+function CodexBrandIcon({ className }: RuntimeBrandIconProps): ReactElement {
+  return (
+    <svg
+      aria-hidden="true"
+      className={cn("size-4 shrink-0", className)}
+      viewBox="0 0 256 260"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        className="fill-[#0D0D0D] dark:fill-white"
+        d="M239.184 106.203a64.716 64.716 0 0 0-5.576-53.103C219.452 28.459 191 15.784 163.213 21.74A65.586 65.586 0 0 0 52.096 45.22a64.716 64.716 0 0 0-43.23 31.36c-14.31 24.602-11.061 55.634 8.033 76.74a64.665 64.665 0 0 0 5.525 53.102c14.174 24.65 42.644 37.324 70.446 31.36a64.72 64.72 0 0 0 48.754 21.744c28.481.025 53.714-18.361 62.414-45.481a64.767 64.767 0 0 0 43.229-31.36c14.137-24.558 10.875-55.423-8.083-76.483Zm-97.56 136.338a48.397 48.397 0 0 1-31.105-11.255l1.535-.87 51.67-29.825a8.595 8.595 0 0 0 4.247-7.367v-72.85l21.845 12.636c.218.111.37.32.409.563v60.367c-.056 26.818-21.783 48.545-48.601 48.601Zm-104.466-44.61a48.345 48.345 0 0 1-5.781-32.589l1.534.921 51.722 29.826a8.339 8.339 0 0 0 8.441 0l63.181-36.425v25.221a.87.87 0 0 1-.358.665l-52.335 30.184c-23.257 13.398-52.97 5.431-66.404-17.803ZM23.549 85.38a48.499 48.499 0 0 1 25.58-21.333v61.39a8.288 8.288 0 0 0 4.195 7.316l62.874 36.272-21.845 12.636a.819.819 0 0 1-.767 0L41.353 151.53c-23.211-13.454-31.171-43.144-17.804-66.405v.256Zm179.466 41.695-63.08-36.63L161.73 77.86a.819.819 0 0 1 .768 0l52.233 30.184a48.6 48.6 0 0 1-7.316 87.635v-61.391a8.544 8.544 0 0 0-4.4-7.213Zm21.742-32.69-1.535-.922-51.619-30.081a8.39 8.39 0 0 0-8.492 0L99.98 99.808V74.587a.716.716 0 0 1 .307-.665l52.233-30.133a48.652 48.652 0 0 1 72.236 50.391v.205ZM88.061 139.097l-21.845-12.585a.87.87 0 0 1-.41-.614V65.685a48.652 48.652 0 0 1 79.757-37.346l-1.535.87-51.67 29.825a8.595 8.595 0 0 0-4.246 7.367l-.051 72.697Zm11.868-25.58 28.138-16.217 28.188 16.218v32.434l-28.086 16.218-28.188-16.218-.052-32.434Z"
+      />
+    </svg>
+  );
+}
+
 export function AgentRuntimeIcon({ runtimeKind, className }: AgentRuntimeIconProps): ReactElement {
-  if (runtimeKind === "opencode") {
-    return <OpenCodeBrandIcon {...(className ? { className } : {})} />;
+  switch (runtimeKind) {
+    case "opencode":
+      return <OpenCodeBrandIcon className={className} />;
+    case "codex":
+      return <CodexBrandIcon className={className} />;
   }
 
-  return <Bot aria-hidden="true" className={cn("size-4 shrink-0", className)} />;
+  const exhaustiveRuntimeKind: never = runtimeKind;
+  return exhaustiveRuntimeKind;
 }

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
@@ -20,8 +20,11 @@ import { DiagnosticsPanelSections } from "./diagnostics-panel-sections";
 export function DiagnosticsPanel(): ReactElement {
   const { activeWorkspace, isSwitchingWorkspace } = useWorkspaceState();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
-  const { runtimeDefinitions, isLoadingRuntimeDefinitions, runtimeDefinitionsError } =
-    useRuntimeAvailabilityContext();
+  const {
+    availableRuntimeDefinitions: runtimeDefinitions,
+    isLoadingRuntimeDefinitions,
+    runtimeDefinitionsError,
+  } = useRuntimeAvailabilityContext();
   const { refreshRepoRuntimeHealthForRepo, hasCachedRepoRuntimeHealth } =
     useChecksOperationsContext();
   const {

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 import { useChecksState, useWorkspaceState } from "@/state";
 import {
   useChecksOperationsContext,
-  useRuntimeDefinitionsContext,
+  useRuntimeAvailabilityContext,
 } from "@/state/app-state-contexts";
 import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
 import { DiagnosticsPanelSections } from "./diagnostics-panel-sections";
@@ -21,7 +21,7 @@ export function DiagnosticsPanel(): ReactElement {
   const { activeWorkspace, isSwitchingWorkspace } = useWorkspaceState();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
   const { runtimeDefinitions, isLoadingRuntimeDefinitions, runtimeDefinitionsError } =
-    useRuntimeDefinitionsContext();
+    useRuntimeAvailabilityContext();
   const { refreshRepoRuntimeHealthForRepo, hasCachedRepoRuntimeHealth } =
     useChecksOperationsContext();
   const {

--- a/packages/frontend/src/components/features/settings/settings-modal-content.test.tsx
+++ b/packages/frontend/src/components/features/settings/settings-modal-content.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
-import { CODEX_RUNTIME_DESCRIPTOR, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import {
+  CODEX_RUNTIME_DESCRIPTOR,
+  DEFAULT_AGENT_RUNTIMES,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type SettingsSnapshot,
+} from "@openducktor/contracts";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { SettingsModalContent } from "./settings-modal-content";
@@ -13,6 +17,7 @@ const createMockSnapshot = (overrides: Partial<SettingsSnapshot> = {}): Settings
   reusablePrompts: [],
   kanban: { doneVisibleDays: 1, emptyColumnDisplay: "show" },
   autopilot: { rules: [] },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {},
   globalPromptOverrides: {},
   ...overrides,
@@ -53,6 +58,14 @@ const createMockController = (snapshot: SettingsSnapshot) => ({
   hasPromptValidationErrors: false,
   reusablePromptValidationState: { errorsById: {}, totalErrorCount: 0 },
   hasReusablePromptValidationErrors: false,
+  runtimeAvailabilityValidationState: {
+    errorsByWorkspaceId: {},
+    errorCountByWorkspaceId: {},
+    totalErrorCount: 0,
+  },
+  hasRuntimeAvailabilityErrors: false,
+  selectedRepoRuntimeAvailabilityErrors: [],
+  selectedRepoRuntimeAvailabilityErrorCount: 0,
   hasRepoScriptValidationErrors: false,
   repoScriptValidationErrorCount: 0,
   showRepoScriptValidationErrors: false,
@@ -80,6 +93,7 @@ const createMockController = (snapshot: SettingsSnapshot) => ({
   updateGlobalGitConfig: () => {},
   updateGlobalGeneralSettings: () => {},
   updateGlobalChatSettings: () => {},
+  updateAgentRuntimes: () => {},
   updateReusablePrompts: () => {},
   updateGlobalKanbanSettings: () => {},
   updateGlobalAutopilotSettings: () => {},

--- a/packages/frontend/src/components/features/settings/settings-modal-content.tsx
+++ b/packages/frontend/src/components/features/settings/settings-modal-content.tsx
@@ -1,4 +1,3 @@
-import { DEFAULT_AGENT_RUNTIMES } from "@openducktor/contracts";
 import type { ReactElement } from "react";
 import { AgentRuntimesSection } from "./settings-agent-runtimes-section";
 import { SettingsAutopilotSection } from "./settings-autopilot-section";
@@ -72,6 +71,7 @@ export function SettingsModalContent({
     selectedRepoDevServerValidationErrors,
     promptValidationState,
     reusablePromptValidationState,
+    selectedRepoRuntimeAvailabilityErrors,
     selectedRepoPromptValidationErrors,
     selectedRepoPromptValidationErrorCount,
     globalPromptRoleTabErrorCounts,
@@ -155,10 +155,10 @@ export function SettingsModalContent({
   if (section === "runtimes") {
     return (
       <AgentRuntimesSection
-        agentRuntimes={snapshotDraft.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES}
+        agentRuntimes={snapshotDraft.agentRuntimes}
         runtimeDefinitions={runtimeDefinitions}
         disabled={isInteractionDisabled}
-        onUpdateAgentRuntimes={updateAgentRuntimes ?? (() => {})}
+        onUpdateAgentRuntimes={updateAgentRuntimes}
       />
     );
   }
@@ -260,7 +260,7 @@ export function SettingsModalContent({
         {repositorySection === "agents" ? (
           <RepositoryAgentsSection
             selectedRepoConfig={selectedRepoConfig}
-            agentRuntimes={snapshotDraft.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES}
+            agentRuntimes={snapshotDraft.agentRuntimes}
             runtimeDefinitions={runtimeDefinitions}
             loadingState={{
               isLoadingRuntimeDefinitions,
@@ -269,6 +269,7 @@ export function SettingsModalContent({
               isSaving,
             }}
             runtimeDefinitionsError={runtimeDefinitionsError}
+            runtimeAvailabilityErrors={selectedRepoRuntimeAvailabilityErrors}
             getCatalogForRuntime={getCatalogForRuntime}
             getCatalogErrorForRuntime={getCatalogErrorForRuntime}
             isCatalogLoadingForRuntime={isCatalogLoadingForRuntime}

--- a/packages/frontend/src/components/features/settings/settings-modal-save-policy.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-save-policy.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type SettingsSnapshot } from "@openducktor/contracts";
 import {
   buildPromptValidationSaveError,
   buildRepoScriptValidationSaveError,
   buildReusablePromptValidationSaveError,
+  buildRuntimeAvailabilitySaveError,
   hasAnyDirtySections,
   hasSameSaveReadyGlobalGitConfig,
   isGlobalGitOnlySave,
@@ -30,6 +31,7 @@ const createSnapshot = (): SettingsSnapshot => ({
     rules: [],
   },
   globalPromptOverrides: {},
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {},
 });
 
@@ -78,6 +80,9 @@ describe("settings-modal-save-policy", () => {
     );
     expect(buildReusablePromptValidationSaveError(1)).toBe(
       "Fix 1 reusable prompt field error before saving.",
+    );
+    expect(buildRuntimeAvailabilitySaveError(2)).toBe(
+      "Fix 2 disabled runtime selections before saving.",
     );
     expect(
       buildRepoScriptValidationSaveError({

--- a/packages/frontend/src/components/features/settings/settings-modal-save-policy.ts
+++ b/packages/frontend/src/components/features/settings/settings-modal-save-policy.ts
@@ -42,6 +42,11 @@ export const buildReusablePromptValidationSaveError = (totalErrorCount: number):
   return `Fix ${totalErrorCount} reusable prompt field error${suffix} before saving.`;
 };
 
+export const buildRuntimeAvailabilitySaveError = (totalErrorCount: number): string => {
+  const suffix = totalErrorCount > 1 ? "s" : "";
+  return `Fix ${totalErrorCount} disabled runtime selection${suffix} before saving.`;
+};
+
 export const buildRepoScriptValidationSaveError = ({
   invalidRepoPathsWithDevServerErrors,
   repoScriptValidationErrorCount,

--- a/packages/frontend/src/components/features/settings/settings-repository-agents-section.test.tsx
+++ b/packages/frontend/src/components/features/settings/settings-repository-agents-section.test.tsx
@@ -62,6 +62,7 @@ describe("RepositoryAgentsSection", () => {
           isSaving: false,
         },
         runtimeDefinitionsError: null,
+        runtimeAvailabilityErrors: [],
         getCatalogForRuntime: () => codexCatalog,
         getCatalogErrorForRuntime: () => null,
         isCatalogLoadingForRuntime: () => false,

--- a/packages/frontend/src/components/features/settings/settings-repository-agents-section.tsx
+++ b/packages/frontend/src/components/features/settings/settings-repository-agents-section.tsx
@@ -25,8 +25,8 @@ import type { ComboboxGroup } from "@/components/ui/combobox";
 import { Combobox } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import {
-  filterEnabledRuntimeDefinitions,
   findRuntimeDefinition,
+  getAvailableRuntimeDefinitions,
   resolveRuntimeKindSelection,
   toAgentRuntimeOptions,
 } from "@/lib/agent-runtime";
@@ -42,6 +42,7 @@ type RepositoryAgentsSectionProps = {
     isSaving: boolean;
   };
   runtimeDefinitionsError: string | null;
+  runtimeAvailabilityErrors: string[];
   getCatalogForRuntime: (runtimeKind: RuntimeKind) => AgentModelCatalog | null;
   getCatalogErrorForRuntime: (runtimeKind: RuntimeKind) => string | null;
   isCatalogLoadingForRuntime: (runtimeKind: RuntimeKind) => boolean;
@@ -164,6 +165,7 @@ export function RepositoryAgentsSection({
   runtimeDefinitions,
   loadingState,
   runtimeDefinitionsError,
+  runtimeAvailabilityErrors,
   getCatalogForRuntime,
   getCatalogErrorForRuntime,
   isCatalogLoadingForRuntime,
@@ -181,10 +183,10 @@ export function RepositoryAgentsSection({
     );
   }
 
-  const enabledRuntimeDefinitions = filterEnabledRuntimeDefinitions(
+  const enabledRuntimeDefinitions = getAvailableRuntimeDefinitions({
     runtimeDefinitions,
     agentRuntimes,
-  );
+  });
   const runtimeOptions = toAgentRuntimeOptions(enabledRuntimeDefinitions);
   const runtimeDropdownClassName = "sm:min-w-[18rem]";
   const agentDropdownClassName = "sm:min-w-[18rem]";
@@ -240,6 +242,13 @@ export function RepositoryAgentsSection({
         <p className="text-xs text-warning-muted">
           Failed to load runtime definitions: {runtimeDefinitionsError}
         </p>
+      ) : null}
+      {runtimeAvailabilityErrors.length > 0 ? (
+        <div className="rounded-md border border-warning-border bg-warning-surface p-3 text-xs text-warning-surface-foreground">
+          {runtimeAvailabilityErrors.map((error) => (
+            <p key={error}>{error}</p>
+          ))}
+        </div>
       ) : null}
       {missingRoleLabels.length > 0 ? (
         <p className="text-xs text-warning-muted">

--- a/packages/frontend/src/components/features/settings/settings-save/settings-save.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-save/settings-save.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   type AgentPromptTemplateId,
   agentPromptTemplateIdValues,
+  DEFAULT_AGENT_RUNTIMES,
   type RepoConfig,
   type RepoPromptOverrides,
 } from "@openducktor/contracts";
@@ -339,6 +340,7 @@ describe("settings save transforms", () => {
       autopilot: {
         rules: [],
       },
+      agentRuntimes: DEFAULT_AGENT_RUNTIMES,
       workspaces: {
         "repo-a": createRepoConfig(),
       },

--- a/packages/frontend/src/components/features/settings/settings-save/settings-snapshot.ts
+++ b/packages/frontend/src/components/features/settings/settings-save/settings-snapshot.ts
@@ -1,5 +1,4 @@
 import type { SettingsSnapshot } from "@openducktor/contracts";
-import { DEFAULT_AGENT_RUNTIMES } from "@openducktor/contracts";
 import { prepareReusablePromptsForSave } from "@/state/read-models/settings-read-model";
 import { prepareAutopilotSettingsForSave } from "./autopilot-settings";
 import { prepareGlobalGitSettingsForSave } from "./global-git-settings";
@@ -22,7 +21,7 @@ export const prepareSettingsSnapshotForSave = (snapshot: SettingsSnapshot): Sett
     reusablePrompts: prepareReusablePromptsForSave(snapshot.reusablePrompts),
     kanban: snapshot.kanban,
     autopilot: prepareAutopilotSettingsForSave(snapshot.autopilot),
-    agentRuntimes: snapshot.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES,
+    agentRuntimes: snapshot.agentRuntimes,
     workspaces,
     globalPromptOverrides: preparePromptOverridesForSave(snapshot.globalPromptOverrides),
   };

--- a/packages/frontend/src/components/features/settings/settings-workspace-selection.test.ts
+++ b/packages/frontend/src/components/features/settings/settings-workspace-selection.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import type { RepoConfig, SettingsSnapshot } from "@openducktor/contracts";
+import {
+  DEFAULT_AGENT_RUNTIMES,
+  type RepoConfig,
+  type SettingsSnapshot,
+} from "@openducktor/contracts";
 import { chooseInitialSettingsWorkspaceId } from "./settings-workspace-selection";
 
 const createRepoConfig = (overrides: Partial<RepoConfig> = {}): RepoConfig => ({
@@ -43,6 +47,7 @@ const createSnapshot = (workspaces: SettingsSnapshot["workspaces"]): SettingsSna
   autopilot: {
     rules: [],
   },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces,
   globalPromptOverrides: {},
 });

--- a/packages/frontend/src/components/features/settings/use-settings-modal-catalog-state.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-catalog-state.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
+  DEFAULT_AGENT_RUNTIMES,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type RuntimeDescriptor,
   type RuntimeKind,
@@ -45,6 +46,8 @@ const createHookHarness = (
 ) => {
   const runtimeDefinitionsContext = {
     runtimeDefinitions: [OPENCODE_DESCRIPTOR],
+    availableRuntimeDefinitions: [OPENCODE_DESCRIPTOR],
+    agentRuntimes: DEFAULT_AGENT_RUNTIMES,
     isLoadingRuntimeDefinitions: false,
     runtimeDefinitionsError: null,
     refreshRuntimeDefinitions: async () => [OPENCODE_DESCRIPTOR],

--- a/packages/frontend/src/components/features/settings/use-settings-modal-controller.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-controller.test.tsx
@@ -47,6 +47,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
     emptyColumnDisplay: "show",
   },
   autopilot: createDefaultAutopilotSettings(),
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {
     repo: {
       workspaceId: "repo",
@@ -169,6 +170,8 @@ const createHookHarness = (
 
   const runtimeDefinitionsContext = {
     runtimeDefinitions,
+    availableRuntimeDefinitions: runtimeDefinitions,
+    agentRuntimes: DEFAULT_AGENT_RUNTIMES,
     isLoadingRuntimeDefinitions: false,
     runtimeDefinitionsError: null,
     refreshRuntimeDefinitions: async () => runtimeDefinitions,

--- a/packages/frontend/src/components/features/settings/use-settings-modal-controller.ts
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-controller.ts
@@ -19,7 +19,7 @@ import { getAvailableRuntimeDefinitions } from "@/lib/agent-runtime";
 import {
   ChecksStateContext,
   useRequiredContext,
-  useRuntimeDefinitionsContext,
+  useRuntimeAvailabilityContext,
   WorkspaceStateContext,
 } from "@/state/app-state-contexts";
 import type { PromptRoleTabId, SettingsSectionId } from "./settings-modal-constants";
@@ -138,8 +138,11 @@ export const useSettingsModalController = ({
   } = workspaceState;
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
   const { runtimeCheck } = checksState;
-  const { runtimeDefinitions, isLoadingRuntimeDefinitions, runtimeDefinitionsError } =
-    useRuntimeDefinitionsContext();
+  const {
+    availableRuntimeDefinitions: runtimeDefinitions,
+    isLoadingRuntimeDefinitions,
+    runtimeDefinitionsError,
+  } = useRuntimeAvailabilityContext();
 
   const {
     loadedSnapshot,

--- a/packages/frontend/src/components/features/settings/use-settings-modal-controller.ts
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-controller.ts
@@ -12,11 +12,10 @@ import type {
   SettingsSnapshot,
   WorkspaceRecord,
 } from "@openducktor/contracts";
-import { DEFAULT_AGENT_RUNTIMES } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import { useEffect, useMemo } from "react";
 import { getNeededCatalogRuntimeKinds } from "@/components/features/settings";
-import { filterEnabledRuntimeDefinitions } from "@/lib/agent-runtime";
+import { getAvailableRuntimeDefinitions } from "@/lib/agent-runtime";
 import {
   ChecksStateContext,
   useRequiredContext,
@@ -35,6 +34,8 @@ import { useSettingsModalRepoScriptValidation } from "./use-settings-modal-repo-
 import { useSettingsModalRepositoryActions } from "./use-settings-modal-repository-actions";
 import type { ReusablePromptValidationState } from "./use-settings-modal-reusable-prompt-validation";
 import { useSettingsModalReusablePromptValidation } from "./use-settings-modal-reusable-prompt-validation";
+import type { RuntimeAvailabilityValidationState } from "./use-settings-modal-runtime-validation";
+import { useSettingsModalRuntimeValidation } from "./use-settings-modal-runtime-validation";
 import { useSettingsModalSaveOrchestration } from "./use-settings-modal-save-orchestration";
 import { useSettingsModalSnapshotState } from "./use-settings-modal-snapshot-state";
 
@@ -71,6 +72,10 @@ export type SettingsModalController = {
   settingsSectionErrorCountById: Record<SettingsSectionId, number>;
   reusablePromptValidationState: ReusablePromptValidationState;
   hasReusablePromptValidationErrors: boolean;
+  runtimeAvailabilityValidationState: RuntimeAvailabilityValidationState;
+  hasRuntimeAvailabilityErrors: boolean;
+  selectedRepoRuntimeAvailabilityErrors: string[];
+  selectedRepoRuntimeAvailabilityErrorCount: number;
   hasRepoScriptValidationErrors: boolean;
   repoScriptValidationErrorCount: number;
   showRepoScriptValidationErrors: boolean;
@@ -89,7 +94,7 @@ export type SettingsModalController = {
   updateGlobalGeneralSettings: (
     updater: (current: SettingsSnapshot["general"]) => SettingsSnapshot["general"],
   ) => void;
-  updateAgentRuntimes?: (updater: (current: AgentRuntimes) => AgentRuntimes) => void;
+  updateAgentRuntimes: (updater: (current: AgentRuntimes) => AgentRuntimes) => void;
   updateReusablePrompts: (updater: (current: ReusablePrompt[]) => ReusablePrompt[]) => void;
   updateGlobalKanbanSettings: (
     updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"],
@@ -177,10 +182,10 @@ export const useSettingsModalController = ({
       getNeededCatalogRuntimeKinds(
         selectedRepoConfig,
         snapshotDraft
-          ? filterEnabledRuntimeDefinitions(
+          ? getAvailableRuntimeDefinitions({
               runtimeDefinitions,
-              snapshotDraft.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES,
-            )
+              agentRuntimes: snapshotDraft.agentRuntimes,
+            })
           : [],
       ),
     [selectedRepoConfig, runtimeDefinitions, snapshotDraft],
@@ -211,12 +216,28 @@ export const useSettingsModalController = ({
   });
   const reusablePromptValidationState = useSettingsModalReusablePromptValidation({ snapshotDraft });
   const hasReusablePromptValidationErrors = reusablePromptValidationState.totalErrorCount > 0;
+  const runtimeAvailabilityValidationState = useSettingsModalRuntimeValidation({
+    runtimeDefinitions,
+    snapshotDraft,
+  });
+  const hasRuntimeAvailabilityErrors = runtimeAvailabilityValidationState.totalErrorCount > 0;
+  const selectedRepoRuntimeAvailabilityErrors = selectedWorkspaceId
+    ? (runtimeAvailabilityValidationState.errorsByWorkspaceId[selectedWorkspaceId] ?? [])
+    : [];
+  const selectedRepoRuntimeAvailabilityErrorCount = selectedRepoRuntimeAvailabilityErrors.length;
   const settingsSectionErrorCountByIdWithReusablePrompts = useMemo(
     () => ({
       ...settingsSectionErrorCountById,
+      repositories:
+        settingsSectionErrorCountById.repositories +
+        runtimeAvailabilityValidationState.totalErrorCount,
       "reusable-prompts": reusablePromptValidationState.totalErrorCount,
     }),
-    [reusablePromptValidationState.totalErrorCount, settingsSectionErrorCountById],
+    [
+      reusablePromptValidationState.totalErrorCount,
+      runtimeAvailabilityValidationState.totalErrorCount,
+      settingsSectionErrorCountById,
+    ],
   );
 
   const {
@@ -277,6 +298,8 @@ export const useSettingsModalController = ({
     promptValidationState,
     hasReusablePromptValidationErrors: hasReusablePromptValidationErrors,
     reusablePromptValidationErrorCount: reusablePromptValidationState.totalErrorCount,
+    hasRuntimeAvailabilityErrors,
+    runtimeAvailabilityErrorCount: runtimeAvailabilityValidationState.totalErrorCount,
     hasRepoScriptValidationErrors,
     repoScriptValidationErrorCount,
     invalidRepoPathsWithDevServerErrors,
@@ -378,6 +401,10 @@ export const useSettingsModalController = ({
     settingsSectionErrorCountById: settingsSectionErrorCountByIdWithReusablePrompts,
     reusablePromptValidationState,
     hasReusablePromptValidationErrors,
+    runtimeAvailabilityValidationState,
+    hasRuntimeAvailabilityErrors,
+    selectedRepoRuntimeAvailabilityErrors,
+    selectedRepoRuntimeAvailabilityErrorCount,
     hasRepoScriptValidationErrors,
     repoScriptValidationErrorCount,
     showRepoScriptValidationErrors,

--- a/packages/frontend/src/components/features/settings/use-settings-modal-dirty-draft-actions.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-dirty-draft-actions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type SettingsSnapshot } from "@openducktor/contracts";
 import { useState } from "react";
 import {
   createHookHarness as createSharedHookHarness,
@@ -36,6 +36,7 @@ const createSnapshot = (): SettingsSnapshot => ({
     rules: [],
   },
   globalPromptOverrides: {},
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {
     repo: {
       workspaceId: "repo",

--- a/packages/frontend/src/components/features/settings/use-settings-modal-dirty-state.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-dirty-state.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type SettingsSnapshot } from "@openducktor/contracts";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
@@ -33,6 +33,7 @@ const createSnapshot = (): SettingsSnapshot => ({
     rules: [],
   },
   globalPromptOverrides: {},
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {},
 });
 

--- a/packages/frontend/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type SettingsSnapshot } from "@openducktor/contracts";
 import { useState } from "react";
 import {
   createHookHarness as createSharedHookHarness,
@@ -34,6 +34,7 @@ const createInitialSnapshot = (): SettingsSnapshot => ({
     rules: [],
   },
   globalPromptOverrides: {},
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {
     "repo-a": {
       workspaceId: "repo-a",

--- a/packages/frontend/src/components/features/settings/use-settings-modal-draft-actions.ts
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-draft-actions.ts
@@ -6,7 +6,6 @@ import type {
   ReusablePrompt,
   SettingsSnapshot,
 } from "@openducktor/contracts";
-import { DEFAULT_AGENT_RUNTIMES } from "@openducktor/contracts";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback } from "react";
 import { ensureDraftAgentDefault } from "@/components/features/settings";
@@ -148,7 +147,7 @@ export const useSettingsModalDraftActions = ({
 
         return {
           ...current,
-          agentRuntimes: updater(current.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES),
+          agentRuntimes: updater(current.agentRuntimes),
         };
       });
     },

--- a/packages/frontend/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type SettingsSnapshot } from "@openducktor/contracts";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
@@ -39,6 +39,7 @@ const createSnapshot = (): SettingsSnapshot => ({
       enabled: true,
     },
   },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {
     "repo-a": {
       workspaceId: "repo-a",

--- a/packages/frontend/src/components/features/settings/use-settings-modal-repo-script-validation.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-repo-script-validation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type SettingsSnapshot } from "@openducktor/contracts";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
@@ -33,6 +33,7 @@ const createSnapshot = (): SettingsSnapshot => ({
     rules: [],
   },
   globalPromptOverrides: {},
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {
     "repo-a": {
       workspaceId: "repo-a",

--- a/packages/frontend/src/components/features/settings/use-settings-modal-runtime-validation.test.ts
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-runtime-validation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CODEX_RUNTIME_DESCRIPTOR,
+  createDefaultAutopilotSettings,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type SettingsSnapshot,
+} from "@openducktor/contracts";
+import { buildRuntimeAvailabilityValidationState } from "./use-settings-modal-runtime-validation";
+
+const createSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  general: {
+    openAgentStudioTabOnBackgroundSessionStart: true,
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  reusablePrompts: [],
+  kanban: {
+    doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
+  },
+  autopilot: createDefaultAutopilotSettings(),
+  agentRuntimes: {
+    opencode: { enabled: true },
+    codex: { enabled: false },
+  },
+  workspaces: {
+    repo: {
+      workspaceId: "repo",
+      workspaceName: "Repo",
+      repoPath: "/repo",
+      defaultRuntimeKind: "codex",
+      worktreeBasePath: undefined,
+      branchPrefix: "odt",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: {
+        providers: {},
+      },
+      hooks: { preStart: [], postComplete: [] },
+      devServers: [],
+      worktreeCopyPaths: [],
+      promptOverrides: {},
+      agentDefaults: {
+        build: {
+          runtimeKind: "codex",
+          providerId: "codex",
+          modelId: "gpt-5.4",
+          variant: "medium",
+          profileId: "",
+        },
+      },
+    },
+  },
+  globalPromptOverrides: {},
+});
+
+describe("settings runtime availability validation", () => {
+  test("reports disabled repo default and role runtimes", () => {
+    const validation = buildRuntimeAvailabilityValidationState({
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
+      snapshotDraft: createSnapshot(),
+    });
+
+    expect(validation.totalErrorCount).toBe(2);
+    expect(validation.errorCountByWorkspaceId.repo).toBe(2);
+    expect(validation.errorsByWorkspaceId.repo).toEqual([
+      'Default agent runtime "Codex" is disabled.',
+      'Builder agent runtime "Codex" is disabled.',
+    ]);
+  });
+
+  test("does not report disabled runtimes while runtime definitions are unavailable", () => {
+    const validation = buildRuntimeAvailabilityValidationState({
+      runtimeDefinitions: [],
+      snapshotDraft: createSnapshot(),
+    });
+
+    expect(validation.totalErrorCount).toBe(0);
+    expect(validation.errorsByWorkspaceId).toEqual({});
+  });
+});

--- a/packages/frontend/src/components/features/settings/use-settings-modal-runtime-validation.ts
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-runtime-validation.ts
@@ -6,8 +6,7 @@ import type {
 } from "@openducktor/contracts";
 import { useMemo } from "react";
 import { getAvailableRuntimeDefinitions, runtimeLabelFor } from "@/lib/agent-runtime";
-
-type RepoRuntimeRole = "spec" | "planner" | "build" | "qa";
+import { ROLE_DEFAULTS } from "./settings-modal-model";
 
 export type RuntimeAvailabilityValidationState = {
   errorsByWorkspaceId: Record<string, string[]>;
@@ -19,13 +18,6 @@ export const EMPTY_RUNTIME_AVAILABILITY_VALIDATION_STATE: RuntimeAvailabilityVal
   errorsByWorkspaceId: {},
   errorCountByWorkspaceId: {},
   totalErrorCount: 0,
-};
-
-const roleLabels: Record<RepoRuntimeRole, string> = {
-  spec: "Spec",
-  planner: "Planner",
-  build: "Builder",
-  qa: "QA",
 };
 
 const findAvailableRuntimeKind = (
@@ -59,7 +51,7 @@ const buildRepoRuntimeAvailabilityErrors = ({
     );
   }
 
-  for (const role of Object.keys(roleLabels) as RepoRuntimeRole[]) {
+  for (const { role, label } of ROLE_DEFAULTS) {
     const roleDefault = repoConfig.agentDefaults[role];
     const runtimeKind = roleDefault?.runtimeKind;
     if (!runtimeKind) {
@@ -69,7 +61,7 @@ const buildRepoRuntimeAvailabilityErrors = ({
       continue;
     }
     errors.push(
-      `${roleLabels[role]} agent runtime "${unavailableRuntimeLabel(allRuntimeDefinitions, runtimeKind)}" is disabled.`,
+      `${label} agent runtime "${unavailableRuntimeLabel(allRuntimeDefinitions, runtimeKind)}" is disabled.`,
     );
   }
 

--- a/packages/frontend/src/components/features/settings/use-settings-modal-runtime-validation.ts
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-runtime-validation.ts
@@ -1,0 +1,135 @@
+import type {
+  RepoConfig,
+  RuntimeDescriptor,
+  RuntimeKind,
+  SettingsSnapshot,
+} from "@openducktor/contracts";
+import { useMemo } from "react";
+import { getAvailableRuntimeDefinitions, runtimeLabelFor } from "@/lib/agent-runtime";
+
+type RepoRuntimeRole = "spec" | "planner" | "build" | "qa";
+
+export type RuntimeAvailabilityValidationState = {
+  errorsByWorkspaceId: Record<string, string[]>;
+  errorCountByWorkspaceId: Record<string, number>;
+  totalErrorCount: number;
+};
+
+export const EMPTY_RUNTIME_AVAILABILITY_VALIDATION_STATE: RuntimeAvailabilityValidationState = {
+  errorsByWorkspaceId: {},
+  errorCountByWorkspaceId: {},
+  totalErrorCount: 0,
+};
+
+const roleLabels: Record<RepoRuntimeRole, string> = {
+  spec: "Spec",
+  planner: "Planner",
+  build: "Builder",
+  qa: "QA",
+};
+
+const findAvailableRuntimeKind = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeKind: RuntimeKind,
+): RuntimeKind | null =>
+  runtimeDefinitions.some((definition) => definition.kind === runtimeKind) ? runtimeKind : null;
+
+const unavailableRuntimeLabel = (
+  allRuntimeDefinitions: RuntimeDescriptor[],
+  runtimeKind: RuntimeKind,
+): string =>
+  runtimeLabelFor({
+    runtimeDefinitions: allRuntimeDefinitions,
+    runtimeKind,
+  });
+
+const buildRepoRuntimeAvailabilityErrors = ({
+  allRuntimeDefinitions,
+  availableRuntimeDefinitions,
+  repoConfig,
+}: {
+  allRuntimeDefinitions: RuntimeDescriptor[];
+  availableRuntimeDefinitions: RuntimeDescriptor[];
+  repoConfig: RepoConfig;
+}): string[] => {
+  const errors: string[] = [];
+  if (!findAvailableRuntimeKind(availableRuntimeDefinitions, repoConfig.defaultRuntimeKind)) {
+    errors.push(
+      `Default agent runtime "${unavailableRuntimeLabel(allRuntimeDefinitions, repoConfig.defaultRuntimeKind)}" is disabled.`,
+    );
+  }
+
+  for (const role of Object.keys(roleLabels) as RepoRuntimeRole[]) {
+    const roleDefault = repoConfig.agentDefaults[role];
+    const runtimeKind = roleDefault?.runtimeKind;
+    if (!runtimeKind) {
+      continue;
+    }
+    if (findAvailableRuntimeKind(availableRuntimeDefinitions, runtimeKind)) {
+      continue;
+    }
+    errors.push(
+      `${roleLabels[role]} agent runtime "${unavailableRuntimeLabel(allRuntimeDefinitions, runtimeKind)}" is disabled.`,
+    );
+  }
+
+  return errors;
+};
+
+export const buildRuntimeAvailabilityValidationState = ({
+  runtimeDefinitions,
+  snapshotDraft,
+}: {
+  runtimeDefinitions: RuntimeDescriptor[];
+  snapshotDraft: SettingsSnapshot;
+}): RuntimeAvailabilityValidationState => {
+  if (runtimeDefinitions.length === 0) {
+    return EMPTY_RUNTIME_AVAILABILITY_VALIDATION_STATE;
+  }
+
+  const availableRuntimeDefinitions = getAvailableRuntimeDefinitions({
+    runtimeDefinitions,
+    agentRuntimes: snapshotDraft.agentRuntimes,
+  });
+  let totalErrorCount = 0;
+  const errorsByWorkspaceId: Record<string, string[]> = {};
+  const errorCountByWorkspaceId: Record<string, number> = {};
+
+  for (const [workspaceId, repoConfig] of Object.entries(snapshotDraft.workspaces)) {
+    const errors = buildRepoRuntimeAvailabilityErrors({
+      allRuntimeDefinitions: runtimeDefinitions,
+      availableRuntimeDefinitions,
+      repoConfig,
+    });
+    if (errors.length === 0) {
+      continue;
+    }
+    errorsByWorkspaceId[workspaceId] = errors;
+    errorCountByWorkspaceId[workspaceId] = errors.length;
+    totalErrorCount += errors.length;
+  }
+
+  return {
+    errorsByWorkspaceId,
+    errorCountByWorkspaceId,
+    totalErrorCount,
+  };
+};
+
+export const useSettingsModalRuntimeValidation = ({
+  runtimeDefinitions,
+  snapshotDraft,
+}: {
+  runtimeDefinitions: RuntimeDescriptor[];
+  snapshotDraft: SettingsSnapshot | null;
+}): RuntimeAvailabilityValidationState => {
+  return useMemo(() => {
+    if (!snapshotDraft) {
+      return EMPTY_RUNTIME_AVAILABILITY_VALIDATION_STATE;
+    }
+    return buildRuntimeAvailabilityValidationState({
+      runtimeDefinitions,
+      snapshotDraft,
+    });
+  }, [runtimeDefinitions, snapshotDraft]);
+};

--- a/packages/frontend/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-save-orchestration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type SettingsSnapshot } from "@openducktor/contracts";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
@@ -35,6 +35,7 @@ const createSnapshot = (): SettingsSnapshot => ({
     rules: [],
   },
   globalPromptOverrides: {},
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {
     repo: {
       workspaceId: "repo",
@@ -65,6 +66,8 @@ const createArgs = (
   promptValidationState: EMPTY_PROMPT_VALIDATION_STATE,
   hasReusablePromptValidationErrors: false,
   reusablePromptValidationErrorCount: 0,
+  hasRuntimeAvailabilityErrors: false,
+  runtimeAvailabilityErrorCount: 0,
   hasRepoScriptValidationErrors: false,
   repoScriptValidationErrorCount: 0,
   invalidRepoPathsWithDevServerErrors: [],
@@ -128,6 +131,30 @@ describe("useSettingsModalSaveOrchestration", () => {
 
     expect(didSave).toBe(false);
     expect(harness.getLatest().saveError).toBe("Fix 2 prompt placeholder errors before saving.");
+    expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
+
+    await harness.unmount();
+  });
+
+  test("blocks disabled runtime selections before persistence", async () => {
+    const saveSettingsSnapshot = mock(async () => {});
+    const harness = createHookHarness(
+      createArgs({
+        hasRuntimeAvailabilityErrors: true,
+        runtimeAvailabilityErrorCount: 2,
+        saveSettingsSnapshot,
+      }),
+    );
+
+    await harness.mount();
+
+    let didSave = true;
+    await harness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(false);
+    expect(harness.getLatest().saveError).toBe("Fix 2 disabled runtime selections before saving.");
     expect(saveSettingsSnapshot).toHaveBeenCalledTimes(0);
 
     await harness.unmount();

--- a/packages/frontend/src/components/features/settings/use-settings-modal-save-orchestration.ts
+++ b/packages/frontend/src/components/features/settings/use-settings-modal-save-orchestration.ts
@@ -7,6 +7,7 @@ import {
   buildPromptValidationSaveError,
   buildRepoScriptValidationSaveError,
   buildReusablePromptValidationSaveError,
+  buildRuntimeAvailabilitySaveError,
   hasAnyDirtySections,
   hasSameSaveReadyGlobalGitConfig,
   isGlobalGitOnlySave,
@@ -24,6 +25,8 @@ type UseSettingsModalSaveOrchestrationArgs = {
   promptValidationState: PromptValidationState;
   hasReusablePromptValidationErrors: boolean;
   reusablePromptValidationErrorCount: number;
+  hasRuntimeAvailabilityErrors: boolean;
+  runtimeAvailabilityErrorCount: number;
   hasRepoScriptValidationErrors: boolean;
   repoScriptValidationErrorCount: number;
   invalidRepoPathsWithDevServerErrors: string[];
@@ -50,6 +53,8 @@ export const useSettingsModalSaveOrchestration = ({
   promptValidationState,
   hasReusablePromptValidationErrors,
   reusablePromptValidationErrorCount,
+  hasRuntimeAvailabilityErrors,
+  runtimeAvailabilityErrorCount,
   hasRepoScriptValidationErrors,
   repoScriptValidationErrorCount,
   invalidRepoPathsWithDevServerErrors,
@@ -114,6 +119,15 @@ export const useSettingsModalSaveOrchestration = ({
       return false;
     }
 
+    if (hasRuntimeAvailabilityErrors) {
+      const reason = buildRuntimeAvailabilitySaveError(runtimeAvailabilityErrorCount);
+      setSaveError(reason);
+      toast.error("Cannot save settings", {
+        description: reason,
+      });
+      return false;
+    }
+
     if (hasRepoScriptValidationErrors) {
       setHasAttemptedRepoScriptSubmit(true);
       const reason = buildRepoScriptValidationSaveError({
@@ -169,11 +183,13 @@ export const useSettingsModalSaveOrchestration = ({
     reusablePromptValidationErrorCount,
     hasPromptValidationErrors,
     hasReusablePromptValidationErrors,
+    hasRuntimeAvailabilityErrors,
     hasRepoScriptValidationErrors,
     invalidRepoPathsWithDevServerErrors,
     loadedSnapshot,
     promptValidationState.totalErrorCount,
     repoScriptValidationErrorCount,
+    runtimeAvailabilityErrorCount,
     saveGlobalGitConfig,
     saveSettingsSnapshot,
     selectedWorkspaceId,

--- a/packages/frontend/src/features/session-start/use-session-start-modal-coordinator.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-coordinator.ts
@@ -1,7 +1,7 @@
 import type { GitBranch } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentRole } from "@openducktor/core";
 import { useCallback } from "react";
-import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
+import { useRuntimeAvailabilityContext } from "@/state/app-state-contexts";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { ActiveWorkspace, RepoSettingsInput } from "@/types/state-slices";
 import { orderStartModesForDisplay } from "./session-start-display";
@@ -76,7 +76,7 @@ export function useSessionStartModalCoordinator({
   repoSettings,
   initialCatalog,
 }: UseSessionStartModalCoordinatorArgs): UseSessionStartModalCoordinatorResult {
-  const { runtimeDefinitions } = useRuntimeDefinitionsContext();
+  const { runtimeDefinitions } = useRuntimeAvailabilityContext();
   const { openStartModal: openRawStartModal, ...modalState } = useSessionStartModalState({
     activeWorkspace,
     branches,

--- a/packages/frontend/src/features/session-start/use-session-start-modal-coordinator.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-coordinator.ts
@@ -76,7 +76,7 @@ export function useSessionStartModalCoordinator({
   repoSettings,
   initialCatalog,
 }: UseSessionStartModalCoordinatorArgs): UseSessionStartModalCoordinatorResult {
-  const { runtimeDefinitions } = useRuntimeAvailabilityContext();
+  const { availableRuntimeDefinitions: runtimeDefinitions } = useRuntimeAvailabilityContext();
   const { openStartModal: openRawStartModal, ...modalState } = useSessionStartModalState({
     activeWorkspace,
     branches,

--- a/packages/frontend/src/lib/agent-runtime.test.ts
+++ b/packages/frontend/src/lib/agent-runtime.test.ts
@@ -13,7 +13,6 @@ import {
   getAvailableRuntimeDefinitionsForStartMode,
   getMissingMandatoryRuntimeCapabilities,
   getRuntimeDescriptorCapabilityConfigErrors,
-  resolveAvailableRuntimeKindSelection,
   resolveRuntimeKindSelection,
   resolveRuntimeKindSelectionState,
   runtimeSupportsCapability,
@@ -369,17 +368,6 @@ describe("agent-runtime capability policies", () => {
         },
       }).map((definition) => definition.kind),
     ).toEqual(["codex"]);
-
-    expect(
-      resolveAvailableRuntimeKindSelection({
-        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
-        agentRuntimes: {
-          opencode: { enabled: true },
-          codex: { enabled: false },
-        },
-        requestedRuntimeKind: "codex",
-      }),
-    ).toBeNull();
 
     expect(
       getAvailableRuntimeDefinitionsForStartMode({

--- a/packages/frontend/src/lib/agent-runtime.test.ts
+++ b/packages/frontend/src/lib/agent-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { RuntimeDescriptor } from "@openducktor/contracts";
 import {
+  CODEX_RUNTIME_DESCRIPTOR,
   OPENCODE_RUNTIME_DESCRIPTOR,
   requiredRuntimeSupportedScopes,
 } from "@openducktor/contracts";
@@ -8,8 +9,11 @@ import {
   filterRuntimeDefinitionsForDefaultSelection,
   filterRuntimeDefinitionsForRole,
   filterRuntimeDefinitionsForStartMode,
+  getAvailableRuntimeDefinitions,
+  getAvailableRuntimeDefinitionsForStartMode,
   getMissingMandatoryRuntimeCapabilities,
   getRuntimeDescriptorCapabilityConfigErrors,
+  resolveAvailableRuntimeKindSelection,
   resolveRuntimeKindSelection,
   resolveRuntimeKindSelectionState,
   runtimeSupportsCapability,
@@ -353,6 +357,40 @@ describe("agent-runtime capability policies", () => {
     expect(filterRuntimeDefinitionsForStartMode([reuseRuntime, forkRuntime], "fork")).toEqual([
       forkRuntime,
     ]);
+  });
+
+  test("resolves available runtimes from enabled runtime settings", () => {
+    expect(
+      getAvailableRuntimeDefinitions({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
+        agentRuntimes: {
+          opencode: { enabled: false },
+          codex: { enabled: true },
+        },
+      }).map((definition) => definition.kind),
+    ).toEqual(["codex"]);
+
+    expect(
+      resolveAvailableRuntimeKindSelection({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
+        agentRuntimes: {
+          opencode: { enabled: true },
+          codex: { enabled: false },
+        },
+        requestedRuntimeKind: "codex",
+      }),
+    ).toBeNull();
+
+    expect(
+      getAvailableRuntimeDefinitionsForStartMode({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
+        agentRuntimes: {
+          opencode: { enabled: true },
+          codex: { enabled: false },
+        },
+        startMode: "fresh",
+      }).map((definition) => definition.kind),
+    ).toEqual(["opencode"]);
   });
 
   test("reports incompatible runtime definitions with runtime-specific context", () => {

--- a/packages/frontend/src/lib/agent-runtime.ts
+++ b/packages/frontend/src/lib/agent-runtime.ts
@@ -40,6 +40,16 @@ export const filterEnabledRuntimeDefinitions = (
 ): RuntimeDescriptor[] =>
   runtimeDefinitions.filter((definition) => isRuntimeEnabled(agentRuntimes, definition.kind));
 
+export const getAvailableRuntimeDefinitions = ({
+  runtimeDefinitions,
+  agentRuntimes,
+}: {
+  runtimeDefinitions: RuntimeDescriptor[];
+  agentRuntimes: AgentRuntimes;
+}): RuntimeDescriptor[] => {
+  return filterEnabledRuntimeDefinitions(runtimeDefinitions, agentRuntimes);
+};
+
 export const findRuntimeDefinition = (
   runtimeDefinitions: RuntimeDescriptor[],
   runtimeKind: RuntimeKind,
@@ -109,6 +119,25 @@ export const resolveRuntimeKindSelection = (
   return resolveRuntimeKindSelectionState(input).runtimeKind;
 };
 
+export const resolveAvailableRuntimeKindSelection = ({
+  runtimeDefinitions,
+  agentRuntimes,
+  requestedRuntimeKind,
+}: {
+  runtimeDefinitions: RuntimeDescriptor[];
+  agentRuntimes: AgentRuntimes;
+  requestedRuntimeKind: RuntimeKind | null;
+}): RuntimeKind | null => {
+  const availableRuntimeDefinitions = getAvailableRuntimeDefinitions({
+    runtimeDefinitions,
+    agentRuntimes,
+  });
+  return resolveRuntimeKindSelection({
+    runtimeDefinitions: availableRuntimeDefinitions,
+    requestedRuntimeKind,
+  });
+};
+
 export const runtimeLabelFor = ({
   runtimeDefinitions,
   runtimeKind,
@@ -131,6 +160,21 @@ export const filterRuntimeDefinitionsForStartMode = (
   startMode: AgentSessionStartMode,
 ): RuntimeDescriptor[] => {
   return runtimeDefinitions.filter((definition) => runtimeSupportsStartMode(definition, startMode));
+};
+
+export const getAvailableRuntimeDefinitionsForStartMode = ({
+  runtimeDefinitions,
+  agentRuntimes,
+  startMode,
+}: {
+  runtimeDefinitions: RuntimeDescriptor[];
+  agentRuntimes: AgentRuntimes;
+  startMode: AgentSessionStartMode;
+}): RuntimeDescriptor[] => {
+  return filterRuntimeDefinitionsForStartMode(
+    getAvailableRuntimeDefinitions({ runtimeDefinitions, agentRuntimes }),
+    startMode,
+  );
 };
 
 export const runtimeSupportsCapability = (

--- a/packages/frontend/src/lib/agent-runtime.ts
+++ b/packages/frontend/src/lib/agent-runtime.ts
@@ -119,25 +119,6 @@ export const resolveRuntimeKindSelection = (
   return resolveRuntimeKindSelectionState(input).runtimeKind;
 };
 
-export const resolveAvailableRuntimeKindSelection = ({
-  runtimeDefinitions,
-  agentRuntimes,
-  requestedRuntimeKind,
-}: {
-  runtimeDefinitions: RuntimeDescriptor[];
-  agentRuntimes: AgentRuntimes;
-  requestedRuntimeKind: RuntimeKind | null;
-}): RuntimeKind | null => {
-  const availableRuntimeDefinitions = getAvailableRuntimeDefinitions({
-    runtimeDefinitions,
-    agentRuntimes,
-  });
-  return resolveRuntimeKindSelection({
-    runtimeDefinitions: availableRuntimeDefinitions,
-    requestedRuntimeKind,
-  });
-};
-
 export const runtimeLabelFor = ({
   runtimeDefinitions,
   runtimeKind,

--- a/packages/frontend/src/pages/agents/agent-studio-test-utils.tsx
+++ b/packages/frontend/src/pages/agents/agent-studio-test-utils.tsx
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_AGENT_RUNTIMES,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type RuntimeDescriptor,
   type TaskCard,
@@ -9,6 +10,7 @@ import {
   type PropsWithChildren,
   type ReactElement,
 } from "react";
+import { getAvailableRuntimeDefinitions } from "@/lib/agent-runtime";
 import { QueryProvider } from "@/lib/query-provider";
 import { ChecksOperationsContext, RuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
@@ -101,11 +103,17 @@ export const createRuntimeDefinitionsContextValue = (
   overrides: Partial<RuntimeDefinitionsContextValue> = {},
 ): RuntimeDefinitionsContextValue => {
   const defaultRuntimeDefinitions = createDefaultRuntimeDefinitions();
+  const runtimeDefinitions = overrides.runtimeDefinitions
+    ? overrides.runtimeDefinitions.map(cloneRuntimeDescriptor)
+    : defaultRuntimeDefinitions;
+  const agentRuntimes = overrides.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES;
 
   return {
-    runtimeDefinitions: overrides.runtimeDefinitions
-      ? overrides.runtimeDefinitions.map(cloneRuntimeDescriptor)
-      : defaultRuntimeDefinitions,
+    runtimeDefinitions,
+    agentRuntimes,
+    availableRuntimeDefinitions:
+      overrides.availableRuntimeDefinitions ??
+      getAvailableRuntimeDefinitions({ runtimeDefinitions, agentRuntimes }),
     isLoadingRuntimeDefinitions: overrides.isLoadingRuntimeDefinitions ?? false,
     runtimeDefinitionsError: overrides.runtimeDefinitionsError ?? null,
     refreshRuntimeDefinitions:

--- a/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.test.tsx
+++ b/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR, type RuntimeDescriptor } from "@openducktor/contracts";
+import {
+  DEFAULT_AGENT_RUNTIMES,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type RuntimeDescriptor,
+} from "@openducktor/contracts";
 import type { AgentFileSearchResult, AgentModelCatalog } from "@openducktor/core";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
 import { QueryProvider } from "@/lib/query-provider";
@@ -153,6 +157,8 @@ const createHookHarness = (
   const runtimeDefinitions = options.runtimeDefinitions ?? [OPENCODE_RUNTIME_DESCRIPTOR];
   const runtimeDefinitionsContext = {
     runtimeDefinitions,
+    availableRuntimeDefinitions: runtimeDefinitions,
+    agentRuntimes: DEFAULT_AGENT_RUNTIMES,
     isLoadingRuntimeDefinitions: false,
     runtimeDefinitionsError: null,
     refreshRuntimeDefinitions: async () => runtimeDefinitions,

--- a/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.test.tsx
+++ b/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.test.tsx
@@ -152,12 +152,16 @@ const createActiveSession = (overrides = {}) =>
 
 const createHookHarness = (
   initialProps: HookArgs,
-  options: { runtimeDefinitions?: RuntimeDescriptor[] } = {},
+  options: {
+    runtimeDefinitions?: RuntimeDescriptor[];
+    availableRuntimeDefinitions?: RuntimeDescriptor[];
+  } = {},
 ) => {
   const runtimeDefinitions = options.runtimeDefinitions ?? [OPENCODE_RUNTIME_DESCRIPTOR];
+  const availableRuntimeDefinitions = options.availableRuntimeDefinitions ?? runtimeDefinitions;
   const runtimeDefinitionsContext = {
     runtimeDefinitions,
-    availableRuntimeDefinitions: runtimeDefinitions,
+    availableRuntimeDefinitions,
     agentRuntimes: DEFAULT_AGENT_RUNTIMES,
     isLoadingRuntimeDefinitions: false,
     runtimeDefinitionsError: null,
@@ -471,6 +475,45 @@ describe("useAgentStudioChatComposer", () => {
         "opencode",
         "/repo/session-worktree",
         "",
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("keeps active session runtime capabilities when that runtime is disabled", async () => {
+    const readSessionFileSearch = mock(async () => FILE_SEARCH_RESULTS);
+    const activeSession = createActiveSession({
+      runtimeKind: "opencode",
+      runtimeRoute: { type: "stdio", identity: "runtime-stdio" },
+      workingDirectory: "/repo/session-worktree",
+    });
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+        readSessionFileSearch,
+      }),
+      {
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        availableRuntimeDefinitions: [],
+      },
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().supportsFileSearch).toBe(true);
+
+      let results: AgentFileSearchResult[] = [];
+      await harness.run(async (state) => {
+        results = await state.searchFiles("src");
+      });
+
+      expect(results).toEqual(FILE_SEARCH_RESULTS);
+      expect(readSessionFileSearch).toHaveBeenCalledWith(
+        "/repo",
+        "opencode",
+        "/repo/session-worktree",
+        "src",
       );
     } finally {
       await harness.unmount();

--- a/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.ts
+++ b/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.ts
@@ -109,7 +109,8 @@ export function useAgentStudioChatComposer({
 }: UseAgentStudioChatComposerArgs): AgentStudioChatComposerState {
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
   const {
-    runtimeDefinitions,
+    availableRuntimeDefinitions,
+    allRuntimeDefinitions,
     loadRepoRuntimeCatalog,
     loadRepoRuntimeSlashCommands,
     loadRepoRuntimeFileSearch,
@@ -145,8 +146,13 @@ export function useAgentStudioChatComposer({
     if (!runtimeKind) {
       return null;
     }
-    return findRuntimeDefinition(runtimeDefinitions, runtimeKind) ? selection : null;
-  }, [repoSettings?.agentDefaults, repoSettings?.defaultRuntimeKind, role, runtimeDefinitions]);
+    return findRuntimeDefinition(availableRuntimeDefinitions, runtimeKind) ? selection : null;
+  }, [
+    availableRuntimeDefinitions,
+    repoSettings?.agentDefaults,
+    repoSettings?.defaultRuntimeKind,
+    role,
+  ]);
   const {
     draftSelection,
     isAwaitingRepoSettingsForWorkspaceRepoPath,
@@ -160,7 +166,7 @@ export function useAgentStudioChatComposer({
       roleDefaultSelection,
       repoDefaultRuntimeKind:
         repoSettings?.defaultRuntimeKind &&
-        findRuntimeDefinition(runtimeDefinitions, repoSettings.defaultRuntimeKind)
+        findRuntimeDefinition(availableRuntimeDefinitions, repoSettings.defaultRuntimeKind)
           ? repoSettings.defaultRuntimeKind
           : null,
     });
@@ -169,7 +175,7 @@ export function useAgentStudioChatComposer({
     draftSelection,
     repoSettings?.defaultRuntimeKind,
     roleDefaultSelection,
-    runtimeDefinitions,
+    availableRuntimeDefinitions,
   ]);
   const activeSessionRuntimeQueryState = useMemo(
     () =>
@@ -194,20 +200,35 @@ export function useAgentStudioChatComposer({
   const { runtimeSupportsSlashCommands, supportsFileSearch } = useMemo(
     () =>
       resolveRuntimePromptInputSupport({
-        runtimeDefinitions,
+        runtimeDefinitions: hasActiveSession ? allRuntimeDefinitions : availableRuntimeDefinitions,
         readyActiveSessionRuntimeKind: activeSessionRuntimeQueryInput?.runtimeKind ?? null,
         selectedRuntimeKind,
       }),
-    [activeSessionRuntimeQueryInput?.runtimeKind, selectedRuntimeKind, runtimeDefinitions],
+    [
+      activeSessionRuntimeQueryInput?.runtimeKind,
+      allRuntimeDefinitions,
+      availableRuntimeDefinitions,
+      hasActiveSession,
+      selectedRuntimeKind,
+    ],
   );
   const supportsProfiles = useMemo(() => {
     const runtimeKind = hasActiveSession ? activeSessionRuntimeKind : selectedRuntimeKind;
     if (!runtimeKind) {
       return true;
     }
+    const runtimeDefinitions = hasActiveSession
+      ? allRuntimeDefinitions
+      : availableRuntimeDefinitions;
     const definition = findRuntimeDefinition(runtimeDefinitions, runtimeKind);
     return definition?.capabilities.optionalSurfaces.supportsProfiles ?? false;
-  }, [activeSessionRuntimeKind, hasActiveSession, runtimeDefinitions, selectedRuntimeKind]);
+  }, [
+    activeSessionRuntimeKind,
+    allRuntimeDefinitions,
+    availableRuntimeDefinitions,
+    hasActiveSession,
+    selectedRuntimeKind,
+  ]);
 
   const composerCatalogQuery = useQuery({
     ...repoRuntimeCatalogQueryOptions(

--- a/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.ts
+++ b/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.ts
@@ -30,7 +30,7 @@ import { resolveActiveSessionChatComposerContext } from "@/features/agent-chat-c
 import { pickDefaultVisibleSelectionForCatalog } from "@/features/session-start";
 import { DEFAULT_RUNTIME_KIND, findRuntimeDefinition } from "@/lib/agent-runtime";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
-import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
+import { useRuntimeAvailabilityContext } from "@/state/app-state-contexts";
 import { resolveAttachedSessionRuntimeQueryState } from "@/state/operations/agent-orchestrator/support/session-runtime-query-state";
 import { repoRuntimeCatalogQueryOptions } from "@/state/queries/runtime-catalog";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -113,7 +113,7 @@ export function useAgentStudioChatComposer({
     loadRepoRuntimeCatalog,
     loadRepoRuntimeSlashCommands,
     loadRepoRuntimeFileSearch,
-  } = useRuntimeDefinitionsContext();
+  } = useRuntimeAvailabilityContext();
   const queryClient = useQueryClient();
   const loadCatalogForRepo = loadCatalog ?? loadRepoRuntimeCatalog;
   const loadSlashCommandsForRepo = loadSlashCommands ?? loadRepoRuntimeSlashCommands;
@@ -134,11 +134,19 @@ export function useAgentStudioChatComposer({
   const activeSessionMessages = activeSessionChatComposerContext.messages;
   const hasActiveSession = activeSessionChatComposerContext.hasActiveSession;
   const roleDefaultSelection = useMemo<AgentModelSelection | null>(() => {
-    return toRoleDefaultModelSelection(
+    const selection = toRoleDefaultModelSelection(
       repoSettings?.agentDefaults[role],
       repoSettings?.defaultRuntimeKind,
     );
-  }, [repoSettings?.agentDefaults, repoSettings?.defaultRuntimeKind, role]);
+    if (!selection) {
+      return null;
+    }
+    const runtimeKind = selection.runtimeKind;
+    if (!runtimeKind) {
+      return null;
+    }
+    return findRuntimeDefinition(runtimeDefinitions, runtimeKind) ? selection : null;
+  }, [repoSettings?.agentDefaults, repoSettings?.defaultRuntimeKind, role, runtimeDefinitions]);
   const {
     draftSelection,
     isAwaitingRepoSettingsForWorkspaceRepoPath,
@@ -150,13 +158,18 @@ export function useAgentStudioChatComposer({
       activeSessionSelectedModel,
       draftSelection,
       roleDefaultSelection,
-      repoDefaultRuntimeKind: repoSettings?.defaultRuntimeKind ?? null,
+      repoDefaultRuntimeKind:
+        repoSettings?.defaultRuntimeKind &&
+        findRuntimeDefinition(runtimeDefinitions, repoSettings.defaultRuntimeKind)
+          ? repoSettings.defaultRuntimeKind
+          : null,
     });
   }, [
     activeSessionSelectedModel,
     draftSelection,
     repoSettings?.defaultRuntimeKind,
     roleDefaultSelection,
+    runtimeDefinitions,
   ]);
   const activeSessionRuntimeQueryState = useMemo(
     () =>

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -19,7 +19,7 @@ import { HumanReviewFeedbackModal } from "@/features/human-review-feedback/human
 import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import {
   useChecksOperationsContext,
-  useRuntimeDefinitionsContext,
+  useRuntimeAvailabilityContext,
 } from "@/state/app-state-contexts";
 import {
   useAgentOperations,
@@ -140,7 +140,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
   const { activeBranch, branches, activeWorkspace } = useWorkspaceState();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
   const { runtimeDefinitions, isLoadingRuntimeDefinitions, runtimeDefinitionsError } =
-    useRuntimeDefinitionsContext();
+    useRuntimeAvailabilityContext();
   const { refreshRepoRuntimeHealthForRepo, hasCachedRepoRuntimeHealth } =
     useChecksOperationsContext();
   const { runtimeHealthByRuntime, isLoadingChecks, refreshChecks } = useChecksState();

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -139,8 +139,11 @@ const noopOpenSession = (
 export function useAgentsPageShellModel(): AgentsPageShellModel {
   const { activeBranch, branches, activeWorkspace } = useWorkspaceState();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
-  const { runtimeDefinitions, isLoadingRuntimeDefinitions, runtimeDefinitionsError } =
-    useRuntimeAvailabilityContext();
+  const {
+    availableRuntimeDefinitions: runtimeDefinitions,
+    isLoadingRuntimeDefinitions,
+    runtimeDefinitionsError,
+  } = useRuntimeAvailabilityContext();
   const { refreshRepoRuntimeHealthForRepo, hasCachedRepoRuntimeHealth } =
     useChecksOperationsContext();
   const { runtimeHealthByRuntime, isLoadingChecks, refreshChecks } = useChecksState();

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-settings.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-settings.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type SettingsSnapshot } from "@openducktor/contracts";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import type { ActiveWorkspace } from "@/types/state-slices";
 import {
@@ -30,6 +30,7 @@ const hostMock = {
       autopilot: {
         rules: [],
       },
+      agentRuntimes: DEFAULT_AGENT_RUNTIMES,
       workspaces: {},
       globalPromptOverrides: {},
     }),
@@ -91,6 +92,7 @@ const createSettingsSnapshot = (
     autopilot: {
       rules: [],
     },
+    agentRuntimes: DEFAULT_AGENT_RUNTIMES,
     workspaces: {},
     globalPromptOverrides: {},
     reusablePrompts: [

--- a/packages/frontend/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { DEFAULT_AGENT_RUNTIMES } from "@openducktor/contracts";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { host } from "@/state/operations/host";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
@@ -119,6 +120,7 @@ beforeEach(() => {
     autopilot: {
       rules: [],
     },
+    agentRuntimes: DEFAULT_AGENT_RUNTIMES,
     workspaces: {},
     globalPromptOverrides: {},
   });

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-actions.attachments.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-actions.attachments.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
 import {
   type AgentChatComposerDraft,
@@ -74,6 +74,8 @@ const createHookHarness = (initialProps: HookArgs) => {
           {
             value: {
               runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+              availableRuntimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+              agentRuntimes: DEFAULT_AGENT_RUNTIMES,
               isLoadingRuntimeDefinitions: false,
               runtimeDefinitionsError: null,
               refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
 import {
   type AgentChatComposerDraft,
@@ -129,6 +129,8 @@ const createHookHarness = (initialProps: HookArgs) => {
           {
             value: {
               runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, QUEUED_RUNTIME_DESCRIPTOR],
+              availableRuntimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, QUEUED_RUNTIME_DESCRIPTOR],
+              agentRuntimes: DEFAULT_AGENT_RUNTIMES,
               isLoadingRuntimeDefinitions: false,
               runtimeDefinitionsError: null,
               refreshRuntimeDefinitions: async () => [
@@ -284,6 +286,7 @@ describe("useAgentStudioSessionActions", () => {
       autopilot: {
         rules: [],
       },
+      agentRuntimes: DEFAULT_AGENT_RUNTIMES,
       workspaces: {},
       globalPromptOverrides: {},
     });

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.kickoff.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.kickoff.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
 import { QueryProvider } from "@/lib/query-provider";
 import { ChecksOperationsContext, RuntimeDefinitionsContext } from "@/state/app-state-contexts";
@@ -57,6 +57,8 @@ const createHookHarness = (initialProps: HookArgs) => {
           {
             value: {
               runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+              availableRuntimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+              agentRuntimes: DEFAULT_AGENT_RUNTIMES,
               isLoadingRuntimeDefinitions: false,
               runtimeDefinitionsError: null,
               refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
 import * as sonnerActual from "sonner";
@@ -124,6 +124,8 @@ const createInternalModalHookHarness = (initialProps: HookArgs) => {
           {
             value: {
               runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+              availableRuntimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+              agentRuntimes: DEFAULT_AGENT_RUNTIMES,
               isLoadingRuntimeDefinitions: false,
               runtimeDefinitionsError: null,
               refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],
@@ -330,6 +332,7 @@ describe("useAgentStudioSessionStartFlow", () => {
       autopilot: {
         rules: [],
       },
+      agentRuntimes: DEFAULT_AGENT_RUNTIMES,
       workspaces: {},
       globalPromptOverrides: {},
     });

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+  DEFAULT_AGENT_RUNTIMES,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type RepoConfig,
   type RepoPromptOverrides,
@@ -250,6 +251,8 @@ const renderPage = async (options?: { waitForKanbanReady?: boolean }): Promise<R
       <RuntimeDefinitionsContext.Provider
         value={{
           runtimeDefinitions: [...RUNTIME_DEFINITIONS],
+          availableRuntimeDefinitions: [...RUNTIME_DEFINITIONS],
+          agentRuntimes: DEFAULT_AGENT_RUNTIMES,
           isLoadingRuntimeDefinitions: false,
           runtimeDefinitionsError: null,
           refreshRuntimeDefinitions: async () => [...RUNTIME_DEFINITIONS],

--- a/packages/frontend/src/pages/kanban/use-kanban-session-start-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-kanban-session-start-flow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
 import { toast } from "sonner";
@@ -100,6 +100,8 @@ const createHookHarness = (initialProps: HookArgs) => {
           {
             value: {
               runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+              availableRuntimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+              agentRuntimes: DEFAULT_AGENT_RUNTIMES,
               isLoadingRuntimeDefinitions: false,
               runtimeDefinitionsError: null,
               refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],

--- a/packages/frontend/src/state/app-state-context-values.test.ts
+++ b/packages/frontend/src/state/app-state-context-values.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { WorkspaceRecord } from "@openducktor/contracts";
+import { DEFAULT_AGENT_RUNTIMES, type WorkspaceRecord } from "@openducktor/contracts";
 import type {
   AgentStateContextValue,
   ChecksStateContextValue,
@@ -75,6 +75,7 @@ describe("app-state-context-values", () => {
         autopilot: {
           rules: [],
         },
+        agentRuntimes: DEFAULT_AGENT_RUNTIMES,
         workspaces: {},
         globalPromptOverrides: {},
       }),

--- a/packages/frontend/src/state/app-state-contexts.ts
+++ b/packages/frontend/src/state/app-state-contexts.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentRuntimes,
   BeadsCheck,
   RuntimeCheck,
   RuntimeDescriptor,
@@ -44,6 +45,8 @@ export type ActiveWorkspaceContextValue = {
 
 export type RuntimeDefinitionsContextValue = {
   runtimeDefinitions: RuntimeDescriptor[];
+  availableRuntimeDefinitions: RuntimeDescriptor[];
+  agentRuntimes: AgentRuntimes;
   isLoadingRuntimeDefinitions: boolean;
   runtimeDefinitionsError: string | null;
   refreshRuntimeDefinitions: () => Promise<RuntimeDescriptor[]>;
@@ -132,6 +135,19 @@ export const useChecksOperationsContext = (): ChecksOperationsContextValue =>
 
 export const useRuntimeDefinitionsContext = (): RuntimeDefinitionsContextValue =>
   useRequiredContext(RuntimeDefinitionsContext, "useRuntimeDefinitionsContext");
+
+export type RuntimeAvailabilityContextValue = RuntimeDefinitionsContextValue & {
+  allRuntimeDefinitions: RuntimeDescriptor[];
+};
+
+export const useRuntimeAvailabilityContext = (): RuntimeAvailabilityContextValue => {
+  const runtimeContext = useRuntimeDefinitionsContext();
+  return {
+    ...runtimeContext,
+    allRuntimeDefinitions: runtimeContext.runtimeDefinitions,
+    runtimeDefinitions: runtimeContext.availableRuntimeDefinitions,
+  };
+};
 
 export const useTaskDataContext = (): TaskDataContextValue =>
   useRequiredContext(TaskDataContext, "useTaskDataContext");

--- a/packages/frontend/src/state/app-state-contexts.ts
+++ b/packages/frontend/src/state/app-state-contexts.ts
@@ -11,7 +11,14 @@ import type {
   AgentModelCatalog,
   AgentSlashCommandCatalog,
 } from "@openducktor/core";
-import { type Context, createContext, type Dispatch, type SetStateAction, use } from "react";
+import {
+  type Context,
+  createContext,
+  type Dispatch,
+  type SetStateAction,
+  use,
+  useMemo,
+} from "react";
 import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
 import type {
   ActiveWorkspace,
@@ -136,17 +143,29 @@ export const useChecksOperationsContext = (): ChecksOperationsContextValue =>
 export const useRuntimeDefinitionsContext = (): RuntimeDefinitionsContextValue =>
   useRequiredContext(RuntimeDefinitionsContext, "useRuntimeDefinitionsContext");
 
-export type RuntimeAvailabilityContextValue = RuntimeDefinitionsContextValue & {
+export type RuntimeAvailabilityContextValue = Omit<
+  RuntimeDefinitionsContextValue,
+  "runtimeDefinitions"
+> & {
   allRuntimeDefinitions: RuntimeDescriptor[];
 };
 
 export const useRuntimeAvailabilityContext = (): RuntimeAvailabilityContextValue => {
   const runtimeContext = useRuntimeDefinitionsContext();
-  return {
-    ...runtimeContext,
-    allRuntimeDefinitions: runtimeContext.runtimeDefinitions,
-    runtimeDefinitions: runtimeContext.availableRuntimeDefinitions,
-  };
+  return useMemo(
+    () => ({
+      availableRuntimeDefinitions: runtimeContext.availableRuntimeDefinitions,
+      allRuntimeDefinitions: runtimeContext.runtimeDefinitions,
+      agentRuntimes: runtimeContext.agentRuntimes,
+      isLoadingRuntimeDefinitions: runtimeContext.isLoadingRuntimeDefinitions,
+      runtimeDefinitionsError: runtimeContext.runtimeDefinitionsError,
+      refreshRuntimeDefinitions: runtimeContext.refreshRuntimeDefinitions,
+      loadRepoRuntimeCatalog: runtimeContext.loadRepoRuntimeCatalog,
+      loadRepoRuntimeSlashCommands: runtimeContext.loadRepoRuntimeSlashCommands,
+      loadRepoRuntimeFileSearch: runtimeContext.loadRepoRuntimeFileSearch,
+    }),
+    [runtimeContext],
+  );
 };
 
 export const useTaskDataContext = (): TaskDataContextValue =>

--- a/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   agentPromptTemplateIdValues,
   type BuildSessionBootstrap,
+  DEFAULT_AGENT_RUNTIMES,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type RepoConfig,
   type RuntimeInstanceSummary,
@@ -70,6 +71,7 @@ const createPromptOverrideSettingsSnapshot = (
   reusablePrompts: [],
   kanban: { doneVisibleDays: 1, emptyColumnDisplay: "show" },
   autopilot: { rules: [] },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {},
   globalPromptOverrides,
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import {
   type AgentSessionRecord,
+  DEFAULT_AGENT_RUNTIMES,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type RuntimeInstanceSummary,
   type TaskCard,
@@ -363,6 +364,7 @@ describe("use-agent-orchestrator-operations", () => {
       autopilot: {
         rules: [],
       },
+      agentRuntimes: DEFAULT_AGENT_RUNTIMES,
       workspaces: {},
       globalPromptOverrides: {},
     });

--- a/packages/frontend/src/state/operations/shared/prompt-overrides.test.ts
+++ b/packages/frontend/src/state/operations/shared/prompt-overrides.test.ts
@@ -1,5 +1,9 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { RepoConfig, SettingsSnapshot } from "@openducktor/contracts";
+import {
+  DEFAULT_AGENT_RUNTIMES,
+  type RepoConfig,
+  type SettingsSnapshot,
+} from "@openducktor/contracts";
 import { clearAppQueryClient } from "@/lib/query-client";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 
@@ -35,6 +39,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
     defaultMergeMethod: "merge_commit",
   },
   general: { openAgentStudioTabOnBackgroundSessionStart: true },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {},
   chat: { showThinkingMessages: false },
   reusablePrompts: [],

--- a/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
-import { agentPromptTemplateIdValues, type SettingsSnapshot } from "@openducktor/contracts";
+import {
+  agentPromptTemplateIdValues,
+  DEFAULT_AGENT_RUNTIMES,
+  type SettingsSnapshot,
+} from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
 import { IsolatedQueryWrapper } from "@/test-utils/isolated-query-wrapper";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
@@ -84,6 +88,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
   autopilot: {
     rules: [],
   },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {},
   globalPromptOverrides: {},
 });
@@ -590,6 +595,7 @@ describe("use-repo-settings-operations", () => {
     const workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
     const normalizedSnapshot: SettingsSnapshot = {
       ...createSettingsSnapshot(),
+      agentRuntimes: DEFAULT_AGENT_RUNTIMES,
       workspaces: {
         "repo-a": {
           ...createRepoConfig(),
@@ -615,6 +621,7 @@ describe("use-repo-settings-operations", () => {
     });
     const snapshot: SettingsSnapshot = {
       ...createSettingsSnapshot(),
+      agentRuntimes: DEFAULT_AGENT_RUNTIMES,
       workspaces: {
         "repo-a": {
           ...createRepoConfig(),
@@ -698,6 +705,7 @@ describe("use-repo-settings-operations", () => {
       autopilot: {
         rules: [],
       },
+      agentRuntimes: DEFAULT_AGENT_RUNTIMES,
       workspaces: {
         "repo-a": {
           workspaceId: "repo-a",
@@ -727,6 +735,7 @@ describe("use-repo-settings-operations", () => {
       expect(forwardedSnapshot).toBeDefined();
       const parsedForwarded = forwardedSnapshot as {
         globalPromptOverrides: Record<string, unknown>;
+        agentRuntimes: unknown;
         workspaces: Record<string, { promptOverrides: Record<string, unknown> }>;
       };
       expect(Object.keys(parsedForwarded.globalPromptOverrides).sort()).toEqual(

--- a/packages/frontend/src/state/operations/workspace/use-workspace-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-operations.test.tsx
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import type { SettingsSnapshot, WorkspaceRecord } from "@openducktor/contracts";
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import {
+  DEFAULT_AGENT_RUNTIMES,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type SettingsSnapshot,
+  type WorkspaceRecord,
+} from "@openducktor/contracts";
 import { useQuery } from "@tanstack/react-query";
 import { render, waitFor } from "@testing-library/react";
 import { act, createElement, type PropsWithChildren, useEffect, useRef, useState } from "react";
@@ -289,6 +293,7 @@ const settingsSnapshot = (repoPaths: string[]): SettingsSnapshot => ({
   autopilot: {
     rules: [],
   },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: Object.fromEntries(
     repoPaths.map((repoPath) => [
       repoPath.replace(/^\//, "").replaceAll("/", "-") || "repo",

--- a/packages/frontend/src/state/providers/app-runtime-provider.test.tsx
+++ b/packages/frontend/src/state/providers/app-runtime-provider.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  DEFAULT_AGENT_RUNTIMES,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type SettingsSnapshot,
+} from "@openducktor/contracts";
+import { createElement, type PropsWithChildren, type ReactElement } from "react";
+import { QueryProvider } from "@/lib/query-provider";
+import { createHookHarness } from "@/test-utils/react-hook-harness";
+import { useRuntimeDefinitionsContext } from "../app-state-contexts";
+import { host } from "../operations/host";
+import { AppRuntimeProvider } from "./app-runtime-provider";
+
+const createSettingsSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  general: {
+    openAgentStudioTabOnBackgroundSessionStart: true,
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  reusablePrompts: [],
+  kanban: {
+    doneVisibleDays: 1,
+    emptyColumnDisplay: "show",
+  },
+  autopilot: {
+    rules: [],
+  },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
+  workspaces: {},
+  globalPromptOverrides: {},
+});
+
+const createWrapper = ({ children }: PropsWithChildren): ReactElement =>
+  createElement(
+    QueryProvider,
+    { useIsolatedClient: true },
+    createElement(
+      AppRuntimeProvider,
+      {
+        loadRepoRuntimeCatalog: async () => {
+          throw new Error("catalog loader not configured");
+        },
+        loadRepoRuntimeSlashCommands: async () => ({ commands: [] }),
+        loadRepoRuntimeFileSearch: async () => [],
+      },
+      children,
+    ),
+  );
+
+describe("AppRuntimeProvider", () => {
+  test("surfaces settings snapshot failures as runtime availability errors", async () => {
+    const originalRuntimeDefinitionsList = host.runtimeDefinitionsList;
+    const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
+    host.runtimeDefinitionsList = mock(async () => [OPENCODE_RUNTIME_DESCRIPTOR]) as never;
+    host.workspaceGetSettingsSnapshot = mock(async () => {
+      throw new Error("settings unavailable");
+    }) as never;
+
+    const harness = createHookHarness(() => useRuntimeDefinitionsContext(), undefined, {
+      wrapper: createWrapper,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (state) =>
+          state.runtimeDefinitionsError === "Failed to load runtime settings: settings unavailable",
+      );
+
+      const state = harness.getLatest();
+      expect(state.runtimeDefinitions).toEqual([OPENCODE_RUNTIME_DESCRIPTOR]);
+      expect(state.availableRuntimeDefinitions).toEqual([]);
+    } finally {
+      await harness.unmount();
+      host.runtimeDefinitionsList = originalRuntimeDefinitionsList;
+      host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+    }
+  });
+
+  test("publishes available runtime definitions from runtime settings", async () => {
+    const originalRuntimeDefinitionsList = host.runtimeDefinitionsList;
+    const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
+    host.runtimeDefinitionsList = mock(async () => [OPENCODE_RUNTIME_DESCRIPTOR]) as never;
+    host.workspaceGetSettingsSnapshot = mock(async () => createSettingsSnapshot()) as never;
+
+    const harness = createHookHarness(() => useRuntimeDefinitionsContext(), undefined, {
+      wrapper: createWrapper,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.availableRuntimeDefinitions.length === 1);
+
+      expect(harness.getLatest().runtimeDefinitionsError).toBeNull();
+      expect(harness.getLatest().availableRuntimeDefinitions).toEqual([
+        OPENCODE_RUNTIME_DESCRIPTOR,
+      ]);
+    } finally {
+      await harness.unmount();
+      host.runtimeDefinitionsList = originalRuntimeDefinitionsList;
+      host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+    }
+  });
+});

--- a/packages/frontend/src/state/providers/app-runtime-provider.tsx
+++ b/packages/frontend/src/state/providers/app-runtime-provider.tsx
@@ -52,9 +52,11 @@ export function AppRuntimeProvider({
     isPending: isLoadingRuntimeDefinitions,
     refetch,
   } = useQuery(runtimeDefinitionsQueryOptions());
-  const { data: settingsSnapshot, isPending: isLoadingSettingsSnapshot } = useQuery(
-    settingsSnapshotQueryOptions(),
-  );
+  const {
+    data: settingsSnapshot,
+    error: settingsSnapshotError,
+    isPending: isLoadingSettingsSnapshot,
+  } = useQuery(settingsSnapshotQueryOptions());
 
   const activeWorkspaceValue = useMemo<ActiveWorkspaceContextValue>(
     () => ({
@@ -64,7 +66,11 @@ export function AppRuntimeProvider({
     [activeWorkspace],
   );
 
-  const runtimeDefinitionsError = error ? errorMessage(error) : null;
+  const runtimeDefinitionsError = error
+    ? errorMessage(error)
+    : settingsSnapshotError
+      ? `Failed to load runtime settings: ${errorMessage(settingsSnapshotError)}`
+      : null;
   const agentRuntimes = settingsSnapshot?.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES;
   const availableRuntimeDefinitions = useMemo(
     () =>

--- a/packages/frontend/src/state/providers/app-runtime-provider.tsx
+++ b/packages/frontend/src/state/providers/app-runtime-provider.tsx
@@ -1,4 +1,8 @@
-import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
+import {
+  DEFAULT_AGENT_RUNTIMES,
+  type RuntimeDescriptor,
+  type RuntimeKind,
+} from "@openducktor/contracts";
 import type {
   AgentFileSearchResult,
   AgentModelCatalog,
@@ -6,6 +10,7 @@ import type {
 } from "@openducktor/core";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { type PropsWithChildren, type ReactElement, useMemo, useState } from "react";
+import { getAvailableRuntimeDefinitions } from "@/lib/agent-runtime";
 import { errorMessage } from "@/lib/errors";
 import {
   ActiveWorkspaceContext,
@@ -14,6 +19,7 @@ import {
   type RuntimeDefinitionsContextValue,
 } from "../app-state-contexts";
 import { runtimeDefinitionsQueryOptions, runtimeQueryKeys } from "../queries/runtime";
+import { settingsSnapshotQueryOptions } from "../queries/workspace";
 
 type AppRuntimeProviderProps = PropsWithChildren<{
   loadRepoRuntimeCatalog: (
@@ -46,6 +52,9 @@ export function AppRuntimeProvider({
     isPending: isLoadingRuntimeDefinitions,
     refetch,
   } = useQuery(runtimeDefinitionsQueryOptions());
+  const { data: settingsSnapshot, isPending: isLoadingSettingsSnapshot } = useQuery(
+    settingsSnapshotQueryOptions(),
+  );
 
   const activeWorkspaceValue = useMemo<ActiveWorkspaceContextValue>(
     () => ({
@@ -56,11 +65,19 @@ export function AppRuntimeProvider({
   );
 
   const runtimeDefinitionsError = error ? errorMessage(error) : null;
+  const agentRuntimes = settingsSnapshot?.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES;
+  const availableRuntimeDefinitions = useMemo(
+    () =>
+      settingsSnapshot ? getAvailableRuntimeDefinitions({ runtimeDefinitions, agentRuntimes }) : [],
+    [agentRuntimes, runtimeDefinitions, settingsSnapshot],
+  );
 
   const runtimeDefinitionsValue = useMemo<RuntimeDefinitionsContextValue>(
     () => ({
       runtimeDefinitions,
-      isLoadingRuntimeDefinitions,
+      availableRuntimeDefinitions,
+      agentRuntimes,
+      isLoadingRuntimeDefinitions: isLoadingRuntimeDefinitions || isLoadingSettingsSnapshot,
       runtimeDefinitionsError,
       refreshRuntimeDefinitions: async (): Promise<RuntimeDescriptor[]> => {
         await queryClient.invalidateQueries({
@@ -77,10 +94,13 @@ export function AppRuntimeProvider({
       loadRepoRuntimeFileSearch,
     }),
     [
+      agentRuntimes,
+      availableRuntimeDefinitions,
       loadRepoRuntimeCatalog,
       loadRepoRuntimeFileSearch,
       loadRepoRuntimeSlashCommands,
       isLoadingRuntimeDefinitions,
+      isLoadingSettingsSnapshot,
       queryClient,
       refetch,
       runtimeDefinitions,

--- a/packages/frontend/src/state/providers/checks-state-provider.tsx
+++ b/packages/frontend/src/state/providers/checks-state-provider.tsx
@@ -23,8 +23,7 @@ export function ChecksStateProvider({
   children,
 }: ChecksStateProviderProps): ReactElement {
   const { activeWorkspace } = useActiveWorkspaceContext();
-  const { runtimeDefinitions } = useRuntimeAvailabilityContext();
-  const enabledRuntimeDefinitions = useMemo(() => runtimeDefinitions, [runtimeDefinitions]);
+  const { availableRuntimeDefinitions } = useRuntimeAvailabilityContext();
   const {
     runtimeCheck,
     runtimeCheckFailureKind,
@@ -44,7 +43,7 @@ export function ChecksStateProvider({
     clearActiveRepoRuntimeHealth,
   } = useChecks({
     activeWorkspace,
-    runtimeDefinitions: enabledRuntimeDefinitions,
+    runtimeDefinitions: availableRuntimeDefinitions,
     checkRepoRuntimeHealth,
   });
 

--- a/packages/frontend/src/state/providers/checks-state-provider.tsx
+++ b/packages/frontend/src/state/providers/checks-state-provider.tsx
@@ -1,7 +1,5 @@
-import { DEFAULT_AGENT_RUNTIMES, type RuntimeKind } from "@openducktor/contracts";
-import { useQuery } from "@tanstack/react-query";
+import type { RuntimeKind } from "@openducktor/contracts";
 import { type PropsWithChildren, type ReactElement, useMemo } from "react";
-import { filterEnabledRuntimeDefinitions } from "@/lib/agent-runtime";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { buildChecksStateValue } from "../app-state-context-values";
 import {
@@ -9,10 +7,9 @@ import {
   type ChecksOperationsContextValue,
   ChecksStateContext,
   useActiveWorkspaceContext,
-  useRuntimeDefinitionsContext,
+  useRuntimeAvailabilityContext,
 } from "../app-state-contexts";
 import { useChecks } from "../operations";
-import { settingsSnapshotQueryOptions } from "../queries/workspace";
 
 type ChecksStateProviderProps = PropsWithChildren<{
   checkRepoRuntimeHealth: (
@@ -26,18 +23,8 @@ export function ChecksStateProvider({
   children,
 }: ChecksStateProviderProps): ReactElement {
   const { activeWorkspace } = useActiveWorkspaceContext();
-  const { runtimeDefinitions } = useRuntimeDefinitionsContext();
-  const { data: settingsSnapshot } = useQuery(settingsSnapshotQueryOptions());
-  const enabledRuntimeDefinitions = useMemo(
-    () =>
-      settingsSnapshot
-        ? filterEnabledRuntimeDefinitions(
-            runtimeDefinitions,
-            settingsSnapshot.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES,
-          )
-        : [],
-    [runtimeDefinitions, settingsSnapshot],
-  );
+  const { runtimeDefinitions } = useRuntimeAvailabilityContext();
+  const enabledRuntimeDefinitions = useMemo(() => runtimeDefinitions, [runtimeDefinitions]);
   const {
     runtimeCheck,
     runtimeCheckFailureKind,

--- a/packages/frontend/src/state/queries/tasks.test.ts
+++ b/packages/frontend/src/state/queries/tasks.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import type { AgentSessionRecord, SettingsSnapshot, TaskCard } from "@openducktor/contracts";
+import {
+  type AgentSessionRecord,
+  DEFAULT_AGENT_RUNTIMES,
+  type SettingsSnapshot,
+  type TaskCard,
+} from "@openducktor/contracts";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { hostClient as host } from "@/lib/host-client";
 import { documentQueryKeys } from "./documents";
@@ -25,6 +30,7 @@ const settingsSnapshotFixture: SettingsSnapshot = {
   reusablePrompts: [],
   kanban: { doneVisibleDays: DONE_VISIBLE_DAYS, emptyColumnDisplay: "show" },
   autopilot: { rules: [] },
+  agentRuntimes: DEFAULT_AGENT_RUNTIMES,
   workspaces: {},
   globalPromptOverrides: {},
 };


### PR DESCRIPTION
Summary

Centralizes runtime availability so disabled runtimes are no longer selectable, validates repository runtime defaults against enabled runtime settings, and adds a branded Codex runtime icon wherever runtime options are displayed.

Goal

This PR fixes consistency issues introduced by supporting Codex as a second runtime. Previously, UI flows could still offer OpenCode or Codex even when that runtime was disabled in settings, and repository defaults could keep pointing at disabled runtimes. The goal is to make runtime availability a single application-level contract rather than duplicated filtering at individual call sites.

Technical choices

- Added shared runtime availability helpers in the frontend runtime utility layer, including enabled-runtime filtering and available-runtime selection resolution.
- Extended runtime app state with required `agentRuntimes` and `availableRuntimeDefinitions`, plus a `useRuntimeAvailabilityContext` hook for consumers that need only selectable runtimes.
- Updated session start, Agent Studio, diagnostics, checks, composer, and repository-agent settings paths to consume the centralized available-runtime set.
- Tightened settings snapshot typing so parsed `agentRuntimes` is required, reducing optional handling and repeated defaulting branches.
- Added settings validation that reports disabled repository default/role runtime selections and blocks save until they are fixed.
- Replaced the generic Codex fallback icon with a theme-aware OpenAI/Codex SVG mark and added render coverage for both runtime brand icons.

Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check`
- `cargo test`
- `cargo build`
