### PR TITLE
refactor(frontend): remove unused kanban task invalidation helper

### DIFF
--- a/packages/frontend/src/state/queries/tasks.ts
+++ b/packages/frontend/src/state/queries/tasks.ts
@@ -50,20 +50,6 @@ export const invalidateRepoTaskDataQueries = (
   });
 };
 
-export const invalidateKanbanTaskQueries = (
-  queryClient: QueryClient,
-  repoPath: string,
-  options?: {
-    refetchType?: "active" | "inactive" | "all" | "none";
-  },
-) => {
-  return queryClient.invalidateQueries({
-    queryKey: taskQueryKeys.repoDataPrefix(repoPath),
-    exact: false,
-    ...(options?.refetchType ? { refetchType: options.refetchType } : {}),
-  });
-};
-
 export const refetchActiveKanbanQueries = (
   queryClient: QueryClient,
   repoPath: string,


### PR DESCRIPTION
Summary

Remove the unused duplicate `invalidateKanbanTaskQueries` export from the frontend task query module.

Context

The task query module already exposes `invalidateRepoTaskDataQueries` for invalidating repo task data queries. `invalidateKanbanTaskQueries` had the same implementation against `taskQueryKeys.repoDataPrefix(repoPath)` and had no active references outside its own export, so it added a second API name without a distinct behavior or ownership boundary.

Implementation

- Deleted `invalidateKanbanTaskQueries` from `packages/frontend/src/state/queries/tasks.ts`.
- Kept `invalidateRepoTaskDataQueries` as the single repo task-data invalidation helper.
- Confirmed no remaining references to the deleted export.

Verification

- `bun run --filter @openducktor/frontend typecheck`
- `bun run --filter @openducktor/frontend test`
- `bun run --filter @openducktor/frontend lint`