### PR TITLE
refactor(electron): migrate package workflows to Effect

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -38,6 +38,7 @@
     "bun-types": "^1.3.14",
     "electron": "^42.4.1",
     "electron-builder": "^26.15.3",
+    "effect": "^3.21.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "vite": "^8.0.16"

--- a/apps/electron/scripts/build.ts
+++ b/apps/electron/scripts/build.ts
@@ -2,6 +2,9 @@ import { cp } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanDirectory, runCommand } from "@openducktor/build-tools";
+import { Effect } from "effect";
+import { runElectronEffect } from "../src/effect/electron-boundary";
+import { ElectronOperationError, errorMessage } from "../src/effect/electron-errors";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptDirectory, "..");
@@ -27,35 +30,75 @@ export const copySqliteTaskStoreMigrations = ({
   sourceDirectory,
   targetDirectory,
 }: SqliteTaskStoreMigrationCopyPlan): Promise<void> =>
-  cp(sourceDirectory, targetDirectory, { force: true, recursive: true });
+  runElectronEffect(copySqliteTaskStoreMigrationsEffect({ sourceDirectory, targetDirectory }));
 
-export const buildElectronPackage = async (): Promise<void> => {
-  await cleanDirectory(join(packageRoot, "dist"));
-  await Promise.all([
-    runCommand({
-      command: ["bun", "run", "build:main"],
-      cwd: packageRoot,
-      label: "Electron main build",
-    }),
-    runCommand({
-      command: ["bun", "run", "build:preload"],
-      cwd: packageRoot,
-      label: "Electron preload build",
-    }),
-    runCommand({
-      command: ["bun", "run", "build:renderer"],
-      cwd: packageRoot,
-      label: "Electron renderer build",
-    }),
-  ]);
-  await copySqliteTaskStoreMigrations(
-    resolveSqliteTaskStoreMigrationCopyPlan({
-      electronPackageRoot: packageRoot,
-      workspaceRoot,
-    }),
-  );
-};
+export const copySqliteTaskStoreMigrationsEffect = ({
+  sourceDirectory,
+  targetDirectory,
+}: SqliteTaskStoreMigrationCopyPlan): Effect.Effect<void, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: () => cp(sourceDirectory, targetDirectory, { force: true, recursive: true }),
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.build.copy-sqlite-migrations",
+        message: errorMessage(cause),
+        path: sourceDirectory,
+        cause,
+        details: { targetDirectory },
+      }),
+  });
+
+const runBuildCommandEffect = (
+  label: string,
+  command: readonly [string, ...string[]],
+): Effect.Effect<void, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: () => runCommand({ command, cwd: packageRoot, label }),
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.build.run-command",
+        message: errorMessage(cause),
+        cause,
+        details: { command, label },
+      }),
+  });
+
+export const buildElectronPackageEffect = (): Effect.Effect<void, ElectronOperationError> =>
+  Effect.gen(function* () {
+    yield* Effect.tryPromise({
+      try: () => cleanDirectory(join(packageRoot, "dist")),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.build.clean-dist",
+          message: errorMessage(cause),
+          path: join(packageRoot, "dist"),
+          cause,
+        }),
+    });
+    yield* Effect.all(
+      [
+        runBuildCommandEffect("Electron main build", ["bun", "run", "build:main"]),
+        runBuildCommandEffect("Electron preload build", ["bun", "run", "build:preload"]),
+        runBuildCommandEffect("Electron renderer build", ["bun", "run", "build:renderer"]),
+      ],
+      { concurrency: "unbounded" },
+    );
+    yield* copySqliteTaskStoreMigrationsEffect(
+      resolveSqliteTaskStoreMigrationCopyPlan({
+        electronPackageRoot: packageRoot,
+        workspaceRoot,
+      }),
+    );
+  });
+
+export const buildElectronPackage = (): Promise<void> =>
+  runElectronEffect(buildElectronPackageEffect());
 
 if (import.meta.main) {
-  await buildElectronPackage();
+  try {
+    await buildElectronPackage();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
 }

--- a/apps/electron/scripts/dev.test.ts
+++ b/apps/electron/scripts/dev.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
-import { Effect } from "effect";
+import { Cause, Chunk, Effect, Exit } from "effect";
 import { runElectronEffect } from "../src/effect/electron-boundary";
 import {
   closeRendererServer,
   electronGracefulShutdownSignal,
   electronRuntimeEnv,
+  mainEffect,
   resolveMacosAppBundlePath,
   resolveMacosDevExecutablePath,
   resolveRendererDevPort,
@@ -55,6 +56,38 @@ describe("electron dev script", () => {
       operation: "electron.dev.resolve-renderer-dev-port",
       field: "ELECTRON_RENDERER_DEV_PORT",
     });
+  });
+
+  test("keeps invalid renderer dev port in the main Effect failure channel", async () => {
+    const originalPort = process.env.ELECTRON_RENDERER_DEV_PORT;
+    process.env.ELECTRON_RENDERER_DEV_PORT = "0";
+
+    try {
+      const exit = await Effect.runPromiseExit(mainEffect());
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (!Exit.isFailure(exit)) {
+        throw new Error("Expected mainEffect to fail for an invalid renderer dev port.");
+      }
+
+      const failureOption = Chunk.head(Cause.failures(exit.cause));
+      expect(failureOption._tag).toBe("Some");
+      if (failureOption._tag !== "Some") {
+        throw new Error("Expected mainEffect to fail through the typed error channel.");
+      }
+
+      expect(failureOption.value).toMatchObject({
+        _tag: "ElectronValidationError",
+        operation: "electron.dev.resolve-renderer-dev-port",
+        field: "ELECTRON_RENDERER_DEV_PORT",
+      });
+      expect(Chunk.isEmpty(Cause.defects(exit.cause))).toBe(true);
+    } finally {
+      if (originalPort === undefined) {
+        delete process.env.ELECTRON_RENDERER_DEV_PORT;
+      } else {
+        process.env.ELECTRON_RENDERER_DEV_PORT = originalPort;
+      }
+    }
   });
 
   test("does not launch Electron in Node compatibility mode", () => {

--- a/apps/electron/scripts/dev.test.ts
+++ b/apps/electron/scripts/dev.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
+import { Effect } from "effect";
 import { runElectronEffect } from "../src/effect/electron-boundary";
 import {
   closeRendererServer,
@@ -9,6 +10,7 @@ import {
   resolveMacosDevExecutablePath,
   resolveRendererDevPort,
   resolveRequiredMacosAppBundlePath,
+  runElectronDevLifecycleEffect,
   shouldRestartElectronForChange,
   stopElectronEffect,
 } from "./dev";
@@ -247,5 +249,59 @@ describe("electron dev script", () => {
       operation: "electron.dev.stop-electron",
     });
     expect((error as Error).message).toContain("Electron did not exit after forced shutdown");
+  });
+
+  test("runs the dev watcher and Electron process lifecycle as an Effect", async () => {
+    const watchedRoots: string[][] = [];
+    const watchedEvents: string[] = [];
+    const startCalls: Array<{ executablePath: string; rendererDevUrl: string }> = [];
+    let buildCalls = 0;
+    let closeCalls = 0;
+    const rendererServer = {
+      close: async () => {
+        closeCalls += 1;
+      },
+      config: { server: { port: 1430 } },
+      resolvedUrls: { local: ["http://127.0.0.1:1430/"] },
+      watcher: {
+        add(roots: string[]) {
+          watchedRoots.push(roots);
+        },
+        on(event: string) {
+          watchedEvents.push(event);
+        },
+      },
+    };
+
+    const exitCode = await runElectronEffect(
+      runElectronDevLifecycleEffect({
+        buildBundles: () =>
+          Effect.sync(() => {
+            buildCalls += 1;
+          }),
+        electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
+        rendererDevUrl: "http://127.0.0.1:1430",
+        rendererServer: rendererServer as never,
+        startElectronProcess: (rendererDevUrl, electronExecutablePath) => {
+          startCalls.push({ executablePath: electronExecutablePath, rendererDevUrl });
+          return {
+            exited: Promise.resolve(0),
+            kill() {},
+          } as never;
+        },
+      }),
+    );
+
+    expect(exitCode).toBe(0);
+    expect(buildCalls).toBe(1);
+    expect(startCalls).toEqual([
+      {
+        executablePath: "/repo/node_modules/electron/dist/Electron",
+        rendererDevUrl: "http://127.0.0.1:1430",
+      },
+    ]);
+    expect(watchedRoots).toHaveLength(1);
+    expect(watchedEvents).toEqual(["add", "change", "unlink"]);
+    expect(closeCalls).toBe(1);
   });
 });

--- a/apps/electron/scripts/dev.test.ts
+++ b/apps/electron/scripts/dev.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
-import { Cause, Chunk, Effect, Exit } from "effect";
+import { Cause, Chunk, Effect, Exit, Fiber } from "effect";
 import { runElectronEffect } from "../src/effect/electron-boundary";
 import { ElectronOperationError } from "../src/effect/electron-errors";
 import {
@@ -240,7 +240,7 @@ describe("electron dev script", () => {
       },
     };
 
-    await closeRendererServer(rendererServer as never);
+    await closeRendererServer(rendererServer);
 
     expect(closeCalls).toBe(1);
     expect(closeIdleConnectionsCalls).toBe(1);
@@ -264,9 +264,7 @@ describe("electron dev script", () => {
       },
     };
 
-    await expect(closeRendererServer(rendererServer as never)).rejects.toThrow(
-      "renderer close failed",
-    );
+    await expect(closeRendererServer(rendererServer)).rejects.toThrow("renderer close failed");
     expect(closeIdleConnectionsCalls).toBe(1);
     expect(closeAllConnectionsCalls).toBe(1);
   });
@@ -277,7 +275,7 @@ describe("electron dev script", () => {
       close: () => new Promise<void>(() => {}),
     };
 
-    await closeRendererServer(rendererServer as never, async (durationMs) => {
+    await closeRendererServer(rendererServer, async (durationMs) => {
       timeoutMs = durationMs;
     });
 
@@ -294,7 +292,7 @@ describe("electron dev script", () => {
     };
 
     const error = await runElectronEffect(
-      stopElectronEffect(electron as never, async () => undefined),
+      stopElectronEffect(electron, async () => undefined),
     ).catch((caught: unknown) => caught);
 
     expect(signals).toEqual([electronGracefulShutdownSignal(process.platform), 9]);
@@ -337,13 +335,13 @@ describe("electron dev script", () => {
         electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
         processHandlers: fakeProcessHandlers.processHandlers,
         rendererDevUrl: "http://127.0.0.1:1430",
-        rendererServer: rendererServer as never,
+        rendererServer,
         startElectronProcess: (rendererDevUrl, electronExecutablePath) => {
           startCalls.push({ executablePath: electronExecutablePath, rendererDevUrl });
           return {
             exited: Promise.resolve(0),
             kill() {},
-          } as never;
+          };
         },
       }),
     );
@@ -371,6 +369,65 @@ describe("electron dev script", () => {
     ]);
   });
 
+  test("cleans up Electron dev lifecycle resources when the Effect is interrupted", async () => {
+    const fakeProcessHandlers = createFakeProcessHandlers();
+    const killSignals: Array<NodeJS.Signals | number | undefined> = [];
+    let closeCalls = 0;
+    let markStarted: () => void = () => {};
+    let resolveElectronExit: (exitCode: number) => void = () => {};
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const electronExited = new Promise<number>((resolve) => {
+      resolveElectronExit = resolve;
+    });
+    const rendererServer = {
+      close: async () => {
+        closeCalls += 1;
+      },
+      config: { server: { port: 1430 } },
+      resolvedUrls: { local: ["http://127.0.0.1:1430/"] },
+      watcher: {
+        add() {},
+        on() {},
+      },
+    };
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.fork(
+          runElectronDevLifecycleEffect({
+            buildBundles: () => Effect.void,
+            electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
+            processHandlers: fakeProcessHandlers.processHandlers,
+            rendererDevUrl: "http://127.0.0.1:1430",
+            rendererServer,
+            startElectronProcess: () => {
+              markStarted();
+              return {
+                exited: electronExited,
+                kill(signal?: NodeJS.Signals | number) {
+                  killSignals.push(signal);
+                  resolveElectronExit(0);
+                },
+              };
+            },
+          }),
+        );
+        yield* Effect.promise(() => started);
+        yield* Fiber.interrupt(fiber);
+      }),
+    );
+
+    expect(killSignals).toEqual([electronGracefulShutdownSignal(process.platform)]);
+    expect(closeCalls).toBe(1);
+    expect(fakeProcessHandlers.removed.map(({ event }) => event)).toEqual([
+      "SIGTERM",
+      "SIGINT",
+      "exit",
+    ]);
+  });
+
   test("keeps initial lifecycle setup failures in the typed failure channel", async () => {
     const fakeProcessHandlers = createFakeProcessHandlers();
     const setupError = new ElectronOperationError({
@@ -393,7 +450,7 @@ describe("electron dev script", () => {
         electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
         processHandlers: fakeProcessHandlers.processHandlers,
         rendererDevUrl: "http://127.0.0.1:1430",
-        rendererServer: rendererServer as never,
+        rendererServer,
         startElectronProcess: () => {
           throw new Error("Electron should not launch after setup failure.");
         },
@@ -452,13 +509,13 @@ describe("electron dev script", () => {
         electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
         processHandlers: fakeProcessHandlers.processHandlers,
         rendererDevUrl: "http://127.0.0.1:1430",
-        rendererServer: rendererServer as never,
+        rendererServer,
         startElectronProcess: () => {
           startCalls += 1;
           return {
             exited: Promise.resolve(0),
             kill() {},
-          } as never;
+          };
         },
       }),
     );

--- a/apps/electron/scripts/dev.test.ts
+++ b/apps/electron/scripts/dev.test.ts
@@ -309,7 +309,7 @@ describe("electron dev script", () => {
     const watchedRoots: string[][] = [];
     const watchedEvents: string[] = [];
     const startCalls: Array<{ executablePath: string; rendererDevUrl: string }> = [];
-    const processHandlerFake = createFakeProcessHandlers();
+    const fakeProcessHandlers = createFakeProcessHandlers();
     let buildCalls = 0;
     let closeCalls = 0;
     const rendererServer = {
@@ -335,7 +335,7 @@ describe("electron dev script", () => {
             buildCalls += 1;
           }),
         electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
-        processHandlers: processHandlerFake.processHandlers,
+        processHandlers: fakeProcessHandlers.processHandlers,
         rendererDevUrl: "http://127.0.0.1:1430",
         rendererServer: rendererServer as never,
         startElectronProcess: (rendererDevUrl, electronExecutablePath) => {
@@ -359,12 +359,12 @@ describe("electron dev script", () => {
     expect(watchedRoots).toHaveLength(1);
     expect(watchedEvents).toEqual(["add", "change", "unlink"]);
     expect(closeCalls).toBe(1);
-    expect(processHandlerFake.registered.map(({ event }) => event)).toEqual([
+    expect(fakeProcessHandlers.registered.map(({ event }) => event)).toEqual([
       "SIGINT",
       "SIGTERM",
       "exit",
     ]);
-    expect(processHandlerFake.removed.map(({ event }) => event)).toEqual([
+    expect(fakeProcessHandlers.removed.map(({ event }) => event)).toEqual([
       "exit",
       "SIGTERM",
       "SIGINT",
@@ -372,7 +372,7 @@ describe("electron dev script", () => {
   });
 
   test("keeps initial lifecycle setup failures in the typed failure channel", async () => {
-    const processHandlerFake = createFakeProcessHandlers();
+    const fakeProcessHandlers = createFakeProcessHandlers();
     const setupError = new ElectronOperationError({
       operation: "electron.dev.test-build",
       message: "build failed before launch",
@@ -391,7 +391,7 @@ describe("electron dev script", () => {
       runElectronDevLifecycleEffect({
         buildBundles: () => Effect.fail(setupError),
         electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
-        processHandlers: processHandlerFake.processHandlers,
+        processHandlers: fakeProcessHandlers.processHandlers,
         rendererDevUrl: "http://127.0.0.1:1430",
         rendererServer: rendererServer as never,
         startElectronProcess: () => {
@@ -412,7 +412,7 @@ describe("electron dev script", () => {
     }
 
     expect(failureOption.value).toBe(setupError);
-    expect(processHandlerFake.removed.map(({ event }) => event)).toEqual([
+    expect(fakeProcessHandlers.removed.map(({ event }) => event)).toEqual([
       "exit",
       "SIGTERM",
       "SIGINT",

--- a/apps/electron/scripts/dev.test.ts
+++ b/apps/electron/scripts/dev.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import { Cause, Chunk, Effect, Exit } from "effect";
 import { runElectronEffect } from "../src/effect/electron-boundary";
+import { ElectronOperationError } from "../src/effect/electron-errors";
 import {
   closeRendererServer,
+  type ElectronDevProcessHandlers,
   electronGracefulShutdownSignal,
   electronRuntimeEnv,
   mainEffect,
@@ -15,6 +17,25 @@ import {
   shouldRestartElectronForChange,
   stopElectronEffect,
 } from "./dev";
+
+const createFakeProcessHandlers = () => {
+  const registered: Array<{ event: string; listener: () => void }> = [];
+  const removed: Array<{ event: string; listener: () => void }> = [];
+  const processHandlers: ElectronDevProcessHandlers = {
+    off(event, listener) {
+      removed.push({ event, listener });
+    },
+    once(event, listener) {
+      registered.push({ event, listener });
+    },
+  };
+
+  return {
+    processHandlers,
+    registered,
+    removed,
+  };
+};
 
 describe("electron dev script", () => {
   test("uses the default renderer dev server port", () => {
@@ -288,6 +309,7 @@ describe("electron dev script", () => {
     const watchedRoots: string[][] = [];
     const watchedEvents: string[] = [];
     const startCalls: Array<{ executablePath: string; rendererDevUrl: string }> = [];
+    const processHandlerFake = createFakeProcessHandlers();
     let buildCalls = 0;
     let closeCalls = 0;
     const rendererServer = {
@@ -313,6 +335,7 @@ describe("electron dev script", () => {
             buildCalls += 1;
           }),
         electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
+        processHandlers: processHandlerFake.processHandlers,
         rendererDevUrl: "http://127.0.0.1:1430",
         rendererServer: rendererServer as never,
         startElectronProcess: (rendererDevUrl, electronExecutablePath) => {
@@ -336,5 +359,63 @@ describe("electron dev script", () => {
     expect(watchedRoots).toHaveLength(1);
     expect(watchedEvents).toEqual(["add", "change", "unlink"]);
     expect(closeCalls).toBe(1);
+    expect(processHandlerFake.registered.map(({ event }) => event)).toEqual([
+      "SIGINT",
+      "SIGTERM",
+      "exit",
+    ]);
+    expect(processHandlerFake.removed.map(({ event }) => event)).toEqual([
+      "exit",
+      "SIGTERM",
+      "SIGINT",
+    ]);
+  });
+
+  test("keeps initial lifecycle setup failures in the typed failure channel", async () => {
+    const processHandlerFake = createFakeProcessHandlers();
+    const setupError = new ElectronOperationError({
+      operation: "electron.dev.test-build",
+      message: "build failed before launch",
+    });
+    const rendererServer = {
+      close: async () => {},
+      config: { server: { port: 1430 } },
+      resolvedUrls: { local: ["http://127.0.0.1:1430/"] },
+      watcher: {
+        add() {},
+        on() {},
+      },
+    };
+
+    const exit = await Effect.runPromiseExit(
+      runElectronDevLifecycleEffect({
+        buildBundles: () => Effect.fail(setupError),
+        electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
+        processHandlers: processHandlerFake.processHandlers,
+        rendererDevUrl: "http://127.0.0.1:1430",
+        rendererServer: rendererServer as never,
+        startElectronProcess: () => {
+          throw new Error("Electron should not launch after setup failure.");
+        },
+      }),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) {
+      throw new Error("Expected initial lifecycle setup failure to fail the Effect.");
+    }
+
+    const failureOption = Chunk.head(Cause.failures(exit.cause));
+    expect(failureOption._tag).toBe("Some");
+    if (failureOption._tag !== "Some") {
+      throw new Error("Expected setup failure in the typed failure channel.");
+    }
+
+    expect(failureOption.value).toBe(setupError);
+    expect(processHandlerFake.removed.map(({ event }) => event)).toEqual([
+      "exit",
+      "SIGTERM",
+      "SIGINT",
+    ]);
   });
 });

--- a/apps/electron/scripts/dev.test.ts
+++ b/apps/electron/scripts/dev.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
+import { runElectronEffect } from "../src/effect/electron-boundary";
 import {
   closeRendererServer,
   electronGracefulShutdownSignal,
@@ -7,7 +8,9 @@ import {
   resolveMacosAppBundlePath,
   resolveMacosDevExecutablePath,
   resolveRendererDevPort,
+  resolveRequiredMacosAppBundlePath,
   shouldRestartElectronForChange,
+  stopElectronEffect,
 } from "./dev";
 
 describe("electron dev script", () => {
@@ -24,9 +27,32 @@ describe("electron dev script", () => {
     expect(() => resolveRendererDevPort("1430abc")).toThrow(
       "ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: 1430abc",
     );
+    expect(() => resolveRendererDevPort("0")).toThrow(
+      "ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: 0",
+    );
+    expect(() => resolveRendererDevPort("-1")).toThrow(
+      "ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: -1",
+    );
     expect(() => resolveRendererDevPort("70000")).toThrow(
       "ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: 70000",
     );
+  });
+
+  test("uses typed errors for malformed renderer dev server ports", () => {
+    const error = (() => {
+      try {
+        resolveRendererDevPort("0");
+      } catch (caught) {
+        return caught;
+      }
+      throw new Error("Expected resolveRendererDevPort to fail.");
+    })();
+
+    expect(error).toMatchObject({
+      _tag: "ElectronValidationError",
+      operation: "electron.dev.resolve-renderer-dev-port",
+      field: "ELECTRON_RENDERER_DEV_PORT",
+    });
   });
 
   test("does not launch Electron in Node compatibility mode", () => {
@@ -45,6 +71,23 @@ describe("electron dev script", () => {
       ),
     ).toBe("/repo/node_modules/electron/dist/Electron.app");
     expect(resolveMacosAppBundlePath("/repo/node_modules/.bin/electron")).toBeNull();
+  });
+
+  test("fails with a typed error when the macOS Electron executable is outside an app bundle", () => {
+    const error = (() => {
+      try {
+        resolveRequiredMacosAppBundlePath("/repo/node_modules/.bin/electron");
+      } catch (caught) {
+        return caught;
+      }
+      throw new Error("Expected resolveRequiredMacosAppBundlePath to fail.");
+    })();
+
+    expect(error).toMatchObject({
+      _tag: "ElectronOperationError",
+      operation: "electron.dev.resolve-macos-app-bundle",
+      path: "/repo/node_modules/.bin/electron",
+    });
   });
 
   test("resolves the OpenDucktor macOS dev executable inside the copied app bundle", () => {
@@ -183,5 +226,26 @@ describe("electron dev script", () => {
     });
 
     expect(timeoutMs).toBe(3_000);
+  });
+
+  test("fails when Electron does not exit after forced shutdown", async () => {
+    const signals: Array<NodeJS.Signals | number | undefined> = [];
+    const electron = {
+      exited: new Promise<number>(() => {}),
+      kill(signal?: NodeJS.Signals | number) {
+        signals.push(signal);
+      },
+    };
+
+    const error = await runElectronEffect(
+      stopElectronEffect(electron as never, async () => undefined),
+    ).catch((caught: unknown) => caught);
+
+    expect(signals).toEqual([electronGracefulShutdownSignal(process.platform), 9]);
+    expect(error).toMatchObject({
+      _tag: "ElectronOperationError",
+      operation: "electron.dev.stop-electron",
+    });
+    expect((error as Error).message).toContain("Electron did not exit after forced shutdown");
   });
 });

--- a/apps/electron/scripts/dev.test.ts
+++ b/apps/electron/scripts/dev.test.ts
@@ -412,10 +412,58 @@ describe("electron dev script", () => {
     }
 
     expect(failureOption.value).toBe(setupError);
-    expect(fakeProcessHandlers.removed.map(({ event }) => event)).toEqual([
-      "exit",
-      "SIGTERM",
-      "SIGINT",
-    ]);
+    expect(fakeProcessHandlers.removed.map(({ event }) => event)).toEqual(["SIGTERM", "SIGINT"]);
+  });
+
+  test("does not launch Electron when shutdown starts during bundle build", async () => {
+    const fakeProcessHandlers = createFakeProcessHandlers();
+    const rendererServer = {
+      close: async () => {},
+      config: { server: { port: 1430 } },
+      resolvedUrls: { local: ["http://127.0.0.1:1430/"] },
+      watcher: {
+        add() {},
+        on() {},
+      },
+    };
+    let startCalls = 0;
+
+    const exitCode = await runElectronEffect(
+      runElectronDevLifecycleEffect({
+        buildBundles: () =>
+          Effect.tryPromise({
+            try: async () => {
+              const shutdownHandler = fakeProcessHandlers.registered.find(
+                ({ event }) => event === "SIGTERM",
+              );
+              if (!shutdownHandler) {
+                throw new Error("Expected SIGTERM handler to be registered before build.");
+              }
+              shutdownHandler.listener();
+              await Promise.resolve();
+            },
+            catch: (cause) =>
+              new ElectronOperationError({
+                operation: "electron.dev.test-build",
+                message: cause instanceof Error ? cause.message : String(cause),
+                cause,
+              }),
+          }),
+        electronExecutablePath: "/repo/node_modules/electron/dist/Electron",
+        processHandlers: fakeProcessHandlers.processHandlers,
+        rendererDevUrl: "http://127.0.0.1:1430",
+        rendererServer: rendererServer as never,
+        startElectronProcess: () => {
+          startCalls += 1;
+          return {
+            exited: Promise.resolve(0),
+            kill() {},
+          } as never;
+        },
+      }),
+    );
+
+    expect(exitCode).toBe(143);
+    expect(startCalls).toBe(0);
   });
 });

--- a/apps/electron/scripts/dev.ts
+++ b/apps/electron/scripts/dev.ts
@@ -3,7 +3,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Effect, Exit } from "effect";
-import { createServer, type ViteDevServer } from "vite";
+import { createServer } from "vite";
 import { runElectronEffect } from "../src/effect/electron-boundary";
 import {
   resolveRendererDevPortEffect,
@@ -21,14 +21,26 @@ import {
   resolveSqliteTaskStoreMigrationCopyPlan,
 } from "./build";
 
-type ManagedElectronProcess = Bun.Subprocess<"ignore", "inherit", "inherit">;
+export type ManagedElectronProcess = {
+  readonly exited: Promise<number>;
+  kill(signal?: NodeJS.Signals | number): void;
+};
 type ForceCloseableHttpServer = {
   closeAllConnections?: () => void;
   closeIdleConnections?: () => void;
 };
-type ViteDevServerWithHttpConnections = ViteDevServer & {
-  httpServer?: ForceCloseableHttpServer | null;
+type ElectronDevRendererWatcher = {
+  add(paths: string | readonly string[]): unknown;
+  on(event: "add" | "change" | "unlink", listener: (filePath: string) => void): unknown;
 };
+export type ElectronDevRendererServer = {
+  close(): Promise<void>;
+  config: { server: { port?: number | null } };
+  httpServer?: object | null;
+  resolvedUrls?: { local: string[] } | null;
+  watcher: ElectronDevRendererWatcher;
+};
+type ElectronDevRendererServerHandle = Pick<ElectronDevRendererServer, "close" | "httpServer">;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -396,7 +408,7 @@ export const buildElectronBundlesEffect = (): Effect.Effect<void, ElectronOperat
   });
 
 const resolveRendererDevUrlEffect = (
-  server: ViteDevServer,
+  server: ElectronDevRendererServer,
 ): Effect.Effect<string, ElectronOperationError> =>
   Effect.try({
     try: () => resolveRendererDevUrl(server),
@@ -418,7 +430,7 @@ const resolveElectronDevExecutablePathEffect = (): Effect.Effect<string, Electro
 
 const createRendererDevServerEffect = (
   port: number,
-): Effect.Effect<ViteDevServer, ElectronOperationError> =>
+): Effect.Effect<ElectronDevRendererServer, ElectronOperationError> =>
   Effect.tryPromise({
     try: async () => {
       const server = await createServer({
@@ -443,7 +455,7 @@ const createRendererDevServerEffect = (
       }),
   });
 
-const resolveRendererDevUrl = (server: ViteDevServer): string => {
+const resolveRendererDevUrl = (server: ElectronDevRendererServer): string => {
   const localUrl = server.resolvedUrls?.local.find((url) => url.includes(RENDERER_DEV_HOST));
   if (localUrl) {
     return localUrl.replace(/\/$/u, "");
@@ -483,10 +495,23 @@ const startElectron = (
     },
   });
 
-const forceCloseRendererConnections = (server: ViteDevServer): void => {
-  const httpServer = (server as ViteDevServerWithHttpConnections).httpServer;
-  httpServer?.closeIdleConnections?.();
-  httpServer?.closeAllConnections?.();
+const callRendererConnectionCloseMethod = (
+  httpServer: object | null | undefined,
+  method: keyof ForceCloseableHttpServer,
+): void => {
+  if (!httpServer || !(method in httpServer)) {
+    return;
+  }
+
+  const close = Reflect.get(httpServer, method);
+  if (typeof close === "function") {
+    close.call(httpServer);
+  }
+};
+
+const forceCloseRendererConnections = (server: ElectronDevRendererServerHandle): void => {
+  callRendererConnectionCloseMethod(server.httpServer, "closeIdleConnections");
+  callRendererConnectionCloseMethod(server.httpServer, "closeAllConnections");
 };
 
 export const stopElectronEffect = (
@@ -530,14 +555,14 @@ export const stopElectronEffect = (
   });
 
 export const closeRendererServer = async (
-  server: ViteDevServer | null,
+  server: ElectronDevRendererServerHandle | null,
   closeSleep: (durationMs: number) => Promise<unknown> = sleep,
 ): Promise<void> => {
   await runElectronEffect(closeRendererServerEffect(server, closeSleep));
 };
 
 export const closeRendererServerEffect = (
-  server: ViteDevServer | null,
+  server: ElectronDevRendererServerHandle | null,
   closeSleep: (durationMs: number) => Promise<unknown> = sleep,
 ): Effect.Effect<void, ElectronOperationError> => {
   if (!server) {
@@ -600,7 +625,7 @@ type ElectronDevLifecycleOptions = {
   electronExecutablePath: string;
   processHandlers?: ElectronDevProcessHandlers;
   rendererDevUrl: string;
-  rendererServer: ViteDevServer;
+  rendererServer: ElectronDevRendererServer;
   startElectronProcess?: StartElectronProcess;
 };
 
@@ -828,6 +853,44 @@ export const runElectronDevLifecycleEffect = ({
         });
       });
 
+    const interruptCleanupEffect = (): Effect.Effect<void, never> =>
+      Effect.gen(function* () {
+        if (settled || shutdownStarted) {
+          return;
+        }
+
+        shutdownStarted = true;
+        if (restartTimer) {
+          clearTimeout(restartTimer);
+          restartTimer = null;
+        }
+        removeRegisteredProcessHandlers({ keepExitHandler: true });
+
+        const stopExit = yield* Effect.exit(stopElectronEffect(electron));
+        if (Exit.isFailure(stopExit)) {
+          yield* Effect.sync(() => {
+            console.error(
+              "[electron:dev] Electron shutdown after lifecycle interruption failed.",
+              causeToElectronBoundaryError(stopExit.cause),
+            );
+          });
+        }
+
+        const closeExit = yield* Effect.exit(closeRendererServerEffect(rendererServer));
+        if (Exit.isFailure(closeExit)) {
+          yield* Effect.sync(() => {
+            console.error(
+              "[electron:dev] Renderer shutdown after lifecycle interruption failed.",
+              causeToElectronBoundaryError(closeExit.cause),
+            );
+          });
+        }
+
+        yield* Effect.sync(() => {
+          removeRegisteredProcessHandlers({ keepExitHandler: false });
+        });
+      });
+
     runLifecycleTask(
       Effect.gen(function* () {
         yield* registerWatcherEffect();
@@ -836,6 +899,8 @@ export const runElectronDevLifecycleEffect = ({
       }),
       completeFailure,
     );
+
+    return interruptCleanupEffect();
   });
 
 export const mainEffect = (): Effect.Effect<

--- a/apps/electron/scripts/dev.ts
+++ b/apps/electron/scripts/dev.ts
@@ -624,17 +624,38 @@ export const runElectronDevLifecycleEffect = ({
     }> = [];
     let settled = false;
 
-    const settle = (effect: Effect.Effect<number, ElectronOperationError>): void => {
+    const removeRegisteredProcessHandlers = ({
+      keepExitHandler,
+    }: {
+      keepExitHandler: boolean;
+    }): void => {
+      const retainedProcessHandlers: Array<{
+        event: ElectronDevProcessEvent;
+        listener: () => void;
+      }> = [];
+      while (registeredProcessHandlers.length > 0) {
+        const registered = registeredProcessHandlers.pop();
+        if (!registered) {
+          continue;
+        }
+        if (keepExitHandler && registered.event === "exit") {
+          retainedProcessHandlers.push(registered);
+          continue;
+        }
+        processHandlers.off(registered.event, registered.listener);
+      }
+      registeredProcessHandlers.push(...retainedProcessHandlers.reverse());
+    };
+
+    const settle = (
+      effect: Effect.Effect<number, ElectronOperationError>,
+      options: { keepExitHandler?: boolean } = {},
+    ): void => {
       if (settled) {
         return;
       }
       settled = true;
-      while (registeredProcessHandlers.length > 0) {
-        const registered = registeredProcessHandlers.pop();
-        if (registered) {
-          processHandlers.off(registered.event, registered.listener);
-        }
-      }
+      removeRegisteredProcessHandlers({ keepExitHandler: options.keepExitHandler ?? false });
       resume(effect);
     };
 
@@ -644,7 +665,9 @@ export const runElectronDevLifecycleEffect = ({
     };
 
     const completeFailure = (cause: unknown): void => {
-      settle(Effect.fail(toElectronOperationError(cause, "electron.dev.lifecycle")));
+      settle(Effect.fail(toElectronOperationError(cause, "electron.dev.lifecycle")), {
+        keepExitHandler: true,
+      });
     };
 
     const shutdownEffect = (exitCode: number): Effect.Effect<void, ElectronOperationError> =>
@@ -690,7 +713,13 @@ export const runElectronDevLifecycleEffect = ({
 
     const launchElectronEffect = (): Effect.Effect<void, ElectronOperationError> =>
       Effect.gen(function* () {
+        if (shutdownStarted || settled) {
+          return;
+        }
         yield* buildBundles();
+        if (shutdownStarted || settled) {
+          return;
+        }
         const nextElectron = yield* Effect.sync(() =>
           startElectronProcess(rendererDevUrl, electronExecutablePath),
         );
@@ -716,31 +745,35 @@ export const runElectronDevLifecycleEffect = ({
         }
 
         restarting = true;
-        const restartExit = yield* Effect.exit(
-          Effect.gen(function* () {
-            console.log(
-              "[electron:dev] Restarting Electron after main-process dependency change...",
+        while (!shutdownStarted) {
+          restartQueued = false;
+          const restartExit = yield* Effect.exit(
+            Effect.gen(function* () {
+              console.log(
+                "[electron:dev] Restarting Electron after main-process dependency change...",
+              );
+              yield* stopElectronEffect(electron);
+              yield* launchElectronEffect();
+            }),
+          );
+          if (Exit.isFailure(restartExit)) {
+            yield* Effect.sync(() => {
+              restarting = false;
+            });
+            return yield* Effect.fail(
+              toElectronOperationError(
+                causeToElectronBoundaryError(restartExit.cause),
+                "electron.dev.restart-electron",
+              ),
             );
-            yield* stopElectronEffect(electron);
-            yield* launchElectronEffect();
-          }),
-        );
+          }
+          if (!restartQueued) {
+            break;
+          }
+        }
         yield* Effect.sync(() => {
           restarting = false;
         });
-        if (Exit.isFailure(restartExit)) {
-          return yield* Effect.fail(
-            toElectronOperationError(
-              causeToElectronBoundaryError(restartExit.cause),
-              "electron.dev.restart-electron",
-            ),
-          );
-        }
-
-        if (restartQueued) {
-          restartQueued = false;
-          yield* restartElectronEffect();
-        }
       });
 
     const scheduleRestart = (): void => {
@@ -830,7 +863,15 @@ export const mainEffect = (): Effect.Effect<
       return lifecycleExit.value;
     }
 
-    yield* closeRendererServerEffect(rendererServer);
+    const closeExit = yield* Effect.exit(closeRendererServerEffect(rendererServer));
+    if (Exit.isFailure(closeExit)) {
+      yield* Effect.sync(() => {
+        console.error(
+          "[electron:dev] Renderer shutdown after lifecycle failure failed.",
+          causeToElectronBoundaryError(closeExit.cause),
+        );
+      });
+    }
     return yield* Effect.fail(
       toElectronOperationError(
         causeToElectronBoundaryError(lifecycleExit.cause),

--- a/apps/electron/scripts/dev.ts
+++ b/apps/electron/scripts/dev.ts
@@ -2,12 +2,20 @@ import { copyFile, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
 import { createServer, type ViteDevServer } from "vite";
 import { runElectronEffect } from "../src/effect/electron-boundary";
 import { resolveRendererDevPort as resolveRendererDevPortFromConfig } from "../src/effect/electron-config";
-import { ElectronOperationError, errorMessage } from "../src/effect/electron-errors";
-import { copySqliteTaskStoreMigrations, resolveSqliteTaskStoreMigrationCopyPlan } from "./build";
+import {
+  causeToElectronBoundaryError,
+  ElectronOperationError,
+  errorMessage,
+  toElectronOperationError,
+} from "../src/effect/electron-errors";
+import {
+  copySqliteTaskStoreMigrationsEffect,
+  resolveSqliteTaskStoreMigrationCopyPlan,
+} from "./build";
 
 type ManagedElectronProcess = Bun.Subprocess<"ignore", "inherit", "inherit">;
 type ForceCloseableHttpServer = {
@@ -330,20 +338,31 @@ const resolveElectronDevExecutablePath = async (): Promise<string> => {
   return prepareMacosDevElectronBundle(electronExecutablePath);
 };
 
-const buildElectronBundles = async (): Promise<void> => {
-  await runStep("Electron main build", ["bun", "run", "build:main"]);
-  await runStep("Electron preload build", ["bun", "run", "build:preload"]);
-  await copySqliteTaskStoreMigrations(
-    resolveSqliteTaskStoreMigrationCopyPlan({
-      electronPackageRoot: packageRoot,
-      workspaceRoot,
-    }),
-  );
-};
+export const buildElectronBundlesEffect = (): Effect.Effect<void, ElectronOperationError> =>
+  Effect.gen(function* () {
+    yield* runStepEffect("Electron main build", ["bun", "run", "build:main"]);
+    yield* runStepEffect("Electron preload build", ["bun", "run", "build:preload"]);
+    yield* copySqliteTaskStoreMigrationsEffect(
+      resolveSqliteTaskStoreMigrationCopyPlan({
+        electronPackageRoot: packageRoot,
+        workspaceRoot,
+      }),
+    );
+  });
 
-const createRendererDevServer = async (port: number): Promise<ViteDevServer> => {
-  return runElectronEffect(createRendererDevServerEffect(port));
-};
+const resolveRendererDevUrlEffect = (
+  server: ViteDevServer,
+): Effect.Effect<string, ElectronOperationError> =>
+  Effect.try({
+    try: () => resolveRendererDevUrl(server),
+    catch: (cause) => toElectronOperationError(cause, "electron.dev.resolve-renderer-url"),
+  });
+
+const resolveElectronDevExecutablePathEffect = (): Effect.Effect<string, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: resolveElectronDevExecutablePath,
+    catch: (cause) => toElectronOperationError(cause, "electron.dev.resolve-executable-path"),
+  });
 
 const createRendererDevServerEffect = (
   port: number,
@@ -458,9 +477,6 @@ export const stopElectronEffect = (
       }),
   });
 
-const stopElectron = (electron: ManagedElectronProcess | null): Promise<void> =>
-  runElectronEffect(stopElectronEffect(electron));
-
 export const closeRendererServer = async (
   server: ViteDevServer | null,
   closeSleep: (durationMs: number) => Promise<unknown> = sleep,
@@ -506,125 +522,227 @@ export const closeRendererServerEffect = (
   });
 };
 
-const main = async (): Promise<number> => {
-  const rendererPort = resolveRendererDevPort(process.env.ELECTRON_RENDERER_DEV_PORT);
-  const electronExecutablePath = await resolveElectronDevExecutablePath();
-  const rendererServer = await createRendererDevServer(rendererPort);
-  const rendererDevUrl = resolveRendererDevUrl(rendererServer);
-  let electron: ManagedElectronProcess | null = null;
-  let shutdownStarted = false;
-  let restarting = false;
-  let restartQueued = false;
-  let restartTimer: ReturnType<typeof setTimeout> | null = null;
-  let resolveExit: (exitCode: number) => void = () => {};
-  const exited = new Promise<number>((resolve) => {
-    resolveExit = resolve;
-  });
+type StartElectronProcess = (
+  rendererDevUrl: string,
+  electronExecutablePath: string,
+) => ManagedElectronProcess;
 
-  const shutdown = async (exitCode: number): Promise<void> => {
-    if (shutdownStarted) {
-      return;
-    }
-    shutdownStarted = true;
-    if (restartTimer) {
-      clearTimeout(restartTimer);
-      restartTimer = null;
-    }
-    await stopElectron(electron);
-    await closeRendererServer(rendererServer);
-    resolveExit(exitCode);
-  };
-
-  const launchElectron = async (): Promise<void> => {
-    await buildElectronBundles();
-    const nextElectron = startElectron(rendererDevUrl, electronExecutablePath);
-    electron = nextElectron;
-    void nextElectron.exited.then((exitCode) => {
-      if (electron === nextElectron) {
-        electron = null;
-      }
-      if (!shutdownStarted && !restarting) {
-        void shutdown(exitCode);
-      }
-    });
-  };
-
-  const restartElectron = async (): Promise<void> => {
-    if (shutdownStarted) {
-      return;
-    }
-    if (restarting) {
-      restartQueued = true;
-      return;
-    }
-
-    restarting = true;
-    try {
-      console.log("[electron:dev] Restarting Electron after main-process dependency change...");
-      await stopElectron(electron);
-      await launchElectron();
-    } finally {
-      restarting = false;
-    }
-
-    if (restartQueued) {
-      restartQueued = false;
-      await restartElectron();
-    }
-  };
-
-  const scheduleRestart = (): void => {
-    if (shutdownStarted) {
-      return;
-    }
-    if (restartTimer) {
-      clearTimeout(restartTimer);
-    }
-    restartTimer = setTimeout(() => {
-      restartTimer = null;
-      void restartElectron().catch((error: unknown) => {
-        console.error(error);
-        void shutdown(1);
-      });
-    }, ELECTRON_RESTART_DEBOUNCE_MS);
-  };
-
-  const handleWatchedFileChange = (filePath: string): void => {
-    if (shouldRestartElectronForChange(filePath)) {
-      scheduleRestart();
-    }
-  };
-
-  try {
-    rendererServer.watcher.add([...ELECTRON_RESTART_WATCH_ROOTS]);
-    rendererServer.watcher.on("add", handleWatchedFileChange);
-    rendererServer.watcher.on("change", handleWatchedFileChange);
-    rendererServer.watcher.on("unlink", handleWatchedFileChange);
-
-    process.once("SIGINT", () => {
-      console.log("[electron:dev] Received SIGINT, shutting down...");
-      void shutdown(130);
-    });
-    process.once("SIGTERM", () => {
-      console.log("[electron:dev] Received SIGTERM, shutting down...");
-      void shutdown(143);
-    });
-    process.once("exit", () => {
-      if (electron) {
-        electron.kill();
-      }
-    });
-
-    await launchElectron();
-    return exited;
-  } catch (error) {
-    await closeRendererServer(rendererServer);
-    throw error;
-  }
+type ElectronDevLifecycleOptions = {
+  buildBundles?: () => Effect.Effect<void, ElectronOperationError>;
+  electronExecutablePath: string;
+  rendererDevUrl: string;
+  rendererServer: ViteDevServer;
+  startElectronProcess?: StartElectronProcess;
 };
 
+export const runElectronDevLifecycleEffect = ({
+  buildBundles = buildElectronBundlesEffect,
+  electronExecutablePath,
+  rendererDevUrl,
+  rendererServer,
+  startElectronProcess = startElectron,
+}: ElectronDevLifecycleOptions): Effect.Effect<number, ElectronOperationError> =>
+  Effect.async<number, ElectronOperationError>((resume) => {
+    let electron: ManagedElectronProcess | null = null;
+    let shutdownStarted = false;
+    let restarting = false;
+    let restartQueued = false;
+    let restartTimer: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
+
+    const settle = (effect: Effect.Effect<number, ElectronOperationError>): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resume(effect);
+    };
+
+    const completeFailure = (cause: unknown): void => {
+      settle(Effect.fail(toElectronOperationError(cause, "electron.dev.lifecycle")));
+    };
+
+    const shutdownEffect = (exitCode: number): Effect.Effect<void, ElectronOperationError> =>
+      Effect.gen(function* () {
+        if (shutdownStarted) {
+          return;
+        }
+        shutdownStarted = true;
+        if (restartTimer) {
+          clearTimeout(restartTimer);
+          restartTimer = null;
+        }
+        yield* stopElectronEffect(electron);
+        yield* closeRendererServerEffect(rendererServer);
+        yield* Effect.sync(() => {
+          settle(Effect.succeed(exitCode));
+        });
+      });
+
+    const runShutdown = (exitCode: number): void => {
+      void Effect.runPromiseExit(shutdownEffect(exitCode)).then((exit) => {
+        if (Exit.isFailure(exit)) {
+          completeFailure(causeToElectronBoundaryError(exit.cause));
+        }
+      });
+    };
+
+    const runLifecycleTask = (effect: Effect.Effect<void, ElectronOperationError>): void => {
+      void Effect.runPromiseExit(effect).then((exit) => {
+        if (Exit.isFailure(exit)) {
+          const error = causeToElectronBoundaryError(exit.cause);
+          console.error(error);
+          runShutdown(1);
+        }
+      });
+    };
+
+    const launchElectronEffect = (): Effect.Effect<void, ElectronOperationError> =>
+      Effect.gen(function* () {
+        yield* buildBundles();
+        const nextElectron = yield* Effect.sync(() =>
+          startElectronProcess(rendererDevUrl, electronExecutablePath),
+        );
+        electron = nextElectron;
+        void nextElectron.exited.then((exitCode) => {
+          if (electron === nextElectron) {
+            electron = null;
+          }
+          if (!shutdownStarted && !restarting) {
+            runShutdown(exitCode);
+          }
+        });
+      });
+
+    const restartElectronEffect = (): Effect.Effect<void, ElectronOperationError> =>
+      Effect.gen(function* () {
+        if (shutdownStarted) {
+          return;
+        }
+        if (restarting) {
+          restartQueued = true;
+          return;
+        }
+
+        restarting = true;
+        const restartExit = yield* Effect.exit(
+          Effect.gen(function* () {
+            console.log(
+              "[electron:dev] Restarting Electron after main-process dependency change...",
+            );
+            yield* stopElectronEffect(electron);
+            yield* launchElectronEffect();
+          }),
+        );
+        yield* Effect.sync(() => {
+          restarting = false;
+        });
+        if (Exit.isFailure(restartExit)) {
+          return yield* Effect.fail(
+            toElectronOperationError(
+              causeToElectronBoundaryError(restartExit.cause),
+              "electron.dev.restart-electron",
+            ),
+          );
+        }
+
+        if (restartQueued) {
+          restartQueued = false;
+          yield* restartElectronEffect();
+        }
+      });
+
+    const scheduleRestart = (): void => {
+      if (shutdownStarted) {
+        return;
+      }
+      if (restartTimer) {
+        clearTimeout(restartTimer);
+      }
+      restartTimer = setTimeout(() => {
+        restartTimer = null;
+        runLifecycleTask(restartElectronEffect());
+      }, ELECTRON_RESTART_DEBOUNCE_MS);
+    };
+
+    const handleWatchedFileChange = (filePath: string): void => {
+      if (shouldRestartElectronForChange(filePath)) {
+        scheduleRestart();
+      }
+    };
+
+    const registerWatcherEffect = (): Effect.Effect<void, ElectronOperationError> =>
+      Effect.try({
+        try: () => {
+          rendererServer.watcher.add([...ELECTRON_RESTART_WATCH_ROOTS]);
+          rendererServer.watcher.on("add", handleWatchedFileChange);
+          rendererServer.watcher.on("change", handleWatchedFileChange);
+          rendererServer.watcher.on("unlink", handleWatchedFileChange);
+        },
+        catch: (cause) =>
+          new ElectronOperationError({
+            operation: "electron.dev.register-watcher",
+            message: errorMessage(cause),
+            cause,
+          }),
+      });
+
+    const registerProcessHandlersEffect = (): Effect.Effect<void, never> =>
+      Effect.sync(() => {
+        process.once("SIGINT", () => {
+          console.log("[electron:dev] Received SIGINT, shutting down...");
+          runShutdown(130);
+        });
+        process.once("SIGTERM", () => {
+          console.log("[electron:dev] Received SIGTERM, shutting down...");
+          runShutdown(143);
+        });
+        process.once("exit", () => {
+          if (electron) {
+            electron.kill();
+          }
+        });
+      });
+
+    runLifecycleTask(
+      Effect.gen(function* () {
+        yield* registerWatcherEffect();
+        yield* registerProcessHandlersEffect();
+        yield* launchElectronEffect();
+      }),
+    );
+  });
+
+export const mainEffect = (): Effect.Effect<number, ElectronOperationError> =>
+  Effect.gen(function* () {
+    const rendererPort = resolveRendererDevPort(process.env.ELECTRON_RENDERER_DEV_PORT);
+    const electronExecutablePath = yield* resolveElectronDevExecutablePathEffect();
+    const rendererServer = yield* createRendererDevServerEffect(rendererPort);
+    const lifecycleExit = yield* Effect.exit(
+      Effect.gen(function* () {
+        const rendererDevUrl = yield* resolveRendererDevUrlEffect(rendererServer);
+        return yield* runElectronDevLifecycleEffect({
+          electronExecutablePath,
+          rendererDevUrl,
+          rendererServer,
+        });
+      }),
+    );
+    if (Exit.isSuccess(lifecycleExit)) {
+      return lifecycleExit.value;
+    }
+
+    yield* closeRendererServerEffect(rendererServer);
+    return yield* Effect.fail(
+      toElectronOperationError(
+        causeToElectronBoundaryError(lifecycleExit.cause),
+        "electron.dev.main",
+      ),
+    );
+  });
+
 if (import.meta.main) {
-  const exitCode = await main().catch((error: unknown) => {
+  const exitCode = await runElectronEffect(mainEffect()).catch((error: unknown) => {
     console.error(error);
     return 1;
   });

--- a/apps/electron/scripts/dev.ts
+++ b/apps/electron/scripts/dev.ts
@@ -5,10 +5,14 @@ import { fileURLToPath } from "node:url";
 import { Effect, Exit } from "effect";
 import { createServer, type ViteDevServer } from "vite";
 import { runElectronEffect } from "../src/effect/electron-boundary";
-import { resolveRendererDevPort as resolveRendererDevPortFromConfig } from "../src/effect/electron-config";
+import {
+  resolveRendererDevPortEffect,
+  resolveRendererDevPort as resolveRendererDevPortFromConfig,
+} from "../src/effect/electron-config";
 import {
   causeToElectronBoundaryError,
   ElectronOperationError,
+  type ElectronValidationError,
   errorMessage,
   toElectronOperationError,
 } from "../src/effect/electron-errors";
@@ -713,9 +717,15 @@ export const runElectronDevLifecycleEffect = ({
     );
   });
 
-export const mainEffect = (): Effect.Effect<number, ElectronOperationError> =>
+export const mainEffect = (): Effect.Effect<
+  number,
+  ElectronOperationError | ElectronValidationError
+> =>
   Effect.gen(function* () {
-    const rendererPort = resolveRendererDevPort(process.env.ELECTRON_RENDERER_DEV_PORT);
+    const rendererPort = yield* resolveRendererDevPortEffect(
+      process.env.ELECTRON_RENDERER_DEV_PORT,
+      "electron.dev.resolve-renderer-dev-port",
+    );
     const electronExecutablePath = yield* resolveElectronDevExecutablePathEffect();
     const rendererServer = yield* createRendererDevServerEffect(rendererPort);
     const lifecycleExit = yield* Effect.exit(

--- a/apps/electron/scripts/dev.ts
+++ b/apps/electron/scripts/dev.ts
@@ -333,6 +333,19 @@ const prepareMacosDevElectronBundleEffect = (
     const existingSignature = yield* readFileIfExistsEffect(markerPath);
     const devExecutableExists = yield* fileExistsEffect(devExecutablePath);
     const shouldCopyBundle = existingSignature !== signature || !devExecutableExists;
+    const resolveResourcePath = (fileName: string): string =>
+      path.join(devAppPath, "Contents", "Resources", fileName);
+    const copyIconResourceEffect = (
+      targetFileName: string,
+    ): Effect.Effect<void, ElectronOperationError> => {
+      const targetPath = resolveResourcePath(targetFileName);
+      return runDevFileOperationEffect(
+        "electron.dev.copy-macos-dev-icon",
+        iconPath,
+        () => copyFile(iconPath, targetPath),
+        { targetPath },
+      );
+    };
 
     yield* runDevFileOperationEffect("electron.dev.create-macos-dev-root", devRoot, () =>
       mkdir(devRoot, { recursive: true }),
@@ -352,22 +365,9 @@ const prepareMacosDevElectronBundleEffect = (
       ]);
     }
 
-    yield* runDevFileOperationEffect(
-      "electron.dev.copy-macos-dev-icon",
-      iconPath,
-      () =>
-        copyFile(
-          iconPath,
-          path.join(devAppPath, "Contents", "Resources", MACOS_DEV_ICON_FILE_NAME),
-        ),
-      { targetPath: path.join(devAppPath, "Contents", "Resources", MACOS_DEV_ICON_FILE_NAME) },
-    );
-    yield* runDevFileOperationEffect("electron.dev.copy-macos-dev-icon", iconPath, () =>
-      copyFile(iconPath, path.join(devAppPath, "Contents", "Resources", "icon.icns")),
-    );
-    yield* runDevFileOperationEffect("electron.dev.copy-macos-dev-icon", iconPath, () =>
-      copyFile(iconPath, path.join(devAppPath, "Contents", "Resources", "electron.icns")),
-    );
+    yield* copyIconResourceEffect(MACOS_DEV_ICON_FILE_NAME);
+    yield* copyIconResourceEffect("icon.icns");
+    yield* copyIconResourceEffect("electron.icns");
     yield* replacePlistStringEffect(infoPlistPath, "CFBundleDisplayName", APPLICATION_NAME);
     yield* replacePlistStringEffect(infoPlistPath, "CFBundleName", APPLICATION_NAME);
     yield* replacePlistStringEffect(

--- a/apps/electron/scripts/dev.ts
+++ b/apps/electron/scripts/dev.ts
@@ -2,7 +2,11 @@ import { copyFile, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { Effect } from "effect";
 import { createServer, type ViteDevServer } from "vite";
+import { runElectronEffect } from "../src/effect/electron-boundary";
+import { resolveRendererDevPort as resolveRendererDevPortFromConfig } from "../src/effect/electron-config";
+import { ElectronOperationError, errorMessage } from "../src/effect/electron-errors";
 import { copySqliteTaskStoreMigrations, resolveSqliteTaskStoreMigrationCopyPlan } from "./build";
 
 type ManagedElectronProcess = Bun.Subprocess<"ignore", "inherit", "inherit">;
@@ -24,7 +28,6 @@ const APPLICATION_NAME = "OpenDucktor";
 const MACOS_DEV_BUNDLE_IDENTIFIER = "com.openducktor.app.dev";
 const MACOS_DEV_ICON_FILE_NAME = "openducktor-dev-rounded.icns";
 const RENDERER_DEV_HOST = "127.0.0.1";
-const DEFAULT_RENDERER_DEV_PORT = 1430;
 const ELECTRON_RESTART_DEBOUNCE_MS = 100;
 const RENDERER_CLOSE_TIMEOUT_MS = 3_000;
 const ELECTRON_STOP_TIMEOUT_MS = 30_000;
@@ -52,64 +55,132 @@ const ELECTRON_RESTART_EXTENSIONS = new Set([
 const sleep = (durationMs: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, durationMs));
 
-const runStep = async (label: string, command: string[]): Promise<void> => {
-  const process = Bun.spawn(command, {
-    cwd: packageRoot,
-    stdout: "inherit",
-    stderr: "inherit",
+const runStepEffect = (
+  label: string,
+  command: string[],
+): Effect.Effect<void, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const process = Bun.spawn(command, {
+        cwd: packageRoot,
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      const exitCode = await process.exited;
+      if (exitCode !== 0) {
+        throw new Error(`${label} failed with exit code ${exitCode}.`);
+      }
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.dev.run-step",
+        message: errorMessage(cause),
+        cause,
+        details: { command, label },
+      }),
   });
-  const exitCode = await process.exited;
-  if (exitCode !== 0) {
-    throw new Error(`${label} failed with exit code ${exitCode}.`);
-  }
-};
 
-const readFileIfExists = async (filePath: string): Promise<string | null> => {
-  try {
-    return await readFile(filePath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw error;
-  }
-};
+const runStep = (label: string, command: string[]): Promise<void> =>
+  runElectronEffect(runStepEffect(label, command));
 
-const fileExists = async (filePath: string): Promise<boolean> => {
-  try {
-    await stat(filePath);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-    throw error;
-  }
-};
+const nodeErrorCode = (cause: unknown): string | null =>
+  typeof cause === "object" && cause !== null && "code" in cause && typeof cause.code === "string"
+    ? cause.code
+    : null;
 
-const assertFileExists = async (filePath: string, label: string): Promise<void> => {
-  let metadata: Awaited<ReturnType<typeof stat>>;
-  try {
-    metadata = await stat(filePath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`${label} was not found: ${filePath}`);
-    }
-    throw error;
-  }
+const readFileIfExistsEffect = (
+  filePath: string,
+): Effect.Effect<string | null, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: () => readFile(filePath, "utf8"),
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.dev.read-file",
+        message: errorMessage(cause),
+        path: filePath,
+        cause,
+        details: { code: nodeErrorCode(cause) },
+      }),
+  }).pipe(
+    Effect.catchAll((error) =>
+      error.details?.code === "ENOENT" ? Effect.succeed(null) : Effect.fail(error),
+    ),
+  );
 
-  if (!metadata.isFile()) {
-    throw new Error(`${label} must be a file: ${filePath}`);
-  }
-};
+const readFileIfExists = (filePath: string): Promise<string | null> =>
+  runElectronEffect(readFileIfExistsEffect(filePath));
 
-const fileSignature = async (filePath: string): Promise<{ mtimeMs: number; size: number }> => {
-  const metadata = await stat(filePath);
-  return {
-    mtimeMs: metadata.mtimeMs,
-    size: metadata.size,
-  };
-};
+const fileExistsEffect = (filePath: string): Effect.Effect<boolean, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      await stat(filePath);
+      return true;
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.dev.stat-file",
+        message: errorMessage(cause),
+        path: filePath,
+        cause,
+        details: { code: nodeErrorCode(cause) },
+      }),
+  }).pipe(
+    Effect.catchAll((error) =>
+      error.details?.code === "ENOENT" ? Effect.succeed(false) : Effect.fail(error),
+    ),
+  );
+
+const fileExists = (filePath: string): Promise<boolean> =>
+  runElectronEffect(fileExistsEffect(filePath));
+
+const assertFileExistsEffect = (
+  filePath: string,
+  label: string,
+): Effect.Effect<void, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const metadata = await stat(filePath);
+      if (!metadata.isFile()) {
+        throw new Error(`${label} must be a file: ${filePath}`);
+      }
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.dev.assert-file-exists",
+        message:
+          nodeErrorCode(cause) === "ENOENT"
+            ? `${label} was not found: ${filePath}`
+            : errorMessage(cause),
+        path: filePath,
+        cause,
+      }),
+  });
+
+const assertFileExists = (filePath: string, label: string): Promise<void> =>
+  runElectronEffect(assertFileExistsEffect(filePath, label));
+
+const fileSignatureEffect = (
+  filePath: string,
+): Effect.Effect<{ mtimeMs: number; size: number }, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const metadata = await stat(filePath);
+      return {
+        mtimeMs: metadata.mtimeMs,
+        size: metadata.size,
+      };
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.dev.file-signature",
+        message: errorMessage(cause),
+        path: filePath,
+        cause,
+      }),
+  });
+
+const fileSignature = (filePath: string): Promise<{ mtimeMs: number; size: number }> =>
+  runElectronEffect(fileSignatureEffect(filePath));
 
 const normalizePath = (filePath: string): string => path.resolve(filePath);
 
@@ -119,25 +190,7 @@ const isWithinDirectory = (directory: string, candidate: string): boolean => {
 };
 
 export const resolveRendererDevPort = (rawPort: string | undefined): number => {
-  const trimmedPort = rawPort?.trim();
-  if (!trimmedPort) {
-    return DEFAULT_RENDERER_DEV_PORT;
-  }
-
-  if (!/^\d+$/.test(trimmedPort)) {
-    throw new Error(
-      `ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: ${rawPort}`,
-    );
-  }
-
-  const port = Number(trimmedPort);
-  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
-    throw new Error(
-      `ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: ${rawPort}`,
-    );
-  }
-
-  return port;
+  return resolveRendererDevPortFromConfig(rawPort, "electron.dev.resolve-renderer-dev-port");
 };
 
 export const shouldRestartElectronForChange = (
@@ -160,6 +213,19 @@ export const resolveMacosAppBundlePath = (electronExecutablePath: string): strin
   }
 
   return appBundlePath;
+};
+
+export const resolveRequiredMacosAppBundlePath = (electronExecutablePath: string): string => {
+  const sourceAppPath = resolveMacosAppBundlePath(electronExecutablePath);
+  if (!sourceAppPath) {
+    throw new ElectronOperationError({
+      operation: "electron.dev.resolve-macos-app-bundle",
+      message: `Electron macOS dev executable is not inside an app bundle: ${electronExecutablePath}`,
+      path: electronExecutablePath,
+    });
+  }
+
+  return sourceAppPath;
 };
 
 export const resolveMacosDevAppPath = (): string =>
@@ -213,12 +279,7 @@ const buildMacosDevAppSignature = async ({
   )}\n`;
 
 const prepareMacosDevElectronBundle = async (sourceExecutablePath: string): Promise<string> => {
-  const sourceAppPath = resolveMacosAppBundlePath(sourceExecutablePath);
-  if (!sourceAppPath) {
-    throw new Error(
-      `Electron macOS dev executable is not inside an app bundle: ${sourceExecutablePath}`,
-    );
-  }
+  const sourceAppPath = resolveRequiredMacosAppBundlePath(sourceExecutablePath);
 
   const devRoot = path.join(packageRoot, ".electron-dev");
   const devAppPath = resolveMacosDevAppPath();
@@ -281,19 +342,35 @@ const buildElectronBundles = async (): Promise<void> => {
 };
 
 const createRendererDevServer = async (port: number): Promise<ViteDevServer> => {
-  const server = await createServer({
-    root: packageRoot,
-    configFile: path.join(packageRoot, "vite.config.ts"),
-    server: {
-      host: RENDERER_DEV_HOST,
-      port,
-      strictPort: true,
-    },
-  });
-  await server.listen(port);
-  server.printUrls();
-  return server;
+  return runElectronEffect(createRendererDevServerEffect(port));
 };
+
+const createRendererDevServerEffect = (
+  port: number,
+): Effect.Effect<ViteDevServer, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const server = await createServer({
+        root: packageRoot,
+        configFile: path.join(packageRoot, "vite.config.ts"),
+        server: {
+          host: RENDERER_DEV_HOST,
+          port,
+          strictPort: true,
+        },
+      });
+      await server.listen(port);
+      server.printUrls();
+      return server;
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.dev.create-renderer-server",
+        message: errorMessage(cause),
+        cause,
+        details: { port },
+      }),
+  });
 
 const resolveRendererDevUrl = (server: ViteDevServer): string => {
   const localUrl = server.resolvedUrls?.local.find((url) => url.includes(RENDERER_DEV_HOST));
@@ -303,7 +380,10 @@ const resolveRendererDevUrl = (server: ViteDevServer): string => {
 
   const configuredPort = server.config.server.port;
   if (!configuredPort) {
-    throw new Error("Vite renderer dev server did not expose a configured port.");
+    throw new ElectronOperationError({
+      operation: "electron.dev.resolve-renderer-url",
+      message: "Vite renderer dev server did not expose a configured port.",
+    });
   }
 
   return `http://${RENDERER_DEV_HOST}:${configuredPort}`;
@@ -338,47 +418,92 @@ const forceCloseRendererConnections = (server: ViteDevServer): void => {
   httpServer?.closeAllConnections?.();
 };
 
-const stopElectron = async (electron: ManagedElectronProcess | null): Promise<void> => {
-  if (!electron) {
-    return;
-  }
+export const stopElectronEffect = (
+  electron: ManagedElectronProcess | null,
+  stopSleep: (durationMs: number) => Promise<unknown> = sleep,
+): Effect.Effect<void, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      if (!electron) {
+        return;
+      }
 
-  let exited = false;
-  const exitedPromise = electron.exited.then(() => {
-    exited = true;
+      let exited = false;
+      const exitedPromise = electron.exited.then(() => {
+        exited = true;
+      });
+
+      const gracefulSignal = electronGracefulShutdownSignal(process.platform);
+      console.log(`[electron:dev] Requesting Electron shutdown with ${gracefulSignal}...`);
+      electron.kill(gracefulSignal);
+      await Promise.race([exitedPromise, stopSleep(ELECTRON_STOP_TIMEOUT_MS)]);
+      if (!exited) {
+        console.error(
+          `[electron:dev] Electron did not exit within ${ELECTRON_STOP_TIMEOUT_MS}ms; forcing shutdown...`,
+        );
+        electron.kill(9);
+        await Promise.race([exitedPromise, stopSleep(ELECTRON_STOP_TIMEOUT_MS)]);
+        if (!exited) {
+          throw new Error(
+            `[electron:dev] Electron did not exit after forced shutdown within ${ELECTRON_STOP_TIMEOUT_MS}ms.`,
+          );
+        }
+      }
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.dev.stop-electron",
+        message: errorMessage(cause),
+        cause,
+      }),
   });
 
-  const gracefulSignal = electronGracefulShutdownSignal(process.platform);
-  console.log(`[electron:dev] Requesting Electron shutdown with ${gracefulSignal}...`);
-  electron.kill(gracefulSignal);
-  await Promise.race([exitedPromise, sleep(ELECTRON_STOP_TIMEOUT_MS)]);
-  if (!exited) {
-    console.error(
-      `[electron:dev] Electron did not exit within ${ELECTRON_STOP_TIMEOUT_MS}ms; forcing shutdown...`,
-    );
-    electron.kill(9);
-    await Promise.race([exitedPromise, sleep(ELECTRON_STOP_TIMEOUT_MS)]);
-    if (!exited) {
-      throw new Error(
-        `[electron:dev] Electron did not exit after forced shutdown within ${ELECTRON_STOP_TIMEOUT_MS}ms.`,
-      );
-    }
-  }
-};
+const stopElectron = (electron: ManagedElectronProcess | null): Promise<void> =>
+  runElectronEffect(stopElectronEffect(electron));
 
 export const closeRendererServer = async (
   server: ViteDevServer | null,
   closeSleep: (durationMs: number) => Promise<unknown> = sleep,
 ): Promise<void> => {
-  if (server) {
-    let closePromise: Promise<void>;
-    try {
-      closePromise = server.close();
-    } finally {
-      forceCloseRendererConnections(server);
-    }
-    await Promise.race([closePromise, closeSleep(RENDERER_CLOSE_TIMEOUT_MS)]);
+  await runElectronEffect(closeRendererServerEffect(server, closeSleep));
+};
+
+export const closeRendererServerEffect = (
+  server: ViteDevServer | null,
+  closeSleep: (durationMs: number) => Promise<unknown> = sleep,
+): Effect.Effect<void, ElectronOperationError> => {
+  if (!server) {
+    return Effect.void;
   }
+
+  return Effect.gen(function* () {
+    const closePromise = yield* Effect.try({
+      try: () => {
+        try {
+          return server.close();
+        } finally {
+          forceCloseRendererConnections(server);
+        }
+      },
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.dev.close-renderer-server",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+    yield* Effect.tryPromise({
+      try: async () => {
+        await Promise.race([closePromise, closeSleep(RENDERER_CLOSE_TIMEOUT_MS)]);
+      },
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.dev.close-renderer-server",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+  });
 };
 
 const main = async (): Promise<number> => {

--- a/apps/electron/scripts/dev.ts
+++ b/apps/electron/scripts/dev.ts
@@ -92,9 +92,6 @@ const runStepEffect = (
       }),
   });
 
-const runStep = (label: string, command: string[]): Promise<void> =>
-  runElectronEffect(runStepEffect(label, command));
-
 const nodeErrorCode = (cause: unknown): string | null =>
   typeof cause === "object" && cause !== null && "code" in cause && typeof cause.code === "string"
     ? cause.code
@@ -119,9 +116,6 @@ const readFileIfExistsEffect = (
     ),
   );
 
-const readFileIfExists = (filePath: string): Promise<string | null> =>
-  runElectronEffect(readFileIfExistsEffect(filePath));
-
 const fileExistsEffect = (filePath: string): Effect.Effect<boolean, ElectronOperationError> =>
   Effect.tryPromise({
     try: async () => {
@@ -141,9 +135,6 @@ const fileExistsEffect = (filePath: string): Effect.Effect<boolean, ElectronOper
       error.details?.code === "ENOENT" ? Effect.succeed(false) : Effect.fail(error),
     ),
   );
-
-const fileExists = (filePath: string): Promise<boolean> =>
-  runElectronEffect(fileExistsEffect(filePath));
 
 const assertFileExistsEffect = (
   filePath: string,
@@ -168,9 +159,6 @@ const assertFileExistsEffect = (
       }),
   });
 
-const assertFileExists = (filePath: string, label: string): Promise<void> =>
-  runElectronEffect(assertFileExistsEffect(filePath, label));
-
 const fileSignatureEffect = (
   filePath: string,
 ): Effect.Effect<{ mtimeMs: number; size: number }, ElectronOperationError> =>
@@ -190,9 +178,6 @@ const fileSignatureEffect = (
         cause,
       }),
   });
-
-const fileSignature = (filePath: string): Promise<{ mtimeMs: number; size: number }> =>
-  runElectronEffect(fileSignatureEffect(filePath));
 
 const normalizePath = (filePath: string): string => path.resolve(filePath);
 
@@ -248,12 +233,32 @@ export const resolveMacosDevExecutablePath = (devAppPath: string, executableName
 
 const resolveElectronExecutablePath = (): string => String(nodeRequire("electron"));
 
-const replacePlistString = async (
+const runDevFileOperationEffect = (
+  operation: string,
+  filePath: string,
+  action: () => Promise<unknown>,
+  details?: Record<string, unknown>,
+): Effect.Effect<void, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      await action();
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation,
+        message: errorMessage(cause),
+        path: filePath,
+        cause,
+        details,
+      }),
+  });
+
+const replacePlistStringEffect = (
   infoPlistPath: string,
   key: string,
   value: string,
-): Promise<void> => {
-  await runStep(`Electron dev app ${key}`, [
+): Effect.Effect<void, ElectronOperationError> =>
+  runStepEffect(`Electron dev app ${key}`, [
     "/usr/bin/plutil",
     "-replace",
     key,
@@ -261,9 +266,8 @@ const replacePlistString = async (
     value,
     infoPlistPath,
   ]);
-};
 
-const buildMacosDevAppSignature = async ({
+const buildMacosDevAppSignatureEffect = ({
   devAppPath,
   iconPath,
   sourceAppPath,
@@ -273,74 +277,111 @@ const buildMacosDevAppSignature = async ({
   iconPath: string;
   sourceAppPath: string;
   sourceExecutablePath: string;
-}): Promise<string> =>
-  `${JSON.stringify(
-    {
-      appName: APPLICATION_NAME,
-      bundleIdentifier: MACOS_DEV_BUNDLE_IDENTIFIER,
+}): Effect.Effect<string, ElectronOperationError> =>
+  Effect.gen(function* () {
+    const icon = yield* fileSignatureEffect(iconPath);
+    const sourceExecutable = yield* fileSignatureEffect(sourceExecutablePath);
+    const sourceInfoPlist = yield* fileSignatureEffect(
+      path.join(sourceAppPath, "Contents", "Info.plist"),
+    );
+
+    return `${JSON.stringify(
+      {
+        appName: APPLICATION_NAME,
+        bundleIdentifier: MACOS_DEV_BUNDLE_IDENTIFIER,
+        devAppPath,
+        icon,
+        iconFileName: MACOS_DEV_ICON_FILE_NAME,
+        sourceAppPath,
+        sourceExecutablePath,
+        sourceExecutable,
+        sourceInfoPlist,
+      },
+      null,
+      2,
+    )}\n`;
+  });
+
+const resolveRequiredMacosAppBundlePathEffect = (
+  sourceExecutablePath: string,
+): Effect.Effect<string, ElectronOperationError> =>
+  Effect.try({
+    try: () => resolveRequiredMacosAppBundlePath(sourceExecutablePath),
+    catch: (cause) => toElectronOperationError(cause, "electron.dev.resolve-macos-app-bundle"),
+  });
+
+const prepareMacosDevElectronBundleEffect = (
+  sourceExecutablePath: string,
+): Effect.Effect<string, ElectronOperationError> =>
+  Effect.gen(function* () {
+    const sourceAppPath = yield* resolveRequiredMacosAppBundlePathEffect(sourceExecutablePath);
+
+    const devRoot = path.join(packageRoot, ".electron-dev");
+    const devAppPath = resolveMacosDevAppPath();
+    const executableName = path.basename(sourceExecutablePath);
+    const devExecutablePath = resolveMacosDevExecutablePath(devAppPath, executableName);
+    const iconPath = path.join(packageRoot, "resources", "icon.icns");
+    const infoPlistPath = path.join(devAppPath, "Contents", "Info.plist");
+    const markerPath = path.join(devRoot, "app-source.json");
+    yield* assertFileExistsEffect(iconPath, "Electron macOS dev icon");
+    const signature = yield* buildMacosDevAppSignatureEffect({
       devAppPath,
-      icon: await fileSignature(iconPath),
-      iconFileName: MACOS_DEV_ICON_FILE_NAME,
+      iconPath,
       sourceAppPath,
       sourceExecutablePath,
-      sourceExecutable: await fileSignature(sourceExecutablePath),
-      sourceInfoPlist: await fileSignature(path.join(sourceAppPath, "Contents", "Info.plist")),
-    },
-    null,
-    2,
-  )}\n`;
+    });
+    const existingSignature = yield* readFileIfExistsEffect(markerPath);
+    const devExecutableExists = yield* fileExistsEffect(devExecutablePath);
+    const shouldCopyBundle = existingSignature !== signature || !devExecutableExists;
 
-const prepareMacosDevElectronBundle = async (sourceExecutablePath: string): Promise<string> => {
-  const sourceAppPath = resolveRequiredMacosAppBundlePath(sourceExecutablePath);
+    yield* runDevFileOperationEffect("electron.dev.create-macos-dev-root", devRoot, () =>
+      mkdir(devRoot, { recursive: true }),
+    );
+    if (shouldCopyBundle) {
+      yield* runDevFileOperationEffect("electron.dev.remove-macos-dev-marker", markerPath, () =>
+        rm(markerPath, { force: true }),
+      );
+      yield* runDevFileOperationEffect("electron.dev.remove-macos-dev-app", devAppPath, () =>
+        rm(devAppPath, { force: true, recursive: true }),
+      );
+      yield* runStepEffect("Electron macOS dev app copy", [
+        "/bin/cp",
+        "-cR",
+        sourceAppPath,
+        devAppPath,
+      ]);
+    }
 
-  const devRoot = path.join(packageRoot, ".electron-dev");
-  const devAppPath = resolveMacosDevAppPath();
-  const executableName = path.basename(sourceExecutablePath);
-  const devExecutablePath = resolveMacosDevExecutablePath(devAppPath, executableName);
-  const iconPath = path.join(packageRoot, "resources", "icon.icns");
-  const infoPlistPath = path.join(devAppPath, "Contents", "Info.plist");
-  const markerPath = path.join(devRoot, "app-source.json");
-  await assertFileExists(iconPath, "Electron macOS dev icon");
-  const signature = await buildMacosDevAppSignature({
-    devAppPath,
-    iconPath,
-    sourceAppPath,
-    sourceExecutablePath,
+    yield* runDevFileOperationEffect(
+      "electron.dev.copy-macos-dev-icon",
+      iconPath,
+      () =>
+        copyFile(
+          iconPath,
+          path.join(devAppPath, "Contents", "Resources", MACOS_DEV_ICON_FILE_NAME),
+        ),
+      { targetPath: path.join(devAppPath, "Contents", "Resources", MACOS_DEV_ICON_FILE_NAME) },
+    );
+    yield* runDevFileOperationEffect("electron.dev.copy-macos-dev-icon", iconPath, () =>
+      copyFile(iconPath, path.join(devAppPath, "Contents", "Resources", "icon.icns")),
+    );
+    yield* runDevFileOperationEffect("electron.dev.copy-macos-dev-icon", iconPath, () =>
+      copyFile(iconPath, path.join(devAppPath, "Contents", "Resources", "electron.icns")),
+    );
+    yield* replacePlistStringEffect(infoPlistPath, "CFBundleDisplayName", APPLICATION_NAME);
+    yield* replacePlistStringEffect(infoPlistPath, "CFBundleName", APPLICATION_NAME);
+    yield* replacePlistStringEffect(
+      infoPlistPath,
+      "CFBundleIdentifier",
+      MACOS_DEV_BUNDLE_IDENTIFIER,
+    );
+    yield* replacePlistStringEffect(infoPlistPath, "CFBundleIconFile", MACOS_DEV_ICON_FILE_NAME);
+    yield* runDevFileOperationEffect("electron.dev.write-macos-dev-marker", markerPath, () =>
+      writeFile(markerPath, signature, "utf8"),
+    );
+
+    return devExecutablePath;
   });
-  const existingSignature = await readFileIfExists(markerPath);
-  const shouldCopyBundle =
-    existingSignature !== signature || !(await fileExists(devExecutablePath));
-
-  await mkdir(devRoot, { recursive: true });
-  if (shouldCopyBundle) {
-    await rm(markerPath, { force: true });
-    await rm(devAppPath, { force: true, recursive: true });
-    await runStep("Electron macOS dev app copy", ["/bin/cp", "-cR", sourceAppPath, devAppPath]);
-  }
-
-  await copyFile(
-    iconPath,
-    path.join(devAppPath, "Contents", "Resources", MACOS_DEV_ICON_FILE_NAME),
-  );
-  await copyFile(iconPath, path.join(devAppPath, "Contents", "Resources", "icon.icns"));
-  await copyFile(iconPath, path.join(devAppPath, "Contents", "Resources", "electron.icns"));
-  await replacePlistString(infoPlistPath, "CFBundleDisplayName", APPLICATION_NAME);
-  await replacePlistString(infoPlistPath, "CFBundleName", APPLICATION_NAME);
-  await replacePlistString(infoPlistPath, "CFBundleIdentifier", MACOS_DEV_BUNDLE_IDENTIFIER);
-  await replacePlistString(infoPlistPath, "CFBundleIconFile", MACOS_DEV_ICON_FILE_NAME);
-  await writeFile(markerPath, signature, "utf8");
-
-  return devExecutablePath;
-};
-
-const resolveElectronDevExecutablePath = async (): Promise<string> => {
-  const electronExecutablePath = resolveElectronExecutablePath();
-  if (process.platform !== "darwin") {
-    return electronExecutablePath;
-  }
-
-  return prepareMacosDevElectronBundle(electronExecutablePath);
-};
 
 export const buildElectronBundlesEffect = (): Effect.Effect<void, ElectronOperationError> =>
   Effect.gen(function* () {
@@ -363,9 +404,16 @@ const resolveRendererDevUrlEffect = (
   });
 
 const resolveElectronDevExecutablePathEffect = (): Effect.Effect<string, ElectronOperationError> =>
-  Effect.tryPromise({
-    try: resolveElectronDevExecutablePath,
-    catch: (cause) => toElectronOperationError(cause, "electron.dev.resolve-executable-path"),
+  Effect.gen(function* () {
+    const electronExecutablePath = yield* Effect.try({
+      try: resolveElectronExecutablePath,
+      catch: (cause) => toElectronOperationError(cause, "electron.dev.resolve-executable-path"),
+    });
+    if (process.platform !== "darwin") {
+      return electronExecutablePath;
+    }
+
+    return yield* prepareMacosDevElectronBundleEffect(electronExecutablePath);
   });
 
 const createRendererDevServerEffect = (
@@ -531,9 +579,26 @@ type StartElectronProcess = (
   electronExecutablePath: string,
 ) => ManagedElectronProcess;
 
+type ElectronDevProcessEvent = "SIGINT" | "SIGTERM" | "exit";
+
+export type ElectronDevProcessHandlers = {
+  off(event: ElectronDevProcessEvent, listener: () => void): void;
+  once(event: ElectronDevProcessEvent, listener: () => void): void;
+};
+
+const defaultElectronDevProcessHandlers: ElectronDevProcessHandlers = {
+  off(event, listener) {
+    process.off(event, listener);
+  },
+  once(event, listener) {
+    process.once(event, listener);
+  },
+};
+
 type ElectronDevLifecycleOptions = {
   buildBundles?: () => Effect.Effect<void, ElectronOperationError>;
   electronExecutablePath: string;
+  processHandlers?: ElectronDevProcessHandlers;
   rendererDevUrl: string;
   rendererServer: ViteDevServer;
   startElectronProcess?: StartElectronProcess;
@@ -542,6 +607,7 @@ type ElectronDevLifecycleOptions = {
 export const runElectronDevLifecycleEffect = ({
   buildBundles = buildElectronBundlesEffect,
   electronExecutablePath,
+  processHandlers = defaultElectronDevProcessHandlers,
   rendererDevUrl,
   rendererServer,
   startElectronProcess = startElectron,
@@ -552,6 +618,10 @@ export const runElectronDevLifecycleEffect = ({
     let restarting = false;
     let restartQueued = false;
     let restartTimer: ReturnType<typeof setTimeout> | null = null;
+    const registeredProcessHandlers: Array<{
+      event: ElectronDevProcessEvent;
+      listener: () => void;
+    }> = [];
     let settled = false;
 
     const settle = (effect: Effect.Effect<number, ElectronOperationError>): void => {
@@ -559,7 +629,18 @@ export const runElectronDevLifecycleEffect = ({
         return;
       }
       settled = true;
+      while (registeredProcessHandlers.length > 0) {
+        const registered = registeredProcessHandlers.pop();
+        if (registered) {
+          processHandlers.off(registered.event, registered.listener);
+        }
+      }
       resume(effect);
+    };
+
+    const registerProcessHandler = (event: ElectronDevProcessEvent, listener: () => void): void => {
+      processHandlers.once(event, listener);
+      registeredProcessHandlers.push({ event, listener });
     };
 
     const completeFailure = (cause: unknown): void => {
@@ -591,12 +672,18 @@ export const runElectronDevLifecycleEffect = ({
       });
     };
 
-    const runLifecycleTask = (effect: Effect.Effect<void, ElectronOperationError>): void => {
+    const shutdownAfterLifecycleFailure = (cause: unknown): void => {
+      console.error(cause);
+      runShutdown(1);
+    };
+
+    const runLifecycleTask = (
+      effect: Effect.Effect<void, ElectronOperationError>,
+      onFailure: (cause: unknown) => void,
+    ): void => {
       void Effect.runPromiseExit(effect).then((exit) => {
         if (Exit.isFailure(exit)) {
-          const error = causeToElectronBoundaryError(exit.cause);
-          console.error(error);
-          runShutdown(1);
+          onFailure(causeToElectronBoundaryError(exit.cause));
         }
       });
     };
@@ -665,7 +752,7 @@ export const runElectronDevLifecycleEffect = ({
       }
       restartTimer = setTimeout(() => {
         restartTimer = null;
-        runLifecycleTask(restartElectronEffect());
+        runLifecycleTask(restartElectronEffect(), shutdownAfterLifecycleFailure);
       }, ELECTRON_RESTART_DEBOUNCE_MS);
     };
 
@@ -693,15 +780,15 @@ export const runElectronDevLifecycleEffect = ({
 
     const registerProcessHandlersEffect = (): Effect.Effect<void, never> =>
       Effect.sync(() => {
-        process.once("SIGINT", () => {
+        registerProcessHandler("SIGINT", () => {
           console.log("[electron:dev] Received SIGINT, shutting down...");
           runShutdown(130);
         });
-        process.once("SIGTERM", () => {
+        registerProcessHandler("SIGTERM", () => {
           console.log("[electron:dev] Received SIGTERM, shutting down...");
           runShutdown(143);
         });
-        process.once("exit", () => {
+        registerProcessHandler("exit", () => {
           if (electron) {
             electron.kill();
           }
@@ -714,6 +801,7 @@ export const runElectronDevLifecycleEffect = ({
         yield* registerProcessHandlersEffect();
         yield* launchElectronEffect();
       }),
+      completeFailure,
     );
   });
 

--- a/apps/electron/scripts/electron-release-targets.ts
+++ b/apps/electron/scripts/electron-release-targets.ts
@@ -1,3 +1,5 @@
+import { ElectronValidationError } from "../src/effect/electron-errors";
+
 export type ElectronReleasePlatform = "linux" | "macos" | "windows";
 export type ElectronReleaseArch = "arm64" | "x64";
 
@@ -24,7 +26,11 @@ export const resolveHostReleasePlatform = (platform: NodeJS.Platform): ElectronR
     return target;
   }
 
-  throw new Error(`Unsupported Electron release host platform: ${platform}`);
+  throw new ElectronValidationError({
+    operation: "electron.release-target.resolve-host-platform",
+    message: `Unsupported Electron release host platform: ${platform}`,
+    platform,
+  });
 };
 
 export const resolveHostReleaseArch = (arch: NodeJS.Architecture): ElectronReleaseArch => {
@@ -33,5 +39,9 @@ export const resolveHostReleaseArch = (arch: NodeJS.Architecture): ElectronRelea
     return target;
   }
 
-  throw new Error(`Unsupported Electron release host architecture: ${arch}`);
+  throw new ElectronValidationError({
+    operation: "electron.release-target.resolve-host-arch",
+    message: `Unsupported Electron release host architecture: ${arch}`,
+    arch,
+  });
 };

--- a/apps/electron/scripts/package-build.test.ts
+++ b/apps/electron/scripts/package-build.test.ts
@@ -178,4 +178,32 @@ describe("build Electron release artifact", () => {
       await rm(baseDirectory, { force: true, recursive: true });
     }
   });
+
+  it("uses a typed error when no platform release artifacts were produced", async () => {
+    const baseDirectory = await mkdtemp(join(tmpdir(), "openducktor-electron-release-"));
+    const releaseDirectory = join(baseDirectory, "release");
+    const outputDirectory = join(baseDirectory, "release-publish");
+
+    try {
+      await mkdir(releaseDirectory, { recursive: true });
+
+      const error = await collectReleaseArtifacts({
+        outputDirectory,
+        platform: "macos",
+        releaseDirectory,
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        _tag: "ElectronOperationError",
+        operation: "electron.package.collect-release-artifacts",
+        path: releaseDirectory,
+        platform: "macos",
+      });
+      expect((error as Error).message).toBe(
+        "No Electron release artifacts were produced for macos.",
+      );
+    } finally {
+      await rm(baseDirectory, { force: true, recursive: true });
+    }
+  });
 });

--- a/apps/electron/scripts/package-build.test.ts
+++ b/apps/electron/scripts/package-build.test.ts
@@ -153,4 +153,29 @@ describe("build Electron release artifact", () => {
       await rm(baseDirectory, { force: true, recursive: true });
     }
   });
+
+  it("uses a typed error when the release directory is missing", async () => {
+    const baseDirectory = await mkdtemp(join(tmpdir(), "openducktor-electron-release-"));
+    const releaseDirectory = join(baseDirectory, "release");
+    const outputDirectory = join(baseDirectory, "release-publish");
+
+    try {
+      const error = await collectReleaseArtifacts({
+        outputDirectory,
+        platform: "macos",
+        releaseDirectory,
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        _tag: "ElectronOperationError",
+        operation: "electron.package.read-release-directory",
+        path: releaseDirectory,
+      });
+      expect((error as Error).message).toBe(
+        `Electron release directory is missing: ${releaseDirectory}`,
+      );
+    } finally {
+      await rm(baseDirectory, { force: true, recursive: true });
+    }
+  });
 });

--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -1,7 +1,15 @@
+import type { Dirent } from "node:fs";
 import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runCommand } from "@openducktor/build-tools";
+import { Effect } from "effect";
+import { runElectronEffect } from "../src/effect/electron-boundary";
+import {
+  ElectronOperationError,
+  ElectronValidationError,
+  errorMessage,
+} from "../src/effect/electron-errors";
 import {
   detectHostReleaseArch,
   detectHostReleasePlatform,
@@ -9,8 +17,8 @@ import {
   type ElectronReleasePlatform,
 } from "./electron-release-targets";
 import { electronSidecarDisplayName } from "./electron-sidecar-manifest";
-import { prepareElectronSidecars } from "./prepare-electron-sidecars";
-import { verifyPackagedElectronSidecars } from "./verify-electron-sidecar-package";
+import { prepareElectronSidecarsEffect } from "./prepare-electron-sidecars";
+import { verifyPackagedElectronSidecarsEffect } from "./verify-electron-sidecar-package";
 
 export type ElectronPackageBuildOptions = {
   arch: ElectronReleaseArch;
@@ -98,18 +106,29 @@ export const resolveElectronBuilderEnv = (
 export const isReleaseArtifact = (platform: ElectronReleasePlatform, fileName: string): boolean =>
   artifactExtensions[platform].has(extname(fileName));
 
-const readReleaseDirectoryEntries = async (releaseDirectory: string) => {
-  try {
-    return await readdir(releaseDirectory, { withFileTypes: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`Electron release directory is missing: ${releaseDirectory}`);
-    }
-    throw error;
-  }
-};
+const nodeErrorCode = (cause: unknown): string | null =>
+  typeof cause === "object" && cause !== null && "code" in cause && typeof cause.code === "string"
+    ? cause.code
+    : null;
 
-export const collectReleaseArtifacts = async ({
+const readReleaseDirectoryEntriesEffect = (
+  releaseDirectory: string,
+): Effect.Effect<Dirent<string>[], ElectronOperationError> =>
+  Effect.tryPromise({
+    try: () => readdir(releaseDirectory, { withFileTypes: true }),
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.package.read-release-directory",
+        message:
+          nodeErrorCode(cause) === "ENOENT"
+            ? `Electron release directory is missing: ${releaseDirectory}`
+            : errorMessage(cause),
+        path: releaseDirectory,
+        cause,
+      }),
+  });
+
+export const collectReleaseArtifactsEffect = ({
   outputDirectory,
   platform,
   releaseDirectory,
@@ -117,31 +136,94 @@ export const collectReleaseArtifacts = async ({
   outputDirectory: string;
   platform: ElectronReleasePlatform;
   releaseDirectory: string;
-}): Promise<string[]> => {
-  const entries = await readReleaseDirectoryEntries(releaseDirectory);
-  await rm(outputDirectory, { force: true, recursive: true });
-  await mkdir(outputDirectory, { recursive: true });
+}): Effect.Effect<string[], ElectronOperationError> =>
+  Effect.gen(function* () {
+    const entries = yield* readReleaseDirectoryEntriesEffect(releaseDirectory);
+    yield* Effect.tryPromise({
+      try: () => rm(outputDirectory, { force: true, recursive: true }),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.package.clean-artifact-output",
+          message: errorMessage(cause),
+          path: outputDirectory,
+          cause,
+        }),
+    });
+    yield* Effect.tryPromise({
+      try: () => mkdir(outputDirectory, { recursive: true }),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.package.create-artifact-output",
+          message: errorMessage(cause),
+          path: outputDirectory,
+          cause,
+        }),
+    });
 
-  const artifactEntries = entries.filter(
-    (entry) => entry.isFile() && isReleaseArtifact(platform, entry.name),
-  );
-  const copiedArtifacts = await Promise.all(
-    artifactEntries.map(async (entry) => {
-      const sourcePath = join(releaseDirectory, entry.name);
-      const targetPath = join(outputDirectory, entry.name);
-      await copyFile(sourcePath, targetPath);
-      return targetPath;
-    }),
-  );
+    const artifactEntries = entries.filter(
+      (entry) => entry.isFile() && isReleaseArtifact(platform, entry.name),
+    );
+    const copiedArtifacts = yield* Effect.all(
+      artifactEntries.map((entry) => {
+        const sourcePath = join(releaseDirectory, entry.name);
+        const targetPath = join(outputDirectory, entry.name);
+        return Effect.tryPromise({
+          try: async () => {
+            await copyFile(sourcePath, targetPath);
+            return targetPath;
+          },
+          catch: (cause) =>
+            new ElectronOperationError({
+              operation: "electron.package.copy-release-artifact",
+              message: errorMessage(cause),
+              path: sourcePath,
+              cause,
+              details: { targetPath },
+            }),
+        });
+      }),
+      { concurrency: "unbounded" },
+    );
 
-  if (copiedArtifacts.length === 0) {
-    throw new Error(`No Electron release artifacts were produced for ${platform}.`);
-  }
+    if (copiedArtifacts.length === 0) {
+      return yield* new ElectronOperationError({
+        operation: "electron.package.collect-release-artifacts",
+        message: `No Electron release artifacts were produced for ${platform}.`,
+        path: releaseDirectory,
+        platform,
+      });
+    }
 
-  return copiedArtifacts;
-};
+    return copiedArtifacts;
+  });
 
-export const buildElectronPackage = async ({
+export const collectReleaseArtifacts = (input: {
+  outputDirectory: string;
+  platform: ElectronReleasePlatform;
+  releaseDirectory: string;
+}): Promise<string[]> => runElectronEffect(collectReleaseArtifactsEffect(input));
+
+const runPackageCommandEffect = ({
+  command,
+  cwd,
+  env,
+  label,
+}: Parameters<typeof runCommand>[0]): Effect.Effect<void, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: () => {
+      const input = env === undefined ? { command, cwd, label } : { command, cwd, env, label };
+      return runCommand(input);
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.package.run-command",
+        message: errorMessage(cause),
+        cause,
+        details: { command, cwd, label },
+      }),
+  });
+
+export const buildElectronPackageEffect = ({
   arch,
   electronPackageDirectory,
   outputDirectory,
@@ -149,62 +231,82 @@ export const buildElectronPackage = async ({
   signed,
   stageReleaseArtifacts,
   workspaceRoot,
-}: ElectronPackageBuildOptions): Promise<string[]> => {
-  const releaseDirectory = join(electronPackageDirectory, "release");
+}: ElectronPackageBuildOptions): Effect.Effect<
+  string[],
+  ElectronOperationError | ElectronValidationError
+> =>
+  Effect.gen(function* () {
+    const releaseDirectory = join(electronPackageDirectory, "release");
 
-  await rm(releaseDirectory, { force: true, recursive: true });
-  await prepareElectronSidecars({
-    arch,
-    electronPackageDirectory,
-    platform,
-    workspaceRoot,
+    yield* Effect.tryPromise({
+      try: () => rm(releaseDirectory, { force: true, recursive: true }),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.package.clean-release-directory",
+          message: errorMessage(cause),
+          path: releaseDirectory,
+          cause,
+        }),
+    });
+    yield* prepareElectronSidecarsEffect({
+      arch,
+      electronPackageDirectory,
+      platform,
+      workspaceRoot,
+    });
+
+    yield* runPackageCommandEffect({
+      command: ["bun", "run", "build"],
+      cwd: electronPackageDirectory,
+      label: "Electron app build",
+    });
+    yield* runPackageCommandEffect({
+      command: [
+        "bun",
+        "run",
+        "builder",
+        "--",
+        ...resolveElectronBuilderArgs({ arch, platform, signed, stageReleaseArtifacts }),
+      ],
+      cwd: electronPackageDirectory,
+      env: resolveElectronBuilderEnv(signed, process.env),
+      label: "Electron Builder package",
+    });
+
+    const verifiedSidecars = yield* verifyPackagedElectronSidecarsEffect({
+      arch,
+      platform,
+      releaseDirectory,
+    });
+    for (const sidecar of verifiedSidecars) {
+      console.log(
+        `Verified packaged Electron ${electronSidecarDisplayName(sidecar.id)} sidecar payload: ${
+          sidecar.path
+        }`,
+      );
+    }
+
+    if (!stageReleaseArtifacts) {
+      return [];
+    }
+
+    if (!outputDirectory) {
+      return yield* new ElectronValidationError({
+        operation: "electron.package.require-output-directory",
+        message: "--output-dir is required when staging Electron release artifacts.",
+        field: "outputDirectory",
+      });
+    }
+
+    return yield* collectReleaseArtifactsEffect({
+      outputDirectory,
+      platform,
+      releaseDirectory,
+    });
   });
 
-  await runCommand({
-    command: ["bun", "run", "build"],
-    cwd: electronPackageDirectory,
-    label: "Electron app build",
-  });
-  await runCommand({
-    command: [
-      "bun",
-      "run",
-      "builder",
-      "--",
-      ...resolveElectronBuilderArgs({ arch, platform, signed, stageReleaseArtifacts }),
-    ],
-    cwd: electronPackageDirectory,
-    env: resolveElectronBuilderEnv(signed, process.env),
-    label: "Electron Builder package",
-  });
-
-  const verifiedSidecars = await verifyPackagedElectronSidecars({
-    arch,
-    platform,
-    releaseDirectory,
-  });
-  for (const sidecar of verifiedSidecars) {
-    console.log(
-      `Verified packaged Electron ${electronSidecarDisplayName(sidecar.id)} sidecar payload: ${
-        sidecar.path
-      }`,
-    );
-  }
-
-  if (!stageReleaseArtifacts) {
-    return [];
-  }
-
-  if (!outputDirectory) {
-    throw new Error("--output-dir is required when staging Electron release artifacts.");
-  }
-
-  return collectReleaseArtifacts({
-    outputDirectory,
-    platform,
-    releaseDirectory,
-  });
-};
+export const buildElectronPackage = (input: ElectronPackageBuildOptions): Promise<string[]> =>
+  runElectronEffect(buildElectronPackageEffect(input));
 
 const readFlagValue = (args: string[], name: string): string | undefined => {
   const index = args.indexOf(name);
@@ -220,7 +322,12 @@ const parsePlatform = (value: string | undefined): ElectronReleasePlatform => {
     return platform;
   }
 
-  throw new Error("Expected --platform to be one of: linux, macos, windows.");
+  throw new ElectronValidationError({
+    operation: "electron.package.parse-platform",
+    message: "Expected --platform to be one of: linux, macos, windows.",
+    field: "platform",
+    platform: value,
+  });
 };
 
 const parseArch = (value: string | undefined): ElectronReleaseArch => {
@@ -229,7 +336,12 @@ const parseArch = (value: string | undefined): ElectronReleaseArch => {
     return arch;
   }
 
-  throw new Error("Expected --arch to be one of: arm64, x64.");
+  throw new ElectronValidationError({
+    operation: "electron.package.parse-arch",
+    message: "Expected --arch to be one of: arm64, x64.",
+    field: "arch",
+    arch: value,
+  });
 };
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -237,28 +349,33 @@ const electronPackageDirectory = dirname(scriptDirectory);
 const workspaceRoot = resolve(electronPackageDirectory, "../..");
 
 if (import.meta.main) {
-  const args = process.argv.slice(2);
-  const stageReleaseArtifacts = hasFlag(args, "--stage-release-artifacts");
-  const outputDirectoryValue = readFlagValue(args, "--output-dir");
-  const outputDirectory =
-    outputDirectoryValue || stageReleaseArtifacts
-      ? resolve(electronPackageDirectory, outputDirectoryValue ?? "release-publish")
-      : undefined;
+  try {
+    const args = process.argv.slice(2);
+    const stageReleaseArtifacts = hasFlag(args, "--stage-release-artifacts");
+    const outputDirectoryValue = readFlagValue(args, "--output-dir");
+    const outputDirectory =
+      outputDirectoryValue || stageReleaseArtifacts
+        ? resolve(electronPackageDirectory, outputDirectoryValue ?? "release-publish")
+        : undefined;
 
-  const artifacts = await buildElectronPackage({
-    arch: parseArch(readFlagValue(args, "--arch")),
-    electronPackageDirectory,
-    outputDirectory,
-    platform: parsePlatform(readFlagValue(args, "--platform")),
-    signed: hasFlag(args, "--signed"),
-    stageReleaseArtifacts,
-    workspaceRoot,
-  });
+    const artifacts = await buildElectronPackage({
+      arch: parseArch(readFlagValue(args, "--arch")),
+      electronPackageDirectory,
+      outputDirectory,
+      platform: parsePlatform(readFlagValue(args, "--platform")),
+      signed: hasFlag(args, "--signed"),
+      stageReleaseArtifacts,
+      workspaceRoot,
+    });
 
-  if (stageReleaseArtifacts) {
-    console.log("Staged Electron release artifacts:");
-    for (const artifact of artifacts) {
-      console.log(`- ${artifact}`);
+    if (stageReleaseArtifacts) {
+      console.log("Staged Electron release artifacts:");
+      for (const artifact of artifacts) {
+        console.log(`- ${artifact}`);
+      }
     }
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
   }
 }

--- a/apps/electron/scripts/package-build.ts
+++ b/apps/electron/scripts/package-build.ts
@@ -186,12 +186,14 @@ export const collectReleaseArtifactsEffect = ({
     );
 
     if (copiedArtifacts.length === 0) {
-      return yield* new ElectronOperationError({
-        operation: "electron.package.collect-release-artifacts",
-        message: `No Electron release artifacts were produced for ${platform}.`,
-        path: releaseDirectory,
-        platform,
-      });
+      return yield* Effect.fail(
+        new ElectronOperationError({
+          operation: "electron.package.collect-release-artifacts",
+          message: `No Electron release artifacts were produced for ${platform}.`,
+          path: releaseDirectory,
+          platform,
+        }),
+      );
     }
 
     return copiedArtifacts;
@@ -291,11 +293,13 @@ export const buildElectronPackageEffect = ({
     }
 
     if (!outputDirectory) {
-      return yield* new ElectronValidationError({
-        operation: "electron.package.require-output-directory",
-        message: "--output-dir is required when staging Electron release artifacts.",
-        field: "outputDirectory",
-      });
+      return yield* Effect.fail(
+        new ElectronValidationError({
+          operation: "electron.package.require-output-directory",
+          message: "--output-dir is required when staging Electron release artifacts.",
+          field: "outputDirectory",
+        }),
+      );
     }
 
     return yield* collectReleaseArtifactsEffect({

--- a/apps/electron/scripts/prepare-electron-sidecars.test.ts
+++ b/apps/electron/scripts/prepare-electron-sidecars.test.ts
@@ -107,15 +107,20 @@ describe("prepareElectronSidecars", () => {
     await writeFile(staleOutput, "stale");
     await rm(mcpEntrypoint);
 
-    await expect(
-      prepareElectronSidecars({
-        arch: "x64",
-        electronPackageDirectory,
-        platform: "linux",
-        workspaceRoot,
-        ...makeSideEffectingHooks(sideEffects),
-      }),
-    ).rejects.toThrow("OpenDucktor MCP entrypoint is missing");
+    const error = await prepareElectronSidecars({
+      arch: "x64",
+      electronPackageDirectory,
+      platform: "linux",
+      workspaceRoot,
+      ...makeSideEffectingHooks(sideEffects),
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      _tag: "ElectronValidationError",
+      operation: "electron.sidecar.assert-file-exists",
+      path: mcpEntrypoint,
+    });
+    expect((error as Error).message).toContain("OpenDucktor MCP entrypoint is missing");
     expect(sideEffects).toEqual([]);
     await expect(stat(staleOutput)).resolves.toMatchObject({ size: 5 });
   });

--- a/apps/electron/scripts/prepare-electron-sidecars.ts
+++ b/apps/electron/scripts/prepare-electron-sidecars.ts
@@ -3,6 +3,13 @@ import { chmod, mkdir, rm, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { $ } from "bun";
+import { Effect } from "effect";
+import { runElectronEffect } from "../src/effect/electron-boundary";
+import {
+  ElectronOperationError,
+  ElectronValidationError,
+  errorMessage,
+} from "../src/effect/electron-errors";
 import {
   type ElectronReleaseArch,
   type ElectronReleasePlatform,
@@ -61,7 +68,7 @@ export const resolveElectronSidecarBuildPlan = ({
   };
 };
 
-const assertSidecarFile = async ({
+const assertSidecarFileEffect = ({
   label,
   path,
   platform,
@@ -69,51 +76,83 @@ const assertSidecarFile = async ({
   label: string;
   path: string;
   platform: ElectronReleasePlatform;
-}): Promise<Stats> => {
-  try {
-    const metadata = await stat(path);
-    if (!metadata.isFile()) {
-      throw new Error("expected a file but found a non-file entry");
-    }
-    if (metadata.size === 0) {
-      throw new Error("expected a non-empty file");
-    }
-    if (platform !== "windows" && process.platform !== "win32" && (metadata.mode & 0o111) === 0) {
-      throw new Error("expected an executable file");
-    }
-    return metadata;
-  } catch (cause) {
-    if (cause instanceof Error) {
-      throw new Error(`${label} is invalid: ${cause.message}. Expected path: ${path}`, { cause });
-    }
-    throw cause;
-  }
-};
+}): Effect.Effect<Stats, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const metadata = await stat(path);
+      if (!metadata.isFile()) {
+        throw new Error("expected a file but found a non-file entry");
+      }
+      if (metadata.size === 0) {
+        throw new Error("expected a non-empty file");
+      }
+      if (platform !== "windows" && process.platform !== "win32" && (metadata.mode & 0o111) === 0) {
+        throw new Error("expected an executable file");
+      }
+      return metadata;
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.sidecar.verify-compiled",
+        message: `${label} is invalid: ${errorMessage(cause)}. Expected path: ${path}`,
+        path,
+        platform,
+        cause,
+      }),
+  });
 
-const assertFileExists = async (path: string, label: string): Promise<void> => {
-  try {
-    const metadata = await stat(path);
-    if (metadata.isFile()) {
-      return;
-    }
-  } catch {
-    // Report a single actionable error below.
-  }
-
-  throw new Error(`${label} is missing: ${path}`);
-};
+const assertFileExistsEffect = (
+  path: string,
+  label: string,
+): Effect.Effect<void, ElectronValidationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const metadata = await stat(path);
+      if (!metadata.isFile()) {
+        throw new Error("expected a file but found a non-file entry");
+      }
+    },
+    catch: (cause) =>
+      new ElectronValidationError({
+        operation: "electron.sidecar.assert-file-exists",
+        message: `${label} is missing: ${path}`,
+        path,
+        cause,
+      }),
+  });
 
 const compileMcpSidecar = async (plan: ElectronSidecarBuildPlan): Promise<void> => {
   await $`bun build --compile --outfile ${plan.outputPaths["openducktor-mcp"]} ${plan.entrypoint}`;
 };
 
-const resetSidecarOutput = async (plan: ElectronSidecarBuildPlan): Promise<void> => {
-  await assertFileExists(plan.entrypoint, "OpenDucktor MCP entrypoint");
-  await rm(plan.outputDirectory, { force: true, recursive: true });
-  await mkdir(plan.outputDirectory, { recursive: true });
-};
+const resetSidecarOutputEffect = (
+  plan: ElectronSidecarBuildPlan,
+): Effect.Effect<void, ElectronOperationError | ElectronValidationError> =>
+  Effect.gen(function* () {
+    yield* assertFileExistsEffect(plan.entrypoint, "OpenDucktor MCP entrypoint");
+    yield* Effect.tryPromise({
+      try: () => rm(plan.outputDirectory, { force: true, recursive: true }),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.sidecar.clean-output",
+          message: errorMessage(cause),
+          path: plan.outputDirectory,
+          cause,
+        }),
+    });
+    yield* Effect.tryPromise({
+      try: () => mkdir(plan.outputDirectory, { recursive: true }),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.sidecar.create-output",
+          message: errorMessage(cause),
+          path: plan.outputDirectory,
+          cause,
+        }),
+    });
+  });
 
-const compileAndVerifyMcpSidecar = async ({
+const compileAndVerifyMcpSidecarEffect = ({
   chmodFile,
   compile,
   plan,
@@ -123,22 +162,73 @@ const compileAndVerifyMcpSidecar = async ({
   compile: (plan: ElectronSidecarBuildPlan) => Promise<void>;
   plan: ElectronSidecarBuildPlan;
   platform: ElectronReleasePlatform;
-}): Promise<PreparedElectronSidecar> => {
-  const outputPath = plan.outputPaths["openducktor-mcp"];
-  await compile(plan);
-  if (platform !== "windows") {
-    await chmodFile(outputPath, 0o755);
-  }
-  await assertSidecarFile({
-    label: "Compiled OpenDucktor MCP sidecar",
-    path: outputPath,
-    platform,
+}): Effect.Effect<PreparedElectronSidecar, ElectronOperationError> =>
+  Effect.gen(function* () {
+    const outputPath = plan.outputPaths["openducktor-mcp"];
+    yield* Effect.tryPromise({
+      try: () => compile(plan),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.sidecar.compile-mcp",
+          message: errorMessage(cause),
+          path: outputPath,
+          platform,
+          cause,
+        }),
+    });
+    if (platform !== "windows") {
+      yield* Effect.tryPromise({
+        try: () => chmodFile(outputPath, 0o755),
+        catch: (cause) =>
+          new ElectronOperationError({
+            operation: "electron.sidecar.chmod",
+            message: errorMessage(cause),
+            path: outputPath,
+            platform,
+            cause,
+          }),
+      });
+    }
+    yield* assertSidecarFileEffect({
+      label: "Compiled OpenDucktor MCP sidecar",
+      path: outputPath,
+      platform,
+    });
+
+    return { id: "openducktor-mcp", outputPath };
   });
 
-  return { id: "openducktor-mcp", outputPath };
-};
+export const prepareElectronSidecarsEffect = ({
+  arch,
+  chmodFile = chmod,
+  compileMcp = compileMcpSidecar,
+  ...input
+}: PrepareElectronSidecarsInput): Effect.Effect<
+  {
+    plan: ElectronSidecarBuildPlan;
+    sidecars: PreparedElectronSidecar[];
+  },
+  ElectronOperationError | ElectronValidationError
+> =>
+  Effect.gen(function* () {
+    void arch;
+    const plan = resolveElectronSidecarBuildPlan(input);
 
-export const prepareElectronSidecars = async ({
+    yield* resetSidecarOutputEffect(plan);
+    const mcpSidecar = yield* compileAndVerifyMcpSidecarEffect({
+      chmodFile,
+      compile: compileMcp,
+      plan,
+      platform: input.platform,
+    });
+
+    return {
+      plan,
+      sidecars: [mcpSidecar],
+    };
+  });
+
+export const prepareElectronSidecars = ({
   arch,
   chmodFile = chmod,
   compileMcp = compileMcpSidecar,
@@ -146,38 +236,35 @@ export const prepareElectronSidecars = async ({
 }: PrepareElectronSidecarsInput): Promise<{
   plan: ElectronSidecarBuildPlan;
   sidecars: PreparedElectronSidecar[];
-}> => {
-  void arch;
-  const plan = resolveElectronSidecarBuildPlan(input);
-
-  await resetSidecarOutput(plan);
-  const mcpSidecar = await compileAndVerifyMcpSidecar({
-    chmodFile,
-    compile: compileMcp,
-    plan,
-    platform: input.platform,
-  });
-
-  return {
-    plan,
-    sidecars: [mcpSidecar],
-  };
-};
+}> =>
+  runElectronEffect(
+    prepareElectronSidecarsEffect({
+      arch,
+      chmodFile,
+      compileMcp,
+      ...input,
+    }),
+  );
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const electronPackageDirectory = dirname(scriptDirectory);
 const workspaceRoot = resolve(electronPackageDirectory, "../..");
 
 if (import.meta.main) {
-  const prepared = await prepareElectronSidecars({
-    arch: resolveHostReleaseArch(process.arch),
-    electronPackageDirectory,
-    platform: resolveHostReleasePlatform(process.platform),
-    workspaceRoot,
-  });
-  for (const sidecar of prepared.sidecars) {
-    console.log(
-      `Prepared ${electronSidecarDisplayName(sidecar.id)} sidecar: ${sidecar.outputPath}`,
-    );
+  try {
+    const prepared = await prepareElectronSidecars({
+      arch: resolveHostReleaseArch(process.arch),
+      electronPackageDirectory,
+      platform: resolveHostReleasePlatform(process.platform),
+      workspaceRoot,
+    });
+    for (const sidecar of prepared.sidecars) {
+      console.log(
+        `Prepared ${electronSidecarDisplayName(sidecar.id)} sidecar: ${sidecar.outputPath}`,
+      );
+    }
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
   }
 }

--- a/apps/electron/scripts/verify-electron-sidecar-package.test.ts
+++ b/apps/electron/scripts/verify-electron-sidecar-package.test.ts
@@ -158,9 +158,17 @@ describe("verifyPackagedElectronSidecars", () => {
   test("rejects a missing required Windows MCP sidecar at the expected package path", async () => {
     const releaseDirectory = await makeReleaseDirectory();
 
-    await expect(
-      verifyPackagedElectronSidecars({ arch: "x64", platform: "windows", releaseDirectory }),
-    ).rejects.toThrow("openducktor-mcp.exe");
+    const error = await verifyPackagedElectronSidecars({
+      arch: "x64",
+      platform: "windows",
+      releaseDirectory,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      _tag: "ElectronOperationError",
+      operation: "electron.sidecar.verify-packaged",
+    });
+    expect((error as Error).message).toContain("openducktor-mcp.exe");
   });
 
   test("rejects an empty required Windows MCP sidecar", async () => {

--- a/apps/electron/scripts/verify-electron-sidecar-package.test.ts
+++ b/apps/electron/scripts/verify-electron-sidecar-package.test.ts
@@ -205,9 +205,17 @@ describe("verifyPackagedElectronSidecars", () => {
       releaseDirectory,
     });
 
-    await expect(
-      verifyPackagedElectronSidecars({ arch: "x64", platform: "linux", releaseDirectory }),
-    ).rejects.toThrow("expected an executable file");
+    const error = await verifyPackagedElectronSidecars({
+      arch: "x64",
+      platform: "linux",
+      releaseDirectory,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      _tag: "ElectronOperationError",
+      operation: "electron.sidecar.verify-packaged-executable",
+    });
+    expect((error as Error).message).toContain("expected an executable file");
   });
 
   test("accepts non-empty executable macOS MCP sidecar", async () => {

--- a/apps/electron/scripts/verify-electron-sidecar-package.ts
+++ b/apps/electron/scripts/verify-electron-sidecar-package.ts
@@ -1,6 +1,9 @@
 import type { Stats } from "node:fs";
 import { stat } from "node:fs/promises";
 import { join } from "node:path";
+import { Effect } from "effect";
+import { runElectronEffect } from "../src/effect/electron-boundary";
+import { ElectronOperationError, errorMessage } from "../src/effect/electron-errors";
 import type { ElectronReleaseArch, ElectronReleasePlatform } from "./electron-release-targets";
 import {
   ELECTRON_SIDECAR_IDS,
@@ -67,7 +70,7 @@ export const resolvePackagedElectronSidecarPath = ({
   );
 };
 
-const assertPackagedSidecarFile = async ({
+const assertPackagedSidecarFileEffect = ({
   path,
   platform,
   sidecarId,
@@ -75,52 +78,79 @@ const assertPackagedSidecarFile = async ({
   path: string;
   platform: ElectronReleasePlatform;
   sidecarId: ElectronSidecarId;
-}): Promise<Stats> => {
-  try {
-    const metadata = await stat(path);
-    if (!metadata.isFile()) {
-      throw new Error("expected a file but found a non-file entry");
-    }
-    if (metadata.size === 0) {
-      throw new Error("expected a non-empty file");
-    }
-    return metadata;
-  } catch (cause) {
-    if (cause instanceof Error) {
-      throw new Error(
-        `Invalid packaged Electron ${electronSidecarDisplayName(sidecarId)} sidecar payload for ${platform}: ${
-          cause.message
-        }. Expected path: ${path}`,
-        { cause },
-      );
-    }
-    throw cause;
-  }
-};
+}): Effect.Effect<Stats, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const metadata = await stat(path);
+      if (!metadata.isFile()) {
+        throw new Error("expected a file but found a non-file entry");
+      }
+      if (metadata.size === 0) {
+        throw new Error("expected a non-empty file");
+      }
+      return metadata;
+    },
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.sidecar.verify-packaged",
+        message: `Invalid packaged Electron ${electronSidecarDisplayName(
+          sidecarId,
+        )} sidecar payload for ${platform}: ${errorMessage(cause)}. Expected path: ${path}`,
+        path,
+        platform,
+        cause,
+        details: { sidecarId },
+      }),
+  });
 
-export const verifyPackagedElectronSidecars = async ({
+export const verifyPackagedElectronSidecarsEffect = ({
   arch,
   platform,
   releaseDirectory,
-}: VerifyPackagedElectronSidecarsInput): Promise<VerifiedPackagedElectronSidecar[]> => {
-  const verifiedSidecars: VerifiedPackagedElectronSidecar[] = [];
-  for (const sidecarId of ELECTRON_SIDECAR_IDS) {
-    const sidecarPath = resolvePackagedElectronSidecarPath({
+}: VerifyPackagedElectronSidecarsInput): Effect.Effect<
+  VerifiedPackagedElectronSidecar[],
+  ElectronOperationError
+> =>
+  Effect.gen(function* () {
+    const verifiedSidecars: VerifiedPackagedElectronSidecar[] = [];
+    for (const sidecarId of ELECTRON_SIDECAR_IDS) {
+      const sidecarPath = resolvePackagedElectronSidecarPath({
+        arch,
+        platform,
+        releaseDirectory,
+        sidecarId,
+      });
+      const metadata = yield* assertPackagedSidecarFileEffect({
+        path: sidecarPath,
+        platform,
+        sidecarId,
+      });
+
+      if (platform !== "windows" && process.platform !== "win32" && (metadata.mode & 0o111) === 0) {
+        return yield* new ElectronOperationError({
+          operation: "electron.sidecar.verify-packaged-executable",
+          message: `Invalid packaged Electron ${electronSidecarDisplayName(sidecarId)} sidecar payload for ${platform}: expected an executable file. Expected path: ${sidecarPath}`,
+          path: sidecarPath,
+          platform,
+          details: { sidecarId },
+        });
+      }
+
+      verifiedSidecars.push({ id: sidecarId, path: sidecarPath });
+    }
+
+    return verifiedSidecars;
+  });
+
+export const verifyPackagedElectronSidecars = ({
+  arch,
+  platform,
+  releaseDirectory,
+}: VerifyPackagedElectronSidecarsInput): Promise<VerifiedPackagedElectronSidecar[]> =>
+  runElectronEffect(
+    verifyPackagedElectronSidecarsEffect({
       arch,
       platform,
       releaseDirectory,
-      sidecarId,
-    });
-    const metadata = await assertPackagedSidecarFile({ path: sidecarPath, platform, sidecarId });
-
-    if (platform !== "windows" && process.platform !== "win32" && (metadata.mode & 0o111) === 0) {
-      throw new Error(
-        `Invalid packaged Electron ${electronSidecarDisplayName(sidecarId)} sidecar payload for ${platform}: expected an executable file. Expected path: ${sidecarPath}`,
-      );
-    }
-
-    verifiedSidecars.push({ id: sidecarId, path: sidecarPath });
-  }
-
-  return verifiedSidecars;
-};
+    }),
+  );

--- a/apps/electron/scripts/verify-electron-sidecar-package.ts
+++ b/apps/electron/scripts/verify-electron-sidecar-package.ts
@@ -127,13 +127,15 @@ export const verifyPackagedElectronSidecarsEffect = ({
       });
 
       if (platform !== "windows" && process.platform !== "win32" && (metadata.mode & 0o111) === 0) {
-        return yield* new ElectronOperationError({
-          operation: "electron.sidecar.verify-packaged-executable",
-          message: `Invalid packaged Electron ${electronSidecarDisplayName(sidecarId)} sidecar payload for ${platform}: expected an executable file. Expected path: ${sidecarPath}`,
-          path: sidecarPath,
-          platform,
-          details: { sidecarId },
-        });
+        return yield* Effect.fail(
+          new ElectronOperationError({
+            operation: "electron.sidecar.verify-packaged-executable",
+            message: `Invalid packaged Electron ${electronSidecarDisplayName(sidecarId)} sidecar payload for ${platform}: expected an executable file. Expected path: ${sidecarPath}`,
+            path: sidecarPath,
+            platform,
+            details: { sidecarId },
+          }),
+        );
       }
 
       verifiedSidecars.push({ id: sidecarId, path: sidecarPath });

--- a/apps/electron/src/effect/electron-boundary.ts
+++ b/apps/electron/src/effect/electron-boundary.ts
@@ -1,5 +1,5 @@
-import { type Cause, Effect, Exit } from "effect";
-import { causeToElectronBoundaryError, errorMessage } from "./electron-errors";
+import { Effect, Exit } from "effect";
+import { causeToElectronBoundaryError } from "./electron-errors";
 
 export const runElectronEffect = async <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
   const exit = await Effect.runPromiseExit(effect);
@@ -17,8 +17,4 @@ export const runElectronSync = <A, E>(effect: Effect.Effect<A, E>): A => {
   }
 
   throw causeToElectronBoundaryError(exit.cause);
-};
-
-export const logElectronBoundaryError = <E>(cause: Cause.Cause<E>): void => {
-  console.error(errorMessage(causeToElectronBoundaryError(cause)));
 };

--- a/apps/electron/src/effect/electron-boundary.ts
+++ b/apps/electron/src/effect/electron-boundary.ts
@@ -1,0 +1,24 @@
+import { type Cause, Effect, Exit } from "effect";
+import { causeToElectronBoundaryError, errorMessage } from "./electron-errors";
+
+export const runElectronEffect = async <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+
+  throw causeToElectronBoundaryError(exit.cause);
+};
+
+export const runElectronSync = <A, E>(effect: Effect.Effect<A, E>): A => {
+  const exit = Effect.runSyncExit(effect);
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+
+  throw causeToElectronBoundaryError(exit.cause);
+};
+
+export const logElectronBoundaryError = <E>(cause: Cause.Cause<E>): void => {
+  console.error(errorMessage(causeToElectronBoundaryError(cause)));
+};

--- a/apps/electron/src/effect/electron-boundary.ts
+++ b/apps/electron/src/effect/electron-boundary.ts
@@ -1,7 +1,9 @@
 import { Effect, Exit } from "effect";
 import { causeToElectronBoundaryError } from "./electron-errors";
 
-export const runElectronEffect = async <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
+export const runElectronEffect = async <A, E extends Error>(
+  effect: Effect.Effect<A, E>,
+): Promise<A> => {
   const exit = await Effect.runPromiseExit(effect);
   if (Exit.isSuccess(exit)) {
     return exit.value;
@@ -10,7 +12,7 @@ export const runElectronEffect = async <A, E>(effect: Effect.Effect<A, E>): Prom
   throw causeToElectronBoundaryError(exit.cause);
 };
 
-export const runElectronSync = <A, E>(effect: Effect.Effect<A, E>): A => {
+export const runElectronSync = <A, E extends Error>(effect: Effect.Effect<A, E>): A => {
   const exit = Effect.runSyncExit(effect);
   if (Exit.isSuccess(exit)) {
     return exit.value;

--- a/apps/electron/src/effect/electron-config.ts
+++ b/apps/electron/src/effect/electron-config.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { Effect } from "effect";
+import { ElectronValidationError, errorMessage } from "./electron-errors";
+
+export const DEFAULT_RENDERER_DEV_PORT = 1430;
+
+export const resolveRendererDevPortEffect = (
+  rawPort: string | undefined,
+  operation = "electron.config.resolve-renderer-dev-port",
+): Effect.Effect<number, ElectronValidationError> =>
+  Effect.try({
+    try: () => resolveRendererDevPort(rawPort, operation),
+    catch: (cause) =>
+      cause instanceof ElectronValidationError
+        ? cause
+        : new ElectronValidationError({
+            operation,
+            message: errorMessage(cause),
+            field: "ELECTRON_RENDERER_DEV_PORT",
+            cause,
+          }),
+  });
+
+export const resolveRendererDevPort = (
+  rawPort: string | undefined,
+  operation = "electron.config.resolve-renderer-dev-port",
+): number => {
+  const trimmedPort = rawPort?.trim();
+  if (!trimmedPort) {
+    return DEFAULT_RENDERER_DEV_PORT;
+  }
+
+  if (!/^\d+$/.test(trimmedPort)) {
+    throw new ElectronValidationError({
+      operation,
+      message: `ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: ${rawPort}`,
+      field: "ELECTRON_RENDERER_DEV_PORT",
+      details: { rawPort },
+    });
+  }
+
+  const port = Number(trimmedPort);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new ElectronValidationError({
+      operation,
+      message: `ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: ${rawPort}`,
+      field: "ELECTRON_RENDERER_DEV_PORT",
+      details: { rawPort },
+    });
+  }
+
+  return port;
+};
+
+export const readPackageVersionEffect = (
+  packageJsonPath: string,
+): Effect.Effect<string, ElectronValidationError> =>
+  Effect.try({
+    try: () => readPackageVersion(packageJsonPath),
+    catch: (cause) =>
+      cause instanceof ElectronValidationError
+        ? cause
+        : new ElectronValidationError({
+            operation: "electron.config.read-package-version",
+            message: errorMessage(cause),
+            path: packageJsonPath,
+            cause,
+          }),
+  });
+
+export const readPackageVersion = (packageJsonPath: string): string => {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
+    version?: unknown;
+  };
+  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+    throw new ElectronValidationError({
+      operation: "electron.config.read-package-version",
+      message: `Missing package version in ${packageJsonPath}`,
+      path: packageJsonPath,
+      field: "version",
+    });
+  }
+  return packageJson.version;
+};

--- a/apps/electron/src/effect/electron-config.ts
+++ b/apps/electron/src/effect/electron-config.ts
@@ -40,7 +40,7 @@ export const resolveRendererDevPort = (
   }
 
   const port = Number(trimmedPort);
-  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+  if (port <= 0 || port > 65_535) {
     throw new ElectronValidationError({
       operation,
       message: `ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: ${rawPort}`,
@@ -69,9 +69,19 @@ export const readPackageVersionEffect = (
   });
 
 export const readPackageVersion = (packageJsonPath: string): string => {
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
-    version?: unknown;
-  };
+  let packageJson: { version?: unknown };
+  try {
+    packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
+      version?: unknown;
+    };
+  } catch (cause) {
+    throw new ElectronValidationError({
+      operation: "electron.config.read-package-version",
+      message: errorMessage(cause),
+      path: packageJsonPath,
+      cause,
+    });
+  }
   if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
     throw new ElectronValidationError({
       operation: "electron.config.read-package-version",

--- a/apps/electron/src/effect/electron-errors.ts
+++ b/apps/electron/src/effect/electron-errors.ts
@@ -1,0 +1,71 @@
+import { Cause, Chunk, Data, Option } from "effect";
+
+export type ElectronErrorDetails = Readonly<Record<string, unknown>>;
+
+type ElectronErrorContext = {
+  readonly message: string;
+  readonly operation: string;
+  readonly arch?: string | undefined;
+  readonly cause?: unknown | undefined;
+  readonly details?: ElectronErrorDetails | undefined;
+  readonly path?: string | undefined;
+  readonly platform?: string | undefined;
+};
+
+export class ElectronValidationError extends Data.TaggedError("ElectronValidationError")<
+  ElectronErrorContext & {
+    readonly field?: string | undefined;
+  }
+> {}
+
+export class ElectronOperationError extends Data.TaggedError(
+  "ElectronOperationError",
+)<ElectronErrorContext> {}
+
+export class ElectronLifecycleError extends Data.TaggedError("ElectronLifecycleError")<
+  ElectronErrorContext & {
+    readonly reason?: string | undefined;
+  }
+> {}
+
+export type ElectronError =
+  | ElectronLifecycleError
+  | ElectronOperationError
+  | ElectronValidationError;
+
+export const isElectronError = (cause: unknown): cause is ElectronError =>
+  cause instanceof ElectronLifecycleError ||
+  cause instanceof ElectronOperationError ||
+  cause instanceof ElectronValidationError;
+
+export const errorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);
+
+export const toElectronOperationError = (
+  cause: unknown,
+  operation: string,
+  details?: ElectronErrorDetails,
+): ElectronOperationError =>
+  cause instanceof ElectronOperationError
+    ? cause
+    : new ElectronOperationError({
+        operation,
+        message: errorMessage(cause),
+        cause,
+        details,
+      });
+
+export const causeToElectronBoundaryError = <Failure>(
+  cause: Cause.Cause<Failure>,
+): Failure | ElectronOperationError => {
+  const firstFailure = Chunk.head(Cause.failures(cause));
+  if (Option.isSome(firstFailure)) {
+    return firstFailure.value;
+  }
+
+  return new ElectronOperationError({
+    operation: "electron.effect.run",
+    message: Cause.pretty(cause),
+    details: { defect: true },
+  });
+};

--- a/apps/electron/src/main/electron-app-identity.test.ts
+++ b/apps/electron/src/main/electron-app-identity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
 import path from "node:path";
+import { ElectronOperationError } from "../effect/electron-errors";
 import { configureElectronAppIdentity, resolveElectronProfilePath } from "./electron-app-identity";
 
 const customAppName = "Custom App";
@@ -154,23 +155,36 @@ describe("configureElectronAppIdentity", () => {
   });
 
   test("surfaces profile directory creation failures with the app name and profile path", () => {
-    expect(() =>
-      configureElectronAppIdentity(
-        {
-          setName() {},
-          setPath() {
-            throw new Error("setPath should not run after mkdir failure");
+    const error = (() => {
+      try {
+        configureElectronAppIdentity(
+          {
+            setName() {},
+            setPath() {
+              throw new Error("setPath should not run after mkdir failure");
+            },
           },
-        },
-        {
-          appName: customAppName,
-          processEnv: { OPENDUCKTOR_CONFIG_DIR: customConfigPath },
-          createDirectory() {
-            throw new Error("permission denied");
+          {
+            appName: customAppName,
+            processEnv: { OPENDUCKTOR_CONFIG_DIR: customConfigPath },
+            createDirectory() {
+              throw new Error("permission denied");
+            },
           },
-        },
-      ),
-    ).toThrow(
+        );
+      } catch (caught) {
+        return caught;
+      }
+      throw new Error("Expected configureElectronAppIdentity to fail.");
+    })();
+
+    expect(error).toBeInstanceOf(ElectronOperationError);
+    expect(error).toMatchObject({
+      _tag: "ElectronOperationError",
+      operation: "electron.app-identity.prepare-profile-directory",
+      path: customProfilePath,
+    });
+    expect((error as Error).message).toBe(
       `Failed to prepare Custom App Electron profile directory at ${customProfilePath}: permission denied`,
     );
   });

--- a/apps/electron/src/main/electron-app-identity.ts
+++ b/apps/electron/src/main/electron-app-identity.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { resolveOpenDucktorBaseDir } from "@openducktor/host";
+import { ElectronOperationError, errorMessage } from "../effect/electron-errors";
 
 type ElectronAppIdentity = {
   setName(name: string): void;
@@ -15,13 +16,6 @@ type ConfigureElectronAppIdentityOptions = {
   createDirectory?: CreateProfileDirectory;
   processEnv?: NodeJS.ProcessEnv;
   resolveConfigDirectory?: ResolveConfigDirectory;
-};
-
-const errorMessage = (cause: unknown): string => {
-  if (cause instanceof Error) {
-    return cause.message;
-  }
-  return String(cause);
 };
 
 const createProfileDirectory: CreateProfileDirectory = (profilePath) => {
@@ -49,10 +43,13 @@ export const configureElectronAppIdentity = (
     createDirectory(profilePath);
   } catch (cause) {
     const pathContext = profilePath.length > 0 ? ` at ${profilePath}` : "";
-    throw new Error(
-      `Failed to prepare ${appName} Electron profile directory${pathContext}: ${errorMessage(cause)}`,
-      { cause },
-    );
+    throw new ElectronOperationError({
+      operation: "electron.app-identity.prepare-profile-directory",
+      message: `Failed to prepare ${appName} Electron profile directory${pathContext}: ${errorMessage(cause)}`,
+      path: profilePath.length > 0 ? profilePath : undefined,
+      cause,
+      details: { appName },
+    });
   }
   app.setPath("userData", profilePath);
   app.setPath("sessionData", profilePath);

--- a/apps/electron/src/main/electron-host.ts
+++ b/apps/electron/src/main/electron-host.ts
@@ -1,4 +1,5 @@
 export {
   type CreateNodeHostCommandRouterInput as CreateElectronHostCommandRouterInput,
+  createNodeEffectHostCommandRouter as createElectronEffectHostCommandRouter,
   createNodeHostCommandRouter as createElectronHostCommandRouter,
 } from "@openducktor/host";

--- a/apps/electron/src/main/electron-local-attachment-preview.test.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.test.ts
@@ -8,6 +8,15 @@ import {
   registerElectronLocalAttachmentPreviewProtocol,
 } from "./electron-local-attachment-preview";
 
+const captureThrown = (action: () => unknown): unknown => {
+  try {
+    action();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected action to fail.");
+};
+
 describe("electron local attachment previews", () => {
   test("creates an app protocol URL for staged attachment paths", () => {
     const previewUrl = createElectronLocalAttachmentPreviewUrl(
@@ -23,14 +32,7 @@ describe("electron local attachment previews", () => {
   });
 
   test("rejects missing or malformed preview paths", () => {
-    const blankPathError = (() => {
-      try {
-        readLocalAttachmentPreviewPath("  ");
-      } catch (error) {
-        return error;
-      }
-      throw new Error("Expected readLocalAttachmentPreviewPath to fail.");
-    })();
+    const blankPathError = captureThrown(() => readLocalAttachmentPreviewPath("  "));
 
     expect(blankPathError).toBeInstanceOf(ElectronValidationError);
     expect(blankPathError).toMatchObject({
@@ -38,19 +40,40 @@ describe("electron local attachment previews", () => {
       operation: "electron.preview.read-path",
       message: "Local attachment preview path must be a non-empty string.",
     });
-    expect(() => readLocalAttachmentPreviewPath(null)).toThrow(
-      "Local attachment preview path must be a non-empty string.",
-    );
-    expect(() =>
+    const nullPathError = captureThrown(() => readLocalAttachmentPreviewPath(null));
+    expect(nullPathError).toBeInstanceOf(ElectronValidationError);
+    expect(nullPathError).toMatchObject({
+      _tag: "ElectronValidationError",
+      operation: "electron.preview.read-path",
+      field: "path",
+      message: "Local attachment preview path must be a non-empty string.",
+    });
+
+    const invalidUrlError = captureThrown(() =>
       readElectronLocalAttachmentPreviewRequestPath(
         "file:///tmp/openducktor-local-attachments/a.png",
       ),
-    ).toThrow("Invalid local attachment preview URL.");
-    expect(() =>
+    );
+    expect(invalidUrlError).toBeInstanceOf(ElectronValidationError);
+    expect(invalidUrlError).toMatchObject({
+      _tag: "ElectronValidationError",
+      operation: "electron.preview.validate-url",
+      field: "url",
+      message: "Invalid local attachment preview URL.",
+    });
+
+    const malformedUrlError = captureThrown(() =>
       readElectronLocalAttachmentPreviewRequestPath(
         `${ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL}://preview/%`,
       ),
-    ).toThrow("Invalid local attachment preview URL.");
+    );
+    expect(malformedUrlError).toBeInstanceOf(ElectronValidationError);
+    expect(malformedUrlError).toMatchObject({
+      _tag: "ElectronValidationError",
+      operation: "electron.preview.decode-url-path",
+      field: "url",
+      message: "Invalid local attachment preview URL.",
+    });
   });
 
   test("resolves the protocol request through the host before serving the file", async () => {

--- a/apps/electron/src/main/electron-local-attachment-preview.test.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { ElectronValidationError } from "../effect/electron-errors";
 import {
   createElectronLocalAttachmentPreviewUrl,
   ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
@@ -22,9 +23,21 @@ describe("electron local attachment previews", () => {
   });
 
   test("rejects missing or malformed preview paths", () => {
-    expect(() => readLocalAttachmentPreviewPath("  ")).toThrow(
-      "Local attachment preview path must be a non-empty string.",
-    );
+    const blankPathError = (() => {
+      try {
+        readLocalAttachmentPreviewPath("  ");
+      } catch (error) {
+        return error;
+      }
+      throw new Error("Expected readLocalAttachmentPreviewPath to fail.");
+    })();
+
+    expect(blankPathError).toBeInstanceOf(ElectronValidationError);
+    expect(blankPathError).toMatchObject({
+      _tag: "ElectronValidationError",
+      operation: "electron.preview.read-path",
+      message: "Local attachment preview path must be a non-empty string.",
+    });
     expect(() => readLocalAttachmentPreviewPath(null)).toThrow(
       "Local attachment preview path must be a non-empty string.",
     );
@@ -145,6 +158,41 @@ describe("electron local attachment previews", () => {
 
     expect(response.status).toBe(400);
     expect(await response.text()).toBe("Attachment path is not a staged local attachment.");
+  });
+
+  test("returns structured error responses for invalid host resolver return shapes", async () => {
+    let protocolHandler: ((request: Request) => Response | Promise<Response>) | null = null;
+
+    registerElectronLocalAttachmentPreviewProtocol({
+      session: {
+        protocol: {
+          handle(_scheme, handler) {
+            protocolHandler = handler;
+          },
+        },
+      },
+      net: {
+        async fetch() {
+          throw new Error("Fetch should not run when resolution returns an invalid shape.");
+        },
+      },
+      async resolveLocalAttachmentPath() {
+        return null as never;
+      },
+    });
+
+    if (!protocolHandler) {
+      throw new Error("Preview protocol handler was not registered.");
+    }
+
+    const response = await protocolHandler(
+      new Request(
+        createElectronLocalAttachmentPreviewUrl("/tmp/openducktor-local-attachments/staged.png"),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Local attachment preview path must be a non-empty string.");
   });
 
   test("returns structured error responses for preview file serving failures", async () => {

--- a/apps/electron/src/main/electron-local-attachment-preview.test.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.test.ts
@@ -219,7 +219,7 @@ describe("electron local attachment previews", () => {
         },
       },
       async resolveLocalAttachmentPath() {
-        return null as never;
+        return null;
       },
     });
 

--- a/apps/electron/src/main/electron-local-attachment-preview.test.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { ElectronValidationError } from "../effect/electron-errors";
+import { ElectronOperationError, ElectronValidationError } from "../effect/electron-errors";
 import {
   createElectronLocalAttachmentPreviewUrl,
   ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
@@ -142,7 +142,11 @@ describe("electron local attachment previews", () => {
         },
       },
       async resolveLocalAttachmentPath() {
-        throw new Error("Attachment path is not a staged local attachment.");
+        throw new ElectronValidationError({
+          operation: "electron.preview.resolve-host-path",
+          message: "Attachment path is not a staged local attachment.",
+          field: "path",
+        });
       },
     });
 
@@ -158,6 +162,44 @@ describe("electron local attachment previews", () => {
 
     expect(response.status).toBe(400);
     expect(await response.text()).toBe("Attachment path is not a staged local attachment.");
+  });
+
+  test("returns structured error responses for host resolver operation failures", async () => {
+    let protocolHandler: ((request: Request) => Response | Promise<Response>) | null = null;
+
+    registerElectronLocalAttachmentPreviewProtocol({
+      session: {
+        protocol: {
+          handle(_scheme, handler) {
+            protocolHandler = handler;
+          },
+        },
+      },
+      net: {
+        async fetch() {
+          throw new Error("Fetch should not run when host resolution fails.");
+        },
+      },
+      async resolveLocalAttachmentPath() {
+        throw new ElectronOperationError({
+          operation: "electron.preview.resolve-host-path",
+          message: "Host command router failed.",
+        });
+      },
+    });
+
+    if (!protocolHandler) {
+      throw new Error("Preview protocol handler was not registered.");
+    }
+
+    const response = await protocolHandler(
+      new Request(
+        createElectronLocalAttachmentPreviewUrl("/tmp/openducktor-local-attachments/staged.png"),
+      ),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.text()).toBe("Host command router failed.");
   });
 
   test("returns structured error responses for invalid host resolver return shapes", async () => {

--- a/apps/electron/src/main/electron-local-attachment-preview.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.ts
@@ -24,7 +24,7 @@ type ElectronPreviewNet = {
 
 type RegisterElectronLocalAttachmentPreviewProtocolInput = {
   net: ElectronPreviewNet;
-  resolveLocalAttachmentPath: (filePath: string) => Promise<string>;
+  resolveLocalAttachmentPath: (filePath: string) => Promise<unknown>;
   session: ElectronPreviewSession;
 };
 
@@ -138,7 +138,7 @@ const createLocalAttachmentPreviewErrorResponse = (error: unknown, status: 400 |
   });
 
 const resolveLocalAttachmentPathEffect = (
-  resolveLocalAttachmentPath: (filePath: string) => Promise<string>,
+  resolveLocalAttachmentPath: (filePath: string) => Promise<unknown>,
   requestedPath: string,
 ): Effect.Effect<string, ElectronOperationError | ElectronValidationError> =>
   Effect.tryPromise({

--- a/apps/electron/src/main/electron-local-attachment-preview.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.ts
@@ -124,7 +124,7 @@ export const readElectronLocalAttachmentPreviewRequestPathEffect = (
       cause instanceof ElectronValidationError
         ? cause
         : new ElectronValidationError({
-            operation: "electron.preview.parse-url",
+            operation: "electron.preview.read-request-path",
             message: errorMessage(cause),
             field: "url",
             cause,

--- a/apps/electron/src/main/electron-local-attachment-preview.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.ts
@@ -140,17 +140,18 @@ const createLocalAttachmentPreviewErrorResponse = (error: unknown, status: 400 |
 const resolveLocalAttachmentPathEffect = (
   resolveLocalAttachmentPath: (filePath: string) => Promise<string>,
   requestedPath: string,
-): Effect.Effect<string, ElectronValidationError> =>
+): Effect.Effect<string, ElectronOperationError | ElectronValidationError> =>
   Effect.tryPromise({
     try: () => resolveLocalAttachmentPath(requestedPath),
     catch: (cause) =>
-      new ElectronValidationError({
-        operation: "electron.preview.resolve-path",
-        message: errorMessage(cause),
-        field: "path",
-        cause,
-        details: { requestedPath },
-      }),
+      cause instanceof ElectronValidationError || cause instanceof ElectronOperationError
+        ? cause
+        : new ElectronOperationError({
+            operation: "electron.preview.resolve-path",
+            message: errorMessage(cause),
+            path: requestedPath,
+            cause,
+          }),
   }).pipe(
     Effect.flatMap((resolvedPath) =>
       readLocalAttachmentPreviewPathEffect(resolvedPath).pipe(
@@ -207,8 +208,15 @@ export const registerElectronLocalAttachmentPreviewProtocol = ({
     if (Option.isSome(firstFailure) && firstFailure.value instanceof ElectronValidationError) {
       return createLocalAttachmentPreviewErrorResponse(firstFailure.value, 400);
     }
+    if (Option.isSome(firstFailure)) {
+      return createLocalAttachmentPreviewErrorResponse(firstFailure.value, 500);
+    }
     return createLocalAttachmentPreviewErrorResponse(
-      Option.isSome(firstFailure) ? firstFailure.value : Cause.pretty(exit.cause),
+      new ElectronOperationError({
+        operation: "electron.preview.handle-request",
+        message: "Local attachment preview failed.",
+        details: { defect: true },
+      }),
       500,
     );
   });

--- a/apps/electron/src/main/electron-local-attachment-preview.ts
+++ b/apps/electron/src/main/electron-local-attachment-preview.ts
@@ -1,4 +1,10 @@
 import { pathToFileURL } from "node:url";
+import { Cause, Chunk, Effect, Exit, Option } from "effect";
+import {
+  ElectronOperationError,
+  ElectronValidationError,
+  errorMessage,
+} from "../effect/electron-errors";
 
 export const ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL = "openducktor-local-attachment";
 
@@ -24,11 +30,32 @@ type RegisterElectronLocalAttachmentPreviewProtocolInput = {
 
 export const readLocalAttachmentPreviewPath = (filePath: unknown): string => {
   if (typeof filePath !== "string" || filePath.trim().length === 0) {
-    throw new Error("Local attachment preview path must be a non-empty string.");
+    throw new ElectronValidationError({
+      operation: "electron.preview.read-path",
+      message: "Local attachment preview path must be a non-empty string.",
+      field: "path",
+      details: { valueType: typeof filePath },
+    });
   }
 
   return filePath.trim();
 };
+
+export const readLocalAttachmentPreviewPathEffect = (
+  filePath: unknown,
+): Effect.Effect<string, ElectronValidationError> =>
+  Effect.try({
+    try: () => readLocalAttachmentPreviewPath(filePath),
+    catch: (cause) =>
+      cause instanceof ElectronValidationError
+        ? cause
+        : new ElectronValidationError({
+            operation: "electron.preview.read-path",
+            message: errorMessage(cause),
+            field: "path",
+            cause,
+          }),
+  });
 
 export const createElectronLocalAttachmentPreviewUrl = (filePath: string): string => {
   const previewPath = readLocalAttachmentPreviewPath(filePath);
@@ -40,36 +67,120 @@ export const readElectronLocalAttachmentPreviewRequestPath = (requestUrl: string
   try {
     parsedUrl = new URL(requestUrl);
   } catch {
-    throw new Error("Invalid local attachment preview URL.");
+    throw new ElectronValidationError({
+      operation: "electron.preview.parse-url",
+      message: "Invalid local attachment preview URL.",
+      field: "url",
+      details: { requestUrl },
+    });
   }
 
   if (
     parsedUrl.protocol !== `${ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL}:` ||
     parsedUrl.hostname !== ELECTRON_LOCAL_ATTACHMENT_PREVIEW_HOST
   ) {
-    throw new Error("Invalid local attachment preview URL.");
+    throw new ElectronValidationError({
+      operation: "electron.preview.validate-url",
+      message: "Invalid local attachment preview URL.",
+      field: "url",
+      details: { requestUrl },
+    });
   }
 
   const encodedPath = parsedUrl.pathname.startsWith("/")
     ? parsedUrl.pathname.slice(1)
     : parsedUrl.pathname;
   if (encodedPath.length === 0) {
-    throw new Error("Local attachment preview path must be a non-empty string.");
+    throw new ElectronValidationError({
+      operation: "electron.preview.validate-url-path",
+      message: "Local attachment preview path must be a non-empty string.",
+      field: "path",
+      details: { requestUrl },
+    });
   }
 
   try {
     return readLocalAttachmentPreviewPath(decodeURIComponent(encodedPath));
   } catch (error) {
     if (error instanceof URIError) {
-      throw new Error("Invalid local attachment preview URL.");
+      throw new ElectronValidationError({
+        operation: "electron.preview.decode-url-path",
+        message: "Invalid local attachment preview URL.",
+        field: "url",
+        cause: error,
+        details: { requestUrl },
+      });
     }
     throw error;
   }
 };
 
+export const readElectronLocalAttachmentPreviewRequestPathEffect = (
+  requestUrl: string,
+): Effect.Effect<string, ElectronValidationError> =>
+  Effect.try({
+    try: () => readElectronLocalAttachmentPreviewRequestPath(requestUrl),
+    catch: (cause) =>
+      cause instanceof ElectronValidationError
+        ? cause
+        : new ElectronValidationError({
+            operation: "electron.preview.parse-url",
+            message: errorMessage(cause),
+            field: "url",
+            cause,
+            details: { requestUrl },
+          }),
+  });
+
 const createLocalAttachmentPreviewErrorResponse = (error: unknown, status: 400 | 500): Response =>
-  new Response(error instanceof Error ? error.message : "Local attachment preview failed.", {
+  new Response(errorMessage(error) || "Local attachment preview failed.", {
     status,
+  });
+
+const resolveLocalAttachmentPathEffect = (
+  resolveLocalAttachmentPath: (filePath: string) => Promise<string>,
+  requestedPath: string,
+): Effect.Effect<string, ElectronValidationError> =>
+  Effect.tryPromise({
+    try: () => resolveLocalAttachmentPath(requestedPath),
+    catch: (cause) =>
+      new ElectronValidationError({
+        operation: "electron.preview.resolve-path",
+        message: errorMessage(cause),
+        field: "path",
+        cause,
+        details: { requestedPath },
+      }),
+  }).pipe(
+    Effect.flatMap((resolvedPath) =>
+      readLocalAttachmentPreviewPathEffect(resolvedPath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ElectronValidationError({
+              operation: "electron.preview.validate-resolved-path",
+              message: cause.message,
+              field: "path",
+              cause,
+              details: { requestedPath },
+            }),
+        ),
+      ),
+    ),
+  );
+
+const fetchLocalAttachmentPreviewEffect = (
+  net: ElectronPreviewNet,
+  resolvedPath: string,
+): Effect.Effect<Response, ElectronOperationError> =>
+  Effect.tryPromise({
+    try: () => net.fetch(pathToFileURL(resolvedPath).href),
+    catch: (cause) =>
+      new ElectronOperationError({
+        operation: "electron.preview.fetch-file",
+        message: errorMessage(cause),
+        path: resolvedPath,
+        cause,
+      }),
   });
 
 export const registerElectronLocalAttachmentPreviewProtocol = ({
@@ -78,26 +189,27 @@ export const registerElectronLocalAttachmentPreviewProtocol = ({
   session,
 }: RegisterElectronLocalAttachmentPreviewProtocolInput): void => {
   session.protocol.handle(ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL, async (request) => {
-    let requestedPath: string;
-    try {
-      requestedPath = readElectronLocalAttachmentPreviewRequestPath(request.url);
-    } catch (error) {
-      return createLocalAttachmentPreviewErrorResponse(error, 400);
-    }
-
-    let resolvedPath: string;
-    try {
-      resolvedPath = readLocalAttachmentPreviewPath(
-        await resolveLocalAttachmentPath(requestedPath),
+    const effect = Effect.gen(function* () {
+      const requestedPath = yield* readElectronLocalAttachmentPreviewRequestPathEffect(request.url);
+      const resolvedPath = yield* resolveLocalAttachmentPathEffect(
+        resolveLocalAttachmentPath,
+        requestedPath,
       );
-    } catch (error) {
-      return createLocalAttachmentPreviewErrorResponse(error, 400);
+      return yield* fetchLocalAttachmentPreviewEffect(net, resolvedPath);
+    });
+
+    const exit = await Effect.runPromiseExit(effect);
+    if (Exit.isSuccess(exit)) {
+      return exit.value;
     }
 
-    try {
-      return await net.fetch(pathToFileURL(resolvedPath).href);
-    } catch (error) {
-      return createLocalAttachmentPreviewErrorResponse(error, 500);
+    const firstFailure = Chunk.head(Cause.failures(exit.cause));
+    if (Option.isSome(firstFailure) && firstFailure.value instanceof ElectronValidationError) {
+      return createLocalAttachmentPreviewErrorResponse(firstFailure.value, 400);
     }
+    return createLocalAttachmentPreviewErrorResponse(
+      Option.isSome(firstFailure) ? firstFailure.value : Cause.pretty(exit.cause),
+      500,
+    );
   });
 };

--- a/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
+++ b/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { Effect } from "effect";
+import { runElectronEffect } from "../effect/electron-boundary";
+import { ElectronLifecycleError } from "../effect/electron-errors";
+import {
+  composeElectronMainStartupEffect,
+  createElectronMainShutdownController,
+  runElectronMainStartupBoundary,
+} from "./electron-main-lifecycle";
 
 const REPO_ROOT = resolve(import.meta.dir, "../../../..");
 
@@ -27,16 +35,13 @@ describe("Electron main lifecycle policy", () => {
     expect(source).toContain("app.dock.setIcon(");
   });
 
-  test("window close quits through host shutdown instead of keeping macOS app alive", () => {
+  test("window close hides windows and routes through host shutdown", () => {
     const source = readRepoFile("apps/electron/src/main/main.ts");
 
     expect(source).toContain('window.on("close"');
     expect(source).toContain("event.preventDefault();");
     expect(source).toContain("hideWindowsForShutdown();");
     expect(source).not.toContain("window.destroy();");
-    expect(source).toContain('app.on("window-all-closed"');
-    expect(source).toContain('void shutdownHostAndQuit({ reason: "window-all-closed" });');
-    expect(source).toContain("if (hostShutdownStarted)");
   });
 
   test("Windows and Linux keep the menu hidden until the native reveal shortcut", () => {
@@ -45,33 +50,175 @@ describe("Electron main lifecycle policy", () => {
     expect(source).toContain('autoHideMenuBar: process.platform !== "darwin"');
   });
 
-  test("Cmd+Q waits for the host shutdown boundary before quitting", () => {
-    const source = readRepoFile("apps/electron/src/main/main.ts");
+  test("startup runs pre-ready setup before app readiness and initializes host before window", async () => {
+    const calls: string[] = [];
 
-    expect(source).toContain('app.on("before-quit"');
-    expect(source).toContain("event.preventDefault();");
-    expect(source).toContain("hideWindowsForShutdown();");
-    expect(source).toContain("Effect.runPromiseExit(disposeHostEffect(reason))");
-    expect(source).toContain('operation: "electron.main.dispose-host"');
+    const ready = await runElectronEffect(
+      composeElectronMainStartupEffect({
+        configureReady: (preReady: string) =>
+          Effect.sync(() => {
+            calls.push(`configure-ready:${preReady}`);
+            return { router: preReady, session: "renderer-session" };
+          }),
+        createMainWindow: (runtime) =>
+          Effect.sync(() => {
+            calls.push(`create-window:${runtime.session}`);
+          }),
+        initializeHost: (runtime) =>
+          Effect.sync(() => {
+            calls.push(`initialize-host:${runtime.router}`);
+          }),
+        preparePreReady: () =>
+          Effect.sync(() => {
+            calls.push("prepare-pre-ready");
+            return "host-router";
+          }),
+        registerActivateHandler: (runtime) => {
+          calls.push(`register-activate:${runtime.session}`);
+        },
+        waitUntilReady: () =>
+          Effect.sync(() => {
+            calls.push("wait-until-ready");
+          }),
+      }),
+    );
+
+    expect(ready).toEqual({ router: "host-router", session: "renderer-session" });
+    expect(calls).toEqual([
+      "prepare-pre-ready",
+      "wait-until-ready",
+      "configure-ready:host-router",
+      "initialize-host:host-router",
+      "create-window:renderer-session",
+      "register-activate:renderer-session",
+    ]);
   });
 
-  test("main process uses the Effect-native host router internally", () => {
-    const source = readRepoFile("apps/electron/src/main/main.ts");
+  test("startup boundary logs typed setup failures, runs cleanup, marks shutdown, and exits", async () => {
+    const startupError = new ElectronLifecycleError({
+      operation: "electron.main.configure-app-identity",
+      message: "profile setup failed",
+    });
+    const errors: Array<{ error: unknown; message: string }> = [];
+    const exitCodes: number[] = [];
+    let cleanupCalls = 0;
+    let shutdownStarted = false;
+    let shutdownComplete = false;
 
-    expect(source).toContain("createElectronEffectHostCommandRouter");
-    expect(source).toContain("runElectronEffect(hostCommandRouter.invoke");
-    expect(source).toContain("runElectronEffect(initializeHostEffect())");
+    await runElectronMainStartupBoundary({
+      cleanupAfterFailure: () =>
+        Effect.sync(() => {
+          cleanupCalls += 1;
+        }),
+      exitProcess: (exitCode) => {
+        exitCodes.push(exitCode);
+      },
+      logger: {
+        error(message, error) {
+          errors.push({ message, error });
+        },
+        info() {},
+      },
+      markShutdownComplete: () => {
+        shutdownComplete = true;
+      },
+      markShutdownStarted: () => {
+        shutdownStarted = true;
+      },
+      startupEffect: Effect.fail(startupError),
+    });
+
+    expect(cleanupCalls).toBe(1);
+    expect(shutdownStarted).toBe(true);
+    expect(shutdownComplete).toBe(true);
+    expect(exitCodes).toEqual([1]);
+    expect(errors).toEqual([
+      {
+        message: "OpenDucktor Electron startup failed",
+        error: startupError,
+      },
+    ]);
   });
 
-  test("process signals wait for host shutdown before exiting", () => {
-    const source = readRepoFile("apps/electron/src/main/main.ts");
+  test("shutdown controller disposes the host once for concurrent shutdown triggers", async () => {
+    const disposeReasons: string[] = [];
+    const quitCalls: string[] = [];
+    let releaseDispose: () => void = () => {};
+    const disposeGate = new Promise<void>((resolve) => {
+      releaseDispose = resolve;
+    });
+    const controller = createElectronMainShutdownController({
+      disposeHost: (reason) =>
+        Effect.tryPromise({
+          try: async () => {
+            disposeReasons.push(reason);
+            await disposeGate;
+          },
+          catch: (cause) =>
+            new ElectronLifecycleError({
+              operation: "electron.main.dispose-host",
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause,
+            }),
+        }),
+      exitProcess: () => {},
+      logger: {
+        error() {},
+        info() {},
+      },
+      quitApp: () => {
+        quitCalls.push("quit");
+      },
+    });
 
-    expect(source).toContain('process.once("SIGINT"');
-    expect(source).toContain('process.once("SIGTERM"');
-    expect(source).toContain('process.once("SIGHUP"');
-    expect(source).toContain("exitAfterShutdown: true");
-    expect(source).toContain("process.exit(exitCode)");
-    expect(source).toContain("OpenDucktor host shutdown started");
-    expect(source).toContain("OpenDucktor host shutdown complete");
+    const firstShutdown = controller.shutdownHostAndQuit({ reason: "window-all-closed" });
+    const secondShutdown = controller.shutdownHostAndQuit({ reason: "before-quit" });
+
+    await Promise.resolve();
+    expect(disposeReasons).toEqual(["window-all-closed"]);
+    expect(controller.isHostShutdownStarted()).toBe(true);
+
+    releaseDispose();
+    await Promise.all([firstShutdown, secondShutdown]);
+
+    expect(disposeReasons).toEqual(["window-all-closed"]);
+    expect(quitCalls).toEqual(["quit"]);
+    expect(controller.isHostShutdownComplete()).toBe(true);
+  });
+
+  test("shutdown controller exits with failure when host disposal fails on a signal path", async () => {
+    const errors: Array<{ error: unknown; message: string }> = [];
+    const exitCodes: number[] = [];
+    const disposalError = new ElectronLifecycleError({
+      operation: "electron.main.dispose-host",
+      message: "dispose failed",
+      reason: "SIGTERM",
+    });
+
+    const controller = createElectronMainShutdownController({
+      disposeHost: () => Effect.fail(disposalError),
+      exitProcess: (exitCode) => {
+        exitCodes.push(exitCode);
+      },
+      logger: {
+        error(message, error) {
+          errors.push({ message, error });
+        },
+        info() {},
+      },
+      quitApp: () => {
+        throw new Error("Expected signal shutdown to exit instead of quitting the app.");
+      },
+    });
+
+    await controller.shutdownHostAndQuit({ exitAfterShutdown: true, reason: "SIGTERM" });
+
+    expect(exitCodes).toEqual([1]);
+    expect(errors).toEqual([
+      {
+        message: "OpenDucktor host shutdown failed",
+        error: disposalError,
+      },
+    ]);
   });
 });

--- a/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
+++ b/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
@@ -13,7 +13,8 @@ describe("Electron main lifecycle policy", () => {
 
     expect(source).toContain("resolveElectronWindowIcon()");
     expect(source).toContain("nativeImage.createFromPath(iconPath)");
-    expect(source).toContain("throw new Error(");
+    expect(source).toContain("throw new ElectronOperationError({");
+    expect(source).toContain('operation: "electron.main.load-icon"');
     expect(source).toContain("icon is missing or invalid:");
     expect(source).toContain("icon: resolveElectronWindowIcon()");
   });
@@ -50,7 +51,16 @@ describe("Electron main lifecycle policy", () => {
     expect(source).toContain('app.on("before-quit"');
     expect(source).toContain("event.preventDefault();");
     expect(source).toContain("hideWindowsForShutdown();");
-    expect(source).toContain("await hostCommandRouter.dispose();");
+    expect(source).toContain("Effect.runPromiseExit(disposeHostEffect(reason))");
+    expect(source).toContain('operation: "electron.main.dispose-host"');
+  });
+
+  test("main process uses the Effect-native host router internally", () => {
+    const source = readRepoFile("apps/electron/src/main/main.ts");
+
+    expect(source).toContain("createElectronEffectHostCommandRouter");
+    expect(source).toContain("runElectronEffect(hostCommandRouter.invoke");
+    expect(source).toContain("runElectronEffect(initializeHostEffect())");
   });
 
   test("process signals wait for host shutdown before exiting", () => {

--- a/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
+++ b/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { Effect } from "effect";
+import { Cause, Chunk, Effect, Exit } from "effect";
 import { runElectronEffect } from "../effect/electron-boundary";
 import { ElectronLifecycleError } from "../effect/electron-errors";
 import {
@@ -92,6 +92,59 @@ describe("Electron main lifecycle policy", () => {
       "create-window:renderer-session",
       "register-activate:renderer-session",
     ]);
+  });
+
+  test("startup stops before ready configuration when shutdown has started", async () => {
+    const calls: string[] = [];
+    let shutdownStarted = false;
+
+    const exit = await Effect.runPromiseExit(
+      composeElectronMainStartupEffect({
+        configureReady: (preReady: string) =>
+          Effect.sync(() => {
+            calls.push(`configure-ready:${preReady}`);
+            return { router: preReady, session: "renderer-session" };
+          }),
+        createMainWindow: (runtime) =>
+          Effect.sync(() => {
+            calls.push(`create-window:${runtime.session}`);
+          }),
+        initializeHost: (runtime) =>
+          Effect.sync(() => {
+            calls.push(`initialize-host:${runtime.router}`);
+          }),
+        preparePreReady: () =>
+          Effect.sync(() => {
+            calls.push("prepare-pre-ready");
+            return "host-router";
+          }),
+        registerActivateHandler: (runtime) => {
+          calls.push(`register-activate:${runtime.session}`);
+        },
+        shouldContinueStartup: () => !shutdownStarted,
+        waitUntilReady: () =>
+          Effect.sync(() => {
+            calls.push("wait-until-ready");
+            shutdownStarted = true;
+          }),
+      }),
+    );
+
+    expect(calls).toEqual(["prepare-pre-ready", "wait-until-ready"]);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) {
+      throw new Error("Expected startup to fail after shutdown starts.");
+    }
+    const failure = Chunk.head(Cause.failures(exit.cause));
+    expect(failure._tag).toBe("Some");
+    if (failure._tag !== "Some") {
+      throw new Error("Expected startup shutdown failure.");
+    }
+    expect(failure.value).toMatchObject({
+      _tag: "ElectronLifecycleError",
+      operation: "electron.main.configure-ready",
+      reason: "shutdown-started",
+    });
   });
 
   test("startup boundary logs typed setup failures, runs cleanup, marks shutdown, and exits", async () => {

--- a/apps/electron/src/main/electron-main-lifecycle.ts
+++ b/apps/electron/src/main/electron-main-lifecycle.ts
@@ -1,6 +1,10 @@
 import { Effect, Exit } from "effect";
-import type { ElectronError, ElectronLifecycleError } from "../effect/electron-errors";
-import { causeToElectronBoundaryError } from "../effect/electron-errors";
+import {
+  causeToElectronBoundaryError,
+  type ElectronError,
+  type ElectronErrorDetails,
+  ElectronLifecycleError,
+} from "../effect/electron-errors";
 
 type ElectronMainLifecycleLogger = {
   error(message: string, error?: unknown): void;
@@ -13,7 +17,26 @@ export type ElectronMainStartupSteps<PreReady, Ready> = {
   initializeHost(ready: Ready): Effect.Effect<void, ElectronError>;
   preparePreReady(): Effect.Effect<PreReady, ElectronError>;
   registerActivateHandler(ready: Ready): void;
+  shouldContinueStartup?(): boolean;
   waitUntilReady(): Effect.Effect<void, ElectronError>;
+};
+
+const ensureStartupContinuesEffect = (
+  shouldContinueStartup: (() => boolean) | undefined,
+  operation: string,
+  details?: ElectronErrorDetails,
+): Effect.Effect<void, ElectronLifecycleError> => {
+  if (!shouldContinueStartup || shouldContinueStartup()) {
+    return Effect.void;
+  }
+  return Effect.fail(
+    new ElectronLifecycleError({
+      operation,
+      message: "Electron startup stopped because host shutdown has started.",
+      reason: "shutdown-started",
+      details,
+    }),
+  );
 };
 
 export const composeElectronMainStartupEffect = <PreReady, Ready>({
@@ -22,14 +45,28 @@ export const composeElectronMainStartupEffect = <PreReady, Ready>({
   initializeHost,
   preparePreReady,
   registerActivateHandler,
+  shouldContinueStartup,
   waitUntilReady,
 }: ElectronMainStartupSteps<PreReady, Ready>): Effect.Effect<Ready, ElectronError> =>
   Effect.gen(function* () {
     const preReady = yield* preparePreReady();
+    yield* ensureStartupContinuesEffect(shouldContinueStartup, "electron.main.before-ready-wait");
     yield* waitUntilReady();
+    yield* ensureStartupContinuesEffect(shouldContinueStartup, "electron.main.configure-ready", {
+      phase: "configure-ready",
+    });
     const ready = yield* configureReady(preReady);
+    yield* ensureStartupContinuesEffect(shouldContinueStartup, "electron.main.initialize-host", {
+      phase: "initialize-host",
+    });
     yield* initializeHost(ready);
+    yield* ensureStartupContinuesEffect(shouldContinueStartup, "electron.main.create-window", {
+      phase: "create-window",
+    });
     yield* createMainWindow(ready);
+    yield* ensureStartupContinuesEffect(shouldContinueStartup, "electron.main.register-activate", {
+      phase: "register-activate",
+    });
     yield* Effect.sync(() => {
       registerActivateHandler(ready);
     });

--- a/apps/electron/src/main/electron-main-lifecycle.ts
+++ b/apps/electron/src/main/electron-main-lifecycle.ts
@@ -1,0 +1,147 @@
+import { Effect, Exit } from "effect";
+import type { ElectronError, ElectronLifecycleError } from "../effect/electron-errors";
+import { causeToElectronBoundaryError } from "../effect/electron-errors";
+
+type ElectronMainLifecycleLogger = {
+  error(message: string, error?: unknown): void;
+  info(message: string): void;
+};
+
+export type ElectronMainStartupSteps<PreReady, Ready> = {
+  configureReady(preReady: PreReady): Effect.Effect<Ready, ElectronError>;
+  createMainWindow(ready: Ready): Effect.Effect<void, ElectronError>;
+  initializeHost(ready: Ready): Effect.Effect<void, ElectronError>;
+  preparePreReady(): Effect.Effect<PreReady, ElectronError>;
+  registerActivateHandler(ready: Ready): void;
+  waitUntilReady(): Effect.Effect<void, ElectronError>;
+};
+
+export const composeElectronMainStartupEffect = <PreReady, Ready>({
+  configureReady,
+  createMainWindow,
+  initializeHost,
+  preparePreReady,
+  registerActivateHandler,
+  waitUntilReady,
+}: ElectronMainStartupSteps<PreReady, Ready>): Effect.Effect<Ready, ElectronError> =>
+  Effect.gen(function* () {
+    const preReady = yield* preparePreReady();
+    yield* waitUntilReady();
+    const ready = yield* configureReady(preReady);
+    yield* initializeHost(ready);
+    yield* createMainWindow(ready);
+    yield* Effect.sync(() => {
+      registerActivateHandler(ready);
+    });
+    return ready;
+  });
+
+type StartupBoundaryOptions = {
+  cleanupAfterFailure(): Effect.Effect<void, ElectronLifecycleError>;
+  exitProcess(exitCode: number): void;
+  logger: ElectronMainLifecycleLogger;
+  markShutdownComplete(): void;
+  markShutdownStarted(): void;
+  startupEffect: Effect.Effect<unknown, ElectronError>;
+};
+
+export const runElectronMainStartupBoundary = async ({
+  cleanupAfterFailure,
+  exitProcess,
+  logger,
+  markShutdownComplete,
+  markShutdownStarted,
+  startupEffect,
+}: StartupBoundaryOptions): Promise<void> => {
+  const startupExit = await Effect.runPromiseExit(startupEffect);
+  if (Exit.isSuccess(startupExit)) {
+    return;
+  }
+
+  logger.error(
+    "OpenDucktor Electron startup failed",
+    causeToElectronBoundaryError(startupExit.cause),
+  );
+  markShutdownStarted();
+  const cleanupExit = await Effect.runPromiseExit(cleanupAfterFailure());
+  if (Exit.isFailure(cleanupExit)) {
+    logger.error(
+      "OpenDucktor host cleanup after startup failure failed",
+      causeToElectronBoundaryError(cleanupExit.cause),
+    );
+  }
+  markShutdownComplete();
+  exitProcess(1);
+};
+
+export type ElectronMainShutdownOptions = {
+  exitAfterShutdown?: boolean;
+  reason: string;
+};
+
+type ShutdownControllerOptions = {
+  disposeHost(reason: string): Effect.Effect<void, ElectronLifecycleError>;
+  exitProcess(exitCode: number): void;
+  logger: ElectronMainLifecycleLogger;
+  quitApp(): void;
+};
+
+export type ElectronMainShutdownController = {
+  isHostShutdownComplete(): boolean;
+  isHostShutdownStarted(): boolean;
+  markHostShutdownComplete(): void;
+  markHostShutdownStarted(): void;
+  shutdownHostAndQuit(options: ElectronMainShutdownOptions): Promise<void>;
+};
+
+export const createElectronMainShutdownController = ({
+  disposeHost,
+  exitProcess,
+  logger,
+  quitApp,
+}: ShutdownControllerOptions): ElectronMainShutdownController => {
+  let hostShutdownStarted = false;
+  let hostShutdownComplete = false;
+
+  const shutdownHostAndQuit = async ({
+    exitAfterShutdown = false,
+    reason,
+  }: ElectronMainShutdownOptions): Promise<void> => {
+    if (hostShutdownStarted) {
+      return;
+    }
+
+    hostShutdownStarted = true;
+    let exitCode = 0;
+    logger.info(`OpenDucktor host shutdown started (${reason})`);
+    const disposeExit = await Effect.runPromiseExit(disposeHost(reason));
+    if (Exit.isFailure(disposeExit)) {
+      exitCode = 1;
+      logger.error(
+        "OpenDucktor host shutdown failed",
+        causeToElectronBoundaryError(disposeExit.cause),
+      );
+    } else {
+      logger.info("OpenDucktor host shutdown complete");
+    }
+
+    hostShutdownComplete = true;
+    if (exitAfterShutdown) {
+      exitProcess(exitCode);
+      return;
+    }
+    quitApp();
+  };
+
+  return {
+    isHostShutdownComplete: () => hostShutdownComplete,
+    isHostShutdownStarted: () => hostShutdownStarted,
+    markHostShutdownComplete: () => {
+      hostShutdownComplete = true;
+    },
+    markHostShutdownStarted: () => {
+      hostShutdownStarted = true;
+    },
+    shutdownHostAndQuit,
+  };
+};

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createHostEventBus, HOST_EVENT_CHANNELS } from "@openducktor/host";
-import { Effect, Exit } from "effect";
+import {
+  createHostEventBus,
+  type EffectHostCommandRouter,
+  HOST_EVENT_CHANNELS,
+  type HostRuntimeDistribution,
+} from "@openducktor/host";
+import { Effect } from "effect";
 import type {
   BrowserWindow as ElectronBrowserWindow,
   NativeImage as ElectronNativeImage,
@@ -10,11 +15,11 @@ import type {
 import electron from "electron";
 import { runElectronEffect } from "../effect/electron-boundary";
 import {
-  causeToElectronBoundaryError,
   ElectronLifecycleError,
   ElectronOperationError,
   ElectronValidationError,
   errorMessage,
+  isElectronError,
 } from "../effect/electron-errors";
 import {
   ELECTRON_HOST_EVENT_CHANNEL,
@@ -37,6 +42,11 @@ import {
   configureElectronLoopbackCorsPolicy,
   resolveElectronLoopbackCorsOrigin,
 } from "./electron-loopback-cors-policy";
+import {
+  composeElectronMainStartupEffect,
+  createElectronMainShutdownController,
+  runElectronMainStartupBoundary,
+} from "./electron-main-lifecycle";
 import { electronMainLogger } from "./electron-main-logger";
 import { resolveElectronRuntimeDistribution } from "./electron-runtime-distribution";
 import { disableElectronKeychainStorage } from "./electron-storage-policy";
@@ -51,36 +61,126 @@ const isDevelopment = Boolean(rendererDevUrl);
 const distDirectory = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(distDirectory, "../../..");
 
-configureElectronAppIdentity(app, { appName: APPLICATION_NAME });
-disableElectronKeychainStorage(app.commandLine);
-const runtimeDistribution = resolveElectronRuntimeDistribution({
-  platform: process.platform,
-  isPackaged: app.isPackaged,
-  resourcesPath: process.resourcesPath,
-  workspaceRoot,
-});
-
 const hostEventBus = createHostEventBus();
-const hostCommandRouter = createElectronEffectHostCommandRouter({
-  clientVersion: app.getVersion(),
-  eventBus: hostEventBus,
-  lifecycleLogger: electronMainLogger,
-  runtimeDistribution,
-});
-let hostShutdownStarted = false;
-let hostShutdownComplete = false;
+let activeHostCommandRouter: EffectHostCommandRouter | null = null;
 
-protocol.registerSchemesAsPrivileged([
-  {
-    scheme: ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
-    privileges: {
-      secure: true,
-      standard: true,
-      stream: true,
-      supportFetchAPI: true,
-    },
+const shutdownController = createElectronMainShutdownController({
+  disposeHost: (reason) => disposeActiveHostEffect(reason),
+  exitProcess: (exitCode) => {
+    process.exit(exitCode);
   },
-]);
+  logger: electronMainLogger,
+  quitApp: () => {
+    app.quit();
+  },
+});
+
+type ElectronPreReadyRuntime = {
+  hostCommandRouter: EffectHostCommandRouter;
+};
+
+type ElectronReadyRuntime = ElectronPreReadyRuntime & {
+  rendererSession: ElectronSession;
+};
+
+const mapStartupPreparationError = (
+  cause: unknown,
+  operation: string,
+  message: string,
+): ElectronLifecycleError | ElectronOperationError | ElectronValidationError =>
+  isElectronError(cause)
+    ? cause
+    : new ElectronLifecycleError({
+        operation,
+        message,
+        cause,
+      });
+
+const registerPrivilegedProtocolSchemes = (): void => {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
+      privileges: {
+        secure: true,
+        standard: true,
+        stream: true,
+        supportFetchAPI: true,
+      },
+    },
+  ]);
+};
+
+const createElectronHostCommandRouter = (
+  runtimeDistribution: HostRuntimeDistribution,
+): EffectHostCommandRouter =>
+  createElectronEffectHostCommandRouter({
+    clientVersion: app.getVersion(),
+    eventBus: hostEventBus,
+    lifecycleLogger: electronMainLogger,
+    runtimeDistribution,
+  });
+
+const resolveRuntimeDistributionEffect = (): Effect.Effect<
+  HostRuntimeDistribution,
+  ElectronLifecycleError
+> =>
+  Effect.try({
+    try: () =>
+      resolveElectronRuntimeDistribution({
+        platform: process.platform,
+        isPackaged: app.isPackaged,
+        resourcesPath: process.resourcesPath,
+        workspaceRoot,
+      }),
+    catch: (cause) =>
+      new ElectronLifecycleError({
+        operation: "electron.main.resolve-runtime-distribution",
+        message: errorMessage(cause),
+        cause,
+      }),
+  });
+
+const prepareElectronPreReadyRuntimeEffect = (): Effect.Effect<
+  ElectronPreReadyRuntime,
+  ElectronLifecycleError | ElectronOperationError | ElectronValidationError
+> =>
+  Effect.gen(function* () {
+    yield* Effect.try({
+      try: () => configureElectronAppIdentity(app, { appName: APPLICATION_NAME }),
+      catch: (cause) =>
+        mapStartupPreparationError(
+          cause,
+          "electron.main.configure-app-identity",
+          errorMessage(cause),
+        ),
+    });
+    yield* Effect.try({
+      try: () => disableElectronKeychainStorage(app.commandLine),
+      catch: (cause) =>
+        mapStartupPreparationError(
+          cause,
+          "electron.main.disable-keychain-storage",
+          errorMessage(cause),
+        ),
+    });
+    yield* Effect.try({
+      try: registerPrivilegedProtocolSchemes,
+      catch: (cause) =>
+        mapStartupPreparationError(
+          cause,
+          "electron.main.register-privileged-protocols",
+          errorMessage(cause),
+        ),
+    });
+    const runtimeDistribution = yield* resolveRuntimeDistributionEffect();
+    const hostCommandRouter = yield* Effect.try({
+      try: () => createElectronHostCommandRouter(runtimeDistribution),
+      catch: (cause) =>
+        mapStartupPreparationError(cause, "electron.main.create-host-router", errorMessage(cause)),
+    });
+    activeHostCommandRouter = hostCommandRouter;
+    return { hostCommandRouter };
+  });
 
 const getPreloadPath = (): string => path.join(distDirectory, "preload.cjs");
 
@@ -206,15 +306,15 @@ const createMainWindowEffect = (
     });
     registerWindowContextMenu(window, { isDevelopment });
     window.on("close", (event) => {
-      if (hostShutdownComplete) {
+      if (shutdownController.isHostShutdownComplete()) {
         return;
       }
       event.preventDefault();
       hideWindowsForShutdown();
-      if (hostShutdownStarted) {
+      if (shutdownController.isHostShutdownStarted()) {
         return;
       }
-      void shutdownHostAndQuit({ reason: "window-close" });
+      void shutdownController.shutdownHostAndQuit({ reason: "window-close" });
     });
 
     if (rendererDevUrl) {
@@ -259,7 +359,10 @@ const registerHostEventForwarding = (): void => {
   }
 };
 
-const resolveLocalAttachmentPathForPreviewEffect = (filePath: string) =>
+const resolveLocalAttachmentPathForPreviewEffect = (
+  hostCommandRouter: EffectHostCommandRouter,
+  filePath: string,
+) =>
   Effect.gen(function* () {
     const resolved = yield* hostCommandRouter.invoke("workspace_resolve_local_attachment_path", {
       path: filePath,
@@ -287,10 +390,13 @@ const resolveLocalAttachmentPathForPreviewEffect = (filePath: string) =>
     );
   });
 
-const resolveLocalAttachmentPathForPreview = (filePath: string): Promise<string> =>
-  runElectronEffect(resolveLocalAttachmentPathForPreviewEffect(filePath));
+const resolveLocalAttachmentPathForPreview = (
+  hostCommandRouter: EffectHostCommandRouter,
+  filePath: string,
+): Promise<string> =>
+  runElectronEffect(resolveLocalAttachmentPathForPreviewEffect(hostCommandRouter, filePath));
 
-const registerIpcHandlers = (): void => {
+const registerIpcHandlers = (hostCommandRouter: EffectHostCommandRouter): void => {
   ipcMain.handle(ELECTRON_HOST_INVOKE_CHANNEL, async (_event, request: ElectronHostInvokeRequest) =>
     runElectronEffect(hostCommandRouter.invoke(request.command, request.args)),
   );
@@ -301,48 +407,14 @@ const registerIpcHandlers = (): void => {
 
   ipcMain.handle(ELECTRON_LOCAL_ATTACHMENT_PREVIEW_CHANNEL, async (_event, filePath: unknown) => {
     const resolvedPath = await resolveLocalAttachmentPathForPreview(
+      hostCommandRouter,
       readLocalAttachmentPreviewPath(filePath),
     );
     return createElectronLocalAttachmentPreviewUrl(resolvedPath);
   });
 };
 
-type HostShutdownOptions = {
-  exitAfterShutdown?: boolean;
-  reason: string;
-};
-
-const shutdownHostAndQuit = async ({
-  exitAfterShutdown = false,
-  reason,
-}: HostShutdownOptions): Promise<void> => {
-  if (hostShutdownStarted) {
-    return;
-  }
-
-  hostShutdownStarted = true;
-  let exitCode = 0;
-  electronMainLogger.info(`OpenDucktor host shutdown started (${reason})`);
-  const disposeExit = await Effect.runPromiseExit(disposeHostEffect(reason));
-  try {
-    if (Exit.isFailure(disposeExit)) {
-      throw causeToElectronBoundaryError(disposeExit.cause);
-    }
-    electronMainLogger.info("OpenDucktor host shutdown complete");
-  } catch (error) {
-    exitCode = 1;
-    electronMainLogger.error("OpenDucktor host shutdown failed", error);
-  } finally {
-    hostShutdownComplete = true;
-    if (exitAfterShutdown) {
-      process.exit(exitCode);
-    } else {
-      app.quit();
-    }
-  }
-};
-
-const disposeHostEffect = (reason: string) =>
+const disposeHostEffect = (hostCommandRouter: EffectHostCommandRouter, reason: string) =>
   hostCommandRouter.dispose().pipe(
     Effect.mapError(
       (cause) =>
@@ -355,7 +427,14 @@ const disposeHostEffect = (reason: string) =>
     ),
   );
 
-const initializeHostEffect = () =>
+const disposeActiveHostEffect = (reason: string): Effect.Effect<void, ElectronLifecycleError> => {
+  if (!activeHostCommandRouter) {
+    return Effect.void;
+  }
+  return disposeHostEffect(activeHostCommandRouter, reason);
+};
+
+const initializeHostEffect = (hostCommandRouter: EffectHostCommandRouter) =>
   hostCommandRouter.initialize().pipe(
     Effect.mapError(
       (cause) =>
@@ -368,7 +447,7 @@ const initializeHostEffect = () =>
   );
 
 const shutdownHostForSignal = (signal: NodeJS.Signals): void => {
-  void shutdownHostAndQuit({ exitAfterShutdown: true, reason: signal });
+  void shutdownController.shutdownHostAndQuit({ exitAfterShutdown: true, reason: signal });
 };
 
 const hideWindowsForShutdown = (): void => {
@@ -377,62 +456,93 @@ const hideWindowsForShutdown = (): void => {
   }
 };
 
-app
-  .whenReady()
-  .then(async () => {
-    const rendererSession = session.fromPartition(ELECTRON_RENDERER_SESSION_PARTITION);
-    configureElectronLoopbackCorsPolicy(
-      rendererSession,
-      resolveElectronLoopbackCorsOrigin(rendererDevUrl),
-    );
-    registerElectronLocalAttachmentPreviewProtocol({
-      net,
-      resolveLocalAttachmentPath: resolveLocalAttachmentPathForPreview,
-      session: rendererSession,
-    });
-    installApplicationMenu({ isDevelopment, appName: app.name || APPLICATION_NAME });
-    registerIpcHandlers();
-    registerHostEventForwarding();
-    configureElectronDockIcon();
-    await runElectronEffect(initializeHostEffect());
-    await createMainWindow(rendererSession);
+const waitForElectronReadyEffect = (): Effect.Effect<void, ElectronLifecycleError> =>
+  Effect.tryPromise({
+    try: async () => {
+      await app.whenReady();
+    },
+    catch: (cause) =>
+      new ElectronLifecycleError({
+        operation: "electron.main.wait-ready",
+        message: errorMessage(cause),
+        cause,
+      }),
+  });
 
+const configureElectronReadyRuntimeEffect = ({
+  hostCommandRouter,
+}: ElectronPreReadyRuntime): Effect.Effect<
+  ElectronReadyRuntime,
+  ElectronLifecycleError | ElectronOperationError | ElectronValidationError
+> =>
+  Effect.try({
+    try: () => {
+      const rendererSession = session.fromPartition(ELECTRON_RENDERER_SESSION_PARTITION);
+      configureElectronLoopbackCorsPolicy(
+        rendererSession,
+        resolveElectronLoopbackCorsOrigin(rendererDevUrl),
+      );
+      registerElectronLocalAttachmentPreviewProtocol({
+        net,
+        resolveLocalAttachmentPath: (filePath) =>
+          resolveLocalAttachmentPathForPreview(hostCommandRouter, filePath),
+        session: rendererSession,
+      });
+      installApplicationMenu({ isDevelopment, appName: app.name || APPLICATION_NAME });
+      registerIpcHandlers(hostCommandRouter);
+      registerHostEventForwarding();
+      configureElectronDockIcon();
+      return { hostCommandRouter, rendererSession };
+    },
+    catch: (cause) =>
+      mapStartupPreparationError(
+        cause,
+        "electron.main.configure-ready-runtime",
+        errorMessage(cause),
+      ),
+  });
+
+const startupEffect = composeElectronMainStartupEffect({
+  configureReady: configureElectronReadyRuntimeEffect,
+  createMainWindow: ({ rendererSession }) =>
+    createMainWindowEffect(rendererSession).pipe(Effect.asVoid),
+  initializeHost: ({ hostCommandRouter }) => initializeHostEffect(hostCommandRouter),
+  preparePreReady: prepareElectronPreReadyRuntimeEffect,
+  registerActivateHandler: ({ rendererSession }) => {
     app.on("activate", () => {
-      if (hostShutdownStarted) {
+      if (shutdownController.isHostShutdownStarted()) {
         return;
       }
       if (BrowserWindow.getAllWindows().length === 0) {
         void createMainWindow(rendererSession);
       }
     });
-  })
-  .catch((error: unknown) => {
-    electronMainLogger.error("OpenDucktor Electron startup failed", error);
-    hostShutdownStarted = true;
-    void (async () => {
-      const cleanupExit = await Effect.runPromiseExit(disposeHostEffect("startup-failure"));
-      if (Exit.isFailure(cleanupExit)) {
-        electronMainLogger.error(
-          "OpenDucktor host cleanup after startup failure failed",
-          causeToElectronBoundaryError(cleanupExit.cause),
-        );
-      }
-      hostShutdownComplete = true;
-      process.exit(1);
-    })();
-  });
+  },
+  waitUntilReady: waitForElectronReadyEffect,
+});
+
+void runElectronMainStartupBoundary({
+  cleanupAfterFailure: () => disposeActiveHostEffect("startup-failure"),
+  exitProcess: (exitCode) => {
+    process.exit(exitCode);
+  },
+  logger: electronMainLogger,
+  markShutdownComplete: shutdownController.markHostShutdownComplete,
+  markShutdownStarted: shutdownController.markHostShutdownStarted,
+  startupEffect,
+});
 
 app.on("window-all-closed", () => {
-  void shutdownHostAndQuit({ reason: "window-all-closed" });
+  void shutdownController.shutdownHostAndQuit({ reason: "window-all-closed" });
 });
 
 app.on("before-quit", (event) => {
-  if (hostShutdownComplete) {
+  if (shutdownController.isHostShutdownComplete()) {
     return;
   }
   event.preventDefault();
   hideWindowsForShutdown();
-  void shutdownHostAndQuit({ reason: "before-quit" });
+  void shutdownController.shutdownHostAndQuit({ reason: "before-quit" });
 });
 
 process.once("SIGINT", shutdownHostForSignal);

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -64,6 +64,20 @@ const workspaceRoot = path.resolve(distDirectory, "../../..");
 const hostEventBus = createHostEventBus();
 let activeHostCommandRouter: EffectHostCommandRouter | null = null;
 
+const isTaggedHostValidationError = (
+  cause: unknown,
+): cause is {
+  readonly field?: string;
+  readonly message: string;
+  readonly _tag: "HostValidationError";
+} =>
+  typeof cause === "object" &&
+  cause !== null &&
+  "_tag" in cause &&
+  cause._tag === "HostValidationError" &&
+  "message" in cause &&
+  typeof cause.message === "string";
+
 const shutdownController = createElectronMainShutdownController({
   disposeHost: (reason) => disposeActiveHostEffect(reason),
   exitProcess: (exitCode) => {
@@ -364,16 +378,41 @@ const resolveLocalAttachmentPathForPreviewEffect = (
   filePath: string,
 ) =>
   Effect.gen(function* () {
-    const resolved = yield* hostCommandRouter.invoke("workspace_resolve_local_attachment_path", {
-      path: filePath,
-    });
+    const resolved = yield* hostCommandRouter
+      .invoke("workspace_resolve_local_attachment_path", {
+        path: filePath,
+      })
+      .pipe(
+        Effect.mapError((cause) => {
+          if (isElectronError(cause)) {
+            return cause;
+          }
+          if (isTaggedHostValidationError(cause)) {
+            return new ElectronValidationError({
+              operation: "electron.preview.resolve-host-path",
+              message: cause.message,
+              field: cause.field ?? "path",
+              cause,
+              details: { filePath },
+            });
+          }
+          return new ElectronOperationError({
+            operation: "electron.preview.resolve-host-path",
+            message: errorMessage(cause),
+            path: filePath,
+            cause,
+          });
+        }),
+      );
     if (typeof resolved !== "object" || resolved === null || !("path" in resolved)) {
-      return yield* new ElectronValidationError({
-        operation: "electron.preview.resolve-host-path",
-        message: "Local attachment preview resolver returned an invalid response.",
-        field: "path",
-        details: { filePath },
-      });
+      return yield* Effect.fail(
+        new ElectronValidationError({
+          operation: "electron.preview.resolve-host-path",
+          message: "Local attachment preview resolver returned an invalid response.",
+          field: "path",
+          details: { filePath },
+        }),
+      );
     }
 
     return yield* readLocalAttachmentPreviewPathEffect(resolved.path).pipe(
@@ -518,6 +557,7 @@ const startupEffect = composeElectronMainStartupEffect({
       }
     });
   },
+  shouldContinueStartup: () => !shutdownController.isHostShutdownStarted(),
   waitUntilReady: waitForElectronReadyEffect,
 });
 

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -1,12 +1,21 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHostEventBus, HOST_EVENT_CHANNELS } from "@openducktor/host";
+import { Effect, Exit } from "effect";
 import type {
   BrowserWindow as ElectronBrowserWindow,
   NativeImage as ElectronNativeImage,
   Session as ElectronSession,
 } from "electron";
 import electron from "electron";
+import { runElectronEffect } from "../effect/electron-boundary";
+import {
+  causeToElectronBoundaryError,
+  ElectronLifecycleError,
+  ElectronOperationError,
+  ElectronValidationError,
+  errorMessage,
+} from "../effect/electron-errors";
 import {
   ELECTRON_HOST_EVENT_CHANNEL,
   ELECTRON_HOST_INVOKE_CHANNEL,
@@ -16,11 +25,12 @@ import {
   type ElectronHostInvokeRequest,
 } from "../shared/electron-bridge-contract";
 import { configureElectronAppIdentity } from "./electron-app-identity";
-import { createElectronHostCommandRouter } from "./electron-host";
+import { createElectronEffectHostCommandRouter } from "./electron-host";
 import {
   createElectronLocalAttachmentPreviewUrl,
   ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
   readLocalAttachmentPreviewPath,
+  readLocalAttachmentPreviewPathEffect,
   registerElectronLocalAttachmentPreviewProtocol,
 } from "./electron-local-attachment-preview";
 import {
@@ -51,7 +61,7 @@ const runtimeDistribution = resolveElectronRuntimeDistribution({
 });
 
 const hostEventBus = createHostEventBus();
-const hostCommandRouter = createElectronHostCommandRouter({
+const hostCommandRouter = createElectronEffectHostCommandRouter({
   clientVersion: app.getVersion(),
   eventBus: hostEventBus,
   lifecycleLogger: electronMainLogger,
@@ -87,7 +97,12 @@ const resolveElectronWindowIconPath = (): string => {
 const createElectronIconImage = (iconPath: string, label: string): ElectronNativeImage => {
   const icon = nativeImage.createFromPath(iconPath);
   if (icon.isEmpty()) {
-    throw new Error(`Electron ${label} icon is missing or invalid: ${iconPath}`);
+    throw new ElectronOperationError({
+      operation: "electron.main.load-icon",
+      message: `Electron ${label} icon is missing or invalid: ${iconPath}`,
+      path: iconPath,
+      details: { label },
+    });
   }
   return icon;
 };
@@ -110,57 +125,128 @@ const validateExternalUrl = (url: string): string => {
   try {
     parsedUrl = new URL(url.trim());
   } catch {
-    throw new Error("OpenDucktor Electron can only open absolute http or https URLs.");
+    throw new ElectronValidationError({
+      operation: "electron.ipc.open-external-url.validate",
+      message: "OpenDucktor Electron can only open absolute http or https URLs.",
+      field: "url",
+      details: { url },
+    });
   }
 
   if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-    throw new Error("OpenDucktor Electron can only open http or https URLs.");
+    throw new ElectronValidationError({
+      operation: "electron.ipc.open-external-url.validate",
+      message: "OpenDucktor Electron can only open http or https URLs.",
+      field: "url",
+      details: { url, protocol: parsedUrl.protocol },
+    });
   }
 
   return parsedUrl.href;
 };
 
-const createMainWindow = async (
+const openExternalUrlEffect = (
+  url: string,
+): Effect.Effect<void, ElectronOperationError | ElectronValidationError> =>
+  Effect.gen(function* () {
+    const externalUrl = yield* Effect.try({
+      try: () => validateExternalUrl(url),
+      catch: (cause) =>
+        cause instanceof ElectronValidationError
+          ? cause
+          : new ElectronValidationError({
+              operation: "electron.ipc.open-external-url.validate",
+              message: errorMessage(cause),
+              field: "url",
+              cause,
+              details: { url },
+            }),
+    });
+    yield* Effect.tryPromise({
+      try: () => shell.openExternal(externalUrl),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.ipc.open-external-url",
+          message: errorMessage(cause),
+          cause,
+          details: { url: externalUrl },
+        }),
+    });
+  });
+
+const createMainWindowEffect = (
   rendererSession: ElectronSession,
-): Promise<ElectronBrowserWindow> => {
-  const window = new BrowserWindow({
-    width: 1440,
-    height: 960,
-    minWidth: 1024,
-    minHeight: 720,
-    autoHideMenuBar: process.platform !== "darwin",
-    title: "OpenDucktor",
-    icon: resolveElectronWindowIcon(),
-    webPreferences: {
-      contextIsolation: true,
-      devTools: isDevelopment,
-      nodeIntegration: false,
-      preload: getPreloadPath(),
-      sandbox: true,
-      session: rendererSession,
-    },
-  });
-  registerWindowContextMenu(window, { isDevelopment });
-  window.on("close", (event) => {
-    if (hostShutdownComplete) {
-      return;
-    }
-    event.preventDefault();
-    hideWindowsForShutdown();
-    if (hostShutdownStarted) {
-      return;
-    }
-    void shutdownHostAndQuit({ reason: "window-close" });
-  });
+): Effect.Effect<ElectronBrowserWindow, ElectronOperationError> =>
+  Effect.gen(function* () {
+    const window = yield* Effect.try({
+      try: () =>
+        new BrowserWindow({
+          width: 1440,
+          height: 960,
+          minWidth: 1024,
+          minHeight: 720,
+          autoHideMenuBar: process.platform !== "darwin",
+          title: "OpenDucktor",
+          icon: resolveElectronWindowIcon(),
+          webPreferences: {
+            contextIsolation: true,
+            devTools: isDevelopment,
+            nodeIntegration: false,
+            preload: getPreloadPath(),
+            sandbox: true,
+            session: rendererSession,
+          },
+        }),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.main.create-window",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+    registerWindowContextMenu(window, { isDevelopment });
+    window.on("close", (event) => {
+      if (hostShutdownComplete) {
+        return;
+      }
+      event.preventDefault();
+      hideWindowsForShutdown();
+      if (hostShutdownStarted) {
+        return;
+      }
+      void shutdownHostAndQuit({ reason: "window-close" });
+    });
 
-  if (rendererDevUrl) {
-    await window.loadURL(rendererDevUrl);
+    if (rendererDevUrl) {
+      yield* Effect.tryPromise({
+        try: () => window.loadURL(rendererDevUrl),
+        catch: (cause) =>
+          new ElectronOperationError({
+            operation: "electron.main.load-renderer-url",
+            message: errorMessage(cause),
+            cause,
+            details: { rendererDevUrl },
+          }),
+      });
+      return window;
+    }
+
+    const rendererIndexPath = getRendererIndexPath();
+    yield* Effect.tryPromise({
+      try: () => window.loadFile(rendererIndexPath, { hash: ELECTRON_RENDERER_START_PATH }),
+      catch: (cause) =>
+        new ElectronOperationError({
+          operation: "electron.main.load-renderer-file",
+          message: errorMessage(cause),
+          path: rendererIndexPath,
+          cause,
+        }),
+    });
     return window;
-  }
+  });
 
-  await window.loadFile(getRendererIndexPath(), { hash: ELECTRON_RENDERER_START_PATH });
-  return window;
-};
+const createMainWindow = (rendererSession: ElectronSession): Promise<ElectronBrowserWindow> =>
+  runElectronEffect(createMainWindowEffect(rendererSession));
 
 const registerHostEventForwarding = (): void => {
   for (const channel of HOST_EVENT_CHANNELS) {
@@ -173,24 +259,44 @@ const registerHostEventForwarding = (): void => {
   }
 };
 
-const resolveLocalAttachmentPathForPreview = async (filePath: string): Promise<string> => {
-  const resolved = await hostCommandRouter.invoke("workspace_resolve_local_attachment_path", {
-    path: filePath,
-  });
-  if (typeof resolved !== "object" || resolved === null || !("path" in resolved)) {
-    throw new Error("Local attachment preview resolver returned an invalid response.");
-  }
+const resolveLocalAttachmentPathForPreviewEffect = (filePath: string) =>
+  Effect.gen(function* () {
+    const resolved = yield* hostCommandRouter.invoke("workspace_resolve_local_attachment_path", {
+      path: filePath,
+    });
+    if (typeof resolved !== "object" || resolved === null || !("path" in resolved)) {
+      return yield* new ElectronValidationError({
+        operation: "electron.preview.resolve-host-path",
+        message: "Local attachment preview resolver returned an invalid response.",
+        field: "path",
+        details: { filePath },
+      });
+    }
 
-  return readLocalAttachmentPreviewPath(resolved.path);
-};
+    return yield* readLocalAttachmentPreviewPathEffect(resolved.path).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ElectronValidationError({
+            operation: "electron.preview.validate-host-path",
+            message: cause.message,
+            field: "path",
+            cause,
+            details: { filePath },
+          }),
+      ),
+    );
+  });
+
+const resolveLocalAttachmentPathForPreview = (filePath: string): Promise<string> =>
+  runElectronEffect(resolveLocalAttachmentPathForPreviewEffect(filePath));
 
 const registerIpcHandlers = (): void => {
   ipcMain.handle(ELECTRON_HOST_INVOKE_CHANNEL, async (_event, request: ElectronHostInvokeRequest) =>
-    hostCommandRouter.invoke(request.command, request.args),
+    runElectronEffect(hostCommandRouter.invoke(request.command, request.args)),
   );
 
   ipcMain.handle(ELECTRON_OPEN_EXTERNAL_URL_CHANNEL, async (_event, url: string) => {
-    await shell.openExternal(validateExternalUrl(url));
+    await runElectronEffect(openExternalUrlEffect(url));
   });
 
   ipcMain.handle(ELECTRON_LOCAL_ATTACHMENT_PREVIEW_CHANNEL, async (_event, filePath: unknown) => {
@@ -217,8 +323,11 @@ const shutdownHostAndQuit = async ({
   hostShutdownStarted = true;
   let exitCode = 0;
   electronMainLogger.info(`OpenDucktor host shutdown started (${reason})`);
+  const disposeExit = await Effect.runPromiseExit(disposeHostEffect(reason));
   try {
-    await hostCommandRouter.dispose();
+    if (Exit.isFailure(disposeExit)) {
+      throw causeToElectronBoundaryError(disposeExit.cause);
+    }
     electronMainLogger.info("OpenDucktor host shutdown complete");
   } catch (error) {
     exitCode = 1;
@@ -232,6 +341,31 @@ const shutdownHostAndQuit = async ({
     }
   }
 };
+
+const disposeHostEffect = (reason: string) =>
+  hostCommandRouter.dispose().pipe(
+    Effect.mapError(
+      (cause) =>
+        new ElectronLifecycleError({
+          operation: "electron.main.dispose-host",
+          message: errorMessage(cause),
+          reason,
+          cause,
+        }),
+    ),
+  );
+
+const initializeHostEffect = () =>
+  hostCommandRouter.initialize().pipe(
+    Effect.mapError(
+      (cause) =>
+        new ElectronLifecycleError({
+          operation: "electron.main.initialize-host",
+          message: errorMessage(cause),
+          cause,
+        }),
+    ),
+  );
 
 const shutdownHostForSignal = (signal: NodeJS.Signals): void => {
   void shutdownHostAndQuit({ exitAfterShutdown: true, reason: signal });
@@ -260,7 +394,7 @@ app
     registerIpcHandlers();
     registerHostEventForwarding();
     configureElectronDockIcon();
-    await hostCommandRouter.initialize();
+    await runElectronEffect(initializeHostEffect());
     await createMainWindow(rendererSession);
 
     app.on("activate", () => {
@@ -275,18 +409,17 @@ app
   .catch((error: unknown) => {
     electronMainLogger.error("OpenDucktor Electron startup failed", error);
     hostShutdownStarted = true;
-    void hostCommandRouter
-      .dispose()
-      .catch((disposeError: unknown) => {
+    void (async () => {
+      const cleanupExit = await Effect.runPromiseExit(disposeHostEffect("startup-failure"));
+      if (Exit.isFailure(cleanupExit)) {
         electronMainLogger.error(
           "OpenDucktor host cleanup after startup failure failed",
-          disposeError,
+          causeToElectronBoundaryError(cleanupExit.cause),
         );
-      })
-      .finally(() => {
-        hostShutdownComplete = true;
-        process.exit(1);
-      });
+      }
+      hostShutdownComplete = true;
+      process.exit(1);
+    })();
   });
 
 app.on("window-all-closed", () => {

--- a/apps/electron/src/renderer/electron-shell-bridge.test.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { ElectronValidationError } from "../effect/electron-errors";
 import type { OpenDucktorElectronApi } from "../shared/electron-bridge-contract";
-import { createElectronShellBridge } from "./electron-shell-bridge";
+import {
+  createElectronShellBridge,
+  ElectronPreloadBridgeUnavailableError,
+} from "./electron-shell-bridge";
 
 const originalWindow = globalThis.window;
 
@@ -12,12 +14,21 @@ const setElectronApi = (electronApi: OpenDucktorElectronApi | undefined): void =
   });
 };
 
-const createElectronApi = (): OpenDucktorElectronApi => ({
-  invoke: mock(async () => ({})),
-  subscribe: mock(() => () => {}),
-  openExternalUrl: mock(async () => {}),
-  resolveLocalAttachmentPreviewSrc: mock(async () => "file:///tmp/brief.md"),
-});
+const createElectronApi = (): {
+  electronApi: OpenDucktorElectronApi;
+  unsubscribe: ReturnType<typeof mock>;
+} => {
+  const unsubscribe = mock(() => {});
+  return {
+    electronApi: {
+      invoke: mock(async () => ({})),
+      subscribe: mock(() => unsubscribe),
+      openExternalUrl: mock(async () => {}),
+      resolveLocalAttachmentPreviewSrc: mock(async () => "file:///tmp/brief.md"),
+    },
+    unsubscribe,
+  };
+};
 
 describe("electron shell bridge", () => {
   afterEach(() => {
@@ -39,29 +50,53 @@ describe("electron shell bridge", () => {
       throw new Error("Expected createElectronShellBridge to fail.");
     })();
 
-    expect(error).toBeInstanceOf(ElectronValidationError);
-    expect(error).toMatchObject({
-      _tag: "ElectronValidationError",
-      operation: "electron.renderer.get-preload-bridge",
-    });
+    expect(error).toBeInstanceOf(ElectronPreloadBridgeUnavailableError);
     expect((error as Error).message).toContain(
       "OpenDucktor Electron preload bridge is unavailable.",
     );
   });
 
   test("uses the preload bridge for event subscriptions and shell capabilities", async () => {
-    const electronApi = createElectronApi();
+    const { electronApi, unsubscribe: unsubscribeSpy } = createElectronApi();
     setElectronApi(electronApi);
 
     const bridge = createElectronShellBridge();
     const listener = mock(() => {});
-    const unsubscribe = await bridge.subscribeTaskEvents(listener);
+    const unsubscribeRunEvents = await bridge.subscribeRunEvents(listener);
+    const unsubscribeDevServerEvents = await bridge.subscribeDevServerEvents(listener);
+    const unsubscribeTaskEvents = await bridge.subscribeTaskEvents(listener);
+    const unsubscribeCodexAppServerEvents = await bridge.subscribeCodexAppServerEvents(listener);
 
     expect(bridge.capabilities).toEqual({
       canOpenExternalUrls: true,
       canPreviewLocalAttachments: true,
     });
+    expect(electronApi.subscribe).toHaveBeenCalledWith("openducktor://run-event", listener);
+    expect(electronApi.subscribe).toHaveBeenCalledWith("openducktor://dev-server-event", listener);
     expect(electronApi.subscribe).toHaveBeenCalledWith("openducktor://task-event", listener);
-    expect(typeof unsubscribe).toBe("function");
+    expect(electronApi.subscribe).toHaveBeenCalledWith(
+      "openducktor://codex-app-server-event",
+      listener,
+    );
+
+    unsubscribeRunEvents();
+    unsubscribeDevServerEvents();
+    unsubscribeTaskEvents();
+    unsubscribeCodexAppServerEvents();
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(4);
+  });
+
+  test("uses the preload bridge for shell actions", async () => {
+    const { electronApi } = createElectronApi();
+    setElectronApi(electronApi);
+
+    const bridge = createElectronShellBridge();
+    await bridge.openExternalUrl("https://openducktor.local/docs");
+    await expect(bridge.resolveLocalAttachmentPreviewSrc("brief.md")).resolves.toBe(
+      "file:///tmp/brief.md",
+    );
+
+    expect(electronApi.openExternalUrl).toHaveBeenCalledWith("https://openducktor.local/docs");
+    expect(electronApi.resolveLocalAttachmentPreviewSrc).toHaveBeenCalledWith("brief.md");
   });
 });

--- a/apps/electron/src/renderer/electron-shell-bridge.test.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { ElectronValidationError } from "../effect/electron-errors";
 import type { OpenDucktorElectronApi } from "../shared/electron-bridge-contract";
 import { createElectronShellBridge } from "./electron-shell-bridge";
 
@@ -29,7 +30,21 @@ describe("electron shell bridge", () => {
   test("fails fast when the preload bridge was not installed", () => {
     setElectronApi(undefined);
 
-    expect(() => createElectronShellBridge()).toThrow(
+    const error = (() => {
+      try {
+        createElectronShellBridge();
+      } catch (caught) {
+        return caught;
+      }
+      throw new Error("Expected createElectronShellBridge to fail.");
+    })();
+
+    expect(error).toBeInstanceOf(ElectronValidationError);
+    expect(error).toMatchObject({
+      _tag: "ElectronValidationError",
+      operation: "electron.renderer.get-preload-bridge",
+    });
+    expect((error as Error).message).toContain(
       "OpenDucktor Electron preload bridge is unavailable.",
     );
   });

--- a/apps/electron/src/renderer/electron-shell-bridge.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.ts
@@ -1,6 +1,5 @@
 import type { ShellBridge } from "@openducktor/frontend";
 import { createHostClient } from "@openducktor/host-client";
-import { ElectronValidationError } from "../effect/electron-errors";
 import type { OpenDucktorElectronApi } from "../shared/electron-bridge-contract";
 
 const RUN_EVENT_CHANNEL = "openducktor://run-event";
@@ -8,14 +7,19 @@ const DEV_SERVER_EVENT_CHANNEL = "openducktor://dev-server-event";
 const TASK_EVENT_CHANNEL = "openducktor://task-event";
 const CODEX_APP_SERVER_EVENT_CHANNEL = "openducktor://codex-app-server-event";
 
+export class ElectronPreloadBridgeUnavailableError extends Error {
+  constructor() {
+    super(
+      "OpenDucktor Electron preload bridge is unavailable. Check that BrowserWindow webPreferences.preload points to the built preload.cjs file.",
+    );
+    this.name = "ElectronPreloadBridgeUnavailableError";
+  }
+}
+
 const getElectronApi = (): OpenDucktorElectronApi => {
   const electronApi = window.openducktorElectron;
   if (!electronApi) {
-    throw new ElectronValidationError({
-      operation: "electron.renderer.get-preload-bridge",
-      message:
-        "OpenDucktor Electron preload bridge is unavailable. Check that BrowserWindow webPreferences.preload points to the built preload.cjs file.",
-    });
+    throw new ElectronPreloadBridgeUnavailableError();
   }
 
   return electronApi;

--- a/apps/electron/src/renderer/electron-shell-bridge.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.ts
@@ -1,5 +1,6 @@
 import type { ShellBridge } from "@openducktor/frontend";
 import { createHostClient } from "@openducktor/host-client";
+import { ElectronValidationError } from "../effect/electron-errors";
 import type { OpenDucktorElectronApi } from "../shared/electron-bridge-contract";
 
 const RUN_EVENT_CHANNEL = "openducktor://run-event";
@@ -10,9 +11,11 @@ const CODEX_APP_SERVER_EVENT_CHANNEL = "openducktor://codex-app-server-event";
 const getElectronApi = (): OpenDucktorElectronApi => {
   const electronApi = window.openducktorElectron;
   if (!electronApi) {
-    throw new Error(
-      "OpenDucktor Electron preload bridge is unavailable. Check that BrowserWindow webPreferences.preload points to the built preload.cjs file.",
-    );
+    throw new ElectronValidationError({
+      operation: "electron.renderer.get-preload-bridge",
+      message:
+        "OpenDucktor Electron preload bridge is unavailable. Check that BrowserWindow webPreferences.preload points to the built preload.cjs file.",
+    });
   }
 
   return electronApi;

--- a/apps/electron/src/vite-config.test.ts
+++ b/apps/electron/src/vite-config.test.ts
@@ -47,4 +47,29 @@ describe("resolveAppVersion", () => {
       await rm(tempDirectory, { force: true, recursive: true });
     }
   });
+
+  test("fails with a typed error when the package file is malformed", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "openducktor-electron-vite-config-"));
+    const packageJsonPath = join(tempDirectory, "package.json");
+
+    try {
+      await writeFile(packageJsonPath, "{not-json");
+      const error = (() => {
+        try {
+          resolveAppVersion({}, packageJsonPath);
+        } catch (caught) {
+          return caught;
+        }
+        throw new Error("Expected resolveAppVersion to fail.");
+      })();
+
+      expect(error).toMatchObject({
+        _tag: "ElectronValidationError",
+        operation: "electron.config.read-package-version",
+        path: packageJsonPath,
+      });
+    } finally {
+      await rm(tempDirectory, { force: true, recursive: true });
+    }
+  });
 });

--- a/apps/electron/src/vite-config.test.ts
+++ b/apps/electron/src/vite-config.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import packageJson from "../package.json";
 import { resolveAppVersion } from "../vite.config";
 
@@ -17,5 +20,31 @@ describe("resolveAppVersion", () => {
 
   test("uses the Electron package version when ODT_APP_VERSION is blank", () => {
     expect(resolveAppVersion({ ODT_APP_VERSION: "   " })).toBe(packageJson.version);
+  });
+
+  test("fails with a typed error when the package version is missing", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "openducktor-electron-vite-config-"));
+    const packageJsonPath = join(tempDirectory, "package.json");
+
+    try {
+      await writeFile(packageJsonPath, "{}");
+      const error = (() => {
+        try {
+          resolveAppVersion({}, packageJsonPath);
+        } catch (caught) {
+          return caught;
+        }
+        throw new Error("Expected resolveAppVersion to fail.");
+      })();
+
+      expect(error).toMatchObject({
+        _tag: "ElectronValidationError",
+        operation: "electron.config.read-package-version",
+        path: packageJsonPath,
+      });
+      expect((error as Error).message).toBe(`Missing package version in ${packageJsonPath}`);
+    } finally {
+      await rm(tempDirectory, { force: true, recursive: true });
+    }
   });
 });

--- a/apps/electron/vite.config.ts
+++ b/apps/electron/vite.config.ts
@@ -1,52 +1,29 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, searchForWorkspaceRoot } from "vite";
+import { runElectronSync } from "./src/effect/electron-boundary";
+import {
+  readPackageVersionEffect,
+  resolveRendererDevPortEffect,
+} from "./src/effect/electron-config";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const workspaceRoot = path.resolve(__dirname, "../..");
 const packagesRoot = path.join(workspaceRoot, "packages");
-const DEFAULT_RENDERER_DEV_PORT = 1430;
 
-const readPackageVersion = (packageJsonPath = path.resolve(__dirname, "package.json")): string => {
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
-    version?: unknown;
-  };
-  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
-    throw new Error(`Missing package version in ${packageJsonPath}`);
-  }
-  return packageJson.version;
-};
-
-export const resolveAppVersion = (env: NodeJS.ProcessEnv = process.env): string => {
+export const resolveAppVersion = (
+  env: NodeJS.ProcessEnv = process.env,
+  packageJsonPath = path.resolve(__dirname, "package.json"),
+): string => {
   const versionOverride = env.ODT_APP_VERSION?.trim();
-  return versionOverride || readPackageVersion();
+  return versionOverride || runElectronSync(readPackageVersionEffect(packageJsonPath));
 };
 
-const resolveRendererDevPort = (): number => {
-  const configuredPort = process.env.ELECTRON_RENDERER_DEV_PORT?.trim();
-  if (!configuredPort) {
-    return DEFAULT_RENDERER_DEV_PORT;
-  }
-
-  if (!/^\d+$/.test(configuredPort)) {
-    throw new Error(
-      `ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: ${configuredPort}`,
-    );
-  }
-
-  const port = Number(configuredPort);
-  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
-    throw new Error(
-      `ELECTRON_RENDERER_DEV_PORT must be a TCP port between 1 and 65535: ${configuredPort}`,
-    );
-  }
-
-  return port;
-};
+const resolveRendererDevPort = (): number =>
+  runElectronSync(resolveRendererDevPortEffect(process.env.ELECTRON_RENDERER_DEV_PORT));
 
 export default defineConfig({
   base: "./",

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "@types/node": "^25.9.2",
         "@vitejs/plugin-react": "^6.0.2",
         "bun-types": "^1.3.14",
+        "effect": "^3.21.4",
         "electron": "^42.4.1",
         "electron-builder": "^26.15.3",
         "react": "^19.2.7",


### PR DESCRIPTION
Summary: Migrates the Electron package's package/build/dev workflow surfaces and main-process startup boundaries to Effect-native typed errors while preserving existing public Promise-compatible entrypoints.

## Goal

The host package already uses Effect for explicit error channels and clearer I/O boundaries. This PR applies the same pattern to Electron-owned workflows so Electron startup, dev orchestration, package/build scripts, sidecar preparation, renderer config, and local attachment preview handling fail through typed, actionable errors instead of ad hoc thrown exceptions.

## Implementation

- Added Electron-focused Effect helpers for typed operation errors, validation errors, and `Effect` to `Promise` boundary execution.
- Migrated Electron package scripts for build, dev, package build, sidecar preparation, sidecar verification, and release-target resolution to Effect sequencing while keeping CLI entrypoints Promise-compatible.
- Moved main-process lifecycle setup and shutdown coordination behind Effect-aware boundaries, including startup failure logging and cleanup behavior.
- Preserved preload/renderer and host command boundaries as Promise-compatible API surfaces while moving fallible Electron-owned internals into typed failure channels.
- Added and updated focused tests around typed failures, lifecycle setup failures, dev watcher behavior, config validation, packaging paths, app identity, local attachment previews, and renderer shell bridge behavior.

## Verification

- `env TMPDIR=/Users/maxsky5/.openducktor/worktrees/openducktor/openduckto-os9o/.tmp rtk bun run lint`
- `env TMPDIR=/Users/maxsky5/.openducktor/worktrees/openducktor/openduckto-os9o/.tmp rtk bun run typecheck`
- `env TMPDIR=/Users/maxsky5/.openducktor/worktrees/openducktor/openduckto-os9o/.tmp rtk bun run test` passed outside the sandbox after sandboxed local TCP tests failed with `EPERM`/listen errors.
- `env TMPDIR=/Users/maxsky5/.openducktor/worktrees/openducktor/openduckto-os9o/.tmp rtk bun run build`

Cargo was not run because this repository contains no `Cargo.toml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Electron dev/build/packaging and main lifecycle orchestration for more reliable startup, shutdown, and restart behavior.
  * Added structured, typed validation/operation errors across Electron flows (ports, URLs, sidecars, previews, and bundle checks).

* **Bug Fixes**
  * Fixed error handling to consistently report actionable details for missing/invalid artifacts, migrations, executables, and macOS bundle requirements.
  * Improved local attachment preview validation and error responses; added a dedicated preload-bridge unavailable error.

* **Tests**
  * Expanded test coverage to assert structured error details and lifecycle/shutdown ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->