### PR TITLE
refactor(frontend): decompose agent studio shell model

### DIFF
--- a/packages/frontend/src/pages/agents/shell/agents-page-right-panel-runtime.tsx
+++ b/packages/frontend/src/pages/agents/shell/agents-page-right-panel-runtime.tsx
@@ -1,0 +1,59 @@
+import { memo, type ReactElement, useEffect } from "react";
+import { MemoizedAgentStudioRightPanel } from "@/components/features/agents/agent-studio-right-panel";
+import { useAgentStudioBuildWorktreeRefresh } from "@/features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh";
+import type { AgentStudioOrchestrationSelectionContext } from "../use-agent-studio-orchestration-controller";
+import {
+  type UseAgentsPageRightPanelModelArgs,
+  useAgentsPageRightPanelModel,
+} from "../use-agents-page-right-panel-model";
+import {
+  useForwardedWorktreeRefresh,
+  type WorktreeRefreshRef,
+} from "./use-forwarded-worktree-refresh";
+
+export const AgentsPageRightPanelRuntime = memo(function AgentsPageRightPanelRuntime({
+  refreshWorktreeRef,
+  ...args
+}: UseAgentsPageRightPanelModelArgs & {
+  refreshWorktreeRef: WorktreeRefreshRef;
+}): ReactElement | null {
+  const { rightPanelModel, refreshWorktree } = useAgentsPageRightPanelModel(args);
+
+  useEffect(() => {
+    refreshWorktreeRef.current = refreshWorktree;
+    return () => {
+      if (refreshWorktreeRef.current === refreshWorktree) {
+        refreshWorktreeRef.current = null;
+      }
+    };
+  }, [refreshWorktree, refreshWorktreeRef]);
+
+  return rightPanelModel ? <MemoizedAgentStudioRightPanel model={rightPanelModel} /> : null;
+});
+
+export function AgentsPageBuildWorktreeRefreshRuntime({
+  panelKind,
+  isPanelOpen,
+  viewRole,
+  activeSession,
+  isSessionHistoryHydrating,
+  refreshWorktreeRef,
+}: {
+  panelKind: "documents" | "build_tools" | null;
+  isPanelOpen: boolean;
+  viewRole: UseAgentsPageRightPanelModelArgs["viewRole"];
+  activeSession: AgentStudioOrchestrationSelectionContext["viewActiveSession"];
+  isSessionHistoryHydrating: boolean;
+  refreshWorktreeRef: WorktreeRefreshRef;
+}): null {
+  const refreshWorktree = useForwardedWorktreeRefresh(refreshWorktreeRef);
+
+  useAgentStudioBuildWorktreeRefresh({
+    viewRole: panelKind === "build_tools" && isPanelOpen ? viewRole : null,
+    activeSession,
+    isSessionHistoryHydrating,
+    refreshWorktree,
+  });
+
+  return null;
+}

--- a/packages/frontend/src/pages/agents/shell/use-agent-studio-selection-intent-state.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agent-studio-selection-intent-state.ts
@@ -1,0 +1,82 @@
+import type { AgentRole } from "@openducktor/core";
+import { useCallback, useEffect, useState } from "react";
+import {
+  type AgentStudioSelectionIntent,
+  isSelectionIntentResolved,
+} from "./agent-studio-selection-intent";
+
+type UseAgentStudioSelectionIntentStateArgs = {
+  isRepoNavigationBoundaryPending: boolean;
+  taskIdParam: string;
+  sessionParam: string | null;
+  roleFromQuery: AgentRole;
+};
+
+export type AgentStudioSelectionIntentState = {
+  selectionIntentForController: AgentStudioSelectionIntent | null;
+  isSessionSelectionResolving: boolean;
+  scheduleSelectionIntent: (intent: AgentStudioSelectionIntent) => void;
+};
+
+export function useAgentStudioSelectionIntentState({
+  isRepoNavigationBoundaryPending,
+  taskIdParam,
+  sessionParam,
+  roleFromQuery,
+}: UseAgentStudioSelectionIntentStateArgs): AgentStudioSelectionIntentState {
+  const [selectionIntent, setSelectionIntent] = useState<AgentStudioSelectionIntent | null>(null);
+  const [sessionlessSelection, setSessionlessSelection] =
+    useState<AgentStudioSelectionIntent | null>(null);
+
+  const scheduleSelectionIntent = useCallback((intent: AgentStudioSelectionIntent): void => {
+    setSelectionIntent(intent);
+    setSessionlessSelection(intent.externalSessionId === null ? intent : null);
+  }, []);
+
+  const activeSessionlessSelection =
+    sessionlessSelection &&
+    sessionlessSelection.taskId === taskIdParam &&
+    sessionlessSelection.role === roleFromQuery &&
+    sessionParam === null
+      ? sessionlessSelection
+      : null;
+
+  useEffect(() => {
+    if (isRepoNavigationBoundaryPending) {
+      setSelectionIntent(null);
+      return;
+    }
+
+    if (!selectionIntent) {
+      return;
+    }
+
+    const selectionIntentResolved = isSelectionIntentResolved({
+      selectionIntent,
+      taskIdParam,
+      sessionParam,
+      roleFromQuery,
+    });
+
+    if (selectionIntentResolved) {
+      setSelectionIntent(null);
+    }
+  }, [isRepoNavigationBoundaryPending, roleFromQuery, selectionIntent, sessionParam, taskIdParam]);
+
+  const isSessionSelectionResolving = Boolean(
+    selectionIntent &&
+      !isRepoNavigationBoundaryPending &&
+      !isSelectionIntentResolved({
+        selectionIntent,
+        taskIdParam,
+        sessionParam,
+        roleFromQuery,
+      }),
+  );
+
+  return {
+    selectionIntentForController: selectionIntent ?? activeSessionlessSelection,
+    isSessionSelectionResolving,
+    scheduleSelectionIntent,
+  };
+}

--- a/packages/frontend/src/pages/agents/shell/use-agent-studio-worktree-recovery-signal.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agent-studio-worktree-recovery-signal.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from "react";
+import type { AgentsPageRouteSessionModel } from "./use-agents-page-route-session-model";
+
+type UseAgentStudioWorktreeRecoverySignalArgs = {
+  workspaceRepoPath: string | null;
+  selection: AgentsPageRouteSessionModel["selection"];
+  isForegroundLoadingTasks: boolean;
+};
+
+export function useAgentStudioWorktreeRecoverySignal({
+  workspaceRepoPath,
+  selection,
+  isForegroundLoadingTasks,
+}: UseAgentStudioWorktreeRecoverySignalArgs): number {
+  const [worktreeRecoverySignal, setWorktreeRecoverySignal] = useState(0);
+  const lastWorktreeRecoveryKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const nextRecoveryKey = [
+      workspaceRepoPath ?? "",
+      selection.viewTaskId ?? "",
+      selection.viewSelectedTask?.updatedAt ?? "",
+      selection.viewSelectedTask?.status ?? "",
+      selection.viewActiveSession?.externalSessionId ?? "",
+      selection.viewActiveSession?.status ?? "",
+      selection.viewActiveSession?.workingDirectory ?? "",
+      selection.isViewSessionHistoryHydrating ? "1" : "0",
+      isForegroundLoadingTasks ? "1" : "0",
+    ].join(":");
+
+    if (lastWorktreeRecoveryKeyRef.current === null) {
+      lastWorktreeRecoveryKeyRef.current = nextRecoveryKey;
+      return;
+    }
+
+    if (lastWorktreeRecoveryKeyRef.current === nextRecoveryKey) {
+      return;
+    }
+
+    lastWorktreeRecoveryKeyRef.current = nextRecoveryKey;
+    setWorktreeRecoverySignal((previous) => previous + 1);
+  }, [
+    isForegroundLoadingTasks,
+    selection.isViewSessionHistoryHydrating,
+    selection.viewActiveSession?.externalSessionId,
+    selection.viewActiveSession?.status,
+    selection.viewActiveSession?.workingDirectory,
+    selection.viewSelectedTask?.status,
+    selection.viewSelectedTask?.updatedAt,
+    selection.viewTaskId,
+    workspaceRepoPath,
+  ]);
+
+  return worktreeRecoverySignal;
+}

--- a/packages/frontend/src/pages/agents/shell/use-agent-studio-worktree-recovery-signal.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agent-studio-worktree-recovery-signal.ts
@@ -1,9 +1,22 @@
 import { useEffect, useRef, useState } from "react";
-import type { AgentsPageRouteSessionModel } from "./use-agents-page-route-session-model";
+
+type WorktreeRecoverySelection = {
+  viewTaskId: string;
+  viewSelectedTask: {
+    status?: string | null;
+    updatedAt?: string | null;
+  } | null;
+  viewActiveSession: {
+    externalSessionId: string;
+    status: string;
+    workingDirectory: string | null;
+  } | null;
+  isViewSessionHistoryHydrating: boolean;
+};
 
 type UseAgentStudioWorktreeRecoverySignalArgs = {
   workspaceRepoPath: string | null;
-  selection: AgentsPageRouteSessionModel["selection"];
+  selection: WorktreeRecoverySelection;
   isForegroundLoadingTasks: boolean;
 };
 

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useMemo } from "react";
+import { type RefObject, useCallback, useMemo } from "react";
 import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import type {
   useAgentOperations,
@@ -168,18 +168,20 @@ export function useAgentsPageOrchestrationShellModel({
     startSessionRequest: orchestration.startSessionRequest,
   });
 
+  const handleResolveGitConflictQuickAction = useCallback(() => {
+    void gitConflictQuickActionContextRef.current?.resolveWithBuilder();
+  }, [gitConflictQuickActionContextRef]);
+
   const agentStudioHeaderModel = useMemo(
     () => ({
       ...orchestration.agentStudioHeaderModel,
       onResolveGitConflictQuickAction: gitConflictQuickActionContext
-        ? () => {
-            void gitConflictQuickActionContextRef.current?.resolveWithBuilder();
-          }
+        ? handleResolveGitConflictQuickAction
         : null,
     }),
     [
       gitConflictQuickActionContext,
-      gitConflictQuickActionContextRef,
+      handleResolveGitConflictQuickAction,
       orchestration.agentStudioHeaderModel,
     ],
   );

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
@@ -1,0 +1,193 @@
+import { type RefObject, useMemo } from "react";
+import { toAgentSessionSummary } from "@/state/agent-sessions-store";
+import type {
+  useAgentOperations,
+  useTasksState,
+  useWorkspaceState,
+} from "@/state/app-state-provider";
+import { useAgentStudioOrchestrationController } from "../use-agent-studio-orchestration-controller";
+import { useAgentStudioRebaseConflictResolution } from "../use-agent-studio-rebase-conflict-resolution";
+import type { AgentStudioGitConflictQuickActionContext } from "../use-agents-page-right-panel-model";
+import type { AgentsPageRouteSessionModel } from "./use-agents-page-route-session-model";
+
+type UseAgentsPageOrchestrationShellModelArgs = {
+  activeWorkspace: ReturnType<typeof useWorkspaceState>["activeWorkspace"];
+  branches: ReturnType<typeof useWorkspaceState>["branches"];
+  runtimeDefinitions: Parameters<
+    typeof useAgentStudioOrchestrationController
+  >[0]["runtimeDefinitions"];
+  isForegroundLoadingTasks: boolean;
+  routeSession: AgentsPageRouteSessionModel;
+  hasActiveGitConflict: boolean;
+  gitConflictQuickActionContext: AgentStudioGitConflictQuickActionContext | null;
+  gitConflictQuickActionContextRef: RefObject<AgentStudioGitConflictQuickActionContext | null>;
+  openTaskDetails: () => void;
+  agentOperations: Pick<
+    ReturnType<typeof useAgentOperations>,
+    | "bootstrapTaskSessions"
+    | "hydrateRequestedTaskSessionHistory"
+    | "readSessionFileSearch"
+    | "readSessionSlashCommands"
+    | "startAgentSession"
+    | "settleStartedAgentSession"
+    | "sendAgentMessage"
+    | "stopAgentSession"
+    | "updateAgentSessionModel"
+    | "replyAgentApproval"
+    | "answerAgentQuestion"
+  >;
+  humanRequestChangesTask: ReturnType<typeof useTasksState>["humanRequestChangesTask"];
+  setTaskTargetBranch: ReturnType<typeof useTasksState>["setTaskTargetBranch"];
+};
+
+export type AgentsPageOrchestrationShellModel = {
+  orchestration: ReturnType<typeof useAgentStudioOrchestrationController>;
+  orchestrationSelection: Parameters<typeof useAgentStudioOrchestrationController>[0]["selection"];
+  handleResolveRebaseConflict: ReturnType<
+    typeof useAgentStudioRebaseConflictResolution
+  >["handleResolveRebaseConflict"];
+  agentStudioHeaderModel: ReturnType<
+    typeof useAgentStudioOrchestrationController
+  >["agentStudioHeaderModel"];
+};
+
+export function useAgentsPageOrchestrationShellModel({
+  activeWorkspace,
+  branches,
+  runtimeDefinitions,
+  isForegroundLoadingTasks,
+  routeSession,
+  hasActiveGitConflict,
+  gitConflictQuickActionContext,
+  gitConflictQuickActionContextRef,
+  openTaskDetails,
+  agentOperations,
+  humanRequestChangesTask,
+  setTaskTargetBranch,
+}: UseAgentsPageOrchestrationShellModelArgs): AgentsPageOrchestrationShellModel {
+  const {
+    selection,
+    readiness,
+    contextSwitchVersion,
+    isSessionSelectionResolving,
+    scheduleQueryUpdate,
+    signalContextSwitchIntent,
+    scheduleSelectionIntent,
+  } = routeSession;
+
+  const draftStateKey = useMemo(
+    () =>
+      [
+        selection.viewTaskId,
+        selection.viewRole,
+        selection.viewActiveSession?.externalSessionId ?? "new",
+        contextSwitchVersion,
+      ].join(":"),
+    [
+      contextSwitchVersion,
+      selection.viewActiveSession?.externalSessionId,
+      selection.viewRole,
+      selection.viewTaskId,
+    ],
+  );
+
+  const orchestrationSelection = {
+    ...selection,
+    contextSwitchVersion,
+    isSessionSelectionResolving,
+    isLoadingTasks: isForegroundLoadingTasks,
+  };
+
+  const orchestration = useAgentStudioOrchestrationController({
+    activeWorkspace,
+    branches,
+    runtimeDefinitions,
+    selection: orchestrationSelection,
+    readiness,
+    hasActiveGitConflict,
+    draftStateKey,
+    actions: {
+      updateQuery: scheduleQueryUpdate,
+      onContextSwitchIntent: signalContextSwitchIntent,
+      openTaskDetails,
+      startAgentSession: agentOperations.startAgentSession,
+      settleStartedAgentSession: agentOperations.settleStartedAgentSession,
+      sendAgentMessage: agentOperations.sendAgentMessage,
+      stopAgentSession: agentOperations.stopAgentSession,
+      updateAgentSessionModel: agentOperations.updateAgentSessionModel,
+      readSessionFileSearch: agentOperations.readSessionFileSearch,
+      readSessionSlashCommands: agentOperations.readSessionSlashCommands,
+      bootstrapTaskSessions: agentOperations.bootstrapTaskSessions,
+      hydrateRequestedTaskSessionHistory: agentOperations.hydrateRequestedTaskSessionHistory,
+      humanRequestChangesTask,
+      setTaskTargetBranch,
+      replyAgentApproval: agentOperations.replyAgentApproval,
+      answerAgentQuestion: agentOperations.answerAgentQuestion,
+      scheduleSelectionIntent,
+    },
+  });
+
+  const activeSessionSummary = useMemo(
+    () =>
+      selection.activeSessionSummary ??
+      (selection.activeSession ? toAgentSessionSummary(selection.activeSession) : null),
+    [selection.activeSession, selection.activeSessionSummary],
+  );
+  const viewActiveSessionSummary = useMemo(
+    () =>
+      selection.viewActiveSessionSummary ??
+      (selection.viewActiveSession ? toAgentSessionSummary(selection.viewActiveSession) : null),
+    [selection.viewActiveSession, selection.viewActiveSessionSummary],
+  );
+  const rebaseConflictSelection = useMemo(
+    () => ({
+      viewTaskId: selection.viewTaskId,
+      viewSelectedTask: selection.viewSelectedTask,
+      viewActiveSession: viewActiveSessionSummary,
+      activeSession: activeSessionSummary,
+      selectedSessionById: selection.selectedSessionById,
+      viewSessionsForTask: selection.viewSessionsForTask,
+      sessionsForTask: selection.sessionsForTask,
+    }),
+    [
+      activeSessionSummary,
+      selection.selectedSessionById,
+      selection.sessionsForTask,
+      selection.viewSelectedTask,
+      selection.viewSessionsForTask,
+      selection.viewTaskId,
+      viewActiveSessionSummary,
+    ],
+  );
+
+  const { handleResolveRebaseConflict } = useAgentStudioRebaseConflictResolution({
+    activeWorkspace,
+    selection: rebaseConflictSelection,
+    scheduleQueryUpdate,
+    onContextSwitchIntent: signalContextSwitchIntent,
+    startSessionRequest: orchestration.startSessionRequest,
+  });
+
+  const agentStudioHeaderModel = useMemo(
+    () => ({
+      ...orchestration.agentStudioHeaderModel,
+      onResolveGitConflictQuickAction: gitConflictQuickActionContext
+        ? () => {
+            void gitConflictQuickActionContextRef.current?.resolveWithBuilder();
+          }
+        : null,
+    }),
+    [
+      gitConflictQuickActionContext,
+      gitConflictQuickActionContextRef,
+      orchestration.agentStudioHeaderModel,
+    ],
+  );
+
+  return {
+    orchestration,
+    orchestrationSelection,
+    handleResolveRebaseConflict,
+    agentStudioHeaderModel,
+  };
+}

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-right-panel-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-right-panel-shell-model.tsx
@@ -1,21 +1,18 @@
-import { memo, type ReactElement, useEffect, useMemo, useRef } from "react";
-import { MemoizedAgentStudioRightPanel } from "@/components/features/agents/agent-studio-right-panel";
+import { type ReactElement, useMemo, useRef } from "react";
 import type { BuildToolsSessionDescriptor } from "@/features/agent-studio-build-tools/use-agent-studio-build-tools-bootstrap";
-import { useAgentStudioBuildWorktreeRefresh } from "@/features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh";
 import type { GitDiffRefresh } from "@/features/agent-studio-git";
 import type {
   AgentStudioOrchestrationSelectionContext,
   useAgentStudioOrchestrationController,
 } from "../use-agent-studio-orchestration-controller";
-import {
-  type AgentStudioGitConflictQuickActionContext,
-  type UseAgentsPageRightPanelModelArgs,
-  useAgentsPageRightPanelModel,
+import type {
+  AgentStudioGitConflictQuickActionContext,
+  UseAgentsPageRightPanelModelArgs,
 } from "../use-agents-page-right-panel-model";
 import {
-  useForwardedWorktreeRefresh,
-  type WorktreeRefreshRef,
-} from "./use-forwarded-worktree-refresh";
+  AgentsPageBuildWorktreeRefreshRuntime,
+  AgentsPageRightPanelRuntime,
+} from "./agents-page-right-panel-runtime";
 
 type UseAgentsPageRightPanelShellModelArgs = {
   activeWorkspace: UseAgentsPageRightPanelModelArgs["activeWorkspace"];
@@ -37,53 +34,6 @@ export type AgentsPageRightPanelShellModel = {
   isRightPanelVisible: boolean;
   rightPanelContent: ReactElement | null;
 };
-
-const AgentsPageRightPanelRuntime = memo(function AgentsPageRightPanelRuntime({
-  refreshWorktreeRef,
-  ...args
-}: UseAgentsPageRightPanelModelArgs & {
-  refreshWorktreeRef: WorktreeRefreshRef;
-}): ReactElement | null {
-  const { rightPanelModel, refreshWorktree } = useAgentsPageRightPanelModel(args);
-
-  useEffect(() => {
-    refreshWorktreeRef.current = refreshWorktree;
-    return () => {
-      if (refreshWorktreeRef.current === refreshWorktree) {
-        refreshWorktreeRef.current = null;
-      }
-    };
-  }, [refreshWorktree, refreshWorktreeRef]);
-
-  return rightPanelModel ? <MemoizedAgentStudioRightPanel model={rightPanelModel} /> : null;
-});
-
-function AgentsPageBuildWorktreeRefreshRuntime({
-  panelKind,
-  isPanelOpen,
-  viewRole,
-  activeSession,
-  isSessionHistoryHydrating,
-  refreshWorktreeRef,
-}: {
-  panelKind: "documents" | "build_tools" | null;
-  isPanelOpen: boolean;
-  viewRole: UseAgentsPageRightPanelModelArgs["viewRole"];
-  activeSession: AgentStudioOrchestrationSelectionContext["viewActiveSession"];
-  isSessionHistoryHydrating: boolean;
-  refreshWorktreeRef: WorktreeRefreshRef;
-}): null {
-  const refreshWorktree = useForwardedWorktreeRefresh(refreshWorktreeRef);
-
-  useAgentStudioBuildWorktreeRefresh({
-    viewRole: panelKind === "build_tools" && isPanelOpen ? viewRole : null,
-    activeSession,
-    isSessionHistoryHydrating,
-    refreshWorktree,
-  });
-
-  return null;
-}
 
 export function useAgentsPageRightPanelShellModel({
   activeWorkspace,

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-right-panel-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-right-panel-shell-model.tsx
@@ -16,7 +16,7 @@ import {
 
 type UseAgentsPageRightPanelShellModelArgs = {
   activeWorkspace: UseAgentsPageRightPanelModelArgs["activeWorkspace"];
-  branches: UseAgentsPageRightPanelModelArgs["branches"];
+  branches: NonNullable<UseAgentsPageRightPanelModelArgs["branches"]>;
   activeBranch: UseAgentsPageRightPanelModelArgs["activeBranch"];
   selection: AgentStudioOrchestrationSelectionContext;
   orchestration: ReturnType<typeof useAgentStudioOrchestrationController>;
@@ -101,7 +101,7 @@ export function useAgentsPageRightPanelShellModel({
         onResolveGitConflict={onResolveGitConflict}
         onGitConflictQuickActionContextChange={onGitConflictQuickActionContextChange}
         refreshWorktreeRef={rightPanelRefreshWorktreeRef}
-        {...(branches ? { branches } : {})}
+        branches={branches}
       />
     </>
   ) : null;

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-right-panel-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-right-panel-shell-model.tsx
@@ -16,7 +16,7 @@ import {
 
 type UseAgentsPageRightPanelShellModelArgs = {
   activeWorkspace: UseAgentsPageRightPanelModelArgs["activeWorkspace"];
-  branches: NonNullable<UseAgentsPageRightPanelModelArgs["branches"]>;
+  branches: UseAgentsPageRightPanelModelArgs["branches"];
   activeBranch: UseAgentsPageRightPanelModelArgs["activeBranch"];
   selection: AgentStudioOrchestrationSelectionContext;
   orchestration: ReturnType<typeof useAgentStudioOrchestrationController>;
@@ -84,7 +84,6 @@ export function useAgentsPageRightPanelShellModel({
       />
       <AgentsPageRightPanelRuntime
         activeWorkspace={activeWorkspace}
-        branches={branches}
         activeBranch={activeBranch}
         viewRole={selection.viewRole}
         viewTaskId={selection.viewTaskId}
@@ -102,6 +101,7 @@ export function useAgentsPageRightPanelShellModel({
         onResolveGitConflict={onResolveGitConflict}
         onGitConflictQuickActionContextChange={onGitConflictQuickActionContextChange}
         refreshWorktreeRef={rightPanelRefreshWorktreeRef}
+        {...(branches ? { branches } : {})}
       />
     </>
   ) : null;

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-right-panel-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-right-panel-shell-model.tsx
@@ -1,0 +1,163 @@
+import { memo, type ReactElement, useEffect, useMemo, useRef } from "react";
+import { MemoizedAgentStudioRightPanel } from "@/components/features/agents/agent-studio-right-panel";
+import type { BuildToolsSessionDescriptor } from "@/features/agent-studio-build-tools/use-agent-studio-build-tools-bootstrap";
+import { useAgentStudioBuildWorktreeRefresh } from "@/features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh";
+import type { GitDiffRefresh } from "@/features/agent-studio-git";
+import type {
+  AgentStudioOrchestrationSelectionContext,
+  useAgentStudioOrchestrationController,
+} from "../use-agent-studio-orchestration-controller";
+import {
+  type AgentStudioGitConflictQuickActionContext,
+  type UseAgentsPageRightPanelModelArgs,
+  useAgentsPageRightPanelModel,
+} from "../use-agents-page-right-panel-model";
+import {
+  useForwardedWorktreeRefresh,
+  type WorktreeRefreshRef,
+} from "./use-forwarded-worktree-refresh";
+
+type UseAgentsPageRightPanelShellModelArgs = {
+  activeWorkspace: UseAgentsPageRightPanelModelArgs["activeWorkspace"];
+  branches: NonNullable<UseAgentsPageRightPanelModelArgs["branches"]>;
+  activeBranch: UseAgentsPageRightPanelModelArgs["activeBranch"];
+  selection: AgentStudioOrchestrationSelectionContext;
+  orchestration: ReturnType<typeof useAgentStudioOrchestrationController>;
+  worktreeRecoverySignal: number;
+  setTaskTargetBranch: NonNullable<UseAgentsPageRightPanelModelArgs["setTaskTargetBranch"]>;
+  detectingPullRequestTaskId: UseAgentsPageRightPanelModelArgs["detectingPullRequestTaskId"];
+  onDetectPullRequest: UseAgentsPageRightPanelModelArgs["onDetectPullRequest"];
+  onResolveGitConflict: UseAgentsPageRightPanelModelArgs["onResolveGitConflict"];
+  onGitConflictQuickActionContextChange: (
+    context: AgentStudioGitConflictQuickActionContext | null,
+  ) => void;
+};
+
+export type AgentsPageRightPanelShellModel = {
+  isRightPanelVisible: boolean;
+  rightPanelContent: ReactElement | null;
+};
+
+const AgentsPageRightPanelRuntime = memo(function AgentsPageRightPanelRuntime({
+  refreshWorktreeRef,
+  ...args
+}: UseAgentsPageRightPanelModelArgs & {
+  refreshWorktreeRef: WorktreeRefreshRef;
+}): ReactElement | null {
+  const { rightPanelModel, refreshWorktree } = useAgentsPageRightPanelModel(args);
+
+  useEffect(() => {
+    refreshWorktreeRef.current = refreshWorktree;
+    return () => {
+      if (refreshWorktreeRef.current === refreshWorktree) {
+        refreshWorktreeRef.current = null;
+      }
+    };
+  }, [refreshWorktree, refreshWorktreeRef]);
+
+  return rightPanelModel ? <MemoizedAgentStudioRightPanel model={rightPanelModel} /> : null;
+});
+
+function AgentsPageBuildWorktreeRefreshRuntime({
+  panelKind,
+  isPanelOpen,
+  viewRole,
+  activeSession,
+  isSessionHistoryHydrating,
+  refreshWorktreeRef,
+}: {
+  panelKind: "documents" | "build_tools" | null;
+  isPanelOpen: boolean;
+  viewRole: UseAgentsPageRightPanelModelArgs["viewRole"];
+  activeSession: AgentStudioOrchestrationSelectionContext["viewActiveSession"];
+  isSessionHistoryHydrating: boolean;
+  refreshWorktreeRef: WorktreeRefreshRef;
+}): null {
+  const refreshWorktree = useForwardedWorktreeRefresh(refreshWorktreeRef);
+
+  useAgentStudioBuildWorktreeRefresh({
+    viewRole: panelKind === "build_tools" && isPanelOpen ? viewRole : null,
+    activeSession,
+    isSessionHistoryHydrating,
+    refreshWorktree,
+  });
+
+  return null;
+}
+
+export function useAgentsPageRightPanelShellModel({
+  activeWorkspace,
+  branches,
+  activeBranch,
+  selection,
+  orchestration,
+  worktreeRecoverySignal,
+  setTaskTargetBranch,
+  detectingPullRequestTaskId,
+  onDetectPullRequest,
+  onResolveGitConflict,
+  onGitConflictQuickActionContextChange,
+}: UseAgentsPageRightPanelShellModelArgs): AgentsPageRightPanelShellModel {
+  const rightPanelRefreshWorktreeRef = useRef<GitDiffRefresh | null>(null);
+
+  const isRightPanelVisible = Boolean(
+    orchestration.rightPanel.panelKind && orchestration.rightPanel.isPanelOpen,
+  );
+  const rightPanelSessionRole = selection.viewActiveSession?.role ?? null;
+  const rightPanelSessionStatus = selection.viewActiveSession?.status ?? null;
+  const rightPanelSessionWorkingDirectory = selection.viewActiveSession?.workingDirectory ?? null;
+  const rightPanelHasActiveSession = selection.viewActiveSession != null;
+  const rightPanelSession = useMemo<BuildToolsSessionDescriptor>(
+    () => ({
+      role: rightPanelSessionRole,
+      status: rightPanelSessionStatus,
+      workingDirectory: rightPanelSessionWorkingDirectory,
+      hasActiveSession: rightPanelHasActiveSession,
+    }),
+    [
+      rightPanelHasActiveSession,
+      rightPanelSessionRole,
+      rightPanelSessionStatus,
+      rightPanelSessionWorkingDirectory,
+    ],
+  );
+
+  const rightPanelContent = orchestration.rightPanel.panelKind ? (
+    <>
+      <AgentsPageBuildWorktreeRefreshRuntime
+        panelKind={orchestration.rightPanel.panelKind}
+        isPanelOpen={orchestration.rightPanel.isPanelOpen}
+        viewRole={selection.viewRole}
+        activeSession={selection.viewActiveSession}
+        isSessionHistoryHydrating={selection.isViewSessionHistoryHydrating}
+        refreshWorktreeRef={rightPanelRefreshWorktreeRef}
+      />
+      <AgentsPageRightPanelRuntime
+        activeWorkspace={activeWorkspace}
+        branches={branches}
+        activeBranch={activeBranch}
+        viewRole={selection.viewRole}
+        viewTaskId={selection.viewTaskId}
+        session={rightPanelSession}
+        viewSelectedTask={selection.viewSelectedTask}
+        panelKind={orchestration.rightPanel.panelKind}
+        isPanelOpen={orchestration.rightPanel.isPanelOpen}
+        isViewSessionHistoryHydrating={selection.isViewSessionHistoryHydrating}
+        documentsModel={orchestration.agentStudioWorkspaceSidebarModel}
+        repoSettings={orchestration.repoSettings}
+        worktreeRecoverySignal={worktreeRecoverySignal}
+        setTaskTargetBranch={setTaskTargetBranch}
+        detectingPullRequestTaskId={detectingPullRequestTaskId}
+        onDetectPullRequest={onDetectPullRequest}
+        onResolveGitConflict={onResolveGitConflict}
+        onGitConflictQuickActionContextChange={onGitConflictQuickActionContextChange}
+        refreshWorktreeRef={rightPanelRefreshWorktreeRef}
+      />
+    </>
+  ) : null;
+
+  return {
+    isRightPanelVisible,
+    rightPanelContent,
+  };
+}

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
@@ -1,0 +1,290 @@
+import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
+import type { AgentModelCatalog, AgentRole, AgentSessionTodoItem } from "@openducktor/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigationType, useSearchParams } from "react-router-dom";
+import type { AgentSessionSummary } from "@/state/agent-sessions-store";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { ActiveWorkspace } from "@/types/state-slices";
+import type { AgentStudioQueryUpdate } from "../agent-studio-navigation";
+import { useAgentStudioQuerySessionSync } from "../use-agent-studio-query-session-sync";
+import { useAgentStudioQuerySync } from "../use-agent-studio-query-sync";
+import { useAgentStudioSelectionController } from "../use-agent-studio-selection-controller";
+import { useAgentStudioReadiness } from "../use-agents-page-readiness";
+import {
+  type AgentStudioSelectionIntent,
+  isSelectionIntentResolved,
+} from "./agent-studio-selection-intent";
+
+type UseAgentsPageRouteSessionModelArgs = {
+  activeWorkspace: ActiveWorkspace | null;
+  workspaceRepoPath: string | null;
+  runtimeDefinitions: RuntimeDescriptor[];
+  isLoadingRuntimeDefinitions: boolean;
+  runtimeDefinitionsError: string | null;
+  runtimeHealthByRuntime: Parameters<typeof useAgentStudioReadiness>[0]["runtimeHealthByRuntime"];
+  isLoadingChecks: boolean;
+  refreshChecks: () => Promise<void>;
+  refreshRepoRuntimeHealthForRepo: (repoPath: string, force?: boolean) => Promise<unknown>;
+  hasCachedRepoRuntimeHealth: (repoPath: string, runtimeKinds: RuntimeKind[]) => boolean;
+  tasks: Parameters<typeof useAgentStudioSelectionController>[0]["tasks"];
+  isForegroundLoadingTasks: boolean;
+  sessions: AgentSessionSummary[];
+  hydrateRequestedTaskSessionHistory: (input: {
+    taskId: string;
+    externalSessionId: string;
+  }) => Promise<void>;
+  ensureSessionReadyForView: (input: {
+    taskId: string;
+    externalSessionId: string;
+    repoReadinessState: Parameters<
+      typeof useAgentStudioSelectionController
+    >[0]["agentStudioReadinessState"];
+    recoveryDedupKey?: string | null;
+  }) => Promise<boolean>;
+  readSessionModelCatalog: (
+    repoPath: string,
+    runtimeKind: NonNullable<AgentSessionState["runtimeKind"]>,
+  ) => Promise<AgentModelCatalog>;
+  readSessionTodos: (
+    repoPath: string,
+    runtimeKind: NonNullable<AgentSessionState["runtimeKind"]>,
+    workingDirectory: string,
+    externalSessionId: string,
+  ) => Promise<AgentSessionTodoItem[]>;
+};
+
+export type AgentsPageRouteSessionModel = {
+  navigationPersistenceError: Error | null;
+  retryNavigationPersistence: () => void;
+  scheduleQueryUpdate: (updates: AgentStudioQueryUpdate) => void;
+  signalContextSwitchIntent: () => void;
+  contextSwitchVersion: number;
+  selection: ReturnType<typeof useAgentStudioSelectionController>;
+  readiness: ReturnType<typeof useAgentStudioReadiness>;
+  isSessionSelectionResolving: boolean;
+  worktreeRecoverySignal: number;
+  scheduleSelectionIntent: (intent: {
+    taskId: string;
+    externalSessionId: string | null;
+    role: AgentRole;
+  }) => void;
+};
+
+export function useAgentsPageRouteSessionModel({
+  activeWorkspace,
+  workspaceRepoPath,
+  runtimeDefinitions,
+  isLoadingRuntimeDefinitions,
+  runtimeDefinitionsError,
+  runtimeHealthByRuntime,
+  isLoadingChecks,
+  refreshChecks,
+  refreshRepoRuntimeHealthForRepo,
+  hasCachedRepoRuntimeHealth,
+  tasks,
+  isForegroundLoadingTasks,
+  sessions,
+  hydrateRequestedTaskSessionHistory,
+  ensureSessionReadyForView,
+  readSessionModelCatalog,
+  readSessionTodos,
+}: UseAgentsPageRouteSessionModelArgs): AgentsPageRouteSessionModel {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigationType = useNavigationType();
+  const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
+  const [selectionIntent, setSelectionIntent] = useState<AgentStudioSelectionIntent | null>(null);
+  const [sessionlessSelection, setSessionlessSelection] =
+    useState<AgentStudioSelectionIntent | null>(null);
+  const [worktreeRecoverySignal, setWorktreeRecoverySignal] = useState(0);
+  const lastWorktreeRecoveryKeyRef = useRef<string | null>(null);
+
+  const {
+    taskIdParam,
+    sessionParam,
+    hasExplicitRoleParam,
+    roleFromQuery,
+    isRepoNavigationBoundaryPending,
+    navigationPersistenceError,
+    retryNavigationPersistence,
+    updateQuery,
+  } = useAgentStudioQuerySync({
+    activeWorkspace,
+    navigationType,
+    searchParams,
+    setSearchParams,
+  });
+
+  const scheduleQueryUpdate = useCallback(
+    (updates: AgentStudioQueryUpdate): void => {
+      updateQuery(updates);
+    },
+    [updateQuery],
+  );
+
+  const signalContextSwitchIntent = useCallback((): void => {
+    setContextSwitchVersion((current) => current + 1);
+  }, []);
+
+  const scheduleSelectionIntent = useCallback(
+    (intent: { taskId: string; externalSessionId: string | null; role: AgentRole }): void => {
+      setSelectionIntent(intent);
+      setSessionlessSelection(intent.externalSessionId === null ? intent : null);
+    },
+    [],
+  );
+
+  const activeSessionlessSelection =
+    sessionlessSelection &&
+    sessionlessSelection.taskId === taskIdParam &&
+    sessionlessSelection.role === roleFromQuery &&
+    sessionParam === null
+      ? sessionlessSelection
+      : null;
+
+  const readiness = useAgentStudioReadiness({
+    activeWorkspace,
+    runtimeDefinitions,
+    isLoadingRuntimeDefinitions,
+    runtimeDefinitionsError,
+    runtimeHealthByRuntime,
+    isLoadingChecks,
+    refreshChecks,
+  });
+
+  const selection = useAgentStudioSelectionController({
+    activeWorkspace,
+    isRepoNavigationBoundaryPending,
+    tasks,
+    isLoadingTasks: isForegroundLoadingTasks,
+    sessions,
+    taskIdParam,
+    sessionParam,
+    hasExplicitRoleParam,
+    roleFromQuery,
+    selectionIntent: selectionIntent ?? activeSessionlessSelection,
+    updateQuery: scheduleQueryUpdate,
+    agentStudioReadinessState: readiness.agentStudioReadinessState,
+    hydrateRequestedTaskSessionHistory,
+    ensureSessionReadyForView,
+    runtimeDefinitions,
+    readSessionModelCatalog,
+    readSessionTodos,
+    clearComposerInput: signalContextSwitchIntent,
+    onContextSwitchIntent: signalContextSwitchIntent,
+  });
+
+  useEffect(() => {
+    if (isRepoNavigationBoundaryPending) {
+      setSelectionIntent(null);
+      return;
+    }
+
+    if (!selectionIntent) {
+      return;
+    }
+
+    const selectionIntentResolved = isSelectionIntentResolved({
+      selectionIntent,
+      taskIdParam,
+      sessionParam,
+      roleFromQuery,
+    });
+
+    if (selectionIntentResolved) {
+      setSelectionIntent(null);
+    }
+  }, [isRepoNavigationBoundaryPending, roleFromQuery, selectionIntent, sessionParam, taskIdParam]);
+
+  const isSessionSelectionResolving = Boolean(
+    selectionIntent &&
+      !isRepoNavigationBoundaryPending &&
+      !isSelectionIntentResolved({
+        selectionIntent,
+        taskIdParam,
+        sessionParam,
+        roleFromQuery,
+      }),
+  );
+
+  useEffect(() => {
+    const nextRecoveryKey = [
+      workspaceRepoPath ?? "",
+      selection.viewTaskId ?? "",
+      selection.viewSelectedTask?.updatedAt ?? "",
+      selection.viewSelectedTask?.status ?? "",
+      selection.viewActiveSession?.externalSessionId ?? "",
+      selection.viewActiveSession?.status ?? "",
+      selection.viewActiveSession?.workingDirectory ?? "",
+      selection.isViewSessionHistoryHydrating ? "1" : "0",
+      isForegroundLoadingTasks ? "1" : "0",
+    ].join(":");
+
+    if (lastWorktreeRecoveryKeyRef.current === null) {
+      lastWorktreeRecoveryKeyRef.current = nextRecoveryKey;
+      return;
+    }
+
+    if (lastWorktreeRecoveryKeyRef.current === nextRecoveryKey) {
+      return;
+    }
+
+    lastWorktreeRecoveryKeyRef.current = nextRecoveryKey;
+    setWorktreeRecoverySignal((previous) => previous + 1);
+  }, [
+    isForegroundLoadingTasks,
+    selection.isViewSessionHistoryHydrating,
+    selection.viewActiveSession?.externalSessionId,
+    selection.viewActiveSession?.status,
+    selection.viewActiveSession?.workingDirectory,
+    selection.viewSelectedTask?.status,
+    selection.viewSelectedTask?.updatedAt,
+    selection.viewTaskId,
+    workspaceRepoPath,
+  ]);
+
+  useEffect(() => {
+    if (!workspaceRepoPath || runtimeDefinitions.length === 0 || isLoadingChecks) {
+      return;
+    }
+
+    const runtimeKinds = runtimeDefinitions.map((definition) => definition.kind);
+    if (hasCachedRepoRuntimeHealth(workspaceRepoPath, runtimeKinds)) {
+      return;
+    }
+
+    void refreshRepoRuntimeHealthForRepo(workspaceRepoPath, false);
+  }, [
+    workspaceRepoPath,
+    hasCachedRepoRuntimeHealth,
+    isLoadingChecks,
+    refreshRepoRuntimeHealthForRepo,
+    runtimeDefinitions,
+  ]);
+
+  useAgentStudioQuerySessionSync({
+    isRepoNavigationBoundaryPending,
+    isLoadingTasks: isForegroundLoadingTasks,
+    tasks,
+    taskIdParam,
+    sessionParam,
+    selectedSessionById: selection.selectedSessionById,
+    taskId: selection.taskId,
+    activeSession: selection.activeSession,
+    roleFromQuery,
+    isActiveTaskHydrated: selection.isActiveTaskHydrated,
+    scheduleQueryUpdate,
+  });
+
+  return {
+    navigationPersistenceError,
+    retryNavigationPersistence,
+    scheduleQueryUpdate,
+    signalContextSwitchIntent,
+    contextSwitchVersion,
+    selection,
+    readiness,
+    isSessionSelectionResolving,
+    worktreeRecoverySignal,
+    scheduleSelectionIntent,
+  };
+}

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
@@ -1,6 +1,6 @@
 import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentRole, AgentSessionTodoItem } from "@openducktor/core";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigationType, useSearchParams } from "react-router-dom";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -10,10 +10,8 @@ import { useAgentStudioQuerySessionSync } from "../use-agent-studio-query-sessio
 import { useAgentStudioQuerySync } from "../use-agent-studio-query-sync";
 import { useAgentStudioSelectionController } from "../use-agent-studio-selection-controller";
 import { useAgentStudioReadiness } from "../use-agents-page-readiness";
-import {
-  type AgentStudioSelectionIntent,
-  isSelectionIntentResolved,
-} from "./agent-studio-selection-intent";
+import { useAgentStudioSelectionIntentState } from "./use-agent-studio-selection-intent-state";
+import { useAgentStudioWorktreeRecoverySignal } from "./use-agent-studio-worktree-recovery-signal";
 
 type UseAgentsPageRouteSessionModelArgs = {
   activeWorkspace: ActiveWorkspace | null;
@@ -92,11 +90,6 @@ export function useAgentsPageRouteSessionModel({
   const [searchParams, setSearchParams] = useSearchParams();
   const navigationType = useNavigationType();
   const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
-  const [selectionIntent, setSelectionIntent] = useState<AgentStudioSelectionIntent | null>(null);
-  const [sessionlessSelection, setSessionlessSelection] =
-    useState<AgentStudioSelectionIntent | null>(null);
-  const [worktreeRecoverySignal, setWorktreeRecoverySignal] = useState(0);
-  const lastWorktreeRecoveryKeyRef = useRef<string | null>(null);
 
   const {
     taskIdParam,
@@ -125,21 +118,13 @@ export function useAgentsPageRouteSessionModel({
     setContextSwitchVersion((current) => current + 1);
   }, []);
 
-  const scheduleSelectionIntent = useCallback(
-    (intent: { taskId: string; externalSessionId: string | null; role: AgentRole }): void => {
-      setSelectionIntent(intent);
-      setSessionlessSelection(intent.externalSessionId === null ? intent : null);
-    },
-    [],
-  );
-
-  const activeSessionlessSelection =
-    sessionlessSelection &&
-    sessionlessSelection.taskId === taskIdParam &&
-    sessionlessSelection.role === roleFromQuery &&
-    sessionParam === null
-      ? sessionlessSelection
-      : null;
+  const { selectionIntentForController, isSessionSelectionResolving, scheduleSelectionIntent } =
+    useAgentStudioSelectionIntentState({
+      isRepoNavigationBoundaryPending,
+      taskIdParam,
+      sessionParam,
+      roleFromQuery,
+    });
 
   const readiness = useAgentStudioReadiness({
     activeWorkspace,
@@ -161,7 +146,7 @@ export function useAgentsPageRouteSessionModel({
     sessionParam,
     hasExplicitRoleParam,
     roleFromQuery,
-    selectionIntent: selectionIntent ?? activeSessionlessSelection,
+    selectionIntent: selectionIntentForController,
     updateQuery: scheduleQueryUpdate,
     agentStudioReadinessState: readiness.agentStudioReadinessState,
     hydrateRequestedTaskSessionHistory,
@@ -173,74 +158,11 @@ export function useAgentsPageRouteSessionModel({
     onContextSwitchIntent: signalContextSwitchIntent,
   });
 
-  useEffect(() => {
-    if (isRepoNavigationBoundaryPending) {
-      setSelectionIntent(null);
-      return;
-    }
-
-    if (!selectionIntent) {
-      return;
-    }
-
-    const selectionIntentResolved = isSelectionIntentResolved({
-      selectionIntent,
-      taskIdParam,
-      sessionParam,
-      roleFromQuery,
-    });
-
-    if (selectionIntentResolved) {
-      setSelectionIntent(null);
-    }
-  }, [isRepoNavigationBoundaryPending, roleFromQuery, selectionIntent, sessionParam, taskIdParam]);
-
-  const isSessionSelectionResolving = Boolean(
-    selectionIntent &&
-      !isRepoNavigationBoundaryPending &&
-      !isSelectionIntentResolved({
-        selectionIntent,
-        taskIdParam,
-        sessionParam,
-        roleFromQuery,
-      }),
-  );
-
-  useEffect(() => {
-    const nextRecoveryKey = [
-      workspaceRepoPath ?? "",
-      selection.viewTaskId ?? "",
-      selection.viewSelectedTask?.updatedAt ?? "",
-      selection.viewSelectedTask?.status ?? "",
-      selection.viewActiveSession?.externalSessionId ?? "",
-      selection.viewActiveSession?.status ?? "",
-      selection.viewActiveSession?.workingDirectory ?? "",
-      selection.isViewSessionHistoryHydrating ? "1" : "0",
-      isForegroundLoadingTasks ? "1" : "0",
-    ].join(":");
-
-    if (lastWorktreeRecoveryKeyRef.current === null) {
-      lastWorktreeRecoveryKeyRef.current = nextRecoveryKey;
-      return;
-    }
-
-    if (lastWorktreeRecoveryKeyRef.current === nextRecoveryKey) {
-      return;
-    }
-
-    lastWorktreeRecoveryKeyRef.current = nextRecoveryKey;
-    setWorktreeRecoverySignal((previous) => previous + 1);
-  }, [
-    isForegroundLoadingTasks,
-    selection.isViewSessionHistoryHydrating,
-    selection.viewActiveSession?.externalSessionId,
-    selection.viewActiveSession?.status,
-    selection.viewActiveSession?.workingDirectory,
-    selection.viewSelectedTask?.status,
-    selection.viewSelectedTask?.updatedAt,
-    selection.viewTaskId,
+  const worktreeRecoverySignal = useAgentStudioWorktreeRecoverySignal({
     workspaceRepoPath,
-  ]);
+    selection,
+    isForegroundLoadingTasks,
+  });
 
   useEffect(() => {
     if (!workspaceRepoPath || runtimeDefinitions.length === 0 || isLoadingChecks) {

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -1,22 +1,6 @@
-import type { AgentRole } from "@openducktor/core";
-import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigationType, useSearchParams } from "react-router-dom";
+import { type ReactElement, useCallback, useRef, useState } from "react";
 import { SessionStartModal } from "@/components/features/agents";
-import { MemoizedAgentStudioRightPanel } from "@/components/features/agents/agent-studio-right-panel";
-import type {
-  ActiveTaskSessionContextByTaskId,
-  KanbanTaskSession,
-} from "@/components/features/kanban/kanban-task-activity";
-import { MergedPullRequestConfirmDialog } from "@/components/features/pull-requests/merged-pull-request-confirm-dialog";
-import {
-  TaskDetailsSheetController,
-  type TaskDetailsSheetControllerHandle,
-} from "@/components/features/task-details/task-details-sheet-controller";
-import type { BuildToolsSessionDescriptor } from "@/features/agent-studio-build-tools/use-agent-studio-build-tools-bootstrap";
-import { useAgentStudioBuildWorktreeRefresh } from "@/features/agent-studio-build-tools/use-agent-studio-build-worktree-refresh";
-import type { GitDiffRefresh } from "@/features/agent-studio-git";
 import { HumanReviewFeedbackModal } from "@/features/human-review-feedback/human-review-feedback-modal";
-import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import {
   useChecksOperationsContext,
   useRuntimeAvailabilityContext,
@@ -28,30 +12,13 @@ import {
   useTasksState,
   useWorkspaceState,
 } from "@/state/app-state-provider";
-import type { AgentStudioQueryUpdate } from "../agent-studio-navigation";
-import {
-  type AgentStudioOrchestrationSelectionContext,
-  useAgentStudioOrchestrationController,
-} from "../use-agent-studio-orchestration-controller";
-import { useAgentStudioQuerySessionSync } from "../use-agent-studio-query-session-sync";
-import { useAgentStudioQuerySync } from "../use-agent-studio-query-sync";
-import { useAgentStudioRebaseConflictResolution } from "../use-agent-studio-rebase-conflict-resolution";
-import { useAgentStudioSelectionController } from "../use-agent-studio-selection-controller";
-import { useAgentStudioReadiness } from "../use-agents-page-readiness";
-import {
-  type AgentStudioGitConflictQuickActionContext,
-  type UseAgentsPageRightPanelModelArgs,
-  useAgentsPageRightPanelModel,
-} from "../use-agents-page-right-panel-model";
-import {
-  type AgentStudioSelectionIntent,
-  isSelectionIntentResolved,
-} from "./agent-studio-selection-intent";
+import type { useAgentStudioOrchestrationController } from "../use-agent-studio-orchestration-controller";
+import type { AgentStudioGitConflictQuickActionContext } from "../use-agents-page-right-panel-model";
 import { gitConflictQuickActionContextsEqual } from "./git-conflict-quick-action-context";
-import {
-  useForwardedWorktreeRefresh,
-  type WorktreeRefreshRef,
-} from "./use-forwarded-worktree-refresh";
+import { useAgentsPageOrchestrationShellModel } from "./use-agents-page-orchestration-shell-model";
+import { useAgentsPageRightPanelShellModel } from "./use-agents-page-right-panel-shell-model";
+import { useAgentsPageRouteSessionModel } from "./use-agents-page-route-session-model";
+import { useAgentsPageShellOverlays } from "./use-agents-page-shell-overlays";
 
 type AgentsPageShellModel = {
   activeWorkspace: ReturnType<typeof useWorkspaceState>["activeWorkspace"];
@@ -80,62 +47,6 @@ type AgentsPageShellModel = {
   taskDetailsSheet: ReactElement;
 };
 
-const AgentsPageRightPanelRuntime = memo(function AgentsPageRightPanelRuntime({
-  refreshWorktreeRef,
-  ...args
-}: UseAgentsPageRightPanelModelArgs & {
-  refreshWorktreeRef: WorktreeRefreshRef;
-}): ReactElement | null {
-  const { rightPanelModel, refreshWorktree } = useAgentsPageRightPanelModel(args);
-
-  useEffect(() => {
-    refreshWorktreeRef.current = refreshWorktree;
-    return () => {
-      if (refreshWorktreeRef.current === refreshWorktree) {
-        refreshWorktreeRef.current = null;
-      }
-    };
-  }, [refreshWorktree, refreshWorktreeRef]);
-
-  return rightPanelModel ? <MemoizedAgentStudioRightPanel model={rightPanelModel} /> : null;
-});
-
-function AgentsPageBuildWorktreeRefreshRuntime({
-  panelKind,
-  isPanelOpen,
-  viewRole,
-  activeSession,
-  isSessionHistoryHydrating,
-  refreshWorktreeRef,
-}: {
-  panelKind: "documents" | "build_tools" | null;
-  isPanelOpen: boolean;
-  viewRole: UseAgentsPageRightPanelModelArgs["viewRole"];
-  activeSession: AgentStudioOrchestrationSelectionContext["viewActiveSession"];
-  isSessionHistoryHydrating: boolean;
-  refreshWorktreeRef: WorktreeRefreshRef;
-}): null {
-  const refreshWorktree = useForwardedWorktreeRefresh(refreshWorktreeRef);
-
-  useAgentStudioBuildWorktreeRefresh({
-    viewRole: panelKind === "build_tools" && isPanelOpen ? viewRole : null,
-    activeSession,
-    isSessionHistoryHydrating,
-    refreshWorktree,
-  });
-
-  return null;
-}
-
-const EMPTY_TASK_SESSIONS_BY_TASK_ID = new Map<string, KanbanTaskSession[]>();
-const EMPTY_ACTIVE_TASK_SESSION_CONTEXT_BY_TASK_ID: ActiveTaskSessionContextByTaskId = new Map();
-
-const noopOpenSession = (
-  _taskId: string,
-  _role: AgentRole,
-  _options?: { externalSessionId?: string | null },
-): void => {};
-
 export function useAgentsPageShellModel(): AgentsPageShellModel {
   const { activeBranch, branches, activeWorkspace } = useWorkspaceState();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
@@ -161,70 +72,46 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     unlinkingPullRequestTaskId,
     setTaskTargetBranch,
   } = useTasksState();
+  const agentOperations = useAgentOperations();
   const {
-    bootstrapTaskSessions,
     hydrateRequestedTaskSessionHistory,
     ensureSessionReadyForView,
-    readSessionFileSearch,
     readSessionModelCatalog,
-    readSessionSlashCommands,
     readSessionTodos,
-    startAgentSession,
-    settleStartedAgentSession,
-    sendAgentMessage,
-    stopAgentSession,
-    updateAgentSessionModel,
-    replyAgentApproval,
-    answerAgentQuestion,
-  } = useAgentOperations();
+  } = agentOperations;
   const sessions = useAgentSessionSummaries();
 
-  const [searchParams, setSearchParams] = useSearchParams();
-  const navigationType = useNavigationType();
-  const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
-  const [selectionIntent, setSelectionIntent] = useState<AgentStudioSelectionIntent | null>(null);
-  const [sessionlessSelection, setSessionlessSelection] =
-    useState<AgentStudioSelectionIntent | null>(null);
   const [gitConflictQuickActionContext, setGitConflictQuickActionContext] =
     useState<AgentStudioGitConflictQuickActionContext | null>(null);
   const gitConflictQuickActionContextRef = useRef<AgentStudioGitConflictQuickActionContext | null>(
     null,
   );
-  const taskDetailsSheetRef = useRef<TaskDetailsSheetControllerHandle | null>(null);
-  const rightPanelRefreshWorktreeRef = useRef<GitDiffRefresh | null>(null);
+  const routeSession = useAgentsPageRouteSessionModel({
+    activeWorkspace,
+    workspaceRepoPath,
+    runtimeDefinitions,
+    isLoadingRuntimeDefinitions,
+    runtimeDefinitionsError,
+    runtimeHealthByRuntime,
+    isLoadingChecks,
+    refreshChecks,
+    refreshRepoRuntimeHealthForRepo,
+    hasCachedRepoRuntimeHealth,
+    tasks,
+    isForegroundLoadingTasks,
+    sessions,
+    hydrateRequestedTaskSessionHistory,
+    ensureSessionReadyForView,
+    readSessionModelCatalog,
+    readSessionTodos,
+  });
   const {
-    taskIdParam,
-    sessionParam,
-    hasExplicitRoleParam,
-    roleFromQuery,
-    isRepoNavigationBoundaryPending,
     navigationPersistenceError,
     retryNavigationPersistence,
-    updateQuery,
-  } = useAgentStudioQuerySync({
-    activeWorkspace,
-    navigationType,
-    searchParams,
-    setSearchParams,
-  });
+    selection,
+    worktreeRecoverySignal,
+  } = routeSession;
 
-  const scheduleQueryUpdate = useCallback(
-    (updates: AgentStudioQueryUpdate): void => {
-      updateQuery(updates);
-    },
-    [updateQuery],
-  );
-
-  const signalContextSwitchIntent = useCallback((): void => {
-    setContextSwitchVersion((current) => current + 1);
-  }, []);
-  const scheduleSelectionIntent = useCallback(
-    (intent: { taskId: string; externalSessionId: string | null; role: AgentRole }): void => {
-      setSelectionIntent(intent);
-      setSessionlessSelection(intent.externalSessionId === null ? intent : null);
-    },
-    [],
-  );
   const handleGitConflictQuickActionContextChange = useCallback(
     (context: AgentStudioGitConflictQuickActionContext | null): void => {
       gitConflictQuickActionContextRef.current = context;
@@ -234,86 +121,6 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     },
     [],
   );
-
-  const clearComposerInput = signalContextSwitchIntent;
-  const activeSessionlessSelection =
-    sessionlessSelection &&
-    sessionlessSelection.taskId === taskIdParam &&
-    sessionlessSelection.role === roleFromQuery &&
-    sessionParam === null
-      ? sessionlessSelection
-      : null;
-  const readiness = useAgentStudioReadiness({
-    activeWorkspace,
-    runtimeDefinitions,
-    isLoadingRuntimeDefinitions,
-    runtimeDefinitionsError,
-    runtimeHealthByRuntime,
-    isLoadingChecks,
-    refreshChecks,
-  });
-
-  const selection = useAgentStudioSelectionController({
-    activeWorkspace,
-    isRepoNavigationBoundaryPending,
-    tasks,
-    isLoadingTasks: isForegroundLoadingTasks,
-    sessions,
-    taskIdParam,
-    sessionParam,
-    hasExplicitRoleParam,
-    roleFromQuery,
-    selectionIntent: selectionIntent ?? activeSessionlessSelection,
-    updateQuery: scheduleQueryUpdate,
-    agentStudioReadinessState: readiness.agentStudioReadinessState,
-    hydrateRequestedTaskSessionHistory,
-    ensureSessionReadyForView,
-    runtimeDefinitions,
-    readSessionModelCatalog,
-    readSessionTodos,
-    clearComposerInput,
-    onContextSwitchIntent: signalContextSwitchIntent,
-  });
-
-  useEffect(() => {
-    if (isRepoNavigationBoundaryPending) {
-      setSelectionIntent(null);
-      return;
-    }
-
-    if (!selectionIntent) {
-      return;
-    }
-
-    const selectionIntentResolved = isSelectionIntentResolved({
-      selectionIntent,
-      taskIdParam,
-      sessionParam,
-      roleFromQuery,
-    });
-
-    if (selectionIntentResolved) {
-      setSelectionIntent(null);
-    }
-  }, [isRepoNavigationBoundaryPending, roleFromQuery, selectionIntent, sessionParam, taskIdParam]);
-
-  const isSessionSelectionResolving = Boolean(
-    selectionIntent &&
-      !isRepoNavigationBoundaryPending &&
-      !isSelectionIntentResolved({
-        selectionIntent,
-        taskIdParam,
-        sessionParam,
-        roleFromQuery,
-      }),
-  );
-
-  const openTaskDetails = useCallback((): void => {
-    if (!selection.viewSelectedTask) {
-      return;
-    }
-    taskDetailsSheetRef.current?.openTask(selection.viewSelectedTask.id);
-  }, [selection.viewSelectedTask]);
 
   const handleDetectPullRequest = useCallback(
     (taskId: string): void => {
@@ -337,234 +144,53 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     cancelLinkMergedPullRequest();
   }, [cancelLinkMergedPullRequest]);
 
-  const draftStateKey = useMemo(
-    () =>
-      [
-        selection.viewTaskId,
-        selection.viewRole,
-        selection.viewActiveSession?.externalSessionId ?? "new",
-        contextSwitchVersion,
-      ].join(":"),
-    [
-      contextSwitchVersion,
-      selection.viewActiveSession?.externalSessionId,
-      selection.viewRole,
-      selection.viewTaskId,
-    ],
-  );
-
-  const [worktreeRecoverySignal, setWorktreeRecoverySignal] = useState(0);
-  const lastWorktreeRecoveryKeyRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    const nextRecoveryKey = [
-      workspaceRepoPath ?? "",
-      selection.viewTaskId ?? "",
-      selection.viewSelectedTask?.updatedAt ?? "",
-      selection.viewSelectedTask?.status ?? "",
-      selection.viewActiveSession?.externalSessionId ?? "",
-      selection.viewActiveSession?.status ?? "",
-      selection.viewActiveSession?.workingDirectory ?? "",
-      selection.isViewSessionHistoryHydrating ? "1" : "0",
-      isForegroundLoadingTasks ? "1" : "0",
-    ].join(":");
-
-    if (lastWorktreeRecoveryKeyRef.current === null) {
-      lastWorktreeRecoveryKeyRef.current = nextRecoveryKey;
-      return;
-    }
-
-    if (lastWorktreeRecoveryKeyRef.current === nextRecoveryKey) {
-      return;
-    }
-
-    lastWorktreeRecoveryKeyRef.current = nextRecoveryKey;
-    setWorktreeRecoverySignal((previous) => previous + 1);
-  }, [
-    isForegroundLoadingTasks,
-    selection.isViewSessionHistoryHydrating,
-    selection.viewActiveSession?.externalSessionId,
-    selection.viewActiveSession?.status,
-    selection.viewActiveSession?.workingDirectory,
-    selection.viewSelectedTask?.status,
-    selection.viewSelectedTask?.updatedAt,
-    selection.viewTaskId,
-    workspaceRepoPath,
-  ]);
-
-  useEffect(() => {
-    if (!workspaceRepoPath || runtimeDefinitions.length === 0 || isLoadingChecks) {
-      return;
-    }
-    const runtimeKinds = runtimeDefinitions.map((definition) => definition.kind);
-    if (hasCachedRepoRuntimeHealth(workspaceRepoPath, runtimeKinds)) {
-      return;
-    }
-    void refreshRepoRuntimeHealthForRepo(workspaceRepoPath, false);
-  }, [
-    workspaceRepoPath,
-    hasCachedRepoRuntimeHealth,
-    isLoadingChecks,
-    refreshRepoRuntimeHealthForRepo,
-    runtimeDefinitions,
-  ]);
-
-  useAgentStudioQuerySessionSync({
-    isRepoNavigationBoundaryPending,
-    isLoadingTasks: isForegroundLoadingTasks,
+  const { openTaskDetails, mergedPullRequestModal, taskDetailsSheet } = useAgentsPageShellOverlays({
+    activeWorkspace,
     tasks,
-    taskIdParam,
-    sessionParam,
-    selectedSessionById: selection.selectedSessionById,
-    taskId: selection.taskId,
-    activeSession: selection.activeSession,
-    roleFromQuery,
-    isActiveTaskHydrated: selection.isActiveTaskHydrated,
-    scheduleQueryUpdate,
+    selectedTaskId: selection.viewSelectedTask?.id ?? null,
+    pendingMergedPullRequest,
+    linkingMergedPullRequestTaskId,
+    detectingPullRequestTaskId,
+    unlinkingPullRequestTaskId,
+    onDetectPullRequest: handleDetectPullRequest,
+    onUnlinkPullRequest: handleUnlinkPullRequest,
+    onLinkMergedPullRequest: handleLinkMergedPullRequest,
+    onCancelLinkMergedPullRequest: handleCancelLinkMergedPullRequest,
   });
 
-  const orchestration = useAgentStudioOrchestrationController({
+  const {
+    orchestration,
+    orchestrationSelection,
+    handleResolveRebaseConflict,
+    agentStudioHeaderModel,
+  } = useAgentsPageOrchestrationShellModel({
     activeWorkspace,
     branches,
     runtimeDefinitions,
-    selection: {
-      ...selection,
-      contextSwitchVersion,
-      isSessionSelectionResolving,
-      isLoadingTasks: isForegroundLoadingTasks,
-    },
-    readiness,
+    isForegroundLoadingTasks,
+    routeSession,
     hasActiveGitConflict: gitConflictQuickActionContext !== null,
-    draftStateKey,
-    actions: {
-      updateQuery: scheduleQueryUpdate,
-      onContextSwitchIntent: signalContextSwitchIntent,
-      openTaskDetails,
-      startAgentSession,
-      settleStartedAgentSession,
-      sendAgentMessage,
-      stopAgentSession,
-      updateAgentSessionModel,
-      readSessionFileSearch,
-      readSessionSlashCommands,
-      bootstrapTaskSessions,
-      hydrateRequestedTaskSessionHistory,
-      humanRequestChangesTask,
-      setTaskTargetBranch,
-      replyAgentApproval,
-      answerAgentQuestion,
-      scheduleSelectionIntent,
-    },
+    gitConflictQuickActionContext,
+    gitConflictQuickActionContextRef,
+    openTaskDetails,
+    agentOperations,
+    humanRequestChangesTask,
+    setTaskTargetBranch,
   });
 
-  const { startSessionRequest } = orchestration;
-  const activeSessionSummary = useMemo(
-    () =>
-      selection.activeSessionSummary ??
-      (selection.activeSession ? toAgentSessionSummary(selection.activeSession) : null),
-    [selection.activeSession, selection.activeSessionSummary],
-  );
-  const viewActiveSessionSummary = useMemo(
-    () =>
-      selection.viewActiveSessionSummary ??
-      (selection.viewActiveSession ? toAgentSessionSummary(selection.viewActiveSession) : null),
-    [selection.viewActiveSession, selection.viewActiveSessionSummary],
-  );
-  const rebaseConflictSelection = useMemo(
-    () => ({
-      viewTaskId: selection.viewTaskId,
-      viewSelectedTask: selection.viewSelectedTask,
-      viewActiveSession: viewActiveSessionSummary,
-      activeSession: activeSessionSummary,
-      selectedSessionById: selection.selectedSessionById,
-      viewSessionsForTask: selection.viewSessionsForTask,
-      sessionsForTask: selection.sessionsForTask,
-    }),
-    [
-      activeSessionSummary,
-      selection.selectedSessionById,
-      selection.sessionsForTask,
-      selection.viewSelectedTask,
-      selection.viewSessionsForTask,
-      selection.viewTaskId,
-      viewActiveSessionSummary,
-    ],
-  );
-
-  const { handleResolveRebaseConflict } = useAgentStudioRebaseConflictResolution({
+  const { isRightPanelVisible, rightPanelContent } = useAgentsPageRightPanelShellModel({
     activeWorkspace,
-    selection: rebaseConflictSelection,
-    scheduleQueryUpdate,
-    onContextSwitchIntent: signalContextSwitchIntent,
-    startSessionRequest,
+    branches: branches ?? [],
+    activeBranch,
+    selection: orchestrationSelection,
+    orchestration,
+    worktreeRecoverySignal,
+    setTaskTargetBranch,
+    detectingPullRequestTaskId,
+    onDetectPullRequest: handleDetectPullRequest,
+    onResolveGitConflict: handleResolveRebaseConflict,
+    onGitConflictQuickActionContextChange: handleGitConflictQuickActionContextChange,
   });
-
-  const isRightPanelVisible = Boolean(
-    orchestration.rightPanel.panelKind && orchestration.rightPanel.isPanelOpen,
-  );
-  const rightPanelSessionRole = selection.viewActiveSession?.role ?? null;
-  const rightPanelSessionStatus = selection.viewActiveSession?.status ?? null;
-  const rightPanelSessionWorkingDirectory = selection.viewActiveSession?.workingDirectory ?? null;
-  const rightPanelHasActiveSession = selection.viewActiveSession != null;
-  const rightPanelSession = useMemo<BuildToolsSessionDescriptor>(
-    () => ({
-      role: rightPanelSessionRole,
-      status: rightPanelSessionStatus,
-      workingDirectory: rightPanelSessionWorkingDirectory,
-      hasActiveSession: rightPanelHasActiveSession,
-    }),
-    [
-      rightPanelHasActiveSession,
-      rightPanelSessionRole,
-      rightPanelSessionStatus,
-      rightPanelSessionWorkingDirectory,
-    ],
-  );
-  const rightPanelContent = orchestration.rightPanel.panelKind ? (
-    <>
-      <AgentsPageBuildWorktreeRefreshRuntime
-        panelKind={orchestration.rightPanel.panelKind}
-        isPanelOpen={orchestration.rightPanel.isPanelOpen}
-        viewRole={selection.viewRole}
-        activeSession={selection.viewActiveSession}
-        isSessionHistoryHydrating={selection.isViewSessionHistoryHydrating}
-        refreshWorktreeRef={rightPanelRefreshWorktreeRef}
-      />
-      <AgentsPageRightPanelRuntime
-        activeWorkspace={activeWorkspace}
-        branches={branches}
-        activeBranch={activeBranch}
-        viewRole={selection.viewRole}
-        viewTaskId={selection.viewTaskId}
-        session={rightPanelSession}
-        viewSelectedTask={selection.viewSelectedTask}
-        panelKind={orchestration.rightPanel.panelKind}
-        isPanelOpen={orchestration.rightPanel.isPanelOpen}
-        isViewSessionHistoryHydrating={selection.isViewSessionHistoryHydrating}
-        documentsModel={orchestration.agentStudioWorkspaceSidebarModel}
-        repoSettings={orchestration.repoSettings}
-        worktreeRecoverySignal={worktreeRecoverySignal}
-        setTaskTargetBranch={setTaskTargetBranch}
-        detectingPullRequestTaskId={detectingPullRequestTaskId}
-        onDetectPullRequest={handleDetectPullRequest}
-        onResolveGitConflict={handleResolveRebaseConflict}
-        onGitConflictQuickActionContextChange={handleGitConflictQuickActionContextChange}
-        refreshWorktreeRef={rightPanelRefreshWorktreeRef}
-      />
-    </>
-  ) : null;
-
-  const agentStudioHeaderModel = useMemo(
-    () => ({
-      ...orchestration.agentStudioHeaderModel,
-      onResolveGitConflictQuickAction: gitConflictQuickActionContext
-        ? () => {
-            void gitConflictQuickActionContextRef.current?.resolveWithBuilder();
-          }
-        : null,
-    }),
-    [gitConflictQuickActionContext, orchestration.agentStudioHeaderModel],
-  );
 
   const sessionStartModal = orchestration.sessionStartModal ? (
     <SessionStartModal model={orchestration.sessionStartModal} />
@@ -572,31 +198,6 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
 
   const humanReviewFeedbackModal = (
     <HumanReviewFeedbackModal model={orchestration.humanReviewFeedbackModal} />
-  );
-
-  const mergedPullRequestModal = pendingMergedPullRequest ? (
-    <MergedPullRequestConfirmDialog
-      pullRequest={pendingMergedPullRequest.pullRequest}
-      isLinking={pendingMergedPullRequest.taskId === linkingMergedPullRequestTaskId}
-      onCancel={handleCancelLinkMergedPullRequest}
-      onConfirm={() => void handleLinkMergedPullRequest()}
-    />
-  ) : null;
-
-  const taskDetailsSheet = (
-    <TaskDetailsSheetController
-      ref={taskDetailsSheetRef}
-      activeWorkspace={activeWorkspace}
-      allTasks={tasks}
-      taskSessionsByTaskId={EMPTY_TASK_SESSIONS_BY_TASK_ID}
-      activeTaskSessionContextByTaskId={EMPTY_ACTIVE_TASK_SESSION_CONTEXT_BY_TASK_ID}
-      workflowActionsEnabled={false}
-      onOpenSession={noopOpenSession}
-      onDetectPullRequest={handleDetectPullRequest}
-      onUnlinkPullRequest={handleUnlinkPullRequest}
-      detectingPullRequestTaskId={detectingPullRequestTaskId}
-      unlinkingPullRequestTaskId={unlinkingPullRequestTaskId}
-    />
   );
 
   return {

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -72,13 +72,22 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     unlinkingPullRequestTaskId,
     setTaskTargetBranch,
   } = useTasksState();
-  const agentOperations = useAgentOperations();
   const {
+    bootstrapTaskSessions,
     hydrateRequestedTaskSessionHistory,
     ensureSessionReadyForView,
+    readSessionFileSearch,
     readSessionModelCatalog,
+    readSessionSlashCommands,
     readSessionTodos,
-  } = agentOperations;
+    startAgentSession,
+    settleStartedAgentSession,
+    sendAgentMessage,
+    stopAgentSession,
+    updateAgentSessionModel,
+    replyAgentApproval,
+    answerAgentQuestion,
+  } = useAgentOperations();
   const sessions = useAgentSessionSummaries();
 
   const [gitConflictQuickActionContext, setGitConflictQuickActionContext] =
@@ -165,7 +174,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     agentStudioHeaderModel,
   } = useAgentsPageOrchestrationShellModel({
     activeWorkspace,
-    branches,
+    branches: branches ?? [],
     runtimeDefinitions,
     isForegroundLoadingTasks,
     routeSession,
@@ -173,7 +182,19 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     gitConflictQuickActionContext,
     gitConflictQuickActionContextRef,
     openTaskDetails,
-    agentOperations,
+    agentOperations: {
+      bootstrapTaskSessions,
+      hydrateRequestedTaskSessionHistory,
+      readSessionFileSearch,
+      readSessionSlashCommands,
+      startAgentSession,
+      settleStartedAgentSession,
+      sendAgentMessage,
+      stopAgentSession,
+      updateAgentSessionModel,
+      replyAgentApproval,
+      answerAgentQuestion,
+    },
     humanRequestChangesTask,
     setTaskTargetBranch,
   });

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -180,7 +180,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
 
   const { isRightPanelVisible, rightPanelContent } = useAgentsPageRightPanelShellModel({
     activeWorkspace,
-    branches: branches ?? [],
+    branches,
     activeBranch,
     selection: orchestrationSelection,
     orchestration,

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-overlays.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-overlays.tsx
@@ -1,0 +1,97 @@
+import type { AgentRole } from "@openducktor/core";
+import { type ReactElement, useCallback, useRef } from "react";
+import type {
+  ActiveTaskSessionContextByTaskId,
+  KanbanTaskSession,
+} from "@/components/features/kanban/kanban-task-activity";
+import { MergedPullRequestConfirmDialog } from "@/components/features/pull-requests/merged-pull-request-confirm-dialog";
+import {
+  TaskDetailsSheetController,
+  type TaskDetailsSheetControllerHandle,
+} from "@/components/features/task-details/task-details-sheet-controller";
+import type { useTasksState, useWorkspaceState } from "@/state/app-state-provider";
+
+type UseAgentsPageShellOverlaysArgs = {
+  activeWorkspace: ReturnType<typeof useWorkspaceState>["activeWorkspace"];
+  tasks: ReturnType<typeof useTasksState>["tasks"];
+  selectedTaskId: string | null;
+  pendingMergedPullRequest: ReturnType<typeof useTasksState>["pendingMergedPullRequest"];
+  linkingMergedPullRequestTaskId: ReturnType<
+    typeof useTasksState
+  >["linkingMergedPullRequestTaskId"];
+  detectingPullRequestTaskId: ReturnType<typeof useTasksState>["detectingPullRequestTaskId"];
+  unlinkingPullRequestTaskId: ReturnType<typeof useTasksState>["unlinkingPullRequestTaskId"];
+  onDetectPullRequest: (taskId: string) => void;
+  onUnlinkPullRequest: (taskId: string) => void;
+  onLinkMergedPullRequest: () => Promise<void>;
+  onCancelLinkMergedPullRequest: () => void;
+};
+
+export type AgentsPageShellOverlaysModel = {
+  openTaskDetails: () => void;
+  mergedPullRequestModal: ReactElement | null;
+  taskDetailsSheet: ReactElement;
+};
+
+const EMPTY_TASK_SESSIONS_BY_TASK_ID = new Map<string, KanbanTaskSession[]>();
+const EMPTY_ACTIVE_TASK_SESSION_CONTEXT_BY_TASK_ID: ActiveTaskSessionContextByTaskId = new Map();
+
+const noopOpenSession = (
+  _taskId: string,
+  _role: AgentRole,
+  _options?: { externalSessionId?: string | null },
+): void => {};
+
+export function useAgentsPageShellOverlays({
+  activeWorkspace,
+  tasks,
+  selectedTaskId,
+  pendingMergedPullRequest,
+  linkingMergedPullRequestTaskId,
+  detectingPullRequestTaskId,
+  unlinkingPullRequestTaskId,
+  onDetectPullRequest,
+  onUnlinkPullRequest,
+  onLinkMergedPullRequest,
+  onCancelLinkMergedPullRequest,
+}: UseAgentsPageShellOverlaysArgs): AgentsPageShellOverlaysModel {
+  const taskDetailsSheetRef = useRef<TaskDetailsSheetControllerHandle | null>(null);
+
+  const openTaskDetails = useCallback((): void => {
+    if (!selectedTaskId) {
+      return;
+    }
+    taskDetailsSheetRef.current?.openTask(selectedTaskId);
+  }, [selectedTaskId]);
+
+  const mergedPullRequestModal = pendingMergedPullRequest ? (
+    <MergedPullRequestConfirmDialog
+      pullRequest={pendingMergedPullRequest.pullRequest}
+      isLinking={pendingMergedPullRequest.taskId === linkingMergedPullRequestTaskId}
+      onCancel={onCancelLinkMergedPullRequest}
+      onConfirm={() => void onLinkMergedPullRequest()}
+    />
+  ) : null;
+
+  const taskDetailsSheet = (
+    <TaskDetailsSheetController
+      ref={taskDetailsSheetRef}
+      activeWorkspace={activeWorkspace}
+      allTasks={tasks}
+      taskSessionsByTaskId={EMPTY_TASK_SESSIONS_BY_TASK_ID}
+      activeTaskSessionContextByTaskId={EMPTY_ACTIVE_TASK_SESSION_CONTEXT_BY_TASK_ID}
+      workflowActionsEnabled={false}
+      onOpenSession={noopOpenSession}
+      onDetectPullRequest={onDetectPullRequest}
+      onUnlinkPullRequest={onUnlinkPullRequest}
+      detectingPullRequestTaskId={detectingPullRequestTaskId}
+      unlinkingPullRequestTaskId={unlinkingPullRequestTaskId}
+    />
+  );
+
+  return {
+    openTaskDetails,
+    mergedPullRequestModal,
+    taskDetailsSheet,
+  };
+}


### PR DESCRIPTION
Summary: Decomposes the Agent Studio shell model into focused submodels so the top-level shell hook is easier to read, test, and maintain.

Goal:
The existing useAgentsPageShellModel hook had grown into a multi-responsibility composition point for route state, runtime readiness, session selection, orchestration actions, right-panel wiring, overlays, and task details. This PR reduces that hook back to a thin composition layer and moves each responsibility into a smaller local model.

Technical approach:
- Extracted route/session/query/readiness behavior into useAgentsPageRouteSessionModel.
- Extracted selection-intent lifecycle and worktree recovery signaling into dedicated hooks so route/session state does not own unrelated internal mechanisms.
- Extracted orchestration, rebase conflict handling, and header quick-action wiring into useAgentsPageOrchestrationShellModel.
- Extracted right-panel shell wiring and moved right-panel runtime components into a component-only module to keep React fast-refresh boundaries clean.
- Extracted task details and pull-request overlay wiring into useAgentsPageShellOverlays.
- Kept behavior and public contracts stable; no fallback logic or API changes were introduced.

Verification:
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cd apps/desktop/src-tauri && cargo fmt --all --check
- cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings
- bun run check:rust
- bun run test:rust
- cd apps/desktop/src-tauri && cargo build --workspace
- React Doctor diff scan: 100/100, no issues

Notes:
Bun tests passed with existing React act/suspense warnings in unrelated document copy/snapshot tests. Vite build passed with existing chunk-size warnings.