### PR TITLE
fix(frontend): settle stale session presence on hydration

### DIFF
--- a/apps/electron/scripts/package-build.test.ts
+++ b/apps/electron/scripts/package-build.test.ts
@@ -108,17 +108,10 @@ describe("build Electron release artifact", () => {
 
     try {
       await mkdir(releaseDirectory, { recursive: true });
-      await writeFile(join(releaseDirectory, "OpenDucktor-Electron-0.3.1-mac-arm64.dmg"), "dmg");
-      await writeFile(
-        join(releaseDirectory, "OpenDucktor-Electron-0.3.1-mac-arm64.dmg.blockmap"),
-        "blockmap",
-      );
-      await writeFile(join(releaseDirectory, "OpenDucktor-Electron-0.3.1-mac-arm64.zip"), "zip");
-      await writeFile(join(releaseDirectory, "OpenDucktor.app"), "app bundle marker");
-      await writeFile(
-        join(releaseDirectory, "OpenDucktor-Electron-0.3.1-linux-x64.AppImage"),
-        "app",
-      );
+      await Promise.all([
+        writeFile(join(releaseDirectory, "OpenDucktor-Electron-0.3.1-mac-arm64.dmg"), "dmg"),
+        writeFile(join(releaseDirectory, "OpenDucktor-Electron-0.3.1-linux-x64.AppImage"), "app"),
+      ]);
 
       const artifacts = await collectReleaseArtifacts({
         outputDirectory,
@@ -128,15 +121,9 @@ describe("build Electron release artifact", () => {
 
       expect(artifacts.map((artifact) => basename(artifact)).sort()).toEqual([
         "OpenDucktor-Electron-0.3.1-mac-arm64.dmg",
-        "OpenDucktor-Electron-0.3.1-mac-arm64.dmg.blockmap",
-        "OpenDucktor-Electron-0.3.1-mac-arm64.zip",
       ]);
       const outputEntries = await readdir(outputDirectory);
-      expect(outputEntries.sort()).toEqual([
-        "OpenDucktor-Electron-0.3.1-mac-arm64.dmg",
-        "OpenDucktor-Electron-0.3.1-mac-arm64.dmg.blockmap",
-        "OpenDucktor-Electron-0.3.1-mac-arm64.zip",
-      ]);
+      expect(outputEntries).toEqual(["OpenDucktor-Electron-0.3.1-mac-arm64.dmg"]);
     } finally {
       await rm(baseDirectory, { force: true, recursive: true });
     }

--- a/apps/electron/scripts/package-build.test.ts
+++ b/apps/electron/scripts/package-build.test.ts
@@ -128,4 +128,25 @@ describe("build Electron release artifact", () => {
       await rm(baseDirectory, { force: true, recursive: true });
     }
   });
+
+  it("preserves release directory read errors that are not missing-directory failures", async () => {
+    const baseDirectory = await mkdtemp(join(tmpdir(), "openducktor-electron-release-"));
+    const releaseDirectory = join(baseDirectory, "release");
+    const outputDirectory = join(baseDirectory, "release-publish");
+
+    try {
+      await writeFile(releaseDirectory, "not a directory");
+
+      const error = await collectReleaseArtifacts({
+        outputDirectory,
+        platform: "macos",
+        releaseDirectory,
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).not.toContain("Electron release directory is missing");
+    } finally {
+      await rm(baseDirectory, { force: true, recursive: true });
+    }
+  });
 });

--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { copyFile, mkdir, readdir, rm, stat } from "node:fs/promises";
+import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { prepareMcpSidecar } from "./prepare-mcp-sidecar";
@@ -114,17 +114,12 @@ export const resolveElectronBuilderEnv = (
 export const isReleaseArtifact = (platform: ElectronReleasePlatform, fileName: string): boolean =>
   artifactExtensions[platform].has(extname(fileName));
 
-const assertDirectoryExists = async (path: string, label: string): Promise<void> => {
+const readReleaseDirectoryEntries = async (releaseDirectory: string) => {
   try {
-    const metadata = await stat(path);
-    if (metadata.isDirectory()) {
-      return;
-    }
+    return await readdir(releaseDirectory, { withFileTypes: true });
   } catch {
-    // Report a single actionable error below.
+    throw new Error(`Electron release directory is missing: ${releaseDirectory}`);
   }
-
-  throw new Error(`${label} is missing: ${path}`);
 };
 
 const runCommand = ({ args, command, cwd, env = process.env }: RunCommandInput): Promise<void> =>
@@ -158,11 +153,10 @@ export const collectReleaseArtifacts = async ({
   platform: ElectronReleasePlatform;
   releaseDirectory: string;
 }): Promise<string[]> => {
-  await assertDirectoryExists(releaseDirectory, "Electron release directory");
+  const entries = await readReleaseDirectoryEntries(releaseDirectory);
   await rm(outputDirectory, { force: true, recursive: true });
   await mkdir(outputDirectory, { recursive: true });
 
-  const entries = await readdir(releaseDirectory, { withFileTypes: true });
   const artifactEntries = entries.filter(
     (entry) => entry.isFile() && isReleaseArtifact(platform, entry.name),
   );

--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -117,8 +117,11 @@ export const isReleaseArtifact = (platform: ElectronReleasePlatform, fileName: s
 const readReleaseDirectoryEntries = async (releaseDirectory: string) => {
   try {
     return await readdir(releaseDirectory, { withFileTypes: true });
-  } catch {
-    throw new Error(`Electron release directory is missing: ${releaseDirectory}`);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`Electron release directory is missing: ${releaseDirectory}`);
+    }
+    throw error;
   }
 };
 

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-session-hydration.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-session-hydration.ts
@@ -12,16 +12,13 @@ type UseAgentChatSessionHydrationParams = {
   activeTaskId: string;
   activeSession: AgentSessionState | null;
   historyPreludeMode?: AgentSessionHistoryPreludeMode;
-  allowLiveSessionResume?: boolean;
   persistedRecords?: AgentSessionRecord[];
   repoReadinessState: SessionRepoReadinessState;
   ensureSessionReadyForView: (input: {
     taskId: string;
     externalSessionId: string;
     repoReadinessState: SessionRepoReadinessState;
-    recoveryDedupKey?: string | null;
     historyPreludeMode?: AgentSessionHistoryPreludeMode;
-    allowLiveSessionResume?: boolean;
     persistedRecords?: AgentSessionRecord[];
   }) => Promise<boolean>;
 };
@@ -71,7 +68,6 @@ export function useAgentChatSessionHydration({
   activeTaskId,
   activeSession,
   historyPreludeMode,
-  allowLiveSessionResume,
   persistedRecords,
   repoReadinessState,
   ensureSessionReadyForView,
@@ -107,7 +103,6 @@ export function useAgentChatSessionHydration({
       externalSessionId: activeExternalSessionId,
       repoReadinessState,
       ...(historyPreludeMode ? { historyPreludeMode } : {}),
-      ...(allowLiveSessionResume !== undefined ? { allowLiveSessionResume } : {}),
       ...(persistedRecords ? { persistedRecords } : {}),
     })
       .then(() => {
@@ -124,7 +119,6 @@ export function useAgentChatSessionHydration({
     activeTaskId,
     ensureSessionReadyForView,
     historyPreludeMode,
-    allowLiveSessionResume,
     persistedRecords,
     repoReadinessState,
     shouldEnsureSessionReady,

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
@@ -37,7 +37,6 @@ type UseAgentsPageRouteSessionModelArgs = {
     repoReadinessState: Parameters<
       typeof useAgentStudioSelectionController
     >[0]["agentStudioReadinessState"];
-    recoveryDedupKey?: string | null;
   }) => Promise<boolean>;
   readSessionModelCatalog: (
     repoPath: string,

--- a/packages/frontend/src/pages/agents/use-agent-studio-selection-controller.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-selection-controller.test.tsx
@@ -235,7 +235,7 @@ describe("useAgentStudioSelectionController", () => {
     }
   });
 
-  test("opts normal view hydration into live session resume", async () => {
+  test("prepares the selected view session without opting into live resume", async () => {
     const ensureSessionReadyForView = mock(async () => true);
     const session = createSession("task-1", "session-live", {
       historyHydrationState: "not_requested",
@@ -252,13 +252,11 @@ describe("useAgentStudioSelectionController", () => {
     try {
       await harness.mount();
 
-      expect(ensureSessionReadyForView).toHaveBeenCalledWith(
-        expect.objectContaining({
-          taskId: "task-1",
-          externalSessionId: "session-live",
-          allowLiveSessionResume: true,
-        }),
-      );
+      expect(ensureSessionReadyForView).toHaveBeenCalledWith({
+        taskId: "task-1",
+        externalSessionId: "session-live",
+        repoReadinessState: "ready",
+      });
     } finally {
       await harness.unmount();
     }

--- a/packages/frontend/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -45,7 +45,6 @@ type UseAgentStudioSelectionControllerArgs = {
     taskId: string;
     externalSessionId: string;
     repoReadinessState: AgentStudioReadinessState;
-    recoveryDedupKey?: string | null;
   }) => Promise<boolean>;
   runtimeDefinitions: RuntimeDescriptor[];
   readSessionModelCatalog: (
@@ -425,7 +424,6 @@ export function useAgentStudioSelectionController({
     activeTaskId: viewTaskId,
     activeSession: viewSessionRuntimeData.session,
     repoReadinessState: agentStudioReadinessState,
-    allowLiveSessionResume: true,
     ensureSessionReadyForView,
   });
 

--- a/packages/frontend/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -15,7 +15,6 @@ type UseAgentStudioTaskHydrationParams = {
     taskId: string;
     externalSessionId: string;
     repoReadinessState: AgentStudioReadinessState;
-    recoveryDedupKey?: string | null;
   }) => Promise<boolean>;
 };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/public-operations.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/public-operations.ts
@@ -60,9 +60,7 @@ type CreatePublicOperationsArgs = {
     taskId: string;
     externalSessionId: string;
     repoReadinessState: SessionRepoReadinessState;
-    recoveryDedupKey?: string | null;
     historyPreludeMode?: AgentSessionHistoryPreludeMode;
-    allowLiveSessionResume?: boolean;
     persistedRecords?: AgentSessionRecord[];
   }) => Promise<boolean>;
   reconcileLiveTaskSessions: (input: {

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-agent-session-hydration.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-agent-session-hydration.ts
@@ -109,14 +109,12 @@ export const useAgentSessionHydration = ({
       externalSessionId,
       repoReadinessState,
       historyPreludeMode,
-      allowLiveSessionResume,
       persistedRecords,
     }: {
       taskId: string;
       externalSessionId: string;
       repoReadinessState: SessionRepoReadinessState;
       historyPreludeMode?: AgentSessionHistoryPreludeMode;
-      allowLiveSessionResume?: boolean;
       persistedRecords?: AgentSessionRecord[];
     }): Promise<boolean> => {
       const session = sessionsRef.current[externalSessionId] ?? null;
@@ -131,7 +129,6 @@ export const useAgentSessionHydration = ({
         externalSessionId,
         historyPolicy: requiresHydratedAgentSessionHistory(session) ? "requested_only" : "none",
         ...(historyPreludeMode ? { historyPreludeMode } : {}),
-        ...(allowLiveSessionResume !== undefined ? { allowLiveSessionResume } : {}),
         ...(persistedRecords ? { persistedRecords } : {}),
       });
       return true;

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -132,9 +132,7 @@ export const createLoadAgentSessions = ({
       ? (sessionsRef.current[requestedSessionId] ?? null)
       : null;
     const shouldReconcileRequestedLiveSession =
-      shouldHydrateRequestedSession &&
-      options?.allowLiveSessionResume === true &&
-      shouldReconcileRequestedSessionLiveness(requestedSession);
+      shouldHydrateRequestedSession && shouldReconcileRequestedSessionLiveness(requestedSession);
     const shouldReconcileLiveSessions =
       mode === "reconcile_live" ||
       shouldRecoverRuntimeAttachment ||

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -38,6 +38,8 @@ type CreateLoadAgentSessionsArgs = {
 };
 
 const REQUESTED_SESSION_LIVE_RECONCILE_STATUSES = new Set<AgentSessionState["status"]>([
+  // A locally stopped session can still have a late runtime acknowledgement in flight.
+  // Reconcile once on requested-history loads so the runtime remains the source of liveness truth.
   "stopped",
   "starting",
   "running",

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -97,7 +97,7 @@ const createSessionStateFixture = (): AgentSessionState => ({
 });
 
 describe("reattach-live-session", () => {
-  test("does not apply an idle snapshot during live reattach", async () => {
+  test("settles a stale running session when runtime presence is idle", async () => {
     let state: AgentSessionState = { ...createSessionStateFixture(), status: "running" };
     let resumed = false;
     let attachedSessionId: string | null = null;
@@ -139,9 +139,55 @@ describe("reattach-live-session", () => {
     expect(reattached).toBe(false);
     expect(resumed).toBe(false);
     expect(attachedSessionId).toBeNull();
-    expect(state.status).toBe("running");
+    expect(state.status).toBe("idle");
     expect(state.runtimeId).toBe("runtime-1");
-    expect(state.pendingApprovals).toEqual(createSessionStateFixture().pendingApprovals);
+    expect(state.pendingApprovals).toEqual([]);
+  });
+
+  test("does not settle idle runtime presence while a local send is pending", async () => {
+    let state: AgentSessionState = {
+      ...createSessionStateFixture(),
+      status: "running",
+      pendingUserMessageStartedAt: 123,
+    };
+
+    const reattachLiveSession = createReattachLiveSession({
+      adapter: {
+        hasSession: () => true,
+      },
+      repoPath: "/tmp/repo",
+      getCurrentSession: () => state,
+      updateSession: (externalSessionId, updater) => {
+        if (externalSessionId !== "external-1") {
+          return;
+        }
+        state = updater(state);
+      },
+      attachSessionListener: () => {
+        throw new Error("should not attach idle session");
+      },
+      promptOverrides: {},
+      attachMissingLiveSession: async () => {
+        throw new Error("should not resume idle session");
+      },
+      readSessionPresence: async () =>
+        toSessionPresenceSnapshot({
+          externalSessionId: "external-1",
+          title: "Session",
+          startedAt: "2026-03-22T12:00:00.000Z",
+          status: { type: "idle" },
+          pendingApprovals: [],
+          pendingQuestions: [],
+          workingDirectory: "/tmp/repo/worktree",
+        }),
+      isStaleRepoOperation: () => false,
+    });
+
+    const reattached = await reattachLiveSession(sessionRecordFixture);
+
+    expect(reattached).toBe(false);
+    expect(state.status).toBe("running");
+    expect(state.pendingUserMessageStartedAt).toBe(123);
   });
 
   test("does not adopt runtime presence for an error session without pending input", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -154,7 +154,7 @@ describe("reattach-live-session", () => {
       selectedModel: { providerId: "openai", modelId: "gpt-5" },
       pendingUserMessageStartedAt: 123,
     };
-    const state: AgentSessionState = originalSession;
+    const state: AgentSessionState = structuredClone(originalSession);
 
     const reattachLiveSession = createReattachLiveSession({
       adapter: {
@@ -192,13 +192,13 @@ describe("reattach-live-session", () => {
   });
 
   test("does not adopt runtime presence for an error session without pending input", async () => {
-    const originalSession = {
+    const originalSession: AgentSessionState = {
       ...createSessionStateFixture(),
       status: "error" as const,
       pendingApprovals: [],
       pendingQuestions: [],
     };
-    const state: AgentSessionState = originalSession;
+    const state: AgentSessionState = structuredClone(originalSession);
 
     const reattachLiveSession = createReattachLiveSession({
       adapter: {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -145,11 +145,16 @@ describe("reattach-live-session", () => {
   });
 
   test("does not settle idle runtime presence while a local send is pending", async () => {
-    let state: AgentSessionState = {
+    const originalSession: AgentSessionState = {
       ...createSessionStateFixture(),
       status: "running",
+      runtimeId: "runtime-current",
+      workingDirectory: "/tmp/repo/current-worktree",
+      runtimeRecoveryState: "recovering_runtime",
+      selectedModel: { providerId: "openai", modelId: "gpt-5" },
       pendingUserMessageStartedAt: 123,
     };
+    const state: AgentSessionState = originalSession;
 
     const reattachLiveSession = createReattachLiveSession({
       adapter: {
@@ -157,11 +162,8 @@ describe("reattach-live-session", () => {
       },
       repoPath: "/tmp/repo",
       getCurrentSession: () => state,
-      updateSession: (externalSessionId, updater) => {
-        if (externalSessionId !== "external-1") {
-          return;
-        }
-        state = updater(state);
+      updateSession: () => {
+        throw new Error("should not update session while local send is pending");
       },
       attachSessionListener: () => {
         throw new Error("should not attach idle session");
@@ -186,8 +188,7 @@ describe("reattach-live-session", () => {
     const reattached = await reattachLiveSession(sessionRecordFixture);
 
     expect(reattached).toBe(false);
-    expect(state.status).toBe("running");
-    expect(state.pendingUserMessageStartedAt).toBe(123);
+    expect(state).toEqual(originalSession);
   });
 
   test("does not adopt runtime presence for an error session without pending input", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
@@ -67,6 +67,9 @@ const canApplyNonAttachablePresence = (
   current: AgentSessionState,
   snapshot: AgentSessionPresenceSnapshot,
 ): boolean => {
+  if (hasPendingOutboundSend(current)) {
+    return false;
+  }
   if (shouldSettleNonLivePresence(current)) {
     return true;
   }

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
@@ -1,6 +1,7 @@
 import type { AgentSessionRecord, RepoPromptOverrides, RuntimeKind } from "@openducktor/contracts";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
+import { hasPendingOutboundSend } from "../support/pending-outbound-send";
 import {
   type AgentSessionPresenceSnapshot,
   applyAgentSessionPresenceSnapshotToSession,
@@ -39,6 +40,9 @@ const canAdoptRuntimePresence = (current: AgentSessionState): boolean => {
   return true;
 };
 
+const shouldSettleNonLivePresence = (current: AgentSessionState): boolean =>
+  current.status === "running" && !hasPendingOutboundSend(current);
+
 const applyRuntimeIdentityFromPresence = (
   current: AgentSessionState,
   snapshot: Extract<AgentSessionPresenceSnapshot, { presence: "runtime" }>,
@@ -58,6 +62,16 @@ const applyRuntimeIdentityFromPresence = (
   promptOverrides,
   selectedModel,
 });
+
+const canApplyNonAttachablePresence = (
+  current: AgentSessionState,
+  snapshot: AgentSessionPresenceSnapshot,
+): boolean => {
+  if (shouldSettleNonLivePresence(current)) {
+    return true;
+  }
+  return snapshot.presence === "runtime" && canAdoptRuntimePresence(current);
+};
 
 export const createReattachLiveSession = ({
   adapter,
@@ -90,25 +104,37 @@ export const createReattachLiveSession = ({
     }
     const selectedModel = normalizePersistedSelection(record.selectedModel);
     if (!isAttachableAgentSessionPresenceSnapshot(sessionPresence)) {
-      if (sessionPresence.presence === "runtime") {
-        const currentSession = getCurrentSession(record.externalSessionId);
-        if (!currentSession || !canAdoptRuntimePresence(currentSession) || isStaleRepoOperation()) {
-          return false;
-        }
-        updateSession(
-          record.externalSessionId,
-          (current) => {
-            if (!canAdoptRuntimePresence(current)) {
-              return current;
-            }
+      const currentSession = getCurrentSession(record.externalSessionId);
+      if (
+        !currentSession ||
+        !canApplyNonAttachablePresence(currentSession, sessionPresence) ||
+        isStaleRepoOperation()
+      ) {
+        return false;
+      }
+      updateSession(
+        record.externalSessionId,
+        (current) => {
+          const mergedSelectedModel = mergeModelSelection(
+            current.selectedModel,
+            selectedModel ?? undefined,
+          );
+          if (shouldSettleNonLivePresence(current)) {
+            return applyAgentSessionPresenceSnapshotToSession(current, sessionPresence, {
+              promptOverrides,
+              selectedModel: mergedSelectedModel,
+            });
+          }
+          if (sessionPresence.presence === "runtime" && canAdoptRuntimePresence(current)) {
             return applyRuntimeIdentityFromPresence(current, sessionPresence, {
               promptOverrides,
-              selectedModel: mergeModelSelection(current.selectedModel, selectedModel ?? undefined),
+              selectedModel: mergedSelectedModel,
             });
-          },
-          { persist: false },
-        );
-      }
+          }
+          return current;
+        },
+        { persist: false },
+      );
       return false;
     }
     const currentSession = getCurrentSession(record.externalSessionId);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle.test.ts
@@ -98,4 +98,30 @@ describe("deriveAgentSessionViewLifecycle", () => {
     expect(lifecycle.canRenderHistory).toBe(true);
     expect(lifecycle.shouldEnsureReadyForView).toBe(true);
   });
+
+  test("does not request view readiness while a local outbound send is pending", () => {
+    const lifecycle = deriveAgentSessionViewLifecycle({
+      session: createSession({
+        status: "running",
+        historyHydrationState: "hydrated",
+        runtimeId: "runtime-1",
+        runtimeKind: "codex",
+        workingDirectory: "/tmp/repo/worktree",
+        pendingUserMessageStartedAt: 123,
+        messages: [
+          {
+            id: "message-1",
+            role: "user",
+            content: "new turn",
+            timestamp: "2026-02-22T08:00:03.000Z",
+          },
+        ],
+      }),
+      repoReadinessState: "ready",
+    });
+
+    expect(lifecycle.phase).toBe("ready");
+    expect(lifecycle.canRenderHistory).toBe(true);
+    expect(lifecycle.shouldEnsureReadyForView).toBe(false);
+  });
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/session-view-lifecycle.ts
@@ -4,6 +4,7 @@ import {
   requiresHydratedAgentSessionHistory,
 } from "../support/history-hydration";
 import { getSessionMessageCount } from "../support/messages";
+import { hasPendingOutboundSend } from "../support/pending-outbound-send";
 import { hasAttachedSessionRuntime } from "../support/session-runtime-attachment";
 
 export type SessionRepoReadinessState = "ready" | "checking" | "blocked";
@@ -51,7 +52,10 @@ export const deriveAgentSessionViewLifecycle = ({
   const hasTranscript = getSessionMessageCount(session) > 0;
   const hasRuntimeAttachment = hasAttachedSessionRuntime(session);
   const shouldRefreshRunningAttachedSession =
-    repoReadinessState === "ready" && hasRuntimeAttachment && session.status === "running";
+    repoReadinessState === "ready" &&
+    hasRuntimeAttachment &&
+    session.status === "running" &&
+    !hasPendingOutboundSend(session);
 
   if (repoReadinessState !== "ready" && sessionNeedsHydration && !hasTranscript) {
     return {

--- a/packages/frontend/src/types/state-slices.ts
+++ b/packages/frontend/src/types/state-slices.ts
@@ -179,9 +179,7 @@ export type AgentStateContextValue = {
     taskId: string;
     externalSessionId: string;
     repoReadinessState: SessionRepoReadinessState;
-    recoveryDedupKey?: string | null;
     historyPreludeMode?: import("./agent-orchestrator").AgentSessionHistoryPreludeMode;
-    allowLiveSessionResume?: boolean;
     persistedRecords?: AgentSessionRecord[];
   }) => Promise<boolean>;
   reconcileLiveTaskSessions: (input: {


### PR DESCRIPTION
## Summary
- remove view-hydration live-resume flags so opening a transcript does not promote stale sessions to running
- reconcile requested-session liveness through the existing session-load path when the local record still looks live
- settle stale running sessions from runtime presence unless a local outbound send is pending

## Goal
Fix Codex idle sessions appearing as running when revisited, without adding another frontend cache or view-specific liveness path.

## Context
The sidebar/task liveness source already knows when sessions are idle. The regression came from view hydration carrying live-resume intent into transcript opening, which could revive stale local running state during history hydration.

## Technical choices
- keep liveness settlement in adapter-backed runtime reconciliation, not in the view hook
- remove allowLiveSessionResume and recoveryDedupKey from view readiness APIs
- keep pending outbound sends protected from idle settlement while the user message is in flight
- cover the stale-running settlement and pending-send guard with focused frontend tests

## Verification
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- bun run check:rust
- bun run test:rust
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents premature session state changes when a local outbound message is pending; improves session readiness behavior during reattachment.

* **Refactor**
  * Tightened session hydration contracts to remove obsolete options, simplifying how sessions are prepared for view.

* **Tests**
  * Updated and added tests to validate session reattachment, lifecycle, and readiness behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->