### PR TITLE
fix: tolerate missing task worktrees during cleanup

### DIFF
--- a/packages/host/src/application/git/git-service.test.ts
+++ b/packages/host/src/application/git/git-service.test.ts
@@ -503,7 +503,10 @@ const createFakeGitPort = ({
       });
     },
   }) as GitPort as unknown as GitPort;
-const createFakeSettingsConfig = (config: GlobalConfig | null): SettingsConfigPort => ({
+const createFakeSettingsConfig = (
+  config: GlobalConfig | null,
+  existingPaths?: Set<string>,
+): SettingsConfigPort => ({
   readConfig() {
     return Effect.tryPromise({
       try: async () => {
@@ -550,8 +553,8 @@ const createFakeSettingsConfig = (config: GlobalConfig | null): SettingsConfigPo
         }),
     });
   },
-  pathExists() {
-    return Effect.succeed(true);
+  pathExists(path) {
+    return Effect.succeed(existingPaths === undefined || existingPaths.has(path));
   },
   join(...paths) {
     return paths.join("/");
@@ -1187,6 +1190,31 @@ describe("createGitService", () => {
       ),
     ).rejects.toThrow("outside managed roots");
     expect(calls).toEqual(["removeWorktree:/canonical/repo|/outside/task-1|true"]);
+  });
+  test("skips filesystem cleanup for missing stranded worktrees outside managed roots", async () => {
+    const calls: string[] = [];
+    const service = createGitService({
+      gitPort: createFakeGitPort({
+        canonicalPaths: { "/repo": "/canonical/repo" },
+        gitRepositories: ["/canonical/repo"],
+        calls,
+        removeWorktreeErrors: {
+          "/canonical/repo|/legacy/repo/task-1|true": new Error("fatal: is not a working tree"),
+        },
+      }),
+      settingsConfig: createFakeSettingsConfig(createConfig(), new Set(["/canonical/repo"])),
+      worktreeFiles: createFakeWorktreeFiles(calls),
+    });
+    await expect(
+      Effect.runPromise(
+        service.removeWorktree({
+          repoPath: "/repo",
+          worktreePath: "/legacy/repo/task-1",
+          force: true,
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(calls).toEqual(["removeWorktree:/canonical/repo|/legacy/repo/task-1|true"]);
   });
   test("resets a worktree selection after validating the current snapshot", async () => {
     const statusData: GitWorktreeStatusData = {

--- a/packages/host/src/application/git/git-service.test.ts
+++ b/packages/host/src/application/git/git-service.test.ts
@@ -1191,7 +1191,7 @@ describe("createGitService", () => {
     ).rejects.toThrow("outside managed roots");
     expect(calls).toEqual(["removeWorktree:/canonical/repo|/outside/task-1|true"]);
   });
-  test("skips filesystem cleanup for missing stranded worktrees outside managed roots", async () => {
+  test("rejects missing forced stranded worktree cleanup outside managed roots", async () => {
     const calls: string[] = [];
     const service = createGitService({
       gitPort: createFakeGitPort({
@@ -1213,7 +1213,7 @@ describe("createGitService", () => {
           force: true,
         }),
       ),
-    ).resolves.toEqual({ ok: true });
+    ).rejects.toThrow("outside managed roots");
     expect(calls).toEqual(["removeWorktree:/canonical/repo|/legacy/repo/task-1|true"]);
   });
   test("resets a worktree selection after validating the current snapshot", async () => {

--- a/packages/host/src/application/git/git-service.ts
+++ b/packages/host/src/application/git/git-service.ts
@@ -284,6 +284,7 @@ export const createGitService = (input: GitPort | CreateGitServiceInput): GitSer
             repoPath: canonicalRepoPath,
             worktreePath,
             force,
+            missingOutsideManagedRootPathPolicy: "fail",
           },
         );
         return { ok: true };

--- a/packages/host/src/application/git/worktree-removal.ts
+++ b/packages/host/src/application/git/worktree-removal.ts
@@ -21,7 +21,7 @@ const managedWorktreeBasePath = (settingsConfig: SettingsConfigPort, canonicalRe
       ? settingsConfig.resolveConfiguredPath(repoConfig.worktreeBasePath)
       : settingsConfig.defaultWorktreeBasePath(repoConfig.workspaceId),
   );
-const assertForcedCleanupAllowed = (
+const resolveForcedFilesystemCleanup = (
   { settingsConfig, worktreeFiles }: RemoveWorktreeAndFilesystemPathDependencies,
   input: Pick<RemoveWorktreeAndFilesystemPathInput, "managedWorktreeBasePath" | "repoPath">,
   effectiveWorktreePath: string,
@@ -36,14 +36,18 @@ const assertForcedCleanupAllowed = (
       managedBase,
       effectiveWorktreePath,
     );
-    if (!insideRepo && !insideManagedBase) {
-      return yield* Effect.fail(
-        new HostValidationError({
-          message: `Refusing forced worktree cleanup outside managed roots for ${effectiveWorktreePath}`,
-          cause,
-        }),
-      );
+    if (insideRepo || insideManagedBase) {
+      return "cleanup-filesystem-path" as const;
     }
+    if (!(yield* settingsConfig.pathExists(effectiveWorktreePath))) {
+      return "skip-filesystem-cleanup" as const;
+    }
+    return yield* Effect.fail(
+      new HostValidationError({
+        message: `Refusing forced worktree cleanup outside managed roots for ${effectiveWorktreePath}`,
+        cause,
+      }),
+    );
   });
 export const removeWorktreeAndFilesystemPath = (
   dependencies: RemoveWorktreeAndFilesystemPathDependencies,
@@ -55,17 +59,23 @@ export const removeWorktreeAndFilesystemPath = (
     const effectiveWorktreePath = worktreeFiles.resolveWorktreePath(repoPath, worktreePath);
     if (yield* worktreeFiles.pathIsWithinRoot(effectiveWorktreePath, repoPath)) {
       return yield* Effect.fail(
-        new HostValidationError({ message: "worktree path cannot be the repository root" }),
+        new HostValidationError({
+          message: "worktree path cannot be the repository root",
+        }),
       );
     }
-    yield* gitPort.removeWorktree(repoPath, worktreePath, force).pipe(
+    const filesystemCleanup = yield* gitPort.removeWorktree(repoPath, worktreePath, force).pipe(
+      Effect.as("cleanup-filesystem-path" as const),
       Effect.catchAll((error) => {
         if (!force || !isDefinitiveNonWorktreeGitError(error)) {
           return Effect.fail(error);
         }
-        return assertForcedCleanupAllowed(dependencies, input, effectiveWorktreePath, error);
+        return resolveForcedFilesystemCleanup(dependencies, input, effectiveWorktreePath, error);
       }),
     );
+    if (filesystemCleanup === "skip-filesystem-cleanup") {
+      return;
+    }
     yield* worktreeFiles.removePathIfPresent(effectiveWorktreePath).pipe(
       Effect.mapError(
         (error) =>

--- a/packages/host/src/application/git/worktree-removal.ts
+++ b/packages/host/src/application/git/worktree-removal.ts
@@ -7,6 +7,7 @@ import { findRepoConfigByPath, isDefinitiveNonWorktreeGitError } from "./git-ser
 export type RemoveWorktreeAndFilesystemPathInput = {
   force: boolean;
   managedWorktreeBasePath?: string;
+  missingOutsideManagedRootPathPolicy: "fail" | "skip";
   repoPath: string;
   worktreePath: string;
 };
@@ -23,7 +24,10 @@ const managedWorktreeBasePath = (settingsConfig: SettingsConfigPort, canonicalRe
   );
 const resolveForcedFilesystemCleanup = (
   { settingsConfig, worktreeFiles }: RemoveWorktreeAndFilesystemPathDependencies,
-  input: Pick<RemoveWorktreeAndFilesystemPathInput, "managedWorktreeBasePath" | "repoPath">,
+  input: Pick<
+    RemoveWorktreeAndFilesystemPathInput,
+    "managedWorktreeBasePath" | "missingOutsideManagedRootPathPolicy" | "repoPath"
+  >,
   effectiveWorktreePath: string,
   cause: unknown,
 ) =>
@@ -39,7 +43,10 @@ const resolveForcedFilesystemCleanup = (
     if (insideRepo || insideManagedBase) {
       return "cleanup-filesystem-path" as const;
     }
-    if (!(yield* settingsConfig.pathExists(effectiveWorktreePath))) {
+    if (
+      input.missingOutsideManagedRootPathPolicy === "skip" &&
+      !(yield* settingsConfig.pathExists(effectiveWorktreePath))
+    ) {
       return "skip-filesystem-cleanup" as const;
     }
     return yield* Effect.fail(

--- a/packages/host/src/application/tasks/support/builder-worktree-cleanup.ts
+++ b/packages/host/src/application/tasks/support/builder-worktree-cleanup.ts
@@ -252,6 +252,7 @@ export const rollbackFailedBuildWorktree = (
           repoPath,
           worktreePath,
           force: true,
+          missingOutsideManagedRootPathPolicy: "fail",
         },
       ),
     );

--- a/packages/host/src/application/tasks/task-service-crud-and-reset.test.ts
+++ b/packages/host/src/application/tasks/task-service-crud-and-reset.test.ts
@@ -850,6 +850,92 @@ describe("createTaskService task mutations and reset", () => {
       },
     ]);
   });
+  test("deletes tasks when a stale outside-root worktree path is already missing", async () => {
+    const calls: unknown[] = [];
+    const taskStore: TaskStorePort = {
+      listTasks(input) {
+        return Effect.sync(() => {
+          calls.push({ type: "list", input });
+          return [
+            task({
+              id: "task-1",
+              status: "closed",
+              agentSessions: [
+                createAgentSessionRecord({ workingDirectory: "/legacy/repo/task-1" }),
+              ],
+            }),
+          ];
+        });
+      },
+      deleteTask(input) {
+        return Effect.sync(() => {
+          calls.push({ type: "delete", input });
+          return true;
+        });
+      },
+    };
+    const taskActivityGuard: TaskActivityGuardPort = {
+      ensureNoActiveTaskDeleteRuns(input) {
+        return Effect.sync(() => {
+          calls.push({ type: "activityGuard", input });
+        });
+      },
+      ensureNoActiveTaskResetActivity() {
+        return Effect.dieMessage("unexpected reset activity guard");
+      },
+    };
+    await expect(
+      Effect.runPromise(
+        createTaskService({
+          devServerService: createDirectMergeDevServerService(calls),
+          gitPort: createDirectMergeGitPort({
+            calls,
+            branches: {
+              "/repo": [{ name: "odt/task-1", isCurrent: false, isRemote: false }],
+            },
+            removeWorktreeErrors: {
+              "/repo|/legacy/repo/task-1|true": new Error(
+                "fatal: '/legacy/repo/task-1' is not a working tree",
+              ),
+            },
+          }),
+          settingsConfig: createBuildSettingsConfig(new Set(["/repo"])),
+          taskActivityGuard,
+          taskStore,
+          worktreeFiles: createCleanupWorktreeFiles(calls),
+          workspaceSettingsService: createBuildWorkspaceSettingsService({
+            workspaceId: "repo",
+            repoPath: "/repo",
+            hooks: { preStart: [], postComplete: [] },
+          }),
+        }).deleteTask({ repoPath: "/repo", taskId: "task-1", deleteSubtasks: false }),
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(calls).toEqual([
+      { type: "list", input: { repoPath: "/repo" } },
+      {
+        type: "activityGuard",
+        input: {
+          repoPath: "/repo",
+          taskIds: ["task-1"],
+          tasks: [expect.objectContaining({ id: "task-1" })],
+        },
+      },
+      { type: "listBranches", workingDir: "/repo" },
+      { type: "stopDevServers", input: { repoPath: "/repo", taskId: "task-1" } },
+      {
+        type: "removeWorktree",
+        repoPath: "/repo",
+        worktreePath: "/legacy/repo/task-1",
+        force: true,
+      },
+      { type: "deleteLocalBranch", repoPath: "/repo", branch: "odt/task-1", force: true },
+      {
+        type: "delete",
+        input: { repoPath: "/repo", taskId: "task-1", deleteSubtasks: false },
+      },
+    ]);
+  });
   test("fails fast when task deletion needs live activity checks but no guard is configured", async () => {
     const taskStore: TaskStorePort = {
       listTasks() {

--- a/packages/host/src/application/tasks/use-cases/delete-task.ts
+++ b/packages/host/src/application/tasks/use-cases/delete-task.ts
@@ -125,6 +125,7 @@ export const createTaskDeleteUseCase = ({
               worktreePath,
               force: true,
               managedWorktreeBasePath,
+              missingOutsideManagedRootPathPolicy: "skip",
             },
           );
           removedWorktrees.push(worktreePath);

--- a/packages/host/src/application/tasks/use-cases/reset-implementation.ts
+++ b/packages/host/src/application/tasks/use-cases/reset-implementation.ts
@@ -129,6 +129,7 @@ export const createTaskImplementationResetUseCase = ({
               worktreePath,
               force: true,
               managedWorktreeBasePath,
+              missingOutsideManagedRootPathPolicy: "skip",
             },
           );
           removedWorktrees.push(worktreePath);

--- a/packages/host/src/application/tasks/use-cases/reset-task.ts
+++ b/packages/host/src/application/tasks/use-cases/reset-task.ts
@@ -125,6 +125,7 @@ export const createTaskFullResetUseCase = ({
               worktreePath,
               force: true,
               managedWorktreeBasePath,
+              missingOutsideManagedRootPathPolicy: "skip",
             },
           );
           removedWorktrees.push(worktreePath);


### PR DESCRIPTION
Summary
- Allow forced worktree cleanup to continue when Git reports the target is no longer a worktree and the filesystem path is already missing.
- Keep the existing safety guard for outside-root paths that still exist.
- Add a regression test for missing stranded worktrees outside current managed roots.

Goal
Deleting, resetting, or resetting implementation for an old task should not be blocked just because its recorded worktree has already disappeared. The previous cleanup path still attempted to validate and remove that stale path, which surfaced a HostValidationError for paths outside the current managed roots. This PR makes the cleanup idempotent for already-missing worktrees while preserving the protection against deleting arbitrary existing paths.

Technical approach
The fix stays in the shared host git cleanup helper used by task delete, task reset, implementation reset, and rollback cleanup. When git worktree removal fails with a definitive non-worktree error, the helper now resolves whether filesystem cleanup is required: paths inside the repository or managed worktree root are still cleaned, existing outside-root paths are still rejected, and missing outside-root paths are treated as already gone. The git-service regression test now models path existence explicitly so it can cover this legacy missing-worktree case.

Verification
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- Cargo checks: not applicable; this checkout has no Cargo.toml
