### PR TITLE
fix(host): ignore idle Codex sessions during task cleanup

### DIFF
--- a/packages/host/src/adapters/codex/codex-session-status-probe.test.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.test.ts
@@ -88,4 +88,10 @@ describe("probeCodexSessionStatus", () => {
       hasLiveSession: false,
     });
   });
+
+  test("fails fast when Codex returns an unsupported thread status", async () => {
+    await expect(probeThreadStatus({ status: { type: "paused" } as never })).rejects.toThrow(
+      "Codex thread/read response thread has unsupported Codex thread status: paused",
+    );
+  });
 });

--- a/packages/host/src/adapters/codex/codex-session-status-probe.test.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { HostOperationError } from "../../effect/host-errors";
+import type { CodexAppServerRequestResult } from "../../ports/codex-app-server-port";
+import { probeCodexSessionStatus } from "./codex-session-status-probe";
+
+const codexResult = (value: unknown) => Effect.succeed(value as CodexAppServerRequestResult);
+
+const probeThreadStatus = (input: {
+  status: { type: "active"; activeFlags: [] } | { type: "idle" | "notLoaded" | "systemError" };
+  cwd?: string;
+}) =>
+  Effect.runPromise(
+    probeCodexSessionStatus({
+      codexAppServer: {
+        request() {
+          return codexResult({
+            thread: {
+              id: "thread-1",
+              cwd: input.cwd ?? "/repo/worktree",
+              status: input.status,
+            },
+          });
+        },
+      },
+      runtimeId: "runtime-1",
+      externalSessionId: "thread-1",
+      workingDirectory: "/repo/worktree",
+    }),
+  );
+
+describe("probeCodexSessionStatus", () => {
+  test("reports active and systemError Codex threads as live", async () => {
+    await expect(
+      probeThreadStatus({ status: { type: "active", activeFlags: [] } }),
+    ).resolves.toEqual({
+      supported: true,
+      hasLiveSession: true,
+    });
+
+    await expect(probeThreadStatus({ status: { type: "systemError" } })).resolves.toEqual({
+      supported: true,
+      hasLiveSession: true,
+    });
+  });
+
+  test("reports idle, notLoaded, and other-worktree Codex threads as inactive", async () => {
+    await expect(probeThreadStatus({ status: { type: "idle" } })).resolves.toEqual({
+      supported: true,
+      hasLiveSession: false,
+    });
+
+    await expect(probeThreadStatus({ status: { type: "notLoaded" } })).resolves.toEqual({
+      supported: true,
+      hasLiveSession: false,
+    });
+
+    await expect(
+      probeThreadStatus({ status: { type: "active", activeFlags: [] }, cwd: "/repo/other" }),
+    ).resolves.toEqual({
+      supported: true,
+      hasLiveSession: false,
+    });
+  });
+
+  test("reports missing Codex threads as inactive", async () => {
+    await expect(
+      Effect.runPromise(
+        probeCodexSessionStatus({
+          codexAppServer: {
+            request() {
+              return Effect.fail(
+                new HostOperationError({
+                  operation: "codexAppServer.request",
+                  message: "thread not found",
+                  details: { method: "thread/read" },
+                }),
+              );
+            },
+          },
+          runtimeId: "runtime-1",
+          externalSessionId: "thread-missing",
+          workingDirectory: "/repo/worktree",
+        }),
+      ),
+    ).resolves.toEqual({
+      supported: true,
+      hasLiveSession: false,
+    });
+  });
+});

--- a/packages/host/src/adapters/codex/codex-session-status-probe.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.ts
@@ -1,6 +1,10 @@
 import { Effect } from "effect";
 import { HostOperationError } from "../../effect/host-errors";
-import type { CodexAppServerError, CodexAppServerPort } from "../../ports/codex-app-server-port";
+import type {
+  CodexAppServerError,
+  CodexAppServerPort,
+  CodexSessionStatus,
+} from "../../ports/codex-app-server-port";
 import { readCodexThread } from "./codex-thread-lookup";
 
 export type CodexSessionStatusProbeInput = {
@@ -16,6 +20,21 @@ const isCodexThreadNotFoundError = (cause: CodexAppServerError): boolean =>
   cause instanceof HostOperationError &&
   cause.details?.method === "thread/read" &&
   cause.message.toLowerCase().includes("not found");
+
+const isActiveCodexThreadStatus = (status: CodexSessionStatus): boolean => {
+  switch (status) {
+    case "active":
+    case "systemError":
+      return true;
+    case "idle":
+    case "notLoaded":
+      return false;
+    default: {
+      const unhandledStatus: never = status;
+      return unhandledStatus;
+    }
+  }
+};
 
 export const probeCodexSessionStatus = (
   input: CodexSessionStatusProbeInput,
@@ -39,6 +58,7 @@ export const probeCodexSessionStatus = (
     const thread = threadResult.right;
     return {
       supported: true,
-      hasLiveSession: thread.cwd === input.workingDirectory && thread.status.type !== "notLoaded",
+      hasLiveSession:
+        thread.cwd === input.workingDirectory && isActiveCodexThreadStatus(thread.status.type),
     };
   });

--- a/packages/host/src/adapters/codex/codex-session-status-probe.ts
+++ b/packages/host/src/adapters/codex/codex-session-status-probe.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { HostOperationError } from "../../effect/host-errors";
+import { HostOperationError, HostValidationError } from "../../effect/host-errors";
 import type {
   CodexAppServerError,
   CodexAppServerPort,
@@ -21,17 +21,24 @@ const isCodexThreadNotFoundError = (cause: CodexAppServerError): boolean =>
   cause.details?.method === "thread/read" &&
   cause.message.toLowerCase().includes("not found");
 
-const isActiveCodexThreadStatus = (status: CodexSessionStatus): boolean => {
-  switch (status) {
+const isLiveCodexThreadStatus = (
+  statusType: CodexSessionStatus,
+): Effect.Effect<boolean, HostValidationError> => {
+  switch (statusType) {
     case "active":
     case "systemError":
-      return true;
+      return Effect.succeed(true);
     case "idle":
     case "notLoaded":
-      return false;
+      return Effect.succeed(false);
     default: {
-      const unhandledStatus: never = status;
-      return unhandledStatus;
+      const unhandledStatus: never = statusType;
+      return Effect.fail(
+        new HostValidationError({
+          message: `Unsupported Codex thread status: ${String(unhandledStatus)}`,
+          details: { statusType: unhandledStatus },
+        }),
+      );
     }
   }
 };
@@ -56,9 +63,12 @@ export const probeCodexSessionStatus = (
       return yield* Effect.fail(threadResult.left);
     }
     const thread = threadResult.right;
+    const hasLiveSession =
+      thread.cwd === input.workingDirectory
+        ? yield* isLiveCodexThreadStatus(thread.status.type)
+        : false;
     return {
       supported: true,
-      hasLiveSession:
-        thread.cwd === input.workingDirectory && isActiveCodexThreadStatus(thread.status.type),
+      hasLiveSession,
     };
   });

--- a/packages/host/src/adapters/runtimes/runtime-registry.test.ts
+++ b/packages/host/src/adapters/runtimes/runtime-registry.test.ts
@@ -399,7 +399,7 @@ describe("createRuntimeRegistry", () => {
           workingDirectory: "/repo/worktree",
         }),
       ),
-    ).resolves.toEqual({ supported: true, hasLiveSession: true });
+    ).resolves.toEqual({ supported: true, hasLiveSession: false });
     await expect(
       Effect.runPromise(
         probeSessionStatus({


### PR DESCRIPTION
Summary:
Fixes task delete/reset cleanup so idle Codex sessions no longer block destructive task operations as if builder work were still active.

Goal:
Deleting or resetting a task with persisted Codex build sessions could fail with “Cannot delete tasks with active builder work in progress” even after the Codex thread had gone idle. Users had to restart OpenDucktor to clear the stale-seeming state. The guard should consult live runtime state and only block when the current Codex thread is actually active.

Technical choices:
- Kept the fix at the Codex runtime probe boundary instead of adding frontend or task-delete fallbacks.
- Made Codex activity classification explicit and exhaustive over `CodexSessionStatus`.
- Treat `active` and `systemError` as blocking live work, while `idle`, `notLoaded`, missing threads, and other-worktree threads are inactive for task cleanup.
- Added source-level probe coverage and updated the runtime-registry integration expectation for idle Codex threads.

Verification:
- `env -u ODT_HOST_TOKEN -u ODT_FORBID_WORKSPACE_ID_INPUT bun run lint`
- `env -u ODT_HOST_TOKEN -u ODT_FORBID_WORKSPACE_ID_INPUT bun run typecheck`
- `env -u ODT_HOST_TOKEN -u ODT_FORBID_WORKSPACE_ID_INPUT bun run test`
- `env -u ODT_HOST_TOKEN -u ODT_FORBID_WORKSPACE_ID_INPUT bun run build`
- `cargo fmt --all --check`
- `bun run check:rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run test:rust`
- `cargo build`