### PR TITLE
fix: stabilize agent session presence

### DIFF
--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -841,6 +841,24 @@ describe("opencode-sdk-adapter", () => {
       ...mock.client,
       session: {
         ...mock.client.session,
+        list: async (input?: unknown) => {
+          mock.listCalls.push(input);
+          return {
+            data: [
+              {
+                id: "external-session-1",
+                projectID: "project-1",
+                directory: defaultWorkingDirectory,
+                title: "BUILD task-1",
+                time: {
+                  created: Date.parse("2026-02-22T12:00:00.000Z"),
+                  updated: Date.parse("2026-02-22T12:00:00.000Z"),
+                },
+              },
+            ],
+            error: undefined,
+          };
+        },
         status: async (input?: unknown) => {
           mock.statusCalls.push(input);
           return {
@@ -893,6 +911,8 @@ describe("opencode-sdk-adapter", () => {
       agentSessionStatus: "running",
       status: { type: "busy" },
     });
+    expect(mock.listCalls).toEqual([undefined]);
+    expect(mock.statusCalls).toEqual([{ directory: defaultWorkingDirectory }]);
   });
 
   test("sendUserMessage keeps presence active while resolving workflow tools", async () => {

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -18,6 +18,20 @@ type TestAdapterInternals = {
   clearPendingSubagentInputEvent: (externalSessionId: string, requestId: string) => void;
 };
 
+const createDeferred = <T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} => {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+};
+
 const defaultRepoPath = "/repo";
 const defaultWorkingDirectory = "/repo";
 
@@ -817,6 +831,256 @@ describe("opencode-sdk-adapter", () => {
             ],
           },
         ],
+      },
+    ]);
+  });
+
+  test("readSessionPresence keeps a newly attached local session active through idle runtime status", async () => {
+    const mock = makeMockClient();
+    const idleStatusClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        status: async (input?: unknown) => {
+          mock.statusCalls.push(input);
+          return {
+            data: {
+              "external-session-1": { type: "idle" },
+            },
+            error: undefined,
+          };
+        },
+      },
+      permission: {
+        ...mock.client.permission,
+        list: async (input?: unknown) => {
+          mock.permissionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      question: {
+        ...mock.client.question,
+        list: async (input?: unknown) => {
+          mock.questionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => idleStatusClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    const snapshot = await adapter.readSessionPresence({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      externalSessionId: "external-session-1",
+    });
+
+    expect(snapshot).toMatchObject({
+      presence: "runtime",
+      classification: "running",
+      agentSessionStatus: "running",
+      status: { type: "busy" },
+    });
+  });
+
+  test("sendUserMessage keeps presence active while resolving workflow tools", async () => {
+    const mock = makeMockClient();
+    const mcpStatusDeferred = createDeferred<{
+      data: { openducktor: { status: string } };
+      error: undefined;
+    }>();
+    const mcpStatusCalls: unknown[] = [];
+    const toolIdCalls: unknown[] = [];
+    const promptAsyncCalls: unknown[] = [];
+    const activeDuringToolSelectionClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        status: async (input?: unknown) => {
+          mock.statusCalls.push(input);
+          return {
+            data: {
+              "external-session-1": { type: "idle" },
+            },
+            error: undefined,
+          };
+        },
+        promptAsync: async (input: unknown) => {
+          promptAsyncCalls.push(input);
+          return { data: undefined, error: undefined };
+        },
+      },
+      permission: {
+        ...mock.client.permission,
+        list: async (input?: unknown) => {
+          mock.permissionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      question: {
+        ...mock.client.question,
+        list: async (input?: unknown) => {
+          mock.questionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      mcp: {
+        status: async (input: unknown) => {
+          mcpStatusCalls.push(input);
+          return mcpStatusDeferred.promise;
+        },
+        connect: async () => ({ data: true, error: undefined }),
+      },
+      tool: {
+        ids: async (input: unknown) => {
+          toolIdCalls.push(input);
+          return { data: ["odt_read_task"], error: undefined };
+        },
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => activeDuringToolSelectionClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    const sendPromise = adapter.sendUserMessage({
+      externalSessionId: "external-session-1",
+      parts: [{ kind: "text", text: "Continue" }],
+    });
+
+    expect(mcpStatusCalls).toEqual([{ directory: defaultWorkingDirectory }]);
+
+    const snapshot = await adapter.readSessionPresence({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      externalSessionId: "external-session-1",
+    });
+
+    expect(snapshot).toMatchObject({
+      presence: "runtime",
+      classification: "running",
+      agentSessionStatus: "running",
+      status: { type: "busy" },
+    });
+
+    mcpStatusDeferred.resolve({
+      data: { openducktor: { status: "connected" } },
+      error: undefined,
+    });
+    await sendPromise;
+
+    expect(toolIdCalls).toEqual([{ directory: defaultWorkingDirectory }]);
+    expect(promptAsyncCalls).toHaveLength(1);
+  });
+
+  test("readSessionPresence does not synthesize local presence for another working directory", async () => {
+    const mock = makeMockClient();
+    const emptyListClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        list: async (input?: unknown) => {
+          mock.listCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => emptyListClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    const snapshot = await adapter.readSessionPresence({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: "/other",
+      externalSessionId: "external-session-1",
+    });
+
+    expect(snapshot).toMatchObject({
+      presence: "stale",
+      classification: "stale",
+      ref: {
+        externalSessionId: "external-session-1",
+        workingDirectory: "/other",
+      },
+    });
+  });
+
+  test("listSessionPresence includes attached local sessions before runtime list catches up", async () => {
+    const mock = makeMockClient();
+    const emptyListClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        list: async (input?: unknown) => {
+          mock.listCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => emptyListClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    const snapshots = await adapter.listSessionPresence({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      directories: [defaultWorkingDirectory],
+    });
+
+    expect(snapshots).toMatchObject([
+      {
+        presence: "runtime",
+        classification: "running",
+        ref: {
+          externalSessionId: "external-session-1",
+          workingDirectory: defaultWorkingDirectory,
+        },
+        status: { type: "busy" },
+        pendingApprovals: [],
+        pendingQuestions: [],
       },
     ]);
   });

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -241,31 +241,31 @@ export class OpencodeSdkAdapter
           )
         : null;
 
-    return [...this.sessions.values()].flatMap((session) => {
+    const snapshots: LiveAgentSessionSnapshot[] = [];
+    for (const session of this.sessions.values()) {
       if (
         input.existingExternalSessionIds.has(session.externalSessionId) ||
         session.eventTransportKey !== input.runtimeEndpoint ||
         session.input.repoPath !== input.repoPath ||
         session.input.runtimeKind !== input.runtimeKind
       ) {
-        return [];
+        continue;
       }
 
       const workingDirectory = normalizeSessionDirectory(session.input.workingDirectory);
       if (!workingDirectory) {
-        return [];
+        continue;
       }
       if (requestedDirectorySet && !requestedDirectorySet.has(workingDirectory)) {
-        return [];
+        continue;
       }
 
-      return [
-        {
-          ...this.toLocallyAttachedPresenceSnapshot(session),
-          workingDirectory,
-        },
-      ];
-    });
+      snapshots.push({
+        ...this.toLocallyAttachedPresenceSnapshot(session),
+        workingDirectory,
+      });
+    }
+    return snapshots;
   }
 
   async startSession(input: StartAgentSessionInput): Promise<AgentSessionSummary> {
@@ -551,13 +551,13 @@ export class OpencodeSdkAdapter
       });
     }
 
+    const canonicalWorkingDirectory =
+      scannedSnapshot?.workingDirectory ?? localSessionWorkingDirectory ?? input.workingDirectory;
     return toAgentSessionPresenceSnapshotFromLiveSnapshot({
-      ref: scannedSnapshot
-        ? {
-            ...input,
-            workingDirectory: scannedSnapshot.workingDirectory,
-          }
-        : input,
+      ref: {
+        ...input,
+        workingDirectory: canonicalWorkingDirectory,
+      },
       runtimeId,
       snapshot: this.applyLocalActivityToPresenceSnapshot(
         runtimeClientInput.runtimeEndpoint,

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -16,6 +16,7 @@ import type {
   ListAgentModelsInput,
   ListLiveAgentSessionsInput,
   ListSessionPresenceInput,
+  LiveAgentSessionSnapshot,
   LiveAgentSessionSummary,
   LoadAgentFileStatusInput,
   LoadAgentSessionDiffInput,
@@ -50,8 +51,11 @@ import {
   type SessionEventListeners,
   subscribeSessionEvents,
 } from "./event-emitter";
-import { setSessionIdle } from "./event-stream/shared";
-import { listOpencodeLiveAgentSessionSnapshots } from "./live-session-snapshots";
+import { setSessionActive, setSessionIdle } from "./event-stream/shared";
+import {
+  listOpencodeLiveAgentSessionSnapshots,
+  normalizeSessionDirectory,
+} from "./live-session-snapshots";
 import { sendUserMessage } from "./message-execution";
 import {
   loadAndSeedSessionHistory,
@@ -185,6 +189,83 @@ export class OpencodeSdkAdapter
 
   listRuntimeDefinitions(): RuntimeDescriptor[] {
     return [this.getRuntimeDefinition()];
+  }
+
+  private toLocallyAttachedPresenceSnapshot(session: SessionRecord): LiveAgentSessionSnapshot {
+    return {
+      externalSessionId: session.externalSessionId,
+      title: session.input.role
+        ? `${session.input.role.toUpperCase()} ${session.input.taskId}`
+        : "OpenCode",
+      workingDirectory: session.input.workingDirectory,
+      startedAt: session.summary.startedAt,
+      status: session.hasIdleSinceActivity ? { type: "idle" } : { type: "busy" },
+      pendingApprovals: [],
+      pendingQuestions: [],
+    };
+  }
+
+  private applyLocalActivityToPresenceSnapshot(
+    runtimeEndpoint: string,
+    snapshot: LiveAgentSessionSnapshot,
+  ): LiveAgentSessionSnapshot {
+    const localSession = this.sessions.get(snapshot.externalSessionId);
+    if (
+      !localSession ||
+      localSession.eventTransportKey !== runtimeEndpoint ||
+      localSession.hasIdleSinceActivity ||
+      snapshot.status.type !== "idle"
+    ) {
+      return snapshot;
+    }
+
+    return {
+      ...snapshot,
+      status: { type: "busy" },
+    };
+  }
+
+  private listLocallyAttachedPresenceSnapshots(input: {
+    runtimeEndpoint: string;
+    repoPath: string;
+    runtimeKind: string;
+    directories?: string[];
+    existingExternalSessionIds: Set<string>;
+  }): LiveAgentSessionSnapshot[] {
+    const requestedDirectorySet =
+      input.directories && input.directories.length > 0
+        ? new Set(
+            input.directories
+              .map((directory) => normalizeSessionDirectory(directory))
+              .filter((directory): directory is string => directory !== undefined),
+          )
+        : null;
+
+    return [...this.sessions.values()].flatMap((session) => {
+      if (
+        input.existingExternalSessionIds.has(session.externalSessionId) ||
+        session.eventTransportKey !== input.runtimeEndpoint ||
+        session.input.repoPath !== input.repoPath ||
+        session.input.runtimeKind !== input.runtimeKind
+      ) {
+        return [];
+      }
+
+      const workingDirectory = normalizeSessionDirectory(session.input.workingDirectory);
+      if (!workingDirectory) {
+        return [];
+      }
+      if (requestedDirectorySet && !requestedDirectorySet.has(workingDirectory)) {
+        return [];
+      }
+
+      return [
+        {
+          ...this.toLocallyAttachedPresenceSnapshot(session),
+          workingDirectory,
+        },
+      ];
+    });
   }
 
   async startSession(input: StartAgentSessionInput): Promise<AgentSessionSummary> {
@@ -401,7 +482,17 @@ export class OpencodeSdkAdapter
       now: this.now,
       ...(input.directories ? { directories: input.directories } : {}),
     });
-    return snapshots.map((snapshot) =>
+    const existingExternalSessionIds = new Set(
+      snapshots.map((snapshot) => snapshot.externalSessionId),
+    );
+    const locallyAttachedSnapshots = this.listLocallyAttachedPresenceSnapshots({
+      runtimeEndpoint: runtimeClientInput.runtimeEndpoint,
+      repoPath: input.repoPath,
+      runtimeKind: input.runtimeKind,
+      ...(input.directories ? { directories: input.directories } : {}),
+      existingExternalSessionIds,
+    });
+    return [...snapshots, ...locallyAttachedSnapshots].map((snapshot) =>
       toAgentSessionPresenceSnapshotFromLiveSnapshot({
         ref: {
           repoPath: input.repoPath,
@@ -410,7 +501,10 @@ export class OpencodeSdkAdapter
           externalSessionId: snapshot.externalSessionId,
         },
         runtimeId,
-        snapshot,
+        snapshot: this.applyLocalActivityToPresenceSnapshot(
+          runtimeClientInput.runtimeEndpoint,
+          snapshot,
+        ),
       }),
     );
   }
@@ -430,18 +524,45 @@ export class OpencodeSdkAdapter
       directories: [input.workingDirectory],
       now: this.now,
     });
-    const snapshot =
+    const scannedSnapshot =
       snapshots.find((candidate) => candidate.externalSessionId === input.externalSessionId) ??
       null;
+    const localSession = this.sessions.get(input.externalSessionId);
+    const localSessionWorkingDirectory = normalizeSessionDirectory(
+      localSession?.input.workingDirectory,
+    );
+    const requestedWorkingDirectory = normalizeSessionDirectory(input.workingDirectory);
+    const matchingLocalSession =
+      localSession?.eventTransportKey === runtimeClientInput.runtimeEndpoint &&
+      localSession.input.repoPath === input.repoPath &&
+      localSession.input.runtimeKind === input.runtimeKind &&
+      localSessionWorkingDirectory !== undefined &&
+      localSessionWorkingDirectory === requestedWorkingDirectory
+        ? localSession
+        : null;
+    const snapshot =
+      scannedSnapshot ??
+      (matchingLocalSession ? this.toLocallyAttachedPresenceSnapshot(matchingLocalSession) : null);
+    if (!snapshot) {
+      return toAgentSessionPresenceSnapshotFromLiveSnapshot({
+        ref: input,
+        runtimeId,
+        snapshot: null,
+      });
+    }
+
     return toAgentSessionPresenceSnapshotFromLiveSnapshot({
-      ref: snapshot
+      ref: scannedSnapshot
         ? {
             ...input,
-            workingDirectory: snapshot.workingDirectory,
+            workingDirectory: scannedSnapshot.workingDirectory,
           }
         : input,
       runtimeId,
-      snapshot,
+      snapshot: this.applyLocalActivityToPresenceSnapshot(
+        runtimeClientInput.runtimeEndpoint,
+        snapshot,
+      ),
     });
   }
 
@@ -588,7 +709,7 @@ export class OpencodeSdkAdapter
 
   async sendUserMessage(input: SendAgentUserMessageInput): Promise<void> {
     const session = requireSession(this.sessions, input.externalSessionId);
-    const tools = await this.resolveSessionToolSelection(session);
+    setSessionActive(session);
     this.emit(input.externalSessionId, {
       type: "session_status",
       externalSessionId: input.externalSessionId,
@@ -596,6 +717,7 @@ export class OpencodeSdkAdapter
       status: { type: "busy" },
     });
     try {
+      const tools = await this.resolveSessionToolSelection(session);
       await sendUserMessage({
         session,
         request: input,

--- a/packages/core/src/services/agent-session-presence.ts
+++ b/packages/core/src/services/agent-session-presence.ts
@@ -48,15 +48,20 @@ export const toLiveAgentSessionRuntimeStatus = (
   return "idle";
 };
 
-export const toAgentSessionPresenceSnapshotFromLiveSnapshot = ({
-  ref,
-  runtimeId,
-  snapshot,
-}: {
-  ref: AgentSessionRef;
-  runtimeId: string | null;
-  snapshot: LiveAgentSessionSnapshot | null;
-}): AgentSessionPresenceSnapshot => {
+export const toAgentSessionPresenceSnapshotFromLiveSnapshot = (
+  input:
+    | {
+        ref: AgentSessionRef;
+        runtimeId: string | null;
+        snapshot: LiveAgentSessionSnapshot;
+      }
+    | {
+        ref: AgentSessionRef;
+        runtimeId: string | null;
+        snapshot: null;
+      },
+): AgentSessionPresenceSnapshot => {
+  const { ref, runtimeId, snapshot } = input;
   if (!snapshot) {
     return {
       presence: "stale",

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -446,6 +446,61 @@ describe("useAgentStudioPageModels", () => {
     await harness.unmount();
   });
 
+  test("does not mark session history loading during background hydration when transcript can render", async () => {
+    const cachedSession = createSession("session-hydrating", "external-hydrating", {
+      messages: [
+        {
+          id: "assistant-cached",
+          role: "assistant",
+          content: "Cached transcript",
+          timestamp: "2026-02-22T08:00:05.000Z",
+        },
+      ],
+    });
+    const harness = createHookHarness(
+      createHookArgs({
+        selectedSessionCore: {
+          activeSession: cachedSession,
+          sessionsForTask: [cachedSession],
+          isSessionHistoryHydrated: true,
+          isSessionHistoryHydrating: true,
+        },
+      }),
+    );
+
+    await harness.mount();
+
+    const thread = harness.getLatest().agentChatModel.thread;
+    expect(thread.isSessionHistoryLoading).toBe(false);
+    const html = renderToStaticMarkup(createElement(AgentChatThread, { model: thread }));
+    expect(html).toContain("Cached transcript");
+    expect(html).not.toContain("Loading session");
+
+    await harness.unmount();
+  });
+
+  test("marks session history loading while hydration blocks transcript rendering", async () => {
+    const pendingSession = createSession("session-pending", "external-pending", {
+      messages: [],
+    });
+    const harness = createHookHarness(
+      createHookArgs({
+        selectedSessionCore: {
+          activeSession: pendingSession,
+          sessionsForTask: [pendingSession],
+          isSessionHistoryHydrated: false,
+          isSessionHistoryHydrating: true,
+        },
+      }),
+    );
+
+    await harness.mount();
+
+    expect(harness.getLatest().agentChatModel.thread.isSessionHistoryLoading).toBe(true);
+
+    await harness.unmount();
+  });
+
   test("selects role-specific sidebar document", async () => {
     const specSession = createSession("session-spec", "external-spec", { role: "spec" });
     const harness = createHookHarness(

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.ts
@@ -233,6 +233,9 @@ export function useAgentStudioPageModels({
     [contextUsageContextWindow, contextUsageOutputLimit, contextUsageTotalTokens],
   );
   const selectedRuntimeReadiness = selectedSession.runtime.runtimeReadiness;
+  const isSessionHistoryBlockingRender =
+    selectedSession.runtime.isSessionHistoryHydrating &&
+    !selectedSession.runtime.isSessionHistoryHydrated;
   const runtimeReadiness = useMemo(
     () => ({
       readinessState: selectedRuntimeReadiness.readinessState,
@@ -377,7 +380,7 @@ export function useAgentStudioPageModels({
     isSessionSelectionResolving: selectedSession.runtime.isSessionSelectionResolving,
     showThinkingMessages: chatSettings.showThinkingMessages,
     isSessionWorking: sessionActions.isSessionWorking,
-    isSessionHistoryLoading: selectedSession.runtime.isSessionHistoryHydrating,
+    isSessionHistoryLoading: isSessionHistoryBlockingRender,
     isWaitingForRuntimeReadiness: selectedSession.runtime.isWaitingForRuntimeReadiness,
     runtimeDefinitions: selectedSession.runtime.runtimeDefinitions,
     sessionRuntimeDataError: selectedSession.runtime.sessionRuntimeDataError,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages-reconcile-overlays.test.ts
@@ -42,7 +42,9 @@ const createCompletedAssistantHistory = (reason = "stop") => [
   },
 ];
 
-const createSuccessfulHydrationRuntimePlanner = (): HydrationRuntimePlanner => ({
+const createSuccessfulHydrationRuntimePlanner = (
+  status: "busy" | "idle" = "busy",
+): HydrationRuntimePlanner => ({
   repoPath: "/tmp/repo",
   resolveHydrationRuntime: async () => ({
     ok: true,
@@ -51,7 +53,7 @@ const createSuccessfulHydrationRuntimePlanner = (): HydrationRuntimePlanner => (
   }),
   readSessionPresence: async () =>
     createSessionPresenceSnapshot("external-1", "/tmp/repo/worktree", {
-      status: { type: "idle" },
+      status: { type: status },
     }),
 });
 
@@ -170,7 +172,7 @@ describe("load-sessions-stages", () => {
     expect(stateHarness.getState()["external-1"]?.status).toBe("starting");
   });
 
-  test("settles pending outbound sends when reconcile sees idle runtime presence", async () => {
+  test("keeps pending outbound sends when adapter reports the session is still active", async () => {
     const stateHarness = createStateHarness({
       "external-1": createSession({
         status: "running",
@@ -200,7 +202,7 @@ describe("load-sessions-stages", () => {
         }),
         readSessionPresence: async () =>
           createSessionPresenceSnapshot("external-1", "/tmp/repo/worktree", {
-            status: { type: "idle" },
+            status: { type: "busy" },
           }),
       },
       promptAssembler: {
@@ -211,15 +213,15 @@ describe("load-sessions-stages", () => {
     });
 
     const session = stateHarness.getState()["external-1"];
-    expect(session?.status).toBe("idle");
-    expect(session?.pendingUserMessageStartedAt).toBeUndefined();
-    expect(session?.draftAssistantText).toBe("");
-    expect(session?.draftAssistantMessageId).toBeNull();
-    expect(session?.draftReasoningText).toBe("");
-    expect(session?.draftReasoningMessageId).toBeNull();
+    expect(session?.status).toBe("running");
+    expect(session?.pendingUserMessageStartedAt).toBe(123);
+    expect(session?.draftAssistantText).toBe("partial assistant");
+    expect(session?.draftAssistantMessageId).toBe("assistant-draft");
+    expect(session?.draftReasoningText).toBe("partial reasoning");
+    expect(session?.draftReasoningMessageId).toBe("reasoning-draft");
   });
 
-  test("settles pending outbound sends when requested-history runtime presence is idle", async () => {
+  test("settles pending outbound sends when adapter reports idle presence", async () => {
     const stateHarness = createStateHarness({
       "external-1": createSession({
         status: "running",
@@ -242,7 +244,7 @@ describe("load-sessions-stages", () => {
       isStaleRepoOperation: () => false,
       recordsToHydrate: [createRecord()],
       historyHydrationSessionIds: new Set(["external-1"]),
-      runtimePlanner: createSuccessfulHydrationRuntimePlanner(),
+      runtimePlanner: createSuccessfulHydrationRuntimePlanner("idle"),
       promptAssembler: {
         buildHydrationPreludeMessages: async () => [],
         buildHydrationSystemPrompt: async () => "",
@@ -340,7 +342,7 @@ describe("load-sessions-stages", () => {
     expect(session?.historyHydrationState).toBe("hydrated");
   });
 
-  test("settles pending outbound sends from idle presence even when hydrated history has no stop finish", async () => {
+  test("settles pending outbound sends from idle presence without a stop finish", async () => {
     const stateHarness = createStateHarness({
       "external-1": createSession({
         status: "running",
@@ -359,7 +361,7 @@ describe("load-sessions-stages", () => {
       isStaleRepoOperation: () => false,
       recordsToHydrate: [createRecord()],
       historyHydrationSessionIds: new Set(["external-1"]),
-      runtimePlanner: createSuccessfulHydrationRuntimePlanner(),
+      runtimePlanner: createSuccessfulHydrationRuntimePlanner("idle"),
       promptAssembler: {
         buildHydrationPreludeMessages: async () => [],
         buildHydrationSystemPrompt: async () => "",

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -29,17 +29,32 @@ const sessionRecordFixture: AgentSessionRecord = {
 const toSessionPresenceSnapshot = (
   snapshot: Parameters<typeof toAgentSessionPresenceSnapshotFromLiveSnapshot>[0]["snapshot"],
   runtimeResolution: Extract<ResolvedHydrationRuntime, { ok: true }> = localHttpRuntimeResolution,
-) =>
-  toAgentSessionPresenceSnapshotFromLiveSnapshot({
+) => {
+  const ref = {
+    repoPath: "/tmp/repo",
+    runtimeKind: runtimeResolution.runtimeRef.runtimeKind,
+    externalSessionId: sessionRecordFixture.externalSessionId,
+    workingDirectory: runtimeResolution.workingDirectory,
+  };
+  const runtimeId = runtimeResolution === stdioRuntimeResolution ? "runtime-stdio" : "runtime-1";
+  if (!snapshot) {
+    return toAgentSessionPresenceSnapshotFromLiveSnapshot({
+      ref,
+      runtimeId,
+      snapshot: null,
+    });
+  }
+  return toAgentSessionPresenceSnapshotFromLiveSnapshot({
     ref: {
       repoPath: "/tmp/repo",
       runtimeKind: runtimeResolution.runtimeRef.runtimeKind,
       externalSessionId: sessionRecordFixture.externalSessionId,
       workingDirectory: runtimeResolution.workingDirectory,
     },
-    runtimeId: runtimeResolution === stdioRuntimeResolution ? "runtime-stdio" : "runtime-1",
+    runtimeId,
     snapshot,
   });
+};
 
 const createSessionStateFixture = (): AgentSessionState => ({
   externalSessionId: "external-1",

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.test.ts
@@ -280,6 +280,45 @@ describe("session-presence", () => {
     expect(applied.pendingQuestions).toEqual([]);
   });
 
+  test("keeps pending outbound sends when runtime presence is retrying", () => {
+    const snapshot = toAgentSessionPresenceSnapshotFromLiveSnapshot({
+      ref: sessionRefFixture,
+      runtimeId: "runtime-1",
+      snapshot: {
+        externalSessionId: "external-1",
+        title: " Builder Session ",
+        startedAt: "2026-03-01T09:00:00.000Z",
+        status: { type: "retry", attempt: 2, message: "try again", nextEpochMs: 1234 },
+        pendingApprovals: [],
+        pendingQuestions: [],
+        workingDirectory: "/tmp/repo/worktree",
+      },
+    });
+
+    const applied = applyAgentSessionPresenceSnapshotToSession(
+      createSessionState({
+        status: "idle",
+        pendingUserMessageStartedAt: 123,
+        draftAssistantText: "partial assistant",
+        draftAssistantMessageId: "assistant-draft",
+        draftReasoningText: "partial reasoning",
+        draftReasoningMessageId: "reasoning-draft",
+      }),
+      snapshot,
+    );
+
+    if (snapshot.presence !== "runtime") {
+      throw new Error("Expected live snapshot.");
+    }
+    expect(snapshot.agentSessionStatus).toBe("running");
+    expect(applied.status).toBe("running");
+    expect(applied.pendingUserMessageStartedAt).toBe(123);
+    expect(applied.draftAssistantText).toBe("partial assistant");
+    expect(applied.draftAssistantMessageId).toBe("assistant-draft");
+    expect(applied.draftReasoningText).toBe("partial reasoning");
+    expect(applied.draftReasoningMessageId).toBe("reasoning-draft");
+  });
+
   test("treats pending input and non-idle runtime status as attachable", () => {
     const createPresence = (overrides: Partial<AgentSessionPresenceSnapshot> = {}) =>
       toAgentSessionPresenceSnapshotFromLiveSnapshot({

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.test.ts
@@ -143,6 +143,71 @@ describe("session-presence", () => {
     expect(applied.draftReasoningMessageId).toBeNull();
   });
 
+  test("keeps pending outbound sends running when runtime presence is busy", () => {
+    const snapshot = toAgentSessionPresenceSnapshotFromLiveSnapshot({
+      ref: sessionRefFixture,
+      runtimeId: "runtime-1",
+      snapshot: {
+        externalSessionId: "external-1",
+        title: " Builder Session ",
+        startedAt: "2026-03-01T09:00:00.000Z",
+        status: { type: "busy" },
+        pendingApprovals: [],
+        pendingQuestions: [],
+        workingDirectory: "/tmp/repo/worktree",
+      },
+    });
+
+    const applied = applyAgentSessionPresenceSnapshotToSession(
+      createSessionState({
+        pendingUserMessageStartedAt: 123,
+        draftAssistantText: "partial assistant",
+        draftAssistantMessageId: "assistant-draft",
+      }),
+      snapshot,
+    );
+
+    expect(applied.status).toBe("running");
+    expect(applied.pendingUserMessageStartedAt).toBe(123);
+    expect(applied.draftAssistantText).toBe("partial assistant");
+    expect(applied.draftAssistantMessageId).toBe("assistant-draft");
+  });
+
+  test("settles pending outbound sends when runtime reports pending input", () => {
+    const liveApproval = {
+      requestId: "live-approval",
+    } as AgentSessionState["pendingApprovals"][number];
+    const snapshot = toAgentSessionPresenceSnapshotFromLiveSnapshot({
+      ref: sessionRefFixture,
+      runtimeId: "runtime-1",
+      snapshot: {
+        externalSessionId: "external-1",
+        title: " Builder Session ",
+        startedAt: "2026-03-01T09:00:00.000Z",
+        status: { type: "idle" },
+        pendingApprovals: [liveApproval],
+        pendingQuestions: [],
+        workingDirectory: "/tmp/repo/worktree",
+      },
+    });
+
+    const applied = applyAgentSessionPresenceSnapshotToSession(
+      createSessionState({
+        pendingUserMessageStartedAt: 123,
+        draftAssistantText: "partial assistant",
+        draftAssistantMessageId: "assistant-draft",
+      }),
+      snapshot,
+    );
+
+    expect(snapshot.classification).toBe("waiting_for_permission");
+    expect(applied.status).toBe("idle");
+    expect(applied.pendingUserMessageStartedAt).toBeUndefined();
+    expect(applied.draftAssistantText).toBe("");
+    expect(applied.draftAssistantMessageId).toBeNull();
+    expect(applied.pendingApprovals).toEqual([liveApproval]);
+  });
+
   test("marks persisted-only pending outbound sends as recovering runtime", () => {
     const snapshot = toPersistedOnlyAgentSessionPresenceSnapshot({
       ref: sessionRefFixture,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.ts
@@ -95,8 +95,6 @@ export const applyAgentSessionPresenceSnapshotToSession = (
         status = "starting";
       }
     }
-    // Runtime idle presence is authoritative for outbound-send settlement; the send path
-    // invalidates cached presence before starting a new turn.
     const pendingOutboundSendFields =
       snapshot.agentSessionStatus === "idle" ? settlePendingOutboundSendFields() : {};
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-presence.ts
@@ -95,6 +95,8 @@ export const applyAgentSessionPresenceSnapshotToSession = (
         status = "starting";
       }
     }
+    // Preserve outbound drafts while runtime presence is still running; idle presence,
+    // including pending input handoff, settles the outbound turn.
     const pendingOutboundSendFields =
       snapshot.agentSessionStatus === "idle" ? settlePendingOutboundSendFields() : {};
 


### PR DESCRIPTION
Summary:
Stabilizes agent-session presence reporting for Opencode start and send flows while keeping shared presence handling adapter-agnostic.

Goal:
Opencode sessions could flicker between idle and live when a session was just started or while a user message was entering the runtime. The root cause was that shared frontend/core code was being asked to compensate for runtime-specific timing behavior. This PR moves that responsibility back into the Opencode adapter and keeps the common presence contract focused on whether a session is idle or running.

Technical choices:
- Keep core/frontend presence semantics runtime-neutral: they consume normalized presence snapshots only.
- Normalize Opencode-specific startup/send races inside the adapter with local session activity state.
- Include locally attached sessions in presence scans before the runtime list catches up, scoped by runtime endpoint, repo, runtime kind, and working directory.
- Mark Opencode sessions active before workflow-tool resolution so MCP reconnect/tool discovery cannot expose an idle presence snapshot during an outbound turn.
- Treat background history hydration as non-blocking when an existing transcript is already hydrated, avoiding a transient Loading session overlay over visible messages.

Verification:
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- bun run check:rust
- bun run test:rust
- cargo build --workspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now remain visible and tracked even when not yet reflected in remote presence results.
  * User messages automatically mark sessions as active during tool selection workflows.

* **Bug Fixes**
  * Session history loading states now accurately reflect when content can be rendered versus blocked.
  * Sessions correctly maintain their presence status during runtime state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->