### PR TITLE
feat(host): support cross-platform open in tools

### DIFF
--- a/packages/contracts/src/system-open-schemas.ts
+++ b/packages/contracts/src/system-open-schemas.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 export const systemOpenInToolIdValues = [
   "finder",
+  "explorer",
+  "xdg-open",
   "terminal",
   "iterm2",
   "ghostty",

--- a/packages/frontend/src/components/features/agents/agent-studio-git-panel/open-in-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-git-panel/open-in-menu.test.tsx
@@ -266,6 +266,82 @@ describe("OpenInMenu", () => {
     }
   });
 
+  test("falls back from an absent persisted tool to the first discovered tool without launching", async () => {
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    const storageKey = toRightPanelStorageKey();
+    globalThis.localStorage.setItem(storageKey, JSON.stringify({ openInToolId: "zed" }));
+    host.systemListOpenInTools = mock(
+      async () =>
+        [
+          { toolId: "explorer", iconDataUrl: null },
+          { toolId: "vscode", iconDataUrl: null },
+        ] satisfies SystemOpenInToolInfo[],
+    );
+    const onOpenInTool = mock(async () => {});
+
+    try {
+      rendered = render(
+        <QueryProvider useIsolatedClient>
+          <TooltipProvider>
+            <OpenInMenu
+              contextMode="repository"
+              targetPath="/tmp/repo"
+              disabledReason={null}
+              onOpenInTool={onOpenInTool}
+            />
+          </TooltipProvider>
+        </QueryProvider>,
+      );
+
+      await screen.findByTestId("agent-studio-git-open-in-icon-explorer");
+
+      expect(screen.getByTestId("agent-studio-git-open-in-default-button").textContent).toContain(
+        "File Explorer",
+      );
+      expect(onOpenInTool).not.toHaveBeenCalled();
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+    }
+  });
+
+  test("shows platform-neutral empty discovery copy and disables the default action", async () => {
+    const originalSystemListOpenInTools = host.systemListOpenInTools;
+    const systemListOpenInTools = mock(async () => [] satisfies SystemOpenInToolInfo[]);
+    host.systemListOpenInTools = systemListOpenInTools;
+
+    try {
+      rendered = render(
+        <QueryProvider useIsolatedClient>
+          <TooltipProvider>
+            <OpenInMenu
+              contextMode="worktree"
+              targetPath="/tmp/worktrees/task-24"
+              disabledReason={null}
+              onOpenInTool={async () => {}}
+            />
+          </TooltipProvider>
+        </QueryProvider>,
+      );
+
+      const defaultButton = screen.getByTestId(
+        "agent-studio-git-open-in-default-button",
+      ) as HTMLButtonElement;
+      expect(defaultButton.disabled).toBe(true);
+
+      await runWithReactAct(async () => {
+        fireEvent.click(screen.getByTestId("agent-studio-git-open-in-trigger"));
+      });
+
+      await screen.findByTestId("agent-studio-git-open-in-empty");
+      expect(
+        screen.getByText("No supported Open In tools were found on this platform."),
+      ).toBeTruthy();
+      expect(screen.queryByText(/on this Mac/i)).toBeNull();
+    } finally {
+      host.systemListOpenInTools = originalSystemListOpenInTools;
+    }
+  });
+
   test("retry forces a fresh discovery request after a discovery error", async () => {
     const originalSystemListOpenInTools = host.systemListOpenInTools;
     const systemListOpenInTools = mock(async (forceRefresh = false) => {
@@ -298,6 +374,10 @@ describe("OpenInMenu", () => {
       });
 
       expect(await screen.findByTestId("agent-studio-git-open-in-error")).toBeTruthy();
+      expect(
+        (screen.getByTestId("agent-studio-git-open-in-default-button") as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
 
       await runWithReactAct(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Retry" }));

--- a/packages/frontend/src/components/features/agents/agent-studio-git-panel/open-in-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-git-panel/open-in-menu.tsx
@@ -147,6 +147,34 @@ function OpenInActionGroup({ children }: { children: ReactNode }): ReactElement 
   );
 }
 
+function OpenInRefreshButton({
+  isRefreshingTools,
+  onRefresh,
+  label,
+}: {
+  isRefreshingTools: boolean;
+  onRefresh: () => void;
+  label: string;
+}): ReactElement {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-7 text-[11px]"
+      onClick={onRefresh}
+      disabled={isRefreshingTools}
+    >
+      {isRefreshingTools ? (
+        <LoaderCircle className="size-3.5 animate-spin" />
+      ) : (
+        <RefreshCw className="size-3.5" />
+      )}
+      {label}
+    </Button>
+  );
+}
+
 export function OpenInMenu({
   contextMode,
   targetPath,
@@ -199,6 +227,8 @@ export function OpenInMenu({
     onOpenInTool,
   });
   const isTriggerDisabled = resolvedDisabledReason != null;
+  const isDefaultActionDisabled =
+    isTriggerDisabled || toolsQuery.isPending || toolsQuery.isError || defaultTool == null;
   const hasMenuTrigger =
     alternativeTools.length > 0 ||
     toolsQuery.isPending ||
@@ -254,7 +284,7 @@ export function OpenInMenu({
     defaultToolLabel,
     defaultToolIcon,
     onClick: defaultTool ? () => void handleOpenInTool(defaultTool.toolId) : null,
-    disabled: isTriggerDisabled,
+    disabled: isDefaultActionDisabled,
     isPending: defaultToolIsPending,
     hasMenuTrigger,
   });
@@ -301,23 +331,13 @@ export function OpenInMenu({
             <div className="space-y-3 p-3" data-testid="agent-studio-git-open-in-error">
               <p className="text-sm text-foreground">Supported app discovery failed.</p>
               <p className="text-[11px] text-muted-foreground">{errorMessage(toolsQuery.error)}</p>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-7 text-[11px]"
-                onClick={() => {
+              <OpenInRefreshButton
+                isRefreshingTools={isRefreshingTools}
+                label="Retry"
+                onRefresh={() => {
                   void handleRefreshTools();
                 }}
-                disabled={isRefreshingTools}
-              >
-                {isRefreshingTools ? (
-                  <LoaderCircle className="size-3.5 animate-spin" />
-                ) : (
-                  <RefreshCw className="size-3.5" />
-                )}
-                Retry
-              </Button>
+              />
             </div>
           ) : (
             <ScrollArea className="max-h-80">
@@ -346,8 +366,18 @@ export function OpenInMenu({
                   );
                 })}
                 {toolsQuery.data?.length === 0 ? (
-                  <div className="p-3 text-sm text-muted-foreground">
-                    No supported apps are currently available on this Mac.
+                  <div
+                    className="space-y-3 p-3 text-sm text-muted-foreground"
+                    data-testid="agent-studio-git-open-in-empty"
+                  >
+                    <p>No supported Open In tools were found on this platform.</p>
+                    <OpenInRefreshButton
+                      isRefreshingTools={isRefreshingTools}
+                      label="Refresh"
+                      onRefresh={() => {
+                        void handleRefreshTools();
+                      }}
+                    />
                   </div>
                 ) : null}
               </div>

--- a/packages/frontend/src/components/features/agents/agent-studio-git-panel/open-in-tool-metadata.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-git-panel/open-in-tool-metadata.tsx
@@ -1,7 +1,6 @@
 import type { SystemOpenInToolId, SystemOpenInToolInfo } from "@openducktor/contracts";
 import { AppWindowMac, FolderOpen, Terminal } from "lucide-react";
 import type { ReactElement } from "react";
-import { cn } from "@/lib/utils";
 
 type OpenInToolUiMetadata = {
   label: string;
@@ -10,6 +9,8 @@ type OpenInToolUiMetadata = {
 
 const OPEN_IN_TOOL_METADATA: Record<SystemOpenInToolId, OpenInToolUiMetadata> = {
   finder: { label: "Finder", fallbackKind: "finder" },
+  explorer: { label: "File Explorer", fallbackKind: "finder" },
+  "xdg-open": { label: "Files", fallbackKind: "finder" },
   terminal: { label: "Terminal", fallbackKind: "terminal" },
   iterm2: { label: "iTerm2", fallbackKind: "terminal" },
   ghostty: { label: "Ghostty", fallbackKind: "terminal" },
@@ -48,9 +49,7 @@ function OpenInFallbackIcon({ toolId }: { toolId: SystemOpenInToolId }): ReactEl
 
   return (
     <span
-      className={cn(
-        "flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground",
-      )}
+      className="flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground"
       data-testid={`agent-studio-git-open-in-icon-${toolId}`}
       aria-hidden="true"
     >

--- a/packages/host/src/adapters/open-in-tools/open-in-tool-catalog.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tool-catalog.ts
@@ -16,6 +16,7 @@ export type CommandOpenInToolMetadata = {
   platforms: NodeJS.Platform[];
   commands: string[];
   args?: (directoryPath: string, command: string) => string[];
+  allowNonZeroExit?: boolean;
 };
 
 export const MAC_OPEN_IN_TOOL_CATALOG: MacOpenInToolMetadata[] = [
@@ -61,6 +62,7 @@ export const COMMAND_OPEN_IN_TOOL_CATALOG: CommandOpenInToolMetadata[] = [
     label: "File Explorer",
     platforms: ["win32"],
     commands: ["explorer.exe"],
+    allowNonZeroExit: true,
   },
   {
     id: "xdg-open",
@@ -81,7 +83,7 @@ export const COMMAND_OPEN_IN_TOOL_CATALOG: CommandOpenInToolMetadata[] = [
     platforms: ["linux"],
     commands: ["x-terminal-emulator", "gnome-terminal", "konsole", "xfce4-terminal"],
     args: (directoryPath, command) => {
-      if (command === "gnome-terminal") {
+      if (command === "x-terminal-emulator" || command === "gnome-terminal") {
         return [`--working-directory=${directoryPath}`];
       }
       if (command === "konsole") {

--- a/packages/host/src/adapters/open-in-tools/open-in-tool-catalog.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tool-catalog.ts
@@ -1,0 +1,186 @@
+import type { SystemOpenInToolId } from "@openducktor/contracts";
+import { HostValidationError } from "../../effect/host-errors";
+
+export type OpenInLaunchStrategy = "open-directory" | "editor" | "jetbrains";
+
+export type MacOpenInToolMetadata = {
+  id: SystemOpenInToolId;
+  label: string;
+  appNames: string[];
+  launchStrategy: OpenInLaunchStrategy;
+};
+
+export type CommandOpenInToolMetadata = {
+  id: SystemOpenInToolId;
+  label: string;
+  platforms: NodeJS.Platform[];
+  commands: string[];
+  args?: (directoryPath: string, command: string) => string[];
+};
+
+export const MAC_OPEN_IN_TOOL_CATALOG: MacOpenInToolMetadata[] = [
+  { id: "finder", label: "Finder", appNames: ["Finder"], launchStrategy: "open-directory" },
+  { id: "terminal", label: "Terminal", appNames: ["Terminal"], launchStrategy: "open-directory" },
+  {
+    id: "iterm2",
+    label: "iTerm2",
+    appNames: ["iTerm2", "iTerm"],
+    launchStrategy: "open-directory",
+  },
+  { id: "ghostty", label: "Ghostty", appNames: ["Ghostty"], launchStrategy: "open-directory" },
+  { id: "vscode", label: "VS Code", appNames: ["Visual Studio Code"], launchStrategy: "editor" },
+  { id: "cursor", label: "Cursor", appNames: ["Cursor"], launchStrategy: "editor" },
+  { id: "zed", label: "Zed", appNames: ["Zed"], launchStrategy: "editor" },
+  {
+    id: "intellij-idea",
+    label: "IntelliJ IDEA",
+    appNames: ["IntelliJ IDEA", "IntelliJ IDEA CE"],
+    launchStrategy: "jetbrains",
+  },
+  { id: "webstorm", label: "WebStorm", appNames: ["WebStorm"], launchStrategy: "jetbrains" },
+  {
+    id: "pycharm",
+    label: "PyCharm",
+    appNames: ["PyCharm", "PyCharm CE"],
+    launchStrategy: "jetbrains",
+  },
+  { id: "phpstorm", label: "PhpStorm", appNames: ["PhpStorm"], launchStrategy: "jetbrains" },
+  { id: "rider", label: "Rider", appNames: ["Rider"], launchStrategy: "jetbrains" },
+  { id: "rustrover", label: "RustRover", appNames: ["RustRover"], launchStrategy: "jetbrains" },
+  {
+    id: "android-studio",
+    label: "Android Studio",
+    appNames: ["Android Studio"],
+    launchStrategy: "jetbrains",
+  },
+];
+
+export const COMMAND_OPEN_IN_TOOL_CATALOG: CommandOpenInToolMetadata[] = [
+  {
+    id: "explorer",
+    label: "File Explorer",
+    platforms: ["win32"],
+    commands: ["explorer.exe"],
+  },
+  {
+    id: "xdg-open",
+    label: "Files",
+    platforms: ["linux"],
+    commands: ["xdg-open"],
+  },
+  {
+    id: "terminal",
+    label: "Terminal",
+    platforms: ["win32"],
+    commands: ["wt.exe", "wt"],
+    args: (directoryPath) => ["-d", directoryPath],
+  },
+  {
+    id: "terminal",
+    label: "Terminal",
+    platforms: ["linux"],
+    commands: ["x-terminal-emulator", "gnome-terminal", "konsole", "xfce4-terminal"],
+    args: (directoryPath, command) => {
+      if (command === "gnome-terminal") {
+        return [`--working-directory=${directoryPath}`];
+      }
+      if (command === "konsole") {
+        return ["--workdir", directoryPath];
+      }
+      if (command === "xfce4-terminal") {
+        return ["--working-directory", directoryPath];
+      }
+      return [];
+    },
+  },
+  {
+    id: "vscode",
+    label: "VS Code",
+    platforms: ["win32", "linux"],
+    commands: ["code"],
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    platforms: ["win32", "linux"],
+    commands: ["cursor"],
+  },
+  {
+    id: "zed",
+    label: "Zed",
+    platforms: ["win32", "linux"],
+    commands: ["zed"],
+  },
+  {
+    id: "intellij-idea",
+    label: "IntelliJ IDEA",
+    platforms: ["win32", "linux"],
+    commands: ["idea"],
+  },
+  {
+    id: "webstorm",
+    label: "WebStorm",
+    platforms: ["win32", "linux"],
+    commands: ["webstorm"],
+  },
+  {
+    id: "pycharm",
+    label: "PyCharm",
+    platforms: ["win32", "linux"],
+    commands: ["pycharm"],
+  },
+  {
+    id: "phpstorm",
+    label: "PhpStorm",
+    platforms: ["win32", "linux"],
+    commands: ["phpstorm"],
+  },
+  {
+    id: "rider",
+    label: "Rider",
+    platforms: ["win32", "linux"],
+    commands: ["rider"],
+  },
+  {
+    id: "rustrover",
+    label: "RustRover",
+    platforms: ["win32", "linux"],
+    commands: ["rustrover"],
+  },
+  {
+    id: "android-studio",
+    label: "Android Studio",
+    platforms: ["win32", "linux"],
+    commands: ["studio"],
+  },
+];
+
+export const macMetadataForTool = (toolId: SystemOpenInToolId): MacOpenInToolMetadata => {
+  const metadata = MAC_OPEN_IN_TOOL_CATALOG.find((candidate) => candidate.id === toolId);
+  if (!metadata) {
+    throw new HostValidationError({
+      field: "toolId",
+      message: `Unsupported Open In tool: ${toolId}`,
+      details: { toolId },
+    });
+  }
+  return metadata;
+};
+
+export const commandMetadataForTool = (
+  toolId: SystemOpenInToolId,
+  platform: NodeJS.Platform,
+): CommandOpenInToolMetadata => {
+  const metadata = COMMAND_OPEN_IN_TOOL_CATALOG.find(
+    (candidate) => candidate.id === toolId && candidate.platforms.includes(platform),
+  );
+  if (!metadata) {
+    throw new HostValidationError({
+      field: "toolId",
+      message: `Unsupported Open In tool ${toolId} on ${platform}.`,
+      details: { toolId, platform },
+    });
+  }
+
+  return metadata;
+};

--- a/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.test.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.test.ts
@@ -212,7 +212,25 @@ describe("createOpenInToolsAdapter", () => {
 
     await Effect.runPromise(port.openDirectoryInTool("/tmp/repo with spaces", "xdg-open"));
 
-    expect(launches).toEqual([{ command: "xdg-open", args: ["/tmp/repo with spaces"] }]);
+    expect(launches).toEqual([{ command: "/usr/bin/xdg-open", args: ["/tmp/repo with spaces"] }]);
+  });
+
+  test("launches x-terminal-emulator with working-directory arguments", async () => {
+    const { launches, systemCommands } = createSystemCommands({
+      resolvedCommands: {
+        "x-terminal-emulator": "/usr/bin/x-terminal-emulator",
+      },
+    });
+    const port = createOpenInToolsAdapter({ platform: "linux", systemCommands });
+
+    await Effect.runPromise(port.openDirectoryInTool("/tmp/repo with spaces", "terminal"));
+
+    expect(launches).toEqual([
+      {
+        command: "/usr/bin/x-terminal-emulator",
+        args: ["--working-directory=/tmp/repo with spaces"],
+      },
+    ]);
   });
 
   test("launches Linux terminals with command-specific directory arguments", async () => {
@@ -228,7 +246,7 @@ describe("createOpenInToolsAdapter", () => {
     await Effect.runPromise(port.openDirectoryInTool("/tmp/repo with spaces", "terminal"));
 
     expect(launches).toEqual([
-      { command: "konsole", args: ["--workdir", "/tmp/repo with spaces"] },
+      { command: "/usr/bin/konsole", args: ["--workdir", "/tmp/repo with spaces"] },
     ]);
   });
 
@@ -250,7 +268,30 @@ describe("createOpenInToolsAdapter", () => {
     await Effect.runPromise(port.openDirectoryInTool(String.raw`C:\repo with spaces`, "terminal"));
 
     expect(launches).toEqual([
-      { command: "wt.exe", args: ["-d", String.raw`C:\repo with spaces`] },
+      {
+        command: String.raw`C:\Users\dev\AppData\Local\Microsoft\WindowsApps\wt.exe`,
+        args: ["-d", String.raw`C:\repo with spaces`],
+      },
+    ]);
+  });
+
+  test("treats File Explorer non-zero exit as a successful delegated launch", async () => {
+    const { launches, systemCommands } = createSystemCommands({
+      resolvedCommands: {
+        "explorer.exe": String.raw`C:\Windows\explorer.exe`,
+      },
+      runOk: false,
+      runStderr: "",
+    });
+    const port = createOpenInToolsAdapter({ platform: "win32", systemCommands });
+
+    await Effect.runPromise(port.openDirectoryInTool(String.raw`C:\repo with spaces`, "explorer"));
+
+    expect(launches).toEqual([
+      {
+        command: String.raw`C:\Windows\explorer.exe`,
+        args: [String.raw`C:\repo with spaces`],
+      },
     ]);
   });
 

--- a/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.test.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.test.ts
@@ -1,10 +1,12 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Effect } from "effect";
-import type { OpenInCommandRunner } from "./open-in-tools-adapter";
-import { createOpenInToolsAdapter as createEffectOpenInToolsAdapter } from "./open-in-tools-adapter";
+import { HostValidationError } from "../../effect/host-errors";
+import type { SystemCommandPort } from "../../ports/system-command-port";
+import { createSystemCommandRunner } from "../system/system-command-runner";
+import { createOpenInToolsAdapter, type OpenInCommandRunner } from "./open-in-tools-adapter";
 
-const createOpenInToolsAdapter = (...args: Parameters<typeof createEffectOpenInToolsAdapter>) =>
-  createEffectOpenInToolsAdapter(...args);
 const createRunner = () => {
   const calls: Array<{
     program: string;
@@ -19,6 +21,39 @@ const createRunner = () => {
   };
   return { calls, runner };
 };
+
+const createSystemCommands = ({
+  resolvedCommands,
+  runOk = true,
+  runStderr = "",
+}: {
+  resolvedCommands: Record<string, string | null>;
+  runOk?: boolean;
+  runStderr?: string;
+}) => {
+  const launches: Array<{ command: string; args: string[] }> = [];
+  const systemCommands: Pick<SystemCommandPort, "resolveCommandPath" | "runCommandAllowFailure"> = {
+    resolveCommandPath(command) {
+      return Effect.succeed(resolvedCommands[command] ?? null);
+    },
+    runCommandAllowFailure(command, args) {
+      launches.push({ command, args });
+      return Effect.succeed({ ok: runOk, stdout: "", stderr: runStderr });
+    },
+  };
+
+  return { launches, systemCommands };
+};
+
+const withTempDir = async (run: (root: string) => Promise<void>): Promise<void> => {
+  const root = await mkdtemp(join(tmpdir(), "odt-open-in-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+};
+
 describe("createOpenInToolsAdapter", () => {
   test("discovers installed macOS applications with bounded application icons", async () => {
     const calls: Array<{
@@ -111,6 +146,24 @@ describe("createOpenInToolsAdapter", () => {
       args: ["-a", "/Applications/Visual Studio Code.app", "/repo"],
     });
   });
+  test("rejects macOS contract-valid but unsupported selected tools as validation errors", async () => {
+    const port = createOpenInToolsAdapter({
+      platform: "darwin",
+      pathExists: () => Effect.succeed(false),
+      pathIsDirectory: () => Effect.succeed(false),
+    });
+
+    const result = await Effect.runPromise(
+      Effect.either(port.openDirectoryInTool("/repo", "explorer")),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag !== "Left") {
+      return;
+    }
+    expect(result.left).toBeInstanceOf(HostValidationError);
+    expect(result.left).toHaveProperty("message", "Unsupported Open In tool: explorer");
+  });
   test("opens external URLs with the platform browser command", async () => {
     const { calls, runner } = createRunner();
     const port = createOpenInToolsAdapter({
@@ -126,10 +179,145 @@ describe("createOpenInToolsAdapter", () => {
       "Opening external URLs is not supported on aix.",
     );
   });
-  test("rejects open-in discovery on non-macOS platforms", async () => {
-    const port = createOpenInToolsAdapter({ platform: "linux" });
+  test("discovers Linux tools from command resolution", async () => {
+    const { systemCommands } = createSystemCommands({
+      resolvedCommands: {
+        "xdg-open": "/usr/bin/xdg-open",
+        "x-terminal-emulator": "/usr/bin/x-terminal-emulator",
+        code: "/usr/bin/code",
+        cursor: null,
+      },
+    });
+    const port = createOpenInToolsAdapter({ platform: "linux", systemCommands });
+
+    await expect(Effect.runPromise(port.discoverOpenInTools())).resolves.toEqual([
+      { toolId: "xdg-open", iconDataUrl: null },
+      { toolId: "terminal", iconDataUrl: null },
+      { toolId: "vscode", iconDataUrl: null },
+    ]);
+  });
+
+  test("returns an empty Linux discovery result when supported commands are missing", async () => {
+    const { systemCommands } = createSystemCommands({ resolvedCommands: {} });
+    const port = createOpenInToolsAdapter({ platform: "linux", systemCommands });
+
+    await expect(Effect.runPromise(port.discoverOpenInTools())).resolves.toEqual([]);
+  });
+
+  test("launches Linux selected tools with paths containing spaces", async () => {
+    const { launches, systemCommands } = createSystemCommands({
+      resolvedCommands: { "xdg-open": "/usr/bin/xdg-open" },
+    });
+    const port = createOpenInToolsAdapter({ platform: "linux", systemCommands });
+
+    await Effect.runPromise(port.openDirectoryInTool("/tmp/repo with spaces", "xdg-open"));
+
+    expect(launches).toEqual([{ command: "xdg-open", args: ["/tmp/repo with spaces"] }]);
+  });
+
+  test("launches Linux terminals with command-specific directory arguments", async () => {
+    const { launches, systemCommands } = createSystemCommands({
+      resolvedCommands: {
+        "x-terminal-emulator": null,
+        "gnome-terminal": null,
+        konsole: "/usr/bin/konsole",
+      },
+    });
+    const port = createOpenInToolsAdapter({ platform: "linux", systemCommands });
+
+    await Effect.runPromise(port.openDirectoryInTool("/tmp/repo with spaces", "terminal"));
+
+    expect(launches).toEqual([
+      { command: "konsole", args: ["--workdir", "/tmp/repo with spaces"] },
+    ]);
+  });
+
+  test("discovers and launches Windows tools through command resolution", async () => {
+    const { launches, systemCommands } = createSystemCommands({
+      resolvedCommands: {
+        "explorer.exe": String.raw`C:\Windows\explorer.exe`,
+        "wt.exe": String.raw`C:\Users\dev\AppData\Local\Microsoft\WindowsApps\wt.exe`,
+        code: String.raw`C:\Users\dev\AppData\Local\Programs\Microsoft VS Code\bin\code.cmd`,
+      },
+    });
+    const port = createOpenInToolsAdapter({ platform: "win32", systemCommands });
+
+    await expect(Effect.runPromise(port.discoverOpenInTools())).resolves.toEqual([
+      { toolId: "explorer", iconDataUrl: null },
+      { toolId: "terminal", iconDataUrl: null },
+      { toolId: "vscode", iconDataUrl: null },
+    ]);
+    await Effect.runPromise(port.openDirectoryInTool(String.raw`C:\repo with spaces`, "terminal"));
+
+    expect(launches).toEqual([
+      { command: "wt.exe", args: ["-d", String.raw`C:\repo with spaces`] },
+    ]);
+  });
+
+  test("discovers and launches Windows command-script tools through the real command runner", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    await withTempDir(async (root) => {
+      const toolDirectory = join(root, "tool dir");
+      const targetDirectory = join(root, "repo with spaces");
+      const markerPath = join(root, "opened.txt");
+      await mkdir(toolDirectory);
+      await mkdir(targetDirectory);
+      await writeFile(
+        join(toolDirectory, "code.CMD"),
+        "@echo off\r\necho %~1>%ODT_OPEN_IN_MARKER%\r\n",
+      );
+      const systemCommands = createSystemCommandRunner({
+        platform: "win32",
+        env: {
+          PATH: toolDirectory,
+          PATHEXT: ".CMD",
+          ODT_OPEN_IN_MARKER: markerPath,
+          ComSpec: process.env.ComSpec,
+        },
+      });
+      const port = createOpenInToolsAdapter({ platform: "win32", systemCommands });
+
+      await expect(Effect.runPromise(port.discoverOpenInTools())).resolves.toContainEqual({
+        toolId: "vscode",
+        iconDataUrl: null,
+      });
+      await Effect.runPromise(port.openDirectoryInTool(targetDirectory, "vscode"));
+
+      await expect(readFile(markerPath, "utf8")).resolves.toBe(`${targetDirectory}\r\n`);
+    });
+  });
+
+  test("rejects selected command tools that disappear before launch", async () => {
+    const { systemCommands } = createSystemCommands({
+      resolvedCommands: { code: null },
+    });
+    const port = createOpenInToolsAdapter({ platform: "linux", systemCommands });
+
+    await expect(Effect.runPromise(port.openDirectoryInTool("/repo", "vscode"))).rejects.toThrow(
+      "VS Code is not installed or is no longer discoverable on linux.",
+    );
+  });
+
+  test("rejects failed command tool launches with selected command details", async () => {
+    const { systemCommands } = createSystemCommands({
+      resolvedCommands: { code: "/usr/bin/code" },
+      runOk: false,
+      runStderr: "permission denied",
+    });
+    const port = createOpenInToolsAdapter({ platform: "linux", systemCommands });
+
+    await expect(Effect.runPromise(port.openDirectoryInTool("/repo", "vscode"))).rejects.toThrow(
+      "Command code exited unsuccessfully",
+    );
+  });
+
+  test("rejects open-in discovery on unsupported platforms", async () => {
+    const port = createOpenInToolsAdapter({ platform: "aix" });
     await expect(Effect.runPromise(port.discoverOpenInTools())).rejects.toThrow(
-      "Open In tool discovery is only supported on macOS.",
+      "Open In tool discovery is not supported on aix.",
     );
   });
 });

--- a/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.ts
@@ -150,6 +150,7 @@ export const createOpenInToolsAdapter = ({
     COMMAND_OPEN_IN_TOOL_CATALOG.filter((metadata) => metadata.platforms.includes(platform));
   const resolveCommandPath = (command: string) => {
     if (!systemCommands.resolveCommandPath) {
+      // The port keeps command resolution optional for callers that only run known commands.
       return Effect.fail(
         new HostOperationError({
           operation: "openInTools.resolveCommandPath",
@@ -205,7 +206,7 @@ export const createOpenInToolsAdapter = ({
     Effect.gen(function* () {
       const args = metadata.args?.(directoryPath, command) ?? [directoryPath];
       const result = yield* systemCommands
-        .runCommandAllowFailure(command, args, {
+        .runCommandAllowFailure(resolvedCommand, args, {
           cwd: directoryPath,
         })
         .pipe(
@@ -226,7 +227,7 @@ export const createOpenInToolsAdapter = ({
               }),
           ),
         );
-      if (!result.ok) {
+      if (!result.ok && metadata.allowNonZeroExit !== true) {
         return yield* Effect.fail(
           new HostOperationError({
             operation: "openInTools.openDirectoryInTool",

--- a/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.ts
@@ -14,18 +14,19 @@ import {
   toHostPathStatError,
 } from "../../effect/host-errors";
 import { type OpenInToolsPort, OpenInToolsPortTag } from "../../ports/open-in-tools-port";
+import type { SystemCommandPort } from "../../ports/system-command-port";
+import { createSystemCommandRunner } from "../system/system-command-runner";
 import { resolveMacOsAppIconDataUrl } from "./macos-open-in-icons";
+import {
+  COMMAND_OPEN_IN_TOOL_CATALOG,
+  type CommandOpenInToolMetadata,
+  commandMetadataForTool,
+  MAC_OPEN_IN_TOOL_CATALOG,
+  type MacOpenInToolMetadata,
+  macMetadataForTool,
+} from "./open-in-tool-catalog";
 
 const execFileAsync = promisify(execFile);
-
-type OpenInLaunchStrategy = "open-directory" | "editor" | "jetbrains";
-
-type OpenInToolMetadata = {
-  id: SystemOpenInToolId;
-  label: string;
-  appNames: string[];
-  launchStrategy: OpenInLaunchStrategy;
-};
 
 type CommandResult = {
   stdout: string;
@@ -47,44 +48,9 @@ export type CreateOpenInToolsAdapterInput = {
   realpathFn?: (
     inputPath: string,
   ) => Effect.Effect<string, HostPathAccessError | HostPathNotFoundError>;
+  systemCommands?: Pick<SystemCommandPort, "resolveCommandPath" | "runCommandAllowFailure">;
+  processEnv?: NodeJS.ProcessEnv;
 };
-
-const OPEN_IN_TOOL_CATALOG: OpenInToolMetadata[] = [
-  { id: "finder", label: "Finder", appNames: ["Finder"], launchStrategy: "open-directory" },
-  { id: "terminal", label: "Terminal", appNames: ["Terminal"], launchStrategy: "open-directory" },
-  {
-    id: "iterm2",
-    label: "iTerm2",
-    appNames: ["iTerm2", "iTerm"],
-    launchStrategy: "open-directory",
-  },
-  { id: "ghostty", label: "Ghostty", appNames: ["Ghostty"], launchStrategy: "open-directory" },
-  { id: "vscode", label: "VS Code", appNames: ["Visual Studio Code"], launchStrategy: "editor" },
-  { id: "cursor", label: "Cursor", appNames: ["Cursor"], launchStrategy: "editor" },
-  { id: "zed", label: "Zed", appNames: ["Zed"], launchStrategy: "editor" },
-  {
-    id: "intellij-idea",
-    label: "IntelliJ IDEA",
-    appNames: ["IntelliJ IDEA", "IntelliJ IDEA CE"],
-    launchStrategy: "jetbrains",
-  },
-  { id: "webstorm", label: "WebStorm", appNames: ["WebStorm"], launchStrategy: "jetbrains" },
-  {
-    id: "pycharm",
-    label: "PyCharm",
-    appNames: ["PyCharm", "PyCharm CE"],
-    launchStrategy: "jetbrains",
-  },
-  { id: "phpstorm", label: "PhpStorm", appNames: ["PhpStorm"], launchStrategy: "jetbrains" },
-  { id: "rider", label: "Rider", appNames: ["Rider"], launchStrategy: "jetbrains" },
-  { id: "rustrover", label: "RustRover", appNames: ["RustRover"], launchStrategy: "jetbrains" },
-  {
-    id: "android-studio",
-    label: "Android Studio",
-    appNames: ["Android Studio"],
-    launchStrategy: "jetbrains",
-  },
-];
 
 const defaultRunner: OpenInCommandRunner = (program, args, options) =>
   Effect.tryPromise({
@@ -129,29 +95,8 @@ const candidateApplicationPaths = (appName: string, homeDirectory: () => string)
   ];
 };
 
-const metadataForTool = (toolId: SystemOpenInToolId): OpenInToolMetadata => {
-  const metadata = OPEN_IN_TOOL_CATALOG.find((candidate) => candidate.id === toolId);
-  if (!metadata) {
-    throw new HostValidationError({
-      field: "toolId",
-      message: `Unsupported Open In tool: ${toolId}`,
-      details: { toolId },
-    });
-  }
-  return metadata;
-};
-
-const ensureMacOs = (platform: NodeJS.Platform, operation: string) => {
-  if (platform !== "darwin") {
-    throw new HostValidationError({
-      message: `${operation} is only supported on macOS.`,
-      details: { platform, operation },
-    });
-  }
-};
-
 const buildLaunchArgs = (
-  metadata: OpenInToolMetadata,
+  metadata: MacOpenInToolMetadata,
   appPath: string,
   directoryPath: string,
 ): string[] => {
@@ -187,6 +132,8 @@ export const createOpenInToolsAdapter = ({
   pathExists = defaultPathExists,
   pathIsDirectory = defaultPathIsDirectory,
   homeDirectory = homedir,
+  processEnv = process.env,
+  systemCommands = createSystemCommandRunner({ env: processEnv, platform }),
   realpathFn = (inputPath) =>
     Effect.tryPromise({
       try: () => realpath(inputPath),
@@ -199,6 +146,104 @@ export const createOpenInToolsAdapter = ({
         toHostOperationError(cause, "openInTools.runCommand", { program, args, cwd: options?.cwd }),
       ),
     );
+  const supportedCommandMetadata = () =>
+    COMMAND_OPEN_IN_TOOL_CATALOG.filter((metadata) => metadata.platforms.includes(platform));
+  const resolveCommandPath = (command: string) => {
+    if (!systemCommands.resolveCommandPath) {
+      return Effect.fail(
+        new HostOperationError({
+          operation: "openInTools.resolveCommandPath",
+          message: "Open In command discovery requires system command resolution.",
+          details: { command, platform },
+        }),
+      );
+    }
+
+    return systemCommands.resolveCommandPath(command);
+  };
+  const resolveCommandTool = (metadata: CommandOpenInToolMetadata) =>
+    Effect.gen(function* () {
+      for (const command of metadata.commands) {
+        const resolvedCommand = yield* resolveCommandPath(command);
+        if (resolvedCommand) {
+          return {
+            metadata,
+            command,
+            resolvedCommand,
+          };
+        }
+      }
+      return null;
+    });
+  const resolveCommandToolOrFail = (toolId: SystemOpenInToolId) =>
+    Effect.gen(function* () {
+      const metadata = yield* Effect.try({
+        try: () => commandMetadataForTool(toolId, platform),
+        catch: (cause) =>
+          cause instanceof HostValidationError
+            ? cause
+            : toHostOperationError(cause, "openInTools.commandMetadataForTool"),
+      });
+      const resolved = yield* resolveCommandTool(metadata);
+      if (!resolved) {
+        return yield* Effect.fail(
+          new HostValidationError({
+            field: "toolId",
+            message: `${metadata.label} is not installed or is no longer discoverable on ${platform}.`,
+            details: { toolId, platform, commands: metadata.commands },
+          }),
+        );
+      }
+      return resolved;
+    });
+  const openDirectoryWithCommandTool = (
+    metadata: CommandOpenInToolMetadata,
+    command: string,
+    resolvedCommand: string,
+    directoryPath: string,
+  ) =>
+    Effect.gen(function* () {
+      const args = metadata.args?.(directoryPath, command) ?? [directoryPath];
+      const result = yield* systemCommands
+        .runCommandAllowFailure(command, args, {
+          cwd: directoryPath,
+        })
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new HostOperationError({
+                operation: "openInTools.openDirectoryInTool",
+                message: `Failed to open ${directoryPath} in ${metadata.label}: ${error.message}`,
+                details: {
+                  platform,
+                  toolId: metadata.id,
+                  directoryPath,
+                  command,
+                  resolvedCommand,
+                  args,
+                },
+                cause: error,
+              }),
+          ),
+        );
+      if (!result.ok) {
+        return yield* Effect.fail(
+          new HostOperationError({
+            operation: "openInTools.openDirectoryInTool",
+            message: `Failed to open ${directoryPath} in ${metadata.label}. Command ${command} exited unsuccessfully.`,
+            details: {
+              platform,
+              toolId: metadata.id,
+              directoryPath,
+              command,
+              resolvedCommand,
+              args,
+              stderr: result.stderr,
+            },
+          }),
+        );
+      }
+    });
   const resolveApplicationPathByName = (
     appName: string,
   ): Effect.Effect<string | null, HostOperationError | HostPathAccessError> =>
@@ -232,7 +277,7 @@ export const createOpenInToolsAdapter = ({
     });
 
   const resolveApplicationPath = (
-    metadata: OpenInToolMetadata,
+    metadata: MacOpenInToolMetadata,
   ): Effect.Effect<string | null, HostOperationError | HostPathAccessError> =>
     Effect.gen(function* () {
       for (const appName of metadata.appNames) {
@@ -246,7 +291,7 @@ export const createOpenInToolsAdapter = ({
     });
 
   const buildToolInfo = (
-    metadata: OpenInToolMetadata,
+    metadata: MacOpenInToolMetadata,
     appPath: string,
   ): Effect.Effect<SystemOpenInToolInfo, HostOperationError | HostPathAccessError> =>
     Effect.gen(function* () {
@@ -263,7 +308,7 @@ export const createOpenInToolsAdapter = ({
     });
 
   const resolveDiscoveredTool = (
-    metadata: OpenInToolMetadata,
+    metadata: MacOpenInToolMetadata,
   ): Effect.Effect<SystemOpenInToolInfo | null, HostOperationError | HostPathAccessError> =>
     Effect.gen(function* () {
       const appPath = yield* resolveApplicationPath(metadata);
@@ -282,27 +327,57 @@ export const createOpenInToolsAdapter = ({
     },
     discoverOpenInTools() {
       return Effect.gen(function* () {
-        yield* Effect.try({
-          try: () => ensureMacOs(platform, "Open In tool discovery"),
-          catch: (cause) => toHostOperationError(cause, "openInTools.ensureMacOs"),
-        });
+        if (platform === "darwin") {
+          const discoveredTools = yield* Effect.forEach(
+            MAC_OPEN_IN_TOOL_CATALOG,
+            resolveDiscoveredTool,
+            {
+              concurrency: "unbounded",
+            },
+          );
+          return discoveredTools.filter((tool): tool is SystemOpenInToolInfo => tool !== null);
+        }
 
-        const discoveredTools = yield* Effect.forEach(OPEN_IN_TOOL_CATALOG, resolveDiscoveredTool, {
+        const commandMetadata = supportedCommandMetadata();
+        if (commandMetadata.length === 0) {
+          return yield* Effect.fail(
+            new HostValidationError({
+              message: `Open In tool discovery is not supported on ${platform}.`,
+              details: { platform },
+            }),
+          );
+        }
+
+        const discoveredTools = yield* Effect.forEach(commandMetadata, resolveCommandTool, {
           concurrency: "unbounded",
         });
-        return discoveredTools.filter((tool): tool is SystemOpenInToolInfo => tool !== null);
+        return discoveredTools
+          .filter(
+            (
+              tool,
+            ): tool is {
+              metadata: CommandOpenInToolMetadata;
+              command: string;
+              resolvedCommand: string;
+            } => tool !== null,
+          )
+          .map(({ metadata }) => ({ toolId: metadata.id, iconDataUrl: null }));
       });
     },
     openDirectoryInTool(directoryPath, toolId) {
       return Effect.gen(function* () {
-        yield* Effect.try({
-          try: () => ensureMacOs(platform, "Opening directories in external tools"),
-          catch: (cause) => toHostOperationError(cause, "openInTools.ensureMacOs"),
-        });
+        if (platform !== "darwin") {
+          const { metadata, command, resolvedCommand } = yield* resolveCommandToolOrFail(toolId);
+          yield* openDirectoryWithCommandTool(metadata, command, resolvedCommand, directoryPath);
+          return;
+        }
 
         const metadata = yield* Effect.try({
-          try: () => metadataForTool(toolId),
-          catch: (cause) => toHostOperationError(cause, "openInTools.metadataForTool"),
+          try: () => macMetadataForTool(toolId),
+          catch: (cause) =>
+            cause instanceof HostValidationError
+              ? cause
+              : toHostOperationError(cause, "openInTools.macMetadataForTool"),
         });
         const appPath = yield* resolveApplicationPath(metadata);
         if (!appPath) {

--- a/packages/host/src/composition/node/node-host-default-ports.ts
+++ b/packages/host/src/composition/node/node-host-default-ports.ts
@@ -107,7 +107,7 @@ const makeNodeHostDefaultPorts = (
       filesystem: input.filesystem ?? createFilesystemAdapter(),
       git: input.git ?? createGitCliAdapter({ processEnv }),
       localAttachments: input.localAttachments ?? createLocalAttachmentAdapter(),
-      openInTools: input.openInTools ?? createOpenInToolsAdapter(),
+      openInTools: input.openInTools ?? createOpenInToolsAdapter({ processEnv, systemCommands }),
       processEnv,
       runtimeHealth,
       settingsConfig: input.settingsConfig ?? createSettingsConfigAdapter(),


### PR DESCRIPTION
Summary:
Add cross-platform Open In discovery and launch support for Electron-capable hosts, covering Windows, Linux, and existing macOS behavior without changing the IPC command contracts.

Goal:
The Open In feature previously only had macOS host behavior while the Electron host is expected to work across Windows and Linux too. That meant non-macOS users would not detect common local tools such as Explorer, terminals, editors, and IDEs. This PR makes the feature real on Windows and Linux instead of relying on macOS-only app discovery.

Implementation:
- Extends the shared Open In tool IDs with platform file-manager entries.
- Moves Open In metadata into a host catalog split between macOS app bundles and command-based Windows/Linux tools.
- Uses the shared SystemCommandPort for Windows/Linux discovery and launch so PATH/PATHEXT and Electron process environment handling stay centralized.
- Supports Windows File Explorer, Windows Terminal, Linux xdg-open, common Linux terminal commands, and existing editor/IDE CLIs.
- Preserves macOS app discovery, app icons, and macOS-specific launch behavior.
- Keeps selected-tool validation errors distinct from launch operation failures.
- Updates the frontend menu to render platform-neutral empty/error states and keep unavailable actions disabled.

Verification:
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cd apps/desktop/src-tauri && cargo fmt --all --check
- cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings
- bun run check:rust
- bun run test:rust
- cd apps/desktop/src-tauri && cargo build --workspace