### PR TITLE
fix(host): route git validation through Effect errors

### DIFF
--- a/packages/host/src/application/git/git-service-inputs.ts
+++ b/packages/host/src/application/git/git-service-inputs.ts
@@ -112,20 +112,24 @@ export const resolveGitWorkingDirectory = (
     }
     return canonicalWorkingDir;
   });
-export const requireGlobalConfig = (payload: GlobalConfig | null): GlobalConfig => {
+export const requireGlobalConfig = (
+  payload: GlobalConfig | null,
+): Effect.Effect<GlobalConfig, HostValidationError> => {
   if (payload === null) {
-    throw new HostValidationError({
-      message: "No OpenDucktor workspace config is available for git worktree mutation.",
-    });
+    return Effect.fail(
+      new HostValidationError({
+        message: "No OpenDucktor workspace config is available for git worktree mutation.",
+      }),
+    );
   }
-  return payload;
+  return Effect.succeed(payload);
 };
 export const findRepoConfigByPath = (
   settingsConfig: SettingsConfigPort,
   canonicalRepoPath: string,
 ) =>
   Effect.gen(function* () {
-    const config = requireGlobalConfig(yield* settingsConfig.readConfig());
+    const config = yield* requireGlobalConfig(yield* settingsConfig.readConfig());
     for (const repoConfig of Object.values(config.workspaces)) {
       const configuredRepoPath = yield* settingsConfig.canonicalizePath(repoConfig.repoPath);
       if (configuredRepoPath === canonicalRepoPath) {
@@ -150,27 +154,31 @@ export const isDefinitiveNonWorktreeGitError = (error: unknown): boolean => {
 };
 export const requireSettingsConfig = (
   settingsConfig: SettingsConfigPort | undefined,
-): SettingsConfigPort => {
+): Effect.Effect<SettingsConfigPort, HostDependencyError> => {
   if (!settingsConfig) {
-    throw new HostDependencyError({
-      dependency: "settingsConfig",
-      operation: "git.worktree_mutation",
-      message: "Settings config port is required for git worktree mutation commands.",
-    });
+    return Effect.fail(
+      new HostDependencyError({
+        dependency: "settingsConfig",
+        operation: "git.worktree_mutation",
+        message: "Settings config port is required for git worktree mutation commands.",
+      }),
+    );
   }
-  return settingsConfig;
+  return Effect.succeed(settingsConfig);
 };
 export const requireWorktreeFiles = (
   worktreeFiles: WorktreeFilePort | undefined,
-): WorktreeFilePort => {
+): Effect.Effect<WorktreeFilePort, HostDependencyError> => {
   if (!worktreeFiles) {
-    throw new HostDependencyError({
-      dependency: "worktreeFiles",
-      operation: "git.worktree_mutation",
-      message: "Worktree file port is required for git worktree mutation commands.",
-    });
+    return Effect.fail(
+      new HostDependencyError({
+        dependency: "worktreeFiles",
+        operation: "git.worktree_mutation",
+        message: "Worktree file port is required for git worktree mutation commands.",
+      }),
+    );
   }
-  return worktreeFiles;
+  return Effect.succeed(worktreeFiles);
 };
 export const cleanupFailedCreatedWorktree = (
   gitPort: GitPort,

--- a/packages/host/src/application/git/git-service-types.ts
+++ b/packages/host/src/application/git/git-service-types.ts
@@ -18,7 +18,11 @@ import type {
   GitWorktreeSummary,
 } from "@openducktor/contracts";
 import type { Effect } from "effect";
-import type { HostOperationError, HostValidationError } from "../../effect/host-errors";
+import type {
+  HostDependencyError,
+  HostOperationError,
+  HostValidationError,
+} from "../../effect/host-errors";
 import type { GitPortError } from "../../ports/git-port";
 import type { SettingsConfigError } from "../../ports/settings-config-port";
 import type { WorktreeFileError } from "../../ports/worktree-file-port";
@@ -38,6 +42,7 @@ import type {
 
 export type GitServiceError =
   | GitPortError
+  | HostDependencyError
   | HostOperationError
   | HostValidationError
   | SettingsConfigError

--- a/packages/host/src/application/git/git-service.test.ts
+++ b/packages/host/src/application/git/git-service.test.ts
@@ -1038,10 +1038,7 @@ describe("createGitService", () => {
       ),
     );
     expect(error).toBeInstanceOf(HostDependencyError);
-    if (!(error instanceof HostDependencyError)) {
-      throw new Error("expected missing settings config to fail with HostDependencyError");
-    }
-    expect(error.dependency).toBe("settingsConfig");
+    expect(error).toMatchObject({ dependency: "settingsConfig" });
     expect(calls).toEqual([]);
   });
   test("fails create worktree through the Effect channel when worktree files are missing", async () => {
@@ -1065,10 +1062,7 @@ describe("createGitService", () => {
       ),
     );
     expect(error).toBeInstanceOf(HostDependencyError);
-    if (!(error instanceof HostDependencyError)) {
-      throw new Error("expected missing worktree files to fail with HostDependencyError");
-    }
-    expect(error.dependency).toBe("worktreeFiles");
+    expect(error).toMatchObject({ dependency: "worktreeFiles" });
     expect(calls).toEqual([]);
   });
   test("fails create worktree through the Effect channel when workspace config is missing", async () => {
@@ -1143,10 +1137,7 @@ describe("createGitService", () => {
       ),
     );
     expect(error).toBeInstanceOf(HostDependencyError);
-    if (!(error instanceof HostDependencyError)) {
-      throw new Error("expected missing settings config to fail with HostDependencyError");
-    }
-    expect(error.dependency).toBe("settingsConfig");
+    expect(error).toMatchObject({ dependency: "settingsConfig" });
     expect(calls).toEqual([]);
   });
   test("fails remove worktree through the Effect channel when worktree files are missing", async () => {
@@ -1169,10 +1160,7 @@ describe("createGitService", () => {
       ),
     );
     expect(error).toBeInstanceOf(HostDependencyError);
-    if (!(error instanceof HostDependencyError)) {
-      throw new Error("expected missing worktree files to fail with HostDependencyError");
-    }
-    expect(error.dependency).toBe("worktreeFiles");
+    expect(error).toMatchObject({ dependency: "worktreeFiles" });
     expect(calls).toEqual([]);
   });
   test("rejects forced stranded worktree cleanup outside managed roots", async () => {

--- a/packages/host/src/application/git/git-service.test.ts
+++ b/packages/host/src/application/git/git-service.test.ts
@@ -1149,6 +1149,32 @@ describe("createGitService", () => {
     expect(error.dependency).toBe("settingsConfig");
     expect(calls).toEqual([]);
   });
+  test("fails remove worktree through the Effect channel when worktree files are missing", async () => {
+    const calls: string[] = [];
+    const service = createGitService({
+      gitPort: createFakeGitPort({
+        canonicalPaths: { "/repo": "/canonical/repo" },
+        gitRepositories: ["/canonical/repo"],
+        calls,
+      }),
+      settingsConfig: createFakeSettingsConfig(createConfig()),
+    });
+    const error = await Effect.runPromise(
+      Effect.flip(
+        service.removeWorktree({
+          repoPath: "/repo",
+          worktreePath: "/managed/repo/task-1",
+          force: true,
+        }),
+      ),
+    );
+    expect(error).toBeInstanceOf(HostDependencyError);
+    if (!(error instanceof HostDependencyError)) {
+      throw new Error("expected missing worktree files to fail with HostDependencyError");
+    }
+    expect(error.dependency).toBe("worktreeFiles");
+    expect(calls).toEqual([]);
+  });
   test("rejects forced stranded worktree cleanup outside managed roots", async () => {
     const calls: string[] = [];
     const service = createGitService({

--- a/packages/host/src/application/git/git-service.test.ts
+++ b/packages/host/src/application/git/git-service.test.ts
@@ -16,7 +16,11 @@ import type {
 } from "@openducktor/contracts";
 import { globalConfigSchema } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { HostOperationError } from "../../effect/host-errors";
+import {
+  HostDependencyError,
+  HostOperationError,
+  HostValidationError,
+} from "../../effect/host-errors";
 import type {
   GitPort,
   GitPushBranchOptions,
@@ -499,7 +503,7 @@ const createFakeGitPort = ({
       });
     },
   }) as GitPort as unknown as GitPort;
-const createFakeSettingsConfig = (config: GlobalConfig): SettingsConfigPort => ({
+const createFakeSettingsConfig = (config: GlobalConfig | null): SettingsConfigPort => ({
   readConfig() {
     return Effect.tryPromise({
       try: async () => {
@@ -1013,6 +1017,87 @@ describe("createGitService", () => {
       "copyConfiguredPaths:/canonical/repo|/worktrees/repo-task|.env",
     ]);
   });
+  test("fails create worktree through the Effect channel when settings config is missing", async () => {
+    const calls: string[] = [];
+    const service = createGitService({
+      gitPort: createFakeGitPort({
+        canonicalPaths: { "/repo": "/canonical/repo" },
+        gitRepositories: ["/canonical/repo"],
+        calls,
+      }),
+      worktreeFiles: createFakeWorktreeFiles(calls),
+    });
+    const error = await Effect.runPromise(
+      Effect.flip(
+        service.createWorktree({
+          repoPath: "/repo",
+          worktreePath: "/worktrees/repo-task",
+          branch: "feature/task",
+          createBranch: true,
+        }),
+      ),
+    );
+    expect(error).toBeInstanceOf(HostDependencyError);
+    if (!(error instanceof HostDependencyError)) {
+      throw new Error("expected missing settings config to fail with HostDependencyError");
+    }
+    expect(error.dependency).toBe("settingsConfig");
+    expect(calls).toEqual([]);
+  });
+  test("fails create worktree through the Effect channel when worktree files are missing", async () => {
+    const calls: string[] = [];
+    const service = createGitService({
+      gitPort: createFakeGitPort({
+        canonicalPaths: { "/repo": "/canonical/repo" },
+        gitRepositories: ["/canonical/repo"],
+        calls,
+      }),
+      settingsConfig: createFakeSettingsConfig(createConfig()),
+    });
+    const error = await Effect.runPromise(
+      Effect.flip(
+        service.createWorktree({
+          repoPath: "/repo",
+          worktreePath: "/worktrees/repo-task",
+          branch: "feature/task",
+          createBranch: true,
+        }),
+      ),
+    );
+    expect(error).toBeInstanceOf(HostDependencyError);
+    if (!(error instanceof HostDependencyError)) {
+      throw new Error("expected missing worktree files to fail with HostDependencyError");
+    }
+    expect(error.dependency).toBe("worktreeFiles");
+    expect(calls).toEqual([]);
+  });
+  test("fails create worktree through the Effect channel when workspace config is missing", async () => {
+    const calls: string[] = [];
+    const service = createGitService({
+      gitPort: createFakeGitPort({
+        canonicalPaths: { "/repo": "/canonical/repo" },
+        gitRepositories: ["/canonical/repo"],
+        calls,
+      }),
+      settingsConfig: createFakeSettingsConfig(null),
+      worktreeFiles: createFakeWorktreeFiles(calls),
+    });
+    const error = await Effect.runPromise(
+      Effect.flip(
+        service.createWorktree({
+          repoPath: "/repo",
+          worktreePath: "/worktrees/repo-task",
+          branch: "feature/task",
+          createBranch: true,
+        }),
+      ),
+    );
+    expect(error).toBeInstanceOf(HostValidationError);
+    expect(error.message).toBe(
+      "No OpenDucktor workspace config is available for git worktree mutation.",
+    );
+    expect(calls).toEqual([]);
+  });
   test("removes a worktree and cleans up the filesystem path", async () => {
     const calls: string[] = [];
     const service = createGitService({
@@ -1037,6 +1122,32 @@ describe("createGitService", () => {
       "removeWorktree:/canonical/repo|/managed/repo/task-1|true",
       "removePathIfPresent:/managed/repo/task-1",
     ]);
+  });
+  test("fails remove worktree through the Effect channel when settings config is missing", async () => {
+    const calls: string[] = [];
+    const service = createGitService({
+      gitPort: createFakeGitPort({
+        canonicalPaths: { "/repo": "/canonical/repo" },
+        gitRepositories: ["/canonical/repo"],
+        calls,
+      }),
+      worktreeFiles: createFakeWorktreeFiles(calls),
+    });
+    const error = await Effect.runPromise(
+      Effect.flip(
+        service.removeWorktree({
+          repoPath: "/repo",
+          worktreePath: "/managed/repo/task-1",
+          force: true,
+        }),
+      ),
+    );
+    expect(error).toBeInstanceOf(HostDependencyError);
+    if (!(error instanceof HostDependencyError)) {
+      throw new Error("expected missing settings config to fail with HostDependencyError");
+    }
+    expect(error.dependency).toBe("settingsConfig");
+    expect(calls).toEqual([]);
   });
   test("rejects forced stranded worktree cleanup outside managed roots", async () => {
     const calls: string[] = [];

--- a/packages/host/src/application/git/git-service.ts
+++ b/packages/host/src/application/git/git-service.ts
@@ -227,10 +227,10 @@ export const createGitService = (input: GitPort | CreateGitServiceInput): GitSer
     createWorktree(input) {
       return Effect.gen(function* () {
         const { repoPath, worktreePath, branch, createBranch } = input;
-        const canonicalRepoPath = yield* resolveGitWorkingDirectory(gitPort, repoPath, undefined);
         const config = yield* requireSettingsConfig(settingsConfig);
-        const repoConfig = yield* findRepoConfigByPath(config, canonicalRepoPath);
         const files = yield* requireWorktreeFiles(worktreeFiles);
+        const canonicalRepoPath = yield* resolveGitWorkingDirectory(gitPort, repoPath, undefined);
+        const repoConfig = yield* findRepoConfigByPath(config, canonicalRepoPath);
         yield* gitPort.createWorktree(canonicalRepoPath, worktreePath, branch, createBranch);
         yield* files
           .copyConfiguredPaths(canonicalRepoPath, worktreePath, repoConfig.worktreeCopyPaths)
@@ -271,9 +271,9 @@ export const createGitService = (input: GitPort | CreateGitServiceInput): GitSer
     removeWorktree(input) {
       return Effect.gen(function* () {
         const { repoPath, worktreePath, force } = input;
-        const canonicalRepoPath = yield* resolveGitWorkingDirectory(gitPort, repoPath, undefined);
-        const files = yield* requireWorktreeFiles(worktreeFiles);
         const config = yield* requireSettingsConfig(settingsConfig);
+        const files = yield* requireWorktreeFiles(worktreeFiles);
+        const canonicalRepoPath = yield* resolveGitWorkingDirectory(gitPort, repoPath, undefined);
         yield* removeWorktreeAndFilesystemPath(
           {
             gitPort,

--- a/packages/host/src/application/git/git-service.ts
+++ b/packages/host/src/application/git/git-service.ts
@@ -228,9 +228,9 @@ export const createGitService = (input: GitPort | CreateGitServiceInput): GitSer
       return Effect.gen(function* () {
         const { repoPath, worktreePath, branch, createBranch } = input;
         const canonicalRepoPath = yield* resolveGitWorkingDirectory(gitPort, repoPath, undefined);
-        const config = requireSettingsConfig(settingsConfig);
+        const config = yield* requireSettingsConfig(settingsConfig);
         const repoConfig = yield* findRepoConfigByPath(config, canonicalRepoPath);
-        const files = requireWorktreeFiles(worktreeFiles);
+        const files = yield* requireWorktreeFiles(worktreeFiles);
         yield* gitPort.createWorktree(canonicalRepoPath, worktreePath, branch, createBranch);
         yield* files
           .copyConfiguredPaths(canonicalRepoPath, worktreePath, repoConfig.worktreeCopyPaths)
@@ -272,11 +272,12 @@ export const createGitService = (input: GitPort | CreateGitServiceInput): GitSer
       return Effect.gen(function* () {
         const { repoPath, worktreePath, force } = input;
         const canonicalRepoPath = yield* resolveGitWorkingDirectory(gitPort, repoPath, undefined);
-        const files = requireWorktreeFiles(worktreeFiles);
+        const files = yield* requireWorktreeFiles(worktreeFiles);
+        const config = yield* requireSettingsConfig(settingsConfig);
         yield* removeWorktreeAndFilesystemPath(
           {
             gitPort,
-            settingsConfig: requireSettingsConfig(settingsConfig),
+            settingsConfig: config,
             worktreeFiles: files,
           },
           {


### PR DESCRIPTION
Summary: Route expected Git worktree validation and dependency failures through the typed Effect error channel instead of synchronous throws.

## Goal
Git worktree mutation helpers previously threw `HostValidationError` and `HostDependencyError` directly while their callers were already running inside `Effect.gen`. Those expected failures could bypass the service error channel, which made them less composable and less transport-safe. This PR makes those failures explicit `Effect` values and keeps missing worktree dependencies represented by the Git service contract.

## Technical Choices
- Converted `requireGlobalConfig`, `requireSettingsConfig`, and `requireWorktreeFiles` to return `Effect.Effect` values that fail with the same actionable host errors.
- Updated `createWorktree`, `removeWorktree`, and `findRepoConfigByPath` to `yield*` the validation helpers so failures stay in the typed Effect channel.
- Added `HostDependencyError` to `GitServiceError`, matching the missing-port failure mode for worktree mutation commands.
- Added regression coverage for missing settings config, missing worktree file port, and missing workspace config on worktree mutation paths, then simplified the dependency assertions to avoid test-only narrowing boilerplate.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cd apps/desktop/src-tauri && cargo fmt --all --check`
- `cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test`
- `cd apps/desktop/src-tauri && cargo build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure handling for git/worktree operations when workspace settings or worktree files are missing, ensuring operations fail cleanly and avoid unintended side effects.
  * Clearer validation and dependency checks to prevent incomplete or partial operations.

* **Tests**
  * Added tests covering missing configuration and file scenarios for worktree creation and removal to verify failures and no side effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->