### PR TITLE
fix(host): guarantee Codex pending request cleanup

### DIFF
--- a/packages/host/src/adapters/codex/codex-app-server-pending-response.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-pending-response.ts
@@ -30,7 +30,7 @@ export const acquirePendingResponse = ({
   rememberCancelledSentRequest,
 }: PendingResponseInput) =>
   Effect.sync(() => {
-    let timeout: NodeJS.Timeout;
+    let timeout: NodeJS.Timeout | undefined;
     let released = false;
     let finished = false;
     let writeStarted = false;

--- a/packages/host/src/adapters/codex/codex-app-server-pending-response.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-pending-response.ts
@@ -1,0 +1,112 @@
+import { Effect } from "effect";
+import { HostOperationError, toHostOperationError } from "../../effect/host-errors";
+import type {
+  CodexAppServerRequestMethod,
+  CodexAppServerRequestResult,
+} from "../../ports/codex-app-server-port";
+import { resolveAfterQueuedMessages } from "./codex-app-server-transport-messages";
+import type {
+  CodexAppServerTransportError,
+  PendingCodexAppServerRequest,
+} from "./codex-app-server-transport-types";
+
+type ResponseEffect = Effect.Effect<CodexAppServerRequestResult, CodexAppServerTransportError>;
+
+type PendingResponseInput = {
+  id: number;
+  method: CodexAppServerRequestMethod;
+  runtimeId: string;
+  requestTimeoutMs: number;
+  pending: Map<number, PendingCodexAppServerRequest>;
+  rememberCancelledSentRequest(id: number): void;
+};
+
+export const acquirePendingResponse = ({
+  id,
+  method,
+  runtimeId,
+  requestTimeoutMs,
+  pending,
+  rememberCancelledSentRequest,
+}: PendingResponseInput) =>
+  Effect.sync(() => {
+    let timeout: NodeJS.Timeout;
+    let released = false;
+    let finished = false;
+    let writeStarted = false;
+    let resumeEffect: ((effect: ResponseEffect) => void) | null = null;
+    let settledEffect: ResponseEffect | null = null;
+
+    const release = (options: { preserveLateResponse?: boolean } = {}): void => {
+      if (released) {
+        return;
+      }
+      released = true;
+      clearTimeout(timeout);
+      pending.delete(id);
+      if (options.preserveLateResponse && writeStarted && !finished) {
+        rememberCancelledSentRequest(id);
+      }
+    };
+
+    const finish = (effect: ResponseEffect): void => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      release();
+      if (resumeEffect) {
+        resumeEffect(effect);
+        return;
+      }
+      settledEffect = effect;
+    };
+
+    timeout = setTimeout(() => {
+      finish(
+        Effect.fail(
+          new HostOperationError({
+            operation: `codexAppServerTransport.request.${method}`,
+            message: `Timed out waiting for Codex app-server request ${method} on runtime ${runtimeId} after ${requestTimeoutMs}ms`,
+            details: { runtimeId, method, requestTimeoutMs },
+          }),
+        ),
+      );
+    }, requestTimeoutMs);
+
+    pending.set(id, {
+      method,
+      timeout,
+      resolve: (value) => {
+        resolveAfterQueuedMessages((resolvedValue) => finish(Effect.succeed(resolvedValue)), value);
+      },
+      reject: (error) => {
+        finish(
+          Effect.fail(
+            toHostOperationError(error, `codexAppServerTransport.request.${method}`, {
+              runtimeId,
+              method,
+            }),
+          ),
+        );
+      },
+    });
+
+    const response = Effect.async<CodexAppServerRequestResult, CodexAppServerTransportError>(
+      (resume) => {
+        if (settledEffect) {
+          resume(settledEffect);
+          return;
+        }
+        resumeEffect = resume;
+      },
+    );
+
+    return {
+      markWriteStarted() {
+        writeStarted = true;
+      },
+      release,
+      response,
+    };
+  });

--- a/packages/host/src/adapters/codex/codex-app-server-pending-response.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-pending-response.ts
@@ -76,8 +76,8 @@ export const acquirePendingResponse = ({
 
     pending.set(id, {
       method,
-      timeout,
       resolve: (value) => {
+        release();
         resolveAfterQueuedMessages((resolvedValue) => finish(Effect.succeed(resolvedValue)), value);
       },
       reject: (error) => {

--- a/packages/host/src/adapters/codex/codex-app-server-request-writer.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-request-writer.ts
@@ -1,8 +1,14 @@
 import type { Writable } from "node:stream";
 import { Effect } from "effect";
-import { HostOperationError, toHostOperationError } from "../../effect/host-errors";
+import { HostOperationError } from "../../effect/host-errors";
 
-const WRITE_OPERATION = "codexAppServerTransport.writeLine";
+const createWriteError = (runtimeId: string, cause: unknown) =>
+  new HostOperationError({
+    operation: "codexAppServerTransport.sendMessage",
+    message: `Failed writing Codex app-server message for runtime ${runtimeId}`,
+    cause,
+    details: { runtimeId },
+  });
 
 type WriteCodexAppServerRequestInput = {
   stdin: Writable;
@@ -17,41 +23,45 @@ export const writeCodexAppServerRequestLine = ({
   runtimeId,
   markWriteStarted,
 }: WriteCodexAppServerRequestInput): Effect.Effect<void, HostOperationError> =>
-  Effect.async<void, HostOperationError>((resume) => {
-    let active = true;
-    let writeReturned = false;
-    let writeFailedSynchronously = false;
+  Effect.gen(function* () {
+    const line = yield* Effect.try({
+      try: () => `${JSON.stringify(payload)}\n`,
+      catch: (cause) => createWriteError(runtimeId, cause),
+    });
 
-    stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
-      if (!writeReturned && error) {
+    yield* Effect.async<void, HostOperationError>((resume) => {
+      let active = true;
+      let writeReturned = false;
+      let writeFailedSynchronously = false;
+
+      try {
+        stdin.write(line, (error) => {
+          if (!writeReturned && error) {
+            writeFailedSynchronously = true;
+          }
+          if (!active) {
+            return;
+          }
+          if (error) {
+            resume(Effect.fail(createWriteError(runtimeId, error)));
+            return;
+          }
+          resume(Effect.void);
+        });
+      } catch (error) {
         writeFailedSynchronously = true;
+        if (active) {
+          resume(Effect.fail(createWriteError(runtimeId, error)));
+        }
       }
-      if (!active) {
-        return;
-      }
-      if (error) {
-        resume(Effect.fail(toHostOperationError(error, WRITE_OPERATION)));
-        return;
-      }
-      resume(Effect.void);
-    });
 
-    writeReturned = true;
-    if (!writeFailedSynchronously) {
-      markWriteStarted();
-    }
+      writeReturned = true;
+      if (!writeFailedSynchronously) {
+        markWriteStarted();
+      }
 
-    return Effect.sync(() => {
-      active = false;
+      return Effect.sync(() => {
+        active = false;
+      });
     });
-  }).pipe(
-    Effect.mapError(
-      (error) =>
-        new HostOperationError({
-          operation: "codexAppServerTransport.sendMessage",
-          message: `Failed writing Codex app-server message for runtime ${runtimeId}`,
-          cause: error,
-          details: { runtimeId },
-        }),
-    ),
-  );
+  });

--- a/packages/host/src/adapters/codex/codex-app-server-request-writer.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-request-writer.ts
@@ -1,0 +1,57 @@
+import type { Writable } from "node:stream";
+import { Effect } from "effect";
+import { HostOperationError, toHostOperationError } from "../../effect/host-errors";
+
+const WRITE_OPERATION = "codexAppServerTransport.writeLine";
+
+type WriteCodexAppServerRequestInput = {
+  stdin: Writable;
+  payload: Record<string, unknown>;
+  runtimeId: string;
+  markWriteStarted(): void;
+};
+
+export const writeCodexAppServerRequestLine = ({
+  stdin,
+  payload,
+  runtimeId,
+  markWriteStarted,
+}: WriteCodexAppServerRequestInput): Effect.Effect<void, HostOperationError> =>
+  Effect.async<void, HostOperationError>((resume) => {
+    let active = true;
+    let writeReturned = false;
+    let writeFailedSynchronously = false;
+
+    stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
+      if (!writeReturned && error) {
+        writeFailedSynchronously = true;
+      }
+      if (!active) {
+        return;
+      }
+      if (error) {
+        resume(Effect.fail(toHostOperationError(error, WRITE_OPERATION)));
+        return;
+      }
+      resume(Effect.void);
+    });
+
+    writeReturned = true;
+    if (!writeFailedSynchronously) {
+      markWriteStarted();
+    }
+
+    return Effect.sync(() => {
+      active = false;
+    });
+  }).pipe(
+    Effect.mapError(
+      (error) =>
+        new HostOperationError({
+          operation: "codexAppServerTransport.sendMessage",
+          message: `Failed writing Codex app-server message for runtime ${runtimeId}`,
+          cause: error,
+          details: { runtimeId },
+        }),
+    ),
+  );

--- a/packages/host/src/adapters/codex/codex-app-server-transport-types.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-types.ts
@@ -36,7 +36,6 @@ export type CodexAppServerEventEmitter = (event: CodexAppServerStreamEvent) => v
 
 export type PendingCodexAppServerRequest = {
   method: CodexAppServerRequestMethod;
-  timeout: NodeJS.Timeout;
   resolve(value: CodexAppServerRequestResult): void;
   reject(error: Error): void;
 };

--- a/packages/host/src/adapters/codex/codex-app-server-transport.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.test.ts
@@ -196,6 +196,78 @@ describe("createCodexAppServerTransport", () => {
     }
   });
 
+  test("keeps the transport usable after a late response to an interrupted sent request", async () => {
+    let writeCount = 0;
+    const stdin = {
+      write(_chunk: string, callback: (error?: Error | null) => void) {
+        writeCount += 1;
+        if (writeCount > 1) {
+          callback();
+        }
+        return true;
+      },
+      destroy() {},
+    } as unknown as Writable;
+    const child = createChild(stdin);
+    const transport = createCodexAppServerTransport("runtime-1", child, 1_000);
+
+    try {
+      const interruptedFiber = Effect.runFork(
+        transport.request({
+          method: "model/list",
+          params: {},
+        }),
+      );
+      await waitForStreamEvents();
+
+      expect(writeCount).toBe(1);
+
+      await Effect.runPromise(Fiber.interrupt(interruptedFiber));
+      child.stdout.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { data: [], nextCursor: null } })}\n`,
+      );
+      await waitForStreamEvents();
+
+      const nextResponse = Effect.runPromise(
+        transport.request({
+          method: "model/list",
+          params: {},
+        }),
+      );
+      await waitForStreamEvents();
+      child.stdout.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id: 2, result: { data: [], nextCursor: null } })}\n`,
+      );
+
+      await expect(nextResponse).resolves.toEqual({ data: [], nextCursor: null });
+    } finally {
+      await Effect.runPromise(transport.close());
+    }
+  });
+
+  test("still fails fast for responses with genuinely unexpected ids", async () => {
+    const child = createChild();
+    const transport = createCodexAppServerTransport("runtime-1", child, 1_000);
+
+    try {
+      child.stdout.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id: 99, result: { data: [], nextCursor: null } })}\n`,
+      );
+      await waitForStreamEvents();
+
+      await expect(
+        Effect.runPromise(
+          transport.request({
+            method: "model/list",
+            params: {},
+          }),
+        ),
+      ).rejects.toThrow("Received Codex app-server response with unexpected id 99 for runtime-1");
+    } finally {
+      await Effect.runPromise(transport.close());
+    }
+  });
+
   test("clears the pending request timeout when send fails", async () => {
     const stdin = {
       write(_chunk: string, callback: (error?: Error | null) => void) {

--- a/packages/host/src/adapters/codex/codex-app-server-transport.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.test.ts
@@ -296,4 +296,41 @@ describe("createCodexAppServerTransport", () => {
       await Effect.runPromise(transport.close());
     }
   });
+
+  test("clears the pending request timeout when serialization fails", async () => {
+    const child = createChild();
+    const transport = createCodexAppServerTransport("runtime-1", child, 1_000);
+    const clearTimeoutRecorder = recordClearTimeouts();
+    const circularParams: Record<string, unknown> = {};
+    circularParams.self = circularParams;
+
+    try {
+      await expect(
+        Effect.runPromise(
+          transport.request({
+            method: "model/list",
+            params: circularParams as never,
+          }),
+        ),
+      ).rejects.toThrow("Failed writing Codex app-server message for runtime runtime-1");
+
+      expect(clearTimeoutRecorder.clearedTimeouts).toHaveLength(1);
+
+      const nextResponse = Effect.runPromise(
+        transport.request({
+          method: "model/list",
+          params: {},
+        }),
+      );
+      await waitForStreamEvents();
+      child.stdout.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id: 2, result: { data: [], nextCursor: null } })}\n`,
+      );
+
+      await expect(nextResponse).resolves.toEqual({ data: [], nextCursor: null });
+    } finally {
+      clearTimeoutRecorder.restore();
+      await Effect.runPromise(transport.close());
+    }
+  });
 });

--- a/packages/host/src/adapters/codex/codex-app-server-transport.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.test.ts
@@ -1,19 +1,38 @@
 import type { ChildProcessByStdio } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { PassThrough } from "node:stream";
-import { Effect } from "effect";
+import { PassThrough, Writable } from "node:stream";
+import { Effect, Fiber } from "effect";
 import type { CodexAppServerProtocolMessage } from "../../ports/codex-app-server-port";
 import { createCodexAppServerTransport } from "./codex-app-server-transport";
 
-const createChild = (): ChildProcessByStdio<PassThrough, PassThrough, PassThrough> => {
-  const child = new EventEmitter() as ChildProcessByStdio<PassThrough, PassThrough, PassThrough>;
-  child.stdin = new PassThrough();
+const createChild = (
+  stdin: Writable = new PassThrough(),
+): ChildProcessByStdio<Writable, PassThrough, PassThrough> => {
+  const child = new EventEmitter() as ChildProcessByStdio<Writable, PassThrough, PassThrough>;
+  child.stdin = stdin;
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
   return child;
 };
 
 const waitForStreamEvents = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+const recordClearTimeouts = () => {
+  const originalClearTimeout = globalThis.clearTimeout;
+  const clearedTimeouts: ReturnType<typeof globalThis.setTimeout>[] = [];
+
+  globalThis.clearTimeout = ((timeoutId: ReturnType<typeof globalThis.setTimeout>) => {
+    clearedTimeouts.push(timeoutId);
+    originalClearTimeout(timeoutId);
+  }) as typeof globalThis.clearTimeout;
+
+  return {
+    clearedTimeouts,
+    restore() {
+      globalThis.clearTimeout = originalClearTimeout;
+    },
+  };
+};
 
 describe("createCodexAppServerTransport", () => {
   test("keeps emitted notifications drainable after a request response", async () => {
@@ -144,5 +163,65 @@ describe("createCodexAppServerTransport", () => {
     await expect(
       Effect.runPromise(transport.request({ method: "model/list", params: {} })),
     ).rejects.not.toThrow("first-error-line");
+  });
+
+  test("clears the pending request timeout when interrupted during send", async () => {
+    let writeCount = 0;
+    const stdin = new Writable({
+      write(_chunk, _encoding, _callback) {
+        writeCount += 1;
+      },
+    });
+    const child = createChild(stdin);
+    const transport = createCodexAppServerTransport("runtime-1", child, 1_000);
+    const clearTimeoutRecorder = recordClearTimeouts();
+
+    try {
+      const fiber = Effect.runFork(
+        transport.request({
+          method: "model/list",
+          params: {},
+        }),
+      );
+      await waitForStreamEvents();
+
+      expect(writeCount).toBe(1);
+
+      await Effect.runPromise(Fiber.interrupt(fiber));
+
+      expect(clearTimeoutRecorder.clearedTimeouts).toHaveLength(1);
+    } finally {
+      clearTimeoutRecorder.restore();
+      await Effect.runPromise(transport.close());
+    }
+  });
+
+  test("clears the pending request timeout when send fails", async () => {
+    const stdin = {
+      write(_chunk: string, callback: (error?: Error | null) => void) {
+        callback(new Error("write failed"));
+        return false;
+      },
+      destroy() {},
+    } as unknown as Writable;
+    const child = createChild(stdin);
+    const transport = createCodexAppServerTransport("runtime-1", child, 1_000);
+    const clearTimeoutRecorder = recordClearTimeouts();
+
+    try {
+      await expect(
+        Effect.runPromise(
+          transport.request({
+            method: "model/list",
+            params: {},
+          }),
+        ),
+      ).rejects.toThrow("Failed writing Codex app-server message for runtime runtime-1");
+
+      expect(clearTimeoutRecorder.clearedTimeouts).toHaveLength(1);
+    } finally {
+      clearTimeoutRecorder.restore();
+      await Effect.runPromise(transport.close());
+    }
   });
 });

--- a/packages/host/src/adapters/codex/codex-app-server-transport.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.ts
@@ -67,6 +67,7 @@ export const createCodexAppServerTransport = (
     for (const request of pending.values()) {
       request.reject(error);
     }
+    pending.clear();
   };
 
   const ensureOpen = (): void => {
@@ -450,6 +451,7 @@ export const createCodexAppServerTransport = (
             }),
           );
         }
+        pending.clear();
       });
     },
   };

--- a/packages/host/src/adapters/codex/codex-app-server-transport.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.ts
@@ -15,6 +15,7 @@ import {
   parseCodexAppServerRequestResult,
 } from "../../ports/codex-app-server-protocol";
 import { acquirePendingResponse } from "./codex-app-server-pending-response";
+import { writeCodexAppServerRequestLine } from "./codex-app-server-request-writer";
 import {
   appendCapturedStderr,
   extractErrorMessage,
@@ -88,13 +89,10 @@ export const createCodexAppServerTransport = (
         toHostOperationError(cause, "codexAppServerTransport.ensureOpen", { runtimeId }),
     });
 
-  const sendMessage = (
-    message: Record<string, unknown>,
-    options: { onWriteStarted?: () => void } = {},
-  ) =>
+  const sendMessage = (message: Record<string, unknown>) =>
     Effect.gen(function* () {
       yield* ensureOpenEffect();
-      yield* writeJsonLine(child.stdin, message, options).pipe(
+      yield* writeJsonLine(child.stdin, message).pipe(
         Effect.mapError(
           (error) =>
             new HostOperationError({
@@ -105,6 +103,17 @@ export const createCodexAppServerTransport = (
             }),
         ),
       );
+    });
+
+  const sendRequestMessage = (message: Record<string, unknown>, markWriteStarted: () => void) =>
+    Effect.gen(function* () {
+      yield* ensureOpenEffect();
+      yield* writeCodexAppServerRequestLine({
+        stdin: child.stdin,
+        payload: message,
+        runtimeId,
+        markWriteStarted,
+      });
     });
 
   const forgetCancelledSentRequest = (id: number): boolean => {
@@ -373,16 +382,14 @@ export const createCodexAppServerTransport = (
           }),
           ({ markWriteStarted, response }) =>
             Effect.gen(function* () {
-              yield* sendMessage(
+              yield* sendRequestMessage(
                 {
                   jsonrpc: "2.0",
                   id,
                   method,
                   ...(params !== undefined ? { params } : {}),
                 },
-                {
-                  onWriteStarted: markWriteStarted,
-                },
+                markWriteStarted,
               );
               return yield* response;
             }),

--- a/packages/host/src/adapters/codex/codex-app-server-transport.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.ts
@@ -1,5 +1,5 @@
 import { createInterface } from "node:readline";
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
 import {
   HostOperationError,
   HostResourceError,
@@ -8,33 +8,31 @@ import {
 } from "../../effect/host-errors";
 import type {
   CodexAppServerProtocolMessage,
-  CodexAppServerRequestMethod,
-  CodexAppServerRequestResult,
   CodexAppServerRespondInput,
 } from "../../ports/codex-app-server-port";
 import {
   type CodexAppServerClientRequest,
   parseCodexAppServerRequestResult,
 } from "../../ports/codex-app-server-protocol";
+import { acquirePendingResponse } from "./codex-app-server-pending-response";
 import {
   appendCapturedStderr,
   extractErrorMessage,
   isJsonRecord,
   parseStreamMessage,
   pushBoundedMessage,
-  resolveAfterQueuedMessages,
 } from "./codex-app-server-transport-messages";
 import type {
   CodexAppServerChildTransport,
   CodexAppServerEventEmitter,
   CodexAppServerStreamEvent,
-  CodexAppServerTransportError,
   CodexChildProcess,
   PendingCodexAppServerRequest,
 } from "./codex-app-server-transport-types";
 import { writeJsonLine } from "./codex-json-line-writer";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+const MAX_CANCELLED_SENT_REQUEST_IDS = 1_000;
 
 export const createCodexAppServerTransport = (
   runtimeId: string,
@@ -46,6 +44,7 @@ export const createCodexAppServerTransport = (
   let closed = false;
   let fatalError: Error | null = null;
   const pending = new Map<number, PendingCodexAppServerRequest>();
+  const cancelledSentRequests = new Map<number, NodeJS.Timeout>();
   const notifications: CodexAppServerProtocolMessage[] = [];
   const serverRequests: CodexAppServerProtocolMessage[] = [];
   let stderrOutput = "";
@@ -57,6 +56,10 @@ export const createCodexAppServerTransport = (
       fatalError = error;
     }
     closed = true;
+    for (const timeout of cancelledSentRequests.values()) {
+      clearTimeout(timeout);
+    }
+    cancelledSentRequests.clear();
     for (const [id, request] of pending) {
       clearTimeout(request.timeout);
       request.reject(error);
@@ -85,10 +88,13 @@ export const createCodexAppServerTransport = (
         toHostOperationError(cause, "codexAppServerTransport.ensureOpen", { runtimeId }),
     });
 
-  const sendMessage = (message: Record<string, unknown>) =>
+  const sendMessage = (
+    message: Record<string, unknown>,
+    options: { onWriteStarted?: () => void } = {},
+  ) =>
     Effect.gen(function* () {
       yield* ensureOpenEffect();
-      yield* writeJsonLine(child.stdin, message).pipe(
+      yield* writeJsonLine(child.stdin, message, options).pipe(
         Effect.mapError(
           (error) =>
             new HostOperationError({
@@ -101,89 +107,37 @@ export const createCodexAppServerTransport = (
       );
     });
 
-  const acquirePendingResponse = (id: number, method: CodexAppServerRequestMethod) =>
-    Effect.sync(() => {
-      type ResponseEffect = Effect.Effect<
-        CodexAppServerRequestResult,
-        CodexAppServerTransportError
-      >;
-      let timeout: NodeJS.Timeout;
-      let released = false;
-      let finished = false;
-      let resumeEffect: ((effect: ResponseEffect) => void) | null = null;
-      let settledEffect: ResponseEffect | null = null;
+  const forgetCancelledSentRequest = (id: number): boolean => {
+    const timeout = cancelledSentRequests.get(id);
+    if (!timeout) {
+      return false;
+    }
+    clearTimeout(timeout);
+    cancelledSentRequests.delete(id);
+    return true;
+  };
 
-      const release = (): void => {
-        if (released) {
-          return;
-        }
-        released = true;
-        clearTimeout(timeout);
-        pending.delete(id);
-      };
-
-      const finish = (effect: ResponseEffect): void => {
-        if (finished) {
-          return;
-        }
-        finished = true;
-        release();
-        if (resumeEffect) {
-          resumeEffect(effect);
-          return;
-        }
-        settledEffect = effect;
-      };
-
-      timeout = setTimeout(() => {
-        finish(
-          Effect.fail(
-            new HostOperationError({
-              operation: `codexAppServerTransport.request.${method}`,
-              message: `Timed out waiting for Codex app-server request ${method} on runtime ${runtimeId} after ${requestTimeoutMs}ms`,
-              details: { runtimeId, method, requestTimeoutMs },
-            }),
-          ),
-        );
-      }, requestTimeoutMs);
-
-      pending.set(id, {
-        method,
-        timeout,
-        resolve: (value) => {
-          resolveAfterQueuedMessages(
-            (resolvedValue) => finish(Effect.succeed(resolvedValue)),
-            value,
-          );
-        },
-        reject: (error) => {
-          finish(
-            Effect.fail(
-              toHostOperationError(error, `codexAppServerTransport.request.${method}`, {
-                runtimeId,
-                method,
-              }),
-            ),
-          );
-        },
-      });
-
-      const response = Effect.async<CodexAppServerRequestResult, CodexAppServerTransportError>(
-        (resume) => {
-          if (settledEffect) {
-            resume(settledEffect);
-            return;
-          }
-          resumeEffect = resume;
-        },
-      );
-
-      return { release, response };
-    });
+  const rememberCancelledSentRequest = (id: number): void => {
+    forgetCancelledSentRequest(id);
+    const timeout = setTimeout(() => {
+      cancelledSentRequests.delete(id);
+    }, requestTimeoutMs);
+    cancelledSentRequests.set(id, timeout);
+    if (cancelledSentRequests.size <= MAX_CANCELLED_SENT_REQUEST_IDS) {
+      return;
+    }
+    const oldestId = cancelledSentRequests.keys().next().value;
+    if (typeof oldestId === "number") {
+      forgetCancelledSentRequest(oldestId);
+    }
+  };
 
   const resolveResponse = (id: number, message: Record<string, unknown>): void => {
     const request = pending.get(id);
     if (!request) {
+      if (forgetCancelledSentRequest(id)) {
+        return;
+      }
       failFast(
         new HostValidationError({
           message: `Received Codex app-server response with unexpected id ${id} for ${runtimeId}`,
@@ -409,18 +363,31 @@ export const createCodexAppServerTransport = (
         yield* ensureOpenEffect();
         const id = nextRequestId++;
         return yield* Effect.acquireUseRelease(
-          acquirePendingResponse(id, method),
-          ({ response }) =>
+          acquirePendingResponse({
+            id,
+            method,
+            pending,
+            rememberCancelledSentRequest,
+            requestTimeoutMs,
+            runtimeId,
+          }),
+          ({ markWriteStarted, response }) =>
             Effect.gen(function* () {
-              yield* sendMessage({
-                jsonrpc: "2.0",
-                id,
-                method,
-                ...(params !== undefined ? { params } : {}),
-              });
+              yield* sendMessage(
+                {
+                  jsonrpc: "2.0",
+                  id,
+                  method,
+                  ...(params !== undefined ? { params } : {}),
+                },
+                {
+                  onWriteStarted: markWriteStarted,
+                },
+              );
               return yield* response;
             }),
-          ({ release }) => Effect.sync(release),
+          ({ release }, exit) =>
+            Effect.sync(() => release({ preserveLateResponse: Exit.isInterrupted(exit) })),
         );
       });
     },
@@ -474,6 +441,10 @@ export const createCodexAppServerTransport = (
         child.stdin.destroy();
         child.stdout.destroy();
         child.stderr.destroy();
+        for (const timeout of cancelledSentRequests.values()) {
+          clearTimeout(timeout);
+        }
+        cancelledSentRequests.clear();
         for (const [id, request] of pending) {
           clearTimeout(request.timeout);
           request.reject(

--- a/packages/host/src/adapters/codex/codex-app-server-transport.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.ts
@@ -28,6 +28,7 @@ import type {
   CodexAppServerChildTransport,
   CodexAppServerEventEmitter,
   CodexAppServerStreamEvent,
+  CodexAppServerTransportError,
   CodexChildProcess,
   PendingCodexAppServerRequest,
 } from "./codex-app-server-transport-types";
@@ -100,86 +101,85 @@ export const createCodexAppServerTransport = (
       );
     });
 
-  const waitForResponse = (id: number, method: CodexAppServerRequestMethod) => {
-    type ResponseEffect = Effect.Effect<
-      CodexAppServerRequestResult,
-      HostOperationError | HostResourceError | HostValidationError
-    >;
-    let resumeEffect: ((effect: ResponseEffect) => void) | null = null;
-    let settledEffect: ResponseEffect | null = null;
-    let abortSignal: AbortSignal | null = null;
-    let abortHandler: (() => void) | null = null;
+  const acquirePendingResponse = (id: number, method: CodexAppServerRequestMethod) =>
+    Effect.sync(() => {
+      type ResponseEffect = Effect.Effect<
+        CodexAppServerRequestResult,
+        CodexAppServerTransportError
+      >;
+      let timeout: NodeJS.Timeout;
+      let released = false;
+      let finished = false;
+      let resumeEffect: ((effect: ResponseEffect) => void) | null = null;
+      let settledEffect: ResponseEffect | null = null;
 
-    const finish = (effect: ResponseEffect): void => {
-      if (abortSignal && abortHandler) {
-        abortSignal.removeEventListener("abort", abortHandler);
-        abortSignal = null;
-        abortHandler = null;
-      }
-      if (resumeEffect) {
-        resumeEffect(effect);
-        return;
-      }
-      settledEffect = effect;
-    };
-
-    const timeout = setTimeout(() => {
-      pending.delete(id);
-      finish(
-        Effect.fail(
-          new HostOperationError({
-            operation: `codexAppServerTransport.request.${method}`,
-            message: `Timed out waiting for Codex app-server request ${method} on runtime ${runtimeId} after ${requestTimeoutMs}ms`,
-            details: { runtimeId, method, requestTimeoutMs },
-          }),
-        ),
-      );
-    }, requestTimeoutMs);
-
-    pending.set(id, {
-      method,
-      timeout,
-      resolve: (value) => {
-        resolveAfterQueuedMessages((resolvedValue) => finish(Effect.succeed(resolvedValue)), value);
-      },
-      reject: (error) => {
-        finish(
-          Effect.fail(
-            toHostOperationError(error, `codexAppServerTransport.request.${method}`, {
-              runtimeId,
-              method,
-            }),
-          ),
-        );
-      },
-    });
-
-    return Effect.async<
-      CodexAppServerRequestResult,
-      HostOperationError | HostResourceError | HostValidationError
-    >((resume, signal) => {
-      if (settledEffect) {
-        resume(settledEffect);
-        return;
-      }
-      resumeEffect = resume;
-      abortSignal = signal;
-      abortHandler = () => {
+      const release = (): void => {
+        if (released) {
+          return;
+        }
+        released = true;
         clearTimeout(timeout);
         pending.delete(id);
+      };
+
+      const finish = (effect: ResponseEffect): void => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        release();
+        if (resumeEffect) {
+          resumeEffect(effect);
+          return;
+        }
+        settledEffect = effect;
+      };
+
+      timeout = setTimeout(() => {
         finish(
           Effect.fail(
             new HostOperationError({
               operation: `codexAppServerTransport.request.${method}`,
-              message: `Codex app-server request ${method} was interrupted for runtime ${runtimeId}.`,
-              details: { runtimeId, method },
+              message: `Timed out waiting for Codex app-server request ${method} on runtime ${runtimeId} after ${requestTimeoutMs}ms`,
+              details: { runtimeId, method, requestTimeoutMs },
             }),
           ),
         );
-      };
-      signal.addEventListener("abort", abortHandler, { once: true });
+      }, requestTimeoutMs);
+
+      pending.set(id, {
+        method,
+        timeout,
+        resolve: (value) => {
+          resolveAfterQueuedMessages(
+            (resolvedValue) => finish(Effect.succeed(resolvedValue)),
+            value,
+          );
+        },
+        reject: (error) => {
+          finish(
+            Effect.fail(
+              toHostOperationError(error, `codexAppServerTransport.request.${method}`, {
+                runtimeId,
+                method,
+              }),
+            ),
+          );
+        },
+      });
+
+      const response = Effect.async<CodexAppServerRequestResult, CodexAppServerTransportError>(
+        (resume) => {
+          if (settledEffect) {
+            resume(settledEffect);
+            return;
+          }
+          resumeEffect = resume;
+        },
+      );
+
+      return { release, response };
     });
-  };
 
   const resolveResponse = (id: number, message: Record<string, unknown>): void => {
     const request = pending.get(id);
@@ -408,24 +408,20 @@ export const createCodexAppServerTransport = (
       return Effect.gen(function* () {
         yield* ensureOpenEffect();
         const id = nextRequestId++;
-        const response = waitForResponse(id, method);
-        const sendResult = yield* Effect.either(
-          sendMessage({
-            jsonrpc: "2.0",
-            id,
-            method,
-            ...(params !== undefined ? { params } : {}),
-          }),
+        return yield* Effect.acquireUseRelease(
+          acquirePendingResponse(id, method),
+          ({ response }) =>
+            Effect.gen(function* () {
+              yield* sendMessage({
+                jsonrpc: "2.0",
+                id,
+                method,
+                ...(params !== undefined ? { params } : {}),
+              });
+              return yield* response;
+            }),
+          ({ release }) => Effect.sync(release),
         );
-        if (sendResult._tag === "Left") {
-          const pendingRequest = pending.get(id);
-          if (pendingRequest) {
-            clearTimeout(pendingRequest.timeout);
-            pending.delete(id);
-          }
-          return yield* Effect.fail(sendResult.left);
-        }
-        return yield* response;
       });
     },
     notify(notification) {

--- a/packages/host/src/adapters/codex/codex-app-server-transport.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.ts
@@ -33,7 +33,6 @@ import type {
 import { writeJsonLine } from "./codex-json-line-writer";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
-const MAX_CANCELLED_SENT_REQUEST_IDS = 1_000;
 
 export const createCodexAppServerTransport = (
   runtimeId: string,
@@ -52,19 +51,21 @@ export const createCodexAppServerTransport = (
   let stdoutClosed = false;
   let stderrClosed = false;
 
+  const clearCancelledSentRequests = (): void => {
+    for (const timeout of cancelledSentRequests.values()) {
+      clearTimeout(timeout);
+    }
+    cancelledSentRequests.clear();
+  };
+
   const failFast = (error: Error): void => {
     if (!fatalError) {
       fatalError = error;
     }
     closed = true;
-    for (const timeout of cancelledSentRequests.values()) {
-      clearTimeout(timeout);
-    }
-    cancelledSentRequests.clear();
-    for (const [id, request] of pending) {
-      clearTimeout(request.timeout);
+    clearCancelledSentRequests();
+    for (const request of pending.values()) {
       request.reject(error);
-      pending.delete(id);
     }
   };
 
@@ -127,18 +128,10 @@ export const createCodexAppServerTransport = (
   };
 
   const rememberCancelledSentRequest = (id: number): void => {
-    forgetCancelledSentRequest(id);
     const timeout = setTimeout(() => {
       cancelledSentRequests.delete(id);
     }, requestTimeoutMs);
     cancelledSentRequests.set(id, timeout);
-    if (cancelledSentRequests.size <= MAX_CANCELLED_SENT_REQUEST_IDS) {
-      return;
-    }
-    const oldestId = cancelledSentRequests.keys().next().value;
-    if (typeof oldestId === "number") {
-      forgetCancelledSentRequest(oldestId);
-    }
   };
 
   const resolveResponse = (id: number, message: Record<string, unknown>): void => {
@@ -156,8 +149,6 @@ export const createCodexAppServerTransport = (
       );
       return;
     }
-    pending.delete(id);
-    clearTimeout(request.timeout);
 
     if ("error" in message) {
       request.reject(
@@ -448,12 +439,8 @@ export const createCodexAppServerTransport = (
         child.stdin.destroy();
         child.stdout.destroy();
         child.stderr.destroy();
-        for (const timeout of cancelledSentRequests.values()) {
-          clearTimeout(timeout);
-        }
-        cancelledSentRequests.clear();
+        clearCancelledSentRequests();
         for (const [id, request] of pending) {
-          clearTimeout(request.timeout);
           request.reject(
             new HostResourceError({
               resource: "codexAppServerTransport",
@@ -462,7 +449,6 @@ export const createCodexAppServerTransport = (
               details: { runtimeId, requestId: id },
             }),
           );
-          pending.delete(id);
         }
       });
     },

--- a/packages/host/src/adapters/codex/codex-json-line-writer.ts
+++ b/packages/host/src/adapters/codex/codex-json-line-writer.ts
@@ -7,15 +7,10 @@ const WRITE_OPERATION = "codexAppServerTransport.writeLine";
 export const writeJsonLine = (
   stdin: Writable,
   payload: unknown,
-  options: { onWriteStarted?: () => void } = {},
 ): Effect.Effect<void, HostOperationError> =>
   Effect.async((resume) => {
     let active = true;
-    let writeCallbackFinished = false;
-    let writeCallbackFailed = false;
     stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
-      writeCallbackFinished = true;
-      writeCallbackFailed = Boolean(error);
       if (!active) {
         return;
       }
@@ -25,9 +20,6 @@ export const writeJsonLine = (
       }
       resume(Effect.void);
     });
-    if (!writeCallbackFinished || !writeCallbackFailed) {
-      options.onWriteStarted?.();
-    }
     return Effect.sync(() => {
       active = false;
     });

--- a/packages/host/src/adapters/codex/codex-json-line-writer.ts
+++ b/packages/host/src/adapters/codex/codex-json-line-writer.ts
@@ -7,10 +7,15 @@ const WRITE_OPERATION = "codexAppServerTransport.writeLine";
 export const writeJsonLine = (
   stdin: Writable,
   payload: unknown,
+  options: { onWriteStarted?: () => void } = {},
 ): Effect.Effect<void, HostOperationError> =>
   Effect.async((resume) => {
     let active = true;
+    let writeCallbackFinished = false;
+    let writeCallbackFailed = false;
     stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
+      writeCallbackFinished = true;
+      writeCallbackFailed = Boolean(error);
       if (!active) {
         return;
       }
@@ -20,6 +25,9 @@ export const writeJsonLine = (
       }
       resume(Effect.void);
     });
+    if (!writeCallbackFinished || !writeCallbackFailed) {
+      options.onWriteStarted?.();
+    }
     return Effect.sync(() => {
       active = false;
     });


### PR DESCRIPTION
## Summary
Guarantees Codex app-server pending request cleanup across cancellation, send failure, close, and late-response paths.

## Goal
`waitForResponse()` previously registered pending requests and timers before the returned Effect was guaranteed to stay running. If a request was interrupted during send or before response cleanup, stale pending entries and timers could survive cancellation. This PR moves pending response ownership into the request Effect lifecycle and tightens the surrounding request-write and close cleanup paths.

## Technical Choices
- Extracted pending response acquisition into `acquirePendingResponse`, so timeout creation, pending registration, release, and late-response preservation share one scoped lifecycle.
- Used `Effect.acquireUseRelease` from the transport request path to ensure pending entries and timers release on interruption, send failure, close, timeout, and normal completion.
- Added cancelled-sent request tracking so responses for interrupted-but-written requests are ignored only for their bounded timeout window; genuinely unexpected ids still fail fast.
- Isolated request-line writing in `writeCodexAppServerRequestLine`, with JSON serialization and stream write failures reported as typed `HostOperationError`s through the Effect error channel.
- Kept close and fatal-error cleanup self-contained by explicitly clearing pending entries after rejecting outstanding requests.

## Testing
- [x] `bun test packages/host/src/adapters/codex/codex-app-server-transport.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `cd apps/desktop/src-tauri && cargo fmt --all --check`
- [x] `cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cd apps/desktop/src-tauri && cargo check --workspace`
- [x] `cd apps/desktop/src-tauri && cargo test --workspace`
- [x] `cd apps/desktop/src-tauri && cargo build --workspace`

## Checklist
- [x] Pending request timers are cleared on interruption and failed send/serialization paths.
- [x] Pending entries are released through the scoped Effect lifecycle.
- [x] Late responses for cancelled sent requests do not poison the transport.
- [x] Unexpected response ids still fail fast.
- [x] PR feedback threads have been addressed or explicitly answered.

## Related Issues
- OpenDucktor task: `openducktor-5xbk`

## Breaking Changes
None.
