### PR TITLE
feat: name Codex workflow sessions

### DIFF
--- a/packages/adapters-codex-app-server/src/app-server-client.test.ts
+++ b/packages/adapters-codex-app-server/src/app-server-client.test.ts
@@ -23,6 +23,26 @@ describe("createCodexAppServerClient", () => {
     ]);
   });
 
+  test("sends thread/name/set requests", async () => {
+    const calls: CodexJsonRpcRequest[] = [];
+    const transport: CodexJsonRpcTransport = {
+      async request(request) {
+        calls.push(request);
+        return {};
+      },
+    };
+    const client = createCodexAppServerClient(transport);
+    await expect(
+      client.threadSetName({ threadId: "thread-1", name: "BUILD task-1" }),
+    ).resolves.toEqual({});
+    expect(calls).toEqual([
+      {
+        method: "thread/name/set",
+        params: { threadId: "thread-1", name: "BUILD task-1" },
+      },
+    ]);
+  });
+
   test("sends cwd-scoped skills/list requests", async () => {
     const calls: CodexJsonRpcRequest[] = [];
     const transport: CodexJsonRpcTransport = {

--- a/packages/adapters-codex-app-server/src/app-server-client.ts
+++ b/packages/adapters-codex-app-server/src/app-server-client.ts
@@ -8,6 +8,7 @@ import type {
   CodexSkillsListResponse,
   CodexThreadForkParams,
   CodexThreadResumeParams,
+  CodexThreadSetNameParams,
   CodexThreadStartParams,
   CodexTurnInterruptParams,
   CodexTurnStartParams,
@@ -29,6 +30,9 @@ export const createCodexAppServerClient = (
     },
     async threadStart(params: CodexThreadStartParams) {
       return transport.request({ method: "thread/start", params });
+    },
+    async threadSetName(params: CodexThreadSetNameParams) {
+      return transport.request({ method: "thread/name/set", params });
     },
     async threadResume(params: CodexThreadResumeParams) {
       return transport.request({ method: "thread/resume", params });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import {
+  createAdapterWithTransport,
   createHarness,
   makeRuntimeSummary,
   RecordingTransport,
 } from "./codex-app-server-adapter.test-harness";
 import { codexTurnKey } from "./codex-app-server-requests";
 import { CodexAppServerAdapter } from "./index";
+
+class NameFailingTransport extends RecordingTransport {
+  async request<Response>(
+    request: Parameters<RecordingTransport["request"]>[0],
+  ): Promise<Response> {
+    if (request.method === "thread/name/set") {
+      this.calls.push(request);
+      throw new Error("name failed");
+    }
+    return super.request<Response>(request);
+  }
+}
 
 describe("CodexAppServerAdapter lifecycle", () => {
   test("returns the Codex runtime definition", () => {
@@ -54,6 +67,30 @@ describe("CodexAppServerAdapter lifecycle", () => {
         name: "BUILD task-1",
       },
     });
+  });
+
+  test("keeps started sessions addressable when thread naming fails", async () => {
+    const transport = new NameFailingTransport("runtime-ensure", false);
+    const adapter = createAdapterWithTransport(transport);
+
+    await expect(
+      adapter.startSession({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        taskId: "task-1",
+        role: "build",
+        systemPrompt: "Use the repo rules.",
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    ).rejects.toThrow("name failed");
+
+    expect(adapter.hasSession("thread/start-runtime-ensure")).toBe(true);
+    expect(transport.calls.map((call) => call.method)).toEqual([
+      "model/list",
+      "thread/start",
+      "thread/name/set",
+    ]);
   });
 
   test("caches Codex model lists per runtime", async () => {
@@ -133,7 +170,7 @@ describe("CodexAppServerAdapter lifecycle", () => {
       model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
     });
 
-    await adapter.forkSession({
+    const forkSummary = await adapter.forkSession({
       repoPath: "/repo",
       runtimeKind: "codex",
       workingDirectory: "/repo",
@@ -145,10 +182,12 @@ describe("CodexAppServerAdapter lifecycle", () => {
     });
 
     expect(requireRepoRuntime).toHaveBeenCalledTimes(2);
+    expect(forkSummary.title).toBe("QA task-1");
     expect(transports.get("runtime-live")?.calls.map((call) => call.method)).toEqual([
       "model/list",
       "thread/resume",
       "thread/fork",
+      "thread/name/set",
     ]);
     expect(transports.get("runtime-live")?.calls[1]?.params).toEqual({
       threadId: "thread-9",
@@ -163,6 +202,13 @@ describe("CodexAppServerAdapter lifecycle", () => {
       developerInstructions: "Review the fork.",
       model: "gpt-5",
       effort: "medium",
+    });
+    expect(transports.get("runtime-live")?.calls[3]).toEqual({
+      method: "thread/name/set",
+      params: {
+        threadId: "thread/fork-runtime-live",
+        name: "QA task-1",
+      },
     });
   });
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
@@ -29,12 +29,14 @@ describe("CodexAppServerAdapter lifecycle", () => {
     });
 
     expect(summary.externalSessionId).toBe("thread/start-runtime-ensure");
+    expect(summary.title).toBe("BUILD task-1");
     expect(ensureRepoRuntime).toHaveBeenCalledTimes(1);
     expect(requireRepoRuntime).not.toHaveBeenCalled();
     expect(transports.has("runtime-ensure")).toBe(true);
     expect(transports.get("runtime-ensure")?.calls.map((call) => call.method)).toEqual([
       "model/list",
       "thread/start",
+      "thread/name/set",
     ]);
     expect(transports.get("runtime-ensure")?.calls[1]).toEqual({
       method: "thread/start",
@@ -43,6 +45,13 @@ describe("CodexAppServerAdapter lifecycle", () => {
         developerInstructions: "Use the repo rules.",
         model: "gpt-5",
         effort: "medium",
+      },
+    });
+    expect(transports.get("runtime-ensure")?.calls[2]).toEqual({
+      method: "thread/name/set",
+      params: {
+        threadId: "thread/start-runtime-ensure",
+        name: "BUILD task-1",
       },
     });
   });
@@ -179,9 +188,10 @@ describe("CodexAppServerAdapter lifecycle", () => {
     expect(transports.get("runtime-ensure")?.calls.map((call) => call.method)).toEqual([
       "model/list",
       "thread/start",
+      "thread/name/set",
       "turn/start",
     ]);
-    expect(transports.get("runtime-ensure")?.calls[2]).toEqual({
+    expect(transports.get("runtime-ensure")?.calls[3]).toEqual({
       method: "turn/start",
       params: {
         threadId: "thread/start-runtime-ensure",
@@ -215,7 +225,7 @@ describe("CodexAppServerAdapter lifecycle", () => {
       parts: [{ kind: "text", text: "Use deeper reasoning" }],
     });
 
-    expect(transports.get("runtime-ensure")?.calls[2]).toEqual({
+    expect(transports.get("runtime-ensure")?.calls[3]).toEqual({
       method: "turn/start",
       params: {
         threadId: "thread/start-runtime-ensure",
@@ -440,6 +450,13 @@ describe("CodexAppServerAdapter lifecycle", () => {
         developerInstructions: "Use the repo rules.",
         model: "gpt-5",
         effort: "medium",
+      },
+    });
+    expect(transport.calls[2]).toEqual({
+      method: "thread/name/set",
+      params: {
+        threadId: "thread/start-runtime-ensure",
+        name: "BUILD task-1",
       },
     });
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.presence.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.presence.test.ts
@@ -394,6 +394,7 @@ describe("CodexAppServerAdapter presence", () => {
     ).resolves.toMatchObject({
       presence: "runtime",
       agentSessionStatus: "running",
+      title: "BUILD task-1",
       ref: expect.objectContaining({ externalSessionId: summary.externalSessionId }),
     });
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -94,6 +94,8 @@ export class RecordingTransport implements CodexJsonRpcTransport {
           startedAt: "2026-05-07T00:00:00.000Z",
         } as Response;
       }
+      case "thread/name/set":
+        return {} as Response;
       case "turn/start": {
         if (
           !Array.isArray((params as { input?: unknown })?.input) ||

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -199,14 +199,14 @@ export class CodexAppServerAdapter
     this.clearThreadInventory(runtimeId);
     const title = formatWorkflowAgentSessionTitle(input.role, input.taskId);
     const session = sessionStateFromThreadStart(input, runtimeId, model, response, title);
-    await client.threadSetName({
-      threadId: session.threadId,
-      name: title,
-    });
     const { summary } = session;
     this.clearHistoryOnlyIdleThreadLoad(summary.externalSessionId);
     this.sessions.set(summary.externalSessionId, session);
     void this.drainBufferedStreamEvents(summary.externalSessionId);
+    await client.threadSetName({
+      threadId: session.threadId,
+      name: title,
+    });
 
     return summary;
   }
@@ -252,11 +252,16 @@ export class CodexAppServerAdapter
       effort: toTransportModelSelection(model).effort,
     });
     this.clearThreadInventory(runtimeId);
-    const session = sessionStateFromThreadFork(input, runtimeId, model, response);
+    const title = formatWorkflowAgentSessionTitle(input.role, input.taskId);
+    const session = sessionStateFromThreadFork(input, runtimeId, model, response, title);
     const { summary } = session;
     this.clearHistoryOnlyIdleThreadLoad(summary.externalSessionId);
     this.sessions.set(summary.externalSessionId, session);
     void this.drainBufferedStreamEvents(summary.externalSessionId);
+    await client.threadSetName({
+      threadId: session.threadId,
+      name: title,
+    });
 
     return summary;
   }

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -34,6 +34,7 @@ import type {
   StartAgentSessionInput,
   UpdateAgentSessionModelInput,
 } from "@openducktor/core";
+import { formatWorkflowAgentSessionTitle } from "@openducktor/core";
 import { requireCodexServerRequestId } from "./codex-app-server-approvals";
 import { applyFinalAssistantTurnMetadata } from "./codex-app-server-history";
 import {
@@ -187,15 +188,21 @@ export class CodexAppServerAdapter
     const { client, runtimeId } = await this.runtimeClients.resolve(input, "start session");
     this.ensureRuntimeEventSubscription(runtimeId);
     await this.models.validate(client, runtimeId, model);
+    const transportModel = toTransportModelSelection(model);
 
     const response = await client.threadStart({
       cwd: input.workingDirectory,
       developerInstructions: input.systemPrompt,
-      model: toTransportModelSelection(model).model,
-      effort: toTransportModelSelection(model).effort,
+      model: transportModel.model,
+      effort: transportModel.effort,
     });
     this.clearThreadInventory(runtimeId);
-    const session = sessionStateFromThreadStart(input, runtimeId, model, response);
+    const title = formatWorkflowAgentSessionTitle(input.role, input.taskId);
+    const session = sessionStateFromThreadStart(input, runtimeId, model, response, title);
+    await client.threadSetName({
+      threadId: session.threadId,
+      name: title,
+    });
     const { summary } = session;
     this.clearHistoryOnlyIdleThreadLoad(summary.externalSessionId);
     this.sessions.set(summary.externalSessionId, session);

--- a/packages/adapters-codex-app-server/src/codex-app-server-presence.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-presence.ts
@@ -34,7 +34,7 @@ export const toPresenceSnapshot = (
       workingDirectory: session.workingDirectory,
     },
     runtimeId: session.runtimeId,
-    title: session.role ? `Codex ${session.role}` : "Codex",
+    title: session.summary.title ?? (session.role ? `Codex ${session.role}` : "Codex"),
     startedAt: session.summary.startedAt,
     status: hasPendingInput ? { type: "busy" } : status,
     agentSessionStatus: hasPendingInput ? "running" : agentSessionStatus,

--- a/packages/adapters-codex-app-server/src/codex-app-server-threads.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-threads.ts
@@ -28,11 +28,13 @@ export const extractThreadId = (
 export const toSessionSummary = (input: {
   externalSessionId: string;
   startedAt: string;
+  title?: string;
   role: AgentRole | null;
   status: AgentSessionSummary["status"];
 }): AgentSessionSummary => ({
   externalSessionId: input.externalSessionId,
   runtimeKind: "codex",
+  ...(input.title ? { title: input.title } : {}),
   role: input.role,
   startedAt: input.startedAt,
   status: input.status,

--- a/packages/adapters-codex-app-server/src/codex-session-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-lifecycle.ts
@@ -80,11 +80,13 @@ export const sessionStateFromThreadFork = (
   runtimeId: string,
   model: AgentModelSelection,
   response: CodexThreadForkResult,
+  title: string,
 ): CodexSessionState => {
   const { externalSessionId, startedAt } = extractThreadId(response, "thread/fork");
   const summary = toSessionSummary({
     externalSessionId,
     startedAt: startedAt ?? new Date().toISOString(),
+    title,
     role: input.role,
     status: "running",
   });

--- a/packages/adapters-codex-app-server/src/codex-session-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-lifecycle.ts
@@ -55,11 +55,13 @@ export const sessionStateFromThreadStart = (
   runtimeId: string,
   model: AgentModelSelection,
   response: CodexThreadStartResult,
+  title: string,
 ): CodexSessionState => {
   const { externalSessionId, startedAt } = extractThreadId(response, "thread/start");
   const summary = toSessionSummary({
     externalSessionId,
     startedAt: startedAt ?? new Date().toISOString(),
+    title,
     role: input.role,
     status: "running",
   });
@@ -182,6 +184,7 @@ const sessionStateFromThreadResumeResponse = (
   const summary = toSessionSummary({
     externalSessionId,
     startedAt: startedAt ?? threadSnapshot.startedAt,
+    title: threadSnapshot.title,
     role: input.role,
     status: threadSnapshot.status.agentSessionStatus,
   });

--- a/packages/adapters-codex-app-server/src/index.ts
+++ b/packages/adapters-codex-app-server/src/index.ts
@@ -19,6 +19,7 @@ export type {
   CodexThreadForkResult,
   CodexThreadResumeParams,
   CodexThreadResumeResult,
+  CodexThreadSetNameParams,
   CodexThreadStartParams,
   CodexThreadStartResult,
   CodexTurnStartParams,

--- a/packages/adapters-codex-app-server/src/types.ts
+++ b/packages/adapters-codex-app-server/src/types.ts
@@ -179,6 +179,11 @@ export type CodexThreadForkParams = {
   effort: string;
 };
 
+export type CodexThreadSetNameParams = {
+  threadId: string;
+  name: string;
+};
+
 export type CodexTurnStartParams = {
   threadId: string;
   input: CodexUserInput[];
@@ -260,6 +265,7 @@ export type CodexAppServerClient = {
   threadStart(params: CodexThreadStartParams): Promise<CodexThreadStartResult>;
   threadResume(params: CodexThreadResumeParams): Promise<CodexThreadResumeResult>;
   threadFork(params: CodexThreadForkParams): Promise<CodexThreadForkResult>;
+  threadSetName(params: CodexThreadSetNameParams): Promise<Record<string, never>>;
   turnStart(params: CodexTurnStartParams): Promise<CodexTurnStartResult>;
   turnSteer(params: CodexTurnSteerParams): Promise<CodexTurnSteerResult>;
   turnInterrupt(params: CodexTurnInterruptParams): Promise<Record<string, never>>;

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -99,6 +99,7 @@ describe("OpencodeSdkAdapter index", () => {
 
     expect(summary.externalSessionId).toBe("session-opencode-1");
     expect(summary.role).toBe("planner");
+    expect(summary.title).toBe("PLANNER task-1");
     expect(mock.session.createCalls).toHaveLength(1);
     expect(mock.session.createCalls[0]).toMatchObject({
       directory: "/repo",

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -30,7 +30,10 @@ import type {
   StartAgentSessionInput,
   UpdateAgentSessionModelInput,
 } from "@openducktor/core";
-import { toAgentSessionPresenceSnapshotFromLiveSnapshot } from "@openducktor/core";
+import {
+  formatWorkflowAgentSessionTitle,
+  toAgentSessionPresenceSnapshotFromLiveSnapshot,
+} from "@openducktor/core";
 import {
   connectMcpServer,
   getMcpStatus,
@@ -223,7 +226,7 @@ export class OpencodeSdkAdapter
     return {
       externalSessionId: session.externalSessionId,
       title: session.input.role
-        ? `${session.input.role.toUpperCase()} ${session.input.taskId}`
+        ? formatWorkflowAgentSessionTitle(session.input.role, session.input.taskId)
         : "OpenCode",
       workingDirectory: session.input.workingDirectory,
       startedAt: session.summary.startedAt,
@@ -302,7 +305,7 @@ export class OpencodeSdkAdapter
     const client = this.createClient(runtimeClientInput);
     const created = await client.session.create({
       directory: input.workingDirectory,
-      title: `${input.role.toUpperCase()} ${input.taskId}`,
+      title: formatWorkflowAgentSessionTitle(input.role, input.taskId),
       permission: buildRoleScopedPermissionRules({
         role: input.role,
         runtimeDescriptor: runtimeDefinition,

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -1,5 +1,6 @@
 import type { Event, OpencodeClient, Session } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent, AgentSessionSummary } from "@openducktor/core";
+import { formatWorkflowAgentSessionTitle } from "@openducktor/core";
 import { unwrapData } from "./data-utils";
 import {
   assertGlobalEventSupport,
@@ -319,6 +320,14 @@ export const registerSession = (input: {
 }): AgentSessionSummary => {
   const summary: AgentSessionSummary = {
     externalSessionId: input.externalSessionId,
+    ...(input.sessionInput.role
+      ? {
+          title: formatWorkflowAgentSessionTitle(
+            input.sessionInput.role,
+            input.sessionInput.taskId,
+          ),
+        }
+      : {}),
     role: input.sessionInput.role,
     startedAt: input.startedAt,
     status: "running",

--- a/packages/contracts/src/codex-app-server-protocol.ts
+++ b/packages/contracts/src/codex-app-server-protocol.ts
@@ -148,6 +148,11 @@ export type CodexAppServerThreadForkParams = CodexAppServerThreadResumeParams & 
   ephemeral?: boolean | null;
   threadSource?: CodexAppServerThreadSource | null;
 };
+export type CodexAppServerThreadSetNameParams = {
+  threadId: string;
+  name: string;
+};
+export type CodexAppServerThreadSetNameResult = Record<string, never>;
 export type CodexAppServerThreadStartResult = {
   approvalPolicy: CodexAppServerAskForApproval;
   approvalsReviewer: CodexAppServerApprovalsReviewer;
@@ -503,6 +508,10 @@ export type CodexAppServerClientRequestMap = {
   "thread/start": {
     params: CodexAppServerThreadStartParams;
     result: CodexAppServerThreadStartResult;
+  };
+  "thread/name/set": {
+    params: CodexAppServerThreadSetNameParams;
+    result: CodexAppServerThreadSetNameResult;
   };
   "thread/turns/list": {
     params: CodexAppServerThreadTurnsListParams;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from "./guards";
 export * from "./ports/agent-engine";
 export * from "./services/agent-file-references";
 export * from "./services/agent-session-presence";
+export * from "./services/agent-session-title";
 export * from "./services/agent-session-todos";
 export * from "./services/agent-system-prompts";
 export * from "./services/agent-user-message-parts";

--- a/packages/core/src/ports/agent-engine.ts
+++ b/packages/core/src/ports/agent-engine.ts
@@ -230,6 +230,7 @@ export type EventUnsubscribe = () => void;
 export type AgentSessionSummary = {
   externalSessionId: ExternalSessionId;
   runtimeKind?: RuntimeKind;
+  title?: string;
   role: AgentRole | null;
   startedAt: string;
   status: "starting" | "running" | "idle" | "error" | "stopped";

--- a/packages/core/src/services/agent-session-title.test.ts
+++ b/packages/core/src/services/agent-session-title.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { formatWorkflowAgentSessionTitle } from "./agent-session-title";
+
+describe("formatWorkflowAgentSessionTitle", () => {
+  test("formats workflow session titles from role and task id", () => {
+    expect(formatWorkflowAgentSessionTitle("build", "task-1")).toBe("BUILD task-1");
+  });
+});

--- a/packages/core/src/services/agent-session-title.test.ts
+++ b/packages/core/src/services/agent-session-title.test.ts
@@ -5,4 +5,15 @@ describe("formatWorkflowAgentSessionTitle", () => {
   test("formats workflow session titles from role and task id", () => {
     expect(formatWorkflowAgentSessionTitle("build", "task-1")).toBe("BUILD task-1");
   });
+
+  test("formats every workflow role", () => {
+    expect(formatWorkflowAgentSessionTitle("spec", "task-2")).toBe("SPEC task-2");
+    expect(formatWorkflowAgentSessionTitle("planner", "task-3")).toBe("PLANNER task-3");
+    expect(formatWorkflowAgentSessionTitle("qa", "task-4")).toBe("QA task-4");
+  });
+
+  test("preserves caller-provided task id text", () => {
+    expect(formatWorkflowAgentSessionTitle("build", "")).toBe("BUILD ");
+    expect(formatWorkflowAgentSessionTitle("build", "task-!@#")).toBe("BUILD task-!@#");
+  });
 });

--- a/packages/core/src/services/agent-session-title.ts
+++ b/packages/core/src/services/agent-session-title.ts
@@ -1,0 +1,4 @@
+import type { AgentRole } from "../types/agent-orchestrator";
+
+export const formatWorkflowAgentSessionTitle = (role: AgentRole, taskId: string): string =>
+  `${role.toUpperCase()} ${taskId}`;

--- a/packages/frontend/src/state/agent-runtime-registry.test.ts
+++ b/packages/frontend/src/state/agent-runtime-registry.test.ts
@@ -116,7 +116,13 @@ describe("agent-runtime-registry", () => {
           nextCursor: null,
         };
       }
-      return { thread: { id: "thread-codex" }, startedAt: "2026-02-22T09:00:00.000Z" };
+      if (method === "thread/start") {
+        return { thread: { id: "thread-codex" }, startedAt: "2026-02-22T09:00:00.000Z" };
+      }
+      if (method === "thread/name/set") {
+        return {};
+      }
+      throw new Error(`Unexpected Codex app-server request method: ${method}`);
     }) as typeof host.codexAppServerRequest;
     configureShellBridge({
       client: {} as HostClient,
@@ -156,9 +162,16 @@ describe("agent-runtime-registry", () => {
 
       expect(runtimeEnsureCalls).toEqual([["/repo", "codex"]]);
       expect(runtimeListCalls).toEqual([["/repo", "codex"]]);
-      expect(codexRequestCalls[0]?.[0]).toBe("runtime-codex-ensure");
-      expect(codexRequestCalls[1]?.[0]).toBe("runtime-codex-ensure");
-      expect(codexRequestCalls[2]?.[0]).toBe("runtime-codex-live");
+      expect(codexRequestCalls.map(([runtimeId, method]) => [runtimeId, method])).toEqual([
+        ["runtime-codex-ensure", "model/list"],
+        ["runtime-codex-ensure", "thread/start"],
+        ["runtime-codex-ensure", "thread/name/set"],
+        ["runtime-codex-live", "model/list"],
+      ]);
+      expect(codexRequestCalls[2]?.[2]).toEqual({
+        threadId: "thread-codex",
+        name: "BUILD task-1",
+      });
     } finally {
       host.runtimeEnsure = originalRuntimeEnsure;
       host.runtimeList = originalRuntimeList;

--- a/packages/frontend/src/state/agent-sessions-store.ts
+++ b/packages/frontend/src/state/agent-sessions-store.ts
@@ -96,7 +96,7 @@ const areSummariesEquivalent = (
 ): boolean => {
   return (
     left?.externalSessionId === right.externalSessionId &&
-    left.title === right.title &&
+    left?.title === right.title &&
     left.taskId === right.taskId &&
     left.role === right.role &&
     left.status === right.status &&

--- a/packages/frontend/src/state/agent-sessions-store.ts
+++ b/packages/frontend/src/state/agent-sessions-store.ts
@@ -5,6 +5,7 @@ export type AgentSessionsById = Record<string, AgentSessionState>;
 export type AgentSessionSummary = Pick<
   AgentSessionState,
   | "externalSessionId"
+  | "title"
   | "repoPath"
   | "taskId"
   | "role"
@@ -57,6 +58,7 @@ const sortByStartedAtDesc = (left: AgentSessionState, right: AgentSessionState):
 
 export const toAgentSessionSummary = (session: AgentSessionState): AgentSessionSummary => ({
   externalSessionId: session.externalSessionId,
+  ...(session.title ? { title: session.title } : {}),
   repoPath: session.repoPath,
   taskId: session.taskId,
   role: session.role,
@@ -94,6 +96,7 @@ const areSummariesEquivalent = (
 ): boolean => {
   return (
     left?.externalSessionId === right.externalSessionId &&
+    left.title === right.title &&
     left.taskId === right.taskId &&
     left.role === right.role &&
     left.status === right.status &&

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-local-state.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/start-session-local-state.ts
@@ -30,6 +30,7 @@ export const buildInitialSession = ({
   createRepoScopedAgentSessionState(
     {
       externalSessionId: startedCtx.summary.externalSessionId,
+      ...(startedCtx.summary.title ? { title: startedCtx.summary.title } : {}),
       taskId: startedCtx.taskId,
       runtimeKind: requireConfiguredRuntimeKind(
         runtime.runtimeKind ?? selectedModel?.runtimeKind,

--- a/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-live-reconcile.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/lifecycle/load-sessions-live-reconcile.test.ts
@@ -50,7 +50,10 @@ describe("agent-orchestrator live session reconciliation", () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {
         "external-stale": {
-          ...persistedRecord,
+          externalSessionId: persistedRecord.externalSessionId,
+          role: persistedRecord.role,
+          startedAt: persistedRecord.startedAt,
+          workingDirectory: persistedRecord.workingDirectory,
           repoPath: "/tmp/repo",
           taskId: "task-1",
           status: "stopped",
@@ -165,8 +168,10 @@ describe("agent-orchestrator live session reconciliation", () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {
         "external-1": {
-          ...persistedRecord,
-          externalSessionId: "external-1",
+          externalSessionId: persistedRecord.externalSessionId,
+          role: persistedRecord.role,
+          startedAt: persistedRecord.startedAt,
+          workingDirectory: persistedRecord.workingDirectory,
           runtimeKind: "opencode",
           repoPath: "/tmp/repo",
           taskId: "task-1",

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -31,6 +31,7 @@ describe("agent-orchestrator/support/persistence", () => {
   test("hydrates persisted sessions as stopped until runtime reconciliation", () => {
     const hydrated = fromPersistedSessionRecord(recordFixture, "task-1", repoPathFixture);
     expect(hydrated.status).toBe("stopped");
+    expect(hydrated.title).toBe("BUILD task-1");
     expect(hydrated.runtimeKind).toBe("opencode");
     expect(hydrated.runtimeId).toBeNull();
     expect(hydrated.pendingApprovals).toEqual([]);

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -90,6 +90,7 @@ describe("agent-orchestrator/support/persistence", () => {
     expect(persisted.runtimeKind).toBe("opencode");
     expect(persisted.selectedModel).toEqual(recordFixture.selectedModel);
     expect("taskId" in persisted).toBe(false);
+    expect("title" in persisted).toBe(false);
   });
 
   test("preserves non-default runtime kind across persistence", () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -5,6 +5,7 @@ import type {
   AgentSessionHistoryMessage,
   AgentUserMessageDisplayPart,
 } from "@openducktor/core";
+import { formatWorkflowAgentSessionTitle } from "@openducktor/core";
 import { createRepoScopedAgentSessionState } from "@/state/repo-scoped-agent-session";
 import type {
   AgentChatMessage,
@@ -83,6 +84,7 @@ export const fromPersistedSessionRecord = (
   return createRepoScopedAgentSessionState(
     {
       externalSessionId: session.externalSessionId,
+      title: formatWorkflowAgentSessionTitle(session.role, fallbackTaskId),
       purpose: "primary",
       taskId: fallbackTaskId,
       role: session.role,

--- a/packages/host/src/interface/commands/codex-app-server-command-handlers.test.ts
+++ b/packages/host/src/interface/commands/codex-app-server-command-handlers.test.ts
@@ -27,6 +27,10 @@ describe("createCodexAppServerCommandHandlers", () => {
     const service: CodexAppServerService = {
       request(input) {
         calls.push({ method: "request", input });
+        if (input.method === "thread/name/set") {
+          const result: Record<string, never> = {};
+          return Effect.succeed(result);
+        }
         return Effect.succeed({ data: [], nextCursor: null });
       },
       listLoadedThreads(input) {
@@ -82,6 +86,13 @@ describe("createCodexAppServerCommandHandlers", () => {
       }),
     ).resolves.toEqual({ data: [], nextCursor: null });
     await expect(
+      router.invoke("codex_app_server_request", {
+        runtimeId: "runtime-1",
+        method: "thread/name/set",
+        params: { threadId: "thread-1", name: "BUILD task-1" },
+      }),
+    ).resolves.toEqual({});
+    await expect(
       router.invoke("codex_app_server_notifications", { runtimeId: "runtime-1" }),
     ).resolves.toEqual([codexStatusNotification]);
     await expect(
@@ -121,6 +132,14 @@ describe("createCodexAppServerCommandHandlers", () => {
           runtimeId: "runtime-1",
           method: "fuzzyFileSearch",
           params: { query: "src", roots: ["/repo"], cancellationToken: null },
+        },
+      },
+      {
+        method: "request",
+        input: {
+          runtimeId: "runtime-1",
+          method: "thread/name/set",
+          params: { threadId: "thread-1", name: "BUILD task-1" },
         },
       },
       {

--- a/packages/host/src/ports/codex-app-server-port.ts
+++ b/packages/host/src/ports/codex-app-server-port.ts
@@ -24,6 +24,7 @@ export const CODEX_APP_SERVER_REQUEST_METHODS = [
   "thread/read",
   "thread/resume",
   "thread/start",
+  "thread/name/set",
   "thread/turns/list",
   "skills/list",
   "turn/start",


### PR DESCRIPTION
Summary
- Adds workflow-aware titles for Codex and OpenCode sessions so OpenDucktor agent sessions are easier to identify.
- Wires Codex app-server session naming through the typed host/app-server protocol with a new `thread/name/set` route.
- Keeps persisted session records durable by deriving display titles during hydration instead of storing transient runtime naming data.

Goal
OpenDucktor already made OpenCode sessions easy to find with custom names. This PR gives Codex sessions the same treatment, making build/spec/planner/QA sessions recognizable when checking active Codex sessions.

Technical Choices
- Added a small shared `formatWorkflowAgentSessionTitle` core helper so runtime adapters use one title convention.
- Extended the Codex app-server contract, host port, command handler tests, and adapter client with `threadSetName`.
- Applied titles during Codex lifecycle startup after session creation, while OpenCode now uses the shared formatter through its registry path.
- Preserved durable `AgentSessionRecord` shape and reconstructs frontend session titles from task id and role when loading persisted records.

Verification
- `bun run --filter @openducktor/host test src/interface/commands/codex-app-server-command-handlers.test.ts`
- `bun run --filter @openducktor/host test`
- `bun run --filter @openducktor/contracts test`
- `bun run --filter @openducktor/core test`
- `bun run --filter @openducktor/adapters-codex-app-server test`
- `bun run --filter @openducktor/adapters-opencode-sdk test`
- `bun run --filter @openducktor/build-tools test`
- `bun run --filter @openducktor/path-support test`
- `bun run --filter @openducktor/mcp test`
- `bun run --filter @openducktor/web test`
- `bun run --filter @openducktor/frontend test`
- `bun run --filter @openducktor/electron test`
- `bun run --filter @openducktor/host-client test`
- `bun run test:scripts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `git diff --check`

Notes
- No Cargo checks were applicable because this checkout has no `Cargo.toml`.
- The MCP and web package tests were rerun outside the sandbox because their localhost server tests are blocked by the managed sandbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now include workflow-derived titles; threads are named for clearer identification and shown in presence snapshots.
  * Runtime tooling now validates OpenCode version and surfaces unsupported-version errors during startup/health checks.

* **Tests**
  * Added and extended tests covering thread naming, session title formatting, persistence, transport interactions, and OpenCode version validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->