### PR TITLE
fix(electron): show app version in sidebar

### DIFF
--- a/apps/electron/src/vite-config.test.ts
+++ b/apps/electron/src/vite-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import packageJson from "./package.json";
-import { resolveAppVersion } from "./vite.config";
+import packageJson from "../package.json";
+import { resolveAppVersion } from "../vite.config";
 
 describe("resolveAppVersion", () => {
   test("uses ODT_APP_VERSION when provided", () => {

--- a/apps/electron/vite.config.test.ts
+++ b/apps/electron/vite.config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import packageJson from "./package.json";
+import { resolveAppVersion } from "./vite.config";
+
+describe("resolveAppVersion", () => {
+  test("uses ODT_APP_VERSION when provided", () => {
+    expect(resolveAppVersion({ ODT_APP_VERSION: "9.8.7" })).toBe("9.8.7");
+  });
+
+  test("uses the Electron package version when ODT_APP_VERSION is absent", () => {
+    expect(resolveAppVersion({})).toBe(packageJson.version);
+  });
+
+  test("uses the Electron package version when ODT_APP_VERSION is empty", () => {
+    expect(resolveAppVersion({ ODT_APP_VERSION: "" })).toBe(packageJson.version);
+  });
+
+  test("uses the Electron package version when ODT_APP_VERSION is blank", () => {
+    expect(resolveAppVersion({ ODT_APP_VERSION: "   " })).toBe(packageJson.version);
+  });
+});

--- a/apps/electron/vite.config.ts
+++ b/apps/electron/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
@@ -9,6 +10,21 @@ const __dirname = path.dirname(__filename);
 const workspaceRoot = path.resolve(__dirname, "../..");
 const packagesRoot = path.join(workspaceRoot, "packages");
 const DEFAULT_RENDERER_DEV_PORT = 1430;
+
+const readPackageVersion = (packageJsonPath = path.resolve(__dirname, "package.json")): string => {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
+    version?: unknown;
+  };
+  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+    throw new Error(`Missing package version in ${packageJsonPath}`);
+  }
+  return packageJson.version;
+};
+
+export const resolveAppVersion = (env: NodeJS.ProcessEnv = process.env): string => {
+  const versionOverride = env.ODT_APP_VERSION?.trim();
+  return versionOverride || readPackageVersion();
+};
 
 const resolveRendererDevPort = (): number => {
   const configuredPort = process.env.ELECTRON_RENDERER_DEV_PORT?.trim();
@@ -36,7 +52,7 @@ export default defineConfig({
   base: "./",
   plugins: [react(), tailwindcss()],
   define: {
-    "import.meta.env.VITE_ODT_APP_VERSION": JSON.stringify(process.env.ODT_APP_VERSION ?? ""),
+    "import.meta.env.VITE_ODT_APP_VERSION": JSON.stringify(resolveAppVersion()),
   },
   resolve: {
     alias: [


### PR DESCRIPTION
## Summary
- inject Electron renderer app version from ODT_APP_VERSION when provided
- fall back to apps/electron/package.json version so AppBrand renders the version under OpenDucktor
- add Electron Vite config tests for override, absent, empty, and blank version env values

## Verification
- bun run --filter @openducktor/electron test
- bun run --filter @openducktor/electron lint
- bun run --filter @openducktor/electron typecheck
- bun run --filter @openducktor/electron build
- QA approved in ODT for openducktor-wwm4