### PR TITLE
refactor(host): extract Beads repository lifecycle manager

### DIFF
--- a/packages/host/src/adapters/beads/bd-command-provider.test.ts
+++ b/packages/host/src/adapters/beads/bd-command-provider.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path, { delimiter } from "node:path";
+import { Effect } from "effect";
+import type {
+  BeadsCommandJsonOutput,
+  RunBdJson,
+} from "../../infrastructure/beads/task-store/beads-raw-issue";
+import { createBdCommandProvider } from "./bd-command-provider";
+import type { BeadsSharedServerContext } from "./beads-cli-context";
+
+const TEST_SHARED_DOLT_TOOL_PATHS = {
+  dolt: "dolt",
+};
+
+const createBeadsCliContext = (beadsDir: string, bdPath = "bd"): BeadsSharedServerContext => ({
+  repoPath: "/repo",
+  repoId: "repo-12345678",
+  databaseName: "odt_repo_123456789abc",
+  attachmentRoot: path.dirname(beadsDir),
+  beadsDir,
+  workingDir: path.dirname(beadsDir),
+  serverStatePath: "/config/beads/shared-server/server.json",
+  sharedServer: {
+    pid: process.pid,
+    host: "127.0.0.1",
+    port: 36000,
+    user: "root",
+    ownerPid: process.pid,
+    acquisition: "started_by_owner",
+    sharedServerRoot: "/config/beads/shared-server",
+    doltDataDir: "/config/beads/shared-server/dolt",
+    startedAt: "2026-05-10T00:00:00Z",
+  },
+  env: {
+    BEADS_DIR: beadsDir,
+    BEADS_DOLT_SERVER_MODE: "1",
+    BEADS_DOLT_SERVER_HOST: "127.0.0.1",
+    BEADS_DOLT_SERVER_PORT: "36000",
+    BEADS_DOLT_SERVER_USER: "root",
+  },
+  tools: {
+    beads: bdPath,
+  },
+  sharedDoltTools: TEST_SHARED_DOLT_TOOL_PATHS,
+});
+
+const createExistingBeadsCliContext = async (bdPath = "bd"): Promise<BeadsSharedServerContext> => {
+  const attachmentRoot = await mkdtemp(path.join(tmpdir(), "odt-bd-provider-test-"));
+  const beadsDir = path.join(attachmentRoot, ".beads");
+  await mkdir(beadsDir);
+  return createBeadsCliContext(beadsDir, bdPath);
+};
+
+const createFakeBd = async (binDir: string, script: string): Promise<string> => {
+  const scriptPath = path.join(binDir, "bd.mjs");
+  await writeFile(scriptPath, script);
+  if (process.platform === "win32") {
+    const bdPath = path.join(binDir, "bd.cmd");
+    await writeFile(bdPath, `@echo off\r\nbun "%~dp0bd.mjs" %*\r\n`);
+    return bdPath;
+  }
+  const bdPath = path.join(binDir, "bd");
+  await writeFile(bdPath, `#!/bin/sh\nexec bun "$(dirname "$0")/bd.mjs" "$@"\n`);
+  await chmod(bdPath, 0o755);
+  return bdPath;
+};
+
+describe("createBdCommandProvider", () => {
+  test("binds default JSON runners to one prepared shared-server context per repo operation", async () => {
+    const binDir = await mkdtemp(path.join(tmpdir(), "odt-fake-bd-bin-"));
+    const bdPath = await createFakeBd(
+      binDir,
+      `console.log(JSON.stringify({
+  args: process.argv.slice(2),
+  beadsDir: process.env.BEADS_DIR,
+  doltServerPort: process.env.BEADS_DOLT_SERVER_PORT
+}));\n`,
+    );
+    const context = await createExistingBeadsCliContext(bdPath);
+    context.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+    const contextRequests: Array<{
+      repoPath: string;
+      requireSharedServer: boolean | undefined;
+    }> = [];
+    const provider = createBdCommandProvider({
+      resolveCliContext(repoPath, options) {
+        return Effect.sync(() => {
+          contextRequests.push({
+            repoPath,
+            requireSharedServer: options?.requireSharedServer,
+          });
+          return context;
+        });
+      },
+    });
+
+    const runBdJsonForOperation = await Effect.runPromise(provider.runBdJsonForRepo("/repo"));
+    const first = await Effect.runPromise(runBdJsonForOperation("/repo", ["where"]));
+    const second = await Effect.runPromise(runBdJsonForOperation("/repo", ["status"]));
+
+    expect(contextRequests).toEqual([{ repoPath: "/repo", requireSharedServer: true }]);
+    expect(first).toMatchObject({
+      args: ["where", "--json"],
+      beadsDir: context.beadsDir,
+      doltServerPort: "36000",
+    });
+    expect(second).toMatchObject({
+      args: ["status", "--json"],
+      beadsDir: context.beadsDir,
+      doltServerPort: "36000",
+    });
+  });
+
+  test("uses configured JSON runners without pre-resolving a context", async () => {
+    const context = await createExistingBeadsCliContext();
+    let contextResolved = false;
+    const configuredRunBdJson: RunBdJson = (repoPath, args, callContext) =>
+      Effect.succeed({
+        args,
+        hasContext: callContext !== undefined,
+        repoPath,
+      });
+    const provider = createBdCommandProvider({
+      runBdJson: configuredRunBdJson,
+      resolveCliContext() {
+        contextResolved = true;
+        return Effect.succeed(context);
+      },
+    });
+
+    const runBdJsonForOperation = await Effect.runPromise(provider.runBdJsonForRepo("/repo"));
+    const output: BeadsCommandJsonOutput = await Effect.runPromise(
+      runBdJsonForOperation("/repo", ["list"]),
+    );
+
+    expect(contextResolved).toBe(false);
+    expect(output).toEqual({
+      args: ["list"],
+      hasContext: false,
+      repoPath: "/repo",
+    });
+  });
+});

--- a/packages/host/src/adapters/beads/bd-command-provider.test.ts
+++ b/packages/host/src/adapters/beads/bd-command-provider.test.ts
@@ -8,7 +8,7 @@ import type {
   RunBdJson,
 } from "../../infrastructure/beads/task-store/beads-raw-issue";
 import { createBdCommandProvider } from "./bd-command-provider";
-import { createExistingTestBeadsCliContext, createFakeBd } from "./beads-test-support";
+import { createExistingTestBeadsCliContext, createFakeBd } from "./test-support/beads-test-support";
 
 describe("createBdCommandProvider", () => {
   test("binds default JSON runners to one prepared shared-server context per repo operation", async () => {

--- a/packages/host/src/adapters/beads/bd-command-provider.test.ts
+++ b/packages/host/src/adapters/beads/bd-command-provider.test.ts
@@ -1,60 +1,152 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Effect } from "effect";
 import type {
   BeadsCommandJsonOutput,
+  RunBd,
   RunBdJson,
 } from "../../infrastructure/beads/task-store/beads-raw-issue";
 import { createBdCommandProvider } from "./bd-command-provider";
 import { createExistingTestBeadsCliContext, createFakeBd } from "./test-support/beads-test-support";
 
-describe("createBdCommandProvider", () => {
-  test("binds default JSON runners to one prepared shared-server context per repo operation", async () => {
-    const binDir = await mkdtemp(path.join(tmpdir(), "odt-fake-bd-bin-"));
-    const bdPath = await createFakeBd(
-      binDir,
-      `console.log(JSON.stringify({
+const bdContextEchoScript = `console.log(JSON.stringify({
   args: process.argv.slice(2),
   beadsDir: process.env.BEADS_DIR,
   doltServerPort: process.env.BEADS_DOLT_SERVER_PORT
-}));\n`,
-    );
+}));\n`;
+
+const withFakeBd = async <T>(
+  script: string,
+  runTest: (bdPath: string) => Promise<T>,
+): Promise<T> => {
+  const binDir = await mkdtemp(path.join(tmpdir(), "odt-fake-bd-bin-"));
+  try {
+    const bdPath = await createFakeBd(binDir, script);
+    const result = await runTest(bdPath);
+    return result;
+  } finally {
+    await rm(binDir, { recursive: true, force: true });
+  }
+};
+
+describe("createBdCommandProvider", () => {
+  test("binds default JSON runners to one prepared shared-server context per repo operation", async () => {
+    await withFakeBd(bdContextEchoScript, async (bdPath) => {
+      const context = await createExistingTestBeadsCliContext({
+        bdPath,
+        prefix: "odt-bd-provider-test-",
+      });
+      const contextRequests: Array<{
+        repoPath: string;
+        requireSharedServer: boolean | undefined;
+      }> = [];
+      const provider = createBdCommandProvider({
+        resolveCliContext(repoPath, options) {
+          return Effect.sync(() => {
+            contextRequests.push({
+              repoPath,
+              requireSharedServer: options?.requireSharedServer,
+            });
+            return context;
+          });
+        },
+      });
+
+      const runBdJsonForOperation = await Effect.runPromise(provider.runBdJsonForRepo("/repo"));
+      const first = await Effect.runPromise(runBdJsonForOperation("/repo", ["where"]));
+      const second = await Effect.runPromise(runBdJsonForOperation("/repo", ["status"]));
+
+      expect(contextRequests).toEqual([{ repoPath: "/repo", requireSharedServer: true }]);
+      expect(first).toMatchObject({
+        args: ["where", "--json"],
+        beadsDir: context.beadsDir,
+        doltServerPort: "36000",
+      });
+      expect(second).toMatchObject({
+        args: ["status", "--json"],
+        beadsDir: context.beadsDir,
+        doltServerPort: "36000",
+      });
+    });
+  });
+
+  test("binds default non-JSON runners to one prepared shared-server context per repo operation", async () => {
+    await withFakeBd(bdContextEchoScript, async (bdPath) => {
+      const context = await createExistingTestBeadsCliContext({
+        bdPath,
+        prefix: "odt-bd-provider-test-",
+      });
+      const contextRequests: Array<{
+        repoPath: string;
+        requireSharedServer: boolean | undefined;
+      }> = [];
+      const provider = createBdCommandProvider({
+        resolveCliContext(repoPath, options) {
+          return Effect.sync(() => {
+            contextRequests.push({
+              repoPath,
+              requireSharedServer: options?.requireSharedServer,
+            });
+            return context;
+          });
+        },
+      });
+
+      const runBdForOperation = await Effect.runPromise(provider.runBdForRepo("/repo"));
+      const first = JSON.parse(
+        await Effect.runPromise(runBdForOperation("/repo", ["delete", "task-1"])),
+      );
+      const second = JSON.parse(
+        await Effect.runPromise(runBdForOperation("/repo", ["delete", "--force", "task-2"])),
+      );
+
+      expect(contextRequests).toEqual([{ repoPath: "/repo", requireSharedServer: true }]);
+      expect(first).toMatchObject({
+        args: ["delete", "task-1"],
+        beadsDir: context.beadsDir,
+        doltServerPort: "36000",
+      });
+      expect(second).toMatchObject({
+        args: ["delete", "--force", "task-2"],
+        beadsDir: context.beadsDir,
+        doltServerPort: "36000",
+      });
+    });
+  });
+
+  test("uses configured non-JSON runners without pre-resolving a context", async () => {
     const context = await createExistingTestBeadsCliContext({
-      bdPath,
       prefix: "odt-bd-provider-test-",
     });
-    const contextRequests: Array<{
-      repoPath: string;
-      requireSharedServer: boolean | undefined;
-    }> = [];
+    let contextResolved = false;
+    const configuredRunBd: RunBd = (repoPath, args, callContext) =>
+      Effect.succeed(
+        JSON.stringify({
+          args,
+          hasContext: callContext !== undefined,
+          repoPath,
+        }),
+      );
     const provider = createBdCommandProvider({
-      resolveCliContext(repoPath, options) {
-        return Effect.sync(() => {
-          contextRequests.push({
-            repoPath,
-            requireSharedServer: options?.requireSharedServer,
-          });
-          return context;
-        });
+      runBd: configuredRunBd,
+      resolveCliContext() {
+        contextResolved = true;
+        return Effect.succeed(context);
       },
     });
 
-    const runBdJsonForOperation = await Effect.runPromise(provider.runBdJsonForRepo("/repo"));
-    const first = await Effect.runPromise(runBdJsonForOperation("/repo", ["where"]));
-    const second = await Effect.runPromise(runBdJsonForOperation("/repo", ["status"]));
+    const runBdForOperation = await Effect.runPromise(provider.runBdForRepo("/repo"));
+    const output = JSON.parse(
+      await Effect.runPromise(runBdForOperation("/repo", ["delete", "task-1"])),
+    );
 
-    expect(contextRequests).toEqual([{ repoPath: "/repo", requireSharedServer: true }]);
-    expect(first).toMatchObject({
-      args: ["where", "--json"],
-      beadsDir: context.beadsDir,
-      doltServerPort: "36000",
-    });
-    expect(second).toMatchObject({
-      args: ["status", "--json"],
-      beadsDir: context.beadsDir,
-      doltServerPort: "36000",
+    expect(contextResolved).toBe(false);
+    expect(output).toEqual({
+      args: ["delete", "task-1"],
+      hasContext: false,
+      repoPath: "/repo",
     });
   });
 

--- a/packages/host/src/adapters/beads/bd-command-provider.test.ts
+++ b/packages/host/src/adapters/beads/bd-command-provider.test.ts
@@ -1,71 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import path, { delimiter } from "node:path";
+import path from "node:path";
 import { Effect } from "effect";
 import type {
   BeadsCommandJsonOutput,
   RunBdJson,
 } from "../../infrastructure/beads/task-store/beads-raw-issue";
 import { createBdCommandProvider } from "./bd-command-provider";
-import type { BeadsSharedServerContext } from "./beads-cli-context";
-
-const TEST_SHARED_DOLT_TOOL_PATHS = {
-  dolt: "dolt",
-};
-
-const createBeadsCliContext = (beadsDir: string, bdPath = "bd"): BeadsSharedServerContext => ({
-  repoPath: "/repo",
-  repoId: "repo-12345678",
-  databaseName: "odt_repo_123456789abc",
-  attachmentRoot: path.dirname(beadsDir),
-  beadsDir,
-  workingDir: path.dirname(beadsDir),
-  serverStatePath: "/config/beads/shared-server/server.json",
-  sharedServer: {
-    pid: process.pid,
-    host: "127.0.0.1",
-    port: 36000,
-    user: "root",
-    ownerPid: process.pid,
-    acquisition: "started_by_owner",
-    sharedServerRoot: "/config/beads/shared-server",
-    doltDataDir: "/config/beads/shared-server/dolt",
-    startedAt: "2026-05-10T00:00:00Z",
-  },
-  env: {
-    BEADS_DIR: beadsDir,
-    BEADS_DOLT_SERVER_MODE: "1",
-    BEADS_DOLT_SERVER_HOST: "127.0.0.1",
-    BEADS_DOLT_SERVER_PORT: "36000",
-    BEADS_DOLT_SERVER_USER: "root",
-  },
-  tools: {
-    beads: bdPath,
-  },
-  sharedDoltTools: TEST_SHARED_DOLT_TOOL_PATHS,
-});
-
-const createExistingBeadsCliContext = async (bdPath = "bd"): Promise<BeadsSharedServerContext> => {
-  const attachmentRoot = await mkdtemp(path.join(tmpdir(), "odt-bd-provider-test-"));
-  const beadsDir = path.join(attachmentRoot, ".beads");
-  await mkdir(beadsDir);
-  return createBeadsCliContext(beadsDir, bdPath);
-};
-
-const createFakeBd = async (binDir: string, script: string): Promise<string> => {
-  const scriptPath = path.join(binDir, "bd.mjs");
-  await writeFile(scriptPath, script);
-  if (process.platform === "win32") {
-    const bdPath = path.join(binDir, "bd.cmd");
-    await writeFile(bdPath, `@echo off\r\nbun "%~dp0bd.mjs" %*\r\n`);
-    return bdPath;
-  }
-  const bdPath = path.join(binDir, "bd");
-  await writeFile(bdPath, `#!/bin/sh\nexec bun "$(dirname "$0")/bd.mjs" "$@"\n`);
-  await chmod(bdPath, 0o755);
-  return bdPath;
-};
+import { createExistingTestBeadsCliContext, createFakeBd } from "./beads-test-support";
 
 describe("createBdCommandProvider", () => {
   test("binds default JSON runners to one prepared shared-server context per repo operation", async () => {
@@ -78,8 +21,10 @@ describe("createBdCommandProvider", () => {
   doltServerPort: process.env.BEADS_DOLT_SERVER_PORT
 }));\n`,
     );
-    const context = await createExistingBeadsCliContext(bdPath);
-    context.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+    const context = await createExistingTestBeadsCliContext({
+      bdPath,
+      prefix: "odt-bd-provider-test-",
+    });
     const contextRequests: Array<{
       repoPath: string;
       requireSharedServer: boolean | undefined;
@@ -114,7 +59,9 @@ describe("createBdCommandProvider", () => {
   });
 
   test("uses configured JSON runners without pre-resolving a context", async () => {
-    const context = await createExistingBeadsCliContext();
+    const context = await createExistingTestBeadsCliContext({
+      prefix: "odt-bd-provider-test-",
+    });
     let contextResolved = false;
     const configuredRunBdJson: RunBdJson = (repoPath, args, callContext) =>
       Effect.succeed({

--- a/packages/host/src/adapters/beads/bd-command-provider.ts
+++ b/packages/host/src/adapters/beads/bd-command-provider.ts
@@ -1,0 +1,58 @@
+import { Effect } from "effect";
+import {
+  defaultRunBd,
+  defaultRunBdJson,
+} from "../../infrastructure/beads/task-store/beads-command-runner";
+import type {
+  ResolveBeadsCliContext,
+  RunBd,
+  RunBdJson,
+} from "../../infrastructure/beads/task-store/beads-raw-issue";
+import type { TaskStoreError } from "../../ports/task-repository-ports";
+
+export type CreateBdCommandProviderInput = {
+  resolveCliContext: ResolveBeadsCliContext;
+  runBd?: RunBd;
+  runBdJson?: RunBdJson;
+};
+
+export type BdCommandProvider = {
+  resolveCliContext: ResolveBeadsCliContext;
+  runBd: RunBd;
+  runBdForRepo(repoPath: string): Effect.Effect<RunBd, TaskStoreError>;
+  runBdJson: RunBdJson;
+  runBdJsonForRepo(repoPath: string): Effect.Effect<RunBdJson, TaskStoreError>;
+};
+
+export const createBdCommandProvider = ({
+  resolveCliContext,
+  runBd,
+  runBdJson,
+}: CreateBdCommandProviderInput): BdCommandProvider => {
+  const effectiveRunBd = runBd ?? defaultRunBd(resolveCliContext);
+  const effectiveRunBdJson = runBdJson ?? defaultRunBdJson(resolveCliContext);
+
+  return {
+    resolveCliContext,
+    runBd: effectiveRunBd,
+    runBdForRepo(repoPath) {
+      return Effect.gen(function* () {
+        if (runBd) {
+          return effectiveRunBd;
+        }
+        const context = yield* resolveCliContext(repoPath, { requireSharedServer: true });
+        return (commandRepoPath, args) => effectiveRunBd(commandRepoPath, args, context);
+      });
+    },
+    runBdJson: effectiveRunBdJson,
+    runBdJsonForRepo(repoPath) {
+      return Effect.gen(function* () {
+        if (runBdJson) {
+          return effectiveRunBdJson;
+        }
+        const context = yield* resolveCliContext(repoPath, { requireSharedServer: true });
+        return (commandRepoPath, args) => effectiveRunBdJson(commandRepoPath, args, context);
+      });
+    },
+  };
+};

--- a/packages/host/src/adapters/beads/bd-command-provider.ts
+++ b/packages/host/src/adapters/beads/bd-command-provider.ts
@@ -18,6 +18,7 @@ export type CreateBdCommandProviderInput = {
 
 export type BdCommandProvider = {
   runBdForRepo(repoPath: string): Effect.Effect<RunBd, TaskStoreError>;
+  /** Raw JSON runner accepting optional context; runBdJsonForRepo returns a repo-bound runner. */
   runBdJson: RunBdJson;
   runBdJsonForRepo(repoPath: string): Effect.Effect<RunBdJson, TaskStoreError>;
 };
@@ -37,7 +38,9 @@ export const createBdCommandProvider = ({
           return effectiveRunBd;
         }
         const context = yield* resolveCliContext(repoPath, { requireSharedServer: true });
-        return (commandRepoPath, args) => effectiveRunBd(commandRepoPath, args, context);
+        const boundRunBd: RunBd = (commandRepoPath, args, _callContext) =>
+          effectiveRunBd(commandRepoPath, args, context);
+        return boundRunBd;
       });
     },
     runBdJson: effectiveRunBdJson,
@@ -47,7 +50,9 @@ export const createBdCommandProvider = ({
           return effectiveRunBdJson;
         }
         const context = yield* resolveCliContext(repoPath, { requireSharedServer: true });
-        return (commandRepoPath, args) => effectiveRunBdJson(commandRepoPath, args, context);
+        const boundRunBdJson: RunBdJson = (commandRepoPath, args, _callContext) =>
+          effectiveRunBdJson(commandRepoPath, args, context);
+        return boundRunBdJson;
       });
     },
   };

--- a/packages/host/src/adapters/beads/bd-command-provider.ts
+++ b/packages/host/src/adapters/beads/bd-command-provider.ts
@@ -17,8 +17,6 @@ export type CreateBdCommandProviderInput = {
 };
 
 export type BdCommandProvider = {
-  resolveCliContext: ResolveBeadsCliContext;
-  runBd: RunBd;
   runBdForRepo(repoPath: string): Effect.Effect<RunBd, TaskStoreError>;
   runBdJson: RunBdJson;
   runBdJsonForRepo(repoPath: string): Effect.Effect<RunBdJson, TaskStoreError>;
@@ -33,8 +31,6 @@ export const createBdCommandProvider = ({
   const effectiveRunBdJson = runBdJson ?? defaultRunBdJson(resolveCliContext);
 
   return {
-    resolveCliContext,
-    runBd: effectiveRunBd,
     runBdForRepo(repoPath) {
       return Effect.gen(function* () {
         if (runBd) {

--- a/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Effect } from "effect";
+import { HostOperationError } from "../../effect/host-errors";
+import { createToolDiscoveryAdapter } from "../system/tool-discovery";
+import type { BeadsSharedServerContext } from "./beads-cli-context";
+import { createBeadsCliContextManager } from "./beads-cli-context-manager";
+
+const TEST_BEADS_TOOL_PATHS = {
+  beads: "bd",
+};
+
+const TEST_SHARED_DOLT_TOOL_PATHS = {
+  dolt: "dolt",
+};
+
+const createToolDiscoveryPort = () =>
+  createToolDiscoveryAdapter({
+    systemCommands: {
+      resolveCommandPath: (command) => Effect.succeed(command),
+      runCommandAllowFailure: () => Effect.succeed({ ok: false, stdout: "", stderr: "" }),
+      versionCommand: () => Effect.succeed(null),
+    },
+  });
+
+const createBeadsCliContext = (beadsDir: string): BeadsSharedServerContext => ({
+  repoPath: "/repo",
+  repoId: "repo-12345678",
+  databaseName: "odt_repo_123456789abc",
+  attachmentRoot: path.dirname(beadsDir),
+  beadsDir,
+  workingDir: path.dirname(beadsDir),
+  serverStatePath: "/config/beads/shared-server/server.json",
+  sharedServer: {
+    pid: process.pid,
+    host: "127.0.0.1",
+    port: 36000,
+    user: "root",
+    ownerPid: process.pid,
+    acquisition: "started_by_owner",
+    sharedServerRoot: "/config/beads/shared-server",
+    doltDataDir: "/config/beads/shared-server/dolt",
+    startedAt: "2026-05-10T00:00:00Z",
+  },
+  env: {
+    BEADS_DIR: beadsDir,
+    BEADS_DOLT_SERVER_MODE: "1",
+    BEADS_DOLT_SERVER_HOST: "127.0.0.1",
+    BEADS_DOLT_SERVER_PORT: "36000",
+    BEADS_DOLT_SERVER_USER: "root",
+  },
+  tools: TEST_BEADS_TOOL_PATHS,
+  sharedDoltTools: TEST_SHARED_DOLT_TOOL_PATHS,
+});
+
+const createExistingBeadsCliContext = async (): Promise<BeadsSharedServerContext> => {
+  const attachmentRoot = await mkdtemp(path.join(tmpdir(), "odt-beads-manager-test-"));
+  const beadsDir = path.join(attachmentRoot, ".beads");
+  await mkdir(beadsDir);
+  return createBeadsCliContext(beadsDir);
+};
+
+const testOperationError = (cause: unknown) =>
+  new HostOperationError({
+    operation: "test.effect",
+    message: cause instanceof Error ? cause.message : String(cause),
+    cause,
+  });
+
+describe("createBeadsCliContextManager", () => {
+  test("deduplicates concurrent shared-server context resolution", async () => {
+    const context = await createExistingBeadsCliContext();
+    let resolveContextRequested: () => void = () => {};
+    const contextRequested = new Promise<void>((resolve) => {
+      resolveContextRequested = resolve;
+    });
+    let resolveContext: (context: BeadsSharedServerContext) => void = () => {};
+    const contextResolution = new Promise<BeadsSharedServerContext>((resolve) => {
+      resolveContext = resolve;
+    });
+    let contextResolutionAttempts = 0;
+    const manager = createBeadsCliContextManager({
+      processEnv: {},
+      toolDiscovery: createToolDiscoveryPort(),
+      resolveCliContext(_repoPath, options) {
+        return Effect.tryPromise({
+          try: async () => {
+            expect(options.requireSharedServer).toBe(true);
+            contextResolutionAttempts += 1;
+            resolveContextRequested();
+            return contextResolution;
+          },
+          catch: testOperationError,
+        });
+      },
+    });
+
+    const first = Effect.runPromise(
+      manager.resolveCliContext("/repo", { requireSharedServer: true }),
+    );
+    const second = Effect.runPromise(
+      manager.resolveCliContext("/repo", { requireSharedServer: true }),
+    );
+
+    await contextRequested;
+    resolveContext(context);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([context, context]);
+    expect(contextResolutionAttempts).toBe(1);
+  });
+
+  test("waits for in-flight context resolution before stopping owned shared servers", async () => {
+    const context = await createExistingBeadsCliContext();
+    let resolveContextRequested: () => void = () => {};
+    const contextRequested = new Promise<void>((resolve) => {
+      resolveContextRequested = resolve;
+    });
+    let resolveContext: (context: BeadsSharedServerContext) => void = () => {};
+    const contextResolution = new Promise<BeadsSharedServerContext>((resolve) => {
+      resolveContext = resolve;
+    });
+    const stoppedServers: Array<{
+      pid: number;
+      serverStatePath: string;
+    }> = [];
+    const manager = createBeadsCliContextManager({
+      processEnv: {},
+      toolDiscovery: createToolDiscoveryPort(),
+      resolveCliContext() {
+        return Effect.tryPromise({
+          try: async () => {
+            resolveContextRequested();
+            return contextResolution;
+          },
+          catch: testOperationError,
+        });
+      },
+      stopSharedDoltServer(sharedServer, serverStatePath) {
+        return Effect.sync(() => {
+          stoppedServers.push({ pid: sharedServer.pid, serverStatePath });
+        });
+      },
+    });
+
+    const resolution = Effect.runPromise(
+      manager.resolveCliContext("/repo", { requireSharedServer: true }),
+    );
+    await contextRequested;
+    const close = Effect.runPromise(manager.close());
+    resolveContext(context);
+
+    await expect(resolution).resolves.toBe(context);
+    await expect(close).resolves.toEqual({ stoppedSharedDoltServers: 1 });
+    expect(stoppedServers).toEqual([
+      {
+        pid: process.pid,
+        serverStatePath: "/config/beads/shared-server/server.json",
+      },
+    ]);
+  });
+});

--- a/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
@@ -57,10 +57,6 @@ describe("createBeadsCliContextManager", () => {
       prefix: "odt-beads-manager-test-",
     });
     let contextResolutionAttempts = 0;
-    const stoppedServers: Array<{
-      pid: number;
-      serverStatePath: string;
-    }> = [];
     const manager = createBeadsCliContextManager({
       processEnv: {},
       toolDiscovery: createTestToolDiscoveryPort(),
@@ -74,11 +70,6 @@ describe("createBeadsCliContextManager", () => {
           return context;
         });
       },
-      stopSharedDoltServer(sharedServer, serverStatePath) {
-        return Effect.sync(() => {
-          stoppedServers.push({ pid: sharedServer.pid, serverStatePath });
-        });
-      },
     });
 
     await expect(
@@ -87,16 +78,7 @@ describe("createBeadsCliContextManager", () => {
     await expect(
       Effect.runPromise(manager.resolveCliContext("/repo", { requireSharedServer: true })),
     ).resolves.toBe(context);
-    await expect(Effect.runPromise(manager.close())).resolves.toEqual({
-      stoppedSharedDoltServers: 1,
-    });
     expect(contextResolutionAttempts).toBe(2);
-    expect(stoppedServers).toEqual([
-      {
-        pid: process.pid,
-        serverStatePath: "/config/beads/shared-server/server.json",
-      },
-    ]);
   });
 
   test("waits for in-flight context resolution before stopping owned shared servers", async () => {

--- a/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
@@ -1,77 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import { Effect } from "effect";
-import { HostOperationError } from "../../effect/host-errors";
-import { createToolDiscoveryAdapter } from "../system/tool-discovery";
 import type { BeadsSharedServerContext } from "./beads-cli-context";
 import { createBeadsCliContextManager } from "./beads-cli-context-manager";
-
-const TEST_BEADS_TOOL_PATHS = {
-  beads: "bd",
-};
-
-const TEST_SHARED_DOLT_TOOL_PATHS = {
-  dolt: "dolt",
-};
-
-const createToolDiscoveryPort = () =>
-  createToolDiscoveryAdapter({
-    systemCommands: {
-      resolveCommandPath: (command) => Effect.succeed(command),
-      runCommandAllowFailure: () => Effect.succeed({ ok: false, stdout: "", stderr: "" }),
-      versionCommand: () => Effect.succeed(null),
-    },
-  });
-
-const createBeadsCliContext = (beadsDir: string): BeadsSharedServerContext => ({
-  repoPath: "/repo",
-  repoId: "repo-12345678",
-  databaseName: "odt_repo_123456789abc",
-  attachmentRoot: path.dirname(beadsDir),
-  beadsDir,
-  workingDir: path.dirname(beadsDir),
-  serverStatePath: "/config/beads/shared-server/server.json",
-  sharedServer: {
-    pid: process.pid,
-    host: "127.0.0.1",
-    port: 36000,
-    user: "root",
-    ownerPid: process.pid,
-    acquisition: "started_by_owner",
-    sharedServerRoot: "/config/beads/shared-server",
-    doltDataDir: "/config/beads/shared-server/dolt",
-    startedAt: "2026-05-10T00:00:00Z",
-  },
-  env: {
-    BEADS_DIR: beadsDir,
-    BEADS_DOLT_SERVER_MODE: "1",
-    BEADS_DOLT_SERVER_HOST: "127.0.0.1",
-    BEADS_DOLT_SERVER_PORT: "36000",
-    BEADS_DOLT_SERVER_USER: "root",
-  },
-  tools: TEST_BEADS_TOOL_PATHS,
-  sharedDoltTools: TEST_SHARED_DOLT_TOOL_PATHS,
-});
-
-const createExistingBeadsCliContext = async (): Promise<BeadsSharedServerContext> => {
-  const attachmentRoot = await mkdtemp(path.join(tmpdir(), "odt-beads-manager-test-"));
-  const beadsDir = path.join(attachmentRoot, ".beads");
-  await mkdir(beadsDir);
-  return createBeadsCliContext(beadsDir);
-};
-
-const testOperationError = (cause: unknown) =>
-  new HostOperationError({
-    operation: "test.effect",
-    message: cause instanceof Error ? cause.message : String(cause),
-    cause,
-  });
+import {
+  createExistingTestBeadsCliContext,
+  createTestToolDiscoveryPort,
+  testOperationError,
+} from "./beads-test-support";
 
 describe("createBeadsCliContextManager", () => {
   test("deduplicates concurrent shared-server context resolution", async () => {
-    const context = await createExistingBeadsCliContext();
+    const context = await createExistingTestBeadsCliContext({
+      prefix: "odt-beads-manager-test-",
+    });
     let resolveContextRequested: () => void = () => {};
     const contextRequested = new Promise<void>((resolve) => {
       resolveContextRequested = resolve;
@@ -83,7 +24,7 @@ describe("createBeadsCliContextManager", () => {
     let contextResolutionAttempts = 0;
     const manager = createBeadsCliContextManager({
       processEnv: {},
-      toolDiscovery: createToolDiscoveryPort(),
+      toolDiscovery: createTestToolDiscoveryPort(),
       resolveCliContext(_repoPath, options) {
         return Effect.tryPromise({
           try: async () => {
@@ -112,7 +53,9 @@ describe("createBeadsCliContextManager", () => {
   });
 
   test("waits for in-flight context resolution before stopping owned shared servers", async () => {
-    const context = await createExistingBeadsCliContext();
+    const context = await createExistingTestBeadsCliContext({
+      prefix: "odt-beads-manager-test-",
+    });
     let resolveContextRequested: () => void = () => {};
     const contextRequested = new Promise<void>((resolve) => {
       resolveContextRequested = resolve;
@@ -127,7 +70,7 @@ describe("createBeadsCliContextManager", () => {
     }> = [];
     const manager = createBeadsCliContextManager({
       processEnv: {},
-      toolDiscovery: createToolDiscoveryPort(),
+      toolDiscovery: createTestToolDiscoveryPort(),
       resolveCliContext() {
         return Effect.tryPromise({
           try: async () => {

--- a/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { Effect } from "effect";
 import type { BeadsSharedServerContext } from "./beads-cli-context";
 import { createBeadsCliContextManager } from "./beads-cli-context-manager";
@@ -7,6 +9,9 @@ import {
   createTestToolDiscoveryPort,
   testOperationError,
 } from "./test-support/beads-test-support";
+
+const missingRepoPath = () =>
+  path.join(tmpdir(), `odt-missing-repo-${Date.now()}-${Math.random().toString(16).slice(2)}`);
 
 describe("createBeadsCliContextManager", () => {
   test("deduplicates concurrent shared-server context resolution", async () => {
@@ -131,5 +136,61 @@ describe("createBeadsCliContextManager", () => {
         serverStatePath: "/config/beads/shared-server/server.json",
       },
     ]);
+  });
+
+  test("does not create non-shared context flights after close begins", async () => {
+    const context = await createExistingTestBeadsCliContext({
+      prefix: "odt-beads-manager-test-",
+    });
+    let contextResolutionAttempts = 0;
+    const manager = createBeadsCliContextManager({
+      processEnv: {},
+      toolDiscovery: createTestToolDiscoveryPort(),
+      resolveCliContext() {
+        contextResolutionAttempts += 1;
+        return Effect.succeed(context);
+      },
+    });
+    const repoPath = missingRepoPath();
+
+    const resolution = Effect.runPromise(manager.resolveCliContext(repoPath)).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await expect(Effect.runPromise(manager.close())).resolves.toEqual({
+      stoppedSharedDoltServers: 0,
+    });
+
+    expect(String(await resolution)).toContain("Beads task store is closing.");
+    expect(contextResolutionAttempts).toBe(0);
+  });
+
+  test("does not reserve shared-server context flights after close begins", async () => {
+    const context = await createExistingTestBeadsCliContext({
+      prefix: "odt-beads-manager-test-",
+    });
+    let contextResolutionAttempts = 0;
+    const manager = createBeadsCliContextManager({
+      processEnv: {},
+      toolDiscovery: createTestToolDiscoveryPort(),
+      resolveCliContext() {
+        contextResolutionAttempts += 1;
+        return Effect.succeed(context);
+      },
+    });
+    const repoPath = missingRepoPath();
+
+    const resolution = Effect.runPromise(
+      manager.resolveCliContext(repoPath, { requireSharedServer: true }),
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await expect(Effect.runPromise(manager.close())).resolves.toEqual({
+      stoppedSharedDoltServers: 0,
+    });
+
+    expect(String(await resolution)).toContain("Beads task store is closing.");
+    expect(contextResolutionAttempts).toBe(0);
   });
 });

--- a/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-manager.test.ts
@@ -6,7 +6,7 @@ import {
   createExistingTestBeadsCliContext,
   createTestToolDiscoveryPort,
   testOperationError,
-} from "./beads-test-support";
+} from "./test-support/beads-test-support";
 
 describe("createBeadsCliContextManager", () => {
   test("deduplicates concurrent shared-server context resolution", async () => {
@@ -50,6 +50,53 @@ describe("createBeadsCliContextManager", () => {
 
     await expect(Promise.all([first, second])).resolves.toEqual([context, context]);
     expect(contextResolutionAttempts).toBe(1);
+  });
+
+  test("evicts failed shared-server context flights before retrying", async () => {
+    const context = await createExistingTestBeadsCliContext({
+      prefix: "odt-beads-manager-test-",
+    });
+    let contextResolutionAttempts = 0;
+    const stoppedServers: Array<{
+      pid: number;
+      serverStatePath: string;
+    }> = [];
+    const manager = createBeadsCliContextManager({
+      processEnv: {},
+      toolDiscovery: createTestToolDiscoveryPort(),
+      resolveCliContext(_repoPath, options) {
+        return Effect.gen(function* () {
+          expect(options.requireSharedServer).toBe(true);
+          contextResolutionAttempts += 1;
+          if (contextResolutionAttempts === 1) {
+            return yield* Effect.fail(testOperationError(new Error("first context failed")));
+          }
+          return context;
+        });
+      },
+      stopSharedDoltServer(sharedServer, serverStatePath) {
+        return Effect.sync(() => {
+          stoppedServers.push({ pid: sharedServer.pid, serverStatePath });
+        });
+      },
+    });
+
+    await expect(
+      Effect.runPromise(manager.resolveCliContext("/repo", { requireSharedServer: true })),
+    ).rejects.toThrow("first context failed");
+    await expect(
+      Effect.runPromise(manager.resolveCliContext("/repo", { requireSharedServer: true })),
+    ).resolves.toBe(context);
+    await expect(Effect.runPromise(manager.close())).resolves.toEqual({
+      stoppedSharedDoltServers: 1,
+    });
+    expect(contextResolutionAttempts).toBe(2);
+    expect(stoppedServers).toEqual([
+      {
+        pid: process.pid,
+        serverStatePath: "/config/beads/shared-server/server.json",
+      },
+    ]);
   });
 
   test("waits for in-flight context resolution before stopping owned shared servers", async () => {

--- a/packages/host/src/adapters/beads/beads-cli-context-manager.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-manager.ts
@@ -1,5 +1,9 @@
 import { Cause, Effect } from "effect";
-import { HostOperationError, toHostOperationError } from "../../effect/host-errors";
+import {
+  HostOperationError,
+  HostResourceError,
+  toHostOperationError,
+} from "../../effect/host-errors";
 import type {
   BeadsTaskRepositoryShutdownResult,
   ResolveBeadsCliContext,
@@ -100,6 +104,32 @@ export const createBeadsCliContextManager = ({
   const cliContextFlights = new Set<BeadsCliContextFlight>();
   const readyCliContexts = new Map<string, BeadsCliContextFlight>();
   let closing = false;
+  const closingError = () =>
+    new HostResourceError({
+      resource: "beadsTaskStore",
+      operation: "beadsCliContextManager.resolveCliContext",
+      message: "Beads task store is closing.",
+    });
+  const reserveTrackedCliContextFlight = (): Effect.Effect<BeadsCliContextFlight, TaskStoreError> =>
+    Effect.suspend(() =>
+      closing
+        ? Effect.fail(closingError())
+        : Effect.succeed(createTrackedCliContextFlight(cliContextFlights)),
+    );
+  const reserveReadyCliContextFlightIfOpen = (
+    cacheKey: string,
+  ): Effect.Effect<BeadsCliContextFlightReservation, TaskStoreError> =>
+    Effect.suspend(() =>
+      closing
+        ? Effect.fail(closingError())
+        : Effect.succeed(
+            reserveReadyCliContextFlight({
+              cacheKey,
+              cliContextFlights,
+              readyCliContexts,
+            }),
+          ),
+    );
   const resolveBeadsToolPaths = createBeadsToolPathResolver(toolDiscovery);
   const resolveSharedDoltToolPaths = createSharedDoltToolPathResolver(toolDiscovery);
   const resolveContextRequest = createBeadsCliContextRequestResolver({
@@ -116,16 +146,16 @@ export const createBeadsCliContextManager = ({
     return context;
   };
   const trackCliContextResolution = (
-    contextEffect: Effect.Effect<BeadsCliContext, TaskStoreError>,
+    resolveContext: () => Effect.Effect<BeadsCliContext, TaskStoreError>,
   ): Effect.Effect<BeadsCliContext, TaskStoreError> =>
     Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
-        const flight = yield* Effect.sync(() => createTrackedCliContextFlight(cliContextFlights));
+        const flight = yield* reserveTrackedCliContextFlight();
         yield* forkCliContextFlightResolution({
           cliContextFlights,
           flight,
           rememberOwnedContext,
-          resolveContext: contextEffect,
+          resolveContext: resolveContext(),
         });
         return yield* restore(awaitBeadsCliContextFlight(flight));
       }),
@@ -134,20 +164,15 @@ export const createBeadsCliContextManager = ({
     Effect.gen(function* () {
       const request = yield* resolveContextRequest(repoPath, options);
       if (request.options.requireSharedServer !== true) {
-        return yield* trackCliContextResolution(
-          resolveCliContext(request.repoPath, request.options),
+        const optionalServerOptions = request.options;
+        return yield* trackCliContextResolution(() =>
+          resolveCliContext(request.repoPath, optionalServerOptions),
         );
       }
       const sharedServerOptions = request.options;
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const reservation = yield* Effect.sync(() =>
-            reserveReadyCliContextFlight({
-              cacheKey: request.cacheKey,
-              cliContextFlights,
-              readyCliContexts,
-            }),
-          );
+          const reservation = yield* reserveReadyCliContextFlightIfOpen(request.cacheKey);
           if (reservation._tag === "existing") {
             return yield* restore(awaitBeadsCliContextFlight(reservation.flight));
           }

--- a/packages/host/src/adapters/beads/beads-cli-context-manager.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-manager.ts
@@ -1,0 +1,175 @@
+import { Cause, Effect } from "effect";
+import { HostOperationError, toHostOperationError } from "../../effect/host-errors";
+import type {
+  BeadsTaskRepositoryShutdownResult,
+  ResolveBeadsCliContext,
+  ResolveRawBeadsCliContext,
+  ResolveWorkspaceIdForRepoPath,
+} from "../../infrastructure/beads/task-store/beads-raw-issue";
+import type { TaskStoreError } from "../../ports/task-repository-ports";
+import type { ToolDiscoveryPort } from "../../ports/tool-discovery-port";
+import {
+  type BeadsCliContext,
+  resolveBeadsCliContext,
+  type StopSharedDoltServer,
+  stopOwnedSharedDoltServer,
+} from "./beads-cli-context";
+import {
+  awaitBeadsCliContextFlight,
+  type BeadsCliContextFlight,
+  makeBeadsCliContextFlight,
+  resolveBeadsCliContextFlight,
+} from "./beads-cli-context-flight";
+import { createBeadsCliContextRequestResolver } from "./beads-cli-context-request";
+import { createBeadsToolPathResolver, createSharedDoltToolPathResolver } from "./beads-tool-paths";
+
+export type CreateBeadsCliContextManagerInput = {
+  processEnv?: NodeJS.ProcessEnv;
+  resolveCliContext?: ResolveRawBeadsCliContext;
+  resolveWorkspaceIdForRepoPath?: ResolveWorkspaceIdForRepoPath;
+  stopSharedDoltServer?: StopSharedDoltServer;
+  toolDiscovery: ToolDiscoveryPort;
+};
+
+export type BeadsCliContextManager = {
+  close(): Effect.Effect<BeadsTaskRepositoryShutdownResult, TaskStoreError>;
+  resolveCliContext: ResolveBeadsCliContext;
+};
+
+export const createBeadsCliContextManager = ({
+  processEnv = process.env,
+  resolveCliContext = resolveBeadsCliContext,
+  resolveWorkspaceIdForRepoPath,
+  stopSharedDoltServer = stopOwnedSharedDoltServer,
+  toolDiscovery,
+}: CreateBeadsCliContextManagerInput): BeadsCliContextManager => {
+  const ownedSharedDoltServers = new Map<string, BeadsCliContext["sharedServer"]>();
+  const cliContextFlights = new Set<BeadsCliContextFlight>();
+  const readyCliContexts = new Map<string, BeadsCliContextFlight>();
+  let closing = false;
+  const resolveBeadsToolPaths = createBeadsToolPathResolver(toolDiscovery);
+  const resolveSharedDoltToolPaths = createSharedDoltToolPathResolver(toolDiscovery);
+  const resolveContextRequest = createBeadsCliContextRequestResolver({
+    isClosing: () => closing,
+    processEnv,
+    resolveBeadsToolPaths,
+    resolveSharedDoltToolPaths,
+    ...(resolveWorkspaceIdForRepoPath === undefined ? {} : { resolveWorkspaceIdForRepoPath }),
+  });
+  const rememberOwnedContext = (context: BeadsCliContext): BeadsCliContext => {
+    if (context.sharedServer?.ownerPid === process.pid) {
+      ownedSharedDoltServers.set(context.serverStatePath, context.sharedServer);
+    }
+    return context;
+  };
+  const trackCliContextResolution = (
+    contextEffect: Effect.Effect<BeadsCliContext, TaskStoreError>,
+  ): Effect.Effect<BeadsCliContext, TaskStoreError> =>
+    Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const flight = yield* Effect.sync(() => {
+          const nextFlight = makeBeadsCliContextFlight();
+          cliContextFlights.add(nextFlight);
+          return nextFlight;
+        });
+        yield* Effect.forkDaemon(
+          resolveBeadsCliContextFlight({
+            flight,
+            releaseReservation: Effect.sync(() => cliContextFlights.delete(flight)),
+            rememberOwnedContext,
+            resolveContext: contextEffect,
+          }),
+        );
+        return yield* restore(awaitBeadsCliContextFlight(flight));
+      }),
+    );
+  const resolveManagedCliContext: ResolveBeadsCliContext = (repoPath, options = {}) =>
+    Effect.gen(function* () {
+      const request = yield* resolveContextRequest(repoPath, options);
+      if (request.options.requireSharedServer !== true) {
+        return yield* trackCliContextResolution(
+          resolveCliContext(request.repoPath, request.options),
+        );
+      }
+      const sharedServerOptions = request.options;
+      return yield* Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          const reservation = yield* Effect.sync(() => {
+            const cached = readyCliContexts.get(request.cacheKey);
+            if (cached) {
+              return { _tag: "existing" as const, flight: cached };
+            }
+            const flight = makeBeadsCliContextFlight();
+            cliContextFlights.add(flight);
+            readyCliContexts.set(request.cacheKey, flight);
+            return { _tag: "created" as const, flight };
+          });
+          if (reservation._tag === "existing") {
+            return yield* restore(awaitBeadsCliContextFlight(reservation.flight));
+          }
+          yield* Effect.forkDaemon(
+            resolveBeadsCliContextFlight({
+              evictCachedContext: Effect.sync(() => {
+                if (readyCliContexts.get(request.cacheKey) === reservation.flight) {
+                  readyCliContexts.delete(request.cacheKey);
+                }
+              }),
+              flight: reservation.flight,
+              releaseReservation: Effect.sync(() => cliContextFlights.delete(reservation.flight)),
+              rememberOwnedContext,
+              resolveContext: resolveCliContext(request.repoPath, sharedServerOptions),
+            }),
+          );
+          return yield* restore(awaitBeadsCliContextFlight(reservation.flight));
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        toHostOperationError(cause, "beadsCliContextManager.resolveCliContext", {
+          repoPath,
+          requireSharedServer: options.requireSharedServer === true,
+        }),
+      ),
+    );
+
+  return {
+    resolveCliContext: resolveManagedCliContext,
+    close() {
+      return Effect.gen(function* () {
+        closing = true;
+        yield* Effect.forEach(
+          [...cliContextFlights],
+          (flight) => Effect.either(awaitBeadsCliContextFlight(flight)),
+          { concurrency: "unbounded" },
+        );
+        const errors: string[] = [];
+        let stoppedSharedDoltServers = 0;
+        for (const [serverStatePath, sharedServer] of ownedSharedDoltServers) {
+          if (!sharedServer) {
+            continue;
+          }
+          const stopResult = yield* Effect.exit(
+            stopSharedDoltServer(sharedServer, serverStatePath),
+          );
+          if (stopResult._tag === "Success") {
+            stoppedSharedDoltServers += 1;
+            ownedSharedDoltServers.delete(serverStatePath);
+          } else {
+            const message = Cause.pretty(stopResult.cause);
+            errors.push(`Failed stopping shared Dolt server ${sharedServer.pid}: ${message}`);
+          }
+        }
+        if (errors.length > 0) {
+          return yield* Effect.fail(
+            new HostOperationError({
+              operation: "beadsCliContextManager.close",
+              message: errors.join("\n"),
+              details: { failures: errors },
+            }),
+          );
+        }
+        return { stoppedSharedDoltServers };
+      });
+    },
+  };
+};

--- a/packages/host/src/adapters/beads/beads-cli-context-manager.ts
+++ b/packages/host/src/adapters/beads/beads-cli-context-manager.ts
@@ -36,6 +36,59 @@ export type BeadsCliContextManager = {
   resolveCliContext: ResolveBeadsCliContext;
 };
 
+type BeadsCliContextFlightReservation =
+  | { _tag: "existing"; flight: BeadsCliContextFlight }
+  | { _tag: "created"; flight: BeadsCliContextFlight };
+
+const createTrackedCliContextFlight = (
+  cliContextFlights: Set<BeadsCliContextFlight>,
+): BeadsCliContextFlight => {
+  const flight = makeBeadsCliContextFlight();
+  cliContextFlights.add(flight);
+  return flight;
+};
+
+const reserveReadyCliContextFlight = ({
+  cacheKey,
+  cliContextFlights,
+  readyCliContexts,
+}: {
+  cacheKey: string;
+  cliContextFlights: Set<BeadsCliContextFlight>;
+  readyCliContexts: Map<string, BeadsCliContextFlight>;
+}): BeadsCliContextFlightReservation => {
+  const cached = readyCliContexts.get(cacheKey);
+  if (cached) {
+    return { _tag: "existing", flight: cached };
+  }
+  const flight = createTrackedCliContextFlight(cliContextFlights);
+  readyCliContexts.set(cacheKey, flight);
+  return { _tag: "created", flight };
+};
+
+const forkCliContextFlightResolution = ({
+  cliContextFlights,
+  evictCachedContext,
+  flight,
+  rememberOwnedContext,
+  resolveContext,
+}: {
+  cliContextFlights: Set<BeadsCliContextFlight>;
+  evictCachedContext?: Effect.Effect<void>;
+  flight: BeadsCliContextFlight;
+  rememberOwnedContext: (context: BeadsCliContext) => BeadsCliContext;
+  resolveContext: Effect.Effect<BeadsCliContext, TaskStoreError>;
+}): Effect.Effect<void> =>
+  Effect.forkDaemon(
+    resolveBeadsCliContextFlight({
+      ...(evictCachedContext === undefined ? {} : { evictCachedContext }),
+      flight,
+      releaseReservation: Effect.sync(() => cliContextFlights.delete(flight)),
+      rememberOwnedContext,
+      resolveContext,
+    }),
+  ).pipe(Effect.asVoid);
+
 export const createBeadsCliContextManager = ({
   processEnv = process.env,
   resolveCliContext = resolveBeadsCliContext,
@@ -67,19 +120,13 @@ export const createBeadsCliContextManager = ({
   ): Effect.Effect<BeadsCliContext, TaskStoreError> =>
     Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
-        const flight = yield* Effect.sync(() => {
-          const nextFlight = makeBeadsCliContextFlight();
-          cliContextFlights.add(nextFlight);
-          return nextFlight;
+        const flight = yield* Effect.sync(() => createTrackedCliContextFlight(cliContextFlights));
+        yield* forkCliContextFlightResolution({
+          cliContextFlights,
+          flight,
+          rememberOwnedContext,
+          resolveContext: contextEffect,
         });
-        yield* Effect.forkDaemon(
-          resolveBeadsCliContextFlight({
-            flight,
-            releaseReservation: Effect.sync(() => cliContextFlights.delete(flight)),
-            rememberOwnedContext,
-            resolveContext: contextEffect,
-          }),
-        );
         return yield* restore(awaitBeadsCliContextFlight(flight));
       }),
     );
@@ -94,32 +141,27 @@ export const createBeadsCliContextManager = ({
       const sharedServerOptions = request.options;
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const reservation = yield* Effect.sync(() => {
-            const cached = readyCliContexts.get(request.cacheKey);
-            if (cached) {
-              return { _tag: "existing" as const, flight: cached };
-            }
-            const flight = makeBeadsCliContextFlight();
-            cliContextFlights.add(flight);
-            readyCliContexts.set(request.cacheKey, flight);
-            return { _tag: "created" as const, flight };
-          });
+          const reservation = yield* Effect.sync(() =>
+            reserveReadyCliContextFlight({
+              cacheKey: request.cacheKey,
+              cliContextFlights,
+              readyCliContexts,
+            }),
+          );
           if (reservation._tag === "existing") {
             return yield* restore(awaitBeadsCliContextFlight(reservation.flight));
           }
-          yield* Effect.forkDaemon(
-            resolveBeadsCliContextFlight({
-              evictCachedContext: Effect.sync(() => {
-                if (readyCliContexts.get(request.cacheKey) === reservation.flight) {
-                  readyCliContexts.delete(request.cacheKey);
-                }
-              }),
-              flight: reservation.flight,
-              releaseReservation: Effect.sync(() => cliContextFlights.delete(reservation.flight)),
-              rememberOwnedContext,
-              resolveContext: resolveCliContext(request.repoPath, sharedServerOptions),
+          yield* forkCliContextFlightResolution({
+            cliContextFlights,
+            evictCachedContext: Effect.sync(() => {
+              if (readyCliContexts.get(request.cacheKey) === reservation.flight) {
+                readyCliContexts.delete(request.cacheKey);
+              }
             }),
-          );
+            flight: reservation.flight,
+            rememberOwnedContext,
+            resolveContext: resolveCliContext(request.repoPath, sharedServerOptions),
+          });
           return yield* restore(awaitBeadsCliContextFlight(reservation.flight));
         }),
       );

--- a/packages/host/src/adapters/beads/beads-task-repository.test.ts
+++ b/packages/host/src/adapters/beads/beads-task-repository.test.ts
@@ -5,7 +5,7 @@ import { gunzipSync, gzipSync } from "node:zlib";
 import { Effect } from "effect";
 import { HostOperationError } from "../../effect/host-errors";
 import type { BeadsCommandJsonOutput } from "../../infrastructure/beads/task-store/beads-raw-issue";
-import type { BeadsCliContext, BeadsSharedServerContext } from "./beads-cli-context";
+import type { BeadsCliContext } from "./beads-cli-context";
 import { createBeadsTaskRepository } from "./beads-task-repository";
 import {
   createTestBeadsCliContext as createBeadsCliContext,
@@ -36,49 +36,23 @@ const createTestBeadsTaskRepository = (
     ...input,
   });
 describe("createBeadsTaskRepository", () => {
-  test("stops the owned shared Dolt server on close", async () => {
+  test("delegates close to the Beads CLI context manager", async () => {
     const context = await createExistingBeadsCliContext();
     const stoppedServers: Array<{
       pid: number;
       serverStatePath: string;
     }> = [];
     const port = createTestBeadsTaskRepository({
-      resolveCliContext: () =>
-        Effect.tryPromise({
-          try: async () => {
-            return context;
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
-        }),
+      resolveCliContext: () => Effect.succeed(context),
       runBdJson() {
-        return Effect.tryPromise({
-          try: async () => {
-            return { path: context.beadsDir };
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
-        });
+        return Effect.succeed({ path: context.beadsDir });
       },
       stopSharedDoltServer(sharedServer, serverStatePath) {
-        return Effect.tryPromise({
-          try: async () => {
-            stoppedServers.push({ pid: sharedServer.pid, serverStatePath });
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
+        return Effect.sync(() => {
+          stoppedServers.push({
+            pid: sharedServer.pid,
+            serverStatePath,
+          });
         });
       },
     });
@@ -90,138 +64,6 @@ describe("createBeadsTaskRepository", () => {
         serverStatePath: "/config/beads/shared-server/server.json",
       },
     ]);
-  });
-  test("waits for in-flight shared Dolt server context resolution before close", async () => {
-    const context = await createExistingBeadsCliContext();
-    const stoppedServers: Array<{
-      pid: number;
-      serverStatePath: string;
-    }> = [];
-    let resolveContextRequested: () => void = () => {};
-    const contextRequested = new Promise<void>((resolve) => {
-      resolveContextRequested = resolve;
-    });
-    let resolveContext: (context: BeadsSharedServerContext) => void = () => {};
-    const contextResolution = new Promise<BeadsSharedServerContext>((resolve) => {
-      resolveContext = resolve;
-    });
-    const port = createTestBeadsTaskRepository({
-      resolveCliContext() {
-        return Effect.tryPromise({
-          try: async () => {
-            resolveContextRequested();
-            return contextResolution;
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
-        });
-      },
-      runBdJson() {
-        return Effect.tryPromise({
-          try: async () => {
-            return { path: context.beadsDir };
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
-        });
-      },
-      stopSharedDoltServer(sharedServer, serverStatePath) {
-        return Effect.tryPromise({
-          try: async () => {
-            stoppedServers.push({ pid: sharedServer.pid, serverStatePath });
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
-        });
-      },
-    });
-    const diagnose = Effect.runPromise(
-      port.diagnoseRepoStore?.({ repoPath: "/repo", prepare: true }),
-    );
-    await contextRequested;
-    const close = Effect.runPromise(port.close());
-    resolveContext(context);
-    await expect(diagnose).resolves.toMatchObject({ status: "ready" });
-    await expect(close).resolves.toEqual({ stoppedSharedDoltServers: 1 });
-    expect(stoppedServers).toEqual([
-      {
-        pid: process.pid,
-        serverStatePath: "/config/beads/shared-server/server.json",
-      },
-    ]);
-  });
-  test("deduplicates concurrent shared Dolt server context resolution", async () => {
-    const context = await createExistingBeadsCliContext();
-    let resolveContextRequested: () => void = () => {};
-    const contextRequested = new Promise<void>((resolve) => {
-      resolveContextRequested = resolve;
-    });
-    let resolveContext: (context: BeadsSharedServerContext) => void = () => {};
-    const contextResolution = new Promise<BeadsSharedServerContext>((resolve) => {
-      resolveContext = resolve;
-    });
-    let contextResolutionAttempts = 0;
-    const port = createTestBeadsTaskRepository({
-      resolveCliContext() {
-        return Effect.tryPromise({
-          try: async () => {
-            contextResolutionAttempts += 1;
-            resolveContextRequested();
-            return contextResolution;
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
-        });
-      },
-      runBdJson() {
-        return Effect.succeed({ path: context.beadsDir });
-      },
-    });
-
-    const first = Effect.runPromise(port.diagnoseRepoStore?.({ repoPath: "/repo", prepare: true }));
-    const second = Effect.runPromise(
-      port.diagnoseRepoStore?.({ repoPath: "/repo", prepare: true }),
-    );
-
-    await contextRequested;
-    resolveContext(context);
-
-    const expectedDiagnosis = {
-      category: "healthy",
-      status: "ready",
-      isReady: true,
-      detail: "Beads attachment and shared Dolt server are healthy.",
-      attachment: {
-        path: context.beadsDir,
-        databaseName: "odt_repo_123456789abc",
-      },
-      sharedServer: {
-        host: "127.0.0.1",
-        port: 36000,
-        ownershipState: "owned_by_current_process",
-      },
-    } as const;
-    await expect(Promise.all([first, second])).resolves.toEqual([
-      expectedDiagnosis,
-      expectedDiagnosis,
-    ]);
-    expect(contextResolutionAttempts).toBe(1);
   });
   test("diagnoses a ready Beads repo store from bd where", async () => {
     const context = await createExistingBeadsCliContext();

--- a/packages/host/src/adapters/beads/beads-task-repository.test.ts
+++ b/packages/host/src/adapters/beads/beads-task-repository.test.ts
@@ -12,7 +12,7 @@ import {
   createExistingTestBeadsCliContext as createExistingBeadsCliContext,
   createFakeBd,
   createTestToolDiscoveryPort as createToolDiscoveryPort,
-} from "./beads-test-support";
+} from "./test-support/beads-test-support";
 
 const encodedMarkdown = (markdown: string): string => gzipSync(markdown).toString("base64");
 type RawTaskFixture = { [key in string]?: BeadsCommandJsonOutput };

--- a/packages/host/src/adapters/beads/beads-task-repository.test.ts
+++ b/packages/host/src/adapters/beads/beads-task-repository.test.ts
@@ -28,11 +28,11 @@ const rawTask = (overrides: RawTaskFixture = {}): RawTaskFixture => ({
   ...overrides,
 });
 const createTestBeadsTaskRepository = (
-  input: Omit<Parameters<typeof createBeadsTaskRepository>[0], "toolDiscovery"> &
-    Partial<Pick<Parameters<typeof createBeadsTaskRepository>[0], "toolDiscovery">>,
+  input: Omit<Parameters<typeof createBeadsTaskRepository>[0], "toolDiscovery">,
+  toolDiscovery = createToolDiscoveryPort(),
 ) =>
   createBeadsTaskRepository({
-    toolDiscovery: createToolDiscoveryPort(),
+    toolDiscovery,
     ...input,
   });
 describe("createBeadsTaskRepository", () => {
@@ -411,35 +411,39 @@ if (args.join(" ") === "list --limit 0 --json") {
     expect(refreshed[0]?.title).toBe("Task 2");
   });
   test("resolves Dolt before context resolution for task commands that require the shared server", async () => {
-    const port = createTestBeadsTaskRepository({
-      toolDiscovery: createToolDiscoveryPort(["dolt"]),
-      resolveCliContext() {
-        return Effect.tryPromise({
-          try: async () => {
-            throw new Error("Dolt preflight should run before context resolution.");
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
-        });
+    const port = createTestBeadsTaskRepository(
+      {
+        resolveCliContext() {
+          return Effect.tryPromise({
+            try: async () => {
+              throw new Error("Dolt preflight should run before context resolution.");
+            },
+            catch: (cause) =>
+              new HostOperationError({
+                operation: "test.effect",
+                message: cause instanceof Error ? cause.message : String(cause),
+                cause: cause,
+              }),
+          });
+        },
       },
-    });
+      createToolDiscoveryPort(["dolt"]),
+    );
     await expect(Effect.runPromise(port.listTasks({ repoPath: "/repo" }))).rejects.toThrow(
       "dolt not found. Checked OPENDUCKTOR_DOLT_PATH, PATH. Install dolt and ensure it is available on PATH, or set OPENDUCKTOR_DOLT_PATH.",
     );
   });
   test("diagnoses existing Beads store without requiring Dolt when preparation is disabled", async () => {
     const context = await createExistingBeadsCliContext();
-    const port = createTestBeadsTaskRepository({
-      toolDiscovery: createToolDiscoveryPort(["dolt"]),
-      resolveCliContext: () => Effect.succeed(context),
-      runBdJson() {
-        return Effect.succeed({ path: context.beadsDir });
+    const port = createTestBeadsTaskRepository(
+      {
+        resolveCliContext: () => Effect.succeed(context),
+        runBdJson() {
+          return Effect.succeed({ path: context.beadsDir });
+        },
       },
-    });
+      createToolDiscoveryPort(["dolt"]),
+    );
 
     await expect(
       Effect.runPromise(port.diagnoseRepoStore?.({ repoPath: "/repo", prepare: false })),

--- a/packages/host/src/adapters/beads/beads-task-repository.test.ts
+++ b/packages/host/src/adapters/beads/beads-task-repository.test.ts
@@ -1,13 +1,18 @@
-import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import path, { delimiter } from "node:path";
+import path from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { Effect } from "effect";
 import { HostOperationError } from "../../effect/host-errors";
 import type { BeadsCommandJsonOutput } from "../../infrastructure/beads/task-store/beads-raw-issue";
-import { createToolDiscoveryAdapter } from "../system/tool-discovery";
 import type { BeadsCliContext, BeadsSharedServerContext } from "./beads-cli-context";
 import { createBeadsTaskRepository } from "./beads-task-repository";
+import {
+  createTestBeadsCliContext as createBeadsCliContext,
+  createExistingTestBeadsCliContext as createExistingBeadsCliContext,
+  createFakeBd,
+  createTestToolDiscoveryPort as createToolDiscoveryPort,
+} from "./beads-test-support";
 
 const encodedMarkdown = (markdown: string): string => gzipSync(markdown).toString("base64");
 type RawTaskFixture = { [key in string]?: BeadsCommandJsonOutput };
@@ -22,57 +27,6 @@ const rawTask = (overrides: RawTaskFixture = {}): RawTaskFixture => ({
   created_at: "2026-05-10T00:00:00Z",
   ...overrides,
 });
-const TEST_BEADS_TOOL_PATHS = {
-  beads: "bd",
-};
-
-const TEST_SHARED_DOLT_TOOL_PATHS = {
-  dolt: "dolt",
-};
-const createToolDiscoveryPort = (missingCommands: string[] = []) =>
-  createToolDiscoveryAdapter({
-    systemCommands: {
-      resolveCommandPath: (command) =>
-        Effect.succeed(missingCommands.includes(command) ? null : command),
-      versionCommand: () => Effect.succeed(null),
-      runCommandAllowFailure: () => Effect.succeed({ ok: false, stdout: "", stderr: "" }),
-    },
-  });
-const createBeadsCliContext = (beadsDir: string): BeadsSharedServerContext => ({
-  repoPath: "/repo",
-  repoId: "repo-12345678",
-  databaseName: "odt_repo_123456789abc",
-  attachmentRoot: path.dirname(beadsDir),
-  beadsDir,
-  workingDir: path.dirname(beadsDir),
-  serverStatePath: "/config/beads/shared-server/server.json",
-  sharedServer: {
-    pid: process.pid,
-    host: "127.0.0.1",
-    port: 36000,
-    user: "root",
-    ownerPid: process.pid,
-    acquisition: "started_by_owner",
-    sharedServerRoot: "/config/beads/shared-server",
-    doltDataDir: "/config/beads/shared-server/dolt",
-    startedAt: "2026-05-10T00:00:00Z",
-  },
-  env: {
-    BEADS_DIR: beadsDir,
-    BEADS_DOLT_SERVER_MODE: "1",
-    BEADS_DOLT_SERVER_HOST: "127.0.0.1",
-    BEADS_DOLT_SERVER_PORT: "36000",
-    BEADS_DOLT_SERVER_USER: "root",
-  },
-  tools: TEST_BEADS_TOOL_PATHS,
-  sharedDoltTools: TEST_SHARED_DOLT_TOOL_PATHS,
-});
-const createExistingBeadsCliContext = async (): Promise<BeadsSharedServerContext> => {
-  const attachmentRoot = await mkdtemp(path.join(tmpdir(), "odt-beads-test-"));
-  const beadsDir = path.join(attachmentRoot, ".beads");
-  await mkdir(beadsDir);
-  return createBeadsCliContext(beadsDir);
-};
 const createTestBeadsTaskRepository = (
   input: Omit<Parameters<typeof createBeadsTaskRepository>[0], "toolDiscovery"> &
     Partial<Pick<Parameters<typeof createBeadsTaskRepository>[0], "toolDiscovery">>,
@@ -81,19 +35,6 @@ const createTestBeadsTaskRepository = (
     toolDiscovery: createToolDiscoveryPort(),
     ...input,
   });
-const createFakeBd = async (binDir: string, script: string): Promise<string> => {
-  const scriptPath = path.join(binDir, "bd.mjs");
-  await writeFile(scriptPath, script);
-  if (process.platform === "win32") {
-    const bdPath = path.join(binDir, "bd.cmd");
-    await writeFile(bdPath, `@echo off\r\nbun "%~dp0bd.mjs" %*\r\n`);
-    return bdPath;
-  }
-  const bdPath = path.join(binDir, "bd");
-  await writeFile(bdPath, `#!/bin/sh\nexec bun "$(dirname "$0")/bd.mjs" "$@"\n`);
-  await chmod(bdPath, 0o755);
-  return bdPath;
-};
 describe("createBeadsTaskRepository", () => {
   test("stops the owned shared Dolt server on close", async () => {
     const context = await createExistingBeadsCliContext();
@@ -497,7 +438,6 @@ describe("createBeadsTaskRepository", () => {
       `console.log(JSON.stringify([{ id: "task-1", title: "Task", status: "open", priority: 0, issue_type: "task", labels: [], updated_at: "2026-05-10T00:00:00Z", created_at: "2026-05-10T00:00:00Z" }]));\n`,
     );
     context.tools = { beads: bdPath };
-    context.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
     const requestedWorkspaceIds: Array<string | null | undefined> = [];
     const port = createTestBeadsTaskRepository({
       resolveWorkspaceIdForRepoPath() {
@@ -550,7 +490,6 @@ if (args.join(" ") === "list --limit 0 --json") {
 `,
     );
     context.tools = { beads: bdPath };
-    context.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
     const requestedWorkspaceIds: Array<string | null | undefined> = [];
     const port = createTestBeadsTaskRepository({
       resolveWorkspaceIdForRepoPath() {

--- a/packages/host/src/adapters/beads/beads-task-repository.ts
+++ b/packages/host/src/adapters/beads/beads-task-repository.ts
@@ -1,9 +1,4 @@
-import { Cause, Clock, Effect } from "effect";
-import { HostOperationError, toHostOperationError } from "../../effect/host-errors";
-import {
-  defaultRunBd,
-  defaultRunBdJson,
-} from "../../infrastructure/beads/task-store/beads-command-runner";
+import { Clock, Effect } from "effect";
 import { diagnoseRepoStoreWithBd } from "../../infrastructure/beads/task-store/beads-documents";
 import {
   clearAgentSessionsByRolesWithBd,
@@ -18,7 +13,6 @@ import {
 import type {
   BeadsTaskRepository,
   CreateBeadsTaskRepositoryInput,
-  ResolveBeadsCliContext,
 } from "../../infrastructure/beads/task-store/beads-raw-issue";
 import {
   createTaskWithBd,
@@ -30,22 +24,10 @@ import {
   transitionTaskWithBd,
   updateTaskWithBd,
 } from "../../infrastructure/beads/task-store/beads-task-commands";
-import type { TaskStoreError } from "../../ports/task-repository-ports";
-import {
-  type BeadsCliContext,
-  resolveBeadsCliContext,
-  stopOwnedSharedDoltServer,
-} from "./beads-cli-context";
-import {
-  awaitBeadsCliContextFlight,
-  type BeadsCliContextFlight,
-  makeBeadsCliContextFlight,
-  resolveBeadsCliContextFlight,
-} from "./beads-cli-context-flight";
-import { createBeadsCliContextRequestResolver } from "./beads-cli-context-request";
+import { createBdCommandProvider } from "./bd-command-provider";
+import { createBeadsCliContextManager } from "./beads-cli-context-manager";
 import { cloneTasks, createTaskListCache } from "./beads-task-list-cache";
 import { mapTaskStoreErrors } from "./beads-task-store-errors";
-import { createBeadsToolPathResolver, createSharedDoltToolPathResolver } from "./beads-tool-paths";
 
 export type { BeadsTaskRepository } from "../../infrastructure/beads/task-store/beads-raw-issue";
 
@@ -54,157 +36,27 @@ export const createBeadsTaskRepository = ({
   processEnv = process.env,
   runBd,
   runBdJson,
-  resolveCliContext = resolveBeadsCliContext,
+  resolveCliContext,
   resolveWorkspaceIdForRepoPath,
-  stopSharedDoltServer = stopOwnedSharedDoltServer,
+  stopSharedDoltServer,
   toolDiscovery,
 }: CreateBeadsTaskRepositoryInput): BeadsTaskRepository => {
-  const ownedSharedDoltServers = new Map<string, BeadsCliContext["sharedServer"]>();
-  const cliContextFlights = new Set<BeadsCliContextFlight>();
-  const readyCliContexts = new Map<string, BeadsCliContextFlight>();
   const taskListCache = createTaskListCache();
-  let closing = false;
-  const resolveBeadsToolPaths = createBeadsToolPathResolver(toolDiscovery);
-  const resolveSharedDoltToolPaths = createSharedDoltToolPathResolver(toolDiscovery);
-  const resolveContextRequest = createBeadsCliContextRequestResolver({
-    isClosing: () => closing,
+  const cliContextManager = createBeadsCliContextManager({
     processEnv,
-    resolveBeadsToolPaths,
-    resolveSharedDoltToolPaths,
+    toolDiscovery,
+    ...(resolveCliContext === undefined ? {} : { resolveCliContext }),
+    ...(stopSharedDoltServer === undefined ? {} : { stopSharedDoltServer }),
     ...(resolveWorkspaceIdForRepoPath === undefined ? {} : { resolveWorkspaceIdForRepoPath }),
   });
-  const trackOwnedSharedServer = (context: BeadsCliContext): BeadsCliContext => {
-    if (context.sharedServer?.ownerPid === process.pid) {
-      ownedSharedDoltServers.set(context.serverStatePath, context.sharedServer);
-    }
-    return context;
-  };
-  const trackCliContextResolution = (
-    contextEffect: Effect.Effect<BeadsCliContext, TaskStoreError>,
-  ): Effect.Effect<BeadsCliContext, TaskStoreError> =>
-    Effect.uninterruptibleMask((restore) =>
-      Effect.gen(function* () {
-        const flight = yield* Effect.sync(() => {
-          const nextFlight = makeBeadsCliContextFlight();
-          cliContextFlights.add(nextFlight);
-          return nextFlight;
-        });
-        yield* Effect.forkDaemon(
-          resolveBeadsCliContextFlight({
-            flight,
-            releaseReservation: Effect.sync(() => cliContextFlights.delete(flight)),
-            rememberOwnedContext: trackOwnedSharedServer,
-            resolveContext: contextEffect,
-          }),
-        );
-        return yield* restore(awaitBeadsCliContextFlight(flight));
-      }),
-    );
-  const resolveEffectiveCliContext: ResolveBeadsCliContext = (repoPath, options = {}) =>
-    Effect.gen(function* () {
-      const request = yield* resolveContextRequest(repoPath, options);
-      if (request.options.requireSharedServer !== true) {
-        return yield* trackCliContextResolution(
-          resolveCliContext(request.repoPath, request.options),
-        );
-      }
-      const sharedServerOptions = request.options;
-      return yield* Effect.uninterruptibleMask((restore) =>
-        Effect.gen(function* () {
-          const reservation = yield* Effect.sync(() => {
-            const cached = readyCliContexts.get(request.cacheKey);
-            if (cached) {
-              return { _tag: "existing" as const, flight: cached };
-            }
-            const flight = makeBeadsCliContextFlight();
-            cliContextFlights.add(flight);
-            readyCliContexts.set(request.cacheKey, flight);
-            return { _tag: "created" as const, flight };
-          });
-          if (reservation._tag === "existing") {
-            return yield* restore(awaitBeadsCliContextFlight(reservation.flight));
-          }
-          yield* Effect.forkDaemon(
-            resolveBeadsCliContextFlight({
-              evictCachedContext: Effect.sync(() => {
-                if (readyCliContexts.get(request.cacheKey) === reservation.flight) {
-                  readyCliContexts.delete(request.cacheKey);
-                }
-              }),
-              flight: reservation.flight,
-              releaseReservation: Effect.sync(() => cliContextFlights.delete(reservation.flight)),
-              rememberOwnedContext: trackOwnedSharedServer,
-              resolveContext: resolveCliContext(request.repoPath, sharedServerOptions),
-            }),
-          );
-          return yield* restore(awaitBeadsCliContextFlight(reservation.flight));
-        }),
-      );
-    }).pipe(
-      Effect.mapError((cause) =>
-        toHostOperationError(cause, "beadsTaskRepository.resolveEffectiveCliContext", {
-          repoPath,
-          requireSharedServer: options.requireSharedServer === true,
-        }),
-      ),
-    );
-  const effectiveRunBd = runBd ?? defaultRunBd(resolveEffectiveCliContext);
-  const effectiveRunBdJson = runBdJson ?? defaultRunBdJson(resolveEffectiveCliContext);
-  const runBdJsonForRepo = (repoPath: string) =>
-    Effect.gen(function* () {
-      if (runBdJson) {
-        return effectiveRunBdJson;
-      }
-      const context = yield* resolveEffectiveCliContext(repoPath, { requireSharedServer: true });
-      return (commandRepoPath: string, args: string[]) =>
-        effectiveRunBdJson(commandRepoPath, args, context);
-    });
-  const runBdForRepo = (repoPath: string) =>
-    Effect.gen(function* () {
-      if (runBd) {
-        return effectiveRunBd;
-      }
-      const context = yield* resolveEffectiveCliContext(repoPath, { requireSharedServer: true });
-      return (commandRepoPath: string, args: string[]) =>
-        effectiveRunBd(commandRepoPath, args, context);
-    });
+  const commandProvider = createBdCommandProvider({
+    resolveCliContext: cliContextManager.resolveCliContext,
+    ...(runBd === undefined ? {} : { runBd }),
+    ...(runBdJson === undefined ? {} : { runBdJson }),
+  });
   const repository: BeadsTaskRepository = {
     close() {
-      return Effect.gen(function* () {
-        closing = true;
-        yield* Effect.forEach(
-          [...cliContextFlights],
-          (flight) => Effect.either(awaitBeadsCliContextFlight(flight)),
-          { concurrency: "unbounded" },
-        );
-        const errors: string[] = [];
-        let stoppedSharedDoltServers = 0;
-        for (const [serverStatePath, sharedServer] of ownedSharedDoltServers) {
-          if (!sharedServer) {
-            continue;
-          }
-          const stopResult = yield* Effect.exit(
-            stopSharedDoltServer(sharedServer, serverStatePath),
-          );
-          if (stopResult._tag === "Success") {
-            stoppedSharedDoltServers += 1;
-            ownedSharedDoltServers.delete(serverStatePath);
-          } else {
-            const message = Cause.pretty(stopResult.cause);
-            errors.push(`Failed stopping shared Dolt server ${sharedServer.pid}: ${message}`);
-          }
-        }
-        if (errors.length > 0) {
-          return yield* Effect.fail(
-            new HostOperationError({
-              operation: "beadsTaskRepository.close",
-              message: errors.join("\n"),
-              details: { failures: errors },
-            }),
-          );
-        }
-        return { stoppedSharedDoltServers };
-      });
+      return cliContextManager.close();
     },
     listTasks({ repoPath, doneVisibleDays }) {
       return Effect.gen(function* () {
@@ -217,7 +69,7 @@ export const createBeadsTaskRepository = ({
         if (cached.tasks) {
           return cached.tasks;
         }
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const tasks = yield* listTasksWithBd(runBdJsonForOperation, now, repoPath, doneVisibleDays);
         taskListCache.cacheTaskListIfGeneration(
           repoPath,
@@ -231,35 +83,35 @@ export const createBeadsTaskRepository = ({
     },
     getTask({ repoPath, taskId }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         return yield* getTaskWithBd(runBdJsonForOperation, repoPath, taskId);
       });
     },
     getTaskMetadata({ repoPath, taskId }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         return yield* getTaskMetadataWithBd(runBdJsonForOperation, repoPath, taskId);
       });
     },
     diagnoseRepoStore({ repoPath, prepare = false }) {
       return Effect.gen(function* () {
         return yield* diagnoseRepoStoreWithBd(
-          effectiveRunBdJson,
+          commandProvider.runBdJson,
           repoPath,
-          resolveEffectiveCliContext,
+          commandProvider.resolveCliContext,
           prepare,
         );
       });
     },
     listPullRequestSyncCandidates({ repoPath }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         return yield* listPullRequestSyncCandidatesWithBd(runBdJsonForOperation, now, repoPath);
       });
     },
     setSpecDocument({ repoPath, taskId, markdown }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const document = yield* writeDocumentWithBd(
           runBdJsonForOperation,
           now,
@@ -274,7 +126,7 @@ export const createBeadsTaskRepository = ({
     },
     setPlanDocument({ repoPath, taskId, markdown }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const document = yield* writeDocumentWithBd(
           runBdJsonForOperation,
           now,
@@ -289,7 +141,7 @@ export const createBeadsTaskRepository = ({
     },
     recordQaOutcome({ repoPath, taskId, status, markdown, verdict }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const task = yield* recordQaOutcomeWithBd(
           runBdJsonForOperation,
           now,
@@ -305,7 +157,7 @@ export const createBeadsTaskRepository = ({
     },
     upsertAgentSession({ repoPath, taskId, session }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const updated = yield* upsertAgentSessionWithBd(
           runBdJsonForOperation,
           repoPath,
@@ -318,7 +170,7 @@ export const createBeadsTaskRepository = ({
     },
     setPullRequest({ repoPath, taskId, pullRequest }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const updated = yield* setPullRequestWithBd(
           runBdJsonForOperation,
           repoPath,
@@ -331,7 +183,7 @@ export const createBeadsTaskRepository = ({
     },
     setDirectMerge({ repoPath, taskId, directMerge }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const updated = yield* setDirectMergeWithBd(
           runBdJsonForOperation,
           repoPath,
@@ -344,7 +196,7 @@ export const createBeadsTaskRepository = ({
     },
     clearAgentSessionsByRoles({ repoPath, taskId, roles }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const updated = yield* clearAgentSessionsByRolesWithBd(
           runBdJsonForOperation,
           repoPath,
@@ -357,7 +209,7 @@ export const createBeadsTaskRepository = ({
     },
     clearWorkflowDocuments({ repoPath, taskId }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const updated = yield* clearWorkflowDocumentsWithBd(
           runBdJsonForOperation,
           repoPath,
@@ -369,7 +221,7 @@ export const createBeadsTaskRepository = ({
     },
     clearQaReports({ repoPath, taskId }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const updated = yield* clearQaReportsWithBd(runBdJsonForOperation, repoPath, taskId);
         taskListCache.invalidateTaskListCache(repoPath);
         return updated;
@@ -377,7 +229,7 @@ export const createBeadsTaskRepository = ({
     },
     createTask({ repoPath, task }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const created = yield* createTaskWithBd(runBdJsonForOperation, repoPath, task);
         taskListCache.invalidateTaskListCache(repoPath);
         return created;
@@ -385,7 +237,7 @@ export const createBeadsTaskRepository = ({
     },
     updateTask({ repoPath, taskId, patch }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const updated = yield* updateTaskWithBd(runBdJsonForOperation, repoPath, taskId, patch);
         taskListCache.invalidateTaskListCache(repoPath);
         return updated;
@@ -393,7 +245,7 @@ export const createBeadsTaskRepository = ({
     },
     transitionTask({ repoPath, taskId, status }) {
       return Effect.gen(function* () {
-        const runBdJsonForOperation = yield* runBdJsonForRepo(repoPath);
+        const runBdJsonForOperation = yield* commandProvider.runBdJsonForRepo(repoPath);
         const updated = yield* transitionTaskWithBd(
           runBdJsonForOperation,
           repoPath,
@@ -406,7 +258,7 @@ export const createBeadsTaskRepository = ({
     },
     deleteTask({ repoPath, taskId, deleteSubtasks }) {
       return Effect.gen(function* () {
-        const runBdForOperation = yield* runBdForRepo(repoPath);
+        const runBdForOperation = yield* commandProvider.runBdForRepo(repoPath);
         const deleted = yield* deleteTaskWithBd(
           runBdForOperation,
           repoPath,

--- a/packages/host/src/adapters/beads/beads-task-repository.ts
+++ b/packages/host/src/adapters/beads/beads-task-repository.ts
@@ -98,7 +98,7 @@ export const createBeadsTaskRepository = ({
         return yield* diagnoseRepoStoreWithBd(
           commandProvider.runBdJson,
           repoPath,
-          commandProvider.resolveCliContext,
+          cliContextManager.resolveCliContext,
           prepare,
         );
       });

--- a/packages/host/src/adapters/beads/beads-test-support.ts
+++ b/packages/host/src/adapters/beads/beads-test-support.ts
@@ -1,0 +1,89 @@
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Effect } from "effect";
+import { HostOperationError } from "../../effect/host-errors";
+import { createToolDiscoveryAdapter } from "../system/tool-discovery";
+import type { BeadsSharedServerContext } from "./beads-cli-context";
+
+export const createTestToolDiscoveryPort = (missingCommands: string[] = []) =>
+  createToolDiscoveryAdapter({
+    systemCommands: {
+      resolveCommandPath: (command) =>
+        Effect.succeed(missingCommands.includes(command) ? null : command),
+      runCommandAllowFailure: () => Effect.succeed({ ok: false, stdout: "", stderr: "" }),
+      versionCommand: () => Effect.succeed(null),
+    },
+  });
+
+export const createTestBeadsCliContext = (
+  beadsDir: string,
+  bdPath = "bd",
+): BeadsSharedServerContext => ({
+  repoPath: "/repo",
+  repoId: "repo-12345678",
+  databaseName: "odt_repo_123456789abc",
+  attachmentRoot: path.dirname(beadsDir),
+  beadsDir,
+  workingDir: path.dirname(beadsDir),
+  serverStatePath: "/config/beads/shared-server/server.json",
+  sharedServer: {
+    pid: process.pid,
+    host: "127.0.0.1",
+    port: 36000,
+    user: "root",
+    ownerPid: process.pid,
+    acquisition: "started_by_owner",
+    sharedServerRoot: "/config/beads/shared-server",
+    doltDataDir: "/config/beads/shared-server/dolt",
+    startedAt: "2026-05-10T00:00:00Z",
+  },
+  env: {
+    ...(process.env.PATH === undefined ? {} : { PATH: process.env.PATH }),
+    BEADS_DIR: beadsDir,
+    BEADS_DOLT_SERVER_MODE: "1",
+    BEADS_DOLT_SERVER_HOST: "127.0.0.1",
+    BEADS_DOLT_SERVER_PORT: "36000",
+    BEADS_DOLT_SERVER_USER: "root",
+  },
+  tools: {
+    beads: bdPath,
+  },
+  sharedDoltTools: {
+    dolt: "dolt",
+  },
+});
+
+export const createExistingTestBeadsCliContext = async ({
+  bdPath = "bd",
+  prefix = "odt-beads-test-",
+}: {
+  bdPath?: string;
+  prefix?: string;
+} = {}): Promise<BeadsSharedServerContext> => {
+  const attachmentRoot = await mkdtemp(path.join(tmpdir(), prefix));
+  const beadsDir = path.join(attachmentRoot, ".beads");
+  await mkdir(beadsDir);
+  return createTestBeadsCliContext(beadsDir, bdPath);
+};
+
+export const createFakeBd = async (binDir: string, script: string): Promise<string> => {
+  const scriptPath = path.join(binDir, "bd.mjs");
+  await writeFile(scriptPath, script);
+  if (process.platform === "win32") {
+    const bdPath = path.join(binDir, "bd.cmd");
+    await writeFile(bdPath, `@echo off\r\nbun "%~dp0bd.mjs" %*\r\n`);
+    return bdPath;
+  }
+  const bdPath = path.join(binDir, "bd");
+  await writeFile(bdPath, `#!/bin/sh\nexec bun "$(dirname "$0")/bd.mjs" "$@"\n`);
+  await chmod(bdPath, 0o755);
+  return bdPath;
+};
+
+export const testOperationError = (cause: unknown) =>
+  new HostOperationError({
+    operation: "test.effect",
+    message: cause instanceof Error ? cause.message : String(cause),
+    cause,
+  });

--- a/packages/host/src/adapters/beads/test-support/beads-test-support.ts
+++ b/packages/host/src/adapters/beads/test-support/beads-test-support.ts
@@ -2,9 +2,9 @@ import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Effect } from "effect";
-import { HostOperationError } from "../../effect/host-errors";
-import { createToolDiscoveryAdapter } from "../system/tool-discovery";
-import type { BeadsSharedServerContext } from "./beads-cli-context";
+import { HostOperationError } from "../../../effect/host-errors";
+import { createToolDiscoveryAdapter } from "../../system/tool-discovery";
+import type { BeadsSharedServerContext } from "../beads-cli-context";
 
 export const createTestToolDiscoveryPort = (missingCommands: string[] = []) =>
   createToolDiscoveryAdapter({


### PR DESCRIPTION
Summary
This PR extracts Beads CLI lifecycle responsibilities out of `createBeadsTaskRepository` so the repository can focus on task operations and cache invalidation.

Goal
`createBeadsTaskRepository` previously owned CLI context resolution, shared Dolt server ownership and shutdown, command-runner binding, task-list caching, task operations, and error mapping in one large adapter factory. The goal is to separate Beads process lifecycle behavior from task mutation/read behavior, making shutdown semantics and command binding easier to reason about and test independently.

Technical choices
- Added `BeadsCliContextManager` to own Beads context request resolution, shared-server context flights, failed-flight eviction before retry, owned shared Dolt server tracking, and close-time shutdown.
- Added `BdCommandProvider` to bind default `bd` and `bd --json` runners to a repo-scoped shared-server context while preserving configured runner behavior without pre-resolving context.
- Kept `createBeadsTaskRepository` focused on task operations, task-list cache invalidation, diagnostics wiring, and error mapping.
- Moved shared Beads adapter fixtures into focused test support. Lifecycle behavior now lives in the manager tests; repository tests keep only a narrow close-delegation seam plus task operation behavior.
- Per the cleanup pass, removed unused provider surface and duplicate repository-level lifecycle coverage.

Verification
- No `Cargo.toml` exists in this checkout, so cargo checks do not apply.
- `bun run lint` passed. It still reports existing optional-chain warnings outside this Beads scope, but exits successfully.
- `bun run typecheck` passed.
- `bun run test` passed.
- `bun run build` passed. Build emits existing Vite/chunk-size warnings, but exits successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced concurrent request handling and shared server lifecycle management
  * Improved error recovery for context resolution failures
  * Better resource cleanup and graceful shutdown

<!-- end of auto-generated comment: release notes by coderabbit.ai -->