### PR TITLE
fix: preserve Codex turn model metadata

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
@@ -164,6 +164,55 @@ describe("CodexAppServerAdapter lifecycle", () => {
     });
   });
 
+  test("updates the session model used for subsequent turns", async () => {
+    const { adapter, transports } = createHarness();
+
+    await adapter.startSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "spec",
+      systemPrompt: "Use the repo rules.",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    adapter.updateSessionModel({
+      externalSessionId: "thread/start-runtime-ensure",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "high" },
+    });
+
+    await adapter.sendUserMessage({
+      externalSessionId: "thread/start-runtime-ensure",
+      parts: [{ kind: "text", text: "Use deeper reasoning" }],
+    });
+
+    expect(transports.get("runtime-ensure")?.calls[2]).toEqual({
+      method: "turn/start",
+      params: {
+        threadId: "thread/start-runtime-ensure",
+        input: [{ type: "text", text: "Use deeper reasoning" }],
+        model: "gpt-5",
+        effort: "high",
+      },
+    });
+
+    const history = await adapter.loadSessionHistory({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      externalSessionId: "thread/start-runtime-ensure",
+    });
+    const assistantMessage = history.find(
+      (message) => message.role === "assistant" && message.messageId === "msg-1",
+    );
+    expect(assistantMessage?.model).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+    });
+  });
+
   test("starts a Codex repo runtime when hydrating a saved session", async () => {
     const { adapter, ensureRepoRuntime, requireRepoRuntime, transports } = createHarness();
 
@@ -269,9 +318,9 @@ describe("CodexAppServerAdapter lifecycle", () => {
         taskId: "task-1",
         role: "build",
         systemPrompt: "Use the repo rules.",
-        model: { providerId: "openai", modelId: "gpt-5", variant: "high" },
+        model: { providerId: "openai", modelId: "gpt-5", variant: "xhigh" },
       }),
-    ).rejects.toThrow("does not support reasoning effort 'high'");
+    ).rejects.toThrow("does not support reasoning effort 'xhigh'");
   });
 
   test("fails clearly when a live runtime is missing", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
@@ -4,6 +4,7 @@ import {
   makeRuntimeSummary,
   RecordingTransport,
 } from "./codex-app-server-adapter.test-harness";
+import { codexTurnKey } from "./codex-app-server-requests";
 import { CodexAppServerAdapter } from "./index";
 
 describe("CodexAppServerAdapter lifecycle", () => {
@@ -66,6 +67,33 @@ describe("CodexAppServerAdapter lifecycle", () => {
     });
     const transport = transports.get("runtime-task-1");
     expect(transport?.calls.filter((call) => call.method === "model/list")).toHaveLength(1);
+  });
+
+  test("clears per-turn model metadata when local stop cleanup runs", async () => {
+    const { adapter } = createHarness();
+
+    await adapter.startSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    const modelByTurnKey = (
+      adapter as unknown as { modelByTurnKey: Map<string, { providerId: string }> }
+    ).modelByTurnKey;
+    const stoppedSessionTurnKey = codexTurnKey("thread/start-runtime-ensure", "turn-stopped");
+    const otherSessionTurnKey = codexTurnKey("thread/other", "turn-active");
+    modelByTurnKey.set(stoppedSessionTurnKey, { providerId: "openai" });
+    modelByTurnKey.set(otherSessionTurnKey, { providerId: "openai" });
+
+    await adapter.stopSession("thread/start-runtime-ensure");
+
+    expect(modelByTurnKey.has(stoppedSessionTurnKey)).toBe(false);
+    expect(modelByTurnKey.has(otherSessionTurnKey)).toBe(true);
   });
 
   test("lists models through the required live runtime id", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -535,6 +535,67 @@ describe("CodexAppServerAdapter streaming", () => {
     });
   });
 
+  test("uses active turn model for completed user messages without turn id", async () => {
+    const drainNotifications = mock(async (_runtimeId: string) => [] as unknown[]);
+    const { adapter, transports } = createHarness({ drainNotifications }, { deferTurnStart: true });
+
+    await adapter.startSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    const events: unknown[] = [];
+    adapter.subscribeEvents("thread/start-runtime-ensure", (event) => events.push(event));
+    drainNotifications.mockImplementationOnce(async () => {
+      adapter.updateSessionModel({
+        externalSessionId: "thread/start-runtime-ensure",
+        model: { providerId: "openai", modelId: "gpt-5", variant: "high" },
+      });
+      setTimeout(() => {
+        transports.get("runtime-ensure")?.turnStartDeferred.resolve({
+          turn: { id: "turn-without-item-id", status: "completed" },
+        });
+      }, 0);
+      return [
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread/start-runtime-ensure",
+            item: {
+              type: "userMessage",
+              id: "user-without-turn-id",
+              content: [{ type: "text", text: "Use the original turn model" }],
+            },
+          },
+        },
+      ];
+    });
+
+    await adapter.sendUserMessage({
+      externalSessionId: "thread/start-runtime-ensure",
+      parts: [{ kind: "text", text: "Use the original turn model" }],
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    const userMessage = events.find(
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        "type" in event &&
+        event.type === "user_message",
+    );
+    expect(userMessage).toMatchObject({
+      type: "user_message",
+      message: "Use the original turn model",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+  });
+
   test("ignores notifications for other Codex threads", async () => {
     const drainNotifications = mock(
       async (_runtimeId: string) =>

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -458,6 +458,83 @@ describe("CodexAppServerAdapter streaming", () => {
     );
   });
 
+  test("preserves turn model when item notifications reveal the turn id before turn started", async () => {
+    const drainNotifications = mock(async (_runtimeId: string) => [] as unknown[]);
+    const { adapter, transports } = createHarness({ drainNotifications }, { deferTurnStart: true });
+
+    await adapter.startSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+    adapter.updateSessionModel({
+      externalSessionId: "thread/start-runtime-ensure",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "high" },
+    });
+
+    const events: unknown[] = [];
+    adapter.subscribeEvents("thread/start-runtime-ensure", (event) => events.push(event));
+    drainNotifications.mockImplementationOnce(async () => {
+      setTimeout(() => {
+        transports.get("runtime-ensure")?.turnStartDeferred.resolve({
+          turn: { id: "turn-notification-first", status: "completed" },
+        });
+      }, 0);
+      return [
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread/start-runtime-ensure",
+            turnId: "turn-notification-first",
+            item: {
+              type: "agentMessage",
+              id: "agent-notification-first",
+              phase: "final_answer",
+              text: "Done with low reasoning.",
+            },
+          },
+        },
+        {
+          method: "turn/started",
+          params: {
+            threadId: "thread/start-runtime-ensure",
+            turn: { id: "turn-notification-first" },
+          },
+        },
+        {
+          method: "turn/completed",
+          params: {
+            threadId: "thread/start-runtime-ensure",
+            turn: { id: "turn-notification-first", status: "completed" },
+          },
+        },
+      ];
+    });
+
+    await adapter.sendUserMessage({
+      externalSessionId: "thread/start-runtime-ensure",
+      parts: [{ kind: "text", text: "Use shallow reasoning" }],
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    const assistantMessage = events.find(
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        "type" in event &&
+        event.type === "assistant_message",
+    );
+    expect(assistantMessage).toMatchObject({
+      type: "assistant_message",
+      message: "Done with low reasoning.",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+  });
+
   test("ignores notifications for other Codex threads", async () => {
     const drainNotifications = mock(
       async (_runtimeId: string) =>

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -94,7 +94,7 @@ export class RecordingTransport implements CodexJsonRpcTransport {
           startedAt: "2026-05-07T00:00:00.000Z",
         } as Response;
       }
-      case "turn/start":
+      case "turn/start": {
         if (
           !Array.isArray((params as { input?: unknown })?.input) ||
           (params as { input: Array<{ type?: unknown }> }).input.some(
@@ -103,9 +103,13 @@ export class RecordingTransport implements CodexJsonRpcTransport {
         ) {
           throw new Error("Invalid request: missing field `type`");
         }
-        await this.turnStartDeferred.promise;
+        const deferred = await this.turnStartDeferred.promise;
+        if (typeof deferred === "object" && deferred !== null && "turn" in deferred) {
+          return deferred as Response;
+        }
         this.turnStartCount += 1;
         return { turn: { id: `turn-${this.turnStartCount}`, status: "completed" } } as Response;
+      }
       case "turn/steer":
         return { turnId: "turn-steered" } as Response;
       case "thread/read":

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -35,6 +35,7 @@ export const createDeferred = <T>() => {
 export class RecordingTransport implements CodexJsonRpcTransport {
   readonly calls: CodexJsonRpcRequest[] = [];
   readonly turnStartDeferred = createDeferred<unknown>();
+  private turnStartCount = 0;
 
   constructor(
     private readonly runtimeId: string,
@@ -61,6 +62,7 @@ export class RecordingTransport implements CodexJsonRpcTransport {
               hidden: false,
               supportedReasoningEfforts: [
                 { reasoningEffort: "medium", description: "Balanced reasoning" },
+                { reasoningEffort: "high", description: "Deep reasoning" },
               ],
               defaultReasoningEffort: {
                 reasoningEffort: "medium",
@@ -101,7 +103,9 @@ export class RecordingTransport implements CodexJsonRpcTransport {
         ) {
           throw new Error("Invalid request: missing field `type`");
         }
-        return (await this.turnStartDeferred.promise) as Response;
+        await this.turnStartDeferred.promise;
+        this.turnStartCount += 1;
+        return { turn: { id: `turn-${this.turnStartCount}`, status: "completed" } } as Response;
       case "turn/steer":
         return { turnId: "turn-steered" } as Response;
       case "thread/read":

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -983,6 +983,11 @@ export class CodexAppServerAdapter
         this.tokenUsageByTurnKey.delete(turnKey);
       }
     }
+    for (const turnKey of [...this.modelByTurnKey.keys()]) {
+      if (turnKey.startsWith(turnKeyPrefix)) {
+        this.modelByTurnKey.delete(turnKey);
+      }
+    }
   }
 
   private ensureRuntimeEventSubscription(runtimeId: string): void {
@@ -1499,7 +1504,9 @@ export class CodexAppServerAdapter
       if (this.consumeSyntheticUserMessage(session.threadId, message)) {
         return;
       }
-      const model = this.modelForTurn(session, turnId) ?? session.model;
+      const model =
+        this.modelForTurn(session, turnId) ??
+        this.activeTurnsBySessionId.get(session.threadId)?.model;
       this.emitSessionEvent(session.threadId, {
         type: "user_message",
         externalSessionId: session.threadId,

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -397,6 +397,28 @@ export class CodexAppServerAdapter
     }
   }
 
+  private bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean {
+    if (activeTurn.turnId && activeTurn.turnId !== turnId) {
+      return false;
+    }
+
+    const didBind = !activeTurn.turnId;
+    activeTurn.turnId = turnId;
+    this.modelByTurnKey.set(codexTurnKey(activeTurn.session.threadId, turnId), activeTurn.model);
+    return didBind;
+  }
+
+  private flushQueuedUserMessagesLater(activeTurn: ActiveCodexTurn): void {
+    void this.flushQueuedUserMessages(activeTurn).catch((error) => {
+      this.emitSessionEvent(activeTurn.session.threadId, {
+        type: "session_error",
+        externalSessionId: activeTurn.session.threadId,
+        timestamp: new Date().toISOString(),
+        message: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
   private async startTurnForSession(
     externalSessionId: string,
     parts: import("@openducktor/core").AgentUserMessagePart[],
@@ -465,17 +487,9 @@ export class CodexAppServerAdapter
       .then((result) => {
         const turnId = extractTurnId(result);
         if (turnId) {
-          activeTurnState.turnId = turnId;
-          this.modelByTurnKey.set(codexTurnKey(session.threadId, turnId), model);
+          this.bindActiveTurnId(activeTurnState, turnId);
         }
-        void this.flushQueuedUserMessages(activeTurnState).catch((error) => {
-          this.emitSessionEvent(session.threadId, {
-            type: "session_error",
-            externalSessionId: session.threadId,
-            timestamp: new Date().toISOString(),
-            message: error instanceof Error ? error.message : String(error),
-          });
-        });
+        this.flushQueuedUserMessagesLater(activeTurnState);
         if (!this.options.subscribeEvents && !this.options.drainNotifications) {
           this.emitUserMessage(session, parts, model);
           activeTurnState.markTurnSettled();
@@ -1223,16 +1237,12 @@ export class CodexAppServerAdapter
       const timestamp = timestampFromCodexParams(notification.params);
       const notificationTurnId = extractTurnId(notification.params);
       const activeTurn = this.activeTurnsBySessionId.get(session.threadId);
-      if (notificationTurnId && activeTurn && !activeTurn.turnId) {
-        activeTurn.turnId = notificationTurnId;
-        void this.flushQueuedUserMessages(activeTurn).catch((error) => {
-          this.emitSessionEvent(session.threadId, {
-            type: "session_error",
-            externalSessionId: session.threadId,
-            timestamp: new Date().toISOString(),
-            message: error instanceof Error ? error.message : String(error),
-          });
-        });
+      if (
+        notificationTurnId &&
+        activeTurn &&
+        this.bindActiveTurnId(activeTurn, notificationTurnId)
+      ) {
+        this.flushQueuedUserMessagesLater(activeTurn);
       }
 
       if (notification.method === "turn/started") {
@@ -1243,9 +1253,8 @@ export class CodexAppServerAdapter
         };
         const turn = isPlainObject(notification.params) ? notification.params.turn : null;
         const turnId = isPlainObject(turn) ? extractStringField(turn, ["id", "turnId"]) : null;
-        if (turnId && activeTurn && !activeTurn.turnId) {
-          activeTurn.turnId = turnId;
-          this.modelByTurnKey.set(codexTurnKey(session.threadId, turnId), activeTurn.model);
+        if (turnId && activeTurn && this.bindActiveTurnId(activeTurn, turnId)) {
+          this.flushQueuedUserMessagesLater(activeTurn);
         }
         continue;
       }
@@ -1325,9 +1334,12 @@ export class CodexAppServerAdapter
             this.completedAgentMessagesByTurnKey.delete(turnKey);
           }
           this.tokenUsageByTurnKey.delete(turnKey);
+          this.modelByTurnKey.delete(turnKey);
         } else if (turnId) {
-          this.completedAgentMessagesByTurnKey.delete(codexTurnKey(session.threadId, turnId));
-          this.tokenUsageByTurnKey.delete(codexTurnKey(session.threadId, turnId));
+          const turnKey = codexTurnKey(session.threadId, turnId);
+          this.completedAgentMessagesByTurnKey.delete(turnKey);
+          this.tokenUsageByTurnKey.delete(turnKey);
+          this.modelByTurnKey.delete(turnKey);
         }
         activeTurn?.markTurnSettled();
         session.liveStatus = {
@@ -1792,9 +1804,8 @@ export class CodexAppServerAdapter
 
     const requestTurnId = extractTurnId(rawRequest.params);
     const activeTurn = this.activeTurnsBySessionId.get(session.threadId);
-    if (requestTurnId && activeTurn && !activeTurn.turnId) {
-      activeTurn.turnId = requestTurnId;
-      void this.flushQueuedUserMessages(activeTurn);
+    if (requestTurnId && activeTurn && this.bindActiveTurnId(activeTurn, requestTurnId)) {
+      this.flushQueuedUserMessagesLater(activeTurn);
     }
 
     if (rawRequest.method === CODEX_USER_INPUT_REQUEST_METHOD) {
@@ -1804,9 +1815,8 @@ export class CodexAppServerAdapter
           `Codex question request thread '${parsed.threadId}' does not match active session '${session.threadId}'.`,
         );
       }
-      if (activeTurn && !activeTurn.turnId) {
-        activeTurn.turnId = parsed.turnId;
-        void this.flushQueuedUserMessages(activeTurn);
+      if (activeTurn && this.bindActiveTurnId(activeTurn, parsed.turnId)) {
+        this.flushQueuedUserMessagesLater(activeTurn);
       }
       const questionInput = {
         requestId: parsed.request.requestId,

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -189,9 +189,15 @@ export class CodexAppServerAdapter
   private readonly syntheticUserMessageTextsByThreadId = new Map<string, string[]>();
   private readonly completedAgentMessagesByTurnKey = new Map<
     string,
-    { session: CodexSessionState; item: Record<string, unknown>; timestamp: string }
+    {
+      session: CodexSessionState;
+      item: Record<string, unknown>;
+      timestamp: string;
+      model?: AgentModelSelection;
+    }
   >();
   private readonly tokenUsageByTurnKey = new Map<string, CodexTokenUsageTotals>();
+  private readonly modelByTurnKey = new Map<string, AgentModelSelection>();
   private readonly runtimeEventSubscriptionsByRuntimeId = new Map<string, CodexLiveEventPump>();
   private readonly eventBacklogBySessionId = new Map<string, AgentEvent[]>();
   private readonly latestTodosBySessionId = new Map<string, AgentSessionTodoItem[]>();
@@ -423,6 +429,7 @@ export class CodexAppServerAdapter
       this.activeTurnsBySessionId.delete(session.threadId);
     }
 
+    const model = requireModelSelection(requestedModel ?? session.model);
     let turnSettled = false;
     const handledRequestKeys = new Set<string>();
     const activeTurnState: ActiveCodexTurn = {
@@ -435,10 +442,10 @@ export class CodexAppServerAdapter
       },
       handledRequestKeys,
       queuedUserMessages: [],
+      model,
     };
     this.activeTurnsBySessionId.set(session.threadId, activeTurnState);
 
-    const model = requireModelSelection(requestedModel ?? session.model);
     const client = this.clientForRuntime(session.runtimeId);
     try {
       await this.models.validate(client, session.runtimeId, model);
@@ -459,6 +466,7 @@ export class CodexAppServerAdapter
         const turnId = extractTurnId(result);
         if (turnId) {
           activeTurnState.turnId = turnId;
+          this.modelByTurnKey.set(codexTurnKey(session.threadId, turnId), model);
         }
         void this.flushQueuedUserMessages(activeTurnState).catch((error) => {
           this.emitSessionEvent(session.threadId, {
@@ -469,7 +477,7 @@ export class CodexAppServerAdapter
           });
         });
         if (!this.options.subscribeEvents && !this.options.drainNotifications) {
-          this.emitUserMessage(session, parts);
+          this.emitUserMessage(session, parts, model);
           activeTurnState.markTurnSettled();
         } else if (isPlainObject(result.turn) && isTerminalTurnStatus(result.turn)) {
           activeTurnState.markTurnSettled();
@@ -483,7 +491,7 @@ export class CodexAppServerAdapter
     activeTurnState.turnStartPromise = turnStartPromise;
 
     if (this.options.subscribeEvents) {
-      this.emitUserMessage(session, parts);
+      this.emitUserMessage(session, parts, model);
       void turnStartPromise.catch((error) => {
         this.emitSessionEvent(session.threadId, {
           type: "session_error",
@@ -548,7 +556,12 @@ export class CodexAppServerAdapter
       input.externalSessionId,
     );
     return codexTurnItemsFromThreadRead(response)
-      .flatMap(({ item, turnId, timestamp, isFinalAgentMessage, turnTiming }, index) => {
+      .flatMap(({ item, turnId, timestamp, isFinalAgentMessage, turnTiming, model }, index) => {
+        const turnModel =
+          model ??
+          (turnId
+            ? this.modelByTurnKey.get(codexTurnKey(input.externalSessionId, turnId))
+            : undefined);
         let finalTokenUsage: CodexTokenUsageTotals | null = null;
         if (isFinalAgentMessage && turnId) {
           finalTokenUsage =
@@ -570,7 +583,7 @@ export class CodexAppServerAdapter
           },
         );
         if (canonicalEvents.length > 0) {
-          const history = projectCodexCanonicalEventsToHistory(canonicalEvents, session?.model);
+          const history = projectCodexCanonicalEventsToHistory(canonicalEvents, turnModel);
           if (isFinalAgentMessage) {
             return history.map((message) =>
               applyFinalAssistantTurnMetadata(message, turnTiming, finalTokenUsage),
@@ -581,7 +594,7 @@ export class CodexAppServerAdapter
         const message = toHistoryMessage(
           item,
           `codex-history-${index}`,
-          session?.model,
+          turnModel,
           timestamp ?? undefined,
           isFinalAgentMessage,
           turnTiming,
@@ -670,8 +683,16 @@ export class CodexAppServerAdapter
     return todos;
   }
 
-  updateSessionModel(_: UpdateAgentSessionModelInput): void {
-    unsupported("updateSessionModel");
+  updateSessionModel(input: UpdateAgentSessionModelInput): void {
+    const session = this.sessions.get(input.externalSessionId);
+    if (!session) {
+      throw new Error(`Unknown Codex session '${input.externalSessionId}'.`);
+    }
+    if (input.model) {
+      session.model = input.model;
+      return;
+    }
+    delete session.model;
   }
 
   async attachSession(input: AttachAgentSessionInput): Promise<AgentSessionSummary> {
@@ -1224,6 +1245,7 @@ export class CodexAppServerAdapter
         const turnId = isPlainObject(turn) ? extractStringField(turn, ["id", "turnId"]) : null;
         if (turnId && activeTurn && !activeTurn.turnId) {
           activeTurn.turnId = turnId;
+          this.modelByTurnKey.set(codexTurnKey(session.threadId, turnId), activeTurn.model);
         }
         continue;
       }
@@ -1279,7 +1301,9 @@ export class CodexAppServerAdapter
           },
         );
         if (canonicalEvents.length > 0) {
-          this.emitCanonicalEvents(canonicalEvents);
+          this.emitCanonicalEvents(
+            this.withTurnModel(canonicalEvents, session, notificationTurnId),
+          );
           continue;
         }
       }
@@ -1288,19 +1312,19 @@ export class CodexAppServerAdapter
         const turn = isPlainObject(notification.params) ? notification.params.turn : null;
         const turnId = isPlainObject(turn) ? extractStringField(turn, ["id", "turnId"]) : null;
         if (turnId && isPlainObject(turn) && turn.status === "completed") {
-          const bufferedAgentMessage = this.completedAgentMessagesByTurnKey.get(
-            codexTurnKey(session.threadId, turnId),
-          );
+          const turnKey = codexTurnKey(session.threadId, turnId);
+          const bufferedAgentMessage = this.completedAgentMessagesByTurnKey.get(turnKey);
           if (bufferedAgentMessage) {
             this.emitFinalAgentMessage(
               bufferedAgentMessage.session,
               bufferedAgentMessage.item,
               bufferedAgentMessage.timestamp,
-              this.tokenUsageByTurnKey.get(codexTurnKey(session.threadId, turnId)),
+              this.tokenUsageByTurnKey.get(turnKey),
+              bufferedAgentMessage.model ?? this.modelForTurn(session, turnId),
             );
-            this.completedAgentMessagesByTurnKey.delete(codexTurnKey(session.threadId, turnId));
+            this.completedAgentMessagesByTurnKey.delete(turnKey);
           }
-          this.tokenUsageByTurnKey.delete(codexTurnKey(session.threadId, turnId));
+          this.tokenUsageByTurnKey.delete(turnKey);
         } else if (turnId) {
           this.completedAgentMessagesByTurnKey.delete(codexTurnKey(session.threadId, turnId));
           this.tokenUsageByTurnKey.delete(codexTurnKey(session.threadId, turnId));
@@ -1379,7 +1403,18 @@ export class CodexAppServerAdapter
     }
   }
 
-  private emitUserMessage(session: CodexSessionState, parts: AgentUserMessagePart[]): void {
+  private modelForTurn(
+    session: CodexSessionState,
+    turnId: string | null,
+  ): AgentModelSelection | undefined {
+    return turnId ? this.modelByTurnKey.get(codexTurnKey(session.threadId, turnId)) : undefined;
+  }
+
+  private emitUserMessage(
+    session: CodexSessionState,
+    parts: AgentUserMessagePart[],
+    model: AgentModelSelection | undefined,
+  ): void {
     const message = serializeAgentUserMessagePartsToText(parts);
     if (this.options.subscribeEvents) {
       const codexEchoText = codexUserInputListToText(toCodexUserInputList(parts));
@@ -1398,7 +1433,7 @@ export class CodexAppServerAdapter
       message,
       parts: toDisplayParts(parts),
       state: "read",
-      ...(session.model ? { model: session.model } : {}),
+      ...(model ? { model } : {}),
     });
   }
 
@@ -1452,6 +1487,7 @@ export class CodexAppServerAdapter
       if (this.consumeSyntheticUserMessage(session.threadId, message)) {
         return;
       }
+      const model = this.modelForTurn(session, turnId) ?? session.model;
       this.emitSessionEvent(session.threadId, {
         type: "user_message",
         externalSessionId: session.threadId,
@@ -1460,7 +1496,7 @@ export class CodexAppServerAdapter
         message,
         parts: input.map(codexUserInputToDisplayPart),
         state: "read",
-        ...(session.model ? { model: session.model } : {}),
+        ...(model ? { model } : {}),
       });
       return;
     }
@@ -1488,10 +1524,12 @@ export class CodexAppServerAdapter
           const turnKey = codexTurnKey(session.threadId, turnId);
           const existing = this.completedAgentMessagesByTurnKey.get(turnKey);
           if (!existing || shouldReplaceCodexBufferedFinalAgentMessage(existing.item, item)) {
+            const model = this.modelForTurn(session, turnId);
             this.completedAgentMessagesByTurnKey.set(turnKey, {
               session,
               item,
               timestamp,
+              ...(model ? { model } : {}),
             });
           }
         }
@@ -1509,7 +1547,7 @@ export class CodexAppServerAdapter
       },
     );
     if (canonicalEvents.length > 0) {
-      this.emitCanonicalEvents(canonicalEvents);
+      this.emitCanonicalEvents(this.withTurnModel(canonicalEvents, session, turnId));
       return;
     }
 
@@ -1545,6 +1583,7 @@ export class CodexAppServerAdapter
     item: Record<string, unknown>,
     timestamp: string,
     tokenUsage?: CodexTokenUsageTotals,
+    model?: AgentModelSelection,
   ): void {
     const itemId = codexItemId(item, `codex-item-${Date.now()}`);
     const text = extractStringField(item, ["text"]);
@@ -1561,9 +1600,26 @@ export class CodexAppServerAdapter
         ...(typeof tokenUsage?.contextWindow === "number"
           ? { contextWindow: tokenUsage.contextWindow }
           : {}),
-        ...(session.model ? { model: session.model } : {}),
+        ...(model ? { model } : {}),
       });
     }
+  }
+
+  private withTurnModel(
+    events: CodexCanonicalEvent[],
+    session: CodexSessionState,
+    turnId: string | null,
+  ): CodexCanonicalEvent[] {
+    const model = this.modelForTurn(session, turnId);
+    if (!model) {
+      return events;
+    }
+    return events.map((event) => {
+      if ((event.kind === "user_message" || event.kind === "assistant_message") && !event.model) {
+        return { ...event, model };
+      }
+      return event;
+    });
   }
 
   private emitSessionEvent(externalSessionId: string, event: AgentEvent): void {

--- a/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
@@ -1,3 +1,4 @@
+import type { AgentModelSelection } from "@openducktor/core";
 import type { CodexSessionState, CodexTurnStartResult, CodexUserInput } from "./types";
 
 export const unsupported = (surface: string): never => {
@@ -17,6 +18,7 @@ export type ActiveCodexTurn = {
   markTurnSettled: () => void;
   handledRequestKeys: Set<string>;
   queuedUserMessages: CodexUserInput[][];
+  model: AgentModelSelection;
   turnId?: string;
 };
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -34,4 +34,30 @@ describe("Codex App Server transcript parsing", () => {
       variant: "high",
     });
   });
+
+  test("does not invent a provider when thread reads omit provider metadata", () => {
+    const items = codexTurnItemsFromThreadRead({
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            model: "gpt-5",
+            reasoningEffort: "high",
+            items: [
+              {
+                id: "message-1",
+                type: "agentMessage",
+                phase: "final_answer",
+                text: "Done",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.model).toBeUndefined();
+  });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { codexTurnItemsFromThreadRead } from "./codex-app-server-transcript";
+
+describe("Codex App Server transcript parsing", () => {
+  test("preserves turn model and reasoning effort from thread reads", () => {
+    const items = codexTurnItemsFromThreadRead({
+      thread: {
+        modelProvider: "openai",
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            startedAt: 1_778_112_001,
+            completedAt: 1_778_112_031,
+            model: "gpt-5",
+            reasoningEffort: "high",
+            items: [
+              {
+                id: "message-1",
+                type: "agentMessage",
+                phase: "final_answer",
+                text: "Done",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.model).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+    });
+  });
+});

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -72,6 +72,7 @@ export type CodexThreadReadItem = {
   timestamp: string | null;
   isFinalAgentMessage: boolean;
   turnTiming: CodexTurnTiming | null;
+  model?: AgentModelSelection;
 };
 
 export type CodexHistoryTokenUsageFields = {
@@ -216,6 +217,7 @@ export const codexTurnItemsFromThreadRead = (value: unknown): CodexThreadReadIte
   if (!Array.isArray(value.thread.turns)) {
     throw new Error("Codex thread/read response is missing thread turns.");
   }
+  const threadModelProvider = extractStringField(value.thread, ["modelProvider", "model_provider"]);
   return value.thread.turns.flatMap((turn): CodexThreadReadItem[] => {
     if (!isPlainObject(turn)) {
       return [];
@@ -231,6 +233,19 @@ export const codexTurnItemsFromThreadRead = (value: unknown): CodexThreadReadIte
       (typeof startedAtSeconds === "number" && typeof completedAtSeconds === "number"
         ? Math.max(0, (completedAtSeconds - startedAtSeconds) * 1000)
         : null);
+    const modelId = extractStringField(turn, ["model", "modelId", "model_id"]);
+    const providerId =
+      extractStringField(turn, ["modelProvider", "model_provider", "providerId", "provider_id"]) ??
+      threadModelProvider ??
+      "codex";
+    const variant = extractStringField(turn, ["effort", "reasoningEffort", "reasoning_effort"]);
+    const model = modelId
+      ? {
+          providerId,
+          modelId,
+          ...(variant ? { variant } : {}),
+        }
+      : undefined;
     return items.map((item) => {
       const itemIsFinalAgentMessage = finalAgentMessageId !== null && item === finalAgentMessageId;
       let timestampSeconds: number | null;
@@ -251,6 +266,7 @@ export const codexTurnItemsFromThreadRead = (value: unknown): CodexThreadReadIte
           itemIsFinalAgentMessage && typeof durationMs === "number" && durationMs > 0
             ? { durationMs }
             : null,
+        ...(model ? { model } : {}),
       };
     });
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -236,16 +236,16 @@ export const codexTurnItemsFromThreadRead = (value: unknown): CodexThreadReadIte
     const modelId = extractStringField(turn, ["model", "modelId", "model_id"]);
     const providerId =
       extractStringField(turn, ["modelProvider", "model_provider", "providerId", "provider_id"]) ??
-      threadModelProvider ??
-      "codex";
+      threadModelProvider;
     const variant = extractStringField(turn, ["effort", "reasoningEffort", "reasoning_effort"]);
-    const model = modelId
-      ? {
-          providerId,
-          modelId,
-          ...(variant ? { variant } : {}),
-        }
-      : undefined;
+    const model =
+      modelId && providerId
+        ? {
+            providerId,
+            modelId,
+            ...(variant ? { variant } : {}),
+          }
+        : undefined;
     return items.map((item) => {
       const itemIsFinalAgentMessage = finalAgentMessageId !== null && item === finalAgentMessageId;
       let timestampSeconds: number | null;

--- a/packages/frontend/src/components/features/agents/index.ts
+++ b/packages/frontend/src/components/features/agents/index.ts
@@ -22,6 +22,7 @@ export type {
   AgentStudioWorkspaceSidebarModel,
 } from "./agent-studio-workspace-sidebar";
 export {
+  catalogModelOptionValue,
   toModelGroupsByProvider,
   toModelOptions,
   toPrimaryAgentOptions,

--- a/packages/frontend/src/features/agent-chat-composer/model-selection/use-model-selection-actions.ts
+++ b/packages/frontend/src/features/agent-chat-composer/model-selection/use-model-selection-actions.ts
@@ -1,6 +1,7 @@
 import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentModelSelection } from "@openducktor/core";
 import { useCallback } from "react";
+import { catalogModelOptionValue } from "@/components/features/agents";
 
 export const useModelSelectionActions = ({
   activeExternalSessionId,
@@ -64,7 +65,9 @@ export const useModelSelectionActions = ({
       if (!selectionCatalog || !selectedRuntimeKind) {
         return;
       }
-      const model = selectionCatalog.models.find((entry) => entry.id === nextValue);
+      const model = selectionCatalog.models.find(
+        (entry) => catalogModelOptionValue(entry) === nextValue,
+      );
       if (!model) {
         return;
       }

--- a/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.test.tsx
+++ b/packages/frontend/src/pages/agents/chat-composer/use-agent-studio-chat-composer.test.tsx
@@ -102,6 +102,31 @@ const CATALOG_WITHOUT_PROFILES: AgentModelCatalog = {
   profiles: [],
 };
 
+const CATALOG_WITH_TRANSPORT_MODEL_IDS: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
+  models: [
+    {
+      id: "gpt-5",
+      providerId: "openai",
+      providerName: "OpenAI",
+      modelId: "gpt-5",
+      modelName: "GPT-5",
+      variants: ["medium", "high"],
+    },
+    {
+      id: "claude-sonnet",
+      providerId: "anthropic",
+      providerName: "Anthropic",
+      modelId: "claude-sonnet",
+      modelName: "Claude Sonnet",
+      variants: ["default"],
+    },
+  ],
+  defaultModelsByProvider: {
+    openai: "gpt-5",
+  },
+};
+
 const EMPTY_CATALOG: AgentModelCatalog = {
   runtime: OPENCODE_RUNTIME_DESCRIPTOR,
   models: [],
@@ -764,6 +789,42 @@ describe("useAgentStudioChatComposer", () => {
         modelId: "gpt-5",
         variant: "high",
         profileId: "build-agent",
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("updates active session model when catalog ids differ from provider model option values", async () => {
+    const updateAgentSessionModel = mock(() => {});
+    const activeSession = createActiveSession({
+      modelCatalog: CATALOG_WITH_TRANSPORT_MODEL_IDS,
+      selectedModel: {
+        runtimeKind: "opencode",
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "medium",
+      },
+    });
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+        loadCatalog: async () => CATALOG_WITH_TRANSPORT_MODEL_IDS,
+        updateAgentSessionModel,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.run(() => {
+        harness.getLatest().handleSelectModel("anthropic/claude-sonnet");
+      });
+
+      expect(updateAgentSessionModel).toHaveBeenCalledWith(activeSession.externalSessionId, {
+        runtimeKind: "opencode",
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+        variant: "default",
       });
     } finally {
       await harness.unmount();

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-context-idle.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-context-idle.test.ts
@@ -680,6 +680,8 @@ describe("agent-orchestrator session context usage and idle settlement", () => {
       kind: "assistant",
       agentRole: "spec",
       isFinal: true,
+    });
+    expect(sessionMessageAt(getSession(sessionsRef), 0)?.meta).not.toMatchObject({
       providerId: "openai",
       modelId: "gpt-5",
       variant: "high",

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-helpers.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-helpers.ts
@@ -144,7 +144,14 @@ export const settleDraftToIdle = (
       timestamp,
       current.messages,
     );
-    const finalized = finalizeDraftAssistantMessage(current, timestamp, durationMs);
+    const model = context.turn.turnModelBySessionRef?.current[context.store.externalSessionId];
+    const finalized = finalizeDraftAssistantMessage(
+      current,
+      timestamp,
+      durationMs,
+      undefined,
+      model ?? undefined,
+    );
     shouldClear = shouldClearTurnFromCurrentState(current);
     return {
       ...finalized,

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -382,14 +382,16 @@ const resolveFinalAssistantSnapshot = ({
   current,
   durationMs,
   event,
+  model,
   shouldPreserveContextUsage,
 }: {
   current: AgentSessionState;
   durationMs: number | undefined;
   event: AssistantMessageEvent;
+  model: AgentSessionState["selectedModel"] | null;
   shouldPreserveContextUsage: boolean;
 }) => {
-  const baseContextUsage = toSessionContextUsage(current, event.totalTokens, event.model);
+  const baseContextUsage = toSessionContextUsage(current, event.totalTokens, model ?? undefined);
   const nextContextUsage =
     baseContextUsage && typeof event.contextWindow === "number"
       ? { ...baseContextUsage, contextWindow: event.contextWindow }
@@ -403,7 +405,7 @@ const resolveFinalAssistantSnapshot = ({
       current,
       durationMs,
       event.totalTokens ?? resolvedContextUsage?.totalTokens,
-      event.model,
+      model ?? undefined,
     ),
   };
   if (typeof resolvedContextUsage?.contextWindow === "number") {
@@ -457,10 +459,15 @@ export const handleAssistantMessage = (
     const shouldPreserveContextUsage =
       nextContextUsageWasEstablishedForMessage(context, event.messageId) &&
       current.contextUsage !== null;
+    const model =
+      event.model ??
+      context.turn.turnModelBySessionRef?.current[context.store.externalSessionId] ??
+      null;
     const nextSnapshot = resolveFinalAssistantSnapshot({
       current,
       durationMs,
       event,
+      model,
       shouldPreserveContextUsage,
     });
     return {
@@ -743,6 +750,8 @@ export const handleSessionError = (
           event.timestamp,
           current.messages,
         ),
+        undefined,
+        context.turn.turnModelBySessionRef?.current[context.store.externalSessionId] ?? undefined,
       );
       const appendUserStoppedNotice =
         Boolean(current.stopRequestedAt) && isStopAbortSessionErrorMessage(sessionErrorMessage);
@@ -806,6 +815,8 @@ export const handleSessionFinished = (
           event.timestamp,
           current.messages,
         ),
+        undefined,
+        context.turn.turnModelBySessionRef?.current[context.store.externalSessionId] ?? undefined,
       );
       const appendUserStoppedNotice = Boolean(current.stopRequestedAt);
       return {

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1774,10 +1774,6 @@ describe("agent-orchestrator/handlers/start-session", () => {
             kind: "assistant",
             agentRole: "build",
             isFinal: false,
-            providerId: "openai",
-            modelId: "gpt-5",
-            variant: "default",
-            profileId: "build",
           },
         },
       ]);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-requested-history.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-requested-history.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { CODEX_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import {
   type AgentSessionRecord,
   type AgentSessionState,
@@ -157,6 +158,194 @@ describe("agent-orchestrator requested history hydration", () => {
     ]);
     expect(attachCalls).toEqual([{ externalSessionId: "external-child-1" }]);
     expect(state["external-child-1"]?.status).toBe("running");
+  });
+
+  test("hydrates Codex history with per-turn model metadata instead of current selection", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const updateSession = (
+      externalSessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[externalSessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [externalSessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      queryClient,
+      activeWorkspace: {
+        repoPath: "/tmp/repo",
+        workspaceId: "workspace-1",
+        workspaceName: "Active Workspace",
+      },
+      adapter: createAdapter({
+        loadSessionHistory: async () => [
+          {
+            messageId: "turn-1-user",
+            role: "user",
+            state: "read",
+            timestamp: "2026-02-22T08:00:00.000Z",
+            text: "Use low reasoning",
+            displayParts: [{ kind: "text", text: "Use low reasoning" }],
+            model: {
+              providerId: "codex",
+              modelId: "gpt-5.3-codex",
+              variant: "low",
+            },
+            parts: [],
+          },
+          {
+            messageId: "turn-1-assistant",
+            role: "assistant",
+            timestamp: "2026-02-22T08:00:02.000Z",
+            text: "Low response",
+            totalTokens: 25,
+            contextWindow: 128_000,
+            model: {
+              providerId: "codex",
+              modelId: "gpt-5.3-codex",
+              variant: "low",
+            },
+            parts: [
+              {
+                kind: "step",
+                messageId: "turn-1-assistant",
+                partId: "turn-1-finish",
+                phase: "finish",
+                reason: "stop",
+              },
+            ],
+          },
+          {
+            messageId: "turn-2-user",
+            role: "user",
+            state: "read",
+            timestamp: "2026-02-22T08:01:00.000Z",
+            text: "Use high reasoning",
+            displayParts: [{ kind: "text", text: "Use high reasoning" }],
+            model: {
+              providerId: "codex",
+              modelId: "gpt-5.3-codex",
+              variant: "high",
+            },
+            parts: [],
+          },
+          {
+            messageId: "turn-2-assistant",
+            role: "assistant",
+            timestamp: "2026-02-22T08:01:03.000Z",
+            text: "High response",
+            totalTokens: 50,
+            contextWindow: 128_000,
+            model: {
+              providerId: "codex",
+              modelId: "gpt-5.3-codex",
+              variant: "high",
+            },
+            parts: [
+              {
+                kind: "step",
+                messageId: "turn-2-assistant",
+                partId: "turn-2-finish",
+                phase: "finish",
+                reason: "stop",
+              },
+            ],
+          },
+        ],
+      }),
+      repoEpochRef: { current: 2 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [createTaskFixture()] },
+      updateSession,
+      loadRepoPromptOverrides: async () => ({}),
+    });
+    const preloadedRuntimeLists = new Map<"codex", RuntimeInstanceSummary[]>([
+      [
+        "codex",
+        [
+          {
+            kind: "codex",
+            runtimeId: "runtime-codex",
+            repoPath: "/tmp/repo",
+            taskId: null,
+            role: "workspace",
+            workingDirectory: "/tmp/repo",
+            runtimeRoute: {
+              type: "local_http",
+              endpoint: "http://127.0.0.1:1430",
+            },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: CODEX_RUNTIME_DESCRIPTOR,
+          },
+        ],
+      ],
+    ]);
+
+    await loadAgentSessions("task-1", {
+      mode: "requested_history",
+      targetExternalSessionId: "external-codex-1",
+      historyPolicy: "requested_only",
+      preloadedRuntimeLists,
+      persistedRecords: [
+        persistedSessionRecord({
+          runtimeKind: "codex",
+          externalSessionId: "external-codex-1",
+          taskId: "task-1",
+          role: "build",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          workingDirectory: "/tmp/repo",
+          selectedModel: {
+            runtimeKind: "codex",
+            providerId: "codex",
+            modelId: "gpt-5.3-codex",
+            variant: "medium",
+          },
+        }),
+      ],
+    });
+
+    const session = getSession(state, "external-codex-1");
+    const assistantMessages = sessionMessagesToArray(session).filter(
+      (message) => message.role === "assistant",
+    );
+
+    expect(assistantMessages.map((message) => message.content)).toEqual([
+      "Low response",
+      "High response",
+    ]);
+    expect(assistantMessages.map((message) => message.meta?.kind)).toEqual([
+      "assistant",
+      "assistant",
+    ]);
+    expect(
+      assistantMessages.map((message) =>
+        message.meta?.kind === "assistant" ? message.meta.variant : undefined,
+      ),
+    ).toEqual(["low", "high"]);
+    expect(session.contextUsage).toMatchObject({
+      totalTokens: 50,
+      providerId: "codex",
+      modelId: "gpt-5.3-codex",
+      variant: "high",
+    });
   });
 
   test("uses the resolved working directory for requested-history live lookups and state updates", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -713,7 +713,6 @@ type HydratedRecordHistoryState = {
   sessionPresence: AgentSessionPresenceSnapshot | null;
   hydratedMessages: AgentSessionState["messages"];
   hydratedSubagentPendingInputByExternalSessionId: HydratedSubagentPendingInputOverlay;
-  selectedModel: ReturnType<typeof normalizePersistedSelection>;
 };
 
 const shouldPreserveStartingStatusFromIdlePresence = (loadMode: AgentSessionLoadMode): boolean =>
@@ -860,7 +859,6 @@ const applyHydratedRecordHistory = (
     sessionPresence,
     hydratedMessages,
     hydratedSubagentPendingInputByExternalSessionId,
-    selectedModel,
     loadMode,
   }: HydratedRecordHistoryState,
 ): AgentSessionState => {
@@ -897,7 +895,7 @@ const applyHydratedRecordHistory = (
       pendingQuestionsByChildExternalSessionId:
         hydratedSubagentPendingInputByExternalSessionId.pendingQuestionsByChildExternalSessionId,
     }),
-    contextUsage: historyToSessionContextUsage(history, selectedModel),
+    contextUsage: historyToSessionContextUsage(history),
     messages: mergeHydratedMessages(current.externalSessionId, hydratedMessages, current.messages),
   };
 
@@ -999,7 +997,6 @@ const hydrateRecordHistory = async ({
         sessionPresence,
         hydratedMessages,
         hydratedSubagentPendingInputByExternalSessionId,
-        selectedModel,
         loadMode,
       }),
     { persist: false },

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/assistant-meta.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/assistant-meta.test.ts
@@ -48,15 +48,17 @@ const sessionFixture: AgentSessionState = {
 };
 
 describe("agent-orchestrator/support/assistant-meta", () => {
-  test("builds assistant meta from session context", () => {
+  test("does not invent assistant model metadata from current session selection", () => {
     const meta = toAssistantMessageMeta(sessionFixture, 1200, 42);
     expect(meta.kind).toBe("assistant");
-    expect(meta.providerId).toBe("openai");
+    expect(meta.providerId).toBeUndefined();
+    expect(meta.modelId).toBeUndefined();
+    expect(meta.variant).toBeUndefined();
     expect(meta.durationMs).toBe(1200);
     expect(meta.totalTokens).toBe(42);
   });
 
-  test("merges partial message metadata over session selection", () => {
+  test("uses explicit message model metadata without current-session fallback fields", () => {
     const meta = toAssistantMessageMeta(
       {
         ...sessionFixture,
@@ -78,8 +80,8 @@ describe("agent-orchestrator/support/assistant-meta", () => {
 
     expect(meta.providerId).toBe("anthropic");
     expect(meta.modelId).toBe("claude-3-7-sonnet");
-    expect(meta.profileId).toBe("Hephaestus");
-    expect(meta.variant).toBe("high");
+    expect(meta.profileId).toBeUndefined();
+    expect(meta.variant).toBeUndefined();
   });
 
   test("finalizes draft assistant text into a message", () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/assistant-meta.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/assistant-meta.ts
@@ -6,6 +6,16 @@ import type {
 import { appendSessionMessage, findLastSessionMessage, updateLastSessionMessage } from "./messages";
 import { mergeModelSelection } from "./models";
 
+type AssistantMessageMetaInput = {
+  role: AgentSessionState["role"] | null;
+  model?: AgentSessionState["selectedModel"] | undefined;
+  isFinal: boolean;
+  durationMs?: number | undefined;
+  totalTokens?: number | undefined;
+  contextWindow?: number | undefined;
+  outputLimit?: number | undefined;
+};
+
 const resolveModelDescriptor = (
   session: AgentSessionState,
   model: AgentSessionState["selectedModel"] | null,
@@ -47,31 +57,51 @@ export const toSessionContextUsage = (
   };
 };
 
-export const toAssistantMessageMeta = (
-  session: AgentSessionState,
-  durationMs?: number,
-  totalTokens?: number,
-  model?: AgentSessionState["selectedModel"],
-): Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "assistant" }> => {
-  const effectiveModel = mergeModelSelection(session.selectedModel, model ?? undefined);
-  const selectedModelDescriptor = resolveModelDescriptor(session, effectiveModel);
+export const createAssistantMessageMeta = ({
+  role,
+  model,
+  isFinal,
+  durationMs,
+  totalTokens,
+  contextWindow,
+  outputLimit,
+}: AssistantMessageMetaInput): Extract<
+  NonNullable<AgentChatMessage["meta"]>,
+  { kind: "assistant" }
+> => {
+  const effectiveModel = mergeModelSelection(null, model ?? undefined);
   return {
     kind: "assistant",
-    isFinal: true,
-    ...(session.role ? { agentRole: session.role } : {}),
+    isFinal,
+    ...(role ? { agentRole: role } : {}),
     ...(effectiveModel?.providerId ? { providerId: effectiveModel.providerId } : {}),
     ...(effectiveModel?.modelId ? { modelId: effectiveModel.modelId } : {}),
     ...(effectiveModel?.variant ? { variant: effectiveModel.variant } : {}),
     ...(effectiveModel?.profileId ? { profileId: effectiveModel.profileId } : {}),
     ...(typeof durationMs === "number" ? { durationMs } : {}),
     ...(typeof totalTokens === "number" && totalTokens > 0 ? { totalTokens } : {}),
-    ...(typeof selectedModelDescriptor?.contextWindow === "number"
-      ? { contextWindow: selectedModelDescriptor.contextWindow }
-      : {}),
-    ...(typeof selectedModelDescriptor?.outputLimit === "number"
-      ? { outputLimit: selectedModelDescriptor.outputLimit }
-      : {}),
+    ...(typeof contextWindow === "number" && contextWindow > 0 ? { contextWindow } : {}),
+    ...(typeof outputLimit === "number" && outputLimit > 0 ? { outputLimit } : {}),
   };
+};
+
+export const toAssistantMessageMeta = (
+  session: AgentSessionState,
+  durationMs?: number,
+  totalTokens?: number,
+  model?: AgentSessionState["selectedModel"],
+): Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "assistant" }> => {
+  const effectiveModel = mergeModelSelection(null, model ?? undefined);
+  const selectedModelDescriptor = resolveModelDescriptor(session, effectiveModel);
+  return createAssistantMessageMeta({
+    role: session.role,
+    isFinal: true,
+    model,
+    durationMs,
+    totalTokens,
+    contextWindow: selectedModelDescriptor?.contextWindow,
+    outputLimit: selectedModelDescriptor?.outputLimit,
+  });
 };
 
 export const finalizeDraftAssistantMessage = (

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -239,60 +239,53 @@ describe("agent-orchestrator/support/persistence", () => {
   });
 
   test("extracts latest final assistant context usage from hydrated history", () => {
-    const contextUsage = historyToSessionContextUsage(
-      [
-        {
-          messageId: "m-assistant-1",
-          role: "assistant",
-          timestamp: "2026-02-22T08:00:02.000Z",
-          text: "Working",
-          totalTokens: 50,
-          model: {
-            providerId: "openai",
-            modelId: "gpt-5",
-            profileId: "Ares",
-            variant: "high",
-          },
-          parts: [
-            {
-              kind: "step",
-              messageId: "m-assistant-1",
-              partId: "p-step-intermediate",
-              phase: "finish",
-              reason: "length",
-            },
-          ],
-        },
-        {
-          messageId: "m-assistant-2",
-          role: "assistant",
-          timestamp: "2026-02-22T08:00:05.000Z",
-          text: "Done",
-          totalTokens: 123,
-          contextWindow: 1_000,
-          model: {
-            providerId: "anthropic",
-            modelId: "claude-3-7-sonnet",
-            profileId: "Hephaestus",
-            variant: "max",
-          },
-          parts: [
-            {
-              kind: "step",
-              messageId: "m-assistant-2",
-              partId: "p-step-finish",
-              phase: "finish",
-              reason: "stop",
-            },
-          ],
-        },
-      ],
+    const contextUsage = historyToSessionContextUsage([
       {
-        runtimeKind: "opencode",
-        providerId: "openai",
-        modelId: "gpt-5",
+        messageId: "m-assistant-1",
+        role: "assistant",
+        timestamp: "2026-02-22T08:00:02.000Z",
+        text: "Working",
+        totalTokens: 50,
+        model: {
+          providerId: "openai",
+          modelId: "gpt-5",
+          profileId: "Ares",
+          variant: "high",
+        },
+        parts: [
+          {
+            kind: "step",
+            messageId: "m-assistant-1",
+            partId: "p-step-intermediate",
+            phase: "finish",
+            reason: "length",
+          },
+        ],
       },
-    );
+      {
+        messageId: "m-assistant-2",
+        role: "assistant",
+        timestamp: "2026-02-22T08:00:05.000Z",
+        text: "Done",
+        totalTokens: 123,
+        contextWindow: 1_000,
+        model: {
+          providerId: "anthropic",
+          modelId: "claude-3-7-sonnet",
+          profileId: "Hephaestus",
+          variant: "max",
+        },
+        parts: [
+          {
+            kind: "step",
+            messageId: "m-assistant-2",
+            partId: "p-step-finish",
+            phase: "finish",
+            reason: "stop",
+          },
+        ],
+      },
+    ]);
 
     expect(contextUsage).toEqual({
       totalTokens: 123,
@@ -301,6 +294,33 @@ describe("agent-orchestrator/support/persistence", () => {
       modelId: "claude-3-7-sonnet",
       profileId: "Hephaestus",
       variant: "max",
+    });
+  });
+
+  test("does not invent hydrated context usage model metadata from the selected session model", () => {
+    const contextUsage = historyToSessionContextUsage([
+      {
+        messageId: "m-assistant",
+        role: "assistant",
+        timestamp: "2026-02-22T08:00:05.000Z",
+        text: "Done",
+        totalTokens: 123,
+        contextWindow: 1_000,
+        parts: [
+          {
+            kind: "step",
+            messageId: "m-assistant",
+            partId: "p-step-finish",
+            phase: "finish",
+            reason: "stop",
+          },
+        ],
+      },
+    ]);
+
+    expect(contextUsage).toEqual({
+      totalTokens: 123,
+      contextWindow: 1_000,
     });
   });
 
@@ -776,7 +796,7 @@ describe("agent-orchestrator/support/persistence", () => {
     });
   });
 
-  test("preserves session-selected agent when history model metadata is partial", () => {
+  test("preserves only explicit history model metadata when it is partial", () => {
     const messages = historyToChatMessages(
       [
         {
@@ -810,10 +830,43 @@ describe("agent-orchestrator/support/persistence", () => {
     expect(assistant.meta.isFinal).toBe(false);
     expect(assistant.meta.providerId).toBe("anthropic");
     expect(assistant.meta.modelId).toBe("claude-3-7-sonnet");
-    expect(assistant.meta.profileId).toBe("Hephaestus");
-    expect(assistant.meta.variant).toBe("high");
+    expect(assistant.meta.profileId).toBeUndefined();
+    expect(assistant.meta.variant).toBeUndefined();
     expect(assistant.meta.totalTokens).toBeUndefined();
     expect(assistant.meta.durationMs).toBeUndefined();
+  });
+
+  test("does not invent hydrated assistant model metadata from the selected session model", () => {
+    const messages = historyToChatMessages(
+      [
+        {
+          messageId: "m-assistant",
+          role: "assistant",
+          timestamp: "2026-02-22T08:00:02.000Z",
+          text: "Done",
+          parts: [],
+        },
+      ],
+      {
+        role: "build",
+        selectedModel: {
+          runtimeKind: "codex",
+          providerId: "codex",
+          modelId: "gpt-5.3-codex",
+          variant: "high",
+        },
+      },
+    );
+
+    const assistant = messages.find((entry) => entry.role === "assistant");
+    if (!assistant || assistant.meta?.kind !== "assistant") {
+      throw new Error("Expected assistant message with assistant meta");
+    }
+    expect(assistant.meta.isFinal).toBe(false);
+    expect(assistant.meta.providerId).toBeUndefined();
+    expect(assistant.meta.modelId).toBeUndefined();
+    expect(assistant.meta.profileId).toBeUndefined();
+    expect(assistant.meta.variant).toBeUndefined();
   });
 
   test("keeps intermediate assistant history text non-final until a step-finish exists", () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -12,6 +12,7 @@ import type {
   AgentSessionState,
 } from "@/types/agent-orchestrator";
 import { formatToolContent } from "../agent-tool-messages";
+import { createAssistantMessageMeta } from "./assistant-meta";
 import {
   mergeTurnActivityTimestamp,
   readAssistantActivityStartedAtMsFromMessages,
@@ -123,30 +124,6 @@ export const fromPersistedSessionRecord = (
     },
     repoPath,
   );
-};
-
-const assistantMessageMeta = (
-  role: AgentRole | null,
-  selectedModel: AgentModelSelection | null,
-  messageModel: AgentModelSelection | undefined,
-  isFinal: boolean,
-  durationMs: number | undefined,
-  totalTokens: number | undefined,
-  contextWindow: number | undefined,
-) => {
-  const effectiveModel = mergeModelSelection(selectedModel, messageModel);
-  return {
-    kind: "assistant",
-    ...(role ? { agentRole: role } : {}),
-    isFinal,
-    ...(effectiveModel?.providerId ? { providerId: effectiveModel.providerId } : {}),
-    ...(effectiveModel?.modelId ? { modelId: effectiveModel.modelId } : {}),
-    ...(effectiveModel?.variant ? { variant: effectiveModel.variant } : {}),
-    ...(effectiveModel?.profileId ? { profileId: effectiveModel.profileId } : {}),
-    ...(isFinal && typeof durationMs === "number" && durationMs > 0 ? { durationMs } : {}),
-    ...(isFinal && typeof totalTokens === "number" && totalTokens > 0 ? { totalTokens } : {}),
-    ...(isFinal && typeof contextWindow === "number" && contextWindow > 0 ? { contextWindow } : {}),
-  } satisfies Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "assistant" }>;
 };
 
 const isFinalAssistantHistoryMessage = (message: AgentSessionHistoryMessage): boolean => {
@@ -425,15 +402,14 @@ export const historyToChatMessages = (
           : undefined;
       let meta: AgentChatMessage["meta"] | undefined;
       if (message.role === "assistant") {
-        meta = assistantMessageMeta(
-          sessionContext.role,
-          sessionContext.selectedModel,
-          message.model,
-          isFinalAssistantMessage,
-          isFinalAssistantMessage ? assistantDurationMs : undefined,
-          isFinalAssistantMessage ? message.totalTokens : undefined,
-          isFinalAssistantMessage ? message.contextWindow : undefined,
-        );
+        meta = createAssistantMessageMeta({
+          role: sessionContext.role,
+          model: message.model,
+          isFinal: isFinalAssistantMessage,
+          durationMs: isFinalAssistantMessage ? assistantDurationMs : undefined,
+          totalTokens: isFinalAssistantMessage ? message.totalTokens : undefined,
+          contextWindow: isFinalAssistantMessage ? message.contextWindow : undefined,
+        });
       } else if (message.role === "user") {
         meta = userMessageMeta(message.model, message.state, userDisplayParts);
       } else if (message.role === "system" && message.notice) {
@@ -472,7 +448,6 @@ export const historyToChatMessages = (
 
 export const historyToSessionContextUsage = (
   history: AgentSessionHistoryMessage[],
-  selectedModel: AgentModelSelection | null,
 ): AgentSessionContextUsage | null => {
   for (let index = history.length - 1; index >= 0; index -= 1) {
     const message = history[index];
@@ -486,7 +461,7 @@ export const historyToSessionContextUsage = (
       continue;
     }
 
-    const effectiveModel = mergeModelSelection(selectedModel, message.model);
+    const effectiveModel = mergeModelSelection(null, message.model);
     return {
       totalTokens: message.totalTokens,
       ...(typeof message.contextWindow === "number"


### PR DESCRIPTION
Summary

Preserves Codex per-turn model and reasoning metadata across live streaming and hydrated Agent Studio sessions.

Goal

Codex sessions were displaying the current composer/session model and reasoning level on older turns after reload. That made mixed low/medium/high turns appear as if they were all produced with the latest selected reasoning level. This PR fixes that gap by treating turn model metadata as runtime-owned history, not UI selection state.

Technical choices

- Implemented Codex App Server model updates so changing the active session model affects subsequent turns instead of crashing.
- Tracked Codex turn model metadata from turn start responses and streamed turn-start notifications.
- Parsed per-turn model, provider, and reasoning effort from Codex thread reads during history hydration.
- Stamped live user and assistant transcript events with the in-flight turn model.
- Refactored frontend assistant metadata creation so live finalization and hydrated history share one explicit-turn-model-only helper.
- Removed selected-model fallback from hydrated context usage, preventing reloads from inventing metadata for past turns.
- Fixed Agent Studio model selection when catalog ids differ from provider/model option values.
- Added regression coverage for mixed Codex reasoning turns and hydration through requested-history session loading.

Verification

- rtk bun run typecheck
- rtk bun run lint
- rtk bun run test
- rtk bun run build
- rtk cargo fmt --all --check, from apps/desktop/src-tauri
- rtk bun run check:rust
- rtk bun run test:rust
- rtk cargo clippy --workspace --all-targets -- -D warnings, from apps/desktop/src-tauri
- rtk bun run react-doctor:diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now track the specific model used for each conversation turn instead of just the overall selection.
  * Model switching during an active session is properly recorded and reflected in conversation history.
  * Session history now preserves per-turn model metadata for accurate historical context.

* **Tests**
  * Added comprehensive test coverage for per-turn model tracking and session history preservation.
  * Added tests verifying model metadata extraction from conversation transcripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->