### PR TITLE
fix(electron): start repo runtimes outside diagnostics

### DIFF
--- a/packages/frontend/src/components/features/repository/open-repository-modal.test.tsx
+++ b/packages/frontend/src/components/features/repository/open-repository-modal.test.tsx
@@ -29,6 +29,9 @@ const addWorkspaceMock = mock(
   }): Promise<void> => {},
 );
 const selectWorkspaceMock = mock(async (_repoPath: string): Promise<void> => {});
+const actualAppStateProviderModule = await import("../../../state/app-state-provider");
+const actualButtonModule = await import("@/components/ui/button");
+const actualDialogModule = await import("@/components/ui/dialog");
 
 function SeedFilesystemDirectory(): ReactNode {
   const queryClient = useQueryClient();
@@ -123,9 +126,9 @@ describe("OpenRepositoryModal", () => {
 
   afterEach(async () => {
     await restoreMockedModules([
-      ["@/state/app-state-provider", () => import("../../../state/app-state-provider")],
-      ["@/components/ui/button", () => import("@/components/ui/button")],
-      ["@/components/ui/dialog", () => import("@/components/ui/dialog")],
+      ["@/state/app-state-provider", async () => actualAppStateProviderModule],
+      ["@/components/ui/button", async () => actualButtonModule],
+      ["@/components/ui/dialog", async () => actualDialogModule],
     ]);
   });
 

--- a/packages/frontend/src/components/features/task-details/task-details-sheet.test.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-sheet.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createElement, type PropsWithChildren } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { QueryProvider } from "@/lib/query-provider";
@@ -60,6 +60,16 @@ const IsolatedProviders = ({ children }: PropsWithChildren) => (
 
 describe("TaskDetailsSheet", () => {
   beforeEach(async () => {
+    await restoreMockedModules([
+      ["@/state/app-state-provider", async () => actualAppStateProviderModule],
+    ]);
+    mock.module("@/state/app-state-provider", () => ({
+      ...actualAppStateProviderModule,
+      useWorkspaceState: () => createWorkspaceStateValue(),
+    }));
+  });
+
+  afterEach(async () => {
     await restoreMockedModules([
       ["@/state/app-state-provider", async () => actualAppStateProviderModule],
     ]);

--- a/packages/frontend/src/components/features/task-details/use-task-delete-impact.ts
+++ b/packages/frontend/src/components/features/task-details/use-task-delete-impact.ts
@@ -1,7 +1,7 @@
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import { useQueries } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { useWorkspaceState } from "@/state";
+import { useWorkspaceState } from "@/state/app-state-provider";
 import { agentSessionListQueryOptions } from "@/state/queries/agent-sessions";
 
 type TaskDeleteImpact = {

--- a/packages/frontend/src/components/layout/workspace-rail.test.tsx
+++ b/packages/frontend/src/components/layout/workspace-rail.test.tsx
@@ -29,6 +29,7 @@ const workspaceRecord = (
 
 let workspaceState: WorkspaceStateContextValue;
 let WorkspaceRail: typeof import("./workspace-rail").WorkspaceRail;
+const actualAppStateProviderModule = await import("../../state/app-state-provider");
 
 describe("WorkspaceRail", () => {
   beforeEach(async () => {
@@ -74,7 +75,7 @@ describe("WorkspaceRail", () => {
 
   afterEach(async () => {
     await restoreMockedModules([
-      ["@/state/app-state-provider", () => import("../../state/app-state-provider")],
+      ["@/state/app-state-provider", async () => actualAppStateProviderModule],
     ]);
   });
 

--- a/packages/frontend/src/state/agent-runtime-registry.ts
+++ b/packages/frontend/src/state/agent-runtime-registry.ts
@@ -32,6 +32,7 @@ type AgentRuntimeRegistry = {
   registeredRuntimeKinds: RuntimeKind[];
   getAdapter: (runtimeKind: RuntimeKind) => RegisteredRuntimeAdapter;
   getRuntimeDefinition: (runtimeKind: RuntimeKind) => AgentRuntimeDefinition;
+  startRepoRuntime: (ref: RepoRuntimeRef) => Promise<RuntimeInstanceSummary>;
   createAgentEngine: () => AgentEnginePort;
 };
 
@@ -160,6 +161,7 @@ export const createAgentRuntimeRegistry = (): AgentRuntimeRegistry => {
     registeredRuntimeKinds,
     getAdapter,
     getRuntimeDefinition,
+    startRepoRuntime: hostRepoRuntimeResolver.ensureRepoRuntime,
     createAgentEngine: () => new RuntimeRegistryAgentEngine(getAdapter, registeredRuntimeKinds),
   };
 };

--- a/packages/frontend/src/state/app-state-provider.tsx
+++ b/packages/frontend/src/state/app-state-provider.tsx
@@ -36,18 +36,17 @@ import {
   useWorkspacePresenceContext,
   WorkspaceStateContext,
 } from "./app-state-contexts";
-import { createHostRuntimeCatalogOperations } from "./operations";
-import {
-  AgentStudioStateProvider,
-  AppLifecycleStateProvider,
-  AppRuntimeProvider,
-  AutopilotProvider,
-  ChecksStateProvider,
-  DelegationStateProvider,
-  SpecStateProvider,
-  TasksStateProvider,
-  WorkspaceStateProvider,
-} from "./providers";
+import { createHostRuntimeCatalogOperations } from "./operations/shared/runtime-catalog";
+import { ensureRuntimeAndInvalidateReadinessQueries } from "./operations/shared/runtime-readiness-publication";
+import { AgentStudioStateProvider } from "./providers/agent-studio-state-provider";
+import { AppLifecycleStateProvider } from "./providers/app-lifecycle-state-provider";
+import { AppRuntimeProvider } from "./providers/app-runtime-provider";
+import { AutopilotProvider } from "./providers/autopilot-provider";
+import { ChecksStateProvider } from "./providers/checks-state-provider";
+import { DelegationStateProvider } from "./providers/delegation-state-provider";
+import { SpecStateProvider } from "./providers/spec-state-provider";
+import { TasksStateProvider } from "./providers/tasks-state-provider";
+import { WorkspaceStateProvider } from "./providers/workspace-state-provider";
 
 export function AppStateProvider({ children }: PropsWithChildren): ReactElement {
   const runtimeRegistry = useMemo(() => createAgentRuntimeRegistry(), []);
@@ -59,6 +58,19 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
     (repoPath: string, runtimeKind: RuntimeKind) =>
       runtimeCatalogOperations.checkRepoRuntimeHealth(repoPath, runtimeKind),
     [runtimeCatalogOperations],
+  );
+  const startRepoRuntime = useCallback(
+    (repoPath: string, runtimeKind: RuntimeKind) =>
+      ensureRuntimeAndInvalidateReadinessQueries({
+        repoPath,
+        runtimeKind,
+        ensureRuntime: (nextRepoPath, nextRuntimeKind) =>
+          runtimeRegistry.startRepoRuntime({
+            repoPath: nextRepoPath,
+            runtimeKind: nextRuntimeKind,
+          }),
+      }),
+    [runtimeRegistry],
   );
 
   return (
@@ -73,7 +85,7 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
             <WorkspaceStateProvider>
               <DelegationStateProvider>
                 <AgentStudioStateProvider agentEngine={agentEngine}>
-                  <AppLifecycleStateProvider>
+                  <AppLifecycleStateProvider startRepoRuntime={startRepoRuntime}>
                     <AutopilotProvider>{children}</AutopilotProvider>
                   </AppLifecycleStateProvider>
                 </AgentStudioStateProvider>

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { BeadsCheck } from "@openducktor/contracts";
+import {
+  type BeadsCheck,
+  CODEX_RUNTIME_DESCRIPTOR,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type RuntimeInstanceSummary,
+  type RuntimeKind,
+} from "@openducktor/contracts";
 import { createHostClient } from "@openducktor/host-client";
 import { CancelledError } from "@tanstack/react-query";
 import { act } from "react";
@@ -68,6 +74,25 @@ const makeMissingAttachmentBeadsCheck = (): BeadsCheck =>
     },
   });
 
+const makeRuntimeSummary = (repoPath: string, runtimeKind: RuntimeKind): RuntimeInstanceSummary => {
+  const descriptor =
+    runtimeKind === "codex" ? CODEX_RUNTIME_DESCRIPTOR : OPENCODE_RUNTIME_DESCRIPTOR;
+  return {
+    kind: runtimeKind,
+    runtimeId: `${runtimeKind}-runtime`,
+    repoPath,
+    taskId: null,
+    role: "workspace",
+    workingDirectory: repoPath,
+    runtimeRoute:
+      runtimeKind === "codex"
+        ? { type: "stdio", identity: `${runtimeKind}-runtime` }
+        : { type: "local_http", endpoint: "http://127.0.0.1:3030" },
+    startedAt: "2026-02-22T08:00:00.000Z",
+    descriptor,
+  };
+};
+
 const createActiveWorkspace = (
   repoPath: string,
   workspaceId = repoPath.replace(/^\//, "").replaceAll("/", "-"),
@@ -81,12 +106,21 @@ type UseAppLifecycleArgs = Parameters<
   Awaited<typeof import("./use-app-lifecycle")>["useAppLifecycle"]
 >[0];
 
-type LegacyUseAppLifecycleArgs = Omit<UseAppLifecycleArgs, "activeWorkspace"> & {
-  activeWorkspace?: ActiveWorkspace | null;
-  activeRepo?: string | null;
-  setEvents?: unknown;
-  setRunCompletionSignal?: unknown;
-};
+type LegacyUseAppLifecycleArgs = Omit<
+  UseAppLifecycleArgs,
+  "activeWorkspace" | "runtimeDefinitions" | "refreshRepoRuntimeHealthForRepo" | "startRepoRuntime"
+> &
+  Partial<
+    Pick<
+      UseAppLifecycleArgs,
+      "runtimeDefinitions" | "refreshRepoRuntimeHealthForRepo" | "startRepoRuntime"
+    >
+  > & {
+    activeWorkspace?: ActiveWorkspace | null;
+    activeRepo?: string | null;
+    setEvents?: unknown;
+    setRunCompletionSignal?: unknown;
+  };
 
 const normalizeHookArgs = ({
   activeWorkspace,
@@ -94,6 +128,14 @@ const normalizeHookArgs = ({
   ...rest
 }: LegacyUseAppLifecycleArgs): UseAppLifecycleArgs => ({
   ...rest,
+  runtimeDefinitions: rest.runtimeDefinitions ?? [],
+  refreshRepoRuntimeHealthForRepo: rest.refreshRepoRuntimeHealthForRepo ?? mock(async () => ({})),
+  startRepoRuntime:
+    rest.startRepoRuntime ??
+    mock(
+      async (repoPath, runtimeKind): Promise<RuntimeInstanceSummary> =>
+        makeRuntimeSummary(repoPath, runtimeKind),
+    ),
   activeWorkspace: activeWorkspace ?? (activeRepo ? createActiveWorkspace(activeRepo) : null),
 });
 beforeEach(() => {
@@ -167,6 +209,293 @@ afterEach(async () => {
 });
 
 describe("useAppLifecycle", () => {
+  test("starts configured repo runtimes in the lifecycle without waiting before loading repository data", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const runtimeDeferred = createDeferred<RuntimeInstanceSummary>();
+    const startRepoRuntime = mock(async (_repoPath: string, _runtimeKind: string) => {
+      return runtimeDeferred.promise;
+    });
+    const refreshRepoRuntimeHealthForRepo = mock(async () => ({}));
+    const refreshTaskData = mock(async () => {});
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () =>
+          makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+        ),
+        refreshRepoRuntimeHealthForRepo,
+        refreshTaskData,
+        startRepoRuntime,
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+
+    await harness.mount();
+    try {
+      await harness.waitFor(() => refreshTaskData.mock.calls.length > 0);
+
+      expect(startRepoRuntime).toHaveBeenCalledWith("/repo", "opencode");
+      expect(startRepoRuntime).toHaveBeenCalledWith("/repo", "codex");
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", undefined, {
+        forceFreshTaskList: false,
+      });
+      expect(refreshRepoRuntimeHealthForRepo).toHaveBeenCalledWith("/repo", true);
+    } finally {
+      runtimeDeferred.resolve(makeRuntimeSummary("/repo", "opencode"));
+      await harness.unmount();
+    }
+  });
+
+  test("refreshes runtime health as each runtime startup settles and reports every failure", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const opencodeStartup = createDeferred<RuntimeInstanceSummary>();
+    const codexStartup = createDeferred<RuntimeInstanceSummary>();
+    const startRepoRuntime = mock((_repoPath: string, runtimeKind: RuntimeKind) => {
+      return runtimeKind === "opencode" ? opencodeStartup.promise : codexStartup.promise;
+    });
+    const refreshRepoRuntimeHealthForRepo = mock(async () => ({}));
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () =>
+          makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+        ),
+        refreshRepoRuntimeHealthForRepo,
+        refreshTaskData: mock(async () => {}),
+        startRepoRuntime,
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+
+    await harness.mount();
+    try {
+      await harness.waitFor(() => refreshRepoRuntimeHealthForRepo.mock.calls.length === 1);
+      expect(refreshRepoRuntimeHealthForRepo).toHaveBeenLastCalledWith("/repo", true);
+
+      await harness.run(async () => {
+        opencodeStartup.reject(new Error("opencode unavailable"));
+      });
+      await harness.waitFor(() => refreshRepoRuntimeHealthForRepo.mock.calls.length === 2);
+      expect(refreshRepoRuntimeHealthForRepo).toHaveBeenLastCalledWith("/repo", true);
+
+      await harness.run(async () => {
+        codexStartup.reject(new Error("codex unavailable"));
+      });
+      await harness.waitFor(() => refreshRepoRuntimeHealthForRepo.mock.calls.length === 3);
+      expect(refreshRepoRuntimeHealthForRepo).toHaveBeenLastCalledWith("/repo", true);
+
+      expect(toastError).toHaveBeenCalledWith("Runtime startup failed for opencode", {
+        description: "opencode unavailable",
+      });
+      expect(toastError).toHaveBeenCalledWith("Runtime startup failed for codex", {
+        description: "codex unavailable",
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("does not show runtime diagnostics unavailable when runtime health refresh is cancelled", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const startup = createDeferred<RuntimeInstanceSummary>();
+    const refreshRepoRuntimeHealthForRepo = mock(async () => {
+      throw new CancelledError();
+    });
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () =>
+          makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+        ),
+        refreshRepoRuntimeHealthForRepo,
+        refreshTaskData: mock(async () => {}),
+        startRepoRuntime: mock(async () => startup.promise),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+
+    await harness.mount();
+    try {
+      await harness.waitFor(() => refreshRepoRuntimeHealthForRepo.mock.calls.length === 1);
+
+      expect(
+        toastError.mock.calls.some(([title]) => title === "Runtime diagnostics unavailable"),
+      ).toBe(false);
+    } finally {
+      startup.resolve(makeRuntimeSummary("/repo", "opencode"));
+      await harness.unmount();
+    }
+  });
+
+  test("shows runtime diagnostics unavailable when runtime health refresh fails", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const startup = createDeferred<RuntimeInstanceSummary>();
+    const refreshRepoRuntimeHealthForRepo = mock(async () => {
+      throw new Error("diagnostics transport failed");
+    });
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () =>
+          makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+        ),
+        refreshRepoRuntimeHealthForRepo,
+        refreshTaskData: mock(async () => {}),
+        startRepoRuntime: mock(async () => startup.promise),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+
+    await harness.mount();
+    try {
+      await harness.waitFor(() =>
+        toastError.mock.calls.some(([title]) => title === "Runtime diagnostics unavailable"),
+      );
+
+      expect(toastError).toHaveBeenCalledWith("Runtime diagnostics unavailable", {
+        description: "diagnostics transport failed",
+      });
+    } finally {
+      startup.resolve(makeRuntimeSummary("/repo", "opencode"));
+      await harness.unmount();
+    }
+  });
+
+  test("does not restart runtimes when runtime definitions are referentially new but semantically unchanged", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const startRepoRuntime = mock(async (repoPath: string, runtimeKind: RuntimeKind) =>
+      makeRuntimeSummary(repoPath, runtimeKind),
+    );
+    const baseArgs: HookArgs = {
+      activeRepo: "/repo",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => {}),
+      refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+      refreshBeadsCheckForRepo: mock(async () =>
+        makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+      ),
+      refreshRepoRuntimeHealthForRepo: mock(async () => ({})),
+      refreshTaskData: mock(async () => {}),
+      startRepoRuntime,
+      clearBranchData: mock(() => {}),
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+
+    await harness.mount();
+    try {
+      await harness.waitFor(() => startRepoRuntime.mock.calls.length === 2);
+
+      await harness.update({
+        args: {
+          ...baseArgs,
+          runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
+        },
+      });
+
+      expect(startRepoRuntime).toHaveBeenCalledTimes(2);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("starts runtimes when runtime definitions load after the initial lifecycle render", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = LegacyUseAppLifecycleArgs;
+
+    const startRepoRuntime = mock(async (repoPath: string, runtimeKind: RuntimeKind) =>
+      makeRuntimeSummary(repoPath, runtimeKind),
+    );
+    const refreshRepoRuntimeHealthForRepo = mock(async () => ({}));
+    const baseArgs: HookArgs = {
+      activeRepo: "/repo",
+      runtimeDefinitions: [],
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => {}),
+      refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+      refreshBeadsCheckForRepo: mock(async () =>
+        makeBeadsCheck({ beadsOk: true, beadsPath: "/repo/.beads", beadsError: null }),
+      ),
+      refreshRepoRuntimeHealthForRepo,
+      refreshTaskData: mock(async () => {}),
+      startRepoRuntime,
+      clearBranchData: mock(() => {}),
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(normalizeHookArgs(args));
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+
+    await harness.mount();
+    try {
+      await harness.update({
+        args: {
+          ...baseArgs,
+          runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        },
+      });
+
+      await harness.waitFor(() => startRepoRuntime.mock.calls.length === 1);
+      expect(startRepoRuntime).toHaveBeenCalledWith("/repo", "opencode");
+      expect(refreshRepoRuntimeHealthForRepo).toHaveBeenCalledWith("/repo", true);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("refreshes active repo task data when an external task event arrives", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = LegacyUseAppLifecycleArgs;

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.ts
@@ -2,8 +2,11 @@ import {
   type BeadsCheck,
   externalTaskSyncEventSchema,
   type RepoStoreHealth,
+  type RuntimeDescriptor,
+  type RuntimeInstanceSummary,
+  type RuntimeKind,
 } from "@openducktor/contracts";
-import { CancelledError } from "@tanstack/react-query";
+import { CancelledError, isCancelledError } from "@tanstack/react-query";
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { toast } from "sonner";
 import { BROWSER_LIVE_STREAM_WARNING_EVENT_KIND } from "@/lib/browser-live/constants";
@@ -12,6 +15,7 @@ import { errorMessage } from "@/lib/errors";
 import { hostBridge } from "@/lib/host-client";
 import type { TaskDataRefreshOptions } from "@/state/app-state-contexts";
 import { getBlockingRepoStoreHealth, summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
+import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
 import type { ActiveWorkspace } from "@/types/state-slices";
 
 const BEADS_PREPARATION_TOAST_DELAY_MS = 1_000;
@@ -40,32 +44,42 @@ const rememberProcessedExternalTaskEvent = (
 
 type UseAppLifecycleArgs = {
   activeWorkspace: ActiveWorkspace | null;
+  runtimeDefinitions: RuntimeDescriptor[];
   refreshWorkspaces: () => Promise<void>;
   refreshBranches: (force?: boolean) => Promise<void>;
   refreshRuntimeCheck: (force?: boolean) => Promise<unknown>;
   refreshBeadsCheckForRepo: (repoPath: string, force?: boolean) => Promise<BeadsCheck>;
+  refreshRepoRuntimeHealthForRepo: (
+    repoPath: string,
+    force?: boolean,
+  ) => Promise<RepoRuntimeHealthMap>;
   refreshTaskData: (
     repoPath: string,
     taskIdOrIds?: string | string[],
     options?: TaskDataRefreshOptions,
   ) => Promise<void>;
+  startRepoRuntime: (repoPath: string, runtimeKind: RuntimeKind) => Promise<RuntimeInstanceSummary>;
   clearBranchData: () => void;
   beadsPreparationToastDelayMs?: number;
 };
 
 export function useAppLifecycle({
   activeWorkspace,
+  runtimeDefinitions,
   refreshWorkspaces,
   refreshBranches,
   refreshRuntimeCheck,
   refreshBeadsCheckForRepo,
+  refreshRepoRuntimeHealthForRepo,
   refreshTaskData,
+  startRepoRuntime,
   clearBranchData,
   beadsPreparationToastDelayMs = BEADS_PREPARATION_TOAST_DELAY_MS,
 }: UseAppLifecycleArgs): void {
   const repoLoadVersionRef = useRef(0);
   const activeWorkspaceRef = useRef(activeWorkspace);
   const refreshTaskDataRef = useRef(refreshTaskData);
+  const runtimeKindsKey = runtimeDefinitions.map((definition) => definition.kind).join(",");
   const processedTaskEventIdsRef = useRef(new Set<string>());
   const processedTaskEventOrderRef = useRef<string[]>([]);
   const lastExternalTaskSyncFailureToastRef = useRef<{
@@ -95,6 +109,60 @@ export function useAppLifecycle({
       },
     );
   }, [refreshRuntimeCheck, refreshWorkspaces]);
+
+  useEffect(() => {
+    const repoPath = activeWorkspace?.repoPath ?? null;
+    if (!repoPath || runtimeKindsKey.length === 0) {
+      return;
+    }
+
+    let disposed = false;
+    const runtimeKinds = runtimeKindsKey.split(",") as RuntimeKind[];
+
+    const refreshRuntimeHealth = (): void => {
+      void refreshRepoRuntimeHealthForRepo(repoPath, true).catch((error: unknown) => {
+        if (
+          disposed ||
+          activeWorkspaceRef.current?.repoPath !== repoPath ||
+          isCancelledError(error)
+        ) {
+          return;
+        }
+        toast.error("Runtime diagnostics unavailable", {
+          description: errorMessage(error),
+        });
+      });
+    };
+
+    refreshRuntimeHealth();
+
+    for (const runtimeKind of runtimeKinds) {
+      void startRepoRuntime(repoPath, runtimeKind)
+        .catch((error: unknown) => {
+          if (disposed || activeWorkspaceRef.current?.repoPath !== repoPath) {
+            return;
+          }
+          toast.error(`Runtime startup failed for ${runtimeKind}`, {
+            description: errorMessage(error),
+          });
+        })
+        .finally(() => {
+          if (disposed || activeWorkspaceRef.current?.repoPath !== repoPath) {
+            return;
+          }
+          refreshRuntimeHealth();
+        });
+    }
+
+    return () => {
+      disposed = true;
+    };
+  }, [
+    activeWorkspace?.repoPath,
+    refreshRepoRuntimeHealthForRepo,
+    runtimeKindsKey,
+    startRepoRuntime,
+  ]);
 
   useEffect(() => {
     let disposed = false;

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-hydration-effects.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-hydration-effects.test.tsx
@@ -21,6 +21,7 @@ describe("useRepoSessionHydrationEffects", () => {
             loadCalls.push({ taskId, mode: "reconcile_live" });
           },
         },
+        isSessionRuntimeReady: () => true,
       });
     const harness = createHookHarness<{ repoPath: string | null }, ReturnType<typeof Harness>>(
       Harness,
@@ -35,6 +36,52 @@ describe("useRepoSessionHydrationEffects", () => {
     const countAfterRepoReset = loadCalls.length;
     await Promise.resolve();
     expect(loadCalls).toHaveLength(countAfterRepoReset);
+    await harness.unmount();
+  });
+
+  test("waits for persisted session runtime readiness before reconciling", async () => {
+    const loadCalls: Array<{ taskId: string; mode: string | undefined }> = [];
+    const preloadCalls: unknown[] = [];
+    const Harness = ({
+      repoPath,
+      runtimeReady,
+    }: {
+      repoPath: string | null;
+      runtimeReady: boolean;
+    }) =>
+      useRepoSessionHydrationEffects({
+        workspaceRepoPath: repoPath,
+        tasks: repoPath ? [createTaskWithSession()] : [],
+        currentWorkspaceRepoPathRef: { current: repoPath },
+        sessionHydration: {
+          bootstrapTaskSessions: async (taskId) => {
+            loadCalls.push({ taskId, mode: undefined });
+          },
+          reconcileLiveTaskSessions: async ({ taskId }) => {
+            loadCalls.push({ taskId, mode: "reconcile_live" });
+          },
+        },
+        prepareRepoSessionPresencePreloads: async (input) => {
+          preloadCalls.push(input);
+          return { preloadedSessionPresenceByKey: new Map() };
+        },
+        isSessionRuntimeReady: () => runtimeReady,
+      });
+
+    const harness = createHookHarness<
+      { repoPath: string | null; runtimeReady: boolean },
+      ReturnType<typeof Harness>
+    >(Harness, { repoPath: "/tmp/repo", runtimeReady: false });
+    await harness.mount();
+
+    expect(preloadCalls).toHaveLength(0);
+    expect(loadCalls).toHaveLength(0);
+
+    await harness.update({ repoPath: "/tmp/repo", runtimeReady: true });
+    await harness.waitFor(() => loadCalls.length >= 1);
+
+    expect(preloadCalls).toHaveLength(1);
+    expect(loadCalls).toContainEqual({ taskId: "task-1", mode: "reconcile_live" });
     await harness.unmount();
   });
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-hydration-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-hydration-effects.ts
@@ -1,4 +1,4 @@
-import type { AgentSessionRecord, TaskCard } from "@openducktor/contracts";
+import type { AgentSessionRecord, RuntimeKind, TaskCard } from "@openducktor/contracts";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createRepoSessionHydrationService } from "../lifecycle/repo-session-hydration-service";
 import type { RepoSessionPresencePreloads } from "../lifecycle/repo-session-presence-preloads";
@@ -16,6 +16,7 @@ type UseRepoSessionHydrationEffectsArgs = {
     repoPath: string;
     records: AgentSessionRecord[];
   }) => Promise<RepoSessionPresencePreloads>;
+  isSessionRuntimeReady: (runtimeKind: RuntimeKind) => boolean;
 };
 
 export const useRepoSessionHydrationEffects = ({
@@ -24,6 +25,7 @@ export const useRepoSessionHydrationEffects = ({
   currentWorkspaceRepoPathRef,
   sessionHydration,
   prepareRepoSessionPresencePreloads,
+  isSessionRuntimeReady,
 }: UseRepoSessionHydrationEffectsArgs) => {
   const [sessionRetryTick, setSessionRetryTick] = useState(0);
 
@@ -70,6 +72,7 @@ export const useRepoSessionHydrationEffects = ({
         tasks,
         isCancelled: () => cancelled,
         isCurrentRepo: isCurrentActiveRepo,
+        isRuntimeReady: isSessionRuntimeReady,
       });
     })();
 
@@ -79,6 +82,7 @@ export const useRepoSessionHydrationEffects = ({
   }, [
     workspaceRepoPath,
     isCurrentActiveRepo,
+    isSessionRuntimeReady,
     repoSessionHydrationService,
     sessionRetryTick,
     tasks,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.test.ts
@@ -21,6 +21,7 @@ const createDeferred = <T>() => {
 
 const repoPath = "/tmp/repo";
 const worktreePath = "/tmp/repo/worktree";
+const runtimeReady = () => true;
 
 const taskWithSession = (taskId: string, externalSessionId: string): TaskCard => ({
   id: taskId,
@@ -97,6 +98,34 @@ describe("repo-session-hydration-service", () => {
 
     expect(bootstrapCalls).toBe(1);
     expect(retryRequests).toBe(0);
+    service.dispose();
+  });
+
+  test("does not bootstrap a task again after the first bootstrap succeeds", async () => {
+    const bootstrapTaskSessions = mock(async () => {});
+    const task = taskWithSession("task-1", "external-1");
+    const service = createRepoSessionHydrationService({
+      sessionHydration: {
+        bootstrapTaskSessions,
+        reconcileLiveTaskSessions: async () => {},
+      },
+      onRetryRequested: () => {},
+    });
+
+    await service.bootstrapPendingTasks({
+      repoPath,
+      tasks: [task],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+    await service.bootstrapPendingTasks({
+      repoPath,
+      tasks: [task],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+    });
+
+    expect(bootstrapTaskSessions).toHaveBeenCalledTimes(1);
     service.dispose();
   });
 
@@ -183,6 +212,7 @@ describe("repo-session-hydration-service", () => {
       tasks: [taskOne, taskTwo],
       isCancelled: () => false,
       isCurrentRepo: () => true,
+      isRuntimeReady: runtimeReady,
     });
 
     expect(prepareRepoSessionPresencePreloads).toHaveBeenCalledTimes(1);
@@ -203,6 +233,88 @@ describe("repo-session-hydration-service", () => {
       },
     ]);
     service.dispose();
+  });
+
+  test("keeps pending records untouched until their runtime is ready", async () => {
+    const reconcileLiveTaskSessions = mock(async () => {});
+    const prepareRepoSessionPresencePreloads = mock(async () => ({
+      preloadedSessionPresenceByKey: new Map(),
+    }));
+    const service = createRepoSessionHydrationService({
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions,
+      },
+      prepareRepoSessionPresencePreloads,
+      onRetryRequested: () => {},
+    });
+    const task = taskWithSession("task-1", "external-1");
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [task],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+      isRuntimeReady: () => false,
+    });
+
+    expect(prepareRepoSessionPresencePreloads).toHaveBeenCalledTimes(0);
+    expect(reconcileLiveTaskSessions).toHaveBeenCalledTimes(0);
+
+    await service.reconcilePendingTasks({
+      repoPath,
+      tasks: [task],
+      isCancelled: () => false,
+      isCurrentRepo: () => true,
+      isRuntimeReady: () => true,
+    });
+
+    expect(prepareRepoSessionPresencePreloads).toHaveBeenCalledTimes(1);
+    expect(reconcileLiveTaskSessions).toHaveBeenCalledTimes(1);
+    service.dispose();
+  });
+
+  test("isolates records with invalid runtime metadata instead of aborting the reconcile batch", async () => {
+    const invalidTask = taskWithSession("task-invalid", "external-invalid");
+    invalidTask.agentSessions = [
+      {
+        ...(invalidTask.agentSessions?.[0] as AgentSessionRecord),
+        // This deliberately simulates persisted data from an older/invalid schema.
+        runtimeKind: "legacy-runtime" as AgentSessionRecord["runtimeKind"],
+      },
+    ];
+    const validTask = taskWithSession("task-valid", "external-valid");
+    const reconcileCalls: string[] = [];
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const service = createRepoSessionHydrationService({
+      sessionHydration: {
+        bootstrapTaskSessions: async () => {},
+        reconcileLiveTaskSessions: async ({ taskId }) => {
+          reconcileCalls.push(taskId);
+        },
+      },
+      onRetryRequested: () => {},
+    });
+
+    try {
+      await service.reconcilePendingTasks({
+        repoPath,
+        tasks: [invalidTask, validTask],
+        isCancelled: () => false,
+        isCurrentRepo: () => true,
+        isRuntimeReady: runtimeReady,
+      });
+
+      expect(reconcileCalls).toEqual(["task-valid"]);
+      expect(
+        consoleErrorSpy.mock.calls.some(([message]) =>
+          String(message).includes("Failed to reconcile agent sessions for task 'task-invalid'"),
+        ),
+      ).toBe(true);
+    } finally {
+      service.dispose();
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   test("hydrates durable sessions when live presence preload fails", async () => {
@@ -232,6 +344,7 @@ describe("repo-session-hydration-service", () => {
         tasks: [task],
         isCancelled: () => false,
         isCurrentRepo: () => true,
+        isRuntimeReady: runtimeReady,
       });
 
       expect(bootstrapCalls).toEqual([{ taskId: "task-1", records: taskRecords }]);
@@ -262,12 +375,14 @@ describe("repo-session-hydration-service", () => {
       tasks: [task],
       isCancelled: () => false,
       isCurrentRepo: () => true,
+      isRuntimeReady: runtimeReady,
     });
     await service.reconcilePendingTasks({
       repoPath,
       tasks: [task],
       isCancelled: () => false,
       isCurrentRepo: () => true,
+      isRuntimeReady: runtimeReady,
     });
 
     expect(prepareRepoSessionPresencePreloads).toHaveBeenCalledTimes(1);

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/repo-session-hydration-service.ts
@@ -1,4 +1,5 @@
-import type { AgentSessionRecord, TaskCard } from "@openducktor/contracts";
+import type { AgentSessionRecord, RuntimeKind, TaskCard } from "@openducktor/contracts";
+import { readPersistedRuntimeKind } from "../support/session-runtime-metadata";
 import type { RepoSessionPresencePreloads } from "./repo-session-presence-preloads";
 import type { SessionHydrationOperations } from "./session-hydration-operations";
 
@@ -7,6 +8,13 @@ type HydrationScope = "bootstrap" | "reconcile";
 const nextSessionRetryDelayMs = (attempt: number): number => Math.min(5_000, 500 * 2 ** attempt);
 
 const getTaskRecords = (task: TaskCard): AgentSessionRecord[] => task.agentSessions ?? [];
+
+const areRecordRuntimesReady = (
+  records: AgentSessionRecord[],
+  isRuntimeReady: (runtimeKind: RuntimeKind) => boolean,
+): boolean => {
+  return records.every((record) => isRuntimeReady(readPersistedRuntimeKind(record)));
+};
 
 const toTaskRecordKey = (taskId: string, records: AgentSessionRecord[]): string => {
   const recordKeys = records
@@ -152,22 +160,37 @@ export const createRepoSessionHydrationService = ({
       tasks,
       isCancelled,
       isCurrentRepo,
+      isRuntimeReady,
     }: {
       repoPath: string;
       tasks: TaskCard[];
       isCancelled: () => boolean;
       isCurrentRepo: (repoPath: string) => boolean;
+      isRuntimeReady: (runtimeKind: RuntimeKind) => boolean;
     }): Promise<void> {
       const inFlight = getOrCreateRepoSet(inFlightReconcileTasksByRepo, repoPath);
       const reconciledRecordKeys = getOrCreateRepoSet(reconciledRecordKeysByRepo, repoPath);
-      const pendingTaskEntries = tasks.flatMap((task) => {
+      const pendingTaskEntries: Array<{
+        task: TaskCard;
+        records: AgentSessionRecord[];
+        recordKey: string;
+      }> = [];
+      for (const task of tasks) {
         const records = getTaskRecords(task);
         const recordKey = toTaskRecordKey(task.id, records);
         if (records.length === 0 || inFlight.has(task.id) || reconciledRecordKeys.has(recordKey)) {
-          return [];
+          continue;
         }
-        return [{ task, records, recordKey }];
-      });
+        try {
+          if (!areRecordRuntimesReady(records, isRuntimeReady)) {
+            continue;
+          }
+        } catch (error) {
+          scheduleRetry("reconcile", repoPath, task.id, error);
+          continue;
+        }
+        pendingTaskEntries.push({ task, records, recordKey });
+      }
       for (const entry of pendingTaskEntries) {
         inFlight.add(entry.task.id);
       }

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
@@ -91,6 +91,7 @@ export const createHookHarness = (args: {
     ...args,
     activeWorkspace: args.activeWorkspace ?? createDefaultActiveWorkspace(args.activeRepo),
     agentEngine: args.agentEngine ?? new OpencodeSdkAdapter(),
+    isSessionRuntimeReady: () => true,
   };
 
   const Harness = () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -1,4 +1,4 @@
-import type { AgentSessionRecord, TaskCard } from "@openducktor/contracts";
+import type { AgentSessionRecord, RuntimeKind, TaskCard } from "@openducktor/contracts";
 import type { AgentEnginePort } from "@openducktor/core";
 import { useCallback, useMemo } from "react";
 import type { AgentSessionsStore } from "@/state/agent-sessions-store";
@@ -34,6 +34,7 @@ type UseAgentOrchestratorOperationsArgs = {
     options?: { forceFreshTaskList?: boolean },
   ) => Promise<void>;
   agentEngine: AgentEnginePort;
+  isSessionRuntimeReady: (runtimeKind: RuntimeKind) => boolean;
   /**
    * Optional dependency seam for tests and specialized callers.
    * Pass a stable reference, such as a module-level object or a `useMemo` result;
@@ -65,6 +66,7 @@ export function useAgentOrchestratorOperations({
   tasks,
   refreshTaskData,
   agentEngine,
+  isSessionRuntimeReady,
   dependencies,
 }: UseAgentOrchestratorOperationsArgs): UseAgentOrchestratorOperationsResult {
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
@@ -164,6 +166,7 @@ export function useAgentOrchestratorOperations({
     currentWorkspaceRepoPathRef: refBridges.currentWorkspaceRepoPathRef,
     sessionHydration,
     prepareRepoSessionPresencePreloads: prepareSessionPresencePreloads,
+    isSessionRuntimeReady,
   });
   const ensureRuntime = useMemo(
     () =>

--- a/packages/frontend/src/state/operations/shared/runtime-catalog.test.ts
+++ b/packages/frontend/src/state/operations/shared/runtime-catalog.test.ts
@@ -4,6 +4,7 @@ import {
   type RepoRuntimeHealthCheck,
   type RepoRuntimeStartupStatus,
   type RuntimeInstanceSummary,
+  type RuntimeKind,
 } from "@openducktor/contracts";
 import type {
   AgentFileSearchResult,
@@ -112,7 +113,7 @@ const fileSearchResultsFixture: AgentFileSearchResult[] = [
 ];
 
 const createDeps = (overrides: Partial<CatalogDependencies> = {}): CatalogDependencies => ({
-  repoRuntimeHealth: async () => ({
+  repoRuntimeHealthStatus: async () => ({
     ...healthyRepoRuntimeHealthFixture,
     status: "checking",
     runtime: {
@@ -138,7 +139,7 @@ const createDeps = (overrides: Partial<CatalogDependencies> = {}): CatalogDepend
       failureKind: "timeout",
     },
   }),
-  listRuntimesForRepo: async () => [runtimeFixture],
+  listRuntimesForRepo: async (_runtimeKind: RuntimeKind, _repoPath: string) => [runtimeFixture],
   listAvailableModels: async () => catalogFixture,
   listAvailableSlashCommands: async () => slashCommandCatalogFixture,
   searchFiles: async () => fileSearchResultsFixture,
@@ -251,13 +252,13 @@ describe("runtime-catalog", () => {
     });
   });
 
-  test("delegates repo runtime health to the active host readiness command", async () => {
-    const repoRuntimeHealth = mock(async () => healthyRepoRuntimeHealthFixture);
-    const operations = createRuntimeCatalogOperations(createDeps({ repoRuntimeHealth }));
+  test("delegates repo runtime health to the status-only host command", async () => {
+    const repoRuntimeHealthStatus = mock(async () => healthyRepoRuntimeHealthFixture);
+    const operations = createRuntimeCatalogOperations(createDeps({ repoRuntimeHealthStatus }));
 
     const result = await operations.checkRepoRuntimeHealth("/tmp/repo", "opencode");
 
-    expect(repoRuntimeHealth).toHaveBeenCalledWith("opencode", "/tmp/repo");
+    expect(repoRuntimeHealthStatus).toHaveBeenCalledWith("opencode", "/tmp/repo");
     expect(result).toEqual(healthyRepoRuntimeHealthFixture);
   });
 });

--- a/packages/frontend/src/state/operations/shared/runtime-catalog.ts
+++ b/packages/frontend/src/state/operations/shared/runtime-catalog.ts
@@ -22,7 +22,7 @@ export type RuntimeCatalogAdapter = Pick<
 >;
 
 type RuntimeCatalogDependencies = {
-  repoRuntimeHealth: (
+  repoRuntimeHealthStatus: (
     runtimeKind: RuntimeKind,
     repoPath: string,
   ) => Promise<RepoRuntimeHealthCheck>;
@@ -102,7 +102,7 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
     repoPath: string,
     runtimeKind: RuntimeKind,
   ): Promise<RepoRuntimeHealthCheck> => {
-    return deps.repoRuntimeHealth(runtimeKind, repoPath);
+    return deps.repoRuntimeHealthStatus(runtimeKind, repoPath);
   };
 
   return {
@@ -119,7 +119,8 @@ export const createHostRuntimeCatalogOperations = (
   getAdapter: (runtimeKind: RuntimeKind) => RuntimeCatalogAdapter,
 ): RuntimeCatalogOperations =>
   createRuntimeCatalogOperations({
-    repoRuntimeHealth: (runtimeKind, repoPath) => host.repoRuntimeHealth(repoPath, runtimeKind),
+    repoRuntimeHealthStatus: (runtimeKind, repoPath) =>
+      host.repoRuntimeHealthStatus(repoPath, runtimeKind),
     listRuntimesForRepo: (runtimeKind, repoPath) =>
       ensureRuntimeListFromQuery(appQueryClient, runtimeKind, repoPath),
     listAvailableModels: (input) =>

--- a/packages/frontend/src/state/providers/agent-studio-state-provider.tsx
+++ b/packages/frontend/src/state/providers/agent-studio-state-provider.tsx
@@ -1,14 +1,17 @@
+import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentEnginePort } from "@openducktor/core";
-import type { PropsWithChildren, ReactElement } from "react";
+import { type PropsWithChildren, type ReactElement, useCallback } from "react";
+import { isRepoRuntimeReady } from "@/lib/repo-runtime-health";
 import {
   AgentOperationsContext,
   AgentSessionsContext,
+  ChecksStateContext,
   useRequiredContext,
   useTaskControlContext,
   useTaskDataContext,
   WorkspaceStateContext,
 } from "../app-state-contexts";
-import { useAgentOrchestratorOperations } from "../operations";
+import { useAgentOrchestratorOperations } from "../operations/agent-orchestrator/use-agent-orchestrator-operations";
 
 type AgentStudioStateProviderProps = PropsWithChildren<{
   agentEngine: AgentEnginePort;
@@ -19,13 +22,23 @@ export function AgentStudioStateProvider({
   children,
 }: AgentStudioStateProviderProps): ReactElement {
   const { activeWorkspace } = useRequiredContext(WorkspaceStateContext, "AgentStudioStateProvider");
+  const { runtimeHealthByRuntime } = useRequiredContext(
+    ChecksStateContext,
+    "AgentStudioStateProvider",
+  );
   const { tasks } = useTaskDataContext();
   const { refreshTaskData } = useTaskControlContext();
+  const isSessionRuntimeReady = useCallback(
+    (runtimeKind: RuntimeKind): boolean =>
+      isRepoRuntimeReady(runtimeHealthByRuntime[runtimeKind] ?? null),
+    [runtimeHealthByRuntime],
+  );
   const { sessionStore, operations } = useAgentOrchestratorOperations({
     activeWorkspace,
     tasks,
     refreshTaskData,
     agentEngine,
+    isSessionRuntimeReady,
   });
 
   return (

--- a/packages/frontend/src/state/providers/app-lifecycle-state-provider.tsx
+++ b/packages/frontend/src/state/providers/app-lifecycle-state-provider.tsx
@@ -1,29 +1,43 @@
+import type { RuntimeInstanceSummary, RuntimeKind } from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
 import {
   useChecksOperationsContext,
   useRequiredContext,
+  useRuntimeAvailabilityContext,
   useTaskControlContext,
   useWorkspaceOperationsContext,
   WorkspaceStateContext,
 } from "../app-state-contexts";
 import { useAppLifecycle } from "../lifecycle/use-app-lifecycle";
 
-export function AppLifecycleStateProvider({ children }: PropsWithChildren): ReactElement {
+type AppLifecycleStateProviderProps = PropsWithChildren<{
+  startRepoRuntime: (repoPath: string, runtimeKind: RuntimeKind) => Promise<RuntimeInstanceSummary>;
+}>;
+
+export function AppLifecycleStateProvider({
+  children,
+  startRepoRuntime,
+}: AppLifecycleStateProviderProps): ReactElement {
   const { activeWorkspace } = useRequiredContext(
     WorkspaceStateContext,
     "AppLifecycleStateProvider",
   );
   const { refreshWorkspaces, refreshBranches, clearBranchData } = useWorkspaceOperationsContext();
-  const { refreshRuntimeCheck, refreshBeadsCheckForRepo } = useChecksOperationsContext();
+  const { availableRuntimeDefinitions } = useRuntimeAvailabilityContext();
+  const { refreshRuntimeCheck, refreshBeadsCheckForRepo, refreshRepoRuntimeHealthForRepo } =
+    useChecksOperationsContext();
   const { refreshTaskData } = useTaskControlContext();
 
   useAppLifecycle({
     activeWorkspace,
+    runtimeDefinitions: availableRuntimeDefinitions,
     refreshWorkspaces,
     refreshBranches,
     refreshRuntimeCheck,
     refreshBeadsCheckForRepo,
+    refreshRepoRuntimeHealthForRepo,
     refreshTaskData,
+    startRepoRuntime,
     clearBranchData,
   });
 

--- a/packages/frontend/src/state/providers/app-runtime-provider.test.tsx
+++ b/packages/frontend/src/state/providers/app-runtime-provider.test.tsx
@@ -4,11 +4,13 @@ import {
   OPENCODE_RUNTIME_DESCRIPTOR,
   type SettingsSnapshot,
 } from "@openducktor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
 import { QueryProvider } from "@/lib/query-provider";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
 import { useRuntimeDefinitionsContext } from "../app-state-contexts";
 import { host } from "../operations/host";
+import { settingsSnapshotQueryOptions } from "../queries/workspace";
 import { AppRuntimeProvider } from "./app-runtime-provider";
 
 const createSettingsSnapshot = (): SettingsSnapshot => ({
@@ -100,6 +102,56 @@ describe("AppRuntimeProvider", () => {
       expect(harness.getLatest().availableRuntimeDefinitions).toEqual([
         OPENCODE_RUNTIME_DESCRIPTOR,
       ]);
+    } finally {
+      await harness.unmount();
+      host.runtimeDefinitionsList = originalRuntimeDefinitionsList;
+      host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+    }
+  });
+
+  test("keeps runtime availability stable when only the theme setting changes", async () => {
+    const originalRuntimeDefinitionsList = host.runtimeDefinitionsList;
+    const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
+    host.runtimeDefinitionsList = mock(async () => [OPENCODE_RUNTIME_DESCRIPTOR]) as never;
+    host.workspaceGetSettingsSnapshot = mock(async () => createSettingsSnapshot()) as never;
+
+    const harness = createHookHarness(
+      () => ({
+        queryClient: useQueryClient(),
+        runtimeDefinitions: useRuntimeDefinitionsContext(),
+      }),
+      undefined,
+      { wrapper: createWrapper },
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (state) => state.runtimeDefinitions.availableRuntimeDefinitions.length === 1,
+      );
+
+      const firstContext = harness.getLatest().runtimeDefinitions;
+      const firstAvailableRuntimeDefinitions = firstContext.availableRuntimeDefinitions;
+
+      await harness.run(({ queryClient }) => {
+        queryClient.setQueryData(
+          settingsSnapshotQueryOptions().queryKey,
+          (current: SettingsSnapshot | undefined) => {
+            if (!current) {
+              throw new Error("Expected settings snapshot to be cached");
+            }
+
+            return {
+              ...current,
+              theme: "dark" as const,
+            };
+          },
+        );
+      });
+
+      const nextContext = harness.getLatest().runtimeDefinitions;
+      expect(nextContext).toBe(firstContext);
+      expect(nextContext.availableRuntimeDefinitions).toBe(firstAvailableRuntimeDefinitions);
     } finally {
       await harness.unmount();
       host.runtimeDefinitionsList = originalRuntimeDefinitionsList;

--- a/packages/frontend/src/state/providers/app-runtime-provider.tsx
+++ b/packages/frontend/src/state/providers/app-runtime-provider.tsx
@@ -72,10 +72,13 @@ export function AppRuntimeProvider({
       ? `Failed to load runtime settings: ${errorMessage(settingsSnapshotError)}`
       : null;
   const agentRuntimes = settingsSnapshot?.agentRuntimes ?? DEFAULT_AGENT_RUNTIMES;
+  const hasSettingsSnapshot = settingsSnapshot !== undefined;
   const availableRuntimeDefinitions = useMemo(
     () =>
-      settingsSnapshot ? getAvailableRuntimeDefinitions({ runtimeDefinitions, agentRuntimes }) : [],
-    [agentRuntimes, runtimeDefinitions, settingsSnapshot],
+      hasSettingsSnapshot
+        ? getAvailableRuntimeDefinitions({ runtimeDefinitions, agentRuntimes })
+        : [],
+    [agentRuntimes, hasSettingsSnapshot, runtimeDefinitions],
   );
 
   const runtimeDefinitionsValue = useMemo<RuntimeDefinitionsContextValue>(

--- a/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
+++ b/packages/host/src/adapters/dev-servers/dev-server-process-adapter.test.ts
@@ -269,7 +269,7 @@ setInterval(() => {}, 1000);
 
     const port = createEffectDevServerProcessAdapter({
       processEnv: { PATH: process.env.PATH },
-      startGracePeriodMs: 20,
+      startGracePeriodMs: 1_000,
       stopTimeoutMs: 100,
     });
     const command = "definitely-missing-dev-server-command-odt-wr4e --flag";
@@ -281,7 +281,6 @@ setInterval(() => {}, 1000);
         onOutput: () => {},
       }),
     );
-    await new Promise((resolve) => setTimeout(resolve, 20));
 
     expect(failure).toMatchObject({
       _tag: "DevServerProcessStartExitError",
@@ -309,7 +308,6 @@ setInterval(() => {}, 1000);
         onOutput: () => {},
       }),
     );
-    await new Promise((resolve) => setTimeout(resolve, 20));
 
     expect(failure).toBeInstanceOf(HostOperationError);
     expect(failure).toMatchObject({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic runtime initialization and health monitoring during app startup.
  * Added runtime diagnostics with error notifications when runtime startup fails.

* **Tests**
  * Expanded test coverage for runtime lifecycle management and health monitoring.
  * Added tests for session reconciliation behavior dependent on runtime readiness status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maxsky5/openducktor/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->