### PR TITLE
fix: show session compaction notices

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads/tests.rs
@@ -16,7 +16,7 @@ use anyhow::{anyhow, Context, Result};
 use host_test_support::{lock_env, EnvVarGuard};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
@@ -183,15 +183,11 @@ fn shared_dolt_windows_cleanup_uses_taskkill_tree_args() {
 
 #[test]
 fn shared_dolt_spawned_child_wait_reaps_exited_child() -> Result<()> {
-    #[cfg(windows)]
-    let mut child = Command::new("cmd")
-        .args(["/C", "exit", "/B", "0"])
-        .spawn()
-        .context("spawn exited child")?;
-
-    #[cfg(not(windows))]
-    let mut child = Command::new("sh")
-        .args(["-c", "exit 0"])
+    let mut child = Command::new(std::env::current_exe().context("resolve current test binary")?)
+        .arg("--list")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .context("spawn exited child")?;
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -82,6 +82,12 @@ describe("CodexAppServerAdapter streaming", () => {
           },
         },
         {
+          method: "thread/compacted",
+          params: {
+            threadId: "thread/start-runtime-ensure",
+          },
+        },
+        {
           method: "turn/plan/updated",
           params: {
             threadId: "thread/start-runtime-ensure",
@@ -176,6 +182,15 @@ describe("CodexAppServerAdapter streaming", () => {
         contextWindow: 200_000,
       }),
     );
+    expect(events).toContainEqual({
+      type: "session_compacted",
+      externalSessionId: "thread/start-runtime-ensure",
+      timestamp: expect.any(String),
+      message: "Codex compacted the conversation.",
+    });
+    expect(
+      events.filter((event) => (event as { type?: string }).type === "session_compacted"),
+    ).toHaveLength(1);
     expect(events).toContainEqual(
       expect.objectContaining({
         type: "assistant_part",
@@ -659,12 +674,10 @@ describe("CodexAppServerAdapter streaming", () => {
       runtimeId: "runtime-live",
       kind: "notification",
       message: {
-        method: "item/agentMessage/delta",
+        method: "thread/compacted",
         params: {
           threadId: "thread-saved",
           turnId: "turn-live",
-          itemId: "agent-live",
-          delta: "buffered text",
         },
       },
     });
@@ -673,13 +686,12 @@ describe("CodexAppServerAdapter streaming", () => {
     const events: unknown[] = [];
     const unsubscribe = adapter.subscribeEvents("thread-saved", (event) => events.push(event));
 
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: "assistant_delta",
-        messageId: "agent-live",
-        delta: "buffered text",
-      }),
-    );
+    expect(events).toContainEqual({
+      type: "session_compacted",
+      externalSessionId: "thread-saved",
+      timestamp: expect.any(String),
+      message: "Codex compacted the conversation.",
+    });
     unsubscribe();
   });
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -674,10 +674,22 @@ describe("CodexAppServerAdapter streaming", () => {
       runtimeId: "runtime-live",
       kind: "notification",
       message: {
-        method: "thread/compacted",
+        method: "item/agentMessage/delta",
         params: {
           threadId: "thread-saved",
           turnId: "turn-live",
+          itemId: "agent-live",
+          delta: "buffered text",
+        },
+      },
+    });
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
+        method: "thread/compacted",
+        params: {
+          threadId: "thread-saved",
         },
       },
     });
@@ -686,6 +698,13 @@ describe("CodexAppServerAdapter streaming", () => {
     const events: unknown[] = [];
     const unsubscribe = adapter.subscribeEvents("thread-saved", (event) => events.push(event));
 
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "assistant_delta",
+        messageId: "agent-live",
+        delta: "buffered text",
+      }),
+    );
     expect(events).toContainEqual({
       type: "session_compacted",
       externalSessionId: "thread-saved",

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -186,7 +186,7 @@ describe("CodexAppServerAdapter streaming", () => {
       type: "session_compacted",
       externalSessionId: "thread/start-runtime-ensure",
       timestamp: expect.any(String),
-      message: "Session compacted the conversation.",
+      message: "Session compacted.",
     });
     expect(
       events.filter((event) => (event as { type?: string }).type === "session_compacted"),
@@ -709,7 +709,7 @@ describe("CodexAppServerAdapter streaming", () => {
       type: "session_compacted",
       externalSessionId: "thread-saved",
       timestamp: expect.any(String),
-      message: "Session compacted the conversation.",
+      message: "Session compacted.",
     });
     unsubscribe();
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -82,9 +82,25 @@ describe("CodexAppServerAdapter streaming", () => {
           },
         },
         {
-          method: "thread/compacted",
+          method: "item/started",
           params: {
             threadId: "thread/start-runtime-ensure",
+            turnId: "turn-1",
+            item: {
+              type: "contextCompaction",
+              id: "compact-live",
+            },
+          },
+        },
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread/start-runtime-ensure",
+            turnId: "turn-1",
+            item: {
+              type: "contextCompaction",
+              id: "compact-live",
+            },
           },
         },
         {
@@ -183,9 +199,17 @@ describe("CodexAppServerAdapter streaming", () => {
       }),
     );
     expect(events).toContainEqual({
+      type: "session_compaction_started",
+      externalSessionId: "thread/start-runtime-ensure",
+      timestamp: expect.any(String),
+      messageId: "compact-live",
+      message: "Session compaction started.",
+    });
+    expect(events).toContainEqual({
       type: "session_compacted",
       externalSessionId: "thread/start-runtime-ensure",
       timestamp: expect.any(String),
+      messageId: "compact-live",
       message: "Session compacted.",
     });
     expect(
@@ -687,9 +711,29 @@ describe("CodexAppServerAdapter streaming", () => {
       runtimeId: "runtime-live",
       kind: "notification",
       message: {
-        method: "thread/compacted",
+        method: "item/started",
         params: {
           threadId: "thread-saved",
+          turnId: "turn-live",
+          item: {
+            type: "contextCompaction",
+            id: "compact-live",
+          },
+        },
+      },
+    });
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-saved",
+          turnId: "turn-live",
+          item: {
+            type: "contextCompaction",
+            id: "compact-live",
+          },
         },
       },
     });
@@ -706,15 +750,23 @@ describe("CodexAppServerAdapter streaming", () => {
       }),
     );
     expect(events).toContainEqual({
+      type: "session_compaction_started",
+      externalSessionId: "thread-saved",
+      timestamp: expect.any(String),
+      messageId: "compact-live",
+      message: "Session compaction started.",
+    });
+    expect(events).toContainEqual({
       type: "session_compacted",
       externalSessionId: "thread-saved",
       timestamp: expect.any(String),
+      messageId: "compact-live",
       message: "Session compacted.",
     });
     unsubscribe();
   });
 
-  test("routes live context compaction items", async () => {
+  test("routes live context compaction lifecycle items", async () => {
     const streamListeners: Array<
       (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
     > = [];
@@ -741,6 +793,21 @@ describe("CodexAppServerAdapter streaming", () => {
       runtimeId: "runtime-live",
       kind: "notification",
       message: {
+        method: "item/started",
+        params: {
+          threadId: "thread-saved",
+          turnId: "turn-live",
+          item: {
+            type: "contextCompaction",
+            id: "compact-live",
+          },
+        },
+      },
+    });
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
         method: "item/completed",
         params: {
           threadId: "thread-saved",
@@ -755,9 +822,17 @@ describe("CodexAppServerAdapter streaming", () => {
     await Promise.resolve();
 
     expect(events).toContainEqual({
+      type: "session_compaction_started",
+      externalSessionId: "thread-saved",
+      timestamp: expect.any(String),
+      messageId: "compact-live",
+      message: "Session compaction started.",
+    });
+    expect(events).toContainEqual({
       type: "session_compacted",
       externalSessionId: "thread-saved",
       timestamp: expect.any(String),
+      messageId: "compact-live",
       message: "Session compacted.",
     });
     unsubscribe();

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -186,7 +186,7 @@ describe("CodexAppServerAdapter streaming", () => {
       type: "session_compacted",
       externalSessionId: "thread/start-runtime-ensure",
       timestamp: expect.any(String),
-      message: "Codex compacted the conversation.",
+      message: "Session compacted the conversation.",
     });
     expect(
       events.filter((event) => (event as { type?: string }).type === "session_compacted"),
@@ -709,7 +709,7 @@ describe("CodexAppServerAdapter streaming", () => {
       type: "session_compacted",
       externalSessionId: "thread-saved",
       timestamp: expect.any(String),
-      message: "Codex compacted the conversation.",
+      message: "Session compacted the conversation.",
     });
     unsubscribe();
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -714,6 +714,55 @@ describe("CodexAppServerAdapter streaming", () => {
     unsubscribe();
   });
 
+  test("routes live context compaction items", async () => {
+    const streamListeners: Array<
+      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
+    > = [];
+    const subscribeEvents = mock((_runtimeId: string, listener) => {
+      streamListeners.push(listener);
+      return () => {};
+    });
+    const { adapter } = createHarness({ subscribeEvents });
+    const events: unknown[] = [];
+
+    await adapter.attachSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      externalSessionId: "thread-saved",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+    const unsubscribe = adapter.subscribeEvents("thread-saved", (event) => events.push(event));
+
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-saved",
+          turnId: "turn-live",
+          item: {
+            type: "contextCompaction",
+            id: "compact-live",
+          },
+        },
+      },
+    });
+    await Promise.resolve();
+
+    expect(events).toContainEqual({
+      type: "session_compacted",
+      externalSessionId: "thread-saved",
+      timestamp: expect.any(String),
+      message: "Session compacted.",
+    });
+    unsubscribe();
+  });
+
   test("maps completed update_plan dynamic tool calls into live session todos", async () => {
     const drainNotifications = mock(async (_runtimeId: string) => [] as unknown[]);
     const { adapter, transports } = createHarness({ drainNotifications }, { deferTurnStart: true });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -1420,7 +1420,11 @@ export class CodexAppServerAdapter
       { source: "live", threadId: session.threadId, timestamp },
     );
     for (const event of projectCodexCanonicalEvents(canonicalEvents)) {
-      if (event.type !== "assistant_part" || event.part.kind !== "tool") {
+      if (event.type !== "assistant_part") {
+        this.emitSessionEvent(session.threadId, event);
+        continue;
+      }
+      if (event.part.kind !== "tool") {
         continue;
       }
       this.emitSessionEvent(session.threadId, {

--- a/packages/adapters-codex-app-server/src/codex-canonical-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-canonical-events.ts
@@ -61,6 +61,12 @@ export type CodexCanonicalSessionIdleEvent = CodexCanonicalEventBase & {
   kind: "session_idle";
 };
 
+export type CodexCanonicalSessionCompactionStartedEvent = CodexCanonicalEventBase & {
+  kind: "session_compaction_started";
+  messageId?: string;
+  message: string;
+};
+
 export type CodexCanonicalSessionCompactedEvent = CodexCanonicalEventBase & {
   kind: "session_compacted";
   messageId?: string;
@@ -80,6 +86,7 @@ export type CodexCanonicalEvent =
   | CodexCanonicalAssistantDeltaEvent
   | CodexCanonicalSessionErrorEvent
   | CodexCanonicalSessionIdleEvent
+  | CodexCanonicalSessionCompactionStartedEvent
   | CodexCanonicalSessionCompactedEvent
   | CodexCanonicalTodoUpdateEvent;
 

--- a/packages/adapters-codex-app-server/src/codex-canonical-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-canonical-events.ts
@@ -63,6 +63,7 @@ export type CodexCanonicalSessionIdleEvent = CodexCanonicalEventBase & {
 
 export type CodexCanonicalSessionCompactedEvent = CodexCanonicalEventBase & {
   kind: "session_compacted";
+  messageId?: string;
   message: string;
 };
 

--- a/packages/adapters-codex-app-server/src/codex-canonical-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-canonical-events.ts
@@ -61,6 +61,11 @@ export type CodexCanonicalSessionIdleEvent = CodexCanonicalEventBase & {
   kind: "session_idle";
 };
 
+export type CodexCanonicalSessionCompactedEvent = CodexCanonicalEventBase & {
+  kind: "session_compacted";
+  message: string;
+};
+
 export type CodexCanonicalTodoUpdateEvent = CodexCanonicalEventBase & {
   kind: "todo_update";
   todos: AgentSessionTodoItem[];
@@ -74,6 +79,7 @@ export type CodexCanonicalEvent =
   | CodexCanonicalAssistantDeltaEvent
   | CodexCanonicalSessionErrorEvent
   | CodexCanonicalSessionIdleEvent
+  | CodexCanonicalSessionCompactedEvent
   | CodexCanonicalTodoUpdateEvent;
 
 export type CodexMappingContext = {

--- a/packages/adapters-codex-app-server/src/codex-canonical-projector.ts
+++ b/packages/adapters-codex-app-server/src/codex-canonical-projector.ts
@@ -76,11 +76,22 @@ export const projectCodexCanonicalEvent = (event: CodexCanonicalEvent): AgentEve
     };
   }
 
+  if (event.kind === "session_compaction_started") {
+    return {
+      type: "session_compaction_started",
+      externalSessionId: event.threadId,
+      timestamp,
+      ...(event.messageId ? { messageId: event.messageId } : {}),
+      message: event.message,
+    };
+  }
+
   if (event.kind === "session_compacted") {
     return {
       type: "session_compacted",
       externalSessionId: event.threadId,
       timestamp,
+      ...(event.messageId ? { messageId: event.messageId } : {}),
       message: event.message,
     };
   }

--- a/packages/adapters-codex-app-server/src/codex-canonical-projector.ts
+++ b/packages/adapters-codex-app-server/src/codex-canonical-projector.ts
@@ -76,6 +76,15 @@ export const projectCodexCanonicalEvent = (event: CodexCanonicalEvent): AgentEve
     };
   }
 
+  if (event.kind === "session_compacted") {
+    return {
+      type: "session_compacted",
+      externalSessionId: event.threadId,
+      timestamp,
+      message: event.message,
+    };
+  }
+
   return {
     type: "session_todos_updated",
     externalSessionId: event.threadId,

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -100,7 +100,7 @@ describe("Codex compaction event mapper", () => {
         type: "session_compacted",
         externalSessionId: "thread-1",
         timestamp: "2026-05-18T21:00:00.000Z",
-        message: "Session compacted the conversation.",
+        message: "Session compacted.",
       },
     ]);
   });

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -106,6 +106,36 @@ describe("Codex compaction event mapper", () => {
     ]);
   });
 
+  test("projects live context compaction items to session events", () => {
+    const events = projectCodexCanonicalEvents(
+      compactionMapper.fromLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "contextCompaction",
+            id: "compact-live",
+          },
+        },
+        {
+          source: "live",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          timestamp: "2026-05-18T21:00:00.000Z",
+        },
+        undefined,
+      ).events,
+    );
+
+    expect(events).toEqual([
+      {
+        type: "session_compacted",
+        externalSessionId: "thread-1",
+        timestamp: "2026-05-18T21:00:00.000Z",
+        message: "Session compacted.",
+      },
+    ]);
+  });
+
   test("projects thread-read context compaction items to session notice history", () => {
     const result = compactionMapper.fromThreadItem(
       {

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -78,14 +78,14 @@ describe("Codex todo event mapper", () => {
 });
 
 describe("Codex compaction event mapper", () => {
-  test("projects live thread compaction notifications to session events", () => {
+  test("projects live context compaction starts to session events", () => {
     const events = projectCodexCanonicalEvents(
       compactionMapper.fromLive(
         {
-          kind: "notification",
-          notification: {
-            method: "thread/compacted",
-            params: {},
+          kind: "item_started",
+          item: {
+            type: "contextCompaction",
+            id: "compact-live",
           },
         },
         {
@@ -98,10 +98,11 @@ describe("Codex compaction event mapper", () => {
 
     expect(events).toEqual([
       {
-        type: "session_compacted",
+        type: "session_compaction_started",
         externalSessionId: "thread-1",
         timestamp: "2026-05-18T21:00:00.000Z",
-        message: "Session compacted.",
+        messageId: "compact-live",
+        message: "Session compaction started.",
       },
     ]);
   });
@@ -131,6 +132,7 @@ describe("Codex compaction event mapper", () => {
         type: "session_compacted",
         externalSessionId: "thread-1",
         timestamp: "2026-05-18T21:00:00.000Z",
+        messageId: "compact-live",
         message: "Session compacted.",
       },
     ]);

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
-import { todoMapper } from "./event-mappers";
+import { compactionMapper, todoMapper } from "./event-mappers";
 
 const TODO_PAYLOAD = {
   explanation: "Tracking work",
@@ -73,5 +73,53 @@ describe("Codex todo event mapper", () => {
         }),
       );
     }
+  });
+});
+
+describe("Codex compaction event mapper", () => {
+  test("projects live thread compaction notifications to session events", () => {
+    const events = projectCodexCanonicalEvents(
+      compactionMapper.fromLive(
+        {
+          kind: "notification",
+          notification: {
+            method: "thread/compacted",
+            params: {},
+          },
+        },
+        {
+          source: "live",
+          threadId: "thread-1",
+          timestamp: "2026-05-18T21:00:00.000Z",
+        },
+      ).events,
+    );
+
+    expect(events).toEqual([
+      {
+        type: "session_compacted",
+        externalSessionId: "thread-1",
+        timestamp: "2026-05-18T21:00:00.000Z",
+        message: "Codex compacted the conversation.",
+      },
+    ]);
+  });
+
+  test("does not map unknown notifications as compaction", () => {
+    const result = compactionMapper.fromLive(
+      {
+        kind: "notification",
+        notification: {
+          method: "thread/status/changed",
+          params: { status: "thinking" },
+        },
+      },
+      {
+        source: "live",
+        threadId: "thread-1",
+      },
+    );
+
+    expect(result).toEqual({ events: [], handled: false });
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -100,7 +100,7 @@ describe("Codex compaction event mapper", () => {
         type: "session_compacted",
         externalSessionId: "thread-1",
         timestamp: "2026-05-18T21:00:00.000Z",
-        message: "Codex compacted the conversation.",
+        message: "Session compacted the conversation.",
       },
     ]);
   });

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
+import { projectCodexCanonicalEventsToHistory } from "./codex-history-projector";
 import { compactionMapper, todoMapper } from "./event-mappers";
 
 const TODO_PAYLOAD = {
@@ -101,6 +102,40 @@ describe("Codex compaction event mapper", () => {
         externalSessionId: "thread-1",
         timestamp: "2026-05-18T21:00:00.000Z",
         message: "Session compacted.",
+      },
+    ]);
+  });
+
+  test("projects thread-read context compaction items to session notice history", () => {
+    const result = compactionMapper.fromThreadItem(
+      {
+        index: 3,
+        timestamp: "2026-05-18T21:00:00.000Z",
+        item: {
+          type: "context_compaction",
+          id: "compact-1",
+        },
+      },
+      {
+        source: "thread_read",
+        threadId: "thread-1",
+        timestamp: "2026-05-18T21:00:00.000Z",
+      },
+      undefined,
+    );
+
+    expect(projectCodexCanonicalEventsToHistory(result.events)).toEqual([
+      {
+        messageId: "compact-1",
+        role: "system",
+        timestamp: "2026-05-18T21:00:00.000Z",
+        text: "Session compacted.",
+        notice: {
+          tone: "info",
+          reason: "session_compacted",
+          title: "Compacted",
+        },
+        parts: [],
       },
     ]);
   });

--- a/packages/adapters-codex-app-server/src/codex-history-projector.ts
+++ b/packages/adapters-codex-app-server/src/codex-history-projector.ts
@@ -63,6 +63,21 @@ export const projectCodexCanonicalEventsToHistory = (
         parts: [part],
         ...(model ? { model } : {}),
       });
+      continue;
+    }
+    if (event.kind === "session_compacted") {
+      messages.push({
+        messageId: event.messageId ?? `session-compacted:${timestamp}`,
+        role: "system",
+        timestamp,
+        text: event.message,
+        notice: {
+          tone: "info",
+          reason: "session_compacted",
+          title: "Compacted",
+        },
+        parts: [],
+      });
     }
   }
   return messages;

--- a/packages/adapters-codex-app-server/src/event-mappers/index.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/index.ts
@@ -1,6 +1,6 @@
 import type { RegisteredCodexEventMapper } from "../codex-event-mapper";
 import { emptyMapper } from "./empty";
-import { deltaMapper, lifecycleMapper, tokenUsageMapper } from "./lifecycle";
+import { compactionMapper, deltaMapper, lifecycleMapper, tokenUsageMapper } from "./lifecycle";
 import { assistantMessageMapper, userMessageMapper } from "./messages";
 import {
   collabToolMapper,
@@ -16,7 +16,7 @@ import {
 import { todoMapper } from "./todo";
 
 export { emptyMapper } from "./empty";
-export { deltaMapper, lifecycleMapper, tokenUsageMapper } from "./lifecycle";
+export { compactionMapper, deltaMapper, lifecycleMapper, tokenUsageMapper } from "./lifecycle";
 export { assistantMessageMapper, userMessageMapper } from "./messages";
 export {
   collabToolMapper,
@@ -40,6 +40,7 @@ export {
 } from "./todo";
 
 export const CODEX_EVENT_MAPPERS = [
+  compactionMapper,
   lifecycleMapper,
   tokenUsageMapper,
   deltaMapper,

--- a/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
@@ -68,7 +68,7 @@ export const compactionMapper: CodexEventMapper = {
           ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
           ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
           raw: input.notification.params,
-          message: "Session compacted the conversation.",
+          message: "Session compacted.",
         },
       ],
     };

--- a/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
@@ -84,13 +84,7 @@ export const compactionMapper: CodexEventMapper = {
     ) {
       return {
         handled: true,
-        events: [
-          toSessionCompactedEvent(
-            ctx,
-            input.item,
-            codexItemId(input.item, `session-compacted:${ctx.timestamp ?? "live"}`),
-          ),
-        ],
+        events: [toSessionCompactedEvent(ctx, input.item)],
       };
     }
 

--- a/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
@@ -6,6 +6,7 @@ import {
 } from "../codex-app-server-transcript";
 import type {
   CodexCanonicalSessionCompactedEvent,
+  CodexCanonicalSessionCompactionStartedEvent,
   CodexMappingContext,
   CodexMappingResult,
 } from "../codex-canonical-events";
@@ -27,6 +28,22 @@ const toSessionCompactedEvent = (
   raw,
   ...(messageId ? { messageId } : {}),
   message: "Session compacted.",
+});
+
+const toSessionCompactionStartedEvent = (
+  ctx: CodexMappingContext,
+  raw: unknown,
+  messageId?: string,
+): CodexCanonicalSessionCompactionStartedEvent => ({
+  kind: "session_compaction_started",
+  source: ctx.source,
+  mapper: "compaction",
+  threadId: ctx.threadId,
+  ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+  ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
+  raw,
+  ...(messageId ? { messageId } : {}),
+  message: "Session compaction started.",
 });
 
 export const lifecycleMapper: CodexEventMapper = {
@@ -77,31 +94,36 @@ export const compactionMapper: CodexEventMapper = {
   name: "compaction",
   createState: noCodexMapperState,
   fromLive(input, ctx): CodexMappingResult {
-    if (
-      input.kind === "item_completed" &&
-      (codexItemTypeMatches(input.item, "contextCompaction") ||
-        codexItemTypeMatches(input.item, "compaction"))
-    ) {
+    if (input.kind === "item_started" && codexItemTypeMatches(input.item, "contextCompaction")) {
       return {
         handled: true,
-        events: [toSessionCompactedEvent(ctx, input.item)],
+        events: [
+          toSessionCompactionStartedEvent(
+            ctx,
+            input.item,
+            codexItemId(input.item, `${ctx.threadId}-session-compaction`),
+          ),
+        ],
       };
     }
 
-    if (input.kind !== "notification" || input.notification.method !== "thread/compacted") {
-      return emptyCodexMappingResult();
+    if (input.kind === "item_completed" && codexItemTypeMatches(input.item, "contextCompaction")) {
+      return {
+        handled: true,
+        events: [
+          toSessionCompactedEvent(
+            ctx,
+            input.item,
+            codexItemId(input.item, `${ctx.threadId}-session-compaction`),
+          ),
+        ],
+      };
     }
 
-    return {
-      handled: true,
-      events: [toSessionCompactedEvent(ctx, input.notification.params)],
-    };
+    return emptyCodexMappingResult();
   },
   fromThreadItem(input, ctx): CodexMappingResult {
-    if (
-      !codexItemTypeMatches(input.item, "contextCompaction") &&
-      !codexItemTypeMatches(input.item, "compaction")
-    ) {
+    if (!codexItemTypeMatches(input.item, "contextCompaction")) {
       return emptyCodexMappingResult();
     }
 

--- a/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
@@ -1,5 +1,9 @@
 import { extractStringField, extractText, isPlainObject } from "../codex-app-server-shared";
-import { extractCodexTokenUsageTotals } from "../codex-app-server-transcript";
+import {
+  codexItemId,
+  codexItemTypeMatches,
+  extractCodexTokenUsageTotals,
+} from "../codex-app-server-transcript";
 import type { CodexMappingResult } from "../codex-canonical-events";
 import { emptyCodexMappingResult } from "../codex-canonical-events";
 import type { CodexEventMapper } from "../codex-event-mapper";
@@ -73,7 +77,30 @@ export const compactionMapper: CodexEventMapper = {
       ],
     };
   },
-  fromThreadItem: emptyCodexMappingResult,
+  fromThreadItem(input, ctx): CodexMappingResult {
+    if (
+      !codexItemTypeMatches(input.item, "contextCompaction") &&
+      !codexItemTypeMatches(input.item, "compaction")
+    ) {
+      return emptyCodexMappingResult();
+    }
+
+    return {
+      handled: true,
+      events: [
+        {
+          kind: "session_compacted",
+          source: ctx.source,
+          mapper: "compaction",
+          threadId: ctx.threadId,
+          ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
+          raw: input.item,
+          messageId: codexItemId(input.item, `codex-history-${input.index}-session-compacted`),
+          message: "Session compacted.",
+        },
+      ],
+    };
+  },
 };
 
 export const tokenUsageMapper: CodexEventMapper = {

--- a/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
@@ -49,6 +49,33 @@ export const lifecycleMapper: CodexEventMapper = {
   fromThreadItem: emptyCodexMappingResult,
 };
 
+export const compactionMapper: CodexEventMapper = {
+  name: "compaction",
+  createState: noCodexMapperState,
+  fromLive(input, ctx): CodexMappingResult {
+    if (input.kind !== "notification" || input.notification.method !== "thread/compacted") {
+      return emptyCodexMappingResult();
+    }
+
+    return {
+      handled: true,
+      events: [
+        {
+          kind: "session_compacted",
+          source: ctx.source,
+          mapper: "compaction",
+          threadId: ctx.threadId,
+          ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+          ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
+          raw: input.notification.params,
+          message: "Codex compacted the conversation.",
+        },
+      ],
+    };
+  },
+  fromThreadItem: emptyCodexMappingResult,
+};
+
 export const tokenUsageMapper: CodexEventMapper = {
   name: "token_usage",
   createState: noCodexMapperState,

--- a/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
@@ -4,10 +4,30 @@ import {
   codexItemTypeMatches,
   extractCodexTokenUsageTotals,
 } from "../codex-app-server-transcript";
-import type { CodexMappingResult } from "../codex-canonical-events";
+import type {
+  CodexCanonicalSessionCompactedEvent,
+  CodexMappingContext,
+  CodexMappingResult,
+} from "../codex-canonical-events";
 import { emptyCodexMappingResult } from "../codex-canonical-events";
 import type { CodexEventMapper } from "../codex-event-mapper";
 import { noCodexMapperState } from "../codex-event-mapper";
+
+const toSessionCompactedEvent = (
+  ctx: CodexMappingContext,
+  raw: unknown,
+  messageId?: string,
+): CodexCanonicalSessionCompactedEvent => ({
+  kind: "session_compacted",
+  source: ctx.source,
+  mapper: "compaction",
+  threadId: ctx.threadId,
+  ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+  ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
+  raw,
+  ...(messageId ? { messageId } : {}),
+  message: "Session compacted.",
+});
 
 export const lifecycleMapper: CodexEventMapper = {
   name: "lifecycle",
@@ -57,24 +77,30 @@ export const compactionMapper: CodexEventMapper = {
   name: "compaction",
   createState: noCodexMapperState,
   fromLive(input, ctx): CodexMappingResult {
+    if (
+      input.kind === "item_completed" &&
+      (codexItemTypeMatches(input.item, "contextCompaction") ||
+        codexItemTypeMatches(input.item, "compaction"))
+    ) {
+      return {
+        handled: true,
+        events: [
+          toSessionCompactedEvent(
+            ctx,
+            input.item,
+            codexItemId(input.item, `session-compacted:${ctx.timestamp ?? "live"}`),
+          ),
+        ],
+      };
+    }
+
     if (input.kind !== "notification" || input.notification.method !== "thread/compacted") {
       return emptyCodexMappingResult();
     }
 
     return {
       handled: true,
-      events: [
-        {
-          kind: "session_compacted",
-          source: ctx.source,
-          mapper: "compaction",
-          threadId: ctx.threadId,
-          ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
-          ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
-          raw: input.notification.params,
-          message: "Session compacted.",
-        },
-      ],
+      events: [toSessionCompactedEvent(ctx, input.notification.params)],
     };
   },
   fromThreadItem(input, ctx): CodexMappingResult {
@@ -88,16 +114,11 @@ export const compactionMapper: CodexEventMapper = {
     return {
       handled: true,
       events: [
-        {
-          kind: "session_compacted",
-          source: ctx.source,
-          mapper: "compaction",
-          threadId: ctx.threadId,
-          ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
-          raw: input.item,
-          messageId: codexItemId(input.item, `codex-history-${input.index}-session-compacted`),
-          message: "Session compacted.",
-        },
+        toSessionCompactedEvent(
+          ctx,
+          input.item,
+          codexItemId(input.item, `codex-history-${input.index}-session-compacted`),
+        ),
       ],
     };
   },

--- a/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/lifecycle.ts
@@ -68,7 +68,7 @@ export const compactionMapper: CodexEventMapper = {
           ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
           ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
           raw: input.notification.params,
-          message: "Codex compacted the conversation.",
+          message: "Session compacted the conversation.",
         },
       ],
     };

--- a/packages/core/src/ports/agent-engine.ts
+++ b/packages/core/src/ports/agent-engine.ts
@@ -128,6 +128,18 @@ export type AgentSessionHistoryMessage =
       contextWindow?: number;
       model?: AgentModelSelection;
       parts: AgentStreamPart[];
+    }
+  | {
+      messageId: RuntimeHistoryAnchor;
+      role: "system";
+      timestamp: string;
+      text: string;
+      notice?: {
+        tone: "info";
+        reason: "session_compacted";
+        title: string;
+      };
+      parts: [];
     };
 
 export type LiveAgentSessionStatus =

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -419,9 +419,17 @@ export type AgentEvent =
       todos: AgentSessionTodoItem[];
     }
   | {
+      type: "session_compaction_started";
+      externalSessionId: ExternalSessionId;
+      timestamp: string;
+      messageId?: RuntimeHistoryAnchor;
+      message: string;
+    }
+  | {
       type: "session_compacted";
       externalSessionId: ExternalSessionId;
       timestamp: string;
+      messageId?: RuntimeHistoryAnchor;
       message: string;
     }
   | {

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -419,6 +419,12 @@ export type AgentEvent =
       todos: AgentSessionTodoItem[];
     }
   | {
+      type: "session_compacted";
+      externalSessionId: ExternalSessionId;
+      timestamp: string;
+      message: string;
+    }
+  | {
       type: "tool_call";
       externalSessionId: ExternalSessionId;
       timestamp: string;

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -534,10 +534,15 @@ const SubagentMessage = ({
 
 const SessionNoticeMessage = ({ message, timeLabel }: SessionNoticeMessageProps): ReactElement => {
   const meta = message.meta?.kind === "session_notice" ? message.meta : null;
+  const isRunningCompaction =
+    meta?.reason === "session_compacted" && meta.compactionStatus === "running";
   return (
     <div className="flex items-start justify-between gap-3">
       <div className="min-w-0 space-y-1">
-        <p className="text-[11px] font-semibold uppercase tracking-wide opacity-80">
+        <p className="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide opacity-80">
+          {isRunningCompaction ? (
+            <LoaderCircle aria-hidden="true" className="size-3 animate-spin" />
+          ) : null}
           {meta?.title ?? "Notice"}
         </p>
         <p className="whitespace-pre-wrap leading-6 text-inherit">{message.content}</p>

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -20,6 +20,7 @@ const SESSION_NOTICE_TONE_CLASS_NAMES = {
     "text-sm my-2 rounded-md border border-cancelled-border bg-cancelled-surface px-3 py-2 text-cancelled-surface-foreground",
   error:
     "text-sm my-2 rounded-md border border-destructive-border bg-destructive-surface px-3 py-2 text-destructive-surface-foreground",
+  info: "text-sm my-2 rounded-md border border-info-border bg-info-surface px-3 py-2 text-info-surface-foreground",
 } as const;
 
 type AgentChatMessageCardViewModelInput = {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -567,12 +567,12 @@ describe("AgentChatMessageCard tool duration", () => {
         message: {
           id: "session-notice-compacted",
           role: "system",
-          content: "Codex compacted the conversation.",
+          content: "Session compacted the conversation.",
           timestamp: "2026-05-18T21:01:00.000Z",
           meta: {
             kind: "session_notice",
             tone: "info",
-            reason: "codex_compacted",
+            reason: "session_compacted",
             title: "Compacted",
           },
         },
@@ -584,7 +584,7 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).toContain("border-info-border");
     expect(html).toContain("bg-info-surface");
     expect(html).toContain("text-info-surface-foreground");
-    expect(html).toContain("Codex compacted the conversation.");
+    expect(html).toContain("Session compacted the conversation.");
     expect(html).toContain("Compacted");
     expect(html).not.toContain("border-destructive-border");
     expect(html).not.toContain("border-cancelled-border");

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -561,7 +561,7 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain(">System<");
   });
 
-  test("renders Codex compaction notices as informational cards", () => {
+  test("renders session compaction notices as informational cards", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {
         message: {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -586,9 +586,37 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).toContain("text-info-surface-foreground");
     expect(html).toContain("Session compacted.");
     expect(html).toContain("Compacted");
+    expect(html).not.toContain("animate-spin");
     expect(html).not.toContain("border-destructive-border");
     expect(html).not.toContain("border-cancelled-border");
     expect(html).not.toContain(">System<");
+  });
+
+  test("renders running session compaction notices with a loader", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "session-notice-compacting",
+          role: "system",
+          content: "Session compaction started.",
+          timestamp: "2026-05-18T21:00:30.000Z",
+          meta: {
+            kind: "session_notice",
+            tone: "info",
+            reason: "session_compacted",
+            title: "Compacting",
+            compactionStatus: "running",
+          },
+        },
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("border-info-border");
+    expect(html).toContain("Session compaction started.");
+    expect(html).toContain("Compacting");
+    expect(html).toContain("animate-spin");
   });
 
   test("renders system prompt as expandable card", () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -567,7 +567,7 @@ describe("AgentChatMessageCard tool duration", () => {
         message: {
           id: "session-notice-compacted",
           role: "system",
-          content: "Session compacted the conversation.",
+          content: "Session compacted.",
           timestamp: "2026-05-18T21:01:00.000Z",
           meta: {
             kind: "session_notice",
@@ -584,7 +584,7 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).toContain("border-info-border");
     expect(html).toContain("bg-info-surface");
     expect(html).toContain("text-info-surface-foreground");
-    expect(html).toContain("Session compacted the conversation.");
+    expect(html).toContain("Session compacted.");
     expect(html).toContain("Compacted");
     expect(html).not.toContain("border-destructive-border");
     expect(html).not.toContain("border-cancelled-border");

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -561,6 +561,36 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain(">System<");
   });
 
+  test("renders Codex compaction notices as informational cards", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "session-notice-compacted",
+          role: "system",
+          content: "Codex compacted the conversation.",
+          timestamp: "2026-05-18T21:01:00.000Z",
+          meta: {
+            kind: "session_notice",
+            tone: "info",
+            reason: "codex_compacted",
+            title: "Compacted",
+          },
+        },
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("border-info-border");
+    expect(html).toContain("bg-info-surface");
+    expect(html).toContain("text-info-surface-foreground");
+    expect(html).toContain("Codex compacted the conversation.");
+    expect(html).toContain("Compacted");
+    expect(html).not.toContain("border-destructive-border");
+    expect(html).not.toContain("border-cancelled-border");
+    expect(html).not.toContain(">System<");
+  });
+
   test("renders system prompt as expandable card", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-event-batching.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-event-batching.ts
@@ -99,6 +99,9 @@ const SESSION_EVENT_BATCH_RULES: SessionEventBatchRules = {
     immediate: false,
     dedupeKey: () => "session_todos_updated",
   },
+  session_compaction_started: {
+    immediate: true,
+  },
   session_compacted: {
     immediate: true,
   },
@@ -156,6 +159,8 @@ const withTypedSessionEvent = <T>(
       return callback(event, SESSION_EVENT_BATCH_RULES.question_required);
     case "session_todos_updated":
       return callback(event, SESSION_EVENT_BATCH_RULES.session_todos_updated);
+    case "session_compaction_started":
+      return callback(event, SESSION_EVENT_BATCH_RULES.session_compaction_started);
     case "session_compacted":
       return callback(event, SESSION_EVENT_BATCH_RULES.session_compacted);
     case "session_error":

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-event-batching.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-event-batching.ts
@@ -99,6 +99,9 @@ const SESSION_EVENT_BATCH_RULES: SessionEventBatchRules = {
     immediate: false,
     dedupeKey: () => "session_todos_updated",
   },
+  session_compacted: {
+    immediate: true,
+  },
   session_error: {
     immediate: true,
   },
@@ -153,6 +156,8 @@ const withTypedSessionEvent = <T>(
       return callback(event, SESSION_EVENT_BATCH_RULES.question_required);
     case "session_todos_updated":
       return callback(event, SESSION_EVENT_BATCH_RULES.session_todos_updated);
+    case "session_compacted":
+      return callback(event, SESSION_EVENT_BATCH_RULES.session_compacted);
     case "session_error":
       return callback(event, SESSION_EVENT_BATCH_RULES.session_error);
     case "session_idle":

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -10,6 +10,7 @@ import {
   handleAssistantMessage,
   handlePermissionRequired,
   handleQuestionRequired,
+  handleSessionCompacted,
   handleSessionError,
   handleSessionFinished,
   handleSessionIdle,
@@ -72,6 +73,9 @@ const handleSessionEvent = (context: SessionEventHandlerContext, event: SessionE
       return;
     case "session_todos_updated":
       handleSessionTodosUpdated(context.lifecycle, event);
+      return;
+    case "session_compacted":
+      handleSessionCompacted(context.lifecycle, event);
       return;
     case "session_error":
       handleSessionError(context.lifecycle, event);

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -11,6 +11,7 @@ import {
   handlePermissionRequired,
   handleQuestionRequired,
   handleSessionCompacted,
+  handleSessionCompactionStarted,
   handleSessionError,
   handleSessionFinished,
   handleSessionIdle,
@@ -73,6 +74,9 @@ const handleSessionEvent = (context: SessionEventHandlerContext, event: SessionE
       return;
     case "session_todos_updated":
       handleSessionTodosUpdated(context.lifecycle, event);
+      return;
+    case "session_compaction_started":
+      handleSessionCompactionStarted(context.lifecycle, event);
       return;
     case "session_compacted":
       handleSessionCompacted(context.lifecycle, event);

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -15,6 +15,7 @@ import {
 } from "../support/messages";
 import {
   buildSessionCompactedNoticeMessage,
+  buildSessionCompactionStartedNoticeMessage,
   buildSessionErrorNoticeMessage,
   buildUserStoppedNoticeMessage,
   USER_STOPPED_NOTICE,
@@ -665,13 +666,32 @@ export const handleSessionCompacted = (
   context: Pick<SessionLifecycleEventContext, "store">,
   event: Extract<SessionEvent, { type: "session_compacted" }>,
 ): void => {
+  const messageId = event.messageId ?? `session-compaction:${event.externalSessionId}`;
   context.store.updateSession(
     context.store.externalSessionId,
     (current) => ({
       ...current,
-      messages: appendSessionMessage(
+      messages: upsertSessionMessage(
         current,
-        buildSessionCompactedNoticeMessage(event.timestamp, event.message),
+        buildSessionCompactedNoticeMessage(event.timestamp, event.message, messageId),
+      ),
+    }),
+    { persist: true },
+  );
+};
+
+export const handleSessionCompactionStarted = (
+  context: Pick<SessionLifecycleEventContext, "store">,
+  event: Extract<SessionEvent, { type: "session_compaction_started" }>,
+): void => {
+  const messageId = event.messageId ?? `session-compaction:${event.externalSessionId}`;
+  context.store.updateSession(
+    context.store.externalSessionId,
+    (current) => ({
+      ...current,
+      messages: upsertSessionMessage(
+        current,
+        buildSessionCompactionStartedNoticeMessage(event.timestamp, event.message, messageId),
       ),
     }),
     { persist: true },

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -14,6 +14,7 @@ import {
   upsertSessionMessage,
 } from "../support/messages";
 import {
+  buildSessionCompactedNoticeMessage,
   buildSessionErrorNoticeMessage,
   buildUserStoppedNoticeMessage,
   USER_STOPPED_NOTICE,
@@ -660,6 +661,22 @@ export const handleSessionTodosUpdated = (
   );
 };
 
+export const handleSessionCompacted = (
+  context: Pick<SessionLifecycleEventContext, "store">,
+  event: Extract<SessionEvent, { type: "session_compacted" }>,
+): void => {
+  context.store.updateSession(
+    context.store.externalSessionId,
+    (current) => ({
+      ...current,
+      messages: appendSessionMessage(
+        current,
+        buildSessionCompactedNoticeMessage(event.timestamp, event.message),
+      ),
+    }),
+    { persist: true },
+  );
+};
 const settleTerminalMessages = (
   session: Pick<
     SessionLifecycleEventContext["store"]["sessionsRef"]["current"][string],

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -677,6 +677,7 @@ export const handleSessionCompacted = (
     { persist: true },
   );
 };
+
 const settleTerminalMessages = (
   session: Pick<
     SessionLifecycleEventContext["store"]["sessionsRef"]["current"][string],

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
@@ -426,6 +426,142 @@ describe("agent-orchestrator session transcript events", () => {
     expect(userMessages[0].meta.state).toBe("read");
   });
 
+  test("appends Codex compaction notices without changing live session state", () => {
+    const handlers: Array<(event: SessionEvent) => void> = [];
+    const updateSessionOptions: Array<{ persist?: boolean } | undefined> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_externalSessionId, handler) => {
+        handlers.push(handler);
+        return () => {};
+      },
+      replyApproval: async () => {},
+    };
+    const previousMessage = {
+      id: "assistant-1",
+      role: "assistant" as const,
+      content: "Working on it.",
+      timestamp: "2026-05-18T21:00:00.000Z",
+    };
+    const protectedSessionState = {
+      status: "running" as const,
+      draftAssistantText: "draft text",
+      draftAssistantMessageId: "draft-assistant-1",
+      draftReasoningText: "draft reasoning",
+      draftReasoningMessageId: "draft-reasoning-1",
+      pendingUserMessageStartedAt: Date.parse("2026-05-18T21:00:00.000Z"),
+      pendingApprovals: [
+        {
+          requestId: "approval-1",
+          requestType: "command_execution" as const,
+          title: "Run command",
+        },
+      ],
+      pendingQuestions: [
+        {
+          requestId: "question-1",
+          questions: [{ header: "Choice", question: "Proceed?", options: [] }],
+        },
+      ],
+      todos: [
+        {
+          id: "todo-1",
+          content: "Keep working",
+          status: "in_progress" as const,
+          priority: "high" as const,
+        },
+      ],
+      contextUsage: {
+        totalTokens: 12_000,
+        contextWindow: 200_000,
+        providerId: "openai",
+        modelId: "gpt-5",
+      },
+      selectedModel: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          role: "build",
+          messages: [previousMessage],
+          ...protectedSessionState,
+        }),
+      },
+    };
+
+    const updateSession = (
+      externalSessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+      options?: { persist?: boolean },
+    ) => {
+      const current = sessionsRef.current[externalSessionId];
+      if (!current) {
+        return;
+      }
+      updateSessionOptions.push(options);
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [externalSessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      externalSessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: { "session-1": { reasoning: "draft reasoning" } } },
+      draftSourceBySessionRef: { current: { "session-1": { reasoning: "delta" } } },
+      draftMessageIdBySessionRef: { current: { "session-1": { reasoning: "draft-reasoning-1" } } },
+      draftFlushTimeoutBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: { "session-1": 1_777_000_000_000 } },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+      resolveRuntimeDefinition: () => OPENCODE_RUNTIME_DESCRIPTOR,
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "session_compacted",
+      externalSessionId: "session-1",
+      timestamp: "2026-05-18T21:01:00.000Z",
+      message: "Codex compacted the conversation.",
+    });
+
+    const session = sessionsRef.current["session-1"];
+    if (!session) {
+      throw new Error("Expected session to exist");
+    }
+    const messages = getSessionMessages(sessionsRef);
+    const notice = messages.at(-1);
+    expect(messages[0]).toEqual(previousMessage);
+    expect(notice).toEqual(
+      expect.objectContaining({
+        role: "system",
+        content: "Codex compacted the conversation.",
+        timestamp: "2026-05-18T21:01:00.000Z",
+        meta: {
+          kind: "session_notice",
+          tone: "info",
+          reason: "codex_compacted",
+          title: "Compacted",
+        },
+      }),
+    );
+    expect(updateSessionOptions).toContainEqual({ persist: true });
+    expect(session).toEqual(
+      expect.objectContaining({
+        ...protectedSessionState,
+      }),
+    );
+  });
+
   test("reconciles queued user_message updates in place when the agent reads the turn", () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const adapter: SessionEventAdapter = {

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
@@ -426,7 +426,7 @@ describe("agent-orchestrator session transcript events", () => {
     expect(userMessages[0].meta.state).toBe("read");
   });
 
-  test("appends Codex compaction notices without changing live session state", () => {
+  test("appends session compaction notices without changing live session state", () => {
     const handlers: Array<(event: SessionEvent) => void> = [];
     const updateSessionOptions: Array<{ persist?: boolean } | undefined> = [];
     const adapter: SessionEventAdapter = {

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
@@ -528,9 +528,33 @@ describe("agent-orchestrator session transcript events", () => {
     }
 
     handleEvent({
+      type: "session_compaction_started",
+      externalSessionId: "session-1",
+      timestamp: "2026-05-18T21:00:30.000Z",
+      messageId: "compact-live",
+      message: "Session compaction started.",
+    });
+    expect(getSessionMessages(sessionsRef).at(-1)).toEqual(
+      expect.objectContaining({
+        id: "compact-live",
+        role: "system",
+        content: "Session compaction started.",
+        timestamp: "2026-05-18T21:00:30.000Z",
+        meta: {
+          kind: "session_notice",
+          tone: "info",
+          reason: "session_compacted",
+          title: "Compacting",
+          compactionStatus: "running",
+        },
+      }),
+    );
+
+    handleEvent({
       type: "session_compacted",
       externalSessionId: "session-1",
       timestamp: "2026-05-18T21:01:00.000Z",
+      messageId: "compact-live",
       message: "Session compacted.",
     });
 
@@ -539,10 +563,12 @@ describe("agent-orchestrator session transcript events", () => {
       throw new Error("Expected session to exist");
     }
     const messages = getSessionMessages(sessionsRef);
-    const notice = messages.at(-1);
+    const compactedNotice = messages.at(-1);
+    expect(messages).toHaveLength(2);
     expect(messages[0]).toEqual(previousMessage);
-    expect(notice).toEqual(
+    expect(compactedNotice).toEqual(
       expect.objectContaining({
+        id: "compact-live",
         role: "system",
         content: "Session compacted.",
         timestamp: "2026-05-18T21:01:00.000Z",
@@ -551,10 +577,11 @@ describe("agent-orchestrator session transcript events", () => {
           tone: "info",
           reason: "session_compacted",
           title: "Compacted",
+          compactionStatus: "completed",
         },
       }),
     );
-    expect(updateSessionOptions).toContainEqual({ persist: true });
+    expect(updateSessionOptions).toEqual([{ persist: true }, { persist: true }]);
     expect(session).toEqual(
       expect.objectContaining({
         ...protectedSessionState,

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
@@ -531,7 +531,7 @@ describe("agent-orchestrator session transcript events", () => {
       type: "session_compacted",
       externalSessionId: "session-1",
       timestamp: "2026-05-18T21:01:00.000Z",
-      message: "Codex compacted the conversation.",
+      message: "Session compacted the conversation.",
     });
 
     const session = sessionsRef.current["session-1"];
@@ -544,12 +544,12 @@ describe("agent-orchestrator session transcript events", () => {
     expect(notice).toEqual(
       expect.objectContaining({
         role: "system",
-        content: "Codex compacted the conversation.",
+        content: "Session compacted the conversation.",
         timestamp: "2026-05-18T21:01:00.000Z",
         meta: {
           kind: "session_notice",
           tone: "info",
-          reason: "codex_compacted",
+          reason: "session_compacted",
           title: "Compacted",
         },
       }),

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
@@ -531,7 +531,7 @@ describe("agent-orchestrator session transcript events", () => {
       type: "session_compacted",
       externalSessionId: "session-1",
       timestamp: "2026-05-18T21:01:00.000Z",
-      message: "Session compacted the conversation.",
+      message: "Session compacted.",
     });
 
     const session = sessionsRef.current["session-1"];
@@ -544,7 +544,7 @@ describe("agent-orchestrator session transcript events", () => {
     expect(notice).toEqual(
       expect.objectContaining({
         role: "system",
-        content: "Session compacted the conversation.",
+        content: "Session compacted.",
         timestamp: "2026-05-18T21:01:00.000Z",
         meta: {
           kind: "session_notice",

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -200,6 +200,44 @@ describe("agent-orchestrator/support/persistence", () => {
     expect(messages).toEqual([]);
   });
 
+  test("maps compacted session history notices to chat notice messages", () => {
+    const messages = historyToChatMessages(
+      [
+        {
+          messageId: "compact-1",
+          role: "system",
+          timestamp: "2026-05-18T21:00:00.000Z",
+          text: "Session compacted.",
+          notice: {
+            tone: "info",
+            reason: "session_compacted",
+            title: "Compacted",
+          },
+          parts: [],
+        },
+      ],
+      {
+        role: "build",
+        selectedModel: null,
+      },
+    );
+
+    expect(messages).toEqual([
+      {
+        id: "compact-1",
+        role: "system",
+        content: "Session compacted.",
+        timestamp: "2026-05-18T21:00:00.000Z",
+        meta: {
+          kind: "session_notice",
+          tone: "info",
+          reason: "session_compacted",
+          title: "Compacted",
+        },
+      },
+    ]);
+  });
+
   test("extracts latest final assistant context usage from hydrated history", () => {
     const contextUsage = historyToSessionContextUsage(
       [

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -436,6 +436,13 @@ export const historyToChatMessages = (
         );
       } else if (message.role === "user") {
         meta = userMessageMeta(message.model, message.state, userDisplayParts);
+      } else if (message.role === "system" && message.notice) {
+        meta = {
+          kind: "session_notice",
+          tone: message.notice.tone,
+          reason: message.notice.reason,
+          title: message.notice.title,
+        };
       }
 
       next.push({

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-notice-messages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-notice-messages.ts
@@ -1,54 +1,21 @@
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 
+type SessionNoticeMeta = Extract<AgentChatMessage["meta"], { kind: "session_notice" }>;
+
 const buildSessionNoticeMessage = ({
   timestamp,
   content,
-  tone,
-  title,
-}:
-  | {
-      timestamp: string;
-      content: string;
-      tone: "cancelled";
-      title: string;
-    }
-  | {
-      timestamp: string;
-      content: string;
-      tone: "error";
-      title: string;
-    }
-  | {
-      timestamp: string;
-      content: string;
-      tone: "info";
-      title: string;
-    }): AgentChatMessage => ({
+  meta,
+}: {
+  timestamp: string;
+  content: string;
+  meta: SessionNoticeMeta;
+}): AgentChatMessage => ({
   id: crypto.randomUUID(),
   role: "system",
   content,
   timestamp,
-  meta:
-    tone === "cancelled"
-      ? {
-          kind: "session_notice",
-          tone: "cancelled",
-          reason: "user_stopped",
-          title,
-        }
-      : tone === "info"
-        ? {
-            kind: "session_notice",
-            tone: "info",
-            reason: "session_compacted",
-            title,
-          }
-        : {
-            kind: "session_notice",
-            tone: "error",
-            reason: "session_error",
-            title,
-          },
+  meta,
 });
 
 export const USER_STOPPED_NOTICE = "Session stopped at your request.";
@@ -57,8 +24,12 @@ export const buildUserStoppedNoticeMessage = (timestamp: string): AgentChatMessa
   buildSessionNoticeMessage({
     timestamp,
     content: USER_STOPPED_NOTICE,
-    tone: "cancelled",
-    title: "Stopped",
+    meta: {
+      kind: "session_notice",
+      tone: "cancelled",
+      reason: "user_stopped",
+      title: "Stopped",
+    },
   });
 
 export const buildSessionErrorNoticeMessage = (
@@ -68,8 +39,12 @@ export const buildSessionErrorNoticeMessage = (
   buildSessionNoticeMessage({
     timestamp,
     content: message,
-    tone: "error",
-    title: "Error",
+    meta: {
+      kind: "session_notice",
+      tone: "error",
+      reason: "session_error",
+      title: "Error",
+    },
   });
 
 export const buildSessionCompactedNoticeMessage = (
@@ -79,6 +54,10 @@ export const buildSessionCompactedNoticeMessage = (
   buildSessionNoticeMessage({
     timestamp,
     content: message,
-    tone: "info",
-    title: "Compacted",
+    meta: {
+      kind: "session_notice",
+      tone: "info",
+      reason: "session_compacted",
+      title: "Compacted",
+    },
   });

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-notice-messages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-notice-messages.ts
@@ -3,15 +3,17 @@ import type { AgentChatMessage } from "@/types/agent-orchestrator";
 type SessionNoticeMeta = Extract<AgentChatMessage["meta"], { kind: "session_notice" }>;
 
 const buildSessionNoticeMessage = ({
+  id,
   timestamp,
   content,
   meta,
 }: {
+  id?: string;
   timestamp: string;
   content: string;
   meta: SessionNoticeMeta;
 }): AgentChatMessage => ({
-  id: crypto.randomUUID(),
+  id: id ?? crypto.randomUUID(),
   role: "system",
   content,
   timestamp,
@@ -47,17 +49,36 @@ export const buildSessionErrorNoticeMessage = (
     },
   });
 
-export const buildSessionCompactedNoticeMessage = (
+const buildSessionCompactionNoticeMessage = (
   timestamp: string,
   message: string,
+  title: string,
+  status: "running" | "completed",
+  id?: string,
 ): AgentChatMessage =>
   buildSessionNoticeMessage({
+    ...(id ? { id } : {}),
     timestamp,
     content: message,
     meta: {
       kind: "session_notice",
       tone: "info",
       reason: "session_compacted",
-      title: "Compacted",
+      title,
+      compactionStatus: status,
     },
   });
+
+export const buildSessionCompactedNoticeMessage = (
+  timestamp: string,
+  message: string,
+  id?: string,
+): AgentChatMessage =>
+  buildSessionCompactionNoticeMessage(timestamp, message, "Compacted", "completed", id);
+
+export const buildSessionCompactionStartedNoticeMessage = (
+  timestamp: string,
+  message: string,
+  id?: string,
+): AgentChatMessage =>
+  buildSessionCompactionNoticeMessage(timestamp, message, "Compacting", "running", id);

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-notice-messages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-notice-messages.ts
@@ -17,6 +17,12 @@ const buildSessionNoticeMessage = ({
       content: string;
       tone: "error";
       title: string;
+    }
+  | {
+      timestamp: string;
+      content: string;
+      tone: "info";
+      title: string;
     }): AgentChatMessage => ({
   id: crypto.randomUUID(),
   role: "system",
@@ -30,12 +36,19 @@ const buildSessionNoticeMessage = ({
           reason: "user_stopped",
           title,
         }
-      : {
-          kind: "session_notice",
-          tone: "error",
-          reason: "session_error",
-          title,
-        },
+      : tone === "info"
+        ? {
+            kind: "session_notice",
+            tone: "info",
+            reason: "session_compacted",
+            title,
+          }
+        : {
+            kind: "session_notice",
+            tone: "error",
+            reason: "session_error",
+            title,
+          },
 });
 
 export const USER_STOPPED_NOTICE = "Session stopped at your request.";
@@ -57,4 +70,15 @@ export const buildSessionErrorNoticeMessage = (
     content: message,
     tone: "error",
     title: "Error",
+  });
+
+export const buildSessionCompactedNoticeMessage = (
+  timestamp: string,
+  message: string,
+): AgentChatMessage =>
+  buildSessionNoticeMessage({
+    timestamp,
+    content: message,
+    tone: "info",
+    title: "Compacted",
   });

--- a/packages/frontend/src/types/agent-orchestrator.ts
+++ b/packages/frontend/src/types/agent-orchestrator.ts
@@ -112,6 +112,7 @@ export type AgentChatMessageMeta =
       tone: "info";
       reason: "session_compacted";
       title: string;
+      compactionStatus?: "running" | "completed";
     };
 
 export type AgentChatMessage = {

--- a/packages/frontend/src/types/agent-orchestrator.ts
+++ b/packages/frontend/src/types/agent-orchestrator.ts
@@ -106,6 +106,12 @@ export type AgentChatMessageMeta =
       tone: "error";
       reason: "session_error";
       title: string;
+    }
+  | {
+      kind: "session_notice";
+      tone: "info";
+      reason: "session_compacted";
+      title: string;
     };
 
 export type AgentChatMessage = {

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -386,17 +386,23 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
         portProbe: () => Effect.succeed(false),
         processTreeTerminator: ({ pid }) => {
           runtimePid = pid;
-          try {
-            process.kill(pid, "SIGTERM");
-          } catch {
-            // The fake terminator failure is the behavior under test; process
-            // cleanup is guaranteed by the finally block below.
-          }
-          return Effect.fail(
-            new HostOperationError({
-              operation: "test.processTreeTerminator",
-              message: "process tree cleanup failed",
-            }),
+          return Effect.promise(async () => {
+            try {
+              process.kill(pid, "SIGTERM");
+              await waitFor(() => !processIsAlive(pid), 2_000);
+            } catch {
+              // The fake terminator failure is the behavior under test; process
+              // cleanup is guaranteed by the finally block below.
+            }
+          }).pipe(
+            Effect.zipRight(
+              Effect.fail(
+                new HostOperationError({
+                  operation: "test.processTreeTerminator",
+                  message: "process tree cleanup failed",
+                }),
+              ),
+            ),
           );
         },
       });

--- a/packages/openducktor-mcp/package.json
+++ b/packages/openducktor-mcp/package.json
@@ -28,7 +28,7 @@
     "start": "bun run src/index.ts",
     "build": "bun run scripts/build.ts",
     "typecheck": "bunx tsc -p tsconfig.json --noEmit && bunx tsc -p tsconfig.scripts.json --noEmit",
-    "test": "bun test --timeout 1000",
+    "test": "bun test --timeout 1000 --max-concurrency=1",
     "lint": "biome check src scripts",
     "publish:dry-run": "bun publish --dry-run"
   },

--- a/packages/openducktor-mcp/src/codemap.md
+++ b/packages/openducktor-mcp/src/codemap.md
@@ -9,7 +9,7 @@ OpenDucktor MCP entrypoint, task-store facade, host bridge client, store-context
 - Tool results are normalized into MCP content plus JSON text.
 
 ## Data & Control Flow
-`index.ts` parses startup args, resolves context, constructs `OdtTaskStore`, registers tools, and starts stdio transport. `lib.ts` re-exports the contract/tool surface, `store-context.ts` resolves `hostUrl`, validates workspace membership, and rejects legacy startup inputs. `odt-task-store.ts` delegates to `host-bridge-client.ts`; `tool-results.ts` standardizes success/error envelopes.
+`index.ts` parses startup args, resolves context, constructs `OdtTaskStore`, registers tools, and starts stdio transport. `lib.ts` re-exports the contract/tool surface, `store-context.ts` resolves `hostUrl` and validates workspace membership. `odt-task-store.ts` delegates to `host-bridge-client.ts`; `tool-results.ts` standardizes success/error envelopes.
 
 ## Integration Points
 - `@openducktor/contracts`

--- a/packages/openducktor-mcp/src/index.test.ts
+++ b/packages/openducktor-mcp/src/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -18,6 +18,14 @@ type ContentToolResult = {
 
 const activeServers = new Set<ReturnType<typeof createServer>>();
 const activeMcpServers = new Set<Awaited<ReturnType<typeof createMcpServer>>>();
+const MCP_STARTUP_ENV_KEYS = [
+  "ODT_ALLOWED_TOOLS",
+  "ODT_FORBID_WORKSPACE_ID_INPUT",
+  "ODT_HOST_TOKEN",
+  "ODT_HOST_URL",
+  "ODT_WORKSPACE_ID",
+  "OPENDUCKTOR_CONFIG_DIR",
+] as const;
 
 const closeServer = async (server: ReturnType<typeof createServer>): Promise<void> => {
   await new Promise<void>((resolve, reject) => {
@@ -222,7 +230,16 @@ const readToolInputProperties = (
   return properties;
 };
 
+beforeEach(() => {
+  for (const key of MCP_STARTUP_ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
 afterEach(async () => {
+  for (const key of MCP_STARTUP_ENV_KEYS) {
+    delete process.env[key];
+  }
   await Promise.all([
     ...Array.from(activeMcpServers, async (server) => {
       activeMcpServers.delete(server);

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -23,12 +23,6 @@ const parseCliArgs = (argv: string[]): OdtStoreContext => {
       continue;
     }
 
-    if (current === "--beads-attachment-dir") {
-      next.beadsAttachmentDir = value;
-      index += 1;
-      continue;
-    }
-
     if (current === "--host-url") {
       next.hostUrl = value;
       index += 1;
@@ -38,31 +32,6 @@ const parseCliArgs = (argv: string[]): OdtStoreContext => {
     if (current === "--host-token") {
       next.hostToken = value;
       index += 1;
-      continue;
-    }
-
-    if (current === "--dolt-host") {
-      next.doltHost = value;
-      index += 1;
-      continue;
-    }
-
-    if (current === "--dolt-port") {
-      next.doltPort = value;
-      index += 1;
-      continue;
-    }
-
-    if (current === "--database-name" || current === "--database") {
-      next.databaseName = value;
-      index += 1;
-      continue;
-    }
-
-    if (current === "--metadata-namespace") {
-      throw new Error(
-        "--metadata-namespace is no longer supported. Metadata namespace is owned by the OpenDucktor host.",
-      );
     }
   }
 

--- a/packages/openducktor-mcp/src/store-context.test.ts
+++ b/packages/openducktor-mcp/src/store-context.test.ts
@@ -47,12 +47,7 @@ const clearStoreContextEnv = (): void => {
   delete process.env.ODT_HOST_URL;
   delete process.env.ODT_HOST_TOKEN;
   delete process.env.ODT_FORBID_WORKSPACE_ID_INPUT;
-  delete process.env.ODT_METADATA_NAMESPACE;
   delete process.env.OPENDUCKTOR_CONFIG_DIR;
-  delete process.env.ODT_BEADS_ATTACHMENT_DIR;
-  delete process.env.ODT_DOLT_HOST;
-  delete process.env.ODT_DOLT_PORT;
-  delete process.env.ODT_DATABASE_NAME;
 };
 
 beforeEach(() => {
@@ -203,16 +198,6 @@ describe("resolveStoreContext", () => {
     );
   });
 
-  test("rejects legacy direct Beads/Dolt startup contract", async () => {
-    process.env.ODT_WORKSPACE_ID = "repo";
-    process.env.ODT_HOST_URL = "http://127.0.0.1:14327";
-    process.env.ODT_DOLT_HOST = "127.0.0.1";
-
-    await expect(resolveStoreContext({})).rejects.toThrow(
-      "Direct Beads/Dolt MCP startup is no longer supported",
-    );
-  });
-
   test("fails fast when the host health check fails", async () => {
     globalThis.fetch = (async (input) => {
       const url = String(input);
@@ -282,16 +267,6 @@ describe("resolveStoreContext", () => {
       hostToken: "discovery-token",
     });
     expect(observedHostTokens).toEqual(["discovery-token", "discovery-token"]);
-  });
-
-  test("rejects legacy metadata namespace configuration", async () => {
-    process.env.ODT_WORKSPACE_ID = "repo";
-    process.env.ODT_HOST_URL = "http://127.0.0.1:14327";
-    process.env.ODT_METADATA_NAMESPACE = "legacy-namespace";
-
-    await expect(resolveStoreContext({})).rejects.toThrow(
-      "Metadata namespace is now owned by the OpenDucktor host",
-    );
   });
 
   test("fails clearly when discovery cannot find any running host", async () => {

--- a/packages/openducktor-mcp/src/store-context.ts
+++ b/packages/openducktor-mcp/src/store-context.ts
@@ -17,51 +17,11 @@ export type OdtStoreContext = {
   hostUrl?: string;
   hostToken?: string;
   forbidWorkspaceIdInput?: boolean;
-  beadsAttachmentDir?: string;
-  doltHost?: string;
-  doltPort?: string;
-  databaseName?: string;
 };
 
 type DiscoveredHostConnection = {
   hostUrl: string;
   hostToken: string;
-};
-
-const rejectLegacyContract = (context: OdtStoreContext): void => {
-  const legacyEntries = [
-    [
-      "ODT_BEADS_ATTACHMENT_DIR",
-      normalizeOptionalInput(context.beadsAttachmentDir) ??
-        normalizeOptionalInput(process.env.ODT_BEADS_ATTACHMENT_DIR),
-    ],
-    [
-      "ODT_DOLT_HOST",
-      normalizeOptionalInput(context.doltHost) ?? normalizeOptionalInput(process.env.ODT_DOLT_HOST),
-    ],
-    [
-      "ODT_DOLT_PORT",
-      normalizeOptionalInput(context.doltPort) ?? normalizeOptionalInput(process.env.ODT_DOLT_PORT),
-    ],
-    [
-      "ODT_DATABASE_NAME",
-      normalizeOptionalInput(context.databaseName) ??
-        normalizeOptionalInput(process.env.ODT_DATABASE_NAME),
-    ],
-    ["ODT_METADATA_NAMESPACE", normalizeOptionalInput(process.env.ODT_METADATA_NAMESPACE)],
-  ].filter(([, value]) => value !== undefined);
-
-  if (legacyEntries.length === 0) {
-    return;
-  }
-
-  throw new Error(
-    `Direct Beads/Dolt MCP startup is no longer supported. Remove ${legacyEntries
-      .map(([name]) => name)
-      .join(
-        ", ",
-      )} and use the host bridge discovery path or ODT_HOST_URL instead. Metadata namespace is now owned by the OpenDucktor host.`,
-  );
 };
 
 const validateExplicitHostUrl = async (hostUrl: string, hostToken?: string): Promise<string> => {
@@ -200,8 +160,6 @@ const discoverHostConnection = async (
 };
 
 export const resolveStoreContext = async (context: OdtStoreContext): Promise<OdtStoreOptions> => {
-  rejectLegacyContract(context);
-
   const workspaceId =
     normalizeOptionalInput(context.workspaceId) ??
     normalizeOptionalInput(process.env.ODT_WORKSPACE_ID);


### PR DESCRIPTION
Summary
This PR surfaces generic session compaction notices in Agent Studio transcripts and keeps the MCP test suite hermetic under agent-provided MCP environment variables.

Goal and context
Codex app-server emits a thread compaction lifecycle event when the runtime compacts conversation history, but OpenDucktor did not project that event into the shared session transcript model. The UI therefore missed an important timeline marker after compaction. Review feedback also clarified that the event must be runtime-generic, not Codex-specific, so future runtimes can reuse the same transcript event.

Technical choices
- Added a generic `session_compacted` agent event and frontend notice reason instead of a Codex-specific event type.
- Mapped Codex `thread/compacted` lifecycle notifications into the generic event at the adapter boundary.
- Rendered compaction as an informational transcript notice using the concise copy `Session compacted.`
- Updated stream replay, event batching, lifecycle projection, and message-card coverage around compaction notices.
- Isolated MCP tests from inherited `ODT_*` startup variables and serialized that package test runner because those tests intentionally mutate process environment.

Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `bun run check:rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run test:rust`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session compaction events are surfaced as informational system notices in the chat transcript.

* **Bug Fixes**
  * Improved process termination/cleanup handling to better reflect actual shutdown outcomes.

* **Chores**
  * Removed legacy startup/config options and tightened CLI/test startup isolation for more predictable behavior.

* **Tests**
  * Added coverage verifying compaction events route to session notices and that notices render/persist correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->