### PR TITLE
refactor: consolidate MCP health failure assembly

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -339,6 +339,74 @@ mod tests {
     }
 
     #[test]
+    fn repo_runtime_health_reports_reconnect_failure() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let (port, server_handle) = spawn_runtime_http_server(vec![
+            runtime_http_response(
+                "200 OK",
+                r#"{"openducktor":{"status":"disconnected","error":"not connected"}}"#,
+            ),
+            runtime_http_response(
+                "504 Gateway Timeout",
+                r#"{"error":{"message":"connect timed out"}}"#,
+            ),
+        ])?;
+        let runtime = host_domain::RuntimeInstanceSummary {
+            kind: AgentRuntimeKind::opencode(),
+            runtime_id: "runtime-reconnect-failure".to_string(),
+            repo_path: "/tmp/repo-health-reconnect-failure".to_string(),
+            task_id: None,
+            role: host_domain::RuntimeRole::Workspace,
+            working_directory: "/tmp/repo-health-reconnect-failure".to_string(),
+            runtime_route: host_domain::RuntimeRoute::LocalHttp {
+                endpoint: format!("http://127.0.0.1:{port}"),
+            },
+            started_at: "2026-04-04T16:00:00Z".to_string(),
+            descriptor: builtin_opencode_runtime_descriptor(),
+        };
+        insert_workspace_runtime(&service, runtime.clone())?;
+
+        let health =
+            service.repo_runtime_health("opencode", "/tmp/repo-health-reconnect-failure")?;
+        let requests = server_handle.join().expect("server thread should finish");
+
+        assert!(
+            requests[0].starts_with("GET /mcp?directory=%2Ftmp%2Frepo-health-reconnect-failure ")
+        );
+        assert!(requests[1].starts_with(
+            "POST /mcp/openducktor/connect?directory=%2Ftmp%2Frepo-health-reconnect-failure "
+        ));
+        assert_eq!(health.runtime.status, RepoRuntimeHealthState::Ready);
+        assert_eq!(health.status, RepoRuntimeHealthState::Checking);
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.status),
+            Some(RepoRuntimeMcpStatus::Reconnecting)
+        );
+        assert_eq!(
+            health
+                .mcp
+                .as_ref()
+                .and_then(|value| value.server_status.as_deref()),
+            Some("disconnected")
+        );
+        assert!(health
+            .mcp
+            .as_ref()
+            .and_then(|value| value.detail.as_deref())
+            .is_some_and(|value| value.contains("Failed to reconnect MCP server 'openducktor'")));
+        assert_eq!(
+            health.mcp.as_ref().and_then(|value| value.failure_kind),
+            Some(RepoRuntimeStartupFailureKind::Timeout)
+        );
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.tool_ids.clone()),
+            Some(Vec::new())
+        );
+        service.runtime_stop(runtime.runtime_id.as_str())?;
+        Ok(())
+    }
+
+    #[test]
     fn repo_runtime_health_reports_mcp_query_failure() -> Result<()> {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
         let (port, server_handle) = spawn_runtime_http_server(vec![runtime_http_response(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -339,6 +339,58 @@ mod tests {
     }
 
     #[test]
+    fn repo_runtime_health_reports_mcp_query_failure() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let (port, server_handle) = spawn_runtime_http_server(vec![runtime_http_response(
+            "504 Gateway Timeout",
+            r#"{"error":{"message":"status probe timed out"}}"#,
+        )])?;
+        let runtime = host_domain::RuntimeInstanceSummary {
+            kind: AgentRuntimeKind::opencode(),
+            runtime_id: "runtime-mcp-query-failure".to_string(),
+            repo_path: "/tmp/repo-health-mcp-query-failure".to_string(),
+            task_id: None,
+            role: host_domain::RuntimeRole::Workspace,
+            working_directory: "/tmp/repo-health-mcp-query-failure".to_string(),
+            runtime_route: host_domain::RuntimeRoute::LocalHttp {
+                endpoint: format!("http://127.0.0.1:{port}"),
+            },
+            started_at: "2026-04-04T16:00:00Z".to_string(),
+            descriptor: builtin_opencode_runtime_descriptor(),
+        };
+        insert_workspace_runtime(&service, runtime.clone())?;
+
+        let health =
+            service.repo_runtime_health("opencode", "/tmp/repo-health-mcp-query-failure")?;
+        let requests = server_handle.join().expect("server thread should finish");
+
+        assert!(
+            requests[0].starts_with("GET /mcp?directory=%2Ftmp%2Frepo-health-mcp-query-failure ")
+        );
+        assert_eq!(health.runtime.status, RepoRuntimeHealthState::Ready);
+        assert_eq!(health.status, RepoRuntimeHealthState::Checking);
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.status),
+            Some(RepoRuntimeMcpStatus::Checking)
+        );
+        assert!(health
+            .mcp
+            .as_ref()
+            .and_then(|value| value.detail.as_deref())
+            .is_some_and(|value| value.contains("Failed to query runtime MCP status")));
+        assert_eq!(
+            health.mcp.as_ref().and_then(|value| value.failure_kind),
+            Some(RepoRuntimeStartupFailureKind::Timeout)
+        );
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.tool_ids.clone()),
+            Some(Vec::new())
+        );
+        service.runtime_stop(runtime.runtime_id.as_str())?;
+        Ok(())
+    }
+
+    #[test]
     fn repo_runtime_health_returns_structured_failure_when_refresh_after_reconnect_fails(
     ) -> Result<()> {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
@@ -387,6 +439,14 @@ mod tests {
             .is_some_and(
                 |value| value.contains("Failed to refresh runtime MCP status after reconnect")
             ));
+        assert_eq!(
+            health.mcp.as_ref().and_then(|value| value.failure_kind),
+            Some(RepoRuntimeStartupFailureKind::Timeout)
+        );
+        assert_eq!(
+            health.mcp.as_ref().map(|value| value.tool_ids.clone()),
+            Some(Vec::new())
+        );
         service.runtime_stop(runtime.runtime_id.as_str())?;
         Ok(())
     }
@@ -575,6 +635,10 @@ mod tests {
             .as_ref()
             .and_then(|value| value.detail.as_deref())
             .is_some_and(|value| value.contains("Failed to load runtime MCP tool ids")));
+        assert_eq!(
+            health.mcp.as_ref().and_then(|value| value.failure_kind),
+            Some(RepoRuntimeStartupFailureKind::Timeout)
+        );
         assert_eq!(
             health.mcp.as_ref().map(|value| value.tool_ids.clone()),
             Some(Vec::new())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -195,6 +195,27 @@ mod tests {
         )
     }
 
+    fn workspace_opencode_runtime(
+        runtime_id: &str,
+        repo_path: &str,
+        port: u16,
+        started_at: &str,
+    ) -> host_domain::RuntimeInstanceSummary {
+        host_domain::RuntimeInstanceSummary {
+            kind: AgentRuntimeKind::opencode(),
+            runtime_id: runtime_id.to_string(),
+            repo_path: repo_path.to_string(),
+            task_id: None,
+            role: host_domain::RuntimeRole::Workspace,
+            working_directory: repo_path.to_string(),
+            runtime_route: RuntimeRoute::LocalHttp {
+                endpoint: format!("http://127.0.0.1:{port}"),
+            },
+            started_at: started_at.to_string(),
+            descriptor: builtin_opencode_runtime_descriptor(),
+        }
+    }
+
     fn insert_workspace_runtime(
         service: &AppService,
         runtime: host_domain::RuntimeInstanceSummary,
@@ -253,19 +274,12 @@ mod tests {
             runtime_http_response("200 OK", r#"{"openducktor":{"status":"connected"}}"#),
             runtime_http_response("200 OK", r#"["odt_read_task"]"#),
         ])?;
-        let runtime = host_domain::RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
-            runtime_id: "runtime-ready".to_string(),
-            repo_path: "/tmp/repo-health-ready".to_string(),
-            task_id: None,
-            role: host_domain::RuntimeRole::Workspace,
-            working_directory: "/tmp/repo-health-ready".to_string(),
-            runtime_route: host_domain::RuntimeRoute::LocalHttp {
-                endpoint: format!("http://127.0.0.1:{port}"),
-            },
-            started_at: "2026-04-04T16:00:00Z".to_string(),
-            descriptor: builtin_opencode_runtime_descriptor(),
-        };
+        let runtime = workspace_opencode_runtime(
+            "runtime-ready",
+            "/tmp/repo-health-ready",
+            port,
+            "2026-04-04T16:00:00Z",
+        );
         insert_workspace_runtime(&service, runtime.clone())?;
 
         let health = service.repo_runtime_health("opencode", "/tmp/repo-health-ready")?;
@@ -304,19 +318,12 @@ mod tests {
             runtime_http_response("200 OK", r#"{"openducktor":{"status":"connected"}}"#),
             runtime_http_response("200 OK", r#"["odt_read_task"]"#),
         ])?;
-        let runtime = host_domain::RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
-            runtime_id: "runtime-reconnect".to_string(),
-            repo_path: "/tmp/repo-health-reconnect".to_string(),
-            task_id: None,
-            role: host_domain::RuntimeRole::Workspace,
-            working_directory: "/tmp/repo-health-reconnect".to_string(),
-            runtime_route: host_domain::RuntimeRoute::LocalHttp {
-                endpoint: format!("http://127.0.0.1:{port}"),
-            },
-            started_at: "2026-04-04T16:00:00Z".to_string(),
-            descriptor: builtin_opencode_runtime_descriptor(),
-        };
+        let runtime = workspace_opencode_runtime(
+            "runtime-reconnect",
+            "/tmp/repo-health-reconnect",
+            port,
+            "2026-04-04T16:00:00Z",
+        );
         insert_workspace_runtime(&service, runtime.clone())?;
 
         let health = service.repo_runtime_health("opencode", "/tmp/repo-health-reconnect")?;
@@ -351,19 +358,12 @@ mod tests {
                 r#"{"error":{"message":"connect timed out"}}"#,
             ),
         ])?;
-        let runtime = host_domain::RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
-            runtime_id: "runtime-reconnect-failure".to_string(),
-            repo_path: "/tmp/repo-health-reconnect-failure".to_string(),
-            task_id: None,
-            role: host_domain::RuntimeRole::Workspace,
-            working_directory: "/tmp/repo-health-reconnect-failure".to_string(),
-            runtime_route: host_domain::RuntimeRoute::LocalHttp {
-                endpoint: format!("http://127.0.0.1:{port}"),
-            },
-            started_at: "2026-04-04T16:00:00Z".to_string(),
-            descriptor: builtin_opencode_runtime_descriptor(),
-        };
+        let runtime = workspace_opencode_runtime(
+            "runtime-reconnect-failure",
+            "/tmp/repo-health-reconnect-failure",
+            port,
+            "2026-04-04T16:00:00Z",
+        );
         insert_workspace_runtime(&service, runtime.clone())?;
 
         let health =
@@ -413,19 +413,12 @@ mod tests {
             "504 Gateway Timeout",
             r#"{"error":{"message":"status probe timed out"}}"#,
         )])?;
-        let runtime = host_domain::RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
-            runtime_id: "runtime-mcp-query-failure".to_string(),
-            repo_path: "/tmp/repo-health-mcp-query-failure".to_string(),
-            task_id: None,
-            role: host_domain::RuntimeRole::Workspace,
-            working_directory: "/tmp/repo-health-mcp-query-failure".to_string(),
-            runtime_route: host_domain::RuntimeRoute::LocalHttp {
-                endpoint: format!("http://127.0.0.1:{port}"),
-            },
-            started_at: "2026-04-04T16:00:00Z".to_string(),
-            descriptor: builtin_opencode_runtime_descriptor(),
-        };
+        let runtime = workspace_opencode_runtime(
+            "runtime-mcp-query-failure",
+            "/tmp/repo-health-mcp-query-failure",
+            port,
+            "2026-04-04T16:00:00Z",
+        );
         insert_workspace_runtime(&service, runtime.clone())?;
 
         let health =
@@ -473,19 +466,12 @@ mod tests {
                 r#"{"error":{"message":"status probe timed out"}}"#,
             ),
         ])?;
-        let runtime = host_domain::RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
-            runtime_id: "runtime-refresh-failure".to_string(),
-            repo_path: "/tmp/repo-health-refresh-failure".to_string(),
-            task_id: None,
-            role: host_domain::RuntimeRole::Workspace,
-            working_directory: "/tmp/repo-health-refresh-failure".to_string(),
-            runtime_route: host_domain::RuntimeRoute::LocalHttp {
-                endpoint: format!("http://127.0.0.1:{port}"),
-            },
-            started_at: "2026-04-04T16:00:00Z".to_string(),
-            descriptor: builtin_opencode_runtime_descriptor(),
-        };
+        let runtime = workspace_opencode_runtime(
+            "runtime-refresh-failure",
+            "/tmp/repo-health-refresh-failure",
+            port,
+            "2026-04-04T16:00:00Z",
+        );
         insert_workspace_runtime(&service, runtime.clone())?;
 
         let health = service.repo_runtime_health("opencode", "/tmp/repo-health-refresh-failure")?;
@@ -561,19 +547,12 @@ mod tests {
             ],
             Duration::from_millis(150),
         )?;
-        let runtime = host_domain::RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
-            runtime_id: "runtime-startup-failed-mcp".to_string(),
-            repo_path: "/tmp/repo-health-startup-failed-mcp".to_string(),
-            task_id: None,
-            role: host_domain::RuntimeRole::Workspace,
-            working_directory: "/tmp/repo-health-startup-failed-mcp".to_string(),
-            runtime_route: host_domain::RuntimeRoute::LocalHttp {
-                endpoint: format!("http://127.0.0.1:{port}"),
-            },
-            started_at,
-            descriptor: builtin_opencode_runtime_descriptor(),
-        };
+        let runtime = workspace_opencode_runtime(
+            "runtime-startup-failed-mcp",
+            "/tmp/repo-health-startup-failed-mcp",
+            port,
+            started_at.as_str(),
+        );
         insert_workspace_runtime(&service, runtime.clone())?;
 
         let health =
@@ -622,19 +601,12 @@ mod tests {
             runtime_http_response("200 OK", r#"{"openducktor":{"status":"connected"}}"#),
             runtime_http_response("200 OK", r#"["odt_read_task"]"#),
         ])?;
-        let runtime = host_domain::RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
-            runtime_id: "runtime-startup-retry-success".to_string(),
-            repo_path: "/tmp/repo-health-startup-retry-success".to_string(),
-            task_id: None,
-            role: host_domain::RuntimeRole::Workspace,
-            working_directory: "/tmp/repo-health-startup-retry-success".to_string(),
-            runtime_route: host_domain::RuntimeRoute::LocalHttp {
-                endpoint: format!("http://127.0.0.1:{port}"),
-            },
-            started_at,
-            descriptor: builtin_opencode_runtime_descriptor(),
-        };
+        let runtime = workspace_opencode_runtime(
+            "runtime-startup-retry-success",
+            "/tmp/repo-health-startup-retry-success",
+            port,
+            started_at.as_str(),
+        );
         insert_workspace_runtime(&service, runtime.clone())?;
 
         let health =
@@ -667,19 +639,12 @@ mod tests {
                 r#"{"error":{"message":"tool ids timed out"}}"#,
             ),
         ])?;
-        let runtime = host_domain::RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::opencode(),
-            runtime_id: "runtime-tool-ids-failure".to_string(),
-            repo_path: "/tmp/repo-health-tool-ids-failure".to_string(),
-            task_id: None,
-            role: host_domain::RuntimeRole::Workspace,
-            working_directory: "/tmp/repo-health-tool-ids-failure".to_string(),
-            runtime_route: host_domain::RuntimeRoute::LocalHttp {
-                endpoint: format!("http://127.0.0.1:{port}"),
-            },
-            started_at: "2026-04-04T16:00:00Z".to_string(),
-            descriptor: builtin_opencode_runtime_descriptor(),
-        };
+        let runtime = workspace_opencode_runtime(
+            "runtime-tool-ids-failure",
+            "/tmp/repo-health-tool-ids-failure",
+            port,
+            "2026-04-04T16:00:00Z",
+        );
         insert_workspace_runtime(&service, runtime.clone())?;
 
         let health =

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/mod.rs
@@ -48,8 +48,12 @@ struct FailedRepoRuntimeMcpHealthInput {
     mcp_failure_kind: RepoRuntimeStartupFailureKind,
     mcp_server_status: Option<String>,
     available_tool_ids: Vec<String>,
-    progress_stage: RuntimeHealthWorkflowStage,
-    progress_source: RuntimeHealthProgress,
+    progress: FailedRepoRuntimeMcpProgressInput,
+}
+
+struct FailedRepoRuntimeMcpProgressInput {
+    stage: RuntimeHealthWorkflowStage,
+    source: RuntimeHealthProgress,
 }
 
 fn repo_runtime_is_within_mcp_startup_grace_window(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/mod.rs
@@ -47,7 +47,6 @@ struct FailedRepoRuntimeMcpHealthInput {
     mcp_error: String,
     mcp_failure_kind: RepoRuntimeStartupFailureKind,
     mcp_server_status: Option<String>,
-    available_tool_ids: Vec<String>,
     progress: FailedRepoRuntimeMcpProgressInput,
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/mod.rs
@@ -1,7 +1,7 @@
 use super::repo_health_snapshot::{
     build_repo_runtime_health_check, map_startup_stage_to_failed_health,
     map_startup_stage_to_health, repo_runtime_progress, RepoRuntimeHealthCheckInput,
-    RepoRuntimeProgressInput, RuntimeHealthWorkflowStage,
+    RepoRuntimeProgressInput, RuntimeHealthProgress, RuntimeHealthWorkflowStage,
 };
 use super::AppService;
 use crate::app_service::runtime_registry::{ResolvedRuntimeMcpStatus, RuntimeHealthCheckFailure};
@@ -39,6 +39,16 @@ pub(in crate::app_service::runtime_orchestrator) struct CompleteRepoRuntimeHealt
     host_status: Option<RepoRuntimeStartupStatus>,
     observation: Option<RepoRuntimeHealthObservation>,
     allow_restart: bool,
+}
+
+struct FailedRepoRuntimeMcpHealthInput {
+    checked_at: String,
+    runtime: RuntimeInstanceSummary,
+    mcp_error: String,
+    mcp_failure_kind: RepoRuntimeStartupFailureKind,
+    mcp_server_status: Option<String>,
+    available_tool_ids: Vec<String>,
+    progress: RuntimeHealthProgress,
 }
 
 fn repo_runtime_is_within_mcp_startup_grace_window(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/mod.rs
@@ -48,7 +48,8 @@ struct FailedRepoRuntimeMcpHealthInput {
     mcp_failure_kind: RepoRuntimeStartupFailureKind,
     mcp_server_status: Option<String>,
     available_tool_ids: Vec<String>,
-    progress: RuntimeHealthProgress,
+    progress_stage: RuntimeHealthWorkflowStage,
+    progress_source: RuntimeHealthProgress,
 }
 
 fn repo_runtime_is_within_mcp_startup_grace_window(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
@@ -1,6 +1,25 @@
 use super::*;
 
 impl AppService {
+    fn failed_repo_runtime_mcp_health(
+        input: FailedRepoRuntimeMcpHealthInput,
+    ) -> RepoRuntimeHealthCheck {
+        build_repo_runtime_health_check(RepoRuntimeHealthCheckInput {
+            checked_at: input.checked_at,
+            runtime: Some(input.runtime),
+            runtime_ok: true,
+            runtime_error: None,
+            runtime_failure_kind: None,
+            supports_mcp_status: true,
+            mcp_ok: false,
+            mcp_error: Some(input.mcp_error),
+            mcp_failure_kind: Some(input.mcp_failure_kind),
+            mcp_server_status: input.mcp_server_status,
+            available_tool_ids: input.available_tool_ids,
+            progress: Some(input.progress),
+        })
+    }
+
     pub fn repo_runtime_health(
         &self,
         runtime_kind: &str,
@@ -257,19 +276,14 @@ impl AppService {
                 return self.store_repo_runtime_health(
                     &runtime_kind,
                     repo_key.as_str(),
-                    build_repo_runtime_health_check(RepoRuntimeHealthCheckInput {
+                    Self::failed_repo_runtime_mcp_health(FailedRepoRuntimeMcpHealthInput {
                         checked_at: checked_at.clone(),
-                        runtime: Some(runtime.clone()),
-                        runtime_ok: true,
-                        runtime_error: None,
-                        runtime_failure_kind: None,
-                        supports_mcp_status: true,
-                        mcp_ok: false,
-                        mcp_error: Some(mcp_message.clone()),
-                        mcp_failure_kind: Some(error.failure_kind),
+                        runtime: runtime.clone(),
+                        mcp_error: mcp_message,
+                        mcp_failure_kind: error.failure_kind,
                         mcp_server_status: None,
                         available_tool_ids: Vec::new(),
-                        progress: Some(repo_runtime_progress(RepoRuntimeProgressInput {
+                        progress: repo_runtime_progress(RepoRuntimeProgressInput {
                             stage: checking_progress.stage,
                             observation,
                             host: host_status,
@@ -279,7 +293,7 @@ impl AppService {
                             updated_at: Some(checked_at.clone()),
                             elapsed_ms: checking_progress.elapsed_ms,
                             attempts: checking_progress.attempts,
-                        })),
+                        }),
                     }),
                 );
             }
@@ -344,20 +358,15 @@ impl AppService {
                             return self.store_repo_runtime_health(
                                 &runtime_kind,
                                 repo_key.as_str(),
-                                build_repo_runtime_health_check(RepoRuntimeHealthCheckInput {
-                                    checked_at: checked_at.clone(),
-                                    runtime: Some(runtime.clone()),
-                                    runtime_ok: true,
-                                    runtime_error: None,
-                                    runtime_failure_kind: None,
-                                    supports_mcp_status: true,
-                                    mcp_ok: false,
-                                    mcp_error: Some(refresh_message.clone()),
-                                    mcp_failure_kind: Some(error.failure_kind),
-                                    mcp_server_status: mcp_status.status.clone(),
-                                    available_tool_ids: Vec::new(),
-                                    progress: Some(repo_runtime_progress(
-                                        RepoRuntimeProgressInput {
+                                Self::failed_repo_runtime_mcp_health(
+                                    FailedRepoRuntimeMcpHealthInput {
+                                        checked_at: checked_at.clone(),
+                                        runtime: runtime.clone(),
+                                        mcp_error: refresh_message,
+                                        mcp_failure_kind: error.failure_kind,
+                                        mcp_server_status: mcp_status.status.clone(),
+                                        available_tool_ids: Vec::new(),
+                                        progress: repo_runtime_progress(RepoRuntimeProgressInput {
                                             stage: reconnect_progress.stage,
                                             observation: reconnect_progress.observation,
                                             host: reconnect_progress.host.clone(),
@@ -367,9 +376,9 @@ impl AppService {
                                             updated_at: Some(checked_at.clone()),
                                             elapsed_ms: reconnect_progress.elapsed_ms,
                                             attempts: reconnect_progress.attempts,
-                                        },
-                                    )),
-                                }),
+                                        }),
+                                    },
+                                ),
                             );
                         }
                     };
@@ -388,19 +397,14 @@ impl AppService {
                     return self.store_repo_runtime_health(
                         &runtime_kind,
                         repo_key.as_str(),
-                        build_repo_runtime_health_check(RepoRuntimeHealthCheckInput {
+                        Self::failed_repo_runtime_mcp_health(FailedRepoRuntimeMcpHealthInput {
                             checked_at: checked_at.clone(),
-                            runtime: Some(runtime.clone()),
-                            runtime_ok: true,
-                            runtime_error: None,
-                            runtime_failure_kind: None,
-                            supports_mcp_status: true,
-                            mcp_ok: false,
-                            mcp_error: Some(mcp_message.clone()),
-                            mcp_failure_kind: Some(error.failure_kind),
+                            runtime: runtime.clone(),
+                            mcp_error: mcp_message,
+                            mcp_failure_kind: error.failure_kind,
                             mcp_server_status: mcp_status.status.clone(),
                             available_tool_ids: Vec::new(),
-                            progress: Some(repo_runtime_progress(RepoRuntimeProgressInput {
+                            progress: repo_runtime_progress(RepoRuntimeProgressInput {
                                 stage: reconnect_progress.stage,
                                 observation: reconnect_progress.observation,
                                 host: reconnect_progress.host,
@@ -410,7 +414,7 @@ impl AppService {
                                 updated_at: Some(checked_at.clone()),
                                 elapsed_ms: reconnect_progress.elapsed_ms,
                                 attempts: reconnect_progress.attempts,
-                            })),
+                            }),
                         }),
                     );
                 }
@@ -444,40 +448,39 @@ impl AppService {
             attempts: checking_progress.attempts,
         });
 
-        let (mcp_ok, mcp_error, mcp_failure_kind, available_tool_ids, progress) = if mcp_ok {
+        let (mcp_ok, mcp_error, mcp_failure_kind, available_tool_ids) = if mcp_ok {
             match runtime_delegate.load_tool_ids(&runtime) {
-                Ok(tool_ids) => (true, None, None, tool_ids, progress),
+                Ok(tool_ids) => (true, None, None, tool_ids),
                 Err(error) => {
                     let tool_ids_message =
                         format!("Failed to load runtime MCP tool ids: {}", error.message);
-                    let failed_progress = repo_runtime_progress(RepoRuntimeProgressInput {
-                        stage: RuntimeHealthWorkflowStage::RuntimeReady,
-                        observation,
-                        host: host_status.clone(),
-                        checked_at: checked_at.clone(),
-                        failure_reason: None,
-                        started_at: Some(runtime.started_at.clone()),
-                        updated_at: Some(checked_at.clone()),
-                        elapsed_ms: checking_progress.elapsed_ms,
-                        attempts: checking_progress.attempts,
-                    });
-                    (
-                        false,
-                        Some(tool_ids_message),
-                        Some(error.failure_kind),
-                        Vec::new(),
-                        failed_progress,
-                    )
+                    return self.store_repo_runtime_health(
+                        &runtime_kind,
+                        repo_key.as_str(),
+                        Self::failed_repo_runtime_mcp_health(FailedRepoRuntimeMcpHealthInput {
+                            checked_at: checked_at.clone(),
+                            runtime: runtime.clone(),
+                            mcp_error: tool_ids_message,
+                            mcp_failure_kind: error.failure_kind,
+                            mcp_server_status: mcp_status.status.clone(),
+                            available_tool_ids: Vec::new(),
+                            progress: repo_runtime_progress(RepoRuntimeProgressInput {
+                                stage: RuntimeHealthWorkflowStage::RuntimeReady,
+                                observation,
+                                host: host_status.clone(),
+                                checked_at: checked_at.clone(),
+                                failure_reason: None,
+                                started_at: Some(runtime.started_at.clone()),
+                                updated_at: Some(checked_at.clone()),
+                                elapsed_ms: checking_progress.elapsed_ms,
+                                attempts: checking_progress.attempts,
+                            }),
+                        }),
+                    );
                 }
             }
         } else {
-            (
-                false,
-                mcp_error,
-                mcp_status.failure_kind,
-                Vec::new(),
-                progress,
-            )
+            (false, mcp_error, mcp_status.failure_kind, Vec::new())
         };
 
         self.store_repo_runtime_health(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
@@ -4,16 +4,17 @@ impl AppService {
     fn failed_repo_runtime_mcp_health(
         input: FailedRepoRuntimeMcpHealthInput,
     ) -> RepoRuntimeHealthCheck {
+        let FailedRepoRuntimeMcpProgressInput { stage, source } = input.progress;
         let progress = repo_runtime_progress(RepoRuntimeProgressInput {
-            stage: input.progress_stage,
-            observation: input.progress_source.observation,
-            host: input.progress_source.host,
+            stage,
+            observation: source.observation,
+            host: source.host,
             checked_at: input.checked_at.clone(),
             failure_reason: None,
-            started_at: input.progress_source.started_at,
+            started_at: source.started_at,
             updated_at: Some(input.checked_at.clone()),
-            elapsed_ms: input.progress_source.elapsed_ms,
-            attempts: input.progress_source.attempts,
+            elapsed_ms: source.elapsed_ms,
+            attempts: source.attempts,
         });
 
         build_repo_runtime_health_check(RepoRuntimeHealthCheckInput {
@@ -295,8 +296,10 @@ impl AppService {
                         mcp_failure_kind: error.failure_kind,
                         mcp_server_status: None,
                         available_tool_ids: Vec::new(),
-                        progress_stage: checking_progress.stage,
-                        progress_source: checking_progress,
+                        progress: FailedRepoRuntimeMcpProgressInput {
+                            stage: checking_progress.stage,
+                            source: checking_progress,
+                        },
                     }),
                 );
             }
@@ -369,8 +372,10 @@ impl AppService {
                                         mcp_failure_kind: error.failure_kind,
                                         mcp_server_status: mcp_status.status.clone(),
                                         available_tool_ids: Vec::new(),
-                                        progress_stage: reconnect_progress.stage,
-                                        progress_source: reconnect_progress.clone(),
+                                        progress: FailedRepoRuntimeMcpProgressInput {
+                                            stage: reconnect_progress.stage,
+                                            source: reconnect_progress.clone(),
+                                        },
                                     },
                                 ),
                             );
@@ -398,8 +403,10 @@ impl AppService {
                             mcp_failure_kind: error.failure_kind,
                             mcp_server_status: mcp_status.status.clone(),
                             available_tool_ids: Vec::new(),
-                            progress_stage: reconnect_progress.stage,
-                            progress_source: reconnect_progress,
+                            progress: FailedRepoRuntimeMcpProgressInput {
+                                stage: reconnect_progress.stage,
+                                source: reconnect_progress,
+                            },
                         }),
                     );
                 }
@@ -449,8 +456,10 @@ impl AppService {
                             mcp_failure_kind: error.failure_kind,
                             mcp_server_status: mcp_status.status.clone(),
                             available_tool_ids: Vec::new(),
-                            progress_stage: RuntimeHealthWorkflowStage::RuntimeReady,
-                            progress_source: checking_progress.clone(),
+                            progress: FailedRepoRuntimeMcpProgressInput {
+                                stage: RuntimeHealthWorkflowStage::RuntimeReady,
+                                source: checking_progress.clone(),
+                            },
                         }),
                     );
                 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
@@ -372,7 +372,7 @@ impl AppService {
                                         mcp_server_status: mcp_status.status.clone(),
                                         progress: FailedRepoRuntimeMcpProgressInput {
                                             stage: reconnect_progress.stage,
-                                            source: reconnect_progress.clone(),
+                                            source: reconnect_progress,
                                         },
                                     },
                                 ),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
@@ -4,6 +4,18 @@ impl AppService {
     fn failed_repo_runtime_mcp_health(
         input: FailedRepoRuntimeMcpHealthInput,
     ) -> RepoRuntimeHealthCheck {
+        let progress = repo_runtime_progress(RepoRuntimeProgressInput {
+            stage: input.progress_stage,
+            observation: input.progress_source.observation,
+            host: input.progress_source.host,
+            checked_at: input.checked_at.clone(),
+            failure_reason: None,
+            started_at: input.progress_source.started_at,
+            updated_at: Some(input.checked_at.clone()),
+            elapsed_ms: input.progress_source.elapsed_ms,
+            attempts: input.progress_source.attempts,
+        });
+
         build_repo_runtime_health_check(RepoRuntimeHealthCheckInput {
             checked_at: input.checked_at,
             runtime: Some(input.runtime),
@@ -16,7 +28,7 @@ impl AppService {
             mcp_failure_kind: Some(input.mcp_failure_kind),
             mcp_server_status: input.mcp_server_status,
             available_tool_ids: input.available_tool_ids,
-            progress: Some(input.progress),
+            progress: Some(progress),
         })
     }
 
@@ -283,17 +295,8 @@ impl AppService {
                         mcp_failure_kind: error.failure_kind,
                         mcp_server_status: None,
                         available_tool_ids: Vec::new(),
-                        progress: repo_runtime_progress(RepoRuntimeProgressInput {
-                            stage: checking_progress.stage,
-                            observation,
-                            host: host_status,
-                            checked_at: checked_at.clone(),
-                            failure_reason: None,
-                            started_at: Some(runtime.started_at.clone()),
-                            updated_at: Some(checked_at.clone()),
-                            elapsed_ms: checking_progress.elapsed_ms,
-                            attempts: checking_progress.attempts,
-                        }),
+                        progress_stage: checking_progress.stage,
+                        progress_source: checking_progress,
                     }),
                 );
             }
@@ -366,17 +369,8 @@ impl AppService {
                                         mcp_failure_kind: error.failure_kind,
                                         mcp_server_status: mcp_status.status.clone(),
                                         available_tool_ids: Vec::new(),
-                                        progress: repo_runtime_progress(RepoRuntimeProgressInput {
-                                            stage: reconnect_progress.stage,
-                                            observation: reconnect_progress.observation,
-                                            host: reconnect_progress.host.clone(),
-                                            checked_at: checked_at.clone(),
-                                            failure_reason: None,
-                                            started_at: reconnect_progress.started_at.clone(),
-                                            updated_at: Some(checked_at.clone()),
-                                            elapsed_ms: reconnect_progress.elapsed_ms,
-                                            attempts: reconnect_progress.attempts,
-                                        }),
+                                        progress_stage: reconnect_progress.stage,
+                                        progress_source: reconnect_progress.clone(),
                                     },
                                 ),
                             );
@@ -404,17 +398,8 @@ impl AppService {
                             mcp_failure_kind: error.failure_kind,
                             mcp_server_status: mcp_status.status.clone(),
                             available_tool_ids: Vec::new(),
-                            progress: repo_runtime_progress(RepoRuntimeProgressInput {
-                                stage: reconnect_progress.stage,
-                                observation: reconnect_progress.observation,
-                                host: reconnect_progress.host,
-                                checked_at: checked_at.clone(),
-                                failure_reason: None,
-                                started_at: reconnect_progress.started_at,
-                                updated_at: Some(checked_at.clone()),
-                                elapsed_ms: reconnect_progress.elapsed_ms,
-                                attempts: reconnect_progress.attempts,
-                            }),
+                            progress_stage: reconnect_progress.stage,
+                            progress_source: reconnect_progress,
                         }),
                     );
                 }
@@ -464,17 +449,8 @@ impl AppService {
                             mcp_failure_kind: error.failure_kind,
                             mcp_server_status: mcp_status.status.clone(),
                             available_tool_ids: Vec::new(),
-                            progress: repo_runtime_progress(RepoRuntimeProgressInput {
-                                stage: RuntimeHealthWorkflowStage::RuntimeReady,
-                                observation,
-                                host: host_status.clone(),
-                                checked_at: checked_at.clone(),
-                                failure_reason: None,
-                                started_at: Some(runtime.started_at.clone()),
-                                updated_at: Some(checked_at.clone()),
-                                elapsed_ms: checking_progress.elapsed_ms,
-                                attempts: checking_progress.attempts,
-                            }),
+                            progress_stage: RuntimeHealthWorkflowStage::RuntimeReady,
+                            progress_source: checking_progress.clone(),
                         }),
                     );
                 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/repo_health/orchestration.rs
@@ -28,7 +28,7 @@ impl AppService {
             mcp_error: Some(input.mcp_error),
             mcp_failure_kind: Some(input.mcp_failure_kind),
             mcp_server_status: input.mcp_server_status,
-            available_tool_ids: input.available_tool_ids,
+            available_tool_ids: Vec::new(),
             progress: Some(progress),
         })
     }
@@ -295,7 +295,6 @@ impl AppService {
                         mcp_error: mcp_message,
                         mcp_failure_kind: error.failure_kind,
                         mcp_server_status: None,
-                        available_tool_ids: Vec::new(),
                         progress: FailedRepoRuntimeMcpProgressInput {
                             stage: checking_progress.stage,
                             source: checking_progress,
@@ -371,7 +370,6 @@ impl AppService {
                                         mcp_error: refresh_message,
                                         mcp_failure_kind: error.failure_kind,
                                         mcp_server_status: mcp_status.status.clone(),
-                                        available_tool_ids: Vec::new(),
                                         progress: FailedRepoRuntimeMcpProgressInput {
                                             stage: reconnect_progress.stage,
                                             source: reconnect_progress.clone(),
@@ -402,7 +400,6 @@ impl AppService {
                             mcp_error: mcp_message,
                             mcp_failure_kind: error.failure_kind,
                             mcp_server_status: mcp_status.status.clone(),
-                            available_tool_ids: Vec::new(),
                             progress: FailedRepoRuntimeMcpProgressInput {
                                 stage: reconnect_progress.stage,
                                 source: reconnect_progress,
@@ -455,7 +452,6 @@ impl AppService {
                             mcp_error: tool_ids_message,
                             mcp_failure_kind: error.failure_kind,
                             mcp_server_status: mcp_status.status.clone(),
-                            available_tool_ids: Vec::new(),
                             progress: FailedRepoRuntimeMcpProgressInput {
                                 stage: RuntimeHealthWorkflowStage::RuntimeReady,
                                 source: checking_progress.clone(),


### PR DESCRIPTION
Summary: Consolidates duplicated MCP failure health-check assembly in the repo runtime health orchestrator while preserving the existing fail-fast behavior and failure details.

## Goal

The repo runtime health path had several branches manually constructing nearly identical MCP-failure `RepoRuntimeHealthCheckInput` values. This PR reduces that duplication so MCP status failures, reconnect failures, refresh-after-reconnect failures, and tool-id failures share one construction path without introducing fallback behavior or changing the resulting health payloads.

## Technical Choices

- Introduced a focused private helper input for failed MCP health checks so repeated runtime-ok/MCP-failed fields, timestamps, and empty available-tool lists are assembled in one place.
- Kept each failure branch responsible for the values that actually vary: failure message, failure kind, server status, server capability details, and progress source/stage.
- Preserved the existing return points and stored-health side effects so originating MCP failures still surface directly instead of being masked.
- Added focused Rust test coverage around the reconnect failure branch and kept existing exact assertions for MCP status/detail/failure-kind behavior.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`

Notes: the Bun test/build commands completed successfully with non-failing existing warnings from React `act(...)` output and Vite chunk-size reporting.
