### PR TITLE
fix(codex): preserve idle status when attaching sessions

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.presence.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.presence.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, mock, test } from "bun:test";
-import { createHarness, waitForEvent } from "./codex-app-server-adapter.test-harness";
+import {
+  createHarness,
+  RecordingTransport,
+  waitForEvent,
+} from "./codex-app-server-adapter.test-harness";
+import type { CodexJsonRpcRequest } from "./index";
+
+class ThreadIdOnlyResumeTransport extends RecordingTransport {
+  async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
+    if (request.method === "thread/resume") {
+      return {
+        threadId: (request.params as { threadId: string }).threadId,
+        startedAt: "2026-05-07T00:00:00.000Z",
+      } as Response;
+    }
+    return super.request<Response>(request);
+  }
+}
 
 describe("CodexAppServerAdapter presence", () => {
   test("uses one Codex thread inventory during startup presence checks", async () => {
@@ -127,6 +144,99 @@ describe("CodexAppServerAdapter presence", () => {
     expect(transports.get("runtime-live")?.calls.map((call) => call.method)).not.toContain(
       "turn/start",
     );
+  });
+
+  test("attaches an idle Codex thread without marking it running", async () => {
+    const { adapter } = createHarness();
+
+    await expect(
+      adapter.attachSession({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        taskId: "task-1",
+        role: "build",
+        systemPrompt: "Use the repo rules.",
+        externalSessionId: "thread-idle",
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    ).resolves.toMatchObject({
+      externalSessionId: "thread-idle",
+      status: "idle",
+    });
+
+    await expect(
+      adapter.readSessionPresence({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "thread-idle",
+      }),
+    ).resolves.toMatchObject({ classification: "idle", agentSessionStatus: "idle" });
+  });
+
+  test("resumes an idle Codex thread without marking it running", async () => {
+    const { adapter } = createHarness();
+
+    await expect(
+      adapter.resumeSession({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        taskId: "task-1",
+        role: "build",
+        systemPrompt: "Use the repo rules.",
+        externalSessionId: "thread-idle",
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    ).resolves.toMatchObject({
+      externalSessionId: "thread-idle",
+      status: "idle",
+    });
+
+    await expect(
+      adapter.readSessionPresence({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "thread-idle",
+      }),
+    ).resolves.toMatchObject({ classification: "idle", agentSessionStatus: "idle" });
+  });
+
+  test("rejects Codex resume responses without a thread status", async () => {
+    const transport = new ThreadIdOnlyResumeTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      transportFactory: mock(() => transport),
+    });
+    const expectedMessage =
+      "Codex thread/resume response for thread 'thread-idle' is missing thread status.";
+
+    await expect(
+      adapter.resumeSession({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        taskId: "task-1",
+        role: "build",
+        systemPrompt: "Use the repo rules.",
+        externalSessionId: "thread-idle",
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    ).rejects.toThrow(expectedMessage);
+
+    await expect(
+      adapter.attachSession({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        taskId: "task-1",
+        role: "build",
+        systemPrompt: "Use the repo rules.",
+        externalSessionId: "thread-idle",
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    ).rejects.toThrow(expectedMessage);
   });
 
   test("streams messages and completion after refresh attach", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -75,20 +75,23 @@ export class RecordingTransport implements CodexJsonRpcTransport {
         } as Response;
       case "thread/start":
       case "thread/resume":
-      case "thread/fork":
+      case "thread/fork": {
+        const threadId =
+          method === "thread/resume"
+            ? (params as { threadId: string }).threadId
+            : `${method}-${this.runtimeId}`;
         return {
           thread: {
-            id:
-              method === "thread/resume"
-                ? (params as { threadId: string }).threadId
-                : `${method}-${this.runtimeId}`,
+            id: threadId,
             cwd: "/repo",
             createdAt: 1_778_112_000,
             preview: "Live Codex session",
-            status: { type: "active", activeFlags: [] },
+            status:
+              threadId === "thread-idle" ? { type: "idle" } : { type: "active", activeFlags: [] },
           },
           startedAt: "2026-05-07T00:00:00.000Z",
         } as Response;
+      }
       case "turn/start":
         if (
           !Array.isArray((params as { input?: unknown })?.input) ||

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -62,7 +62,7 @@ import {
   type CodexThreadSnapshot,
   codexThreadStatusSnapshot,
   extractThreadId,
-  threadSnapshotFromReadResponse,
+  requireThreadSnapshotFromReadResponse,
   toSessionSummary,
 } from "./codex-app-server-threads";
 import {
@@ -209,6 +209,7 @@ export class CodexAppServerAdapter
       externalSessionId,
       startedAt: startedAt ?? new Date().toISOString(),
       role: input.role,
+      status: "running",
     });
 
     this.sessions.set(summary.externalSessionId, {
@@ -244,14 +245,19 @@ export class CodexAppServerAdapter
     });
     this.clearThreadInventory(runtimeId);
     const { externalSessionId, startedAt } = extractThreadId(response, "thread/resume");
-    const threadSnapshot = threadSnapshotFromReadResponse(response);
+    const threadSnapshot = requireThreadSnapshotFromReadResponse(
+      response,
+      "thread/resume",
+      externalSessionId,
+    );
 
     const summary = toSessionSummary({
       externalSessionId,
-      startedAt: startedAt ?? threadSnapshot?.startedAt ?? new Date().toISOString(),
+      startedAt: startedAt ?? threadSnapshot.startedAt,
       role: input.role,
+      status: threadSnapshot.status.agentSessionStatus,
     });
-    const liveStatus = threadSnapshot?.status;
+    const liveStatus = threadSnapshot.status;
 
     this.sessions.set(summary.externalSessionId, {
       summary,
@@ -292,6 +298,7 @@ export class CodexAppServerAdapter
       externalSessionId,
       startedAt: startedAt ?? new Date().toISOString(),
       role: input.role,
+      status: "running",
     });
 
     this.sessions.set(summary.externalSessionId, {
@@ -602,13 +609,18 @@ export class CodexAppServerAdapter
       ...(model ? { effort: toTransportModelSelection(model).effort } : {}),
     });
     const { externalSessionId, startedAt } = extractThreadId(response, "thread/resume");
-    const threadSnapshot = threadSnapshotFromReadResponse(response);
+    const threadSnapshot = requireThreadSnapshotFromReadResponse(
+      response,
+      "thread/resume",
+      externalSessionId,
+    );
     const summary = toSessionSummary({
       externalSessionId,
-      startedAt: startedAt ?? threadSnapshot?.startedAt ?? new Date().toISOString(),
+      startedAt: startedAt ?? threadSnapshot.startedAt,
       role: input.role,
+      status: threadSnapshot.status.agentSessionStatus,
     });
-    const liveStatus = threadSnapshot?.status;
+    const liveStatus = threadSnapshot.status;
     const sessionState: CodexSessionState = {
       summary,
       ...(model ? { model } : {}),

--- a/packages/adapters-codex-app-server/src/codex-app-server-threads.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-threads.ts
@@ -29,12 +29,13 @@ export const toSessionSummary = (input: {
   externalSessionId: string;
   startedAt: string;
   role: AgentRole | null;
+  status: AgentSessionSummary["status"];
 }): AgentSessionSummary => ({
   externalSessionId: input.externalSessionId,
   runtimeKind: "codex",
   role: input.role,
   startedAt: input.startedAt,
-  status: "running",
+  status: input.status,
 });
 
 export type CodexThreadStatusSnapshot = {
@@ -128,3 +129,17 @@ export const codexLoadedThreadIds = (response: unknown): Set<string> =>
 
 export const threadSnapshotFromReadResponse = (response: unknown): CodexThreadSnapshot | null =>
   isPlainObject(response) ? codexThreadSnapshot(response.thread) : null;
+
+export const requireThreadSnapshotFromReadResponse = (
+  response: unknown,
+  action: string,
+  externalSessionId: string,
+): CodexThreadSnapshot => {
+  const threadSnapshot = threadSnapshotFromReadResponse(response);
+  if (!threadSnapshot) {
+    throw new Error(
+      `Codex ${action} response for thread '${externalSessionId}' is missing thread status.`,
+    );
+  }
+  return threadSnapshot;
+};


### PR DESCRIPTION
## Summary
Fixes Codex refresh/attach behavior so an already-idle Codex thread is not displayed as running after the user returns to the session.

## Context
Task `openducktor-n7db` reports that Codex sessions can go idle while the user is away, then appear as running after the UI refreshes them. This is Codex-specific; OpenCode does not use this Codex App Server attach/resume path.

## Implementation
- Preserve the Codex thread snapshot status when `thread/resume` returns a thread during `resumeSession` or `attachSession`.
- Fail fast when `thread/resume` does not return a parseable thread status instead of inventing a `running` state.
- Keep new session start/fork summaries explicitly running.
- Make Codex session summary status explicit at every call site.
- Add regression tests for idle `attachSession`, idle `resumeSession`, and missing thread-status responses.

## Verification
- `bun test packages/adapters-codex-app-server/src/codex-app-server-adapter.presence.test.ts`
- `bun run --filter @openducktor/adapters-codex-app-server typecheck`
- `bun run --filter @openducktor/adapters-codex-app-server lint`
- `bun run --filter @openducktor/adapters-codex-app-server test`
- `bun run typecheck`
- `bun run lint`
- `env -u ODT_HOST_TOKEN -u ODT_FORBID_WORKSPACE_ID_INPUT bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `git diff --check`

Note: plain `bun run test` inherited this Builder session's MCP bridge env (`ODT_HOST_TOKEN` / `ODT_FORBID_WORKSPACE_ID_INPUT`) and failed an unrelated MCP environment-expectation test. The clean-env root test run above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Idle threads are no longer incorrectly marked as running during attach and resume.
  * Resume now rejects incomplete thread status responses.

* **Behavior Changes**
  * Session summaries now preserve explicit session status from the source instead of defaulting to running.
  * Newly started or forked sessions are explicitly reported as running.

* **Tests**
  * Added tests for idle-thread handling and for rejecting missing-status responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->