### PR TITLE
fix(codex): support image attachments in Electron sessions

### DIFF
--- a/apps/electron/src/main/electron-host.test.ts
+++ b/apps/electron/src/main/electron-host.test.ts
@@ -753,11 +753,24 @@ describe("createElectronHostCommandRouter", () => {
 
   test("registers migrated Codex app-server host commands", async () => {
     const calls: unknown[] = [];
+    const modelListResponse = {
+      data: [
+        {
+          id: "gpt-5",
+          model: "gpt-5",
+          displayName: "GPT-5",
+          supportedReasoningEfforts: [{ reasoningEffort: "medium" }],
+          inputModalities: ["text", "image"],
+          isDefault: true,
+        },
+      ],
+      nextCursor: null,
+    };
     const codexAppServer: CodexAppServerPort = {
       request: (input) =>
         Effect.sync(() => {
           calls.push({ method: "request", input });
-          return { ok: true };
+          return modelListResponse;
         }),
       drainNotifications: (runtimeId) =>
         Effect.sync(() => {
@@ -788,7 +801,7 @@ describe("createElectronHostCommandRouter", () => {
         method: "model/list",
         params: { request: "catalog" },
       }),
-    ).resolves.toEqual({ ok: true });
+    ).resolves.toEqual(modelListResponse);
     await expect(
       router.invoke("codex_app_server_notifications", { runtimeId: "runtime-1" }),
     ).resolves.toEqual([{ method: "codex/app-server/ready" }]);

--- a/apps/electron/src/main/electron-local-attachment-preview.test.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createElectronLocalAttachmentPreviewUrl,
+  ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
+  readElectronLocalAttachmentPreviewRequestPath,
+  readLocalAttachmentPreviewPath,
+  registerElectronLocalAttachmentPreviewProtocol,
+} from "./electron-local-attachment-preview";
+
+describe("electron local attachment previews", () => {
+  test("creates an app protocol URL for staged attachment paths", () => {
+    const previewUrl = createElectronLocalAttachmentPreviewUrl(
+      "/tmp/openducktor-local-attachments/staged screenshot.png",
+    );
+
+    expect(previewUrl).toBe(
+      `${ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL}://preview/%2Ftmp%2Fopenducktor-local-attachments%2Fstaged%20screenshot.png`,
+    );
+    expect(readElectronLocalAttachmentPreviewRequestPath(previewUrl)).toBe(
+      "/tmp/openducktor-local-attachments/staged screenshot.png",
+    );
+  });
+
+  test("rejects missing or malformed preview paths", () => {
+    expect(() => readLocalAttachmentPreviewPath("  ")).toThrow(
+      "Local attachment preview path must be a non-empty string.",
+    );
+    expect(() => readLocalAttachmentPreviewPath(null)).toThrow(
+      "Local attachment preview path must be a non-empty string.",
+    );
+    expect(() =>
+      readElectronLocalAttachmentPreviewRequestPath(
+        "file:///tmp/openducktor-local-attachments/a.png",
+      ),
+    ).toThrow("Invalid local attachment preview URL.");
+    expect(() =>
+      readElectronLocalAttachmentPreviewRequestPath(
+        `${ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL}://preview/%`,
+      ),
+    ).toThrow("Invalid local attachment preview URL.");
+  });
+
+  test("resolves the protocol request through the host before serving the file", async () => {
+    let protocolHandler: ((request: Request) => Response | Promise<Response>) | null = null;
+    const resolvedPaths: string[] = [];
+    const servedUrls: string[] = [];
+
+    registerElectronLocalAttachmentPreviewProtocol({
+      session: {
+        protocol: {
+          handle(scheme, handler) {
+            expect(scheme).toBe(ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL);
+            protocolHandler = handler;
+          },
+        },
+      },
+      net: {
+        async fetch(url) {
+          servedUrls.push(url);
+          return new Response("image bytes", { status: 200 });
+        },
+      },
+      async resolveLocalAttachmentPath(filePath) {
+        resolvedPaths.push(filePath);
+        return "/tmp/openducktor-local-attachments/resolved.png";
+      },
+    });
+
+    if (!protocolHandler) {
+      throw new Error("Preview protocol handler was not registered.");
+    }
+
+    const response = await protocolHandler(
+      new Request(
+        createElectronLocalAttachmentPreviewUrl("/tmp/openducktor-local-attachments/staged.png"),
+      ),
+    );
+
+    expect(resolvedPaths).toEqual(["/tmp/openducktor-local-attachments/staged.png"]);
+    expect(servedUrls).toEqual(["file:///tmp/openducktor-local-attachments/resolved.png"]);
+    expect(await response.text()).toBe("image bytes");
+  });
+});

--- a/apps/electron/src/main/electron-local-attachment-preview.test.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.test.ts
@@ -80,4 +80,105 @@ describe("electron local attachment previews", () => {
     expect(servedUrls).toEqual(["file:///tmp/openducktor-local-attachments/resolved.png"]);
     expect(await response.text()).toBe("image bytes");
   });
+
+  test("returns structured error responses for invalid preview requests", async () => {
+    let protocolHandler: ((request: Request) => Response | Promise<Response>) | null = null;
+
+    registerElectronLocalAttachmentPreviewProtocol({
+      session: {
+        protocol: {
+          handle(_scheme, handler) {
+            protocolHandler = handler;
+          },
+        },
+      },
+      net: {
+        async fetch() {
+          throw new Error("Fetch should not run for invalid requests.");
+        },
+      },
+      async resolveLocalAttachmentPath() {
+        throw new Error("Resolve should not run for invalid requests.");
+      },
+    });
+
+    if (!protocolHandler) {
+      throw new Error("Preview protocol handler was not registered.");
+    }
+
+    const response = await protocolHandler(new Request("file:///tmp/not-a-preview.png"));
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Invalid local attachment preview URL.");
+  });
+
+  test("returns structured error responses for rejected host resolution", async () => {
+    let protocolHandler: ((request: Request) => Response | Promise<Response>) | null = null;
+
+    registerElectronLocalAttachmentPreviewProtocol({
+      session: {
+        protocol: {
+          handle(_scheme, handler) {
+            protocolHandler = handler;
+          },
+        },
+      },
+      net: {
+        async fetch() {
+          throw new Error("Fetch should not run when resolution fails.");
+        },
+      },
+      async resolveLocalAttachmentPath() {
+        throw new Error("Attachment path is not a staged local attachment.");
+      },
+    });
+
+    if (!protocolHandler) {
+      throw new Error("Preview protocol handler was not registered.");
+    }
+
+    const response = await protocolHandler(
+      new Request(
+        createElectronLocalAttachmentPreviewUrl("/tmp/openducktor-local-attachments/outside.png"),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Attachment path is not a staged local attachment.");
+  });
+
+  test("returns structured error responses for preview file serving failures", async () => {
+    let protocolHandler: ((request: Request) => Response | Promise<Response>) | null = null;
+
+    registerElectronLocalAttachmentPreviewProtocol({
+      session: {
+        protocol: {
+          handle(_scheme, handler) {
+            protocolHandler = handler;
+          },
+        },
+      },
+      net: {
+        async fetch() {
+          throw new Error("Failed to load preview bytes.");
+        },
+      },
+      async resolveLocalAttachmentPath() {
+        return "/tmp/openducktor-local-attachments/resolved.png";
+      },
+    });
+
+    if (!protocolHandler) {
+      throw new Error("Preview protocol handler was not registered.");
+    }
+
+    const response = await protocolHandler(
+      new Request(
+        createElectronLocalAttachmentPreviewUrl("/tmp/openducktor-local-attachments/staged.png"),
+      ),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.text()).toBe("Failed to load preview bytes.");
+  });
 });

--- a/apps/electron/src/main/electron-local-attachment-preview.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.ts
@@ -67,17 +67,37 @@ export const readElectronLocalAttachmentPreviewRequestPath = (requestUrl: string
   }
 };
 
+const createLocalAttachmentPreviewErrorResponse = (error: unknown, status: 400 | 500): Response =>
+  new Response(error instanceof Error ? error.message : "Local attachment preview failed.", {
+    status,
+  });
+
 export const registerElectronLocalAttachmentPreviewProtocol = ({
   net,
   resolveLocalAttachmentPath,
   session,
 }: RegisterElectronLocalAttachmentPreviewProtocolInput): void => {
   session.protocol.handle(ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL, async (request) => {
-    const requestedPath = readElectronLocalAttachmentPreviewRequestPath(request.url);
-    const resolvedPath = readLocalAttachmentPreviewPath(
-      await resolveLocalAttachmentPath(requestedPath),
-    );
+    let requestedPath: string;
+    try {
+      requestedPath = readElectronLocalAttachmentPreviewRequestPath(request.url);
+    } catch (error) {
+      return createLocalAttachmentPreviewErrorResponse(error, 400);
+    }
 
-    return net.fetch(pathToFileURL(resolvedPath).href);
+    let resolvedPath: string;
+    try {
+      resolvedPath = readLocalAttachmentPreviewPath(
+        await resolveLocalAttachmentPath(requestedPath),
+      );
+    } catch (error) {
+      return createLocalAttachmentPreviewErrorResponse(error, 400);
+    }
+
+    try {
+      return await net.fetch(pathToFileURL(resolvedPath).href);
+    } catch (error) {
+      return createLocalAttachmentPreviewErrorResponse(error, 500);
+    }
   });
 };

--- a/apps/electron/src/main/electron-local-attachment-preview.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.ts
@@ -1,0 +1,83 @@
+import { pathToFileURL } from "node:url";
+
+export const ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL = "openducktor-local-attachment";
+
+const ELECTRON_LOCAL_ATTACHMENT_PREVIEW_HOST = "preview";
+
+type ElectronPreviewProtocol = {
+  handle(scheme: string, handler: (request: Request) => Response | Promise<Response>): void;
+};
+
+type ElectronPreviewSession = {
+  protocol: ElectronPreviewProtocol;
+};
+
+type ElectronPreviewNet = {
+  fetch(url: string): Promise<Response>;
+};
+
+type RegisterElectronLocalAttachmentPreviewProtocolInput = {
+  net: ElectronPreviewNet;
+  resolveLocalAttachmentPath: (filePath: string) => Promise<string>;
+  session: ElectronPreviewSession;
+};
+
+export const readLocalAttachmentPreviewPath = (filePath: unknown): string => {
+  if (typeof filePath !== "string" || filePath.trim().length === 0) {
+    throw new Error("Local attachment preview path must be a non-empty string.");
+  }
+
+  return filePath.trim();
+};
+
+export const createElectronLocalAttachmentPreviewUrl = (filePath: string): string => {
+  const previewPath = readLocalAttachmentPreviewPath(filePath);
+  return `${ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL}://${ELECTRON_LOCAL_ATTACHMENT_PREVIEW_HOST}/${encodeURIComponent(previewPath)}`;
+};
+
+export const readElectronLocalAttachmentPreviewRequestPath = (requestUrl: string): string => {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(requestUrl);
+  } catch {
+    throw new Error("Invalid local attachment preview URL.");
+  }
+
+  if (
+    parsedUrl.protocol !== `${ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL}:` ||
+    parsedUrl.hostname !== ELECTRON_LOCAL_ATTACHMENT_PREVIEW_HOST
+  ) {
+    throw new Error("Invalid local attachment preview URL.");
+  }
+
+  const encodedPath = parsedUrl.pathname.startsWith("/")
+    ? parsedUrl.pathname.slice(1)
+    : parsedUrl.pathname;
+  if (encodedPath.length === 0) {
+    throw new Error("Local attachment preview path must be a non-empty string.");
+  }
+
+  try {
+    return readLocalAttachmentPreviewPath(decodeURIComponent(encodedPath));
+  } catch (error) {
+    if (error instanceof URIError) {
+      throw new Error("Invalid local attachment preview URL.");
+    }
+    throw error;
+  }
+};
+
+export const registerElectronLocalAttachmentPreviewProtocol = ({
+  net,
+  resolveLocalAttachmentPath,
+  session,
+}: RegisterElectronLocalAttachmentPreviewProtocolInput): void => {
+  session.protocol.handle(ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL, async (request) => {
+    const requestedPath = readElectronLocalAttachmentPreviewRequestPath(request.url);
+    const resolvedPath = readLocalAttachmentPreviewPath(
+      await resolveLocalAttachmentPath(requestedPath),
+    );
+
+    return net.fetch(pathToFileURL(resolvedPath).href);
+  });
+};

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { createHostEventBus, HOST_EVENT_CHANNELS } from "@openducktor/host";
 import type { BrowserWindow as ElectronBrowserWindow } from "electron";
 import electron from "electron";
@@ -13,6 +13,12 @@ import {
 } from "../shared/electron-bridge-contract";
 import { createElectronHostCommandRouter } from "./electron-host";
 import {
+  createElectronLocalAttachmentPreviewUrl,
+  ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
+  readLocalAttachmentPreviewPath,
+  registerElectronLocalAttachmentPreviewProtocol,
+} from "./electron-local-attachment-preview";
+import {
   configureElectronLoopbackCorsPolicy,
   resolveElectronLoopbackCorsOrigin,
 } from "./electron-loopback-cors-policy";
@@ -21,7 +27,7 @@ import { configureElectronProcessEnvironment } from "./electron-process-environm
 import { disableElectronKeychainStorage } from "./electron-storage-policy";
 import { installApplicationMenu, registerWindowContextMenu } from "./main-menu";
 
-const { app, BrowserWindow, ipcMain, session, shell } = electron;
+const { app, BrowserWindow, ipcMain, net, protocol, session, shell } = electron;
 const APPLICATION_NAME = "OpenDucktor";
 const ELECTRON_RENDERER_START_PATH = "/kanban";
 const rendererDevUrl = process.env.VITE_DEV_SERVER_URL;
@@ -46,6 +52,17 @@ let hostShutdownStarted = false;
 let hostShutdownComplete = false;
 
 app.setName(APPLICATION_NAME);
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
+    privileges: {
+      secure: true,
+      standard: true,
+      stream: true,
+      supportFetchAPI: true,
+    },
+  },
+]);
 
 const getPreloadPath = (): string => path.join(distDirectory, "preload.cjs");
 
@@ -111,6 +128,17 @@ const registerHostEventForwarding = (): void => {
   }
 };
 
+const resolveLocalAttachmentPathForPreview = async (filePath: string): Promise<string> => {
+  const resolved = await hostCommandRouter.invoke("workspace_resolve_local_attachment_path", {
+    path: filePath,
+  });
+  if (typeof resolved !== "object" || resolved === null || !("path" in resolved)) {
+    throw new Error("Local attachment preview resolver returned an invalid response.");
+  }
+
+  return readLocalAttachmentPreviewPath(resolved.path);
+};
+
 const registerIpcHandlers = (): void => {
   ipcMain.handle(ELECTRON_HOST_INVOKE_CHANNEL, async (_event, request: ElectronHostInvokeRequest) =>
     hostCommandRouter.invoke(request.command, request.args),
@@ -120,12 +148,11 @@ const registerIpcHandlers = (): void => {
     await shell.openExternal(validateExternalUrl(url));
   });
 
-  ipcMain.handle(ELECTRON_LOCAL_ATTACHMENT_PREVIEW_CHANNEL, (_event, filePath: string) => {
-    if (typeof filePath !== "string" || filePath.trim().length === 0) {
-      throw new Error("Local attachment preview path must be a non-empty string.");
-    }
-
-    return pathToFileURL(filePath).href;
+  ipcMain.handle(ELECTRON_LOCAL_ATTACHMENT_PREVIEW_CHANNEL, async (_event, filePath: unknown) => {
+    const resolvedPath = await resolveLocalAttachmentPathForPreview(
+      readLocalAttachmentPreviewPath(filePath),
+    );
+    return createElectronLocalAttachmentPreviewUrl(resolvedPath);
   });
 };
 
@@ -178,6 +205,11 @@ app
       session.defaultSession,
       resolveElectronLoopbackCorsOrigin(rendererDevUrl),
     );
+    registerElectronLocalAttachmentPreviewProtocol({
+      net,
+      resolveLocalAttachmentPath: resolveLocalAttachmentPathForPreview,
+      session: session.defaultSession,
+    });
     installApplicationMenu({ isDevelopment, appName: app.name || APPLICATION_NAME });
     registerIpcHandlers();
     registerHostEventForwarding();

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -875,6 +875,61 @@ describe("CodexAppServerAdapter streaming", () => {
     unsubscribe();
   });
 
+  test("emits sent image attachments with staged paths", async () => {
+    const subscribeEvents = mock(() => () => {});
+    const { adapter } = createHarness({ subscribeEvents });
+
+    await adapter.startSession({
+      repoPath: "/repo",
+      runtimeKind: "codex",
+      workingDirectory: "/repo",
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "Use the repo rules.",
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    const events: unknown[] = [];
+    const unsubscribe = adapter.subscribeEvents("thread/start-runtime-ensure", (event) =>
+      events.push(event),
+    );
+
+    await adapter.sendUserMessage({
+      externalSessionId: "thread/start-runtime-ensure",
+      parts: [
+        { kind: "text", text: "Inspect this screenshot" },
+        {
+          kind: "attachment",
+          attachment: {
+            id: "attachment-1",
+            kind: "image",
+            name: "Screenshot 2026-05-20 at 21.01.45.png",
+            path: "/tmp/openducktor-local-attachments/staged-screenshot.png",
+            mime: "image/png",
+          },
+        },
+      ],
+      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "user_message",
+        parts: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "attachment",
+            attachment: expect.objectContaining({
+              kind: "image",
+              name: "Screenshot 2026-05-20 at 21.01.45.png",
+              path: "/tmp/openducktor-local-attachments/staged-screenshot.png",
+            }),
+          }),
+        ]),
+      }),
+    );
+    unsubscribe();
+  });
+
   test("replays streamed events that arrive before UI subscription", async () => {
     const streamListeners: Array<
       (event: { runtimeId: string; kind: "notification"; message: unknown }) => void

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -282,7 +282,9 @@ const emitCompletedItem = (
       timestamp,
       messageId: itemId,
       message,
-      parts: input.map(codexUserInputToDisplayPart),
+      parts: input.map((part, index) =>
+        codexUserInputToDisplayPart(part, { index, messageId: itemId }),
+      ),
       state: "read",
       ...(model ? { model } : {}),
     });

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -24,7 +24,7 @@ import {
   codexItemTypeMatches,
   codexUserInputListToText,
   codexUserInputsFromItem,
-  codexUserInputToDisplayPart,
+  codexUserInputsToDisplayParts,
   extractCodexTokenUsageTotals,
   shouldReplaceCodexBufferedFinalAgentMessage,
   timestampFromCodexParams,
@@ -282,9 +282,7 @@ const emitCompletedItem = (
       timestamp,
       messageId: itemId,
       message,
-      parts: input.map((part, index) =>
-        codexUserInputToDisplayPart(part, { index, messageId: itemId }),
-      ),
+      parts: codexUserInputsToDisplayParts(input, itemId),
       state: "read",
       ...(model ? { model } : {}),
     });

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { codexTurnItemsFromThreadRead } from "./codex-app-server-transcript";
+import { codexTurnItemsFromThreadRead, toCodexUserInput } from "./codex-app-server-transcript";
 
 describe("Codex App Server transcript parsing", () => {
   test("preserves turn model and reasoning effort from thread reads", () => {
@@ -59,5 +59,22 @@ describe("Codex App Server transcript parsing", () => {
 
     expect(items).toHaveLength(1);
     expect(items[0]?.model).toBeUndefined();
+  });
+
+  test("rejects non-image attachments because Codex app-server has no document input shape", () => {
+    expect(() =>
+      toCodexUserInput({
+        kind: "attachment",
+        attachment: {
+          id: "attachment-1",
+          path: "/tmp/brief.pdf",
+          name: "brief.pdf",
+          kind: "pdf",
+          mime: "application/pdf",
+        },
+      }),
+    ).toThrow(
+      "Codex app-server does not support pdf attachments. Codex user input supports text, file references, and images only.",
+    );
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -84,6 +84,10 @@ describe("Codex App Server transcript parsing", () => {
                     type: "localImage",
                     path: "/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
                   },
+                  {
+                    type: "localImage",
+                    path: "/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+                  },
                 ],
               },
             ],
@@ -96,13 +100,22 @@ describe("Codex App Server transcript parsing", () => {
 
     expect(message).toMatchObject({
       role: "user",
-      text: "Inspect this screenshot /tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+      text: "Inspect this screenshot /tmp/openducktor-local-attachments/Screenshot 2026-05-20.png /tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
       displayParts: [
         { kind: "text", text: "Inspect this screenshot" },
         {
           kind: "attachment",
           attachment: {
-            id: "codex-local-image:/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+            id: "codex-local-image:user-1:1",
+            kind: "image",
+            name: "Screenshot 2026-05-20.png",
+            path: "/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+          },
+        },
+        {
+          kind: "attachment",
+          attachment: {
+            id: "codex-local-image:user-1:2",
             kind: "image",
             name: "Screenshot 2026-05-20.png",
             path: "/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -82,7 +82,7 @@ describe("Codex App Server transcript parsing", () => {
                   },
                   {
                     type: "localImage",
-                    path: "/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+                    path: "/tmp/openducktor-local-attachments/550e8400-e29b-41d4-a716-446655440000-Screenshot 2026-05-20.png",
                   },
                   {
                     type: "localImage",
@@ -100,7 +100,7 @@ describe("Codex App Server transcript parsing", () => {
 
     expect(message).toMatchObject({
       role: "user",
-      text: "Inspect this screenshot /tmp/openducktor-local-attachments/Screenshot 2026-05-20.png /tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+      text: "Inspect this screenshot /tmp/openducktor-local-attachments/550e8400-e29b-41d4-a716-446655440000-Screenshot 2026-05-20.png /tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
       displayParts: [
         { kind: "text", text: "Inspect this screenshot" },
         {
@@ -109,7 +109,7 @@ describe("Codex App Server transcript parsing", () => {
             id: "codex-local-image:user-1:1",
             kind: "image",
             name: "Screenshot 2026-05-20.png",
-            path: "/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+            path: "/tmp/openducktor-local-attachments/550e8400-e29b-41d4-a716-446655440000-Screenshot 2026-05-20.png",
           },
         },
         {

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { codexTurnItemsFromThreadRead } from "./codex-app-server-transcript";
+import { codexTurnItemsFromThreadRead, toHistoryMessage } from "./codex-app-server-transcript";
 
 describe("Codex App Server transcript parsing", () => {
   test("preserves turn model and reasoning effort from thread reads", () => {
@@ -59,5 +59,56 @@ describe("Codex App Server transcript parsing", () => {
 
     expect(items).toHaveLength(1);
     expect(items[0]?.model).toBeUndefined();
+  });
+
+  test("hydrates local images as attachment display parts", () => {
+    const items = codexTurnItemsFromThreadRead({
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            startedAt: 1_778_112_001,
+            completedAt: 1_778_112_031,
+            items: [
+              {
+                id: "user-1",
+                type: "userMessage",
+                content: [
+                  {
+                    type: "text",
+                    text: "Inspect this screenshot",
+                    text_elements: [],
+                  },
+                  {
+                    type: "localImage",
+                    path: "/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const message = toHistoryMessage(items[0]?.item, "fallback-id");
+
+    expect(message).toMatchObject({
+      role: "user",
+      text: "Inspect this screenshot /tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+      displayParts: [
+        { kind: "text", text: "Inspect this screenshot" },
+        {
+          kind: "attachment",
+          attachment: {
+            id: "codex-local-image:/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+            kind: "image",
+            name: "Screenshot 2026-05-20.png",
+            path: "/tmp/openducktor-local-attachments/Screenshot 2026-05-20.png",
+          },
+        },
+      ],
+    });
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { codexTurnItemsFromThreadRead, toCodexUserInput } from "./codex-app-server-transcript";
+import { codexTurnItemsFromThreadRead } from "./codex-app-server-transcript";
 
 describe("Codex App Server transcript parsing", () => {
   test("preserves turn model and reasoning effort from thread reads", () => {
@@ -59,22 +59,5 @@ describe("Codex App Server transcript parsing", () => {
 
     expect(items).toHaveLength(1);
     expect(items[0]?.model).toBeUndefined();
-  });
-
-  test("rejects non-image attachments because Codex app-server has no document input shape", () => {
-    expect(() =>
-      toCodexUserInput({
-        kind: "attachment",
-        attachment: {
-          id: "attachment-1",
-          path: "/tmp/brief.pdf",
-          name: "brief.pdf",
-          kind: "pdf",
-          mime: "application/pdf",
-        },
-      }),
-    ).toThrow(
-      "Codex app-server does not support pdf attachments. Codex user input supports text, file references, and images only.",
-    );
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -917,8 +917,15 @@ type CodexUserInputDisplayContext = {
   messageId: string;
 };
 
+const stagedAttachmentUuidPrefixPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-/i;
+
 const codexLocalImageNameFromPath = (path: string): string => {
-  return path.replaceAll("\\", "/").split("/").filter(Boolean).at(-1) ?? path;
+  const fileName = path.replaceAll("\\", "/").split("/").filter(Boolean).at(-1) ?? path;
+  if (fileName.length <= 37 || !stagedAttachmentUuidPrefixPattern.test(fileName)) {
+    return fileName;
+  }
+  return fileName.slice(37);
 };
 
 const codexUserInputToDisplayPart = (

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -304,7 +304,9 @@ export const toHistoryMessage = (
       timestamp: messageTimestamp,
       text,
       displayParts:
-        input.length > 0 ? input.map(codexUserInputToDisplayPart) : [{ kind: "text", text }],
+        input.length > 0
+          ? input.map((part, index) => codexUserInputToDisplayPart(part, { index, messageId }))
+          : [{ kind: "text", text }],
       state: "read",
       parts: toHistoryParts(item, messageId, text),
       ...(model ? { model } : {}),
@@ -910,11 +912,19 @@ export const userInputText = (input: CodexUserInput): string => {
   return input.path;
 };
 
+type CodexUserInputDisplayContext = {
+  index: number;
+  messageId: string;
+};
+
 const codexLocalImageNameFromPath = (path: string): string => {
   return path.replaceAll("\\", "/").split("/").filter(Boolean).at(-1) ?? path;
 };
 
-export const codexUserInputToDisplayPart = (input: CodexUserInput): AgentUserMessageDisplayPart => {
+export const codexUserInputToDisplayPart = (
+  input: CodexUserInput,
+  context: CodexUserInputDisplayContext,
+): AgentUserMessageDisplayPart => {
   if (input.type === "text") {
     return { kind: "text", text: input.text };
   }
@@ -922,7 +932,7 @@ export const codexUserInputToDisplayPart = (input: CodexUserInput): AgentUserMes
     return {
       kind: "attachment",
       attachment: {
-        id: `codex-local-image:${input.path}`,
+        id: `codex-local-image:${context.messageId}:${context.index}`,
         kind: "image",
         name: codexLocalImageNameFromPath(input.path),
         path: input.path,

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -873,6 +873,11 @@ export const toCodexUserInput = (part: AgentUserMessagePart): CodexUserInput => 
   if (part.kind === "attachment" && part.attachment.kind === "image") {
     return { type: "localImage", path: part.attachment.path };
   }
+  if (part.kind === "attachment") {
+    throw new Error(
+      `Codex app-server does not support ${part.attachment.kind} attachments. Codex user input supports text, file references, and images only.`,
+    );
+  }
 
   throw new Error(`Codex app-server does not support '${part.kind}' user message parts.`);
 };

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -873,11 +873,6 @@ export const toCodexUserInput = (part: AgentUserMessagePart): CodexUserInput => 
   if (part.kind === "attachment" && part.attachment.kind === "image") {
     return { type: "localImage", path: part.attachment.path };
   }
-  if (part.kind === "attachment") {
-    throw new Error(
-      `Codex app-server does not support ${part.attachment.kind} attachments. Codex user input supports text, file references, and images only.`,
-    );
-  }
 
   throw new Error(`Codex app-server does not support '${part.kind}' user message parts.`);
 };

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -910,9 +910,24 @@ export const userInputText = (input: CodexUserInput): string => {
   return input.path;
 };
 
+const codexLocalImageNameFromPath = (path: string): string => {
+  return path.replaceAll("\\", "/").split("/").filter(Boolean).at(-1) ?? path;
+};
+
 export const codexUserInputToDisplayPart = (input: CodexUserInput): AgentUserMessageDisplayPart => {
   if (input.type === "text") {
     return { kind: "text", text: input.text };
+  }
+  if (input.type === "localImage") {
+    return {
+      kind: "attachment",
+      attachment: {
+        id: `codex-local-image:${input.path}`,
+        kind: "image",
+        name: codexLocalImageNameFromPath(input.path),
+        path: input.path,
+      },
+    };
   }
   return { kind: "text", text: userInputText(input), synthetic: true };
 };

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -305,7 +305,7 @@ export const toHistoryMessage = (
       text,
       displayParts:
         input.length > 0
-          ? input.map((part, index) => codexUserInputToDisplayPart(part, { index, messageId }))
+          ? codexUserInputsToDisplayParts(input, messageId)
           : [{ kind: "text", text }],
       state: "read",
       parts: toHistoryParts(item, messageId, text),
@@ -921,7 +921,7 @@ const codexLocalImageNameFromPath = (path: string): string => {
   return path.replaceAll("\\", "/").split("/").filter(Boolean).at(-1) ?? path;
 };
 
-export const codexUserInputToDisplayPart = (
+const codexUserInputToDisplayPart = (
   input: CodexUserInput,
   context: CodexUserInputDisplayContext,
 ): AgentUserMessageDisplayPart => {
@@ -941,6 +941,12 @@ export const codexUserInputToDisplayPart = (
   }
   return { kind: "text", text: userInputText(input), synthetic: true };
 };
+
+export const codexUserInputsToDisplayParts = (
+  input: CodexUserInput[],
+  messageId: string,
+): AgentUserMessageDisplayPart[] =>
+  input.map((part, index) => codexUserInputToDisplayPart(part, { index, messageId }));
 
 export const codexUserInputListToText = (input: CodexUserInput[]): string => {
   return input.map(userInputText).join(" ").trim();

--- a/packages/adapters-codex-app-server/src/event-mappers/messages.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/messages.ts
@@ -38,6 +38,7 @@ export const userMessageMapper: CodexEventMapper = {
     if (message.trim().length === 0) {
       return emptyCodexMappingResult();
     }
+    const messageId = codexItemId(input.item, `${ctx.threadId}-user-${input.index}`);
     return {
       handled: true,
       events: [
@@ -50,11 +51,11 @@ export const userMessageMapper: CodexEventMapper = {
             ? { timestamp: ctx.timestamp ?? input.timestamp }
             : {}),
           raw: input.item,
-          messageId: codexItemId(input.item, `${ctx.threadId}-user-${input.index}`),
+          messageId,
           message,
           displayParts:
             parts.length > 0
-              ? parts.map(codexUserInputToDisplayPart)
+              ? parts.map((part, index) => codexUserInputToDisplayPart(part, { index, messageId }))
               : [{ kind: "text", text: message }],
           state: "read",
         },

--- a/packages/adapters-codex-app-server/src/event-mappers/messages.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/messages.ts
@@ -8,7 +8,7 @@ import {
   codexItemTypeMatches,
   codexUserInputListToText,
   codexUserInputsFromItem,
-  codexUserInputToDisplayPart,
+  codexUserInputsToDisplayParts,
   terminalHistoryPart,
 } from "../codex-app-server-transcript";
 import type { CodexMappingResult } from "../codex-canonical-events";
@@ -55,7 +55,7 @@ export const userMessageMapper: CodexEventMapper = {
           message,
           displayParts:
             parts.length > 0
-              ? parts.map((part, index) => codexUserInputToDisplayPart(part, { index, messageId }))
+              ? codexUserInputsToDisplayParts(parts, messageId)
               : [{ kind: "text", text: message }],
           state: "read",
         },

--- a/packages/adapters-codex-app-server/src/model-catalog.test.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { toCatalog } from "./model-catalog";
-import type { CodexInputModality, CodexModelListResponse } from "./types";
+import type { CodexModelListResponse } from "./types";
 
-const createModelListResponse = (
-  inputModalities: CodexInputModality[],
-): CodexModelListResponse => ({
+const createModelListResponse = (inputModalities: string[]): CodexModelListResponse => ({
   data: [
     {
       id: "gpt-5",

--- a/packages/adapters-codex-app-server/src/model-catalog.test.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { toCatalog } from "./model-catalog";
-import type { CodexModelListResponse } from "./types";
+import type { CodexInputModality, CodexModelListResponse } from "./types";
 
-const createModelListResponse = (inputModalities: string[]): CodexModelListResponse => ({
+const createModelListResponse = (
+  inputModalities: CodexInputModality[],
+): CodexModelListResponse => ({
   data: [
     {
       id: "gpt-5",

--- a/packages/adapters-codex-app-server/src/model-catalog.test.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { toCatalog } from "./model-catalog";
 import type { CodexModelListResponse } from "./types";
 
-const createModelListResponse = (inputModalities?: string[]): CodexModelListResponse => ({
+const createModelListResponse = (inputModalities: string[]): CodexModelListResponse => ({
   data: [
     {
       id: "gpt-5",
@@ -12,7 +12,7 @@ const createModelListResponse = (inputModalities?: string[]): CodexModelListResp
       hidden: false,
       supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Balanced" }],
       defaultReasoningEffort: "medium",
-      ...(inputModalities ? { inputModalities } : {}),
+      inputModalities,
       supportsPersonality: true,
       isDefault: true,
     },
@@ -37,17 +37,6 @@ describe("Codex model catalog mapping", () => {
 
     expect(catalog.models[0]?.attachmentSupport).toEqual({
       image: false,
-      audio: false,
-      video: false,
-      pdf: false,
-    });
-  });
-
-  test("uses Codex protocol default modalities for legacy model records", () => {
-    const catalog = toCatalog(createModelListResponse());
-
-    expect(catalog.models[0]?.attachmentSupport).toEqual({
-      image: true,
       audio: false,
       video: false,
       pdf: false,

--- a/packages/adapters-codex-app-server/src/model-catalog.test.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { toCatalog } from "./model-catalog";
+import type { CodexModelListResponse } from "./types";
+
+const createModelListResponse = (inputModalities?: string[]): CodexModelListResponse => ({
+  data: [
+    {
+      id: "gpt-5",
+      model: "gpt-5",
+      displayName: "GPT-5",
+      description: "GPT-5 model",
+      hidden: false,
+      supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Balanced" }],
+      defaultReasoningEffort: "medium",
+      ...(inputModalities ? { inputModalities } : {}),
+      supportsPersonality: true,
+      isDefault: true,
+    },
+  ],
+  nextCursor: null,
+});
+
+describe("Codex model catalog mapping", () => {
+  test("maps Codex image input modality to image attachment support", () => {
+    const catalog = toCatalog(createModelListResponse(["text", "image"]));
+
+    expect(catalog.models[0]?.attachmentSupport).toEqual({
+      image: true,
+      audio: false,
+      video: false,
+      pdf: false,
+    });
+  });
+
+  test("does not advertise image attachment support for text-only Codex models", () => {
+    const catalog = toCatalog(createModelListResponse(["text"]));
+
+    expect(catalog.models[0]?.attachmentSupport).toEqual({
+      image: false,
+      audio: false,
+      video: false,
+      pdf: false,
+    });
+  });
+
+  test("uses Codex protocol default modalities for legacy model records", () => {
+    const catalog = toCatalog(createModelListResponse());
+
+    expect(catalog.models[0]?.attachmentSupport).toEqual({
+      image: true,
+      audio: false,
+      video: false,
+      pdf: false,
+    });
+  });
+});

--- a/packages/adapters-codex-app-server/src/model-catalog.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.ts
@@ -47,10 +47,8 @@ export const toTransportModelSelection = (model: AgentModelSelection) => ({
 });
 
 const toAttachmentSupport = (inputModalities: string[]): AgentModelAttachmentSupport => {
-  const modalities = new Set(inputModalities);
-
   return {
-    image: modalities.has("image"),
+    image: inputModalities.includes("image"),
     audio: false,
     video: false,
     pdf: false,

--- a/packages/adapters-codex-app-server/src/model-catalog.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.ts
@@ -1,7 +1,13 @@
 import { CODEX_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
-import type { AgentModelCatalog, AgentModelSelection } from "@openducktor/core";
+import type {
+  AgentModelAttachmentSupport,
+  AgentModelCatalog,
+  AgentModelSelection,
+} from "@openducktor/core";
 import { CODEX_MODEL_CATALOG_TTL_MS } from "./codex-app-server-shared";
 import type { CodexAppServerClient, CodexModelListResponse } from "./types";
+
+const DEFAULT_CODEX_INPUT_MODALITIES = ["text", "image"] as const;
 
 export const requireModelSelection = (
   model: AgentModelSelection | undefined,
@@ -42,6 +48,17 @@ export const toTransportModelSelection = (model: AgentModelSelection) => ({
   effort: model.variant as string,
 });
 
+const toAttachmentSupport = (inputModalities?: string[]): AgentModelAttachmentSupport => {
+  const modalities = new Set(inputModalities ?? DEFAULT_CODEX_INPUT_MODALITIES);
+
+  return {
+    image: modalities.has("image"),
+    audio: false,
+    video: false,
+    pdf: false,
+  };
+};
+
 export const toCatalog = (response: CodexModelListResponse): AgentModelCatalog => ({
   runtime: CODEX_RUNTIME_DESCRIPTOR,
   models: response.data.map((model) => ({
@@ -51,6 +68,7 @@ export const toCatalog = (response: CodexModelListResponse): AgentModelCatalog =
     modelId: model.model,
     modelName: model.displayName,
     variants: model.supportedReasoningEfforts.map((effort) => effort.reasoningEffort),
+    attachmentSupport: toAttachmentSupport(model.inputModalities),
   })),
   defaultModelsByProvider: response.data.some((model) => model.isDefault)
     ? {

--- a/packages/adapters-codex-app-server/src/model-catalog.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.ts
@@ -5,7 +5,7 @@ import type {
   AgentModelSelection,
 } from "@openducktor/core";
 import { CODEX_MODEL_CATALOG_TTL_MS } from "./codex-app-server-shared";
-import type { CodexAppServerClient, CodexInputModality, CodexModelListResponse } from "./types";
+import type { CodexAppServerClient, CodexModelListResponse } from "./types";
 
 export const requireModelSelection = (
   model: AgentModelSelection | undefined,
@@ -46,9 +46,7 @@ export const toTransportModelSelection = (model: AgentModelSelection) => ({
   effort: model.variant as string,
 });
 
-const toAttachmentSupport = (
-  inputModalities: CodexInputModality[],
-): AgentModelAttachmentSupport => {
+const toAttachmentSupport = (inputModalities: string[]): AgentModelAttachmentSupport => {
   const modalities = new Set(inputModalities);
 
   return {

--- a/packages/adapters-codex-app-server/src/model-catalog.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.ts
@@ -5,7 +5,7 @@ import type {
   AgentModelSelection,
 } from "@openducktor/core";
 import { CODEX_MODEL_CATALOG_TTL_MS } from "./codex-app-server-shared";
-import type { CodexAppServerClient, CodexModelListResponse } from "./types";
+import type { CodexAppServerClient, CodexInputModality, CodexModelListResponse } from "./types";
 
 export const requireModelSelection = (
   model: AgentModelSelection | undefined,
@@ -46,7 +46,9 @@ export const toTransportModelSelection = (model: AgentModelSelection) => ({
   effort: model.variant as string,
 });
 
-const toAttachmentSupport = (inputModalities: string[]): AgentModelAttachmentSupport => {
+const toAttachmentSupport = (
+  inputModalities: CodexInputModality[],
+): AgentModelAttachmentSupport => {
   const modalities = new Set(inputModalities);
 
   return {

--- a/packages/adapters-codex-app-server/src/model-catalog.ts
+++ b/packages/adapters-codex-app-server/src/model-catalog.ts
@@ -7,8 +7,6 @@ import type {
 import { CODEX_MODEL_CATALOG_TTL_MS } from "./codex-app-server-shared";
 import type { CodexAppServerClient, CodexModelListResponse } from "./types";
 
-const DEFAULT_CODEX_INPUT_MODALITIES = ["text", "image"] as const;
-
 export const requireModelSelection = (
   model: AgentModelSelection | undefined,
 ): AgentModelSelection => {
@@ -48,8 +46,8 @@ export const toTransportModelSelection = (model: AgentModelSelection) => ({
   effort: model.variant as string,
 });
 
-const toAttachmentSupport = (inputModalities?: string[]): AgentModelAttachmentSupport => {
-  const modalities = new Set(inputModalities ?? DEFAULT_CODEX_INPUT_MODALITIES);
+const toAttachmentSupport = (inputModalities: string[]): AgentModelAttachmentSupport => {
+  const modalities = new Set(inputModalities);
 
   return {
     image: modalities.has("image"),

--- a/packages/adapters-codex-app-server/src/types.ts
+++ b/packages/adapters-codex-app-server/src/types.ts
@@ -61,6 +61,8 @@ export type CodexRepoRuntimeResolverPort = {
   requireRuntimeById?(ref: RepoRuntimeRef, runtimeId: string): Promise<RuntimeInstanceSummary>;
 };
 
+export type CodexInputModality = "text" | "image";
+
 export type CodexModelCatalogRecord = {
   id: string;
   model: string;
@@ -72,7 +74,7 @@ export type CodexModelCatalogRecord = {
     description?: string;
   }>;
   defaultReasoningEffort?: string | { reasoningEffort: string; description?: string };
-  inputModalities: string[];
+  inputModalities: CodexInputModality[];
   supportsPersonality?: boolean;
   isDefault?: boolean;
 };

--- a/packages/adapters-codex-app-server/src/types.ts
+++ b/packages/adapters-codex-app-server/src/types.ts
@@ -72,7 +72,7 @@ export type CodexModelCatalogRecord = {
     description?: string;
   }>;
   defaultReasoningEffort?: string | { reasoningEffort: string; description?: string };
-  inputModalities?: string[];
+  inputModalities: string[];
   supportsPersonality?: boolean;
   isDefault?: boolean;
 };

--- a/packages/adapters-codex-app-server/src/types.ts
+++ b/packages/adapters-codex-app-server/src/types.ts
@@ -61,8 +61,6 @@ export type CodexRepoRuntimeResolverPort = {
   requireRuntimeById?(ref: RepoRuntimeRef, runtimeId: string): Promise<RuntimeInstanceSummary>;
 };
 
-export type CodexInputModality = "text" | "image";
-
 export type CodexModelCatalogRecord = {
   id: string;
   model: string;
@@ -74,7 +72,7 @@ export type CodexModelCatalogRecord = {
     description?: string;
   }>;
   defaultReasoningEffort?: string | { reasoningEffort: string; description?: string };
-  inputModalities: CodexInputModality[];
+  inputModalities: string[];
   supportsPersonality?: boolean;
   isDefault?: boolean;
 };

--- a/packages/frontend/src/state/agent-runtime-registry.test.ts
+++ b/packages/frontend/src/state/agent-runtime-registry.test.ts
@@ -103,6 +103,7 @@ describe("agent-runtime-registry", () => {
               id: "gpt-5",
               model: "gpt-5",
               displayName: "GPT-5",
+              inputModalities: ["text", "image"],
               supportedReasoningEfforts: [
                 { reasoningEffort: "medium", description: "Balanced reasoning" },
               ],
@@ -189,6 +190,7 @@ describe("agent-runtime-registry", () => {
               id: "gpt-5",
               model: "gpt-5",
               displayName: "GPT-5",
+              inputModalities: ["text", "image"],
               supportedReasoningEfforts: [
                 { reasoningEffort: "medium", description: "Balanced reasoning" },
               ],

--- a/packages/host-client/src/index.test.ts
+++ b/packages/host-client/src/index.test.ts
@@ -1556,10 +1556,23 @@ describe("HostClient", () => {
   });
 
   test("codex app-server commands use expected IPC routes", async () => {
+    const modelListResponse = {
+      data: [
+        {
+          id: "gpt-5",
+          model: "gpt-5",
+          displayName: "GPT-5",
+          supportedReasoningEfforts: [{ reasoningEffort: "medium" }],
+          inputModalities: ["text", "image"],
+          isDefault: true,
+        },
+      ],
+      nextCursor: null,
+    };
     const { client, calls } = createClient((command) => {
       switch (command) {
         case "codex_app_server_request":
-          return { ok: true };
+          return modelListResponse;
         case "codex_app_server_respond":
           return null;
         case "codex_app_server_notifications":
@@ -1571,7 +1584,9 @@ describe("HostClient", () => {
       }
     });
 
-    await client.codexAppServerRequest("runtime-1", "model/list", { request: "catalog" });
+    await expect(
+      client.codexAppServerRequest("runtime-1", "model/list", { request: "catalog" }),
+    ).resolves.toEqual(modelListResponse);
     await client.codexAppServerRespond("runtime-1", 7, { ok: true });
     await client.codexAppServerNotifications("runtime-1");
     await client.codexAppServerRequests("runtime-1");


### PR DESCRIPTION
Summary: This pull request fixes Codex image attachment support across model capability discovery, Electron attachment previews, and hydrated transcript rendering.

Goal:
Codex sessions can send local image attachments, but the app had three mismatches after the Electron migration: Codex model capabilities were not mapped from the app-server modality contract, Electron preview URLs could not reliably serve staged local files, and hydrated Codex history did not reconstruct image attachments for sent user messages. The result was inconsistent behavior between live sessions and hydrated transcripts.

Technical choices:
- Map Codex attachment support only from explicit app-server input modalities. Image support is enabled when the model declares the image modality; audio, video, and PDF remain false because Codex does not advertise those modalities through this contract.
- Serve Electron attachment previews through an app-owned custom protocol instead of exposing raw file URLs. The protocol resolves every requested path back through the host local-attachment resolver before serving bytes, keeping the file-serving policy centralized at the host boundary.
- Hydrate Codex localImage inputs as image attachment display parts with stable message-scoped ids and filenames derived from the local path. This preserves duplicate same-path attachments in one message without inventing broader global attachment state.
- Centralize Codex user-input display-part mapping so live, mapped, and hydrated user messages all share the same image attachment id rule.

Verification:
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- bun run check:rust
- bun run test:rust
- cargo build --workspace