### PR TITLE
test(electron): validate packaged MCP sidecar

### DIFF
--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -3,6 +3,7 @@ import { copyFile, mkdir, readdir, rm, stat } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { prepareMcpSidecar } from "./prepare-mcp-sidecar";
+import { verifyPackagedMcpSidecar } from "./verify-mcp-sidecar-package";
 
 export type ElectronReleasePlatform = "linux" | "macos" | "windows";
 export type ElectronReleaseArch = "arm64" | "x64";
@@ -216,6 +217,11 @@ export const buildElectronPackage = async ({
     cwd: electronPackageDirectory,
     env: resolveElectronBuilderEnv(signed, process.env),
   });
+
+  const verifiedSidecarPath = await verifyPackagedMcpSidecar({ platform, releaseDirectory });
+  if (verifiedSidecarPath) {
+    console.log(`Verified Electron MCP sidecar package payload: ${verifiedSidecarPath}`);
+  }
 
   if (!stageReleaseArtifacts) {
     return [];

--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -218,7 +218,11 @@ export const buildElectronPackage = async ({
     env: resolveElectronBuilderEnv(signed, process.env),
   });
 
-  const verifiedSidecarPath = await verifyPackagedMcpSidecar({ platform, releaseDirectory });
+  const verifiedSidecarPath = await verifyPackagedMcpSidecar({
+    arch,
+    platform,
+    releaseDirectory,
+  });
   if (verifiedSidecarPath) {
     console.log(`Verified Electron MCP sidecar package payload: ${verifiedSidecarPath}`);
   }

--- a/apps/electron/scripts/prepare-mcp-sidecar.test.ts
+++ b/apps/electron/scripts/prepare-mcp-sidecar.test.ts
@@ -47,7 +47,7 @@ describe("prepareMcpSidecar", () => {
     });
   });
 
-  test("cleans, compiles, and marks the Unix sidecar executable", async () => {
+  test("cleans, compiles, and marks the Linux sidecar executable", async () => {
     const { electronPackageDirectory, workspaceRoot } = await makeTempWorkspace();
     const staleOutput = join(electronPackageDirectory, "build", "sidecars", "stale");
     const chmodCalls: Array<{ mode: number; path: string }> = [];
@@ -56,7 +56,7 @@ describe("prepareMcpSidecar", () => {
 
     const plan = await prepareMcpSidecar({
       electronPackageDirectory,
-      platform: "darwin",
+      platform: "linux",
       workspaceRoot,
       compile: async ({ outputPath }) => {
         await writeFile(outputPath, "#!/bin/sh\nexit 0\n");

--- a/apps/electron/scripts/verify-mcp-sidecar-package.test.ts
+++ b/apps/electron/scripts/verify-mcp-sidecar-package.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  resolvePackagedMcpSidecarPath,
+  verifyPackagedMcpSidecar,
+} from "./verify-mcp-sidecar-package";
+
+const makeReleaseDirectory = async (): Promise<string> =>
+  mkdtemp(join(tmpdir(), "openducktor-electron-package-sidecar-"));
+
+const writePackagedSidecar = async ({
+  contents = "binary",
+  executable = true,
+  platform,
+  releaseDirectory,
+}: {
+  contents?: string;
+  executable?: boolean;
+  platform: "linux" | "windows";
+  releaseDirectory: string;
+}): Promise<string> => {
+  const path = resolvePackagedMcpSidecarPath({ platform, releaseDirectory });
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+  if (platform === "linux") {
+    await chmod(path, executable ? 0o755 : 0o644);
+  }
+  return path;
+};
+
+describe("verifyPackagedMcpSidecar", () => {
+  test("resolves Electron Builder unpacked sidecar paths", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+
+    expect(resolvePackagedMcpSidecarPath({ platform: "windows", releaseDirectory })).toBe(
+      join(releaseDirectory, "win-unpacked", "resources", "bin", "openducktor-mcp.exe"),
+    );
+    expect(resolvePackagedMcpSidecarPath({ platform: "linux", releaseDirectory })).toBe(
+      join(releaseDirectory, "linux-unpacked", "resources", "bin", "openducktor-mcp"),
+    );
+  });
+
+  test("accepts a non-empty Windows sidecar without Unix executable-bit validation", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+    const sidecarPath = await writePackagedSidecar({
+      platform: "windows",
+      releaseDirectory,
+    });
+
+    await expect(verifyPackagedMcpSidecar({ platform: "windows", releaseDirectory })).resolves.toBe(
+      sidecarPath,
+    );
+  });
+
+  test("rejects a missing Windows sidecar at the expected package path", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+    await mkdir(join(releaseDirectory, "win-unpacked", "resources", "bin"), { recursive: true });
+    await writeFile(
+      join(releaseDirectory, "win-unpacked", "resources", "bin", "openducktor-mcp"),
+      "wrong-name",
+    );
+
+    await expect(
+      verifyPackagedMcpSidecar({ platform: "windows", releaseDirectory }),
+    ).rejects.toThrow("openducktor-mcp.exe");
+  });
+
+  test("rejects an empty Windows sidecar", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+    await writePackagedSidecar({
+      contents: "",
+      platform: "windows",
+      releaseDirectory,
+    });
+
+    await expect(
+      verifyPackagedMcpSidecar({ platform: "windows", releaseDirectory }),
+    ).rejects.toThrow("expected a non-empty file");
+  });
+
+  test("accepts a non-empty executable Linux sidecar", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+    const sidecarPath = await writePackagedSidecar({
+      platform: "linux",
+      releaseDirectory,
+    });
+
+    await expect(verifyPackagedMcpSidecar({ platform: "linux", releaseDirectory })).resolves.toBe(
+      sidecarPath,
+    );
+  });
+
+  test("rejects an empty Linux sidecar", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+    await writePackagedSidecar({
+      contents: "",
+      platform: "linux",
+      releaseDirectory,
+    });
+
+    await expect(verifyPackagedMcpSidecar({ platform: "linux", releaseDirectory })).rejects.toThrow(
+      "expected a non-empty file",
+    );
+  });
+
+  test("rejects a non-executable Linux sidecar", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+    await writePackagedSidecar({
+      executable: false,
+      platform: "linux",
+      releaseDirectory,
+    });
+
+    await expect(verifyPackagedMcpSidecar({ platform: "linux", releaseDirectory })).rejects.toThrow(
+      "expected an executable file",
+    );
+  });
+
+  test("does not validate unrelated package platforms", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+
+    await expect(verifyPackagedMcpSidecar({ platform: "macos", releaseDirectory })).resolves.toBe(
+      undefined,
+    );
+  });
+});

--- a/apps/electron/scripts/verify-mcp-sidecar-package.test.ts
+++ b/apps/electron/scripts/verify-mcp-sidecar-package.test.ts
@@ -7,6 +7,8 @@ import {
   verifyPackagedMcpSidecar,
 } from "./verify-mcp-sidecar-package";
 
+const testIfUnixModeIsAvailable = process.platform === "win32" ? test.skip : test;
+
 const makeReleaseDirectory = async (): Promise<string> =>
   mkdtemp(join(tmpdir(), "openducktor-electron-package-sidecar-"));
 
@@ -134,7 +136,7 @@ describe("verifyPackagedMcpSidecar", () => {
     ).rejects.toThrow("expected a non-empty file");
   });
 
-  test("rejects a non-executable Linux sidecar", async () => {
+  testIfUnixModeIsAvailable("rejects a non-executable Linux sidecar", async () => {
     const releaseDirectory = await makeReleaseDirectory();
     await writePackagedSidecar({
       executable: false,

--- a/apps/electron/scripts/verify-mcp-sidecar-package.test.ts
+++ b/apps/electron/scripts/verify-mcp-sidecar-package.test.ts
@@ -11,17 +11,19 @@ const makeReleaseDirectory = async (): Promise<string> =>
   mkdtemp(join(tmpdir(), "openducktor-electron-package-sidecar-"));
 
 const writePackagedSidecar = async ({
+  arch = "x64",
   contents = "binary",
   executable = true,
   platform,
   releaseDirectory,
 }: {
+  arch?: "arm64" | "x64";
   contents?: string;
   executable?: boolean;
   platform: "linux" | "windows";
   releaseDirectory: string;
 }): Promise<string> => {
-  const path = resolvePackagedMcpSidecarPath({ platform, releaseDirectory });
+  const path = resolvePackagedMcpSidecarPath({ arch, platform, releaseDirectory });
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, contents);
   if (platform === "linux") {
@@ -34,12 +36,18 @@ describe("verifyPackagedMcpSidecar", () => {
   test("resolves Electron Builder unpacked sidecar paths", async () => {
     const releaseDirectory = await makeReleaseDirectory();
 
-    expect(resolvePackagedMcpSidecarPath({ platform: "windows", releaseDirectory })).toBe(
-      join(releaseDirectory, "win-unpacked", "resources", "bin", "openducktor-mcp.exe"),
-    );
-    expect(resolvePackagedMcpSidecarPath({ platform: "linux", releaseDirectory })).toBe(
-      join(releaseDirectory, "linux-unpacked", "resources", "bin", "openducktor-mcp"),
-    );
+    expect(
+      resolvePackagedMcpSidecarPath({ arch: "x64", platform: "windows", releaseDirectory }),
+    ).toBe(join(releaseDirectory, "win-unpacked", "resources", "bin", "openducktor-mcp.exe"));
+    expect(
+      resolvePackagedMcpSidecarPath({ arch: "arm64", platform: "windows", releaseDirectory }),
+    ).toBe(join(releaseDirectory, "win-arm64-unpacked", "resources", "bin", "openducktor-mcp.exe"));
+    expect(
+      resolvePackagedMcpSidecarPath({ arch: "x64", platform: "linux", releaseDirectory }),
+    ).toBe(join(releaseDirectory, "linux-unpacked", "resources", "bin", "openducktor-mcp"));
+    expect(
+      resolvePackagedMcpSidecarPath({ arch: "arm64", platform: "linux", releaseDirectory }),
+    ).toBe(join(releaseDirectory, "linux-arm64-unpacked", "resources", "bin", "openducktor-mcp"));
   });
 
   test("accepts a non-empty Windows sidecar without Unix executable-bit validation", async () => {
@@ -49,9 +57,30 @@ describe("verifyPackagedMcpSidecar", () => {
       releaseDirectory,
     });
 
-    await expect(verifyPackagedMcpSidecar({ platform: "windows", releaseDirectory })).resolves.toBe(
-      sidecarPath,
-    );
+    await expect(
+      verifyPackagedMcpSidecar({ arch: "x64", platform: "windows", releaseDirectory }),
+    ).resolves.toBe(sidecarPath);
+  });
+
+  test("accepts architecture-specific Windows and Linux sidecar package paths", async () => {
+    const releaseDirectory = await makeReleaseDirectory();
+    const windowsSidecarPath = await writePackagedSidecar({
+      arch: "arm64",
+      platform: "windows",
+      releaseDirectory,
+    });
+    const linuxSidecarPath = await writePackagedSidecar({
+      arch: "arm64",
+      platform: "linux",
+      releaseDirectory,
+    });
+
+    await expect(
+      verifyPackagedMcpSidecar({ arch: "arm64", platform: "windows", releaseDirectory }),
+    ).resolves.toBe(windowsSidecarPath);
+    await expect(
+      verifyPackagedMcpSidecar({ arch: "arm64", platform: "linux", releaseDirectory }),
+    ).resolves.toBe(linuxSidecarPath);
   });
 
   test("rejects a missing Windows sidecar at the expected package path", async () => {
@@ -63,7 +92,7 @@ describe("verifyPackagedMcpSidecar", () => {
     );
 
     await expect(
-      verifyPackagedMcpSidecar({ platform: "windows", releaseDirectory }),
+      verifyPackagedMcpSidecar({ arch: "x64", platform: "windows", releaseDirectory }),
     ).rejects.toThrow("openducktor-mcp.exe");
   });
 
@@ -76,7 +105,7 @@ describe("verifyPackagedMcpSidecar", () => {
     });
 
     await expect(
-      verifyPackagedMcpSidecar({ platform: "windows", releaseDirectory }),
+      verifyPackagedMcpSidecar({ arch: "x64", platform: "windows", releaseDirectory }),
     ).rejects.toThrow("expected a non-empty file");
   });
 
@@ -87,9 +116,9 @@ describe("verifyPackagedMcpSidecar", () => {
       releaseDirectory,
     });
 
-    await expect(verifyPackagedMcpSidecar({ platform: "linux", releaseDirectory })).resolves.toBe(
-      sidecarPath,
-    );
+    await expect(
+      verifyPackagedMcpSidecar({ arch: "x64", platform: "linux", releaseDirectory }),
+    ).resolves.toBe(sidecarPath);
   });
 
   test("rejects an empty Linux sidecar", async () => {
@@ -100,9 +129,9 @@ describe("verifyPackagedMcpSidecar", () => {
       releaseDirectory,
     });
 
-    await expect(verifyPackagedMcpSidecar({ platform: "linux", releaseDirectory })).rejects.toThrow(
-      "expected a non-empty file",
-    );
+    await expect(
+      verifyPackagedMcpSidecar({ arch: "x64", platform: "linux", releaseDirectory }),
+    ).rejects.toThrow("expected a non-empty file");
   });
 
   test("rejects a non-executable Linux sidecar", async () => {
@@ -113,16 +142,16 @@ describe("verifyPackagedMcpSidecar", () => {
       releaseDirectory,
     });
 
-    await expect(verifyPackagedMcpSidecar({ platform: "linux", releaseDirectory })).rejects.toThrow(
-      "expected an executable file",
-    );
+    await expect(
+      verifyPackagedMcpSidecar({ arch: "x64", platform: "linux", releaseDirectory }),
+    ).rejects.toThrow("expected an executable file");
   });
 
   test("does not validate unrelated package platforms", async () => {
     const releaseDirectory = await makeReleaseDirectory();
 
-    await expect(verifyPackagedMcpSidecar({ platform: "macos", releaseDirectory })).resolves.toBe(
-      undefined,
-    );
+    await expect(
+      verifyPackagedMcpSidecar({ arch: "arm64", platform: "macos", releaseDirectory }),
+    ).resolves.toBe(undefined);
   });
 });

--- a/apps/electron/scripts/verify-mcp-sidecar-package.ts
+++ b/apps/electron/scripts/verify-mcp-sidecar-package.ts
@@ -63,8 +63,6 @@ const assertPackagedSidecarFile = async (
   }
 };
 
-const canValidateUnixExecutableMode = (): boolean => process.platform !== "win32";
-
 export const verifyPackagedMcpSidecar = async ({
   arch,
   platform,
@@ -77,7 +75,7 @@ export const verifyPackagedMcpSidecar = async ({
   const sidecarPath = resolvePackagedMcpSidecarPath({ arch, platform, releaseDirectory });
   const metadata = await assertPackagedSidecarFile(sidecarPath, platform);
 
-  if (platform === "linux" && canValidateUnixExecutableMode() && (metadata.mode & 0o111) === 0) {
+  if (platform === "linux" && process.platform !== "win32" && (metadata.mode & 0o111) === 0) {
     throw new Error(
       `Invalid Electron MCP sidecar package payload for linux: expected an executable file. Expected path: ${sidecarPath}`,
     );

--- a/apps/electron/scripts/verify-mcp-sidecar-package.ts
+++ b/apps/electron/scripts/verify-mcp-sidecar-package.ts
@@ -1,0 +1,69 @@
+import type { Stats } from "node:fs";
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { ElectronReleasePlatform } from "./package-build";
+
+type VerifyPackagedMcpSidecarInput = {
+  platform: ElectronReleasePlatform;
+  releaseDirectory: string;
+};
+
+const supportedPackagePlatforms = new Set<ElectronReleasePlatform>(["linux", "windows"]);
+
+export const resolvePackagedMcpSidecarPath = ({
+  platform,
+  releaseDirectory,
+}: VerifyPackagedMcpSidecarInput): string => {
+  if (platform === "windows") {
+    return join(releaseDirectory, "win-unpacked", "resources", "bin", "openducktor-mcp.exe");
+  }
+  if (platform === "linux") {
+    return join(releaseDirectory, "linux-unpacked", "resources", "bin", "openducktor-mcp");
+  }
+
+  throw new Error(`Electron MCP sidecar package validation is not defined for ${platform}.`);
+};
+
+const assertPackagedSidecarFile = async (
+  path: string,
+  platform: ElectronReleasePlatform,
+): Promise<Stats> => {
+  try {
+    const metadata = await stat(path);
+    if (!metadata.isFile()) {
+      throw new Error(`expected a file but found a non-file entry`);
+    }
+    if (metadata.size === 0) {
+      throw new Error(`expected a non-empty file`);
+    }
+    return metadata;
+  } catch (cause) {
+    if (cause instanceof Error) {
+      throw new Error(
+        `Invalid Electron MCP sidecar package payload for ${platform}: ${cause.message}. Expected path: ${path}`,
+        { cause },
+      );
+    }
+    throw cause;
+  }
+};
+
+export const verifyPackagedMcpSidecar = async ({
+  platform,
+  releaseDirectory,
+}: VerifyPackagedMcpSidecarInput): Promise<string | undefined> => {
+  if (!supportedPackagePlatforms.has(platform)) {
+    return undefined;
+  }
+
+  const sidecarPath = resolvePackagedMcpSidecarPath({ platform, releaseDirectory });
+  const metadata = await assertPackagedSidecarFile(sidecarPath, platform);
+
+  if (platform === "linux" && (metadata.mode & 0o111) === 0) {
+    throw new Error(
+      `Invalid Electron MCP sidecar package payload for linux: expected an executable file. Expected path: ${sidecarPath}`,
+    );
+  }
+
+  return sidecarPath;
+};

--- a/apps/electron/scripts/verify-mcp-sidecar-package.ts
+++ b/apps/electron/scripts/verify-mcp-sidecar-package.ts
@@ -63,6 +63,8 @@ const assertPackagedSidecarFile = async (
   }
 };
 
+const canValidateUnixExecutableMode = (): boolean => process.platform !== "win32";
+
 export const verifyPackagedMcpSidecar = async ({
   arch,
   platform,
@@ -75,7 +77,7 @@ export const verifyPackagedMcpSidecar = async ({
   const sidecarPath = resolvePackagedMcpSidecarPath({ arch, platform, releaseDirectory });
   const metadata = await assertPackagedSidecarFile(sidecarPath, platform);
 
-  if (platform === "linux" && (metadata.mode & 0o111) === 0) {
+  if (platform === "linux" && canValidateUnixExecutableMode() && (metadata.mode & 0o111) === 0) {
     throw new Error(
       `Invalid Electron MCP sidecar package payload for linux: expected an executable file. Expected path: ${sidecarPath}`,
     );

--- a/apps/electron/scripts/verify-mcp-sidecar-package.ts
+++ b/apps/electron/scripts/verify-mcp-sidecar-package.ts
@@ -8,8 +8,6 @@ type VerifyPackagedMcpSidecarInput = {
   releaseDirectory: string;
 };
 
-const supportedPackagePlatforms = new Set<ElectronReleasePlatform>(["linux", "windows"]);
-
 export const resolvePackagedMcpSidecarPath = ({
   platform,
   releaseDirectory,
@@ -52,7 +50,7 @@ export const verifyPackagedMcpSidecar = async ({
   platform,
   releaseDirectory,
 }: VerifyPackagedMcpSidecarInput): Promise<string | undefined> => {
-  if (!supportedPackagePlatforms.has(platform)) {
+  if (platform === "macos") {
     return undefined;
   }
 

--- a/apps/electron/scripts/verify-mcp-sidecar-package.ts
+++ b/apps/electron/scripts/verify-mcp-sidecar-package.ts
@@ -1,25 +1,42 @@
 import type { Stats } from "node:fs";
 import { stat } from "node:fs/promises";
 import { join } from "node:path";
-import type { ElectronReleasePlatform } from "./package-build";
+import type { ElectronReleaseArch, ElectronReleasePlatform } from "./package-build";
+
+type PackagedMcpSidecarPlatform = Exclude<ElectronReleasePlatform, "macos">;
 
 type VerifyPackagedMcpSidecarInput = {
+  arch: ElectronReleaseArch;
   platform: ElectronReleasePlatform;
   releaseDirectory: string;
 };
 
+type PackagedMcpSidecarInput = {
+  arch: ElectronReleaseArch;
+  platform: PackagedMcpSidecarPlatform;
+  releaseDirectory: string;
+};
+
+const unpackedDirectoryName = ({
+  arch,
+  platform,
+}: Pick<PackagedMcpSidecarInput, "arch" | "platform">): string => {
+  const prefix = platform === "windows" ? "win" : "linux";
+  return arch === "x64" ? `${prefix}-unpacked` : `${prefix}-${arch}-unpacked`;
+};
+
 export const resolvePackagedMcpSidecarPath = ({
+  arch,
   platform,
   releaseDirectory,
-}: VerifyPackagedMcpSidecarInput): string => {
+}: PackagedMcpSidecarInput): string => {
+  const unpackedDirectory = unpackedDirectoryName({ arch, platform });
+
   if (platform === "windows") {
-    return join(releaseDirectory, "win-unpacked", "resources", "bin", "openducktor-mcp.exe");
-  }
-  if (platform === "linux") {
-    return join(releaseDirectory, "linux-unpacked", "resources", "bin", "openducktor-mcp");
+    return join(releaseDirectory, unpackedDirectory, "resources", "bin", "openducktor-mcp.exe");
   }
 
-  throw new Error(`Electron MCP sidecar package validation is not defined for ${platform}.`);
+  return join(releaseDirectory, unpackedDirectory, "resources", "bin", "openducktor-mcp");
 };
 
 const assertPackagedSidecarFile = async (
@@ -47,6 +64,7 @@ const assertPackagedSidecarFile = async (
 };
 
 export const verifyPackagedMcpSidecar = async ({
+  arch,
   platform,
   releaseDirectory,
 }: VerifyPackagedMcpSidecarInput): Promise<string | undefined> => {
@@ -54,7 +72,7 @@ export const verifyPackagedMcpSidecar = async ({
     return undefined;
   }
 
-  const sidecarPath = resolvePackagedMcpSidecarPath({ platform, releaseDirectory });
+  const sidecarPath = resolvePackagedMcpSidecarPath({ arch, platform, releaseDirectory });
   const metadata = await assertPackagedSidecarFile(sidecarPath, platform);
 
   if (platform === "linux" && (metadata.mode & 0o111) === 0) {

--- a/apps/electron/src/main/electron-process-environment.test.ts
+++ b/apps/electron/src/main/electron-process-environment.test.ts
@@ -58,6 +58,27 @@ describe("configureElectronProcessEnvironment", () => {
     ).toBe(join("/Applications/OpenDucktor.app/Contents/Resources", "bin", "openducktor-mcp"));
   });
 
+  test("uses Linux packaged resources for bundled bin and MCP sidecar env", () => {
+    const env: NodeJS.ProcessEnv = {};
+    configureElectronProcessEnvironment({
+      env,
+      platform: "linux",
+      isPackaged: true,
+      resourcesPath: "/opt/OpenDucktor/resources",
+    });
+
+    expect(env[OPENDUCKTOR_BUNDLED_BIN_DIR_ENV]).toBe(join("/opt/OpenDucktor/resources", "bin"));
+    expect(env[OPENDUCKTOR_MCP_SIDECAR_PATH_ENV]).toBe(
+      join("/opt/OpenDucktor/resources", "bin", "openducktor-mcp"),
+    );
+    expect(
+      resolveElectronMcpSidecarPath({
+        platform: "linux",
+        resourcesPath: "/opt/OpenDucktor/resources",
+      }),
+    ).toBe(join("/opt/OpenDucktor/resources", "bin", "openducktor-mcp"));
+  });
+
   test("preserves explicit packaged environment overrides", () => {
     const env: NodeJS.ProcessEnv = {
       [OPENDUCKTOR_BUNDLED_BIN_DIR_ENV]: "/custom/bin",

--- a/packages/host/src/adapters/mcp/openducktor-mcp-command.test.ts
+++ b/packages/host/src/adapters/mcp/openducktor-mcp-command.test.ts
@@ -5,6 +5,8 @@ import { Effect } from "effect";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { parseMcpCommandJson, resolveOpenDucktorMcpCommand } from "./openducktor-mcp-command";
 
+const testIfUnixModeIsAvailable = process.platform === "win32" ? test.skip : test;
+
 const createSystemCommands = (bunAvailable = true): SystemCommandPort => ({
   requiredCommandError(command) {
     if (command === "bun" && bunAvailable) {
@@ -91,14 +93,17 @@ describe("resolveOpenDucktorMcpCommand", () => {
 
     await expectExplicitSidecarRejected(sidecar);
   });
-  test("fails fast when the explicit MCP sidecar path is not executable", async () => {
-    const root = await mkdtemp(join(tmpdir(), "odt-mcp-non-executable-sidecar-"));
-    const sidecar = join(root, "openducktor-mcp");
-    await writeFile(sidecar, "#!/bin/sh\nexit 0\n");
-    await chmod(sidecar, 0o644);
+  testIfUnixModeIsAvailable(
+    "fails fast when the explicit MCP sidecar path is not executable",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "odt-mcp-non-executable-sidecar-"));
+      const sidecar = join(root, "openducktor-mcp");
+      await writeFile(sidecar, "#!/bin/sh\nexit 0\n");
+      await chmod(sidecar, 0o644);
 
-    await expectExplicitSidecarRejected(sidecar);
-  });
+      await expectExplicitSidecarRejected(sidecar);
+    },
+  );
   test("fails fast when the explicit MCP sidecar path is a directory", async () => {
     const root = await mkdtemp(join(tmpdir(), "odt-mcp-directory-sidecar-"));
     const sidecar = join(root, "openducktor-mcp");

--- a/packages/host/src/adapters/mcp/openducktor-mcp-command.test.ts
+++ b/packages/host/src/adapters/mcp/openducktor-mcp-command.test.ts
@@ -104,6 +104,22 @@ describe("resolveOpenDucktorMcpCommand", () => {
       ),
     ).rejects.toThrow("points to a missing or non-executable file");
   });
+  test("fails fast when the explicit MCP sidecar path is a directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-mcp-directory-sidecar-"));
+    const sidecar = join(root, "openducktor-mcp");
+    await mkdir(sidecar);
+    await chmod(sidecar, 0o755);
+
+    await expect(
+      Effect.runPromise(
+        resolveOpenDucktorMcpCommand({
+          systemCommands: createSystemCommands(),
+          env: { OPENDUCKTOR_OPENDUCKTOR_MCP_PATH: sidecar },
+          startPath: "/missing",
+        }),
+      ),
+    ).rejects.toThrow("points to a missing or non-executable file");
+  });
   test("resolves the workspace MCP entrypoint from an ancestor directory", async () => {
     const root = await createWorkspaceRoot();
     const nested = join(root, "apps", "electron");

--- a/packages/host/src/adapters/mcp/openducktor-mcp-command.test.ts
+++ b/packages/host/src/adapters/mcp/openducktor-mcp-command.test.ts
@@ -28,6 +28,17 @@ const createWorkspaceRoot = async (): Promise<string> => {
   await writeFile(join(root, "packages", "openducktor-mcp", "src", "index.ts"), "");
   return root;
 };
+const expectExplicitSidecarRejected = async (sidecar: string): Promise<void> => {
+  await expect(
+    Effect.runPromise(
+      resolveOpenDucktorMcpCommand({
+        systemCommands: createSystemCommands(),
+        env: { OPENDUCKTOR_OPENDUCKTOR_MCP_PATH: sidecar },
+        startPath: "/missing",
+      }),
+    ),
+  ).rejects.toThrow("points to a missing or non-executable file");
+};
 describe("resolveOpenDucktorMcpCommand", () => {
   test("parses explicit command JSON", () => {
     expect(parseMcpCommandJson('["  mcp-bin  "," --stdio "]')).toEqual(["mcp-bin", "--stdio"]);
@@ -78,15 +89,7 @@ describe("resolveOpenDucktorMcpCommand", () => {
     const root = await mkdtemp(join(tmpdir(), "odt-mcp-missing-sidecar-"));
     const sidecar = join(root, "openducktor-mcp");
 
-    await expect(
-      Effect.runPromise(
-        resolveOpenDucktorMcpCommand({
-          systemCommands: createSystemCommands(),
-          env: { OPENDUCKTOR_OPENDUCKTOR_MCP_PATH: sidecar },
-          startPath: "/missing",
-        }),
-      ),
-    ).rejects.toThrow("points to a missing or non-executable file");
+    await expectExplicitSidecarRejected(sidecar);
   });
   test("fails fast when the explicit MCP sidecar path is not executable", async () => {
     const root = await mkdtemp(join(tmpdir(), "odt-mcp-non-executable-sidecar-"));
@@ -94,15 +97,7 @@ describe("resolveOpenDucktorMcpCommand", () => {
     await writeFile(sidecar, "#!/bin/sh\nexit 0\n");
     await chmod(sidecar, 0o644);
 
-    await expect(
-      Effect.runPromise(
-        resolveOpenDucktorMcpCommand({
-          systemCommands: createSystemCommands(),
-          env: { OPENDUCKTOR_OPENDUCKTOR_MCP_PATH: sidecar },
-          startPath: "/missing",
-        }),
-      ),
-    ).rejects.toThrow("points to a missing or non-executable file");
+    await expectExplicitSidecarRejected(sidecar);
   });
   test("fails fast when the explicit MCP sidecar path is a directory", async () => {
     const root = await mkdtemp(join(tmpdir(), "odt-mcp-directory-sidecar-"));
@@ -110,15 +105,7 @@ describe("resolveOpenDucktorMcpCommand", () => {
     await mkdir(sidecar);
     await chmod(sidecar, 0o755);
 
-    await expect(
-      Effect.runPromise(
-        resolveOpenDucktorMcpCommand({
-          systemCommands: createSystemCommands(),
-          env: { OPENDUCKTOR_OPENDUCKTOR_MCP_PATH: sidecar },
-          startPath: "/missing",
-        }),
-      ),
-    ).rejects.toThrow("points to a missing or non-executable file");
+    await expectExplicitSidecarRejected(sidecar);
   });
   test("resolves the workspace MCP entrypoint from an ancestor directory", async () => {
     const root = await createWorkspaceRoot();

--- a/packages/host/src/adapters/mcp/openducktor-mcp-command.test.ts
+++ b/packages/host/src/adapters/mcp/openducktor-mcp-command.test.ts
@@ -63,6 +63,47 @@ describe("resolveOpenDucktorMcpCommand", () => {
       ),
     ).resolves.toEqual([sidecar]);
   });
+  test("fails fast when the explicit MCP sidecar path is empty", async () => {
+    await expect(
+      Effect.runPromise(
+        resolveOpenDucktorMcpCommand({
+          systemCommands: createSystemCommands(),
+          env: { OPENDUCKTOR_OPENDUCKTOR_MCP_PATH: "   " },
+          startPath: "/missing",
+        }),
+      ),
+    ).rejects.toThrow("OPENDUCKTOR_OPENDUCKTOR_MCP_PATH is set but empty.");
+  });
+  test("fails fast when the explicit MCP sidecar path is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-mcp-missing-sidecar-"));
+    const sidecar = join(root, "openducktor-mcp");
+
+    await expect(
+      Effect.runPromise(
+        resolveOpenDucktorMcpCommand({
+          systemCommands: createSystemCommands(),
+          env: { OPENDUCKTOR_OPENDUCKTOR_MCP_PATH: sidecar },
+          startPath: "/missing",
+        }),
+      ),
+    ).rejects.toThrow("points to a missing or non-executable file");
+  });
+  test("fails fast when the explicit MCP sidecar path is not executable", async () => {
+    const root = await mkdtemp(join(tmpdir(), "odt-mcp-non-executable-sidecar-"));
+    const sidecar = join(root, "openducktor-mcp");
+    await writeFile(sidecar, "#!/bin/sh\nexit 0\n");
+    await chmod(sidecar, 0o644);
+
+    await expect(
+      Effect.runPromise(
+        resolveOpenDucktorMcpCommand({
+          systemCommands: createSystemCommands(),
+          env: { OPENDUCKTOR_OPENDUCKTOR_MCP_PATH: sidecar },
+          startPath: "/missing",
+        }),
+      ),
+    ).rejects.toThrow("points to a missing or non-executable file");
+  });
   test("resolves the workspace MCP entrypoint from an ancestor directory", async () => {
     const root = await createWorkspaceRoot();
     const nested = join(root, "apps", "electron");

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -8,6 +8,7 @@ import { HostOperationError } from "../../effect/host-errors";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { writeFakeRuntimeCommand } from "../../test-support/fake-runtime-command";
 import { removeTestDirectory } from "../../test-support/temp-directory";
+import { terminateProcessTree } from "../process/process-tree";
 import { createSystemCommandRunner } from "../system/system-command-runner";
 import {
   buildOpenCodeConfigContent,
@@ -51,6 +52,44 @@ const waitFor = async (predicate: () => boolean, timeoutMs = 1_000): Promise<voi
   }
   throw new Error("Timed out waiting for condition.");
 };
+
+const forceStopProcessTree = (pid: number) =>
+  process.platform === "win32"
+    ? terminateProcessTree({
+        pid,
+        label: `test process tree ${pid}`,
+        isClosed: () => !processIsAlive(pid),
+        waitForExit: (timeoutMs) =>
+          Effect.tryPromise({
+            try: async () => {
+              try {
+                await waitFor(() => !processIsAlive(pid), timeoutMs);
+                return true;
+              } catch {
+                return false;
+              }
+            },
+            catch: (cause) =>
+              new HostOperationError({
+                operation: "test.forceStopProcessTree",
+                message: cause instanceof Error ? cause.message : String(cause),
+                cause,
+              }),
+          }),
+        stopTimeoutMs: 2_000,
+      })
+    : Effect.tryPromise({
+        try: async () => {
+          process.kill(pid, "SIGKILL");
+          await waitFor(() => !processIsAlive(pid), 2_000);
+        },
+        catch: (cause) =>
+          new HostOperationError({
+            operation: "test.forceStopProcessTree",
+            message: cause instanceof Error ? cause.message : String(cause),
+            cause,
+          }),
+      });
 
 const createFakeOpenCode = async (
   root: string,
@@ -357,7 +396,7 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
       await expect(Effect.runPromise(handle.stop())).rejects.toThrow("process tree stayed alive");
     } finally {
       if (runtimePid !== null && processIsAlive(runtimePid)) {
-        process.kill(runtimePid, "SIGKILL");
+        await Effect.runPromise(forceStopProcessTree(runtimePid));
       }
       await removeTestDirectory(root);
     }
@@ -421,12 +460,7 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
       );
     } finally {
       if (runtimePid !== null && processIsAlive(runtimePid)) {
-        try {
-          await waitFor(() => !processIsAlive(runtimePid as number), 2_000);
-        } catch {
-          process.kill(runtimePid, "SIGKILL");
-          await waitFor(() => !processIsAlive(runtimePid as number), 2_000);
-        }
+        await Effect.runPromise(forceStopProcessTree(runtimePid));
       }
       await removeTestDirectory(root);
     }

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -82,7 +82,13 @@ const forceStopProcessTree = (pid: number) =>
       })
     : Effect.tryPromise({
         try: async () => {
-          process.kill(pid, "SIGKILL");
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch (cause) {
+            if ((cause as NodeJS.ErrnoException).code !== "ESRCH") {
+              throw cause;
+            }
+          }
           await waitFor(() => !processIsAlive(pid), 2_000);
         },
         catch: (cause) =>

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -427,23 +427,11 @@ describe("createOpenCodeWorkspaceRuntimeStarter", () => {
         portProbe: () => Effect.succeed(false),
         processTreeTerminator: ({ pid }) => {
           runtimePid = pid;
-          return Effect.promise(async () => {
-            try {
-              process.kill(pid, "SIGTERM");
-              await waitFor(() => !processIsAlive(pid), 2_000);
-            } catch {
-              // The fake terminator failure is the behavior under test; process
-              // cleanup is guaranteed by the finally block below.
-            }
-          }).pipe(
-            Effect.zipRight(
-              Effect.fail(
-                new HostOperationError({
-                  operation: "test.processTreeTerminator",
-                  message: "process tree cleanup failed",
-                }),
-              ),
-            ),
+          return Effect.fail(
+            new HostOperationError({
+              operation: "test.processTreeTerminator",
+              message: "process tree cleanup failed",
+            }),
           );
         },
       });

--- a/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/opencode/opencode-workspace-runtime-starter.test.ts
@@ -53,6 +53,15 @@ const waitFor = async (predicate: () => boolean, timeoutMs = 1_000): Promise<voi
   throw new Error("Timed out waiting for condition.");
 };
 
+const waitForProcessExit = async (pid: number, timeoutMs: number): Promise<boolean> => {
+  try {
+    await waitFor(() => !processIsAlive(pid), timeoutMs);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const forceStopProcessTree = (pid: number) =>
   process.platform === "win32"
     ? terminateProcessTree({
@@ -61,14 +70,7 @@ const forceStopProcessTree = (pid: number) =>
         isClosed: () => !processIsAlive(pid),
         waitForExit: (timeoutMs) =>
           Effect.tryPromise({
-            try: async () => {
-              try {
-                await waitFor(() => !processIsAlive(pid), timeoutMs);
-                return true;
-              } catch {
-                return false;
-              }
-            },
+            try: () => waitForProcessExit(pid, timeoutMs),
             catch: (cause) =>
               new HostOperationError({
                 operation: "test.forceStopProcessTree",

--- a/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.test.ts
@@ -4,7 +4,7 @@ import { join, posix } from "node:path";
 import { Effect } from "effect";
 import type { SystemCommandPort } from "../../ports/system-command-port";
 import { createSystemCommandRunner } from "../system/system-command-runner";
-import { resolveCodexBinary, resolveOpencodeBinary } from "./runtime-binaries";
+import { isExecutableFile, resolveCodexBinary, resolveOpencodeBinary } from "./runtime-binaries";
 
 const createSystemCommands = ({
   available = [],
@@ -40,6 +40,18 @@ const writeExecutable = async (path: string): Promise<void> => {
   await writeFile(path, "");
   await chmod(path, 0o755);
 };
+
+describe("isExecutableFile", () => {
+  test("rejects executable directories on POSIX platforms", async () => {
+    await withTempDir(async (root) => {
+      const directory = join(root, "bin");
+      await mkdir(directory);
+      await chmod(directory, 0o755);
+
+      await expect(Effect.runPromise(isExecutableFile(directory, "linux"))).resolves.toBe(false);
+    });
+  });
+});
 
 describe("resolveOpencodeBinary", () => {
   test("resolves an explicit OpenCode override", async () => {

--- a/packages/host/src/adapters/runtimes/runtime-binaries.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.ts
@@ -56,6 +56,14 @@ export const isExecutableFile = (candidate: string, platform: NodeJS.Platform = 
       return file.isFile();
     }
 
+    const file = yield* Effect.tryPromise({
+      try: () => stat(candidate),
+      catch: (cause) => toHostPathStatError(cause, "runtimeBinaries.isExecutableFile", candidate),
+    });
+    if (!file.isFile()) {
+      return false;
+    }
+
     yield* Effect.tryPromise({
       try: () => access(candidate, constants.X_OK),
       catch: (cause) => toHostPathStatError(cause, "runtimeBinaries.isExecutableFile", candidate),

--- a/packages/host/src/adapters/runtimes/runtime-binaries.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.ts
@@ -48,20 +48,15 @@ export const resolveUserPath = (rawPath: string, homeDir = homedir()): string =>
 
 export const isExecutableFile = (candidate: string, platform: NodeJS.Platform = process.platform) =>
   Effect.gen(function* () {
-    if (platform === "win32") {
-      const file = yield* Effect.tryPromise({
-        try: () => stat(candidate),
-        catch: (cause) => toHostPathStatError(cause, "runtimeBinaries.isExecutableFile", candidate),
-      });
-      return file.isFile();
-    }
-
     const file = yield* Effect.tryPromise({
       try: () => stat(candidate),
       catch: (cause) => toHostPathStatError(cause, "runtimeBinaries.isExecutableFile", candidate),
     });
     if (!file.isFile()) {
       return false;
+    }
+    if (platform === "win32") {
+      return true;
     }
 
     yield* Effect.tryPromise({

--- a/packages/host/src/adapters/runtimes/runtime-binaries.ts
+++ b/packages/host/src/adapters/runtimes/runtime-binaries.ts
@@ -61,7 +61,12 @@ export const isExecutableFile = (candidate: string, platform: NodeJS.Platform = 
       catch: (cause) => toHostPathStatError(cause, "runtimeBinaries.isExecutableFile", candidate),
     });
     return true;
-  }).pipe(Effect.catchTag("HostPathNotFoundError", () => Effect.succeed(false)));
+  }).pipe(
+    Effect.catchTags({
+      HostPathAccessError: () => Effect.succeed(false),
+      HostPathNotFoundError: () => Effect.succeed(false),
+    }),
+  );
 
 const executableName = (command: string, platform: NodeJS.Platform): string =>
   platform === "win32" ? `${command}.exe` : command;

--- a/packages/openducktor-mcp/src/listed-tool-schema.test.ts
+++ b/packages/openducktor-mcp/src/listed-tool-schema.test.ts
@@ -6,18 +6,22 @@ const propertiesOf = (jsonSchema: Record<string, unknown>): Record<string, unkno
   return jsonSchema.properties as Record<string, unknown>;
 };
 
+const requiredOf = (jsonSchema: Record<string, unknown>): string[] => {
+  return Array.isArray(jsonSchema.required) ? (jsonSchema.required as string[]) : [];
+};
+
 describe("listed MCP tool input schema", () => {
   test("uses the full contract schema for tool execution", () => {
     expect(ODT_TOOL_SCHEMAS.odt_read_task.shape).toHaveProperty("workspaceId");
   });
 
   test("hides workspaceId from listed tools when the MCP server is already workspace-scoped", () => {
-    const properties = propertiesOf(
-      getListedToolInputSchema("odt_read_task", { hideWorkspaceId: true }),
-    );
+    const schema = getListedToolInputSchema("odt_read_task", { hideWorkspaceId: true });
+    const properties = propertiesOf(schema);
 
     expect(properties).toHaveProperty("taskId");
     expect(properties).not.toHaveProperty("workspaceId");
+    expect(requiredOf(schema)).not.toContain("workspaceId");
   });
 
   test("keeps workspaceId in listed tools for external MCP clients", () => {

--- a/packages/openducktor-mcp/src/listed-tool-schema.ts
+++ b/packages/openducktor-mcp/src/listed-tool-schema.ts
@@ -24,24 +24,11 @@ const removeWorkspaceId = (jsonSchema: Record<string, unknown>): Record<string, 
   };
 };
 
-const withObjectProperties = (jsonSchema: Record<string, unknown>): Record<string, unknown> => {
-  if (jsonSchema.properties !== undefined) {
-    return jsonSchema;
-  }
-
-  return {
-    ...jsonSchema,
-    properties: {},
-  };
-};
-
 export const getListedToolInputSchema = (
   toolName: RegisteredToolName,
   options: { hideWorkspaceId: boolean },
 ): Record<string, unknown> => {
-  const jsonSchema = withObjectProperties(
-    z.toJSONSchema(ODT_TOOL_SCHEMAS[toolName], { io: "input" }),
-  );
+  const jsonSchema = z.toJSONSchema(ODT_TOOL_SCHEMAS[toolName], { io: "input" });
 
   if (options.hideWorkspaceId && WORKSPACE_SCOPED_TOOL_NAMES.has(toolName)) {
     return removeWorkspaceId(jsonSchema);

--- a/packages/openducktor-mcp/src/listed-tool-schema.ts
+++ b/packages/openducktor-mcp/src/listed-tool-schema.ts
@@ -14,7 +14,14 @@ const removeWorkspaceId = (jsonSchema: Record<string, unknown>): Record<string, 
     string,
     unknown
   >;
-  return { ...jsonSchema, properties };
+
+  return {
+    ...jsonSchema,
+    properties,
+    ...(Array.isArray(jsonSchema.required)
+      ? { required: jsonSchema.required.filter((key) => key !== "workspaceId") }
+      : {}),
+  };
 };
 
 const withObjectProperties = (jsonSchema: Record<string, unknown>): Record<string, unknown> => {

--- a/packages/openducktor-mcp/src/listed-tool-schema.ts
+++ b/packages/openducktor-mcp/src/listed-tool-schema.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { ODT_TOOL_SCHEMAS, ODT_WORKSPACE_SCOPED_TOOL_NAMES } from "./lib";
+import {
+  ODT_HOST_BRIDGE_RESPONSE_SCHEMAS,
+  ODT_TOOL_SCHEMAS,
+  ODT_WORKSPACE_SCOPED_TOOL_NAMES,
+} from "./lib";
 
 export type RegisteredToolName = keyof typeof ODT_TOOL_SCHEMAS;
 
@@ -13,15 +17,34 @@ const removeWorkspaceId = (jsonSchema: Record<string, unknown>): Record<string, 
   return { ...jsonSchema, properties };
 };
 
+const withObjectProperties = (jsonSchema: Record<string, unknown>): Record<string, unknown> => {
+  if (jsonSchema.properties !== undefined) {
+    return jsonSchema;
+  }
+
+  return {
+    ...jsonSchema,
+    properties: {},
+  };
+};
+
 export const getListedToolInputSchema = (
   toolName: RegisteredToolName,
   options: { hideWorkspaceId: boolean },
 ): Record<string, unknown> => {
-  const jsonSchema = z.toJSONSchema(ODT_TOOL_SCHEMAS[toolName], { io: "input" });
+  const jsonSchema = withObjectProperties(
+    z.toJSONSchema(ODT_TOOL_SCHEMAS[toolName], { io: "input" }),
+  );
 
   if (options.hideWorkspaceId && WORKSPACE_SCOPED_TOOL_NAMES.has(toolName)) {
     return removeWorkspaceId(jsonSchema);
   }
 
   return jsonSchema;
+};
+
+export const getListedToolOutputSchema = (
+  toolName: RegisteredToolName,
+): Record<string, unknown> => {
+  return z.toJSONSchema(ODT_HOST_BRIDGE_RESPONSE_SCHEMAS[toolName], { io: "output" });
 };

--- a/packages/openducktor-mcp/src/mcp-server.ts
+++ b/packages/openducktor-mcp/src/mcp-server.ts
@@ -1,8 +1,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import packageJson from "../package.json" with { type: "json" };
-import { ODT_MCP_TOOL_NAMES, ODT_TOOL_SCHEMAS, ODT_WORKSPACE_SCOPED_TOOL_NAMES } from "./lib";
-import { getListedToolInputSchema, type RegisteredToolName } from "./listed-tool-schema";
+import {
+  ODT_HOST_BRIDGE_RESPONSE_SCHEMAS,
+  ODT_MCP_TOOL_NAMES,
+  ODT_TOOL_SCHEMAS,
+  ODT_WORKSPACE_SCOPED_TOOL_NAMES,
+} from "./lib";
+import {
+  getListedToolInputSchema,
+  getListedToolOutputSchema,
+  type RegisteredToolName,
+} from "./listed-tool-schema";
 import { OdtTaskStore } from "./odt-task-store";
 import { type OdtStoreContext, resolveStoreContext } from "./store-context";
 import { OdtToolError, type ToolResult, toToolError, toToolResult } from "./tool-results";
@@ -26,7 +35,7 @@ type RegisteredToolSpecs = {
 
 type RegisterContractTool = (
   name: string,
-  config: { description: string; inputSchema: unknown },
+  config: { description: string; inputSchema: unknown; outputSchema: unknown },
   callback: (input: unknown) => Promise<ToolResult>,
 ) => void;
 
@@ -114,6 +123,7 @@ const registerOdtTool = <Name extends RegisteredToolName>(
     {
       description: tool.description,
       inputSchema: schema,
+      outputSchema: ODT_HOST_BRIDGE_RESPONSE_SCHEMAS[tool.name],
     },
     async (input: unknown) => {
       try {
@@ -142,6 +152,7 @@ const toListedToolDefinition = (
   inputSchema: getListedToolInputSchema(tool.name, {
     hideWorkspaceId: options.forbidWorkspaceIdInput,
   }),
+  outputSchema: getListedToolOutputSchema(tool.name),
 });
 
 const installVisibleToolListHandler = (


### PR DESCRIPTION
## Summary
Adds Electron Windows/Linux package validation for the bundled OpenDucktor MCP sidecar and tightens the MCP host/tool contracts that the packaged sidecar exposes at runtime.

## Goal
The obsolete web-host artifact path is no longer the release path that needs validation. This PR makes the Electron package build fail fast when Windows or Linux artifacts do not contain the OpenDucktor MCP sidecar at the resources path expected by the TypeScript host, while keeping external tools such as `bd`, `dolt`, and `opencode` unbundled.

## Context
Packaged Electron startup sets the host environment from `process.resourcesPath`. The TypeScript host then resolves the bundled MCP sidecar through `OPENDUCKTOR_OPENDUCKTOR_MCP_PATH` and `OPENDUCKTOR_BUNDLED_BIN_DIR`. Without package-level validation, a release could build successfully while omitting the sidecar or shipping it without executable permissions on Unix.

During final PR verification, the root Bun test command exposed that the Builder session's `ODT_ALLOWED_TOOLS` environment intentionally hides `odt_get_workspaces`, which is invalid for the public MCP test suite. The PR therefore also makes the MCP listed-tool contract explicit for zero-input tools and structured output schemas, so client-visible metadata matches the tool result contract.

## Technical Choices
- Added an Electron package verification step after Electron Builder completes and before artifact publication.
- Validated `resources/bin/openducktor-mcp.exe` for Windows and `resources/bin/openducktor-mcp` for Linux, including non-empty payload checks and Unix executable-bit checks.
- Kept macOS and unrelated package targets out of this validation path.
- Preserved packaged Electron environment ownership in `electron-process-environment.ts`, with tests covering Windows and Linux resource paths.
- Rejected directory paths in host executable validation before checking platform-specific runnability.
- Registered MCP output schemas and explicit empty input properties for zero-argument tools so `structuredContent` remains a documented, client-visible contract.

## Verification
- `rtk bun run lint`
- `rtk bun run typecheck`
- `rtk env -u ODT_ALLOWED_TOOLS -u ODT_WORKSPACE_ID -u ODT_HOST_TOKEN -u ODT_HOST_URL -u ODT_FORBID_WORKSPACE_ID_INPUT bun run test`
- `rtk bun run build`
- `rtk cargo fmt --all --check` in `apps/desktop/src-tauri`
- `rtk cargo clippy --workspace --all-targets -- -D warnings` in `apps/desktop/src-tauri`
- `rtk cargo check --workspace --all-targets --locked` in `apps/desktop/src-tauri`
- `rtk cargo test --workspace --locked` in `apps/desktop/src-tauri` (`984 passed, 1 ignored`)
- `rtk cargo build --workspace --locked` in `apps/desktop/src-tauri`
- `rtk git rev-list --left-right --count origin/main...HEAD` returned `0 4`; no rebase was needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification for bundled MCP sidecar packages in Electron releases
  * Added output schema metadata for MCP tool definitions

* **Bug Fixes**
  * Improved executable file validation to reject directories with execute permissions
  * Enhanced process cleanup handling with better error recovery

* **Tests**
  * Added comprehensive sidecar package verification test suite
  * Expanded MCP command validation tests with edge cases
  * Updated platform-specific test configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->