### PR TITLE
fix(electron): declare renderer React deps

### DIFF
--- a/apps/electron/knip.config.ts
+++ b/apps/electron/knip.config.ts
@@ -1,4 +1,9 @@
 export default {
   entry: ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
+  ignoreDependencies: [
+    // Required by @vitejs/plugin-react optimizeDeps during cold Electron renderer startup.
+    "react",
+    "react-dom",
+  ],
   project: ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
 };

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -39,6 +39,8 @@
     "bun-types": "^1.3.14",
     "electron": "^42.3.0",
     "electron-builder": "^26.8.1",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
     "vite": "^8.0.14"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,8 @@
         "bun-types": "^1.3.14",
         "electron": "^42.3.0",
         "electron-builder": "^26.8.1",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "vite": "^8.0.14",
       },
     },

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,0 +1,11 @@
+export default {
+  workspaces: {
+    "apps/electron": {
+      ignoreDependencies: [
+        // Required by @vitejs/plugin-react optimizeDeps during cold Electron renderer startup.
+        "react",
+        "react-dom",
+      ],
+    },
+  },
+};

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,11 +1,7 @@
+import electronKnipConfig from "./apps/electron/knip.config";
+
 export default {
   workspaces: {
-    "apps/electron": {
-      ignoreDependencies: [
-        // Required by @vitejs/plugin-react optimizeDeps during cold Electron renderer startup.
-        "react",
-        "react-dom",
-      ],
-    },
+    "apps/electron": electronKnipConfig,
   },
 };


### PR DESCRIPTION
Summary
Declare React and React DOM directly in the Electron workspace so Vite can resolve the React plugin optimizer entries during a fresh Electron renderer cold start.

Goal
The first `bun run electron:dev` in a new worktree printed Vite warnings for `react`, `react-dom`, `react/jsx-dev-runtime`, and `react/jsx-runtime` because `@vitejs/plugin-react` injects those ids into `optimizeDeps.include`, but the Electron workspace did not own the React dependencies it asks Vite to optimize.

Technical choices
- Added `react` and `react-dom` to `@openducktor/electron` devDependencies so the Electron renderer app can resolve the optimizer dependencies from its own package boundary.
- Added a root Knip workspace exception for the Electron workspace, documenting that these dependencies are intentionally present for Vite plugin resolution rather than source imports.
- Updated `bun.lock` via `bun install`; no new package versions were downloaded because the frontend workspace already pins the same React versions.

Verification
- `bun run deps:unused:deps`
- cold Vite renderer start after clearing `apps/electron/node_modules/.vite`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

Cargo
No Cargo checks were applicable because the repository has no `Cargo.toml` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added React and React-DOM dependencies to the Electron application.
  * Updated build configuration to optimize dependency handling for the Electron workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->