### PR TITLE
fix(frontend): refresh git panel for git tool activity

### DIFF
--- a/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.test.ts
@@ -68,6 +68,8 @@ describe("shouldRefreshGitPanelAfterToolCompletion", () => {
       "(git status)",
       "{ git status; }",
       "touch src/generated.ts",
+      "FOO=1 rm generated.ts",
+      "env FOO=1 rm generated.ts",
       "ln -s source target",
       "rsync -a src/ dist/",
       "tar -xf archive.tar",
@@ -96,6 +98,8 @@ describe("shouldRefreshGitPanelAfterToolCompletion", () => {
       "rg TODO",
       "cat README.md",
       "echo ready",
+      "echo rm",
+      'printf "rm"',
       "cmd 2>&1",
       "exec 3>&2",
     ];

--- a/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.test.ts
@@ -57,12 +57,27 @@ describe("shouldRefreshGitPanelAfterToolCompletion", () => {
   test("refreshes for shell commands that can change git panel state", () => {
     const refreshCommands = [
       "git status",
+      "git;",
+      "git && echo done",
+      "GIT_DIR=.git git status",
+      "GIT_AUTHOR_NAME=bot git commit -m test",
+      "env FOO=1 git status",
       "rtk git diff --stat",
       "cd repo && git reset --soft HEAD~1",
       "pwd; git commit -m test",
+      "(git status)",
+      "{ git status; }",
       "touch src/generated.ts",
+      "ln -s source target",
+      "rsync -a src/ dist/",
+      "tar -xf archive.tar",
+      "unzip archive.zip",
       "sed -i '' 's/a/b/' src/app.ts",
+      "sed -ni 's/a/b/' src/app.ts",
+      "sed -in 's/a/b/' src/app.ts",
+      "perl -pi -e 's/a/b/' src/app.ts",
       "printf test > README.md",
+      "printf test >> README.md",
       "cat source.ts | tee target.ts",
     ];
 
@@ -74,7 +89,16 @@ describe("shouldRefreshGitPanelAfterToolCompletion", () => {
   });
 
   test("does not refresh for shell commands outside the git-panel refresh policy", () => {
-    const ignoredCommands = ["", "pwd", "ls", "rg TODO", "cat README.md", "echo ready"];
+    const ignoredCommands = [
+      "",
+      "pwd",
+      "ls",
+      "rg TODO",
+      "cat README.md",
+      "echo ready",
+      "cmd 2>&1",
+      "exec 3>&2",
+    ];
 
     for (const command of ignoredCommands) {
       expect(shouldRefreshGitPanelAfterToolCompletion(buildToolMeta("bash", { command }))).toBe(

--- a/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolMessageMeta } from "./git-panel-refresh-policy";
+import { shouldRefreshGitPanelAfterToolCompletion } from "./git-panel-refresh-policy";
+
+const buildToolMeta = (tool: string, input?: Record<string, unknown>): ToolMessageMeta => ({
+  kind: "tool",
+  partId: `part-${tool}`,
+  callId: `call-${tool}`,
+  tool,
+  status: "completed",
+  ...(input ? { input } : {}),
+});
+
+describe("shouldRefreshGitPanelAfterToolCompletion", () => {
+  test("refreshes for known file-editing tools", () => {
+    const editTools = [
+      "apply_patch",
+      "edit",
+      "file_write",
+      "multiedit",
+      "multi_edit",
+      "patch",
+      "str_replace",
+      "str_replace_based_edit_tool",
+      "write",
+      "create",
+      "insert",
+      "replace",
+      "ast_grep_replace",
+      "lsp_rename",
+    ];
+
+    for (const tool of editTools) {
+      expect(shouldRefreshGitPanelAfterToolCompletion(buildToolMeta(tool))).toBe(true);
+    }
+  });
+
+  test("does not refresh for read-only, interaction, or unknown tools", () => {
+    const ignoredTools = [
+      "",
+      "ast_grep_search",
+      "grep",
+      "look_at",
+      "odt_read_task",
+      "read",
+      "skill",
+      "todowrite",
+      "unknown_runtime_tool",
+      "webfetch",
+    ];
+
+    for (const tool of ignoredTools) {
+      expect(shouldRefreshGitPanelAfterToolCompletion(buildToolMeta(tool))).toBe(false);
+    }
+  });
+
+  test("refreshes for shell commands that can change git panel state", () => {
+    const refreshCommands = [
+      "git status",
+      "rtk git diff --stat",
+      "cd repo && git reset --soft HEAD~1",
+      "pwd; git commit -m test",
+      "touch src/generated.ts",
+      "sed -i '' 's/a/b/' src/app.ts",
+      "printf test > README.md",
+      "cat source.ts | tee target.ts",
+    ];
+
+    for (const command of refreshCommands) {
+      expect(shouldRefreshGitPanelAfterToolCompletion(buildToolMeta("bash", { command }))).toBe(
+        true,
+      );
+    }
+  });
+
+  test("does not refresh for shell commands outside the git-panel refresh policy", () => {
+    const ignoredCommands = ["", "pwd", "ls", "rg TODO", "cat README.md", "echo ready"];
+
+    for (const command of ignoredCommands) {
+      expect(shouldRefreshGitPanelAfterToolCompletion(buildToolMeta("bash", { command }))).toBe(
+        false,
+      );
+    }
+  });
+
+  test("does not treat non-shell tool command inputs as shell commands", () => {
+    expect(
+      shouldRefreshGitPanelAfterToolCompletion(
+        buildToolMeta("unknown_runtime_tool", { command: "git status" }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.ts
@@ -1,0 +1,63 @@
+import type { AgentChatMessageMeta } from "@/types/agent-orchestrator";
+
+export type ToolMessageMeta = Extract<NonNullable<AgentChatMessageMeta>, { kind: "tool" }>;
+
+const SHELL_TOOL_NAMES = new Set(["bash", "shell", "exec", "command"]);
+
+const GIT_COMMAND_PATTERN = /(?:^|[;&|\n]\s*)(?:rtk\s+)?git(?:\s|$)/;
+
+const GIT_PANEL_REFRESH_TOOL_NAMES_BY_REASON = {
+  fileEdit: [
+    "apply_patch",
+    "edit",
+    "file_write",
+    "multiedit",
+    "multi_edit",
+    "patch",
+    "str_replace",
+    "str_replace_based_edit_tool",
+    "write",
+  ],
+  fileCreateOrReplace: ["create", "insert", "replace"],
+  languageServerMutation: ["ast_grep_replace", "lsp_rename"],
+} as const satisfies Record<string, readonly string[]>;
+
+const GIT_PANEL_REFRESH_TOOL_NAMES: ReadonlySet<string> = new Set(
+  Object.values(GIT_PANEL_REFRESH_TOOL_NAMES_BY_REASON).flat(),
+);
+
+const GIT_PANEL_REFRESH_SHELL_PATTERNS_BY_REASON = {
+  gitState: [GIT_COMMAND_PATTERN],
+  fileMutation: [/\b(rm|mv|cp|mkdir|rmdir|touch|chmod|chown|truncate)\b/],
+  inPlaceEdit: [/\b(sed\s+-i|perl\s+-i)\b/],
+  redirectWrite: [/>+\s*[^=]/, /\btee\b/],
+} as const satisfies Record<string, readonly RegExp[]>;
+
+const GIT_PANEL_REFRESH_SHELL_PATTERNS = Object.values(
+  GIT_PANEL_REFRESH_SHELL_PATTERNS_BY_REASON,
+).flat();
+
+const shouldRefreshGitPanelAfterShellCommand = (command: string): boolean => {
+  const normalized = command.trim().toLowerCase();
+  return (
+    normalized.length > 0 &&
+    GIT_PANEL_REFRESH_SHELL_PATTERNS.some((pattern) => pattern.test(normalized))
+  );
+};
+
+export const shouldRefreshGitPanelAfterToolCompletion = (meta: ToolMessageMeta): boolean => {
+  const toolName = meta.tool.trim().toLowerCase();
+  if (toolName.length === 0) {
+    return false;
+  }
+  if (GIT_PANEL_REFRESH_TOOL_NAMES.has(toolName)) {
+    return true;
+  }
+
+  const command = typeof meta.input?.command === "string" ? meta.input.command : "";
+  if (SHELL_TOOL_NAMES.has(toolName)) {
+    return shouldRefreshGitPanelAfterShellCommand(command);
+  }
+
+  return false;
+};

--- a/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.ts
@@ -4,7 +4,32 @@ export type ToolMessageMeta = Extract<NonNullable<AgentChatMessageMeta>, { kind:
 
 const SHELL_TOOL_NAMES = new Set(["bash", "shell", "exec", "command"]);
 
-const GIT_COMMAND_PATTERN = /(?:^|[;&|\n]\s*)(?:rtk\s+)?git(?:\s|$)/;
+const SHELL_COMMAND_PREFIX_PATTERN = String.raw`(?:^|[;&|\n({!]\s*)`;
+const SHELL_ENV_PREFIX_PATTERN = String.raw`(?:(?:[a-z_][a-z0-9_]*=\S+\s+)|(?:env\s+(?:[a-z_][a-z0-9_]*=\S+\s+)+))*`;
+
+const shellCommandPattern = (commandNames: readonly string[]): RegExp =>
+  new RegExp(String.raw`\b(?:${commandNames.join("|")})\b`);
+
+const GIT_COMMAND_PATTERN = new RegExp(
+  `${SHELL_COMMAND_PREFIX_PATTERN}${SHELL_ENV_PREFIX_PATTERN}(?:rtk\\s+)?git\\b`,
+  "i",
+);
+
+const FILE_MUTATION_COMMAND_NAMES = [
+  "rm",
+  "mv",
+  "cp",
+  "mkdir",
+  "rmdir",
+  "touch",
+  "chmod",
+  "chown",
+  "truncate",
+  "ln",
+  "tar",
+  "unzip",
+  "rsync",
+] as const;
 
 const GIT_PANEL_REFRESH_TOOL_NAMES_BY_REASON = {
   fileEdit: [
@@ -28,9 +53,9 @@ const GIT_PANEL_REFRESH_TOOL_NAMES: ReadonlySet<string> = new Set(
 
 const GIT_PANEL_REFRESH_SHELL_PATTERNS_BY_REASON = {
   gitState: [GIT_COMMAND_PATTERN],
-  fileMutation: [/\b(rm|mv|cp|mkdir|rmdir|touch|chmod|chown|truncate)\b/],
-  inPlaceEdit: [/\b(sed\s+-i|perl\s+-i)\b/],
-  redirectWrite: [/>+\s*[^=]/, /\btee\b/],
+  fileMutation: [shellCommandPattern(FILE_MUTATION_COMMAND_NAMES)],
+  inPlaceEdit: [/\b(?:sed|perl)\s+(?:-[a-z]*\s+)*-[a-z]*i[a-z]*(?:\s|$)/],
+  redirectWrite: [/>+\s*[^&=]/, /\btee\b/],
 } as const satisfies Record<string, readonly RegExp[]>;
 
 const GIT_PANEL_REFRESH_SHELL_PATTERNS = Object.values(

--- a/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/git-panel-refresh-policy.ts
@@ -8,7 +8,10 @@ const SHELL_COMMAND_PREFIX_PATTERN = String.raw`(?:^|[;&|\n({!]\s*)`;
 const SHELL_ENV_PREFIX_PATTERN = String.raw`(?:(?:[a-z_][a-z0-9_]*=\S+\s+)|(?:env\s+(?:[a-z_][a-z0-9_]*=\S+\s+)+))*`;
 
 const shellCommandPattern = (commandNames: readonly string[]): RegExp =>
-  new RegExp(String.raw`\b(?:${commandNames.join("|")})\b`);
+  new RegExp(
+    `${SHELL_COMMAND_PREFIX_PATTERN}${SHELL_ENV_PREFIX_PATTERN}(?:${commandNames.join("|")})\\b`,
+    "i",
+  );
 
 const GIT_COMMAND_PATTERN = new RegExp(
   `${SHELL_COMMAND_PREFIX_PATTERN}${SHELL_ENV_PREFIX_PATTERN}(?:rtk\\s+)?git\\b`,

--- a/packages/frontend/src/features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh.test.tsx
+++ b/packages/frontend/src/features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh.test.tsx
@@ -80,7 +80,7 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
     }
   });
 
-  test("refreshes worktree for newly completed mutating build tools", async () => {
+  test("refreshes worktree for newly completed refresh-worthy build tools", async () => {
     const harness = createHookHarness({
       ...createBaseArgs(),
       activeSession: createAgentSessionFixture({
@@ -108,7 +108,7 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
           role: "build",
           messages: [
             ...sessionMessagesToArray(createCompletedToolSession("apply_patch", "tool-1")),
-            ...sessionMessagesToArray(createCompletedToolSession("bash", "tool-2")),
+            ...sessionMessagesToArray(createCompletedToolSession("write", "tool-2")),
           ],
         }),
       });
@@ -178,7 +178,7 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
     }
   });
 
-  test("ignores read-only tools and non-build sessions", async () => {
+  test("ignores non-edit tools and non-build sessions", async () => {
     const harness = createHookHarness({
       ...createBaseArgs(),
       activeSession: createCompletedToolSession("read", "tool-1"),
@@ -202,15 +202,19 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
 
       await harness.update({
         ...createBaseArgs(),
-        activeSession: createCompletedToolSession("bash", "tool-1c", {
-          command: "git status",
-        }),
+        activeSession: createCompletedToolSession("look_at", "tool-1d"),
       });
       expect(refreshWorktreeMock).not.toHaveBeenCalled();
 
       await harness.update({
         ...createBaseArgs(),
-        activeSession: createCompletedToolSession("look_at", "tool-1d"),
+        activeSession: createCompletedToolSession("unknown_runtime_tool", "tool-1e"),
+      });
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createCompletedToolSession("bash", "tool-1f"),
       });
       expect(refreshWorktreeMock).not.toHaveBeenCalled();
 
@@ -230,6 +234,46 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
         }),
       });
       expect(refreshWorktreeMock).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("refreshes once when newly completed tools include refresh-worthy shell commands", async () => {
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: createAgentSessionFixture({
+        externalSessionId: "build-session-1",
+        role: "build",
+        messages: [],
+      }),
+    });
+
+    try {
+      await harness.mount();
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createAgentSessionFixture({
+          externalSessionId: "build-session-1",
+          role: "build",
+          messages: [
+            ...sessionMessagesToArray(
+              createCompletedToolSession("bash", "tool-1", {
+                command: "pwd",
+              }),
+            ),
+            ...sessionMessagesToArray(
+              createCompletedToolSession("bash", "tool-2", {
+                command: "git status",
+              }),
+            ),
+          ],
+        }),
+      });
+      expect(refreshWorktreeMock).toHaveBeenCalledTimes(1);
+      expect(refreshWorktreeMock).toHaveBeenLastCalledWith("soft");
     } finally {
       await harness.unmount();
     }

--- a/packages/frontend/src/features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh.ts
@@ -5,66 +5,15 @@ import {
   forEachSessionMessage,
   forEachSessionMessageFrom,
 } from "@/state/operations/agent-orchestrator/support/messages";
-import { isReadOnlyShellCommand, isSafeReadToolName } from "@/state/operations/permission-policy";
 
-import type { AgentChatMessageMeta, AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { shouldRefreshGitPanelAfterToolCompletion } from "./git-panel-refresh-policy";
 
 type UseAgentStudioBuildWorktreeRefreshArgs = {
   viewRole: string | null;
   activeSession: AgentSessionState | null;
   isSessionHistoryHydrating: boolean;
   refreshWorktree: GitDiffRefresh;
-};
-
-const EXPLICIT_NON_WORKTREE_TOOL_NAMES = new Set([
-  "ast_grep_search",
-  "background_output",
-  "context7_query-docs",
-  "context7_resolve-library-id",
-  "distill",
-  "grep_app_searchGitHub",
-  "lsp_diagnostics",
-  "lsp_find_references",
-  "lsp_goto_definition",
-  "lsp_prepare_rename",
-  "lsp_symbols",
-  "look_at",
-  "odt_read_task",
-  "prune",
-  "question",
-  "session_info",
-  "session_list",
-  "session_read",
-  "session_search",
-  "skill",
-  "task",
-  "todowrite",
-  "webfetch",
-  "websearch_web_search_exa",
-]);
-
-const SHELL_TOOL_NAMES = new Set(["bash", "shell", "exec", "command"]);
-
-type ToolMessageMeta = Extract<NonNullable<AgentChatMessageMeta>, { kind: "tool" }>;
-
-const isReadOnlyNonWorktreeTool = (toolName: string): boolean =>
-  EXPLICIT_NON_WORKTREE_TOOL_NAMES.has(toolName) || isSafeReadToolName(toolName);
-
-const canToolAffectWorktree = (meta: ToolMessageMeta): boolean => {
-  const toolName = meta.tool.trim().toLowerCase();
-  if (toolName.length === 0) {
-    return false;
-  }
-  if (isReadOnlyNonWorktreeTool(toolName)) {
-    return false;
-  }
-
-  const command = typeof meta.input?.command === "string" ? meta.input.command : "";
-  if (SHELL_TOOL_NAMES.has(toolName) && command.length > 0 && isReadOnlyShellCommand(command)) {
-    return false;
-  }
-
-  return true;
 };
 
 const seedProcessedToolMessageKeys = (session: AgentSessionState): Set<string> => {
@@ -80,7 +29,7 @@ const seedProcessedToolMessageKeys = (session: AgentSessionState): Set<string> =
   return keys;
 };
 
-const collectCompletedWorktreeAffectingToolKeys = (session: AgentSessionState): Set<string> => {
+const collectCompletedGitPanelRefreshToolKeys = (session: AgentSessionState): Set<string> => {
   const keys = new Set<string>();
   forEachSessionMessage(session, (message) => {
     const meta = message.meta;
@@ -88,7 +37,7 @@ const collectCompletedWorktreeAffectingToolKeys = (session: AgentSessionState): 
       return;
     }
 
-    if (canToolAffectWorktree(meta)) {
+    if (shouldRefreshGitPanelAfterToolCompletion(meta)) {
       keys.add(`${session.externalSessionId}:${message.id}`);
     }
   });
@@ -115,7 +64,7 @@ export function useAgentStudioBuildWorktreeRefresh({
     if (isSessionHistoryHydrating) {
       if (!wasSessionHistoryHydratingRef.current) {
         completedToolKeysBeforeHydrationRef.current =
-          collectCompletedWorktreeAffectingToolKeys(activeSession);
+          collectCompletedGitPanelRefreshToolKeys(activeSession);
       }
       wasSessionHistoryHydratingRef.current = true;
       return;
@@ -161,7 +110,7 @@ export function useAgentStudioBuildWorktreeRefresh({
       }
 
       processedToolMessageKeysRef.current.add(messageKey);
-      if (canToolAffectWorktree(meta)) {
+      if (shouldRefreshGitPanelAfterToolCompletion(meta)) {
         shouldRefresh = true;
       }
     });


### PR DESCRIPTION
Summary
- Fix Agent Studio Git panel refreshes so they are driven by an explicit refresh policy instead of treating every completed builder tool as worktree-affecting.
- Refresh after known file-editing tools and after shell commands that can change Git panel state, including any git command such as git status, git commit, git reset, and rtk git invocations.
- Move the policy into a dedicated pure helper with focused tests, leaving the React hook responsible for hydration, deduping, and refresh wiring.

Goal
The Git panel was refreshing for every builder tool call because the previous logic defaulted unknown tools to worktree-affecting unless they were on a read-only denylist. That was too broad for non-edit tools, but Git commands still need to refresh because they can change branch, status, ahead/behind, or diff state shown by the panel.

Technical choices
- Added git-panel-refresh-policy.ts with shouldRefreshGitPanelAfterToolCompletion as the single decision point.
- Structured refresh allowlists by reason: direct file edits, create/replace operations, LSP mutations, git state commands, filesystem mutations, in-place edits, and shell redirects.
- Kept this separate from approval-policy because read-only approval semantics and Git panel refresh semantics differ; git status is read-only for approval, but refresh-worthy for the panel.
- Updated useAgentStudioBuildWorktreeRefresh to call the policy only when a new completed tool message is observed, preserving existing session-open, history-hydration, and dedupe behavior.

Verification
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- bun run check:rust
- bun run test:rust
- cargo build --workspace
- bun run react-doctor:diff
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git panel now intelligently refreshes when tools complete operations that may modify the repository (file edits, creates/replaces, and certain shell commands).

* **Refactor**
  * Centralized the Git-refresh decision logic into a single policy used by the worktree refresh hook.

* **Tests**
  * Broadened test coverage for refresh detection, including shell-command heuristics and various tool scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->