### PR TITLE
fix: restore PierreDiff inline comment selection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1566,7 +1566,7 @@
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
-    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+    "tmp": ["tmp@0.2.6", "", {}, "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="],
 
     "tmp-promise": ["tmp-promise@3.0.3", "", { "dependencies": { "tmp": "^0.2.0" } }, "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ=="],
 

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer-model.ts
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer-model.ts
@@ -1,0 +1,283 @@
+import type {
+  DiffLineAnnotation,
+  FileDiffMetadata,
+  Hunk,
+  SelectedLineRange,
+  SelectionSide,
+} from "@pierre/diffs";
+import { getSingularPatch } from "@pierre/diffs";
+import type {
+  InlineCommentContextLine,
+  InlineCommentSide,
+} from "@/state/use-inline-comment-draft-store";
+import { selectRenderableDiff } from "./renderable-patch";
+
+const MAX_RENDERABLE_DIFF_CACHE_ENTRIES = 64;
+const INLINE_COMMENT_CONTEXT_RADIUS = 2;
+
+export type PierreDiffSelection = {
+  selectedLines: SelectedLineRange;
+  side: InlineCommentSide;
+  startLine: number;
+  endLine: number;
+  codeContext: InlineCommentContextLine[];
+  language: string | null;
+};
+
+export type HunkResetAnnotationMetadata = {
+  kind: "hunk-reset";
+  hunkIndex: number;
+};
+
+type RenderableFileDiff = {
+  fileDiff: FileDiffMetadata | null;
+  normalizedPatch: string | null;
+  fallbackPatch: string;
+};
+
+type DiffSideLine = {
+  lineNumber: number;
+  text: string;
+};
+
+const resolveHunkResetAnchor = (
+  hunk: Hunk,
+  hunkIndex: number,
+): DiffLineAnnotation<HunkResetAnnotationMetadata> | null => {
+  let currentAdditionLine = hunk.additionStart;
+  let currentDeletionLine = hunk.deletionStart;
+  let lastAdditionLine: number | null = null;
+  let lastDeletionLine: number | null = null;
+
+  for (const segment of hunk.hunkContent) {
+    if (segment.type === "context") {
+      currentAdditionLine += segment.lines;
+      currentDeletionLine += segment.lines;
+      continue;
+    }
+
+    if (segment.additions > 0) {
+      lastAdditionLine = currentAdditionLine + segment.additions - 1;
+      currentAdditionLine += segment.additions;
+    }
+
+    if (segment.deletions > 0) {
+      lastDeletionLine = currentDeletionLine + segment.deletions - 1;
+      currentDeletionLine += segment.deletions;
+    }
+  }
+
+  if (lastAdditionLine != null) {
+    return {
+      side: "additions",
+      lineNumber: lastAdditionLine,
+      metadata: { kind: "hunk-reset", hunkIndex },
+    };
+  }
+
+  if (lastDeletionLine != null) {
+    return {
+      side: "deletions",
+      lineNumber: lastDeletionLine,
+      metadata: { kind: "hunk-reset", hunkIndex },
+    };
+  }
+
+  return null;
+};
+
+export const getHunkResetAnnotations = (
+  fileDiff: FileDiffMetadata,
+): DiffLineAnnotation<HunkResetAnnotationMetadata>[] => {
+  return fileDiff.hunks.reduce<DiffLineAnnotation<HunkResetAnnotationMetadata>[]>(
+    (annotations, hunk, hunkIndex) => {
+      const annotation = resolveHunkResetAnchor(hunk, hunkIndex);
+      if (annotation) {
+        annotations.push(annotation);
+      }
+      return annotations;
+    },
+    [],
+  );
+};
+
+const tryGetSingularPatch = (patch: string) => {
+  try {
+    return getSingularPatch(patch);
+  } catch {
+    return null;
+  }
+};
+
+const normalizeDiffLineText = (value: string): string => value.replace(/\n$/, "");
+
+const renderableFileDiffCache = new Map<string, RenderableFileDiff>();
+
+export const getRenderableFileDiff = (patch: string, filePath: string) => {
+  const cacheKey = `${filePath}\u0000${patch}`;
+  const cached = renderableFileDiffCache.get(cacheKey);
+  if (cached) {
+    renderableFileDiffCache.delete(cacheKey);
+    renderableFileDiffCache.set(cacheKey, cached);
+    return cached;
+  }
+
+  const normalizedPatch = selectRenderableDiff(patch, filePath);
+  const fileDiff = normalizedPatch ? tryGetSingularPatch(normalizedPatch) : null;
+  const result = {
+    fileDiff,
+    normalizedPatch,
+    fallbackPatch: normalizedPatch ?? patch,
+  } satisfies RenderableFileDiff;
+
+  renderableFileDiffCache.set(cacheKey, result);
+  if (renderableFileDiffCache.size > MAX_RENDERABLE_DIFF_CACHE_ENTRIES) {
+    const oldestKey = renderableFileDiffCache.keys().next().value;
+    if (typeof oldestKey === "string") {
+      renderableFileDiffCache.delete(oldestKey);
+    }
+  }
+
+  return result;
+};
+
+const normalizeSelectedLineRange = (selectedLines: SelectedLineRange): SelectedLineRange => {
+  const normalizedStartSide = selectedLines.side;
+  const normalizedEndSide = selectedLines.endSide ?? normalizedStartSide;
+
+  const withOptionalSides = (
+    range: Pick<SelectedLineRange, "start" | "end">,
+    startSide: SelectionSide | undefined,
+    endSide: SelectionSide | undefined,
+  ): SelectedLineRange => {
+    return {
+      ...range,
+      ...(startSide ? { side: startSide } : {}),
+      ...(endSide ? { endSide } : {}),
+    };
+  };
+
+  if (selectedLines.start < selectedLines.end) {
+    return withOptionalSides(selectedLines, normalizedStartSide, normalizedEndSide);
+  }
+
+  if (selectedLines.start === selectedLines.end) {
+    return withOptionalSides(
+      {
+        start: selectedLines.start,
+        end: selectedLines.end,
+      },
+      normalizedStartSide,
+      normalizedEndSide,
+    );
+  }
+
+  return withOptionalSides(
+    {
+      start: selectedLines.end,
+      end: selectedLines.start,
+    },
+    normalizedEndSide,
+    normalizedStartSide,
+  );
+};
+
+const mapSelectionSide = (side: SelectionSide | undefined): InlineCommentSide => {
+  return side === "deletions" ? "old" : "new";
+};
+
+const buildSideLines = (fileDiff: FileDiffMetadata, side: SelectionSide): DiffSideLine[] => {
+  const lines = side === "deletions" ? fileDiff.deletionLines : fileDiff.additionLines;
+  const sideLines: DiffSideLine[] = [];
+
+  for (const hunk of fileDiff.hunks) {
+    let additionLineNumber = hunk.additionStart;
+    let deletionLineNumber = hunk.deletionStart;
+
+    for (const content of hunk.hunkContent) {
+      if (content.type === "context") {
+        for (let index = 0; index < content.lines; index += 1) {
+          sideLines.push({
+            lineNumber:
+              side === "deletions" ? deletionLineNumber + index : additionLineNumber + index,
+            text: normalizeDiffLineText(
+              lines[
+                (side === "deletions" ? content.deletionLineIndex : content.additionLineIndex) +
+                  index
+              ] ?? "",
+            ),
+          });
+        }
+        additionLineNumber += content.lines;
+        deletionLineNumber += content.lines;
+        continue;
+      }
+
+      if (side === "deletions") {
+        for (let index = 0; index < content.deletions; index += 1) {
+          sideLines.push({
+            lineNumber: deletionLineNumber + index,
+            text: normalizeDiffLineText(lines[content.deletionLineIndex + index] ?? ""),
+          });
+        }
+      }
+
+      if (side === "additions") {
+        for (let index = 0; index < content.additions; index += 1) {
+          sideLines.push({
+            lineNumber: additionLineNumber + index,
+            text: normalizeDiffLineText(lines[content.additionLineIndex + index] ?? ""),
+          });
+        }
+      }
+
+      additionLineNumber += content.additions;
+      deletionLineNumber += content.deletions;
+    }
+  }
+
+  return sideLines;
+};
+
+export const buildPierreDiffSelection = (
+  fileDiff: FileDiffMetadata,
+  selectedLines: SelectedLineRange | null,
+): PierreDiffSelection | null => {
+  if (selectedLines == null) {
+    return null;
+  }
+
+  const normalizedSelection = normalizeSelectedLineRange(selectedLines);
+  const startSide = normalizedSelection.side ?? "additions";
+  const endSide = normalizedSelection.endSide ?? startSide;
+  if (startSide !== endSide) {
+    return null;
+  }
+
+  const sideLines = buildSideLines(fileDiff, startSide);
+  const startIndex = sideLines.findIndex((line) => line.lineNumber === normalizedSelection.start);
+  const endIndex = sideLines.findIndex((line) => line.lineNumber === normalizedSelection.end);
+  if (startIndex < 0 || endIndex < 0) {
+    return null;
+  }
+
+  const contextStartIndex = Math.max(0, startIndex - INLINE_COMMENT_CONTEXT_RADIUS);
+  const contextEndIndex = Math.min(sideLines.length - 1, endIndex + INLINE_COMMENT_CONTEXT_RADIUS);
+  const codeContext = sideLines.slice(contextStartIndex, contextEndIndex + 1).map((line, index) => {
+    const absoluteIndex = contextStartIndex + index;
+    return {
+      lineNumber: line.lineNumber,
+      text: line.text,
+      isSelected: absoluteIndex >= startIndex && absoluteIndex <= endIndex,
+    } satisfies InlineCommentContextLine;
+  });
+
+  return {
+    selectedLines: normalizedSelection,
+    side: mapSelectionSide(startSide),
+    startLine: normalizedSelection.start,
+    endLine: normalizedSelection.end,
+    codeContext,
+    language: fileDiff.lang ?? null,
+  };
+};

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import {
   withCapturedConsoleMethods,
   withCapturedOutputStreams,
@@ -7,15 +8,69 @@ import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 
 let pierreViewerModule: typeof import("./pierre-diff-viewer");
 
+const OMITTED_SELECTED_LINES_LABEL = "__omitted__";
+const mockedGutterSelection = {
+  start: 2,
+  end: 3,
+  side: "additions" as const,
+  endSide: "additions" as const,
+};
+const selectionPatch = [
+  "diff --git a/src/app.ts b/src/app.ts",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -1,4 +1,5 @@",
+  " one",
+  "-two",
+  "+two updated",
+  "+two extra",
+  " three",
+  " four",
+  "",
+].join("\n");
+
 beforeEach(async () => {
   await withCapturedOutputStreams(["stdout", "stderr"], async (chunksByStream) => {
     await withCapturedConsoleMethods(
       ["debug", "error", "info", "log", "warn"],
       async (consoleCalls) => {
         mock.module("@pierre/diffs/react", () => ({
-          FileDiff: () => null,
+          FileDiff: (props: {
+            options?: {
+              onGutterUtilityClick?: (range: unknown) => void;
+              onLineSelectionChange?: (range: unknown) => void;
+            };
+            selectedLines?: unknown;
+          }) => {
+            const { options } = props;
+            const selectedLinesText = Object.hasOwn(props, "selectedLines")
+              ? JSON.stringify(props.selectedLines)
+              : OMITTED_SELECTED_LINES_LABEL;
+            return (
+              <div>
+                <output data-testid="pierre-selected-lines">{selectedLinesText}</output>
+                <button
+                  type="button"
+                  data-testid="pierre-selection-change"
+                  onClick={() => options?.onLineSelectionChange?.(mockedGutterSelection)}
+                >
+                  Selection change
+                </button>
+                <button
+                  type="button"
+                  data-testid="pierre-gutter-utility"
+                  onClick={() => options?.onGutterUtilityClick?.(mockedGutterSelection)}
+                >
+                  Gutter utility
+                </button>
+              </div>
+            );
+          },
           Virtualizer: ({ children }: { children: React.ReactNode }) => children,
           useWorkerPool: () => null,
+        }));
+        mock.module("@/components/layout/theme-provider", () => ({
+          useTheme: () => ({ theme: "light", setTheme: () => undefined }),
         }));
 
         pierreViewerModule = await import("./pierre-diff-viewer");
@@ -35,11 +90,19 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  cleanup();
+
   await withCapturedOutputStreams(["stdout", "stderr"], async (chunksByStream) => {
     await withCapturedConsoleMethods(
       ["debug", "error", "info", "log", "warn"],
       async (consoleCalls) => {
-        await restoreMockedModules([["@pierre/diffs/react", () => import("@pierre/diffs/react")]]);
+        await restoreMockedModules([
+          ["@pierre/diffs/react", () => import("@pierre/diffs/react")],
+          [
+            "@/components/layout/theme-provider",
+            () => import("@/components/layout/theme-provider"),
+          ],
+        ]);
         for (const calls of Object.values(consoleCalls)) {
           for (const call of calls) {
             expect(call).toEqual([]);
@@ -51,6 +114,85 @@ afterEach(async () => {
     for (const chunk of [...chunksByStream.stdout, ...chunksByStream.stderr]) {
       expect(chunk).toBe("[]\n");
     }
+  });
+});
+
+describe("PierreDiffViewer", () => {
+  test("keeps controlled selected lines in sync while dragging from the gutter utility", () => {
+    const { PierreDiffViewer } = pierreViewerModule;
+
+    render(
+      <PierreDiffViewer
+        patch={selectionPatch}
+        filePath="src/app.ts"
+        enableLineSelection
+        enableGutterUtility
+        selectedLines={null}
+        onLineSelectionEnd={mock()}
+      />,
+    );
+
+    expect(screen.getByTestId("pierre-selected-lines").textContent).toBe("null");
+
+    fireEvent.click(screen.getByTestId("pierre-selection-change"));
+
+    expect(screen.getByTestId("pierre-selected-lines").textContent).toBe(
+      JSON.stringify(mockedGutterSelection),
+    );
+  });
+
+  test("leaves selected lines uncontrolled when the caller omits selectedLines", () => {
+    const { PierreDiffViewer } = pierreViewerModule;
+
+    render(
+      <PierreDiffViewer
+        patch={selectionPatch}
+        filePath="src/app.ts"
+        enableLineSelection
+        onLineSelectionEnd={mock()}
+      />,
+    );
+
+    expect(screen.getByTestId("pierre-selected-lines").textContent).toBe(
+      OMITTED_SELECTED_LINES_LABEL,
+    );
+
+    fireEvent.click(screen.getByTestId("pierre-selection-change"));
+
+    expect(screen.getByTestId("pierre-selected-lines").textContent).toBe(
+      OMITTED_SELECTED_LINES_LABEL,
+    );
+  });
+
+  test("opens inline comment selection from the gutter utility", () => {
+    const { PierreDiffViewer } = pierreViewerModule;
+    const onLineSelectionEnd = mock();
+
+    render(
+      <PierreDiffViewer
+        patch={selectionPatch}
+        filePath="src/app.ts"
+        enableGutterUtility
+        onLineSelectionEnd={onLineSelectionEnd}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("pierre-gutter-utility"));
+
+    expect(onLineSelectionEnd).toHaveBeenCalledWith({
+      selectedLines: mockedGutterSelection,
+      side: "new",
+      startLine: 2,
+      endLine: 3,
+      codeContext: [
+        { lineNumber: 1, text: "one", isSelected: false },
+        { lineNumber: 2, text: "two updated", isSelected: true },
+        { lineNumber: 3, text: "two extra", isSelected: true },
+        { lineNumber: 4, text: "three", isSelected: false },
+        { lineNumber: 5, text: "four", isSelected: false },
+      ],
+      language: null,
+    });
   });
 });
 

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -39,6 +39,7 @@ beforeEach(async () => {
             options?: {
               onGutterUtilityClick?: (range: unknown) => void;
               onLineSelectionChange?: (range: unknown) => void;
+              onLineSelectionStart?: (range: unknown) => void;
             };
             selectedLines?: unknown;
           }) => {
@@ -49,6 +50,13 @@ beforeEach(async () => {
             return (
               <div>
                 <output data-testid="pierre-selected-lines">{selectedLinesText}</output>
+                <button
+                  type="button"
+                  data-testid="pierre-selection-start"
+                  onClick={() => options?.onLineSelectionStart?.(mockedGutterSelection)}
+                >
+                  Selection start
+                </button>
                 <button
                   type="button"
                   data-testid="pierre-selection-change"
@@ -134,7 +142,7 @@ describe("PierreDiffViewer", () => {
 
     expect(screen.getByTestId("pierre-selected-lines").textContent).toBe("null");
 
-    fireEvent.click(screen.getByTestId("pierre-selection-change"));
+    fireEvent.click(screen.getByTestId("pierre-selection-start"));
 
     expect(screen.getByTestId("pierre-selected-lines").textContent).toBe(
       JSON.stringify(mockedGutterSelection),
@@ -162,6 +170,25 @@ describe("PierreDiffViewer", () => {
     expect(screen.getByTestId("pierre-selected-lines").textContent).toBe(
       OMITTED_SELECTED_LINES_LABEL,
     );
+  });
+
+  test("does not mirror controlled selected lines without a completion handler", () => {
+    const { PierreDiffViewer } = pierreViewerModule;
+
+    render(
+      <PierreDiffViewer
+        patch={selectionPatch}
+        filePath="src/app.ts"
+        enableLineSelection
+        selectedLines={null}
+      />,
+    );
+
+    expect(screen.getByTestId("pierre-selected-lines").textContent).toBe("null");
+
+    fireEvent.click(screen.getByTestId("pierre-selection-start"));
+
+    expect(screen.getByTestId("pierre-selected-lines").textContent).toBe("null");
   });
 
   test("opens inline comment selection from the gutter utility", () => {

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -7,6 +7,7 @@ import {
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 
 let pierreViewerModule: typeof import("./pierre-diff-viewer");
+let pierreViewerModelModule: typeof import("./pierre-diff-viewer-model");
 
 const OMITTED_SELECTED_LINES_LABEL = "__omitted__";
 const mockedGutterSelection = {
@@ -82,6 +83,7 @@ beforeEach(async () => {
         }));
 
         pierreViewerModule = await import("./pierre-diff-viewer");
+        pierreViewerModelModule = await import("./pierre-diff-viewer-model");
 
         for (const calls of Object.values(consoleCalls)) {
           for (const call of calls) {
@@ -224,7 +226,9 @@ describe("PierreDiffViewer", () => {
 });
 
 const requireFileDiff = (
-  fileDiff: ReturnType<typeof import("./pierre-diff-viewer")["getRenderableFileDiff"]>["fileDiff"],
+  fileDiff: ReturnType<
+    typeof import("./pierre-diff-viewer-model")["getRenderableFileDiff"]
+  >["fileDiff"],
 ) => {
   expect(fileDiff).not.toBeNull();
   if (fileDiff == null) {
@@ -235,7 +239,7 @@ const requireFileDiff = (
 
 describe("getRenderableFileDiff", () => {
   test("parses valid git patches", async () => {
-    const { getRenderableFileDiff } = pierreViewerModule;
+    const { getRenderableFileDiff } = pierreViewerModelModule;
     const patch =
       "diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n";
 
@@ -247,7 +251,7 @@ describe("getRenderableFileDiff", () => {
   });
 
   test("normalizes hunk-only patches with the current file path", async () => {
-    const { getRenderableFileDiff } = pierreViewerModule;
+    const { getRenderableFileDiff } = pierreViewerModelModule;
     const result = getRenderableFileDiff("@@ -1 +1 @@\n-old\n+new\n", "src/hunk.ts");
 
     expect(result.normalizedPatch).toBe(
@@ -257,7 +261,7 @@ describe("getRenderableFileDiff", () => {
   });
 
   test("keeps normalized raw diff text when parsing still fails", async () => {
-    const { getRenderableFileDiff } = pierreViewerModule;
+    const { getRenderableFileDiff } = pierreViewerModelModule;
     const result = await withCapturedOutputStreams(["stdout", "stderr"], async (chunksByStream) => {
       return await withCapturedConsoleMethods(
         ["debug", "error", "info", "log", "warn"],
@@ -287,7 +291,7 @@ describe("getRenderableFileDiff", () => {
   });
 
   test("builds hunk reset annotations for the first and subsequent hunks", async () => {
-    const { getHunkResetAnnotations, getRenderableFileDiff } = pierreViewerModule;
+    const { getHunkResetAnnotations, getRenderableFileDiff } = pierreViewerModelModule;
     const patch = [
       "diff --git a/src/app.ts b/src/app.ts",
       "--- a/src/app.ts",
@@ -323,7 +327,7 @@ describe("getRenderableFileDiff", () => {
   });
 
   test("falls back to deletion lines for delete-only hunks", async () => {
-    const { getHunkResetAnnotations, getRenderableFileDiff } = pierreViewerModule;
+    const { getHunkResetAnnotations, getRenderableFileDiff } = pierreViewerModelModule;
     const patch = [
       "diff --git a/src/app.ts b/src/app.ts",
       "--- a/src/app.ts",
@@ -345,7 +349,7 @@ describe("getRenderableFileDiff", () => {
   });
 
   test("builds an inline comment selection snapshot for additions with surrounding context", async () => {
-    const { buildPierreDiffSelection, getRenderableFileDiff } = pierreViewerModule;
+    const { buildPierreDiffSelection, getRenderableFileDiff } = pierreViewerModelModule;
     const patch = [
       "diff --git a/src/app.ts b/src/app.ts",
       "--- a/src/app.ts",
@@ -390,7 +394,7 @@ describe("getRenderableFileDiff", () => {
   });
 
   test("builds an inline comment selection snapshot for old-side ranges", async () => {
-    const { buildPierreDiffSelection, getRenderableFileDiff } = pierreViewerModule;
+    const { buildPierreDiffSelection, getRenderableFileDiff } = pierreViewerModelModule;
     const patch = [
       "diff --git a/src/app.ts b/src/app.ts",
       "--- a/src/app.ts",
@@ -432,7 +436,7 @@ describe("getRenderableFileDiff", () => {
   });
 
   test("rejects mixed-side selections for inline comments", async () => {
-    const { buildPierreDiffSelection, getRenderableFileDiff } = pierreViewerModule;
+    const { buildPierreDiffSelection, getRenderableFileDiff } = pierreViewerModelModule;
     const patch = [
       "diff --git a/src/app.ts b/src/app.ts",
       "--- a/src/app.ts",

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -413,7 +413,9 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
   const { theme } = useTheme();
   const isSelectionControlled = selectedLines !== undefined;
   const shouldMirrorSelectionChanges =
-    isSelectionControlled && (enableLineSelection || enableGutterUtility);
+    isSelectionControlled &&
+    onLineSelectionEnd != null &&
+    (enableLineSelection || enableGutterUtility);
   const [transientSelectedLines, setTransientSelectedLines] = useState<
     SelectedLineRange | null | undefined
   >(undefined);

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -1,11 +1,4 @@
-import type {
-  DiffLineAnnotation,
-  FileDiffMetadata,
-  Hunk,
-  SelectedLineRange,
-  SelectionSide,
-} from "@pierre/diffs";
-import { getSingularPatch } from "@pierre/diffs";
+import type { DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
 import { FileDiff as PierreReactFileDiff, useWorkerPool } from "@pierre/diffs/react";
 import type { DiffRendererInstance } from "@pierre/diffs/worker";
 import { Undo2 } from "lucide-react";
@@ -22,24 +15,17 @@ import {
 import { useTheme } from "@/components/layout/theme-provider";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import type {
-  InlineCommentContextLine,
-  InlineCommentSide,
-} from "@/state/use-inline-comment-draft-store";
-import { selectRenderableDiff } from "./renderable-patch";
+import type { HunkResetAnnotationMetadata, PierreDiffSelection } from "./pierre-diff-viewer-model";
+import {
+  buildPierreDiffSelection,
+  getHunkResetAnnotations,
+  getRenderableFileDiff,
+} from "./pierre-diff-viewer-model";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
 export type PierreDiffStyle = "split" | "unified";
-
-export type PierreDiffSelection = {
-  selectedLines: SelectedLineRange;
-  side: InlineCommentSide;
-  startLine: number;
-  endLine: number;
-  codeContext: InlineCommentContextLine[];
-  language: string | null;
-};
+export type { PierreDiffSelection } from "./pierre-diff-viewer-model";
 
 type PierreDiffViewerProps = {
   /** Raw unified diff / patch string (e.g. from `git diff`). */
@@ -79,7 +65,6 @@ const HUNK_RESET_ANNOTATION_WRAPPER_CLASS_NAME = "contents";
 const HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE = "data-hunk-reset-annotation";
 const HUNK_RESET_BUTTON_CLASS_NAME =
   "pointer-events-auto absolute right-3 top-1 h-7 gap-1.5 px-2.5 text-[11px] shadow-sm";
-const MAX_RENDERABLE_DIFF_CACHE_ENTRIES = 64;
 const DIFF_SCROLL_CONTAINER_CLASS_NAME = "max-h-[min(70vh,48rem)] overflow-auto";
 const HUNK_RESET_FLOATING_CSS = `
 [data-line-annotation]:has([${HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE}]),
@@ -100,124 +85,6 @@ const HUNK_RESET_FLOATING_CSS = `
   background-color: transparent !important;
 }
 `;
-
-type HunkResetAnnotationMetadata = {
-  kind: "hunk-reset";
-  hunkIndex: number;
-};
-
-const resolveHunkResetAnchor = (
-  hunk: Hunk,
-  hunkIndex: number,
-): DiffLineAnnotation<HunkResetAnnotationMetadata> | null => {
-  let currentAdditionLine = hunk.additionStart;
-  let currentDeletionLine = hunk.deletionStart;
-  let lastAdditionLine: number | null = null;
-  let lastDeletionLine: number | null = null;
-
-  for (const segment of hunk.hunkContent) {
-    if (segment.type === "context") {
-      currentAdditionLine += segment.lines;
-      currentDeletionLine += segment.lines;
-      continue;
-    }
-
-    if (segment.additions > 0) {
-      lastAdditionLine = currentAdditionLine + segment.additions - 1;
-      currentAdditionLine += segment.additions;
-    }
-
-    if (segment.deletions > 0) {
-      lastDeletionLine = currentDeletionLine + segment.deletions - 1;
-      currentDeletionLine += segment.deletions;
-    }
-  }
-
-  if (lastAdditionLine != null) {
-    return {
-      side: "additions",
-      lineNumber: lastAdditionLine,
-      metadata: { kind: "hunk-reset", hunkIndex },
-    };
-  }
-
-  if (lastDeletionLine != null) {
-    return {
-      side: "deletions",
-      lineNumber: lastDeletionLine,
-      metadata: { kind: "hunk-reset", hunkIndex },
-    };
-  }
-
-  return null;
-};
-
-export const getHunkResetAnnotations = (
-  fileDiff: FileDiffMetadata,
-): DiffLineAnnotation<HunkResetAnnotationMetadata>[] => {
-  return fileDiff.hunks.reduce<DiffLineAnnotation<HunkResetAnnotationMetadata>[]>(
-    (annotations, hunk, hunkIndex) => {
-      const annotation = resolveHunkResetAnchor(hunk, hunkIndex);
-      if (annotation) {
-        annotations.push(annotation);
-      }
-      return annotations;
-    },
-    [],
-  );
-};
-
-const tryGetSingularPatch = (patch: string) => {
-  try {
-    return getSingularPatch(patch);
-  } catch {
-    return null;
-  }
-};
-
-type RenderableFileDiff = {
-  fileDiff: FileDiffMetadata | null;
-  normalizedPatch: string | null;
-  fallbackPatch: string;
-};
-
-type DiffSideLine = {
-  lineNumber: number;
-  text: string;
-};
-
-const INLINE_COMMENT_CONTEXT_RADIUS = 2;
-const normalizeDiffLineText = (value: string): string => value.replace(/\n$/, "");
-
-const renderableFileDiffCache = new Map<string, RenderableFileDiff>();
-
-export const getRenderableFileDiff = (patch: string, filePath: string) => {
-  const cacheKey = `${filePath}\u0000${patch}`;
-  const cached = renderableFileDiffCache.get(cacheKey);
-  if (cached) {
-    renderableFileDiffCache.delete(cacheKey);
-    renderableFileDiffCache.set(cacheKey, cached);
-    return cached;
-  }
-
-  const normalizedPatch = selectRenderableDiff(patch, filePath);
-  const fileDiff = normalizedPatch ? tryGetSingularPatch(normalizedPatch) : null;
-  const result = {
-    fileDiff,
-    normalizedPatch,
-    fallbackPatch: normalizedPatch ?? patch,
-  } satisfies RenderableFileDiff;
-
-  renderableFileDiffCache.set(cacheKey, result);
-  if (renderableFileDiffCache.size > MAX_RENDERABLE_DIFF_CACHE_ENTRIES) {
-    const oldestKey = renderableFileDiffCache.keys().next().value;
-    if (typeof oldestKey === "string") {
-      renderableFileDiffCache.delete(oldestKey);
-    }
-  }
-
-  return result;
-};
 
 export const PierreDiffPreloader = memo(function PierreDiffPreloader({
   patch,
@@ -251,147 +118,6 @@ export const PierreDiffPreloader = memo(function PierreDiffPreloader({
 
   return null;
 });
-
-const normalizeSelectedLineRange = (selectedLines: SelectedLineRange): SelectedLineRange => {
-  const normalizedStartSide = selectedLines.side;
-  const normalizedEndSide = selectedLines.endSide ?? normalizedStartSide;
-
-  const withOptionalSides = (
-    range: Pick<SelectedLineRange, "start" | "end">,
-    startSide: SelectionSide | undefined,
-    endSide: SelectionSide | undefined,
-  ): SelectedLineRange => {
-    return {
-      ...range,
-      ...(startSide ? { side: startSide } : {}),
-      ...(endSide ? { endSide } : {}),
-    };
-  };
-
-  if (selectedLines.start < selectedLines.end) {
-    return withOptionalSides(selectedLines, normalizedStartSide, normalizedEndSide);
-  }
-
-  if (selectedLines.start === selectedLines.end) {
-    return withOptionalSides(
-      {
-        start: selectedLines.start,
-        end: selectedLines.end,
-      },
-      normalizedStartSide,
-      normalizedEndSide,
-    );
-  }
-
-  return withOptionalSides(
-    {
-      start: selectedLines.end,
-      end: selectedLines.start,
-    },
-    normalizedEndSide,
-    normalizedStartSide,
-  );
-};
-
-const mapSelectionSide = (side: SelectionSide | undefined): InlineCommentSide => {
-  return side === "deletions" ? "old" : "new";
-};
-
-const buildSideLines = (fileDiff: FileDiffMetadata, side: SelectionSide): DiffSideLine[] => {
-  const lines = side === "deletions" ? fileDiff.deletionLines : fileDiff.additionLines;
-  const sideLines: DiffSideLine[] = [];
-
-  for (const hunk of fileDiff.hunks) {
-    let additionLineNumber = hunk.additionStart;
-    let deletionLineNumber = hunk.deletionStart;
-
-    for (const content of hunk.hunkContent) {
-      if (content.type === "context") {
-        for (let index = 0; index < content.lines; index += 1) {
-          sideLines.push({
-            lineNumber:
-              side === "deletions" ? deletionLineNumber + index : additionLineNumber + index,
-            text: normalizeDiffLineText(
-              lines[
-                (side === "deletions" ? content.deletionLineIndex : content.additionLineIndex) +
-                  index
-              ] ?? "",
-            ),
-          });
-        }
-        additionLineNumber += content.lines;
-        deletionLineNumber += content.lines;
-        continue;
-      }
-
-      if (side === "deletions") {
-        for (let index = 0; index < content.deletions; index += 1) {
-          sideLines.push({
-            lineNumber: deletionLineNumber + index,
-            text: normalizeDiffLineText(lines[content.deletionLineIndex + index] ?? ""),
-          });
-        }
-      }
-
-      if (side === "additions") {
-        for (let index = 0; index < content.additions; index += 1) {
-          sideLines.push({
-            lineNumber: additionLineNumber + index,
-            text: normalizeDiffLineText(lines[content.additionLineIndex + index] ?? ""),
-          });
-        }
-      }
-
-      additionLineNumber += content.additions;
-      deletionLineNumber += content.deletions;
-    }
-  }
-
-  return sideLines;
-};
-
-export const buildPierreDiffSelection = (
-  fileDiff: FileDiffMetadata,
-  selectedLines: SelectedLineRange | null,
-): PierreDiffSelection | null => {
-  if (selectedLines == null) {
-    return null;
-  }
-
-  const normalizedSelection = normalizeSelectedLineRange(selectedLines);
-  const startSide = normalizedSelection.side ?? "additions";
-  const endSide = normalizedSelection.endSide ?? startSide;
-  if (startSide !== endSide) {
-    return null;
-  }
-
-  const sideLines = buildSideLines(fileDiff, startSide);
-  const startIndex = sideLines.findIndex((line) => line.lineNumber === normalizedSelection.start);
-  const endIndex = sideLines.findIndex((line) => line.lineNumber === normalizedSelection.end);
-  if (startIndex < 0 || endIndex < 0) {
-    return null;
-  }
-
-  const contextStartIndex = Math.max(0, startIndex - INLINE_COMMENT_CONTEXT_RADIUS);
-  const contextEndIndex = Math.min(sideLines.length - 1, endIndex + INLINE_COMMENT_CONTEXT_RADIUS);
-  const codeContext = sideLines.slice(contextStartIndex, contextEndIndex + 1).map((line, index) => {
-    const absoluteIndex = contextStartIndex + index;
-    return {
-      lineNumber: line.lineNumber,
-      text: line.text,
-      isSelected: absoluteIndex >= startIndex && absoluteIndex <= endIndex,
-    } satisfies InlineCommentContextLine;
-  });
-
-  return {
-    selectedLines: normalizedSelection,
-    side: mapSelectionSide(startSide),
-    startLine: normalizedSelection.start,
-    endLine: normalizedSelection.end,
-    codeContext,
-    language: fileDiff.lang ?? null,
-  };
-};
 
 // ─── Component ─────────────────────────────────────────────────────────────────
 

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -17,6 +17,7 @@ import {
   useEffect,
   useId,
   useMemo,
+  useState,
 } from "react";
 import { useTheme } from "@/components/layout/theme-provider";
 import { Button } from "@/components/ui/button";
@@ -403,13 +404,19 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
   enableHunkReset = false,
   isHunkResetDisabled = false,
   onResetHunk,
-  selectedLines = null,
+  selectedLines,
   onLineSelectionEnd,
   lineAnnotations = [],
   renderAnnotation,
   className,
 }: PierreDiffViewerProps): ReactElement {
   const { theme } = useTheme();
+  const isSelectionControlled = selectedLines !== undefined;
+  const shouldMirrorSelectionChanges =
+    isSelectionControlled && (enableLineSelection || enableGutterUtility);
+  const [transientSelectedLines, setTransientSelectedLines] = useState<
+    SelectedLineRange | null | undefined
+  >(undefined);
   const { fileDiff, fallbackPatch } = useMemo(
     () => getRenderableFileDiff(patch, filePath),
     [filePath, patch],
@@ -426,10 +433,29 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
     () =>
       onLineSelectionEnd && fileDiff != null
         ? (range: SelectedLineRange | null) => {
+            setTransientSelectedLines(undefined);
             onLineSelectionEnd(buildPierreDiffSelection(fileDiff, range));
           }
         : undefined,
     [fileDiff, onLineSelectionEnd],
+  );
+  const handleLineSelectionChange = useMemo(
+    () =>
+      shouldMirrorSelectionChanges
+        ? (range: SelectedLineRange | null) => {
+            setTransientSelectedLines(range);
+          }
+        : undefined,
+    [shouldMirrorSelectionChanges],
+  );
+  const handleGutterUtilityClick = useMemo(
+    () =>
+      enableGutterUtility && handleLineSelectionEnd
+        ? (range: SelectedLineRange) => {
+            handleLineSelectionEnd(range);
+          }
+        : undefined,
+    [enableGutterUtility, handleLineSelectionEnd],
   );
   const options = useMemo(
     () => ({
@@ -442,20 +468,32 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
       overflow: "wrap" as const,
       disableFileHeader: true,
       enableLineSelection,
-      enableGutterUtility,
+      enableGutterUtility: handleGutterUtilityClick != null,
+      ...(handleLineSelectionChange
+        ? {
+            onLineSelectionStart: handleLineSelectionChange,
+            onLineSelectionChange: handleLineSelectionChange,
+          }
+        : {}),
       ...(handleLineSelectionEnd ? { onLineSelectionEnd: handleLineSelectionEnd } : {}),
+      ...(handleGutterUtilityClick ? { onGutterUtilityClick: handleGutterUtilityClick } : {}),
       ...(enableHunkReset ? { unsafeCSS: HUNK_RESET_FLOATING_CSS } : {}),
     }),
     [
       diffStyle,
-      enableGutterUtility,
       enableHunkReset,
       enableLineSelection,
+      handleGutterUtilityClick,
+      handleLineSelectionChange,
       handleLineSelectionEnd,
       lineDiffType,
       theme,
     ],
   );
+  const renderedSelectedLines =
+    transientSelectedLines !== undefined ? transientSelectedLines : selectedLines;
+  const selectedLinesProps =
+    renderedSelectedLines !== undefined ? { selectedLines: renderedSelectedLines } : {};
   const handleRenderAnnotation = useCallback(
     (annotation: DiffLineAnnotation<unknown>) => {
       const metadata = annotation.metadata;
@@ -503,7 +541,7 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
       <div className={DIFF_SCROLL_CONTAINER_CLASS_NAME}>
         <PierreReactFileDiff
           fileDiff={fileDiff}
-          selectedLines={selectedLines}
+          {...selectedLinesProps}
           options={options}
           lineAnnotations={mergedLineAnnotations}
           renderAnnotation={handleRenderAnnotation}


### PR DESCRIPTION
Summary

Restores inline comment selection in the git diff after the PierreDiff upgrade, including the visual selected-line background while dragging from the gutter plus button.

Goal and context

PierreDiff now expects the gutter utility click and transient drag selection to be wired explicitly. The git panel already owns the final inline comment selection, but the wrapper was not forwarding the gutter utility click and was not mirroring drag selection while the caller controlled selectedLines.

Technical choices

- Wire PierreDiff gutter utility clicks through the same selection builder used by completed line selection.
- Mirror transient selected lines only when selectedLines is controlled, so uncontrolled PierreDiff usage stays untouched.
- Keep the wrapper narrow and add focused regression coverage for click, drag highlight, and omitted selectedLines behavior.

Verification

- bun run typecheck
- bun run lint
- bun run test
- bun run build
- bun run check:rust
- bun run test:rust
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diff viewer supports both controlled and uncontrolled line-selection modes (transient selection when not controlled).
  * Selecting lines produces an inline-comment payload including selected lines, side, start/end lines, code context, and language.
  * Gutter utility actions complete selection consistently; optional styling for hunk-reset applied.

* **Tests**
  * Expanded interaction tests for selection sync, uncontrolled/controlled behaviors, gutter clicks, and callback invocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->