### PR TITLE
Validate TypeScript host tool discovery

### DIFF
--- a/apps/electron/src/main/electron-process-environment.test.ts
+++ b/apps/electron/src/main/electron-process-environment.test.ts
@@ -32,6 +32,7 @@ describe("configureElectronProcessEnvironment", () => {
     });
 
     expect(env[OPENDUCKTOR_MCP_SIDECAR_PATH_ENV]).toBeUndefined();
+    expect(env[OPENDUCKTOR_BUNDLED_BIN_DIR_ENV]).toBeUndefined();
   });
 
   test("points packaged hosts at the Electron resources MCP sidecar", () => {
@@ -57,7 +58,38 @@ describe("configureElectronProcessEnvironment", () => {
     ).toBe(join("/Applications/OpenDucktor.app/Contents/Resources", "bin", "openducktor-mcp"));
   });
 
+  test("preserves explicit packaged environment overrides", () => {
+    const env: NodeJS.ProcessEnv = {
+      [OPENDUCKTOR_BUNDLED_BIN_DIR_ENV]: "/custom/bin",
+      [OPENDUCKTOR_MCP_SIDECAR_PATH_ENV]: "/custom/openducktor-mcp",
+    };
+
+    configureElectronProcessEnvironment({
+      env,
+      platform: "linux",
+      isPackaged: true,
+      resourcesPath: "/opt/OpenDucktor/resources",
+    });
+
+    expect(env[OPENDUCKTOR_BUNDLED_BIN_DIR_ENV]).toBe("/custom/bin");
+    expect(env[OPENDUCKTOR_MCP_SIDECAR_PATH_ENV]).toBe("/custom/openducktor-mcp");
+  });
+
   test("uses the Windows sidecar executable name on Windows", () => {
+    const env: NodeJS.ProcessEnv = {};
+    configureElectronProcessEnvironment({
+      env,
+      platform: "win32",
+      isPackaged: true,
+      resourcesPath: "C:\\Program Files\\OpenDucktor\\resources",
+    });
+
+    expect(env[OPENDUCKTOR_BUNDLED_BIN_DIR_ENV]).toBe(
+      join("C:\\Program Files\\OpenDucktor\\resources", "bin"),
+    );
+    expect(env[OPENDUCKTOR_MCP_SIDECAR_PATH_ENV]).toBe(
+      join("C:\\Program Files\\OpenDucktor\\resources", "bin", "openducktor-mcp.exe"),
+    );
     expect(
       resolveElectronMcpSidecarPath({
         platform: "win32",

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { RUNTIME_DESCRIPTORS_BY_KIND } from "@openducktor/contracts";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { removeTestDirectory } from "../../test-support/temp-directory";
+import { createSystemCommandRunner } from "../system/system-command-runner";
 import { createCodexAppServerTransportRegistry } from "./codex-app-server-transport-registry";
 import {
   buildCodexMcpConfigArgs,
@@ -200,6 +201,61 @@ describe("createCodexWorkspaceRuntimeStarter", () => {
       await expect(
         codexAppServer.request({ runtimeId: "runtime-1", method: "thread/loaded/list" }),
       ).rejects.toThrow("Codex app-server transport not found for runtime runtime-1");
+    } finally {
+      if (originalCapturePath === undefined) {
+        delete process.env.CODEX_CAPTURE_PATH;
+      } else {
+        process.env.CODEX_CAPTURE_PATH = originalCapturePath;
+      }
+      await removeTestDirectory(root);
+    }
+  });
+
+  test("starts a Windows PATH-discovered cmd Codex app-server runtime", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    const root = await mkdtemp(join(tmpdir(), "odt-codex-path-starter-"));
+    const originalCapturePath = process.env.CODEX_CAPTURE_PATH;
+    try {
+      const repo = join(root, "repo");
+      await mkdir(repo);
+      const capturePath = join(root, "capture.json");
+      process.env.CODEX_CAPTURE_PATH = capturePath;
+      const codexBinary = await createFakeCodex(root);
+      const codexAppServer = createCodexAppServerTransportRegistry();
+      const pathWithFakeRuntime = `${root};${process.env.PATH ?? ""}`;
+      const starter = createCodexWorkspaceRuntimeStarter({
+        systemCommands: createSystemCommandRunner({
+          env: { ...process.env, PATH: pathWithFakeRuntime, PATHEXT: ".CMD" },
+          platform: "win32",
+        }),
+        processEnv: { ...process.env, PATH: pathWithFakeRuntime, PATHEXT: ".CMD" },
+        codexAppServer,
+        mcpCommand: ["mcp-bin", "--stdio"],
+        clientVersion: "0.3.1-test",
+        resolveMcpBridgeConnection: async () => ({
+          workspaceId: "repo",
+          hostUrl: "http://127.0.0.1:14327",
+          hostToken: "token-1",
+        }),
+        requestTimeoutMs: 4_000,
+        runtimeId: () => "runtime-path",
+      });
+
+      expect(codexBinary.endsWith(".cmd")).toBe(true);
+      const handle = await starter.startWorkspaceRuntime({
+        runtimeKind: "codex",
+        repoPath: repo,
+        workingDirectory: repo,
+        descriptor: RUNTIME_DESCRIPTORS_BY_KIND.codex,
+      });
+
+      expect(handle.runtime.runtimeId).toBe("runtime-path");
+      const capture = JSON.parse(await readFile(capturePath, "utf8"));
+      expect(capture.args).toContain("app-server");
+      await expect(handle.stop()).resolves.toBeUndefined();
     } finally {
       if (originalCapturePath === undefined) {
         delete process.env.CODEX_CAPTURE_PATH;

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
@@ -14,6 +14,7 @@ import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "../mcp/openducktor-mcp-command";
 import { shouldStartDetachedProcessGroup, signalProcessTree } from "../process/process-tree";
 import { resolveCodexBinary } from "../runtimes/runtime-binaries";
+import { createSystemCommandLaunch } from "../system/system-command-runner";
 import {
   type CodexAppServerEventEmitter,
   createCodexAppServerTransport,
@@ -148,16 +149,6 @@ const stopChildProcess = async (
   throw new Error(`Timed out waiting for Codex app-server process group ${pid} to stop.`);
 };
 
-const codexCommand = (binary: string, args: string[]): { file: string; args: string[] } => {
-  const lowerBinary = binary.toLowerCase();
-  const isWindowsCommandScript =
-    process.platform === "win32" && (lowerBinary.endsWith(".cmd") || lowerBinary.endsWith(".bat"));
-
-  return isWindowsCommandScript
-    ? { file: process.env.ComSpec ?? "cmd.exe", args: ["/d", "/c", "call", binary, ...args] }
-    : { file: binary, args };
-};
-
 export const createCodexWorkspaceRuntimeStarter = ({
   systemCommands,
   codexAppServer,
@@ -187,12 +178,14 @@ export const createCodexWorkspaceRuntimeStarter = ({
       resolveConfiguredMcpCommand(processEnv, mcpCommand) ??
       (await resolveOpenDucktorMcpCommand({ systemCommands, env: processEnv }));
     const binary = codexBinary ?? (await resolveCodexBinary(systemCommands, processEnv));
-    const command = codexCommand(binary, [
-      ...buildCodexMcpConfigArgs(resolvedMcpCommand),
-      "app-server",
-    ]);
+    const command = createSystemCommandLaunch(
+      binary,
+      [...buildCodexMcpConfigArgs(resolvedMcpCommand), "app-server"],
+      processEnv,
+      process.platform,
+    );
     const nextRuntimeId = runtimeId();
-    const child = spawn(command.file, command.args, {
+    const child = spawn(command.command, command.args, {
       cwd: input.workingDirectory,
       detached: shouldStartDetachedProcessGroup(),
       env: {

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
@@ -197,6 +197,7 @@ export const createCodexWorkspaceRuntimeStarter = ({
         ODT_ALLOWED_TOOLS: ODT_WORKFLOW_AGENT_TOOL_NAMES.join(","),
       },
       stdio: ["pipe", "pipe", "pipe"],
+      windowsVerbatimArguments: command.windowsVerbatimArguments === true,
     }) as CodexChildProcess;
     const pid = child.pid;
     if (!pid || pid <= 0) {

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { RUNTIME_DESCRIPTORS_BY_KIND } from "@openducktor/contracts";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { removeTestDirectory } from "../../test-support/temp-directory";
+import { createSystemCommandRunner } from "../system/system-command-runner";
 import {
   buildOpenCodeConfigContent,
   createOpenCodeWorkspaceRuntimeStarter,
@@ -144,6 +145,51 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
         startedAt: "2026-05-10T10:00:00.000Z",
       });
 
+      await expect(handle.stop()).resolves.toBeUndefined();
+    } finally {
+      await removeTestDirectory(root);
+    }
+  });
+
+  test("starts a Windows PATH-discovered cmd OpenCode runtime", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    const root = await mkdtemp(join(tmpdir(), "odt-opencode-path-starter-"));
+    try {
+      const repo = join(root, "repo");
+      await mkdir(repo);
+      const opencodeBinary = await createFakeOpenCode(root);
+      const pathWithFakeRuntime = `${root};${process.env.PATH ?? ""}`;
+      const starter = createOpenCodeWorkspaceRuntimeStarter({
+        systemCommands: createSystemCommandRunner({
+          env: { ...process.env, PATH: pathWithFakeRuntime, PATHEXT: ".CMD" },
+          platform: "win32",
+        }),
+        processEnv: { ...process.env, PATH: pathWithFakeRuntime, PATHEXT: ".CMD" },
+        mcpCommand: ["mcp-bin"],
+        resolveMcpBridgeConnection: async () => ({
+          workspaceId: "repo",
+          hostUrl: "http://127.0.0.1:14327",
+          hostToken: "token-1",
+        }),
+        startupTimeoutMs: 2_000,
+        retryDelayMs: 20,
+        portAllocator: async () => 43123,
+        portProbe: async () => true,
+        runtimeId: () => "runtime-path",
+      });
+
+      expect(opencodeBinary.endsWith(".cmd")).toBe(true);
+      const handle = await starter.startWorkspaceRuntime({
+        runtimeKind: "opencode",
+        repoPath: repo,
+        workingDirectory: repo,
+        descriptor: RUNTIME_DESCRIPTORS_BY_KIND.opencode,
+      });
+
+      expect(handle.runtime.runtimeId).toBe("runtime-path");
       await expect(handle.stop()).resolves.toBeUndefined();
     } finally {
       await removeTestDirectory(root);

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
@@ -13,6 +13,7 @@ import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "../mcp/openducktor-mcp-command";
 import { shouldStartDetachedProcessGroup, signalProcessTree } from "../process/process-tree";
 import { resolveOpencodeBinary } from "../runtimes/runtime-binaries";
+import { createSystemCommandLaunch } from "../system/system-command-runner";
 
 export type OpenCodeMcpBridgeConnection = {
   workspaceId: string;
@@ -239,7 +240,13 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
     const configContent = buildOpenCodeConfigContent(bridge, resolvedMcpCommand);
     const binary = opencodeBinary ?? (await resolveOpencodeBinary(systemCommands, processEnv));
     const port = await portAllocator();
-    const child = spawn(binary, ["serve", "--hostname", "127.0.0.1", "--port", port.toString()], {
+    const command = createSystemCommandLaunch(
+      binary,
+      ["serve", "--hostname", "127.0.0.1", "--port", port.toString()],
+      processEnv,
+      process.platform,
+    );
+    const child = spawn(command.command, command.args, {
       cwd: input.workingDirectory,
       detached: shouldStartDetachedProcessGroup(),
       env: {

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
@@ -254,6 +254,7 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
         OPENCODE_CONFIG_CONTENT: configContent,
       },
       stdio: ["ignore", "pipe", "pipe"],
+      windowsVerbatimArguments: command.windowsVerbatimArguments === true,
     });
     const pid = child.pid;
     if (!pid || pid <= 0) {

--- a/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
@@ -256,7 +256,7 @@ describe("resolveCodexBinary", () => {
       resolveCodexBinary(
         createSystemCommands(),
         {},
-        { resourcesPath: "/opt/OpenDucktor/resources" },
+        { platform: "linux", resourcesPath: "/opt/OpenDucktor/resources" },
       ),
     ).rejects.toThrow(
       "codex not found. Checked OPENDUCKTOR_CODEX_BINARY, bundled locations (OPENDUCKTOR_BUNDLED_BIN_DIR, /opt/OpenDucktor/resources/bin/codex), and PATH. Install codex, fix PATH, or set OPENDUCKTOR_CODEX_BINARY.",

--- a/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
@@ -2,11 +2,15 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SystemCommandPort } from "../../ports/system-command-port";
-import { resolveCodexBinary } from "./runtime-binaries";
+import { resolveCodexBinary, resolveOpencodeBinary } from "./runtime-binaries";
 
-const createSystemCommands = (): SystemCommandPort => ({
+const createSystemCommands = ({
+  available = [],
+}: {
+  available?: string[];
+} = {}): SystemCommandPort => ({
   async requiredCommandError(command) {
-    return `Required command \`${command}\` not found.`;
+    return available.includes(command) ? null : `Required command \`${command}\` not found.`;
   },
   async versionCommand() {
     return null;
@@ -16,24 +20,176 @@ const createSystemCommands = (): SystemCommandPort => ({
   },
 });
 
+const withTempDir = async (run: (root: string) => Promise<void>): Promise<void> => {
+  const root = await mkdtemp(join(tmpdir(), "odt-runtime-binaries-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+};
+
+const writeExecutable = async (path: string): Promise<void> => {
+  await writeFile(path, "");
+  await chmod(path, 0o755);
+};
+
+describe("resolveOpencodeBinary", () => {
+  test("resolves an explicit OpenCode override", async () => {
+    await withTempDir(async (root) => {
+      const opencode = join(root, "opencode");
+      await writeExecutable(opencode);
+
+      await expect(
+        resolveOpencodeBinary(createSystemCommands(), {
+          OPENDUCKTOR_OPENCODE_BINARY: opencode,
+        }),
+      ).resolves.toBe(opencode);
+    });
+  });
+
+  test("fails when an explicit OpenCode override is empty", async () => {
+    await expect(
+      resolveOpencodeBinary(createSystemCommands(), {
+        OPENDUCKTOR_OPENCODE_BINARY: " ",
+      }),
+    ).rejects.toThrow("Configured OpenCode override OPENDUCKTOR_OPENCODE_BINARY is empty");
+  });
+
+  test("fails when an explicit OpenCode override is not runnable", async () => {
+    await expect(
+      resolveOpencodeBinary(createSystemCommands(), {
+        OPENDUCKTOR_OPENCODE_BINARY: "/missing/opencode",
+      }),
+    ).rejects.toThrow(
+      "Configured OpenCode override OPENDUCKTOR_OPENCODE_BINARY points to a missing or non-executable file: /missing/opencode",
+    );
+  });
+
+  test("expands quoted home-relative OpenCode overrides", async () => {
+    await withTempDir(async (root) => {
+      const binDir = join(root, "bin");
+      await mkdir(binDir);
+      const opencode = join(binDir, "opencode");
+      await writeExecutable(opencode);
+
+      await expect(
+        resolveOpencodeBinary(
+          createSystemCommands(),
+          {
+            OPENDUCKTOR_OPENCODE_BINARY: `"~/bin/opencode"`,
+          },
+          { homeDir: root },
+        ),
+      ).resolves.toBe(opencode);
+    });
+  });
+
+  test("resolves the POSIX standard OpenCode install path before PATH", async () => {
+    await withTempDir(async (root) => {
+      const binDir = join(root, ".opencode", "bin");
+      await mkdir(binDir, { recursive: true });
+      const opencode = join(binDir, "opencode");
+      await writeExecutable(opencode);
+
+      await expect(
+        resolveOpencodeBinary(
+          createSystemCommands({ available: ["opencode"] }),
+          {},
+          { homeDir: root, platform: "linux" },
+        ),
+      ).resolves.toBe(opencode);
+    });
+  });
+
+  test("resolves the Windows standard OpenCode install path", async () => {
+    await withTempDir(async (root) => {
+      const binDir = join(root, ".opencode", "bin");
+      await mkdir(binDir, { recursive: true });
+      const opencode = join(binDir, "opencode.exe");
+      await writeFile(opencode, "");
+
+      await expect(
+        resolveOpencodeBinary(createSystemCommands(), {}, { homeDir: root, platform: "win32" }),
+      ).resolves.toBe(opencode);
+    });
+  });
+
+  test("uses PATH fallback after OpenCode override and standard locations", async () => {
+    await expect(
+      resolveOpencodeBinary(createSystemCommands({ available: ["opencode"] }), {}),
+    ).resolves.toBe("opencode");
+  });
+
+  test("reports considered OpenCode locations when missing", async () => {
+    await expect(
+      resolveOpencodeBinary(
+        createSystemCommands(),
+        {},
+        { homeDir: "/home/alice", platform: "linux" },
+      ),
+    ).rejects.toThrow(
+      "opencode not found. Checked OPENDUCKTOR_OPENCODE_BINARY, standard install location /home/alice/.opencode/bin/opencode, and PATH. Install opencode or set OPENDUCKTOR_OPENCODE_BINARY.",
+    );
+  });
+});
+
 describe("resolveCodexBinary", () => {
+  test("uses an explicit Codex override before bundled locations and PATH", async () => {
+    await withTempDir(async (root) => {
+      const override = join(root, "codex");
+      await writeExecutable(override);
+      const binDir = join(root, "bin");
+      await mkdir(binDir);
+      await writeExecutable(join(binDir, "codex"));
+
+      await expect(
+        resolveCodexBinary(createSystemCommands({ available: ["codex"] }), {
+          OPENDUCKTOR_CODEX_BINARY: override,
+          OPENDUCKTOR_BUNDLED_BIN_DIR: binDir,
+        }),
+      ).resolves.toBe(override);
+    });
+  });
+
   test("resolves a bundled Codex binary before PATH", async () => {
-    const root = await mkdtemp(join(tmpdir(), "odt-runtime-binaries-"));
-    try {
+    await withTempDir(async (root) => {
       const binDir = join(root, "bin");
       await mkdir(binDir);
       const codex = join(binDir, process.platform === "win32" ? "codex.exe" : "codex");
-      await writeFile(codex, "");
-      await chmod(codex, 0o755);
+      await writeExecutable(codex);
 
       await expect(
-        resolveCodexBinary(createSystemCommands(), {
+        resolveCodexBinary(createSystemCommands({ available: ["codex"] }), {
           OPENDUCKTOR_BUNDLED_BIN_DIR: binDir,
         }),
       ).resolves.toBe(codex);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
+  });
+
+  test("resolves Codex from Electron resources before PATH", async () => {
+    await withTempDir(async (root) => {
+      const binDir = join(root, "resources", "bin");
+      await mkdir(binDir, { recursive: true });
+      const codex = join(binDir, "codex.exe");
+      await writeFile(codex, "");
+
+      await expect(
+        resolveCodexBinary(
+          createSystemCommands({ available: ["codex"] }),
+          {},
+          { platform: "win32", resourcesPath: join(root, "resources") },
+        ),
+      ).resolves.toBe(codex);
+    });
+  });
+
+  test("fails when an explicit Codex override is empty", async () => {
+    await expect(
+      resolveCodexBinary(createSystemCommands(), {
+        OPENDUCKTOR_CODEX_BINARY: "",
+      }),
+    ).rejects.toThrow("Configured Codex override OPENDUCKTOR_CODEX_BINARY is empty");
   });
 
   test("fails when an explicit Codex override is not executable", async () => {
@@ -43,6 +199,32 @@ describe("resolveCodexBinary", () => {
       }),
     ).rejects.toThrow(
       "Configured Codex override OPENDUCKTOR_CODEX_BINARY points to a missing or non-executable file: /missing/codex",
+    );
+  });
+
+  test("fails when the bundled bin directory env var is empty", async () => {
+    await expect(
+      resolveCodexBinary(createSystemCommands(), {
+        OPENDUCKTOR_BUNDLED_BIN_DIR: " ",
+      }),
+    ).rejects.toThrow("Configured bundled binary directory OPENDUCKTOR_BUNDLED_BIN_DIR is empty");
+  });
+
+  test("uses PATH fallback after Codex override and bundled locations", async () => {
+    await expect(
+      resolveCodexBinary(createSystemCommands({ available: ["codex"] }), {}),
+    ).resolves.toBe("codex");
+  });
+
+  test("reports considered Codex locations when missing", async () => {
+    await expect(
+      resolveCodexBinary(
+        createSystemCommands(),
+        {},
+        { resourcesPath: "/opt/OpenDucktor/resources" },
+      ),
+    ).rejects.toThrow(
+      "codex not found. Checked OPENDUCKTOR_CODEX_BINARY, bundled locations (OPENDUCKTOR_BUNDLED_BIN_DIR, /opt/OpenDucktor/resources/bin/codex), and PATH. Install codex, fix PATH, or set OPENDUCKTOR_CODEX_BINARY.",
     );
   });
 });

--- a/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { createSystemCommandRunner } from "../system/system-command-runner";
 import { resolveCodexBinary, resolveOpencodeBinary } from "./runtime-binaries";
@@ -92,6 +92,7 @@ describe("resolveOpencodeBinary", () => {
       await mkdir(binDir, { recursive: true });
       const opencode = join(binDir, "opencode");
       await writeExecutable(opencode);
+      const expectedResolvedPath = posix.join(root, ".opencode", "bin", "opencode");
 
       await expect(
         resolveOpencodeBinary(
@@ -99,7 +100,7 @@ describe("resolveOpencodeBinary", () => {
           {},
           { homeDir: root, platform: "linux" },
         ),
-      ).resolves.toBe(opencode);
+      ).resolves.toBe(expectedResolvedPath);
     });
   });
 

--- a/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
@@ -2,6 +2,7 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SystemCommandPort } from "../../ports/system-command-port";
+import { createSystemCommandRunner } from "../system/system-command-runner";
 import { resolveCodexBinary, resolveOpencodeBinary } from "./runtime-binaries";
 
 const createSystemCommands = ({
@@ -121,6 +122,25 @@ describe("resolveOpencodeBinary", () => {
     ).resolves.toBe("opencode");
   });
 
+  test("returns the resolved Windows PATHEXT OpenCode path for PATH fallback", async () => {
+    await withTempDir(async (root) => {
+      const opencode = join(root, "opencode.cmd");
+      await writeFile(opencode, "");
+      const systemCommands = createSystemCommandRunner({
+        env: { PATH: root, PATHEXT: ".cmd" },
+        platform: "win32",
+      });
+
+      await expect(
+        resolveOpencodeBinary(
+          systemCommands,
+          { PATH: root, PATHEXT: ".cmd" },
+          { platform: "win32" },
+        ),
+      ).resolves.toBe(opencode);
+    });
+  });
+
   test("reports considered OpenCode locations when missing", async () => {
     await expect(
       resolveOpencodeBinary(
@@ -214,6 +234,21 @@ describe("resolveCodexBinary", () => {
     await expect(
       resolveCodexBinary(createSystemCommands({ available: ["codex"] }), {}),
     ).resolves.toBe("codex");
+  });
+
+  test("returns the resolved Windows PATHEXT Codex path for PATH fallback", async () => {
+    await withTempDir(async (root) => {
+      const codex = join(root, "codex.bat");
+      await writeFile(codex, "");
+      const systemCommands = createSystemCommandRunner({
+        env: { PATH: root, PATHEXT: ".bat" },
+        platform: "win32",
+      });
+
+      await expect(
+        resolveCodexBinary(systemCommands, { PATH: root, PATHEXT: ".bat" }, { platform: "win32" }),
+      ).resolves.toBe(codex);
+    });
   });
 
   test("reports considered Codex locations when missing", async () => {

--- a/packages/host/src/adapters/runtimes/runtime-binaries.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.ts
@@ -1,10 +1,16 @@
 import { constants } from "node:fs";
-import { access } from "node:fs/promises";
+import { access, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 
 const BUNDLED_BIN_DIR_ENV = "OPENDUCKTOR_BUNDLED_BIN_DIR";
+
+export type RuntimeBinaryResolutionOptions = {
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+  resourcesPath?: string | null;
+};
 
 const stripMatchingQuotes = (value: string): string => {
   if (value.length < 2) {
@@ -17,19 +23,27 @@ const stripMatchingQuotes = (value: string): string => {
     : value;
 };
 
-export const resolveUserPath = (rawPath: string): string => {
+export const resolveUserPath = (rawPath: string, homeDir = homedir()): string => {
   const trimmed = stripMatchingQuotes(rawPath.trim());
   if (trimmed === "~") {
-    return homedir();
+    return homeDir;
   }
   if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
-    return join(homedir(), trimmed.slice(2));
+    return join(homeDir, trimmed.slice(2));
   }
   return trimmed;
 };
 
-export const isExecutableFile = async (candidate: string): Promise<boolean> => {
+export const isExecutableFile = async (
+  candidate: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<boolean> => {
   try {
+    if (platform === "win32") {
+      const file = await stat(candidate);
+      return file.isFile();
+    }
+
     await access(candidate, constants.X_OK);
     return true;
   } catch {
@@ -37,10 +51,15 @@ export const isExecutableFile = async (candidate: string): Promise<boolean> => {
   }
 };
 
-const executableName = (command: string): string =>
-  process.platform === "win32" ? `${command}.exe` : command;
+const executableName = (command: string, platform: NodeJS.Platform): string =>
+  platform === "win32" ? `${command}.exe` : command;
 
-const processResourcesPath = (): string | null => {
+const processResourcesPath = (configuredResourcesPath?: string | null): string | null => {
+  if (configuredResourcesPath !== undefined) {
+    return typeof configuredResourcesPath === "string" && configuredResourcesPath.trim().length > 0
+      ? configuredResourcesPath
+      : null;
+  }
   const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
   return typeof resourcesPath === "string" && resourcesPath.trim().length > 0
     ? resourcesPath
@@ -50,19 +69,27 @@ const processResourcesPath = (): string | null => {
 const resolveBundledCommand = async (
   command: string,
   env: NodeJS.ProcessEnv,
+  options: {
+    platform: NodeJS.Platform;
+    homeDir: string;
+    resourcesPath: string | null | undefined;
+  },
 ): Promise<string | null> => {
   const configuredBinDir = env[BUNDLED_BIN_DIR_ENV];
-  const resourcesPath = processResourcesPath();
+  if (configuredBinDir !== undefined && configuredBinDir.trim().length === 0) {
+    throw new Error(`Configured bundled binary directory ${BUNDLED_BIN_DIR_ENV} is empty`);
+  }
+  const resourcesPath = processResourcesPath(options.resourcesPath);
   const candidateDirs = [
     ...(configuredBinDir && configuredBinDir.trim().length > 0
-      ? [resolveUserPath(configuredBinDir)]
+      ? [resolveUserPath(configuredBinDir, options.homeDir)]
       : []),
     ...(resourcesPath ? [join(resourcesPath, "bin")] : []),
   ];
 
   for (const directory of candidateDirs) {
-    const candidate = join(directory, executableName(command));
-    if (await isExecutableFile(candidate)) {
+    const candidate = join(directory, executableName(command, options.platform));
+    if (await isExecutableFile(candidate, options.platform)) {
       return candidate;
     }
   }
@@ -73,14 +100,17 @@ const resolveBundledCommand = async (
 export const resolveOpencodeBinary = async (
   systemCommands: SystemCommandPort,
   env: NodeJS.ProcessEnv = process.env,
+  options: RuntimeBinaryResolutionOptions = {},
 ): Promise<string> => {
+  const platform = options.platform ?? process.platform;
+  const homeDir = options.homeDir ?? homedir();
   const overrideBinary = env.OPENDUCKTOR_OPENCODE_BINARY;
   if (overrideBinary !== undefined) {
     if (overrideBinary.trim().length === 0) {
       throw new Error("Configured OpenCode override OPENDUCKTOR_OPENCODE_BINARY is empty");
     }
-    const resolvedOverride = resolveUserPath(overrideBinary);
-    if (await isExecutableFile(resolvedOverride)) {
+    const resolvedOverride = resolveUserPath(overrideBinary, homeDir);
+    if (await isExecutableFile(resolvedOverride, platform)) {
       return resolvedOverride;
     }
     throw new Error(
@@ -88,8 +118,13 @@ export const resolveOpencodeBinary = async (
     );
   }
 
-  const homeCandidate = join(homedir(), ".opencode", "bin", "opencode");
-  if (await isExecutableFile(homeCandidate)) {
+  const homeCandidate = join(
+    homeDir,
+    ".opencode",
+    "bin",
+    platform === "win32" ? "opencode.exe" : "opencode",
+  );
+  if (await isExecutableFile(homeCandidate, platform)) {
     return homeCandidate;
   }
 
@@ -98,20 +133,25 @@ export const resolveOpencodeBinary = async (
     return "opencode";
   }
 
-  throw new Error("opencode not found in standard install locations, PATH, or ~/.opencode/bin");
+  throw new Error(
+    `opencode not found. Checked OPENDUCKTOR_OPENCODE_BINARY, standard install location ${homeCandidate}, and PATH. Install opencode or set OPENDUCKTOR_OPENCODE_BINARY.`,
+  );
 };
 
 export const resolveCodexBinary = async (
   systemCommands: SystemCommandPort,
   env: NodeJS.ProcessEnv = process.env,
+  options: RuntimeBinaryResolutionOptions = {},
 ): Promise<string> => {
+  const platform = options.platform ?? process.platform;
+  const homeDir = options.homeDir ?? homedir();
   const overrideBinary = env.OPENDUCKTOR_CODEX_BINARY;
   if (overrideBinary !== undefined) {
     if (overrideBinary.trim().length === 0) {
       throw new Error("Configured Codex override OPENDUCKTOR_CODEX_BINARY is empty");
     }
-    const resolvedOverride = resolveUserPath(overrideBinary);
-    if (await isExecutableFile(resolvedOverride)) {
+    const resolvedOverride = resolveUserPath(overrideBinary, homeDir);
+    if (await isExecutableFile(resolvedOverride, platform)) {
       return resolvedOverride;
     }
     throw new Error(
@@ -119,7 +159,11 @@ export const resolveCodexBinary = async (
     );
   }
 
-  const bundled = await resolveBundledCommand("codex", env);
+  const bundled = await resolveBundledCommand("codex", env, {
+    platform,
+    homeDir,
+    resourcesPath: options.resourcesPath,
+  });
   if (bundled !== null) {
     return bundled;
   }
@@ -129,5 +173,12 @@ export const resolveCodexBinary = async (
     return "codex";
   }
 
-  throw new Error("codex not found in bundled locations or PATH");
+  const resourcesPath = processResourcesPath(options.resourcesPath);
+  const bundledLocations = [
+    `${BUNDLED_BIN_DIR_ENV}`,
+    ...(resourcesPath ? [join(resourcesPath, "bin", executableName("codex", platform))] : []),
+  ].join(", ");
+  throw new Error(
+    `codex not found. Checked OPENDUCKTOR_CODEX_BINARY, bundled locations (${bundledLocations}), and PATH. Install codex, fix PATH, or set OPENDUCKTOR_CODEX_BINARY.`,
+  );
 };

--- a/packages/host/src/adapters/runtimes/runtime-binaries.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.ts
@@ -97,6 +97,19 @@ const resolveBundledCommand = async (
   return null;
 };
 
+const resolvePathCommand = async (
+  command: string,
+  systemCommands: SystemCommandPort,
+  env: NodeJS.ProcessEnv,
+): Promise<string | null> => {
+  const resolved = await systemCommands.resolveCommandPath?.(command, env);
+  if (resolved !== undefined) {
+    return resolved;
+  }
+
+  return (await systemCommands.requiredCommandError(command)) === null ? command : null;
+};
+
 export const resolveOpencodeBinary = async (
   systemCommands: SystemCommandPort,
   env: NodeJS.ProcessEnv = process.env,
@@ -128,9 +141,9 @@ export const resolveOpencodeBinary = async (
     return homeCandidate;
   }
 
-  const missing = await systemCommands.requiredCommandError("opencode");
-  if (missing === null) {
-    return "opencode";
+  const pathCommand = await resolvePathCommand("opencode", systemCommands, env);
+  if (pathCommand !== null) {
+    return pathCommand;
   }
 
   throw new Error(
@@ -168,9 +181,9 @@ export const resolveCodexBinary = async (
     return bundled;
   }
 
-  const missing = await systemCommands.requiredCommandError("codex");
-  if (missing === null) {
-    return "codex";
+  const pathCommand = await resolvePathCommand("codex", systemCommands, env);
+  if (pathCommand !== null) {
+    return pathCommand;
   }
 
   const resourcesPath = processResourcesPath(options.resourcesPath);

--- a/packages/host/src/adapters/runtimes/runtime-binaries.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.ts
@@ -1,7 +1,7 @@
 import { constants } from "node:fs";
 import { access, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 
 const BUNDLED_BIN_DIR_ENV = "OPENDUCKTOR_BUNDLED_BIN_DIR";
@@ -54,6 +54,13 @@ export const isExecutableFile = async (
 const executableName = (command: string, platform: NodeJS.Platform): string =>
   platform === "win32" ? `${command}.exe` : command;
 
+const joinRuntimePath = (platform: NodeJS.Platform, ...segments: string[]): string => {
+  if (platform === "win32") {
+    return join(...segments);
+  }
+  return posix.join(...segments);
+};
+
 const processResourcesPath = (configuredResourcesPath?: string | null): string | null => {
   if (configuredResourcesPath !== undefined) {
     return typeof configuredResourcesPath === "string" && configuredResourcesPath.trim().length > 0
@@ -80,15 +87,31 @@ const resolveBundledCommand = async (
     throw new Error(`Configured bundled binary directory ${BUNDLED_BIN_DIR_ENV} is empty`);
   }
   const resourcesPath = processResourcesPath(options.resourcesPath);
-  const candidateDirs = [
+  const candidateDirs: Array<{ directory: string; joinPlatform: NodeJS.Platform }> = [
     ...(configuredBinDir && configuredBinDir.trim().length > 0
-      ? [resolveUserPath(configuredBinDir, options.homeDir)]
+      ? [
+          {
+            directory: resolveUserPath(configuredBinDir, options.homeDir),
+            joinPlatform: process.platform,
+          },
+        ]
       : []),
-    ...(resourcesPath ? [join(resourcesPath, "bin")] : []),
+    ...(resourcesPath
+      ? [
+          {
+            directory: joinRuntimePath(options.platform, resourcesPath, "bin"),
+            joinPlatform: options.platform,
+          },
+        ]
+      : []),
   ];
 
-  for (const directory of candidateDirs) {
-    const candidate = join(directory, executableName(command, options.platform));
+  for (const { directory, joinPlatform } of candidateDirs) {
+    const candidate = joinRuntimePath(
+      joinPlatform,
+      directory,
+      executableName(command, options.platform),
+    );
     if (await isExecutableFile(candidate, options.platform)) {
       return candidate;
     }
@@ -131,7 +154,8 @@ export const resolveOpencodeBinary = async (
     );
   }
 
-  const homeCandidate = join(
+  const homeCandidate = joinRuntimePath(
+    platform,
     homeDir,
     ".opencode",
     "bin",
@@ -189,7 +213,9 @@ export const resolveCodexBinary = async (
   const resourcesPath = processResourcesPath(options.resourcesPath);
   const bundledLocations = [
     `${BUNDLED_BIN_DIR_ENV}`,
-    ...(resourcesPath ? [join(resourcesPath, "bin", executableName("codex", platform))] : []),
+    ...(resourcesPath
+      ? [joinRuntimePath(platform, resourcesPath, "bin", executableName("codex", platform))]
+      : []),
   ].join(", ");
   throw new Error(
     `codex not found. Checked OPENDUCKTOR_CODEX_BINARY, bundled locations (${bundledLocations}), and PATH. Install codex, fix PATH, or set OPENDUCKTOR_CODEX_BINARY.`,

--- a/packages/host/src/adapters/runtimes/runtime-health-probe.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-health-probe.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import type { SystemCommandPort } from "../../ports/system-command-port";
+import { createRuntimeHealthProbe } from "./runtime-health-probe";
+
+const missingSystemCommands: SystemCommandPort = {
+  async requiredCommandError(command) {
+    return `Required command \`${command}\` not found. Install ${command} and ensure it is available on PATH.`;
+  },
+  async versionCommand() {
+    return null;
+  },
+  async runCommandAllowFailure() {
+    return { ok: false, stdout: "", stderr: "" };
+  },
+};
+
+describe("createRuntimeHealthProbe", () => {
+  test("reports actionable missing OpenCode diagnostics", async () => {
+    const probe = createRuntimeHealthProbe(missingSystemCommands, {});
+
+    const health = await probe.getRuntimeHealth("opencode");
+
+    expect(health.ok).toBe(false);
+    expect(health.error).toContain("opencode not found. Checked OPENDUCKTOR_OPENCODE_BINARY");
+    expect(health.error).toContain("standard install location");
+    expect(health.error).toContain("PATH");
+    expect(health.error).toContain("Install opencode or set OPENDUCKTOR_OPENCODE_BINARY.");
+  });
+
+  test("reports actionable missing Codex diagnostics", async () => {
+    const probe = createRuntimeHealthProbe(missingSystemCommands, {});
+
+    const health = await probe.getRuntimeHealth("codex");
+
+    expect(health.ok).toBe(false);
+    expect(health.error).toBe(
+      "codex not found. Checked OPENDUCKTOR_CODEX_BINARY, bundled locations (OPENDUCKTOR_BUNDLED_BIN_DIR), and PATH. Install codex, fix PATH, or set OPENDUCKTOR_CODEX_BINARY.",
+    );
+  });
+});

--- a/packages/host/src/adapters/system/system-command-runner.test.ts
+++ b/packages/host/src/adapters/system/system-command-runner.test.ts
@@ -141,8 +141,8 @@ describe("createSystemCommandRunner", () => {
       await mkdir(toolDir);
       const cmd = join(toolDir, "echo-tool.cmd");
       const bat = join(toolDir, "echo-bat.bat");
-      await writeFile(cmd, "@echo off\r\necho cmd:%1:%2\r\n");
-      await writeFile(bat, "@echo off\r\necho bat:%1:%2\r\n");
+      await writeFile(cmd, "@echo off\r\necho cmd:%~1:%~2\r\n");
+      await writeFile(bat, "@echo off\r\necho bat:%~1:%~2\r\n");
 
       const port = createSystemCommandRunner({
         env: { PATH: toolDir, PATHEXT: ".CMD;.BAT", ComSpec: process.env.ComSpec },

--- a/packages/host/src/adapters/system/system-command-runner.test.ts
+++ b/packages/host/src/adapters/system/system-command-runner.test.ts
@@ -15,6 +15,10 @@ const withTempDir = async (run: (root: string) => Promise<void>): Promise<void> 
 
 describe("createSystemCommandRunner", () => {
   test("resolves required commands from its explicit environment", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
     await withTempDir(async (root) => {
       const executable = join(root, "custom-tool");
       await writeFile(executable, "#!/bin/sh\nexit 0\n");

--- a/packages/host/src/adapters/system/system-command-runner.test.ts
+++ b/packages/host/src/adapters/system/system-command-runner.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createSystemCommandRunner } from "./system-command-runner";
 
+const withTempDir = async (run: (root: string) => Promise<void>): Promise<void> => {
+  const root = await mkdtemp(join(tmpdir(), "odt-system-command-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+};
+
 describe("createSystemCommandRunner", () => {
   test("resolves required commands from its explicit environment", async () => {
-    const root = await mkdtemp(join(tmpdir(), "odt-system-command-"));
-    try {
+    await withTempDir(async (root) => {
       const executable = join(root, "custom-tool");
       await writeFile(executable, "#!/bin/sh\nexit 0\n");
       await chmod(executable, 0o755);
@@ -21,9 +29,84 @@ describe("createSystemCommandRunner", () => {
       await expect(port.requiredCommandError("missing-tool")).resolves.toBe(
         "Required command `missing-tool` not found. Install missing-tool and ensure it is available on PATH.",
       );
-    } finally {
-      await rm(root, { force: true, recursive: true });
-    }
+    });
+  });
+
+  test("requires executable bits for POSIX command discovery", async () => {
+    await withTempDir(async (root) => {
+      const candidate = join(root, "not-executable");
+      await writeFile(candidate, "#!/bin/sh\nexit 0\n");
+      await chmod(candidate, 0o644);
+
+      const port = createSystemCommandRunner({
+        env: { PATH: root },
+        platform: "linux",
+      });
+
+      await expect(port.requiredCommandError("not-executable")).resolves.toBe(
+        "Required command `not-executable` not found. Install not-executable and ensure it is available on PATH.",
+      );
+    });
+  });
+
+  test("uses Windows PATHEXT discovery with caller ordering", async () => {
+    await withTempDir(async (root) => {
+      const cmd = join(root, "tool.CMD");
+      const exe = join(root, "tool.EXE");
+      await writeFile(cmd, "");
+      await writeFile(exe, "");
+
+      const port = createSystemCommandRunner({
+        env: { PATH: root, PATHEXT: ".CMD;.EXE" },
+        platform: "win32",
+      });
+
+      await expect(port.requiredCommandError("tool")).resolves.toBeNull();
+      await expect(port.requiredCommandError("tool.CMD")).resolves.toBeNull();
+    });
+  });
+
+  test("uses default Windows PATHEXT entries when PATHEXT is absent", async () => {
+    await withTempDir(async (root) => {
+      await writeFile(join(root, "tool.BAT"), "");
+
+      const port = createSystemCommandRunner({
+        env: { PATH: root },
+        platform: "win32",
+      });
+
+      await expect(port.requiredCommandError("tool")).resolves.toBeNull();
+    });
+  });
+
+  test("validates Windows runnable files without POSIX executable bits", async () => {
+    await withTempDir(async (root) => {
+      const candidate = join(root, "tool.exe");
+      await writeFile(candidate, "");
+      await chmod(candidate, 0o644);
+
+      const port = createSystemCommandRunner({
+        env: { PATH: root },
+        platform: "win32",
+      });
+
+      await expect(port.requiredCommandError("tool.exe")).resolves.toBeNull();
+    });
+  });
+
+  test("validates explicit command paths directly", async () => {
+    await withTempDir(async (root) => {
+      const candidate = join(root, "custom-tool");
+      await writeFile(candidate, "#!/bin/sh\nexit 0\n");
+      await chmod(candidate, 0o755);
+
+      const port = createSystemCommandRunner({
+        env: { PATH: "" },
+        platform: "linux",
+      });
+
+      await expect(port.requiredCommandError(candidate)).resolves.toBeNull();
+    });
   });
 
   test("passes the explicit environment to spawned commands", async () => {
@@ -42,5 +125,33 @@ describe("createSystemCommandRunner", () => {
 
     expect(result.ok).toBe(true);
     expect(result.stdout.trim()).toBe("from-host-env");
+  });
+
+  test("runs Windows cmd and bat launchers with arguments on native Windows", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    await withTempDir(async (root) => {
+      const toolDir = join(root, "tool dir");
+      await mkdir(toolDir);
+      const cmd = join(toolDir, "echo-tool.cmd");
+      const bat = join(toolDir, "echo-bat.bat");
+      await writeFile(cmd, "@echo off\r\necho cmd:%1:%2\r\n");
+      await writeFile(bat, "@echo off\r\necho bat:%1:%2\r\n");
+
+      const port = createSystemCommandRunner({
+        env: { PATH: toolDir, PATHEXT: ".CMD;.BAT", ComSpec: process.env.ComSpec },
+        platform: "win32",
+      });
+
+      const cmdResult = await port.runCommandAllowFailure("echo-tool", ["one", "two words"]);
+      const batResult = await port.runCommandAllowFailure("echo-bat", ["alpha", "beta words"]);
+
+      expect(cmdResult.ok).toBe(true);
+      expect(cmdResult.stdout.trim()).toBe("cmd:one:two words");
+      expect(batResult.ok).toBe(true);
+      expect(batResult.stdout.trim()).toBe("bat:alpha:beta words");
+    });
   });
 });

--- a/packages/host/src/adapters/system/system-command-runner.ts
+++ b/packages/host/src/adapters/system/system-command-runner.ts
@@ -95,7 +95,7 @@ const quoteWindowsCommandArgument = (value: string): string => {
   if (!/[\s"]/u.test(value)) {
     return value;
   }
-  return `"${value.replaceAll(`"`, `\\"`)}"`;
+  return `"${value.replaceAll(`"`, `""`)}"`;
 };
 
 export const createSystemCommandLaunch = (

--- a/packages/host/src/adapters/system/system-command-runner.ts
+++ b/packages/host/src/adapters/system/system-command-runner.ts
@@ -1,14 +1,38 @@
 import { spawn } from "node:child_process";
 import { constants } from "node:fs";
-import { access } from "node:fs/promises";
-import { delimiter, join } from "node:path";
+import { access, stat } from "node:fs/promises";
+import { extname, join } from "node:path";
 import type { SystemCommandPort, SystemCommandRunResult } from "../../ports/system-command-port";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 10_000;
+const WINDOWS_DEFAULT_PATHEXT = [".EXE", ".CMD", ".BAT", ".COM"];
 
 export type CreateSystemCommandRunnerInput = {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
+};
+
+const pathDelimiterForPlatform = (platform: NodeJS.Platform): string =>
+  platform === "win32" ? ";" : ":";
+
+const commandHasPath = (command: string): boolean =>
+  command.includes("/") || command.includes("\\");
+
+const hasCommandExtension = (command: string): boolean => extname(command).length > 0;
+
+const windowsPathExt = (env: NodeJS.ProcessEnv): string[] => {
+  const configured = env.PATHEXT;
+  if (configured === undefined) {
+    return WINDOWS_DEFAULT_PATHEXT;
+  }
+
+  const extensions = configured
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => (entry.startsWith(".") ? entry : `.${entry}`));
+
+  return extensions.length > 0 ? extensions : WINDOWS_DEFAULT_PATHEXT;
 };
 
 const commandFileNames = (
@@ -16,25 +40,19 @@ const commandFileNames = (
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
 ): string[] => {
-  if (platform !== "win32") {
+  if (platform !== "win32" || hasCommandExtension(command) || commandHasPath(command)) {
     return [command];
   }
 
-  const extensionPattern = /\.[^\\/]+$/;
-  if (extensionPattern.test(command)) {
-    return [command];
-  }
-
-  const pathExt = env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM";
-  return pathExt
-    .split(";")
-    .map((entry) => entry.trim().toLowerCase())
-    .filter(Boolean)
-    .map((extension) => `${command}${extension}`);
+  return windowsPathExt(env).map((extension) => `${command}${extension}`);
 };
 
-const canExecute = async (candidate: string): Promise<boolean> => {
+const canExecute = async (candidate: string, platform: NodeJS.Platform): Promise<boolean> => {
   try {
+    if (platform === "win32") {
+      return (await stat(candidate)).isFile();
+    }
+
     await access(candidate, constants.X_OK);
     return true;
   } catch {
@@ -47,15 +65,15 @@ const resolveCommandPath = async (
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
 ): Promise<string | null> => {
-  if (command.includes("/") || command.includes("\\")) {
-    return (await canExecute(command)) ? command : null;
+  if (commandHasPath(command)) {
+    return (await canExecute(command, platform)) ? command : null;
   }
 
   const pathValue = env.PATH ?? "";
-  for (const directory of pathValue.split(delimiter).filter(Boolean)) {
+  for (const directory of pathValue.split(pathDelimiterForPlatform(platform)).filter(Boolean)) {
     for (const fileName of commandFileNames(command, platform, env)) {
       const candidate = join(directory, fileName);
-      if (await canExecute(candidate)) {
+      if (await canExecute(candidate, platform)) {
         return candidate;
       }
     }
@@ -69,6 +87,34 @@ const firstNonEmptyLine = (value: string): string | null =>
     .split(/\r?\n/)
     .map((line) => line.trim())
     .find(Boolean) ?? null;
+
+const quoteWindowsCommandArgument = (value: string): string => {
+  if (value.length === 0) {
+    return `""`;
+  }
+  if (!/[\s"]/u.test(value)) {
+    return value;
+  }
+  return `"${value.replaceAll(`"`, `\\"`)}"`;
+};
+
+const launchCommand = (
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): { command: string; args: string[] } => {
+  if (platform !== "win32" || !/\.(?:cmd|bat)$/iu.test(command)) {
+    return { command, args };
+  }
+
+  const shell = env.ComSpec?.trim() || process.env.ComSpec || "cmd.exe";
+  const commandLine = `"${[command, ...args].map(quoteWindowsCommandArgument).join(" ")}"`;
+  return {
+    command: shell,
+    args: ["/d", "/s", "/c", commandLine],
+  };
+};
 
 export const createSystemCommandRunner = ({
   env = process.env,
@@ -91,11 +137,14 @@ export const createSystemCommandRunner = ({
       }
     },
 
-    runCommandAllowFailure(command, args, options = {}) {
+    async runCommandAllowFailure(command, args, options = {}) {
+      const commandEnv = { ...env, ...options.env };
+      const resolvedCommand = (await resolveCommandPath(command, commandEnv, platform)) ?? command;
+      const launch = launchCommand(resolvedCommand, args, commandEnv, platform);
       return new Promise<SystemCommandRunResult>((resolve, reject) => {
-        const child = spawn(command, args, {
+        const child = spawn(launch.command, launch.args, {
           cwd: options.cwd,
-          env: { ...env, ...options.env },
+          env: commandEnv,
           stdio: ["ignore", "pipe", "pipe"],
         });
         const stdoutChunks: Buffer[] = [];

--- a/packages/host/src/adapters/system/system-command-runner.ts
+++ b/packages/host/src/adapters/system/system-command-runner.ts
@@ -98,7 +98,7 @@ const quoteWindowsCommandArgument = (value: string): string => {
   return `"${value.replaceAll(`"`, `\\"`)}"`;
 };
 
-const launchCommand = (
+export const createSystemCommandLaunch = (
   command: string,
   args: string[],
   env: NodeJS.ProcessEnv,
@@ -121,6 +121,10 @@ export const createSystemCommandRunner = ({
   platform = process.platform,
 }: CreateSystemCommandRunnerInput = {}): SystemCommandPort => {
   const port: SystemCommandPort = {
+    resolveCommandPath(command, commandEnv = env) {
+      return resolveCommandPath(command, commandEnv, platform);
+    },
+
     async requiredCommandError(command) {
       const resolved = await resolveCommandPath(command, env, platform);
       return resolved === null
@@ -140,7 +144,7 @@ export const createSystemCommandRunner = ({
     async runCommandAllowFailure(command, args, options = {}) {
       const commandEnv = { ...env, ...options.env };
       const resolvedCommand = (await resolveCommandPath(command, commandEnv, platform)) ?? command;
-      const launch = launchCommand(resolvedCommand, args, commandEnv, platform);
+      const launch = createSystemCommandLaunch(resolvedCommand, args, commandEnv, platform);
       return new Promise<SystemCommandRunResult>((resolve, reject) => {
         const child = spawn(launch.command, launch.args, {
           cwd: options.cwd,

--- a/packages/host/src/adapters/system/system-command-runner.ts
+++ b/packages/host/src/adapters/system/system-command-runner.ts
@@ -109,10 +109,10 @@ export const createSystemCommandLaunch = (
   }
 
   const shell = env.ComSpec?.trim() || process.env.ComSpec || "cmd.exe";
-  const commandLine = `"${[command, ...args].map(quoteWindowsCommandArgument).join(" ")}"`;
+  const commandLine = ["call", command, ...args].map(quoteWindowsCommandArgument).join(" ");
   return {
     command: shell,
-    args: ["/d", "/s", "/c", commandLine],
+    args: ["/d", "/c", commandLine],
   };
 };
 

--- a/packages/host/src/adapters/system/system-command-runner.ts
+++ b/packages/host/src/adapters/system/system-command-runner.ts
@@ -103,7 +103,7 @@ export const createSystemCommandLaunch = (
   args: string[],
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
-): { command: string; args: string[] } => {
+): { command: string; args: string[]; windowsVerbatimArguments?: boolean } => {
   if (platform !== "win32" || !/\.(?:cmd|bat)$/iu.test(command)) {
     return { command, args };
   }
@@ -113,6 +113,7 @@ export const createSystemCommandLaunch = (
   return {
     command: shell,
     args: ["/d", "/c", commandLine],
+    windowsVerbatimArguments: true,
   };
 };
 
@@ -150,6 +151,7 @@ export const createSystemCommandRunner = ({
           cwd: options.cwd,
           env: commandEnv,
           stdio: ["ignore", "pipe", "pipe"],
+          windowsVerbatimArguments: launch.windowsVerbatimArguments === true,
         });
         const stdoutChunks: Buffer[] = [];
         const stderrChunks: Buffer[] = [];

--- a/packages/host/src/application/diagnostics/system-diagnostics-service.test.ts
+++ b/packages/host/src/application/diagnostics/system-diagnostics-service.test.ts
@@ -61,7 +61,9 @@ const createSystemCommandPort = ({
   const missing = new Set(missingCommands);
   return {
     requiredCommandError: async (command) =>
-      missing.has(command) ? `Required command \`${command}\` not found.` : null,
+      missing.has(command)
+        ? `Required command \`${command}\` not found. Install ${command} and ensure it is available on PATH.`
+        : null,
     versionCommand: async (command) => (missing.has(command) ? null : `${command} version 1.0.0`),
     runCommandAllowFailure: async (command) => {
       if (command === "gh") {
@@ -157,6 +159,29 @@ describe("createSystemDiagnosticsService", () => {
     expect(refreshed.gitVersion).toBe("git version 2.0.0");
   });
 
+  test("runtimeCheck reports actionable missing git and gh diagnostics", async () => {
+    const service = createSystemDiagnosticsService({
+      runtimeDefinitionsService: createRuntimeDefinitions(["opencode"]),
+      runtimeHealth: createRuntimeHealthPort(),
+      settingsConfig: createSettingsConfig(null),
+      systemCommands: createSystemCommandPort({ missingCommands: ["git", "gh"] }),
+      repoStoreDiagnostics: createTaskStore(),
+    });
+
+    const check = await service.runtimeCheck(true);
+
+    expect(check.gitOk).toBe(false);
+    expect(check.ghOk).toBe(false);
+    expect(check.ghAuthOk).toBe(false);
+    expect(check.ghAuthError).toBe(
+      "Required command `gh` not found. Install gh and ensure it is available on PATH.",
+    );
+    expect(check.errors).toEqual([
+      "Required command `git` not found. Install git and ensure it is available on PATH.",
+      "Required command `gh` not found. Install gh and ensure it is available on PATH.",
+    ]);
+  });
+
   test("beadsCheck returns structured blocking health when bd is missing", async () => {
     const service = createSystemDiagnosticsService({
       runtimeDefinitionsService: createRuntimeDefinitions(),
@@ -171,12 +196,12 @@ describe("createSystemDiagnosticsService", () => {
     expect(check).toEqual({
       beadsOk: false,
       beadsPath: null,
-      beadsError: "Required command `bd` not found.",
+      beadsError: "Required command `bd` not found. Install bd and ensure it is available on PATH.",
       repoStoreHealth: {
         category: "attachment_verification_failed",
         status: "blocking",
         isReady: false,
-        detail: "Required command `bd` not found.",
+        detail: "Required command `bd` not found. Install bd and ensure it is available on PATH.",
         attachment: { path: null, databaseName: null },
         sharedServer: { host: null, port: null, ownershipState: "unavailable" },
       },
@@ -197,12 +222,14 @@ describe("createSystemDiagnosticsService", () => {
     expect(check).toEqual({
       beadsOk: false,
       beadsPath: null,
-      beadsError: "Required command `dolt` not found.",
+      beadsError:
+        "Required command `dolt` not found. Install dolt and ensure it is available on PATH.",
       repoStoreHealth: {
         category: "attachment_verification_failed",
         status: "blocking",
         isReady: false,
-        detail: "Required command `dolt` not found.",
+        detail:
+          "Required command `dolt` not found. Install dolt and ensure it is available on PATH.",
         attachment: { path: null, databaseName: null },
         sharedServer: { host: null, port: null, ownershipState: "unavailable" },
       },

--- a/packages/host/src/ports/system-command-port.ts
+++ b/packages/host/src/ports/system-command-port.ts
@@ -11,6 +11,7 @@ export type SystemCommandRunResult = {
 };
 
 export type SystemCommandPort = {
+  resolveCommandPath?(command: string, env?: NodeJS.ProcessEnv): Promise<string | null>;
   requiredCommandError(command: string): Promise<string | null>;
   versionCommand(
     command: string,

--- a/packages/openducktor-mcp/src/store-context.test.ts
+++ b/packages/openducktor-mcp/src/store-context.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -34,8 +34,7 @@ const createDiscoveryRegistry = async (
   return dir;
 };
 
-afterEach(async () => {
-  globalThis.fetch = originalFetch;
+const clearStoreContextEnv = (): void => {
   delete process.env.ODT_WORKSPACE_ID;
   delete process.env.ODT_HOST_URL;
   delete process.env.ODT_HOST_TOKEN;
@@ -46,6 +45,15 @@ afterEach(async () => {
   delete process.env.ODT_DOLT_HOST;
   delete process.env.ODT_DOLT_PORT;
   delete process.env.ODT_DATABASE_NAME;
+};
+
+beforeEach(() => {
+  clearStoreContextEnv();
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  clearStoreContextEnv();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -54,7 +54,7 @@ describe("TypeScript web host backend", () => {
     } finally {
       await backend.stop();
     }
-  });
+  }, 3_000);
 
   test("rejects invalid browser frontend origins before opening a host port", () => {
     const { validateWebFrontendOrigin } = __typescriptHostBackendTestInternals;


### PR DESCRIPTION
## Summary
- validate TypeScript host command discovery across PATH, PATHEXT, executable checks, and Windows script launch behavior
- resolve OpenCode/Codex binaries through overrides, standard locations, bundled Codex resources, and concrete PATH candidates
- add diagnostics and Electron packaged env coverage for installed-tool prerequisites

## Verification
- bun run --filter @openducktor/host lint/typecheck/test
- bun run --filter @openducktor/electron typecheck/test
- bun run --filter @openducktor/mcp lint/typecheck/test
- bun run --filter @openducktor/web test
- bun run lint
- bun run typecheck
- bun run test

ODT task: openducktor-o3fs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows `.cmd` and `.bat` command execution support.
  * Enhanced error messages when runtime binaries or system commands are missing, with actionable installation guidance.

* **Tests**
  * Added comprehensive test coverage for platform-specific binary resolution and Windows command execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->