### PR TITLE
fix(frontend): use selected token for text selection

### DIFF
--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -369,7 +369,7 @@ pre {
 }
 
 ::selection {
-  background: oklch(from var(--primary) l c h / 25%);
+  background: var(--selected-surface);
 }
 
 ::-webkit-scrollbar {

--- a/packages/frontend/src/styles.test.ts
+++ b/packages/frontend/src/styles.test.ts
@@ -6,7 +6,7 @@ const readStyles = (): string => readFileSync(resolve(import.meta.dir, "styles.c
 
 describe("global styles", () => {
   test("uses the selected surface token for native text selection", () => {
-    const styles = readStyles();
+    const styles = readStyles().replace(/\/\*[\s\S]*?\*\//g, "");
     const selectionRuleMatch = styles.match(/::selection\s*\{([^}]*)\}/);
 
     if (!selectionRuleMatch) {
@@ -14,7 +14,7 @@ describe("global styles", () => {
     }
 
     const selectionRule = selectionRuleMatch[1];
-    expect(selectionRule).toContain("background: var(--selected-surface);");
+    expect(selectionRule).toContain("var(--selected-surface)");
     expect(selectionRule).not.toContain("var(--primary)");
   });
 });

--- a/packages/frontend/src/styles.test.ts
+++ b/packages/frontend/src/styles.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const readStyles = (): string => readFileSync(resolve(import.meta.dir, "styles.css"), "utf8");
+
+describe("global styles", () => {
+  test("uses the selected surface token for native text selection", () => {
+    const styles = readStyles();
+    const selectionRuleMatch = styles.match(/::selection\s*\{([^}]*)\}/);
+
+    if (!selectionRuleMatch) {
+      throw new Error("Expected global ::selection rule in styles.css");
+    }
+
+    const selectionRule = selectionRuleMatch[1];
+    expect(selectionRule).toContain("background: var(--selected-surface);");
+    expect(selectionRule).not.toContain("var(--primary)");
+  });
+});


### PR DESCRIPTION
Summary

This PR updates OpenDucktor native text selection styling so selected text uses the selected surface token instead of the purple primary token, and adds regression coverage for that global CSS rule.

Goal

Selecting text in the app currently uses a background derived from the primary brand color, which makes native text selection appear purple. The task is to align that interaction with the existing selected color token family so text selection matches the rest of OpenDucktor selected-state styling.

Technical choices

The implementation keeps the fix at the source styling layer by changing the global ::selection rule in packages/frontend/src/styles.css from a primary-derived OKLCH color to var(--selected-surface). That reuses the existing light and dark selected-surface token definitions instead of adding component-level overrides or new fallback behavior.

I also added packages/frontend/src/styles.test.ts, which reads the global stylesheet and asserts that ::selection uses var(--selected-surface) and does not reference var(--primary). This guards against regressing native text selection back to the brand primary token.

Verification

Cargo checks: not applicable because this checkout contains no Cargo.toml manifests.

Bun checks, all run with gtimeout 600s:
- bun run lint
- bun run test
- bun run typecheck
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored selection highlight styling to leverage the centralized CSS variable system for improved maintainability, visual consistency, and design system alignment throughout the application interface.

* **Tests**
  * Added test coverage to validate that selection styling correctly implements CSS variables and maintains proper configuration without any deprecated color expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->