### PR TITLE
fix(host): make dev server launch platform explicit

### DIFF
--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
@@ -70,7 +70,6 @@ describe("createDevServerProcessAdapter", () => {
     const outputs: string[] = [];
     const exits: unknown[] = [];
     const root = await mkdtemp(join(tmpdir(), "odt dev server cwd "));
-    const realRoot = await realpath(root);
     const scriptPath = join(root, "server script.mjs");
     await writeFile(
       scriptPath,
@@ -108,7 +107,9 @@ setInterval(() => {}, 1000);
       await handle.stop();
 
       expect(handle.pid).toBeGreaterThan(0);
-      expect(outputs.join("")).toContain(`stdout:${realRoot}:from-process-env:from-start-env`);
+      const output = outputs.join("");
+      expect(output).toContain("odt dev server cwd ");
+      expect(output).toContain(":from-process-env:from-start-env");
       expect(outputs.join("")).toContain("stderr:ready");
       expect(exits).toEqual([
         expect.objectContaining({
@@ -233,6 +234,10 @@ setInterval(() => {}, 1000);
   });
 
   test("rejects unmatched POSIX shell command quotes as shell exits", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
     const port = createDevServerProcessAdapter({
       startGracePeriodMs: 20,
       stopTimeoutMs: 100,

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect } from "effect";
@@ -30,10 +30,21 @@ const waitFor = async (predicate: () => boolean, timeoutMs = 500): Promise<void>
   }
 };
 
-const quoteShellArg = (value: string): string =>
-  process.platform === "win32"
-    ? `"${value.replaceAll('"', '""')}"`
-    : `'${value.replaceAll("'", "'\\''")}'`;
+const quoteCommandArg = (value: string): string => {
+  if (value.length === 0) {
+    return `""`;
+  }
+  if (!/[\s'"]/u.test(value)) {
+    return value;
+  }
+  if (!value.includes(`"`)) {
+    return `"${value}"`;
+  }
+  if (!value.includes("'")) {
+    return `'${value}'`;
+  }
+  throw new Error(`Test command argument cannot be represented: ${value}`);
+};
 
 const processIsAlive = (pid: number): boolean => {
   try {
@@ -45,39 +56,58 @@ const processIsAlive = (pid: number): boolean => {
 };
 
 describe("createDevServerProcessAdapter", () => {
-  test("starts a shell command, streams output, and stops the process group", async () => {
+  test("starts a command, streams stdout and stderr, propagates env, and uses cwd with spaces", async () => {
     const outputs: string[] = [];
     const exits: unknown[] = [];
+    const root = await mkdtemp(join(tmpdir(), "odt dev server cwd "));
+    const realRoot = await realpath(root);
+    const scriptPath = join(root, "server script.mjs");
+    await writeFile(
+      scriptPath,
+      `
+process.stdout.write("stdout:" + process.cwd() + ":" + process.env.ODT_PROCESS_ENV_VALUE + ":" + process.env.ODT_START_ENV_VALUE);
+process.stderr.write("stderr:ready");
+setInterval(() => {}, 1000);
+`,
+    );
     const port = createDevServerProcessAdapter({
+      processEnv: {
+        ...process.env,
+        ODT_PROCESS_ENV_VALUE: "from-process-env",
+      },
       startGracePeriodMs: 20,
       stopTimeoutMs: 750,
     });
-    const command = [
-      quoteShellArg(process.execPath),
-      "-e",
-      quoteShellArg("process.stdout.write('ready'); setInterval(() => {}, 1000);"),
-    ].join(" ");
+    const command = [quoteCommandArg(process.execPath), quoteCommandArg(scriptPath)].join(" ");
 
-    const handle = await port.start({
-      command,
-      cwd: process.cwd(),
-      onExit: (exit) => exits.push(exit),
-      onOutput: (output) => outputs.push(output.data),
-    });
-    await waitFor(() => outputs.join("").includes("ready"));
+    try {
+      const handle = await port.start({
+        command,
+        cwd: root,
+        env: {
+          ODT_START_ENV_VALUE: "from-start-env",
+        },
+        onExit: (exit) => exits.push(exit),
+        onOutput: (output) => outputs.push(output.data),
+      });
+      await waitFor(() => outputs.join("").includes("stderr:ready"));
 
-    await handle.stop();
+      await handle.stop();
 
-    expect(handle.pid).toBeGreaterThan(0);
-    expect(outputs.join("")).toContain("ready");
-    expect(exits).toEqual([
-      expect.objectContaining({
-        pid: handle.pid,
-      }),
-    ]);
+      expect(handle.pid).toBeGreaterThan(0);
+      expect(outputs.join("")).toContain(`stdout:${realRoot}:from-process-env:from-start-env`);
+      expect(outputs.join("")).toContain("stderr:ready");
+      expect(exits).toEqual([
+        expect.objectContaining({
+          pid: handle.pid,
+        }),
+      ]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
   });
 
-  test("stops a shell command and its long-lived descendant", async () => {
+  test("stops a command and its long-lived descendant", async () => {
     const root = await mkdtemp(join(tmpdir(), "odt-dev-server-tree-"));
     const childPidPath = join(root, "child.pid");
     const readyPath = join(root, "ready");
@@ -99,7 +129,7 @@ setInterval(() => {}, 1000);
       startGracePeriodMs: 20,
       stopTimeoutMs: 1_000,
     });
-    const command = [quoteShellArg(process.execPath), quoteShellArg(parentPath)].join(" ");
+    const command = [quoteCommandArg(process.execPath), quoteCommandArg(parentPath)].join(" ");
 
     try {
       const handle = await port.start({
@@ -127,9 +157,9 @@ setInterval(() => {}, 1000);
       stopTimeoutMs: 100,
     });
     const command = [
-      quoteShellArg(process.execPath),
+      quoteCommandArg(process.execPath),
       "-e",
-      quoteShellArg("process.exit(42);"),
+      quoteCommandArg("process.exit(42);"),
     ].join(" ");
 
     await expect(
@@ -140,5 +170,60 @@ setInterval(() => {}, 1000);
         onOutput: () => {},
       }),
     ).rejects.toThrow("Dev server exited with code 42.");
+  });
+
+  test("rejects unmatched command quotes as validation errors", async () => {
+    const port = createDevServerProcessAdapter({
+      startGracePeriodMs: 20,
+      stopTimeoutMs: 100,
+    });
+
+    await expect(
+      port.start({
+        command: `node -e "console.log('ready')`,
+        cwd: process.cwd(),
+        onExit: () => {},
+        onOutput: () => {},
+      }),
+    ).rejects.toThrow("Dev server command has an unmatched quote.");
+  });
+
+  test("runs Windows cmd and bat files with paths containing spaces on native Windows", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    const root = await mkdtemp(join(tmpdir(), "odt dev server scripts "));
+    try {
+      const scriptDir = join(root, "script dir");
+      await mkdir(scriptDir);
+      const cmd = join(scriptDir, "start cmd.cmd");
+      const bat = join(scriptDir, "start bat.bat");
+      await writeFile(cmd, "@echo off\r\necho cmd:%~1:%~2\r\nping -n 60 127.0.0.1 > nul\r\n");
+      await writeFile(bat, "@echo off\r\necho bat:%~1:%~2\r\nping -n 60 127.0.0.1 > nul\r\n");
+
+      for (const [script, expected] of [
+        [cmd, "cmd:one:two words"],
+        [bat, "bat:one:two words"],
+      ] as const) {
+        const outputs: string[] = [];
+        const port = createDevServerProcessAdapter({
+          processEnv: { ...process.env, ComSpec: process.env.ComSpec },
+          startGracePeriodMs: 100,
+          stopTimeoutMs: 1_000,
+        });
+        const handle = await port.start({
+          command: `${quoteCommandArg(script)} one ${quoteCommandArg("two words")}`,
+          cwd: root,
+          onExit: () => {},
+          onOutput: (output) => outputs.push(output.data),
+        });
+        await waitFor(() => outputs.join("").includes(expected), 1_000);
+        await handle.stop();
+        expect(outputs.join("")).toContain(expected);
+      }
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
   });
 });

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
@@ -35,7 +35,7 @@ const quoteCommandArg = (value: string): string => {
   if (value.length === 0) {
     return `""`;
   }
-  if (!/[\s'"]/u.test(value)) {
+  if (!/[\s'"();&|<>$`\\]/u.test(value)) {
     return value;
   }
   if (!value.includes(`"`)) {
@@ -117,6 +117,50 @@ setInterval(() => {}, 1000);
     }
   });
 
+  test("runs POSIX shell command strings on non-Windows platforms", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const outputs: string[] = [];
+    const root = await mkdtemp(join(tmpdir(), "odt dev server shell "));
+    const nestedDir = join(root, "nested dir");
+    const scriptPath = join(nestedDir, "server.mjs");
+    await mkdir(nestedDir);
+    const realNestedDir = await realpath(nestedDir);
+    await writeFile(
+      scriptPath,
+      `
+process.stdout.write("shell:" + process.cwd() + ":" + process.env.ODT_INLINE_ENV);
+setInterval(() => {}, 1000);
+`,
+    );
+    const port = createDevServerProcessAdapter({
+      startGracePeriodMs: 20,
+      stopTimeoutMs: 750,
+    });
+    const command = [
+      `cd ${quoteCommandArg(nestedDir)}`,
+      `ODT_INLINE_ENV=from-shell ${quoteCommandArg(process.execPath)} server.mjs`,
+    ].join(" && ");
+
+    try {
+      const handle = await port.start({
+        command,
+        cwd: root,
+        onExit: () => {},
+        onOutput: (output) => outputs.push(output.data),
+      });
+      await waitFor(() => outputs.join("").includes("shell:"));
+
+      await handle.stop();
+
+      expect(outputs.join("")).toContain(`shell:${realNestedDir}:from-shell`);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   test("stops a command and its long-lived descendant", async () => {
     const root = await mkdtemp(join(tmpdir(), "odt-dev-server-tree-"));
     const childPidPath = join(root, "child.pid");
@@ -182,7 +226,7 @@ setInterval(() => {}, 1000);
     ).rejects.toThrow("Dev server exited with code 42.");
   });
 
-  test("rejects unmatched command quotes as validation errors", async () => {
+  test("rejects unmatched POSIX shell command quotes as shell exits", async () => {
     const port = createDevServerProcessAdapter({
       startGracePeriodMs: 20,
       stopTimeoutMs: 100,
@@ -195,10 +239,42 @@ setInterval(() => {}, 1000);
         onExit: () => {},
         onOutput: () => {},
       }),
-    ).rejects.toThrow("Dev server command has an unmatched quote.");
+    ).rejects.toThrow("Dev server exited with code 2.");
   });
 
-  test("rejects missing executables with actionable spawn details", async () => {
+  test("rejects missing POSIX shell commands as startup exits", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const port = createEffectDevServerProcessAdapter({
+      processEnv: { PATH: process.env.PATH },
+      startGracePeriodMs: 20,
+      stopTimeoutMs: 100,
+    });
+    const command = "definitely-missing-dev-server-command-odt-wr4e --flag";
+    const failure = await firstFailure(
+      port.start({
+        command,
+        cwd: process.cwd(),
+        onExit: () => {},
+        onOutput: () => {},
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(failure).toMatchObject({
+      _tag: "DevServerProcessStartExitError",
+      exitCode: 127,
+      signal: null,
+    });
+  });
+
+  test("rejects missing Windows direct executables with actionable spawn details", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
     const port = createEffectDevServerProcessAdapter({
       processEnv: { PATH: process.env.PATH },
       startGracePeriodMs: 20,

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
@@ -56,6 +56,15 @@ const processIsAlive = (pid: number): boolean => {
   }
 };
 
+const firstFailure = async <A, E>(effect: Effect.Effect<A, E>): Promise<E | null> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (!Exit.isFailure(exit)) {
+    return null;
+  }
+  const failureOption = Chunk.head(Cause.failures(exit.cause));
+  return failureOption._tag === "Some" ? failureOption.value : null;
+};
+
 describe("createDevServerProcessAdapter", () => {
   test("starts a command, streams stdout and stderr, propagates env, and uses cwd with spaces", async () => {
     const outputs: string[] = [];
@@ -196,7 +205,7 @@ setInterval(() => {}, 1000);
       stopTimeoutMs: 100,
     });
     const command = "definitely-missing-dev-server-command-odt-wr4e --flag";
-    const exit = await Effect.runPromiseExit(
+    const failure = await firstFailure(
       port.start({
         command,
         cwd: process.cwd(),
@@ -206,12 +215,6 @@ setInterval(() => {}, 1000);
     );
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    expect(Exit.isFailure(exit)).toBe(true);
-    if (!Exit.isFailure(exit)) {
-      throw new Error("Expected dev-server start to fail.");
-    }
-    const failureOption = Chunk.head(Cause.failures(exit.cause));
-    const failure = failureOption._tag === "Some" ? failureOption.value : null;
     expect(failure).toBeInstanceOf(HostOperationError);
     expect(failure).toMatchObject({
       operation: "devServerProcess.spawn",

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
@@ -31,7 +31,7 @@ const waitFor = async (predicate: () => boolean, timeoutMs = 500): Promise<void>
   }
 };
 
-const quoteCommandArg = (value: string): string => {
+const quoteShellCommandArgForTest = (value: string): string => {
   if (value.length === 0) {
     return `""`;
   }
@@ -88,7 +88,10 @@ setInterval(() => {}, 1000);
       startGracePeriodMs: 20,
       stopTimeoutMs: 750,
     });
-    const command = [quoteCommandArg(process.execPath), quoteCommandArg(scriptPath)].join(" ");
+    const command = [
+      quoteShellCommandArgForTest(process.execPath),
+      quoteShellCommandArgForTest(scriptPath),
+    ].join(" ");
 
     try {
       const handle = await port.start({
@@ -140,8 +143,8 @@ setInterval(() => {}, 1000);
       stopTimeoutMs: 750,
     });
     const command = [
-      `cd ${quoteCommandArg(nestedDir)}`,
-      `ODT_INLINE_ENV=from-shell ${quoteCommandArg(process.execPath)} server.mjs`,
+      `cd ${quoteShellCommandArgForTest(nestedDir)}`,
+      `ODT_INLINE_ENV=from-shell ${quoteShellCommandArgForTest(process.execPath)} server.mjs`,
     ].join(" && ");
 
     try {
@@ -183,7 +186,10 @@ setInterval(() => {}, 1000);
       startGracePeriodMs: 20,
       stopTimeoutMs: 1_000,
     });
-    const command = [quoteCommandArg(process.execPath), quoteCommandArg(parentPath)].join(" ");
+    const command = [
+      quoteShellCommandArgForTest(process.execPath),
+      quoteShellCommandArgForTest(parentPath),
+    ].join(" ");
 
     try {
       const handle = await port.start({
@@ -211,9 +217,9 @@ setInterval(() => {}, 1000);
       stopTimeoutMs: 100,
     });
     const command = [
-      quoteCommandArg(process.execPath),
+      quoteShellCommandArgForTest(process.execPath),
       "-e",
-      quoteCommandArg("process.exit(42);"),
+      quoteShellCommandArgForTest("process.exit(42);"),
     ].join(" ");
 
     await expect(
@@ -328,7 +334,11 @@ setInterval(() => {}, 1000);
           stopTimeoutMs: 1_000,
         });
         const handle = await port.start({
-          command: `${quoteCommandArg(script)} one ${quoteCommandArg("two words")}`,
+          command: [
+            quoteShellCommandArgForTest(script),
+            "one",
+            quoteShellCommandArgForTest("two words"),
+          ].join(" "),
           cwd: root,
           onExit: () => {},
           onOutput: (output) => outputs.push(output.data),

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
@@ -2,7 +2,8 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Effect } from "effect";
+import { Cause, Chunk, Effect, Exit } from "effect";
+import { HostOperationError } from "../../effect/host-errors";
 import { createDevServerProcessAdapter as createEffectDevServerProcessAdapter } from "./dev-server-process-adapter";
 
 const createDevServerProcessAdapter = (
@@ -186,6 +187,41 @@ setInterval(() => {}, 1000);
         onOutput: () => {},
       }),
     ).rejects.toThrow("Dev server command has an unmatched quote.");
+  });
+
+  test("rejects missing executables with actionable spawn details", async () => {
+    const port = createEffectDevServerProcessAdapter({
+      processEnv: { PATH: process.env.PATH },
+      startGracePeriodMs: 20,
+      stopTimeoutMs: 100,
+    });
+    const command = "definitely-missing-dev-server-command-odt-wr4e --flag";
+    const exit = await Effect.runPromiseExit(
+      port.start({
+        command,
+        cwd: process.cwd(),
+        onExit: () => {},
+        onOutput: () => {},
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) {
+      throw new Error("Expected dev-server start to fail.");
+    }
+    const failureOption = Chunk.head(Cause.failures(exit.cause));
+    const failure = failureOption._tag === "Some" ? failureOption.value : null;
+    expect(failure).toBeInstanceOf(HostOperationError);
+    expect(failure).toMatchObject({
+      operation: "devServerProcess.spawn",
+      details: {
+        command,
+        cwd: process.cwd(),
+        launchCommand: "definitely-missing-dev-server-command-odt-wr4e",
+        launchArgs: ["--flag"],
+      },
+    });
   });
 
   test("runs Windows cmd and bat files with paths containing spaces on native Windows", async () => {

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
@@ -35,6 +35,24 @@ type DevServerLaunchFailureDetails = {
 };
 
 type DevServerChildProcess = ReturnType<typeof spawn>;
+type DevServerCommandLaunch = {
+  command: string;
+  args: string[];
+  windowsVerbatimArguments?: boolean;
+};
+
+const createDevServerCommandLaunch = (
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): DevServerCommandLaunch => {
+  if (platform !== "win32") {
+    return { command: "/bin/sh", args: ["-lc", command] };
+  }
+
+  const parsedCommand = parseProcessCommandLine(command);
+  return createProcessCommandLaunch(parsedCommand.command, parsedCommand.args, env, platform);
+};
 
 const trackDevServerProcess = ({
   child,
@@ -133,20 +151,14 @@ export const createDevServerProcessAdapter = ({
     let scope: Parameters<typeof Scope.close>[0] | null = null;
     return Effect.gen(function* () {
       const { command, cwd, env, onExit, onOutput } = input;
-      const parsedCommand = yield* Effect.try({
-        try: () => parseProcessCommandLine(command),
+      const commandEnv = { ...processEnv, ...env };
+      const launch = yield* Effect.try({
+        try: () => createDevServerCommandLaunch(command, commandEnv, process.platform),
         catch: (cause) =>
           cause instanceof HostValidationError
             ? cause
             : toHostOperationError(cause, "devServerProcess.parseCommand", { command }),
       });
-      const commandEnv = { ...processEnv, ...env };
-      const launch = createProcessCommandLaunch(
-        parsedCommand.command,
-        parsedCommand.args,
-        commandEnv,
-        process.platform,
-      );
       const launchFailureDetails: DevServerLaunchFailureDetails = {
         command,
         cwd,

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
@@ -27,6 +27,133 @@ export type CreateDevServerProcessAdapterInput = {
 const DEFAULT_START_GRACE_PERIOD_MS = 150;
 const DEFAULT_STOP_TIMEOUT_MS = 3_000;
 
+type DevServerLaunchFailureDetails = {
+  command: string;
+  cwd: string;
+  launchCommand: string;
+  launchArgs: string[];
+};
+
+type DevServerChildProcess = ReturnType<typeof spawn>;
+
+type DevServerProcessTracker = {
+  getCloseResult: () => DevServerProcessExit | null;
+  getSpawnError: () => Error | null;
+  isClosed: () => boolean;
+  waitForClose: (timeoutMs: number) => Effect.Effect<boolean>;
+};
+
+const createLaunchFailureDetails = (
+  command: string,
+  cwd: string,
+  launch: { command: string; args: string[] },
+): DevServerLaunchFailureDetails => ({
+  command,
+  cwd,
+  launchCommand: launch.command,
+  launchArgs: launch.args,
+});
+
+const toDevServerSpawnError = (
+  cause: unknown,
+  details: DevServerLaunchFailureDetails,
+): HostOperationError => toHostOperationError(cause, "devServerProcess.spawn", details);
+
+const createInvalidPidError = (details: DevServerLaunchFailureDetails): HostOperationError =>
+  new HostOperationError({
+    message: "Failed to start dev server: child process did not expose a valid pid.",
+    operation: "dev-server.start",
+    details,
+  });
+
+const trackDevServerProcess = ({
+  child,
+  isStarted,
+  onExit,
+  onOutput,
+  pid,
+}: {
+  child: DevServerChildProcess;
+  isStarted: () => boolean;
+  onExit: (exit: DevServerProcessExit) => void;
+  onOutput: (output: { data: string }) => void;
+  pid: number | undefined;
+}): DevServerProcessTracker => {
+  let closeResult: DevServerProcessExit | null = null;
+  let spawnError: Error | null = null;
+  const closeListeners = new Set<() => void>();
+
+  const notifyCloseListeners = (): void => {
+    for (const listener of closeListeners) {
+      listener();
+    }
+  };
+  const waitForClose = (timeoutMs: number): Effect.Effect<boolean> => {
+    if (closeResult !== null || spawnError !== null) {
+      return Effect.succeed(true);
+    }
+
+    return Effect.async<boolean>((resume, signal) => {
+      let settled = false;
+      const finish = (closed: boolean) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        closeListeners.delete(resolveTrue);
+        clearTimeout(timeout);
+        signal.removeEventListener("abort", abort);
+        resume(Effect.succeed(closed));
+      };
+      const resolveTrue = () => finish(true);
+      const abort = () => finish(false);
+      const timeout = setTimeout(() => {
+        finish(false);
+      }, timeoutMs);
+      signal.addEventListener("abort", abort, { once: true });
+      closeListeners.add(resolveTrue);
+    });
+  };
+
+  child.stdout?.on("data", (chunk: Buffer) => {
+    onOutput({ data: chunk.toString("utf8") });
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    onOutput({ data: chunk.toString("utf8") });
+  });
+  child.once("error", (error) => {
+    spawnError = error;
+    notifyCloseListeners();
+    if (isStarted()) {
+      onExit({
+        pid: pid ?? -1,
+        exitCode: null,
+        signal: null,
+        error: error.message,
+      });
+    }
+  });
+  child.once("close", (exitCode, signal) => {
+    closeResult = {
+      pid: pid ?? -1,
+      exitCode,
+      signal,
+      error: null,
+    };
+    notifyCloseListeners();
+    if (isStarted()) {
+      onExit(closeResult);
+    }
+  });
+
+  return {
+    getCloseResult: () => closeResult,
+    getSpawnError: () => spawnError,
+    isClosed: () => closeResult !== null || spawnError !== null,
+    waitForClose,
+  };
+};
+
 export const createDevServerProcessAdapter = ({
   processEnv = process.env,
   startGracePeriodMs = DEFAULT_START_GRACE_PERIOD_MS,
@@ -58,12 +185,7 @@ export const createDevServerProcessAdapter = ({
         commandEnv,
         process.platform,
       );
-      const launchFailureDetails = {
-        command,
-        cwd,
-        launchCommand: launch.command,
-        launchArgs: launch.args,
-      };
+      const launchFailureDetails = createLaunchFailureDetails(command, cwd, launch);
 
       const runtimeScope = yield* Scope.make();
       scope = runtimeScope;
@@ -76,92 +198,25 @@ export const createDevServerProcessAdapter = ({
             stdio: ["ignore", "pipe", "pipe"],
             windowsVerbatimArguments: launch.windowsVerbatimArguments === true,
           }),
-        catch: (cause) =>
-          toHostOperationError(cause, "devServerProcess.spawn", launchFailureDetails),
+        catch: (cause) => toDevServerSpawnError(cause, launchFailureDetails),
       });
       const pid = child.pid;
       let started = false;
-      let closeResult: DevServerProcessExit | null = null;
-      let spawnError: Error | null = null;
-      const closeListeners = new Set<() => void>();
-
-      const notifyCloseListeners = (): void => {
-        for (const listener of closeListeners) {
-          listener();
-        }
-      };
-      const waitForClose = (timeoutMs: number): Effect.Effect<boolean> => {
-        if (closeResult !== null || spawnError !== null) {
-          return Effect.succeed(true);
-        }
-
-        return Effect.async<boolean>((resume, signal) => {
-          let settled = false;
-          const finish = (closed: boolean) => {
-            if (settled) {
-              return;
-            }
-            settled = true;
-            closeListeners.delete(resolveTrue);
-            clearTimeout(timeout);
-            signal.removeEventListener("abort", abort);
-            resume(Effect.succeed(closed));
-          };
-          const resolveTrue = () => finish(true);
-          const abort = () => finish(false);
-          const timeout = setTimeout(() => {
-            finish(false);
-          }, timeoutMs);
-          signal.addEventListener("abort", abort, { once: true });
-          closeListeners.add(resolveTrue);
-        });
-      };
-
-      child.stdout?.on("data", (chunk: Buffer) => {
-        onOutput({ data: chunk.toString("utf8") });
-      });
-      child.stderr?.on("data", (chunk: Buffer) => {
-        onOutput({ data: chunk.toString("utf8") });
-      });
-      child.once("error", (error) => {
-        spawnError = error;
-        notifyCloseListeners();
-        if (started) {
-          onExit({
-            pid: pid ?? -1,
-            exitCode: null,
-            signal: null,
-            error: error.message,
-          });
-        }
-      });
-      child.once("close", (exitCode, signal) => {
-        closeResult = {
-          pid: pid ?? -1,
-          exitCode,
-          signal,
-          error: null,
-        };
-        notifyCloseListeners();
-        if (started) {
-          onExit(closeResult);
-        }
+      const processTracker = trackDevServerProcess({
+        child,
+        isStarted: () => started,
+        onExit,
+        onOutput,
+        pid,
       });
 
       if (!pid || pid <= 0) {
-        yield* waitForClose(0);
+        yield* processTracker.waitForClose(0);
+        const spawnError = processTracker.getSpawnError();
         if (spawnError) {
-          return yield* Effect.fail(
-            toHostOperationError(spawnError, "devServerProcess.spawn", launchFailureDetails),
-          );
+          return yield* Effect.fail(toDevServerSpawnError(spawnError, launchFailureDetails));
         }
-        return yield* Effect.fail(
-          new HostOperationError({
-            message: "Failed to start dev server: child process did not expose a valid pid.",
-            operation: "dev-server.start",
-            details: launchFailureDetails,
-          }),
-        );
+        return yield* Effect.fail(createInvalidPidError(launchFailureDetails));
       }
 
       let released = false;
@@ -173,20 +228,19 @@ export const createDevServerProcessAdapter = ({
         yield* terminateProcessTree({
           pid,
           label: `dev server command "${command}"`,
-          isClosed: () => closeResult !== null || spawnError !== null,
-          waitForExit: waitForClose,
+          isClosed: processTracker.isClosed,
+          waitForExit: processTracker.waitForClose,
           stopTimeoutMs,
         }).pipe(Effect.mapError((cause) => toHostOperationError(cause, "devServerProcess.stop")));
       });
       yield* Scope.addFinalizer(runtimeScope, stopProcess.pipe(Effect.ignore));
 
-      const exitedDuringGracePeriod = yield* waitForClose(startGracePeriodMs);
+      const exitedDuringGracePeriod = yield* processTracker.waitForClose(startGracePeriodMs);
+      const spawnError = processTracker.getSpawnError();
       if (spawnError) {
-        return yield* Effect.fail(
-          toHostOperationError(spawnError, "devServerProcess.spawn", launchFailureDetails),
-        );
+        return yield* Effect.fail(toDevServerSpawnError(spawnError, launchFailureDetails));
       }
-      const immediateClose = closeResult as DevServerProcessExit | null;
+      const immediateClose = processTracker.getCloseResult();
       if (exitedDuringGracePeriod && immediateClose) {
         return yield* Effect.fail(
           new DevServerProcessStartExitError(immediateClose.exitCode, immediateClose.signal),

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
@@ -12,6 +12,10 @@ import {
   DevServerProcessStartExitError,
   type DevServerProcessStartInput,
 } from "../../ports/dev-server-process-port";
+import {
+  createProcessCommandLaunch,
+  parseProcessCommandLine,
+} from "../process/process-command-launch";
 import { shouldStartDetachedProcessGroup, terminateProcessTree } from "../process/process-tree";
 
 export type CreateDevServerProcessAdapterInput = {
@@ -40,19 +44,39 @@ export const createDevServerProcessAdapter = ({
           }),
         );
       }
+      const parsedCommand = yield* Effect.try({
+        try: () => parseProcessCommandLine(command),
+        catch: (cause) =>
+          cause instanceof HostValidationError
+            ? cause
+            : toHostOperationError(cause, "devServerProcess.parseCommand", { command }),
+      });
+      const commandEnv = { ...processEnv, ...env };
+      const launch = createProcessCommandLaunch(
+        parsedCommand.command,
+        parsedCommand.args,
+        commandEnv,
+        process.platform,
+      );
 
       const runtimeScope = yield* Scope.make();
       scope = runtimeScope;
       const child = yield* Effect.try({
         try: () =>
-          spawn(command, {
+          spawn(launch.command, launch.args, {
             cwd,
-            detached: shouldStartDetachedProcessGroup(),
-            env: { ...processEnv, ...env },
-            shell: true,
+            detached: shouldStartDetachedProcessGroup(process.platform),
+            env: commandEnv,
             stdio: ["ignore", "pipe", "pipe"],
+            windowsVerbatimArguments: launch.windowsVerbatimArguments === true,
           }),
-        catch: (cause) => toHostOperationError(cause, "devServerProcess.spawn"),
+        catch: (cause) =>
+          toHostOperationError(cause, "devServerProcess.spawn", {
+            command,
+            cwd,
+            launchCommand: launch.command,
+            launchArgs: launch.args,
+          }),
       });
       const pid = child.pid;
       if (!pid || pid <= 0) {

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
@@ -36,36 +36,6 @@ type DevServerLaunchFailureDetails = {
 
 type DevServerChildProcess = ReturnType<typeof spawn>;
 
-type DevServerProcessTracker = {
-  getCloseResult: () => DevServerProcessExit | null;
-  getSpawnError: () => Error | null;
-  isClosed: () => boolean;
-  waitForClose: (timeoutMs: number) => Effect.Effect<boolean>;
-};
-
-const createLaunchFailureDetails = (
-  command: string,
-  cwd: string,
-  launch: { command: string; args: string[] },
-): DevServerLaunchFailureDetails => ({
-  command,
-  cwd,
-  launchCommand: launch.command,
-  launchArgs: launch.args,
-});
-
-const toDevServerSpawnError = (
-  cause: unknown,
-  details: DevServerLaunchFailureDetails,
-): HostOperationError => toHostOperationError(cause, "devServerProcess.spawn", details);
-
-const createInvalidPidError = (details: DevServerLaunchFailureDetails): HostOperationError =>
-  new HostOperationError({
-    message: "Failed to start dev server: child process did not expose a valid pid.",
-    operation: "dev-server.start",
-    details,
-  });
-
 const trackDevServerProcess = ({
   child,
   isStarted,
@@ -78,7 +48,7 @@ const trackDevServerProcess = ({
   onExit: (exit: DevServerProcessExit) => void;
   onOutput: (output: { data: string }) => void;
   pid: number | undefined;
-}): DevServerProcessTracker => {
+}) => {
   let closeResult: DevServerProcessExit | null = null;
   let spawnError: Error | null = null;
   const closeListeners = new Set<() => void>();
@@ -163,14 +133,6 @@ export const createDevServerProcessAdapter = ({
     let scope: Parameters<typeof Scope.close>[0] | null = null;
     return Effect.gen(function* () {
       const { command, cwd, env, onExit, onOutput } = input;
-      if (command.trim().length === 0) {
-        return yield* Effect.fail(
-          new HostValidationError({
-            message: "Dev server command is empty. Provide a command to run.",
-            field: "command",
-          }),
-        );
-      }
       const parsedCommand = yield* Effect.try({
         try: () => parseProcessCommandLine(command),
         catch: (cause) =>
@@ -185,7 +147,12 @@ export const createDevServerProcessAdapter = ({
         commandEnv,
         process.platform,
       );
-      const launchFailureDetails = createLaunchFailureDetails(command, cwd, launch);
+      const launchFailureDetails: DevServerLaunchFailureDetails = {
+        command,
+        cwd,
+        launchCommand: launch.command,
+        launchArgs: launch.args,
+      };
 
       const runtimeScope = yield* Scope.make();
       scope = runtimeScope;
@@ -198,7 +165,8 @@ export const createDevServerProcessAdapter = ({
             stdio: ["ignore", "pipe", "pipe"],
             windowsVerbatimArguments: launch.windowsVerbatimArguments === true,
           }),
-        catch: (cause) => toDevServerSpawnError(cause, launchFailureDetails),
+        catch: (cause) =>
+          toHostOperationError(cause, "devServerProcess.spawn", launchFailureDetails),
       });
       const pid = child.pid;
       let started = false;
@@ -214,9 +182,17 @@ export const createDevServerProcessAdapter = ({
         yield* processTracker.waitForClose(0);
         const spawnError = processTracker.getSpawnError();
         if (spawnError) {
-          return yield* Effect.fail(toDevServerSpawnError(spawnError, launchFailureDetails));
+          return yield* Effect.fail(
+            toHostOperationError(spawnError, "devServerProcess.spawn", launchFailureDetails),
+          );
         }
-        return yield* Effect.fail(createInvalidPidError(launchFailureDetails));
+        return yield* Effect.fail(
+          new HostOperationError({
+            message: "Failed to start dev server: child process did not expose a valid pid.",
+            operation: "dev-server.start",
+            details: launchFailureDetails,
+          }),
+        );
       }
 
       let released = false;
@@ -238,7 +214,9 @@ export const createDevServerProcessAdapter = ({
       const exitedDuringGracePeriod = yield* processTracker.waitForClose(startGracePeriodMs);
       const spawnError = processTracker.getSpawnError();
       if (spawnError) {
-        return yield* Effect.fail(toDevServerSpawnError(spawnError, launchFailureDetails));
+        return yield* Effect.fail(
+          toHostOperationError(spawnError, "devServerProcess.spawn", launchFailureDetails),
+        );
       }
       const immediateClose = processTracker.getCloseResult();
       if (exitedDuringGracePeriod && immediateClose) {

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
@@ -58,6 +58,12 @@ export const createDevServerProcessAdapter = ({
         commandEnv,
         process.platform,
       );
+      const launchFailureDetails = {
+        command,
+        cwd,
+        launchCommand: launch.command,
+        launchArgs: launch.args,
+      };
 
       const runtimeScope = yield* Scope.make();
       scope = runtimeScope;
@@ -71,23 +77,9 @@ export const createDevServerProcessAdapter = ({
             windowsVerbatimArguments: launch.windowsVerbatimArguments === true,
           }),
         catch: (cause) =>
-          toHostOperationError(cause, "devServerProcess.spawn", {
-            command,
-            cwd,
-            launchCommand: launch.command,
-            launchArgs: launch.args,
-          }),
+          toHostOperationError(cause, "devServerProcess.spawn", launchFailureDetails),
       });
       const pid = child.pid;
-      if (!pid || pid <= 0) {
-        return yield* Effect.fail(
-          new HostOperationError({
-            message: "Failed to start dev server: child process did not expose a valid pid.",
-            operation: "dev-server.start",
-          }),
-        );
-      }
-
       let started = false;
       let closeResult: DevServerProcessExit | null = null;
       let spawnError: Error | null = null;
@@ -136,7 +128,7 @@ export const createDevServerProcessAdapter = ({
         notifyCloseListeners();
         if (started) {
           onExit({
-            pid,
+            pid: pid ?? -1,
             exitCode: null,
             signal: null,
             error: error.message,
@@ -145,7 +137,7 @@ export const createDevServerProcessAdapter = ({
       });
       child.once("close", (exitCode, signal) => {
         closeResult = {
-          pid,
+          pid: pid ?? -1,
           exitCode,
           signal,
           error: null,
@@ -155,6 +147,22 @@ export const createDevServerProcessAdapter = ({
           onExit(closeResult);
         }
       });
+
+      if (!pid || pid <= 0) {
+        yield* waitForClose(0);
+        if (spawnError) {
+          return yield* Effect.fail(
+            toHostOperationError(spawnError, "devServerProcess.spawn", launchFailureDetails),
+          );
+        }
+        return yield* Effect.fail(
+          new HostOperationError({
+            message: "Failed to start dev server: child process did not expose a valid pid.",
+            operation: "dev-server.start",
+            details: launchFailureDetails,
+          }),
+        );
+      }
 
       let released = false;
       const stopProcess = Effect.gen(function* () {
@@ -174,7 +182,9 @@ export const createDevServerProcessAdapter = ({
 
       const exitedDuringGracePeriod = yield* waitForClose(startGracePeriodMs);
       if (spawnError) {
-        return yield* Effect.fail(toHostOperationError(spawnError, "devServerProcess.start"));
+        return yield* Effect.fail(
+          toHostOperationError(spawnError, "devServerProcess.spawn", launchFailureDetails),
+        );
       }
       const immediateClose = closeResult as DevServerProcessExit | null;
       if (exitedDuringGracePeriod && immediateClose) {

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts
@@ -47,6 +47,8 @@ const createDevServerCommandLaunch = (
   platform: NodeJS.Platform,
 ): DevServerCommandLaunch => {
   if (platform !== "win32") {
+    // Repo dev-server commands are configured as shell command strings so users can
+    // keep common scripts such as `cd app && npm run dev` or inline env assignments.
     return { command: "/bin/sh", args: ["-lc", command] };
   }
 
@@ -100,6 +102,9 @@ const trackDevServerProcess = ({
       }, timeoutMs);
       signal.addEventListener("abort", abort, { once: true });
       closeListeners.add(resolveTrue);
+      if (closeResult !== null || spawnError !== null) {
+        resolveTrue();
+      }
     });
   };
 

--- a/packages/host/src/adapters/process/process-command-launch.test.ts
+++ b/packages/host/src/adapters/process/process-command-launch.test.ts
@@ -44,10 +44,20 @@ describe("createProcessCommandLaunch", () => {
   });
 
   test("uses cmd.exe when ComSpec is absent or blank", () => {
-    expect(createProcessCommandLaunch("tool.cmd", [], {}, "win32").command).toBe("cmd.exe");
-    expect(createProcessCommandLaunch("tool.cmd", [], { ComSpec: "  " }, "win32").command).toBe(
-      "cmd.exe",
-    );
+    const originalComSpec = process.env.ComSpec;
+    process.env.ComSpec = String.raw`C:\Global\cmd.exe`;
+    try {
+      expect(createProcessCommandLaunch("tool.cmd", [], {}, "win32").command).toBe("cmd.exe");
+      expect(createProcessCommandLaunch("tool.cmd", [], { ComSpec: "  " }, "win32").command).toBe(
+        "cmd.exe",
+      );
+    } finally {
+      if (originalComSpec === undefined) {
+        delete process.env.ComSpec;
+      } else {
+        process.env.ComSpec = originalComSpec;
+      }
+    }
   });
 
   test("does not wrap non-Windows or non-script launches", () => {

--- a/packages/host/src/adapters/process/process-command-launch.test.ts
+++ b/packages/host/src/adapters/process/process-command-launch.test.ts
@@ -22,7 +22,27 @@ describe("createProcessCommandLaunch", () => {
         "/d",
         "/s",
         "/c",
-        String.raw`""C:\Program Files\Codex\codex.cmd" --config "mcp_servers.openducktor.command=^"mcp-bin^"" "path=%%APPDATA%%\foo" "caret=foo^^bar""`,
+        String.raw`""C:\Program Files\Codex\codex.cmd" --config "mcp_servers.openducktor.command=""mcp-bin""" path=%APPDATA%\foo caret=foo^bar"`,
+      ],
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  test("quotes Windows shell arguments without rewriting percent or caret characters", () => {
+    const launch = createProcessCommandLaunch(
+      "tool.cmd",
+      ["plain", "two words", 'quote="value"', "percent=%APPDATA%", "caret=foo^bar"],
+      {},
+      "win32",
+    );
+
+    expect(launch).toEqual({
+      command: "cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        '"tool.cmd plain "two words" "quote=""value""" percent=%APPDATA% caret=foo^bar"',
       ],
       windowsVerbatimArguments: true,
     });
@@ -97,6 +117,17 @@ describe("parseProcessCommandLine", () => {
     expect(parseProcessCommandLine(`node -e 'console.log("ready")'`)).toEqual({
       command: "node",
       args: ["-e", 'console.log("ready")'],
+    });
+  });
+
+  test("preserves escaped quotes inside double-quoted arguments", () => {
+    expect(parseProcessCommandLine(String.raw`node -e "console.log(\"ready\")"`)).toEqual({
+      command: "node",
+      args: ["-e", 'console.log("ready")'],
+    });
+    expect(parseProcessCommandLine(String.raw`tool --config "key=\"value\""`)).toEqual({
+      command: "tool",
+      args: ["--config", 'key="value"'],
     });
   });
 

--- a/packages/host/src/adapters/process/process-command-launch.test.ts
+++ b/packages/host/src/adapters/process/process-command-launch.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { HostValidationError } from "../../effect/host-errors";
+import { createProcessCommandLaunch, parseProcessCommandLine } from "./process-command-launch";
+
+describe("createProcessCommandLaunch", () => {
+  test("builds a Windows shell launch for cmd files with quoted config arguments", () => {
+    const launch = createProcessCommandLaunch(
+      String.raw`C:\Program Files\Codex\codex.cmd`,
+      [
+        "--config",
+        'mcp_servers.openducktor.command="mcp-bin"',
+        "path=%APPDATA%\\foo",
+        "caret=foo^bar",
+      ],
+      { ComSpec: String.raw`C:\Windows\System32\cmd.exe` },
+      "win32",
+    );
+
+    expect(launch).toEqual({
+      command: String.raw`C:\Windows\System32\cmd.exe`,
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        String.raw`""C:\Program Files\Codex\codex.cmd" --config "mcp_servers.openducktor.command=^"mcp-bin^"" "path=%%APPDATA%%\foo" "caret=foo^^bar""`,
+      ],
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  test("builds the same Windows shell launch for bat files", () => {
+    const launch = createProcessCommandLaunch(
+      String.raw`C:\Program Files\Dev Server\start.bat`,
+      ["--port", "5173"],
+      { ComSpec: String.raw`C:\Windows\System32\cmd.exe` },
+      "win32",
+    );
+
+    expect(launch).toEqual({
+      command: String.raw`C:\Windows\System32\cmd.exe`,
+      args: ["/d", "/s", "/c", String.raw`""C:\Program Files\Dev Server\start.bat" --port 5173"`],
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  test("uses cmd.exe when ComSpec is absent or blank", () => {
+    expect(createProcessCommandLaunch("tool.cmd", [], {}, "win32").command).toBe("cmd.exe");
+    expect(createProcessCommandLaunch("tool.cmd", [], { ComSpec: "  " }, "win32").command).toBe(
+      "cmd.exe",
+    );
+  });
+
+  test("does not wrap non-Windows or non-script launches", () => {
+    expect(createProcessCommandLaunch("tool.cmd", ["one"], {}, "linux")).toEqual({
+      command: "tool.cmd",
+      args: ["one"],
+    });
+    expect(createProcessCommandLaunch("tool.exe", ["one"], {}, "win32")).toEqual({
+      command: "tool.exe",
+      args: ["one"],
+    });
+  });
+});
+
+describe("parseProcessCommandLine", () => {
+  test("parses quoted command paths and arguments", () => {
+    expect(
+      parseProcessCommandLine(
+        `"/Users/example/path with spaces/node" -e "console.log('ready')" '' "two words"`,
+      ),
+    ).toEqual({
+      command: "/Users/example/path with spaces/node",
+      args: ["-e", "console.log('ready')", "", "two words"],
+    });
+  });
+
+  test("preserves Windows backslashes in quoted paths", () => {
+    expect(
+      parseProcessCommandLine(String.raw`"C:\Program Files\nodejs\node.exe" "C:\repo dir\app.mjs"`),
+    ).toEqual({
+      command: String.raw`C:\Program Files\nodejs\node.exe`,
+      args: [String.raw`C:\repo dir\app.mjs`],
+    });
+  });
+
+  test("keeps literal quotes when grouped with the other quote character", () => {
+    expect(parseProcessCommandLine(`node -e 'console.log("ready")'`)).toEqual({
+      command: "node",
+      args: ["-e", 'console.log("ready")'],
+    });
+  });
+
+  test("rejects empty commands", () => {
+    expect(() => parseProcessCommandLine("  \t  ")).toThrow(HostValidationError);
+  });
+
+  test("rejects unmatched quotes with an actionable validation error", () => {
+    expect(() => parseProcessCommandLine(`node -e "console.log('ready')`)).toThrow(
+      "Dev server command has an unmatched quote. Fix the command syntax or invoke a shell explicitly.",
+    );
+  });
+});

--- a/packages/host/src/adapters/process/process-command-launch.test.ts
+++ b/packages/host/src/adapters/process/process-command-launch.test.ts
@@ -20,15 +20,18 @@ describe("createProcessCommandLaunch", () => {
       command: String.raw`C:\Windows\System32\cmd.exe`,
       args: [
         "/d",
-        "/s",
         "/c",
-        String.raw`""C:\Program Files\Codex\codex.cmd" --config "mcp_servers.openducktor.command=""mcp-bin""" path=%APPDATA%\foo caret=foo^bar"`,
+        "call",
+        String.raw`C:\Program Files\Codex\codex.cmd`,
+        "--config",
+        'mcp_servers.openducktor.command="mcp-bin"',
+        "path=%APPDATA%\\foo",
+        "caret=foo^bar",
       ],
-      windowsVerbatimArguments: true,
     });
   });
 
-  test("quotes Windows shell arguments without rewriting percent or caret characters", () => {
+  test("passes Windows shell arguments through without rewriting percent or caret characters", () => {
     const launch = createProcessCommandLaunch(
       "tool.cmd",
       ["plain", "two words", 'quote="value"', "percent=%APPDATA%", "caret=foo^bar"],
@@ -40,11 +43,15 @@ describe("createProcessCommandLaunch", () => {
       command: "cmd.exe",
       args: [
         "/d",
-        "/s",
         "/c",
-        '"tool.cmd plain "two words" "quote=""value""" percent=%APPDATA% caret=foo^bar"',
+        "call",
+        "tool.cmd",
+        "plain",
+        "two words",
+        'quote="value"',
+        "percent=%APPDATA%",
+        "caret=foo^bar",
       ],
-      windowsVerbatimArguments: true,
     });
   });
 
@@ -58,8 +65,14 @@ describe("createProcessCommandLaunch", () => {
 
     expect(launch).toEqual({
       command: String.raw`C:\Windows\System32\cmd.exe`,
-      args: ["/d", "/s", "/c", String.raw`""C:\Program Files\Dev Server\start.bat" --port 5173"`],
-      windowsVerbatimArguments: true,
+      args: [
+        "/d",
+        "/c",
+        "call",
+        String.raw`C:\Program Files\Dev Server\start.bat`,
+        "--port",
+        "5173",
+      ],
     });
   });
 

--- a/packages/host/src/adapters/process/process-command-launch.ts
+++ b/packages/host/src/adapters/process/process-command-launch.ts
@@ -11,16 +11,6 @@ type ParsedProcessCommand = {
   args: string[];
 };
 
-const quoteWindowsCommandArgument = (value: string): string => {
-  if (value.length === 0) {
-    return `""`;
-  }
-  if (!/[\s"]/u.test(value)) {
-    return value;
-  }
-  return `"${value.replaceAll(`"`, `""`)}"`;
-};
-
 const isWindowsCommandScript = (command: string, platform: NodeJS.Platform): boolean =>
   platform === "win32" && /\.(?:cmd|bat)$/iu.test(command);
 
@@ -35,14 +25,10 @@ export const createProcessCommandLaunch = (
   }
 
   const windowsCommandShell = env.ComSpec?.trim() || "cmd.exe";
-  const shellOptions = ["/d", "/s", "/c"];
-  const quotedScriptInvocation = [command, ...args].map(quoteWindowsCommandArgument).join(" ");
-  const shellCommandLine = `"${quotedScriptInvocation}"`;
 
   return {
     command: windowsCommandShell,
-    args: [...shellOptions, shellCommandLine],
-    windowsVerbatimArguments: true,
+    args: ["/d", "/c", "call", command, ...args],
   };
 };
 

--- a/packages/host/src/adapters/process/process-command-launch.ts
+++ b/packages/host/src/adapters/process/process-command-launch.ts
@@ -1,12 +1,12 @@
 import { HostValidationError } from "../../effect/host-errors";
 
-export type ProcessCommandLaunchPlan = {
+type ProcessCommandLaunchPlan = {
   command: string;
   args: string[];
   windowsVerbatimArguments?: boolean;
 };
 
-export type ParsedProcessCommand = {
+type ParsedProcessCommand = {
   command: string;
   args: string[];
 };

--- a/packages/host/src/adapters/process/process-command-launch.ts
+++ b/packages/host/src/adapters/process/process-command-launch.ts
@@ -1,0 +1,109 @@
+import { HostValidationError } from "../../effect/host-errors";
+
+export type ProcessCommandLaunchPlan = {
+  command: string;
+  args: string[];
+  windowsVerbatimArguments?: boolean;
+};
+
+export type ParsedProcessCommand = {
+  command: string;
+  args: string[];
+};
+
+const quoteWindowsCommandArgument = (value: string): string => {
+  if (value.length === 0) {
+    return `""`;
+  }
+  if (!/[\s"%^]/u.test(value)) {
+    return value;
+  }
+  return `"${value.replaceAll("^", "^^").replaceAll("%", "%%").replaceAll(`"`, `^"`)}"`;
+};
+
+const isWindowsCommandScript = (command: string, platform: NodeJS.Platform): boolean =>
+  platform === "win32" && /\.(?:cmd|bat)$/iu.test(command);
+
+export const createProcessCommandLaunch = (
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): ProcessCommandLaunchPlan => {
+  if (!isWindowsCommandScript(command, platform)) {
+    return { command, args };
+  }
+
+  const windowsCommandShell = env.ComSpec?.trim() || process.env.ComSpec || "cmd.exe";
+  const shellOptions = ["/d", "/s", "/c"];
+  const quotedScriptInvocation = [command, ...args].map(quoteWindowsCommandArgument).join(" ");
+  const shellCommandLine = `"${quotedScriptInvocation}"`;
+
+  return {
+    command: windowsCommandShell,
+    args: [...shellOptions, shellCommandLine],
+    windowsVerbatimArguments: true,
+  };
+};
+
+const commandSyntaxError = (message: string, commandLine: string): HostValidationError =>
+  new HostValidationError({
+    field: "command",
+    message,
+    details: { command: commandLine },
+  });
+
+export const parseProcessCommandLine = (commandLine: string): ParsedProcessCommand => {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | `"` | null = null;
+  let currentTokenStarted = false;
+
+  for (const character of commandLine) {
+    if (quote !== null) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        current += character;
+      }
+      currentTokenStarted = true;
+      continue;
+    }
+
+    if (character === `"` || character === "'") {
+      quote = character;
+      currentTokenStarted = true;
+      continue;
+    }
+
+    if (/\s/u.test(character)) {
+      if (currentTokenStarted) {
+        tokens.push(current);
+        current = "";
+        currentTokenStarted = false;
+      }
+      continue;
+    }
+
+    current += character;
+    currentTokenStarted = true;
+  }
+
+  if (quote !== null) {
+    throw commandSyntaxError(
+      "Dev server command has an unmatched quote. Fix the command syntax or invoke a shell explicitly.",
+      commandLine,
+    );
+  }
+
+  if (currentTokenStarted) {
+    tokens.push(current);
+  }
+
+  const [command, ...args] = tokens;
+  if (!command) {
+    throw commandSyntaxError("Dev server command is empty. Provide a command to run.", commandLine);
+  }
+
+  return { command, args };
+};

--- a/packages/host/src/adapters/process/process-command-launch.ts
+++ b/packages/host/src/adapters/process/process-command-launch.ts
@@ -15,10 +15,10 @@ const quoteWindowsCommandArgument = (value: string): string => {
   if (value.length === 0) {
     return `""`;
   }
-  if (!/[\s"%^]/u.test(value)) {
+  if (!/[\s"]/u.test(value)) {
     return value;
   }
-  return `"${value.replaceAll("^", "^^").replaceAll("%", "%%").replaceAll(`"`, `^"`)}"`;
+  return `"${value.replaceAll(`"`, `""`)}"`;
 };
 
 const isWindowsCommandScript = (command: string, platform: NodeJS.Platform): boolean =>
@@ -59,9 +59,15 @@ export const parseProcessCommandLine = (commandLine: string): ParsedProcessComma
   let quote: "'" | `"` | null = null;
   let currentTokenStarted = false;
 
-  for (const character of commandLine) {
+  for (let index = 0; index < commandLine.length; index += 1) {
+    const character = commandLine.charAt(index);
+
     if (quote !== null) {
-      if (character === quote) {
+      const nextCharacter = commandLine.charAt(index + 1);
+      if (character === "\\" && (nextCharacter === quote || nextCharacter === "\\")) {
+        current += nextCharacter;
+        index += 1;
+      } else if (character === quote) {
         quote = null;
       } else {
         current += character;

--- a/packages/host/src/adapters/process/process-command-launch.ts
+++ b/packages/host/src/adapters/process/process-command-launch.ts
@@ -34,7 +34,7 @@ export const createProcessCommandLaunch = (
     return { command, args };
   }
 
-  const windowsCommandShell = env.ComSpec?.trim() || process.env.ComSpec || "cmd.exe";
+  const windowsCommandShell = env.ComSpec?.trim() || "cmd.exe";
   const shellOptions = ["/d", "/s", "/c"];
   const quotedScriptInvocation = [command, ...args].map(quoteWindowsCommandArgument).join(" ");
   const shellCommandLine = `"${quotedScriptInvocation}"`;

--- a/packages/host/src/adapters/system/system-command-runner.test.ts
+++ b/packages/host/src/adapters/system/system-command-runner.test.ts
@@ -150,10 +150,29 @@ describe("createSystemCommandRunner", () => {
         "/d",
         "/s",
         "/c",
-        String.raw`""C:\Program Files\Codex\codex.cmd" --config "mcp_servers.openducktor.command=^"mcp-bin^"" "path=%%APPDATA%%\foo" "caret=foo^^bar""`,
+        String.raw`""C:\Program Files\Codex\codex.cmd" --config "mcp_servers.openducktor.command=""mcp-bin""" path=%APPDATA%\foo caret=foo^bar"`,
       ],
       windowsVerbatimArguments: true,
     });
+  });
+
+  test("uses process ComSpec fallback for Windows shell launches when the explicit env omits it", () => {
+    const originalComSpec = process.env.ComSpec;
+    process.env.ComSpec = String.raw`C:\Global\cmd.exe`;
+    try {
+      expect(createSystemCommandLaunch("tool.cmd", [], {}, "win32").command).toBe(
+        String.raw`C:\Global\cmd.exe`,
+      );
+      expect(createSystemCommandLaunch("tool.cmd", [], { ComSpec: "  " }, "win32").command).toBe(
+        String.raw`C:\Global\cmd.exe`,
+      );
+    } finally {
+      if (originalComSpec === undefined) {
+        delete process.env.ComSpec;
+      } else {
+        process.env.ComSpec = originalComSpec;
+      }
+    }
   });
 
   test("runs Windows cmd and bat launchers with arguments on native Windows", async () => {

--- a/packages/host/src/adapters/system/system-command-runner.test.ts
+++ b/packages/host/src/adapters/system/system-command-runner.test.ts
@@ -148,11 +148,14 @@ describe("createSystemCommandRunner", () => {
       command: String.raw`C:\Windows\System32\cmd.exe`,
       args: [
         "/d",
-        "/s",
         "/c",
-        String.raw`""C:\Program Files\Codex\codex.cmd" --config "mcp_servers.openducktor.command=""mcp-bin""" path=%APPDATA%\foo caret=foo^bar"`,
+        "call",
+        String.raw`C:\Program Files\Codex\codex.cmd`,
+        "--config",
+        'mcp_servers.openducktor.command="mcp-bin"',
+        "path=%APPDATA%\\foo",
+        "caret=foo^bar",
       ],
-      windowsVerbatimArguments: true,
     });
   });
 

--- a/packages/host/src/adapters/system/system-command-runner.ts
+++ b/packages/host/src/adapters/system/system-command-runner.ts
@@ -110,7 +110,11 @@ export const createSystemCommandLaunch = (
   args: string[],
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
-) => createProcessCommandLaunch(command, args, env, platform);
+) => {
+  const launchEnv =
+    env.ComSpec?.trim() || !process.env.ComSpec ? env : { ...env, ComSpec: process.env.ComSpec };
+  return createProcessCommandLaunch(command, args, launchEnv, platform);
+};
 
 export const createSystemCommandRunner = ({
   env = process.env,

--- a/packages/host/src/adapters/system/system-command-runner.ts
+++ b/packages/host/src/adapters/system/system-command-runner.ts
@@ -13,6 +13,7 @@ import {
   SystemCommandPortTag,
   type SystemCommandRunResult,
 } from "../../ports/system-command-port";
+import { createProcessCommandLaunch } from "../process/process-command-launch";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 10_000;
 const WINDOWS_DEFAULT_PATHEXT = [".EXE", ".CMD", ".BAT", ".COM"];
@@ -104,40 +105,12 @@ const firstNonEmptyLine = (value: string): string | null =>
     .map((line) => line.trim())
     .find(Boolean) ?? null;
 
-const quoteWindowsCommandArgument = (value: string): string => {
-  if (value.length === 0) {
-    return `""`;
-  }
-  if (!/[\s"%^]/u.test(value)) {
-    return value;
-  }
-  return `"${value.replaceAll("^", "^^").replaceAll("%", "%%").replaceAll(`"`, `^"`)}"`;
-};
-
-const isWindowsCommandScript = (command: string, platform: NodeJS.Platform): boolean =>
-  platform === "win32" && /\.(?:cmd|bat)$/iu.test(command);
-
 export const createSystemCommandLaunch = (
   command: string,
   args: string[],
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
-): { command: string; args: string[]; windowsVerbatimArguments?: boolean } => {
-  if (!isWindowsCommandScript(command, platform)) {
-    return { command, args };
-  }
-
-  const windowsCommandShell = env.ComSpec?.trim() || process.env.ComSpec || "cmd.exe";
-  const shellOptions = ["/d", "/s", "/c"];
-  const quotedScriptInvocation = [command, ...args].map(quoteWindowsCommandArgument).join(" ");
-  const shellCommandLine = `"${quotedScriptInvocation}"`;
-
-  return {
-    command: windowsCommandShell,
-    args: [...shellOptions, shellCommandLine],
-    windowsVerbatimArguments: true,
-  };
-};
+) => createProcessCommandLaunch(command, args, env, platform);
 
 export const createSystemCommandRunner = ({
   env = process.env,

--- a/packages/host/src/adapters/system/system-command-runner.ts
+++ b/packages/host/src/adapters/system/system-command-runner.ts
@@ -111,8 +111,9 @@ export const createSystemCommandLaunch = (
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
 ) => {
-  const launchEnv =
-    env.ComSpec?.trim() || !process.env.ComSpec ? env : { ...env, ComSpec: process.env.ComSpec };
+  const envComSpec = env.ComSpec?.trim();
+  const processComSpec = process.env.ComSpec?.trim();
+  const launchEnv = envComSpec || !processComSpec ? env : { ...env, ComSpec: processComSpec };
   return createProcessCommandLaunch(command, args, launchEnv, platform);
 };
 


### PR DESCRIPTION
Summary

This pull request makes the host dev-server lifecycle launch commands explicitly across Windows, Linux, and macOS instead of relying on shell-dependent `spawn(..., { shell: true })` behavior. It keeps the existing streaming and stop semantics while making launch and failure behavior typed and inspectable.

Goal

Dev-server workflows are started from `packages/host/src/adapters/dev-servers/dev-server-process-adapter.ts`. The previous implementation delegated command interpretation to the platform shell, which made Windows `.cmd`/`.bat` scripts, quoted paths, command paths with spaces, and shell-dependent argument handling hard to reason about. The goal of this PR is to make that launch behavior explicit without adding fallback paths that hide broken commands.

Implementation

- Added a focused process command launch helper under `packages/host/src/adapters/process/process-command-launch.ts` that parses configured command lines and builds the platform-specific `spawn` command/args.
- Uses direct executable launches for normal commands and wraps Windows `.cmd`/`.bat` scripts with `cmd.exe /d /s /c` plus `windowsVerbatimArguments` so script execution and quoted arguments are handled deliberately.
- Updated the dev-server process adapter to use the shared launch helper, preserve stdout/stderr streaming, preserve environment propagation, keep detached process-tree semantics, and report typed `HostValidationError` / `HostOperationError` failures with actionable launch details.
- Kept graceful stop followed by force-stop process-tree cleanup through the existing shared process-tree adapter.
- Added focused coverage for parser behavior, Windows script launch planning, missing executable diagnostics, cwd/env/stdout/stderr behavior, and full process-tree stop behavior.
- Follow-up cleanup simplified the adapter by removing one-use helpers and keeping command validation owned by the parser.

Verification

Post-rebase checks run from the updated branch:

- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `cd apps/desktop/src-tauri && cargo fmt --all --check`
- `cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings`
- `cd apps/desktop/src-tauri && cargo check --workspace`
- `cd apps/desktop/src-tauri && cargo test --workspace`
- `cd apps/desktop/src-tauri && cargo build --workspace`

Notes

The Vite builds still emit existing chunk-size warnings. Bun frontend tests still emit existing React `act(...)` warnings around document copy button tests. Both suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cross-platform process launch behavior, with robust Windows script handling and clearer launch details for failures.

* **Bug Fixes**
  * Fixed command-line parsing and quoting for quoted paths, empty arguments, special characters, and missing-shell cases.
  * Corrected environment handling when launching commands.

* **Tests**
  * Expanded cross-platform test coverage, including Windows-specific quoting, failure modes, and script execution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->