### PR TITLE
fix(host): harden cross-platform process cleanup

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -28,6 +28,12 @@ pub(crate) use shared_dolt_server::{
     SHARED_DOLT_PORT_RANGE_START,
 };
 
+#[cfg(all(test, unix))]
+pub(crate) use shared_dolt_server::unix_process_tree_signal_target;
+
+#[cfg(all(test, windows))]
+pub(crate) use shared_dolt_server::windows_taskkill_args;
+
 #[cfg(test)]
 #[path = "beads/tests.rs"]
 mod tests;

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -24,7 +24,7 @@ pub use shared_dolt_server::{
 #[cfg(test)]
 pub(crate) use shared_dolt_server::{
     deterministic_shared_dolt_port_candidate, process_matches_expected_dolt_server,
-    wrap_port_candidate, write_dolt_config_file, SHARED_DOLT_PORT_RANGE_LEN,
+    wait_for_child_exit, wrap_port_candidate, write_dolt_config_file, SHARED_DOLT_PORT_RANGE_LEN,
     SHARED_DOLT_PORT_RANGE_START,
 };
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads/shared_dolt_server.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads/shared_dolt_server.rs
@@ -552,12 +552,83 @@ fn cleanup_spawned_child(child: &mut std::process::Child) -> Result<()> {
         .try_wait()
         .context("Failed checking shared Dolt server process state")?;
     if status.is_none() {
-        terminate_shared_dolt_process_tree(child.id())?;
-        child
-            .wait()
-            .context("Failed waiting for spawned shared Dolt server cleanup")?;
+        terminate_spawned_shared_dolt_child(child)?;
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn terminate_spawned_shared_dolt_child(child: &mut std::process::Child) -> Result<()> {
+    let pid = child.id();
+    signal_shared_dolt_process_tree(pid, libc::SIGTERM, "SIGTERM")?;
+    if wait_for_child_exit(child, Duration::from_secs(3))? {
+        return Ok(());
+    }
+
+    signal_shared_dolt_process_tree(pid, libc::SIGKILL, "SIGKILL")?;
+    if wait_for_child_exit(child, Duration::from_secs(2))? {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "Spawned shared Dolt server process {} is still alive after SIGKILL timeout",
+        pid
+    ))
+}
+
+#[cfg(windows)]
+fn terminate_spawned_shared_dolt_child(child: &mut std::process::Child) -> Result<()> {
+    let pid = child.id();
+    let status = Command::new("taskkill")
+        .args(windows_taskkill_args(pid))
+        .status()
+        .with_context(|| format!("Failed running taskkill for spawned Dolt pid {pid}"))?;
+    if wait_for_child_exit(child, Duration::from_secs(2))? {
+        return Ok(());
+    }
+    if status.success() {
+        return Err(anyhow!(
+            "Spawned shared Dolt server process {pid} is still alive after taskkill timeout"
+        ));
+    }
+    Err(anyhow!(
+        "taskkill failed to stop spawned Dolt process tree {pid}"
+    ))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn terminate_spawned_shared_dolt_child(child: &mut std::process::Child) -> Result<()> {
+    child
+        .kill()
+        .context("Failed terminating spawned shared Dolt server process")?;
+    if wait_for_child_exit(child, Duration::from_secs(3))? {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "Spawned shared Dolt server process {} is still alive after termination timeout",
+        child.id()
+    ))
+}
+
+pub(crate) fn wait_for_child_exit(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> Result<bool> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if child
+            .try_wait()
+            .context("Failed checking spawned shared Dolt server process state")?
+            .is_some()
+        {
+            return Ok(true);
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    Ok(child
+        .try_wait()
+        .context("Failed checking spawned shared Dolt server process state")?
+        .is_some())
 }
 
 fn remove_if_exists(path: &Path) -> Result<()> {
@@ -590,21 +661,12 @@ fn terminate_shared_dolt_process_tree(pid: u32) -> Result<()> {
 
     #[cfg(unix)]
     {
-        let process_group_id = unix_process_tree_signal_target(pid);
-        let terminate_status = unsafe { libc::kill(process_group_id, libc::SIGTERM) };
-        if terminate_status != 0 {
-            return Err(std::io::Error::last_os_error())
-                .with_context(|| format!("Failed sending SIGTERM to Dolt process group {pid}"));
-        }
+        signal_shared_dolt_process_tree(pid, libc::SIGTERM, "SIGTERM")?;
         if wait_for_process_exit(pid, Duration::from_secs(3)) {
             return Ok(());
         }
 
-        let kill_status = unsafe { libc::kill(process_group_id, libc::SIGKILL) };
-        if kill_status != 0 {
-            return Err(std::io::Error::last_os_error())
-                .with_context(|| format!("Failed sending SIGKILL to Dolt process group {pid}"));
-        }
+        signal_shared_dolt_process_tree(pid, libc::SIGKILL, "SIGKILL")?;
         if wait_for_process_exit(pid, Duration::from_secs(2)) {
             return Ok(());
         }
@@ -648,6 +710,17 @@ fn terminate_shared_dolt_process_tree(pid: u32) -> Result<()> {
         }
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn signal_shared_dolt_process_tree(pid: u32, signal: i32, label: &str) -> Result<()> {
+    let process_group_id = unix_process_tree_signal_target(pid);
+    let status = unsafe { libc::kill(process_group_id, signal) };
+    if status == 0 {
+        return Ok(());
+    }
+    Err(std::io::Error::last_os_error())
+        .with_context(|| format!("Failed sending {label} to Dolt process group {pid}"))
 }
 
 #[cfg(unix)]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads/shared_dolt_server.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads/shared_dolt_server.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 use sysinfo::Signal;
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use url::Url;
@@ -552,8 +552,10 @@ fn cleanup_spawned_child(child: &mut std::process::Child) -> Result<()> {
         .try_wait()
         .context("Failed checking shared Dolt server process state")?;
     if status.is_none() {
-        let _ = child.kill();
-        let _ = child.wait();
+        terminate_shared_dolt_process_tree(child.id())?;
+        child
+            .wait()
+            .context("Failed waiting for spawned shared Dolt server cleanup")?;
     }
     Ok(())
 }
@@ -578,37 +580,58 @@ fn terminate_process_by_pid(pid: u32, expected_shared_server_root: &Path) -> Res
         ));
     }
 
+    terminate_shared_dolt_process_tree(pid)
+}
+
+fn terminate_shared_dolt_process_tree(pid: u32) -> Result<()> {
+    if !is_process_alive(pid) {
+        return Ok(());
+    }
+
     #[cfg(unix)]
     {
-        let raw_pid = pid as i32;
-        let terminate_status = unsafe { libc::kill(raw_pid, libc::SIGTERM) };
+        let process_group_id = unix_process_tree_signal_target(pid);
+        let terminate_status = unsafe { libc::kill(process_group_id, libc::SIGTERM) };
         if terminate_status != 0 {
             return Err(std::io::Error::last_os_error())
-                .with_context(|| format!("Failed sending SIGTERM to Dolt pid {pid}"));
+                .with_context(|| format!("Failed sending SIGTERM to Dolt process group {pid}"));
         }
         let terminated_after_term = wait_for_process_exit(pid, Duration::from_secs(3));
         if is_process_alive(pid) {
-            let kill_status = unsafe { libc::kill(raw_pid, libc::SIGKILL) };
+            let kill_status = unsafe { libc::kill(process_group_id, libc::SIGKILL) };
             if kill_status != 0 {
-                return Err(std::io::Error::last_os_error())
-                    .with_context(|| format!("Failed sending SIGKILL to Dolt pid {pid}"));
+                return Err(std::io::Error::last_os_error()).with_context(|| {
+                    format!("Failed sending SIGKILL to Dolt process group {pid}")
+                });
             }
             if !wait_for_process_exit(pid, Duration::from_secs(2)) {
                 return Err(anyhow!(
-                    "Dolt pid {} is still alive after SIGKILL timeout",
+                    "Dolt process group {} is still alive after SIGKILL timeout",
                     pid
                 ));
             }
         } else if !terminated_after_term {
             return Err(anyhow!(
-                "Dolt pid {} is still alive after SIGTERM timeout",
+                "Dolt process group {} is still alive after SIGTERM timeout",
                 pid
             ));
         }
         Ok(())
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        let status = Command::new("taskkill")
+            .args(windows_taskkill_args(pid))
+            .status()
+            .with_context(|| format!("Failed running taskkill for Dolt pid {pid}"))?;
+        if status.success() || !is_process_alive(pid) {
+            return Ok(());
+        }
+        Err(anyhow!("taskkill failed to stop Dolt process tree {pid}"))
+    }
+
+    #[cfg(all(not(unix), not(windows)))]
     {
         let mut system = System::new_all();
         system.refresh_processes(ProcessesToUpdate::All, true);
@@ -629,6 +652,21 @@ fn terminate_process_by_pid(pid: u32, expected_shared_server_root: &Path) -> Res
         }
         Ok(())
     }
+}
+
+#[cfg(unix)]
+pub(crate) fn unix_process_tree_signal_target(pid: u32) -> i32 {
+    -(pid as i32)
+}
+
+#[cfg(windows)]
+pub(crate) fn windows_taskkill_args(pid: u32) -> Vec<String> {
+    vec![
+        "/PID".to_string(),
+        pid.to_string(),
+        "/T".to_string(),
+        "/F".to_string(),
+    ]
 }
 
 fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads/shared_dolt_server.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads/shared_dolt_server.rs
@@ -596,27 +596,23 @@ fn terminate_shared_dolt_process_tree(pid: u32) -> Result<()> {
             return Err(std::io::Error::last_os_error())
                 .with_context(|| format!("Failed sending SIGTERM to Dolt process group {pid}"));
         }
-        let terminated_after_term = wait_for_process_exit(pid, Duration::from_secs(3));
-        if is_process_alive(pid) {
-            let kill_status = unsafe { libc::kill(process_group_id, libc::SIGKILL) };
-            if kill_status != 0 {
-                return Err(std::io::Error::last_os_error()).with_context(|| {
-                    format!("Failed sending SIGKILL to Dolt process group {pid}")
-                });
-            }
-            if !wait_for_process_exit(pid, Duration::from_secs(2)) {
-                return Err(anyhow!(
-                    "Dolt process group {} is still alive after SIGKILL timeout",
-                    pid
-                ));
-            }
-        } else if !terminated_after_term {
-            return Err(anyhow!(
-                "Dolt process group {} is still alive after SIGTERM timeout",
-                pid
-            ));
+        if wait_for_process_exit(pid, Duration::from_secs(3)) {
+            return Ok(());
         }
-        Ok(())
+
+        let kill_status = unsafe { libc::kill(process_group_id, libc::SIGKILL) };
+        if kill_status != 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("Failed sending SIGKILL to Dolt process group {pid}"));
+        }
+        if wait_for_process_exit(pid, Duration::from_secs(2)) {
+            return Ok(());
+        }
+
+        Err(anyhow!(
+            "Dolt process group {} is still alive after SIGKILL timeout",
+            pid
+        ))
     }
 
     #[cfg(windows)]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
@@ -159,6 +159,26 @@ fn shared_dolt_server_reports_invalid_dolt_override() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn shared_dolt_unix_cleanup_targets_process_group() {
+    assert_eq!(super::unix_process_tree_signal_target(1234), -1234);
+}
+
+#[cfg(windows)]
+#[test]
+fn shared_dolt_windows_cleanup_uses_taskkill_tree_args() {
+    assert_eq!(
+        super::windows_taskkill_args(1234),
+        vec![
+            "/PID".to_string(),
+            "1234".to_string(),
+            "/T".to_string(),
+            "/F".to_string(),
+        ]
+    );
+}
+
 #[test]
 fn repo_attachment_helpers_use_expected_layouts() {
     let _env_lock = lock_env();

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
@@ -12,10 +12,12 @@ use super::{
     SharedDoltServerState, SHARED_DOLT_PORT_RANGE_LEN, SHARED_DOLT_PORT_RANGE_START,
     SHARED_DOLT_SERVER_HOST, SHARED_DOLT_SERVER_USER,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use host_test_support::{lock_env, EnvVarGuard};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
 
@@ -177,6 +179,31 @@ fn shared_dolt_windows_cleanup_uses_taskkill_tree_args() {
             "/F".to_string(),
         ]
     );
+}
+
+#[test]
+fn shared_dolt_spawned_child_wait_reaps_exited_child() -> Result<()> {
+    #[cfg(windows)]
+    let mut child = Command::new("cmd")
+        .args(["/C", "exit", "/B", "0"])
+        .spawn()
+        .context("spawn exited child")?;
+
+    #[cfg(not(windows))]
+    let mut child = Command::new("sh")
+        .args(["-c", "exit 0"])
+        .spawn()
+        .context("spawn exited child")?;
+
+    assert!(super::wait_for_child_exit(
+        &mut child,
+        Duration::from_secs(2)
+    )?);
+    assert!(child
+        .try_wait()
+        .context("check child after reaping")?
+        .is_some());
+    Ok(())
 }
 
 #[test]

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +8,7 @@ import { removeTestDirectory } from "../../test-support/temp-directory";
 import { createCodexAppServerTransportRegistry } from "./codex-app-server-transport-registry";
 import {
   buildCodexMcpConfigArgs,
+  codexCommand,
   createCodexWorkspaceRuntimeStarter,
 } from "./codex-workspace-runtime-starter";
 
@@ -24,16 +26,21 @@ const createSystemCommands = (): SystemCommandPort => ({
 
 const createFakeCodex = async (
   root: string,
-  { emitStreamEvents = false }: { emitStreamEvents?: boolean } = {},
+  {
+    childPidPath,
+    emitStreamEvents = false,
+  }: { childPidPath?: string; emitStreamEvents?: boolean } = {},
 ): Promise<string> => {
   const scriptPath = join(root, "codex.mjs");
   const executable = join(root, process.platform === "win32" ? "codex.cmd" : "codex");
   await writeFile(
     scriptPath,
-    `import { createInterface } from "node:readline";
+    `import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
 import { writeFileSync } from "node:fs";
 
 const capturePath = process.env.CODEX_CAPTURE_PATH;
+const childPidPath = ${JSON.stringify(childPidPath ?? null)};
 const emitStreamEvents = ${JSON.stringify(emitStreamEvents)};
 const capture = {
   args: process.argv.slice(2),
@@ -53,6 +60,12 @@ if (capturePath) {
 if (!process.argv.includes("app-server")) {
   console.error("expected app-server command");
   process.exit(2);
+}
+if (childPidPath) {
+  const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], {
+    stdio: "ignore",
+  });
+  writeFileSync(childPidPath, String(child.pid));
 }
 
 const lines = createInterface({ input: process.stdin });
@@ -102,6 +115,26 @@ const waitForEvents = async (events: unknown[], count: number): Promise<void> =>
   throw new Error(`Timed out waiting for ${count} Codex app-server event(s).`);
 };
 
+const waitFor = async (predicate: () => boolean, timeoutMs = 1_000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for condition.");
+};
+
+const processIsAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 describe("createCodexWorkspaceRuntimeStarter", () => {
   test("builds Codex MCP config args for OpenDucktor tools", () => {
     expect(buildCodexMcpConfigArgs(["mcp-bin", "--stdio"])).toEqual([
@@ -114,6 +147,13 @@ describe("createCodexWorkspaceRuntimeStarter", () => {
       "--config",
       "mcp_servers.openducktor.enabled=true",
     ]);
+  });
+
+  test("wraps Windows command scripts through cmd.exe", () => {
+    expect(codexCommand("C:\\Tools\\codex.cmd", ["app-server"], "win32", "cmd.exe")).toEqual({
+      file: "cmd.exe",
+      args: ["/d", "/c", "call", "C:\\Tools\\codex.cmd", "app-server"],
+    });
   });
 
   test("fails fast when the MCP bridge connection is not configured", async () => {
@@ -206,6 +246,92 @@ describe("createCodexWorkspaceRuntimeStarter", () => {
       } else {
         process.env.CODEX_CAPTURE_PATH = originalCapturePath;
       }
+      await removeTestDirectory(root);
+    }
+  });
+
+  test("stops the Codex app-server process tree including descendants", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-codex-starter-tree-"));
+    let childPid: number | null = null;
+    try {
+      const repo = join(root, "repo");
+      const childPidPath = join(root, "child.pid");
+      await mkdir(repo);
+      const codexBinary = await createFakeCodex(root, { childPidPath });
+      const codexAppServer = createCodexAppServerTransportRegistry();
+      const starter = createCodexWorkspaceRuntimeStarter({
+        systemCommands: createSystemCommands(),
+        codexAppServer,
+        codexBinary,
+        mcpCommand: ["mcp-bin", "--stdio"],
+        resolveMcpBridgeConnection: async () => ({
+          workspaceId: "repo",
+          hostUrl: "http://127.0.0.1:14327",
+          hostToken: "token-1",
+        }),
+        requestTimeoutMs: 4_000,
+        runtimeId: () => "runtime-tree",
+      });
+
+      const handle = await starter.startWorkspaceRuntime({
+        runtimeKind: "codex",
+        repoPath: repo,
+        workingDirectory: repo,
+        descriptor: RUNTIME_DESCRIPTORS_BY_KIND.codex,
+      });
+      await waitFor(() => existsSync(childPidPath));
+      childPid = Number(await readFile(childPidPath, "utf8"));
+      expect(processIsAlive(childPid)).toBe(true);
+
+      await handle.stop();
+      await waitFor(() => !processIsAlive(childPid as number));
+    } finally {
+      if (childPid !== null && processIsAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+      }
+      await removeTestDirectory(root);
+    }
+  });
+
+  test("keeps process-tree cleanup failures visible while unregistering transport", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-codex-cleanup-failure-"));
+    try {
+      const repo = join(root, "repo");
+      await mkdir(repo);
+      const codexBinary = await createFakeCodex(root);
+      const codexAppServer = createCodexAppServerTransportRegistry();
+      const starter = createCodexWorkspaceRuntimeStarter({
+        systemCommands: createSystemCommands(),
+        codexAppServer,
+        codexBinary,
+        mcpCommand: ["mcp-bin", "--stdio"],
+        resolveMcpBridgeConnection: async () => ({
+          workspaceId: "repo",
+          hostUrl: "http://127.0.0.1:14327",
+          hostToken: "token-1",
+        }),
+        requestTimeoutMs: 4_000,
+        runtimeId: () => "runtime-cleanup-failure",
+        processTreeTerminator: async () => {
+          throw new Error("process tree stayed alive");
+        },
+      });
+
+      const handle = await starter.startWorkspaceRuntime({
+        runtimeKind: "codex",
+        repoPath: repo,
+        workingDirectory: repo,
+        descriptor: RUNTIME_DESCRIPTORS_BY_KIND.codex,
+      });
+
+      await expect(handle.stop()).rejects.toThrow("process tree: process tree stayed alive");
+      await expect(
+        codexAppServer.request({
+          runtimeId: "runtime-cleanup-failure",
+          method: "thread/loaded/list",
+        }),
+      ).rejects.toThrow("Codex app-server transport not found");
+    } finally {
       await removeTestDirectory(root);
     }
   });

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
@@ -12,7 +12,11 @@ import type {
 } from "../../ports/runtime-registry-port";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "../mcp/openducktor-mcp-command";
-import { shouldStartDetachedProcessGroup, terminateProcessTree } from "../process/process-tree";
+import {
+  type ProcessTreePlatform,
+  shouldStartDetachedProcessGroup,
+  terminateProcessTree,
+} from "../process/process-tree";
 import { resolveCodexBinary } from "../runtimes/runtime-binaries";
 import {
   type CodexAppServerEventEmitter,
@@ -21,6 +25,7 @@ import {
 import type { CodexAppServerTransportRegistry } from "./codex-app-server-transport-registry";
 
 type CodexChildProcess = ChildProcessByStdio<Writable, Readable, Readable>;
+type ProcessTreeTerminator = typeof terminateProcessTree;
 
 export type CodexMcpBridgeConnection = {
   workspaceId: string;
@@ -43,6 +48,9 @@ export type CreateCodexWorkspaceRuntimeStarterInput = {
   stopTimeoutMs?: number;
   now?: () => Date;
   runtimeId?: () => string;
+  platform?: ProcessTreePlatform;
+  commandShell?: string;
+  processTreeTerminator?: ProcessTreeTerminator;
 };
 
 const CODEX_MCP_ENV_VARS = [
@@ -125,13 +133,18 @@ const waitForClose = (
   });
 };
 
-const codexCommand = (binary: string, args: string[]): { file: string; args: string[] } => {
+export const codexCommand = (
+  binary: string,
+  args: string[],
+  platform: ProcessTreePlatform = process.platform,
+  commandShell = process.env.ComSpec ?? "cmd.exe",
+): { file: string; args: string[] } => {
   const lowerBinary = binary.toLowerCase();
   const isWindowsCommandScript =
-    process.platform === "win32" && (lowerBinary.endsWith(".cmd") || lowerBinary.endsWith(".bat"));
+    platform === "win32" && (lowerBinary.endsWith(".cmd") || lowerBinary.endsWith(".bat"));
 
   return isWindowsCommandScript
-    ? { file: process.env.ComSpec ?? "cmd.exe", args: ["/d", "/c", "call", binary, ...args] }
+    ? { file: commandShell, args: ["/d", "/c", "call", binary, ...args] }
     : { file: binary, args };
 };
 
@@ -154,6 +167,9 @@ export const createCodexWorkspaceRuntimeStarter = ({
   stopTimeoutMs = DEFAULT_STOP_TIMEOUT_MS,
   now = () => new Date(),
   runtimeId = () => randomUUID(),
+  platform = process.platform,
+  commandShell,
+  processTreeTerminator = terminateProcessTree,
 }: CreateCodexWorkspaceRuntimeStarterInput): RuntimeWorkspaceStarterPort => ({
   async startWorkspaceRuntime(input): Promise<RuntimeWorkspaceHandle> {
     if (input.runtimeKind !== "codex") {
@@ -170,10 +186,12 @@ export const createCodexWorkspaceRuntimeStarter = ({
       resolveConfiguredMcpCommand(processEnv, mcpCommand) ??
       (await resolveOpenDucktorMcpCommand({ systemCommands, env: processEnv }));
     const binary = codexBinary ?? (await resolveCodexBinary(systemCommands, processEnv));
-    const command = codexCommand(binary, [
-      ...buildCodexMcpConfigArgs(resolvedMcpCommand),
-      "app-server",
-    ]);
+    const command = codexCommand(
+      binary,
+      [...buildCodexMcpConfigArgs(resolvedMcpCommand), "app-server"],
+      platform,
+      commandShell,
+    );
     const nextRuntimeId = runtimeId();
     const child = spawn(command.file, command.args, {
       cwd: input.workingDirectory,
@@ -210,7 +228,7 @@ export const createCodexWorkspaceRuntimeStarter = ({
       const errors: string[] = [];
       codexAppServer.unregisterTransport(nextRuntimeId);
       try {
-        await terminateProcessTree({
+        await processTreeTerminator({
           pid,
           label: `Codex app-server runtime ${nextRuntimeId}`,
           isClosed: () => closed,

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
@@ -14,6 +14,7 @@ import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "../mcp/openducktor-mcp-command";
 import {
   type ProcessTreePlatform,
+  type ProcessTreeTerminator,
   shouldStartDetachedProcessGroup,
   terminateProcessTree,
   waitForChildProcessClose,
@@ -26,7 +27,6 @@ import {
 import type { CodexAppServerTransportRegistry } from "./codex-app-server-transport-registry";
 
 type CodexChildProcess = ChildProcessByStdio<Writable, Readable, Readable>;
-type ProcessTreeTerminator = typeof terminateProcessTree;
 
 export type CodexMcpBridgeConnection = {
   workspaceId: string;

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
@@ -16,6 +16,7 @@ import {
   type ProcessTreePlatform,
   shouldStartDetachedProcessGroup,
   terminateProcessTree,
+  waitForChildProcessClose,
 } from "../process/process-tree";
 import { resolveCodexBinary } from "../runtimes/runtime-binaries";
 import {
@@ -109,28 +110,6 @@ const requireBridgeValue = (value: string, label: keyof CodexMcpBridgeConnection
     throw new Error(`Codex MCP bridge ${label} is required.`);
   }
   return trimmed;
-};
-
-const waitForClose = (
-  child: CodexChildProcess,
-  isClosed: () => boolean,
-  timeoutMs: number,
-): Promise<boolean> => {
-  if (isClosed()) {
-    return Promise.resolve(true);
-  }
-
-  return new Promise((resolve) => {
-    const timeout = setTimeout(() => {
-      child.off("close", onClose);
-      resolve(false);
-    }, timeoutMs);
-    const onClose = () => {
-      clearTimeout(timeout);
-      resolve(true);
-    };
-    child.once("close", onClose);
-  });
 };
 
 export const codexCommand = (
@@ -232,7 +211,7 @@ export const createCodexWorkspaceRuntimeStarter = ({
           pid,
           label: `Codex app-server runtime ${nextRuntimeId}`,
           isClosed: () => closed,
-          waitForExit: (timeoutMs) => waitForClose(child, () => closed, timeoutMs),
+          waitForExit: (timeoutMs) => waitForChildProcessClose(child, () => closed, timeoutMs),
           stopTimeoutMs,
         });
       } catch (error) {

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.ts
@@ -12,7 +12,7 @@ import type {
 } from "../../ports/runtime-registry-port";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "../mcp/openducktor-mcp-command";
-import { shouldStartDetachedProcessGroup, signalProcessTree } from "../process/process-tree";
+import { shouldStartDetachedProcessGroup, terminateProcessTree } from "../process/process-tree";
 import { resolveCodexBinary } from "../runtimes/runtime-binaries";
 import {
   type CodexAppServerEventEmitter,
@@ -125,29 +125,6 @@ const waitForClose = (
   });
 };
 
-const stopChildProcess = async (
-  child: CodexChildProcess,
-  pid: number,
-  isClosed: () => boolean,
-  stopTimeoutMs: number,
-): Promise<void> => {
-  if (isClosed()) {
-    return;
-  }
-
-  signalProcessTree(pid, "SIGTERM");
-  if (await waitForClose(child, isClosed, stopTimeoutMs)) {
-    return;
-  }
-
-  signalProcessTree(pid, "SIGKILL");
-  if (await waitForClose(child, isClosed, stopTimeoutMs)) {
-    return;
-  }
-
-  throw new Error(`Timed out waiting for Codex app-server process group ${pid} to stop.`);
-};
-
 const codexCommand = (binary: string, args: string[]): { file: string; args: string[] } => {
   const lowerBinary = binary.toLowerCase();
   const isWindowsCommandScript =
@@ -156,6 +133,12 @@ const codexCommand = (binary: string, args: string[]): { file: string; args: str
   return isWindowsCommandScript
     ? { file: process.env.ComSpec ?? "cmd.exe", args: ["/d", "/c", "call", binary, ...args] }
     : { file: binary, args };
+};
+
+const throwCleanupErrors = (errors: string[]): void => {
+  if (errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
 };
 
 export const createCodexWorkspaceRuntimeStarter = ({
@@ -223,6 +206,28 @@ export const createCodexWorkspaceRuntimeStarter = ({
     );
     codexAppServer.registerTransport(nextRuntimeId, transport);
 
+    const cleanupCodexRuntime = async (): Promise<void> => {
+      const errors: string[] = [];
+      codexAppServer.unregisterTransport(nextRuntimeId);
+      try {
+        await terminateProcessTree({
+          pid,
+          label: `Codex app-server runtime ${nextRuntimeId}`,
+          isClosed: () => closed,
+          waitForExit: (timeoutMs) => waitForClose(child, () => closed, timeoutMs),
+          stopTimeoutMs,
+        });
+      } catch (error) {
+        errors.push(`process tree: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      try {
+        await transport.close();
+      } catch (error) {
+        errors.push(`transport: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      throwCleanupErrors(errors);
+    };
+
     try {
       await transport.request({
         method: "initialize",
@@ -240,9 +245,14 @@ export const createCodexWorkspaceRuntimeStarter = ({
       });
       await transport.notify("initialized", {});
     } catch (error) {
-      codexAppServer.unregisterTransport(nextRuntimeId);
-      await stopChildProcess(child, pid, () => closed, stopTimeoutMs);
-      await transport.close();
+      try {
+        await cleanupCodexRuntime();
+      } catch (cleanupError) {
+        const startupMessage = error instanceof Error ? error.message : String(error);
+        const cleanupMessage =
+          cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+        throw new Error(`${startupMessage}\nCleanup failed:\n${cleanupMessage}`, { cause: error });
+      }
       throw error;
     }
 
@@ -264,9 +274,7 @@ export const createCodexWorkspaceRuntimeStarter = ({
     return {
       runtime,
       async stop() {
-        codexAppServer.unregisterTransport(nextRuntimeId);
-        await stopChildProcess(child, pid, () => closed, stopTimeoutMs);
-        await transport.close();
+        await cleanupCodexRuntime();
       },
     };
   },

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
@@ -1,3 +1,7 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createDevServerProcessAdapter } from "./dev-server-process-adapter";
 
 const waitFor = async (predicate: () => boolean, timeoutMs = 500): Promise<void> => {
@@ -14,6 +18,15 @@ const quoteShellArg = (value: string): string =>
   process.platform === "win32"
     ? `"${value.replaceAll('"', '""')}"`
     : `'${value.replaceAll("'", "'\\''")}'`;
+
+const processIsAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 describe("createDevServerProcessAdapter", () => {
   test("starts a shell command, streams output, and stops the process group", async () => {
@@ -46,6 +59,50 @@ describe("createDevServerProcessAdapter", () => {
         pid: handle.pid,
       }),
     ]);
+  });
+
+  test("stops a shell command and its long-lived descendant", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-dev-server-tree-"));
+    const childPidPath = join(root, "child.pid");
+    const readyPath = join(root, "ready");
+    const parentPath = join(root, "parent.mjs");
+    let childPid: number | null = null;
+    await writeFile(
+      parentPath,
+      `import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], {
+  stdio: "ignore",
+});
+writeFileSync(${JSON.stringify(childPidPath)}, String(child.pid));
+writeFileSync(${JSON.stringify(readyPath)}, "ready");
+setInterval(() => {}, 1000);
+`,
+    );
+    const port = createDevServerProcessAdapter({
+      startGracePeriodMs: 20,
+      stopTimeoutMs: 1_000,
+    });
+    const command = [quoteShellArg(process.execPath), quoteShellArg(parentPath)].join(" ");
+
+    try {
+      const handle = await port.start({
+        command,
+        cwd: root,
+        onExit: () => {},
+        onOutput: () => {},
+      });
+      await waitFor(() => processIsAlive(handle.pid) && existsSync(readyPath), 1_000);
+      childPid = Number(await readFile(childPidPath, "utf8"));
+      expect(processIsAlive(childPid)).toBe(true);
+
+      await handle.stop();
+      await waitFor(() => !processIsAlive(childPid as number), 1_000);
+    } finally {
+      if (childPid !== null && processIsAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+      }
+    }
   });
 
   test("rejects commands that exit during the start grace period", async () => {

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
@@ -6,7 +6,7 @@ import {
   DevServerProcessStartExitError,
   type DevServerProcessStartInput,
 } from "../../ports/dev-server-process-port";
-import { shouldStartDetachedProcessGroup, signalProcessTree } from "../process/process-tree";
+import { shouldStartDetachedProcessGroup, terminateProcessTree } from "../process/process-tree";
 
 export type CreateDevServerProcessAdapterInput = {
   processEnv?: NodeJS.ProcessEnv;
@@ -116,23 +116,13 @@ export const createDevServerProcessAdapter = ({
     return {
       pid,
       async stop() {
-        if (closeResult !== null || spawnError !== null) {
-          return;
-        }
-
-        signalProcessTree(pid, "SIGTERM");
-        if (await waitForClose(stopTimeoutMs)) {
-          return;
-        }
-
-        signalProcessTree(pid, "SIGKILL");
-        if (await waitForClose(stopTimeoutMs)) {
-          return;
-        }
-
-        throw new Error(
-          `Timed out waiting for process group ${pid} to stop after SIGTERM and SIGKILL`,
-        );
+        await terminateProcessTree({
+          pid,
+          label: `dev server command "${command}"`,
+          isClosed: () => closeResult !== null || spawnError !== null,
+          waitForExit: waitForClose,
+          stopTimeoutMs,
+        });
       },
     };
   },

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
@@ -1,5 +1,4 @@
 import { spawn } from "node:child_process";
-import { setTimeout as delay } from "node:timers/promises";
 import {
   type DevServerProcessExit,
   type DevServerProcessPort,
@@ -99,10 +98,7 @@ export const createDevServerProcessAdapter = ({
       }
     });
 
-    const exitedDuringGracePeriod = await Promise.race([
-      waitForClose(startGracePeriodMs),
-      delay(startGracePeriodMs).then(() => false),
-    ]);
+    const exitedDuringGracePeriod = await waitForClose(startGracePeriodMs);
     if (spawnError) {
       throw spawnError;
     }

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -309,4 +309,44 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
       await removeTestDirectory(root);
     }
   });
+
+  test("includes startup timeout cleanup failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-opencode-timeout-cleanup-failure-"));
+    try {
+      const repo = join(root, "repo");
+      await mkdir(repo);
+      const opencodeBinary = await createFakeOpenCode(root);
+      const starter = createOpenCodeWorkspaceRuntimeStarter({
+        systemCommands: createSystemCommands(),
+        opencodeBinary,
+        mcpCommand: ["mcp-bin"],
+        resolveMcpBridgeConnection: async () => ({
+          workspaceId: "repo",
+          hostUrl: "http://127.0.0.1:14327",
+          hostToken: "token-1",
+        }),
+        startupTimeoutMs: 20,
+        retryDelayMs: 5,
+        portAllocator: async () => 43123,
+        portProbe: async () => false,
+        processTreeTerminator: async ({ pid }) => {
+          process.kill(pid, "SIGTERM");
+          throw new Error("process tree cleanup failed");
+        },
+      });
+
+      await expect(
+        starter.startWorkspaceRuntime({
+          runtimeKind: "opencode",
+          repoPath: repo,
+          workingDirectory: repo,
+          descriptor: RUNTIME_DESCRIPTORS_BY_KIND.opencode,
+        }),
+      ).rejects.toThrow(
+        "Timed out waiting for OpenCode runtime on 127.0.0.1:43123. Cleanup failed: process tree cleanup failed",
+      );
+    } finally {
+      await removeTestDirectory(root);
+    }
+  });
 });

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -274,6 +274,7 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
 
   test("reports OpenCode process-tree cleanup failures", async () => {
     const root = await mkdtemp(join(tmpdir(), "odt-opencode-cleanup-failure-"));
+    let runtimePid: number | null = null;
     try {
       const repo = join(root, "repo");
       await mkdir(repo);
@@ -292,7 +293,8 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
         portAllocator: async () => 43123,
         portProbe: async () => true,
         runtimeId: () => "runtime-failure",
-        processTreeTerminator: async () => {
+        processTreeTerminator: async ({ pid }) => {
+          runtimePid = pid;
           throw new Error("process tree stayed alive");
         },
       });
@@ -306,6 +308,9 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
 
       await expect(handle.stop()).rejects.toThrow("process tree stayed alive");
     } finally {
+      if (runtimePid !== null && processIsAlive(runtimePid)) {
+        process.kill(runtimePid, "SIGKILL");
+      }
       await removeTestDirectory(root);
     }
   });

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -1,4 +1,5 @@
-import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { RUNTIME_DESCRIPTORS_BY_KIND } from "@openducktor/contracts";
@@ -21,12 +22,38 @@ const createSystemCommands = (): SystemCommandPort => ({
   },
 });
 
-const createFakeOpenCode = async (root: string): Promise<string> => {
+const processIsAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const waitFor = async (predicate: () => boolean, timeoutMs = 1_000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for condition.");
+};
+
+const createFakeOpenCode = async (
+  root: string,
+  options: { childPidPath?: string } = {},
+): Promise<string> => {
   const scriptPath = join(root, "opencode.mjs");
   const executable = join(root, process.platform === "win32" ? "opencode.cmd" : "opencode");
   await writeFile(
     scriptPath,
-    `const args = process.argv.slice(2);
+    `import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
 if (args[0] !== "serve") {
   console.error("expected serve command");
   process.exit(2);
@@ -35,6 +62,13 @@ const portFlagIndex = args.indexOf("--port");
 if (Number(args[portFlagIndex + 1]) !== 43123) {
   console.error("unexpected port");
   process.exit(2);
+}
+const childPidPath = ${JSON.stringify(options.childPidPath ?? null)};
+if (childPidPath) {
+  const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], {
+    stdio: "ignore",
+  });
+  writeFileSync(childPidPath, String(child.pid));
 }
 const keepAlive = setInterval(() => {}, 1000);
 const stop = () => {
@@ -145,6 +179,132 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
       });
 
       await expect(handle.stop()).resolves.toBeUndefined();
+    } finally {
+      await removeTestDirectory(root);
+    }
+  });
+
+  test("stops the OpenCode runtime process tree including descendants", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-opencode-starter-tree-"));
+    let childPid: number | null = null;
+    try {
+      const repo = join(root, "repo");
+      const childPidPath = join(root, "child.pid");
+      await mkdir(repo);
+      const opencodeBinary = await createFakeOpenCode(root, { childPidPath });
+      const starter = createOpenCodeWorkspaceRuntimeStarter({
+        systemCommands: createSystemCommands(),
+        opencodeBinary,
+        mcpCommand: ["mcp-bin"],
+        resolveMcpBridgeConnection: async () => ({
+          workspaceId: "repo",
+          hostUrl: "http://127.0.0.1:14327",
+          hostToken: "token-1",
+        }),
+        startupTimeoutMs: 2_000,
+        retryDelayMs: 20,
+        portAllocator: async () => 43123,
+        portProbe: async () => true,
+        runtimeId: () => "runtime-tree",
+      });
+
+      const handle = await starter.startWorkspaceRuntime({
+        runtimeKind: "opencode",
+        repoPath: repo,
+        workingDirectory: repo,
+        descriptor: RUNTIME_DESCRIPTORS_BY_KIND.opencode,
+      });
+      await waitFor(() => existsSync(childPidPath));
+      childPid = Number(await readFile(childPidPath, "utf8"));
+      expect(processIsAlive(childPid)).toBe(true);
+
+      await handle.stop();
+      await waitFor(() => !processIsAlive(childPid as number));
+    } finally {
+      if (childPid !== null && processIsAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+      }
+      await removeTestDirectory(root);
+    }
+  });
+
+  test("cleans up a spawned OpenCode process tree after startup timeout", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-opencode-timeout-cleanup-"));
+    let childPid: number | null = null;
+    try {
+      const repo = join(root, "repo");
+      const childPidPath = join(root, "child.pid");
+      await mkdir(repo);
+      const opencodeBinary = await createFakeOpenCode(root, { childPidPath });
+      const starter = createOpenCodeWorkspaceRuntimeStarter({
+        systemCommands: createSystemCommands(),
+        opencodeBinary,
+        mcpCommand: ["mcp-bin"],
+        resolveMcpBridgeConnection: async () => ({
+          workspaceId: "repo",
+          hostUrl: "http://127.0.0.1:14327",
+          hostToken: "token-1",
+        }),
+        startupTimeoutMs: 100,
+        retryDelayMs: 5,
+        portAllocator: async () => 43123,
+        portProbe: async () => {
+          await waitFor(() => existsSync(childPidPath));
+          return false;
+        },
+      });
+
+      await expect(
+        starter.startWorkspaceRuntime({
+          runtimeKind: "opencode",
+          repoPath: repo,
+          workingDirectory: repo,
+          descriptor: RUNTIME_DESCRIPTORS_BY_KIND.opencode,
+        }),
+      ).rejects.toThrow("Timed out waiting for OpenCode runtime on 127.0.0.1:43123.");
+      childPid = Number(await readFile(childPidPath, "utf8"));
+      await waitFor(() => !processIsAlive(childPid as number));
+    } finally {
+      if (childPid !== null && processIsAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+      }
+      await removeTestDirectory(root);
+    }
+  });
+
+  test("reports OpenCode process-tree cleanup failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-opencode-cleanup-failure-"));
+    try {
+      const repo = join(root, "repo");
+      await mkdir(repo);
+      const opencodeBinary = await createFakeOpenCode(root);
+      const starter = createOpenCodeWorkspaceRuntimeStarter({
+        systemCommands: createSystemCommands(),
+        opencodeBinary,
+        mcpCommand: ["mcp-bin"],
+        resolveMcpBridgeConnection: async () => ({
+          workspaceId: "repo",
+          hostUrl: "http://127.0.0.1:14327",
+          hostToken: "token-1",
+        }),
+        startupTimeoutMs: 2_000,
+        retryDelayMs: 20,
+        portAllocator: async () => 43123,
+        portProbe: async () => true,
+        runtimeId: () => "runtime-failure",
+        processTreeTerminator: async () => {
+          throw new Error("process tree stayed alive");
+        },
+      });
+
+      const handle = await starter.startWorkspaceRuntime({
+        runtimeKind: "opencode",
+        repoPath: repo,
+        workingDirectory: repo,
+        descriptor: RUNTIME_DESCRIPTORS_BY_KIND.opencode,
+      });
+
+      await expect(handle.stop()).rejects.toThrow("process tree stayed alive");
     } finally {
       await removeTestDirectory(root);
     }

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
@@ -28,6 +28,8 @@ type LocalPortAllocator = () => Promise<number>;
 
 type LocalPortProbe = (port: number, timeoutMs: number) => Promise<boolean>;
 
+type ProcessTreeTerminator = typeof terminateProcessTree;
+
 export type CreateOpenCodeWorkspaceRuntimeStarterInput = {
   systemCommands: SystemCommandPort;
   resolveMcpBridgeConnection?: OpenCodeMcpBridgeConnectionResolver;
@@ -42,6 +44,7 @@ export type CreateOpenCodeWorkspaceRuntimeStarterInput = {
   runtimeId?: () => string;
   portAllocator?: LocalPortAllocator;
   portProbe?: LocalPortProbe;
+  processTreeTerminator?: ProcessTreeTerminator;
 };
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
@@ -198,6 +201,7 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
   runtimeId = () => randomUUID(),
   portAllocator = pickFreePort,
   portProbe = canConnect,
+  processTreeTerminator = terminateProcessTree,
 }: CreateOpenCodeWorkspaceRuntimeStarterInput): RuntimeWorkspaceStarterPort => ({
   async startWorkspaceRuntime(input): Promise<RuntimeWorkspaceHandle> {
     if (input.runtimeKind !== "opencode") {
@@ -286,7 +290,7 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
         return {
           runtime,
           async stop() {
-            await terminateProcessTree({
+            await processTreeTerminator({
               pid,
               label: `OpenCode runtime ${runtime.runtimeId}`,
               isClosed: () => closed,
@@ -300,7 +304,7 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
       await delay(retryDelayMs);
     }
 
-    await terminateProcessTree({
+    await processTreeTerminator({
       pid,
       label: `OpenCode runtime on 127.0.0.1:${port}`,
       isClosed: () => closed,

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
@@ -11,6 +11,7 @@ import type {
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "../mcp/openducktor-mcp-command";
 import {
+  type ProcessTreeTerminator,
   shouldStartDetachedProcessGroup,
   terminateProcessTree,
   waitForChildProcessClose,
@@ -30,8 +31,6 @@ export type OpenCodeMcpBridgeConnectionResolver = (
 type LocalPortAllocator = () => Promise<number>;
 
 type LocalPortProbe = (port: number, timeoutMs: number) => Promise<boolean>;
-
-type ProcessTreeTerminator = typeof terminateProcessTree;
 
 export type CreateOpenCodeWorkspaceRuntimeStarterInput = {
   systemCommands: SystemCommandPort;

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
@@ -11,7 +11,7 @@ import type {
 } from "../../ports/runtime-registry-port";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "../mcp/openducktor-mcp-command";
-import { shouldStartDetachedProcessGroup, signalProcessTree } from "../process/process-tree";
+import { shouldStartDetachedProcessGroup, terminateProcessTree } from "../process/process-tree";
 import { resolveOpencodeBinary } from "../runtimes/runtime-binaries";
 
 export type OpenCodeMcpBridgeConnection = {
@@ -184,29 +184,6 @@ const waitForClose = (
   });
 };
 
-const stopChildProcess = async (
-  child: OpenCodeChildProcess,
-  pid: number,
-  isClosed: () => boolean,
-  stopTimeoutMs: number,
-): Promise<void> => {
-  if (isClosed()) {
-    return;
-  }
-
-  signalProcessTree(pid, "SIGTERM");
-  if (await waitForClose(child, isClosed, stopTimeoutMs)) {
-    return;
-  }
-
-  signalProcessTree(pid, "SIGKILL");
-  if (await waitForClose(child, isClosed, stopTimeoutMs)) {
-    return;
-  }
-
-  throw new Error(`Timed out waiting for OpenCode process group ${pid} to stop.`);
-};
-
 export const createOpenCodeWorkspaceRuntimeStarter = ({
   systemCommands,
   resolveMcpBridgeConnection,
@@ -309,7 +286,13 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
         return {
           runtime,
           async stop() {
-            await stopChildProcess(child, pid, () => closed, stopTimeoutMs);
+            await terminateProcessTree({
+              pid,
+              label: `OpenCode runtime ${runtime.runtimeId}`,
+              isClosed: () => closed,
+              waitForExit: (timeoutMs) => waitForClose(child, () => closed, timeoutMs),
+              stopTimeoutMs,
+            });
           },
         };
       }
@@ -317,7 +300,13 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
       await delay(retryDelayMs);
     }
 
-    await stopChildProcess(child, pid, () => closed, stopTimeoutMs);
+    await terminateProcessTree({
+      pid,
+      label: `OpenCode runtime on 127.0.0.1:${port}`,
+      isClosed: () => closed,
+      waitForExit: (timeoutMs) => waitForClose(child, () => closed, timeoutMs),
+      stopTimeoutMs,
+    });
     throw new Error(`Timed out waiting for OpenCode runtime on 127.0.0.1:${port}.`);
   },
 });

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
@@ -283,13 +283,19 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
       await delay(retryDelayMs);
     }
 
-    await processTreeTerminator({
-      pid,
-      label: `OpenCode runtime on 127.0.0.1:${port}`,
-      isClosed: () => closed,
-      waitForExit: (timeoutMs) => waitForChildProcessClose(child, () => closed, timeoutMs),
-      stopTimeoutMs,
-    });
-    throw new Error(`Timed out waiting for OpenCode runtime on 127.0.0.1:${port}.`);
+    const timeoutMessage = `Timed out waiting for OpenCode runtime on 127.0.0.1:${port}.`;
+    try {
+      await processTreeTerminator({
+        pid,
+        label: `OpenCode runtime on 127.0.0.1:${port}`,
+        isClosed: () => closed,
+        waitForExit: (timeoutMs) => waitForChildProcessClose(child, () => closed, timeoutMs),
+        stopTimeoutMs,
+      });
+    } catch (error) {
+      const cleanupMessage = error instanceof Error ? error.message : String(error);
+      throw new Error(`${timeoutMessage} Cleanup failed: ${cleanupMessage}`, { cause: error });
+    }
+    throw new Error(timeoutMessage);
   },
 });

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.ts
@@ -1,7 +1,6 @@
-import { type ChildProcessByStdio, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createServer, Socket } from "node:net";
-import type { Readable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
 import { type RuntimeInstanceSummary, runtimeInstanceSummarySchema } from "@openducktor/contracts";
 import type {
@@ -11,7 +10,11 @@ import type {
 } from "../../ports/runtime-registry-port";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "../mcp/openducktor-mcp-command";
-import { shouldStartDetachedProcessGroup, terminateProcessTree } from "../process/process-tree";
+import {
+  shouldStartDetachedProcessGroup,
+  terminateProcessTree,
+  waitForChildProcessClose,
+} from "../process/process-tree";
 import { resolveOpencodeBinary } from "../runtimes/runtime-binaries";
 
 export type OpenCodeMcpBridgeConnection = {
@@ -52,8 +55,6 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 250;
 const DEFAULT_RETRY_DELAY_MS = 100;
 const DEFAULT_STOP_TIMEOUT_MS = 3_000;
 const MAX_CAPTURED_OUTPUT_BYTES = 64 * 1024;
-
-type OpenCodeChildProcess = ChildProcessByStdio<null, Readable, Readable>;
 
 const resolveConfiguredMcpCommand = (
   env: NodeJS.ProcessEnv,
@@ -165,28 +166,6 @@ const canConnect = (port: number, timeoutMs: number): Promise<boolean> =>
     socket.connect(port, "127.0.0.1");
   });
 
-const waitForClose = (
-  child: OpenCodeChildProcess,
-  isClosed: () => boolean,
-  timeoutMs: number,
-): Promise<boolean> => {
-  if (isClosed()) {
-    return Promise.resolve(true);
-  }
-
-  return new Promise((resolve) => {
-    const timeout = setTimeout(() => {
-      child.off("close", onClose);
-      resolve(false);
-    }, timeoutMs);
-    const onClose = () => {
-      clearTimeout(timeout);
-      resolve(true);
-    };
-    child.once("close", onClose);
-  });
-};
-
 export const createOpenCodeWorkspaceRuntimeStarter = ({
   systemCommands,
   resolveMcpBridgeConnection,
@@ -294,7 +273,7 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
               pid,
               label: `OpenCode runtime ${runtime.runtimeId}`,
               isClosed: () => closed,
-              waitForExit: (timeoutMs) => waitForClose(child, () => closed, timeoutMs),
+              waitForExit: (timeoutMs) => waitForChildProcessClose(child, () => closed, timeoutMs),
               stopTimeoutMs,
             });
           },
@@ -308,7 +287,7 @@ export const createOpenCodeWorkspaceRuntimeStarter = ({
       pid,
       label: `OpenCode runtime on 127.0.0.1:${port}`,
       isClosed: () => closed,
-      waitForExit: (timeoutMs) => waitForClose(child, () => closed, timeoutMs),
+      waitForExit: (timeoutMs) => waitForChildProcessClose(child, () => closed, timeoutMs),
       stopTimeoutMs,
     });
     throw new Error(`Timed out waiting for OpenCode runtime on 127.0.0.1:${port}.`);

--- a/packages/host/src/adapters/process/process-tree.test.ts
+++ b/packages/host/src/adapters/process/process-tree.test.ts
@@ -1,8 +1,20 @@
 import {
+  type KillProcess,
   shouldStartDetachedProcessGroup,
   signalProcessTree,
   terminateProcessTree,
 } from "./process-tree";
+
+const noopKill: KillProcess = () => true;
+const noopSpawnSync = () => ({
+  status: 0,
+  signal: null,
+  output: [],
+  pid: 0,
+  stdout: Buffer.alloc(0),
+  stderr: Buffer.alloc(0),
+});
+const processIsAlive = () => true;
 
 describe("process-tree", () => {
   test("selects taskkill for Windows process trees without negative pids", () => {
@@ -10,11 +22,12 @@ describe("process-tree", () => {
 
     signalProcessTree(1234, "SIGTERM", {
       platform: "win32",
-      spawnSync: ((command, args) => {
-        calls.push({ command, args: args as string[] });
-        return { status: 0 };
-      }) as typeof import("node:child_process").spawnSync,
-      isAlive: () => true,
+      kill: noopKill,
+      spawnSync: (command, args) => {
+        calls.push({ command, args });
+        return noopSpawnSync();
+      },
+      isAlive: processIsAlive,
     });
 
     expect(calls).toEqual([
@@ -41,14 +54,15 @@ describe("process-tree", () => {
       stopTimeoutMs: 10,
       signalDependencies: {
         platform: "linux",
-        kill: ((pid, signal) => {
-          if (signal === undefined) {
+        kill: (pid, signal) => {
+          if (signal === undefined || signal === 0) {
             throw new Error("Expected a process signal.");
           }
-          signals.push({ pid, signal: signal as NodeJS.Signals });
+          signals.push({ pid, signal });
           return true;
-        }) as typeof process.kill,
-        isAlive: () => true,
+        },
+        spawnSync: noopSpawnSync,
+        isAlive: processIsAlive,
       },
     });
 
@@ -70,10 +84,13 @@ describe("process-tree", () => {
       },
       stopTimeoutMs: 10,
       signalDependencies: {
-        kill: ((pid, signal) => {
+        platform: "linux",
+        kill: (pid, signal) => {
           signals.push({ pid, signal });
           return true;
-        }) as typeof process.kill,
+        },
+        spawnSync: noopSpawnSync,
+        isAlive: processIsAlive,
       },
     });
 
@@ -90,8 +107,9 @@ describe("process-tree", () => {
         stopTimeoutMs: 5,
         signalDependencies: {
           platform: "linux",
-          kill: (() => true) as typeof process.kill,
-          isAlive: () => true,
+          kill: noopKill,
+          spawnSync: noopSpawnSync,
+          isAlive: processIsAlive,
         },
       }),
     ).rejects.toThrow(
@@ -105,9 +123,10 @@ describe("process-tree", () => {
     expect(() =>
       signalProcessTree(1234, "SIGTERM", {
         platform: "linux",
-        kill: (() => {
+        kill: () => {
           throw error;
-        }) as typeof process.kill,
+        },
+        spawnSync: noopSpawnSync,
         isAlive: () => false,
       }),
     ).not.toThrow();

--- a/packages/host/src/adapters/process/process-tree.test.ts
+++ b/packages/host/src/adapters/process/process-tree.test.ts
@@ -95,7 +95,7 @@ describe("process-tree", () => {
         },
       }),
     ).rejects.toThrow(
-      "Timed out waiting 5ms for stubborn child process tree 4321 to stop after SIGTERM and SIGKILL.",
+      "Timed out waiting 5ms per signal for stubborn child process tree 4321 to stop after SIGTERM and SIGKILL.",
     );
   });
 

--- a/packages/host/src/adapters/process/process-tree.test.ts
+++ b/packages/host/src/adapters/process/process-tree.test.ts
@@ -1,0 +1,115 @@
+import {
+  shouldStartDetachedProcessGroup,
+  signalProcessTree,
+  terminateProcessTree,
+} from "./process-tree";
+
+describe("process-tree", () => {
+  test("selects taskkill for Windows process trees without negative pids", () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    signalProcessTree(1234, "SIGTERM", {
+      platform: "win32",
+      spawnSync: ((command, args) => {
+        calls.push({ command, args: args as string[] });
+        return { status: 0 };
+      }) as typeof import("node:child_process").spawnSync,
+      isAlive: () => true,
+    });
+
+    expect(calls).toEqual([
+      {
+        command: "taskkill",
+        args: ["/pid", "1234", "/t", "/f"],
+      },
+    ]);
+    expect(calls.at(0)?.args).not.toContain("-1234");
+  });
+
+  test("selects detached startup and negative process group signals on Unix-like platforms", async () => {
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+
+    expect(shouldStartDetachedProcessGroup("linux")).toBe(true);
+    expect(shouldStartDetachedProcessGroup("darwin")).toBe(true);
+    expect(shouldStartDetachedProcessGroup("win32")).toBe(false);
+
+    await terminateProcessTree({
+      pid: 1234,
+      label: "test runtime",
+      isClosed: () => false,
+      waitForExit: async () => signals.length >= 2,
+      stopTimeoutMs: 10,
+      signalDependencies: {
+        platform: "linux",
+        kill: ((pid, signal) => {
+          if (signal === undefined) {
+            throw new Error("Expected a process signal.");
+          }
+          signals.push({ pid, signal: signal as NodeJS.Signals });
+          return true;
+        }) as typeof process.kill,
+        isAlive: () => true,
+      },
+    });
+
+    expect(signals).toEqual([
+      { pid: -1234, signal: "SIGTERM" },
+      { pid: -1234, signal: "SIGKILL" },
+    ]);
+  });
+
+  test("accepts already-closed process trees without signaling", async () => {
+    const signals: unknown[] = [];
+
+    await terminateProcessTree({
+      pid: 1234,
+      label: "already closed",
+      isClosed: () => true,
+      waitForExit: async () => {
+        throw new Error("wait should not be called");
+      },
+      stopTimeoutMs: 10,
+      signalDependencies: {
+        kill: ((pid, signal) => {
+          signals.push({ pid, signal });
+          return true;
+        }) as typeof process.kill,
+      },
+    });
+
+    expect(signals).toEqual([]);
+  });
+
+  test("throws an actionable error when the target remains alive after force cleanup", async () => {
+    await expect(
+      terminateProcessTree({
+        pid: 4321,
+        label: "stubborn child",
+        isClosed: () => false,
+        waitForExit: async () => false,
+        stopTimeoutMs: 5,
+        signalDependencies: {
+          platform: "linux",
+          kill: (() => true) as typeof process.kill,
+          isAlive: () => true,
+        },
+      }),
+    ).rejects.toThrow(
+      "Timed out waiting 5ms for stubborn child process tree 4321 to stop after SIGTERM and SIGKILL.",
+    );
+  });
+
+  test("treats already-exited Unix process groups as cleaned up", () => {
+    const error = Object.assign(new Error("missing process"), { code: "ESRCH" });
+
+    expect(() =>
+      signalProcessTree(1234, "SIGTERM", {
+        platform: "linux",
+        kill: (() => {
+          throw error;
+        }) as typeof process.kill,
+        isAlive: () => false,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/host/src/adapters/process/process-tree.ts
+++ b/packages/host/src/adapters/process/process-tree.ts
@@ -107,15 +107,20 @@ export const waitForChildProcessClose = (
   }
 
   return new Promise((resolve) => {
-    const timeout = setTimeout(() => {
-      child.off("close", onClose);
-      resolve(false);
-    }, timeoutMs);
     const onClose = () => {
       clearTimeout(timeout);
       resolve(true);
     };
+    const timeout = setTimeout(() => {
+      child.off("close", onClose);
+      resolve(false);
+    }, timeoutMs);
     child.once("close", onClose);
+    if (isClosed()) {
+      child.off("close", onClose);
+      clearTimeout(timeout);
+      resolve(true);
+    }
   });
 };
 

--- a/packages/host/src/adapters/process/process-tree.ts
+++ b/packages/host/src/adapters/process/process-tree.ts
@@ -1,36 +1,102 @@
 import { spawnSync } from "node:child_process";
 
-const processIsAlive = (pid: number): boolean => {
+export type ProcessTreePlatform = NodeJS.Platform;
+
+type SignalProcessTreeDependencies = {
+  platform?: ProcessTreePlatform;
+  kill?: typeof process.kill;
+  spawnSync?: typeof spawnSync;
+  isAlive?: (pid: number) => boolean;
+};
+
+export type TerminateProcessTreeInput = {
+  pid: number;
+  label: string;
+  isClosed: () => boolean;
+  waitForExit: (timeoutMs: number) => Promise<boolean>;
+  stopTimeoutMs: number;
+  signalDependencies?: SignalProcessTreeDependencies;
+};
+
+export const processIsAlive = (pid: number, kill: typeof process.kill = process.kill): boolean => {
   try {
-    process.kill(pid, 0);
+    kill(pid, 0);
     return true;
   } catch {
     return false;
   }
 };
 
-export const signalProcessTree = (pid: number, signal: NodeJS.Signals): void => {
-  if (process.platform === "win32") {
-    const result = spawnSync("taskkill", ["/pid", String(pid), "/t", "/f"], {
+const isAlreadyExitedError = (error: unknown): boolean =>
+  error instanceof Error && "code" in error && error.code === "ESRCH";
+
+const assertValidPid = (pid: number, label: string): void => {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error(`Cannot stop ${label}: invalid process pid ${pid}.`);
+  }
+};
+
+export const signalProcessTree = (
+  pid: number,
+  signal: NodeJS.Signals,
+  dependencies: SignalProcessTreeDependencies = {},
+): void => {
+  const platform = dependencies.platform ?? process.platform;
+  const kill = dependencies.kill ?? process.kill;
+  const spawnSyncCommand = dependencies.spawnSync ?? spawnSync;
+  const isAlive = dependencies.isAlive ?? ((targetPid: number) => processIsAlive(targetPid, kill));
+
+  if (platform === "win32") {
+    const result = spawnSyncCommand("taskkill", ["/pid", String(pid), "/t", "/f"], {
       stdio: "ignore",
     });
-    if (result.status === 0 || !processIsAlive(pid)) {
+    if (result.status === 0 || !isAlive(pid)) {
       return;
     }
-    throw new Error(`Failed to stop Windows process tree ${pid} with ${signal}.`);
+    throw new Error(`Failed to stop Windows process tree ${pid} with taskkill for ${signal}.`);
   }
 
   try {
-    process.kill(-pid, signal);
+    kill(-pid, signal);
   } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ESRCH") {
+    if (isAlreadyExitedError(error)) {
       return;
     }
-    if (!processIsAlive(pid)) {
+    if (!isAlive(pid)) {
       return;
     }
     throw error;
   }
 };
 
-export const shouldStartDetachedProcessGroup = (): boolean => process.platform !== "win32";
+export const terminateProcessTree = async ({
+  pid,
+  label,
+  isClosed,
+  waitForExit,
+  stopTimeoutMs,
+  signalDependencies,
+}: TerminateProcessTreeInput): Promise<void> => {
+  assertValidPid(pid, label);
+  if (isClosed()) {
+    return;
+  }
+
+  signalProcessTree(pid, "SIGTERM", signalDependencies);
+  if (isClosed() || (await waitForExit(stopTimeoutMs))) {
+    return;
+  }
+
+  signalProcessTree(pid, "SIGKILL", signalDependencies);
+  if (isClosed() || (await waitForExit(stopTimeoutMs))) {
+    return;
+  }
+
+  throw new Error(
+    `Timed out waiting ${stopTimeoutMs}ms for ${label} process tree ${pid} to stop after SIGTERM and SIGKILL.`,
+  );
+};
+
+export const shouldStartDetachedProcessGroup = (
+  platform: ProcessTreePlatform = process.platform,
+): boolean => platform !== "win32";

--- a/packages/host/src/adapters/process/process-tree.ts
+++ b/packages/host/src/adapters/process/process-tree.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { type ChildProcess, spawnSync } from "node:child_process";
 
 export type ProcessTreePlatform = NodeJS.Platform;
 
@@ -95,6 +95,28 @@ export const terminateProcessTree = async ({
   throw new Error(
     `Timed out waiting ${stopTimeoutMs}ms for ${label} process tree ${pid} to stop after SIGTERM and SIGKILL.`,
   );
+};
+
+export const waitForChildProcessClose = (
+  child: Pick<ChildProcess, "once" | "off">,
+  isClosed: () => boolean,
+  timeoutMs: number,
+): Promise<boolean> => {
+  if (isClosed()) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      child.off("close", onClose);
+      resolve(false);
+    }, timeoutMs);
+    const onClose = () => {
+      clearTimeout(timeout);
+      resolve(true);
+    };
+    child.once("close", onClose);
+  });
 };
 
 export const shouldStartDetachedProcessGroup = (

--- a/packages/host/src/adapters/process/process-tree.ts
+++ b/packages/host/src/adapters/process/process-tree.ts
@@ -1,12 +1,23 @@
-import { type ChildProcess, spawnSync } from "node:child_process";
+import {
+  type ChildProcess,
+  type SpawnSyncOptions,
+  type SpawnSyncReturns,
+  spawnSync,
+} from "node:child_process";
 
 export type ProcessTreePlatform = NodeJS.Platform;
+export type KillProcess = (pid: number, signal?: NodeJS.Signals | 0) => boolean;
+type SpawnSyncCommand = (
+  command: string,
+  args: string[],
+  options: SpawnSyncOptions,
+) => SpawnSyncReturns<Buffer>;
 
 type SignalProcessTreeDependencies = {
-  platform?: ProcessTreePlatform;
-  kill?: typeof process.kill;
-  spawnSync?: typeof spawnSync;
-  isAlive?: (pid: number) => boolean;
+  platform: ProcessTreePlatform;
+  kill: KillProcess;
+  spawnSync: SpawnSyncCommand;
+  isAlive: (pid: number) => boolean;
 };
 
 export type TerminateProcessTreeInput = {
@@ -18,7 +29,19 @@ export type TerminateProcessTreeInput = {
   signalDependencies?: SignalProcessTreeDependencies;
 };
 
-export const processIsAlive = (pid: number, kill: typeof process.kill = process.kill): boolean => {
+export type ProcessTreeTerminator = (input: TerminateProcessTreeInput) => Promise<void>;
+
+const defaultSignalProcessTreeDependencies = (): SignalProcessTreeDependencies => {
+  const kill: KillProcess = process.kill;
+  return {
+    platform: process.platform,
+    kill,
+    spawnSync,
+    isAlive: (pid) => processIsAlive(pid, kill),
+  };
+};
+
+export const processIsAlive = (pid: number, kill: KillProcess = process.kill): boolean => {
   try {
     kill(pid, 0);
     return true;
@@ -39,12 +62,9 @@ const assertValidPid = (pid: number, label: string): void => {
 export const signalProcessTree = (
   pid: number,
   signal: NodeJS.Signals,
-  dependencies: SignalProcessTreeDependencies = {},
+  dependencies: SignalProcessTreeDependencies = defaultSignalProcessTreeDependencies(),
 ): void => {
-  const platform = dependencies.platform ?? process.platform;
-  const kill = dependencies.kill ?? process.kill;
-  const spawnSyncCommand = dependencies.spawnSync ?? spawnSync;
-  const isAlive = dependencies.isAlive ?? ((targetPid: number) => processIsAlive(targetPid, kill));
+  const { platform, kill, spawnSync: spawnSyncCommand, isAlive } = dependencies;
 
   if (platform === "win32") {
     const result = spawnSyncCommand("taskkill", ["/pid", String(pid), "/t", "/f"], {

--- a/packages/host/src/adapters/process/process-tree.ts
+++ b/packages/host/src/adapters/process/process-tree.ts
@@ -93,7 +93,7 @@ export const terminateProcessTree = async ({
   }
 
   throw new Error(
-    `Timed out waiting ${stopTimeoutMs}ms for ${label} process tree ${pid} to stop after SIGTERM and SIGKILL.`,
+    `Timed out waiting ${stopTimeoutMs}ms per signal for ${label} process tree ${pid} to stop after SIGTERM and SIGKILL.`,
   );
 };
 

--- a/packages/host/src/composition/host-lifecycle.test.ts
+++ b/packages/host/src/composition/host-lifecycle.test.ts
@@ -62,6 +62,9 @@ describe("host lifecycle shutdown", () => {
         async ensureConnection() {
           throw new Error("ensureConnection should not be called");
         },
+        async ensureExternalDiscoveryReady() {
+          throw new Error("ensureExternalDiscoveryReady should not be called");
+        },
         async close() {
           throw new Error("bridge close failed");
         },

--- a/packages/host/src/composition/host-lifecycle.test.ts
+++ b/packages/host/src/composition/host-lifecycle.test.ts
@@ -1,0 +1,76 @@
+import {
+  createStopMcpHostBridgeStep,
+  type HostLifecycleLogger,
+  runShutdownSteps,
+} from "./host-lifecycle";
+
+const createLogger = (): HostLifecycleLogger & { infos: string[]; errors: string[] } => {
+  const infos: string[] = [];
+  const errors: string[] = [];
+  return {
+    infos,
+    errors,
+    info: (message) => infos.push(message),
+    error: (message) => errors.push(message),
+  };
+};
+
+describe("host lifecycle shutdown", () => {
+  test("continues independent shutdown steps and rejects with labeled failures", async () => {
+    const logger = createLogger();
+    const calls: string[] = [];
+
+    await expect(
+      runShutdownSteps(
+        [
+          {
+            label: "first",
+            async run() {
+              calls.push("first");
+              throw new Error("first failed");
+            },
+          },
+          {
+            label: "second",
+            async run() {
+              calls.push("second");
+            },
+          },
+          {
+            label: "third",
+            async run() {
+              calls.push("third");
+              throw new Error("third failed");
+            },
+          },
+        ],
+        logger,
+      ),
+    ).rejects.toThrow("first: first failed\nthird: third failed");
+
+    expect(calls).toEqual(["first", "second", "third"]);
+    expect(logger.errors).toEqual([
+      "Failed to stop first: first failed",
+      "Failed to stop third: third failed",
+    ]);
+  });
+
+  test("propagates MCP host bridge close failures", async () => {
+    const logger = createLogger();
+    const step = createStopMcpHostBridgeStep(
+      {
+        async ensureConnection() {
+          throw new Error("ensureConnection should not be called");
+        },
+        async close() {
+          throw new Error("bridge close failed");
+        },
+      },
+      logger,
+    );
+
+    await expect(runShutdownSteps([step], logger)).rejects.toThrow(
+      "MCP host bridge: bridge close failed",
+    );
+  });
+});

--- a/packages/host/src/infrastructure/beads/beads-shared-dolt-server.test.ts
+++ b/packages/host/src/infrastructure/beads/beads-shared-dolt-server.test.ts
@@ -5,6 +5,7 @@ import type { BeadsSharedServerPaths, BeadsSharedServerState } from "./beads-con
 import {
   readSharedServerState,
   serverStateIsHealthy,
+  stopOwnedSharedDoltServer,
   writeDoltConfigFile,
   writeSharedServerState,
   yamlQuotePath,
@@ -26,7 +27,10 @@ const createPaths = async (): Promise<BeadsSharedServerPaths> => {
   };
 };
 
-const createState = (paths: BeadsSharedServerPaths): BeadsSharedServerState => ({
+const createState = (
+  paths: BeadsSharedServerPaths,
+  overrides: Partial<BeadsSharedServerState> = {},
+): BeadsSharedServerState => ({
   pid: process.pid,
   host: "127.0.0.1",
   port: 36111,
@@ -36,6 +40,22 @@ const createState = (paths: BeadsSharedServerPaths): BeadsSharedServerState => (
   sharedServerRoot: paths.sharedServerRoot,
   doltDataDir: paths.doltRoot,
   startedAt: "2026-05-10T00:00:00Z",
+  ...overrides,
+});
+
+const createStopState = (
+  overrides: Partial<BeadsSharedServerState> = {},
+): BeadsSharedServerState => ({
+  pid: 999_999_991,
+  ownerPid: process.pid,
+  acquisition: "started_by_owner",
+  host: "127.0.0.1",
+  user: "root",
+  port: 36_001,
+  sharedServerRoot: "/tmp/odt-shared-dolt",
+  doltDataDir: "/tmp/odt-shared-dolt/dolt",
+  startedAt: "2026-05-16T00:00:00.000Z",
+  ...overrides,
 });
 
 describe("readSharedServerState", () => {
@@ -106,6 +126,41 @@ describe("serverStateIsHealthy", () => {
     await expect(
       serverStateIsHealthy({ ...state, doltDataDir: `${paths.doltRoot}-other` }, paths),
     ).resolves.toBe(false);
+  });
+});
+
+describe("stopOwnedSharedDoltServer", () => {
+  test("refuses to stop another owner before touching the state file", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "odt-shared-dolt-stop-"));
+    const statePath = path.join(root, "server.json");
+    await writeFile(statePath, "state");
+
+    await expect(
+      stopOwnedSharedDoltServer(createStopState({ ownerPid: process.pid + 1 }), statePath),
+    ).rejects.toThrow("Refusing to stop shared Dolt server");
+
+    await expect(readFile(statePath, "utf8")).resolves.toBe("state");
+  });
+
+  test("removes state only after the owned process is confirmed gone", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "odt-shared-dolt-stop-"));
+    const statePath = path.join(root, "server.json");
+    await writeFile(statePath, "state");
+
+    await expect(stopOwnedSharedDoltServer(createStopState(), statePath)).resolves
+      .toBeUndefined();
+    await expect(readFile(statePath, "utf8")).rejects.toThrow();
+  });
+
+  test("keeps state visible when process cleanup fails before termination", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "odt-shared-dolt-stop-"));
+    const statePath = path.join(root, "server.json");
+    await writeFile(statePath, "state");
+
+    await expect(stopOwnedSharedDoltServer(createStopState({ pid: 0 }), statePath)).rejects.toThrow(
+      "invalid process pid 0",
+    );
+    await expect(readFile(statePath, "utf8")).resolves.toBe("state");
   });
 });
 

--- a/packages/host/src/infrastructure/beads/beads-shared-dolt-server.test.ts
+++ b/packages/host/src/infrastructure/beads/beads-shared-dolt-server.test.ts
@@ -147,8 +147,7 @@ describe("stopOwnedSharedDoltServer", () => {
     const statePath = path.join(root, "server.json");
     await writeFile(statePath, "state");
 
-    await expect(stopOwnedSharedDoltServer(createStopState(), statePath)).resolves
-      .toBeUndefined();
+    await expect(stopOwnedSharedDoltServer(createStopState(), statePath)).resolves.toBeUndefined();
     await expect(readFile(statePath, "utf8")).rejects.toThrow();
   });
 

--- a/packages/host/src/infrastructure/beads/beads-shared-dolt-server.ts
+++ b/packages/host/src/infrastructure/beads/beads-shared-dolt-server.ts
@@ -13,8 +13,8 @@ import {
 import net from "node:net";
 import path from "node:path";
 import {
+  processIsAlive,
   shouldStartDetachedProcessGroup,
-  signalProcessTree,
   terminateProcessTree,
 } from "../../adapters/process/process-tree";
 import {
@@ -108,19 +108,6 @@ export const readSharedServerState = async (
   return { pid, host, port, user, ownerPid, acquisition, sharedServerRoot, doltDataDir, startedAt };
 };
 
-export const processIsAlive = (pid: number): boolean => {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-export const signalProcess = (pid: number, signal: NodeJS.Signals): void => {
-  signalProcessTree(pid, signal);
-};
-
 export const waitForProcessExit = async (pid: number, timeoutMs: number): Promise<boolean> => {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -131,6 +118,19 @@ export const waitForProcessExit = async (pid: number, timeoutMs: number): Promis
   }
   return !processIsAlive(pid);
 };
+
+const terminateSharedDoltProcess = (
+  pid: number,
+  label: string,
+  stopTimeoutMs = 2_000,
+): Promise<void> =>
+  terminateProcessTree({
+    pid,
+    label,
+    isClosed: () => !processIsAlive(pid),
+    waitForExit: (timeoutMs) => waitForProcessExit(pid, timeoutMs),
+    stopTimeoutMs,
+  });
 
 export type StopSharedDoltServer = (
   state: BeadsSharedServerState,
@@ -144,13 +144,7 @@ export const stopOwnedSharedDoltServer: StopSharedDoltServer = async (state, ser
     );
   }
 
-  await terminateProcessTree({
-    pid: state.pid,
-    label: `shared Dolt server ${state.pid}`,
-    isClosed: () => !processIsAlive(state.pid),
-    waitForExit: (timeoutMs) => waitForProcessExit(state.pid, timeoutMs),
-    stopTimeoutMs: 2_000,
-  });
+  await terminateSharedDoltProcess(state.pid, `shared Dolt server ${state.pid}`);
 
   await unlink(serverStatePath).catch((error: unknown) => {
     if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
@@ -374,15 +368,10 @@ export const spawnSharedDoltServer = async (
   }
 
   const cleanupErrors: string[] = [];
-  if (child.pid && child.pid > 0) {
+  const childPid = child.pid;
+  if (childPid && childPid > 0) {
     try {
-      await terminateProcessTree({
-        pid: child.pid,
-        label: `shared Dolt server on port ${port}`,
-        isClosed: () => !processIsAlive(child.pid as number),
-        waitForExit: (timeoutMs) => waitForProcessExit(child.pid as number, timeoutMs),
-        stopTimeoutMs: 2_000,
-      });
+      await terminateSharedDoltProcess(childPid, `shared Dolt server on port ${port}`);
     } catch (error) {
       cleanupErrors.push(error instanceof Error ? error.message : String(error));
     }

--- a/packages/host/src/infrastructure/beads/beads-shared-dolt-server.ts
+++ b/packages/host/src/infrastructure/beads/beads-shared-dolt-server.ts
@@ -12,7 +12,11 @@ import {
 } from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
-
+import {
+  shouldStartDetachedProcessGroup,
+  signalProcessTree,
+  terminateProcessTree,
+} from "../../adapters/process/process-tree";
 import {
   type BeadsCommandRunner,
   type BeadsSharedServerPaths,
@@ -113,17 +117,8 @@ export const processIsAlive = (pid: number): boolean => {
   }
 };
 
-export const processGroupId = (pid: number): number => (process.platform === "win32" ? pid : -pid);
-
 export const signalProcess = (pid: number, signal: NodeJS.Signals): void => {
-  try {
-    process.kill(processGroupId(pid), signal);
-  } catch (error) {
-    if (typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH") {
-      return;
-    }
-    throw error;
-  }
+  signalProcessTree(pid, signal);
 };
 
 export const waitForProcessExit = async (pid: number, timeoutMs: number): Promise<boolean> => {
@@ -149,15 +144,13 @@ export const stopOwnedSharedDoltServer: StopSharedDoltServer = async (state, ser
     );
   }
 
-  if (processIsAlive(state.pid)) {
-    signalProcess(state.pid, "SIGTERM");
-    if (!(await waitForProcessExit(state.pid, 2_000))) {
-      signalProcess(state.pid, "SIGKILL");
-      if (!(await waitForProcessExit(state.pid, 2_000))) {
-        throw new Error(`Timed out stopping shared Dolt server process ${state.pid}`);
-      }
-    }
-  }
+  await terminateProcessTree({
+    pid: state.pid,
+    label: `shared Dolt server ${state.pid}`,
+    isClosed: () => !processIsAlive(state.pid),
+    waitForExit: (timeoutMs) => waitForProcessExit(state.pid, timeoutMs),
+    stopTimeoutMs: 2_000,
+  });
 
   await unlink(serverStatePath).catch((error: unknown) => {
     if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
@@ -345,7 +338,7 @@ export const spawnSharedDoltServer = async (
   const stderr = await open(stderrLogPath, "w");
   const child = spawn("dolt", ["sql-server", "--config", paths.doltConfigFile], {
     cwd: paths.sharedServerRoot,
-    detached: process.platform !== "win32",
+    detached: shouldStartDetachedProcessGroup(),
     env: paths.env,
     stdio: ["ignore", stdout.fd, stderr.fd],
   });
@@ -380,13 +373,29 @@ export const spawnSharedDoltServer = async (
     };
   }
 
-  child.kill();
+  const cleanupErrors: string[] = [];
+  if (child.pid && child.pid > 0) {
+    try {
+      await terminateProcessTree({
+        pid: child.pid,
+        label: `shared Dolt server on port ${port}`,
+        isClosed: () => !processIsAlive(child.pid as number),
+        waitForExit: (timeoutMs) => waitForProcessExit(child.pid as number, timeoutMs),
+        stopTimeoutMs: 2_000,
+      });
+    } catch (error) {
+      cleanupErrors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
   const stderrOutput = await readFile(stderrLogPath, "utf8").catch(() => "");
   const detail = formatDoltStartupLog(stderrOutput);
+  const startupError = detail
+    ? `Shared Dolt server on port ${port} failed to become ready: ${detail}`
+    : `Shared Dolt server on port ${port} failed to become ready within ${SHARED_DOLT_HEALTH_TIMEOUT_MS}ms`;
   throw new Error(
-    detail
-      ? `Shared Dolt server on port ${port} failed to become ready: ${detail}`
-      : `Shared Dolt server on port ${port} failed to become ready within ${SHARED_DOLT_HEALTH_TIMEOUT_MS}ms`,
+    cleanupErrors.length > 0
+      ? `${startupError}\nCleanup failed: ${cleanupErrors.join("\n")}`
+      : startupError,
   );
 };
 

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -6,22 +6,6 @@ const createHostProcess = (exited: Promise<number>): Bun.Subprocess => {
   return { exited } as Bun.Subprocess;
 };
 
-const createTerminableHostProcess = (pid?: number, exited = Promise.resolve(0)) => {
-  const killCalls: Array<number | NodeJS.Signals | undefined> = [];
-  const child = {
-    pid,
-    exited,
-    kill(signal?: number | NodeJS.Signals) {
-      killCalls.push(signal);
-      return true;
-    },
-  } as unknown as Bun.Subprocess;
-
-  return { child, killCalls };
-};
-
-const noopWindowsProcessTreeTerminator = async () => {};
-
 describe("launcher internals", () => {
   test("waits for the fake host health and token-authenticated session endpoints", async () => {
     const requests: Array<{ url: string; method: string | undefined; token: string | null }> = [];
@@ -132,151 +116,40 @@ describe("launcher internals", () => {
     expect(hostExitCode).toBeNull();
   });
 
-  test("uses process-group signals on non-Windows platforms", async () => {
-    const { child, killCalls } = createTerminableHostProcess(1234);
-    const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
-
-    await __launcherTestInternals.terminateHostProcess(child, {
-      platform: "linux",
-      killProcess(pid, signal) {
-        processKillCalls.push({ pid, signal });
-        return true;
+  test("still stops host services after shutdown request failures", async () => {
+    let stopCalls = 0;
+    let frontendCloseCalls = 0;
+    const hostBackend = {
+      exited: Promise.resolve(0),
+      port: 14327,
+      stop: async () => {
+        stopCalls += 1;
       },
-      terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
-      sleep: async () => {},
-    });
-
-    expect(processKillCalls).toEqual([
-      { pid: -1234, signal: "SIGTERM" },
-      { pid: -1234, signal: 0 },
-      { pid: -1234, signal: "SIGKILL" },
-    ]);
-    expect(killCalls).toEqual([undefined, 9]);
-  });
-
-  test("waits the full process-group grace window before Unix escalation", async () => {
-    const { child } = createTerminableHostProcess(1234, Promise.resolve(0));
-    const calls: string[] = [];
-
-    await __launcherTestInternals.terminateHostProcess(child, {
-      platform: "linux",
-      killProcess(_pid, signal) {
-        calls.push(`process:${signal}`);
-        return true;
+    };
+    const frontendServer = {
+      close: async () => {
+        frontendCloseCalls += 1;
       },
-      terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
-      sleep: async (durationMs) => {
-        calls.push(`sleep:${durationMs}`);
-      },
-    });
-
-    expect(calls).toEqual([
-      "process:SIGTERM",
-      "sleep:3000",
-      "process:0",
-      "process:SIGKILL",
-      "sleep:1000",
-    ]);
-  });
-
-  test("skips Unix SIGKILL when the process group is already gone", async () => {
-    const { child, killCalls } = createTerminableHostProcess(1234);
-    const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
-
-    await __launcherTestInternals.terminateHostProcess(child, {
-      platform: "linux",
-      killProcess(pid, signal) {
-        processKillCalls.push({ pid, signal });
-        if (signal === 0) {
-          throw new Error("process group is gone");
-        }
-        return true;
-      },
-      terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
-      sleep: async () => {},
-    });
-
-    expect(processKillCalls).toEqual([
-      { pid: -1234, signal: "SIGTERM" },
-      { pid: -1234, signal: 0 },
-    ]);
-    expect(killCalls).toEqual([undefined, 9]);
-  });
-
-  test("terminates the Windows process tree without negative process-group signals", async () => {
-    const { child, killCalls } = createTerminableHostProcess(1234);
-    const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
-    const processTreeKills: number[] = [];
-
-    await __launcherTestInternals.terminateHostProcess(child, {
-      platform: "win32",
-      killProcess(pid, signal) {
-        processKillCalls.push({ pid, signal });
-        if (pid < 0) {
-          throw new Error("Windows termination must not use negative PIDs.");
-        }
-        return true;
-      },
-      terminateWindowsProcessTree(pid) {
-        processTreeKills.push(pid);
-        return Promise.resolve();
-      },
-      sleep: async () => {},
-    });
-
-    expect(processKillCalls).toEqual([]);
-    expect(processTreeKills).toEqual([1234]);
-    expect(killCalls).toEqual([]);
-  });
-
-  test("surfaces Windows process-tree termination failures", async () => {
-    const { child } = createTerminableHostProcess(1234);
+    };
 
     await expect(
-      __launcherTestInternals.terminateHostProcess(child, {
-        platform: "win32",
-        killProcess() {
-          throw new Error("killProcess should not be called");
+      __launcherTestInternals.stopLauncherServices({
+        backendUrl: "http://127.0.0.1:14327",
+        controlToken: "control-token",
+        frontendServer,
+        hostBackend,
+        requestShutdown: async () => {
+          throw new Error("shutdown request failed");
         },
-        terminateWindowsProcessTree() {
-          return Promise.reject(new Error("taskkill failed"));
+        closeServer: async (server) => {
+          await server?.close();
         },
-        sleep: async () => {},
+        waitForGracefulExitCode: async () => null,
       }),
-    ).rejects.toThrow("taskkill failed");
-  });
+    ).rejects.toThrow("shutdown request failed");
 
-  test("surfaces Unix process-group signal failures", async () => {
-    const { child } = createTerminableHostProcess(1234);
-
-    await expect(
-      __launcherTestInternals.terminateHostProcess(child, {
-        platform: "linux",
-        killProcess() {
-          throw new Error("SIGTERM failed");
-        },
-        terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
-        sleep: async () => {},
-      }),
-    ).rejects.toThrow("SIGTERM failed");
-  });
-
-  test("skips process-group signals when the host PID is invalid", async () => {
-    const { child, killCalls } = createTerminableHostProcess(0);
-    const processKillCalls: Array<{ pid: number; signal: string | number | undefined }> = [];
-
-    await __launcherTestInternals.terminateHostProcess(child, {
-      platform: "darwin",
-      killProcess(pid, signal) {
-        processKillCalls.push({ pid, signal });
-        return true;
-      },
-      terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
-      sleep: async () => {},
-    });
-
-    expect(processKillCalls).toEqual([]);
-    expect(killCalls).toEqual([undefined, 9]);
+    expect(frontendCloseCalls).toBe(1);
+    expect(stopCalls).toBe(1);
   });
 
   test("builds runtime config JSON for the browser shell", () => {

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -114,22 +114,22 @@ describe("launcher internals", () => {
     ]);
   });
 
-  test("detects when the host exits during the graceful shutdown wait", async () => {
-    const hostExited = await __launcherTestInternals.waitForGracefulHostExit(
+  test("detects the host exit code during the graceful shutdown wait", async () => {
+    const hostExitCode = await __launcherTestInternals.waitForGracefulHostExitCode(
       createHostProcess(Promise.resolve(0)),
       async () => new Promise(() => {}),
     );
 
-    expect(hostExited).toBe(true);
+    expect(hostExitCode).toBe(0);
   });
 
   test("detects when the host needs force termination after graceful shutdown wait", async () => {
-    const hostExited = await __launcherTestInternals.waitForGracefulHostExit(
+    const hostExitCode = await __launcherTestInternals.waitForGracefulHostExitCode(
       createHostProcess(new Promise<number>(() => {})),
       async () => {},
     );
 
-    expect(hostExited).toBe(false);
+    expect(hostExitCode).toBeNull();
   });
 
   test("uses process-group signals on non-Windows platforms", async () => {

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -10,7 +10,7 @@ describe("launcher internals", () => {
   test("waits for the fake host health and token-authenticated session endpoints", async () => {
     const requests: Array<{ url: string; method: string | undefined; token: string | null }> = [];
     let healthAttempts = 0;
-    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = async (url: string | URL | Request, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
       requests.push({
         url: String(url),
@@ -22,7 +22,7 @@ describe("launcher internals", () => {
         return new Response(null, { status: healthAttempts === 1 ? 503 : 200 });
       }
       return new Response(null, { status: 200 });
-    }) as typeof fetch;
+    };
 
     await __launcherTestInternals.waitForBackend(
       "http://127.0.0.1:14327",
@@ -40,9 +40,9 @@ describe("launcher internals", () => {
   });
 
   test("rejects stale hosts that do not know the launcher app token", async () => {
-    const fetchImpl = (async (url: string | URL | Request) => {
+    const fetchImpl = async (url: string | URL | Request) => {
       return new Response(null, { status: String(url).endsWith("/session") ? 403 : 200 });
-    }) as typeof fetch;
+    };
 
     await expect(
       __launcherTestInternals.verifyBackendReadiness(
@@ -64,7 +64,7 @@ describe("launcher internals", () => {
         1_000,
         createHostProcess(exited),
         {
-          fetch: (async () => new Response(null, { status: 503 })) as unknown as typeof fetch,
+          fetch: async () => new Response(null, { status: 503 }),
           sleep: async () => {},
         },
       ),
@@ -73,7 +73,7 @@ describe("launcher internals", () => {
 
   test("sends the launcher control token when shutting down the fake host", async () => {
     const requests: Array<{ url: string; token: string | null; method: string | undefined }> = [];
-    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = async (url: string | URL | Request, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
       requests.push({
         url: String(url),
@@ -81,7 +81,7 @@ describe("launcher internals", () => {
         token: headers.get("x-openducktor-control-token"),
       });
       return new Response(null, { status: 202 });
-    }) as typeof fetch;
+    };
 
     await __launcherTestInternals.requestHostShutdown(
       "http://127.0.0.1:14327",
@@ -133,19 +133,23 @@ describe("launcher internals", () => {
     };
 
     await expect(
-      __launcherTestInternals.stopLauncherServices({
-        backendUrl: "http://127.0.0.1:14327",
-        controlToken: "control-token",
-        frontendServer,
-        hostBackend,
-        requestShutdown: async () => {
-          throw new Error("shutdown request failed");
+      __launcherTestInternals.stopLauncherServices(
+        {
+          backendUrl: "http://127.0.0.1:14327",
+          controlToken: "control-token",
+          frontendServer,
+          hostBackend,
         },
-        closeServer: async (server) => {
-          await server?.close();
+        {
+          requestShutdown: async () => {
+            throw new Error("shutdown request failed");
+          },
+          closeServer: async (server) => {
+            await server?.close();
+          },
+          waitForGracefulExitCode: async () => null,
         },
-        waitForGracefulExitCode: async () => null,
-      }),
+      ),
     ).rejects.toThrow("shutdown request failed");
 
     expect(frontendCloseCalls).toBe(1);

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -6,7 +6,7 @@ const createHostProcess = (exited: Promise<number>): Bun.Subprocess => {
   return { exited } as Bun.Subprocess;
 };
 
-const createTerminableHostProcess = (pid?: number, exited = new Promise<number>(() => {})) => {
+const createTerminableHostProcess = (pid?: number, exited = Promise.resolve(0)) => {
   const killCalls: Array<number | NodeJS.Signals | undefined> = [];
   const child = {
     pid,
@@ -227,6 +227,38 @@ describe("launcher internals", () => {
     expect(processKillCalls).toEqual([]);
     expect(processTreeKills).toEqual([1234]);
     expect(killCalls).toEqual([]);
+  });
+
+  test("surfaces Windows process-tree termination failures", async () => {
+    const { child } = createTerminableHostProcess(1234);
+
+    await expect(
+      __launcherTestInternals.terminateHostProcess(child, {
+        platform: "win32",
+        killProcess() {
+          throw new Error("killProcess should not be called");
+        },
+        terminateWindowsProcessTree() {
+          return Promise.reject(new Error("taskkill failed"));
+        },
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow("taskkill failed");
+  });
+
+  test("surfaces Unix process-group signal failures", async () => {
+    const { child } = createTerminableHostProcess(1234);
+
+    await expect(
+      __launcherTestInternals.terminateHostProcess(child, {
+        platform: "linux",
+        killProcess() {
+          throw new Error("SIGTERM failed");
+        },
+        terminateWindowsProcessTree: noopWindowsProcessTreeTerminator,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow("SIGTERM failed");
   });
 
   test("skips process-group signals when the host PID is invalid", async () => {

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -15,20 +15,22 @@ export type LauncherOptions = {
   readinessTimeoutMs?: number;
 };
 
-type ManagedProcess = Bun.Subprocess;
 type ManagedHost = Pick<Bun.Subprocess, "exited"> | TypescriptHostBackend;
 type BackendReadinessDependencies = {
   fetch: typeof fetch;
   sleep: (durationMs: number) => Promise<unknown>;
 };
-type HostTerminationDependencies = {
-  platform: NodeJS.Platform;
-  killProcess: typeof process.kill;
-  terminateWindowsProcessTree: (pid: number) => Promise<void>;
-  sleep: (durationMs: number) => Promise<unknown>;
-};
 type FrontendServer = {
   close(): Promise<void>;
+};
+type StopLauncherServicesInput = {
+  backendUrl: string;
+  controlToken: string;
+  frontendServer: FrontendServer | null;
+  hostBackend: TypescriptHostBackend;
+  requestShutdown?: typeof requestHostShutdown;
+  closeServer?: typeof closeFrontendServer;
+  waitForGracefulExitCode?: typeof waitForGracefulHostExitCode;
 };
 
 const LOCALHOST = "127.0.0.1";
@@ -37,8 +39,6 @@ const APP_TOKEN_HEADER = "x-openducktor-app-token";
 const VITE_CLOSE_TIMEOUT_MS = 3_000;
 const HOST_GRACEFUL_EXIT_TIMEOUT_MS = 2_000;
 const FORCE_EXIT_SIGNAL_GRACE_MS = 1_500;
-const HOST_FORCE_TERMINATION_GRACE_MS = 3_000;
-const HOST_FORCE_KILL_WAIT_MS = 1_000;
 
 const buildFrontendUrl = (port: number): string => `http://${LOCALHOST}:${port}`;
 const buildBackendUrl = (port: number): string => `http://${LOCALHOST}:${port}`;
@@ -101,90 +101,14 @@ const verifyBackendReadiness = async (
   }
 };
 
-const defaultHostTerminationDependencies: HostTerminationDependencies = {
-  platform: process.platform,
-  killProcess: process.kill,
-  terminateWindowsProcessTree: async (pid: number) => {
-    const taskkill = Bun.spawn({
-      cmd: ["taskkill", "/PID", String(pid), "/T", "/F"],
-      stdout: "ignore",
-      stderr: "ignore",
-    });
-    await Promise.race([taskkill.exited, Bun.sleep(HOST_FORCE_TERMINATION_GRACE_MS)]);
-  },
-  sleep: Bun.sleep,
-};
-
-const waitForHostExit = async (
-  child: ManagedProcess,
-  durationMs: number,
-  sleep: HostTerminationDependencies["sleep"],
-): Promise<number | null> => {
-  return Promise.race([child.exited, sleep(durationMs).then(() => null)]);
-};
-
 const waitForGracefulHostExitCode = async (
   child: ManagedHost,
-  sleep: HostTerminationDependencies["sleep"] = Bun.sleep,
+  sleep: (durationMs: number) => Promise<unknown> = Bun.sleep,
 ): Promise<number | null> => {
   return Promise.race([
     child.exited.then((exitCode) => exitCode),
     sleep(HOST_GRACEFUL_EXIT_TIMEOUT_MS).then(() => null),
   ]);
-};
-
-const terminateHostProcess = async (
-  child: ManagedProcess | null,
-  dependencies: HostTerminationDependencies = defaultHostTerminationDependencies,
-): Promise<void> => {
-  if (!child) {
-    return;
-  }
-
-  const pid = child.pid;
-  const hasProcessGroupPid = typeof pid === "number" && pid > 0;
-
-  if (dependencies.platform === "win32") {
-    if (hasProcessGroupPid) {
-      await dependencies.terminateWindowsProcessTree(pid);
-    } else {
-      child.kill();
-    }
-    const exitCode = await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
-    if (exitCode === null) {
-      throw new Error(`Timed out waiting for OpenDucktor web host process ${pid} to exit.`);
-    }
-    return;
-  }
-
-  if (hasProcessGroupPid) {
-    dependencies.killProcess(-pid, "SIGTERM");
-  }
-
-  child.kill();
-  await dependencies.sleep(HOST_FORCE_TERMINATION_GRACE_MS);
-
-  if (hasProcessGroupPid) {
-    try {
-      dependencies.killProcess(-pid, 0);
-    } catch {
-      child.kill(9);
-      const exitCode = await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
-      if (exitCode === null) {
-        throw new Error(`Timed out waiting for OpenDucktor web host process ${pid} to exit.`);
-      }
-      return;
-    }
-    dependencies.killProcess(-pid, "SIGKILL");
-  }
-
-  child.kill(9);
-  const exitCode = await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
-  if (exitCode === null) {
-    throw new Error(
-      `Timed out waiting for OpenDucktor web host process ${pid ?? "unknown"} to exit.`,
-    );
-  }
 };
 
 const closeFrontendServer = async (server: FrontendServer | null): Promise<void> => {
@@ -285,13 +209,66 @@ const shouldForceExitForRepeatedSignal = (
   graceMs = FORCE_EXIT_SIGNAL_GRACE_MS,
 ): boolean => now - firstSignalReceivedAt >= graceMs;
 
+const throwLauncherShutdownFailures = (failures: unknown[]): void => {
+  if (failures.length === 0) {
+    return;
+  }
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  throw new AggregateError(failures, "OpenDucktor web shutdown failed.");
+};
+
+const stopLauncherServices = async ({
+  backendUrl,
+  controlToken,
+  frontendServer,
+  hostBackend,
+  requestShutdown = requestHostShutdown,
+  closeServer = closeFrontendServer,
+  waitForGracefulExitCode = waitForGracefulHostExitCode,
+}: StopLauncherServicesInput): Promise<void> => {
+  const shutdownResults = await Promise.allSettled([
+    requestShutdown(backendUrl, controlToken),
+    closeServer(frontendServer),
+  ]);
+  const shutdownFailures = shutdownResults
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  for (const failure of shutdownFailures) {
+    logError(failure instanceof Error ? failure.message : failure);
+  }
+
+  let hostExitCode: number | null;
+  try {
+    hostExitCode = await waitForGracefulExitCode(hostBackend);
+    if (hostExitCode === null) {
+      logInfo("Ensuring OpenDucktor TypeScript host has stopped...");
+      await hostBackend.stop();
+      hostExitCode = await hostBackend.exited;
+    }
+  } catch (error) {
+    shutdownFailures.push(error);
+    throwLauncherShutdownFailures(shutdownFailures);
+    return;
+  }
+
+  if (hostExitCode !== 0) {
+    shutdownFailures.push(
+      new Error(`OpenDucktor TypeScript host shutdown failed with exit code ${hostExitCode}.`),
+    );
+  }
+
+  throwLauncherShutdownFailures(shutdownFailures);
+};
+
 export const __launcherTestInternals = {
   buildFrontendDisplayUrls,
   buildBrowserRuntimeConfigJson,
   resolveStaticAssetPath,
   requestHostShutdown,
   shouldForceExitForRepeatedSignal,
-  terminateHostProcess,
+  stopLauncherServices,
   verifyBackendReadiness,
   waitForBackend,
   waitForGracefulHostExitCode,
@@ -425,34 +402,7 @@ export const runLauncher = async (options: LauncherOptions): Promise<number> => 
       logInfo("Stopping OpenDucktor frontend server...");
       logInfo("Stopping OpenDucktor TypeScript host services...");
 
-      const shutdownResults = await Promise.allSettled([
-        requestHostShutdown(backendUrl, controlToken),
-        closeFrontendServer(frontendServer),
-      ]);
-
-      const shutdownError = shutdownResults.find(
-        (result): result is PromiseRejectedResult => result.status === "rejected",
-      );
-      if (shutdownError) {
-        logError(
-          shutdownError.reason instanceof Error
-            ? shutdownError.reason.message
-            : shutdownError.reason,
-        );
-        throw shutdownError.reason;
-      }
-
-      let hostExitCode = await waitForGracefulHostExitCode(hostBackend);
-      if (hostExitCode === null) {
-        logInfo("Ensuring OpenDucktor TypeScript host has stopped...");
-        await hostBackend.stop();
-        hostExitCode = await hostBackend.exited;
-      }
-      if (hostExitCode !== 0) {
-        throw new Error(
-          `OpenDucktor TypeScript host shutdown failed with exit code ${hostExitCode}.`,
-        );
-      }
+      await stopLauncherServices({ backendUrl, controlToken, frontendServer, hostBackend });
       logSuccess("OpenDucktor web stopped.");
     })();
 

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -123,13 +123,13 @@ const waitForHostExit = async (
   await Promise.race([child.exited, sleep(durationMs)]);
 };
 
-const waitForGracefulHostExit = async (
+const waitForGracefulHostExitCode = async (
   child: ManagedHost,
   sleep: HostTerminationDependencies["sleep"] = Bun.sleep,
-): Promise<boolean> => {
+): Promise<number | null> => {
   return Promise.race([
-    child.exited.then(() => true),
-    sleep(HOST_GRACEFUL_EXIT_TIMEOUT_MS).then(() => false),
+    child.exited.then((exitCode) => exitCode),
+    sleep(HOST_GRACEFUL_EXIT_TIMEOUT_MS).then(() => null),
   ]);
 };
 
@@ -285,7 +285,7 @@ export const __launcherTestInternals = {
   terminateHostProcess,
   verifyBackendReadiness,
   waitForBackend,
-  waitForGracefulHostExit,
+  waitForGracefulHostExitCode,
 };
 
 const startViteServer = async (
@@ -430,12 +430,19 @@ export const runLauncher = async (options: LauncherOptions): Promise<number> => 
             ? shutdownError.reason.message
             : shutdownError.reason,
         );
+        throw shutdownError.reason;
       }
 
-      const hostExited = await waitForGracefulHostExit(hostBackend);
-      if (!hostExited) {
+      let hostExitCode = await waitForGracefulHostExitCode(hostBackend);
+      if (hostExitCode === null) {
         logInfo("Ensuring OpenDucktor TypeScript host has stopped...");
         await hostBackend.stop();
+        hostExitCode = await hostBackend.exited;
+      }
+      if (hostExitCode !== 0) {
+        throw new Error(
+          `OpenDucktor TypeScript host shutdown failed with exit code ${hostExitCode}.`,
+        );
       }
       logSuccess("OpenDucktor web stopped.");
     })();

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -16,9 +16,11 @@ export type LauncherOptions = {
 };
 
 type ManagedHost = Pick<Bun.Subprocess, "exited"> | TypescriptHostBackend;
+type FetchFunction = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+type SleepFunction = (durationMs: number) => Promise<unknown>;
 type BackendReadinessDependencies = {
-  fetch: typeof fetch;
-  sleep: (durationMs: number) => Promise<unknown>;
+  fetch: FetchFunction;
+  sleep: SleepFunction;
 };
 type FrontendServer = {
   close(): Promise<void>;
@@ -28,9 +30,11 @@ type StopLauncherServicesInput = {
   controlToken: string;
   frontendServer: FrontendServer | null;
   hostBackend: TypescriptHostBackend;
-  requestShutdown?: typeof requestHostShutdown;
-  closeServer?: typeof closeFrontendServer;
-  waitForGracefulExitCode?: typeof waitForGracefulHostExitCode;
+};
+type LauncherShutdownDependencies = {
+  requestShutdown: (backendUrl: string, controlToken: string) => Promise<void>;
+  closeServer: (server: FrontendServer | null) => Promise<void>;
+  waitForGracefulExitCode: (child: ManagedHost) => Promise<number | null>;
 };
 
 const LOCALHOST = "127.0.0.1";
@@ -58,7 +62,7 @@ const logFrontendAvailability = (port: number): void => {
 const requestHostShutdown = async (
   backendUrl: string,
   controlToken: string,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: FetchFunction = fetch,
 ): Promise<void> => {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 3_000);
@@ -81,7 +85,7 @@ const requestHostShutdown = async (
 const verifyBackendReadiness = async (
   backendUrl: string,
   appToken: string,
-  fetchImpl: typeof fetch,
+  fetchImpl: FetchFunction,
 ): Promise<void> => {
   const healthResponse = await fetchImpl(`${backendUrl}/health`);
   if (!healthResponse.ok) {
@@ -103,7 +107,7 @@ const verifyBackendReadiness = async (
 
 const waitForGracefulHostExitCode = async (
   child: ManagedHost,
-  sleep: (durationMs: number) => Promise<unknown> = Bun.sleep,
+  sleep: SleepFunction = Bun.sleep,
 ): Promise<number | null> => {
   return Promise.race([
     child.exited.then((exitCode) => exitCode),
@@ -219,15 +223,20 @@ const throwLauncherShutdownFailures = (failures: unknown[]): void => {
   throw new AggregateError(failures, "OpenDucktor web shutdown failed.");
 };
 
-const stopLauncherServices = async ({
-  backendUrl,
-  controlToken,
-  frontendServer,
-  hostBackend,
-  requestShutdown = requestHostShutdown,
-  closeServer = closeFrontendServer,
-  waitForGracefulExitCode = waitForGracefulHostExitCode,
-}: StopLauncherServicesInput): Promise<void> => {
+const defaultLauncherShutdownDependencies: LauncherShutdownDependencies = {
+  requestShutdown: requestHostShutdown,
+  closeServer: closeFrontendServer,
+  waitForGracefulExitCode: waitForGracefulHostExitCode,
+};
+
+const stopLauncherServices = async (
+  { backendUrl, controlToken, frontendServer, hostBackend }: StopLauncherServicesInput,
+  {
+    requestShutdown,
+    closeServer,
+    waitForGracefulExitCode,
+  }: LauncherShutdownDependencies = defaultLauncherShutdownDependencies,
+): Promise<void> => {
   const shutdownResults = await Promise.allSettled([
     requestShutdown(backendUrl, controlToken),
     closeServer(frontendServer),

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -119,8 +119,8 @@ const waitForHostExit = async (
   child: ManagedProcess,
   durationMs: number,
   sleep: HostTerminationDependencies["sleep"],
-): Promise<void> => {
-  await Promise.race([child.exited, sleep(durationMs)]);
+): Promise<number | null> => {
+  return Promise.race([child.exited, sleep(durationMs).then(() => null)]);
 };
 
 const waitForGracefulHostExitCode = async (
@@ -146,20 +146,19 @@ const terminateHostProcess = async (
 
   if (dependencies.platform === "win32") {
     if (hasProcessGroupPid) {
-      try {
-        await dependencies.terminateWindowsProcessTree(pid);
-      } catch {}
+      await dependencies.terminateWindowsProcessTree(pid);
     } else {
       child.kill();
     }
-    await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
+    const exitCode = await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
+    if (exitCode === null) {
+      throw new Error(`Timed out waiting for OpenDucktor web host process ${pid} to exit.`);
+    }
     return;
   }
 
   if (hasProcessGroupPid) {
-    try {
-      dependencies.killProcess(-pid, "SIGTERM");
-    } catch {}
+    dependencies.killProcess(-pid, "SIGTERM");
   }
 
   child.kill();
@@ -168,14 +167,24 @@ const terminateHostProcess = async (
   if (hasProcessGroupPid) {
     try {
       dependencies.killProcess(-pid, 0);
-      try {
-        dependencies.killProcess(-pid, "SIGKILL");
-      } catch {}
-    } catch {}
+    } catch {
+      child.kill(9);
+      const exitCode = await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
+      if (exitCode === null) {
+        throw new Error(`Timed out waiting for OpenDucktor web host process ${pid} to exit.`);
+      }
+      return;
+    }
+    dependencies.killProcess(-pid, "SIGKILL");
   }
 
   child.kill(9);
-  await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
+  const exitCode = await waitForHostExit(child, HOST_FORCE_KILL_WAIT_MS, dependencies.sleep);
+  if (exitCode === null) {
+    throw new Error(
+      `Timed out waiting for OpenDucktor web host process ${pid ?? "unknown"} to exit.`,
+    );
+  }
 };
 
 const closeFrontendServer = async (server: FrontendServer | null): Promise<void> => {

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -70,7 +70,7 @@ describe("TypeScript web host backend", () => {
       }
       await rm(tempConfigDir, { force: true, recursive: true });
     }
-  });
+  }, 5_000);
 
   test("rejects invalid browser frontend origins before opening a host port", () => {
     const { validateWebFrontendOrigin } = __typescriptHostBackendTestInternals;


### PR DESCRIPTION
## Summary
- centralize host-owned process tree termination in `packages/host` with shared Windows `taskkill` and Unix process-group signaling behavior
- route OpenCode, Codex app-server, dev-server, MCP sidecar, TypeScript shared-Dolt, and host lifecycle cleanup through explicit fail-fast shutdown paths
- align legacy Rust shared-Dolt cleanup with equivalent Unix process-group and Windows `taskkill /PID /T /F` semantics
- surface local web launcher and host disposal cleanup failures instead of reporting successful shutdown after failed cleanup

## Goal
This task hardens shutdown for host-owned child processes after Electron and browser-mode runtime ownership moved into `packages/host`. The branch targets leaks from OpenCode, Codex, dev-server shells, MCP sidecars, MCP bridge disposal, and shared-Dolt servers on Windows/Linux while preserving the repo no-fallback rule: failed cleanup must produce actionable errors instead of being silently swallowed.

## Implementation
- added `terminateProcessTree` and shared child-close waiting in `packages/host/src/adapters/process/process-tree.ts`
- updated OpenCode, Codex, and dev-server adapters to start detached where supported and stop full process trees
- kept Codex transport cleanup explicit so unregister/transport close errors do not hide process-tree termination failures
- moved TypeScript shared-Dolt stop/startup-failure cleanup onto the shared process-tree helper while preserving owner checks and state unlink ordering
- updated Rust shared-Dolt cleanup as a legacy equivalent path with expected-process validation, Unix process-group termination, Windows `taskkill`, and focused tests
- added host lifecycle tests for labeled shutdown failures and web launcher/backend tests for visible host cleanup failures

## Verification
- `bun run --filter @openducktor/host test`
- `bun run --filter @openducktor/host lint`
- `bun run --filter @openducktor/host typecheck`
- focused cleanup/runtime/web tests: 59 pass
- `cargo test -p host-infra-system shared_dolt -- --nocapture`
- commit hook workspace lint/typecheck plus Rust `cargo check`

## Notes
- Rebased on `origin/main` before pushing.
- CI will provide the final cross-platform PR evidence after publication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable, cross-platform process-tree termination and platform-aware command startup (Windows shell wrapping).

* **Bug Fixes**
  * More reliable descendant-process cleanup; clearer errors when termination fails; startup-time cleanup to avoid orphaned processes.

* **Refactor**
  * Centralized process-lifecycle and shutdown handling across runtimes and the launcher; removed duplicated local termination helpers.

* **Tests**
  * Expanded platform-aware tests for termination, cleanup, startup/stop sequencing, and graceful host exit behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->