### PR TITLE
fix(frontend): settle idle hydrated Codex sessions

### DIFF
--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { copyFile, mkdir, rm, stat } from "node:fs/promises";
+import { copyFile, mkdir, readdir, rm, stat } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { prepareMcpSidecar } from "./prepare-mcp-sidecar";
@@ -157,23 +157,20 @@ export const collectReleaseArtifacts = async ({
   platform: ElectronReleasePlatform;
   releaseDirectory: string;
 }): Promise<string[]> => {
-  const releaseGlob = new Bun.Glob("*");
   const copiedArtifacts: string[] = [];
 
   await assertDirectoryExists(releaseDirectory, "Electron release directory");
   await rm(outputDirectory, { force: true, recursive: true });
   await mkdir(outputDirectory, { recursive: true });
 
-  for await (const entry of releaseGlob.scan({
-    cwd: releaseDirectory,
-    onlyFiles: true,
-  })) {
-    if (!isReleaseArtifact(platform, entry)) {
+  const entries = await readdir(releaseDirectory, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isFile() || !isReleaseArtifact(platform, entry.name)) {
       continue;
     }
 
-    const sourcePath = join(releaseDirectory, entry);
-    const targetPath = join(outputDirectory, entry);
+    const sourcePath = join(releaseDirectory, entry.name);
+    const targetPath = join(outputDirectory, entry.name);
     await copyFile(sourcePath, targetPath);
     copiedArtifacts.push(targetPath);
   }

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
@@ -166,6 +166,75 @@ describe("load-sessions-stages", () => {
     expect(stateHarness.getState()["external-1"]?.status).toBe("running");
   });
 
+  test("settles pending outbound sends when requested history confirms an idle completed turn", async () => {
+    const pendingUserMessageStartedAt = Date.parse("2026-03-01T09:00:00.000Z");
+    const stateHarness = createStateHarness({
+      "external-1": createSession({
+        status: "running",
+        pendingUserMessageStartedAt,
+      }),
+    });
+
+    await hydrateSessionRecordsStage({
+      loadMode: "requested_history",
+      repoPath: "/tmp/repo",
+      adapter: createLifecycleAdapter({
+        loadSessionHistory: async () => [
+          {
+            messageId: "assistant-final",
+            role: "assistant",
+            timestamp: "2026-03-01T09:00:02.000Z",
+            text: "Done",
+            parts: [
+              {
+                kind: "text",
+                messageId: "assistant-final",
+                partId: "assistant-final-text",
+                text: "Done",
+                completed: true,
+              },
+              {
+                kind: "step",
+                messageId: "assistant-final",
+                partId: "assistant-final-finish",
+                phase: "finish",
+                reason: "stop",
+              },
+            ],
+          },
+        ],
+      }),
+      setSessionsById: stateHarness.setSessionsById,
+      updateSession: stateHarness.updateSession,
+      isStaleRepoOperation: () => false,
+      recordsToHydrate: [createRecord()],
+      historyHydrationSessionIds: new Set(["external-1"]),
+      runtimePlanner: {
+        repoPath: "/tmp/repo",
+        resolveHydrationRuntime: async () => ({
+          ok: true,
+          runtimeRef: { repoPath: "/tmp/repo", runtimeKind: "opencode" },
+          workingDirectory: "/tmp/repo/worktree",
+        }),
+        readSessionPresence: async () =>
+          createSessionPresenceSnapshot("external-1", "/tmp/repo/worktree", {
+            status: { type: "idle" },
+          }),
+      },
+      promptAssembler: {
+        buildHydrationPreludeMessages: async () => [],
+        buildHydrationSystemPrompt: async () => "",
+      },
+      getRepoPromptOverrides: async () => ({}),
+      livePresenceMode: "apply",
+    });
+
+    const session = stateHarness.getState()["external-1"];
+    expect(session?.status).toBe("idle");
+    expect(session?.pendingUserMessageStartedAt).toBeUndefined();
+    expect(session?.historyHydrationState).toBe("hydrated");
+  });
+
   test("loads requested-history hydration through the adapter for stdio OpenCode runtimes", async () => {
     const stateHarness = createStateHarness({ "external-1": createSession() });
     let historyLoads = 0;

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
@@ -15,6 +15,46 @@ import {
   type UpdateSession,
 } from "./load-sessions-stages-test-harness";
 
+const pendingUserMessageStartedAt = Date.parse("2026-03-01T09:00:00.000Z");
+
+const createCompletedAssistantHistory = (reason = "stop") => [
+  {
+    messageId: "assistant-final",
+    role: "assistant" as const,
+    timestamp: "2026-03-01T09:00:02.000Z",
+    text: "Done",
+    parts: [
+      {
+        kind: "text" as const,
+        messageId: "assistant-final",
+        partId: "assistant-final-text",
+        text: "Done",
+        completed: true,
+      },
+      {
+        kind: "step" as const,
+        messageId: "assistant-final",
+        partId: "assistant-final-finish",
+        phase: "finish" as const,
+        reason,
+      },
+    ],
+  },
+];
+
+const createSuccessfulHydrationRuntimePlanner = (): HydrationRuntimePlanner => ({
+  repoPath: "/tmp/repo",
+  resolveHydrationRuntime: async () => ({
+    ok: true,
+    runtimeRef: { repoPath: "/tmp/repo", runtimeKind: "opencode" },
+    workingDirectory: "/tmp/repo/worktree",
+  }),
+  readSessionPresence: async () =>
+    createSessionPresenceSnapshot("external-1", "/tmp/repo/worktree", {
+      status: { type: "idle" },
+    }),
+});
+
 describe("load-sessions-stages", () => {
   test("marks requested-history hydration failed when runtime resolution fails", async () => {
     const stateHarness = createStateHarness({ "external-1": createSession() });
@@ -167,11 +207,14 @@ describe("load-sessions-stages", () => {
   });
 
   test("settles pending outbound sends when requested history confirms an idle completed turn", async () => {
-    const pendingUserMessageStartedAt = Date.parse("2026-03-01T09:00:00.000Z");
     const stateHarness = createStateHarness({
       "external-1": createSession({
         status: "running",
         pendingUserMessageStartedAt,
+        draftAssistantText: "partial assistant",
+        draftAssistantMessageId: "assistant-draft",
+        draftReasoningText: "partial reasoning",
+        draftReasoningMessageId: "reasoning-draft",
       }),
     });
 
@@ -179,48 +222,14 @@ describe("load-sessions-stages", () => {
       loadMode: "requested_history",
       repoPath: "/tmp/repo",
       adapter: createLifecycleAdapter({
-        loadSessionHistory: async () => [
-          {
-            messageId: "assistant-final",
-            role: "assistant",
-            timestamp: "2026-03-01T09:00:02.000Z",
-            text: "Done",
-            parts: [
-              {
-                kind: "text",
-                messageId: "assistant-final",
-                partId: "assistant-final-text",
-                text: "Done",
-                completed: true,
-              },
-              {
-                kind: "step",
-                messageId: "assistant-final",
-                partId: "assistant-final-finish",
-                phase: "finish",
-                reason: "stop",
-              },
-            ],
-          },
-        ],
+        loadSessionHistory: async () => createCompletedAssistantHistory(),
       }),
       setSessionsById: stateHarness.setSessionsById,
       updateSession: stateHarness.updateSession,
       isStaleRepoOperation: () => false,
       recordsToHydrate: [createRecord()],
       historyHydrationSessionIds: new Set(["external-1"]),
-      runtimePlanner: {
-        repoPath: "/tmp/repo",
-        resolveHydrationRuntime: async () => ({
-          ok: true,
-          runtimeRef: { repoPath: "/tmp/repo", runtimeKind: "opencode" },
-          workingDirectory: "/tmp/repo/worktree",
-        }),
-        readSessionPresence: async () =>
-          createSessionPresenceSnapshot("external-1", "/tmp/repo/worktree", {
-            status: { type: "idle" },
-          }),
-      },
+      runtimePlanner: createSuccessfulHydrationRuntimePlanner(),
       promptAssembler: {
         buildHydrationPreludeMessages: async () => [],
         buildHydrationSystemPrompt: async () => "",
@@ -232,6 +241,78 @@ describe("load-sessions-stages", () => {
     const session = stateHarness.getState()["external-1"];
     expect(session?.status).toBe("idle");
     expect(session?.pendingUserMessageStartedAt).toBeUndefined();
+    expect(session?.draftAssistantText).toBe("");
+    expect(session?.draftAssistantMessageId).toBeNull();
+    expect(session?.draftReasoningText).toBe("");
+    expect(session?.draftReasoningMessageId).toBeNull();
+    expect(session?.historyHydrationState).toBe("hydrated");
+  });
+
+  test("keeps pending outbound sends when requested history skips live presence", async () => {
+    const stateHarness = createStateHarness({
+      "external-1": createSession({
+        status: "running",
+        pendingUserMessageStartedAt,
+      }),
+    });
+
+    await hydrateSessionRecordsStage({
+      loadMode: "requested_history",
+      repoPath: "/tmp/repo",
+      adapter: createLifecycleAdapter({
+        loadSessionHistory: async () => createCompletedAssistantHistory(),
+      }),
+      setSessionsById: stateHarness.setSessionsById,
+      updateSession: stateHarness.updateSession,
+      isStaleRepoOperation: () => false,
+      recordsToHydrate: [createRecord()],
+      historyHydrationSessionIds: new Set(["external-1"]),
+      runtimePlanner: createSuccessfulHydrationRuntimePlanner(),
+      promptAssembler: {
+        buildHydrationPreludeMessages: async () => [],
+        buildHydrationSystemPrompt: async () => "",
+      },
+      getRepoPromptOverrides: async () => ({}),
+      livePresenceMode: "skip",
+    });
+
+    const session = stateHarness.getState()["external-1"];
+    expect(session?.status).toBe("running");
+    expect(session?.pendingUserMessageStartedAt).toBe(pendingUserMessageStartedAt);
+    expect(session?.historyHydrationState).toBe("hydrated");
+  });
+
+  test("keeps pending outbound sends when hydrated history has no stop finish", async () => {
+    const stateHarness = createStateHarness({
+      "external-1": createSession({
+        status: "running",
+        pendingUserMessageStartedAt,
+      }),
+    });
+
+    await hydrateSessionRecordsStage({
+      loadMode: "requested_history",
+      repoPath: "/tmp/repo",
+      adapter: createLifecycleAdapter({
+        loadSessionHistory: async () => createCompletedAssistantHistory("session_error"),
+      }),
+      setSessionsById: stateHarness.setSessionsById,
+      updateSession: stateHarness.updateSession,
+      isStaleRepoOperation: () => false,
+      recordsToHydrate: [createRecord()],
+      historyHydrationSessionIds: new Set(["external-1"]),
+      runtimePlanner: createSuccessfulHydrationRuntimePlanner(),
+      promptAssembler: {
+        buildHydrationPreludeMessages: async () => [],
+        buildHydrationSystemPrompt: async () => "",
+      },
+      getRepoPromptOverrides: async () => ({}),
+      livePresenceMode: "apply",
+    });
+
+    const session = stateHarness.getState()["external-1"];
+    expect(session?.status).toBe("running");
+    expect(session?.pendingUserMessageStartedAt).toBe(pendingUserMessageStartedAt);
     expect(session?.historyHydrationState).toBe("hydrated");
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -18,6 +18,7 @@ import {
   getSessionMessagesSlice,
 } from "../support/messages";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
+import { shouldSettlePendingOutboundSendFromHydratedHistory } from "../support/pending-outbound-send";
 import {
   fromPersistedSessionRecord,
   historyToChatMessages,
@@ -872,14 +873,22 @@ const applyHydratedRecordHistory = (
     : current;
   const liveSessionTitle =
     sessionPresence?.presence === "runtime" ? sessionPresence.title : undefined;
+  const shouldSettlePendingOutboundSend = shouldSettlePendingOutboundSendFromHydratedHistory(
+    current,
+    history,
+    sessionPresence,
+  );
   const nextSession: AgentSessionState = {
     ...sessionWithLivePresence,
-    status: sessionWithLivePresence.status,
+    status: shouldSettlePendingOutboundSend ? "idle" : sessionWithLivePresence.status,
     runtimeKind: runtimeResolution.runtimeRef.runtimeKind,
     workingDirectory: runtimeResolution.workingDirectory,
     promptOverrides,
     historyHydrationState: "hydrated",
     runtimeRecoveryState: current.runtimeRecoveryState ?? "idle",
+    pendingUserMessageStartedAt: shouldSettlePendingOutboundSend
+      ? undefined
+      : sessionWithLivePresence.pendingUserMessageStartedAt,
     todos: todos.length > 0 ? todos : sessionWithLivePresence.todos,
     subagentPendingApprovalsByExternalSessionId: mergeSubagentPendingApprovalOverlay({
       current: current.subagentPendingApprovalsByExternalSessionId,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -18,7 +18,10 @@ import {
   getSessionMessagesSlice,
 } from "../support/messages";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
-import { shouldSettlePendingOutboundSendFromHydratedHistory } from "../support/pending-outbound-send";
+import {
+  settlePendingOutboundSendFields,
+  shouldSettlePendingOutboundSendFromHydratedHistory,
+} from "../support/pending-outbound-send";
 import {
   fromPersistedSessionRecord,
   historyToChatMessages,
@@ -878,17 +881,24 @@ const applyHydratedRecordHistory = (
     history,
     sessionPresence,
   );
+  const nextStatus: AgentSessionState["status"] = shouldSettlePendingOutboundSend
+    ? "idle"
+    : sessionWithLivePresence.status;
+  const pendingOutboundSendFields =
+    nextStatus === "running"
+      ? {
+          pendingUserMessageStartedAt: sessionWithLivePresence.pendingUserMessageStartedAt,
+        }
+      : settlePendingOutboundSendFields();
   const nextSession: AgentSessionState = {
     ...sessionWithLivePresence,
-    status: shouldSettlePendingOutboundSend ? "idle" : sessionWithLivePresence.status,
+    status: nextStatus,
     runtimeKind: runtimeResolution.runtimeRef.runtimeKind,
     workingDirectory: runtimeResolution.workingDirectory,
     promptOverrides,
     historyHydrationState: "hydrated",
     runtimeRecoveryState: current.runtimeRecoveryState ?? "idle",
-    pendingUserMessageStartedAt: shouldSettlePendingOutboundSend
-      ? undefined
-      : sessionWithLivePresence.pendingUserMessageStartedAt,
+    ...pendingOutboundSendFields,
     todos: todos.length > 0 ? todos : sessionWithLivePresence.todos,
     subagentPendingApprovalsByExternalSessionId: mergeSubagentPendingApprovalOverlay({
       current: current.subagentPendingApprovalsByExternalSessionId,

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/history-finality.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/history-finality.ts
@@ -1,0 +1,11 @@
+import type { AgentSessionHistoryMessage } from "@openducktor/core";
+
+export const isFinalAssistantHistoryMessage = (message: AgentSessionHistoryMessage): boolean => {
+  if (message.role !== "assistant") {
+    return false;
+  }
+
+  return message.parts.some(
+    (part) => part.kind === "step" && part.phase === "finish" && part.reason === "stop",
+  );
+};

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/pending-outbound-send.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/pending-outbound-send.ts
@@ -1,6 +1,15 @@
+import type { AgentSessionHistoryMessage, AgentSessionPresenceSnapshot } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { isFinalAssistantHistoryMessage } from "./history-finality";
 
-export const hasPendingOutboundSend = (session: AgentSessionState): boolean => {
+type SessionWithPendingOutboundSend = AgentSessionState & {
+  pendingUserMessageStartedAt: number;
+  status: "running";
+};
+
+export const hasPendingOutboundSend = (
+  session: AgentSessionState,
+): session is SessionWithPendingOutboundSend => {
   return session.pendingUserMessageStartedAt !== undefined && session.status === "running";
 };
 
@@ -12,4 +21,26 @@ export const shouldKeepPendingOutboundSendActiveOnIdle = (session: AgentSessionS
     session.pendingApprovals.length === 0 &&
     session.pendingQuestions.length === 0
   );
+};
+
+export const shouldSettlePendingOutboundSendFromHydratedHistory = (
+  session: AgentSessionState,
+  history: AgentSessionHistoryMessage[],
+  sessionPresence: AgentSessionPresenceSnapshot | null,
+): boolean => {
+  if (!hasPendingOutboundSend(session)) {
+    return false;
+  }
+  if (sessionPresence?.presence !== "runtime" || sessionPresence.agentSessionStatus !== "idle") {
+    return false;
+  }
+
+  const pendingUserMessageStartedAt = session.pendingUserMessageStartedAt;
+  return history.some((message) => {
+    if (!isFinalAssistantHistoryMessage(message)) {
+      return false;
+    }
+    const completedAtMs = Date.parse(message.timestamp);
+    return !Number.isNaN(completedAtMs) && completedAtMs >= pendingUserMessageStartedAt;
+  });
 };

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/pending-outbound-send.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/pending-outbound-send.ts
@@ -44,3 +44,18 @@ export const shouldSettlePendingOutboundSendFromHydratedHistory = (
     return !Number.isNaN(completedAtMs) && completedAtMs >= pendingUserMessageStartedAt;
   });
 };
+
+export const settlePendingOutboundSendFields = (): Pick<
+  AgentSessionState,
+  | "pendingUserMessageStartedAt"
+  | "draftAssistantText"
+  | "draftAssistantMessageId"
+  | "draftReasoningText"
+  | "draftReasoningMessageId"
+> => ({
+  pendingUserMessageStartedAt: undefined,
+  draftAssistantText: "",
+  draftAssistantMessageId: null,
+  draftReasoningText: "",
+  draftReasoningMessageId: null,
+});

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -20,6 +20,7 @@ import {
   resolveAssistantTurnDurationMs,
 } from "./assistant-turn-duration";
 import { toReasoningMessageId, toToolMessageId } from "./chat-message-ids";
+import { isFinalAssistantHistoryMessage } from "./history-finality";
 import { mergeModelSelection, normalizePersistedSelection } from "./models";
 import { isWorkflowAgentSession } from "./session-purpose";
 import {
@@ -123,16 +124,6 @@ export const fromPersistedSessionRecord = (
       isLoadingModelCatalog: false,
     },
     repoPath,
-  );
-};
-
-const isFinalAssistantHistoryMessage = (message: AgentSessionHistoryMessage): boolean => {
-  if (message.role !== "assistant") {
-    return false;
-  }
-
-  return message.parts.some(
-    (part) => part.kind === "step" && part.phase === "finish" && part.reason === "stop",
   );
 };
 


### PR DESCRIPTION
## Summary

- Settle hydrated Codex sessions with pending outbound sends when live presence is idle and requested history confirms a final stop turn.
- Clear transient pending-send draft fields when hydration leaves the session non-running.
- Add regressions for the successful settlement path, skipped live presence, and non-stop finish reasons.
- Avoid Bun.Glob in Electron release artifact collection so the Windows Electron test stays within the 1000ms Bun test timeout.

## Verification

- bun test apps/electron/scripts/package-build.test.ts --timeout 1000
- bun run --filter @openducktor/electron test
- bun run --filter @openducktor/electron typecheck
- bun run --filter @openducktor/electron lint
- bun test packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
- bun test packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-requested-history.test.ts packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
- bun run --filter @openducktor/frontend typecheck
- bun run --filter @openducktor/frontend lint
- bun run react-doctor:diff
- bun run typecheck
- bun run lint
- bun run test
- bun run build
- bun run check:rust
- bun run test:rust
- cd apps/desktop/src-tauri && cargo fmt --all --check
- cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings
- cd apps/desktop/src-tauri && cargo build

## CI

- TypeScript Workspace Quality (Windows) passed on e7f2e988b636ef2176201d4960b12fe967fcf0a9.