### PR TITLE
feat(host): stop Codex sessions via app-server interrupt

### DIFF
--- a/packages/adapters-codex-app-server/src/app-server-client.test.ts
+++ b/packages/adapters-codex-app-server/src/app-server-client.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { createCodexAppServerClient } from "./app-server-client";
+import type { CodexJsonRpcRequest, CodexJsonRpcTransport } from "./types";
+
+describe("createCodexAppServerClient", () => {
+  test("sends turn/interrupt requests", async () => {
+    const calls: CodexJsonRpcRequest[] = [];
+    const transport: CodexJsonRpcTransport = {
+      async request(request) {
+        calls.push(request);
+        return {};
+      },
+    };
+    const client = createCodexAppServerClient(transport);
+    await expect(client.turnInterrupt({ threadId: "thread-1", turnId: "turn-1" })).resolves.toEqual(
+      {},
+    );
+    expect(calls).toEqual([
+      {
+        method: "turn/interrupt",
+        params: { threadId: "thread-1", turnId: "turn-1" },
+      },
+    ]);
+  });
+});

--- a/packages/adapters-codex-app-server/src/app-server-client.ts
+++ b/packages/adapters-codex-app-server/src/app-server-client.ts
@@ -5,6 +5,7 @@ import type {
   CodexThreadForkParams,
   CodexThreadResumeParams,
   CodexThreadStartParams,
+  CodexTurnInterruptParams,
   CodexTurnStartParams,
   CodexTurnSteerParams,
 } from "./types";
@@ -33,6 +34,9 @@ export const createCodexAppServerClient = (
     },
     async turnSteer(params: CodexTurnSteerParams) {
       return transport.request({ method: "turn/steer", params });
+    },
+    async turnInterrupt(params: CodexTurnInterruptParams) {
+      return transport.request({ method: "turn/interrupt", params });
     },
     async threadRead(params) {
       return transport.request({ method: "thread/read", params });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.approvals.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.approvals.test.ts
@@ -361,6 +361,61 @@ describe("CodexAppServerAdapter approvals", () => {
     });
   });
 
+  test("clears pending Codex input state when local stop cleanup runs", async () => {
+    const { adapter, drainServerRequests } = createHarness({}, { deferTurnStart: true });
+    drainServerRequests.mockImplementationOnce(async () => [
+      {
+        id: 36,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "thread/start-runtime-ensure",
+          turnId: "turn-question",
+          itemId: "item-1",
+          questions: [{ id: "question-1", header: "Confirm", question: "Continue?" }],
+        },
+      },
+    ]);
+
+    await adapter.startSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+    await adapter.sendUserMessage({
+      externalSessionId: "thread/start-runtime-ensure",
+      parts: [{ kind: "text", text: "Start now" }],
+    });
+
+    await expect(
+      adapter.readSessionPresence({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "thread/start-runtime-ensure",
+      }),
+    ).resolves.toMatchObject({
+      classification: "waiting_for_question",
+      pendingQuestions: [expect.objectContaining({ requestId: "36" })],
+    });
+
+    await adapter.stopSession("thread/start-runtime-ensure");
+
+    await expect(
+      adapter.replyQuestion({
+        externalSessionId: "thread/start-runtime-ensure",
+        requestId: "36",
+        answers: [["yes"]],
+      }),
+    ).rejects.toThrow("Unknown Codex question request '36'.");
+    expect(() => adapter.subscribeEvents("thread/start-runtime-ensure", () => {})).toThrow(
+      "Unknown Codex session 'thread/start-runtime-ensure'.",
+    );
+  });
+
   test("steers active Codex turns for queued user messages", async () => {
     const { adapter, drainServerRequests, transports } = createHarness(
       {},

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -907,16 +907,46 @@ export class CodexAppServerAdapter
     if (!session) {
       throw new Error(`Unknown Codex session '${externalSessionId}'.`);
     }
+    this.cleanupSessionState(externalSessionId);
+    if (
+      ![...this.sessions.values()].some((candidate) => candidate.runtimeId === session.runtimeId)
+    ) {
+      this.stopRuntimeEventSubscription(session.runtimeId);
+    }
+  }
+
+  private cleanupSessionState(externalSessionId: string): void {
     this.sessions.delete(externalSessionId);
+    this.listenersBySessionId.delete(externalSessionId);
     this.bufferedNotificationsByThreadId.delete(externalSessionId);
     this.bufferedServerRequestsByThreadId.delete(externalSessionId);
     this.handledStreamRequestKeysByThreadId.delete(externalSessionId);
     this.syntheticUserMessageTextsByThreadId.delete(externalSessionId);
     this.eventBacklogBySessionId.delete(externalSessionId);
-    if (
-      ![...this.sessions.values()].some((candidate) => candidate.runtimeId === session.runtimeId)
-    ) {
-      this.stopRuntimeEventSubscription(session.runtimeId);
+    this.latestTodosBySessionId.delete(externalSessionId);
+    this.activeTurnsBySessionId.delete(externalSessionId);
+    const approvalRequestIds = this.pendingApprovalIdsBySessionId.get(externalSessionId) ?? [];
+    for (const requestId of approvalRequestIds) {
+      this.pendingApprovalsByRequestId.delete(requestId);
+      this.activeTurnsByApprovalRequestId.delete(requestId);
+    }
+    this.pendingApprovalIdsBySessionId.delete(externalSessionId);
+    const questionRequestIds = this.pendingQuestionIdsBySessionId.get(externalSessionId) ?? [];
+    for (const requestId of questionRequestIds) {
+      this.pendingQuestionsByRequestId.delete(requestId);
+      this.activeTurnsByQuestionRequestId.delete(requestId);
+    }
+    this.pendingQuestionIdsBySessionId.delete(externalSessionId);
+    const turnKeyPrefix = `${externalSessionId}:`;
+    for (const turnKey of [...this.completedAgentMessagesByTurnKey.keys()]) {
+      if (turnKey.startsWith(turnKeyPrefix)) {
+        this.completedAgentMessagesByTurnKey.delete(turnKey);
+      }
+    }
+    for (const turnKey of [...this.tokenUsageByTurnKey.keys()]) {
+      if (turnKey.startsWith(turnKeyPrefix)) {
+        this.tokenUsageByTurnKey.delete(turnKey);
+      }
     }
   }
 

--- a/packages/adapters-codex-app-server/src/types.ts
+++ b/packages/adapters-codex-app-server/src/types.ts
@@ -163,6 +163,11 @@ export type CodexTurnSteerResult = {
   turnId?: string;
 };
 
+export type CodexTurnInterruptParams = {
+  threadId: string;
+  turnId: string;
+};
+
 export type CodexThreadStartResult = {
   thread?: {
     id?: string;
@@ -215,6 +220,7 @@ export type CodexAppServerClient = {
   threadFork(params: CodexThreadForkParams): Promise<CodexThreadForkResult>;
   turnStart(params: CodexTurnStartParams): Promise<CodexTurnStartResult>;
   turnSteer(params: CodexTurnSteerParams): Promise<CodexTurnSteerResult>;
+  turnInterrupt(params: CodexTurnInterruptParams): Promise<Record<string, never>>;
   threadRead(params: { threadId: string; includeTurns?: boolean }): Promise<unknown>;
   threadList(params?: { limit?: number; cursor?: string | null }): Promise<unknown>;
   threadLoadedList(params?: { limit?: number; cursor?: string | null }): Promise<unknown>;

--- a/packages/contracts/src/codex-app-server-protocol.ts
+++ b/packages/contracts/src/codex-app-server-protocol.ts
@@ -239,6 +239,11 @@ export type CodexAppServerTurnSteerParams = {
 export type CodexAppServerTurnSteerResult = {
   turnId: string;
 };
+export type CodexAppServerTurnInterruptParams = {
+  threadId: string;
+  turnId: string;
+};
+export type CodexAppServerTurnInterruptResult = Record<string, never>;
 
 export type CodexAppServerReasoningEffortOption = {
   description?: string | null;
@@ -469,6 +474,10 @@ export type CodexAppServerClientRequestMap = {
   "turn/steer": {
     params: CodexAppServerTurnSteerParams;
     result: CodexAppServerTurnSteerResult;
+  };
+  "turn/interrupt": {
+    params: CodexAppServerTurnInterruptParams;
+    result: CodexAppServerTurnInterruptResult;
   };
   gitDiffToRemote: {
     params: CodexAppServerGitDiffToRemoteParams;

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -13,6 +13,11 @@ import {
   findLastSessionMessageByRole,
   upsertSessionMessage,
 } from "../support/messages";
+import {
+  buildSessionErrorNoticeMessage,
+  buildUserStoppedNoticeMessage,
+  USER_STOPPED_NOTICE,
+} from "../support/session-notice-messages";
 import { clearSubagentPendingApprovalFromSessions } from "../support/subagent-approval-overlay";
 import { formatSubagentContent } from "../support/subagent-messages";
 import { mergeTodoListPreservingOrder } from "../support/todos";
@@ -655,60 +660,6 @@ export const handleSessionTodosUpdated = (
   );
 };
 
-const buildSessionNoticeMessage = ({
-  timestamp,
-  content,
-  tone,
-  title,
-}:
-  | {
-      timestamp: string;
-      content: string;
-      tone: "cancelled";
-      title: string;
-    }
-  | {
-      timestamp: string;
-      content: string;
-      tone: "error";
-      title: string;
-    }) => ({
-  id: crypto.randomUUID(),
-  role: "system" as const,
-  content,
-  timestamp,
-  meta:
-    tone === "cancelled"
-      ? {
-          kind: "session_notice" as const,
-          tone: "cancelled" as const,
-          reason: "user_stopped" as const,
-          title,
-        }
-      : {
-          kind: "session_notice" as const,
-          tone: "error" as const,
-          reason: "session_error" as const,
-          title,
-        },
-});
-
-const buildUserStoppedNoticeMessage = (timestamp: string) =>
-  buildSessionNoticeMessage({
-    timestamp,
-    content: "Session stopped at your request.",
-    tone: "cancelled",
-    title: "Stopped",
-  });
-
-const buildSessionErrorNoticeMessage = (timestamp: string, message: string) =>
-  buildSessionNoticeMessage({
-    timestamp,
-    content: message,
-    tone: "error",
-    title: "Error",
-  });
-
 const settleTerminalMessages = (
   session: Pick<
     SessionLifecycleEventContext["store"]["sessionsRef"]["current"][string],
@@ -826,7 +777,7 @@ export const handleSessionFinished = (
           ...(appendUserStoppedNotice
             ? {
                 outcome: "error" as const,
-                errorMessage: "Session stopped at your request.",
+                errorMessage: USER_STOPPED_NOTICE,
                 appendUserStoppedNotice: true,
               }
             : {}),

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -486,6 +486,77 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     }
   });
 
+  test("appends the user-stopped notice when authoritative stop has no local runtime event", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    const originalStopSession = adapter.stopSession;
+    let localStopCalls = 0;
+
+    adapter.hasSession = () => false;
+    adapter.stopSession = async () => {
+      localStopCalls += 1;
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          runtimeKind: "codex",
+          role: "build",
+          messages: [
+            {
+              id: "tool-running",
+              role: "tool",
+              content: "Tool todowrite running...",
+              timestamp: "2026-02-22T08:00:08.000Z",
+              meta: {
+                kind: "tool",
+                partId: "part-tool-running",
+                callId: "call-tool-running",
+                tool: "todowrite",
+                status: "running",
+              },
+            },
+          ],
+        }),
+      },
+    };
+
+    const actions = createSessionActions({
+      adapter,
+      sessionsRef,
+      taskRef: { current: [] },
+    });
+
+    try {
+      await actions.stopAgentSession("session-1");
+
+      expect(localStopCalls).toBe(0);
+      const lastMessage = lastSessionMessageForTest(getSession(sessionsRef));
+      expect(lastMessage?.content).toBe("Session stopped at your request.");
+      expect(lastMessage?.meta).toEqual({
+        kind: "session_notice",
+        tone: "cancelled",
+        reason: "user_stopped",
+        title: "Stopped",
+      });
+      const toolMessage = findSessionMessageForTest(
+        getSession(sessionsRef),
+        (message) => message.id === "tool-running",
+      );
+      expect(toolMessage?.meta?.kind).toBe("tool");
+      if (toolMessage?.meta?.kind !== "tool") {
+        throw new Error("Expected tool metadata");
+      }
+      expect(toolMessage.meta.status).toBe("error");
+      expect(toolMessage.meta.error).toBe("Session stopped at your request.");
+      expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
+      expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
+    } finally {
+      adapter.hasSession = originalHasSession;
+      adapter.stopSession = originalStopSession;
+    }
+  });
+
   test("continues cleanup when local adapter stop fails after authoritative stop", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -20,12 +20,17 @@ import { errorMessage } from "@/lib/errors";
 import { isRoleAvailableForTask, unavailableRoleErrorMessage } from "@/lib/task-agent-workflows";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import type { ActiveWorkspace } from "@/types/state-slices";
+import { settleDanglingTodoToolMessages } from "../agent-tool-messages";
 import { createEnsureSessionReady } from "../lifecycle/ensure-ready";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import { now } from "../support/core";
 import { appendSessionMessage } from "../support/messages";
 import { toPersistedSessionRecord } from "../support/persistence";
 import { annotateQuestionToolMessage } from "../support/question-messages";
+import {
+  buildUserStoppedNoticeMessage,
+  USER_STOPPED_NOTICE,
+} from "../support/session-notice-messages";
 import { isWorkflowAgentSession } from "../support/session-purpose";
 import {
   clearSubagentPendingApprovalFromSessions,
@@ -168,6 +173,21 @@ const applyQuestionAnswerToSession = (
     ),
   };
 };
+
+const appendUserStoppedNotice = (
+  session: AgentSessionState,
+  timestamp: string,
+): AgentSessionState["messages"] =>
+  appendSessionMessage(
+    {
+      externalSessionId: session.externalSessionId,
+      messages: settleDanglingTodoToolMessages(session, timestamp, {
+        outcome: "error",
+        errorMessage: USER_STOPPED_NOTICE,
+      }),
+    },
+    buildUserStoppedNoticeMessage(timestamp),
+  );
 
 export const createAgentSessionActions = ({
   activeWorkspace,
@@ -427,10 +447,15 @@ export const createAgentSessionActions = ({
     }
 
     let stoppedSessionSnapshot: AgentSessionState | null = null;
+    const stoppedAt = now();
     updateSession(externalSessionId, (current) => {
+      const shouldAppendUserStoppedNotice = Boolean(current.stopRequestedAt);
       const nextSession: AgentSessionState = {
         ...current,
         status: "stopped",
+        messages: shouldAppendUserStoppedNotice
+          ? appendUserStoppedNotice(current, stoppedAt)
+          : current.messages,
         draftAssistantText: "",
         draftAssistantMessageId: null,
         draftReasoningText: "",

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-notice-messages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-notice-messages.ts
@@ -1,0 +1,60 @@
+import type { AgentChatMessage } from "@/types/agent-orchestrator";
+
+const buildSessionNoticeMessage = ({
+  timestamp,
+  content,
+  tone,
+  title,
+}:
+  | {
+      timestamp: string;
+      content: string;
+      tone: "cancelled";
+      title: string;
+    }
+  | {
+      timestamp: string;
+      content: string;
+      tone: "error";
+      title: string;
+    }): AgentChatMessage => ({
+  id: crypto.randomUUID(),
+  role: "system",
+  content,
+  timestamp,
+  meta:
+    tone === "cancelled"
+      ? {
+          kind: "session_notice",
+          tone: "cancelled",
+          reason: "user_stopped",
+          title,
+        }
+      : {
+          kind: "session_notice",
+          tone: "error",
+          reason: "session_error",
+          title,
+        },
+});
+
+export const USER_STOPPED_NOTICE = "Session stopped at your request.";
+
+export const buildUserStoppedNoticeMessage = (timestamp: string): AgentChatMessage =>
+  buildSessionNoticeMessage({
+    timestamp,
+    content: USER_STOPPED_NOTICE,
+    tone: "cancelled",
+    title: "Stopped",
+  });
+
+export const buildSessionErrorNoticeMessage = (
+  timestamp: string,
+  message: string,
+): AgentChatMessage =>
+  buildSessionNoticeMessage({
+    timestamp,
+    content: message,
+    tone: "error",
+    title: "Error",
+  });

--- a/packages/host/src/adapters/codex/codex-app-server-response-parsers.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-response-parsers.ts
@@ -1,0 +1,122 @@
+import type {
+  CodexAppServerThread,
+  CodexAppServerThreadTurnsListResponse,
+} from "@openducktor/contracts";
+import { HostValidationError } from "../../effect/host-errors";
+import type {
+  CodexAppServerLoadedThreadListResponse,
+  CodexAppServerThreadListResponse,
+  CodexSessionStatus,
+} from "../../ports/codex-app-server-port";
+
+export const isJsonRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const requireRecord = (value: unknown, context: string): Record<string, unknown> => {
+  if (!isJsonRecord(value)) {
+    throw new HostValidationError({
+      message: `${context} must be an object`,
+      details: { context },
+    });
+  }
+  return value;
+};
+
+const requireString = (value: unknown, context: string): string => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new HostValidationError({
+      message: `${context} must be a non-empty string`,
+      details: { context },
+    });
+  }
+  return value;
+};
+
+const parseCursor = (value: unknown, context: string): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return requireString(value, context);
+};
+
+const parseThreadStatus = (value: unknown, context: string): CodexSessionStatus => {
+  const record = requireRecord(value ?? null, `${context} status`);
+  if (record.type === "idle" || record.type === "notLoaded" || record.type === "systemError") {
+    return record.type;
+  }
+  if (record.type === "active") {
+    if (!Array.isArray(record.activeFlags)) {
+      throw new HostValidationError({
+        message: `${context} active status activeFlags must be an array`,
+        details: { context },
+      });
+    }
+    return record.type;
+  }
+  throw new HostValidationError({
+    message: `${context} has unsupported Codex thread status: ${String(record.type)}`,
+    details: { context, statusType: record.type },
+  });
+};
+
+export const parseLoadedThreadListResponse = (
+  value: unknown,
+): CodexAppServerLoadedThreadListResponse => {
+  const payload = requireRecord(value, "Codex thread/loaded/list response");
+  if (!Array.isArray(payload.data)) {
+    throw new HostValidationError({
+      message: "Codex thread/loaded/list response data must be an array",
+      details: { context: "Codex thread/loaded/list response" },
+    });
+  }
+  return {
+    data: payload.data.map((entry, index) => {
+      return requireString(entry, `Codex loaded thread entry ${index}`);
+    }),
+    nextCursor: parseCursor(payload.nextCursor, "Codex thread/loaded/list nextCursor"),
+  };
+};
+
+export const parseThreadListResponse = (value: unknown): CodexAppServerThreadListResponse => {
+  const payload = requireRecord(value, "Codex thread/list response");
+  if (!Array.isArray(payload.data)) {
+    throw new HostValidationError({
+      message: "Codex thread/list response data must be an array",
+      details: { context: "Codex thread/list response" },
+    });
+  }
+  return {
+    data: payload.data.map((entry, index) => {
+      const record = requireRecord(entry, `Codex thread entry ${index}`);
+      return {
+        id: requireString(record.id, `Codex thread entry ${index} id`),
+        cwd: requireString(record.cwd, `Codex thread entry ${index} cwd`),
+        status: parseThreadStatus(record.status, `Codex thread entry ${index}`),
+      };
+    }),
+    nextCursor: parseCursor(payload.nextCursor, "Codex thread/list nextCursor"),
+    backwardsCursor: parseCursor(payload.backwardsCursor, "Codex thread/list backwardsCursor"),
+  };
+};
+
+export const parseThreadReadResponse = (value: unknown): CodexAppServerThread => {
+  const payload = requireRecord(value, "Codex thread/read response");
+  const thread = requireRecord(payload.thread, "Codex thread/read response thread");
+  requireString(thread.id, "Codex thread/read response thread id");
+  requireString(thread.cwd, "Codex thread/read response thread cwd");
+  parseThreadStatus(thread.status, "Codex thread/read response thread");
+  return thread as unknown as CodexAppServerThread;
+};
+
+export const parseThreadTurnsListResponse = (
+  value: unknown,
+): CodexAppServerThreadTurnsListResponse => {
+  const payload = requireRecord(value, "Codex thread/turns/list response");
+  if (!Array.isArray(payload.data)) {
+    throw new HostValidationError({
+      message: "Codex thread/turns/list response data must be an array",
+      details: { context: "Codex thread/turns/list response" },
+    });
+  }
+  return payload as unknown as CodexAppServerThreadTurnsListResponse;
+};

--- a/packages/host/src/adapters/codex/codex-app-server-transport-registry.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-registry.ts
@@ -5,17 +5,18 @@ import {
   HostValidationError,
 } from "../../effect/host-errors";
 import type {
-  CodexAppServerLoadedThreadListResponse,
   CodexAppServerPort,
   CodexAppServerProtocolMessage,
   CodexAppServerRequestInput,
   CodexAppServerRequestResult,
   CodexAppServerRespondInput,
-  CodexAppServerThreadListResponse,
-  CodexSessionStatus,
 } from "../../ports/codex-app-server-port";
 import { CodexAppServerPortTag } from "../../ports/codex-app-server-port";
 import type { CodexAppServerClientRequest } from "../../ports/codex-app-server-protocol";
+import {
+  parseLoadedThreadListResponse,
+  parseThreadListResponse,
+} from "./codex-app-server-response-parsers";
 import type { CodexAppServerTransportError } from "./codex-app-server-transport-types";
 
 export type CodexAppServerTransportRegistryError = CodexAppServerTransportError | HostResourceError;
@@ -29,94 +30,6 @@ export type CodexAppServerTransport = {
   respond(
     input: Omit<CodexAppServerRespondInput, "runtimeId">,
   ): Effect.Effect<void, CodexAppServerTransportError>;
-};
-
-const isJsonRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const requireRecord = (value: unknown, context: string): Record<string, unknown> => {
-  if (!isJsonRecord(value)) {
-    throw new HostValidationError({
-      message: `${context} must be an object`,
-      details: { context },
-    });
-  }
-  return value;
-};
-
-const requireString = (value: unknown, context: string): string => {
-  if (typeof value !== "string" || value.trim().length === 0) {
-    throw new HostValidationError({
-      message: `${context} must be a non-empty string`,
-      details: { context },
-    });
-  }
-  return value;
-};
-
-const parseCursor = (value: unknown, context: string): string | null => {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  return requireString(value, context);
-};
-
-const parseLoadedThreadListResponse = (value: unknown): CodexAppServerLoadedThreadListResponse => {
-  const payload = requireRecord(value, "Codex thread/loaded/list response");
-  if (!Array.isArray(payload.data)) {
-    throw new HostValidationError({
-      message: "Codex thread/loaded/list response data must be an array",
-      details: { context: "Codex thread/loaded/list response" },
-    });
-  }
-  return {
-    data: payload.data.map((entry, index) => {
-      return requireString(entry, `Codex loaded thread entry ${index}`);
-    }),
-    nextCursor: parseCursor(payload.nextCursor, "Codex thread/loaded/list nextCursor"),
-  };
-};
-
-const parseThreadStatus = (value: unknown, context: string): CodexSessionStatus => {
-  const record = requireRecord(value ?? null, `${context} status`);
-  if (record.type === "idle" || record.type === "notLoaded" || record.type === "systemError") {
-    return record.type;
-  }
-  if (record.type === "active") {
-    if (!Array.isArray(record.activeFlags)) {
-      throw new HostValidationError({
-        message: `${context} active status activeFlags must be an array`,
-        details: { context },
-      });
-    }
-    return record.type;
-  }
-  throw new HostValidationError({
-    message: `${context} has unsupported Codex thread status: ${String(record.type)}`,
-    details: { context, statusType: record.type },
-  });
-};
-
-const parseThreadListResponse = (value: unknown): CodexAppServerThreadListResponse => {
-  const payload = requireRecord(value, "Codex thread/list response");
-  if (!Array.isArray(payload.data)) {
-    throw new HostValidationError({
-      message: "Codex thread/list response data must be an array",
-      details: { context: "Codex thread/list response" },
-    });
-  }
-  return {
-    data: payload.data.map((entry, index) => {
-      const record = requireRecord(entry, `Codex thread entry ${index}`);
-      return {
-        id: requireString(record.id, `Codex thread entry ${index} id`),
-        cwd: requireString(record.cwd, `Codex thread entry ${index} cwd`),
-        status: parseThreadStatus(record.status, `Codex thread entry ${index}`),
-      };
-    }),
-    nextCursor: parseCursor(payload.nextCursor, "Codex thread/list nextCursor"),
-    backwardsCursor: parseCursor(payload.backwardsCursor, "Codex thread/list backwardsCursor"),
-  };
 };
 
 export type CodexAppServerTransportRegistry = CodexAppServerPort & {

--- a/packages/host/src/adapters/codex/codex-session-status-probe.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.ts
@@ -1,11 +1,10 @@
-import type { RuntimeRoute } from "@openducktor/contracts";
 import { Effect } from "effect";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
-import { readCodexThread, runtimeIdFromStdioRoute } from "./codex-thread-lookup";
+import { readCodexThread } from "./codex-thread-lookup";
 
 export type CodexSessionStatusProbeInput = {
   codexAppServer: Pick<CodexAppServerPort, "request">;
-  runtimeRoute: RuntimeRoute;
+  runtimeId: string;
   externalSessionId: string;
   workingDirectory: string;
 };
@@ -22,11 +21,11 @@ export const probeCodexSessionStatus = (
   CodexSessionStatusProbeError
 > =>
   Effect.gen(function* () {
-    const runtimeId = runtimeIdFromStdioRoute(input.runtimeRoute);
-    if (runtimeId === null) {
-      return { supported: false, hasLiveSession: false };
-    }
-    const thread = yield* readCodexThread(input.codexAppServer, runtimeId, input.externalSessionId);
+    const thread = yield* readCodexThread(
+      input.codexAppServer,
+      input.runtimeId,
+      input.externalSessionId,
+    );
     return {
       supported: true,
       hasLiveSession: thread.cwd === input.workingDirectory && thread.status.type === "active",

--- a/packages/host/src/adapters/codex/codex-session-status-probe.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.ts
@@ -1,14 +1,10 @@
 import type { RuntimeRoute } from "@openducktor/contracts";
 import { Effect } from "effect";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
-import {
-  findExactCodexThread,
-  loadCodexLoadedThreadIds,
-  runtimeIdFromStdioRoute,
-} from "./codex-thread-lookup";
+import { readCodexThread, runtimeIdFromStdioRoute } from "./codex-thread-lookup";
 
 export type CodexSessionStatusProbeInput = {
-  codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads">;
+  codexAppServer: Pick<CodexAppServerPort, "request">;
   runtimeRoute: RuntimeRoute;
   externalSessionId: string;
   workingDirectory: string;
@@ -30,24 +26,9 @@ export const probeCodexSessionStatus = (
     if (runtimeId === null) {
       return { supported: false, hasLiveSession: false };
     }
-    const loadedThreadIds = yield* loadCodexLoadedThreadIds(
-      input.codexAppServer,
-      runtimeId,
-      "codexSessionStatusProbe",
-    );
-    if (loadedThreadIds.size === 0) {
-      return { supported: true, hasLiveSession: false };
-    }
-    const thread = yield* findExactCodexThread({
-      codexAppServer: input.codexAppServer,
-      runtimeId,
-      externalSessionId: input.externalSessionId,
-      workingDirectory: input.workingDirectory,
-      operationPrefix: "codexSessionStatusProbe",
-    });
+    const thread = yield* readCodexThread(input.codexAppServer, runtimeId, input.externalSessionId);
     return {
       supported: true,
-      hasLiveSession:
-        thread !== null && loadedThreadIds.has(thread.id) && thread.status === "active",
+      hasLiveSession: thread.cwd === input.workingDirectory && thread.status.type === "active",
     };
   });

--- a/packages/host/src/adapters/codex/codex-session-status-probe.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { HostOperationError } from "../../effect/host-errors";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
 import { readCodexThread } from "./codex-thread-lookup";
 
@@ -11,6 +12,11 @@ export type CodexSessionStatusProbeInput = {
 
 export type CodexSessionStatusProbeError = CodexAppServerError;
 
+const isCodexThreadNotFoundError = (cause: CodexAppServerError): boolean =>
+  cause instanceof HostOperationError &&
+  cause.details?.method === "thread/read" &&
+  cause.message.toLowerCase().includes("not found");
+
 export const probeCodexSessionStatus = (
   input: CodexSessionStatusProbeInput,
 ): Effect.Effect<
@@ -21,13 +27,18 @@ export const probeCodexSessionStatus = (
   CodexSessionStatusProbeError
 > =>
   Effect.gen(function* () {
-    const thread = yield* readCodexThread(
-      input.codexAppServer,
-      input.runtimeId,
-      input.externalSessionId,
+    const threadResult = yield* Effect.either(
+      readCodexThread(input.codexAppServer, input.runtimeId, input.externalSessionId),
     );
+    if (threadResult._tag === "Left") {
+      if (isCodexThreadNotFoundError(threadResult.left)) {
+        return { supported: true, hasLiveSession: false };
+      }
+      return yield* Effect.fail(threadResult.left);
+    }
+    const thread = threadResult.right;
     return {
       supported: true,
-      hasLiveSession: thread.cwd === input.workingDirectory && thread.status.type === "active",
+      hasLiveSession: thread.cwd === input.workingDirectory && thread.status.type !== "notLoaded",
     };
   });

--- a/packages/host/src/adapters/codex/codex-session-status-probe.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.ts
@@ -1,6 +1,5 @@
 import type { RuntimeRoute } from "@openducktor/contracts";
 import { Effect } from "effect";
-import type { HostOperationError } from "../../effect/host-errors";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
 import {
   findExactCodexThread,
@@ -15,23 +14,7 @@ export type CodexSessionStatusProbeInput = {
   workingDirectory: string;
 };
 
-export type CodexSessionStatusProbeError = CodexAppServerError | HostOperationError;
-
-const hasBusyLoadedThread = (
-  input: CodexSessionStatusProbeInput,
-  runtimeId: string,
-  loadedThreadIds: Set<string>,
-) =>
-  Effect.gen(function* () {
-    const thread = yield* findExactCodexThread({
-      codexAppServer: input.codexAppServer,
-      runtimeId,
-      externalSessionId: input.externalSessionId,
-      workingDirectory: input.workingDirectory,
-      operationPrefix: "codexSessionStatusProbe",
-    });
-    return thread !== null && loadedThreadIds.has(thread.id) && thread.status === "active";
-  });
+export type CodexSessionStatusProbeError = CodexAppServerError;
 
 export const probeCodexSessionStatus = (
   input: CodexSessionStatusProbeInput,
@@ -55,8 +38,16 @@ export const probeCodexSessionStatus = (
     if (loadedThreadIds.size === 0) {
       return { supported: true, hasLiveSession: false };
     }
+    const thread = yield* findExactCodexThread({
+      codexAppServer: input.codexAppServer,
+      runtimeId,
+      externalSessionId: input.externalSessionId,
+      workingDirectory: input.workingDirectory,
+      operationPrefix: "codexSessionStatusProbe",
+    });
     return {
       supported: true,
-      hasLiveSession: yield* hasBusyLoadedThread(input, runtimeId, loadedThreadIds),
+      hasLiveSession:
+        thread !== null && loadedThreadIds.has(thread.id) && thread.status === "active",
     };
   });

--- a/packages/host/src/adapters/codex/codex-session-status-probe.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.ts
@@ -1,12 +1,12 @@
 import type { RuntimeRoute } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { HostOperationError } from "../../effect/host-errors";
-import type {
-  CodexAppServerError,
-  CodexAppServerLoadedThreadListResponse,
-  CodexAppServerPort,
-  CodexAppServerThreadListResponse,
-} from "../../ports/codex-app-server-port";
+import type { HostOperationError } from "../../effect/host-errors";
+import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
+import {
+  findExactCodexThread,
+  loadCodexLoadedThreadIds,
+  runtimeIdFromStdioRoute,
+} from "./codex-thread-lookup";
 
 export type CodexSessionStatusProbeInput = {
   codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads">;
@@ -14,89 +14,25 @@ export type CodexSessionStatusProbeInput = {
   externalSessionId: string;
   workingDirectory: string;
 };
+
 export type CodexSessionStatusProbeError = CodexAppServerError | HostOperationError;
-const runtimeIdFromRoute = (runtimeRoute: RuntimeRoute): string | null =>
-  runtimeRoute.type === "stdio" ? runtimeRoute.identity : null;
-const loadLoadedThreadIds = (
-  codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads">,
-  runtimeId: string,
-) =>
-  Effect.gen(function* () {
-    const loadedThreadIds = new Set<string>();
-    const seenCursors = new Set<string>();
-    let cursor: string | null = null;
-    while (true) {
-      if (cursor !== null) {
-        if (seenCursors.has(cursor)) {
-          return yield* Effect.fail(
-            new HostOperationError({
-              operation: "codexSessionStatusProbe.loadLoadedThreadIds",
-              message: "Codex thread/loaded/list returned a repeated pagination cursor",
-              details: { runtimeId, cursor },
-            }),
-          );
-        }
-        seenCursors.add(cursor);
-      }
-      const response: CodexAppServerLoadedThreadListResponse =
-        yield* codexAppServer.listLoadedThreads({
-          runtimeId,
-          cursor,
-          limit: 100,
-        });
-      for (const threadId of response.data) {
-        loadedThreadIds.add(threadId);
-      }
-      cursor = response.nextCursor;
-      if (cursor === null) {
-        return loadedThreadIds;
-      }
-    }
-  });
+
 const hasBusyLoadedThread = (
   input: CodexSessionStatusProbeInput,
   runtimeId: string,
   loadedThreadIds: Set<string>,
 ) =>
   Effect.gen(function* () {
-    const seenCursors = new Set<string>();
-    let cursor: string | null = null;
-    while (true) {
-      if (cursor !== null) {
-        if (seenCursors.has(cursor)) {
-          return yield* Effect.fail(
-            new HostOperationError({
-              operation: "codexSessionStatusProbe.hasBusyLoadedThread",
-              message: "Codex thread/list returned a repeated pagination cursor",
-              details: { runtimeId, cursor },
-            }),
-          );
-        }
-        seenCursors.add(cursor);
-      }
-      const response: CodexAppServerThreadListResponse = yield* input.codexAppServer.listThreads({
-        runtimeId,
-        cursor,
-        limit: 100,
-      });
-      for (const thread of response.data) {
-        if (thread.id !== input.externalSessionId) {
-          continue;
-        }
-        if (!loadedThreadIds.has(thread.id)) {
-          continue;
-        }
-        if (thread.cwd !== input.workingDirectory) {
-          continue;
-        }
-        return thread.status === "active";
-      }
-      cursor = response.nextCursor;
-      if (cursor === null) {
-        return false;
-      }
-    }
+    const thread = yield* findExactCodexThread({
+      codexAppServer: input.codexAppServer,
+      runtimeId,
+      externalSessionId: input.externalSessionId,
+      workingDirectory: input.workingDirectory,
+      operationPrefix: "codexSessionStatusProbe",
+    });
+    return thread !== null && loadedThreadIds.has(thread.id) && thread.status === "active";
   });
+
 export const probeCodexSessionStatus = (
   input: CodexSessionStatusProbeInput,
 ): Effect.Effect<
@@ -107,11 +43,15 @@ export const probeCodexSessionStatus = (
   CodexSessionStatusProbeError
 > =>
   Effect.gen(function* () {
-    const runtimeId = runtimeIdFromRoute(input.runtimeRoute);
+    const runtimeId = runtimeIdFromStdioRoute(input.runtimeRoute);
     if (runtimeId === null) {
       return { supported: false, hasLiveSession: false };
     }
-    const loadedThreadIds = yield* loadLoadedThreadIds(input.codexAppServer, runtimeId);
+    const loadedThreadIds = yield* loadCodexLoadedThreadIds(
+      input.codexAppServer,
+      runtimeId,
+      "codexSessionStatusProbe",
+    );
     if (loadedThreadIds.size === 0) {
       return { supported: true, hasLiveSession: false };
     }

--- a/packages/host/src/adapters/codex/codex-session-stop.ts
+++ b/packages/host/src/adapters/codex/codex-session-stop.ts
@@ -19,9 +19,9 @@ export type CodexSessionStopInput = {
   workingDirectory: string;
 };
 
-export type CodexSessionStopError = CodexAppServerError | HostOperationError | HostValidationError;
+export type CodexSessionStopError = CodexAppServerError;
 
-const loadExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
+const requireExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
   Effect.gen(function* () {
     const thread = yield* findExactCodexThread({
       codexAppServer: input.codexAppServer,
@@ -35,7 +35,7 @@ const loadExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
     }
     return yield* Effect.fail(
       new HostOperationError({
-        operation: "codexSessionStop.loadExactThread",
+        operation: "codexSessionStop.requireExactThread",
         message: "Codex session stop could not find the target thread for the session.",
         details: {
           runtimeId,
@@ -163,7 +163,7 @@ export const stopCodexSession = (
       runtimeId,
       "codexSessionStop",
     );
-    const thread = yield* loadExactThread(input, runtimeId);
+    const thread = yield* requireExactThread(input, runtimeId);
     const turnId = yield* assertInterruptibleThread(input, runtimeId, thread, loadedThreadIds);
     if (turnId === null) {
       return;

--- a/packages/host/src/adapters/codex/codex-session-stop.ts
+++ b/packages/host/src/adapters/codex/codex-session-stop.ts
@@ -1,0 +1,228 @@
+import type { CodexAppServerTurn, RuntimeRoute } from "@openducktor/contracts";
+import { Effect } from "effect";
+import { HostOperationError, HostValidationError } from "../../effect/host-errors";
+import type {
+  CodexAppServerError,
+  CodexAppServerLoadedThreadListResponse,
+  CodexAppServerPort,
+  CodexAppServerThreadEntry,
+  CodexAppServerThreadListResponse,
+} from "../../ports/codex-app-server-port";
+
+export type CodexSessionStopInput = {
+  codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads" | "request">;
+  runtimeRoute: RuntimeRoute;
+  externalSessionId: string;
+  workingDirectory: string;
+};
+
+export type CodexSessionStopError = CodexAppServerError | HostOperationError | HostValidationError;
+
+const runtimeIdFromRoute = (runtimeRoute: RuntimeRoute): string | null =>
+  runtimeRoute.type === "stdio" ? runtimeRoute.identity : null;
+
+const loadLoadedThreadIds = (
+  codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads">,
+  runtimeId: string,
+) =>
+  Effect.gen(function* () {
+    const loadedThreadIds = new Set<string>();
+    const seenCursors = new Set<string>();
+    let cursor: string | null = null;
+    while (true) {
+      if (cursor !== null) {
+        if (seenCursors.has(cursor)) {
+          return yield* Effect.fail(
+            new HostOperationError({
+              operation: "codexSessionStop.loadLoadedThreadIds",
+              message: "Codex thread/loaded/list returned a repeated pagination cursor",
+              details: { runtimeId, cursor },
+            }),
+          );
+        }
+        seenCursors.add(cursor);
+      }
+      const response: CodexAppServerLoadedThreadListResponse =
+        yield* codexAppServer.listLoadedThreads({
+          runtimeId,
+          cursor,
+          limit: 100,
+        });
+      for (const threadId of response.data) {
+        loadedThreadIds.add(threadId);
+      }
+      cursor = response.nextCursor;
+      if (cursor === null) {
+        return loadedThreadIds;
+      }
+    }
+  });
+
+const loadExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
+  Effect.gen(function* () {
+    const seenCursors = new Set<string>();
+    let cursor: string | null = null;
+    while (true) {
+      if (cursor !== null) {
+        if (seenCursors.has(cursor)) {
+          return yield* Effect.fail(
+            new HostOperationError({
+              operation: "codexSessionStop.loadExactThread",
+              message: "Codex thread/list returned a repeated pagination cursor",
+              details: { runtimeId, cursor },
+            }),
+          );
+        }
+        seenCursors.add(cursor);
+      }
+      const response: CodexAppServerThreadListResponse = yield* input.codexAppServer.listThreads({
+        runtimeId,
+        cursor,
+        limit: 100,
+      });
+      for (const thread of response.data) {
+        if (thread.id === input.externalSessionId && thread.cwd === input.workingDirectory) {
+          return thread;
+        }
+      }
+      cursor = response.nextCursor;
+      if (cursor === null) {
+        return yield* Effect.fail(
+          new HostOperationError({
+            operation: "codexSessionStop.loadExactThread",
+            message: "Codex session stop could not find the target thread for the session.",
+            details: {
+              runtimeId,
+              externalSessionId: input.externalSessionId,
+              workingDirectory: input.workingDirectory,
+            },
+          }),
+        );
+      }
+    }
+  });
+
+const isActiveTurn = (turn: CodexAppServerTurn): boolean =>
+  typeof turn.id === "string" &&
+  turn.id.length > 0 &&
+  turn.startedAt !== null &&
+  turn.completedAt === null;
+
+const loadActiveTurnId = (input: CodexSessionStopInput, runtimeId: string) =>
+  Effect.gen(function* () {
+    const result = yield* input.codexAppServer.request({
+      runtimeId,
+      method: "thread/turns/list",
+      params: {
+        threadId: input.externalSessionId,
+        limit: 20,
+        sortDirection: "desc",
+        itemsView: "summary",
+      },
+    });
+    if (typeof result !== "object" || result === null || !("data" in result)) {
+      return yield* Effect.fail(
+        new HostOperationError({
+          operation: "codexSessionStop.loadActiveTurnId",
+          message: "Codex thread/turns/list returned a malformed response.",
+          details: { runtimeId, externalSessionId: input.externalSessionId },
+        }),
+      );
+    }
+    const data = (result as { data: unknown }).data;
+    if (!Array.isArray(data)) {
+      return yield* Effect.fail(
+        new HostOperationError({
+          operation: "codexSessionStop.loadActiveTurnId",
+          message: "Codex thread/turns/list response data must be an array.",
+          details: { runtimeId, externalSessionId: input.externalSessionId },
+        }),
+      );
+    }
+    const activeTurn = data.find((turn): turn is CodexAppServerTurn => {
+      if (typeof turn !== "object" || turn === null) {
+        return false;
+      }
+      return isActiveTurn(turn as CodexAppServerTurn);
+    });
+    if (!activeTurn) {
+      return yield* Effect.fail(
+        new HostOperationError({
+          operation: "codexSessionStop.loadActiveTurnId",
+          message: "Codex session is active but no interruptible active turn was found.",
+          details: {
+            runtimeId,
+            externalSessionId: input.externalSessionId,
+            workingDirectory: input.workingDirectory,
+          },
+        }),
+      );
+    }
+    return activeTurn.id;
+  });
+
+const assertInterruptibleThread = (
+  input: CodexSessionStopInput,
+  runtimeId: string,
+  thread: CodexAppServerThreadEntry,
+  loadedThreadIds: Set<string>,
+) =>
+  Effect.gen(function* () {
+    if (thread.status === "idle" || thread.status === "notLoaded") {
+      return null;
+    }
+    if (thread.status === "systemError") {
+      return yield* Effect.fail(
+        new HostOperationError({
+          operation: "codexSessionStop.assertInterruptibleThread",
+          message: "Codex session thread is in systemError state and cannot be interrupted.",
+          details: {
+            runtimeId,
+            externalSessionId: input.externalSessionId,
+            workingDirectory: input.workingDirectory,
+          },
+        }),
+      );
+    }
+    if (!loadedThreadIds.has(thread.id)) {
+      return yield* Effect.fail(
+        new HostOperationError({
+          operation: "codexSessionStop.assertInterruptibleThread",
+          message: "Codex session is active but the target thread is not loaded.",
+          details: {
+            runtimeId,
+            externalSessionId: input.externalSessionId,
+            workingDirectory: input.workingDirectory,
+          },
+        }),
+      );
+    }
+    return yield* loadActiveTurnId(input, runtimeId);
+  });
+
+export const stopCodexSession = (
+  input: CodexSessionStopInput,
+): Effect.Effect<void, CodexSessionStopError> =>
+  Effect.gen(function* () {
+    const runtimeId = runtimeIdFromRoute(input.runtimeRoute);
+    if (runtimeId === null) {
+      return yield* Effect.fail(
+        new HostValidationError({
+          field: "runtimeRoute",
+          message: "Codex session stop requires a stdio runtime route.",
+          details: { runtimeRouteType: input.runtimeRoute.type },
+        }),
+      );
+    }
+    const loadedThreadIds = yield* loadLoadedThreadIds(input.codexAppServer, runtimeId);
+    const thread = yield* loadExactThread(input, runtimeId);
+    const turnId = yield* assertInterruptibleThread(input, runtimeId, thread, loadedThreadIds);
+    if (turnId === null) {
+      return;
+    }
+    yield* input.codexAppServer.request({
+      runtimeId,
+      method: "turn/interrupt",
+      params: { threadId: input.externalSessionId, turnId },
+    });
+  });

--- a/packages/host/src/adapters/codex/codex-session-stop.ts
+++ b/packages/host/src/adapters/codex/codex-session-stop.ts
@@ -1,13 +1,12 @@
-import type { RuntimeRoute } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { HostOperationError, HostValidationError } from "../../effect/host-errors";
+import { HostOperationError } from "../../effect/host-errors";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
-import { readCodexThread, runtimeIdFromStdioRoute } from "./codex-thread-lookup";
+import { readCodexThread } from "./codex-thread-lookup";
 import { findActiveCodexTurnId } from "./codex-turn-lookup";
 
 export type CodexSessionStopInput = {
   codexAppServer: Pick<CodexAppServerPort, "request">;
-  runtimeRoute: RuntimeRoute;
+  runtimeId: string;
   externalSessionId: string;
   workingDirectory: string;
 };
@@ -37,17 +36,7 @@ export const stopCodexSession = (
   input: CodexSessionStopInput,
 ): Effect.Effect<void, CodexSessionStopError> =>
   Effect.gen(function* () {
-    const runtimeId = runtimeIdFromStdioRoute(input.runtimeRoute);
-    if (runtimeId === null) {
-      return yield* Effect.fail(
-        new HostValidationError({
-          field: "runtimeRoute",
-          message: "Codex session stop requires a stdio runtime route.",
-          details: { runtimeRouteType: input.runtimeRoute.type },
-        }),
-      );
-    }
-    const thread = yield* requireExactThread(input, runtimeId);
+    const thread = yield* requireExactThread(input, input.runtimeId);
     if (thread.status.type === "idle" || thread.status.type === "notLoaded") {
       return;
     }
@@ -57,7 +46,7 @@ export const stopCodexSession = (
           operation: "codexSessionStop",
           message: "Codex session thread is in systemError state and cannot be interrupted.",
           details: {
-            runtimeId,
+            runtimeId: input.runtimeId,
             externalSessionId: input.externalSessionId,
             workingDirectory: input.workingDirectory,
           },
@@ -66,7 +55,7 @@ export const stopCodexSession = (
     }
     const turnId = yield* findActiveCodexTurnId(
       input.codexAppServer,
-      runtimeId,
+      input.runtimeId,
       input.externalSessionId,
     );
     if (turnId === null) {
@@ -75,7 +64,7 @@ export const stopCodexSession = (
           operation: "codexSessionStop",
           message: "Codex session is active but no interruptible active turn was found.",
           details: {
-            runtimeId,
+            runtimeId: input.runtimeId,
             externalSessionId: input.externalSessionId,
             workingDirectory: input.workingDirectory,
           },
@@ -83,7 +72,7 @@ export const stopCodexSession = (
       );
     }
     yield* input.codexAppServer.request({
-      runtimeId,
+      runtimeId: input.runtimeId,
       method: "turn/interrupt",
       params: { threadId: input.externalSessionId, turnId },
     });

--- a/packages/host/src/adapters/codex/codex-session-stop.ts
+++ b/packages/host/src/adapters/codex/codex-session-stop.ts
@@ -3,11 +3,14 @@ import { Effect } from "effect";
 import { HostOperationError, HostValidationError } from "../../effect/host-errors";
 import type {
   CodexAppServerError,
-  CodexAppServerLoadedThreadListResponse,
   CodexAppServerPort,
   CodexAppServerThreadEntry,
-  CodexAppServerThreadListResponse,
 } from "../../ports/codex-app-server-port";
+import {
+  findExactCodexThread,
+  loadCodexLoadedThreadIds,
+  runtimeIdFromStdioRoute,
+} from "./codex-thread-lookup";
 
 export type CodexSessionStopInput = {
   codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads" | "request">;
@@ -18,88 +21,29 @@ export type CodexSessionStopInput = {
 
 export type CodexSessionStopError = CodexAppServerError | HostOperationError | HostValidationError;
 
-const runtimeIdFromRoute = (runtimeRoute: RuntimeRoute): string | null =>
-  runtimeRoute.type === "stdio" ? runtimeRoute.identity : null;
-
-const loadLoadedThreadIds = (
-  codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads">,
-  runtimeId: string,
-) =>
-  Effect.gen(function* () {
-    const loadedThreadIds = new Set<string>();
-    const seenCursors = new Set<string>();
-    let cursor: string | null = null;
-    while (true) {
-      if (cursor !== null) {
-        if (seenCursors.has(cursor)) {
-          return yield* Effect.fail(
-            new HostOperationError({
-              operation: "codexSessionStop.loadLoadedThreadIds",
-              message: "Codex thread/loaded/list returned a repeated pagination cursor",
-              details: { runtimeId, cursor },
-            }),
-          );
-        }
-        seenCursors.add(cursor);
-      }
-      const response: CodexAppServerLoadedThreadListResponse =
-        yield* codexAppServer.listLoadedThreads({
-          runtimeId,
-          cursor,
-          limit: 100,
-        });
-      for (const threadId of response.data) {
-        loadedThreadIds.add(threadId);
-      }
-      cursor = response.nextCursor;
-      if (cursor === null) {
-        return loadedThreadIds;
-      }
-    }
-  });
-
 const loadExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
   Effect.gen(function* () {
-    const seenCursors = new Set<string>();
-    let cursor: string | null = null;
-    while (true) {
-      if (cursor !== null) {
-        if (seenCursors.has(cursor)) {
-          return yield* Effect.fail(
-            new HostOperationError({
-              operation: "codexSessionStop.loadExactThread",
-              message: "Codex thread/list returned a repeated pagination cursor",
-              details: { runtimeId, cursor },
-            }),
-          );
-        }
-        seenCursors.add(cursor);
-      }
-      const response: CodexAppServerThreadListResponse = yield* input.codexAppServer.listThreads({
-        runtimeId,
-        cursor,
-        limit: 100,
-      });
-      for (const thread of response.data) {
-        if (thread.id === input.externalSessionId && thread.cwd === input.workingDirectory) {
-          return thread;
-        }
-      }
-      cursor = response.nextCursor;
-      if (cursor === null) {
-        return yield* Effect.fail(
-          new HostOperationError({
-            operation: "codexSessionStop.loadExactThread",
-            message: "Codex session stop could not find the target thread for the session.",
-            details: {
-              runtimeId,
-              externalSessionId: input.externalSessionId,
-              workingDirectory: input.workingDirectory,
-            },
-          }),
-        );
-      }
+    const thread = yield* findExactCodexThread({
+      codexAppServer: input.codexAppServer,
+      runtimeId,
+      externalSessionId: input.externalSessionId,
+      workingDirectory: input.workingDirectory,
+      operationPrefix: "codexSessionStop",
+    });
+    if (thread) {
+      return thread;
     }
+    return yield* Effect.fail(
+      new HostOperationError({
+        operation: "codexSessionStop.loadExactThread",
+        message: "Codex session stop could not find the target thread for the session.",
+        details: {
+          runtimeId,
+          externalSessionId: input.externalSessionId,
+          workingDirectory: input.workingDirectory,
+        },
+      }),
+    );
   });
 
 const isActiveTurn = (turn: CodexAppServerTurn): boolean =>
@@ -204,7 +148,7 @@ export const stopCodexSession = (
   input: CodexSessionStopInput,
 ): Effect.Effect<void, CodexSessionStopError> =>
   Effect.gen(function* () {
-    const runtimeId = runtimeIdFromRoute(input.runtimeRoute);
+    const runtimeId = runtimeIdFromStdioRoute(input.runtimeRoute);
     if (runtimeId === null) {
       return yield* Effect.fail(
         new HostValidationError({
@@ -214,7 +158,11 @@ export const stopCodexSession = (
         }),
       );
     }
-    const loadedThreadIds = yield* loadLoadedThreadIds(input.codexAppServer, runtimeId);
+    const loadedThreadIds = yield* loadCodexLoadedThreadIds(
+      input.codexAppServer,
+      runtimeId,
+      "codexSessionStop",
+    );
     const thread = yield* loadExactThread(input, runtimeId);
     const turnId = yield* assertInterruptibleThread(input, runtimeId, thread, loadedThreadIds);
     if (turnId === null) {

--- a/packages/host/src/adapters/codex/codex-session-stop.ts
+++ b/packages/host/src/adapters/codex/codex-session-stop.ts
@@ -13,9 +13,13 @@ export type CodexSessionStopInput = {
 
 export type CodexSessionStopError = CodexAppServerError;
 
-const requireExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
+const requireExactThread = (input: CodexSessionStopInput) =>
   Effect.gen(function* () {
-    const thread = yield* readCodexThread(input.codexAppServer, runtimeId, input.externalSessionId);
+    const thread = yield* readCodexThread(
+      input.codexAppServer,
+      input.runtimeId,
+      input.externalSessionId,
+    );
     if (thread.cwd === input.workingDirectory) {
       return thread;
     }
@@ -24,7 +28,7 @@ const requireExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
         operation: "codexSessionStop.requireExactThread",
         message: "Codex session stop could not find the target thread for the session.",
         details: {
-          runtimeId,
+          runtimeId: input.runtimeId,
           externalSessionId: input.externalSessionId,
           workingDirectory: input.workingDirectory,
         },
@@ -36,7 +40,7 @@ export const stopCodexSession = (
   input: CodexSessionStopInput,
 ): Effect.Effect<void, CodexSessionStopError> =>
   Effect.gen(function* () {
-    const thread = yield* requireExactThread(input, input.runtimeId);
+    const thread = yield* requireExactThread(input);
     if (thread.status.type === "idle" || thread.status.type === "notLoaded") {
       return;
     }

--- a/packages/host/src/adapters/codex/codex-session-stop.ts
+++ b/packages/host/src/adapters/codex/codex-session-stop.ts
@@ -57,11 +57,7 @@ export const stopCodexSession = (
         }),
       );
     }
-    const turnId = yield* findActiveCodexTurnId(
-      input.codexAppServer,
-      input.runtimeId,
-      input.externalSessionId,
-    );
+    const turnId = yield* findActiveCodexTurnId(input.codexAppServer, input.runtimeId, thread.id);
     if (turnId === null) {
       return yield* Effect.fail(
         new HostOperationError({
@@ -78,6 +74,6 @@ export const stopCodexSession = (
     yield* input.codexAppServer.request({
       runtimeId: input.runtimeId,
       method: "turn/interrupt",
-      params: { threadId: input.externalSessionId, turnId },
+      params: { threadId: thread.id, turnId },
     });
   });

--- a/packages/host/src/adapters/codex/codex-session-stop.ts
+++ b/packages/host/src/adapters/codex/codex-session-stop.ts
@@ -1,19 +1,15 @@
-import type { CodexAppServerTurn, RuntimeRoute } from "@openducktor/contracts";
+import type {
+  CodexAppServerThreadTurnsListResponse,
+  CodexAppServerTurn,
+  RuntimeRoute,
+} from "@openducktor/contracts";
 import { Effect } from "effect";
 import { HostOperationError, HostValidationError } from "../../effect/host-errors";
-import type {
-  CodexAppServerError,
-  CodexAppServerPort,
-  CodexAppServerThreadEntry,
-} from "../../ports/codex-app-server-port";
-import {
-  findExactCodexThread,
-  loadCodexLoadedThreadIds,
-  runtimeIdFromStdioRoute,
-} from "./codex-thread-lookup";
+import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
+import { readCodexThread, runtimeIdFromStdioRoute } from "./codex-thread-lookup";
 
 export type CodexSessionStopInput = {
-  codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads" | "request">;
+  codexAppServer: Pick<CodexAppServerPort, "request">;
   runtimeRoute: RuntimeRoute;
   externalSessionId: string;
   workingDirectory: string;
@@ -23,14 +19,8 @@ export type CodexSessionStopError = CodexAppServerError;
 
 const requireExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
   Effect.gen(function* () {
-    const thread = yield* findExactCodexThread({
-      codexAppServer: input.codexAppServer,
-      runtimeId,
-      externalSessionId: input.externalSessionId,
-      workingDirectory: input.workingDirectory,
-      operationPrefix: "codexSessionStop",
-    });
-    if (thread) {
+    const thread = yield* readCodexThread(input.codexAppServer, runtimeId, input.externalSessionId);
+    if (thread.cwd === input.workingDirectory) {
       return thread;
     }
     return yield* Effect.fail(
@@ -54,7 +44,7 @@ const isActiveTurn = (turn: CodexAppServerTurn): boolean =>
 
 const loadActiveTurnId = (input: CodexSessionStopInput, runtimeId: string) =>
   Effect.gen(function* () {
-    const result = yield* input.codexAppServer.request({
+    const response = (yield* input.codexAppServer.request({
       runtimeId,
       method: "thread/turns/list",
       params: {
@@ -63,32 +53,8 @@ const loadActiveTurnId = (input: CodexSessionStopInput, runtimeId: string) =>
         sortDirection: "desc",
         itemsView: "summary",
       },
-    });
-    if (typeof result !== "object" || result === null || !("data" in result)) {
-      return yield* Effect.fail(
-        new HostOperationError({
-          operation: "codexSessionStop.loadActiveTurnId",
-          message: "Codex thread/turns/list returned a malformed response.",
-          details: { runtimeId, externalSessionId: input.externalSessionId },
-        }),
-      );
-    }
-    const data = (result as { data: unknown }).data;
-    if (!Array.isArray(data)) {
-      return yield* Effect.fail(
-        new HostOperationError({
-          operation: "codexSessionStop.loadActiveTurnId",
-          message: "Codex thread/turns/list response data must be an array.",
-          details: { runtimeId, externalSessionId: input.externalSessionId },
-        }),
-      );
-    }
-    const activeTurn = data.find((turn): turn is CodexAppServerTurn => {
-      if (typeof turn !== "object" || turn === null) {
-        return false;
-      }
-      return isActiveTurn(turn as CodexAppServerTurn);
-    });
+    })) as CodexAppServerThreadTurnsListResponse;
+    const activeTurn = response.data.find(isActiveTurn);
     if (!activeTurn) {
       return yield* Effect.fail(
         new HostOperationError({
@@ -105,45 +71,6 @@ const loadActiveTurnId = (input: CodexSessionStopInput, runtimeId: string) =>
     return activeTurn.id;
   });
 
-const assertInterruptibleThread = (
-  input: CodexSessionStopInput,
-  runtimeId: string,
-  thread: CodexAppServerThreadEntry,
-  loadedThreadIds: Set<string>,
-) =>
-  Effect.gen(function* () {
-    if (thread.status === "idle" || thread.status === "notLoaded") {
-      return null;
-    }
-    if (thread.status === "systemError") {
-      return yield* Effect.fail(
-        new HostOperationError({
-          operation: "codexSessionStop.assertInterruptibleThread",
-          message: "Codex session thread is in systemError state and cannot be interrupted.",
-          details: {
-            runtimeId,
-            externalSessionId: input.externalSessionId,
-            workingDirectory: input.workingDirectory,
-          },
-        }),
-      );
-    }
-    if (!loadedThreadIds.has(thread.id)) {
-      return yield* Effect.fail(
-        new HostOperationError({
-          operation: "codexSessionStop.assertInterruptibleThread",
-          message: "Codex session is active but the target thread is not loaded.",
-          details: {
-            runtimeId,
-            externalSessionId: input.externalSessionId,
-            workingDirectory: input.workingDirectory,
-          },
-        }),
-      );
-    }
-    return yield* loadActiveTurnId(input, runtimeId);
-  });
-
 export const stopCodexSession = (
   input: CodexSessionStopInput,
 ): Effect.Effect<void, CodexSessionStopError> =>
@@ -158,16 +85,24 @@ export const stopCodexSession = (
         }),
       );
     }
-    const loadedThreadIds = yield* loadCodexLoadedThreadIds(
-      input.codexAppServer,
-      runtimeId,
-      "codexSessionStop",
-    );
     const thread = yield* requireExactThread(input, runtimeId);
-    const turnId = yield* assertInterruptibleThread(input, runtimeId, thread, loadedThreadIds);
-    if (turnId === null) {
+    if (thread.status.type === "idle" || thread.status.type === "notLoaded") {
       return;
     }
+    if (thread.status.type === "systemError") {
+      return yield* Effect.fail(
+        new HostOperationError({
+          operation: "codexSessionStop",
+          message: "Codex session thread is in systemError state and cannot be interrupted.",
+          details: {
+            runtimeId,
+            externalSessionId: input.externalSessionId,
+            workingDirectory: input.workingDirectory,
+          },
+        }),
+      );
+    }
+    const turnId = yield* loadActiveTurnId(input, runtimeId);
     yield* input.codexAppServer.request({
       runtimeId,
       method: "turn/interrupt",

--- a/packages/host/src/adapters/codex/codex-session-stop.ts
+++ b/packages/host/src/adapters/codex/codex-session-stop.ts
@@ -1,12 +1,9 @@
-import type {
-  CodexAppServerThreadTurnsListResponse,
-  CodexAppServerTurn,
-  RuntimeRoute,
-} from "@openducktor/contracts";
+import type { RuntimeRoute } from "@openducktor/contracts";
 import { Effect } from "effect";
 import { HostOperationError, HostValidationError } from "../../effect/host-errors";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
 import { readCodexThread, runtimeIdFromStdioRoute } from "./codex-thread-lookup";
+import { findActiveCodexTurnId } from "./codex-turn-lookup";
 
 export type CodexSessionStopInput = {
   codexAppServer: Pick<CodexAppServerPort, "request">;
@@ -34,41 +31,6 @@ const requireExactThread = (input: CodexSessionStopInput, runtimeId: string) =>
         },
       }),
     );
-  });
-
-const isActiveTurn = (turn: CodexAppServerTurn): boolean =>
-  typeof turn.id === "string" &&
-  turn.id.length > 0 &&
-  turn.startedAt !== null &&
-  turn.completedAt === null;
-
-const loadActiveTurnId = (input: CodexSessionStopInput, runtimeId: string) =>
-  Effect.gen(function* () {
-    const response = (yield* input.codexAppServer.request({
-      runtimeId,
-      method: "thread/turns/list",
-      params: {
-        threadId: input.externalSessionId,
-        limit: 20,
-        sortDirection: "desc",
-        itemsView: "summary",
-      },
-    })) as CodexAppServerThreadTurnsListResponse;
-    const activeTurn = response.data.find(isActiveTurn);
-    if (!activeTurn) {
-      return yield* Effect.fail(
-        new HostOperationError({
-          operation: "codexSessionStop.loadActiveTurnId",
-          message: "Codex session is active but no interruptible active turn was found.",
-          details: {
-            runtimeId,
-            externalSessionId: input.externalSessionId,
-            workingDirectory: input.workingDirectory,
-          },
-        }),
-      );
-    }
-    return activeTurn.id;
   });
 
 export const stopCodexSession = (
@@ -102,7 +64,24 @@ export const stopCodexSession = (
         }),
       );
     }
-    const turnId = yield* loadActiveTurnId(input, runtimeId);
+    const turnId = yield* findActiveCodexTurnId(
+      input.codexAppServer,
+      runtimeId,
+      input.externalSessionId,
+    );
+    if (turnId === null) {
+      return yield* Effect.fail(
+        new HostOperationError({
+          operation: "codexSessionStop",
+          message: "Codex session is active but no interruptible active turn was found.",
+          details: {
+            runtimeId,
+            externalSessionId: input.externalSessionId,
+            workingDirectory: input.workingDirectory,
+          },
+        }),
+      );
+    }
     yield* input.codexAppServer.request({
       runtimeId,
       method: "turn/interrupt",

--- a/packages/host/src/adapters/codex/codex-thread-lookup.ts
+++ b/packages/host/src/adapters/codex/codex-thread-lookup.ts
@@ -1,8 +1,25 @@
 import type { CodexAppServerThread } from "@openducktor/contracts";
 import { Effect } from "effect";
+import { HostValidationError } from "../../effect/host-errors";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
+import { parseThreadReadResponse } from "./codex-app-server-response-parsers";
 
 type CodexThreadReaderPort = Pick<CodexAppServerPort, "request">;
+
+const parseCodexThread = (
+  value: unknown,
+  runtimeId: string,
+  threadId: string,
+): Effect.Effect<CodexAppServerThread, HostValidationError> =>
+  Effect.try({
+    try: () => parseThreadReadResponse(value),
+    catch: (cause) =>
+      new HostValidationError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause,
+        details: { method: "thread/read", runtimeId, threadId },
+      }),
+  });
 
 export const readCodexThread = (
   codexAppServer: CodexThreadReaderPort,
@@ -15,5 +32,5 @@ export const readCodexThread = (
       method: "thread/read",
       params: { threadId, includeTurns: false },
     });
-    return (response as { thread: CodexAppServerThread }).thread;
+    return yield* parseCodexThread(response, runtimeId, threadId);
   });

--- a/packages/host/src/adapters/codex/codex-thread-lookup.ts
+++ b/packages/host/src/adapters/codex/codex-thread-lookup.ts
@@ -1,0 +1,97 @@
+import type { RuntimeRoute } from "@openducktor/contracts";
+import { Effect } from "effect";
+import { HostOperationError } from "../../effect/host-errors";
+import type {
+  CodexAppServerError,
+  CodexAppServerLoadedThreadListResponse,
+  CodexAppServerPort,
+  CodexAppServerThreadEntry,
+  CodexAppServerThreadListResponse,
+} from "../../ports/codex-app-server-port";
+
+export type CodexThreadLookupPort = Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads">;
+
+export type CodexThreadLookupInput = {
+  codexAppServer: CodexThreadLookupPort;
+  runtimeId: string;
+  externalSessionId: string;
+  workingDirectory: string;
+  operationPrefix: string;
+};
+
+export const runtimeIdFromStdioRoute = (runtimeRoute: RuntimeRoute): string | null =>
+  runtimeRoute.type === "stdio" ? runtimeRoute.identity : null;
+
+export const loadCodexLoadedThreadIds = (
+  codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads">,
+  runtimeId: string,
+  operationPrefix: string,
+) =>
+  Effect.gen(function* () {
+    const loadedThreadIds = new Set<string>();
+    const seenCursors = new Set<string>();
+    let cursor: string | null = null;
+    while (true) {
+      if (cursor !== null) {
+        if (seenCursors.has(cursor)) {
+          return yield* Effect.fail(
+            new HostOperationError({
+              operation: `${operationPrefix}.loadLoadedThreadIds`,
+              message: "Codex thread/loaded/list returned a repeated pagination cursor",
+              details: { runtimeId, cursor },
+            }),
+          );
+        }
+        seenCursors.add(cursor);
+      }
+      const response: CodexAppServerLoadedThreadListResponse =
+        yield* codexAppServer.listLoadedThreads({
+          runtimeId,
+          cursor,
+          limit: 100,
+        });
+      for (const threadId of response.data) {
+        loadedThreadIds.add(threadId);
+      }
+      cursor = response.nextCursor;
+      if (cursor === null) {
+        return loadedThreadIds;
+      }
+    }
+  });
+
+export const findExactCodexThread = (
+  input: CodexThreadLookupInput,
+): Effect.Effect<CodexAppServerThreadEntry | null, CodexAppServerError | HostOperationError> =>
+  Effect.gen(function* () {
+    const seenCursors = new Set<string>();
+    let cursor: string | null = null;
+    while (true) {
+      if (cursor !== null) {
+        if (seenCursors.has(cursor)) {
+          return yield* Effect.fail(
+            new HostOperationError({
+              operation: `${input.operationPrefix}.findExactThread`,
+              message: "Codex thread/list returned a repeated pagination cursor",
+              details: { runtimeId: input.runtimeId, cursor },
+            }),
+          );
+        }
+        seenCursors.add(cursor);
+      }
+      const response: CodexAppServerThreadListResponse = yield* input.codexAppServer.listThreads({
+        runtimeId: input.runtimeId,
+        cursor,
+        limit: 100,
+      });
+      for (const thread of response.data) {
+        if (thread.id === input.externalSessionId && thread.cwd === input.workingDirectory) {
+          return thread;
+        }
+      }
+      cursor = response.nextCursor;
+      if (cursor === null) {
+        return null;
+      }
+    }
+  });

--- a/packages/host/src/adapters/codex/codex-thread-lookup.ts
+++ b/packages/host/src/adapters/codex/codex-thread-lookup.ts
@@ -1,97 +1,22 @@
-import type { RuntimeRoute } from "@openducktor/contracts";
+import type { CodexAppServerThread, RuntimeRoute } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { HostOperationError } from "../../effect/host-errors";
-import type {
-  CodexAppServerError,
-  CodexAppServerLoadedThreadListResponse,
-  CodexAppServerPort,
-  CodexAppServerThreadEntry,
-  CodexAppServerThreadListResponse,
-} from "../../ports/codex-app-server-port";
+import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
 
-type CodexThreadLookupPort = Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads">;
-
-type CodexThreadLookupInput = {
-  codexAppServer: CodexThreadLookupPort;
-  runtimeId: string;
-  externalSessionId: string;
-  workingDirectory: string;
-  operationPrefix: string;
-};
+type CodexThreadReaderPort = Pick<CodexAppServerPort, "request">;
 
 export const runtimeIdFromStdioRoute = (runtimeRoute: RuntimeRoute): string | null =>
   runtimeRoute.type === "stdio" ? runtimeRoute.identity : null;
 
-export const loadCodexLoadedThreadIds = (
-  codexAppServer: Pick<CodexAppServerPort, "listLoadedThreads">,
+export const readCodexThread = (
+  codexAppServer: CodexThreadReaderPort,
   runtimeId: string,
-  operationPrefix: string,
-) =>
+  threadId: string,
+): Effect.Effect<CodexAppServerThread, CodexAppServerError> =>
   Effect.gen(function* () {
-    const loadedThreadIds = new Set<string>();
-    const seenCursors = new Set<string>();
-    let cursor: string | null = null;
-    while (true) {
-      if (cursor !== null) {
-        if (seenCursors.has(cursor)) {
-          return yield* Effect.fail(
-            new HostOperationError({
-              operation: `${operationPrefix}.loadLoadedThreadIds`,
-              message: "Codex thread/loaded/list returned a repeated pagination cursor",
-              details: { runtimeId, cursor },
-            }),
-          );
-        }
-        seenCursors.add(cursor);
-      }
-      const response: CodexAppServerLoadedThreadListResponse =
-        yield* codexAppServer.listLoadedThreads({
-          runtimeId,
-          cursor,
-          limit: 100,
-        });
-      for (const threadId of response.data) {
-        loadedThreadIds.add(threadId);
-      }
-      cursor = response.nextCursor;
-      if (cursor === null) {
-        return loadedThreadIds;
-      }
-    }
-  });
-
-export const findExactCodexThread = (
-  input: CodexThreadLookupInput,
-): Effect.Effect<CodexAppServerThreadEntry | null, CodexAppServerError> =>
-  Effect.gen(function* () {
-    const seenCursors = new Set<string>();
-    let cursor: string | null = null;
-    while (true) {
-      if (cursor !== null) {
-        if (seenCursors.has(cursor)) {
-          return yield* Effect.fail(
-            new HostOperationError({
-              operation: `${input.operationPrefix}.findExactThread`,
-              message: "Codex thread/list returned a repeated pagination cursor",
-              details: { runtimeId: input.runtimeId, cursor },
-            }),
-          );
-        }
-        seenCursors.add(cursor);
-      }
-      const response: CodexAppServerThreadListResponse = yield* input.codexAppServer.listThreads({
-        runtimeId: input.runtimeId,
-        cursor,
-        limit: 100,
-      });
-      for (const thread of response.data) {
-        if (thread.id === input.externalSessionId && thread.cwd === input.workingDirectory) {
-          return thread;
-        }
-      }
-      cursor = response.nextCursor;
-      if (cursor === null) {
-        return null;
-      }
-    }
+    const response = yield* codexAppServer.request({
+      runtimeId,
+      method: "thread/read",
+      params: { threadId, includeTurns: false },
+    });
+    return (response as { thread: CodexAppServerThread }).thread;
   });

--- a/packages/host/src/adapters/codex/codex-thread-lookup.ts
+++ b/packages/host/src/adapters/codex/codex-thread-lookup.ts
@@ -1,11 +1,8 @@
-import type { CodexAppServerThread, RuntimeRoute } from "@openducktor/contracts";
+import type { CodexAppServerThread } from "@openducktor/contracts";
 import { Effect } from "effect";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
 
 type CodexThreadReaderPort = Pick<CodexAppServerPort, "request">;
-
-export const runtimeIdFromStdioRoute = (runtimeRoute: RuntimeRoute): string | null =>
-  runtimeRoute.type === "stdio" ? runtimeRoute.identity : null;
 
 export const readCodexThread = (
   codexAppServer: CodexThreadReaderPort,

--- a/packages/host/src/adapters/codex/codex-thread-lookup.ts
+++ b/packages/host/src/adapters/codex/codex-thread-lookup.ts
@@ -9,9 +9,9 @@ import type {
   CodexAppServerThreadListResponse,
 } from "../../ports/codex-app-server-port";
 
-export type CodexThreadLookupPort = Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads">;
+type CodexThreadLookupPort = Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads">;
 
-export type CodexThreadLookupInput = {
+type CodexThreadLookupInput = {
   codexAppServer: CodexThreadLookupPort;
   runtimeId: string;
   externalSessionId: string;
@@ -62,7 +62,7 @@ export const loadCodexLoadedThreadIds = (
 
 export const findExactCodexThread = (
   input: CodexThreadLookupInput,
-): Effect.Effect<CodexAppServerThreadEntry | null, CodexAppServerError | HostOperationError> =>
+): Effect.Effect<CodexAppServerThreadEntry | null, CodexAppServerError> =>
   Effect.gen(function* () {
     const seenCursors = new Set<string>();
     let cursor: string | null = null;

--- a/packages/host/src/adapters/codex/codex-turn-lookup.ts
+++ b/packages/host/src/adapters/codex/codex-turn-lookup.ts
@@ -1,17 +1,32 @@
-import type {
-  CodexAppServerThreadTurnsListResponse,
-  CodexAppServerTurn,
-} from "@openducktor/contracts";
+import type { CodexAppServerTurn } from "@openducktor/contracts";
 import { Effect } from "effect";
+import { HostValidationError } from "../../effect/host-errors";
 import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
+import { isJsonRecord, parseThreadTurnsListResponse } from "./codex-app-server-response-parsers";
 
 type CodexTurnReaderPort = Pick<CodexAppServerPort, "request">;
 
 const isActiveCodexTurn = (turn: CodexAppServerTurn): boolean =>
+  isJsonRecord(turn) &&
   typeof turn.id === "string" &&
   turn.id.length > 0 &&
   turn.startedAt !== null &&
   turn.completedAt === null;
+
+const parseCodexTurnCandidates = (
+  value: unknown,
+  runtimeId: string,
+  threadId: string,
+): Effect.Effect<CodexAppServerTurn[], HostValidationError> =>
+  Effect.try({
+    try: () => parseThreadTurnsListResponse(value).data,
+    catch: (cause) =>
+      new HostValidationError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause,
+        details: { method: "thread/turns/list", runtimeId, threadId },
+      }),
+  });
 
 export const findActiveCodexTurnId = (
   codexAppServer: CodexTurnReaderPort,
@@ -19,7 +34,7 @@ export const findActiveCodexTurnId = (
   threadId: string,
 ): Effect.Effect<string | null, CodexAppServerError> =>
   Effect.gen(function* () {
-    const response = (yield* codexAppServer.request({
+    const response = yield* codexAppServer.request({
       runtimeId,
       method: "thread/turns/list",
       params: {
@@ -28,6 +43,7 @@ export const findActiveCodexTurnId = (
         sortDirection: "desc",
         itemsView: "summary",
       },
-    })) as CodexAppServerThreadTurnsListResponse;
-    return response.data.find(isActiveCodexTurn)?.id ?? null;
+    });
+    const turns = yield* parseCodexTurnCandidates(response, runtimeId, threadId);
+    return turns.find(isActiveCodexTurn)?.id ?? null;
   });

--- a/packages/host/src/adapters/codex/codex-turn-lookup.ts
+++ b/packages/host/src/adapters/codex/codex-turn-lookup.ts
@@ -1,0 +1,33 @@
+import type {
+  CodexAppServerThreadTurnsListResponse,
+  CodexAppServerTurn,
+} from "@openducktor/contracts";
+import { Effect } from "effect";
+import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
+
+type CodexTurnReaderPort = Pick<CodexAppServerPort, "request">;
+
+const isActiveCodexTurn = (turn: CodexAppServerTurn): boolean =>
+  typeof turn.id === "string" &&
+  turn.id.length > 0 &&
+  turn.startedAt !== null &&
+  turn.completedAt === null;
+
+export const findActiveCodexTurnId = (
+  codexAppServer: CodexTurnReaderPort,
+  runtimeId: string,
+  threadId: string,
+): Effect.Effect<string | null, CodexAppServerError> =>
+  Effect.gen(function* () {
+    const response = (yield* codexAppServer.request({
+      runtimeId,
+      method: "thread/turns/list",
+      params: {
+        threadId,
+        limit: 20,
+        sortDirection: "desc",
+        itemsView: "summary",
+      },
+    })) as CodexAppServerThreadTurnsListResponse;
+    return response.data.find(isActiveCodexTurn)?.id ?? null;
+  });

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -386,7 +386,12 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
         portProbe: () => Effect.succeed(false),
         processTreeTerminator: ({ pid }) => {
           runtimePid = pid;
-          process.kill(pid, "SIGTERM");
+          try {
+            process.kill(pid, "SIGTERM");
+          } catch {
+            // The fake terminator failure is the behavior under test; process
+            // cleanup is guaranteed by the finally block below.
+          }
           return Effect.fail(
             new HostOperationError({
               operation: "test.processTreeTerminator",

--- a/packages/host/src/adapters/runtimes/runtime-registry.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.test.ts
@@ -571,7 +571,7 @@ describe("createRuntimeRegistry", () => {
       ),
     ).rejects.toThrow("Codex session is active but no interruptible active turn was found.");
   });
-  test("fails Codex stop without the app-server port or a stdio route", async () => {
+  test("fails Codex stop without the app-server port or a Codex runtime route", async () => {
     const registry = createRuntimeRegistry();
     await expect(
       Effect.runPromise(
@@ -599,6 +599,6 @@ describe("createRuntimeRegistry", () => {
           workingDirectory: "/repo/worktree",
         }),
       ),
-    ).rejects.toThrow("Codex session stop requires a stdio runtime route.");
+    ).rejects.toThrow("Codex app-server operations require a stdio runtime route.");
   });
 });

--- a/packages/host/src/adapters/runtimes/runtime-registry.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.test.ts
@@ -5,7 +5,7 @@ import {
   type RuntimeInstanceSummary,
 } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { toHostOperationError } from "../../effect/host-errors";
+import { HostOperationError, toHostOperationError } from "../../effect/host-errors";
 import type { CodexAppServerRequestResult } from "../../ports/codex-app-server-port";
 import { createRuntimeRegistry as createEffectRuntimeRegistry } from "./runtime-registry";
 
@@ -359,16 +359,20 @@ describe("createRuntimeRegistry", () => {
       codexAppServer: {
         request(input) {
           calls.push(input);
-          const params = input.params as { threadId: "session-1" | "session-2" | "session-3" };
+          const params = input.params as {
+            threadId: "session-1" | "session-2" | "session-3" | "session-4" | "session-5";
+          };
           const statusByThreadId = {
             "session-1": { type: "active", activeFlags: [] },
             "session-2": { type: "idle" },
             "session-3": { type: "systemError" },
+            "session-4": { type: "notLoaded" },
+            "session-5": { type: "active", activeFlags: [] },
           } as const;
           return codexResult({
             thread: {
               id: params.threadId,
-              cwd: "/repo/worktree",
+              cwd: params.threadId === "session-5" ? "/repo/other-worktree" : "/repo/worktree",
               status: statusByThreadId[params.threadId],
             },
           });
@@ -395,13 +399,33 @@ describe("createRuntimeRegistry", () => {
           workingDirectory: "/repo/worktree",
         }),
       ),
-    ).resolves.toEqual({ supported: true, hasLiveSession: false });
+    ).resolves.toEqual({ supported: true, hasLiveSession: true });
     await expect(
       Effect.runPromise(
         probeSessionStatus({
           runtimeKind: "codex",
           runtimeRoute: { type: "stdio", identity: "runtime-1" },
           externalSessionId: "session-3",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).resolves.toEqual({ supported: true, hasLiveSession: true });
+    await expect(
+      Effect.runPromise(
+        probeSessionStatus({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "session-4",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).resolves.toEqual({ supported: true, hasLiveSession: false });
+    await expect(
+      Effect.runPromise(
+        probeSessionStatus({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "session-5",
           workingDirectory: "/repo/worktree",
         }),
       ),
@@ -422,7 +446,63 @@ describe("createRuntimeRegistry", () => {
         method: "thread/read",
         params: { threadId: "session-3", includeTurns: false },
       },
+      {
+        runtimeId: "runtime-1",
+        method: "thread/read",
+        params: { threadId: "session-4", includeTurns: false },
+      },
+      {
+        runtimeId: "runtime-1",
+        method: "thread/read",
+        params: { threadId: "session-5", includeTurns: false },
+      },
     ]);
+  });
+  test("treats missing Codex session probe threads as inactive", async () => {
+    const registry = createRuntimeRegistry({
+      codexAppServer: {
+        request(input) {
+          return Effect.fail(
+            new HostOperationError({
+              operation: `codexAppServerTransport.request.${input.method}`,
+              message: `Codex app-server request ${input.method} failed for runtime ${input.runtimeId}: thread not found`,
+              details: { runtimeId: input.runtimeId, method: input.method },
+            }),
+          );
+        },
+      },
+    });
+    const probeSessionStatus = requireMethod(registry.probeSessionStatus, "probeSessionStatus");
+    await expect(
+      Effect.runPromise(
+        probeSessionStatus({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "missing-session",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).resolves.toEqual({ supported: true, hasLiveSession: false });
+  });
+  test("fails malformed Codex session probe thread payloads with a typed error", async () => {
+    const registry = createRuntimeRegistry({
+      codexAppServer: {
+        request() {
+          return codexResult({});
+        },
+      },
+    });
+    const probeSessionStatus = requireMethod(registry.probeSessionStatus, "probeSessionStatus");
+    await expect(
+      Effect.runPromise(
+        probeSessionStatus({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "session-1",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).rejects.toThrow("Codex thread/read response thread must be an object");
   });
   test("interrupts an active Codex session through the app-server port", async () => {
     const calls: unknown[] = [];
@@ -570,6 +650,34 @@ describe("createRuntimeRegistry", () => {
         }),
       ),
     ).rejects.toThrow("Codex session is active but no interruptible active turn was found.");
+  });
+  test("fails malformed Codex turn-list payloads with a typed error", async () => {
+    const registry = createRuntimeRegistry({
+      codexAppServer: {
+        request(input) {
+          if (input.method === "thread/read") {
+            return codexResult({
+              thread: {
+                id: "session-1",
+                cwd: "/repo/worktree",
+                status: { type: "active", activeFlags: [] },
+              },
+            });
+          }
+          return codexResult({});
+        },
+      },
+    });
+    await expect(
+      Effect.runPromise(
+        registry.stopSession({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "session-1",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).rejects.toThrow("Codex thread/turns/list response data must be an array");
   });
   test("fails Codex stop without the app-server port or a Codex runtime route", async () => {
     const registry = createRuntimeRegistry();

--- a/packages/host/src/adapters/runtimes/runtime-registry.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.test.ts
@@ -6,10 +6,12 @@ import {
 } from "@openducktor/contracts";
 import { Effect } from "effect";
 import { toHostOperationError } from "../../effect/host-errors";
+import type { CodexAppServerRequestResult } from "../../ports/codex-app-server-port";
 import { createRuntimeRegistry as createEffectRuntimeRegistry } from "./runtime-registry";
 
 const createRuntimeRegistry = (...args: Parameters<typeof createEffectRuntimeRegistry>) =>
   createEffectRuntimeRegistry(...args);
+const codexResult = (value: unknown) => Effect.succeed(value as CodexAppServerRequestResult);
 const requireMethod = <T>(method: T | undefined, methodName: string): T => {
   if (!method) {
     throw new Error(`Expected registry to support ${methodName}`);
@@ -355,40 +357,21 @@ describe("createRuntimeRegistry", () => {
     const calls: unknown[] = [];
     const registry = createRuntimeRegistry({
       codexAppServer: {
-        listLoadedThreads(input) {
-          calls.push({
-            runtimeId: input.runtimeId,
-            method: "thread/loaded/list",
-            params: { cursor: input.cursor, limit: input.limit },
-          });
-          return Effect.succeed({
-            data: ["session-1", "session-2", "session-3"],
-            nextCursor: null,
-          });
-        },
-        listThreads(input) {
-          calls.push({
-            runtimeId: input.runtimeId,
-            method: "thread/list",
-            params: { cursor: input.cursor, limit: input.limit },
-          });
-          return Effect.succeed({
-            data: [
-              {
-                id: "session-1",
-                cwd: "/repo/worktree",
-                status: "active",
-              },
-              { id: "session-2", cwd: "/repo/worktree", status: "idle" },
-              { id: "session-3", cwd: "/repo/worktree", status: "systemError" },
-            ],
-            nextCursor: null,
-            backwardsCursor: null,
-          });
-        },
         request(input) {
           calls.push(input);
-          return Effect.succeed({});
+          const params = input.params as { threadId: "session-1" | "session-2" | "session-3" };
+          const statusByThreadId = {
+            "session-1": { type: "active", activeFlags: [] },
+            "session-2": { type: "idle" },
+            "session-3": { type: "systemError" },
+          } as const;
+          return codexResult({
+            thread: {
+              id: params.threadId,
+              cwd: "/repo/worktree",
+              status: statusByThreadId[params.threadId],
+            },
+          });
         },
       },
     });
@@ -426,90 +409,38 @@ describe("createRuntimeRegistry", () => {
     expect(calls).toEqual([
       {
         runtimeId: "runtime-1",
-        method: "thread/loaded/list",
-        params: { cursor: null, limit: 100 },
+        method: "thread/read",
+        params: { threadId: "session-1", includeTurns: false },
       },
       {
         runtimeId: "runtime-1",
-        method: "thread/list",
-        params: { cursor: null, limit: 100 },
+        method: "thread/read",
+        params: { threadId: "session-2", includeTurns: false },
       },
       {
         runtimeId: "runtime-1",
-        method: "thread/loaded/list",
-        params: { cursor: null, limit: 100 },
-      },
-      {
-        runtimeId: "runtime-1",
-        method: "thread/list",
-        params: { cursor: null, limit: 100 },
-      },
-      {
-        runtimeId: "runtime-1",
-        method: "thread/loaded/list",
-        params: { cursor: null, limit: 100 },
-      },
-      {
-        runtimeId: "runtime-1",
-        method: "thread/list",
-        params: { cursor: null, limit: 100 },
+        method: "thread/read",
+        params: { threadId: "session-3", includeTurns: false },
       },
     ]);
-  });
-  test("fails Codex session status probing on repeated pagination cursors", async () => {
-    const registry = createRuntimeRegistry({
-      codexAppServer: {
-        listLoadedThreads() {
-          return Effect.succeed({ data: ["session-1"], nextCursor: "cursor-1" });
-        },
-        listThreads() {
-          return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
-        },
-        request() {
-          return Effect.succeed({});
-        },
-      },
-    });
-    const probeSessionStatus = requireMethod(registry.probeSessionStatus, "probeSessionStatus");
-    await expect(
-      Effect.runPromise(
-        probeSessionStatus({
-          runtimeKind: "codex",
-          runtimeRoute: { type: "stdio", identity: "runtime-1" },
-          externalSessionId: "session-1",
-          workingDirectory: "/repo/worktree",
-        }),
-      ),
-    ).rejects.toThrow("Codex thread/loaded/list returned a repeated pagination cursor");
   });
   test("interrupts an active Codex session through the app-server port", async () => {
     const calls: unknown[] = [];
     const registry = createRuntimeRegistry({
       codexAppServer: {
-        listLoadedThreads(input) {
-          calls.push({
-            runtimeId: input.runtimeId,
-            method: "thread/loaded/list",
-            params: { cursor: input.cursor, limit: input.limit },
-          });
-          return Effect.succeed({ data: ["session-1"], nextCursor: null });
-        },
-        listThreads(input) {
-          calls.push({
-            runtimeId: input.runtimeId,
-            method: "thread/list",
-            params: { cursor: input.cursor, limit: input.limit },
-          });
-          return Effect.succeed({
-            data: [{ id: "session-1", cwd: "/repo/worktree", status: "active" }],
-            nextCursor: null,
-            backwardsCursor: null,
-          });
-        },
         request(input) {
           calls.push(input);
+          if (input.method === "thread/read") {
+            return codexResult({
+              thread: {
+                id: "session-1",
+                cwd: "/repo/worktree",
+                status: { type: "active", activeFlags: [] },
+              },
+            });
+          }
           if (input.method === "thread/turns/list") {
-            return Effect.succeed({
+            return codexResult({
               data: [
                 {
                   id: "turn-1",
@@ -526,7 +457,7 @@ describe("createRuntimeRegistry", () => {
               backwardsCursor: null,
             });
           }
-          return Effect.succeed({});
+          return codexResult({});
         },
       },
     });
@@ -543,13 +474,8 @@ describe("createRuntimeRegistry", () => {
     expect(calls).toEqual([
       {
         runtimeId: "runtime-1",
-        method: "thread/loaded/list",
-        params: { cursor: null, limit: 100 },
-      },
-      {
-        runtimeId: "runtime-1",
-        method: "thread/list",
-        params: { cursor: null, limit: 100 },
+        method: "thread/read",
+        params: { threadId: "session-1", includeTurns: false },
       },
       {
         runtimeId: "runtime-1",
@@ -572,19 +498,15 @@ describe("createRuntimeRegistry", () => {
     const calls: unknown[] = [];
     const registry = createRuntimeRegistry({
       codexAppServer: {
-        listLoadedThreads() {
-          return Effect.succeed({ data: [], nextCursor: null });
-        },
-        listThreads() {
-          return Effect.succeed({
-            data: [{ id: "session-1", cwd: "/repo/worktree", status: "idle" }],
-            nextCursor: null,
-            backwardsCursor: null,
-          });
-        },
         request(input) {
           calls.push(input);
-          return Effect.succeed({});
+          return codexResult({
+            thread: {
+              id: "session-1",
+              cwd: "/repo/worktree",
+              status: { type: "idle" },
+            },
+          });
         },
       },
     });
@@ -598,23 +520,28 @@ describe("createRuntimeRegistry", () => {
         }),
       ),
     ).resolves.toBeUndefined();
-    expect(calls).toEqual([]);
+    expect(calls).toEqual([
+      {
+        runtimeId: "runtime-1",
+        method: "thread/read",
+        params: { threadId: "session-1", includeTurns: false },
+      },
+    ]);
   });
   test("fails active Codex stop when no active turn can be found", async () => {
     const registry = createRuntimeRegistry({
       codexAppServer: {
-        listLoadedThreads() {
-          return Effect.succeed({ data: ["session-1"], nextCursor: null });
-        },
-        listThreads() {
-          return Effect.succeed({
-            data: [{ id: "session-1", cwd: "/repo/worktree", status: "active" }],
-            nextCursor: null,
-            backwardsCursor: null,
-          });
-        },
-        request() {
-          return Effect.succeed({
+        request(input) {
+          if (input.method === "thread/read") {
+            return codexResult({
+              thread: {
+                id: "session-1",
+                cwd: "/repo/worktree",
+                status: { type: "active", activeFlags: [] },
+              },
+            });
+          }
+          return codexResult({
             data: [
               {
                 id: "turn-1",
@@ -658,14 +585,8 @@ describe("createRuntimeRegistry", () => {
     ).rejects.toThrow("Codex session stop requires the Codex app-server port.");
     const codexRegistry = createRuntimeRegistry({
       codexAppServer: {
-        listLoadedThreads() {
-          return Effect.succeed({ data: [], nextCursor: null });
-        },
-        listThreads() {
-          return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
-        },
         request() {
-          return Effect.succeed({});
+          return codexResult({});
         },
       },
     });

--- a/packages/host/src/adapters/runtimes/runtime-registry.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.test.ts
@@ -386,6 +386,10 @@ describe("createRuntimeRegistry", () => {
             backwardsCursor: null,
           });
         },
+        request(input) {
+          calls.push(input);
+          return Effect.succeed({});
+        },
       },
     });
     const probeSessionStatus = requireMethod(registry.probeSessionStatus, "probeSessionStatus");
@@ -461,6 +465,9 @@ describe("createRuntimeRegistry", () => {
         listThreads() {
           return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
         },
+        request() {
+          return Effect.succeed({});
+        },
       },
     });
     const probeSessionStatus = requireMethod(registry.probeSessionStatus, "probeSessionStatus");
@@ -474,5 +481,203 @@ describe("createRuntimeRegistry", () => {
         }),
       ),
     ).rejects.toThrow("Codex thread/loaded/list returned a repeated pagination cursor");
+  });
+  test("interrupts an active Codex session through the app-server port", async () => {
+    const calls: unknown[] = [];
+    const registry = createRuntimeRegistry({
+      codexAppServer: {
+        listLoadedThreads(input) {
+          calls.push({
+            runtimeId: input.runtimeId,
+            method: "thread/loaded/list",
+            params: { cursor: input.cursor, limit: input.limit },
+          });
+          return Effect.succeed({ data: ["session-1"], nextCursor: null });
+        },
+        listThreads(input) {
+          calls.push({
+            runtimeId: input.runtimeId,
+            method: "thread/list",
+            params: { cursor: input.cursor, limit: input.limit },
+          });
+          return Effect.succeed({
+            data: [{ id: "session-1", cwd: "/repo/worktree", status: "active" }],
+            nextCursor: null,
+            backwardsCursor: null,
+          });
+        },
+        request(input) {
+          calls.push(input);
+          if (input.method === "thread/turns/list") {
+            return Effect.succeed({
+              data: [
+                {
+                  id: "turn-1",
+                  startedAt: 1_778_112_001,
+                  completedAt: null,
+                  durationMs: null,
+                  error: null,
+                  items: [],
+                  itemsView: "summary",
+                  status: "running",
+                },
+              ],
+              nextCursor: null,
+              backwardsCursor: null,
+            });
+          }
+          return Effect.succeed({});
+        },
+      },
+    });
+    await expect(
+      Effect.runPromise(
+        registry.stopSession({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "session-1",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    expect(calls).toEqual([
+      {
+        runtimeId: "runtime-1",
+        method: "thread/loaded/list",
+        params: { cursor: null, limit: 100 },
+      },
+      {
+        runtimeId: "runtime-1",
+        method: "thread/list",
+        params: { cursor: null, limit: 100 },
+      },
+      {
+        runtimeId: "runtime-1",
+        method: "thread/turns/list",
+        params: {
+          threadId: "session-1",
+          limit: 20,
+          sortDirection: "desc",
+          itemsView: "summary",
+        },
+      },
+      {
+        runtimeId: "runtime-1",
+        method: "turn/interrupt",
+        params: { threadId: "session-1", turnId: "turn-1" },
+      },
+    ]);
+  });
+  test("treats exact idle Codex sessions as already stopped", async () => {
+    const calls: unknown[] = [];
+    const registry = createRuntimeRegistry({
+      codexAppServer: {
+        listLoadedThreads() {
+          return Effect.succeed({ data: [], nextCursor: null });
+        },
+        listThreads() {
+          return Effect.succeed({
+            data: [{ id: "session-1", cwd: "/repo/worktree", status: "idle" }],
+            nextCursor: null,
+            backwardsCursor: null,
+          });
+        },
+        request(input) {
+          calls.push(input);
+          return Effect.succeed({});
+        },
+      },
+    });
+    await expect(
+      Effect.runPromise(
+        registry.stopSession({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "session-1",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+  test("fails active Codex stop when no active turn can be found", async () => {
+    const registry = createRuntimeRegistry({
+      codexAppServer: {
+        listLoadedThreads() {
+          return Effect.succeed({ data: ["session-1"], nextCursor: null });
+        },
+        listThreads() {
+          return Effect.succeed({
+            data: [{ id: "session-1", cwd: "/repo/worktree", status: "active" }],
+            nextCursor: null,
+            backwardsCursor: null,
+          });
+        },
+        request() {
+          return Effect.succeed({
+            data: [
+              {
+                id: "turn-1",
+                startedAt: 1_778_112_001,
+                completedAt: 1_778_112_031,
+                durationMs: 30,
+                error: null,
+                items: [],
+                itemsView: "summary",
+                status: "completed",
+              },
+            ],
+            nextCursor: null,
+            backwardsCursor: null,
+          });
+        },
+      },
+    });
+    await expect(
+      Effect.runPromise(
+        registry.stopSession({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "session-1",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).rejects.toThrow("Codex session is active but no interruptible active turn was found.");
+  });
+  test("fails Codex stop without the app-server port or a stdio route", async () => {
+    const registry = createRuntimeRegistry();
+    await expect(
+      Effect.runPromise(
+        registry.stopSession({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "stdio", identity: "runtime-1" },
+          externalSessionId: "session-1",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).rejects.toThrow("Codex session stop requires the Codex app-server port.");
+    const codexRegistry = createRuntimeRegistry({
+      codexAppServer: {
+        listLoadedThreads() {
+          return Effect.succeed({ data: [], nextCursor: null });
+        },
+        listThreads() {
+          return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
+        },
+        request() {
+          return Effect.succeed({});
+        },
+      },
+    });
+    await expect(
+      Effect.runPromise(
+        codexRegistry.stopSession({
+          runtimeKind: "codex",
+          runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4096" },
+          externalSessionId: "session-1",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).rejects.toThrow("Codex session stop requires a stdio runtime route.");
   });
 });

--- a/packages/host/src/adapters/runtimes/runtime-registry.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.ts
@@ -25,7 +25,7 @@ import {
 export type CreateRuntimeRegistryInput = {
   runtimes?: RuntimeInstanceSummary[];
   workspaceStarter?: RuntimeWorkspaceStarterPort;
-  codexAppServer?: Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads" | "request">;
+  codexAppServer?: Pick<CodexAppServerPort, "request">;
 };
 
 type RuntimeEnsureFlight = {

--- a/packages/host/src/adapters/runtimes/runtime-registry.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.ts
@@ -32,6 +32,20 @@ type RuntimeEnsureFlight = {
   deferred: Deferred.Deferred<RuntimeInstanceSummary, RuntimeRegistryError>;
 };
 
+const requireCodexRuntimeId = (runtimeRoute: RuntimeInstanceSummary["runtimeRoute"]) =>
+  Effect.gen(function* () {
+    if (runtimeRoute.type === "stdio") {
+      return runtimeRoute.identity;
+    }
+    return yield* Effect.fail(
+      new HostValidationError({
+        field: "runtimeRoute",
+        message: "Codex app-server operations require a stdio runtime route.",
+        details: { runtimeRouteType: runtimeRoute.type },
+      }),
+    );
+  });
+
 export const createRuntimeRegistry = ({
   runtimes = [],
   workspaceStarter,
@@ -201,7 +215,10 @@ export const createRuntimeRegistry = ({
             }),
           );
         }
-        return stopCodexSession({ ...input, codexAppServer });
+        return Effect.gen(function* () {
+          const runtimeId = yield* requireCodexRuntimeId(input.runtimeRoute);
+          return yield* stopCodexSession({ ...input, codexAppServer, runtimeId });
+        });
       }
       return Effect.fail(
         new HostValidationError({
@@ -225,7 +242,10 @@ export const createRuntimeRegistry = ({
             }),
           );
         }
-        return probeCodexSessionStatus({ ...input, codexAppServer });
+        return Effect.gen(function* () {
+          const runtimeId = yield* requireCodexRuntimeId(input.runtimeRoute);
+          return yield* probeCodexSessionStatus({ ...input, codexAppServer, runtimeId });
+        });
       }
       return Effect.succeed({ supported: false, hasLiveSession: false });
     },

--- a/packages/host/src/adapters/runtimes/runtime-registry.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.ts
@@ -13,6 +13,7 @@ import type {
   RuntimeWorkspaceStarterPort,
 } from "../../ports/runtime-registry-port";
 import { probeCodexSessionStatus } from "../codex/codex-session-status-probe";
+import { stopCodexSession } from "../codex/codex-session-stop";
 import {
   findWorkspaceRuntime,
   probeCodexMcpStatus,
@@ -24,7 +25,7 @@ import {
 export type CreateRuntimeRegistryInput = {
   runtimes?: RuntimeInstanceSummary[];
   workspaceStarter?: RuntimeWorkspaceStarterPort;
-  codexAppServer?: Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads">;
+  codexAppServer?: Pick<CodexAppServerPort, "listLoadedThreads" | "listThreads" | "request">;
 };
 
 type RuntimeEnsureFlight = {
@@ -189,6 +190,18 @@ export const createRuntimeRegistry = ({
     stopSession(input) {
       if (input.runtimeKind === "opencode") {
         return stopOpenCodeSession(input);
+      }
+      if (input.runtimeKind === "codex") {
+        if (!codexAppServer) {
+          return Effect.fail(
+            new HostResourceError({
+              resource: "codexAppServer",
+              operation: "runtimeRegistry.stopCodexSession",
+              message: "Codex session stop requires the Codex app-server port.",
+            }),
+          );
+        }
+        return stopCodexSession({ ...input, codexAppServer });
       }
       return Effect.fail(
         new HostValidationError({

--- a/packages/host/src/adapters/runtimes/runtime-registry.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.ts
@@ -1,4 +1,8 @@
-import { type RuntimeInstanceSummary, runtimeInstanceSummarySchema } from "@openducktor/contracts";
+import {
+  type RuntimeInstanceSummary,
+  type RuntimeRoute,
+  runtimeInstanceSummarySchema,
+} from "@openducktor/contracts";
 import { Deferred, Effect, FiberId } from "effect";
 import {
   HostOperationError,
@@ -32,7 +36,7 @@ type RuntimeEnsureFlight = {
   deferred: Deferred.Deferred<RuntimeInstanceSummary, RuntimeRegistryError>;
 };
 
-const requireCodexRuntimeId = (runtimeRoute: RuntimeInstanceSummary["runtimeRoute"]) =>
+const requireCodexRuntimeId = (runtimeRoute: RuntimeRoute) =>
   Effect.gen(function* () {
     if (runtimeRoute.type === "stdio") {
       return runtimeRoute.identity;
@@ -217,7 +221,12 @@ export const createRuntimeRegistry = ({
         }
         return Effect.gen(function* () {
           const runtimeId = yield* requireCodexRuntimeId(input.runtimeRoute);
-          return yield* stopCodexSession({ ...input, codexAppServer, runtimeId });
+          return yield* stopCodexSession({
+            codexAppServer,
+            runtimeId,
+            externalSessionId: input.externalSessionId,
+            workingDirectory: input.workingDirectory,
+          });
         });
       }
       return Effect.fail(
@@ -244,7 +253,12 @@ export const createRuntimeRegistry = ({
         }
         return Effect.gen(function* () {
           const runtimeId = yield* requireCodexRuntimeId(input.runtimeRoute);
-          return yield* probeCodexSessionStatus({ ...input, codexAppServer, runtimeId });
+          return yield* probeCodexSessionStatus({
+            codexAppServer,
+            runtimeId,
+            externalSessionId: input.externalSessionId,
+            workingDirectory: input.workingDirectory,
+          });
         });
       }
       return Effect.succeed({ supported: false, hasLiveSession: false });

--- a/packages/host/src/application/runtimes/runtime-orchestrator-service.test.ts
+++ b/packages/host/src/application/runtimes/runtime-orchestrator-service.test.ts
@@ -47,24 +47,33 @@ const createRuntimeDefinitionsService = () => ({
     return Object.values(RUNTIME_DESCRIPTORS_BY_KIND);
   },
 });
-const createTaskStore = (): TaskStorePort =>
+const createTaskStore = (
+  sessionOverrides: Partial<{
+    externalSessionId: string;
+    role: "build";
+    startedAt: string;
+    runtimeKind: "opencode" | "codex";
+    workingDirectory: string;
+    selectedModel: null;
+  }> = {},
+): TaskStorePort =>
   ({
     getTaskMetadata() {
       return Effect.tryPromise({
         try: async () => {
+          const session = {
+            externalSessionId: "external-session-1",
+            role: "build" as const,
+            startedAt: "2026-05-10T10:00:00.000Z",
+            runtimeKind: "opencode" as const,
+            workingDirectory: "/canonical/repo/worktree",
+            selectedModel: null,
+            ...sessionOverrides,
+          };
           return {
             spec: { markdown: "" },
             plan: { markdown: "" },
-            agentSessions: [
-              {
-                externalSessionId: "external-session-1",
-                role: "build",
-                startedAt: "2026-05-10T10:00:00.000Z",
-                runtimeKind: "opencode",
-                workingDirectory: "/canonical/repo/worktree",
-                selectedModel: null,
-              },
-            ],
+            agentSessions: [session],
           };
         },
         catch: (cause) =>
@@ -667,6 +676,59 @@ describe("createRuntimeOrchestratorService", () => {
       {
         runtimeKind: "opencode",
         runtimeRoute: runtime.runtimeRoute,
+        externalSessionId: "external-session-1",
+        workingDirectory: "/canonical/repo/worktree",
+      },
+    ]);
+  });
+  test("stops persisted Codex sessions through the resolved stdio runtime route", async () => {
+    const calls: unknown[] = [];
+    const runtime = createRuntime({
+      kind: "codex",
+      runtimeId: "runtime-codex-1",
+      workingDirectory: "/canonical/repo/worktree",
+      runtimeRoute: { type: "stdio", identity: "runtime-codex-1" },
+      descriptor: RUNTIME_DESCRIPTORS_BY_KIND.codex,
+    });
+    const registry = createRegistry([], {
+      ensureWorkspaceRuntime() {
+        return Effect.fail(
+          new HostOperationError({
+            operation: "test.effect",
+            message: "unexpected runtime ensure",
+          }),
+        );
+      },
+      listRuntimes() {
+        return Effect.succeed([runtime]);
+      },
+      stopSession(input) {
+        return Effect.sync(() => {
+          calls.push(input);
+        });
+      },
+    });
+    const service = createRuntimeOrchestratorService({
+      gitPort: createGitPort(),
+      runtimeDefinitionsService: createRuntimeDefinitionsService(),
+      runtimeRegistry: registry,
+      taskReader: createTaskStore({ runtimeKind: "codex" }),
+    });
+    await expect(
+      Effect.runPromise(
+        service.agentSessionStop({
+          repoPath: "/repo",
+          taskId: "task-1",
+          externalSessionId: "external-session-1",
+          runtimeKind: "codex",
+          workingDirectory: "/canonical/repo/worktree",
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(calls).toEqual([
+      {
+        runtimeKind: "codex",
+        runtimeRoute: { type: "stdio", identity: "runtime-codex-1" },
         externalSessionId: "external-session-1",
         workingDirectory: "/canonical/repo/worktree",
       },

--- a/packages/host/src/interface/commands/codex-app-server-command-handlers.test.ts
+++ b/packages/host/src/interface/commands/codex-app-server-command-handlers.test.ts
@@ -53,6 +53,13 @@ describe("createCodexAppServerCommandHandlers", () => {
       }),
     ).resolves.toEqual({ data: [], nextCursor: null });
     await expect(
+      router.invoke("codex_app_server_request", {
+        runtimeId: "runtime-1",
+        method: "turn/interrupt",
+        params: { threadId: "thread-1", turnId: "turn-1" },
+      }),
+    ).resolves.toEqual({ data: [], nextCursor: null });
+    await expect(
       router.invoke("codex_app_server_notifications", { runtimeId: "runtime-1" }),
     ).resolves.toEqual([codexStatusNotification]);
     await expect(
@@ -69,6 +76,14 @@ describe("createCodexAppServerCommandHandlers", () => {
       {
         method: "request",
         input: { runtimeId: "runtime-1", method: "model/list", params: {} },
+      },
+      {
+        method: "request",
+        input: {
+          runtimeId: "runtime-1",
+          method: "turn/interrupt",
+          params: { threadId: "thread-1", turnId: "turn-1" },
+        },
       },
       {
         method: "notifications",

--- a/packages/host/src/ports/codex-app-server-port.ts
+++ b/packages/host/src/ports/codex-app-server-port.ts
@@ -27,6 +27,7 @@ export const CODEX_APP_SERVER_REQUEST_METHODS = [
   "thread/turns/list",
   "turn/start",
   "turn/steer",
+  "turn/interrupt",
   "gitDiffToRemote",
 ] as const;
 


### PR DESCRIPTION
Summary
Adds Codex session stop support in the TypeScript host by routing persisted Codex sessions through the host-managed Codex app-server runtime and interrupting the active turn for the target thread.

Goal
Stopping a Codex-backed build session currently fails with `Runtime kind codex does not support session stop in the TypeScript host`. Codex does support interruption through the app-server protocol, so this PR wires the missing host path instead of leaving Codex sessions as unsupported.

Technical approach
- Extends the Codex app-server protocol/client/adapter with the thread and turn methods needed to read a thread, list its turns, and send `turn/interrupt`.
- Adds focused Codex helpers in `packages/host/src/adapters/codex`: thread reading, active turn lookup, status probing, and session stop orchestration.
- Keeps runtime route handling at the runtime registry boundary: generic `RuntimeRoute` inputs are resolved to a Codex runtime id before entering Codex-specific helpers.
- Uses direct `thread/read` by known external session id rather than paginating thread lists or loaded-thread lists.
- Treats idle and not-loaded Codex threads as already stopped, fails clearly on system-error threads, and fails clearly if an active thread has no interruptible active turn.
- Updates runtime registry and runtime orchestrator tests to cover Codex stop/status wiring through the resolved stdio runtime route.

Verification
- `bun run lint`
- `bun run typecheck`
- `env -u ODT_ALLOWED_TOOLS -u ODT_FORBID_WORKSPACE_ID_INPUT -u ODT_HOST_TOKEN -u ODT_HOST_URL -u ODT_WORKSPACE_ID bun run test`
- `env -u ODT_ALLOWED_TOOLS -u ODT_FORBID_WORKSPACE_ID_INPUT -u ODT_HOST_TOKEN -u ODT_HOST_URL -u ODT_WORKSPACE_ID bun run build`
- `cd apps/desktop/src-tauri && cargo fmt --all --check`
- `cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test`
- `cd apps/desktop/src-tauri && cargo build`

Note: the first raw `bun run test` inherited live ODT workflow environment variables from this agent session, which made MCP tests run in workflow-scoped mode. Rerunning with those ODT variables removed produced the clean test result expected for the repo suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to interrupt and stop active Codex sessions (turn interrupt).
  * Streamlined session status probing by reading thread info directly.
  * Host can stop persisted Codex sessions via the runtime registry.

* **Bug Fixes**
  * Improved session cleanup to fully clear buffered state, pending requests/approvals, listeners, and tracking data.
  * App now appends a standardized "user stopped" session notice when sessions are stopped by the user.

* **Tests**
  * Added comprehensive tests for session stop, interrupt flows, parsing/validation, and related integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->