### PR TITLE
fix(git): detect add-add rebase conflicts

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -552,6 +552,7 @@ fn parse_status_porcelain(output: &str) -> Vec<GitFileStatus> {
             let (status, staged) = match (index, worktree) {
                 ('?', '?') => ("untracked".to_string(), false),
                 ('!', '!') => ("ignored".to_string(), false),
+                pair if is_unmerged_status_pair(pair) => ("unmerged".to_string(), true),
                 (i, ' ') if i != ' ' => (porcelain_char_to_status(i), true),
                 (' ', w) if w != ' ' => (porcelain_char_to_status(w), false),
                 (i, _w) => (porcelain_char_to_status(i), true),
@@ -564,6 +565,13 @@ fn parse_status_porcelain(output: &str) -> Vec<GitFileStatus> {
             })
         })
         .collect()
+}
+
+fn is_unmerged_status_pair((index, worktree): (char, char)) -> bool {
+    matches!(
+        (index, worktree),
+        ('D', 'D') | ('A', 'U') | ('U', 'D') | ('U', 'A') | ('D', 'U') | ('A', 'A') | ('U', 'U')
+    )
 }
 
 fn porcelain_char_to_status(ch: char) -> String {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
@@ -323,6 +323,63 @@ fn get_worktree_status_rehydrates_rebase_conflict_context() {
 }
 
 #[test]
+fn get_worktree_status_rehydrates_add_add_rebase_conflict_context() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-add-add-rebase-conflict");
+    let git = GitCliPort::new();
+
+    git.switch_branch(&repo.path, "feature/add-add-conflict", true)
+        .expect("feature branch should be created");
+    fs::write(repo.path.join("new-shared.txt"), "feature value\n")
+        .expect("feature file should write");
+    run_git_ok(&repo.path, &["add", "new-shared.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "feature adds shared file"]);
+
+    git.switch_branch(&repo.path, "main", false)
+        .expect("return to main");
+    fs::write(repo.path.join("new-shared.txt"), "main value\n").expect("main file should write");
+    run_git_ok(&repo.path, &["add", "new-shared.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "main adds shared file"]);
+
+    git.switch_branch(&repo.path, "feature/add-add-conflict", false)
+        .expect("return to feature branch");
+    let rebase_output = Command::new("git")
+        .args(["rebase", "main"])
+        .current_dir(&repo.path)
+        .output()
+        .expect("git rebase should execute");
+    assert!(
+        !rebase_output.status.success(),
+        "rebase should stop on add/add conflicts\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&rebase_output.stdout),
+        String::from_utf8_lossy(&rebase_output.stderr)
+    );
+
+    let status = git
+        .get_worktree_status(&repo.path, "main", GitDiffScope::Target)
+        .expect("worktree status should resolve during add/add rebase conflict");
+
+    assert!(status
+        .file_statuses
+        .iter()
+        .any(|file| file.path == "new-shared.txt" && file.status == "unmerged"));
+    let git_conflict = status
+        .git_conflict
+        .expect("add/add rebase conflict context should be available after reload");
+    assert_eq!(
+        git_conflict.operation,
+        host_domain::GitConflictOperation::Rebase
+    );
+    assert!(git_conflict
+        .conflicted_files
+        .iter()
+        .any(|file| file == "new-shared.txt"));
+}
+
+#[test]
 fn get_worktree_status_rehydrates_rebase_conflict_context_without_upstream() {
     if !git_available() {
         return;

--- a/packages/host/src/adapters/git/git-cli-adapter.test.ts
+++ b/packages/host/src/adapters/git/git-cli-adapter.test.ts
@@ -548,7 +548,7 @@ describe("createGitCliAdapter", () => {
               "rev-parse HEAD": "before\n",
               "config --get branch.feature/electron.remote": "origin\n",
               "config --get branch.feature/electron.merge": "refs/heads/main\n",
-              "status --porcelain=v1 --untracked-files=all": rebaseFailed ? "AA src/main.ts\n" : "",
+              "status --porcelain=v1 --untracked-files=all": rebaseFailed ? "UU src/main.ts\n" : "",
               "fetch --prune -- origin +refs/heads/main:refs/remotes/origin/main":
                 "Fetched origin\n",
               "rev-list --count --left-right --end-of-options refs/remotes/origin/main...HEAD":

--- a/packages/host/src/adapters/git/git-cli-adapter.test.ts
+++ b/packages/host/src/adapters/git/git-cli-adapter.test.ts
@@ -68,6 +68,7 @@ describe("createGitCliAdapter", () => {
           "?? src/new.ts",
           "!! dist/ignored.js",
           "UU src/conflict.ts",
+          "AA src/add-add-conflict.ts",
         ].join("\n"),
       }),
     });
@@ -78,6 +79,7 @@ describe("createGitCliAdapter", () => {
       { path: "src/new.ts", status: "untracked", staged: false },
       { path: "dist/ignored.js", status: "ignored", staged: false },
       { path: "src/conflict.ts", status: "unmerged", staged: true },
+      { path: "src/add-add-conflict.ts", status: "unmerged", staged: true },
     ]);
   });
 
@@ -546,7 +548,7 @@ describe("createGitCliAdapter", () => {
               "rev-parse HEAD": "before\n",
               "config --get branch.feature/electron.remote": "origin\n",
               "config --get branch.feature/electron.merge": "refs/heads/main\n",
-              "status --porcelain=v1 --untracked-files=all": rebaseFailed ? "UU src/main.ts\n" : "",
+              "status --porcelain=v1 --untracked-files=all": rebaseFailed ? "AA src/main.ts\n" : "",
               "fetch --prune -- origin +refs/heads/main:refs/remotes/origin/main":
                 "Fetched origin\n",
               "rev-list --count --left-right --end-of-options refs/remotes/origin/main...HEAD":
@@ -843,7 +845,7 @@ describe("createGitCliAdapter", () => {
             {
               "branch --show-current": "feature/electron\n",
               "rev-parse HEAD": "abc123\n",
-              "status --porcelain=v1 --untracked-files=all": rebaseFailed ? "UU src/main.ts\n" : "",
+              "status --porcelain=v1 --untracked-files=all": rebaseFailed ? "AA src/main.ts\n" : "",
             }[command] ?? "",
           stderr: "",
         };

--- a/packages/host/src/infrastructure/git/git-status.ts
+++ b/packages/host/src/infrastructure/git/git-status.ts
@@ -7,6 +7,8 @@ import type {
 } from "@openducktor/contracts";
 import { type GitCommandRunner, runGit, runGitAllowFailure } from "./git-command-runner";
 
+const unmergedStatusPairs = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
+
 export const parseBranchRows = (output: string): GitBranch[] => {
   const branches = output.split(/\r?\n/).flatMap((line): GitBranch[] => {
     const trimmed = line.trim();
@@ -85,6 +87,11 @@ export const porcelainCharToStatus = (value: string): string => {
   }
 };
 
+export const isUnmergedStatusPair = (index: string, worktree: string): boolean => {
+  const pair = `${index}${worktree}`;
+  return unmergedStatusPairs.has(pair);
+};
+
 export const parseStatusPorcelain = (output: string): FileStatus[] =>
   output.split(/\r?\n/).flatMap((line): FileStatus[] => {
     if (line.length < 4) {
@@ -100,6 +107,9 @@ export const parseStatusPorcelain = (output: string): FileStatus[] =>
     }
     if (index === "!" && worktree === "!") {
       return [{ path: filePath, status: "ignored", staged: false }];
+    }
+    if (isUnmergedStatusPair(index, worktree)) {
+      return [{ path: filePath, status: "unmerged", staged: true }];
     }
     if (index !== " " && worktree === " ") {
       return [{ path: filePath, status: porcelainCharToStatus(index), staged: true }];


### PR DESCRIPTION
Summary
Fixes git conflict rehydration for add/add rebase conflicts in the Electron TypeScript host and keeps the Rust/Tauri git parser in parity.

Goal
When an Agent Studio rebase stops on an add/add conflict, Git reports the conflicted file with the porcelain status pair AA. The Electron host previously classified that as added instead of unmerged, so after an app reload the Git panel could not reconstruct the active conflict state.

Technical choices
- Classify all documented unmerged porcelain status pairs (DD, AU, UD, UA, DU, AA, UU) as unmerged at the git status parser layer.
- Apply the same parser rule in the Rust host implementation so Electron and Tauri behavior stay aligned.
- Add TypeScript adapter coverage for AA status rows and failed rebase/pull conflict results.
- Add a Rust integration regression that creates a real add/add rebase conflict and verifies worktree status rehydrates gitConflict after reload-style status collection.

Verification
- bun run typecheck
- bun run lint
- bun run test
- bun run build
- cd apps/desktop/src-tauri && cargo fmt --all --check
- cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test
- cd apps/desktop/src-tauri && cargo build