### PR TITLE
fix(transcript): standardize runtime file diffs

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
@@ -90,7 +90,7 @@ describe("CodexAppServerAdapter history hydration", () => {
             toolType: "file_edit",
             input: expect.objectContaining({ patch: expect.stringContaining("@@") }),
             output: expect.stringContaining("@@"),
-            fileChanges: [
+            fileDiffs: [
               {
                 file: "/repo/src/app.ts",
                 type: "modified",

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
@@ -93,7 +93,7 @@ describe("CodexAppServerAdapter history hydration", () => {
             fileChanges: [
               {
                 file: "/repo/src/app.ts",
-                type: "update",
+                type: "modified",
                 additions: 1,
                 deletions: 1,
                 diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n",

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
@@ -90,11 +90,15 @@ describe("CodexAppServerAdapter history hydration", () => {
             toolType: "file_edit",
             input: expect.objectContaining({ patch: expect.stringContaining("@@") }),
             output: expect.stringContaining("@@"),
-            metadata: expect.objectContaining({
-              changes: expect.arrayContaining([
-                expect.objectContaining({ path: "/repo/src/app.ts" }),
-              ]),
-            }),
+            fileChanges: [
+              {
+                file: "/repo/src/app.ts",
+                type: "update",
+                additions: 1,
+                deletions: 1,
+                diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new",
+              },
+            ],
           }),
         ],
       }),

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
@@ -96,7 +96,7 @@ describe("CodexAppServerAdapter history hydration", () => {
                 type: "update",
                 additions: 1,
                 deletions: 1,
-                diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new",
+                diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n",
               },
             ],
           }),
@@ -205,7 +205,13 @@ describe("CodexAppServerAdapter history hydration", () => {
         externalSessionId: "thread/start-runtime-ensure",
       }),
     ).resolves.toEqual([
-      { file: "src/app.ts", type: "modified", additions: 1, deletions: 0, diff: "@@" },
+      {
+        file: "src/app.ts",
+        type: "modified",
+        additions: 1,
+        deletions: 0,
+        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n",
+      },
     ]);
   });
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
@@ -329,7 +329,13 @@ describe("CodexAppServerAdapter lifecycle", () => {
         externalSessionId: "thread-saved",
       }),
     ).resolves.toEqual([
-      { file: "src/app.ts", type: "modified", additions: 1, deletions: 0, diff: "@@" },
+      {
+        file: "src/app.ts",
+        type: "modified",
+        additions: 1,
+        deletions: 0,
+        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n",
+      },
     ]);
 
     expect(ensureRepoRuntime).toHaveBeenCalledTimes(2);

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -454,7 +454,7 @@ describe("CodexAppServerAdapter streaming", () => {
           tool: "apply_patch",
           toolType: "file_edit",
           input: { patch },
-          output: patch,
+          output: "--- a/repo/src/app.ts\n+++ b/repo/src/app.ts\n@@\n-old\n+new",
         }),
         expect.objectContaining({
           tool: "webSearch",

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -306,7 +306,13 @@ export class RecordingTransport implements CodexJsonRpcTransport {
           data: [
             {
               fileChanges: [
-                { file: "src/app.ts", type: "modified", additions: 1, deletions: 0, diff: "@@" },
+                {
+                  file: "src/app.ts",
+                  type: "modified",
+                  additions: 1,
+                  deletions: 0,
+                  diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n",
+                },
               ],
             },
           ],

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -83,10 +83,10 @@ import {
   codexTodosFromThreadRead,
   codexTurnItemsFromThreadRead,
   extractCodexTokenUsageTotals,
-  toFileDiffs,
   toHistoryMessage,
 } from "./codex-app-server-transcript";
 import { createCodexEventMapperPipeline } from "./codex-event-mapper-pipeline";
+import { toFileDiffs } from "./codex-file-diffs";
 import { projectCodexCanonicalEventsToHistory } from "./codex-history-projector";
 import { CodexRuntimeClientResolver } from "./codex-runtime-client-resolver";
 import {

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -1,4 +1,3 @@
-import type { FileDiff } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentStreamPart, AgentUserMessagePart } from "@openducktor/core";
 import {
   arrayFromUnknown,
@@ -14,6 +13,12 @@ import {
   stringifyJsonValue,
 } from "./codex-app-server-shared";
 import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
+import {
+  CodexFileDiffParseError,
+  codexFileChangeDiff,
+  codexFileChangeEntries,
+  toFileDiffs,
+} from "./codex-file-diffs";
 import {
   codexDynamicToolDisplayPayload,
   codexDynamicToolErrorFromItem,
@@ -610,20 +615,6 @@ const webSearchInput = (value: Record<string, unknown>): Record<string, unknown>
   return webSearchActionInput(value.action);
 };
 
-const fileChangeDiff = (changes: unknown[]): string | null => {
-  const diffs = changes
-    .filter(isPlainObject)
-    .map((change) => extractStringField(change, ["diff", "patch"]))
-    .filter((diff): diff is string => Boolean(diff));
-  return diffs.length > 0 ? diffs.join("\n") : null;
-};
-
-const fileChangeEntries = (value: Record<string, unknown>): unknown[] => {
-  const changes = arrayFromUnknown(value.changes);
-  const diffs = arrayFromUnknown(value.diffs);
-  return changes.length > 0 ? changes : diffs;
-};
-
 export const extractCodexTokenUsageTotals = (params: unknown): CodexTokenUsageTotals | null => {
   if (!isPlainObject(params)) {
     return null;
@@ -763,9 +754,19 @@ const codexFileChangeStreamParts = (
   messageId: string,
   partId: string,
 ): AgentStreamPart[] => {
-  const changes = fileChangeEntries(value);
-  const diff = fileChangeDiff(changes);
-  const error = codexFileChangeErrorFromItem(value);
+  const changes = codexFileChangeEntries(value);
+  const diff = codexFileChangeDiff(changes);
+  const fileChangesResult = (() => {
+    try {
+      return { fileChanges: toFileDiffs(changes), error: null };
+    } catch (error) {
+      if (error instanceof CodexFileDiffParseError) {
+        return { fileChanges: [], error: error.message };
+      }
+      throw error;
+    }
+  })();
+  const error = fileChangesResult.error ?? codexFileChangeErrorFromItem(value);
   return normalizedCodexToolPart({
     messageId,
     partId,
@@ -774,10 +775,10 @@ const codexFileChangeStreamParts = (
     title: "File changes",
     status: error ? "error" : statusFromCodexStatus(value.status),
     preview: `${changes.length} file change${changes.length === 1 ? "" : "s"}`,
-    ...(diff ? { input: { patch: diff } } : {}),
-    output: diff,
+    ...(fileChangesResult.error ? {} : diff ? { input: { patch: diff }, output: diff } : {}),
     error,
-    metadata: { codexItem: value, changes, diffs: changes, ...(diff ? { diff } : {}) },
+    fileChanges: fileChangesResult.fileChanges,
+    metadata: { codexItem: value },
   });
 };
 
@@ -929,34 +930,6 @@ export const toStreamPart = (
   return [];
 };
 
-export const toFileDiffs = (value: unknown): FileDiff[] => {
-  const entries = arrayFromUnknown(value).flatMap((entry) => {
-    if (!isPlainObject(entry)) {
-      return [entry];
-    }
-    const nested = arrayFromUnknown(entry.fileChanges ?? entry.changes ?? entry.files);
-    return nested.length > 0 ? nested : [entry];
-  });
-  return entries.flatMap((entry): FileDiff[] => {
-    if (!isPlainObject(entry)) {
-      return [];
-    }
-    const file = entry.file ?? entry.path;
-    const diff = entry.diff ?? entry.patch;
-    if (typeof file !== "string" || typeof diff !== "string") {
-      return [];
-    }
-    return [
-      {
-        file,
-        type: typeof entry.type === "string" ? entry.type : "modified",
-        additions: typeof entry.additions === "number" ? entry.additions : 0,
-        deletions: typeof entry.deletions === "number" ? entry.deletions : 0,
-        diff,
-      },
-    ];
-  });
-};
 const toCodexUserInput = (part: AgentUserMessagePart): CodexUserInput => {
   if (part.kind === "text") {
     return { type: "text", text: part.text };

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -15,6 +15,7 @@ import {
 import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
 import {
   CodexFileDiffParseError,
+  codexApplyPatchFileDiffs,
   codexFileChangeDiff,
   codexFileChangeEntries,
   toFileDiffs,
@@ -857,6 +858,7 @@ const codexDynamicToolCallStreamParts = (
   const patch =
     isCodexApplyPatchTool(rawTool) && typeof value.input === "string" ? value.input : null;
   const input = patch ? { ...(args ?? {}), patch } : (args ?? parsedInput ?? undefined);
+  const fileChanges = patch ? codexApplyPatchFileDiffs(patch) : [];
   const resultPayload = codexDynamicToolDisplayPayload(value);
   const output = codexToolResultText(resultPayload);
   const error = codexDynamicToolErrorFromItem(value);
@@ -871,6 +873,7 @@ const codexDynamicToolCallStreamParts = (
     ...(input ? { input } : {}),
     output: failed ? null : (patch ?? output),
     error: error ?? (failed ? output : null),
+    fileChanges,
     metadata: { codexItem: value },
   });
 };

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -16,7 +16,6 @@ import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
 import {
   CodexFileDiffParseError,
   codexApplyPatchFileDiffs,
-  codexFileChangeDiff,
   codexFileChangeEntries,
   toFileDiffs,
 } from "./codex-file-diffs";
@@ -750,13 +749,19 @@ const codexCommandExecutionStreamParts = (
   });
 };
 
+const fileChangesPatchOutput = (fileChanges: ReadonlyArray<{ diff: string }>): string | null => {
+  const diffs = fileChanges
+    .map((fileChange) => fileChange.diff.trim())
+    .filter((diff) => diff.length > 0);
+  return diffs.length > 0 ? diffs.join("\n") : null;
+};
+
 const codexFileChangeStreamParts = (
   value: Record<string, unknown>,
   messageId: string,
   partId: string,
 ): AgentStreamPart[] => {
   const changes = codexFileChangeEntries(value);
-  const diff = codexFileChangeDiff(changes);
   const fileChangesResult = (() => {
     try {
       return { fileChanges: toFileDiffs(changes), error: null };
@@ -767,6 +772,7 @@ const codexFileChangeStreamParts = (
       throw error;
     }
   })();
+  const diff = fileChangesPatchOutput(fileChangesResult.fileChanges);
   const error = fileChangesResult.error ?? codexFileChangeErrorFromItem(value);
   return normalizedCodexToolPart({
     messageId,
@@ -859,6 +865,7 @@ const codexDynamicToolCallStreamParts = (
     isCodexApplyPatchTool(rawTool) && typeof value.input === "string" ? value.input : null;
   const input = patch ? { ...(args ?? {}), patch } : (args ?? parsedInput ?? undefined);
   const fileChanges = patch ? codexApplyPatchFileDiffs(patch) : [];
+  const patchOutput = fileChangesPatchOutput(fileChanges);
   const resultPayload = codexDynamicToolDisplayPayload(value);
   const output = codexToolResultText(resultPayload);
   const error = codexDynamicToolErrorFromItem(value);
@@ -871,7 +878,7 @@ const codexDynamicToolCallStreamParts = (
     rawToolName: rawTool,
     status: failed ? "error" : statusFromCodexStatus(value.status),
     ...(input ? { input } : {}),
-    output: failed ? null : (patch ?? output),
+    output: failed ? null : patch ? patchOutput : output,
     error: error ?? (failed ? output : null),
     fileChanges,
     metadata: { codexItem: value },

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -17,6 +17,8 @@ import {
   CodexFileDiffParseError,
   codexApplyPatchFileDiffs,
   codexFileChangeEntries,
+  codexPatchInputFromToolPayload,
+  fileDiffsPatchOutput,
   toFileDiffs,
 } from "./codex-file-diffs";
 import {
@@ -749,31 +751,24 @@ const codexCommandExecutionStreamParts = (
   });
 };
 
-const fileChangesPatchOutput = (fileChanges: ReadonlyArray<{ diff: string }>): string | null => {
-  const diffs = fileChanges
-    .map((fileChange) => fileChange.diff.trim())
-    .filter((diff) => diff.length > 0);
-  return diffs.length > 0 ? diffs.join("\n") : null;
-};
-
 const codexFileChangeStreamParts = (
   value: Record<string, unknown>,
   messageId: string,
   partId: string,
 ): AgentStreamPart[] => {
   const changes = codexFileChangeEntries(value);
-  const fileChangesResult = (() => {
+  const fileDiffsResult = (() => {
     try {
-      return { fileChanges: toFileDiffs(changes), error: null };
+      return { fileDiffs: toFileDiffs(changes), error: null };
     } catch (error) {
       if (error instanceof CodexFileDiffParseError) {
-        return { fileChanges: [], error: error.message };
+        return { fileDiffs: [], error: error.message };
       }
       throw error;
     }
   })();
-  const diff = fileChangesPatchOutput(fileChangesResult.fileChanges);
-  const error = fileChangesResult.error ?? codexFileChangeErrorFromItem(value);
+  const diff = fileDiffsPatchOutput(fileDiffsResult.fileDiffs);
+  const error = fileDiffsResult.error ?? codexFileChangeErrorFromItem(value);
   return normalizedCodexToolPart({
     messageId,
     partId,
@@ -782,9 +777,9 @@ const codexFileChangeStreamParts = (
     title: "File changes",
     status: error ? "error" : statusFromCodexStatus(value.status),
     preview: `${changes.length} file change${changes.length === 1 ? "" : "s"}`,
-    ...(fileChangesResult.error ? {} : diff ? { input: { patch: diff }, output: diff } : {}),
+    ...(fileDiffsResult.error ? {} : diff ? { input: { patch: diff }, output: diff } : {}),
     error,
-    fileChanges: fileChangesResult.fileChanges,
+    fileDiffs: fileDiffsResult.fileDiffs,
     metadata: { codexItem: value },
   });
 };
@@ -861,11 +856,13 @@ const codexDynamicToolCallStreamParts = (
   );
   const args = extractOptionalObject(value, "arguments") ?? codexObjectInput(value.arguments);
   const parsedInput = parseObjectString(value.input);
-  const patch =
-    isCodexApplyPatchTool(rawTool) && typeof value.input === "string" ? value.input : null;
-  const input = patch ? { ...(args ?? {}), patch } : (args ?? parsedInput ?? undefined);
-  const fileChanges = patch ? codexApplyPatchFileDiffs(patch) : [];
-  const patchOutput = fileChangesPatchOutput(fileChanges);
+  const inputObject = args ?? parsedInput;
+  const patch = isCodexApplyPatchTool(rawTool)
+    ? codexPatchInputFromToolPayload(value, inputObject)
+    : null;
+  const input = patch ? { ...(inputObject ?? {}), patch } : (inputObject ?? undefined);
+  const fileDiffs = patch ? codexApplyPatchFileDiffs(patch) : [];
+  const patchOutput = fileDiffsPatchOutput(fileDiffs);
   const resultPayload = codexDynamicToolDisplayPayload(value);
   const output = codexToolResultText(resultPayload);
   const error = codexDynamicToolErrorFromItem(value);
@@ -880,7 +877,7 @@ const codexDynamicToolCallStreamParts = (
     ...(input ? { input } : {}),
     output: failed ? null : patch ? patchOutput : output,
     error: error ?? (failed ? output : null),
-    fileChanges,
+    fileDiffs,
     metadata: { codexItem: value },
   });
 };

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -185,6 +185,59 @@ describe("Codex todo event mapper", () => {
   });
 });
 
+describe("Codex file change event mapper", () => {
+  test("projects live patch updates to running file-change tool parts", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const events = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "notification",
+          notification: {
+            method: "item/fileChange/patchUpdated",
+            params: {
+              itemId: "patch-1",
+              changes: [
+                {
+                  path: "src/new.ts",
+                  kind: { type: "add" },
+                  diff: "created\n",
+                },
+              ],
+            },
+          },
+        },
+        {
+          source: "live",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          timestamp: "2026-05-09T00:00:00.000Z",
+        },
+      ),
+    );
+
+    expect(projectedTool(events)).toEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          tool: "apply_patch",
+          toolType: "file_edit",
+          status: "running",
+          fileDiffs: [
+            {
+              file: "src/new.ts",
+              type: "added",
+              additions: 1,
+              deletions: 0,
+              diff: "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1,1 @@\n+created\n",
+            },
+          ],
+        }),
+      }),
+    );
+  });
+});
+
 describe("Codex compaction event mapper", () => {
   test("projects live context compaction starts to session events", () => {
     const pipeline = createCodexEventMapperPipeline();

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
@@ -14,7 +14,7 @@ describe("Codex file diffs", () => {
     ).toEqual([
       {
         file: "src/app.ts",
-        type: "update",
+        type: "modified",
         additions: 2,
         deletions: 1,
         diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line\n",
@@ -123,6 +123,46 @@ describe("Codex file diffs", () => {
         additions: 2,
         deletions: 0,
         diff: '--- /dev/null\n+++ b/src/AuthContext.test.tsx\n@@ -0,0 +1,2 @@\n+import { render } from "@testing-library/react";\n+function AuthConsumer() {}\n',
+      },
+    ]);
+  });
+
+  test("renders Codex app-server object-kind added file content as an added-file diff", () => {
+    expect(
+      toFileDiffs([
+        {
+          path: "src/new.ts",
+          kind: { type: "add" },
+          diff: "created\n",
+        },
+      ]),
+    ).toEqual([
+      {
+        file: "src/new.ts",
+        type: "added",
+        additions: 1,
+        deletions: 0,
+        diff: "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1,1 @@\n+created\n",
+      },
+    ]);
+  });
+
+  test("renders Codex app-server object-kind deleted file content as a deleted-file diff", () => {
+    expect(
+      toFileDiffs([
+        {
+          path: "src/old.ts",
+          kind: { type: "delete" },
+          diff: "removed\n",
+        },
+      ]),
+    ).toEqual([
+      {
+        file: "src/old.ts",
+        type: "deleted",
+        additions: 0,
+        deletions: 1,
+        diff: "--- a/src/old.ts\n+++ /dev/null\n@@ -1,1 +0,0 @@\n-removed\n",
       },
     ]);
   });

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { CodexFileDiffParseError, toFileDiffs } from "./codex-file-diffs";
+import { CodexFileDiffParseError, codexApplyPatchFileDiffs, toFileDiffs } from "./codex-file-diffs";
 
 describe("Codex file diffs", () => {
   test("parses Codex file change entries and derives missing counts", () => {
@@ -55,5 +55,63 @@ describe("Codex file diffs", () => {
     expect(() => toFileDiffs([{ file: "src/app.ts" }])).toThrow(
       "Malformed Codex file change: entry 0 is missing string file/path or diff/patch fields.",
     );
+  });
+
+  test("infers added and deleted file diffs with CRLF headers", () => {
+    expect(
+      toFileDiffs([
+        {
+          file: "src/new.ts",
+          diff: "--- /dev/null\r\n+++ b/src/new.ts\r\n@@\r\n+new",
+        },
+        {
+          file: "src/old.ts",
+          diff: "--- a/src/old.ts\r\n+++ /dev/null\r\n@@\r\n-old",
+        },
+      ]),
+    ).toEqual([
+      {
+        file: "src/new.ts",
+        type: "added",
+        additions: 1,
+        deletions: 0,
+        diff: "--- /dev/null\r\n+++ b/src/new.ts\r\n@@\r\n+new",
+      },
+      {
+        file: "src/old.ts",
+        type: "deleted",
+        additions: 0,
+        deletions: 1,
+        diff: "--- a/src/old.ts\r\n+++ /dev/null\r\n@@\r\n-old",
+      },
+    ]);
+  });
+
+  test("parses Codex apply_patch input into structured file diffs", () => {
+    expect(
+      codexApplyPatchFileDiffs(`*** Begin Patch
+*** Update File: src/app.ts
+@@
+-old
++new
+*** Add File: src/new.ts
++created
+*** End Patch`),
+    ).toEqual([
+      {
+        file: "src/app.ts",
+        type: "modified",
+        additions: 1,
+        deletions: 1,
+        diff: "*** Update File: src/app.ts\n@@\n-old\n+new",
+      },
+      {
+        file: "src/new.ts",
+        type: "added",
+        additions: 1,
+        deletions: 0,
+        diff: "*** Add File: src/new.ts\n+created",
+      },
+    ]);
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
@@ -87,17 +87,44 @@ describe("Codex file diffs", () => {
     ]);
   });
 
-  test("rejects Codex file changes that contain full file text instead of a diff", () => {
-    expect(() =>
+  test("keeps modified Codex full-file text metadata-only instead of failing the tool", () => {
+    expect(
       toFileDiffs([
         {
           file: "src/app.ts",
+          type: "modified",
           diff: 'import { render } from "@testing-library/react";\nfunction AuthConsumer() {}\n',
         },
       ]),
-    ).toThrow(
-      "Malformed Codex file change: entry 0 diff/patch for 'src/app.ts' is not a renderable file diff.",
-    );
+    ).toEqual([
+      {
+        file: "src/app.ts",
+        type: "modified",
+        additions: 0,
+        deletions: 0,
+        diff: "",
+      },
+    ]);
+  });
+
+  test("renders added Codex full-file text as an added-file diff", () => {
+    expect(
+      toFileDiffs([
+        {
+          file: "src/AuthContext.test.tsx",
+          type: "added",
+          diff: 'import { render } from "@testing-library/react";\nfunction AuthConsumer() {}\n',
+        },
+      ]),
+    ).toEqual([
+      {
+        file: "src/AuthContext.test.tsx",
+        type: "added",
+        additions: 2,
+        deletions: 0,
+        diff: '--- /dev/null\n+++ b/src/AuthContext.test.tsx\n@@ -0,0 +1,2 @@\n+import { render } from "@testing-library/react";\n+function AuthConsumer() {}\n',
+      },
+    ]);
   });
 
   test("strips Codex full-file preambles before hunk-only diffs", () => {

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { CodexFileDiffParseError, toFileDiffs } from "./codex-file-diffs";
+
+describe("Codex file diffs", () => {
+  test("parses Codex file change entries and derives missing counts", () => {
+    expect(
+      toFileDiffs([
+        {
+          path: "src/app.ts",
+          kind: "update",
+          diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line",
+        },
+      ]),
+    ).toEqual([
+      {
+        file: "src/app.ts",
+        type: "update",
+        additions: 2,
+        deletions: 1,
+        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line",
+      },
+    ]);
+  });
+
+  test("parses nested Codex turn diff entries", () => {
+    expect(
+      toFileDiffs({
+        data: [
+          {
+            fileChanges: [
+              {
+                file: "src/app.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 0,
+                diff: "@@\n+new",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        file: "src/app.ts",
+        type: "modified",
+        additions: 1,
+        deletions: 0,
+        diff: "@@\n+new",
+      },
+    ]);
+  });
+
+  test("rejects malformed Codex file change entries", () => {
+    expect(() => toFileDiffs([{ file: "src/app.ts" }])).toThrow(CodexFileDiffParseError);
+    expect(() => toFileDiffs([{ file: "src/app.ts" }])).toThrow(
+      "Malformed Codex file change: entry 0 is missing string file/path or diff/patch fields.",
+    );
+  });
+});

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
@@ -22,6 +22,27 @@ describe("Codex file diffs", () => {
     ]);
   });
 
+  test("derives counts when Codex runtime counts are not finite", () => {
+    expect(
+      toFileDiffs([
+        {
+          path: "src/app.ts",
+          additions: Number.NaN,
+          deletions: Number.POSITIVE_INFINITY,
+          diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line",
+        },
+      ]),
+    ).toEqual([
+      {
+        file: "src/app.ts",
+        type: "modified",
+        additions: 2,
+        deletions: 1,
+        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line\n",
+      },
+    ]);
+  });
+
   test("parses nested Codex turn diff entries", () => {
     expect(
       toFileDiffs({

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
@@ -17,7 +17,7 @@ describe("Codex file diffs", () => {
         type: "update",
         additions: 2,
         deletions: 1,
-        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line",
+        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line\n",
       },
     ]);
   });
@@ -45,7 +45,7 @@ describe("Codex file diffs", () => {
         type: "modified",
         additions: 1,
         deletions: 0,
-        diff: "@@\n+new",
+        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n+new\n",
       },
     ]);
   });
@@ -75,14 +75,52 @@ describe("Codex file diffs", () => {
         type: "added",
         additions: 1,
         deletions: 0,
-        diff: "--- /dev/null\r\n+++ b/src/new.ts\r\n@@\r\n+new",
+        diff: "--- /dev/null\n+++ b/src/new.ts\n@@\n+new\n",
       },
       {
         file: "src/old.ts",
         type: "deleted",
         additions: 0,
         deletions: 1,
-        diff: "--- a/src/old.ts\r\n+++ /dev/null\r\n@@\r\n-old",
+        diff: "--- a/src/old.ts\n+++ /dev/null\n@@\n-old\n",
+      },
+    ]);
+  });
+
+  test("rejects Codex file changes that contain full file text instead of a diff", () => {
+    expect(() =>
+      toFileDiffs([
+        {
+          file: "src/app.ts",
+          diff: 'import { render } from "@testing-library/react";\nfunction AuthConsumer() {}\n',
+        },
+      ]),
+    ).toThrow(
+      "Malformed Codex file change: entry 0 diff/patch for 'src/app.ts' is not a renderable file diff.",
+    );
+  });
+
+  test("strips Codex full-file preambles before hunk-only diffs", () => {
+    expect(
+      toFileDiffs([
+        {
+          file: "src/AuthContext.test.tsx",
+          diff: `import { render } from "@testing-library/react";
+function AuthConsumer() {}
+
+@@ -1,2 +1,3 @@
+ import { render } from "@testing-library/react";
++import userEvent from "@testing-library/user-event";
+ function AuthConsumer() {}`,
+        },
+      ]),
+    ).toEqual([
+      {
+        file: "src/AuthContext.test.tsx",
+        type: "modified",
+        additions: 1,
+        deletions: 0,
+        diff: '--- a/src/AuthContext.test.tsx\n+++ b/src/AuthContext.test.tsx\n@@ -1,2 +1,3 @@\n import { render } from "@testing-library/react";\n+import userEvent from "@testing-library/user-event";\n function AuthConsumer() {}\n',
       },
     ]);
   });
@@ -103,14 +141,32 @@ describe("Codex file diffs", () => {
         type: "modified",
         additions: 1,
         deletions: 1,
-        diff: "*** Update File: src/app.ts\n@@\n-old\n+new",
+        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n",
       },
       {
         file: "src/new.ts",
         type: "added",
         additions: 1,
         deletions: 0,
-        diff: "*** Add File: src/new.ts\n+created",
+        diff: "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1,1 @@\n+created\n",
+      },
+    ]);
+  });
+
+  test("keeps apply_patch file entries path-only when the body has no renderable diff", () => {
+    expect(
+      codexApplyPatchFileDiffs(`*** Begin Patch
+*** Update File: src/app.ts
+import { render } from "@testing-library/react";
+function AuthConsumer() {}
+*** End Patch`),
+    ).toEqual([
+      {
+        file: "src/app.ts",
+        type: "modified",
+        additions: 0,
+        deletions: 0,
+        diff: "",
       },
     ]);
   });

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
@@ -55,6 +55,9 @@ describe("Codex file diffs", () => {
     expect(() => toFileDiffs([{ file: "src/app.ts" }])).toThrow(
       "Malformed Codex file change: entry 0 is missing string file/path or diff/patch fields.",
     );
+    expect(() => toFileDiffs([{ file: "   ", diff: "@@\n+new" }])).toThrow(
+      "Malformed Codex file change: entry 0 has empty file path.",
+    );
   });
 
   test("infers added and deleted file diffs with CRLF headers", () => {

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.test.ts
@@ -167,6 +167,26 @@ describe("Codex file diffs", () => {
     ]);
   });
 
+  test("uses Codex app-server move targets as the displayed file path", () => {
+    expect(
+      toFileDiffs([
+        {
+          path: "src/old.ts",
+          kind: { type: "update", movePath: "src/new.ts" },
+          diff: "--- a/src/old.ts\n+++ b/src/old.ts\n@@\n-old\n+new\n\nMoved to: src/new.ts",
+        },
+      ]),
+    ).toEqual([
+      {
+        file: "src/new.ts",
+        type: "modified",
+        additions: 1,
+        deletions: 1,
+        diff: "--- a/src/old.ts\n+++ b/src/old.ts\n@@\n-old\n+new\n",
+      },
+    ]);
+  });
+
   test("strips Codex full-file preambles before hunk-only diffs", () => {
     expect(
       toFileDiffs([
@@ -234,6 +254,26 @@ function AuthConsumer() {}
         additions: 0,
         deletions: 0,
         diff: "",
+      },
+    ]);
+  });
+
+  test("parses Codex apply_patch move targets into structured file diffs", () => {
+    expect(
+      codexApplyPatchFileDiffs(`*** Begin Patch
+*** Update File: src/old.ts
+*** Move to: src/new.ts
+@@
+-old
++new
+*** End Patch`),
+    ).toEqual([
+      {
+        file: "src/new.ts",
+        type: "modified",
+        additions: 1,
+        deletions: 1,
+        diff: "--- a/src/new.ts\n+++ b/src/new.ts\n@@\n-old\n+new\n",
       },
     ]);
   });

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.ts
@@ -47,10 +47,10 @@ const inferDiffType = (entry: Record<string, unknown>, diff: string): string => 
   if (typeof explicitType === "string" && explicitType.trim().length > 0) {
     return explicitType;
   }
-  if (/^---\s+\/dev\/null$/m.test(diff)) {
+  if (/^---\s+\/dev\/null\r?$/m.test(diff)) {
     return "added";
   }
-  if (/^\+\+\+\s+\/dev\/null$/m.test(diff)) {
+  if (/^\+\+\+\s+\/dev\/null\r?$/m.test(diff)) {
     return "deleted";
   }
   return "modified";
@@ -94,4 +94,90 @@ export const toFileDiffs = (value: unknown): FileDiff[] => {
 
     return [parseFileDiffEntry(entry, String(entryIndex))];
   });
+};
+
+const APPLY_PATCH_FILE_TYPES = {
+  Add: "added",
+  Delete: "deleted",
+  Update: "modified",
+} as const;
+
+type ApplyPatchFileType = keyof typeof APPLY_PATCH_FILE_TYPES;
+
+type ApplyPatchFileEntry = {
+  file: string;
+  operation: ApplyPatchFileType;
+  lines: string[];
+};
+
+const applyPatchFileHeader = (
+  line: string,
+): { operation: ApplyPatchFileType; file: string } | null => {
+  const match = /^\*\*\* (Add|Delete|Update) File: (.+)$/.exec(line);
+  const operation = match?.[1];
+  const file = match?.[2];
+  if (!operation || !file) {
+    return null;
+  }
+
+  return {
+    operation: operation as ApplyPatchFileType,
+    file: file.trim(),
+  };
+};
+
+const finishApplyPatchEntry = (entry: ApplyPatchFileEntry): FileDiff | null => {
+  if (entry.file.length === 0) {
+    return null;
+  }
+
+  const diff = [`*** ${entry.operation} File: ${entry.file}`, ...entry.lines].join("\n").trimEnd();
+  const counts = countDiffLines(diff);
+  return {
+    file: entry.file,
+    type: APPLY_PATCH_FILE_TYPES[entry.operation],
+    additions: counts.additions,
+    deletions: counts.deletions,
+    diff,
+  };
+};
+
+export const codexApplyPatchFileDiffs = (patch: string): FileDiff[] => {
+  const diffs: FileDiff[] = [];
+  let current: ApplyPatchFileEntry | null = null;
+
+  for (const rawLine of patch.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    const header = applyPatchFileHeader(line);
+    if (header) {
+      if (current) {
+        const diff = finishApplyPatchEntry(current);
+        if (diff) {
+          diffs.push(diff);
+        }
+      }
+      current = { ...header, lines: [] };
+      continue;
+    }
+
+    if (!current || line === "*** Begin Patch" || line === "*** End Patch") {
+      continue;
+    }
+
+    const moveMatch = /^\*\*\* Move to: (.+)$/.exec(line);
+    const movedFile = moveMatch?.[1];
+    if (movedFile) {
+      current.file = movedFile.trim();
+    }
+    current.lines.push(line);
+  }
+
+  if (current) {
+    const diff = finishApplyPatchEntry(current);
+    if (diff) {
+      diffs.push(diff);
+    }
+  }
+
+  return diffs;
 };

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.ts
@@ -42,17 +42,12 @@ const parseFileDiffEntry = (entry: unknown, location: string): FileDiff => {
     );
   }
 
-  const renderableDiff = selectRenderableFileDiff(diff, file);
-  if (!renderableDiff) {
-    throw new CodexFileDiffParseError(
-      `entry ${location} diff/patch for '${file}' is not a renderable file diff.`,
-    );
-  }
-
+  const type = inferDiffType(entry, diff);
+  const renderableDiff = selectRenderableFileDiff(diff, file, { changeType: type }) ?? "";
   const counts = countRenderableFileDiffLines(renderableDiff);
   return {
     file,
-    type: inferDiffType(entry, renderableDiff),
+    type,
     additions: typeof entry.additions === "number" ? entry.additions : counts.additions,
     deletions: typeof entry.deletions === "number" ? entry.deletions : counts.deletions,
     diff: renderableDiff,
@@ -114,11 +109,12 @@ const finishApplyPatchEntry = (entry: ApplyPatchFileEntry): FileDiff | null => {
   const rawDiff = [`*** ${entry.operation} File: ${entry.file}`, ...entry.lines]
     .join("\n")
     .trimEnd();
-  const diff = selectRenderableFileDiff(rawDiff, entry.file) ?? "";
+  const type = APPLY_PATCH_FILE_TYPES[entry.operation];
+  const diff = selectRenderableFileDiff(rawDiff, entry.file, { changeType: type }) ?? "";
   const counts = countRenderableFileDiffLines(diff);
   return {
     file: entry.file,
-    type: APPLY_PATCH_FILE_TYPES[entry.operation],
+    type,
     additions: counts.additions,
     deletions: counts.deletions,
     diff,

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.ts
@@ -73,6 +73,24 @@ const stripMoveTrailer = (diff: string, movePath: string | null): string => {
   return diff.endsWith(trailer) ? diff.slice(0, -trailer.length) : diff;
 };
 
+const selectCodexRenderableDiff = (
+  diff: string,
+  displayedFile: string,
+  sourceFile: string,
+  type: string,
+): string => {
+  const fileCandidates =
+    sourceFile === displayedFile ? [displayedFile] : [sourceFile, displayedFile];
+  for (const fileCandidate of fileCandidates) {
+    const renderableDiff = selectRenderableFileDiff(diff, fileCandidate, { changeType: type });
+    if (renderableDiff) {
+      return renderableDiff;
+    }
+  }
+
+  return "";
+};
+
 const parseFileDiffEntry = (entry: unknown, location: string): FileDiff => {
   if (!isPlainObject(entry)) {
     throw new CodexFileDiffParseError(`entry ${location} must be an object.`);
@@ -87,21 +105,32 @@ const parseFileDiffEntry = (entry: unknown, location: string): FileDiff => {
   }
 
   const movePath = movePathFromKind(entry.kind);
-  const file = movePath ?? rawFile.trim();
+  const sourceFile = rawFile.trim();
+  const file = movePath ?? sourceFile;
   if (file.length === 0) {
     throw new CodexFileDiffParseError(`entry ${location} has empty file path.`);
   }
   const type = inferDiffType(entry, diff);
-  const renderableDiff =
-    selectRenderableFileDiff(stripMoveTrailer(diff, movePath), file, {
-      changeType: type,
-    }) ?? "";
+  const renderableDiff = selectCodexRenderableDiff(
+    stripMoveTrailer(diff, movePath),
+    file,
+    sourceFile,
+    type,
+  );
   const counts = countRenderableFileDiffLines(renderableDiff);
+  const additions =
+    typeof entry.additions === "number" && Number.isFinite(entry.additions)
+      ? entry.additions
+      : counts.additions;
+  const deletions =
+    typeof entry.deletions === "number" && Number.isFinite(entry.deletions)
+      ? entry.deletions
+      : counts.deletions;
   return {
     file,
     type,
-    additions: typeof entry.additions === "number" ? entry.additions : counts.additions,
-    deletions: typeof entry.deletions === "number" ? entry.deletions : counts.deletions,
+    additions,
+    deletions,
     diff: renderableDiff,
   };
 };

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.ts
@@ -15,11 +15,37 @@ export const codexFileChangeEntries = (value: Record<string, unknown>): unknown[
   return changes.length > 0 ? changes : diffs;
 };
 
+const normalizeExplicitDiffType = (value: unknown): string | null => {
+  if (typeof value === "string" && value.trim().length > 0) {
+    const normalized = value.trim();
+    if (normalized === "add") {
+      return "added";
+    }
+    if (normalized === "delete") {
+      return "deleted";
+    }
+    if (normalized === "update") {
+      return "modified";
+    }
+    return normalized;
+  }
+
+  if (isPlainObject(value)) {
+    return normalizeExplicitDiffType(value.type);
+  }
+
+  return null;
+};
+
 const inferDiffType = (entry: Record<string, unknown>, diff: string): string => {
-  const explicitType = entry.type ?? entry.status ?? entry.kind;
-  if (typeof explicitType === "string" && explicitType.trim().length > 0) {
+  const explicitType =
+    normalizeExplicitDiffType(entry.type) ??
+    normalizeExplicitDiffType(entry.status) ??
+    normalizeExplicitDiffType(entry.kind);
+  if (explicitType) {
     return explicitType;
   }
+
   if (/^---\s+\/dev\/null\r?$/m.test(diff)) {
     return "added";
   }

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.ts
@@ -87,7 +87,10 @@ const parseFileDiffEntry = (entry: unknown, location: string): FileDiff => {
   }
 
   const movePath = movePathFromKind(entry.kind);
-  const file = movePath ?? rawFile;
+  const file = movePath ?? rawFile.trim();
+  if (file.length === 0) {
+    throw new CodexFileDiffParseError(`entry ${location} has empty file path.`);
+  }
   const type = inferDiffType(entry, diff);
   const renderableDiff =
     selectRenderableFileDiff(stripMoveTrailer(diff, movePath), file, {

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.ts
@@ -1,0 +1,97 @@
+import type { FileDiff } from "@openducktor/contracts";
+import { arrayFromUnknown, extractStringField, isPlainObject } from "./codex-app-server-shared";
+
+export class CodexFileDiffParseError extends Error {
+  constructor(message: string) {
+    super(`Malformed Codex file change: ${message}`);
+    this.name = "CodexFileDiffParseError";
+  }
+}
+
+export const codexFileChangeDiff = (changes: unknown[]): string | null => {
+  const diffs = changes
+    .filter(isPlainObject)
+    .map((change) => extractStringField(change, ["diff", "patch"]))
+    .filter((diff): diff is string => Boolean(diff));
+  return diffs.length > 0 ? diffs.join("\n") : null;
+};
+
+export const codexFileChangeEntries = (value: Record<string, unknown>): unknown[] => {
+  const changes = arrayFromUnknown(value.changes);
+  const diffs = arrayFromUnknown(value.diffs);
+  return changes.length > 0 ? changes : diffs;
+};
+
+const countDiffLines = (diff: string): Pick<FileDiff, "additions" | "deletions"> => {
+  let additions = 0;
+  let deletions = 0;
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++ ") || line.startsWith("--- ")) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      additions++;
+      continue;
+    }
+    if (line.startsWith("-")) {
+      deletions++;
+    }
+  }
+
+  return { additions, deletions };
+};
+
+const inferDiffType = (entry: Record<string, unknown>, diff: string): string => {
+  const explicitType = entry.type ?? entry.status ?? entry.kind;
+  if (typeof explicitType === "string" && explicitType.trim().length > 0) {
+    return explicitType;
+  }
+  if (/^---\s+\/dev\/null$/m.test(diff)) {
+    return "added";
+  }
+  if (/^\+\+\+\s+\/dev\/null$/m.test(diff)) {
+    return "deleted";
+  }
+  return "modified";
+};
+
+const parseFileDiffEntry = (entry: unknown, location: string): FileDiff => {
+  if (!isPlainObject(entry)) {
+    throw new CodexFileDiffParseError(`entry ${location} must be an object.`);
+  }
+
+  const file = entry.file ?? entry.path;
+  const diff = entry.diff ?? entry.patch;
+  if (typeof file !== "string" || typeof diff !== "string") {
+    throw new CodexFileDiffParseError(
+      `entry ${location} is missing string file/path or diff/patch fields.`,
+    );
+  }
+
+  const counts = countDiffLines(diff);
+  return {
+    file,
+    type: inferDiffType(entry, diff),
+    additions: typeof entry.additions === "number" ? entry.additions : counts.additions,
+    deletions: typeof entry.deletions === "number" ? entry.deletions : counts.deletions,
+    diff,
+  };
+};
+
+export const toFileDiffs = (value: unknown): FileDiff[] => {
+  return arrayFromUnknown(value).flatMap((entry, entryIndex): FileDiff[] => {
+    if (!isPlainObject(entry)) {
+      throw new CodexFileDiffParseError(`entry ${entryIndex} must be an object.`);
+    }
+
+    const nested = arrayFromUnknown(entry.fileChanges ?? entry.changes ?? entry.files);
+    if (nested.length > 0) {
+      return nested.map((nestedEntry, nestedIndex) =>
+        parseFileDiffEntry(nestedEntry, `${entryIndex}.${nestedIndex}`),
+      );
+    }
+
+    return [parseFileDiffEntry(entry, String(entryIndex))];
+  });
+};

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.ts
@@ -1,6 +1,6 @@
 import type { FileDiff } from "@openducktor/contracts";
 import { countRenderableFileDiffLines, selectRenderableFileDiff } from "@openducktor/core";
-import { arrayFromUnknown, isPlainObject } from "./codex-app-server-shared";
+import { arrayFromUnknown, extractStringField, isPlainObject } from "./codex-app-server-shared";
 
 export class CodexFileDiffParseError extends Error {
   constructor(message: string) {
@@ -55,21 +55,44 @@ const inferDiffType = (entry: Record<string, unknown>, diff: string): string => 
   return "modified";
 };
 
+const movePathFromKind = (value: unknown): string | null => {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+
+  const movePath = value.movePath ?? value.move_path;
+  return typeof movePath === "string" && movePath.trim().length > 0 ? movePath.trim() : null;
+};
+
+const stripMoveTrailer = (diff: string, movePath: string | null): string => {
+  if (!movePath) {
+    return diff;
+  }
+
+  const trailer = `\n\nMoved to: ${movePath}`;
+  return diff.endsWith(trailer) ? diff.slice(0, -trailer.length) : diff;
+};
+
 const parseFileDiffEntry = (entry: unknown, location: string): FileDiff => {
   if (!isPlainObject(entry)) {
     throw new CodexFileDiffParseError(`entry ${location} must be an object.`);
   }
 
-  const file = entry.file ?? entry.path;
+  const rawFile = entry.file ?? entry.path;
   const diff = entry.diff ?? entry.patch;
-  if (typeof file !== "string" || typeof diff !== "string") {
+  if (typeof rawFile !== "string" || typeof diff !== "string") {
     throw new CodexFileDiffParseError(
       `entry ${location} is missing string file/path or diff/patch fields.`,
     );
   }
 
+  const movePath = movePathFromKind(entry.kind);
+  const file = movePath ?? rawFile;
   const type = inferDiffType(entry, diff);
-  const renderableDiff = selectRenderableFileDiff(diff, file, { changeType: type }) ?? "";
+  const renderableDiff =
+    selectRenderableFileDiff(stripMoveTrailer(diff, movePath), file, {
+      changeType: type,
+    }) ?? "";
   const counts = countRenderableFileDiffLines(renderableDiff);
   return {
     file,
@@ -95,6 +118,11 @@ export const toFileDiffs = (value: unknown): FileDiff[] => {
 
     return [parseFileDiffEntry(entry, String(entryIndex))];
   });
+};
+
+export const fileDiffsPatchOutput = (fileDiffs: ReadonlyArray<{ diff: string }>): string | null => {
+  const diffs = fileDiffs.map((fileDiff) => fileDiff.diff.trim()).filter((diff) => diff.length > 0);
+  return diffs.length > 0 ? diffs.join("\n") : null;
 };
 
 const APPLY_PATCH_FILE_TYPES = {
@@ -173,6 +201,7 @@ export const codexApplyPatchFileDiffs = (patch: string): FileDiff[] => {
     const movedFile = moveMatch?.[1];
     if (movedFile) {
       current.file = movedFile.trim();
+      continue;
     }
     current.lines.push(line);
   }
@@ -185,4 +214,21 @@ export const codexApplyPatchFileDiffs = (patch: string): FileDiff[] => {
   }
 
   return diffs;
+};
+
+const patchInputFromObject = (value: Record<string, unknown> | null | undefined): string | null =>
+  value
+    ? (extractStringField(value, ["patch"]) ??
+      extractStringField(value, ["patchText", "patch_text"]) ??
+      null)
+    : null;
+
+export const codexPatchInputFromToolPayload = (
+  value: Record<string, unknown>,
+  input: Record<string, unknown> | null | undefined,
+): string | null => {
+  if (typeof value.input === "string") {
+    return value.input;
+  }
+  return patchInputFromObject(input);
 };

--- a/packages/adapters-codex-app-server/src/codex-file-diffs.ts
+++ b/packages/adapters-codex-app-server/src/codex-file-diffs.ts
@@ -1,5 +1,6 @@
 import type { FileDiff } from "@openducktor/contracts";
-import { arrayFromUnknown, extractStringField, isPlainObject } from "./codex-app-server-shared";
+import { countRenderableFileDiffLines, selectRenderableFileDiff } from "@openducktor/core";
+import { arrayFromUnknown, isPlainObject } from "./codex-app-server-shared";
 
 export class CodexFileDiffParseError extends Error {
   constructor(message: string) {
@@ -8,38 +9,10 @@ export class CodexFileDiffParseError extends Error {
   }
 }
 
-export const codexFileChangeDiff = (changes: unknown[]): string | null => {
-  const diffs = changes
-    .filter(isPlainObject)
-    .map((change) => extractStringField(change, ["diff", "patch"]))
-    .filter((diff): diff is string => Boolean(diff));
-  return diffs.length > 0 ? diffs.join("\n") : null;
-};
-
 export const codexFileChangeEntries = (value: Record<string, unknown>): unknown[] => {
   const changes = arrayFromUnknown(value.changes);
   const diffs = arrayFromUnknown(value.diffs);
   return changes.length > 0 ? changes : diffs;
-};
-
-const countDiffLines = (diff: string): Pick<FileDiff, "additions" | "deletions"> => {
-  let additions = 0;
-  let deletions = 0;
-
-  for (const line of diff.split("\n")) {
-    if (line.startsWith("+++ ") || line.startsWith("--- ")) {
-      continue;
-    }
-    if (line.startsWith("+")) {
-      additions++;
-      continue;
-    }
-    if (line.startsWith("-")) {
-      deletions++;
-    }
-  }
-
-  return { additions, deletions };
 };
 
 const inferDiffType = (entry: Record<string, unknown>, diff: string): string => {
@@ -69,13 +42,20 @@ const parseFileDiffEntry = (entry: unknown, location: string): FileDiff => {
     );
   }
 
-  const counts = countDiffLines(diff);
+  const renderableDiff = selectRenderableFileDiff(diff, file);
+  if (!renderableDiff) {
+    throw new CodexFileDiffParseError(
+      `entry ${location} diff/patch for '${file}' is not a renderable file diff.`,
+    );
+  }
+
+  const counts = countRenderableFileDiffLines(renderableDiff);
   return {
     file,
-    type: inferDiffType(entry, diff),
+    type: inferDiffType(entry, renderableDiff),
     additions: typeof entry.additions === "number" ? entry.additions : counts.additions,
     deletions: typeof entry.deletions === "number" ? entry.deletions : counts.deletions,
-    diff,
+    diff: renderableDiff,
   };
 };
 
@@ -131,8 +111,11 @@ const finishApplyPatchEntry = (entry: ApplyPatchFileEntry): FileDiff | null => {
     return null;
   }
 
-  const diff = [`*** ${entry.operation} File: ${entry.file}`, ...entry.lines].join("\n").trimEnd();
-  const counts = countDiffLines(diff);
+  const rawDiff = [`*** ${entry.operation} File: ${entry.file}`, ...entry.lines]
+    .join("\n")
+    .trimEnd();
+  const diff = selectRenderableFileDiff(rawDiff, entry.file) ?? "";
+  const counts = countRenderableFileDiffLines(diff);
   return {
     file: entry.file,
     type: APPLY_PATCH_FILE_TYPES[entry.operation],

--- a/packages/adapters-codex-app-server/src/codex-tool-error-extractor.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-error-extractor.ts
@@ -139,8 +139,16 @@ const failedStatus = (value: unknown): boolean => {
   if (typeof value !== "string") {
     return false;
   }
-  const normalized = value.toLowerCase().replace(/-/g, "_");
-  return normalized === "failed" || normalized === "failure" || normalized === "error";
+  const normalized = value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/-/g, "_");
+  return (
+    normalized === "failed" ||
+    normalized === "failure" ||
+    normalized === "error" ||
+    normalized === "declined"
+  );
 };
 
 const mcpToolErrorFromValue = (value: unknown): string | null => {

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
@@ -59,6 +59,22 @@ describe("Codex tool normalization", () => {
     expect(part?.toolType ?? null).toBe(expected);
   });
 
+  test.each([
+    ["inProgress", "running"],
+    ["in_progress", "running"],
+    ["declined", "error"],
+  ] as const)("maps Codex status %s to %s", (status, expected) => {
+    expect(
+      normalizeCodexToolInvocation({
+        messageId: "message-1",
+        partId: "part-1",
+        callId: "call-1",
+        rawToolName: "functions.apply_patch",
+        status,
+      })?.status,
+    ).toBe(expected);
+  });
+
   test("normalizes ODT tool display identity", () => {
     expect(
       normalizeCodexToolInvocation({
@@ -186,7 +202,7 @@ describe("Codex tool normalization", () => {
         toolType: "file_edit",
         status: "completed",
         output: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new",
-        fileChanges: [
+        fileDiffs: [
           {
             file: "src/app.ts",
             type: "modified",
@@ -224,7 +240,7 @@ describe("Codex tool normalization", () => {
     );
     expect(part).not.toHaveProperty("input");
     expect(part).not.toHaveProperty("output");
-    expect(part).not.toHaveProperty("fileChanges");
+    expect(part).not.toHaveProperty("fileDiffs");
   });
 
   test("keeps non-renderable Codex modified file changes out of tool errors", () => {
@@ -251,7 +267,7 @@ describe("Codex tool normalization", () => {
         tool: "apply_patch",
         toolType: "file_edit",
         status: "completed",
-        fileChanges: [
+        fileDiffs: [
           {
             file: "/Users/maxsky5/.openducktor-local/worktrees/fairnest/apps/web/__tests__/contexts/AuthContext.test.tsx",
             type: "modified",
@@ -295,13 +311,52 @@ describe("Codex tool normalization", () => {
         toolType: "file_edit",
         input: { patch },
         output: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new",
-        fileChanges: [
+        fileDiffs: [
           {
             file: "src/app.ts",
             type: "modified",
             additions: 1,
             deletions: 1,
             diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n",
+          },
+        ],
+      }),
+    );
+  });
+
+  test("attaches structured file changes to dynamic apply_patch arguments", () => {
+    const patch = `*** Begin Patch
+*** Add File: src/new.ts
++created
+*** End Patch`;
+    const part = toStreamPart(
+      {
+        type: "dynamicToolCall",
+        id: "patch-1",
+        namespace: "functions",
+        tool: "apply_patch",
+        arguments: { patch },
+        success: true,
+        status: "completed",
+      },
+      "message-live",
+      "patch-1",
+    )[0];
+
+    expect(part).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        tool: "apply_patch",
+        toolType: "file_edit",
+        input: { patch },
+        output: "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1,1 @@\n+created",
+        fileDiffs: [
+          {
+            file: "src/new.ts",
+            type: "added",
+            additions: 1,
+            deletions: 0,
+            diff: "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1,1 @@\n+created\n",
           },
         ],
       }),
@@ -334,7 +389,7 @@ function AuthConsumer() {}
         tool: "apply_patch",
         toolType: "file_edit",
         input: { patch },
-        fileChanges: [
+        fileDiffs: [
           {
             file: "src/app.ts",
             type: "modified",

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
@@ -161,7 +161,7 @@ describe("Codex tool normalization", () => {
         type: "fileChange",
         id: "change-1",
         status: "completed",
-        changes: [{ file: "src/app.ts", diff: "@@ -1 +1 @@" }],
+        changes: [{ file: "src/app.ts", diff: "@@ -1 +1 @@\n-old\n+new" }],
         content: [
           {
             type: "text",
@@ -185,10 +185,46 @@ describe("Codex tool normalization", () => {
         tool: "apply_patch",
         toolType: "file_edit",
         status: "completed",
-        output: "@@ -1 +1 @@",
+        output: "@@ -1 +1 @@\n-old\n+new",
+        fileChanges: [
+          {
+            file: "src/app.ts",
+            type: "modified",
+            additions: 1,
+            deletions: 1,
+            diff: "@@ -1 +1 @@\n-old\n+new",
+          },
+        ],
       }),
     );
     expect(part).not.toHaveProperty("error");
+  });
+
+  test("marks malformed Codex file changes as tool errors", () => {
+    const part = toStreamPart(
+      {
+        type: "fileChange",
+        id: "change-1",
+        status: "completed",
+        changes: [{ file: "src/app.ts" }],
+      },
+      "message-live",
+      "change-1",
+    )[0];
+
+    expect(part).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        tool: "apply_patch",
+        toolType: "file_edit",
+        status: "error",
+        error:
+          "Malformed Codex file change: entry 0 is missing string file/path or diff/patch fields.",
+      }),
+    );
+    expect(part).not.toHaveProperty("input");
+    expect(part).not.toHaveProperty("output");
+    expect(part).not.toHaveProperty("fileChanges");
   });
 
   test("parses non-patch dynamic tool string input without treating it as a patch", () => {

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
@@ -185,14 +185,14 @@ describe("Codex tool normalization", () => {
         tool: "apply_patch",
         toolType: "file_edit",
         status: "completed",
-        output: "@@ -1 +1 @@\n-old\n+new",
+        output: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new",
         fileChanges: [
           {
             file: "src/app.ts",
             type: "modified",
             additions: 1,
             deletions: 1,
-            diff: "@@ -1 +1 @@\n-old\n+new",
+            diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n",
           },
         ],
       }),
@@ -254,18 +254,58 @@ describe("Codex tool normalization", () => {
         tool: "apply_patch",
         toolType: "file_edit",
         input: { patch },
-        output: patch,
+        output: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new",
         fileChanges: [
           {
             file: "src/app.ts",
             type: "modified",
             additions: 1,
             deletions: 1,
-            diff: "*** Update File: src/app.ts\n@@\n-old\n+new",
+            diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n",
           },
         ],
       }),
     );
+  });
+
+  test("does not echo non-renderable apply_patch input as tool output", () => {
+    const patch = `*** Begin Patch
+*** Update File: src/app.ts
+import { render } from "@testing-library/react";
+function AuthConsumer() {}
+*** End Patch`;
+    const part = toStreamPart(
+      {
+        type: "dynamicToolCall",
+        id: "patch-1",
+        namespace: "functions",
+        tool: "apply_patch",
+        input: patch,
+        success: true,
+        status: "completed",
+      },
+      "message-live",
+      "patch-1",
+    )[0];
+
+    expect(part).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        tool: "apply_patch",
+        toolType: "file_edit",
+        input: { patch },
+        fileChanges: [
+          {
+            file: "src/app.ts",
+            type: "modified",
+            additions: 0,
+            deletions: 0,
+            diff: "",
+          },
+        ],
+      }),
+    );
+    expect(part).not.toHaveProperty("output");
   });
 
   test("parses non-patch dynamic tool string input without treating it as a patch", () => {

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
@@ -227,6 +227,47 @@ describe("Codex tool normalization", () => {
     expect(part).not.toHaveProperty("fileChanges");
   });
 
+  test("attaches structured file changes to dynamic apply_patch calls", () => {
+    const patch = `*** Begin Patch
+*** Update File: src/app.ts
+@@
+-old
++new
+*** End Patch`;
+    const part = toStreamPart(
+      {
+        type: "dynamicToolCall",
+        id: "patch-1",
+        namespace: "functions",
+        tool: "apply_patch",
+        input: patch,
+        success: true,
+        status: "completed",
+      },
+      "message-live",
+      "patch-1",
+    )[0];
+
+    expect(part).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        tool: "apply_patch",
+        toolType: "file_edit",
+        input: { patch },
+        output: patch,
+        fileChanges: [
+          {
+            file: "src/app.ts",
+            type: "modified",
+            additions: 1,
+            deletions: 1,
+            diff: "*** Update File: src/app.ts\n@@\n-old\n+new",
+          },
+        ],
+      }),
+    );
+  });
+
   test("parses non-patch dynamic tool string input without treating it as a patch", () => {
     const part = toStreamPart(
       {

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
@@ -227,6 +227,46 @@ describe("Codex tool normalization", () => {
     expect(part).not.toHaveProperty("fileChanges");
   });
 
+  test("keeps non-renderable Codex modified file changes out of tool errors", () => {
+    const part = toStreamPart(
+      {
+        type: "fileChange",
+        id: "change-1",
+        status: "completed",
+        changes: [
+          {
+            file: "/Users/maxsky5/.openducktor-local/worktrees/fairnest/apps/web/__tests__/contexts/AuthContext.test.tsx",
+            type: "modified",
+            diff: "import { render, screen } from '@testing-library/react';\nfunction AuthConsumer() {}\n",
+          },
+        ],
+      },
+      "message-live",
+      "change-1",
+    )[0];
+
+    expect(part).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        tool: "apply_patch",
+        toolType: "file_edit",
+        status: "completed",
+        fileChanges: [
+          {
+            file: "/Users/maxsky5/.openducktor-local/worktrees/fairnest/apps/web/__tests__/contexts/AuthContext.test.tsx",
+            type: "modified",
+            additions: 0,
+            deletions: 0,
+            diff: "",
+          },
+        ],
+      }),
+    );
+    expect(part).not.toHaveProperty("error");
+    expect(part).not.toHaveProperty("input");
+    expect(part).not.toHaveProperty("output");
+  });
+
   test("attaches structured file changes to dynamic apply_patch calls", () => {
     const patch = `*** Begin Patch
 *** Update File: src/app.ts

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.ts
@@ -1,3 +1,4 @@
+import type { FileDiff } from "@openducktor/contracts";
 import type { AgentToolType } from "@openducktor/core";
 import {
   arrayFromUnknown,
@@ -41,6 +42,7 @@ export type NormalizedCodexToolInvocation = {
   input?: Record<string, unknown>;
   output?: string | null;
   error?: string | null;
+  fileChanges?: FileDiff[];
   metadata?: Record<string, unknown>;
   startedAtMs?: number;
   endedAtMs?: number;
@@ -271,6 +273,7 @@ export const normalizeCodexToolInvocation = ({
   input,
   output,
   error,
+  fileChanges,
   title,
   displayLabel,
   preview,
@@ -301,6 +304,7 @@ export const normalizeCodexToolInvocation = ({
     ...(resolvedPreview ? { preview: resolvedPreview } : {}),
     ...(resolvedOutput ? { output: resolvedOutput } : {}),
     ...(resolvedError ? { error: resolvedError } : {}),
+    ...(fileChanges && fileChanges.length > 0 ? { fileChanges } : {}),
     metadata: {
       ...(metadata ?? {}),
       rawToolName,

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.ts
@@ -42,15 +42,26 @@ export type NormalizedCodexToolInvocation = {
   input?: Record<string, unknown>;
   output?: string | null;
   error?: string | null;
-  fileChanges?: FileDiff[];
+  fileDiffs?: FileDiff[];
   metadata?: Record<string, unknown>;
   startedAtMs?: number;
   endedAtMs?: number;
 };
 
 export const statusFromCodexStatus = (status: unknown): AgentToolStatus => {
-  const normalized = typeof status === "string" ? status.toLowerCase().replace(/-/g, "_") : "";
-  if (normalized === "failed" || normalized === "failure" || normalized === "error") {
+  const normalized =
+    typeof status === "string"
+      ? status
+          .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+          .toLowerCase()
+          .replace(/-/g, "_")
+      : "";
+  if (
+    normalized === "failed" ||
+    normalized === "failure" ||
+    normalized === "error" ||
+    normalized === "declined"
+  ) {
     return "error";
   }
   if (normalized === "running" || normalized === "pending" || normalized === "in_progress") {
@@ -273,7 +284,7 @@ export const normalizeCodexToolInvocation = ({
   input,
   output,
   error,
-  fileChanges,
+  fileDiffs,
   title,
   displayLabel,
   preview,
@@ -304,7 +315,7 @@ export const normalizeCodexToolInvocation = ({
     ...(resolvedPreview ? { preview: resolvedPreview } : {}),
     ...(resolvedOutput ? { output: resolvedOutput } : {}),
     ...(resolvedError ? { error: resolvedError } : {}),
-    ...(fileChanges && fileChanges.length > 0 ? { fileChanges } : {}),
+    ...(fileDiffs && fileDiffs.length > 0 ? { fileDiffs } : {}),
     metadata: {
       ...(metadata ?? {}),
       rawToolName,

--- a/packages/adapters-codex-app-server/src/event-mappers/stream-parts.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/stream-parts.ts
@@ -1,35 +1,49 @@
+import { arrayFromUnknown, extractStringField, isPlainObject } from "../codex-app-server-shared";
 import { codexItemTypeMatches, toStreamPart } from "../codex-app-server-transcript";
-import type { CodexMappingResult } from "../codex-canonical-events";
+import type { CodexMappingContext, CodexMappingResult } from "../codex-canonical-events";
 import { emptyCodexMappingResult } from "../codex-canonical-events";
 import type { CodexEventMapper } from "../codex-event-mapper";
 import { noCodexMapperState } from "../codex-event-mapper";
 import { emptyMapper } from "./empty";
 
+const streamPartEvents = (
+  name: string,
+  ctx: CodexMappingContext,
+  raw: unknown,
+  item: Record<string, unknown>,
+  messageId: string,
+  partId: string,
+  timestamp?: string,
+): CodexMappingResult => ({
+  handled: true,
+  events: toStreamPart(item, messageId, partId).map((part) => {
+    const eventTimestamp = ctx.timestamp ?? timestamp;
+    return {
+      kind: "stream_part",
+      source: ctx.source,
+      mapper: name,
+      threadId: ctx.threadId,
+      ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+      ...(eventTimestamp ? { timestamp: eventTimestamp } : {}),
+      raw,
+      part,
+    };
+  }),
+});
+
 const streamPartMapper = (name: string, itemType: string): CodexEventMapper => ({
   name,
   createState: noCodexMapperState,
   fromLive(input, ctx): CodexMappingResult {
-    if (
-      (input.kind !== "item_completed" && input.kind !== "item_started") ||
-      !codexItemTypeMatches(input.item, itemType)
-    ) {
+    if (input.kind !== "item_completed" && input.kind !== "item_started") {
+      return emptyCodexMappingResult();
+    }
+    if (!codexItemTypeMatches(input.item, itemType)) {
       return emptyCodexMappingResult();
     }
     const itemId =
       typeof input.item.id === "string" ? input.item.id : `${ctx.threadId}-${name}-${Date.now()}`;
-    return {
-      handled: true,
-      events: toStreamPart(input.item, itemId, itemId).map((part) => ({
-        kind: "stream_part",
-        source: ctx.source,
-        mapper: name,
-        threadId: ctx.threadId,
-        ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
-        ...(ctx.timestamp ? { timestamp: ctx.timestamp } : {}),
-        raw: input.item,
-        part,
-      })),
-    };
+    return streamPartEvents(name, ctx, input.item, input.item, itemId, itemId);
   },
   fromThreadItem(input, ctx): CodexMappingResult {
     if (!codexItemTypeMatches(input.item, itemType)) {
@@ -37,28 +51,65 @@ const streamPartMapper = (name: string, itemType: string): CodexEventMapper => (
     }
     const itemId =
       typeof input.item.id === "string" ? input.item.id : `${ctx.threadId}-${name}-${input.index}`;
-    return {
-      handled: true,
-      events: toStreamPart(input.item, itemId, itemId).map((part) => ({
-        kind: "stream_part",
-        source: ctx.source,
-        mapper: name,
-        threadId: ctx.threadId,
-        ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
-        ...((ctx.timestamp ?? input.timestamp)
-          ? { timestamp: ctx.timestamp ?? input.timestamp }
-          : {}),
-        raw: input.item,
-        part,
-      })),
-    };
+    return streamPartEvents(name, ctx, input.item, input.item, itemId, itemId, input.timestamp);
   },
 });
+
+export const fileChangeMapper: CodexEventMapper = {
+  name: "file_change",
+  createState: noCodexMapperState,
+  fromLive(input, ctx): CodexMappingResult {
+    if (
+      input.kind !== "notification" ||
+      input.notification.method !== "item/fileChange/patchUpdated"
+    ) {
+      return emptyCodexMappingResult();
+    }
+
+    const params = isPlainObject(input.notification.params) ? input.notification.params : null;
+    const itemId = extractStringField(params, ["itemId", "item_id"]);
+    const changes = arrayFromUnknown(params?.changes);
+    if (!itemId || changes.length === 0) {
+      return emptyCodexMappingResult();
+    }
+
+    return streamPartEvents(
+      this.name,
+      ctx,
+      input.notification,
+      {
+        type: "fileChange",
+        id: itemId,
+        changes,
+        status: "inProgress",
+      },
+      itemId,
+      itemId,
+    );
+  },
+  fromThreadItem(input, ctx): CodexMappingResult {
+    if (!codexItemTypeMatches(input.item, "fileChange")) {
+      return emptyCodexMappingResult();
+    }
+    const itemId =
+      typeof input.item.id === "string"
+        ? input.item.id
+        : `${ctx.threadId}-file_change-${input.index}`;
+    return streamPartEvents(
+      this.name,
+      ctx,
+      input.item,
+      input.item,
+      itemId,
+      itemId,
+      input.timestamp,
+    );
+  },
+};
 
 export const reasoningMapper = streamPartMapper("reasoning", "reasoning");
 export const planMapper = streamPartMapper("plan", "plan");
 export const commandToolMapper = streamPartMapper("command_tool", "commandExecution");
-export const fileChangeMapper = streamPartMapper("file_change", "fileChange");
 export const mcpToolMapper = streamPartMapper("mcp_tool", "mcpToolCall");
 export const webSearchMapper = streamPartMapper("web_search", "webSearch");
 export const collabToolMapper = streamPartMapper("collab_tool", "collabAgentToolCall");

--- a/packages/adapters-opencode-sdk/src/diff-ops.test.ts
+++ b/packages/adapters-opencode-sdk/src/diff-ops.test.ts
@@ -36,7 +36,7 @@ describe("diff-ops", () => {
         type: "modified",
         additions: 3,
         deletions: 1,
-        diff: "@@ -1 +1 @@",
+        diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n",
       },
     ]);
     expect(requestedUrls).toEqual(["http://127.0.0.1:12345/session/session-1/diff"]);
@@ -65,7 +65,7 @@ describe("diff-ops", () => {
         type: "modified",
         additions: 2,
         deletions: 1,
-        diff: "@@ -1 +1 @@",
+        diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n",
       },
     ]);
   });
@@ -92,9 +92,55 @@ describe("diff-ops", () => {
         type: "modified",
         additions: 2,
         deletions: 1,
-        diff: "@@ -1 +1 @@",
+        diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n",
       },
     ]);
+  });
+
+  test("loadSessionDiff rejects standard payloads with full-file text instead of a diff", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          data: [
+            {
+              file: "src/main.ts",
+              type: "modified",
+              additions: 3,
+              deletions: 1,
+              diff: 'import { render } from "@testing-library/react";\nfunction AuthConsumer() {}\n',
+            },
+          ],
+        }),
+      }) as Response) as typeof fetch;
+
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).rejects.toThrow(
+      "OpenCode request failed: load session diff: unexpected OpenCode diff entry at index 0: diff for 'src/main.ts' is not a renderable file diff",
+    );
+  });
+
+  test("loadSessionDiff rejects snapshot payloads with full-file text instead of a diff", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [
+          {
+            file: "src/main.ts",
+            patch: 'import { render } from "@testing-library/react";\nfunction AuthConsumer() {}\n',
+            additions: 2,
+            deletions: 1,
+            status: "modified",
+          },
+        ],
+      }) as Response) as typeof fetch;
+
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).rejects.toThrow(
+      "OpenCode request failed: load session diff: unexpected OpenCode diff entry at index 0: diff for 'src/main.ts' is not a renderable file diff",
+    );
   });
 
   test("loadSessionDiff rejects malformed OpenCode snapshot diff entries", async () => {

--- a/packages/adapters-opencode-sdk/src/diff-ops.test.ts
+++ b/packages/adapters-opencode-sdk/src/diff-ops.test.ts
@@ -70,7 +70,7 @@ describe("diff-ops", () => {
     ]);
   });
 
-  test("loadSessionDiff rejects malformed OpenCode snapshot diff entries", async () => {
+  test("loadSessionDiff defaults missing OpenCode snapshot diff status to modified", async () => {
     globalThis.fetch = (async () =>
       ({
         ok: true,
@@ -86,8 +86,36 @@ describe("diff-ops", () => {
         ],
       }) as Response) as typeof fetch;
 
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).resolves.toEqual([
+      {
+        file: "src/main.ts",
+        type: "modified",
+        additions: 2,
+        deletions: 1,
+        diff: "@@ -1 +1 @@",
+      },
+    ]);
+  });
+
+  test("loadSessionDiff rejects malformed OpenCode snapshot diff entries", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [
+          {
+            file: "src/main.ts",
+            patch: "@@ -1 +1 @@",
+            additions: Number.NaN,
+            deletions: 1,
+            status: 5,
+          },
+        ],
+      }) as Response) as typeof fetch;
+
     await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).rejects.toThrow(
-      "OpenCode request failed: load session diff: unexpected OpenCode diff entry at index 0: missing file diff fields",
+      "OpenCode request failed: load session diff: unexpected OpenCode diff entry at index 0: invalid additions, status fields",
     );
   });
 

--- a/packages/adapters-opencode-sdk/src/diff-ops.test.ts
+++ b/packages/adapters-opencode-sdk/src/diff-ops.test.ts
@@ -9,8 +9,10 @@ afterEach(() => {
 
 describe("diff-ops", () => {
   test("loadSessionDiff parses wrapped diff payloads", async () => {
-    globalThis.fetch = (async () =>
-      ({
+    const requestedUrls: string[] = [];
+    globalThis.fetch = (async (url: URL | RequestInfo) => {
+      requestedUrls.push(url.toString());
+      return {
         ok: true,
         status: 200,
         statusText: "OK",
@@ -25,7 +27,8 @@ describe("diff-ops", () => {
             },
           ],
         }),
-      }) as Response) as typeof fetch;
+      } as Response;
+    }) as typeof fetch;
 
     await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).resolves.toEqual([
       {
@@ -36,6 +39,56 @@ describe("diff-ops", () => {
         diff: "@@ -1 +1 @@",
       },
     ]);
+    expect(requestedUrls).toEqual(["http://127.0.0.1:12345/session/session-1/diff"]);
+  });
+
+  test("loadSessionDiff parses OpenCode snapshot diff payloads", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [
+          {
+            file: "src/main.ts",
+            patch: "@@ -1 +1 @@",
+            additions: 2,
+            deletions: 1,
+            status: "modified",
+          },
+        ],
+      }) as Response) as typeof fetch;
+
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).resolves.toEqual([
+      {
+        file: "src/main.ts",
+        type: "modified",
+        additions: 2,
+        deletions: 1,
+        diff: "@@ -1 +1 @@",
+      },
+    ]);
+  });
+
+  test("loadSessionDiff rejects malformed OpenCode snapshot diff entries", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [
+          {
+            file: "src/main.ts",
+            patch: "@@ -1 +1 @@",
+            additions: 2,
+            deletions: 1,
+          },
+        ],
+      }) as Response) as typeof fetch;
+
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).rejects.toThrow(
+      "OpenCode request failed: load session diff: unexpected OpenCode diff entry at index 0: missing file diff fields",
+    );
   });
 
   test("loadSessionDiff rejects HTTP failures with status context", async () => {
@@ -55,17 +108,21 @@ describe("diff-ops", () => {
   });
 
   test("loadFileStatus rejects malformed payloads", async () => {
-    globalThis.fetch = (async () =>
-      ({
+    const requestedUrls: string[] = [];
+    globalThis.fetch = (async (url: URL | RequestInfo) => {
+      requestedUrls.push(url.toString());
+      return {
         ok: true,
         status: 200,
         statusText: "OK",
         json: async () => ({ items: [] }),
-      }) as Response) as typeof fetch;
+      } as Response;
+    }) as typeof fetch;
 
     await expect(loadFileStatus("http://127.0.0.1:12345")).rejects.toThrow(
       "OpenCode request failed: load file status: unexpected response payload shape",
     );
+    expect(requestedUrls).toEqual(["http://127.0.0.1:12345/file/status"]);
   });
 
   test("loadFileStatus rejects transport errors", async () => {

--- a/packages/adapters-opencode-sdk/src/diff-ops.test.ts
+++ b/packages/adapters-opencode-sdk/src/diff-ops.test.ts
@@ -97,7 +97,7 @@ describe("diff-ops", () => {
     ]);
   });
 
-  test("loadSessionDiff rejects standard payloads with full-file text instead of a diff", async () => {
+  test("loadSessionDiff keeps modified full-file standard payloads path-only", async () => {
     globalThis.fetch = (async () =>
       ({
         ok: true,
@@ -116,12 +116,48 @@ describe("diff-ops", () => {
         }),
       }) as Response) as typeof fetch;
 
-    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).rejects.toThrow(
-      "OpenCode request failed: load session diff: unexpected OpenCode diff entry at index 0: diff for 'src/main.ts' is not a renderable file diff",
-    );
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).resolves.toEqual([
+      {
+        file: "src/main.ts",
+        type: "modified",
+        additions: 3,
+        deletions: 1,
+        diff: "",
+      },
+    ]);
   });
 
-  test("loadSessionDiff rejects snapshot payloads with full-file text instead of a diff", async () => {
+  test("loadSessionDiff renders added full-file standard payloads as added-file diffs", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          data: [
+            {
+              file: "src/LandingPage.test.tsx",
+              type: "added",
+              additions: 2,
+              deletions: 0,
+              diff: "import LandingPage from '@/components/LandingPage';\ntest('renders', () => {});\n",
+            },
+          ],
+        }),
+      }) as Response) as typeof fetch;
+
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).resolves.toEqual([
+      {
+        file: "src/LandingPage.test.tsx",
+        type: "added",
+        additions: 2,
+        deletions: 0,
+        diff: "--- /dev/null\n+++ b/src/LandingPage.test.tsx\n@@ -0,0 +1,2 @@\n+import LandingPage from '@/components/LandingPage';\n+test('renders', () => {});\n",
+      },
+    ]);
+  });
+
+  test("loadSessionDiff keeps modified full-file snapshot payloads path-only", async () => {
     globalThis.fetch = (async () =>
       ({
         ok: true,
@@ -138,9 +174,44 @@ describe("diff-ops", () => {
         ],
       }) as Response) as typeof fetch;
 
-    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).rejects.toThrow(
-      "OpenCode request failed: load session diff: unexpected OpenCode diff entry at index 0: diff for 'src/main.ts' is not a renderable file diff",
-    );
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).resolves.toEqual([
+      {
+        file: "src/main.ts",
+        type: "modified",
+        additions: 2,
+        deletions: 1,
+        diff: "",
+      },
+    ]);
+  });
+
+  test("loadSessionDiff renders added full-file snapshot payloads as added-file diffs", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [
+          {
+            file: "src/LandingPage.test.tsx",
+            patch:
+              "import LandingPage from '@/components/LandingPage';\ntest('renders', () => {});\n",
+            additions: 2,
+            deletions: 0,
+            status: "added",
+          },
+        ],
+      }) as Response) as typeof fetch;
+
+    await expect(loadSessionDiff("http://127.0.0.1:12345", "session-1")).resolves.toEqual([
+      {
+        file: "src/LandingPage.test.tsx",
+        type: "added",
+        additions: 2,
+        deletions: 0,
+        diff: "--- /dev/null\n+++ b/src/LandingPage.test.tsx\n@@ -0,0 +1,2 @@\n+import LandingPage from '@/components/LandingPage';\n+test('renders', () => {});\n",
+      },
+    ]);
   });
 
   test("loadSessionDiff rejects malformed OpenCode snapshot diff entries", async () => {

--- a/packages/adapters-opencode-sdk/src/diff-ops.ts
+++ b/packages/adapters-opencode-sdk/src/diff-ops.ts
@@ -17,7 +17,7 @@ export const loadSessionDiff = async (
   runtimeHistoryAnchor?: string,
 ): Promise<FileDiff[]> => {
   const url = new URL(
-    `/api/session/${externalSessionId}/diff`,
+    `/session/${externalSessionId}/diff`,
     normalizeRuntimeEndpoint(runtimeEndpoint),
   );
   if (runtimeHistoryAnchor) {
@@ -37,7 +37,7 @@ export const loadSessionDiff = async (
  * Endpoint: GET /file/status
  */
 export const loadFileStatus = async (runtimeEndpoint: string): Promise<FileStatus[]> => {
-  const url = new URL("/api/file/status", normalizeRuntimeEndpoint(runtimeEndpoint));
+  const url = new URL("/file/status", normalizeRuntimeEndpoint(runtimeEndpoint));
 
   try {
     const body = await fetchJson("load file status", url, 10_000);
@@ -69,7 +69,13 @@ const fetchJson = async (action: string, url: URL, timeoutMs: number): Promise<u
 };
 
 function parseFileDiffArray(body: unknown): FileDiff[] {
-  return fileDiffSchema.array().parse(readArrayPayload("load session diff", body));
+  const payload = readArrayPayload("load session diff", body);
+  const standardPayload = fileDiffSchema.array().safeParse(payload);
+  if (standardPayload.success) {
+    return standardPayload.data;
+  }
+
+  return payload.map((entry, index) => parseSnapshotFileDiff(entry, index));
 }
 
 function parseFileStatusArray(body: unknown): FileStatus[] {
@@ -89,4 +95,34 @@ function readArrayPayload(action: string, body: unknown): unknown[] {
   }
 
   throw toOpenCodeRequestError(action, new Error("unexpected response payload shape"));
+}
+
+function parseSnapshotFileDiff(entry: unknown, index: number): FileDiff {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error(`unexpected OpenCode diff entry at index ${index}: expected an object`);
+  }
+
+  const record = entry as Record<string, unknown>;
+  const file = record.file;
+  const patch = record.patch;
+  const additions = record.additions;
+  const deletions = record.deletions;
+  const status = record.status;
+  if (
+    typeof file !== "string" ||
+    typeof patch !== "string" ||
+    typeof additions !== "number" ||
+    typeof deletions !== "number" ||
+    typeof status !== "string"
+  ) {
+    throw new Error(`unexpected OpenCode diff entry at index ${index}: missing file diff fields`);
+  }
+
+  return {
+    file,
+    type: status,
+    additions,
+    deletions,
+    diff: patch,
+  };
 }

--- a/packages/adapters-opencode-sdk/src/diff-ops.ts
+++ b/packages/adapters-opencode-sdk/src/diff-ops.ts
@@ -108,21 +108,43 @@ function parseSnapshotFileDiff(entry: unknown, index: number): FileDiff {
   const additions = record.additions;
   const deletions = record.deletions;
   const status = record.status;
+  const parsedFile = typeof file === "string" ? file : null;
+  const parsedPatch = typeof patch === "string" ? patch : null;
+  const parsedAdditions =
+    typeof additions === "number" && Number.isFinite(additions) ? additions : null;
+  const parsedDeletions =
+    typeof deletions === "number" && Number.isFinite(deletions) ? deletions : null;
+  const type =
+    typeof status === "string" && status.trim().length > 0
+      ? status
+      : status == null
+        ? "modified"
+        : null;
+  const invalidFields = [
+    parsedFile === null ? "file" : null,
+    parsedPatch === null ? "patch" : null,
+    parsedAdditions === null ? "additions" : null,
+    parsedDeletions === null ? "deletions" : null,
+    type ? null : "status",
+  ].filter((field): field is string => Boolean(field));
   if (
-    typeof file !== "string" ||
-    typeof patch !== "string" ||
-    typeof additions !== "number" ||
-    typeof deletions !== "number" ||
-    typeof status !== "string"
+    invalidFields.length > 0 ||
+    parsedFile === null ||
+    parsedPatch === null ||
+    parsedAdditions === null ||
+    parsedDeletions === null ||
+    type === null
   ) {
-    throw new Error(`unexpected OpenCode diff entry at index ${index}: missing file diff fields`);
+    throw new Error(
+      `unexpected OpenCode diff entry at index ${index}: invalid ${invalidFields.join(", ")} fields`,
+    );
   }
 
   return {
-    file,
-    type: status,
-    additions,
-    deletions,
-    diff: patch,
+    file: parsedFile,
+    type,
+    additions: parsedAdditions,
+    deletions: parsedDeletions,
+    diff: parsedPatch,
   };
 }

--- a/packages/adapters-opencode-sdk/src/diff-ops.ts
+++ b/packages/adapters-opencode-sdk/src/diff-ops.ts
@@ -4,6 +4,7 @@ import {
   fileDiffSchema,
   fileStatusSchema,
 } from "@openducktor/contracts";
+import { selectRenderableFileDiff } from "@openducktor/core";
 import { toOpenCodeRequestError } from "./request-errors";
 
 /**
@@ -72,7 +73,7 @@ function parseFileDiffArray(body: unknown): FileDiff[] {
   const payload = readArrayPayload("load session diff", body);
   const standardPayload = fileDiffSchema.array().safeParse(payload);
   if (standardPayload.success) {
-    return standardPayload.data;
+    return standardPayload.data.map((entry, index) => requireRenderableFileDiff(entry, index));
   }
 
   return payload.map((entry, index) => parseSnapshotFileDiff(entry, index));
@@ -140,11 +141,31 @@ function parseSnapshotFileDiff(entry: unknown, index: number): FileDiff {
     );
   }
 
+  return requireRenderableFileDiff(
+    {
+      file: parsedFile,
+      type,
+      additions: parsedAdditions,
+      deletions: parsedDeletions,
+      diff: parsedPatch,
+    },
+    index,
+  );
+}
+
+function requireRenderableFileDiff(entry: FileDiff, index: number): FileDiff {
+  const diff = selectRenderableFileDiff(entry.diff, entry.file);
+  if (!diff) {
+    throw new Error(
+      `unexpected OpenCode diff entry at index ${index}: diff for '${entry.file}' is not a renderable file diff`,
+    );
+  }
+
   return {
-    file: parsedFile,
-    type,
-    additions: parsedAdditions,
-    deletions: parsedDeletions,
-    diff: parsedPatch,
+    file: entry.file,
+    type: entry.type,
+    additions: entry.additions,
+    deletions: entry.deletions,
+    diff,
   };
 }

--- a/packages/adapters-opencode-sdk/src/diff-ops.ts
+++ b/packages/adapters-opencode-sdk/src/diff-ops.ts
@@ -73,7 +73,7 @@ function parseFileDiffArray(body: unknown): FileDiff[] {
   const payload = readArrayPayload("load session diff", body);
   const standardPayload = fileDiffSchema.array().safeParse(payload);
   if (standardPayload.success) {
-    return standardPayload.data.map((entry, index) => requireRenderableFileDiff(entry, index));
+    return standardPayload.data.map(toRenderableFileDiff);
   }
 
   return payload.map((entry, index) => parseSnapshotFileDiff(entry, index));
@@ -141,31 +141,21 @@ function parseSnapshotFileDiff(entry: unknown, index: number): FileDiff {
     );
   }
 
-  return requireRenderableFileDiff(
-    {
-      file: parsedFile,
-      type,
-      additions: parsedAdditions,
-      deletions: parsedDeletions,
-      diff: parsedPatch,
-    },
-    index,
-  );
+  return toRenderableFileDiff({
+    file: parsedFile,
+    type,
+    additions: parsedAdditions,
+    deletions: parsedDeletions,
+    diff: parsedPatch,
+  });
 }
 
-function requireRenderableFileDiff(entry: FileDiff, index: number): FileDiff {
-  const diff = selectRenderableFileDiff(entry.diff, entry.file);
-  if (!diff) {
-    throw new Error(
-      `unexpected OpenCode diff entry at index ${index}: diff for '${entry.file}' is not a renderable file diff`,
-    );
-  }
-
+function toRenderableFileDiff(entry: FileDiff): FileDiff {
   return {
     file: entry.file,
     type: entry.type,
     additions: entry.additions,
     deletions: entry.deletions,
-    diff,
+    diff: selectRenderableFileDiff(entry.diff, entry.file, { changeType: entry.type }) ?? "",
   };
 }

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -120,6 +120,42 @@ test("runEventStreamWithSession uses the configured session input", async () => 
   });
 });
 
+test("runEventStreamWithSession emits permission v2 approval events", async () => {
+  const { emitted } = await runEventStreamWithSession([
+    {
+      type: "permission.v2.asked",
+      properties: {
+        sessionID: "external-session-1",
+        id: "perm-v2-1",
+        permission: "edit",
+        patterns: ["src/**"],
+        metadata: {
+          filepath: "/repo/src/app.ts",
+          diff: "--- /repo/src/app.ts\n+++ /repo/src/app.ts\n@@\n-old\n+new",
+        },
+      },
+    } as unknown as Event,
+  ]);
+
+  expect(emitted).toContainEqual(
+    expect.objectContaining({
+      type: "approval_required",
+      externalSessionId: "external-session-1",
+      requestId: "perm-v2-1",
+      action: { name: "edit" },
+      affectedPaths: ["src/**"],
+      metadata: expect.objectContaining({
+        opencode: expect.objectContaining({
+          metadata: expect.objectContaining({
+            filepath: "/repo/src/app.ts",
+            diff: "--- /repo/src/app.ts\n+++ /repo/src/app.ts\n@@\n-old\n+new",
+          }),
+        }),
+      }),
+    }),
+  );
+});
+
 test("flushPendingSubagentInputEventsForSession preserves original timestamps", () => {
   const emitted: AgentEvent[] = [];
   const runtime: EventStreamRuntime = {
@@ -2476,6 +2512,39 @@ describe("event-stream", () => {
       type: "approval_required",
       externalSessionId: "external-session-1",
       requestId: "perm-child-1",
+      childExternalSessionId: "external-child-session",
+      parentExternalSessionId: "external-session-1",
+      subagentCorrelationKey: "part:assistant-1:subtask-1",
+    });
+  });
+
+  test("runtime event transport forwards known child permission v2 events to parent subscribers", async () => {
+    const { emitted } = await runEventStreamWithSession(
+      [
+        {
+          type: "permission.v2.asked",
+          properties: {
+            sessionID: "external-child-session",
+            id: "perm-child-v2-1",
+            permission: "edit",
+            patterns: ["src/**"],
+          },
+        } as unknown as Event,
+      ],
+      (session) => {
+        session.subagentCorrelationKeyByExternalSessionId.set(
+          "external-child-session",
+          "part:assistant-1:subtask-1",
+        );
+      },
+    );
+
+    const permissionEvents = emitted.filter((event) => event.type === "approval_required");
+    expect(permissionEvents).toHaveLength(1);
+    expect(permissionEvents[0]).toMatchObject({
+      type: "approval_required",
+      externalSessionId: "external-session-1",
+      requestId: "perm-child-v2-1",
       childExternalSessionId: "external-child-session",
       parentExternalSessionId: "external-session-1",
       subagentCorrelationKey: "part:assistant-1:subtask-1",

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -214,10 +214,11 @@ export const isRelevantSubscriberEvent = (
 
   const eventExternalSessionId = readEventSessionId(event);
   if (eventExternalSessionId) {
+    const eventType = String(event.type);
     const properties = "properties" in event ? event.properties : undefined;
     const parentExternalSessionId = readEventParentExternalSessionId(properties);
 
-    if (event.type === "question.asked" && parentExternalSessionId) {
+    if (eventType === "question.asked" && parentExternalSessionId) {
       return parentExternalSessionId === subscriber.externalSessionId;
     }
 
@@ -226,10 +227,11 @@ export const isRelevantSubscriberEvent = (
     }
 
     if (
-      (event.type === "permission.asked" ||
-        event.type === "permission.replied" ||
-        event.type === "question.asked" ||
-        event.type === "question.replied") &&
+      (eventType === "permission.asked" ||
+        eventType === "permission.v2.asked" ||
+        eventType === "permission.replied" ||
+        eventType === "question.asked" ||
+        eventType === "question.replied") &&
       options?.isKnownChildExternalSessionId?.(eventExternalSessionId)
     ) {
       return true;

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -260,7 +260,8 @@ const handleSessionStatusEvent = (event: Event, runtime: EventStreamRuntime): bo
 };
 
 const handlePermissionAskedEvent = (event: Event, runtime: EventStreamRuntime): boolean => {
-  if (event.type !== "permission.asked") {
+  const eventType = String(event.type);
+  if (eventType !== "permission.asked" && eventType !== "permission.v2.asked") {
     return false;
   }
 

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -332,7 +332,7 @@ const removePendingSubagentCorrelationKey = (
 
 const toComparableFilePath = (filePath: string, workingDirectory: string): string => {
   const trimmed = filePath.trim();
-  return toProjectRelativePath(trimmed, workingDirectory).replace(/^\.\//, "");
+  return toProjectRelativePath(trimmed, workingDirectory).replace(/\\/g, "/").replace(/^\.\//, "");
 };
 
 const readToolInputFilePath = (part: Extract<AgentStreamPart, { kind: "tool" }>): string | null => {
@@ -356,7 +356,7 @@ const readPatchMessageIds = (parts: Part[]): string[] => {
 
     const messageId = readPartMessageId(part);
     if (!messageId) {
-      throw new Error("Malformed OpenCode patch history part: missing messageID.");
+      continue;
     }
     messageIds.add(messageId);
   }
@@ -369,13 +369,15 @@ const loadSessionDiffByMessageId = async (
   externalSessionId: string,
   messageIds: string[],
 ): Promise<Map<string, FileDiff[]>> => {
-  const entries = await Promise.all(
+  const results = await Promise.allSettled(
     messageIds.map(
       async (messageId) =>
         [messageId, await loadSessionDiff(runtimeEndpoint, externalSessionId, messageId)] as const,
     ),
   );
-  return new Map(entries);
+  return new Map(
+    results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : [])),
+  );
 };
 
 const withHistoryFileChanges = (

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -1,4 +1,5 @@
 import type { OpencodeClient, Part, Session } from "@opencode-ai/sdk/v2/client";
+import type { FileDiff } from "@openducktor/contracts";
 import type {
   AgentPendingApprovalRequest,
   AgentPendingQuestionRequest,
@@ -14,6 +15,7 @@ import {
   toOpenCodePermissionReply,
 } from "./approval-translation";
 import { unwrapData } from "./data-utils";
+import { loadSessionDiff } from "./diff-ops";
 import { bindSubagentExternalSession, bindSubagentPartCorrelation } from "./event-stream/shared";
 import {
   ensureVisibleUserTextDisplayParts,
@@ -26,6 +28,7 @@ import {
   readVisibleUserTextFromDisplayParts,
   sanitizeAssistantMessage,
 } from "./message-normalizers";
+import { toProjectRelativePath } from "./path-utils";
 import { toOpenCodeRequestError } from "./request-errors";
 import { toIsoFromEpoch } from "./session-runtime-utils";
 import { mapPartToAgentStreamPart } from "./stream-part-mapper";
@@ -163,6 +166,10 @@ type MappedSubagentPart = Extract<AgentStreamPart, { kind: "subagent" }>;
 type ChildSessionLink = {
   externalSessionId: string;
   createdAtMs: number;
+};
+type HistoryPatchContext = {
+  workingDirectory: string;
+  sessionDiffByMessageId: Map<string, FileDiff[]>;
 };
 
 const CHILD_SESSION_START_TOLERANCE_MS = 5_000;
@@ -323,9 +330,91 @@ const removePendingSubagentCorrelationKey = (
   }
 };
 
+const toComparableFilePath = (filePath: string, workingDirectory: string): string => {
+  const trimmed = filePath.trim();
+  return toProjectRelativePath(trimmed, workingDirectory).replace(/^\.\//, "");
+};
+
+const readToolInputFilePath = (part: Extract<AgentStreamPart, { kind: "tool" }>): string | null => {
+  if (!part.input) {
+    return null;
+  }
+  return readString(part.input, ["filePath", "file_path", "path", "file"]) ?? null;
+};
+
+const readPartMessageId = (part: Part): string | null => {
+  const record = asRecord(part);
+  return record ? (readString(record, ["messageID", "messageId", "message_id"]) ?? null) : null;
+};
+
+const readPatchMessageIds = (parts: Part[]): string[] => {
+  const messageIds = new Set<string>();
+  for (const part of parts) {
+    if (part.type !== "patch") {
+      continue;
+    }
+
+    const messageId = readPartMessageId(part);
+    if (!messageId) {
+      throw new Error("Malformed OpenCode patch history part: missing messageID.");
+    }
+    messageIds.add(messageId);
+  }
+
+  return [...messageIds];
+};
+
+const loadSessionDiffByMessageId = async (
+  runtimeEndpoint: string,
+  externalSessionId: string,
+  messageIds: string[],
+): Promise<Map<string, FileDiff[]>> => {
+  const entries = await Promise.all(
+    messageIds.map(
+      async (messageId) =>
+        [messageId, await loadSessionDiff(runtimeEndpoint, externalSessionId, messageId)] as const,
+    ),
+  );
+  return new Map(entries);
+};
+
+const withHistoryFileChanges = (
+  part: AgentStreamPart,
+  patchContext?: HistoryPatchContext,
+): AgentStreamPart => {
+  if (!patchContext || part.kind !== "tool" || part.toolType !== "file_edit") {
+    return part;
+  }
+  if (part.fileChanges && part.fileChanges.length > 0) {
+    return part;
+  }
+  const sessionDiff = patchContext.sessionDiffByMessageId.get(part.messageId);
+  if (!sessionDiff) {
+    return part;
+  }
+  const inputPath = readToolInputFilePath(part);
+  if (!inputPath) {
+    return part;
+  }
+  const inputComparablePath = toComparableFilePath(inputPath, patchContext.workingDirectory);
+  const fileChanges = sessionDiff.filter(
+    (fileChange) =>
+      toComparableFilePath(fileChange.file, patchContext.workingDirectory) === inputComparablePath,
+  );
+  if (fileChanges.length === 0) {
+    return part;
+  }
+
+  return {
+    ...part,
+    fileChanges: [...(part.fileChanges ?? []), ...fileChanges],
+  };
+};
+
 const normalizeHistoryStreamParts = (
   parts: Part[],
   childSessionLinks: ChildSessionLink[] = [],
+  patchContext?: HistoryPatchContext,
 ): AgentStreamPart[] => {
   const pendingBySignature = new Map<string, string[]>();
   const correlationByExternalSessionId = new Map<string, string>();
@@ -333,13 +422,17 @@ const normalizeHistoryStreamParts = (
   const unmatchedChildSessionLinks = [...childSessionLinks];
 
   for (const rawPart of parts) {
+    if (rawPart.type === "patch") {
+      continue;
+    }
+
     const rawMapped = mapPartToAgentStreamPart(rawPart);
     if (!rawMapped || rawMapped.kind === "text") {
       continue;
     }
 
     if (rawMapped.kind !== "subagent") {
-      normalized.push(rawMapped);
+      normalized.push(withHistoryFileChanges(rawMapped, patchContext));
       continue;
     }
 
@@ -533,13 +626,26 @@ export const loadSessionHistory = async (
       return aTime - bTime;
     });
 
+  const assistantRawParts = normalizedEntries.flatMap((item) =>
+    item.entry.info.role === "assistant" ? item.rawParts : [],
+  );
+  const patchMessageIds = readPatchMessageIds(assistantRawParts);
+  const sessionDiffByMessageId =
+    patchMessageIds.length > 0
+      ? await loadSessionDiffByMessageId(
+          input.runtimeEndpoint,
+          input.externalSessionId,
+          patchMessageIds,
+        )
+      : new Map<string, FileDiff[]>();
+  const patchContext =
+    sessionDiffByMessageId.size > 0
+      ? { workingDirectory: input.workingDirectory, sessionDiffByMessageId }
+      : undefined;
   const assistantNormalizedPartsByMessageId = new Map(
-    normalizeHistoryStreamParts(
-      normalizedEntries.flatMap((item) =>
-        item.entry.info.role === "assistant" ? item.rawParts : [],
-      ),
-      childSessionLinks,
-    ).reduce<Map<string, AgentStreamPart[]>>((byMessageId, part) => {
+    normalizeHistoryStreamParts(assistantRawParts, childSessionLinks, patchContext).reduce<
+      Map<string, AgentStreamPart[]>
+    >((byMessageId, part) => {
       const existing = byMessageId.get(part.messageId) ?? [];
       existing.push(part);
       byMessageId.set(part.messageId, existing);

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -1,5 +1,4 @@
 import type { OpencodeClient, Part, Session } from "@opencode-ai/sdk/v2/client";
-import type { FileDiff } from "@openducktor/contracts";
 import type {
   AgentPendingApprovalRequest,
   AgentPendingQuestionRequest,
@@ -15,7 +14,6 @@ import {
   toOpenCodePermissionReply,
 } from "./approval-translation";
 import { unwrapData } from "./data-utils";
-import { loadSessionDiff } from "./diff-ops";
 import { bindSubagentExternalSession, bindSubagentPartCorrelation } from "./event-stream/shared";
 import {
   ensureVisibleUserTextDisplayParts,
@@ -28,7 +26,6 @@ import {
   readVisibleUserTextFromDisplayParts,
   sanitizeAssistantMessage,
 } from "./message-normalizers";
-import { toProjectRelativePath } from "./path-utils";
 import { toOpenCodeRequestError } from "./request-errors";
 import { toIsoFromEpoch } from "./session-runtime-utils";
 import { mapPartToAgentStreamPart } from "./stream-part-mapper";
@@ -166,10 +163,6 @@ type MappedSubagentPart = Extract<AgentStreamPart, { kind: "subagent" }>;
 type ChildSessionLink = {
   externalSessionId: string;
   createdAtMs: number;
-};
-type HistoryPatchContext = {
-  workingDirectory: string;
-  sessionDiffByMessageId: Map<string, FileDiff[]>;
 };
 
 const CHILD_SESSION_START_TOLERANCE_MS = 5_000;
@@ -330,93 +323,9 @@ const removePendingSubagentCorrelationKey = (
   }
 };
 
-const toComparableFilePath = (filePath: string, workingDirectory: string): string => {
-  const trimmed = filePath.trim();
-  return toProjectRelativePath(trimmed, workingDirectory).replace(/\\/g, "/").replace(/^\.\//, "");
-};
-
-const readToolInputFilePath = (part: Extract<AgentStreamPart, { kind: "tool" }>): string | null => {
-  if (!part.input) {
-    return null;
-  }
-  return readString(part.input, ["filePath", "file_path", "path", "file"]) ?? null;
-};
-
-const readPartMessageId = (part: Part): string | null => {
-  const record = asRecord(part);
-  return record ? (readString(record, ["messageID", "messageId", "message_id"]) ?? null) : null;
-};
-
-const readPatchMessageIds = (parts: Part[]): string[] => {
-  const messageIds = new Set<string>();
-  for (const part of parts) {
-    if (part.type !== "patch") {
-      continue;
-    }
-
-    const messageId = readPartMessageId(part);
-    if (!messageId) {
-      continue;
-    }
-    messageIds.add(messageId);
-  }
-
-  return [...messageIds];
-};
-
-const loadSessionDiffByMessageId = async (
-  runtimeEndpoint: string,
-  externalSessionId: string,
-  messageIds: string[],
-): Promise<Map<string, FileDiff[]>> => {
-  const results = await Promise.allSettled(
-    messageIds.map(
-      async (messageId) =>
-        [messageId, await loadSessionDiff(runtimeEndpoint, externalSessionId, messageId)] as const,
-    ),
-  );
-  return new Map(
-    results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : [])),
-  );
-};
-
-const withHistoryFileChanges = (
-  part: AgentStreamPart,
-  patchContext?: HistoryPatchContext,
-): AgentStreamPart => {
-  if (!patchContext || part.kind !== "tool" || part.toolType !== "file_edit") {
-    return part;
-  }
-  if (part.fileChanges && part.fileChanges.length > 0) {
-    return part;
-  }
-  const sessionDiff = patchContext.sessionDiffByMessageId.get(part.messageId);
-  if (!sessionDiff) {
-    return part;
-  }
-  const inputPath = readToolInputFilePath(part);
-  if (!inputPath) {
-    return part;
-  }
-  const inputComparablePath = toComparableFilePath(inputPath, patchContext.workingDirectory);
-  const fileChanges = sessionDiff.filter(
-    (fileChange) =>
-      toComparableFilePath(fileChange.file, patchContext.workingDirectory) === inputComparablePath,
-  );
-  if (fileChanges.length === 0) {
-    return part;
-  }
-
-  return {
-    ...part,
-    fileChanges: [...(part.fileChanges ?? []), ...fileChanges],
-  };
-};
-
 const normalizeHistoryStreamParts = (
   parts: Part[],
   childSessionLinks: ChildSessionLink[] = [],
-  patchContext?: HistoryPatchContext,
 ): AgentStreamPart[] => {
   const pendingBySignature = new Map<string, string[]>();
   const correlationByExternalSessionId = new Map<string, string>();
@@ -434,7 +343,7 @@ const normalizeHistoryStreamParts = (
     }
 
     if (rawMapped.kind !== "subagent") {
-      normalized.push(withHistoryFileChanges(rawMapped, patchContext));
+      normalized.push(rawMapped);
       continue;
     }
 
@@ -631,21 +540,8 @@ export const loadSessionHistory = async (
   const assistantRawParts = normalizedEntries.flatMap((item) =>
     item.entry.info.role === "assistant" ? item.rawParts : [],
   );
-  const patchMessageIds = readPatchMessageIds(assistantRawParts);
-  const sessionDiffByMessageId =
-    patchMessageIds.length > 0
-      ? await loadSessionDiffByMessageId(
-          input.runtimeEndpoint,
-          input.externalSessionId,
-          patchMessageIds,
-        )
-      : new Map<string, FileDiff[]>();
-  const patchContext =
-    sessionDiffByMessageId.size > 0
-      ? { workingDirectory: input.workingDirectory, sessionDiffByMessageId }
-      : undefined;
   const assistantNormalizedPartsByMessageId = new Map(
-    normalizeHistoryStreamParts(assistantRawParts, childSessionLinks, patchContext).reduce<
+    normalizeHistoryStreamParts(assistantRawParts, childSessionLinks).reduce<
       Map<string, AgentStreamPart[]>
     >((byMessageId, part) => {
       const existing = byMessageId.get(part.messageId) ?? [];

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -197,7 +197,7 @@ describe("OpencodeSdkAdapter session history", () => {
             type: "modified",
             additions: 1,
             deletions: 1,
-            diff: "@@ -1 +1 @@\n-old\n+new",
+            diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n-old\n+new\n",
           },
         ],
       });
@@ -393,7 +393,7 @@ describe("OpencodeSdkAdapter session history", () => {
         fileChanges: [
           {
             file: "src/ok.ts",
-            diff: "@@ -1 +1 @@\n-before\n+after",
+            diff: "--- a/src/ok.ts\n+++ b/src/ok.ts\n@@ -1 +1 @@\n-before\n+after\n",
           },
         ],
       });
@@ -516,7 +516,7 @@ describe("OpencodeSdkAdapter session history", () => {
         fileChanges: [
           {
             file: "src/main.ts",
-            diff: "@@ -1 +1 @@\n-first\n+second",
+            diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n-first\n+second\n",
           },
         ],
       });
@@ -525,7 +525,7 @@ describe("OpencodeSdkAdapter session history", () => {
         fileChanges: [
           {
             file: "src/main.ts",
-            diff: "@@ -1 +1 @@\n-second\n+third",
+            diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n-second\n+third\n",
           },
         ],
       });

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -114,6 +114,228 @@ describe("OpencodeSdkAdapter session history", () => {
     });
   });
 
+  test("loadSessionHistory attaches OpenCode patch diffs to edit tool parts", async () => {
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = (async (url: URL | RequestInfo) => {
+      requestedUrls.push(url.toString());
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [
+          {
+            file: "src/main.ts",
+            patch: "@@ -1 +1 @@\n-old\n+new",
+            additions: 1,
+            deletions: 1,
+            status: "modified",
+          },
+        ],
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const mock = makeMockClient({
+        messagesResponse: [
+          {
+            info: {
+              id: "msg-200",
+              role: "assistant",
+              time: { created: Date.parse("2026-02-17T12:00:00Z") },
+            },
+            parts: [
+              {
+                id: "tool-edit-1",
+                sessionID: "session-opencode-1",
+                messageID: "msg-200",
+                callID: "call-edit-1",
+                type: "tool",
+                tool: "edit",
+                state: {
+                  status: "completed",
+                  input: { filePath: "/repo/src/main.ts" },
+                  output: "Edited src/main.ts",
+                },
+              } as unknown as Part,
+              {
+                id: "patch-1",
+                sessionID: "session-opencode-1",
+                messageID: "msg-200",
+                type: "patch",
+                files: ["/repo/src/main.ts"],
+              } as unknown as Part,
+            ],
+          },
+        ],
+      });
+      const adapter = new OpencodeSdkAdapter({
+        createClient: () => mock.client,
+        now: () => "2026-02-17T12:00:00Z",
+      });
+
+      const history = await adapter.loadSessionHistory({
+        ...defaultRepoRuntimeInput,
+        externalSessionId: "session-opencode-1",
+        limit: 100,
+      });
+
+      expect(history).toHaveLength(1);
+      const message = history[0];
+      if (message?.role !== "assistant") {
+        throw new Error("Expected assistant history entry");
+      }
+      const editPart = message.parts.find((part) => part.kind === "tool");
+      expect(editPart).toMatchObject({
+        kind: "tool",
+        tool: "edit",
+        toolType: "file_edit",
+        fileChanges: [
+          {
+            file: "src/main.ts",
+            type: "modified",
+            additions: 1,
+            deletions: 1,
+            diff: "@@ -1 +1 @@\n-old\n+new",
+          },
+        ],
+      });
+      expect(requestedUrls).toEqual([
+        "http://127.0.0.1:12345/session/session-opencode-1/diff?messageID=msg-200",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("loadSessionHistory scopes OpenCode patch diffs to the patch message", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: URL | RequestInfo) => {
+      const messageId = new URL(url.toString()).searchParams.get("messageID");
+      const diffByMessageId: Record<string, string> = {
+        "msg-200": "@@ -1 +1 @@\n-first\n+second",
+        "msg-201": "@@ -1 +1 @@\n-second\n+third",
+      };
+      const patch = messageId ? diffByMessageId[messageId] : undefined;
+      if (!patch) {
+        throw new Error(`Unexpected diff request for message '${messageId ?? ""}'.`);
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [
+          {
+            file: "src/main.ts",
+            patch,
+            additions: 1,
+            deletions: 1,
+            status: "modified",
+          },
+        ],
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const mock = makeMockClient({
+        messagesResponse: [
+          {
+            info: {
+              id: "msg-200",
+              role: "assistant",
+              time: { created: Date.parse("2026-02-17T12:00:00Z") },
+            },
+            parts: [
+              {
+                id: "tool-edit-1",
+                sessionID: "session-opencode-1",
+                messageID: "msg-200",
+                callID: "call-edit-1",
+                type: "tool",
+                tool: "edit",
+                state: {
+                  status: "completed",
+                  input: { filePath: "/repo/src/main.ts" },
+                  output: "Edited src/main.ts",
+                },
+              } as unknown as Part,
+              {
+                id: "patch-1",
+                sessionID: "session-opencode-1",
+                messageID: "msg-200",
+                type: "patch",
+                files: ["/repo/src/main.ts"],
+              } as unknown as Part,
+            ],
+          },
+          {
+            info: {
+              id: "msg-201",
+              role: "assistant",
+              time: { created: Date.parse("2026-02-17T12:01:00Z") },
+            },
+            parts: [
+              {
+                id: "tool-edit-2",
+                sessionID: "session-opencode-1",
+                messageID: "msg-201",
+                callID: "call-edit-2",
+                type: "tool",
+                tool: "edit",
+                state: {
+                  status: "completed",
+                  input: { filePath: "/repo/src/main.ts" },
+                  output: "Edited src/main.ts again",
+                },
+              } as unknown as Part,
+              {
+                id: "patch-2",
+                sessionID: "session-opencode-1",
+                messageID: "msg-201",
+                type: "patch",
+                files: ["/repo/src/main.ts"],
+              } as unknown as Part,
+            ],
+          },
+        ],
+      });
+      const adapter = new OpencodeSdkAdapter({
+        createClient: () => mock.client,
+        now: () => "2026-02-17T12:00:00Z",
+      });
+
+      const history = await adapter.loadSessionHistory({
+        ...defaultRepoRuntimeInput,
+        externalSessionId: "session-opencode-1",
+        limit: 100,
+      });
+
+      expect(history).toHaveLength(2);
+      const firstEdit = history[0]?.parts.find((part) => part.kind === "tool");
+      const secondEdit = history[1]?.parts.find((part) => part.kind === "tool");
+      expect(firstEdit).toMatchObject({
+        kind: "tool",
+        fileChanges: [
+          {
+            file: "src/main.ts",
+            diff: "@@ -1 +1 @@\n-first\n+second",
+          },
+        ],
+      });
+      expect(secondEdit).toMatchObject({
+        kind: "tool",
+        fileChanges: [
+          {
+            file: "src/main.ts",
+            diff: "@@ -1 +1 @@\n-second\n+third",
+          },
+        ],
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("loadSessionHistory normalizes subagent correlation keys like the live stream", async () => {
     const mock = makeMockClient({
       messagesResponse: [

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -116,23 +116,8 @@ describe("OpencodeSdkAdapter session history", () => {
 
   test("loadSessionHistory attaches OpenCode patch diffs to edit tool parts", async () => {
     const originalFetch = globalThis.fetch;
-    const requestedUrls: string[] = [];
-    globalThis.fetch = (async (url: URL | RequestInfo) => {
-      requestedUrls.push(url.toString());
-      return {
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        json: async () => [
-          {
-            file: ".\\src\\main.ts",
-            patch: "@@ -1 +1 @@\n-old\n+new",
-            additions: 1,
-            deletions: 1,
-            status: "modified",
-          },
-        ],
-      } as Response;
+    globalThis.fetch = (async () => {
+      throw new Error("Transcript history must not call the session diff endpoint.");
     }) as typeof fetch;
 
     try {
@@ -156,6 +141,14 @@ describe("OpencodeSdkAdapter session history", () => {
                   status: "completed",
                   input: { filePath: "/repo/src/main.ts" },
                   output: "Edited src/main.ts",
+                  metadata: {
+                    filediff: {
+                      file: "/repo/src/main.ts",
+                      patch: "@@ -1 +1 @@\n-old\n+new",
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  },
                 },
               } as unknown as Part,
               {
@@ -193,17 +186,14 @@ describe("OpencodeSdkAdapter session history", () => {
         output: "Edited src/main.ts",
         fileChanges: [
           {
-            file: ".\\src\\main.ts",
+            file: "/repo/src/main.ts",
             type: "modified",
             additions: 1,
             deletions: 1,
-            diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n-old\n+new\n",
+            diff: "--- a/repo/src/main.ts\n+++ b/repo/src/main.ts\n@@ -1 +1 @@\n-old\n+new\n",
           },
         ],
       });
-      expect(requestedUrls).toEqual([
-        "http://127.0.0.1:12345/session/session-opencode-1/diff?messageID=msg-200",
-      ]);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -273,36 +263,10 @@ describe("OpencodeSdkAdapter session history", () => {
     }
   });
 
-  test("loadSessionHistory preserves history when one OpenCode patch diff request fails", async () => {
+  test("loadSessionHistory uses only tool metadata when patch parts are present", async () => {
     const originalFetch = globalThis.fetch;
-    const requestedUrls: string[] = [];
-    globalThis.fetch = (async (url: URL | RequestInfo) => {
-      requestedUrls.push(url.toString());
-      const messageId = new URL(url.toString()).searchParams.get("messageID");
-      if (messageId === "msg-200") {
-        return {
-          ok: false,
-          status: 502,
-          statusText: "Bad Gateway",
-          json: async () => {
-            throw new Error("should not read body");
-          },
-        } as Response;
-      }
-      return {
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        json: async () => [
-          {
-            file: "src/ok.ts",
-            patch: "@@ -1 +1 @@\n-before\n+after",
-            additions: 1,
-            deletions: 1,
-            status: "modified",
-          },
-        ],
-      } as Response;
+    globalThis.fetch = (async () => {
+      throw new Error("Transcript history must not call the session diff endpoint.");
     }) as typeof fetch;
 
     try {
@@ -355,6 +319,14 @@ describe("OpencodeSdkAdapter session history", () => {
                   status: "completed",
                   input: { filePath: "/repo/src/ok.ts" },
                   output: "Edited src/ok.ts",
+                  metadata: {
+                    filediff: {
+                      file: "src/ok.ts",
+                      patch: "@@ -1 +1 @@\n-before\n+after",
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  },
                 },
               } as unknown as Part,
               {
@@ -397,41 +369,15 @@ describe("OpencodeSdkAdapter session history", () => {
           },
         ],
       });
-      expect(requestedUrls).toEqual([
-        "http://127.0.0.1:12345/session/session-opencode-1/diff?messageID=msg-200",
-        "http://127.0.0.1:12345/session/session-opencode-1/diff?messageID=msg-201",
-      ]);
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  test("loadSessionHistory scopes OpenCode patch diffs to the patch message", async () => {
+  test("loadSessionHistory scopes OpenCode tool diffs to their tool metadata", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async (url: URL | RequestInfo) => {
-      const messageId = new URL(url.toString()).searchParams.get("messageID");
-      const diffByMessageId: Record<string, string> = {
-        "msg-200": "@@ -1 +1 @@\n-first\n+second",
-        "msg-201": "@@ -1 +1 @@\n-second\n+third",
-      };
-      const patch = messageId ? diffByMessageId[messageId] : undefined;
-      if (!patch) {
-        throw new Error(`Unexpected diff request for message '${messageId ?? ""}'.`);
-      }
-      return {
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        json: async () => [
-          {
-            file: "src/main.ts",
-            patch,
-            additions: 1,
-            deletions: 1,
-            status: "modified",
-          },
-        ],
-      } as Response;
+    globalThis.fetch = (async () => {
+      throw new Error("Transcript history must not call the session diff endpoint.");
     }) as typeof fetch;
 
     try {
@@ -455,6 +401,14 @@ describe("OpencodeSdkAdapter session history", () => {
                   status: "completed",
                   input: { filePath: "/repo/src/main.ts" },
                   output: "Edited src/main.ts",
+                  metadata: {
+                    filediff: {
+                      file: "src/main.ts",
+                      patch: "@@ -1 +1 @@\n-first\n+second",
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  },
                 },
               } as unknown as Part,
               {
@@ -484,6 +438,14 @@ describe("OpencodeSdkAdapter session history", () => {
                   status: "completed",
                   input: { filePath: "/repo/src/main.ts" },
                   output: "Edited src/main.ts again",
+                  metadata: {
+                    filediff: {
+                      file: "src/main.ts",
+                      patch: "@@ -1 +1 @@\n-second\n+third",
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  },
                 },
               } as unknown as Part,
               {

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -184,7 +184,7 @@ describe("OpencodeSdkAdapter session history", () => {
         tool: "edit",
         toolType: "file_edit",
         output: "Edited src/main.ts",
-        fileChanges: [
+        fileDiffs: [
           {
             file: "/repo/src/main.ts",
             type: "modified",
@@ -257,7 +257,7 @@ describe("OpencodeSdkAdapter session history", () => {
         toolType: "file_edit",
         output: "Edited src/main.ts",
       });
-      expect(editPart).not.toEqual(expect.objectContaining({ fileChanges: expect.any(Array) }));
+      expect(editPart).not.toEqual(expect.objectContaining({ fileDiffs: expect.any(Array) }));
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -358,11 +358,11 @@ describe("OpencodeSdkAdapter session history", () => {
         kind: "tool",
         output: "Edited src/fail.ts",
       });
-      expect(failedEdit).not.toEqual(expect.objectContaining({ fileChanges: expect.any(Array) }));
+      expect(failedEdit).not.toEqual(expect.objectContaining({ fileDiffs: expect.any(Array) }));
       expect(loadedEdit).toMatchObject({
         kind: "tool",
         output: "Edited src/ok.ts",
-        fileChanges: [
+        fileDiffs: [
           {
             file: "src/ok.ts",
             diff: "--- a/src/ok.ts\n+++ b/src/ok.ts\n@@ -1 +1 @@\n-before\n+after\n",
@@ -475,7 +475,7 @@ describe("OpencodeSdkAdapter session history", () => {
       const secondEdit = history[1]?.parts.find((part) => part.kind === "tool");
       expect(firstEdit).toMatchObject({
         kind: "tool",
-        fileChanges: [
+        fileDiffs: [
           {
             file: "src/main.ts",
             diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n-first\n+second\n",
@@ -484,7 +484,7 @@ describe("OpencodeSdkAdapter session history", () => {
       });
       expect(secondEdit).toMatchObject({
         kind: "tool",
-        fileChanges: [
+        fileDiffs: [
           {
             file: "src/main.ts",
             diff: "--- a/src/main.ts\n+++ b/src/main.ts\n@@ -1 +1 @@\n-second\n+third\n",

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -125,7 +125,7 @@ describe("OpencodeSdkAdapter session history", () => {
         statusText: "OK",
         json: async () => [
           {
-            file: "src/main.ts",
+            file: ".\\src\\main.ts",
             patch: "@@ -1 +1 @@\n-old\n+new",
             additions: 1,
             deletions: 1,
@@ -190,9 +190,10 @@ describe("OpencodeSdkAdapter session history", () => {
         kind: "tool",
         tool: "edit",
         toolType: "file_edit",
+        output: "Edited src/main.ts",
         fileChanges: [
           {
-            file: "src/main.ts",
+            file: ".\\src\\main.ts",
             type: "modified",
             additions: 1,
             deletions: 1,
@@ -202,6 +203,203 @@ describe("OpencodeSdkAdapter session history", () => {
       });
       expect(requestedUrls).toEqual([
         "http://127.0.0.1:12345/session/session-opencode-1/diff?messageID=msg-200",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("loadSessionHistory ignores malformed patch parts without dropping history", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("Diff endpoint should not be called without a patch message id.");
+    }) as typeof fetch;
+
+    try {
+      const mock = makeMockClient({
+        messagesResponse: [
+          {
+            info: {
+              id: "msg-200",
+              role: "assistant",
+              time: { created: Date.parse("2026-02-17T12:00:00Z") },
+            },
+            parts: [
+              {
+                id: "tool-edit-1",
+                sessionID: "session-opencode-1",
+                messageID: "msg-200",
+                callID: "call-edit-1",
+                type: "tool",
+                tool: "edit",
+                state: {
+                  status: "completed",
+                  input: { filePath: "/repo/src/main.ts" },
+                  output: "Edited src/main.ts",
+                },
+              } as unknown as Part,
+              {
+                id: "patch-1",
+                sessionID: "session-opencode-1",
+                type: "patch",
+                files: ["/repo/src/main.ts"],
+              } as unknown as Part,
+            ],
+          },
+        ],
+      });
+      const adapter = new OpencodeSdkAdapter({
+        createClient: () => mock.client,
+        now: () => "2026-02-17T12:00:00Z",
+      });
+
+      const history = await adapter.loadSessionHistory({
+        ...defaultRepoRuntimeInput,
+        externalSessionId: "session-opencode-1",
+        limit: 100,
+      });
+
+      expect(history).toHaveLength(1);
+      const editPart = history[0]?.parts.find((part) => part.kind === "tool");
+      expect(editPart).toMatchObject({
+        kind: "tool",
+        tool: "edit",
+        toolType: "file_edit",
+        output: "Edited src/main.ts",
+      });
+      expect(editPart).not.toEqual(expect.objectContaining({ fileChanges: expect.any(Array) }));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("loadSessionHistory preserves history when one OpenCode patch diff request fails", async () => {
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = (async (url: URL | RequestInfo) => {
+      requestedUrls.push(url.toString());
+      const messageId = new URL(url.toString()).searchParams.get("messageID");
+      if (messageId === "msg-200") {
+        return {
+          ok: false,
+          status: 502,
+          statusText: "Bad Gateway",
+          json: async () => {
+            throw new Error("should not read body");
+          },
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [
+          {
+            file: "src/ok.ts",
+            patch: "@@ -1 +1 @@\n-before\n+after",
+            additions: 1,
+            deletions: 1,
+            status: "modified",
+          },
+        ],
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const mock = makeMockClient({
+        messagesResponse: [
+          {
+            info: {
+              id: "msg-200",
+              role: "assistant",
+              time: { created: Date.parse("2026-02-17T12:00:00Z") },
+            },
+            parts: [
+              {
+                id: "tool-edit-1",
+                sessionID: "session-opencode-1",
+                messageID: "msg-200",
+                callID: "call-edit-1",
+                type: "tool",
+                tool: "edit",
+                state: {
+                  status: "completed",
+                  input: { filePath: "/repo/src/fail.ts" },
+                  output: "Edited src/fail.ts",
+                },
+              } as unknown as Part,
+              {
+                id: "patch-1",
+                sessionID: "session-opencode-1",
+                messageID: "msg-200",
+                type: "patch",
+                files: ["/repo/src/fail.ts"],
+              } as unknown as Part,
+            ],
+          },
+          {
+            info: {
+              id: "msg-201",
+              role: "assistant",
+              time: { created: Date.parse("2026-02-17T12:01:00Z") },
+            },
+            parts: [
+              {
+                id: "tool-edit-2",
+                sessionID: "session-opencode-1",
+                messageID: "msg-201",
+                callID: "call-edit-2",
+                type: "tool",
+                tool: "edit",
+                state: {
+                  status: "completed",
+                  input: { filePath: "/repo/src/ok.ts" },
+                  output: "Edited src/ok.ts",
+                },
+              } as unknown as Part,
+              {
+                id: "patch-2",
+                sessionID: "session-opencode-1",
+                messageID: "msg-201",
+                type: "patch",
+                files: ["/repo/src/ok.ts"],
+              } as unknown as Part,
+            ],
+          },
+        ],
+      });
+      const adapter = new OpencodeSdkAdapter({
+        createClient: () => mock.client,
+        now: () => "2026-02-17T12:00:00Z",
+      });
+
+      const history = await adapter.loadSessionHistory({
+        ...defaultRepoRuntimeInput,
+        externalSessionId: "session-opencode-1",
+        limit: 100,
+      });
+
+      expect(history).toHaveLength(2);
+      const failedEdit = history[0]?.parts.find((part) => part.kind === "tool");
+      const loadedEdit = history[1]?.parts.find((part) => part.kind === "tool");
+      expect(failedEdit).toMatchObject({
+        kind: "tool",
+        output: "Edited src/fail.ts",
+      });
+      expect(failedEdit).not.toEqual(expect.objectContaining({ fileChanges: expect.any(Array) }));
+      expect(loadedEdit).toMatchObject({
+        kind: "tool",
+        output: "Edited src/ok.ts",
+        fileChanges: [
+          {
+            file: "src/ok.ts",
+            diff: "@@ -1 +1 @@\n-before\n+after",
+          },
+        ],
+      });
+      expect(requestedUrls).toEqual([
+        "http://127.0.0.1:12345/session/session-opencode-1/diff?messageID=msg-200",
+        "http://127.0.0.1:12345/session/session-opencode-1/diff?messageID=msg-201",
       ]);
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -78,6 +78,7 @@ const PARENT_CHILD_LOOKUP_EVENT_TYPES = new Set([
   "session.created",
   "session.updated",
   "permission.asked",
+  "permission.v2.asked",
   "permission.replied",
   "question.asked",
   "question.replied",

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -237,6 +237,75 @@ describe("stream-part-mapper", () => {
     });
   });
 
+  test("maps write tool diff metadata to canonical file changes", () => {
+    const part = createToolPart({
+      id: "tool-write-1",
+      tool: "write",
+      status: "completed",
+      input: {
+        filePath: "/repo/src/main.ts",
+        content: "new\n",
+      },
+      output: "Wrote file successfully.",
+      metadata: {
+        filepath: "/repo/src/main.ts",
+        diff: "--- /repo/src/main.ts\n+++ /repo/src/main.ts\n@@ -1 +1 @@\n-old\n+new",
+        exists: true,
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      tool: "write",
+      toolType: "file_edit",
+      fileChanges: [
+        {
+          file: "/repo/src/main.ts",
+          type: "modified",
+          additions: 1,
+          deletions: 1,
+          diff: "--- /repo/src/main.ts\n+++ /repo/src/main.ts\n@@ -1 +1 @@\n-old\n+new\n",
+        },
+      ],
+    });
+  });
+
+  test("renders completed new-file write tool input as an added-file diff", () => {
+    const part = createToolPart({
+      id: "tool-write-new-file-1",
+      tool: "write",
+      status: "completed",
+      input: {
+        filePath: "/repo/apps/web/src/contexts/__tests__/AuthContext.test.tsx",
+        content: "import { render } from '@testing-library/react';\nfunction AuthConsumer() {}\n",
+      },
+      output: "Wrote file successfully.",
+      metadata: {
+        filepath: "/repo/apps/web/src/contexts/__tests__/AuthContext.test.tsx",
+        exists: false,
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      tool: "write",
+      toolType: "file_edit",
+      fileChanges: [
+        {
+          file: "/repo/apps/web/src/contexts/__tests__/AuthContext.test.tsx",
+          type: "added",
+          additions: 2,
+          deletions: 0,
+          diff: "--- /dev/null\n+++ b/repo/apps/web/src/contexts/__tests__/AuthContext.test.tsx\n@@ -0,0 +1,2 @@\n+import { render } from '@testing-library/react';\n+function AuthConsumer() {}\n",
+        },
+      ],
+    });
+  });
+
   test("maps apply_patch files metadata to canonical file changes", () => {
     const part = createToolPart({
       id: "tool-patch-1",

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -190,7 +190,7 @@ describe("stream-part-mapper", () => {
       tool: "edit",
       toolType: "file_edit",
       output: "Edited src/main.ts",
-      fileChanges: [
+      fileDiffs: [
         {
           file: "/repo/src/main.ts",
           type: "modified",
@@ -225,7 +225,7 @@ describe("stream-part-mapper", () => {
       kind: "tool",
       tool: "edit",
       toolType: "file_edit",
-      fileChanges: [
+      fileDiffs: [
         {
           file: "/repo/src/main.ts",
           type: "modified",
@@ -237,7 +237,42 @@ describe("stream-part-mapper", () => {
     });
   });
 
-  test("maps write tool diff metadata to canonical file changes", () => {
+  test("maps edit-created files to added canonical file changes", () => {
+    const part = createToolPart({
+      id: "tool-edit-created-1",
+      tool: "edit",
+      status: "completed",
+      input: { filePath: "/repo/src/new.ts", oldString: "", newString: "created\n" },
+      output: "Edit applied successfully.",
+      metadata: {
+        filediff: {
+          file: "/repo/src/new.ts",
+          patch: "--- /repo/src/new.ts\n+++ /repo/src/new.ts\n@@ -0,0 +1 @@\n+created",
+          additions: 1,
+          deletions: 0,
+        },
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      tool: "edit",
+      toolType: "file_edit",
+      fileDiffs: [
+        {
+          file: "/repo/src/new.ts",
+          type: "added",
+          additions: 1,
+          deletions: 0,
+          diff: "--- /repo/src/new.ts\n+++ /repo/src/new.ts\n@@ -0,0 +1 @@\n+created\n",
+        },
+      ],
+    });
+  });
+
+  test("maps write tool diff metadata to canonical file diffs", () => {
     const part = createToolPart({
       id: "tool-write-1",
       tool: "write",
@@ -260,7 +295,7 @@ describe("stream-part-mapper", () => {
       kind: "tool",
       tool: "write",
       toolType: "file_edit",
-      fileChanges: [
+      fileDiffs: [
         {
           file: "/repo/src/main.ts",
           type: "modified",
@@ -270,6 +305,39 @@ describe("stream-part-mapper", () => {
         },
       ],
     });
+  });
+
+  test("maps existing-file write tool content to canonical file content when no diff exists", () => {
+    const part = createToolPart({
+      id: "tool-write-content-1",
+      tool: "write",
+      status: "completed",
+      input: {
+        filePath: "/repo/src/main.ts",
+        content: "export const value = 1;\n",
+      },
+      output: "Wrote file successfully.",
+      metadata: {
+        filepath: "/repo/src/main.ts",
+        exists: true,
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      tool: "write",
+      toolType: "file_edit",
+      fileContent: [
+        {
+          file: "/repo/src/main.ts",
+          type: "modified",
+          content: "export const value = 1;\n",
+        },
+      ],
+    });
+    expect(mapped).not.toEqual(expect.objectContaining({ fileDiffs: expect.any(Array) }));
   });
 
   test("renders completed new-file write tool input as an added-file diff", () => {
@@ -294,7 +362,7 @@ describe("stream-part-mapper", () => {
       kind: "tool",
       tool: "write",
       toolType: "file_edit",
-      fileChanges: [
+      fileDiffs: [
         {
           file: "/repo/apps/web/src/contexts/__tests__/AuthContext.test.tsx",
           type: "added",
@@ -334,13 +402,56 @@ describe("stream-part-mapper", () => {
       tool: "apply_patch",
       toolType: "file_edit",
       output: "Patch applied",
-      fileChanges: [
+      fileDiffs: [
         {
           file: "src/new.ts",
           type: "added",
           additions: 1,
           deletions: 0,
           diff: "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1 @@\n+created\n",
+        },
+      ],
+    });
+  });
+
+  test("maps apply_patch move metadata to the target path", () => {
+    const part = createToolPart({
+      id: "tool-patch-move-1",
+      tool: "apply_patch",
+      status: "completed",
+      input: {
+        patch:
+          "*** Begin Patch\n*** Update File: src/old.ts\n*** Move to: src/new.ts\n@@\n-old\n+new\n*** End Patch",
+      },
+      output: "Patch applied",
+      metadata: {
+        files: [
+          {
+            filePath: "/repo/src/old.ts",
+            relativePath: "src/new.ts",
+            type: "move",
+            patch: "--- /repo/src/old.ts\n+++ /repo/src/old.ts\n@@\n-old\n+new",
+            additions: 1,
+            deletions: 1,
+            movePath: "/repo/src/new.ts",
+          },
+        ],
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      tool: "apply_patch",
+      toolType: "file_edit",
+      fileDiffs: [
+        {
+          file: "src/new.ts",
+          type: "modified",
+          additions: 1,
+          deletions: 1,
+          diff: "--- /repo/src/old.ts\n+++ /repo/src/old.ts\n@@\n-old\n+new\n",
         },
       ],
     });

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -165,6 +165,118 @@ describe("stream-part-mapper", () => {
     });
   });
 
+  test("maps edit tool filediff metadata to canonical file changes", () => {
+    const part = createToolPart({
+      id: "tool-edit-1",
+      tool: "edit",
+      status: "completed",
+      input: { filePath: "/repo/src/main.ts" },
+      output: "Edited src/main.ts",
+      metadata: {
+        filediff: {
+          file: "/repo/src/main.ts",
+          patch: "@@ -1 +1 @@\n-old\n+new",
+          additions: 1,
+          deletions: 1,
+        },
+      },
+      time: { start: 10, end: 20 },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      tool: "edit",
+      toolType: "file_edit",
+      output: "Edited src/main.ts",
+      fileChanges: [
+        {
+          file: "/repo/src/main.ts",
+          type: "modified",
+          additions: 1,
+          deletions: 1,
+          diff: "--- a/repo/src/main.ts\n+++ b/repo/src/main.ts\n@@ -1 +1 @@\n-old\n+new\n",
+        },
+      ],
+    });
+  });
+
+  test("keeps modified full-file tool metadata path-only instead of rendering file contents", () => {
+    const part = createToolPart({
+      id: "tool-edit-full-file-1",
+      tool: "edit",
+      status: "completed",
+      input: { filePath: "/repo/src/main.ts" },
+      output: "Edited src/main.ts",
+      metadata: {
+        filediff: {
+          file: "/repo/src/main.ts",
+          patch: "import { render } from '@testing-library/react';\nfunction AuthConsumer() {}\n",
+          additions: 2,
+          deletions: 0,
+        },
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      tool: "edit",
+      toolType: "file_edit",
+      fileChanges: [
+        {
+          file: "/repo/src/main.ts",
+          type: "modified",
+          additions: 2,
+          deletions: 0,
+          diff: "",
+        },
+      ],
+    });
+  });
+
+  test("maps apply_patch files metadata to canonical file changes", () => {
+    const part = createToolPart({
+      id: "tool-patch-1",
+      tool: "apply_patch",
+      status: "completed",
+      input: { patch: "*** Begin Patch\n*** Add File: src/new.ts\n+created\n*** End Patch" },
+      output: "Patch applied",
+      metadata: {
+        files: [
+          {
+            filePath: "/repo/src/new.ts",
+            relativePath: "src/new.ts",
+            type: "add",
+            patch: "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1 @@\n+created",
+            additions: 1,
+            deletions: 0,
+          },
+        ],
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      tool: "apply_patch",
+      toolType: "file_edit",
+      output: "Patch applied",
+      fileChanges: [
+        {
+          file: "src/new.ts",
+          type: "added",
+          additions: 1,
+          deletions: 0,
+          diff: "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1 @@\n+created\n",
+        },
+      ],
+    });
+  });
+
   test("preserves cancelled subagent tool statuses", () => {
     const part = createToolPart({
       id: "tool-subagent-cancelled-1",

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -264,15 +264,58 @@ const fileDiffFromToolFileDiffMetadata = (value: unknown, input: unknown): FileD
   });
 };
 
+const fileDiffFromWriteMetadata = (
+  metadata: Record<string, unknown>,
+  input: unknown,
+): FileDiff | null => {
+  const inputRecord = asUnknownRecord(input);
+  const exists = readBooleanProp(metadata, ["exists"]);
+  const file =
+    readStringProp(metadata, ["filepath", "filePath", "file"]) ??
+    readStringProp(inputRecord, ["filePath", "file_path", "path", "file"]);
+  const type: FileDiff["type"] = exists === false ? "added" : "modified";
+  const diff = readStringProp(metadata, ["diff"]);
+
+  if (diff !== undefined) {
+    return normalizeToolMetadataFileDiff({
+      file,
+      type,
+      patch: diff,
+      additions: readNumberProp(metadata, ["additions"]),
+      deletions: readNumberProp(metadata, ["deletions"]),
+    });
+  }
+
+  if (exists !== false) {
+    return null;
+  }
+
+  return normalizeToolMetadataFileDiff({
+    file,
+    type,
+    patch: readStringProp(inputRecord, ["content"]) ?? null,
+    additions: readNumberProp(metadata, ["additions"]),
+    deletions: readNumberProp(metadata, ["deletions"]),
+  });
+};
+
 const readToolMetadataFileChanges = (
   metadata: Record<string, unknown> | undefined,
   toolState: Record<string, unknown>,
+  tool: string,
 ): FileDiff[] => {
   if (!metadata) {
     return [];
   }
 
   const fileChanges: FileDiff[] = [];
+  if (tool === "write") {
+    const writeDiff = fileDiffFromWriteMetadata(metadata, readUnknownProp(toolState, "input"));
+    if (writeDiff) {
+      fileChanges.push(writeDiff);
+    }
+  }
+
   const filediff = fileDiffFromToolFileDiffMetadata(
     readUnknownProp(metadata, "filediff"),
     readUnknownProp(toolState, "input"),
@@ -598,7 +641,7 @@ const buildToolStreamPart = (
 ): ToolStreamPart => {
   const toolType = deriveToolType(part.tool);
   const fileChanges =
-    toolType === "file_edit" ? readToolMetadataFileChanges(metadata, toolState) : [];
+    toolType === "file_edit" ? readToolMetadataFileChanges(metadata, toolState, part.tool) : [];
   const preview = deriveToolPreview({
     tool: part.tool,
     rawInput: readUnknownProp(toolState, "input"),

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -1,6 +1,10 @@
 import type { Part } from "@opencode-ai/sdk/v2/client";
-import { odtToolErrorPayloadSchema } from "@openducktor/contracts";
-import type { AgentStreamPart } from "@openducktor/core";
+import { type FileDiff, odtToolErrorPayloadSchema } from "@openducktor/contracts";
+import {
+  type AgentStreamPart,
+  countRenderableFileDiffLines,
+  selectRenderableFileDiff,
+} from "@openducktor/core";
 import {
   asUnknownRecord,
   readBooleanProp,
@@ -180,6 +184,114 @@ const normalizeMetadata = (value: unknown): Record<string, unknown> | undefined 
     return undefined;
   }
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+};
+
+const normalizeFileDiffType = (value: unknown): FileDiff["type"] => {
+  if (typeof value !== "string") {
+    return "modified";
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "add" || normalized === "added") {
+    return "added";
+  }
+  if (normalized === "delete" || normalized === "deleted") {
+    return "deleted";
+  }
+  return "modified";
+};
+
+const readFileDiffPatch = (value: Record<string, unknown>): string | null => {
+  const patch = readStringProp(value, ["patch"]);
+  if (patch !== undefined) {
+    return patch;
+  }
+  return readStringProp(value, ["diff"]) ?? null;
+};
+
+const normalizeToolMetadataFileDiff = (input: {
+  file: string | undefined;
+  type: FileDiff["type"];
+  patch: string | null;
+  additions: number | undefined;
+  deletions: number | undefined;
+}): FileDiff | null => {
+  const file = input.file?.trim();
+  if (!file || input.patch === null) {
+    return null;
+  }
+
+  const diff = selectRenderableFileDiff(input.patch, file, { changeType: input.type }) ?? "";
+  const counts = countRenderableFileDiffLines(diff);
+  return {
+    file,
+    type: input.type,
+    additions: input.additions ?? counts.additions,
+    deletions: input.deletions ?? counts.deletions,
+    diff,
+  };
+};
+
+const fileDiffFromToolFileMetadata = (value: unknown): FileDiff | null => {
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  return normalizeToolMetadataFileDiff({
+    file: readStringProp(record, ["relativePath"]) ?? readStringProp(record, ["filePath"]),
+    type: normalizeFileDiffType(readUnknownProp(record, "type")),
+    patch: readFileDiffPatch(record),
+    additions: readNumberProp(record, ["additions"]),
+    deletions: readNumberProp(record, ["deletions"]),
+  });
+};
+
+const fileDiffFromToolFileDiffMetadata = (value: unknown, input: unknown): FileDiff | null => {
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return null;
+  }
+  const inputRecord = asUnknownRecord(input);
+
+  return normalizeToolMetadataFileDiff({
+    file:
+      readStringProp(record, ["file"]) ??
+      readStringProp(inputRecord, ["filePath", "file_path", "path", "file"]),
+    type: normalizeFileDiffType(readUnknownProp(record, "status")),
+    patch: readFileDiffPatch(record),
+    additions: readNumberProp(record, ["additions"]),
+    deletions: readNumberProp(record, ["deletions"]),
+  });
+};
+
+const readToolMetadataFileChanges = (
+  metadata: Record<string, unknown> | undefined,
+  toolState: Record<string, unknown>,
+): FileDiff[] => {
+  if (!metadata) {
+    return [];
+  }
+
+  const fileChanges: FileDiff[] = [];
+  const filediff = fileDiffFromToolFileDiffMetadata(
+    readUnknownProp(metadata, "filediff"),
+    readUnknownProp(toolState, "input"),
+  );
+  if (filediff) {
+    fileChanges.push(filediff);
+  }
+
+  const files = readUnknownProp(metadata, "files");
+  if (Array.isArray(files)) {
+    for (const file of files) {
+      const fileDiff = fileDiffFromToolFileMetadata(file);
+      if (fileDiff) {
+        fileChanges.push(fileDiff);
+      }
+    }
+  }
+
+  return fileChanges;
 };
 
 const extractPartTiming = (
@@ -484,6 +596,9 @@ const buildToolStreamPart = (
   timing: ReturnType<typeof extractPartTiming>,
   metadata: Record<string, unknown> | undefined,
 ): ToolStreamPart => {
+  const toolType = deriveToolType(part.tool);
+  const fileChanges =
+    toolType === "file_edit" ? readToolMetadataFileChanges(metadata, toolState) : [];
   const preview = deriveToolPreview({
     tool: part.tool,
     rawInput: readUnknownProp(toolState, "input"),
@@ -496,11 +611,12 @@ const buildToolStreamPart = (
     partId: part.id,
     callId: part.callID,
     tool: part.tool,
-    toolType: deriveToolType(part.tool),
+    toolType,
     status: normalizedStatus,
     input: part.state.input,
     ...(preview ? { preview } : {}),
     ...(metadata ? { metadata } : {}),
+    ...(fileChanges.length > 0 ? { fileChanges } : {}),
     ...timing,
   };
 

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -1,5 +1,5 @@
 import type { Part } from "@opencode-ai/sdk/v2/client";
-import { type FileDiff, odtToolErrorPayloadSchema } from "@openducktor/contracts";
+import { type FileContent, type FileDiff, odtToolErrorPayloadSchema } from "@openducktor/contracts";
 import {
   type AgentStreamPart,
   countRenderableFileDiffLines,
@@ -252,12 +252,16 @@ const fileDiffFromToolFileDiffMetadata = (value: unknown, input: unknown): FileD
     return null;
   }
   const inputRecord = asUnknownRecord(input);
+  const oldString = readUnknownProp(inputRecord, "oldString");
 
   return normalizeToolMetadataFileDiff({
     file:
       readStringProp(record, ["file"]) ??
       readStringProp(inputRecord, ["filePath", "file_path", "path", "file"]),
-    type: normalizeFileDiffType(readUnknownProp(record, "status")),
+    type:
+      typeof oldString === "string" && oldString.length === 0
+        ? "added"
+        : normalizeFileDiffType(readUnknownProp(record, "status")),
     patch: readFileDiffPatch(record),
     additions: readNumberProp(record, ["additions"]),
     deletions: readNumberProp(record, ["deletions"]),
@@ -299,20 +303,50 @@ const fileDiffFromWriteMetadata = (
   });
 };
 
-const readToolMetadataFileChanges = (
+const fileContentFromWriteMetadata = (
+  metadata: Record<string, unknown>,
+  input: unknown,
+): FileContent | null => {
+  const inputRecord = asUnknownRecord(input);
+  const exists = readBooleanProp(metadata, ["exists"]);
+  if (!inputRecord || exists !== true || readStringProp(metadata, ["diff"]) !== undefined) {
+    return null;
+  }
+
+  const file =
+    readStringProp(metadata, ["filepath", "filePath", "file"]) ??
+    readStringProp(inputRecord, ["filePath", "file_path", "path", "file"]);
+  const content = readStringProp(inputRecord, ["content"]);
+  if (!file || content === undefined) {
+    return null;
+  }
+
+  return {
+    file,
+    type: "modified",
+    content,
+  };
+};
+
+type FileEditPayloadFields = {
+  fileDiffs?: FileDiff[];
+  fileContent?: FileContent[];
+};
+
+const readToolMetadataFileEditPayload = (
   metadata: Record<string, unknown> | undefined,
   toolState: Record<string, unknown>,
   tool: string,
-): FileDiff[] => {
+): FileEditPayloadFields => {
   if (!metadata) {
-    return [];
+    return {};
   }
 
-  const fileChanges: FileDiff[] = [];
+  const fileDiffs: FileDiff[] = [];
   if (tool === "write") {
     const writeDiff = fileDiffFromWriteMetadata(metadata, readUnknownProp(toolState, "input"));
     if (writeDiff) {
-      fileChanges.push(writeDiff);
+      fileDiffs.push(writeDiff);
     }
   }
 
@@ -321,7 +355,7 @@ const readToolMetadataFileChanges = (
     readUnknownProp(toolState, "input"),
   );
   if (filediff) {
-    fileChanges.push(filediff);
+    fileDiffs.push(filediff);
   }
 
   const files = readUnknownProp(metadata, "files");
@@ -329,12 +363,21 @@ const readToolMetadataFileChanges = (
     for (const file of files) {
       const fileDiff = fileDiffFromToolFileMetadata(file);
       if (fileDiff) {
-        fileChanges.push(fileDiff);
+        fileDiffs.push(fileDiff);
       }
     }
   }
 
-  return fileChanges;
+  if (fileDiffs.length > 0) {
+    return { fileDiffs };
+  }
+
+  if (tool !== "write") {
+    return {};
+  }
+
+  const fileContent = fileContentFromWriteMetadata(metadata, readUnknownProp(toolState, "input"));
+  return fileContent ? { fileContent: [fileContent] } : {};
 };
 
 const extractPartTiming = (
@@ -640,8 +683,8 @@ const buildToolStreamPart = (
   metadata: Record<string, unknown> | undefined,
 ): ToolStreamPart => {
   const toolType = deriveToolType(part.tool);
-  const fileChanges =
-    toolType === "file_edit" ? readToolMetadataFileChanges(metadata, toolState, part.tool) : [];
+  const fileEditPayload =
+    toolType === "file_edit" ? readToolMetadataFileEditPayload(metadata, toolState, part.tool) : {};
   const preview = deriveToolPreview({
     tool: part.tool,
     rawInput: readUnknownProp(toolState, "input"),
@@ -659,7 +702,7 @@ const buildToolStreamPart = (
     input: part.state.input,
     ...(preview ? { preview } : {}),
     ...(metadata ? { metadata } : {}),
-    ...(fileChanges.length > 0 ? { fileChanges } : {}),
+    ...fileEditPayload,
     ...timing,
   };
 

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -210,6 +210,7 @@ const readFileDiffPatch = (value: Record<string, unknown>): string | null => {
 
 const normalizeToolMetadataFileDiff = (input: {
   file: string | undefined;
+  diffFile?: string | undefined;
   type: FileDiff["type"];
   patch: string | null;
   additions: number | undefined;
@@ -220,7 +221,18 @@ const normalizeToolMetadataFileDiff = (input: {
     return null;
   }
 
-  const diff = selectRenderableFileDiff(input.patch, file, { changeType: input.type }) ?? "";
+  const diffFile = input.diffFile?.trim();
+  const fileCandidates = diffFile && diffFile !== file ? [diffFile, file] : [file];
+  let diff = "";
+  for (const fileCandidate of fileCandidates) {
+    const renderableDiff = selectRenderableFileDiff(input.patch, fileCandidate, {
+      changeType: input.type,
+    });
+    if (renderableDiff) {
+      diff = renderableDiff;
+      break;
+    }
+  }
   const counts = countRenderableFileDiffLines(diff);
   return {
     file,
@@ -239,6 +251,7 @@ const fileDiffFromToolFileMetadata = (value: unknown): FileDiff | null => {
 
   return normalizeToolMetadataFileDiff({
     file: readStringProp(record, ["relativePath"]) ?? readStringProp(record, ["filePath"]),
+    diffFile: readStringProp(record, ["filePath"]),
     type: normalizeFileDiffType(readUnknownProp(record, "type")),
     patch: readFileDiffPatch(record),
     additions: readNumberProp(record, ["additions"]),

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -29,6 +29,7 @@ import type {
   ExternalTaskSyncEvent,
   ExternalTaskSyncEventKind,
   FailureKind,
+  FileContent,
   FileDiff,
   FileStatus,
   GeneralSettings,
@@ -245,6 +246,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "gitTargetBranchSchema",
   "defaultSpecTemplateMarkdown",
   "extractPromptTemplatePlaceholders",
+  "fileContentSchema",
   "fileDiffSchema",
   "fileStatusSchema",
   "gitFileStatusCountsSchema",
@@ -481,6 +483,7 @@ type ExportedTypeContract = {
   GitConflictAbortRequest: GitConflictAbortRequest;
   GitConflictAbortResult: GitConflictAbortResult;
   GitConflictOperation: GitConflictOperation;
+  FileContent: FileContent;
   FileDiff: FileDiff;
   FileStatus: FileStatus;
   FailureKind: FailureKind;

--- a/packages/contracts/src/git-schemas.ts
+++ b/packages/contracts/src/git-schemas.ts
@@ -273,7 +273,7 @@ export const gitConflictAbortResultSchema = z.object({
 });
 export type GitConflictAbortResult = z.infer<typeof gitConflictAbortResultSchema>;
 
-/** A single file diff entry from `GET /session/:id/diff`. */
+/** A single structured file diff entry emitted by runtime adapters or diff endpoints. */
 export const fileDiffSchema = z.object({
   file: z.string(),
   type: z.string(),

--- a/packages/contracts/src/git-schemas.ts
+++ b/packages/contracts/src/git-schemas.ts
@@ -284,6 +284,14 @@ export const fileDiffSchema = z.object({
 });
 export type FileDiff = z.infer<typeof fileDiffSchema>;
 
+/** Full file content emitted by runtime adapters when the tool contract has no diff. */
+export const fileContentSchema = z.object({
+  file: z.string(),
+  type: z.string(),
+  content: z.string(),
+});
+export type FileContent = z.infer<typeof fileContentSchema>;
+
 /** Git file status entry from `GET /file/status`. */
 export const fileStatusSchema = z.object({
   path: z.string(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export * from "./services/approval-policy";
 export * from "./services/kanban-mapper";
 export * from "./services/odt-workflow-tools";
 export * from "./services/planner-spec-service";
+export * from "./services/renderable-file-diffs";
 export * from "./services/runtime-connections";
 export * from "./types/agent-orchestrator";
 export * from "./types/planner";

--- a/packages/core/src/services/renderable-file-diffs.test.ts
+++ b/packages/core/src/services/renderable-file-diffs.test.ts
@@ -74,6 +74,24 @@ function AuthConsumer() {}
     ).toBeNull();
   });
 
+  test("converts full file text to an added-file diff when the adapter marks it added", () => {
+    expect(
+      selectRenderableFileDiff(
+        'import { render } from "@testing-library/react";\nfunction AuthConsumer() {}\n',
+        "src/AuthContext.test.tsx",
+        { changeType: "added" },
+      ),
+    ).toBe(
+      '--- /dev/null\n+++ b/src/AuthContext.test.tsx\n@@ -0,0 +1,2 @@\n+import { render } from "@testing-library/react";\n+function AuthConsumer() {}\n',
+    );
+  });
+
+  test("converts full file text to a deleted-file diff when the adapter marks it deleted", () => {
+    expect(
+      selectRenderableFileDiff("old\ncontent\n", "src/old.ts", { changeType: "deleted" }),
+    ).toBe("--- a/src/old.ts\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-old\n-content\n");
+  });
+
   test("counts changed lines without counting file headers", () => {
     expect(
       countRenderableFileDiffLines("--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line\n"),

--- a/packages/core/src/services/renderable-file-diffs.test.ts
+++ b/packages/core/src/services/renderable-file-diffs.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  countRenderableFileDiffLines,
+  normalizeRenderableFileDiffCandidate,
+  selectRenderableFileDiff,
+} from "./renderable-file-diffs";
+
+describe("renderable file diffs", () => {
+  test("chooses the matching file section from a multi-file git patch", () => {
+    const diff =
+      "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+      "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n";
+
+    expect(selectRenderableFileDiff(diff, "src/second.ts")).toBe(
+      "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+    );
+  });
+
+  test("normalizes classic diff sections for the current file", () => {
+    const diff =
+      "Index: src/first.ts\n==================================================\n--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+      "Index: src/second.ts\n==================================================\n--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n";
+
+    expect(selectRenderableFileDiff(diff, "src/second.ts")).toBe(
+      "--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+    );
+  });
+
+  test("ignores file path mentions inside hunk bodies when matching sections", () => {
+    const diff =
+      'diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-import "./old"\n+import "src/target.ts"\n' +
+      "diff --git a/src/target.ts b/src/target.ts\n--- a/src/target.ts\n+++ b/src/target.ts\n@@ -1 +1 @@\n-old\n+new\n";
+
+    expect(selectRenderableFileDiff(diff, "src/target.ts")).toBe(
+      "diff --git a/src/target.ts b/src/target.ts\n--- a/src/target.ts\n+++ b/src/target.ts\n@@ -1 +1 @@\n-old\n+new\n",
+    );
+  });
+
+  test("synthesizes file headers for hunk-only diffs", () => {
+    expect(normalizeRenderableFileDiffCandidate("@@ -1 +1 @@\n-old\n+new\n", "src/app.ts")).toBe(
+      "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n",
+    );
+  });
+
+  test("drops full-file preambles before hunk-only diffs", () => {
+    const diff = `import { render } from "@testing-library/react";
+function AuthConsumer() {}
+
+@@ -1,2 +1,3 @@
+ import { render } from "@testing-library/react";
++import userEvent from "@testing-library/user-event";
+ function AuthConsumer() {}`;
+
+    expect(selectRenderableFileDiff(diff, "src/AuthContext.test.tsx")).toBe(
+      '--- a/src/AuthContext.test.tsx\n+++ b/src/AuthContext.test.tsx\n@@ -1,2 +1,3 @@\n import { render } from "@testing-library/react";\n+import userEvent from "@testing-library/user-event";\n function AuthConsumer() {}\n',
+    );
+  });
+
+  test("converts apply-patch add and delete sections to unified diffs", () => {
+    expect(selectRenderableFileDiff("*** Add File: src/new.ts\n+created", "src/new.ts")).toBe(
+      "--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1,1 @@\n+created\n",
+    );
+    expect(selectRenderableFileDiff("*** Delete File: src/old.ts\n-removed", "src/old.ts")).toBe(
+      "--- a/src/old.ts\n+++ /dev/null\n@@ -1,1 +0,0 @@\n-removed\n",
+    );
+  });
+
+  test("rejects full file text without diff markers", () => {
+    expect(
+      selectRenderableFileDiff(
+        'import { render } from "@testing-library/react";\nfunction AuthConsumer() {}\n',
+        "src/AuthContext.test.tsx",
+      ),
+    ).toBeNull();
+  });
+
+  test("counts changed lines without counting file headers", () => {
+    expect(
+      countRenderableFileDiffLines("--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n+line\n"),
+    ).toEqual({
+      additions: 2,
+      deletions: 1,
+    });
+  });
+});

--- a/packages/core/src/services/renderable-file-diffs.test.ts
+++ b/packages/core/src/services/renderable-file-diffs.test.ts
@@ -16,6 +16,20 @@ describe("renderable file diffs", () => {
     );
   });
 
+  test("does not choose an unrelated section from a multi-file patch", () => {
+    const diff =
+      "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+      "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n";
+
+    expect(selectRenderableFileDiff(diff, "src/missing.ts")).toBeNull();
+  });
+
+  test("matches repo-relative diff headers to absolute runtime file paths", () => {
+    const diff = "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n";
+
+    expect(selectRenderableFileDiff(diff, "/repo/src/app.ts")).toBe(diff);
+  });
+
   test("normalizes classic diff sections for the current file", () => {
     const diff =
       "Index: src/first.ts\n==================================================\n--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +

--- a/packages/core/src/services/renderable-file-diffs.ts
+++ b/packages/core/src/services/renderable-file-diffs.ts
@@ -1,0 +1,178 @@
+export type FileDiffLineCounts = {
+  additions: number;
+  deletions: number;
+};
+
+const GIT_DIFF_HEADER = /^diff --git /m;
+const CLASSIC_DIFF_HEADER = /^Index: /m;
+const UNIFIED_MULTI_FILE_HEADER = /^--- .+\n\+\+\+ .+/m;
+const APPLY_PATCH_FILE_HEADER = /^\*\*\* (?:Add|Update|Delete) File: /m;
+
+const normalizeNewlines = (value: string): string => value.replace(/\r\n?/g, "\n");
+
+const toDiffHeaderPath = (filePath: string): string =>
+  filePath.replaceAll("\\", "/").replace(/^\/+/, "").replace(/^\.\//, "");
+
+const splitTrimmedNonEmpty = (value: string, separator: RegExp): string[] => {
+  return value.split(separator).reduce<string[]>((chunks, chunk) => {
+    const trimmed = chunk.trim();
+    if (trimmed.length > 0) {
+      chunks.push(trimmed);
+    }
+    return chunks;
+  }, []);
+};
+
+const applyPatchFileContentDiff = (candidate: string, filePath: string): string | null => {
+  const lines = candidate.trim().split("\n");
+  const diffPath = toDiffHeaderPath(filePath);
+  const header = lines[0] ?? "";
+  const isAdd = header.startsWith("*** Add File: ");
+  const isDelete = header.startsWith("*** Delete File: ");
+  if (!isAdd && !isDelete) {
+    return null;
+  }
+
+  const prefix = isAdd ? "+" : "-";
+  const body = lines.slice(1).filter((line) => line.startsWith(prefix));
+  const bodyLines = body.map((line) => line.slice(1));
+  const lineCount = Math.max(bodyLines.length, 1);
+  if (isAdd) {
+    return ["--- /dev/null", `+++ b/${diffPath}`, `@@ -0,0 +1,${lineCount} @@`, ...body, ""].join(
+      "\n",
+    );
+  }
+
+  return [`--- a/${diffPath}`, "+++ /dev/null", `@@ -1,${lineCount} +0,0 @@`, ...body, ""].join(
+    "\n",
+  );
+};
+
+export const normalizeRenderableFileDiffCandidate = (
+  candidate: string,
+  filePath: string,
+): string | null => {
+  const trimmed = normalizeNewlines(candidate).trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const applyPatchDiff = applyPatchFileContentDiff(trimmed, filePath);
+  if (applyPatchDiff) {
+    return applyPatchDiff;
+  }
+
+  const lines = trimmed.split("\n");
+  const markerIndex = lines.findIndex(
+    (line) => line.startsWith("diff --git ") || line.startsWith("--- ") || line.startsWith("@@"),
+  );
+  if (markerIndex < 0) {
+    return null;
+  }
+
+  const rawRelevantLines = lines.slice(markerIndex);
+  const endPatchIndex = rawRelevantLines.findIndex((line, index) =>
+    index > 0 ? line.startsWith("*** End Patch") : false,
+  );
+  const relevantLines =
+    endPatchIndex >= 0 ? rawRelevantLines.slice(0, endPatchIndex) : rawRelevantLines;
+  const normalized = relevantLines.join("\n").trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  if (normalized.startsWith("@@")) {
+    const diffPath = toDiffHeaderPath(filePath);
+    return `--- a/${diffPath}\n+++ b/${diffPath}\n${normalized}\n`;
+  }
+
+  return `${normalized}\n`;
+};
+
+export const splitFileDiffCandidates = (rawDiff: string): string[] => {
+  const trimmed = normalizeNewlines(rawDiff).trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+
+  if (GIT_DIFF_HEADER.test(trimmed)) {
+    return splitTrimmedNonEmpty(trimmed, /(?=^diff --git )/m);
+  }
+
+  if (CLASSIC_DIFF_HEADER.test(trimmed)) {
+    return splitTrimmedNonEmpty(trimmed, /(?=^Index: )/m);
+  }
+
+  if (UNIFIED_MULTI_FILE_HEADER.test(trimmed)) {
+    return splitTrimmedNonEmpty(trimmed, /(?=^--- .+\n\+\+\+ .+)/m);
+  }
+
+  if (APPLY_PATCH_FILE_HEADER.test(trimmed)) {
+    const patchBody = trimmed
+      .replace(/^\*\*\* Begin Patch\s*\n?/m, "")
+      .replace(/\n?\*\*\* End Patch\s*$/m, "");
+    return splitTrimmedNonEmpty(patchBody, /(?=^\*\*\* (?:Add|Update|Delete) File: )/m);
+  }
+
+  return [trimmed];
+};
+
+export const fileDiffCandidateMatchesFile = (candidate: string, filePath: string): boolean => {
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  const quotedPath = normalizedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const suffixPattern = new RegExp(`(^|[\\s"'])((a|b)/)?${quotedPath}($|[\\s"'])`, "m");
+  const headerLines: string[] = [];
+
+  for (const line of normalizeNewlines(candidate).replaceAll("\\", "/").split("\n")) {
+    if (line.startsWith("@@")) {
+      break;
+    }
+
+    headerLines.push(line);
+  }
+
+  return suffixPattern.test(headerLines.join("\n"));
+};
+
+export const selectRenderableFileDiff = (rawDiff: string, filePath: string): string | null => {
+  const candidates = splitFileDiffCandidates(rawDiff);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const matchingCandidate = candidates.find((candidate) =>
+    fileDiffCandidateMatchesFile(candidate, filePath),
+  );
+  if (matchingCandidate) {
+    return normalizeRenderableFileDiffCandidate(matchingCandidate, filePath);
+  }
+
+  for (const candidate of candidates) {
+    const normalizedCandidate = normalizeRenderableFileDiffCandidate(candidate, filePath);
+    if (normalizedCandidate) {
+      return normalizedCandidate;
+    }
+  }
+
+  return null;
+};
+
+export const countRenderableFileDiffLines = (diff: string): FileDiffLineCounts => {
+  let additions = 0;
+  let deletions = 0;
+
+  for (const line of normalizeNewlines(diff).split("\n")) {
+    if (line.startsWith("+++ ") || line.startsWith("--- ")) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      additions++;
+      continue;
+    }
+    if (line.startsWith("-")) {
+      deletions++;
+    }
+  }
+
+  return { additions, deletions };
+};

--- a/packages/core/src/services/renderable-file-diffs.ts
+++ b/packages/core/src/services/renderable-file-diffs.ts
@@ -155,21 +155,78 @@ export const splitFileDiffCandidates = (rawDiff: string): string[] => {
   return [trimmed];
 };
 
-export const fileDiffCandidateMatchesFile = (candidate: string, filePath: string): boolean => {
-  const normalizedPath = filePath.replaceAll("\\", "/");
-  const quotedPath = normalizedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const suffixPattern = new RegExp(`(^|[\\s"'])((a|b)/)?${quotedPath}($|[\\s"'])`, "m");
-  const headerLines: string[] = [];
+const normalizeDiffFilePath = (filePath: string): string =>
+  filePath
+    .trim()
+    .replaceAll("\\", "/")
+    .replace(/^["']|["']$/g, "")
+    .replace(/^\.\//, "");
 
+const normalizeHeaderFilePath = (filePath: string): string =>
+  normalizeDiffFilePath(filePath).replace(/^(?:a|b)\//, "");
+
+const isAbsoluteDiffPath = (filePath: string): boolean =>
+  filePath.startsWith("/") || /^[A-Za-z]:\//.test(filePath);
+
+const diffPathsMatch = (headerPath: string, filePath: string): boolean => {
+  const header = normalizeHeaderFilePath(headerPath);
+  const requested = normalizeDiffFilePath(filePath);
+  if (header.length === 0 || requested.length === 0 || header === "/dev/null") {
+    return false;
+  }
+  if (header === requested) {
+    return true;
+  }
+  if (isAbsoluteDiffPath(requested) && !isAbsoluteDiffPath(header)) {
+    return requested.endsWith(`/${header}`);
+  }
+  if (isAbsoluteDiffPath(header) && !isAbsoluteDiffPath(requested)) {
+    return header.endsWith(`/${requested}`);
+  }
+  return false;
+};
+
+const diffHeaderPaths = (line: string): string[] => {
+  const gitHeader = /^diff --git\s+(\S+)\s+(\S+)$/.exec(line);
+  if (gitHeader) {
+    return [gitHeader[1] ?? "", gitHeader[2] ?? ""];
+  }
+
+  for (const prefix of ["--- ", "+++ ", "Index: "]) {
+    if (line.startsWith(prefix)) {
+      return [line.slice(prefix.length).split(/\s+/)[0] ?? ""];
+    }
+  }
+
+  const applyPatchHeader = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/.exec(line);
+  return applyPatchHeader ? [applyPatchHeader[1] ?? ""] : [];
+};
+
+export const fileDiffCandidateMatchesFile = (candidate: string, filePath: string): boolean => {
   for (const line of normalizeNewlines(candidate).replaceAll("\\", "/").split("\n")) {
     if (line.startsWith("@@")) {
       break;
     }
 
-    headerLines.push(line);
+    if (diffHeaderPaths(line).some((headerPath) => diffPathsMatch(headerPath, filePath))) {
+      return true;
+    }
   }
 
-  return suffixPattern.test(headerLines.join("\n"));
+  return false;
+};
+
+const hasExplicitFileHeader = (candidate: string): boolean => {
+  for (const line of normalizeNewlines(candidate).trim().split("\n")) {
+    if (line.startsWith("@@")) {
+      return false;
+    }
+    if (diffHeaderPaths(line).length > 0) {
+      return true;
+    }
+  }
+
+  return false;
 };
 
 export const selectRenderableFileDiff = (
@@ -189,8 +246,9 @@ export const selectRenderableFileDiff = (
     return normalizeRenderableFileDiffCandidate(matchingCandidate, filePath);
   }
 
-  for (const candidate of candidates) {
-    const normalizedCandidate = normalizeRenderableFileDiffCandidate(candidate, filePath);
+  const fallbackCandidate = candidates.length === 1 ? candidates[0] : null;
+  if (fallbackCandidate && !hasExplicitFileHeader(fallbackCandidate)) {
+    const normalizedCandidate = normalizeRenderableFileDiffCandidate(fallbackCandidate, filePath);
     if (normalizedCandidate) {
       return normalizedCandidate;
     }

--- a/packages/core/src/services/renderable-file-diffs.ts
+++ b/packages/core/src/services/renderable-file-diffs.ts
@@ -3,6 +3,10 @@ export type FileDiffLineCounts = {
   deletions: number;
 };
 
+export type SelectRenderableFileDiffOptions = {
+  changeType?: string | null;
+};
+
 const GIT_DIFF_HEADER = /^diff --git /m;
 const CLASSIC_DIFF_HEADER = /^Index: /m;
 const UNIFIED_MULTI_FILE_HEADER = /^--- .+\n\+\+\+ .+/m;
@@ -12,6 +16,40 @@ const normalizeNewlines = (value: string): string => value.replace(/\r\n?/g, "\n
 
 const toDiffHeaderPath = (filePath: string): string =>
   filePath.replaceAll("\\", "/").replace(/^\/+/, "").replace(/^\.\//, "");
+
+const fullFileDiffModeFromChangeType = (changeType?: string | null): "added" | "deleted" | null => {
+  const normalized = changeType?.trim().toLowerCase();
+  if (normalized === "added") {
+    return "added";
+  }
+  if (normalized === "deleted") {
+    return "deleted";
+  }
+  return null;
+};
+
+const fullFileContentDiff = (
+  rawContent: string,
+  filePath: string,
+  mode: "added" | "deleted",
+): string => {
+  const diffPath = toDiffHeaderPath(filePath);
+  const normalized = normalizeNewlines(rawContent).replace(/\n$/, "");
+  const lines = normalized.length > 0 ? normalized.split("\n") : [];
+  const lineCount = lines.length;
+  const prefix = mode === "added" ? "+" : "-";
+  const body = lines.map((line) => `${prefix}${line}`);
+
+  if (mode === "added") {
+    return ["--- /dev/null", `+++ b/${diffPath}`, `@@ -0,0 +1,${lineCount} @@`, ...body, ""].join(
+      "\n",
+    );
+  }
+
+  return [`--- a/${diffPath}`, "+++ /dev/null", `@@ -1,${lineCount} +0,0 @@`, ...body, ""].join(
+    "\n",
+  );
+};
 
 const splitTrimmedNonEmpty = (value: string, separator: RegExp): string[] => {
   return value.split(separator).reduce<string[]>((chunks, chunk) => {
@@ -134,7 +172,11 @@ export const fileDiffCandidateMatchesFile = (candidate: string, filePath: string
   return suffixPattern.test(headerLines.join("\n"));
 };
 
-export const selectRenderableFileDiff = (rawDiff: string, filePath: string): string | null => {
+export const selectRenderableFileDiff = (
+  rawDiff: string,
+  filePath: string,
+  options: SelectRenderableFileDiffOptions = {},
+): string | null => {
   const candidates = splitFileDiffCandidates(rawDiff);
   if (candidates.length === 0) {
     return null;
@@ -152,6 +194,11 @@ export const selectRenderableFileDiff = (rawDiff: string, filePath: string): str
     if (normalizedCandidate) {
       return normalizedCandidate;
     }
+  }
+
+  const fullFileDiffMode = fullFileDiffModeFromChangeType(options.changeType);
+  if (fullFileDiffMode) {
+    return fullFileContentDiff(rawDiff, filePath, fullFileDiffMode);
   }
 
   return null;

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -8,6 +8,7 @@ import type {
   SkillDescriptor as ContractsSkillDescriptor,
   SlashCommandCatalog as ContractsSlashCommandCatalog,
   SlashCommandDescriptor as ContractsSlashCommandDescriptor,
+  FileContent,
   FileDiff,
   RepoRuntimeRef,
   RuntimeApprovalReplyOutcome,
@@ -327,6 +328,11 @@ export type AgentStreamPart =
       input?: Record<string, unknown>;
       output?: string;
       error?: string;
+      /** Renderable unified diffs emitted by runtime adapters. */
+      fileDiffs?: FileDiff[];
+      /** Full file content emitted when a runtime tool provides content but no diff. */
+      fileContent?: FileContent[];
+      /** @deprecated Use fileDiffs. Kept only for already-persisted transcript messages. */
       fileChanges?: FileDiff[];
       metadata?: Record<string, unknown>;
       startedAtMs?: number;

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -8,6 +8,7 @@ import type {
   SkillDescriptor as ContractsSkillDescriptor,
   SlashCommandCatalog as ContractsSlashCommandCatalog,
   SlashCommandDescriptor as ContractsSlashCommandDescriptor,
+  FileDiff,
   RepoRuntimeRef,
   RuntimeApprovalReplyOutcome,
   RuntimeApprovalRequestType,
@@ -326,6 +327,7 @@ export type AgentStreamPart =
       input?: Record<string, unknown>;
       output?: string;
       error?: string;
+      fileChanges?: FileDiff[];
       metadata?: Record<string, unknown>;
       startedAtMs?: number;
       endedAtMs?: number;

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -24,6 +24,14 @@ const viewerMock = mock(
   ),
 );
 
+const syntaxBlockMock = mock(
+  ({ code, language }: { code: string; language: string; className?: string }) => (
+    <div data-testid="markdown-syntax-block" data-code={code} data-language={language}>
+      {code}
+    </div>
+  ),
+);
+
 const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
@@ -86,6 +94,9 @@ beforeEach(async () => {
     PierreDiffPreloader: preloaderMock,
     PierreDiffViewer: viewerMock,
   }));
+  mock.module("@/components/ui/markdown-syntax-block", () => ({
+    default: syntaxBlockMock,
+  }));
 
   ({ AgentChatFileEditCard } = await import("./agent-chat-file-edit-card"));
   ({ AgentChatSettingsProvider } = await import("./agent-chat-settings-context"));
@@ -95,6 +106,7 @@ afterEach(() => {
   cleanup();
   preloaderMock.mockClear();
   viewerMock.mockClear();
+  syntaxBlockMock.mockClear();
 });
 
 afterAll(() => {
@@ -110,6 +122,10 @@ afterEach(async () => {
     [
       "@/components/features/agents/pierre-diff-viewer",
       () => import("@/components/features/agents/pierre-diff-viewer"),
+    ],
+    [
+      "@/components/ui/markdown-syntax-block",
+      () => import("@/components/ui/markdown-syntax-block"),
     ],
   ]);
 });
@@ -151,25 +167,28 @@ describe("AgentChatFileEditCard", () => {
   test("renders full file content without invoking the diff viewer", () => {
     renderFileEditCard(
       buildContentFileEditData({
+        filePath: "src/AuthContext.test.tsx",
         content: "export const value = 1;\n",
       }),
       true,
     );
 
     expect(screen.getByText("export const value = 1;")).toBeDefined();
+    expect(screen.getByTestId("markdown-syntax-block").getAttribute("data-language")).toBe("tsx");
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
     expect(viewerMock).not.toHaveBeenCalled();
+    expect(syntaxBlockMock).toHaveBeenCalledTimes(1);
   });
 
   test("treats empty file content as expandable content", () => {
-    const { container } = renderFileEditCard(
+    renderFileEditCard(
       buildContentFileEditData({
         content: "",
       }),
       true,
     );
 
-    expect(container.querySelector("pre")).not.toBeNull();
+    expect(screen.getByTestId("markdown-syntax-block").getAttribute("data-code")).toBe("");
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
   });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -48,6 +48,7 @@ const buildContentFileEditData = (
   kind: "content",
   filePath: "src/example.ts",
   content: "export const value = 1;\n",
+  changeType: "modified",
   additions: 0,
   deletions: 0,
   ...overrides,
@@ -170,6 +171,17 @@ describe("AgentChatFileEditCard", () => {
 
     expect(container.querySelector("pre")).not.toBeNull();
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
+  });
+
+  test("uses full-file content change type for the status badge", () => {
+    renderFileEditCard(
+      buildContentFileEditData({
+        changeType: "deleted",
+      }),
+      true,
+    );
+
+    expect(screen.getByText("D")).toBeDefined();
   });
 
   test("collapses an expanded diff card without changing metadata", () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -29,11 +29,35 @@ const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
 };
 const previousActEnvironmentValue = reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
 
-const buildFileEditData = (overrides: Partial<FileEditData> = {}): FileEditData => ({
+type DiffFileEditData = Extract<FileEditData, { kind: "diff" }>;
+type ContentFileEditData = Extract<FileEditData, { kind: "content" }>;
+type PathFileEditData = Extract<FileEditData, { kind: "path" }>;
+
+const buildFileEditData = (overrides: Partial<DiffFileEditData> = {}): DiffFileEditData => ({
+  kind: "diff",
   filePath: "src/example.ts",
   diff: "@@ -1 +1 @@\n-old\n+new\n",
   additions: 1,
   deletions: 1,
+  ...overrides,
+});
+
+const buildContentFileEditData = (
+  overrides: Partial<ContentFileEditData> = {},
+): ContentFileEditData => ({
+  kind: "content",
+  filePath: "src/example.ts",
+  content: "export const value = 1;\n",
+  additions: 0,
+  deletions: 0,
+  ...overrides,
+});
+
+const buildPathFileEditData = (overrides: Partial<PathFileEditData> = {}): PathFileEditData => ({
+  kind: "path",
+  filePath: "src/no-diff.ts",
+  additions: 0,
+  deletions: 0,
   ...overrides,
 });
 
@@ -123,6 +147,31 @@ describe("AgentChatFileEditCard", () => {
     expect(viewerMock).toHaveBeenCalledTimes(1);
   });
 
+  test("renders full file content without invoking the diff viewer", () => {
+    renderFileEditCard(
+      buildContentFileEditData({
+        content: "export const value = 1;\n",
+      }),
+      true,
+    );
+
+    expect(screen.getByText("export const value = 1;")).toBeDefined();
+    expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
+    expect(viewerMock).not.toHaveBeenCalled();
+  });
+
+  test("treats empty file content as expandable content", () => {
+    const { container } = renderFileEditCard(
+      buildContentFileEditData({
+        content: "",
+      }),
+      true,
+    );
+
+    expect(container.querySelector("pre")).not.toBeNull();
+    expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
+  });
+
   test("collapses an expanded diff card without changing metadata", () => {
     renderFileEditCard(buildFileEditData(), true);
 
@@ -163,11 +212,8 @@ describe("AgentChatFileEditCard", () => {
     false,
   ])("keeps no-diff cards on the metadata-only path when expandFileDiffsByDefault is %p", (expandFileDiffsByDefault) => {
     renderFileEditCard(
-      buildFileEditData({
-        diff: null,
+      buildPathFileEditData({
         filePath: "src/no-diff.ts",
-        additions: 0,
-        deletions: 0,
       }),
       expandFileDiffsByDefault,
     );

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -141,6 +141,7 @@ describe("AgentChatFileEditCard", () => {
     expect(viewer.getAttribute("data-file-path")).toBe("src/example.ts");
     expect(viewer.getAttribute("data-patch")).toBe("@@ -1 +1 @@\n-old\n+new\n");
     expect(viewer.getAttribute("data-diff-style")).toBe("split");
+    expect(viewer.parentElement).toBe(screen.getByTestId("agent-chat-file-edit-card"));
     expect(preloaderMock).not.toHaveBeenCalled();
     expect(viewerMock).toHaveBeenCalledTimes(1);
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -24,10 +24,10 @@ const viewerMock = mock(
   ),
 );
 
-const syntaxBlockMock = mock(
-  ({ code, language }: { code: string; language: string; className?: string }) => (
-    <div data-testid="markdown-syntax-block" data-code={code} data-language={language}>
-      {code}
+const fileViewerMock = mock(
+  ({ content, filePath }: { content: string; filePath: string; className?: string }) => (
+    <div data-testid="pierre-file-viewer" data-content={content} data-file-path={filePath}>
+      {content}
     </div>
   ),
 );
@@ -93,9 +93,7 @@ beforeEach(async () => {
   mock.module("@/components/features/agents/pierre-diff-viewer", () => ({
     PierreDiffPreloader: preloaderMock,
     PierreDiffViewer: viewerMock,
-  }));
-  mock.module("@/components/ui/markdown-syntax-block", () => ({
-    default: syntaxBlockMock,
+    PierreFileViewer: fileViewerMock,
   }));
 
   ({ AgentChatFileEditCard } = await import("./agent-chat-file-edit-card"));
@@ -106,7 +104,7 @@ afterEach(() => {
   cleanup();
   preloaderMock.mockClear();
   viewerMock.mockClear();
-  syntaxBlockMock.mockClear();
+  fileViewerMock.mockClear();
 });
 
 afterAll(() => {
@@ -122,10 +120,6 @@ afterEach(async () => {
     [
       "@/components/features/agents/pierre-diff-viewer",
       () => import("@/components/features/agents/pierre-diff-viewer"),
-    ],
-    [
-      "@/components/ui/markdown-syntax-block",
-      () => import("@/components/ui/markdown-syntax-block"),
     ],
   ]);
 });
@@ -174,10 +168,12 @@ describe("AgentChatFileEditCard", () => {
     );
 
     expect(screen.getByText("export const value = 1;")).toBeDefined();
-    expect(screen.getByTestId("markdown-syntax-block").getAttribute("data-language")).toBe("tsx");
+    expect(screen.getByTestId("pierre-file-viewer").getAttribute("data-file-path")).toBe(
+      "src/AuthContext.test.tsx",
+    );
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
     expect(viewerMock).not.toHaveBeenCalled();
-    expect(syntaxBlockMock).toHaveBeenCalledTimes(1);
+    expect(fileViewerMock).toHaveBeenCalledTimes(1);
   });
 
   test("treats empty file content as expandable content", () => {
@@ -188,7 +184,7 @@ describe("AgentChatFileEditCard", () => {
       true,
     );
 
-    expect(screen.getByTestId("markdown-syntax-block").getAttribute("data-code")).toBe("");
+    expect(screen.getByTestId("pierre-file-viewer").getAttribute("data-content")).toBe("");
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
   });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronRight, FilePlus, FileText, FileX } from "lucide-rea
 import { memo, type ReactElement, useEffect, useRef, useState } from "react";
 import { PierreDiffViewer } from "@/components/features/agents/pierre-diff-viewer";
 import { Badge } from "@/components/ui/badge";
+import MarkdownSyntaxBlock from "@/components/ui/markdown-syntax-block";
 import { cn } from "@/lib/utils";
 import type { FileEditData } from "./agent-chat-message-card-model";
 import { useAgentChatSettings } from "./agent-chat-settings-context";
@@ -34,6 +35,12 @@ const DEFAULT_CONFIG = {
   color: "text-blue-400",
   badge: "M",
 } as const;
+
+const languageFromFilePath = (filePath: string): string => {
+  const fileName = filePath.split("/").pop() ?? filePath;
+  const extension = fileName.includes(".") ? (fileName.split(".").pop() ?? "") : "";
+  return extension.toLowerCase();
+};
 
 export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
   data,
@@ -113,9 +120,13 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
         </div>
       ) : null}
       {isExpanded && data.kind === "content" ? (
-        <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words bg-background p-3 font-mono text-[11px] leading-relaxed text-foreground">
-          {data.content}
-        </pre>
+        <div className="max-h-[60vh] overflow-auto">
+          <MarkdownSyntaxBlock
+            language={languageFromFilePath(data.filePath)}
+            code={data.content}
+            className="rounded-none border-0 bg-background"
+          />
+        </div>
       ) : null}
     </div>
   );

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -36,8 +36,8 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
   data,
 }: AgentChatFileEditCardProps): ReactElement {
   const { expandFileDiffsByDefault } = useAgentChatSettings();
-  const hasDiff = Boolean(data.diff);
-  const [isExpanded, setIsExpanded] = useState(hasDiff && expandFileDiffsByDefault);
+  const hasContent = data.kind !== "path";
+  const [isExpanded, setIsExpanded] = useState(hasContent && expandFileDiffsByDefault);
   const hasSyncedInitialDefaultRef = useRef(false);
   const userToggledRef = useRef(false);
 
@@ -56,11 +56,11 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
       return;
     }
 
-    setIsExpanded(hasDiff && expandFileDiffsByDefault);
-  }, [expandFileDiffsByDefault, hasDiff]);
+    setIsExpanded(hasContent && expandFileDiffsByDefault);
+  }, [expandFileDiffsByDefault, hasContent]);
 
   const handleToggle = (): void => {
-    if (!hasDiff) {
+    if (!hasContent) {
       return;
     }
 
@@ -87,7 +87,7 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
         )}
         onClick={handleToggle}
       >
-        {hasDiff ? <ExpandIcon className="size-3 shrink-0 text-muted-foreground" /> : null}
+        {hasContent ? <ExpandIcon className="size-3 shrink-0 text-muted-foreground" /> : null}
         <Icon className={cn("size-3.5 shrink-0", config.color)} />
         <span className="flex-1 truncate font-mono text-[11px]">
           {dirName ? <span className="text-muted-foreground">{dirName}/</span> : null}
@@ -104,10 +104,15 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
         ) : null}
       </button>
 
-      {isExpanded && data.diff ? (
+      {isExpanded && data.kind === "diff" ? (
         <div className="overflow-auto max-h-[60vh]">
           <PierreDiffViewer patch={data.diff} filePath={data.filePath} diffStyle="split" />
         </div>
+      ) : null}
+      {isExpanded && data.kind === "content" ? (
+        <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words bg-background p-3 font-mono text-[11px] leading-relaxed text-foreground">
+          {data.content}
+        </pre>
       ) : null}
     </div>
   );

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -111,9 +111,7 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
       </button>
 
       {isExpanded && data.kind === "diff" ? (
-        <div className="overflow-auto max-h-[60vh]">
-          <PierreDiffViewer patch={data.diff} filePath={data.filePath} diffStyle="split" />
-        </div>
+        <PierreDiffViewer patch={data.diff} filePath={data.filePath} diffStyle="split" />
       ) : null}
       {isExpanded && data.kind === "content" ? (
         <PierreFileViewer filePath={data.filePath} content={data.content} />

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -17,6 +17,9 @@ const STATUS_CONFIG: Record<string, { icon: typeof FileText; color: string; badg
 };
 
 function inferStatus(data: FileEditData): string {
+  if (data.kind === "content" && data.changeType in STATUS_CONFIG) {
+    return data.changeType;
+  }
   if (data.deletions === 0 && data.additions > 0) {
     return "added";
   }

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -1,8 +1,10 @@
 import { ChevronDown, ChevronRight, FilePlus, FileText, FileX } from "lucide-react";
 import { memo, type ReactElement, useEffect, useRef, useState } from "react";
-import { PierreDiffViewer } from "@/components/features/agents/pierre-diff-viewer";
+import {
+  PierreDiffViewer,
+  PierreFileViewer,
+} from "@/components/features/agents/pierre-diff-viewer";
 import { Badge } from "@/components/ui/badge";
-import MarkdownSyntaxBlock from "@/components/ui/markdown-syntax-block";
 import { cn } from "@/lib/utils";
 import type { FileEditData } from "./agent-chat-message-card-model";
 import { useAgentChatSettings } from "./agent-chat-settings-context";
@@ -35,12 +37,6 @@ const DEFAULT_CONFIG = {
   color: "text-blue-400",
   badge: "M",
 } as const;
-
-const languageFromFilePath = (filePath: string): string => {
-  const fileName = filePath.split("/").pop() ?? filePath;
-  const extension = fileName.includes(".") ? (fileName.split(".").pop() ?? "") : "";
-  return extension.toLowerCase();
-};
 
 export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
   data,
@@ -120,13 +116,7 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
         </div>
       ) : null}
       {isExpanded && data.kind === "content" ? (
-        <div className="max-h-[60vh] overflow-auto">
-          <MarkdownSyntaxBlock
-            language={languageFromFilePath(data.filePath)}
-            code={data.content}
-            className="rounded-none border-0 bg-background"
-          />
-        </div>
+        <PierreFileViewer filePath={data.filePath} content={data.content} />
       ) : null}
     </div>
   );

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -943,8 +943,8 @@ describe("agent-chat-message-card-model", () => {
       );
 
       expect(data).toEqual({
+        kind: "path",
         filePath: "src/app.ts",
-        diff: null,
         additions: 0,
         deletions: 0,
       });
@@ -961,19 +961,19 @@ describe("agent-chat-message-card-model", () => {
       );
 
       expect(data).toEqual({
+        kind: "path",
         filePath: "apps/web/src/contexts/AuthContext.tsx",
-        diff: null,
         additions: 0,
         deletions: 0,
       });
     });
 
-    test("extracts structured file changes from tool metadata", () => {
+    test("extracts structured file diffs from tool metadata", () => {
       const data = extractAllFileEditData(
         createToolMeta({
           tool: "edit",
           toolType: "file_edit",
-          fileChanges: [
+          fileDiffs: [
             {
               file: "/repo/src/app.ts",
               type: "modified",
@@ -995,14 +995,42 @@ describe("agent-chat-message-card-model", () => {
 
       expect(data).toEqual([
         {
+          kind: "diff",
           filePath: "src/app.ts",
           diff: "@@ -1 +1,3 @@\n-old\n+new\n+line\n",
           additions: 4,
           deletions: 2,
         },
         {
+          kind: "path",
           filePath: "src/empty.ts",
-          diff: null,
+          additions: 0,
+          deletions: 0,
+        },
+      ]);
+    });
+
+    test("extracts structured file content from tool metadata", () => {
+      const data = extractAllFileEditData(
+        createToolMeta({
+          tool: "write",
+          toolType: "file_edit",
+          fileContent: [
+            {
+              file: "/repo/src/app.ts",
+              type: "modified",
+              content: "export const value = 1;\n",
+            },
+          ],
+        }),
+        "/repo",
+      );
+
+      expect(data).toEqual([
+        {
+          kind: "content",
+          filePath: "src/app.ts",
+          content: "export const value = 1;\n",
           additions: 0,
           deletions: 0,
         },
@@ -1059,7 +1087,7 @@ describe("agent-chat-message-card-model", () => {
           createToolMeta({
             tool: "apply_patch",
             toolType: "file_edit",
-            fileChanges: [
+            fileDiffs: [
               {
                 file: "src/first.ts",
                 type: "modified",
@@ -1088,7 +1116,7 @@ describe("agent-chat-message-card-model", () => {
           createToolMeta({
             tool: "apply_patch",
             toolType: "file_edit",
-            fileChanges: [
+            fileDiffs: [
               {
                 file: "src/patch.ts",
                 type: "modified",
@@ -1111,7 +1139,7 @@ describe("agent-chat-message-card-model", () => {
             tool: "apply_patch",
             toolType: "file_edit",
             status: "running",
-            fileChanges: [
+            fileDiffs: [
               {
                 file: "src/first.ts",
                 type: "modified",

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -1031,6 +1031,7 @@ describe("agent-chat-message-card-model", () => {
           kind: "content",
           filePath: "src/app.ts",
           content: "export const value = 1;\n",
+          changeType: "modified",
           additions: 0,
           deletions: 0,
         },

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -935,32 +935,26 @@ describe("agent-chat-message-card-model", () => {
       expect(isFileEditTool("read")).toBe(false);
     });
 
-    test("extracts file edit data from input path and metadata diff", () => {
+    test("extracts metadata-only file edit data from input path", () => {
       const data = extractFileEditData(
         createToolMeta({
           input: { filePath: "src/app.ts" },
-          metadata: {
-            diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n+line",
-          },
         }),
       );
 
       expect(data).toEqual({
         filePath: "src/app.ts",
-        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n+line\n",
-        additions: 2,
-        deletions: 1,
+        diff: null,
+        additions: 0,
+        deletions: 0,
       });
     });
 
-    test("normalizes file edit paths relative to the session working directory", () => {
+    test("normalizes metadata-only file edit paths relative to the session working directory", () => {
       const data = extractFileEditData(
         createToolMeta({
           input: {
             filePath: "/repo/apps/web/src/contexts/AuthContext.tsx",
-          },
-          metadata: {
-            diff: "--- a/apps/web/src/contexts/AuthContext.tsx\n+++ b/apps/web/src/contexts/AuthContext.tsx\n@@ -1 +1 @@\n-old\n+new",
           },
         }),
         "/repo",
@@ -968,348 +962,59 @@ describe("agent-chat-message-card-model", () => {
 
       expect(data).toEqual({
         filePath: "apps/web/src/contexts/AuthContext.tsx",
-        diff: "--- a/apps/web/src/contexts/AuthContext.tsx\n+++ b/apps/web/src/contexts/AuthContext.tsx\n@@ -1 +1 @@\n-old\n+new\n",
-        additions: 1,
-        deletions: 1,
+        diff: null,
+        additions: 0,
+        deletions: 0,
       });
     });
 
-    test("extracts apply_patch file path and output fallback path", () => {
-      const fromPatch = extractFileEditData(
-        createToolMeta({
-          input: {
-            patch: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
-          },
-        }),
-      );
-      expect(fromPatch).toEqual({
-        filePath: "src/patch.ts",
-        diff: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new\n",
-        additions: 1,
-        deletions: 1,
-      });
-
-      const fromOutput = extractFileEditData(
-        createToolMeta({
-          output: "Updated the following files: M src/output.ts\n@@ -1 +1 @@\n-old\n+new",
-        }),
-      );
-      expect(fromOutput).toEqual({
-        filePath: "src/output.ts",
-        diff: "--- a/src/output.ts\n+++ b/src/output.ts\n@@ -1 +1 @@\n-old\n+new\n",
-        additions: 1,
-        deletions: 1,
-      });
-    });
-
-    test("selects the matching file diff from a multi-file patch", () => {
-      const data = extractFileEditData(
-        createToolMeta({
-          input: { filePath: "src/second.ts" },
-          metadata: {
-            diff:
-              "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
-              "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-          },
-        }),
-      );
-
-      expect(data).toEqual({
-        filePath: "src/second.ts",
-        diff: "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-        additions: 2,
-        deletions: 1,
-      });
-    });
-
-    test("extracts a single classic diff section for the current file", () => {
-      const data = extractFileEditData(
-        createToolMeta({
-          input: { filePath: "src/second.ts" },
-          metadata: {
-            diff:
-              "Index: src/first.ts\n==================================================\n--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
-              "Index: src/second.ts\n==================================================\n--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-          },
-        }),
-      );
-
-      expect(data).toEqual({
-        filePath: "src/second.ts",
-        diff: "--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-        additions: 2,
-        deletions: 1,
-      });
-    });
-
-    test("extracts all file edit data from a multi-file git patch", () => {
+    test("extracts structured file changes from tool metadata", () => {
       const data = extractAllFileEditData(
         createToolMeta({
-          tool: "apply_patch",
+          tool: "edit",
           toolType: "file_edit",
-          input: {
-            patch:
-              "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
-              "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n" +
-              "diff --git a/src/third.ts b/src/third.ts\n--- a/src/third.ts\n+++ b/src/third.ts\n@@ -1,2 +1 @@\n-old\n-remove\n+new\n",
-          },
+          fileChanges: [
+            {
+              file: "/repo/src/app.ts",
+              type: "modified",
+              additions: 4,
+              deletions: 2,
+              diff: "@@ -1 +1,3 @@\n-old\n+new\n+line\n",
+            },
+            {
+              file: "/repo/src/empty.ts",
+              type: "modified",
+              additions: 0,
+              deletions: 0,
+              diff: "",
+            },
+          ],
         }),
+        "/repo",
       );
 
       expect(data).toEqual([
         {
-          filePath: "src/first.ts",
-          diff: "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
-        {
-          filePath: "src/second.ts",
-          diff: "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-          additions: 2,
-          deletions: 1,
-        },
-        {
-          filePath: "src/third.ts",
-          diff: "diff --git a/src/third.ts b/src/third.ts\n--- a/src/third.ts\n+++ b/src/third.ts\n@@ -1,2 +1 @@\n-old\n-remove\n+new\n",
-          additions: 1,
+          filePath: "src/app.ts",
+          diff: "@@ -1 +1,3 @@\n-old\n+new\n+line\n",
+          additions: 4,
           deletions: 2,
         },
-      ]);
-    });
-
-    test("extracts all file edit data from a multi-file classic diff", () => {
-      const data = extractAllFileEditData(
-        createToolMeta({
-          tool: "apply_patch",
-          toolType: "file_edit",
-          metadata: {
-            diff:
-              "Index: src/first.ts\n==================================================\n--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
-              "Index: src/second.ts\n==================================================\n--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-          },
-        }),
-      );
-
-      expect(data).toEqual([
         {
-          filePath: "src/first.ts",
-          diff: "--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
-        {
-          filePath: "src/second.ts",
-          diff: "--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-          additions: 2,
-          deletions: 1,
-        },
-      ]);
-    });
-
-    test("extracts all file edit data from a multi-file unified diff without diff headers", () => {
-      const data = extractAllFileEditData(
-        createToolMeta({
-          tool: "apply_patch",
-          toolType: "file_edit",
-          input: {
-            patch:
-              "--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
-              "--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n",
-          },
-        }),
-      );
-
-      expect(data).toEqual([
-        {
-          filePath: "src/first.ts",
-          diff: "--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
-        {
-          filePath: "src/second.ts",
-          diff: "--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
-      ]);
-    });
-
-    test("extracts Codex file changes from metadata entries", () => {
-      const data = extractAllFileEditData(
-        createToolMeta({
-          tool: "apply_patch",
-          toolType: "file_edit",
-          metadata: {
-            changes: [
-              { path: "/repo/src/first.ts", diff: "@@ -1 +1 @@\n-old\n+new\n" },
-              { path: "/repo/src/second.ts", diff: "@@ -1 +1,2 @@\n-old\n+new\n+line\n" },
-            ],
-          },
-        }),
-        "/repo",
-      );
-
-      expect(data).toEqual([
-        {
-          filePath: "src/first.ts",
-          diff: "--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
-        {
-          filePath: "src/second.ts",
-          diff: "--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-          additions: 2,
-          deletions: 1,
-        },
-      ]);
-    });
-
-    test("extracts Codex file changes from metadata diffs entries", () => {
-      const data = extractAllFileEditData(
-        createToolMeta({
-          tool: "apply_patch",
-          toolType: "file_edit",
-          metadata: {
-            diffs: [{ path: "/repo/src/app.ts", diff: "@@ -1 +1 @@\n-old\n+new\n" }],
-          },
-        }),
-        "/repo",
-      );
-
-      expect(data).toEqual([
-        {
-          filePath: "src/app.ts",
-          diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
-      ]);
-    });
-
-    test("extracts apply_patch custom tool patches from Codex hydration", () => {
-      const data = extractAllFileEditData(
-        createToolMeta({
-          tool: "apply_patch",
-          toolType: "file_edit",
-          input: {
-            patch:
-              "*** Begin Patch\n" +
-              "*** Update File: /repo/src/app.ts\n" +
-              "@@\n" +
-              "-old\n" +
-              "+new\n" +
-              "*** End Patch\n",
-          },
-        }),
-        "/repo",
-      );
-
-      expect(data).toEqual([
-        {
-          filePath: "src/app.ts",
-          diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
-      ]);
-    });
-
-    test("extracts every file from multi-file Codex apply_patch input", () => {
-      const data = extractAllFileEditData(
-        createToolMeta({
-          tool: "apply_patch",
-          toolType: "file_edit",
-          input: {
-            patch:
-              "*** Begin Patch\n" +
-              "*** Add File: /repo/src/new.ts\n" +
-              "+export const created = true;\n" +
-              "*** Update File: /repo/src/app.ts\n" +
-              "@@\n" +
-              "-old\n" +
-              "+new\n" +
-              "*** End Patch\n",
-          },
-        }),
-        "/repo",
-      );
-
-      expect(data).toEqual([
-        {
-          filePath: "src/new.ts",
-          diff:
-            "--- /dev/null\n" +
-            "+++ b/src/new.ts\n" +
-            "@@ -0,0 +1,1 @@\n" +
-            "+export const created = true;\n",
-          additions: 1,
+          filePath: "src/empty.ts",
+          diff: null,
+          additions: 0,
           deletions: 0,
         },
-        {
-          filePath: "src/app.ts",
-          diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
       ]);
-    });
-
-    test("extracts quoted paths and strips diff timestamps", () => {
-      const data = extractAllFileEditData(
-        createToolMeta({
-          tool: "apply_patch",
-          toolType: "file_edit",
-          metadata: {
-            diff:
-              'diff --git "a/src/file with spaces.ts" "b/src/file with spaces.ts"\n' +
-              '--- "a/src/file with spaces.ts"\t2026-03-28 12:00:00 +0000\n' +
-              '+++ "b/src/file with spaces.ts"\t2026-03-28 12:00:00 +0000\n' +
-              "@@ -1 +1 @@\n-old\n+new\n",
-          },
-        }),
-      );
-
-      expect(data).toEqual([
-        {
-          filePath: "src/file with spaces.ts",
-          diff:
-            'diff --git "a/src/file with spaces.ts" "b/src/file with spaces.ts"\n' +
-            '--- "a/src/file with spaces.ts"\t2026-03-28 12:00:00 +0000\n' +
-            '+++ "b/src/file with spaces.ts"\t2026-03-28 12:00:00 +0000\n' +
-            "@@ -1 +1 @@\n-old\n+new\n",
-          additions: 1,
-          deletions: 1,
-        },
-      ]);
-    });
-
-    test("counts content lines that begin with three diff markers", () => {
-      const data = extractFileEditData(
-        createToolMeta({
-          input: { filePath: "src/symbols.ts" },
-          metadata: {
-            diff: "--- a/src/symbols.ts\n+++ b/src/symbols.ts\n@@ -1,2 +1,2 @@\n----old\n----gone\n++++added\n++++kept\n",
-          },
-        }),
-      );
-
-      expect(data).toEqual({
-        filePath: "src/symbols.ts",
-        diff: "--- a/src/symbols.ts\n+++ b/src/symbols.ts\n@@ -1,2 +1,2 @@\n----old\n----gone\n++++added\n++++kept\n",
-        additions: 2,
-        deletions: 2,
-      });
     });
 
     test("extractAllFileEditData preserves single-file behavior", () => {
       const meta = createToolMeta({
-        tool: "apply_patch",
+        tool: "edit",
         toolType: "file_edit",
         input: {
-          patch: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
+          filePath: "src/app.ts",
         },
       });
       const singleFileEditData = extractFileEditData(meta);
@@ -1325,6 +1030,11 @@ describe("agent-chat-message-card-model", () => {
             tool: "apply_patch",
             toolType: "file_edit",
             input: { patch: "@@ -1 +1 @@\n-old\n+new" },
+            metadata: {
+              diff: "@@ -1 +1 @@\n-old\n+new",
+              changes: [{ path: "src/app.ts", diff: "@@ -1 +1 @@\n-old\n+new" }],
+            },
+            output: "Updated the following files: M src/app.ts",
           }),
         ),
       ).toEqual([]);
@@ -1349,11 +1059,22 @@ describe("agent-chat-message-card-model", () => {
           createToolMeta({
             tool: "apply_patch",
             toolType: "file_edit",
-            input: {
-              patch:
-                "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
-                "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n",
-            },
+            fileChanges: [
+              {
+                file: "src/first.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+              {
+                file: "src/second.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+            ],
             output: "Updated 2 files",
           }),
           "",
@@ -1367,9 +1088,15 @@ describe("agent-chat-message-card-model", () => {
           createToolMeta({
             tool: "apply_patch",
             toolType: "file_edit",
-            input: {
-              patch: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
-            },
+            fileChanges: [
+              {
+                file: "src/patch.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+            ],
             output: "Updated 1 file",
           }),
           "",
@@ -1384,11 +1111,22 @@ describe("agent-chat-message-card-model", () => {
             tool: "apply_patch",
             toolType: "file_edit",
             status: "running",
-            input: {
-              patch:
-                "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
-                "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n",
-            },
+            fileChanges: [
+              {
+                file: "src/first.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+              {
+                file: "src/second.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+            ],
             output: "",
           }),
           "",
@@ -1404,7 +1142,7 @@ describe("agent-chat-message-card-model", () => {
             toolType: "file_edit",
             status: "running",
             input: {
-              patch: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
+              filePath: "src/patch.ts",
             },
             output: "",
           }),

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -401,11 +401,22 @@ describe("AgentChatMessageCard tool duration", () => {
             tool: "apply_patch",
             toolType: "file_edit",
             status: "completed",
-            input: {
-              patch:
-                "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
-                "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-            },
+            fileChanges: [
+              {
+                file: "src/first.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+              {
+                file: "src/second.ts",
+                type: "modified",
+                additions: 2,
+                deletions: 1,
+                diff: "@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+              },
+            ],
             output: "Updated 2 files",
           },
         },

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -401,7 +401,7 @@ describe("AgentChatMessageCard tool duration", () => {
             tool: "apply_patch",
             toolType: "file_edit",
             status: "completed",
-            fileChanges: [
+            fileDiffs: [
               {
                 file: "src/first.ts",
                 type: "modified",

--- a/packages/frontend/src/components/features/agents/agent-chat/file-edit-tool.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/file-edit-tool.ts
@@ -1,4 +1,4 @@
-import { patchMatchesFile, selectRenderableDiff, splitPatchCandidates } from "../renderable-patch";
+import type { FileDiff } from "@openducktor/contracts";
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { extractPathFromInput } from "./tool-input-utils";
 import { relativizeDisplayPath } from "./tool-path-utils";
@@ -21,9 +21,6 @@ export const isFileEditTool = (toolName: string): boolean => {
   return FILE_EDIT_TOOLS.has(toolName.toLowerCase());
 };
 
-const HEADER_ADDITION_PREFIX = "+++ ";
-const HEADER_DELETION_PREFIX = "--- ";
-
 export type FileEditData = {
   filePath: string;
   diff: string | null;
@@ -31,197 +28,34 @@ export type FileEditData = {
   deletions: number;
 };
 
-const extractRawDiff = (meta: ToolMeta): string | null => {
-  return typeof meta.metadata?.diff === "string"
-    ? meta.metadata.diff
-    : typeof meta.input?.patch === "string"
-      ? (meta.input.patch as string)
-      : typeof meta.output === "string" && meta.output.includes("@@")
-        ? meta.output
-        : null;
-};
-
-const extractStringField = (value: Record<string, unknown>, keys: string[]): string | null => {
-  for (const key of keys) {
-    const field = value[key];
-    if (typeof field === "string" && field.trim().length > 0) {
-      return field;
-    }
-  }
-  return null;
-};
-
-type MetadataFileChange = {
-  filePath: string;
-  diff: string;
-};
-
-const extractMetadataFileChanges = (meta: ToolMeta): MetadataFileChange[] => {
-  const changes = Array.isArray(meta.metadata?.changes)
-    ? meta.metadata.changes
-    : Array.isArray(meta.metadata?.diffs)
-      ? meta.metadata.diffs
-      : null;
-  if (!Array.isArray(changes)) {
-    return [];
-  }
-
-  return changes.flatMap((change): MetadataFileChange[] => {
-    if (!change || typeof change !== "object" || Array.isArray(change)) {
-      return [];
-    }
-    const record = change as Record<string, unknown>;
-    const filePath = extractStringField(record, ["path", "file"]);
-    const diff = extractStringField(record, ["diff", "patch"]);
-    if (!filePath || !diff) {
-      return [];
-    }
-    return [{ filePath, diff }];
-  });
-};
-
-const countDiffChanges = (diff: string | null): Pick<FileEditData, "additions" | "deletions"> => {
-  let additions = 0;
-  let deletions = 0;
-
-  if (!diff) {
-    return { additions, deletions };
-  }
-
-  for (const line of diff.split("\n")) {
-    if (line.startsWith(HEADER_ADDITION_PREFIX) || line.startsWith(HEADER_DELETION_PREFIX)) {
-      continue;
-    }
-
-    if (line.startsWith("+")) {
-      additions++;
-    } else if (line.startsWith("-")) {
-      deletions++;
-    }
-  }
-
-  return { additions, deletions };
-};
-
-const buildFileEditData = (
+const buildPathOnlyFileEditData = (
   filePath: string,
-  rawDiff: string | null,
   workingDirectory?: string | null,
-): FileEditData => {
-  const displayPath = relativizeDisplayPath(filePath, workingDirectory);
-  const diff = rawDiff
-    ? (selectRenderableDiff(rawDiff, displayPath) ??
-      (displayPath !== filePath ? selectRenderableDiff(rawDiff, filePath) : null))
-    : null;
-  const { additions, deletions } = countDiffChanges(diff);
+): FileEditData => ({
+  filePath: relativizeDisplayPath(filePath, workingDirectory),
+  diff: null,
+  additions: 0,
+  deletions: 0,
+});
 
-  return {
-    filePath: displayPath,
-    diff,
-    additions,
-    deletions,
-  };
-};
-
-const normalizePatchPath = (value: string | undefined): string | null => {
-  if (!value) {
-    return null;
-  }
-
-  let trimmed = value.trim().replace(/\t.*$/, "");
-  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    trimmed = trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
-  }
-
-  if (trimmed.length === 0 || trimmed === "/dev/null") {
-    return null;
-  }
-
-  return trimmed.replace(/^[ab]\//, "");
-};
-
-const extractDiffGitPaths = (
-  candidate: string,
-): { previousPath: string; nextPath: string } | null => {
-  const line = /^diff --git\s+(.+)$/m.exec(candidate)?.[1];
-  if (!line) {
-    return null;
-  }
-
-  const match = /^(?:"((?:[^"\\]|\\.)*)"|(\S+))\s+(?:"((?:[^"\\]|\\.)*)"|(\S+))$/.exec(line.trim());
-  if (!match) {
-    return null;
-  }
-
-  const previousPath = normalizePatchPath(match[1] ?? match[2]);
-  const nextPath = normalizePatchPath(match[3] ?? match[4]);
-  if (!previousPath || !nextPath) {
-    return null;
-  }
-
-  return { previousPath, nextPath };
-};
-
-const extractPatchFilePath = (candidate: string): string | null => {
-  const nextPath = normalizePatchPath(/^\+\+\+\s+(.+)$/m.exec(candidate)?.[1]);
-  if (nextPath) {
-    return nextPath;
-  }
-
-  const previousPath = normalizePatchPath(/^---\s+(.+)$/m.exec(candidate)?.[1]);
-  if (previousPath) {
-    return previousPath;
-  }
-
-  const indexPath = normalizePatchPath(/^Index:\s+(.+)$/m.exec(candidate)?.[1]);
-  if (indexPath) {
-    return indexPath;
-  }
-
-  const applyPatchPath = normalizePatchPath(
-    /^\*\*\*\s+(?:Update|Add|Delete) File:\s+(.+)$/m.exec(candidate)?.[1],
-  );
-  if (applyPatchPath) {
-    return applyPatchPath;
-  }
-
-  return extractDiffGitPaths(candidate)?.nextPath ?? null;
-};
+const buildStructuredFileEditData = (
+  fileChange: FileDiff,
+  workingDirectory?: string | null,
+): FileEditData => ({
+  filePath: relativizeDisplayPath(fileChange.file, workingDirectory),
+  diff: fileChange.diff.trim().length > 0 ? fileChange.diff : null,
+  additions: fileChange.additions,
+  deletions: fileChange.deletions,
+});
 
 export const extractAllFileEditData = (
   meta: ToolMeta,
   workingDirectory?: string | null,
 ): FileEditData[] => {
-  const metadataFileChanges = extractMetadataFileChanges(meta).map((change) =>
-    buildFileEditData(change.filePath, change.diff, workingDirectory),
-  );
-  if (metadataFileChanges.length > 0) {
-    return metadataFileChanges;
-  }
-
-  const rawDiff = extractRawDiff(meta);
-  if (rawDiff) {
-    const fileEditData: FileEditData[] = [];
-    const seenPaths = new Set<string>();
-
-    for (const candidate of splitPatchCandidates(rawDiff)) {
-      const filePath = extractPatchFilePath(candidate);
-      if (!filePath || !patchMatchesFile(candidate, filePath)) {
-        continue;
-      }
-
-      const data = buildFileEditData(filePath, candidate, workingDirectory);
-      if (seenPaths.has(data.filePath)) {
-        continue;
-      }
-
-      fileEditData.push(data);
-      seenPaths.add(data.filePath);
-    }
-
-    if (fileEditData.length > 0) {
-      return fileEditData;
-    }
+  if (meta.fileChanges && meta.fileChanges.length > 0) {
+    return meta.fileChanges.map((fileChange) =>
+      buildStructuredFileEditData(fileChange, workingDirectory),
+    );
   }
 
   const fileEditData = extractFileEditData(meta, workingDirectory);
@@ -232,27 +66,10 @@ export const extractFileEditData = (
   meta: ToolMeta,
   workingDirectory?: string | null,
 ): FileEditData | null => {
-  let filePath = extractPathFromInput(meta.input);
-
-  if (!filePath && typeof meta.input?.patch === "string") {
-    const patchContent = meta.input.patch as string;
-    const patchFilePath = extractPatchFilePath(patchContent);
-    if (patchFilePath) {
-      filePath = patchFilePath;
-    }
-  }
-
-  if (!filePath && typeof meta.output === "string") {
-    const outputFileMatch =
-      /(?:Updated|Modified|Created|Changed)[^:]*:\s*(?:[MADRCU]\s+)?(.+?)$/m.exec(meta.output);
-    if (outputFileMatch?.[1]) {
-      filePath = outputFileMatch[1].trim();
-    }
-  }
-
+  const filePath = extractPathFromInput(meta.input);
   if (!filePath) {
     return null;
   }
 
-  return buildFileEditData(filePath, extractRawDiff(meta), workingDirectory);
+  return buildPathOnlyFileEditData(filePath, workingDirectory);
 };

--- a/packages/frontend/src/components/features/agents/agent-chat/file-edit-tool.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/file-edit-tool.ts
@@ -35,6 +35,7 @@ export type FileEditData =
   | (FileEditDataBase & {
       kind: "content";
       content: string;
+      changeType: string;
     })
   | (FileEditDataBase & {
       kind: "path";
@@ -80,6 +81,7 @@ const buildFileContentEditData = (
   kind: "content",
   filePath: relativizeDisplayPath(fileContent.file, workingDirectory),
   content: fileContent.content,
+  changeType: fileContent.type,
   additions: 0,
   deletions: 0,
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/file-edit-tool.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/file-edit-tool.ts
@@ -1,4 +1,4 @@
-import type { FileDiff } from "@openducktor/contracts";
+import type { FileContent, FileDiff } from "@openducktor/contracts";
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { extractPathFromInput } from "./tool-input-utils";
 import { relativizeDisplayPath } from "./tool-path-utils";
@@ -21,40 +21,86 @@ export const isFileEditTool = (toolName: string): boolean => {
   return FILE_EDIT_TOOLS.has(toolName.toLowerCase());
 };
 
-export type FileEditData = {
+type FileEditDataBase = {
   filePath: string;
-  diff: string | null;
   additions: number;
   deletions: number;
 };
+
+export type FileEditData =
+  | (FileEditDataBase & {
+      kind: "diff";
+      diff: string;
+    })
+  | (FileEditDataBase & {
+      kind: "content";
+      content: string;
+    })
+  | (FileEditDataBase & {
+      kind: "path";
+    });
 
 const buildPathOnlyFileEditData = (
   filePath: string,
   workingDirectory?: string | null,
 ): FileEditData => ({
+  kind: "path",
   filePath: relativizeDisplayPath(filePath, workingDirectory),
-  diff: null,
   additions: 0,
   deletions: 0,
 });
 
-const buildStructuredFileEditData = (
-  fileChange: FileDiff,
+const buildFileDiffEditData = (
+  fileDiff: FileDiff,
+  workingDirectory?: string | null,
+): FileEditData => {
+  const filePath = relativizeDisplayPath(fileDiff.file, workingDirectory);
+  if (fileDiff.diff.trim().length === 0) {
+    return {
+      kind: "path",
+      filePath,
+      additions: fileDiff.additions,
+      deletions: fileDiff.deletions,
+    };
+  }
+
+  return {
+    kind: "diff",
+    filePath,
+    diff: fileDiff.diff,
+    additions: fileDiff.additions,
+    deletions: fileDiff.deletions,
+  };
+};
+
+const buildFileContentEditData = (
+  fileContent: FileContent,
   workingDirectory?: string | null,
 ): FileEditData => ({
-  filePath: relativizeDisplayPath(fileChange.file, workingDirectory),
-  diff: fileChange.diff.trim().length > 0 ? fileChange.diff : null,
-  additions: fileChange.additions,
-  deletions: fileChange.deletions,
+  kind: "content",
+  filePath: relativizeDisplayPath(fileContent.file, workingDirectory),
+  content: fileContent.content,
+  additions: 0,
+  deletions: 0,
 });
 
 export const extractAllFileEditData = (
   meta: ToolMeta,
   workingDirectory?: string | null,
 ): FileEditData[] => {
+  if (meta.fileDiffs && meta.fileDiffs.length > 0) {
+    return meta.fileDiffs.map((fileDiff) => buildFileDiffEditData(fileDiff, workingDirectory));
+  }
+
   if (meta.fileChanges && meta.fileChanges.length > 0) {
     return meta.fileChanges.map((fileChange) =>
-      buildStructuredFileEditData(fileChange, workingDirectory),
+      buildFileDiffEditData(fileChange, workingDirectory),
+    );
+  }
+
+  if (meta.fileContent && meta.fileContent.length > 0) {
+    return meta.fileContent.map((fileContent) =>
+      buildFileContentEditData(fileContent, workingDirectory),
     );
   }
 

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -303,6 +303,7 @@ describe("PierreDiffViewer", () => {
     expect(file.getAttribute("data-disable-file-header")).toBe("true");
     expect(file.getAttribute("data-overflow")).toBe("wrap");
     expect(file.getAttribute("data-theme-type")).toBe("light");
+    expect(file.parentElement?.className).toContain("max-h-[min(70vh,48rem)]");
 
     const firstCacheKey = file.getAttribute("data-cache-key");
     rerender(
@@ -344,7 +345,7 @@ describe("PierreDiffViewer", () => {
 
     const fallback = screen.getByText(/invalid diff body/);
     expect(fallback.parentElement?.className).toContain("overflow-auto");
-    expect(fallback.parentElement?.className).toContain("max-h-[min(70vh,48rem)]");
+    expect(fallback.parentElement?.className).toContain("max-h-[min(60vh,40rem)]");
   });
 });
 

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -313,6 +313,39 @@ describe("PierreDiffViewer", () => {
       firstCacheKey,
     );
   });
+
+  test("keeps raw fallback diffs inside the Pierre scroll container", async () => {
+    const { PierreDiffViewer } = pierreViewerModule;
+
+    await withCapturedOutputStreams(["stdout", "stderr"], async (chunksByStream) => {
+      await withCapturedConsoleMethods(
+        ["debug", "error", "info", "log", "warn"],
+        async (consoleCalls) => {
+          render(
+            <PierreDiffViewer
+              patch="Index: src/app.ts\n=====\ninvalid diff body"
+              filePath="src/app.ts"
+            />,
+          );
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          for (const calls of Object.values(consoleCalls)) {
+            for (const call of calls) {
+              expect(call).toEqual([[]]);
+            }
+          }
+        },
+      );
+
+      for (const chunk of [...chunksByStream.stdout, ...chunksByStream.stderr]) {
+        expect(chunk).toBe("[]\n");
+      }
+    });
+
+    const fallback = screen.getByText(/invalid diff body/);
+    expect(fallback.parentElement?.className).toContain("overflow-auto");
+    expect(fallback.parentElement?.className).toContain("max-h-[min(70vh,48rem)]");
+  });
 });
 
 const requireFileDiff = (

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -40,6 +40,24 @@ beforeEach(async () => {
       ["debug", "error", "info", "log", "warn"],
       async (consoleCalls) => {
         mock.module("@pierre/diffs/react", () => ({
+          File: (props: {
+            file: { name: string; contents: string; cacheKey?: string };
+            options?: {
+              disableFileHeader?: boolean;
+              overflow?: string;
+              themeType?: string;
+            };
+          }) => (
+            <div
+              data-testid="pierre-file"
+              data-cache-key={props.file.cacheKey ?? ""}
+              data-disable-file-header={String(props.options?.disableFileHeader ?? "")}
+              data-file-contents={props.file.contents}
+              data-file-name={props.file.name}
+              data-overflow={String(props.options?.overflow ?? "")}
+              data-theme-type={String(props.options?.themeType ?? "")}
+            />
+          ),
           FileDiff: (props: {
             options?: {
               onGutterUtilityClick?: (range: unknown) => void;
@@ -270,6 +288,30 @@ describe("PierreDiffViewer", () => {
       ],
       language: null,
     });
+  });
+
+  test("renders plain file content through Pierre File with a worker cache key", () => {
+    const { PierreFileViewer } = pierreViewerModule;
+    const { rerender } = render(
+      <PierreFileViewer filePath="src/AuthContext.test.tsx" content="export const value = 1;" />,
+    );
+
+    const file = screen.getByTestId("pierre-file");
+    expect(file.getAttribute("data-file-name")).toBe("src/AuthContext.test.tsx");
+    expect(file.getAttribute("data-file-contents")).toBe("export const value = 1;");
+    expect(file.getAttribute("data-cache-key")).toContain("src/AuthContext.test.tsx:");
+    expect(file.getAttribute("data-disable-file-header")).toBe("true");
+    expect(file.getAttribute("data-overflow")).toBe("wrap");
+    expect(file.getAttribute("data-theme-type")).toBe("light");
+
+    const firstCacheKey = file.getAttribute("data-cache-key");
+    rerender(
+      <PierreFileViewer filePath="src/AuthContext.test.tsx" content="export const value = 2;" />,
+    );
+
+    expect(screen.getByTestId("pierre-file").getAttribute("data-cache-key")).not.toBe(
+      firstCacheKey,
+    );
   });
 });
 

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -303,7 +303,7 @@ describe("PierreDiffViewer", () => {
     expect(file.getAttribute("data-disable-file-header")).toBe("true");
     expect(file.getAttribute("data-overflow")).toBe("wrap");
     expect(file.getAttribute("data-theme-type")).toBe("light");
-    expect(file.parentElement?.className).toContain("max-h-[min(70vh,48rem)]");
+    expect(file.parentElement?.className).toContain("max-h-[min(50vh,32rem)]");
 
     const firstCacheKey = file.getAttribute("data-cache-key");
     rerender(
@@ -345,7 +345,7 @@ describe("PierreDiffViewer", () => {
 
     const fallback = screen.getByText(/invalid diff body/);
     expect(fallback.parentElement?.className).toContain("overflow-auto");
-    expect(fallback.parentElement?.className).toContain("max-h-[min(60vh,40rem)]");
+    expect(fallback.parentElement?.className).toContain("max-h-[min(50vh,32rem)]");
   });
 });
 

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -1,5 +1,9 @@
-import type { DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
-import { FileDiff as PierreReactFileDiff, useWorkerPool } from "@pierre/diffs/react";
+import type { DiffLineAnnotation, FileContents, SelectedLineRange } from "@pierre/diffs";
+import {
+  File as PierreReactFile,
+  FileDiff as PierreReactFileDiff,
+  useWorkerPool,
+} from "@pierre/diffs/react";
 import { Undo2 } from "lucide-react";
 import {
   type CSSProperties,
@@ -50,6 +54,12 @@ type PierreDiffPreloaderProps = {
   filePath: string;
 };
 
+type PierreFileViewerProps = {
+  filePath: string;
+  content: string;
+  className?: string;
+};
+
 const DIFF_THEME = { dark: "pierre-dark", light: "pierre-light" } as const;
 const DIFF_WRAPPER_STYLE = {
   "--diffs-font-size": "12px",
@@ -84,6 +94,15 @@ const HUNK_RESET_FLOATING_CSS = `
 }
 `;
 
+const contentHash = (value: string): string => {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+};
+
 export const PierreDiffPreloader = memo(function PierreDiffPreloader({
   patch,
   filePath,
@@ -103,6 +122,39 @@ export const PierreDiffPreloader = memo(function PierreDiffPreloader({
   }, [fileDiff, workerPool]);
 
   return null;
+});
+
+export const PierreFileViewer = memo(function PierreFileViewer({
+  filePath,
+  content,
+  className,
+}: PierreFileViewerProps): ReactElement {
+  const { theme } = useTheme();
+  const file = useMemo<FileContents>(
+    () => ({
+      name: filePath,
+      contents: content,
+      cacheKey: `${filePath}:${content.length}:${contentHash(content)}`,
+    }),
+    [content, filePath],
+  );
+  const options = useMemo(
+    () => ({
+      theme: DIFF_THEME,
+      themeType: theme,
+      overflow: "wrap" as const,
+      disableFileHeader: true,
+    }),
+    [theme],
+  );
+
+  return (
+    <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
+      <div className={DIFF_SCROLL_CONTAINER_CLASS_NAME}>
+        <PierreReactFile file={file} options={options} />
+      </div>
+    </div>
+  );
 });
 
 // ─── Component ─────────────────────────────────────────────────────────────────

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -67,7 +67,7 @@ const DIFF_WRAPPER_STYLE = {
   "--diffs-tab-size": 2,
 } as CSSProperties;
 const RAW_DIFF_FALLBACK_CLASS_NAME =
-  "overflow-x-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11px] leading-5 text-foreground";
+  "whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11px] leading-5 text-foreground";
 const HUNK_RESET_ANNOTATION_CLASS_NAME = "pointer-events-none relative h-0";
 const HUNK_RESET_ANNOTATION_WRAPPER_CLASS_NAME = "contents";
 const HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE = "data-hunk-reset-annotation";
@@ -304,21 +304,19 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
     content = <pre className={RAW_DIFF_FALLBACK_CLASS_NAME}>{fallbackPatch}</pre>;
   } else {
     content = (
-      <div className={DIFF_SCROLL_CONTAINER_CLASS_NAME}>
-        <PierreReactFileDiff
-          fileDiff={fileDiff}
-          {...selectedLinesProps}
-          options={options}
-          lineAnnotations={mergedLineAnnotations}
-          renderAnnotation={handleRenderAnnotation}
-        />
-      </div>
+      <PierreReactFileDiff
+        fileDiff={fileDiff}
+        {...selectedLinesProps}
+        options={options}
+        lineAnnotations={mergedLineAnnotations}
+        renderAnnotation={handleRenderAnnotation}
+      />
     );
   }
 
   return (
     <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
-      {content}
+      <div className={DIFF_SCROLL_CONTAINER_CLASS_NAME}>{content}</div>
     </div>
   );
 });

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -73,7 +73,8 @@ const HUNK_RESET_ANNOTATION_WRAPPER_CLASS_NAME = "contents";
 const HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE = "data-hunk-reset-annotation";
 const HUNK_RESET_BUTTON_CLASS_NAME =
   "pointer-events-auto absolute right-3 top-1 h-7 gap-1.5 px-2.5 text-[11px] shadow-sm";
-const DIFF_SCROLL_CONTAINER_CLASS_NAME = "max-h-[min(70vh,48rem)] overflow-auto";
+const DIFF_SCROLL_CONTAINER_CLASS_NAME = "max-h-[min(60vh,40rem)] overflow-auto";
+const FILE_SCROLL_CONTAINER_CLASS_NAME = "max-h-[min(70vh,48rem)] overflow-auto";
 const HUNK_RESET_FLOATING_CSS = `
 [data-line-annotation]:has([${HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE}]),
 [data-gutter-buffer='annotation']:has([${HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE}]) {
@@ -150,7 +151,7 @@ export const PierreFileViewer = memo(function PierreFileViewer({
 
   return (
     <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
-      <div className={DIFF_SCROLL_CONTAINER_CLASS_NAME}>
+      <div className={FILE_SCROLL_CONTAINER_CLASS_NAME}>
         <PierreReactFile file={file} options={options} />
       </div>
     </div>

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -73,8 +73,7 @@ const HUNK_RESET_ANNOTATION_WRAPPER_CLASS_NAME = "contents";
 const HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE = "data-hunk-reset-annotation";
 const HUNK_RESET_BUTTON_CLASS_NAME =
   "pointer-events-auto absolute right-3 top-1 h-7 gap-1.5 px-2.5 text-[11px] shadow-sm";
-const DIFF_SCROLL_CONTAINER_CLASS_NAME = "max-h-[min(60vh,40rem)] overflow-auto";
-const FILE_SCROLL_CONTAINER_CLASS_NAME = "max-h-[min(70vh,48rem)] overflow-auto";
+const PIERRE_VIEWER_SCROLL_CONTAINER_CLASS_NAME = "max-h-[min(50vh,32rem)] overflow-auto";
 const HUNK_RESET_FLOATING_CSS = `
 [data-line-annotation]:has([${HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE}]),
 [data-gutter-buffer='annotation']:has([${HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE}]) {
@@ -151,7 +150,7 @@ export const PierreFileViewer = memo(function PierreFileViewer({
 
   return (
     <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
-      <div className={FILE_SCROLL_CONTAINER_CLASS_NAME}>
+      <div className={PIERRE_VIEWER_SCROLL_CONTAINER_CLASS_NAME}>
         <PierreReactFile file={file} options={options} />
       </div>
     </div>
@@ -317,7 +316,7 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
 
   return (
     <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
-      <div className={DIFF_SCROLL_CONTAINER_CLASS_NAME}>{content}</div>
+      <div className={PIERRE_VIEWER_SCROLL_CONTAINER_CLASS_NAME}>{content}</div>
     </div>
   );
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
@@ -113,6 +113,7 @@ const composeToolMessageMeta = (
     ...(input ? { input } : {}),
     ...(output ? { output } : {}),
     ...(error ? { error } : {}),
+    ...(part.fileChanges ? { fileChanges: part.fileChanges } : {}),
     ...(part.metadata ? { metadata: part.metadata } : {}),
     ...(typeof part.startedAtMs === "number" ? { startedAtMs: part.startedAtMs } : {}),
     ...(typeof part.endedAtMs === "number" ? { endedAtMs: part.endedAtMs } : {}),

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
@@ -113,6 +113,8 @@ const composeToolMessageMeta = (
     ...(input ? { input } : {}),
     ...(output ? { output } : {}),
     ...(error ? { error } : {}),
+    ...(part.fileDiffs ? { fileDiffs: part.fileDiffs } : {}),
+    ...(part.fileContent ? { fileContent: part.fileContent } : {}),
     ...(part.fileChanges ? { fileChanges: part.fileChanges } : {}),
     ...(part.metadata ? { metadata: part.metadata } : {}),
     ...(typeof part.startedAtMs === "number" ? { startedAtMs: part.startedAtMs } : {}),

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -187,6 +187,8 @@ const historyPartToChatMessage = (
           ...(input ? { input } : {}),
           ...(output ? { output } : {}),
           ...(error ? { error } : {}),
+          ...(part.fileDiffs ? { fileDiffs: part.fileDiffs } : {}),
+          ...(part.fileContent ? { fileContent: part.fileContent } : {}),
           ...(part.fileChanges ? { fileChanges: part.fileChanges } : {}),
           ...(part.metadata ? { metadata: part.metadata } : {}),
           ...(typeof part.startedAtMs === "number" ? { startedAtMs: part.startedAtMs } : {}),

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -187,6 +187,7 @@ const historyPartToChatMessage = (
           ...(input ? { input } : {}),
           ...(output ? { output } : {}),
           ...(error ? { error } : {}),
+          ...(part.fileChanges ? { fileChanges: part.fileChanges } : {}),
           ...(part.metadata ? { metadata: part.metadata } : {}),
           ...(typeof part.startedAtMs === "number" ? { startedAtMs: part.startedAtMs } : {}),
           ...(typeof part.endedAtMs === "number" ? { endedAtMs: part.endedAtMs } : {}),

--- a/packages/frontend/src/types/agent-orchestrator.ts
+++ b/packages/frontend/src/types/agent-orchestrator.ts
@@ -1,5 +1,6 @@
 import type {
   AgentSessionRecord,
+  FileDiff,
   RepoPromptOverrides,
   RuntimeInstanceSummary,
   RuntimeKind,
@@ -47,6 +48,7 @@ export type AgentChatMessageMeta =
       input?: Record<string, unknown>;
       output?: string;
       error?: string;
+      fileChanges?: FileDiff[];
       metadata?: Record<string, unknown>;
       startedAtMs?: number;
       endedAtMs?: number;

--- a/packages/frontend/src/types/agent-orchestrator.ts
+++ b/packages/frontend/src/types/agent-orchestrator.ts
@@ -1,5 +1,6 @@
 import type {
   AgentSessionRecord,
+  FileContent,
   FileDiff,
   RepoPromptOverrides,
   RuntimeInstanceSummary,
@@ -48,6 +49,9 @@ export type AgentChatMessageMeta =
       input?: Record<string, unknown>;
       output?: string;
       error?: string;
+      fileDiffs?: FileDiff[];
+      fileContent?: FileContent[];
+      /** @deprecated Use fileDiffs. Kept only for already-persisted transcript messages. */
       fileChanges?: FileDiff[];
       metadata?: Record<string, unknown>;
       startedAtMs?: number;


### PR DESCRIPTION
## Summary
- Add a shared `fileChanges` contract to transcript tool parts so the UI renders structured diffs instead of parsing runtime-specific text.
- Move Codex and OpenCode diff extraction into their runtime adapters.
- Simplify file-edit rendering and preserve structured diffs through transcript hydration/persistence.

## Goal and Context
Transcript file edits need one frontend contract while each runtime remains responsible for understanding its own session message shape. This fixes Codex file edits that arrived as mixed full-file plus hunk text without regressing OpenCode diff display.

## Technical Choices
- Codex adapter parses file-change payloads before normalizing tool parts.
- OpenCode adapter loads session diff payloads by patch message id and attaches `FileDiff[]` to edit parts.
- Frontend consumes `part.fileChanges` only, with no runtime-specific diff heuristics.
- Tests cover Codex parsing, OpenCode session history hydration, persistence, and file-edit rendering.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test` (full suite; rerun outside sandbox because sandbox loopback binds failed)
- `bun run build`
- `git diff --check`
- Browser mode with `OPENDUCKTOR_CONFIG_DIR=/Users/maxsky5/.openducktor-local`: verified OpenCode session `fairnest-wk9` / `ses_16ba5df12ffewOL5laDuHGnY20` and Codex session `fairnest-a8v` / `019e8f60-5c55-7441-911e-1683878cdd7b` both render file diffs.
- Cargo checks: not applicable, no `Cargo.toml` in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool messages and UI now carry structured per-file diffs and optional full-file content; file-edit cards render one card per file and display either a unified diff or full file text (new file viewer).

* **Bug Fixes**
  * More reliable diff extraction, rendering and status mapping for streamed/patch updates so diffs, counts and statuses display correctly.

* **Tests**
  * Expanded test coverage for parsing, conversion, streaming, event handling, and UI rendering of diffs and file content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->