### PR TITLE
fix(frontend): preserve subagent pending input on hydration failure

### DIFF
--- a/apps/electron/scripts/package-build.test.ts
+++ b/apps/electron/scripts/package-build.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import {
@@ -131,9 +131,12 @@ describe("build Electron release artifact", () => {
         "OpenDucktor-Electron-0.3.1-mac-arm64.dmg.blockmap",
         "OpenDucktor-Electron-0.3.1-mac-arm64.zip",
       ]);
-      await expect(
-        readFile(join(outputDirectory, "OpenDucktor-Electron-0.3.1-linux-x64.AppImage")),
-      ).rejects.toThrow();
+      const outputEntries = await readdir(outputDirectory);
+      expect(outputEntries.sort()).toEqual([
+        "OpenDucktor-Electron-0.3.1-mac-arm64.dmg",
+        "OpenDucktor-Electron-0.3.1-mac-arm64.dmg.blockmap",
+        "OpenDucktor-Electron-0.3.1-mac-arm64.zip",
+      ]);
     } finally {
       await rm(baseDirectory, { force: true, recursive: true });
     }

--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -158,23 +158,22 @@ export const collectReleaseArtifacts = async ({
   platform: ElectronReleasePlatform;
   releaseDirectory: string;
 }): Promise<string[]> => {
-  const copiedArtifacts: string[] = [];
-
   await assertDirectoryExists(releaseDirectory, "Electron release directory");
   await rm(outputDirectory, { force: true, recursive: true });
   await mkdir(outputDirectory, { recursive: true });
 
   const entries = await readdir(releaseDirectory, { withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isFile() || !isReleaseArtifact(platform, entry.name)) {
-      continue;
-    }
-
-    const sourcePath = join(releaseDirectory, entry.name);
-    const targetPath = join(outputDirectory, entry.name);
-    await copyFile(sourcePath, targetPath);
-    copiedArtifacts.push(targetPath);
-  }
+  const artifactEntries = entries.filter(
+    (entry) => entry.isFile() && isReleaseArtifact(platform, entry.name),
+  );
+  const copiedArtifacts = await Promise.all(
+    artifactEntries.map(async (entry) => {
+      const sourcePath = join(releaseDirectory, entry.name);
+      const targetPath = join(outputDirectory, entry.name);
+      await copyFile(sourcePath, targetPath);
+      return targetPath;
+    }),
+  );
 
   if (copiedArtifacts.length === 0) {
     throw new Error(`No Electron release artifacts were produced for ${platform}.`);

--- a/packages/adapters-opencode-sdk/src/test-support.ts
+++ b/packages/adapters-opencode-sdk/src/test-support.ts
@@ -1,4 +1,5 @@
 import type { Event, OpencodeClient, Part } from "@opencode-ai/sdk/v2";
+import type { RuntimeKind } from "@openducktor/contracts";
 import { ODT_MCP_TOOL_NAMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { OpencodeSdkAdapter as BaseOpencodeSdkAdapter } from "./index";
 import { buildQueuedRequestSignature } from "./user-message-signatures";
@@ -18,38 +19,29 @@ export const defaultRepoRuntimeInput = {
   workingDirectory: "/repo",
 };
 
+const createDefaultRuntimeSummary = (repoPath: string, runtimeKind: RuntimeKind) => ({
+  kind: runtimeKind,
+  runtimeId: "runtime-opencode-1",
+  repoPath,
+  taskId: null,
+  role: "workspace" as const,
+  workingDirectory: defaultRuntimeConnection.workingDirectory,
+  runtimeRoute: {
+    type: "local_http" as const,
+    endpoint: defaultRuntimeConnection.endpoint,
+  },
+  startedAt: "2026-02-17T12:00:00Z",
+  descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+});
+
 export class OpencodeSdkAdapter extends BaseOpencodeSdkAdapter {
   constructor(options: ConstructorParameters<typeof BaseOpencodeSdkAdapter>[0] = {}) {
     super({
       repoRuntimeResolver: {
-        ensureRepoRuntime: async ({ repoPath, runtimeKind }) => ({
-          kind: runtimeKind,
-          runtimeId: "runtime-opencode-1",
-          repoPath,
-          taskId: null,
-          role: "workspace",
-          workingDirectory: defaultRuntimeConnection.workingDirectory,
-          runtimeRoute: {
-            type: "local_http",
-            endpoint: defaultRuntimeConnection.endpoint,
-          },
-          startedAt: "2026-02-17T12:00:00Z",
-          descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
-        }),
-        requireRepoRuntime: async ({ repoPath, runtimeKind }) => ({
-          kind: runtimeKind,
-          runtimeId: "runtime-opencode-1",
-          repoPath,
-          taskId: null,
-          role: "workspace",
-          workingDirectory: defaultRuntimeConnection.workingDirectory,
-          runtimeRoute: {
-            type: "local_http",
-            endpoint: defaultRuntimeConnection.endpoint,
-          },
-          startedAt: "2026-02-17T12:00:00Z",
-          descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
-        }),
+        ensureRepoRuntime: async ({ repoPath, runtimeKind }) =>
+          createDefaultRuntimeSummary(repoPath, runtimeKind),
+        requireRepoRuntime: async ({ repoPath, runtimeKind }) =>
+          createDefaultRuntimeSummary(repoPath, runtimeKind),
       },
       ...options,
     });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
@@ -823,7 +823,7 @@ describe("load-sessions-stages", () => {
     });
   });
 
-  test("keeps successful child pending input when another child hydration fails", async () => {
+  test("preserves failed child pending input when another child hydration succeeds", async () => {
     const stalePermission = {
       requestId: "stale-perm",
       requestType: "permission_grant" as const,
@@ -956,6 +956,7 @@ describe("load-sessions-stages", () => {
     expect(
       stateHarness.getState()["external-1"]?.subagentPendingApprovalsByExternalSessionId,
     ).toEqual({
+      "external-child-session": [stalePermission],
       "external-success-child-session": [livePermission],
     });
     expect(

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -203,19 +203,6 @@ type HydratedSubagentPendingInputOverlay = {
   hydrationError: SubagentPendingInputHydrationError | null;
 };
 
-type HydratedSubagentPendingInputResult =
-  | {
-      status: "success";
-      childExternalSessionId: string;
-      pendingApprovals: AgentSessionPresenceSnapshot["pendingApprovals"];
-      pendingQuestions: AgentSessionPresenceSnapshot["pendingQuestions"];
-    }
-  | {
-      status: "failure";
-      childExternalSessionId: string;
-      reason: string;
-    };
-
 class SubagentPendingInputHydrationError extends Error {
   constructor(message: string) {
     super(message);
@@ -268,25 +255,18 @@ const loadHydratedSubagentPendingInputOverlay = async ({
     return EMPTY_HYDRATED_SUBAGENT_PENDING_INPUT_OVERLAY;
   }
 
-  const results: HydratedSubagentPendingInputResult[] = await Promise.all(
+  const results = await Promise.allSettled(
     childExternalSessionIds.map(async (childExternalSessionId) => {
       try {
-        const snapshot = await readPlannerAgentSessionPresenceSnapshot(runtimePlanner, {
-          ...record,
-          externalSessionId: childExternalSessionId,
-        });
         return {
-          status: "success",
           childExternalSessionId,
-          pendingApprovals: snapshot.presence === "runtime" ? snapshot.pendingApprovals : [],
-          pendingQuestions: snapshot.presence === "runtime" ? snapshot.pendingQuestions : [],
+          snapshot: await readPlannerAgentSessionPresenceSnapshot(runtimePlanner, {
+            ...record,
+            externalSessionId: childExternalSessionId,
+          }),
         };
       } catch (error) {
-        return {
-          status: "failure",
-          childExternalSessionId,
-          reason: errorMessage(error),
-        };
+        throw new Error(`subagent session '${childExternalSessionId}': ${errorMessage(error)}`);
       }
     }),
   );
@@ -295,18 +275,17 @@ const loadHydratedSubagentPendingInputOverlay = async ({
   const scannedChildExternalSessionIds: string[] = [];
   const failures: string[] = [];
   for (const result of results) {
-    if (result.status === "failure") {
-      failures.push(`subagent session '${result.childExternalSessionId}': ${result.reason}`);
+    if (result.status === "rejected") {
+      failures.push(errorMessage(result.reason));
       continue;
     }
-    scannedChildExternalSessionIds.push(result.childExternalSessionId);
-    if (result.pendingApprovals.length > 0) {
-      pendingApprovalsByChildExternalSessionId[result.childExternalSessionId] =
-        result.pendingApprovals;
+    const { childExternalSessionId, snapshot } = result.value;
+    scannedChildExternalSessionIds.push(childExternalSessionId);
+    if (snapshot.presence === "runtime" && snapshot.pendingApprovals.length > 0) {
+      pendingApprovalsByChildExternalSessionId[childExternalSessionId] = snapshot.pendingApprovals;
     }
-    if (result.pendingQuestions.length > 0) {
-      pendingQuestionsByChildExternalSessionId[result.childExternalSessionId] =
-        result.pendingQuestions;
+    if (snapshot.presence === "runtime" && snapshot.pendingQuestions.length > 0) {
+      pendingQuestionsByChildExternalSessionId[childExternalSessionId] = snapshot.pendingQuestions;
     }
   }
   const hydrationError =

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -203,6 +203,19 @@ type HydratedSubagentPendingInputOverlay = {
   hydrationError: SubagentPendingInputHydrationError | null;
 };
 
+type HydratedSubagentPendingInputResult =
+  | {
+      status: "success";
+      childExternalSessionId: string;
+      pendingApprovals: AgentSessionPresenceSnapshot["pendingApprovals"];
+      pendingQuestions: AgentSessionPresenceSnapshot["pendingQuestions"];
+    }
+  | {
+      status: "failure";
+      childExternalSessionId: string;
+      reason: string;
+    };
+
 class SubagentPendingInputHydrationError extends Error {
   constructor(message: string) {
     super(message);
@@ -255,34 +268,47 @@ const loadHydratedSubagentPendingInputOverlay = async ({
     return EMPTY_HYDRATED_SUBAGENT_PENDING_INPUT_OVERLAY;
   }
 
-  const pendingApprovalsByChildExternalSessionId: SubagentPendingApprovalsByExternalSessionId = {};
-  const pendingQuestionsByChildExternalSessionId: SubagentPendingQuestionsByExternalSessionId = {};
-  const scannedChildExternalSessionIds: string[] = [];
-  const failures: string[] = [];
-  await Promise.all(
+  const results: HydratedSubagentPendingInputResult[] = await Promise.all(
     childExternalSessionIds.map(async (childExternalSessionId) => {
       try {
         const snapshot = await readPlannerAgentSessionPresenceSnapshot(runtimePlanner, {
           ...record,
           externalSessionId: childExternalSessionId,
         });
-        scannedChildExternalSessionIds.push(childExternalSessionId);
-        if (snapshot.presence === "runtime" && snapshot.pendingApprovals.length > 0) {
-          pendingApprovalsByChildExternalSessionId[childExternalSessionId] =
-            snapshot.pendingApprovals;
-        }
-        if (snapshot.presence === "runtime" && snapshot.pendingQuestions.length > 0) {
-          pendingQuestionsByChildExternalSessionId[childExternalSessionId] =
-            snapshot.pendingQuestions;
-        }
+        return {
+          status: "success",
+          childExternalSessionId,
+          pendingApprovals: snapshot.presence === "runtime" ? snapshot.pendingApprovals : [],
+          pendingQuestions: snapshot.presence === "runtime" ? snapshot.pendingQuestions : [],
+        };
       } catch (error) {
-        scannedChildExternalSessionIds.push(childExternalSessionId);
-        pendingApprovalsByChildExternalSessionId[childExternalSessionId] = [];
-        pendingQuestionsByChildExternalSessionId[childExternalSessionId] = [];
-        failures.push(`subagent session '${childExternalSessionId}': ${errorMessage(error)}`);
+        return {
+          status: "failure",
+          childExternalSessionId,
+          reason: errorMessage(error),
+        };
       }
     }),
   );
+  const pendingApprovalsByChildExternalSessionId: SubagentPendingApprovalsByExternalSessionId = {};
+  const pendingQuestionsByChildExternalSessionId: SubagentPendingQuestionsByExternalSessionId = {};
+  const scannedChildExternalSessionIds: string[] = [];
+  const failures: string[] = [];
+  for (const result of results) {
+    if (result.status === "failure") {
+      failures.push(`subagent session '${result.childExternalSessionId}': ${result.reason}`);
+      continue;
+    }
+    scannedChildExternalSessionIds.push(result.childExternalSessionId);
+    if (result.pendingApprovals.length > 0) {
+      pendingApprovalsByChildExternalSessionId[result.childExternalSessionId] =
+        result.pendingApprovals;
+    }
+    if (result.pendingQuestions.length > 0) {
+      pendingQuestionsByChildExternalSessionId[result.childExternalSessionId] =
+        result.pendingQuestions;
+    }
+  }
   const hydrationError =
     failures.length > 0
       ? new SubagentPendingInputHydrationError(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed child subagent session hydrations; failed sessions are now properly omitted from pending approval and question mappings, while successful child sessions continue to be processed normally.

* **Chores**
  * Refactored internal build artifact collection process to use parallel operations for improved performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->