### PR TITLE
fix(frontend): trust idle presence on session revisit

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
@@ -294,7 +294,7 @@ describe("CodexAppServerAdapter history hydration", () => {
     ]);
   });
 
-  test("hydrates restored token usage replayed by Codex thread resume", async () => {
+  test("hydrates loaded idle history without resuming the Codex thread", async () => {
     const { adapter, drainNotifications, transports } = createHarness();
 
     drainNotifications.mockImplementation(async () => [
@@ -319,13 +319,9 @@ describe("CodexAppServerAdapter history hydration", () => {
       externalSessionId: "thread-idle",
     });
 
-    expect(transports.get("runtime-ensure")?.calls).toContainEqual({
-      method: "thread/resume",
-      params: {
-        threadId: "thread-idle",
-        cwd: "/repo",
-      },
-    });
+    expect(
+      transports.get("runtime-ensure")?.calls.some((call) => call.method === "thread/resume"),
+    ).toBe(false);
     expect(history.find((message) => message.messageId === "msg-1")).toEqual(
       expect.objectContaining({
         role: "assistant",
@@ -357,6 +353,64 @@ describe("CodexAppServerAdapter history hydration", () => {
         contextWindow: 200_000,
       }),
     );
+  });
+
+  test("hydrates listed idle history without requiring the Codex thread to be loaded", async () => {
+    const calls: CodexJsonRpcRequest[] = [];
+    const transport: CodexJsonRpcTransport = {
+      async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
+        calls.push(request);
+        if (request.method === "thread/loaded/list") {
+          return { data: [], nextCursor: null } as Response;
+        }
+        if (request.method === "thread/list") {
+          return {
+            data: [{ id: "thread-unloaded", cwd: "/repo", createdAt: 1, status: { type: "idle" } }],
+            nextCursor: null,
+          } as Response;
+        }
+        if (request.method === "thread/turns/list") {
+          return {
+            data: [
+              {
+                id: "turn-1",
+                status: "completed",
+                startedAt: 1,
+                completedAt: 2,
+                items: [
+                  {
+                    id: "msg-1",
+                    type: "agentMessage",
+                    phase: "final_answer",
+                    text: "Hydrated from turns",
+                  },
+                ],
+              },
+            ],
+            nextCursor: null,
+          } as Response;
+        }
+        throw new Error(`Unexpected method '${request.method}'.`);
+      },
+    };
+    const adapter = createAdapterWithTransport(transport);
+
+    const history = await adapter.loadSessionHistory({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      externalSessionId: "thread-unloaded",
+    });
+
+    expect(history).toContainEqual(
+      expect.objectContaining({
+        messageId: "msg-1",
+        role: "assistant",
+        text: "Hydrated from turns",
+      }),
+    );
+    expect(calls.some((call) => call.method === "thread/read")).toBe(false);
+    expect(calls.some((call) => call.method === "thread/resume")).toBe(false);
   });
 
   test("hydrates documented thread-read tool item shapes", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.presence.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.presence.test.ts
@@ -18,8 +18,32 @@ class ThreadIdOnlyResumeTransport extends RecordingTransport {
   }
 }
 
+class MutableThreadListTransport extends RecordingTransport {
+  threadSavedStatus: Record<string, unknown> = { type: "active", activeFlags: [] };
+
+  async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
+    if (request.method === "thread/list") {
+      this.calls.push(request);
+      return {
+        data: [
+          {
+            id: "thread-saved",
+            cwd: "/repo",
+            createdAt: 1_778_112_000,
+            preview: "Saved session",
+            status: this.threadSavedStatus,
+          },
+        ],
+        nextCursor: null,
+        backwardsCursor: null,
+      } as Response;
+    }
+    return super.request<Response>(request);
+  }
+}
+
 describe("CodexAppServerAdapter presence", () => {
-  test("uses one Codex thread inventory during startup presence checks", async () => {
+  test("refreshes Codex thread inventory during presence checks", async () => {
     const { adapter, transports } = createHarness();
 
     await expect(
@@ -48,8 +72,8 @@ describe("CodexAppServerAdapter presence", () => {
     ]);
 
     const transport = transports.get("runtime-live");
-    expect(transport?.calls.filter((call) => call.method === "thread/loaded/list")).toHaveLength(1);
-    expect(transport?.calls.filter((call) => call.method === "thread/list")).toHaveLength(1);
+    expect(transport?.calls.filter((call) => call.method === "thread/loaded/list")).toHaveLength(2);
+    expect(transport?.calls.filter((call) => call.method === "thread/list")).toHaveLength(2);
     await expect(
       adapter.readSessionPresence({
         repoPath: "/repo",
@@ -64,8 +88,42 @@ describe("CodexAppServerAdapter presence", () => {
       }),
     );
     expect(transport?.calls.filter((call) => call.method === "thread/read")).toHaveLength(0);
-    expect(transport?.calls.filter((call) => call.method === "thread/loaded/list")).toHaveLength(1);
-    expect(transport?.calls.filter((call) => call.method === "thread/list")).toHaveLength(1);
+    expect(transport?.calls.filter((call) => call.method === "thread/loaded/list")).toHaveLength(3);
+    expect(transport?.calls.filter((call) => call.method === "thread/list")).toHaveLength(3);
+  });
+
+  test("refreshes a known Codex session from runtime thread status", async () => {
+    const transport = new MutableThreadListTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      transportFactory: mock(() => transport),
+    });
+
+    await adapter.attachSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      externalSessionId: "thread-saved",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    transport.threadSavedStatus = { type: "idle" };
+
+    await expect(
+      adapter.readSessionPresence({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "thread-saved",
+      }),
+    ).resolves.toMatchObject({
+      presence: "runtime",
+      classification: "idle",
+      agentSessionStatus: "idle",
+      status: { type: "idle" },
+    });
   });
 
   test("detects live Codex sessions from App Server after adapter refresh", async () => {
@@ -119,6 +177,33 @@ describe("CodexAppServerAdapter presence", () => {
         status: { type: "idle" },
       },
     ]);
+  });
+
+  test("reports a newly started local session while loaded-thread inventory catches up", async () => {
+    const { adapter } = createHarness();
+
+    const summary = await adapter.startSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    await expect(
+      adapter.readSessionPresence({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: summary.externalSessionId,
+      }),
+    ).resolves.toMatchObject({
+      presence: "runtime",
+      agentSessionStatus: "running",
+      ref: expect.objectContaining({ externalSessionId: summary.externalSessionId }),
+    });
   });
 
   test("attaches a missing live Codex session without starting a turn", async () => {
@@ -249,7 +334,13 @@ describe("CodexAppServerAdapter presence", () => {
     });
     const drainNotifications = mock(async () => [] as unknown[]);
     const drainServerRequests = mock(async () => [] as unknown[]);
-    const { adapter } = createHarness({ drainNotifications, drainServerRequests, subscribeEvents });
+    const transport = new MutableThreadListTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      drainNotifications,
+      drainServerRequests,
+      subscribeEvents,
+      transportFactory: mock(() => transport),
+    });
 
     await adapter.attachSession({
       repoPath: "/repo",
@@ -294,6 +385,7 @@ describe("CodexAppServerAdapter presence", () => {
     for (const message of notifications) {
       streamListeners[0]?.({ runtimeId: "runtime-live", kind: "notification", message });
     }
+    transport.threadSavedStatus = { type: "idle" };
 
     await waitForEvent(
       events,
@@ -324,6 +416,65 @@ describe("CodexAppServerAdapter presence", () => {
     unsubscribe();
   });
 
+  test("does not resurrect an idle local session from stale active thread inventory", async () => {
+    const streamListeners: Array<
+      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
+    > = [];
+    const subscribeEvents = mock((_runtimeId: string, listener) => {
+      streamListeners.push(listener);
+      return () => {};
+    });
+    const transport = new MutableThreadListTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      drainNotifications: mock(async () => [] as unknown[]),
+      drainServerRequests: mock(async () => [] as unknown[]),
+      subscribeEvents,
+      transportFactory: mock(() => transport),
+    });
+
+    await adapter.attachSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      externalSessionId: "thread-saved",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    const events: unknown[] = [];
+    const unsubscribe = adapter.subscribeEvents("thread-saved", (event) => events.push(event));
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-saved",
+          turn: { id: "turn-live", status: "completed" },
+        },
+      },
+    });
+
+    await waitForEvent(
+      events,
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        (event as { type?: unknown }).type === "session_idle",
+    );
+    await expect(
+      adapter.readSessionPresence({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "thread-saved",
+      }),
+    ).resolves.toMatchObject({ classification: "idle", agentSessionStatus: "idle" });
+    unsubscribe();
+  });
+
   test("streams messages and completion after refresh resume reattach", async () => {
     const streamListeners: Array<
       (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
@@ -334,7 +485,13 @@ describe("CodexAppServerAdapter presence", () => {
     });
     const drainNotifications = mock(async () => [] as unknown[]);
     const drainServerRequests = mock(async () => [] as unknown[]);
-    const { adapter } = createHarness({ drainNotifications, drainServerRequests, subscribeEvents });
+    const transport = new MutableThreadListTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      drainNotifications,
+      drainServerRequests,
+      subscribeEvents,
+      transportFactory: mock(() => transport),
+    });
 
     await adapter.resumeSession({
       repoPath: "/repo",
@@ -360,6 +517,7 @@ describe("CodexAppServerAdapter presence", () => {
         },
       },
     });
+    transport.threadSavedStatus = { type: "idle" };
 
     await waitForEvent(
       events,

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -68,6 +68,7 @@ import {
   emitCodexUserMessage,
   handleCodexPendingNotifications,
 } from "./codex-app-server-streaming";
+import type { CodexThreadInventory, CodexThreadStatusSnapshot } from "./codex-app-server-threads";
 import {
   type CodexTokenUsageTotals,
   codexTodosFromThreadRead,
@@ -108,6 +109,9 @@ import type {
 } from "./types";
 
 export { createCodexAppServerClient } from "./app-server-client";
+
+const hasCodexThreadReadTurns = (value: unknown): boolean =>
+  isPlainObject(value) && isPlainObject(value.thread) && Array.isArray(value.thread.turns);
 
 export class CodexAppServerAdapter
   implements AgentCatalogPort, AgentSessionPort, AgentWorkspaceInspectionPort
@@ -286,10 +290,10 @@ export class CodexAppServerAdapter
     if (!threadResponse) {
       return [];
     }
-    const response = await this.threadInventory.readThreadWithTurns(
-      client,
-      input.externalSessionId,
-    );
+    const response =
+      !session && hasCodexThreadReadTurns(threadResponse)
+        ? threadResponse
+        : await this.threadInventory.readThreadWithTurns(client, input.externalSessionId);
     const tokenUsageByTurnId = await this.drainThreadReadTokenUsage(
       runtimeId,
       input.externalSessionId,
@@ -478,7 +482,7 @@ export class CodexAppServerAdapter
     const { client, runtimeId } = await this.runtimeClients.resolve(input, "list live sessions", {
       requireLive: true,
     });
-    const inventory = await this.threadInventory.read(client, runtimeId);
+    const inventory = await this.threadInventory.refresh(client, runtimeId);
     if (inventory.loadedIds.size === 0) {
       return [];
     }
@@ -498,9 +502,29 @@ export class CodexAppServerAdapter
   async listSessionPresence(
     input: ListSessionPresenceInput,
   ): Promise<AgentSessionPresenceSnapshot[]> {
-    const localSnapshots = [...this.sessions.values()]
+    const directories = new Set(input.directories ?? []);
+    const localSessions = [...this.sessions.values()]
       .filter((session) => session.repoPath === input.repoPath)
-      .map((session) => this.toPresenceSnapshot(session));
+      .filter((session) => directories.size === 0 || directories.has(session.workingDirectory));
+    const inventoryByRuntimeId = new Map<string, Promise<CodexThreadInventory>>();
+    const refreshRuntimeInventory = (runtimeId: string): Promise<CodexThreadInventory> => {
+      const existing = inventoryByRuntimeId.get(runtimeId);
+      if (existing) {
+        return existing;
+      }
+      const inventory = this.threadInventory.refresh(
+        this.runtimeClients.clientForRuntime(runtimeId),
+        runtimeId,
+      );
+      inventoryByRuntimeId.set(runtimeId, inventory);
+      return inventory;
+    };
+    const localSnapshots = await Promise.all(
+      localSessions.map(async (session) =>
+        this.toRefreshedPresenceSnapshot(session, await refreshRuntimeInventory(session.runtimeId)),
+      ),
+    );
+    const localThreadIds = new Set(localSessions.map((session) => session.threadId));
     const { client, runtimeId } = await this.runtimeClients.resolve(
       input,
       "list session presence",
@@ -508,11 +532,10 @@ export class CodexAppServerAdapter
         requireLive: true,
       },
     );
-    const inventory = await this.threadInventory.read(client, runtimeId);
-    const directories = new Set(input.directories ?? []);
+    const inventory = await this.threadInventory.refresh(client, runtimeId);
     const remoteSnapshots = [...inventory.threadsById.values()]
       .filter((thread) => inventory.loadedIds.has(thread.id))
-      .filter((thread) => !this.sessions.has(thread.id))
+      .filter((thread) => !localThreadIds.has(thread.id))
       .filter((thread) => directories.size === 0 || directories.has(thread.cwd))
       .map((thread) => toPresenceSnapshotFromThread(thread, input, runtimeId));
     return [...localSnapshots, ...remoteSnapshots];
@@ -525,7 +548,11 @@ export class CodexAppServerAdapter
     if (!session) {
       return this.readRemoteSessionPresence(input);
     }
-    return this.toPresenceSnapshot(session);
+    const inventory = await this.threadInventory.refresh(
+      this.runtimeClients.clientForRuntime(session.runtimeId),
+      session.runtimeId,
+    );
+    return this.toRefreshedPresenceSnapshot(session, inventory, input);
   }
 
   async replyApproval(input: ReplyApprovalInput): Promise<void> {
@@ -957,6 +984,7 @@ export class CodexAppServerAdapter
       bindActiveTurnId: (activeTurn, turnId) => this.bindActiveTurnId(activeTurn, turnId),
       flushQueuedUserMessagesLater: (activeTurn) => this.flushQueuedUserMessagesLater(activeTurn),
       bufferNotification: (notification) => this.bufferNotification(notification),
+      setSessionLiveStatus: (session, liveStatus) => this.setSessionLiveStatus(session, liveStatus),
       listenersForSession: (externalSessionId) => this.listenersBySessionId.get(externalSessionId),
     };
   }
@@ -973,6 +1001,7 @@ export class CodexAppServerAdapter
       bindActiveTurnId: (activeTurn, turnId) => this.bindActiveTurnId(activeTurn, turnId),
       bindPendingInputToActiveTurn: (externalSessionId, activeTurn) =>
         this.bindPendingInputToActiveTurn(externalSessionId, activeTurn),
+      setSessionLiveStatus: (session, liveStatus) => this.setSessionLiveStatus(session, liveStatus),
       handlePendingServerRequests: (session, handledRequestKeys) =>
         this.handlePendingServerRequests(session, handledRequestKeys),
       emitUserMessage: (session, parts, model) => this.emitUserMessage(session, parts, model),
@@ -1017,6 +1046,73 @@ export class CodexAppServerAdapter
     );
   }
 
+  private toRefreshedPresenceSnapshot(
+    session: CodexSessionState,
+    inventory: CodexThreadInventory,
+    input?: ReadSessionPresenceInput,
+  ): AgentSessionPresenceSnapshot {
+    const thread = inventory.threadsById.get(session.threadId) ?? null;
+    if (!thread || !inventory.loadedIds.has(session.threadId)) {
+      if (this.hasLocalRuntimePresence(session)) {
+        return this.toPresenceSnapshot(session);
+      }
+      return stalePresence(input ?? this.sessionRef(session), session.runtimeId);
+    }
+    if (thread.cwd !== session.workingDirectory) {
+      return stalePresence(input ?? this.sessionRef(session), session.runtimeId);
+    }
+    const activeTurn = this.activeTurnsBySessionId.get(session.threadId);
+    const hasPendingInput =
+      this.pendingApprovalsForSession(session.threadId).length > 0 ||
+      this.pendingQuestionsForSession(session.threadId).length > 0;
+    if (
+      session.liveStatus?.agentSessionStatus === "idle" &&
+      thread.status.agentSessionStatus === "running" &&
+      !hasPendingInput &&
+      (!activeTurn || activeTurn.isTurnSettled())
+    ) {
+      return this.toPresenceSnapshot(session);
+    }
+    this.setSessionLiveStatus(session, thread.status);
+    return this.toPresenceSnapshot(session);
+  }
+
+  private hasLocalRuntimePresence(session: CodexSessionState): boolean {
+    if (this.pendingApprovalsForSession(session.threadId).length > 0) {
+      return true;
+    }
+    if (this.pendingQuestionsForSession(session.threadId).length > 0) {
+      return true;
+    }
+    const activeTurn = this.activeTurnsBySessionId.get(session.threadId);
+    if (activeTurn && !activeTurn.isTurnSettled()) {
+      return true;
+    }
+    return (
+      session.liveStatus?.agentSessionStatus === "idle" || session.summary.status === "running"
+    );
+  }
+
+  private setSessionLiveStatus(
+    session: CodexSessionState,
+    liveStatus: CodexThreadStatusSnapshot,
+  ): void {
+    session.liveStatus = liveStatus;
+    session.summary = {
+      ...session.summary,
+      status: liveStatus.agentSessionStatus,
+    };
+  }
+
+  private sessionRef(session: CodexSessionState): ReadSessionPresenceInput {
+    return {
+      externalSessionId: session.threadId,
+      repoPath: session.repoPath,
+      runtimeKind: "codex",
+      workingDirectory: session.workingDirectory,
+    };
+  }
+
   private async readRemoteSessionPresence(
     input: ReadSessionPresenceInput,
   ): Promise<AgentSessionPresenceSnapshot> {
@@ -1027,7 +1123,7 @@ export class CodexAppServerAdapter
         requireLive: true,
       },
     );
-    const inventory = await this.threadInventory.read(client, runtimeId);
+    const inventory = await this.threadInventory.refresh(client, runtimeId);
     if (!inventory.loadedIds.has(input.externalSessionId)) {
       return stalePresence(input, runtimeId);
     }

--- a/packages/adapters-codex-app-server/src/codex-app-server-presence.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-presence.ts
@@ -14,12 +14,16 @@ export const toPresenceSnapshot = (
 ): AgentSessionPresenceSnapshot => {
   const hasPendingInput = pendingApprovals.length > 0 || pendingQuestions.length > 0;
   const liveStatus = session.liveStatus;
+  const agentSessionStatus =
+    liveStatus?.agentSessionStatus ?? (session.summary.status === "running" ? "running" : "idle");
+  const status =
+    liveStatus?.status ?? (agentSessionStatus === "running" ? { type: "busy" } : { type: "idle" });
   const classification =
     pendingQuestions.length > 0
       ? "waiting_for_question"
       : pendingApprovals.length > 0
         ? "waiting_for_permission"
-        : (liveStatus?.classification ?? "idle");
+        : (liveStatus?.classification ?? agentSessionStatus);
   return {
     presence: "runtime",
     classification,
@@ -32,8 +36,8 @@ export const toPresenceSnapshot = (
     runtimeId: session.runtimeId,
     title: session.role ? `Codex ${session.role}` : "Codex",
     startedAt: session.summary.startedAt,
-    status: hasPendingInput ? { type: "busy" } : (liveStatus?.status ?? { type: "idle" }),
-    agentSessionStatus: hasPendingInput ? "running" : (liveStatus?.agentSessionStatus ?? "idle"),
+    status: hasPendingInput ? { type: "busy" } : status,
+    agentSessionStatus: hasPendingInput ? "running" : agentSessionStatus,
     pendingApprovals,
     pendingQuestions,
   };

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -17,7 +17,10 @@ import {
   isPlainObject,
   MAX_CODEX_EVENT_BACKLOG_PER_SESSION,
 } from "./codex-app-server-shared";
-import { codexThreadStatusSnapshot } from "./codex-app-server-threads";
+import {
+  type CodexThreadStatusSnapshot,
+  codexThreadStatusSnapshot,
+} from "./codex-app-server-threads";
 import {
   type CodexTokenUsageTotals,
   codexItemId,
@@ -62,6 +65,7 @@ export type CodexStreamingContext = {
   bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean;
   flushQueuedUserMessagesLater(activeTurn: ActiveCodexTurn): void;
   bufferNotification(notification: CodexNotificationRecord): void;
+  setSessionLiveStatus(session: CodexSessionState, liveStatus: CodexThreadStatusSnapshot): void;
   listenersForSession(externalSessionId: string): Set<(event: AgentEvent) => void> | undefined;
 };
 
@@ -381,11 +385,11 @@ export const handleCodexPendingNotifications = async (
     }
 
     if (notification.method === "turn/started") {
-      session.liveStatus = {
+      context.setSessionLiveStatus(session, {
         classification: "running",
         status: { type: "busy" },
         agentSessionStatus: "running",
-      };
+      });
       const turn = isPlainObject(notification.params) ? notification.params.turn : null;
       const turnId = isPlainObject(turn) ? extractStringField(turn, ["id", "turnId"]) : null;
       if (turnId && activeTurn && context.bindActiveTurnId(activeTurn, turnId)) {
@@ -396,7 +400,10 @@ export const handleCodexPendingNotifications = async (
 
     if (notification.method === "thread/status/changed") {
       if (isPlainObject(notification.params)) {
-        session.liveStatus = codexThreadStatusSnapshot(notification.params.status);
+        context.setSessionLiveStatus(
+          session,
+          codexThreadStatusSnapshot(notification.params.status),
+        );
       }
       continue;
     }
@@ -480,11 +487,11 @@ export const handleCodexPendingNotifications = async (
         activeTurn.markTurnSettled();
       }
       if (!activeTurn || shouldSettleActiveTurn) {
-        session.liveStatus = {
+        context.setSessionLiveStatus(session, {
           classification: "idle",
           status: { type: "idle" },
           agentSessionStatus: "idle",
-        };
+        });
       }
       emitCanonicalEvents(
         context,

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { createDeferred } from "./codex-app-server-adapter.test-harness";
+import { CodexThreadInventoryReader } from "./codex-thread-inventory";
+import type { CodexAppServerClient } from "./types";
+
+const threadListResponse = (id: string, preview: string): unknown => ({
+  data: [
+    {
+      id,
+      cwd: "/repo",
+      createdAt: 1,
+      preview,
+      status: { type: "idle" },
+    },
+  ],
+  nextCursor: null,
+});
+
+describe("CodexThreadInventoryReader", () => {
+  test("does not let a stale in-flight read overwrite a refreshed inventory", async () => {
+    const reader = new CodexThreadInventoryReader();
+    const firstLoaded = createDeferred<unknown>();
+    const firstThreads = createDeferred<unknown>();
+    const refreshedLoaded = createDeferred<unknown>();
+    const refreshedThreads = createDeferred<unknown>();
+    const loadedResponses = [firstLoaded, refreshedLoaded];
+    const threadResponses = [firstThreads, refreshedThreads];
+    const client = {
+      threadLoadedList: () => {
+        const response = loadedResponses.shift();
+        if (!response) {
+          throw new Error("Unexpected thread/loaded/list call.");
+        }
+        return response.promise;
+      },
+      threadList: () => {
+        const response = threadResponses.shift();
+        if (!response) {
+          throw new Error("Unexpected thread/list call.");
+        }
+        return response.promise;
+      },
+    } as unknown as CodexAppServerClient;
+
+    const staleRead = reader.read(client, "runtime-1");
+    const refreshedRead = reader.refresh(client, "runtime-1");
+    refreshedLoaded.resolve({ data: ["thread-fresh"], nextCursor: null });
+    refreshedThreads.resolve(threadListResponse("thread-fresh", "Fresh inventory"));
+
+    await expect(refreshedRead).resolves.toMatchObject({ runtimeId: "runtime-1" });
+    firstLoaded.resolve({ data: ["thread-stale"], nextCursor: null });
+    firstThreads.resolve(threadListResponse("thread-stale", "Stale inventory"));
+    await expect(staleRead).resolves.toMatchObject({ runtimeId: "runtime-1" });
+
+    const cached = await reader.read(client, "runtime-1");
+    expect(cached.threadsById.has("thread-fresh")).toBe(true);
+    expect(cached.threadsById.has("thread-stale")).toBe(false);
+  });
+
+  test("loads history turns for listed threads without requiring a loaded runtime thread", async () => {
+    const reader = new CodexThreadInventoryReader();
+    let threadReadCalls = 0;
+    const client = {
+      threadLoadedList: async () => ({ data: [], nextCursor: null }),
+      threadList: async () => threadListResponse("thread-idle", "Idle inventory"),
+      threadTurnsList: async () => ({
+        data: [{ id: "turn-1", status: "completed", items: [] }],
+        nextCursor: null,
+      }),
+      threadRead: async () => {
+        threadReadCalls += 1;
+        throw new Error("thread not loaded: thread-idle");
+      },
+    } as unknown as CodexAppServerClient;
+
+    const response = await reader.attachThreadForHistory(client, "runtime-1", {
+      externalSessionId: "thread-idle",
+      workingDirectory: "/repo",
+    });
+
+    expect(response).toEqual({
+      thread: expect.objectContaining({
+        id: "thread-idle",
+        cwd: "/repo",
+        turns: [expect.objectContaining({ id: "turn-1" })],
+      }),
+    });
+    expect(threadReadCalls).toBe(0);
+  });
+});

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
@@ -33,17 +33,26 @@ export class CodexThreadInventoryReader {
     }
     const nextPending = this.fetch(client, runtimeId).then(
       (inventory) => {
-        this.inventoryByRuntimeId.set(runtimeId, inventory);
-        this.pendingInventoryByRuntimeId.delete(runtimeId);
+        if (this.pendingInventoryByRuntimeId.get(runtimeId) === nextPending) {
+          this.inventoryByRuntimeId.set(runtimeId, inventory);
+          this.pendingInventoryByRuntimeId.delete(runtimeId);
+        }
         return inventory;
       },
       (error) => {
-        this.pendingInventoryByRuntimeId.delete(runtimeId);
+        if (this.pendingInventoryByRuntimeId.get(runtimeId) === nextPending) {
+          this.pendingInventoryByRuntimeId.delete(runtimeId);
+        }
         throw error;
       },
     );
     this.pendingInventoryByRuntimeId.set(runtimeId, nextPending);
     return nextPending;
+  }
+
+  async refresh(client: CodexAppServerClient, runtimeId: string): Promise<CodexThreadInventory> {
+    this.clear(runtimeId);
+    return this.read(client, runtimeId);
   }
 
   async findThread(
@@ -91,16 +100,31 @@ export class CodexThreadInventoryReader {
     runtimeId: string,
     input: { externalSessionId: string; workingDirectory: string },
   ): Promise<unknown | null> {
-    const thread = await this.findThread(client, runtimeId, input.externalSessionId);
+    const inventory = await this.read(client, runtimeId);
+    const thread = inventory.threadsById.get(input.externalSessionId) ?? null;
     if (!thread || thread.cwd !== input.workingDirectory) {
       return null;
     }
-    const response = await client.threadResume({
-      threadId: input.externalSessionId,
-      cwd: input.workingDirectory,
-    });
-    this.clear(runtimeId);
-    return response;
+    if (inventory.loadedIds.has(thread.id)) {
+      try {
+        return await this.readThreadWithTurns(client, thread.id);
+      } catch (error) {
+        if (!isCodexThreadNotLoadedError(error)) {
+          throw error;
+        }
+        this.clear(runtimeId);
+      }
+    }
+    const turns = await this.fetchThreadTurns(client, thread.id);
+    return {
+      thread: {
+        id: thread.id,
+        cwd: thread.cwd,
+        createdAt: Date.parse(thread.startedAt) / 1000,
+        status: thread.status.status,
+        turns,
+      },
+    };
   }
 
   async readThreadWithTurns(client: CodexAppServerClient, threadId: string): Promise<unknown> {

--- a/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
@@ -1,6 +1,10 @@
 import type { AgentEvent, AgentModelSelection, AgentUserMessagePart } from "@openducktor/core";
 import { extractTurnId, isTerminalTurnStatus } from "./codex-app-server-requests";
 import { type ActiveCodexTurn, isPlainObject } from "./codex-app-server-shared";
+import {
+  type CodexThreadStatusSnapshot,
+  codexThreadStatusSnapshot,
+} from "./codex-app-server-threads";
 import { toCodexUserInputList } from "./codex-app-server-transcript";
 import { requireModelSelection, toTransportModelSelection } from "./model-catalog";
 import type { CodexAppServerClient, CodexSessionState } from "./types";
@@ -19,6 +23,7 @@ export type CodexTurnLifecycleContext = {
   ensureRuntimeEventSubscription(runtimeId: string): void;
   bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean;
   bindPendingInputToActiveTurn(externalSessionId: string, activeTurn: ActiveCodexTurn): void;
+  setSessionLiveStatus(session: CodexSessionState, liveStatus: CodexThreadStatusSnapshot): void;
   handlePendingServerRequests(
     session: CodexSessionState,
     handledRequestKeys: Set<string>,
@@ -180,6 +185,7 @@ export const startCodexTurnForSession = async (
         context.emitUserMessage(session, parts, model);
         activeTurnState.markTurnSettled();
       } else if (isPlainObject(result.turn) && isTerminalTurnStatus(result.turn)) {
+        context.setSessionLiveStatus(session, codexThreadStatusSnapshot("idle"));
         activeTurnState.markTurnSettled();
       }
       return result;

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-agent-session-hydration.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-agent-session-hydration.ts
@@ -10,6 +10,7 @@ import {
   deriveAgentSessionViewLifecycle,
   type SessionRepoReadinessState,
 } from "../lifecycle/session-view-lifecycle";
+import { requiresHydratedAgentSessionHistory } from "../support/history-hydration";
 import type { UpdateAgentSession } from "./use-agent-session-mutations";
 
 type LoadAgentSessions = (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
@@ -128,6 +129,7 @@ export const useAgentSessionHydration = ({
       await sessionHydration.hydrateRequestedTaskSession({
         taskId,
         externalSessionId,
+        historyPolicy: requiresHydratedAgentSessionHistory(session) ? "requested_only" : "none",
         ...(historyPreludeMode ? { historyPreludeMode } : {}),
         ...(allowLiveSessionResume !== undefined ? { allowLiveSessionResume } : {}),
         ...(persistedRecords ? { persistedRecords } : {}),

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-requested-history.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-requested-history.test.ts
@@ -7,6 +7,7 @@ import {
   createAdapter,
   createDeferred,
   createLoadAgentSessions,
+  createPresence,
   createTaskFixture,
   createTestQueryClient,
   getSession,
@@ -158,6 +159,304 @@ describe("agent-orchestrator requested history hydration", () => {
     ]);
     expect(attachCalls).toEqual([{ externalSessionId: "external-child-1" }]);
     expect(state["external-child-1"]?.status).toBe("running");
+  });
+
+  test("applies passive presence during requested-history hydration without attaching", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "external-codex-1": {
+          externalSessionId: "external-codex-1",
+          taskId: "task-1",
+          repoPath: "/tmp/repo",
+          role: "build",
+          status: "running",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          runtimeKind: "codex",
+          runtimeId: "runtime-codex",
+          workingDirectory: "/tmp/repo",
+          messages: [],
+          draftAssistantText: "",
+          draftAssistantMessageId: null,
+          draftReasoningText: "",
+          draftReasoningMessageId: null,
+          contextUsage: null,
+          pendingApprovals: [],
+          pendingQuestions: [],
+          todos: [],
+          modelCatalog: null,
+          selectedModel: null,
+          isLoadingModelCatalog: false,
+          promptOverrides: {},
+          historyHydrationState: "not_requested",
+          runtimeRecoveryState: "idle",
+        },
+      },
+    };
+    let state: Record<string, AgentSessionState> = sessionsRef.current;
+    const presenceScans: string[][] = [];
+    const attachCalls: string[] = [];
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const updateSession = (
+      externalSessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[externalSessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [externalSessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      queryClient,
+      activeWorkspace: {
+        repoPath: "/tmp/repo",
+        workspaceId: "workspace-1",
+        workspaceName: "Active Workspace",
+      },
+      adapter: createAdapter({
+        loadSessionHistory: async () => [],
+        attachSession: async (input: AttachSessionInput) => {
+          attachCalls.push(input.externalSessionId);
+          return {
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: "running",
+            runtimeKind: input.runtimeKind,
+          };
+        },
+        listSessionPresence: async (input) => {
+          presenceScans.push(input.directories ?? []);
+          const presence = createPresence("external-codex-1", "/tmp/repo", {
+            status: { type: "idle" },
+          });
+          return [
+            {
+              ...presence,
+              ref: { ...presence.ref, runtimeKind: "codex" },
+              runtimeId: "runtime-codex",
+            },
+          ];
+        },
+        readSessionPresence: async (input) => {
+          const presence = createPresence(input.externalSessionId, input.workingDirectory, {
+            status: { type: "idle" },
+          });
+          return {
+            ...presence,
+            ref: { ...presence.ref, runtimeKind: "codex" },
+            runtimeId: "runtime-codex",
+          };
+        },
+      }),
+      repoEpochRef: { current: 2 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [createTaskFixture()] },
+      updateSession,
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    const preloadedRuntimeLists = new Map<"codex", RuntimeInstanceSummary[]>([
+      [
+        "codex",
+        [
+          {
+            kind: "codex",
+            runtimeId: "runtime-codex",
+            repoPath: "/tmp/repo",
+            taskId: null,
+            role: "workspace",
+            workingDirectory: "/tmp/repo",
+            runtimeRoute: {
+              type: "local_http",
+              endpoint: "http://127.0.0.1:1430",
+            },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: CODEX_RUNTIME_DESCRIPTOR,
+          },
+        ],
+      ],
+    ]);
+
+    await loadAgentSessions("task-1", {
+      mode: "requested_history",
+      targetExternalSessionId: "external-codex-1",
+      historyPolicy: "requested_only",
+      preloadedRuntimeLists,
+      persistedRecords: [
+        persistedSessionRecord({
+          runtimeKind: "codex",
+          externalSessionId: "external-codex-1",
+          taskId: "task-1",
+          role: "build",
+          status: "running",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          workingDirectory: "/tmp/repo",
+        }),
+      ],
+    });
+
+    expect(presenceScans).toEqual([["/tmp/repo"]]);
+    expect(attachCalls).toEqual([]);
+    expect(getSession(state, "external-codex-1").status).toBe("idle");
+  });
+
+  test("applies passive presence for already hydrated requested sessions without reloading history", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "external-codex-1": {
+          externalSessionId: "external-codex-1",
+          taskId: "task-1",
+          repoPath: "/tmp/repo",
+          role: "build",
+          status: "running",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          runtimeKind: "codex",
+          runtimeId: "runtime-codex",
+          workingDirectory: "/tmp/repo",
+          messages: [
+            {
+              id: "message-1",
+              role: "assistant",
+              content: "hydrated transcript",
+              timestamp: "2026-02-22T08:00:03.000Z",
+            },
+          ],
+          draftAssistantText: "",
+          draftAssistantMessageId: null,
+          draftReasoningText: "",
+          draftReasoningMessageId: null,
+          contextUsage: null,
+          pendingApprovals: [],
+          pendingQuestions: [],
+          todos: [],
+          modelCatalog: null,
+          selectedModel: null,
+          isLoadingModelCatalog: false,
+          promptOverrides: {},
+          historyHydrationState: "hydrated",
+          runtimeRecoveryState: "idle",
+        },
+      },
+    };
+    let state: Record<string, AgentSessionState> = sessionsRef.current;
+    let listPresenceCount = 0;
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const updateSession = (
+      externalSessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[externalSessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [externalSessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      queryClient,
+      activeWorkspace: {
+        repoPath: "/tmp/repo",
+        workspaceId: "workspace-1",
+        workspaceName: "Active Workspace",
+      },
+      adapter: createAdapter({
+        loadSessionHistory: async () => {
+          throw new Error("history should not be reloaded for a presence-only refresh");
+        },
+        listSessionPresence: async () => {
+          listPresenceCount += 1;
+          const presence = createPresence("external-codex-1", "/tmp/repo", {
+            status: { type: "idle" },
+          });
+          return [
+            {
+              ...presence,
+              ref: { ...presence.ref, runtimeKind: "codex" },
+              runtimeId: "runtime-codex",
+            },
+          ];
+        },
+      }),
+      repoEpochRef: { current: 2 },
+      currentWorkspaceRepoPathRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [createTaskFixture()] },
+      updateSession,
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    const preloadedRuntimeLists = new Map<"codex", RuntimeInstanceSummary[]>([
+      [
+        "codex",
+        [
+          {
+            kind: "codex",
+            runtimeId: "runtime-codex",
+            repoPath: "/tmp/repo",
+            taskId: null,
+            role: "workspace",
+            workingDirectory: "/tmp/repo",
+            runtimeRoute: {
+              type: "local_http",
+              endpoint: "http://127.0.0.1:1430",
+            },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: CODEX_RUNTIME_DESCRIPTOR,
+          },
+        ],
+      ],
+    ]);
+
+    await loadAgentSessions("task-1", {
+      mode: "requested_history",
+      targetExternalSessionId: "external-codex-1",
+      historyPolicy: "none",
+      preloadedRuntimeLists,
+      persistedRecords: [
+        persistedSessionRecord({
+          runtimeKind: "codex",
+          externalSessionId: "external-codex-1",
+          taskId: "task-1",
+          role: "build",
+          status: "running",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          workingDirectory: "/tmp/repo",
+        }),
+      ],
+    });
+
+    expect(listPresenceCount).toBe(1);
+    expect(getSession(state, "external-codex-1").status).toBe("idle");
+    expect(getSession(state, "external-codex-1").historyHydrationState).toBe("hydrated");
   });
 
   test("hydrates Codex history with per-turn model metadata instead of current selection", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
@@ -170,9 +170,16 @@ describe("load-sessions-stages", () => {
     expect(stateHarness.getState()["external-1"]?.status).toBe("starting");
   });
 
-  test("keeps pending outbound sends active when reconcile sees idle runtime presence", async () => {
+  test("settles pending outbound sends when reconcile sees idle runtime presence", async () => {
     const stateHarness = createStateHarness({
-      "external-1": createSession({ status: "running", pendingUserMessageStartedAt: 123 }),
+      "external-1": createSession({
+        status: "running",
+        pendingUserMessageStartedAt: 123,
+        draftAssistantText: "partial assistant",
+        draftAssistantMessageId: "assistant-draft",
+        draftReasoningText: "partial reasoning",
+        draftReasoningMessageId: "reasoning-draft",
+      }),
     });
 
     await hydrateSessionRecordsStage({
@@ -203,10 +210,16 @@ describe("load-sessions-stages", () => {
       getRepoPromptOverrides: async () => ({}),
     });
 
-    expect(stateHarness.getState()["external-1"]?.status).toBe("running");
+    const session = stateHarness.getState()["external-1"];
+    expect(session?.status).toBe("idle");
+    expect(session?.pendingUserMessageStartedAt).toBeUndefined();
+    expect(session?.draftAssistantText).toBe("");
+    expect(session?.draftAssistantMessageId).toBeNull();
+    expect(session?.draftReasoningText).toBe("");
+    expect(session?.draftReasoningMessageId).toBeNull();
   });
 
-  test("settles pending outbound sends when requested history confirms an idle completed turn", async () => {
+  test("settles pending outbound sends when requested-history runtime presence is idle", async () => {
     const stateHarness = createStateHarness({
       "external-1": createSession({
         status: "running",
@@ -248,6 +261,51 @@ describe("load-sessions-stages", () => {
     expect(session?.historyHydrationState).toBe("hydrated");
   });
 
+  test("keeps pending outbound sends when requested-history runtime presence is running", async () => {
+    const stateHarness = createStateHarness({
+      "external-1": createSession({
+        status: "running",
+        pendingUserMessageStartedAt,
+      }),
+    });
+
+    await hydrateSessionRecordsStage({
+      loadMode: "requested_history",
+      repoPath: "/tmp/repo",
+      adapter: createLifecycleAdapter({
+        loadSessionHistory: async () => createCompletedAssistantHistory(),
+      }),
+      setSessionsById: stateHarness.setSessionsById,
+      updateSession: stateHarness.updateSession,
+      isStaleRepoOperation: () => false,
+      recordsToHydrate: [createRecord()],
+      historyHydrationSessionIds: new Set(["external-1"]),
+      runtimePlanner: {
+        repoPath: "/tmp/repo",
+        resolveHydrationRuntime: async () => ({
+          ok: true,
+          runtimeRef: { repoPath: "/tmp/repo", runtimeKind: "opencode" },
+          workingDirectory: "/tmp/repo/worktree",
+        }),
+        readSessionPresence: async () =>
+          createSessionPresenceSnapshot("external-1", "/tmp/repo/worktree", {
+            status: { type: "busy" },
+          }),
+      },
+      promptAssembler: {
+        buildHydrationPreludeMessages: async () => [],
+        buildHydrationSystemPrompt: async () => "",
+      },
+      getRepoPromptOverrides: async () => ({}),
+      livePresenceMode: "apply",
+    });
+
+    const session = stateHarness.getState()["external-1"];
+    expect(session?.status).toBe("running");
+    expect(session?.pendingUserMessageStartedAt).toBe(pendingUserMessageStartedAt);
+    expect(session?.historyHydrationState).toBe("hydrated");
+  });
+
   test("keeps pending outbound sends when requested history skips live presence", async () => {
     const stateHarness = createStateHarness({
       "external-1": createSession({
@@ -282,7 +340,7 @@ describe("load-sessions-stages", () => {
     expect(session?.historyHydrationState).toBe("hydrated");
   });
 
-  test("keeps pending outbound sends when hydrated history has no stop finish", async () => {
+  test("settles pending outbound sends from idle presence even when hydrated history has no stop finish", async () => {
     const stateHarness = createStateHarness({
       "external-1": createSession({
         status: "running",
@@ -311,8 +369,8 @@ describe("load-sessions-stages", () => {
     });
 
     const session = stateHarness.getState()["external-1"];
-    expect(session?.status).toBe("running");
-    expect(session?.pendingUserMessageStartedAt).toBe(pendingUserMessageStartedAt);
+    expect(session?.status).toBe("idle");
+    expect(session?.pendingUserMessageStartedAt).toBeUndefined();
     expect(session?.historyHydrationState).toBe("hydrated");
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -18,10 +18,7 @@ import {
   getSessionMessagesSlice,
 } from "../support/messages";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
-import {
-  settlePendingOutboundSendFields,
-  shouldSettlePendingOutboundSendFromHydratedHistory,
-} from "../support/pending-outbound-send";
+import { settlePendingOutboundSendFields } from "../support/pending-outbound-send";
 import {
   fromPersistedSessionRecord,
   historyToChatMessages,
@@ -808,6 +805,7 @@ const applyMissingHydrationRuntime = ({
 
 const hydrateRuntimeOnlyRecord = async ({
   loadMode,
+  livePresenceMode,
   updateSession,
   isStaleRepoOperation,
   record,
@@ -815,6 +813,7 @@ const hydrateRuntimeOnlyRecord = async ({
   runtimePlanner,
 }: {
   loadMode: AgentSessionLoadMode;
+  livePresenceMode: LivePresenceHydrationMode;
   updateSession: UpdateSession;
   isStaleRepoOperation: () => boolean;
   record: AgentSessionRecord;
@@ -822,7 +821,9 @@ const hydrateRuntimeOnlyRecord = async ({
   runtimePlanner: HydrationRuntimePlanner;
 }): Promise<void> => {
   const shouldReadSessionPresenceSnapshot =
-    loadMode === "reconcile_live" || loadMode === "recover_runtime_attachment";
+    livePresenceMode === "apply" ||
+    loadMode === "reconcile_live" ||
+    loadMode === "recover_runtime_attachment";
   const sessionPresence = shouldReadSessionPresenceSnapshot
     ? await readPlannerAgentSessionPresenceSnapshot(runtimePlanner, record)
     : null;
@@ -881,14 +882,7 @@ const applyHydratedRecordHistory = (
     : current;
   const liveSessionTitle =
     sessionPresence?.presence === "runtime" ? sessionPresence.title : undefined;
-  const shouldSettlePendingOutboundSend = shouldSettlePendingOutboundSendFromHydratedHistory(
-    current,
-    history,
-    sessionPresence,
-  );
-  const nextStatus: AgentSessionState["status"] = shouldSettlePendingOutboundSend
-    ? "idle"
-    : sessionWithLivePresence.status;
+  const nextStatus: AgentSessionState["status"] = sessionWithLivePresence.status;
   const pendingOutboundSendFields =
     nextStatus === "running"
       ? {
@@ -1068,6 +1062,7 @@ const hydrateSessionRecord = async ({
     if (!shouldHydrateHistory) {
       await hydrateRuntimeOnlyRecord({
         loadMode,
+        livePresenceMode,
         updateSession,
         isStaleRepoOperation,
         record,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -230,6 +230,14 @@ export const createLoadAgentSessions = ({
           }
         }
 
+        const currentRequestedSession = intent.requestedSessionId
+          ? (sessionsRef.current[intent.requestedSessionId] ?? null)
+          : null;
+        const shouldApplyLivePresenceDuringHydration =
+          intent.shouldReconcileLiveSessions ||
+          (intent.shouldHydrateRequestedSession &&
+            currentRequestedSession !== null &&
+            currentRequestedSession.runtimeId !== null);
         await hydrateSessionRecordsStage({
           loadMode: intent.mode,
           repoPath: intent.repoPath,
@@ -243,7 +251,7 @@ export const createLoadAgentSessions = ({
           runtimePlanner,
           promptAssembler,
           getRepoPromptOverrides,
-          livePresenceMode: intent.shouldReconcileLiveSessions ? "apply" : "skip",
+          livePresenceMode: shouldApplyLivePresenceDuringHydration ? "apply" : "skip",
         });
       }
     };

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -82,8 +82,8 @@ const createSessionStateFixture = (): AgentSessionState => ({
 });
 
 describe("reattach-live-session", () => {
-  test("does not resume an idle snapshot with no pending input", async () => {
-    let state = createSessionStateFixture();
+  test("applies an idle snapshot without resuming or attaching", async () => {
+    let state: AgentSessionState = { ...createSessionStateFixture(), status: "running" };
     let resumed = false;
     let attachedSessionId: string | null = null;
 
@@ -123,7 +123,9 @@ describe("reattach-live-session", () => {
     expect(reattached).toBe(false);
     expect(resumed).toBe(false);
     expect(attachedSessionId).toBeNull();
-    expect(state.pendingApprovals).toEqual(createSessionStateFixture().pendingApprovals);
+    expect(state.status).toBe("idle");
+    expect(state.runtimeId).toBe("runtime-1");
+    expect(state.pendingApprovals).toEqual([]);
   });
 
   test("reattaches an idle snapshot when pending input is still live", async () => {
@@ -356,6 +358,51 @@ describe("reattach-live-session", () => {
 
     expect(reattached).toBe(false);
     expect(resumeCalls).toBe(0);
+  });
+
+  test("does not update idle presence when the repo becomes stale before state update", async () => {
+    let state: AgentSessionState = { ...createSessionStateFixture(), status: "running" };
+    let staleChecks = 0;
+
+    const reattachLiveSession = createReattachLiveSession({
+      adapter: {
+        hasSession: () => true,
+      },
+      repoPath: "/tmp/repo",
+      updateSession: (externalSessionId, updater) => {
+        if (externalSessionId !== "external-1") {
+          return;
+        }
+        state = updater(state);
+      },
+      attachSessionListener: () => {
+        throw new Error("should not attach idle session");
+      },
+      promptOverrides: {},
+      attachMissingLiveSession: async () => {
+        throw new Error("should not resume idle session");
+      },
+      readSessionPresence: async () =>
+        toSessionPresenceSnapshot({
+          externalSessionId: "external-1",
+          title: "Session",
+          startedAt: "2026-03-22T12:00:00.000Z",
+          status: { type: "idle" },
+          pendingApprovals: [],
+          pendingQuestions: [],
+          workingDirectory: "/tmp/repo/worktree",
+        }),
+      isStaleRepoOperation: () => {
+        staleChecks += 1;
+        return staleChecks > 1;
+      },
+    });
+
+    const reattached = await reattachLiveSession(sessionRecordFixture);
+
+    expect(reattached).toBe(false);
+    expect(state.status).toBe("running");
+    expect(state.pendingApprovals).toEqual(createSessionStateFixture().pendingApprovals);
   });
 
   test("attempts live discovery for stdio OpenCode runtimes", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
@@ -59,11 +59,25 @@ export const createReattachLiveSession = ({
     if (sessionPresence === STALE_REPO_ABORT) {
       return false;
     }
+    const selectedModel = normalizePersistedSelection(record.selectedModel);
     if (!isAttachableAgentSessionPresenceSnapshot(sessionPresence)) {
+      if (sessionPresence.presence === "runtime") {
+        if (isStaleRepoOperation()) {
+          return false;
+        }
+        updateSession(
+          record.externalSessionId,
+          (current) =>
+            applyAgentSessionPresenceSnapshotToSession(current, sessionPresence, {
+              promptOverrides,
+              selectedModel: mergeModelSelection(current.selectedModel, selectedModel ?? undefined),
+            }),
+          { persist: false },
+        );
+      }
       return false;
     }
 
-    const selectedModel = normalizePersistedSelection(record.selectedModel);
     if (!attachedExistingSession) {
       if (!allowAttachMissingSession) {
         return false;

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-hydration-operations.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-hydration-operations.ts
@@ -5,6 +5,7 @@ import type {
 } from "@openducktor/contracts";
 import type { AgentSessionPresenceSnapshot } from "@openducktor/core";
 import type {
+  AgentSessionHistoryHydrationPolicy,
   AgentSessionHistoryPreludeMode,
   AgentSessionLoadOptions,
 } from "@/types/agent-orchestrator";
@@ -16,6 +17,7 @@ export type SessionHydrationOperations = {
   hydrateRequestedTaskSession: (input: {
     taskId: string;
     externalSessionId: string;
+    historyPolicy?: AgentSessionHistoryHydrationPolicy;
     historyPreludeMode?: AgentSessionHistoryPreludeMode;
     allowLiveSessionResume?: boolean;
     persistedRecords?: AgentSessionRecord[];
@@ -53,6 +55,7 @@ export const createSessionHydrationOperations = ({
     hydrateRequestedTaskSession: ({
       taskId,
       externalSessionId,
+      historyPolicy,
       historyPreludeMode,
       allowLiveSessionResume,
       persistedRecords,
@@ -63,7 +66,7 @@ export const createSessionHydrationOperations = ({
           {
             mode: "requested_history",
             targetExternalSessionId: externalSessionId,
-            historyPolicy: "requested_only",
+            historyPolicy: historyPolicy ?? "requested_only",
             ...(historyPreludeMode ? { historyPreludeMode } : {}),
             allowLiveSessionResume: allowLiveSessionResume ?? false,
           },

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.test.ts
@@ -115,7 +115,7 @@ describe("session-presence", () => {
     expect(applied.runtimeRecoveryState).toBe("recovering_runtime");
   });
 
-  test("keeps pending outbound sends running when idle presence arrives", () => {
+  test("settles pending outbound sends when runtime idle presence arrives", () => {
     const snapshot = toAgentSessionPresenceSnapshotFromLiveSnapshot({
       ref: sessionRefFixture,
       runtimeId: "runtime-1",
@@ -135,7 +135,12 @@ describe("session-presence", () => {
       snapshot,
     );
 
-    expect(applied.status).toBe("running");
+    expect(applied.status).toBe("idle");
+    expect(applied.pendingUserMessageStartedAt).toBeUndefined();
+    expect(applied.draftAssistantText).toBe("");
+    expect(applied.draftAssistantMessageId).toBeNull();
+    expect(applied.draftReasoningText).toBe("");
+    expect(applied.draftReasoningMessageId).toBeNull();
   });
 
   test("marks persisted-only pending outbound sends as recovering runtime", () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.ts
@@ -6,7 +6,10 @@ import {
   toPersistedOnlyAgentSessionPresenceSnapshot,
 } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { hasPendingOutboundSend } from "../support/pending-outbound-send";
+import {
+  hasPendingOutboundSend,
+  settlePendingOutboundSendFields,
+} from "../support/pending-outbound-send";
 import type { ResolvedHydrationRuntime } from "./hydration-runtime-resolution";
 
 export type { AgentSessionPresence, AgentSessionPresenceSnapshot } from "@openducktor/core";
@@ -91,10 +94,11 @@ export const applyAgentSessionPresenceSnapshotToSession = (
       if (options.preserveStartingStatusForIdlePresence === true && current.status === "starting") {
         status = "starting";
       }
-      if (hasPendingOutboundSend(current)) {
-        status = "running";
-      }
     }
+    // Runtime idle presence is authoritative for outbound-send settlement; the send path
+    // invalidates cached presence before starting a new turn.
+    const pendingOutboundSendFields =
+      snapshot.agentSessionStatus === "idle" ? settlePendingOutboundSendFields() : {};
 
     return {
       ...current,
@@ -106,6 +110,7 @@ export const applyAgentSessionPresenceSnapshotToSession = (
       title: snapshot.title,
       pendingApprovals: snapshot.pendingApprovals,
       pendingQuestions: snapshot.pendingQuestions,
+      ...pendingOutboundSendFields,
       ...promptOverridesPatch,
       selectedModel,
     };

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle.test.ts
@@ -73,4 +73,29 @@ describe("deriveAgentSessionViewLifecycle", () => {
     expect(lifecycle.isHistoryHydrationFailed).toBe(false);
     expect(lifecycle.shouldEnsureReadyForView).toBe(true);
   });
+
+  test("requests a view readiness refresh for hydrated attached sessions that still appear running", () => {
+    const lifecycle = deriveAgentSessionViewLifecycle({
+      session: createSession({
+        status: "running",
+        historyHydrationState: "hydrated",
+        runtimeId: "runtime-1",
+        runtimeKind: "codex",
+        workingDirectory: "/tmp/repo/worktree",
+        messages: [
+          {
+            id: "message-1",
+            role: "assistant",
+            content: "already hydrated",
+            timestamp: "2026-02-22T08:00:03.000Z",
+          },
+        ],
+      }),
+      repoReadinessState: "ready",
+    });
+
+    expect(lifecycle.phase).toBe("ready");
+    expect(lifecycle.canRenderHistory).toBe(true);
+    expect(lifecycle.shouldEnsureReadyForView).toBe(true);
+  });
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle.ts
@@ -50,6 +50,8 @@ export const deriveAgentSessionViewLifecycle = ({
   const historyHydrationState = getAgentSessionHistoryHydrationState(session);
   const hasTranscript = getSessionMessageCount(session) > 0;
   const hasRuntimeAttachment = hasAttachedSessionRuntime(session);
+  const shouldRefreshRunningAttachedSession =
+    repoReadinessState === "ready" && hasRuntimeAttachment && session.status === "running";
 
   if (repoReadinessState !== "ready" && sessionNeedsHydration && !hasTranscript) {
     return {
@@ -83,7 +85,7 @@ export const deriveAgentSessionViewLifecycle = ({
       isWaitingForRuntimeReadiness: false,
       isHydratingHistory: false,
       isHistoryHydrationFailed: false,
-      shouldEnsureReadyForView: false,
+      shouldEnsureReadyForView: shouldRefreshRunningAttachedSession,
     };
   }
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/pending-outbound-send.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/pending-outbound-send.ts
@@ -1,6 +1,4 @@
-import type { AgentSessionHistoryMessage, AgentSessionPresenceSnapshot } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { isFinalAssistantHistoryMessage } from "./history-finality";
 
 type SessionWithPendingOutboundSend = AgentSessionState & {
   pendingUserMessageStartedAt: number;
@@ -21,28 +19,6 @@ export const shouldKeepPendingOutboundSendActiveOnIdle = (session: AgentSessionS
     session.pendingApprovals.length === 0 &&
     session.pendingQuestions.length === 0
   );
-};
-
-export const shouldSettlePendingOutboundSendFromHydratedHistory = (
-  session: AgentSessionState,
-  history: AgentSessionHistoryMessage[],
-  sessionPresence: AgentSessionPresenceSnapshot | null,
-): boolean => {
-  if (!hasPendingOutboundSend(session)) {
-    return false;
-  }
-  if (sessionPresence?.presence !== "runtime" || sessionPresence.agentSessionStatus !== "idle") {
-    return false;
-  }
-
-  const pendingUserMessageStartedAt = session.pendingUserMessageStartedAt;
-  return history.some((message) => {
-    if (!isFinalAssistantHistoryMessage(message)) {
-      return false;
-    }
-    const completedAtMs = Date.parse(message.timestamp);
-    return !Number.isNaN(completedAtMs) && completedAtMs >= pendingUserMessageStartedAt;
-  });
 };
 
 export const settlePendingOutboundSendFields = (): Pick<


### PR DESCRIPTION
Summary
- Clear stale pending outbound-send state during requested-history hydration when live runtime presence reports the session idle.
- Invalidate cached session presence when an outbound send starts, so hydration cannot consume an idle snapshot from before the new send.
- Remove transcript/final-message inspection from the idle-settlement path.
- Keep live/reconcile idle-presence behavior unchanged so transient idle snapshots do not clear active sends.

Goal
A revisited Codex session could still appear active after the runtime was idle because the frontend preserved an old pending outbound-send marker unless hydrated transcript history contained a terminal assistant message. That made transcript shape influence session liveness even though the runtime already reports whether the session is idle or running.

Implementation
The requested-history hydration path now trusts the existing AgentSessionPresenceSnapshot state. If the current frontend session has a pending outbound send and requested-history presence is runtime + idle, the pending draft fields are cleared and the session becomes idle. When a user sends a new message, the frontend clears cached presence for that repo first, preventing a recently cached idle snapshot from settling the new pending send. The live/reconcile path remains guarded by the existing presence application behavior, so transient idle snapshots during live send handling still keep pending state active.

Verification
- rtk bun run lint
- rtk bun run typecheck
- rtk bun run test
- rtk bun run build
- rtk bun run check:rust
- rtk bun run test:rust
- rtk sh -lc 'cd apps/desktop/src-tauri && cargo fmt --all --check'\n- rtk sh -lc 'cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings'\n- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending outbound sends now settle to idle when the live runtime is idle; related pending message metadata and drafts are cleared. History hydration no longer triggers unexpected thread resumes.

* **New Features**
  * Sending invalidates the session presence cache to keep status consistent.
  * Session live-status updates are propagated via a dedicated update path for more reliable state synchronization.

* **Tests**
  * Expanded tests covering presence-driven settlement, reattachment behavior, and adapter presence/refresh scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->