### PR TITLE
refactor(frontend): flatten session start decisions

### DIFF
--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
@@ -160,6 +160,20 @@ describe("buildSessionStartModalDecision", () => {
           targetBranch: "refs/remotes/origin",
         },
         requestContext: REQUEST_CONTEXT,
+        selectedModel: null,
+      }),
+    ).toThrow(
+      "Starting a build build_pull_request_generation session for TASK-1 requires an explicit model selection.",
+    );
+
+    expect(() =>
+      buildSessionStartModalDecision({
+        input: {
+          startMode: "fork",
+          sourceExternalSessionId: null,
+          targetBranch: "refs/remotes/origin",
+        },
+        requestContext: REQUEST_CONTEXT,
         selectedModel: SELECTED_MODEL,
       }),
     ).toThrow(

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
@@ -1,10 +1,26 @@
 import { describe, expect, test } from "bun:test";
 import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import type { AgentModelSelection } from "@openducktor/core";
 import {
   assertRuntimeSupportsSelectedStartMode,
+  buildSessionStartModalDecision,
   requireSourceSessionRuntimeKind,
 } from "./use-session-start-modal-runner";
+
+const REQUEST_CONTEXT = {
+  launchActionId: "build_pull_request_generation",
+  role: "build",
+  taskId: "TASK-1",
+} as const;
+
+const SELECTED_MODEL: AgentModelSelection = {
+  runtimeKind: "opencode",
+  providerId: "anthropic",
+  modelId: "claude-sonnet",
+  variant: "high",
+  profileId: "build-agent",
+};
 
 const FORKLESS_RUNTIME = {
   ...OPENCODE_RUNTIME_DESCRIPTOR,
@@ -19,6 +35,99 @@ const FORKLESS_RUNTIME = {
     },
   },
 } as RuntimeDescriptor;
+
+describe("buildSessionStartModalDecision", () => {
+  test("builds a fresh decision with the selected model and no source session", () => {
+    expect(
+      buildSessionStartModalDecision({
+        input: {
+          runInBackground: false,
+          startMode: "fresh",
+          sourceExternalSessionId: null,
+        },
+        requestContext: REQUEST_CONTEXT,
+        selectedModel: SELECTED_MODEL,
+      }),
+    ).toEqual({
+      startMode: "fresh",
+      selectedModel: SELECTED_MODEL,
+    });
+  });
+
+  test("builds a reuse decision with the source session and optional target branch", () => {
+    expect(
+      buildSessionStartModalDecision({
+        input: {
+          runInBackground: false,
+          startMode: "reuse",
+          sourceExternalSessionId: "session-1",
+          targetBranch: "refs/remotes/origin/feature/session-start",
+        },
+        requestContext: REQUEST_CONTEXT,
+        selectedModel: null,
+      }),
+    ).toEqual({
+      startMode: "reuse",
+      sourceExternalSessionId: "session-1",
+      targetBranch: {
+        remote: "origin",
+        branch: "feature/session-start",
+      },
+    });
+  });
+
+  test("builds a fork decision with selected model, source session, and target branch", () => {
+    expect(
+      buildSessionStartModalDecision({
+        input: {
+          runInBackground: true,
+          startMode: "fork",
+          sourceExternalSessionId: "session-2",
+          targetBranch: "refs/heads/local-review",
+        },
+        requestContext: REQUEST_CONTEXT,
+        selectedModel: SELECTED_MODEL,
+      }),
+    ).toEqual({
+      startMode: "fork",
+      selectedModel: SELECTED_MODEL,
+      sourceExternalSessionId: "session-2",
+      targetBranch: {
+        branch: "local-review",
+      },
+    });
+  });
+
+  test("keeps existing guard behavior for missing selected model and source session", () => {
+    expect(() =>
+      buildSessionStartModalDecision({
+        input: {
+          runInBackground: false,
+          startMode: "fresh",
+          sourceExternalSessionId: null,
+        },
+        requestContext: REQUEST_CONTEXT,
+        selectedModel: null,
+      }),
+    ).toThrow(
+      "Starting a build build_pull_request_generation session for TASK-1 requires an explicit model selection.",
+    );
+
+    expect(() =>
+      buildSessionStartModalDecision({
+        input: {
+          runInBackground: false,
+          startMode: "reuse",
+          sourceExternalSessionId: null,
+        },
+        requestContext: REQUEST_CONTEXT,
+        selectedModel: SELECTED_MODEL,
+      }),
+    ).toThrow(
+      "Starting a build build_pull_request_generation session for TASK-1 requires a source session.",
+    );
+  });
+});
 
 describe("assertRuntimeSupportsSelectedStartMode", () => {
   test("accepts a runtime that supports the concrete selected start mode", () => {

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
@@ -41,7 +41,6 @@ describe("buildSessionStartModalDecision", () => {
     expect(
       buildSessionStartModalDecision({
         input: {
-          runInBackground: false,
           startMode: "fresh",
           sourceExternalSessionId: null,
         },
@@ -58,7 +57,6 @@ describe("buildSessionStartModalDecision", () => {
     expect(
       buildSessionStartModalDecision({
         input: {
-          runInBackground: false,
           startMode: "reuse",
           sourceExternalSessionId: "session-1",
           targetBranch: "refs/remotes/origin/feature/session-start",
@@ -80,7 +78,6 @@ describe("buildSessionStartModalDecision", () => {
     expect(
       buildSessionStartModalDecision({
         input: {
-          runInBackground: true,
           startMode: "fork",
           sourceExternalSessionId: "session-2",
           targetBranch: "refs/heads/local-review",
@@ -102,7 +99,6 @@ describe("buildSessionStartModalDecision", () => {
     expect(() =>
       buildSessionStartModalDecision({
         input: {
-          runInBackground: false,
           startMode: "fresh",
           sourceExternalSessionId: null,
         },
@@ -116,7 +112,6 @@ describe("buildSessionStartModalDecision", () => {
     expect(() =>
       buildSessionStartModalDecision({
         input: {
-          runInBackground: false,
           startMode: "reuse",
           sourceExternalSessionId: null,
         },
@@ -132,7 +127,6 @@ describe("buildSessionStartModalDecision", () => {
     expect(() =>
       buildSessionStartModalDecision({
         input: {
-          runInBackground: false,
           startMode: "fresh",
           sourceExternalSessionId: null,
           targetBranch: "refs/remotes/origin",
@@ -147,7 +141,6 @@ describe("buildSessionStartModalDecision", () => {
     expect(() =>
       buildSessionStartModalDecision({
         input: {
-          runInBackground: false,
           startMode: "reuse",
           sourceExternalSessionId: null,
           targetBranch: "refs/remotes/origin",
@@ -162,7 +155,6 @@ describe("buildSessionStartModalDecision", () => {
     expect(() =>
       buildSessionStartModalDecision({
         input: {
-          runInBackground: false,
           startMode: "fork",
           sourceExternalSessionId: null,
           targetBranch: "refs/remotes/origin",

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.test.ts
@@ -127,6 +127,53 @@ describe("buildSessionStartModalDecision", () => {
       "Starting a build build_pull_request_generation session for TASK-1 requires a source session.",
     );
   });
+
+  test("keeps required guard errors ahead of invalid target branch parsing", () => {
+    expect(() =>
+      buildSessionStartModalDecision({
+        input: {
+          runInBackground: false,
+          startMode: "fresh",
+          sourceExternalSessionId: null,
+          targetBranch: "refs/remotes/origin",
+        },
+        requestContext: REQUEST_CONTEXT,
+        selectedModel: null,
+      }),
+    ).toThrow(
+      "Starting a build build_pull_request_generation session for TASK-1 requires an explicit model selection.",
+    );
+
+    expect(() =>
+      buildSessionStartModalDecision({
+        input: {
+          runInBackground: false,
+          startMode: "reuse",
+          sourceExternalSessionId: null,
+          targetBranch: "refs/remotes/origin",
+        },
+        requestContext: REQUEST_CONTEXT,
+        selectedModel: null,
+      }),
+    ).toThrow(
+      "Starting a build build_pull_request_generation session for TASK-1 requires a source session.",
+    );
+
+    expect(() =>
+      buildSessionStartModalDecision({
+        input: {
+          runInBackground: false,
+          startMode: "fork",
+          sourceExternalSessionId: null,
+          targetBranch: "refs/remotes/origin",
+        },
+        requestContext: REQUEST_CONTEXT,
+        selectedModel: SELECTED_MODEL,
+      }),
+    ).toThrow(
+      "Starting a build build_pull_request_generation session for TASK-1 requires a source session.",
+    );
+  });
 });
 
 describe("assertRuntimeSupportsSelectedStartMode", () => {

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
@@ -48,6 +48,8 @@ type SessionStartModalConfirmPayload = Exclude<
   boolean | undefined
 >;
 
+type SessionStartDecisionInput = Omit<SessionStartModalConfirmPayload, "runInBackground">;
+
 type SessionStartDecisionRequestContext = Pick<
   SessionStartModalRunRequest,
   "role" | "launchActionId" | "taskId"
@@ -67,7 +69,7 @@ type PendingModalRun = {
 
 const requireSelectedModel = (
   selection: AgentModelSelection | null,
-  request: Pick<SessionStartModalRunRequest, "role" | "launchActionId" | "taskId">,
+  request: SessionStartDecisionRequestContext,
 ): AgentModelSelection => {
   if (selection) {
     return selection;
@@ -80,7 +82,7 @@ const requireSelectedModel = (
 
 const requireSourceSessionId = (
   sourceExternalSessionId: string | null,
-  request: Pick<SessionStartModalRunRequest, "role" | "launchActionId" | "taskId">,
+  request: SessionStartDecisionRequestContext,
 ): string => {
   if (sourceExternalSessionId) {
     return sourceExternalSessionId;
@@ -96,7 +98,7 @@ export const buildSessionStartModalDecision = ({
   requestContext,
   selectedModel,
 }: {
-  input: SessionStartModalConfirmPayload;
+  input: SessionStartDecisionInput;
   requestContext: SessionStartDecisionRequestContext;
   selectedModel: AgentModelSelection | null;
 }): SessionStartModalDecision => {

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
@@ -43,6 +43,16 @@ type SessionStartModalRunRequest = SessionStartModalOpenRequest & {
   selectedModel?: AgentModelSelection | null;
 };
 
+type SessionStartModalConfirmPayload = Exclude<
+  Parameters<SessionStartModalModel["onConfirm"]>[0],
+  boolean | undefined
+>;
+
+type SessionStartDecisionRequestContext = Pick<
+  SessionStartModalRunRequest,
+  "role" | "launchActionId" | "taskId"
+>;
+
 type SessionStartModalRunResult = {
   decision: SessionStartModalDecision;
   runInBackground: boolean;
@@ -79,6 +89,51 @@ const requireSourceSessionId = (
   throw new Error(
     `Starting a ${request.role} ${request.launchActionId} session for ${request.taskId} requires a source session.`,
   );
+};
+
+export const buildSessionStartModalDecision = ({
+  input,
+  requestContext,
+  selectedModel,
+}: {
+  input: SessionStartModalConfirmPayload;
+  requestContext: SessionStartDecisionRequestContext;
+  selectedModel: AgentModelSelection | null;
+}): SessionStartModalDecision => {
+  const targetBranchFields = input.targetBranch
+    ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
+    : {};
+
+  if (input.startMode === "reuse") {
+    return {
+      startMode: "reuse",
+      sourceExternalSessionId: requireSourceSessionId(
+        input.sourceExternalSessionId,
+        requestContext,
+      ),
+      ...targetBranchFields,
+    };
+  }
+
+  const resolvedSelectedModel = requireSelectedModel(selectedModel, requestContext);
+
+  if (input.startMode === "fork") {
+    return {
+      startMode: "fork",
+      selectedModel: resolvedSelectedModel,
+      sourceExternalSessionId: requireSourceSessionId(
+        input.sourceExternalSessionId,
+        requestContext,
+      ),
+      ...targetBranchFields,
+    };
+  }
+
+  return {
+    startMode: "fresh",
+    selectedModel: resolvedSelectedModel,
+    ...targetBranchFields,
+  };
 };
 
 export const requireSourceSessionRuntimeKind = (
@@ -245,37 +300,11 @@ export function useSessionStartModalRunner({
 
       setIsStarting(true);
       try {
-        const decision: SessionStartModalDecision =
-          input.startMode === "reuse"
-            ? {
-                startMode: "reuse",
-                sourceExternalSessionId: requireSourceSessionId(
-                  input.sourceExternalSessionId,
-                  requestContext,
-                ),
-                ...(input.targetBranch
-                  ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
-                  : {}),
-              }
-            : input.startMode === "fork"
-              ? {
-                  startMode: "fork",
-                  selectedModel: requireSelectedModel(selectionRef.current, requestContext),
-                  sourceExternalSessionId: requireSourceSessionId(
-                    input.sourceExternalSessionId,
-                    requestContext,
-                  ),
-                  ...(input.targetBranch
-                    ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
-                    : {}),
-                }
-              : {
-                  startMode: "fresh",
-                  selectedModel: requireSelectedModel(selectionRef.current, requestContext),
-                  ...(input.targetBranch
-                    ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
-                    : {}),
-                };
+        const decision = buildSessionStartModalDecision({
+          input,
+          requestContext,
+          selectedModel: selectionRef.current,
+        });
 
         if (decision.startMode === "reuse") {
           const sourceOption = existingSessionOptions.find(

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
@@ -100,7 +100,7 @@ export const buildSessionStartModalDecision = ({
   requestContext: SessionStartDecisionRequestContext;
   selectedModel: AgentModelSelection | null;
 }): SessionStartModalDecision => {
-  const targetBranchFields = (): { targetBranch?: GitTargetBranch } =>
+  const buildTargetBranchFields = (): { targetBranch?: GitTargetBranch } =>
     input.targetBranch ? { targetBranch: targetBranchFromSelection(input.targetBranch) } : {};
 
   if (input.startMode === "reuse") {
@@ -112,7 +112,7 @@ export const buildSessionStartModalDecision = ({
     return {
       startMode: "reuse",
       sourceExternalSessionId,
-      ...targetBranchFields(),
+      ...buildTargetBranchFields(),
     };
   }
 
@@ -128,14 +128,14 @@ export const buildSessionStartModalDecision = ({
       startMode: "fork",
       selectedModel: resolvedSelectedModel,
       sourceExternalSessionId,
-      ...targetBranchFields(),
+      ...buildTargetBranchFields(),
     };
   }
 
   return {
     startMode: "fresh",
     selectedModel: resolvedSelectedModel,
-    ...targetBranchFields(),
+    ...buildTargetBranchFields(),
   };
 };
 

--- a/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
+++ b/packages/frontend/src/features/session-start/use-session-start-modal-runner.ts
@@ -100,39 +100,42 @@ export const buildSessionStartModalDecision = ({
   requestContext: SessionStartDecisionRequestContext;
   selectedModel: AgentModelSelection | null;
 }): SessionStartModalDecision => {
-  const targetBranchFields = input.targetBranch
-    ? { targetBranch: targetBranchFromSelection(input.targetBranch) }
-    : {};
+  const targetBranchFields = (): { targetBranch?: GitTargetBranch } =>
+    input.targetBranch ? { targetBranch: targetBranchFromSelection(input.targetBranch) } : {};
 
   if (input.startMode === "reuse") {
+    const sourceExternalSessionId = requireSourceSessionId(
+      input.sourceExternalSessionId,
+      requestContext,
+    );
+
     return {
       startMode: "reuse",
-      sourceExternalSessionId: requireSourceSessionId(
-        input.sourceExternalSessionId,
-        requestContext,
-      ),
-      ...targetBranchFields,
+      sourceExternalSessionId,
+      ...targetBranchFields(),
     };
   }
 
   const resolvedSelectedModel = requireSelectedModel(selectedModel, requestContext);
 
   if (input.startMode === "fork") {
+    const sourceExternalSessionId = requireSourceSessionId(
+      input.sourceExternalSessionId,
+      requestContext,
+    );
+
     return {
       startMode: "fork",
       selectedModel: resolvedSelectedModel,
-      sourceExternalSessionId: requireSourceSessionId(
-        input.sourceExternalSessionId,
-        requestContext,
-      ),
-      ...targetBranchFields,
+      sourceExternalSessionId,
+      ...targetBranchFields(),
     };
   }
 
   return {
     startMode: "fresh",
     selectedModel: resolvedSelectedModel,
-    ...targetBranchFields,
+    ...targetBranchFields(),
   };
 };
 


### PR DESCRIPTION
Summary: Flatten the Agent Studio session-start decision construction so fresh, reuse, and fork starts are built through explicit branch logic instead of a nested ternary.

Goal:
This PR simplifies the session-start modal runner in `packages/frontend/src/features/session-start/use-session-start-modal-runner.ts`. The previous implementation packed mode selection, selected-model guards, source-session guards, and optional target-branch parsing into a nested ternary. That made an active launch path harder to review and easier to break when extending fresh/reuse/fork behavior.

Technical choices:
- Extracted `buildSessionStartModalDecision` as a small pure helper in the runner module rather than introducing a new file or broad abstraction.
- Kept `confirmModal` responsible for modal lifecycle, runtime capability validation, execution, and toast error handling.
- Preserved existing guard ordering by keeping target-branch parsing lazy per branch, after the required selected-model/source-session checks for that mode.
- Narrowed the decision helper input to omit `runInBackground`, since background execution is passed to `pendingRun.execute` and does not affect the decision shape.
- Added focused runner-level tests for fresh, reuse, and fork decision shapes, missing guard behavior, and combined-invalid inputs where model/source-session guard errors must take precedence over invalid target-branch parsing.

Verification:
- `rtk bun run lint`
- `rtk bun run typecheck`
- `rtk bun run test`
- `rtk bun run build`
- `rtk bun run check:rust`
- `rtk bun run test:rust`
- `rtk cargo fmt --all --check` from `apps/desktop/src-tauri`
- `rtk cargo clippy --workspace --all-targets -- -D warnings` from `apps/desktop/src-tauri`

Notes:
The branch was rebased onto `origin/main` before creating this PR.