### PR TITLE
fix(mcp): keep external error results schema-safe

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -16,6 +16,7 @@ import {
 import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
 import {
   codexDynamicToolErrorFromResult,
+  codexDynamicToolResultPayload,
   codexFileChangeErrorFromItem,
   codexMcpToolErrorFromResult,
 } from "./codex-tool-error-extractor";
@@ -870,7 +871,7 @@ const codexDynamicToolCallStreamParts = (
   const patch =
     isCodexApplyPatchTool(rawTool) && typeof value.input === "string" ? value.input : null;
   const input = patch ? { ...(args ?? {}), patch } : (args ?? parsedInput ?? undefined);
-  const resultPayload = value.contentItems ?? value.content_items ?? value.result;
+  const resultPayload = codexDynamicToolResultPayload(value);
   const output = codexToolResultText(resultPayload);
   const error = codexDynamicToolErrorFromResult(resultPayload, value);
   const success = typeof value.success === "boolean" ? value.success : true;

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -15,8 +15,8 @@ import {
 } from "./codex-app-server-shared";
 import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
 import {
-  codexDynamicToolErrorFromResult,
-  codexDynamicToolResultPayload,
+  codexDynamicToolDisplayPayload,
+  codexDynamicToolErrorFromItem,
   codexFileChangeErrorFromItem,
   codexMcpToolErrorFromResult,
 } from "./codex-tool-error-extractor";
@@ -871,9 +871,9 @@ const codexDynamicToolCallStreamParts = (
   const patch =
     isCodexApplyPatchTool(rawTool) && typeof value.input === "string" ? value.input : null;
   const input = patch ? { ...(args ?? {}), patch } : (args ?? parsedInput ?? undefined);
-  const resultPayload = codexDynamicToolResultPayload(value);
+  const resultPayload = codexDynamicToolDisplayPayload(value);
   const output = codexToolResultText(resultPayload);
-  const error = codexDynamicToolErrorFromResult(resultPayload, value);
+  const error = codexDynamicToolErrorFromItem(value);
   const success = typeof value.success === "boolean" ? value.success : true;
   const failed = !success || error !== null;
   return normalizedCodexToolPart({

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -161,6 +161,28 @@ describe("Codex todo event mapper", () => {
     expect(result.handled).toBe(false);
     expect(result.events).toEqual([]);
   });
+
+  test("does not map thread-read todo updates with result errors when content items exist", () => {
+    const result = todoMapper.fromThreadItemObject(
+      {
+        type: "dynamicToolCall",
+        id: "call-1",
+        namespace: "functions",
+        tool: "update_plan",
+        arguments: TODO_PAYLOAD,
+        status: "completed",
+        contentItems: [{ type: "text", text: "Plan update output" }],
+        result: {
+          ok: false,
+          error: { message: "Plan update failed" },
+        },
+      },
+      { source: "thread_read", threadId: "thread-1" },
+    );
+
+    expect(result.handled).toBe(false);
+    expect(result.events).toEqual([]);
+  });
 });
 
 describe("Codex compaction event mapper", () => {

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -135,6 +135,32 @@ describe("Codex todo event mapper", () => {
     expect(secondTool.part.partId).toBe("turn-1-update-plan-2");
     expect(secondTool.part.callId).toBe("turn-1-update-plan-2");
   });
+
+  test("does not map thread-read todo updates with content item errors", () => {
+    const result = todoMapper.fromThreadItemObject(
+      {
+        type: "dynamicToolCall",
+        id: "call-1",
+        namespace: "functions",
+        tool: "update_plan",
+        arguments: TODO_PAYLOAD,
+        status: "completed",
+        contentItems: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              ok: false,
+              error: { message: "Plan update failed" },
+            }),
+          },
+        ],
+      },
+      { source: "thread_read", threadId: "thread-1" },
+    );
+
+    expect(result.handled).toBe(false);
+    expect(result.events).toEqual([]);
+  });
 });
 
 describe("Codex compaction event mapper", () => {

--- a/packages/adapters-codex-app-server/src/codex-tool-error-extractor.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-error-extractor.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  codexDynamicToolDisplayPayload,
+  codexDynamicToolErrorFromItem,
+} from "./codex-tool-error-extractor";
+
+describe("Codex dynamic tool error extraction", () => {
+  test("keeps display payload selection separate from result error scanning", () => {
+    const contentItems = [{ type: "text", text: "Plan update output" }];
+    const item = {
+      type: "dynamicToolCall",
+      contentItems,
+      result: {
+        ok: false,
+        error: { message: "Plan update failed" },
+      },
+    };
+
+    expect(codexDynamicToolDisplayPayload(item)).toBe(contentItems);
+    expect(codexDynamicToolErrorFromItem(item)).toBe("Plan update failed");
+  });
+
+  test("checks visible content before result and raw item fallbacks", () => {
+    const item = {
+      type: "dynamicToolCall",
+      contentItems: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            ok: false,
+            error: { message: "Visible content failed" },
+          }),
+        },
+      ],
+      result: {
+        ok: false,
+        error: { message: "Result failed" },
+      },
+      isError: true,
+      message: "Raw item failed",
+    };
+
+    expect(codexDynamicToolErrorFromItem(item)).toBe("Visible content failed");
+  });
+});

--- a/packages/adapters-codex-app-server/src/codex-tool-error-extractor.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-error-extractor.ts
@@ -190,6 +190,9 @@ export const codexDynamicToolErrorFromResult = (
   return dynamicToolErrorFromValue(resultPayload) ?? dynamicToolErrorFromValue(item);
 };
 
+export const codexDynamicToolResultPayload = (item: Record<string, unknown>): unknown =>
+  item.contentItems ?? item.content_items ?? item.result;
+
 export const codexFileChangeErrorFromItem = (item: Record<string, unknown>): string | null => {
   const explicitError = errorMessageFromValue(item.error) ?? extractStringField(item, ["stderr"]);
   if (explicitError) {

--- a/packages/adapters-codex-app-server/src/codex-tool-error-extractor.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-error-extractor.ts
@@ -183,19 +183,16 @@ export const codexMcpToolErrorFromResult = (
   return mcpToolErrorFromValue(result) ?? (item ? mcpToolErrorFromValue(item) : null);
 };
 
-export const codexDynamicToolErrorFromResult = (
-  resultPayload: unknown,
-  item: Record<string, unknown>,
-): string | null => {
+export const codexDynamicToolDisplayPayload = (item: Record<string, unknown>): unknown =>
+  item.contentItems ?? item.content_items ?? item.result;
+
+export const codexDynamicToolErrorFromItem = (item: Record<string, unknown>): string | null => {
   return (
-    dynamicToolErrorFromValue(resultPayload) ??
+    dynamicToolErrorFromValue(codexDynamicToolDisplayPayload(item)) ??
     dynamicToolErrorFromValue(item.result) ??
     dynamicToolErrorFromValue(item)
   );
 };
-
-export const codexDynamicToolResultPayload = (item: Record<string, unknown>): unknown =>
-  item.contentItems ?? item.content_items ?? item.result;
 
 export const codexFileChangeErrorFromItem = (item: Record<string, unknown>): string | null => {
   const explicitError = errorMessageFromValue(item.error) ?? extractStringField(item, ["stderr"]);

--- a/packages/adapters-codex-app-server/src/codex-tool-error-extractor.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-error-extractor.ts
@@ -187,7 +187,11 @@ export const codexDynamicToolErrorFromResult = (
   resultPayload: unknown,
   item: Record<string, unknown>,
 ): string | null => {
-  return dynamicToolErrorFromValue(resultPayload) ?? dynamicToolErrorFromValue(item);
+  return (
+    dynamicToolErrorFromValue(resultPayload) ??
+    dynamicToolErrorFromValue(item.result) ??
+    dynamicToolErrorFromValue(item)
+  );
 };
 
 export const codexDynamicToolResultPayload = (item: Record<string, unknown>): unknown =>

--- a/packages/adapters-codex-app-server/src/event-mappers/todo.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/todo.ts
@@ -15,10 +15,7 @@ import type {
 } from "../codex-canonical-events";
 import { emptyCodexMappingResult } from "../codex-canonical-events";
 import type { CodexEventMapper, CodexLiveInput, CodexThreadItemInput } from "../codex-event-mapper";
-import {
-  codexDynamicToolErrorFromResult,
-  codexDynamicToolResultPayload,
-} from "../codex-tool-error-extractor";
+import { codexDynamicToolErrorFromItem } from "../codex-tool-error-extractor";
 import { statusFromCodexStatus } from "../codex-tool-normalizer";
 
 const parseJsonObject = (value: unknown): Record<string, unknown> | null => {
@@ -201,8 +198,7 @@ const completedDynamicToolCallEvents = (
   if (!codexItemTypeMatches(item, "dynamicToolCall")) {
     return emptyCodexMappingResult();
   }
-  const resultPayload = codexDynamicToolResultPayload(item);
-  const error = codexDynamicToolErrorFromResult(resultPayload, item);
+  const error = codexDynamicToolErrorFromItem(item);
   if (
     item.success === false ||
     error ||

--- a/packages/adapters-codex-app-server/src/event-mappers/todo.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/todo.ts
@@ -15,7 +15,10 @@ import type {
 } from "../codex-canonical-events";
 import { emptyCodexMappingResult } from "../codex-canonical-events";
 import type { CodexEventMapper, CodexLiveInput, CodexThreadItemInput } from "../codex-event-mapper";
-import { codexDynamicToolErrorFromResult } from "../codex-tool-error-extractor";
+import {
+  codexDynamicToolErrorFromResult,
+  codexDynamicToolResultPayload,
+} from "../codex-tool-error-extractor";
 import { statusFromCodexStatus } from "../codex-tool-normalizer";
 
 const parseJsonObject = (value: unknown): Record<string, unknown> | null => {
@@ -198,7 +201,8 @@ const completedDynamicToolCallEvents = (
   if (!codexItemTypeMatches(item, "dynamicToolCall")) {
     return emptyCodexMappingResult();
   }
-  const error = codexDynamicToolErrorFromResult(item.result, item);
+  const resultPayload = codexDynamicToolResultPayload(item);
+  const error = codexDynamicToolErrorFromResult(resultPayload, item);
   if (
     item.success === false ||
     error ||

--- a/packages/host/src/adapters/mcp/mcp-host-bridge-server.test.ts
+++ b/packages/host/src/adapters/mcp/mcp-host-bridge-server.test.ts
@@ -6,7 +6,11 @@ import { tmpdir } from "node:os";
 
 import path from "node:path";
 
-import { ODT_MCP_TOOL_NAMES, type RepoConfig } from "@openducktor/contracts";
+import {
+  ODT_MCP_TOOL_NAMES,
+  type OdtHostBridgeReady,
+  type RepoConfig,
+} from "@openducktor/contracts";
 import { Effect } from "effect";
 import type { OdtMcpBridgeService } from "../../application/mcp/odt-mcp-bridge-service";
 import type { WorkspaceSettingsService } from "../../application/workspaces/workspace-settings-service";
@@ -250,6 +254,53 @@ describe("createMcpHostBridgeServer", () => {
       await rm(tempDir, { force: true, recursive: true });
     }
   });
+
+  test("returns a bridge error when a response payload cannot be serialized", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "openducktor-mcp-discovery-"));
+    const bridge = createMcpHostBridgeServer({
+      discoveryPath: path.join(tempDir, "runtime", "mcp-bridge.json"),
+      token: "token-1",
+      workspaceSettingsService: createWorkspaceSettingsService(),
+      bridgeService: createBridgeService({
+        ready() {
+          return Effect.succeed({
+            bridgeVersion: 1,
+            toolNames: [...ODT_MCP_TOOL_NAMES],
+            invalid: 1n,
+          } as unknown as OdtHostBridgeReady);
+        },
+        getWorkspaces() {
+          return Effect.succeed({ workspaces: [] });
+        },
+        invoke() {
+          return Effect.dieMessage("unexpected scoped tool invocation");
+        },
+      } as OdtMcpBridgeService),
+    });
+    try {
+      const connection = await Effect.runPromise(bridge.ensureConnection({ repoPath: "/repo" }));
+      const response = await requestJson(`${connection.hostUrl}/invoke/odt_mcp_ready`, {
+        method: "POST",
+        headers: {
+          "x-openducktor-app-token": "token-1",
+        },
+        body: {},
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        ok: false,
+        error: {
+          code: "ODT_HOST_BRIDGE_ERROR",
+          message: expect.stringContaining("BigInt"),
+        },
+      });
+    } finally {
+      await Effect.runPromise(bridge.close());
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
   test("deduplicates concurrent startup requests", async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), "openducktor-mcp-discovery-"));
     const discoveryPath = path.join(tempDir, "runtime", "mcp-bridge.json");

--- a/packages/host/src/adapters/mcp/mcp-host-bridge-server.ts
+++ b/packages/host/src/adapters/mcp/mcp-host-bridge-server.ts
@@ -56,6 +56,11 @@ type McpHostBridgeStartup = {
   deferred: Deferred.Deferred<{ baseUrl: string; port: number }, HostOperationError>;
 };
 
+type BridgeHttpResponse = {
+  readonly statusCode: number;
+  readonly payload: unknown;
+};
+
 const APP_TOKEN_HEADER = "x-openducktor-app-token";
 const MAX_BODY_BYTES = 1024 * 1024;
 const workspaceScopedToolNames = new Set<string>(ODT_WORKSPACE_SCOPED_TOOL_NAMES);
@@ -143,26 +148,20 @@ const readRequestBody = (request: IncomingMessage): Effect.Effect<unknown, HostO
     request.on("error", onError);
   });
 
-const sendJson = (response: ServerResponse, statusCode: number, payload: unknown): void => {
-  if (response.headersSent || response.writableEnded) {
-    return;
-  }
+const bridgeHttpResponse = (statusCode: number, payload: unknown): BridgeHttpResponse => ({
+  statusCode,
+  payload,
+});
+
+const bridgeErrorResponse = (error: unknown): BridgeHttpResponse =>
+  bridgeHttpResponse(400, bridgeErrorPayload(error, errorMessage(error)));
+
+const sendJson = (response: ServerResponse, { statusCode, payload }: BridgeHttpResponse): void => {
   response.writeHead(statusCode, {
     "Content-Type": "application/json",
     "Cache-Control": "no-store",
   });
   response.end(JSON.stringify(payload));
-};
-
-const sendBridgeErrorResponse = (response: ServerResponse, error: unknown): void => {
-  if (response.headersSent || response.writableEnded) {
-    if (!response.writableEnded) {
-      response.destroy(error instanceof Error ? error : undefined);
-    }
-    return;
-  }
-
-  sendJson(response, 400, bridgeErrorPayload(error, errorMessage(error)));
 };
 
 const errorMessage = (error: unknown): string =>
@@ -270,19 +269,16 @@ const createBridgeRequestHandler =
   (request: IncomingMessage, response: ServerResponse): void => {
     const handle = Effect.gen(function* () {
       if (request.method === "GET" && request.url === "/health") {
-        sendJson(response, 200, { ok: true });
-        return;
+        return bridgeHttpResponse(200, { ok: true });
       }
 
       if (request.method !== "POST" || !request.url?.startsWith("/invoke/")) {
-        sendJson(response, 404, bridgeMessagePayload("MCP host bridge endpoint not found."));
-        return;
+        return bridgeHttpResponse(404, bridgeMessagePayload("MCP host bridge endpoint not found."));
       }
 
       const receivedToken = request.headers[APP_TOKEN_HEADER];
       if (receivedToken !== token) {
-        sendJson(
-          response,
+        return bridgeHttpResponse(
           receivedToken === undefined ? 401 : 403,
           bridgeMessagePayload(
             receivedToken === undefined
@@ -290,44 +286,39 @@ const createBridgeRequestHandler =
               : "Invalid OpenDucktor web host app token.",
           ),
         );
-        return;
       }
 
       const command = decodeURIComponent(request.url.slice("/invoke/".length));
       const body = yield* readRequestBody(request);
       if (command === "odt_mcp_ready") {
-        sendJson(response, 200, yield* bridgeService.ready(body));
-        return;
+        return bridgeHttpResponse(200, yield* bridgeService.ready(body));
       }
       if (command === "odt_get_workspaces") {
-        sendJson(response, 200, yield* bridgeService.getWorkspaces(body));
-        return;
+        return bridgeHttpResponse(200, yield* bridgeService.getWorkspaces(body));
       }
 
       if (!workspaceScopedToolNames.has(command)) {
-        sendJson(
-          response,
+        return bridgeHttpResponse(
           404,
           bridgeMessagePayload(`Unknown MCP host bridge command: ${command}`),
         );
-        return;
       }
 
-      sendJson(
-        response,
+      return bridgeHttpResponse(
         200,
         yield* bridgeService.invoke(command as WorkspaceScopedOdtToolName, body),
       );
-    }).pipe(
-      Effect.catchAll((error) =>
-        Effect.sync(() => {
-          sendBridgeErrorResponse(response, error);
-        }),
-      ),
-    );
-    Effect.runPromise(handle).catch((error) => {
-      sendBridgeErrorResponse(response, error);
     });
+    Effect.runPromise(Effect.either(handle))
+      .then((result) => {
+        sendJson(
+          response,
+          result._tag === "Right" ? result.right : bridgeErrorResponse(result.left),
+        );
+      })
+      .catch((error) => {
+        sendJson(response, bridgeErrorResponse(error));
+      });
   };
 
 export const createMcpHostBridgeServer = ({

--- a/packages/host/src/adapters/mcp/mcp-host-bridge-server.ts
+++ b/packages/host/src/adapters/mcp/mcp-host-bridge-server.ts
@@ -157,11 +157,18 @@ const bridgeErrorResponse = (error: unknown): BridgeHttpResponse =>
   bridgeHttpResponse(400, bridgeErrorPayload(error, errorMessage(error)));
 
 const sendJson = (response: ServerResponse, { statusCode, payload }: BridgeHttpResponse): void => {
+  if (response.headersSent || response.writableEnded || response.destroyed) {
+    return;
+  }
+  const body = JSON.stringify(payload);
+  if (response.headersSent || response.writableEnded || response.destroyed) {
+    return;
+  }
   response.writeHead(statusCode, {
     "Content-Type": "application/json",
     "Cache-Control": "no-store",
   });
-  response.end(JSON.stringify(payload));
+  response.end(body);
 };
 
 const errorMessage = (error: unknown): string =>

--- a/packages/host/src/domain/task/task-policy-error.ts
+++ b/packages/host/src/domain/task/task-policy-error.ts
@@ -1,6 +1,10 @@
+import type { OdtToolErrorCode } from "@openducktor/contracts";
 import { Data } from "effect";
 
-export type TaskPolicyErrorCode = "TASK_POLICY_ERROR" | "TASK_TRANSITION_NOT_ALLOWED";
+export type TaskPolicyErrorCode = Extract<
+  OdtToolErrorCode,
+  "TASK_POLICY_ERROR" | "TASK_TRANSITION_NOT_ALLOWED"
+>;
 
 export type TaskPolicyErrorInput = {
   readonly code?: TaskPolicyErrorCode;

--- a/packages/openducktor-mcp/src/index.test.ts
+++ b/packages/openducktor-mcp/src/index.test.ts
@@ -138,6 +138,24 @@ const startMockBridge = async (): Promise<{ url: string; requests: RecordedReque
       if (
         typeof body === "object" &&
         body !== null &&
+        (body as { taskId?: unknown }).taskId === "missing-task"
+      ) {
+        writeJson(
+          response,
+          {
+            ok: false,
+            error: {
+              code: "ODT_HOST_BRIDGE_ERROR",
+              message: "Task missing-task was not found.",
+            },
+          },
+          404,
+        );
+        return;
+      }
+      if (
+        typeof body === "object" &&
+        body !== null &&
         (body as { taskId?: unknown }).taskId === "bad-response"
       ) {
         writeJson(response, { task: { id: "bad-response" } });
@@ -229,14 +247,14 @@ const requireContentToolResult = (result: unknown): ContentToolResult => {
   return result as ContentToolResult;
 };
 
-const expectStructuredError = (
+const expectToolError = (
   result: ContentToolResult,
 ): { code?: unknown; message?: unknown; details?: unknown; issues?: unknown } => {
   expect(result.isError).toBe(true);
-  expect(result.structuredContent).toMatchObject({ ok: false });
+  expect(result.structuredContent).toBeUndefined();
   const textPayload = JSON.parse(result.content[0]?.text ?? "null");
-  expect(textPayload).toEqual(result.structuredContent);
-  const error = (result.structuredContent as { error?: unknown }).error;
+  expect(textPayload).toMatchObject({ ok: false });
+  const error = (textPayload as { error?: unknown }).error;
   expect(error).toBeTruthy();
   return error as { code?: unknown; message?: unknown; details?: unknown; issues?: unknown };
 };
@@ -321,7 +339,7 @@ describe("MCP server tool results", () => {
         },
       });
       const contentResult = requireContentToolResult(result);
-      const error = expectStructuredError(contentResult);
+      const error = expectToolError(contentResult);
 
       expect(error.code).toBe("ODT_WORKSPACE_SCOPE_VIOLATION");
       expect(error.message).toContain("Invalid arguments for tool odt_read_task");
@@ -343,7 +361,7 @@ describe("MCP server tool results", () => {
     }
   });
 
-  test("host bridge HTTP failures return structured tool errors", async () => {
+  test("host bridge HTTP failures return content tool errors", async () => {
     const bridge = await startMockBridge();
     const transport = await createTransport(bridge.url, { workspaceId: "repo" });
     const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
@@ -358,7 +376,7 @@ describe("MCP server tool results", () => {
         },
       });
       const contentResult = requireContentToolResult(result);
-      const error = expectStructuredError(contentResult);
+      const error = expectToolError(contentResult);
 
       expect(error.code).toBe("ODT_HOST_BRIDGE_ERROR");
       expect(error.message).toContain("Unexpected URL: /invoke/odt_set_plan");
@@ -367,7 +385,7 @@ describe("MCP server tool results", () => {
     }
   });
 
-  test("host bridge business errors keep their structured error code", async () => {
+  test("host bridge business errors keep their error code", async () => {
     const bridge = await startMockBridge();
     const transport = await createTransport(bridge.url, { workspaceId: "repo" });
     const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
@@ -382,7 +400,7 @@ describe("MCP server tool results", () => {
         },
       });
       const contentResult = requireContentToolResult(result);
-      const error = expectStructuredError(contentResult);
+      const error = expectToolError(contentResult);
 
       expect(error.code).toBe("TASK_TRANSITION_NOT_ALLOWED");
       expect(error.message).toBe(
@@ -394,7 +412,30 @@ describe("MCP server tool results", () => {
     }
   });
 
-  test("host response schema failures return structured tool errors", async () => {
+  test("odt_read_task bridge errors do not get validated as success output", async () => {
+    const bridge = await startMockBridge();
+    const transport = await createTransport(bridge.url, { workspaceId: "repo" });
+    const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+      const result = await client.callTool({
+        name: "odt_read_task",
+        arguments: {
+          taskId: "missing-task",
+        },
+      });
+      const contentResult = requireContentToolResult(result);
+      const error = expectToolError(contentResult);
+
+      expect(error.code).toBe("ODT_HOST_BRIDGE_ERROR");
+      expect(error.message).toBe("Task missing-task was not found.");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("host response schema failures return content tool errors", async () => {
     const bridge = await startMockBridge();
     const transport = await createTransport(bridge.url, { workspaceId: "repo" });
     const client = new Client({ name: "odt-mcp-test", version: "1.0.0" });
@@ -408,7 +449,7 @@ describe("MCP server tool results", () => {
         },
       });
       const contentResult = requireContentToolResult(result);
-      const error = expectStructuredError(contentResult);
+      const error = expectToolError(contentResult);
 
       expect(error.code).toBe("ODT_HOST_RESPONSE_INVALID");
       expect(error.message).toContain("Invalid response from host odt_read_task");

--- a/packages/openducktor-mcp/src/tool-results.test.ts
+++ b/packages/openducktor-mcp/src/tool-results.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { OdtToolError, toErrorMessage, toToolError } from "./tool-results";
 
 describe("tool result error normalization", () => {
-  test("keeps OdtToolError issues in the top-level structured error payload", () => {
+  test("keeps OdtToolError issues in the content error payload", () => {
     const result = toToolError(
       new OdtToolError({
         code: "ODT_WORKSPACE_SCOPE_VIOLATION",
@@ -19,7 +19,9 @@ describe("tool result error normalization", () => {
       }),
     );
 
-    expect(result.structuredContent).toEqual({
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(JSON.parse(result.content[0]?.text ?? "null")).toEqual({
       ok: false,
       error: {
         code: "ODT_WORKSPACE_SCOPE_VIOLATION",

--- a/packages/openducktor-mcp/src/tool-results.ts
+++ b/packages/openducktor-mcp/src/tool-results.ts
@@ -128,7 +128,6 @@ export const toToolError = (error: unknown): ToolResult => {
         text: JSON.stringify(errorPayload, null, 2),
       },
     ],
-    structuredContent: errorPayload,
     isError: true,
   };
 };


### PR DESCRIPTION
Summary:
Keep OpenDucktor external MCP error results visible to clients by returning error envelopes as content-only MCP errors instead of structuredContent that is validated against success-only output schemas.

Goal:
External MCP clients such as Opencode can validate tool structuredContent against each tool declared output schema. OpenDucktor tools declare success response schemas, so returning `{ ok: false, error: ... }` as structuredContent caused clients to replace the real business error with a schema mismatch like "data must have required property task". This PR fixes that failure mode and also includes the previously missed host/Codex bridge error handling cleanup so coded business errors remain available end to end.

Technical choices:
- Kept successful object payloads unchanged: `toToolResult` still emits structuredContent for success payloads.
- Changed `toToolError` to keep `isError: true` and the canonical JSON error envelope in text content only, avoiding success-schema validation for error results.
- Added a regression for `odt_read_task` bridge failures to prove the coded error survives without structuredContent.
- Centralized Codex dynamic tool result payload extraction so thread-read `contentItems` errors are handled consistently and failed todo tool calls do not hydrate as successful todos.
- Refactored the host MCP bridge request handler to build one `BridgeHttpResponse` and send it once, preserving coded business errors and details from the Effect error channel.

Verification:
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `cargo fmt --all --check`
- `bun run check:rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run test:rust`
- `cargo build --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling consistency for dynamic tool calls across the platform.
  * Enhanced error payload extraction to correctly identify tool call failures.

* **Refactor**
  * Streamlined internal error processing pipelines for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->