### PR TITLE
test(host): cover Beads and Dolt path handling

### DIFF
--- a/packages/host/src/adapters/beads/beads-cli-context-paths.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-paths.test.ts
@@ -1,0 +1,129 @@
+import { mkdtemp, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { databaseNameForWorkspace } from "../../infrastructure/beads/beads-context-model";
+import { resolveBeadsCliContext } from "./beads-cli-context";
+
+describe("resolveBeadsCliContext path identity", () => {
+  test("resolves workspace-scoped managed Beads paths when workspace id is provided", async () => {
+    const configRoot = await mkdtemp(path.join(tmpdir(), "odt-config-workspace-test-"));
+    const repoRoot = await mkdtemp(path.join(tmpdir(), "My Repo-"));
+    const canonicalRepoRoot = await realpath(repoRoot);
+
+    const context = await resolveBeadsCliContext(repoRoot, {
+      processEnv: { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot },
+      requireSharedServer: false,
+      workspaceId: "openducktor",
+    });
+
+    expect(context.repoPath).toBe(canonicalRepoRoot);
+    expect(context.repoId).toBe("openducktor");
+    expect(context.databaseName).toBe("odt_openducktor_14ecb05f675c");
+    expect(context.attachmentRoot).toBe(path.join(configRoot, "beads", "openducktor"));
+    expect(context.beadsDir).toBe(path.join(configRoot, "beads", "openducktor", ".beads"));
+    expect(context.workingDir).toBe(context.attachmentRoot);
+  });
+
+  test("keeps configured workspace identity stable across repo path spelling changes", async () => {
+    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config workspace stable-"));
+    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
+    const workspaceId = "  Workspace With Spaces  ";
+    const repoPaths = [
+      path.join(await mkdtemp(path.join(tmpdir(), "Repo With Spaces-")), "Case Path"),
+      path.join(
+        await mkdtemp(path.join(tmpdir(), "Repo With Backslashes-")),
+        "C:\\Users\\Max Sky\\Repo Name",
+      ),
+      path.join(await mkdtemp(path.join(tmpdir(), "repo-case-")), "Repo Name"),
+    ];
+
+    const contexts = await Promise.all(
+      repoPaths.map((repoPath) =>
+        resolveBeadsCliContext(repoPath, {
+          processEnv,
+          requireSharedServer: false,
+          workspaceId,
+        }),
+      ),
+    );
+
+    for (const context of contexts) {
+      expect(context.repoId).toBe("Workspace With Spaces");
+      expect(context.databaseName).toBe(databaseNameForWorkspace(workspaceId));
+      expect(context.attachmentRoot).toBe(path.join(configRoot, "beads", "Workspace With Spaces"));
+      expect(context.beadsDir).toBe(path.join(context.attachmentRoot, ".beads"));
+      expect(context.workingDir).toBe(context.attachmentRoot);
+    }
+  });
+
+  test("derives repo identity from canonical existing paths and absolute synthetic paths", async () => {
+    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config repo identity-"));
+    const existingRepo = await mkdtemp(path.join(tmpdir(), "Repo With Spaces-"));
+    const canonicalExistingRepo = await realpath(existingRepo);
+    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
+
+    const existingContext = await resolveBeadsCliContext(existingRepo, {
+      processEnv,
+      requireSharedServer: false,
+    });
+
+    expect(existingContext.repoPath).toBe(canonicalExistingRepo);
+    expect(existingContext.repoId).toMatch(/^repo-with-spaces-[a-z0-9]+-[a-f0-9]{8}$/);
+    expect(existingContext.databaseName).toMatch(/^odt_repo_with_spaces_[a-z0-9]+_[a-f0-9]{12}$/);
+
+    const syntheticRepo = path.join(configRoot, "missing repos", "C:\\Users\\Max Sky\\Repo Name");
+    const syntheticContext = await resolveBeadsCliContext(syntheticRepo, {
+      processEnv,
+      requireSharedServer: false,
+    });
+
+    expect(syntheticContext.repoPath).toBe(syntheticRepo);
+    expect(syntheticContext.repoId).toMatch(/^c-users-max-sky-repo-name-[a-f0-9]{8}$/);
+    expect(syntheticContext.databaseName).toMatch(/^odt_c_users_max_sky_repo_name_[a-f0-9]{12}$/);
+  });
+
+  test("treats case-different repo spellings as distinct when no workspace id is configured", async () => {
+    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config case identity-"));
+    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
+    const lowerRepo = path.join(configRoot, "missing repos", "repo name");
+    const upperRepo = path.join(configRoot, "missing repos", "Repo Name");
+
+    const [lowerContext, upperContext] = await Promise.all([
+      resolveBeadsCliContext(lowerRepo, { processEnv, requireSharedServer: false }),
+      resolveBeadsCliContext(upperRepo, { processEnv, requireSharedServer: false }),
+    ]);
+
+    expect(lowerContext.repoPath).toBe(lowerRepo);
+    expect(upperContext.repoPath).toBe(upperRepo);
+    expect(lowerContext.repoId).not.toBe(upperContext.repoId);
+    expect(lowerContext.databaseName).not.toBe(upperContext.databaseName);
+  });
+
+  test("keeps managed paths under config roots with path-edge names", async () => {
+    const configRoot = await mkdtemp(
+      path.join(tmpdir(), "odt config C:\\Users\\Max Sky\\OpenDucktor-"),
+    );
+    const repoRoot = await mkdtemp(path.join(tmpdir(), "Repo With Spaces-"));
+
+    const context = await resolveBeadsCliContext(repoRoot, {
+      processEnv: { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot },
+      requireSharedServer: false,
+      workspaceId: "workspace-id",
+    });
+
+    expect(context.attachmentRoot).toBe(path.join(configRoot, "beads", "workspace-id"));
+    expect(context.beadsDir).toBe(path.join(configRoot, "beads", "workspace-id", ".beads"));
+    expect(context.serverStatePath).toBe(
+      path.join(configRoot, "beads", "shared-server", "server.json"),
+    );
+  });
+
+  test("rejects an empty configured OpenDucktor config dir", async () => {
+    await expect(
+      resolveBeadsCliContext("/repo", {
+        processEnv: { ...process.env, OPENDUCKTOR_CONFIG_DIR: "" },
+        requireSharedServer: false,
+      }),
+    ).rejects.toThrow("OPENDUCKTOR_CONFIG_DIR is set but empty");
+  });
+});

--- a/packages/host/src/adapters/beads/beads-cli-context-paths.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-paths.test.ts
@@ -32,7 +32,7 @@ describe("resolveBeadsCliContext path identity", () => {
       path.join(await mkdtemp(path.join(tmpdir(), "Repo With Spaces-")), "Case Path"),
       path.join(
         await mkdtemp(path.join(tmpdir(), "Repo With Backslashes-")),
-        "C:\\Users\\Max Sky\\Repo Name",
+        "C-Users\\Max Sky\\Repo Name",
       ),
       path.join(await mkdtemp(path.join(tmpdir(), "repo-case-")), "Repo Name"),
     ];
@@ -71,7 +71,7 @@ describe("resolveBeadsCliContext path identity", () => {
     expect(existingContext.repoId).toMatch(/^repo-with-spaces-[a-z0-9]+-[a-f0-9]{8}$/);
     expect(existingContext.databaseName).toMatch(/^odt_repo_with_spaces_[a-z0-9]+_[a-f0-9]{12}$/);
 
-    const syntheticRepo = path.join(configRoot, "missing repos", "C:\\Users\\Max Sky\\Repo Name");
+    const syntheticRepo = path.join(configRoot, "missing repos", "C-Users-Max Sky-Repo Name");
     const syntheticContext = await resolveBeadsCliContext(syntheticRepo, {
       processEnv,
       requireSharedServer: false,
@@ -101,7 +101,7 @@ describe("resolveBeadsCliContext path identity", () => {
 
   test("keeps managed paths under config roots with path-edge names", async () => {
     const configRoot = await mkdtemp(
-      path.join(tmpdir(), "odt config C:\\Users\\Max Sky\\OpenDucktor-"),
+      path.join(tmpdir(), "odt config C-Users-Max Sky-OpenDucktor-"),
     );
     const repoRoot = await mkdtemp(path.join(tmpdir(), "Repo With Spaces-"));
 

--- a/packages/host/src/adapters/beads/beads-cli-context.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context.test.ts
@@ -2,7 +2,6 @@ import { mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { initializeMissingAttachment } from "../../infrastructure/beads/beads-attachment-provisioning";
-import { databaseNameForWorkspace } from "../../infrastructure/beads/beads-context-model";
 import { ensureSharedDoltServerRunning } from "../../infrastructure/beads/beads-shared-dolt-server";
 import {
   type BeadsCliContext,
@@ -91,130 +90,6 @@ describe("resolveBeadsCliContext", () => {
       port: 36001,
       ownershipState: "owned_by_current_process",
     });
-  });
-
-  test("resolves workspace-scoped managed Beads paths when workspace id is provided", async () => {
-    const configRoot = await mkdtemp(path.join(tmpdir(), "odt-config-workspace-test-"));
-    const repoRoot = await mkdtemp(path.join(tmpdir(), "My Repo-"));
-    const canonicalRepoRoot = await realpath(repoRoot);
-
-    const context = await withEnv("OPENDUCKTOR_CONFIG_DIR", configRoot, () =>
-      resolveBeadsCliContext(repoRoot, {
-        requireSharedServer: false,
-        workspaceId: "openducktor",
-      }),
-    );
-
-    expect(context.repoPath).toBe(canonicalRepoRoot);
-    expect(context.repoId).toBe("openducktor");
-    expect(context.databaseName).toBe("odt_openducktor_14ecb05f675c");
-    expect(context.attachmentRoot).toBe(path.join(configRoot, "beads", "openducktor"));
-    expect(context.beadsDir).toBe(path.join(configRoot, "beads", "openducktor", ".beads"));
-    expect(context.workingDir).toBe(context.attachmentRoot);
-  });
-
-  test("keeps configured workspace identity stable across repo path spelling changes", async () => {
-    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config workspace stable-"));
-    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
-    const workspaceId = "  Workspace With Spaces  ";
-    const repoPaths = [
-      path.join(await mkdtemp(path.join(tmpdir(), "Repo With Spaces-")), "Case Path"),
-      path.join(
-        await mkdtemp(path.join(tmpdir(), "Repo With Backslashes-")),
-        "C:\\Users\\Max Sky\\Repo Name",
-      ),
-      path.join(await mkdtemp(path.join(tmpdir(), "repo-case-")), "Repo Name"),
-    ];
-
-    const contexts = await Promise.all(
-      repoPaths.map((repoPath) =>
-        resolveBeadsCliContext(repoPath, {
-          processEnv,
-          requireSharedServer: false,
-          workspaceId,
-        }),
-      ),
-    );
-
-    for (const context of contexts) {
-      expect(context.repoId).toBe("Workspace With Spaces");
-      expect(context.databaseName).toBe(databaseNameForWorkspace(workspaceId));
-      expect(context.attachmentRoot).toBe(path.join(configRoot, "beads", "Workspace With Spaces"));
-      expect(context.beadsDir).toBe(path.join(context.attachmentRoot, ".beads"));
-      expect(context.workingDir).toBe(context.attachmentRoot);
-    }
-  });
-
-  test("derives repo identity from canonical existing paths and absolute synthetic paths", async () => {
-    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config repo identity-"));
-    const existingRepo = await mkdtemp(path.join(tmpdir(), "Repo With Spaces-"));
-    const canonicalExistingRepo = await realpath(existingRepo);
-    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
-
-    const existingContext = await resolveBeadsCliContext(existingRepo, {
-      processEnv,
-      requireSharedServer: false,
-    });
-
-    expect(existingContext.repoPath).toBe(canonicalExistingRepo);
-    expect(existingContext.repoId).toMatch(/^repo-with-spaces-[a-z0-9]+-[a-f0-9]{8}$/);
-    expect(existingContext.databaseName).toMatch(/^odt_repo_with_spaces_[a-z0-9]+_[a-f0-9]{12}$/);
-
-    const syntheticRepo = path.join(configRoot, "missing repos", "C:\\Users\\Max Sky\\Repo Name");
-    const syntheticContext = await resolveBeadsCliContext(syntheticRepo, {
-      processEnv,
-      requireSharedServer: false,
-    });
-
-    expect(syntheticContext.repoPath).toBe(syntheticRepo);
-    expect(syntheticContext.repoId).toMatch(/^c-users-max-sky-repo-name-[a-f0-9]{8}$/);
-    expect(syntheticContext.databaseName).toMatch(/^odt_c_users_max_sky_repo_name_[a-f0-9]{12}$/);
-  });
-
-  test("treats case-different repo spellings as distinct when no workspace id is configured", async () => {
-    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config case identity-"));
-    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
-    const lowerRepo = path.join(configRoot, "missing repos", "repo name");
-    const upperRepo = path.join(configRoot, "missing repos", "Repo Name");
-
-    const [lowerContext, upperContext] = await Promise.all([
-      resolveBeadsCliContext(lowerRepo, { processEnv, requireSharedServer: false }),
-      resolveBeadsCliContext(upperRepo, { processEnv, requireSharedServer: false }),
-    ]);
-
-    expect(lowerContext.repoPath).toBe(lowerRepo);
-    expect(upperContext.repoPath).toBe(upperRepo);
-    expect(lowerContext.repoId).not.toBe(upperContext.repoId);
-    expect(lowerContext.databaseName).not.toBe(upperContext.databaseName);
-  });
-
-  test("keeps managed paths under config roots with path-edge names", async () => {
-    const configRoot = await mkdtemp(
-      path.join(tmpdir(), "odt config C:\\Users\\Max Sky\\OpenDucktor-"),
-    );
-    const repoRoot = await mkdtemp(path.join(tmpdir(), "Repo With Spaces-"));
-    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
-
-    const context = await resolveBeadsCliContext(repoRoot, {
-      processEnv,
-      requireSharedServer: false,
-      workspaceId: "workspace-id",
-    });
-
-    expect(context.attachmentRoot).toBe(path.join(configRoot, "beads", "workspace-id"));
-    expect(context.beadsDir).toBe(path.join(configRoot, "beads", "workspace-id", ".beads"));
-    expect(context.serverStatePath).toBe(
-      path.join(configRoot, "beads", "shared-server", "server.json"),
-    );
-  });
-
-  test("rejects an empty configured OpenDucktor config dir", async () => {
-    await expect(
-      resolveBeadsCliContext("/repo", {
-        processEnv: { ...process.env, OPENDUCKTOR_CONFIG_DIR: "" },
-        requireSharedServer: false,
-      }),
-    ).rejects.toThrow("OPENDUCKTOR_CONFIG_DIR is set but empty");
   });
 
   test("starts shared Dolt when task commands require a shared server", async () => {

--- a/packages/host/src/adapters/beads/beads-cli-context.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context.test.ts
@@ -131,8 +131,8 @@ describe("resolveBeadsCliContext", () => {
     const serverRoot = path.join(configRoot, "beads", "shared-server");
     const state = createSharedServerRecord(serverRoot, {
       port: 36123,
-      sharedServerRoot: path.join(serverRoot, "C:\\Users\\Max Sky\\server"),
-      doltDataDir: path.join(serverRoot, "C:\\Users\\Max Sky\\server", "dolt data"),
+      sharedServerRoot: path.join(serverRoot, "C-Users\\Max Sky\\server"),
+      doltDataDir: path.join(serverRoot, "C-Users\\Max Sky\\server", "dolt data"),
     });
     await mkdir(serverRoot, { recursive: true });
     await writeFile(path.join(serverRoot, "server.json"), JSON.stringify(state));
@@ -345,7 +345,7 @@ describe("createBeadsAttachmentProvisioner", () => {
   });
 
   test("initializes missing path-edge attachments from the attachment root", async () => {
-    const parent = await mkdtemp(path.join(tmpdir(), "odt provisioning C:\\Users\\Max Sky-"));
+    const parent = await mkdtemp(path.join(tmpdir(), "odt provisioning C-Users-Max Sky-"));
     const attachmentRoot = path.join(parent, "Attachment Root With Spaces");
     const beadsDir = path.join(attachmentRoot, ".beads");
     const context: BeadsCliContext = {

--- a/packages/host/src/adapters/beads/beads-cli-context.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context.test.ts
@@ -1,6 +1,8 @@
 import { mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { initializeMissingAttachment } from "../../infrastructure/beads/beads-attachment-provisioning";
+import { databaseNameForWorkspace } from "../../infrastructure/beads/beads-context-model";
 import { ensureSharedDoltServerRunning } from "../../infrastructure/beads/beads-shared-dolt-server";
 import {
   type BeadsCliContext,
@@ -10,6 +12,22 @@ import {
   resolveBeadsCliContext,
   sharedServerHealthFromContext,
 } from "./beads-cli-context";
+
+const createSharedServerRecord = (
+  sharedServerRoot: string,
+  overrides: Partial<NonNullable<BeadsCliContext["sharedServer"]>> = {},
+): NonNullable<BeadsCliContext["sharedServer"]> => ({
+  pid: 123,
+  ownerPid: process.pid,
+  acquisition: "started_by_owner",
+  host: "127.0.0.1",
+  user: "root",
+  port: 36001,
+  sharedServerRoot,
+  doltDataDir: path.join(sharedServerRoot, "dolt"),
+  startedAt: "2026-05-10T00:00:00Z",
+  ...overrides,
+});
 
 const withEnv = async <T>(
   key: string,
@@ -41,17 +59,7 @@ describe("resolveBeadsCliContext", () => {
     await mkdir(serverRoot, { recursive: true });
     await writeFile(
       path.join(serverRoot, "server.json"),
-      JSON.stringify({
-        pid: 123,
-        ownerPid: process.pid,
-        acquisition: "started_by_owner",
-        host: "127.0.0.1",
-        user: "root",
-        port: 36001,
-        sharedServerRoot: serverRoot,
-        doltDataDir: path.join(serverRoot, "dolt"),
-        startedAt: "2026-05-10T00:00:00Z",
-      }),
+      JSON.stringify(createSharedServerRecord(serverRoot)),
     );
 
     const canonicalRepoRoot = await realpath(repoRoot);
@@ -59,17 +67,9 @@ describe("resolveBeadsCliContext", () => {
       resolveBeadsCliContext(repoRoot, {
         requireSharedServer: true,
         async ensureSharedServer(paths) {
-          return {
-            pid: 123,
-            ownerPid: process.pid,
-            acquisition: "started_by_owner",
-            host: "127.0.0.1",
-            user: "root",
-            port: 36001,
-            sharedServerRoot: paths.sharedServerRoot,
+          return createSharedServerRecord(paths.sharedServerRoot, {
             doltDataDir: paths.doltRoot,
-            startedAt: "2026-05-10T00:00:00Z",
-          };
+          });
         },
         ensureAttachment: async () => undefined,
       }),
@@ -113,6 +113,110 @@ describe("resolveBeadsCliContext", () => {
     expect(context.workingDir).toBe(context.attachmentRoot);
   });
 
+  test("keeps configured workspace identity stable across repo path spelling changes", async () => {
+    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config workspace stable-"));
+    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
+    const workspaceId = "  Workspace With Spaces  ";
+    const repoPaths = [
+      path.join(await mkdtemp(path.join(tmpdir(), "Repo With Spaces-")), "Case Path"),
+      path.join(
+        await mkdtemp(path.join(tmpdir(), "Repo With Backslashes-")),
+        "C:\\Users\\Max Sky\\Repo Name",
+      ),
+      path.join(await mkdtemp(path.join(tmpdir(), "repo-case-")), "Repo Name"),
+    ];
+
+    const contexts = await Promise.all(
+      repoPaths.map((repoPath) =>
+        resolveBeadsCliContext(repoPath, {
+          processEnv,
+          requireSharedServer: false,
+          workspaceId,
+        }),
+      ),
+    );
+
+    for (const context of contexts) {
+      expect(context.repoId).toBe("Workspace With Spaces");
+      expect(context.databaseName).toBe(databaseNameForWorkspace(workspaceId));
+      expect(context.attachmentRoot).toBe(path.join(configRoot, "beads", "Workspace With Spaces"));
+      expect(context.beadsDir).toBe(path.join(context.attachmentRoot, ".beads"));
+      expect(context.workingDir).toBe(context.attachmentRoot);
+    }
+  });
+
+  test("derives repo identity from canonical existing paths and absolute synthetic paths", async () => {
+    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config repo identity-"));
+    const existingRepo = await mkdtemp(path.join(tmpdir(), "Repo With Spaces-"));
+    const canonicalExistingRepo = await realpath(existingRepo);
+    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
+
+    const existingContext = await resolveBeadsCliContext(existingRepo, {
+      processEnv,
+      requireSharedServer: false,
+    });
+
+    expect(existingContext.repoPath).toBe(canonicalExistingRepo);
+    expect(existingContext.repoId).toMatch(/^repo-with-spaces-[a-z0-9]+-[a-f0-9]{8}$/);
+    expect(existingContext.databaseName).toMatch(/^odt_repo_with_spaces_[a-z0-9]+_[a-f0-9]{12}$/);
+
+    const syntheticRepo = path.join(configRoot, "missing repos", "C:\\Users\\Max Sky\\Repo Name");
+    const syntheticContext = await resolveBeadsCliContext(syntheticRepo, {
+      processEnv,
+      requireSharedServer: false,
+    });
+
+    expect(syntheticContext.repoPath).toBe(syntheticRepo);
+    expect(syntheticContext.repoId).toMatch(/^c-users-max-sky-repo-name-[a-f0-9]{8}$/);
+    expect(syntheticContext.databaseName).toMatch(/^odt_c_users_max_sky_repo_name_[a-f0-9]{12}$/);
+  });
+
+  test("treats case-different repo spellings as distinct when no workspace id is configured", async () => {
+    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config case identity-"));
+    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
+    const lowerRepo = path.join(configRoot, "missing repos", "repo name");
+    const upperRepo = path.join(configRoot, "missing repos", "Repo Name");
+
+    const [lowerContext, upperContext] = await Promise.all([
+      resolveBeadsCliContext(lowerRepo, { processEnv, requireSharedServer: false }),
+      resolveBeadsCliContext(upperRepo, { processEnv, requireSharedServer: false }),
+    ]);
+
+    expect(lowerContext.repoPath).toBe(lowerRepo);
+    expect(upperContext.repoPath).toBe(upperRepo);
+    expect(lowerContext.repoId).not.toBe(upperContext.repoId);
+    expect(lowerContext.databaseName).not.toBe(upperContext.databaseName);
+  });
+
+  test("keeps managed paths under config roots with path-edge names", async () => {
+    const configRoot = await mkdtemp(
+      path.join(tmpdir(), "odt config C:\\Users\\Max Sky\\OpenDucktor-"),
+    );
+    const repoRoot = await mkdtemp(path.join(tmpdir(), "Repo With Spaces-"));
+    const processEnv = { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot };
+
+    const context = await resolveBeadsCliContext(repoRoot, {
+      processEnv,
+      requireSharedServer: false,
+      workspaceId: "workspace-id",
+    });
+
+    expect(context.attachmentRoot).toBe(path.join(configRoot, "beads", "workspace-id"));
+    expect(context.beadsDir).toBe(path.join(configRoot, "beads", "workspace-id", ".beads"));
+    expect(context.serverStatePath).toBe(
+      path.join(configRoot, "beads", "shared-server", "server.json"),
+    );
+  });
+
+  test("rejects an empty configured OpenDucktor config dir", async () => {
+    await expect(
+      resolveBeadsCliContext("/repo", {
+        processEnv: { ...process.env, OPENDUCKTOR_CONFIG_DIR: "" },
+        requireSharedServer: false,
+      }),
+    ).rejects.toThrow("OPENDUCKTOR_CONFIG_DIR is set but empty");
+  });
+
   test("starts shared Dolt when task commands require a shared server", async () => {
     const configRoot = await mkdtemp(path.join(tmpdir(), "odt-config-missing-server-test-"));
     const repoRoot = await mkdtemp(path.join(tmpdir(), "Repo-"));
@@ -124,17 +228,11 @@ describe("resolveBeadsCliContext", () => {
         requireSharedServer: true,
         async ensureSharedServer(paths) {
           calls.push(paths.sharedServerRoot);
-          return {
+          return createSharedServerRecord(paths.sharedServerRoot, {
             pid: process.pid,
-            ownerPid: process.pid,
-            acquisition: "started_by_owner",
-            host: "127.0.0.1",
-            user: "root",
             port: 36002,
-            sharedServerRoot: paths.sharedServerRoot,
             doltDataDir: paths.doltRoot,
-            startedAt: "2026-05-10T00:00:00Z",
-          };
+          });
         },
         async ensureAttachment(context) {
           attachmentCalls.push(context.beadsDir);
@@ -150,6 +248,33 @@ describe("resolveBeadsCliContext", () => {
       ownerPid: process.pid,
     });
     expect(context.env.BEADS_DOLT_SERVER_PORT).toBe("36002");
+  });
+
+  test("builds Beads env and working directory from path-edge shared server state", async () => {
+    const configRoot = await mkdtemp(path.join(tmpdir(), "odt config shared env-"));
+    const repoRoot = await mkdtemp(path.join(tmpdir(), "Repo With Spaces-"));
+    const serverRoot = path.join(configRoot, "beads", "shared-server");
+    const state = createSharedServerRecord(serverRoot, {
+      port: 36123,
+      sharedServerRoot: path.join(serverRoot, "C:\\Users\\Max Sky\\server"),
+      doltDataDir: path.join(serverRoot, "C:\\Users\\Max Sky\\server", "dolt data"),
+    });
+    await mkdir(serverRoot, { recursive: true });
+    await writeFile(path.join(serverRoot, "server.json"), JSON.stringify(state));
+
+    const context = await resolveBeadsCliContext(repoRoot, {
+      processEnv: { ...process.env, OPENDUCKTOR_CONFIG_DIR: configRoot },
+      requireSharedServer: false,
+      workspaceId: "workspace with spaces",
+    });
+
+    expect(context.workingDir).toBe(context.attachmentRoot);
+    expect(context.env.BEADS_DIR).toBe(context.beadsDir);
+    expect(context.env.BEADS_DOLT_SERVER_MODE).toBe("1");
+    expect(context.env.BEADS_DOLT_SERVER_HOST).toBe("127.0.0.1");
+    expect(context.env.BEADS_DOLT_SERVER_PORT).toBe("36123");
+    expect(context.env.BEADS_DOLT_SERVER_USER).toBe("root");
+    expect(context.serverStatePath).toBe(path.join(serverRoot, "server.json"));
   });
 
   test("serializes concurrent shared Dolt startup for the same config root", async () => {
@@ -342,6 +467,39 @@ describe("createBeadsAttachmentProvisioner", () => {
     await expect(readFile(path.join(context.beadsDir, "config.yaml"), "utf8")).resolves.toBe(
       "json: true\nno-git-ops: true # keep\n",
     );
+  });
+
+  test("initializes missing path-edge attachments from the attachment root", async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), "odt provisioning C:\\Users\\Max Sky-"));
+    const attachmentRoot = path.join(parent, "Attachment Root With Spaces");
+    const beadsDir = path.join(attachmentRoot, ".beads");
+    const context: BeadsCliContext = {
+      ...(await createContext()),
+      attachmentRoot,
+      beadsDir,
+      workingDir: attachmentRoot,
+      env: {
+        BEADS_DIR: beadsDir,
+        BEADS_DOLT_SERVER_MODE: "1",
+        BEADS_DOLT_SERVER_HOST: "127.0.0.1",
+        BEADS_DOLT_SERVER_PORT: "36003",
+        BEADS_DOLT_SERVER_USER: "root",
+      },
+    };
+    const calls: Array<{ command: string; args: string[]; cwd?: string; env?: NodeJS.ProcessEnv }> =
+      [];
+
+    await initializeMissingAttachment(async (input) => {
+      calls.push(input);
+      return { ok: true, stdout: "", stderr: "" };
+    }, context);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe("bd");
+    expect(calls[0]?.cwd).toBe(context.attachmentRoot);
+    expect(calls[0]?.env).toBe(context.env);
+    expect(calls[0]?.args).toContain("--database");
+    expect(calls[0]?.args).toContain(context.databaseName);
   });
 
   test("restores a missing shared database from the attachment backup", async () => {

--- a/packages/host/src/adapters/beads/beads-task-repository.test.ts
+++ b/packages/host/src/adapters/beads/beads-task-repository.test.ts
@@ -189,6 +189,52 @@ describe("createBeadsTaskRepository", () => {
     expect(requestedWorkspaceIds).toEqual(["openducktor"]);
   });
 
+  test("trims and forwards resolved workspace id for path-edge repo inputs", async () => {
+    const context = await createExistingBeadsCliContext();
+    const repoPath = path.join(
+      await mkdtemp(path.join(tmpdir(), "Repo With Spaces-")),
+      "C:\\Users\\Max Sky\\Repo Name",
+    );
+    const workspaceResolverCalls: string[] = [];
+    const contextRequests: Array<{
+      repoPath: string;
+      workspaceId: string | null | undefined;
+      requireSharedServer: boolean | undefined;
+    }> = [];
+    const port = createBeadsTaskRepository({
+      async resolveWorkspaceIdForRepoPath(requestedRepoPath) {
+        workspaceResolverCalls.push(requestedRepoPath);
+        return "  workspace-id-with-spaces  ";
+      },
+      async resolveCliContext(requestedRepoPath, options) {
+        contextRequests.push({
+          repoPath: requestedRepoPath,
+          workspaceId: options?.workspaceId,
+          requireSharedServer: options?.requireSharedServer,
+        });
+        return context;
+      },
+      async runBdJson(_repoPath, _args, callContext) {
+        expect(callContext).toBe(context);
+        return { path: context.beadsDir };
+      },
+    });
+
+    await expect(port.diagnoseRepoStore?.({ repoPath, prepare: true })).resolves.toMatchObject({
+      category: "healthy",
+      status: "ready",
+    });
+
+    expect(workspaceResolverCalls).toEqual([repoPath]);
+    expect(contextRequests).toEqual([
+      {
+        repoPath,
+        workspaceId: "workspace-id-with-spaces",
+        requireSharedServer: true,
+      },
+    ]);
+  });
+
   test("prepares the shared Dolt server when diagnostics request preparation", async () => {
     const context = await createExistingBeadsCliContext();
     const requestedSharedServerModes: Array<boolean | undefined> = [];

--- a/packages/host/src/adapters/beads/beads-task-repository.test.ts
+++ b/packages/host/src/adapters/beads/beads-task-repository.test.ts
@@ -193,7 +193,7 @@ describe("createBeadsTaskRepository", () => {
     const context = await createExistingBeadsCliContext();
     const repoPath = path.join(
       await mkdtemp(path.join(tmpdir(), "Repo With Spaces-")),
-      "C:\\Users\\Max Sky\\Repo Name",
+      "C-Users\\Max Sky\\Repo Name",
     );
     const workspaceResolverCalls: string[] = [];
     const contextRequests: Array<{

--- a/packages/host/src/infrastructure/beads/beads-shared-dolt-server.test.ts
+++ b/packages/host/src/infrastructure/beads/beads-shared-dolt-server.test.ts
@@ -1,0 +1,145 @@
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { BeadsSharedServerPaths, BeadsSharedServerState } from "./beads-context-model";
+import {
+  readSharedServerState,
+  serverStateIsHealthy,
+  writeDoltConfigFile,
+  writeSharedServerState,
+  yamlQuotePath,
+} from "./beads-shared-dolt-server";
+
+const createPaths = async (): Promise<BeadsSharedServerPaths> => {
+  const baseDir = await mkdtemp(path.join(tmpdir(), "odt config shared dolt-"));
+  const beadsRoot = path.join(baseDir, "beads");
+  const sharedServerRoot = path.join(beadsRoot, "shared server C:\\Users\\Max Sky");
+  return {
+    baseDir,
+    beadsRoot,
+    sharedServerRoot,
+    doltRoot: path.join(sharedServerRoot, "dolt data"),
+    cfgDir: path.join(sharedServerRoot, ".doltcfg with spaces"),
+    doltConfigFile: path.join(sharedServerRoot, "dolt-config.yaml"),
+    env: { ...process.env, OPENDUCKTOR_CONFIG_DIR: baseDir },
+    serverStatePath: path.join(sharedServerRoot, "server.json"),
+  };
+};
+
+const createState = (paths: BeadsSharedServerPaths): BeadsSharedServerState => ({
+  pid: process.pid,
+  host: "127.0.0.1",
+  port: 36111,
+  user: "root",
+  ownerPid: process.pid,
+  acquisition: "started_by_owner",
+  sharedServerRoot: paths.sharedServerRoot,
+  doltDataDir: paths.doltRoot,
+  startedAt: "2026-05-10T00:00:00Z",
+});
+
+describe("readSharedServerState", () => {
+  test("preserves path-edge strings from valid server state", async () => {
+    const paths = await createPaths();
+    const state = createState(paths);
+    await writeSharedServerState(paths, state);
+
+    await expect(readSharedServerState(paths.serverStatePath)).resolves.toEqual(state);
+  });
+
+  test("returns null when server state is absent", async () => {
+    const paths = await createPaths();
+
+    await expect(readSharedServerState(paths.serverStatePath)).resolves.toBeNull();
+  });
+
+  test("rejects malformed and non-object server state", async () => {
+    const paths = await createPaths();
+    await mkdir(path.dirname(paths.serverStatePath), { recursive: true });
+    await writeFile(paths.serverStatePath, "{broken");
+
+    await expect(readSharedServerState(paths.serverStatePath)).rejects.toThrow(
+      `Failed parsing shared Dolt server state ${paths.serverStatePath}`,
+    );
+
+    await writeFile(paths.serverStatePath, "[]");
+    await expect(readSharedServerState(paths.serverStatePath)).rejects.toThrow(
+      `Shared Dolt server state ${paths.serverStatePath} must contain a JSON object`,
+    );
+  });
+
+  test.each([
+    "pid",
+    "host",
+    "user",
+    "port",
+    "ownerPid",
+    "sharedServerRoot",
+    "doltDataDir",
+    "startedAt",
+  ])("rejects server state missing %s", async (field) => {
+    const paths = await createPaths();
+    await mkdir(path.dirname(paths.serverStatePath), { recursive: true });
+    const state = createState(paths) as Record<string, unknown>;
+    delete state[field];
+    await writeFile(paths.serverStatePath, JSON.stringify(state));
+
+    await expect(readSharedServerState(paths.serverStatePath)).rejects.toThrow(
+      `Shared Dolt server state ${paths.serverStatePath} is missing pid, host, user, port, ownerPid, sharedServerRoot, doltDataDir, or startedAt`,
+    );
+  });
+});
+
+describe("serverStateIsHealthy", () => {
+  test("rejects mismatched host, user, shared root, and data dir before probing services", async () => {
+    const paths = await createPaths();
+    const state = createState(paths);
+
+    await expect(serverStateIsHealthy({ ...state, host: "127.0.0.2" }, paths)).resolves.toBe(false);
+    await expect(serverStateIsHealthy({ ...state, user: "other" }, paths)).resolves.toBe(false);
+    await expect(
+      serverStateIsHealthy(
+        { ...state, sharedServerRoot: `${paths.sharedServerRoot}-other` },
+        paths,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      serverStateIsHealthy({ ...state, doltDataDir: `${paths.doltRoot}-other` }, paths),
+    ).resolves.toBe(false);
+  });
+});
+
+describe("Dolt config YAML rendering", () => {
+  test("quotes filesystem paths with spaces, backslashes, drive-letter text, and single quotes", () => {
+    expect(yamlQuotePath("C:\\Users\\Max Sky\\Repo Name")).toBe("'C:\\Users\\Max Sky\\Repo Name'");
+    expect(yamlQuotePath("/tmp/OpenDucktor's Config")).toBe("'/tmp/OpenDucktor''s Config'");
+  });
+
+  test("writes deterministic quoted paths and leaves no successful temp file", async () => {
+    const paths = await createPaths();
+    const quotedPaths = {
+      doltRoot: yamlQuotePath(paths.doltRoot),
+      cfgDir: yamlQuotePath(paths.cfgDir),
+      privilegeFile: yamlQuotePath(path.join(paths.cfgDir, "privileges.db")),
+      branchControlFile: yamlQuotePath(path.join(paths.cfgDir, "branch_control.db")),
+    };
+
+    await writeDoltConfigFile(paths, 36112);
+
+    await expect(readFile(paths.doltConfigFile, "utf8")).resolves.toBe(
+      `log_level: info\n` +
+        `behavior:\n` +
+        `  autocommit: true\n` +
+        `listener:\n` +
+        `  host: 127.0.0.1\n` +
+        `  port: 36112\n` +
+        `data_dir: ${quotedPaths.doltRoot}\n` +
+        `cfg_dir: ${quotedPaths.cfgDir}\n` +
+        `privilege_file: ${quotedPaths.privilegeFile}\n` +
+        `branch_control_file: ${quotedPaths.branchControlFile}\n`,
+    );
+    await expect(readdir(paths.sharedServerRoot)).resolves.not.toContain(
+      `dolt-config.yaml.tmp-${process.pid}`,
+    );
+  });
+});

--- a/packages/host/src/infrastructure/beads/beads-shared-dolt-server.test.ts
+++ b/packages/host/src/infrastructure/beads/beads-shared-dolt-server.test.ts
@@ -13,7 +13,7 @@ import {
 const createPaths = async (): Promise<BeadsSharedServerPaths> => {
   const baseDir = await mkdtemp(path.join(tmpdir(), "odt config shared dolt-"));
   const beadsRoot = path.join(baseDir, "beads");
-  const sharedServerRoot = path.join(beadsRoot, "shared server C:\\Users\\Max Sky");
+  const sharedServerRoot = path.join(beadsRoot, "shared server C-Users\\Max Sky");
   return {
     baseDir,
     beadsRoot,


### PR DESCRIPTION
## Summary
- add host Beads CLI context path-identity coverage for configured workspace ids, repo-derived ids, config-root placement, BEADS_DIR, and path-edge inputs
- add shared Dolt server tests for server.json parsing, exact health matching, YAML path quoting, and config file writes
- add task repository coverage for forwarding trimmed workspace ids from path-edge repo inputs

## Scope
- test-only change in packages/host
- no production path normalization, fallback storage, bundled bd/dolt, native smoke tests, or task identity behavior changes

## Verification
- bun run --filter @openducktor/host test
- bun run --filter @openducktor/host typecheck
- bun run --filter @openducktor/host lint