### PR TITLE
refactor(web): migrate package internals to Effect

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,10 +1,12 @@
 import electronKnipConfig from "./apps/electron/knip.config";
 import frontendKnipConfig from "./packages/frontend/knip.config";
+import webKnipConfig from "./packages/openducktor-web/knip.config";
 
 export default {
   tags: ["-internal"],
   workspaces: {
     "apps/electron": electronKnipConfig,
     "packages/frontend": frontendKnipConfig,
+    "packages/openducktor-web": webKnipConfig,
   },
 };

--- a/packages/openducktor-web/knip.config.ts
+++ b/packages/openducktor-web/knip.config.ts
@@ -1,0 +1,4 @@
+export default {
+  entry: ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
+  project: ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
+};

--- a/packages/openducktor-web/package.json
+++ b/packages/openducktor-web/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@openducktor/build-tools": "workspace:*",
+    "@openducktor/contracts": "workspace:*",
     "@openducktor/host-client": "workspace:*",
     "@openducktor/frontend": "workspace:*",
     "@openducktor/host": "workspace:*",

--- a/packages/openducktor-web/scripts/build-cli.ts
+++ b/packages/openducktor-web/scripts/build-cli.ts
@@ -1,14 +1,16 @@
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { markExecutable, runCommand } from "@openducktor/build-tools";
+import { Effect } from "effect";
+import { errorMessage, runWebBoundary, WebDependencyError } from "../src/effect/web-errors";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptDirectory, "..");
 const outputPath = join(packageRoot, "dist", "cli.js");
 
-export const buildWebCli = async (): Promise<void> => {
-  await runCommand({
-    command: [
+export const buildWebCliEffect = (): Effect.Effect<void, WebDependencyError> =>
+  Effect.gen(function* () {
+    const command = [
       "bun",
       "build",
       "--target=bun",
@@ -17,12 +19,32 @@ export const buildWebCli = async (): Promise<void> => {
       "--outfile",
       outputPath,
       "src/cli.ts",
-    ],
-    cwd: packageRoot,
-    label: "Web CLI build",
+    ] satisfies readonly [string, ...string[]];
+    yield* Effect.tryPromise({
+      try: () => runCommand({ command, cwd: packageRoot, label: "Web CLI build" }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "build-command",
+          operation: "web-cli-build",
+          message: errorMessage(cause),
+          cause,
+          details: { command, cwd: packageRoot },
+        }),
+    });
+    yield* Effect.tryPromise({
+      try: () => markExecutable(outputPath),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "filesystem",
+          operation: "mark-web-cli-executable",
+          message: errorMessage(cause),
+          cause,
+          details: { outputPath },
+        }),
+    });
   });
-  await markExecutable(outputPath);
-};
+
+export const buildWebCli = (): Promise<void> => runWebBoundary(buildWebCliEffect());
 
 if (import.meta.main) {
   await buildWebCli();

--- a/packages/openducktor-web/scripts/build-cli.ts
+++ b/packages/openducktor-web/scripts/build-cli.ts
@@ -47,5 +47,8 @@ export const buildWebCliEffect = (): Effect.Effect<void, WebDependencyError> =>
 export const buildWebCli = (): Promise<void> => runWebBoundary(buildWebCliEffect());
 
 if (import.meta.main) {
-  await buildWebCli();
+  await buildWebCli().catch((error: unknown) => {
+    console.error(errorMessage(error));
+    process.exit(1);
+  });
 }

--- a/packages/openducktor-web/scripts/build-mcp.ts
+++ b/packages/openducktor-web/scripts/build-mcp.ts
@@ -1,6 +1,8 @@
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { markExecutable, runCommand } from "@openducktor/build-tools";
+import { Effect } from "effect";
+import { errorMessage, runWebBoundary, WebDependencyError } from "../src/effect/web-errors";
 import { WEB_PACKAGE_MCP_ENTRYPOINT } from "../src/web-runtime-distribution";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -8,9 +10,9 @@ const packageRoot = resolve(scriptDirectory, "..");
 const workspaceRoot = resolve(packageRoot, "../..");
 const outputPath = join(packageRoot, "dist", WEB_PACKAGE_MCP_ENTRYPOINT);
 
-export const buildWebMcpEntrypoint = async (): Promise<void> => {
-  await runCommand({
-    command: [
+export const buildWebMcpEntrypointEffect = (): Effect.Effect<void, WebDependencyError> =>
+  Effect.gen(function* () {
+    const command = [
       "bun",
       "build",
       "--target=bun",
@@ -19,12 +21,33 @@ export const buildWebMcpEntrypoint = async (): Promise<void> => {
       "--banner",
       "#!/usr/bin/env bun",
       join(workspaceRoot, "packages", "openducktor-mcp", "src", "index.ts"),
-    ],
-    cwd: packageRoot,
-    label: "Web MCP entrypoint build",
+    ] satisfies readonly [string, ...string[]];
+    yield* Effect.tryPromise({
+      try: () => runCommand({ command, cwd: packageRoot, label: "Web MCP entrypoint build" }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "build-command",
+          operation: "web-mcp-entrypoint-build",
+          message: errorMessage(cause),
+          cause,
+          details: { command, cwd: packageRoot },
+        }),
+    });
+    yield* Effect.tryPromise({
+      try: () => markExecutable(outputPath),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "filesystem",
+          operation: "mark-web-mcp-entrypoint-executable",
+          message: errorMessage(cause),
+          cause,
+          details: { outputPath },
+        }),
+    });
   });
-  await markExecutable(outputPath);
-};
+
+export const buildWebMcpEntrypoint = (): Promise<void> =>
+  runWebBoundary(buildWebMcpEntrypointEffect());
 
 if (import.meta.main) {
   await buildWebMcpEntrypoint();

--- a/packages/openducktor-web/scripts/build-mcp.ts
+++ b/packages/openducktor-web/scripts/build-mcp.ts
@@ -50,5 +50,8 @@ export const buildWebMcpEntrypoint = (): Promise<void> =>
   runWebBoundary(buildWebMcpEntrypointEffect());
 
 if (import.meta.main) {
-  await buildWebMcpEntrypoint();
+  await buildWebMcpEntrypoint().catch((error: unknown) => {
+    console.error(errorMessage(error));
+    process.exit(1);
+  });
 }

--- a/packages/openducktor-web/scripts/build.ts
+++ b/packages/openducktor-web/scripts/build.ts
@@ -88,5 +88,8 @@ export const buildWebPackageEffect = (): Effect.Effect<void, WebDependencyError>
 export const buildWebPackage = (): Promise<void> => runWebBoundary(buildWebPackageEffect());
 
 if (import.meta.main) {
-  await buildWebPackage();
+  await buildWebPackage().catch((error: unknown) => {
+    console.error(errorMessage(error));
+    process.exit(1);
+  });
 }

--- a/packages/openducktor-web/scripts/build.ts
+++ b/packages/openducktor-web/scripts/build.ts
@@ -2,6 +2,8 @@ import { cp } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanDirectory, runCommand } from "@openducktor/build-tools";
+import { Effect } from "effect";
+import { errorMessage, runWebBoundary, WebDependencyError } from "../src/effect/web-errors";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptDirectory, "..");
@@ -23,36 +25,67 @@ export const resolveWebSqliteTaskStoreMigrationCopyPlan = ({
   targetDirectory: join(packageRoot, "dist", "drizzle"),
 });
 
-export const copyWebSqliteTaskStoreMigrations = ({
+export const copyWebSqliteTaskStoreMigrationsEffect = ({
   sourceDirectory,
   targetDirectory,
-}: WebSqliteTaskStoreMigrationCopyPlan): Promise<void> =>
-  cp(sourceDirectory, targetDirectory, { force: true, recursive: true });
+}: WebSqliteTaskStoreMigrationCopyPlan): Effect.Effect<void, WebDependencyError> =>
+  Effect.tryPromise({
+    try: () => cp(sourceDirectory, targetDirectory, { force: true, recursive: true }),
+    catch: (cause) =>
+      new WebDependencyError({
+        dependency: "filesystem",
+        operation: "copy-web-sqlite-task-store-migrations",
+        message: errorMessage(cause),
+        cause,
+        details: { sourceDirectory, targetDirectory },
+      }),
+  });
 
-export const buildWebPackage = async (): Promise<void> => {
-  await cleanDirectory(join(packageRoot, "dist"));
-  await runCommand({
-    command: ["bun", "run", "build:web-shell"],
-    cwd: packageRoot,
-    label: "Web shell build",
+export const copyWebSqliteTaskStoreMigrations = (
+  input: WebSqliteTaskStoreMigrationCopyPlan,
+): Promise<void> => runWebBoundary(copyWebSqliteTaskStoreMigrationsEffect(input));
+
+const runBuildCommandEffect = (
+  label: string,
+  command: readonly [string, ...string[]],
+): Effect.Effect<void, WebDependencyError> =>
+  Effect.tryPromise({
+    try: () => runCommand({ command, cwd: packageRoot, label }),
+    catch: (cause) =>
+      new WebDependencyError({
+        dependency: "build-command",
+        operation: label,
+        message: errorMessage(cause),
+        cause,
+        details: { command, cwd: packageRoot },
+      }),
   });
-  await runCommand({
-    command: ["bun", "run", "build:cli"],
-    cwd: packageRoot,
-    label: "Web CLI build",
+
+export const buildWebPackageEffect = (): Effect.Effect<void, WebDependencyError> =>
+  Effect.gen(function* () {
+    yield* Effect.tryPromise({
+      try: () => cleanDirectory(join(packageRoot, "dist")),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "filesystem",
+          operation: "clean-web-dist",
+          message: errorMessage(cause),
+          cause,
+          details: { path: join(packageRoot, "dist") },
+        }),
+    });
+    yield* runBuildCommandEffect("Web shell build", ["bun", "run", "build:web-shell"]);
+    yield* runBuildCommandEffect("Web CLI build", ["bun", "run", "build:cli"]);
+    yield* runBuildCommandEffect("Web MCP entrypoint build", ["bun", "run", "build:mcp"]);
+    yield* copyWebSqliteTaskStoreMigrationsEffect(
+      resolveWebSqliteTaskStoreMigrationCopyPlan({
+        packageRoot,
+        workspaceRoot,
+      }),
+    );
   });
-  await runCommand({
-    command: ["bun", "run", "build:mcp"],
-    cwd: packageRoot,
-    label: "Web MCP entrypoint build",
-  });
-  await copyWebSqliteTaskStoreMigrations(
-    resolveWebSqliteTaskStoreMigrationCopyPlan({
-      packageRoot,
-      workspaceRoot,
-    }),
-  );
-};
+
+export const buildWebPackage = (): Promise<void> => runWebBoundary(buildWebPackageEffect());
 
 if (import.meta.main) {
   await buildWebPackage();

--- a/packages/openducktor-web/scripts/dev.test.ts
+++ b/packages/openducktor-web/scripts/dev.test.ts
@@ -70,4 +70,11 @@ describe("web dev script", () => {
 
     return expect(source).resolves.not.toContain("webCli.killed");
   });
+
+  test("stops the child CLI from the Effect finalizer when needed", async () => {
+    const source = await Bun.file(new URL("./dev.ts", import.meta.url)).text();
+
+    expect(source).toContain("if (cleanupCompleted || webCliExited)");
+    expect(source).toContain("keepWebDevProcessAliveDuringEffect(stopWebCliEffect(webCli))");
+  });
 });

--- a/packages/openducktor-web/scripts/dev.test.ts
+++ b/packages/openducktor-web/scripts/dev.test.ts
@@ -76,5 +76,6 @@ describe("web dev script", () => {
 
     expect(source).toContain("if (cleanupCompleted || webCliExited)");
     expect(source).toContain("keepWebDevProcessAliveDuringEffect(stopWebCliEffect(webCli))");
+    expect(source).toContain("force-terminate-timeout");
   });
 });

--- a/packages/openducktor-web/scripts/dev.ts
+++ b/packages/openducktor-web/scripts/dev.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { Effect } from "effect";
+import { errorMessage, runWebBoundary, WebDependencyError } from "../src/effect/web-errors";
 
 type ManagedWebProcess = Bun.Subprocess<"ignore", "inherit", "inherit">;
 type KeepAliveTimer = ReturnType<typeof setInterval>;
@@ -16,19 +18,31 @@ const WEB_SHUTDOWN_KEEP_ALIVE_INTERVAL_MS = 1_000;
 const sleep = (durationMs: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, durationMs));
 
-const waitForProcessExit = async (
+const waitForProcessExitEffect = (
   subprocess: Pick<ManagedWebProcess, "exited">,
   timeoutMs: number,
-): Promise<boolean> => {
-  let exited = false;
-  await Promise.race([
-    subprocess.exited.then(() => {
-      exited = true;
-    }),
-    sleep(timeoutMs),
-  ]);
-  return exited;
-};
+): Effect.Effect<boolean, WebDependencyError> =>
+  Effect.gen(function* () {
+    let exited = false;
+    yield* Effect.tryPromise({
+      try: () =>
+        Promise.race([
+          subprocess.exited.then(() => {
+            exited = true;
+          }),
+          sleep(timeoutMs),
+        ]),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "web-cli-process",
+          operation: "await-exit",
+          message: errorMessage(cause),
+          cause,
+          details: { timeoutMs },
+        }),
+    });
+    return exited;
+  });
 
 export const shouldDetachWebProcessGroup = (
   platform: NodeJS.Platform = process.platform,
@@ -46,85 +60,134 @@ export const buildWebDevProcessEnvironment = (
   FORCE_COLOR: env.FORCE_COLOR ?? "1",
 });
 
-export const keepWebDevProcessAliveDuring = async <T>(
+export const keepWebDevProcessAliveDuringEffect = <T>(
   operation: Promise<T>,
   dependencies: ProcessKeepAliveDependencies = {
     clearInterval,
     setInterval,
   },
-): Promise<T> => {
-  const timer = dependencies.setInterval(() => {}, WEB_SHUTDOWN_KEEP_ALIVE_INTERVAL_MS);
-  try {
-    return await operation;
-  } finally {
-    dependencies.clearInterval(timer);
-  }
-};
+): Effect.Effect<T, WebDependencyError> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => dependencies.setInterval(() => {}, WEB_SHUTDOWN_KEEP_ALIVE_INTERVAL_MS)),
+    () =>
+      Effect.tryPromise({
+        try: () => operation,
+        catch: (cause) =>
+          new WebDependencyError({
+            dependency: "web-dev-operation",
+            operation: "keep-process-alive",
+            message: errorMessage(cause),
+            cause,
+          }),
+      }),
+    (timer) => Effect.sync(() => dependencies.clearInterval(timer)),
+  );
 
-const startWebCli = (args: readonly string[]): ManagedWebProcess =>
-  Bun.spawn(buildWebDevCommand(args), {
-    cwd: packageRoot,
-    detached: shouldDetachWebProcessGroup(),
-    stdout: "inherit",
-    stderr: "inherit",
-    env: buildWebDevProcessEnvironment(),
+export const keepWebDevProcessAliveDuring = <T>(
+  operation: Promise<T>,
+  dependencies: ProcessKeepAliveDependencies = {
+    clearInterval,
+    setInterval,
+  },
+): Promise<T> => runWebBoundary(keepWebDevProcessAliveDuringEffect(operation, dependencies));
+
+const startWebCliEffect = (
+  args: readonly string[],
+): Effect.Effect<ManagedWebProcess, WebDependencyError> =>
+  Effect.try({
+    try: () =>
+      Bun.spawn(buildWebDevCommand(args), {
+        cwd: packageRoot,
+        detached: shouldDetachWebProcessGroup(),
+        stdout: "inherit",
+        stderr: "inherit",
+        env: buildWebDevProcessEnvironment(),
+      }),
+    catch: (cause) =>
+      new WebDependencyError({
+        dependency: "web-cli-process",
+        operation: "spawn",
+        message: errorMessage(cause),
+        cause,
+        details: { args },
+      }),
   });
 
-const stopWebCli = async (webCli: ManagedWebProcess | null): Promise<void> => {
-  if (!webCli) {
-    return;
-  }
-
-  webCli.kill();
-  if (await waitForProcessExit(webCli, WEB_STOP_TIMEOUT_MS)) {
-    return;
-  }
-
-  webCli.kill(9);
-  await waitForProcessExit(webCli, WEB_STOP_TIMEOUT_MS);
-};
-
-export const runWebDev = async (
-  args: readonly string[] = process.argv.slice(2),
-): Promise<number> => {
-  const webCli = startWebCli(args);
-  let webCliExited = false;
-  let shutdownStarted = false;
-  let resolveExit: (exitCode: number) => void = () => {};
-  const exited = new Promise<number>((resolve) => {
-    resolveExit = resolve;
-  });
-
-  const shutdown = async (exitCode: number): Promise<void> => {
-    if (shutdownStarted) {
+const stopWebCliEffect = (
+  webCli: ManagedWebProcess | null,
+): Effect.Effect<void, WebDependencyError> =>
+  Effect.gen(function* () {
+    if (!webCli) {
       return;
     }
-    shutdownStarted = true;
-    await keepWebDevProcessAliveDuring(stopWebCli(webCli));
-    resolveExit(exitCode);
-  };
 
-  void webCli.exited.then((exitCode) => {
-    webCliExited = true;
-    if (!shutdownStarted) {
-      void shutdown(exitCode);
+    yield* Effect.sync(() => webCli.kill());
+    if (yield* waitForProcessExitEffect(webCli, WEB_STOP_TIMEOUT_MS)) {
+      return;
     }
+
+    yield* Effect.sync(() => webCli.kill(9));
+    yield* waitForProcessExitEffect(webCli, WEB_STOP_TIMEOUT_MS);
   });
 
-  process.on("SIGINT", () => {
-    void shutdown(130);
-  });
-  process.on("SIGTERM", () => {
-    void shutdown(143);
-  });
-  process.once("exit", () => {
-    if (!webCliExited) {
-      webCli.kill();
-    }
+export const runWebDevEffect = (
+  args: readonly string[] = process.argv.slice(2),
+): Effect.Effect<number, WebDependencyError> =>
+  Effect.gen(function* () {
+    const webCli = yield* startWebCliEffect(args);
+    let webCliExited = false;
+    let shutdownStarted = false;
+    let resolveExit: (exitCode: number) => void = () => {};
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+
+    const shutdown = async (exitCode: number): Promise<void> => {
+      if (shutdownStarted) {
+        return;
+      }
+      shutdownStarted = true;
+      await runWebBoundary(
+        keepWebDevProcessAliveDuringEffect(runWebBoundary(stopWebCliEffect(webCli))),
+      );
+      resolveExit(exitCode);
+    };
+
+    yield* Effect.sync(() => {
+      void webCli.exited.then((exitCode) => {
+        webCliExited = true;
+        if (!shutdownStarted) {
+          void shutdown(exitCode);
+        }
+      });
+
+      process.on("SIGINT", () => {
+        void shutdown(130);
+      });
+      process.on("SIGTERM", () => {
+        void shutdown(143);
+      });
+      process.once("exit", () => {
+        if (!webCliExited) {
+          webCli.kill();
+        }
+      });
+    });
+
+    return yield* Effect.tryPromise({
+      try: () => exited,
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "web-dev-supervisor",
+          operation: "await-exit",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
   });
 
-  return exited;
-};
+export const runWebDev = (args: readonly string[] = process.argv.slice(2)): Promise<number> =>
+  runWebBoundary(runWebDevEffect(args));
 
 if (import.meta.main) {
   const exitCode = await runWebDev().catch((error: unknown) => {

--- a/packages/openducktor-web/scripts/dev.ts
+++ b/packages/openducktor-web/scripts/dev.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Effect } from "effect";
-import { errorMessage, runWebBoundary, WebDependencyError } from "../src/effect/web-errors";
+import {
+  causeToWebBoundaryError,
+  errorMessage,
+  runWebBoundary,
+  WebDependencyError,
+} from "../src/effect/web-errors";
 
 type ManagedWebProcess = Bun.Subprocess<"ignore", "inherit", "inherit">;
 type KeepAliveTimer = ReturnType<typeof setInterval>;
@@ -159,85 +164,106 @@ export const runWebDevEffect = (
   args: readonly string[] = process.argv.slice(2),
 ): Effect.Effect<number, WebDependencyError> =>
   Effect.gen(function* () {
-    const webCli = yield* startWebCliEffect(args);
     let webCliExited = false;
     let shutdownStarted = false;
-    let resolveExit: (exitCode: number) => void = () => {};
-    let rejectExit: (cause: unknown) => void = () => {};
-    const exited = new Promise<number>((resolve, reject) => {
-      resolveExit = resolve;
-      rejectExit = reject;
-    });
-
-    const shutdown = async (exitCode: number): Promise<void> => {
-      if (shutdownStarted) {
-        return;
-      }
-      shutdownStarted = true;
-      try {
-        await runWebBoundary(keepWebDevProcessAliveDuringEffect(stopWebCliEffect(webCli)));
-        resolveExit(exitCode);
-      } catch (error) {
-        rejectExit(error);
-      }
-    };
-
-    void webCli.exited.then(
-      (exitCode) => {
-        webCliExited = true;
-        if (!shutdownStarted) {
-          void shutdown(exitCode);
-        }
-      },
-      (error: unknown) => {
-        webCliExited = true;
-        if (!shutdownStarted) {
-          shutdownStarted = true;
-          rejectExit(error);
-        }
-      },
-    );
-
-    const handleSigint = (): void => {
-      void shutdown(130);
-    };
-    const handleSigterm = (): void => {
-      void shutdown(143);
-    };
-    const handleExit = (): void => {
-      if (!webCliExited) {
-        try {
-          webCli.kill();
-        } catch (error) {
-          console.error(errorMessage(error));
-        }
-      }
-    };
+    let cleanupCompleted = false;
 
     return yield* Effect.acquireUseRelease(
-      Effect.sync(() => {
-        process.on("SIGINT", handleSigint);
-        process.on("SIGTERM", handleSigterm);
-        process.on("exit", handleExit);
-      }),
-      () =>
-        Effect.tryPromise({
-          try: () => exited,
-          catch: (cause) =>
-            cause instanceof WebDependencyError
-              ? cause
-              : new WebDependencyError({
-                  dependency: "web-dev-supervisor",
-                  operation: "await-exit",
-                  message: errorMessage(cause),
-                  cause,
-                }),
+      startWebCliEffect(args),
+      (webCli) =>
+        Effect.gen(function* () {
+          let resolveExit: (exitCode: number) => void = () => {};
+          let rejectExit: (cause: unknown) => void = () => {};
+          const exited = new Promise<number>((resolve, reject) => {
+            resolveExit = resolve;
+            rejectExit = reject;
+          });
+
+          const shutdown = async (exitCode: number): Promise<void> => {
+            if (shutdownStarted) {
+              return;
+            }
+            shutdownStarted = true;
+            try {
+              await runWebBoundary(keepWebDevProcessAliveDuringEffect(stopWebCliEffect(webCli)));
+              cleanupCompleted = true;
+              resolveExit(exitCode);
+            } catch (error) {
+              cleanupCompleted = true;
+              rejectExit(error);
+            }
+          };
+
+          void webCli.exited.then(
+            (exitCode) => {
+              webCliExited = true;
+              if (!shutdownStarted) {
+                void shutdown(exitCode);
+              }
+            },
+            (error: unknown) => {
+              webCliExited = true;
+              if (!shutdownStarted) {
+                shutdownStarted = true;
+                rejectExit(error);
+              }
+            },
+          );
+
+          const handleSigint = (): void => {
+            void shutdown(130);
+          };
+          const handleSigterm = (): void => {
+            void shutdown(143);
+          };
+          const handleExit = (): void => {
+            if (!webCliExited) {
+              try {
+                webCli.kill();
+              } catch (error) {
+                console.error(errorMessage(error));
+              }
+            }
+          };
+
+          return yield* Effect.acquireUseRelease(
+            Effect.sync(() => {
+              process.on("SIGINT", handleSigint);
+              process.on("SIGTERM", handleSigterm);
+              process.on("exit", handleExit);
+            }),
+            () =>
+              Effect.tryPromise({
+                try: () => exited,
+                catch: (cause) =>
+                  cause instanceof WebDependencyError
+                    ? cause
+                    : new WebDependencyError({
+                        dependency: "web-dev-supervisor",
+                        operation: "await-exit",
+                        message: errorMessage(cause),
+                        cause,
+                      }),
+              }),
+            () =>
+              Effect.sync(() => {
+                process.off("SIGINT", handleSigint);
+                process.off("SIGTERM", handleSigterm);
+                process.off("exit", handleExit);
+              }),
+          );
         }),
-      () =>
-        Effect.sync(() => {
-          process.off("SIGINT", handleSigint);
-          process.off("SIGTERM", handleSigterm);
-          process.off("exit", handleExit);
+      (webCli) =>
+        Effect.gen(function* () {
+          if (cleanupCompleted || webCliExited) {
+            return;
+          }
+          const stopExit = yield* Effect.exit(
+            keepWebDevProcessAliveDuringEffect(stopWebCliEffect(webCli)),
+          );
+          if (stopExit._tag === "Failure") {
+            console.error(errorMessage(causeToWebBoundaryError(stopExit.cause)));
+          }
         }),
     );
   });

--- a/packages/openducktor-web/scripts/dev.ts
+++ b/packages/openducktor-web/scripts/dev.ts
@@ -157,7 +157,14 @@ const stopWebCliEffect = (
           details: { signal: 9 },
         }),
     });
-    yield* waitForProcessExitEffect(webCli, WEB_STOP_TIMEOUT_MS);
+    if (!(yield* waitForProcessExitEffect(webCli, WEB_STOP_TIMEOUT_MS))) {
+      return yield* new WebDependencyError({
+        dependency: "web-cli-process",
+        operation: "force-terminate-timeout",
+        message: `Web CLI process did not exit within ${WEB_STOP_TIMEOUT_MS}ms after SIGKILL.`,
+        details: { signal: 9, timeoutMs: WEB_STOP_TIMEOUT_MS },
+      });
+    }
   });
 
 export const runWebDevEffect = (

--- a/packages/openducktor-web/scripts/dev.ts
+++ b/packages/openducktor-web/scripts/dev.ts
@@ -60,16 +60,28 @@ export const buildWebDevProcessEnvironment = (
   FORCE_COLOR: env.FORCE_COLOR ?? "1",
 });
 
-export const keepWebDevProcessAliveDuringEffect = <T>(
+export const keepWebDevProcessAliveDuringEffect = <T, E>(
+  operation: Effect.Effect<T, E>,
+  dependencies: ProcessKeepAliveDependencies = {
+    clearInterval,
+    setInterval,
+  },
+): Effect.Effect<T, E | WebDependencyError> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => dependencies.setInterval(() => {}, WEB_SHUTDOWN_KEEP_ALIVE_INTERVAL_MS)),
+    () => operation,
+    (timer) => Effect.sync(() => dependencies.clearInterval(timer)),
+  );
+
+export const keepWebDevProcessAliveDuring = <T>(
   operation: Promise<T>,
   dependencies: ProcessKeepAliveDependencies = {
     clearInterval,
     setInterval,
   },
-): Effect.Effect<T, WebDependencyError> =>
-  Effect.acquireUseRelease(
-    Effect.sync(() => dependencies.setInterval(() => {}, WEB_SHUTDOWN_KEEP_ALIVE_INTERVAL_MS)),
-    () =>
+): Promise<T> =>
+  runWebBoundary(
+    keepWebDevProcessAliveDuringEffect(
       Effect.tryPromise({
         try: () => operation,
         catch: (cause) =>
@@ -80,16 +92,9 @@ export const keepWebDevProcessAliveDuringEffect = <T>(
             cause,
           }),
       }),
-    (timer) => Effect.sync(() => dependencies.clearInterval(timer)),
+      dependencies,
+    ),
   );
-
-export const keepWebDevProcessAliveDuring = <T>(
-  operation: Promise<T>,
-  dependencies: ProcessKeepAliveDependencies = {
-    clearInterval,
-    setInterval,
-  },
-): Promise<T> => runWebBoundary(keepWebDevProcessAliveDuringEffect(operation, dependencies));
 
 const startWebCliEffect = (
   args: readonly string[],
@@ -147,9 +152,7 @@ export const runWebDevEffect = (
         return;
       }
       shutdownStarted = true;
-      await runWebBoundary(
-        keepWebDevProcessAliveDuringEffect(runWebBoundary(stopWebCliEffect(webCli))),
-      );
+      await runWebBoundary(keepWebDevProcessAliveDuringEffect(stopWebCliEffect(webCli)));
       resolveExit(exitCode);
     };
 

--- a/packages/openducktor-web/scripts/dev.ts
+++ b/packages/openducktor-web/scripts/dev.ts
@@ -66,7 +66,7 @@ export const keepWebDevProcessAliveDuringEffect = <T, E>(
     clearInterval,
     setInterval,
   },
-): Effect.Effect<T, E | WebDependencyError> =>
+): Effect.Effect<T, E> =>
   Effect.acquireUseRelease(
     Effect.sync(() => dependencies.setInterval(() => {}, WEB_SHUTDOWN_KEEP_ALIVE_INTERVAL_MS)),
     () => operation,

--- a/packages/openducktor-web/scripts/dev.ts
+++ b/packages/openducktor-web/scripts/dev.ts
@@ -126,12 +126,32 @@ const stopWebCliEffect = (
       return;
     }
 
-    yield* Effect.sync(() => webCli.kill());
+    yield* Effect.try({
+      try: () => webCli.kill(),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "web-cli-process",
+          operation: "terminate",
+          message: errorMessage(cause),
+          cause,
+          details: { signal: "SIGTERM" },
+        }),
+    });
     if (yield* waitForProcessExitEffect(webCli, WEB_STOP_TIMEOUT_MS)) {
       return;
     }
 
-    yield* Effect.sync(() => webCli.kill(9));
+    yield* Effect.try({
+      try: () => webCli.kill(9),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "web-cli-process",
+          operation: "force-terminate",
+          message: errorMessage(cause),
+          cause,
+          details: { signal: 9 },
+        }),
+    });
     yield* waitForProcessExitEffect(webCli, WEB_STOP_TIMEOUT_MS);
   });
 
@@ -143,8 +163,10 @@ export const runWebDevEffect = (
     let webCliExited = false;
     let shutdownStarted = false;
     let resolveExit: (exitCode: number) => void = () => {};
-    const exited = new Promise<number>((resolve) => {
+    let rejectExit: (cause: unknown) => void = () => {};
+    const exited = new Promise<number>((resolve, reject) => {
       resolveExit = resolve;
+      rejectExit = reject;
     });
 
     const shutdown = async (exitCode: number): Promise<void> => {
@@ -152,41 +174,72 @@ export const runWebDevEffect = (
         return;
       }
       shutdownStarted = true;
-      await runWebBoundary(keepWebDevProcessAliveDuringEffect(stopWebCliEffect(webCli)));
-      resolveExit(exitCode);
+      try {
+        await runWebBoundary(keepWebDevProcessAliveDuringEffect(stopWebCliEffect(webCli)));
+        resolveExit(exitCode);
+      } catch (error) {
+        rejectExit(error);
+      }
     };
 
-    yield* Effect.sync(() => {
-      void webCli.exited.then((exitCode) => {
+    void webCli.exited.then(
+      (exitCode) => {
         webCliExited = true;
         if (!shutdownStarted) {
           void shutdown(exitCode);
         }
-      });
-
-      process.on("SIGINT", () => {
-        void shutdown(130);
-      });
-      process.on("SIGTERM", () => {
-        void shutdown(143);
-      });
-      process.once("exit", () => {
-        if (!webCliExited) {
-          webCli.kill();
+      },
+      (error: unknown) => {
+        webCliExited = true;
+        if (!shutdownStarted) {
+          shutdownStarted = true;
+          rejectExit(error);
         }
-      });
-    });
+      },
+    );
 
-    return yield* Effect.tryPromise({
-      try: () => exited,
-      catch: (cause) =>
-        new WebDependencyError({
-          dependency: "web-dev-supervisor",
-          operation: "await-exit",
-          message: errorMessage(cause),
-          cause,
+    const handleSigint = (): void => {
+      void shutdown(130);
+    };
+    const handleSigterm = (): void => {
+      void shutdown(143);
+    };
+    const handleExit = (): void => {
+      if (!webCliExited) {
+        try {
+          webCli.kill();
+        } catch (error) {
+          console.error(errorMessage(error));
+        }
+      }
+    };
+
+    return yield* Effect.acquireUseRelease(
+      Effect.sync(() => {
+        process.on("SIGINT", handleSigint);
+        process.on("SIGTERM", handleSigterm);
+        process.on("exit", handleExit);
+      }),
+      () =>
+        Effect.tryPromise({
+          try: () => exited,
+          catch: (cause) =>
+            cause instanceof WebDependencyError
+              ? cause
+              : new WebDependencyError({
+                  dependency: "web-dev-supervisor",
+                  operation: "await-exit",
+                  message: errorMessage(cause),
+                  cause,
+                }),
         }),
-    });
+      () =>
+        Effect.sync(() => {
+          process.off("SIGINT", handleSigint);
+          process.off("SIGTERM", handleSigterm);
+          process.off("exit", handleExit);
+        }),
+    );
   });
 
 export const runWebDev = (args: readonly string[] = process.argv.slice(2)): Promise<number> =>
@@ -194,7 +247,7 @@ export const runWebDev = (args: readonly string[] = process.argv.slice(2)): Prom
 
 if (import.meta.main) {
   const exitCode = await runWebDev().catch((error: unknown) => {
-    console.error(error);
+    console.error(errorMessage(error));
     return 1;
   });
   process.exit(exitCode);

--- a/packages/openducktor-web/src/browser-config.test.ts
+++ b/packages/openducktor-web/src/browser-config.test.ts
@@ -23,15 +23,16 @@ describe("browser web host config", () => {
   });
 
   test("requires the launcher-injected backend URL", () => {
-    expect(() => getBrowserBackendUrl({ VITE_ODT_BROWSER_AUTH_TOKEN: "token" })).toThrow(
-      "OpenDucktor web is missing the local web host URL",
-    );
+    const readBackendUrl = () => getBrowserBackendUrl({ VITE_ODT_BROWSER_AUTH_TOKEN: "token" });
+    expect(readBackendUrl).toThrow("OpenDucktor web is missing the local web host URL");
+    expect(readBackendUrl).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
   });
 
   test("requires the launcher-injected auth token", () => {
-    expect(() =>
-      getBrowserAuthToken({ VITE_ODT_BROWSER_BACKEND_URL: "http://127.0.0.1:14327" }),
-    ).toThrow("OpenDucktor web is missing the local web host app token");
+    const readAuthToken = () =>
+      getBrowserAuthToken({ VITE_ODT_BROWSER_BACKEND_URL: "http://127.0.0.1:14327" });
+    expect(readAuthToken).toThrow("OpenDucktor web is missing the local web host app token");
+    expect(readAuthToken).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
   });
 
   test("matches the shared loopback origin validation cases", async () => {
@@ -44,6 +45,9 @@ describe("browser web host config", () => {
         expect(validate(), testCase.name).toBe(testCase.expected);
       } else {
         expect(validate, testCase.name).toThrow(testCase.errorIncludes);
+        expect(validate, testCase.name).toThrow(
+          expect.objectContaining({ _tag: "WebValidationError" }),
+        );
       }
     }
   });

--- a/packages/openducktor-web/src/browser-config.ts
+++ b/packages/openducktor-web/src/browser-config.ts
@@ -1,3 +1,6 @@
+import { Effect } from "effect";
+import { runWebSyncBoundary, WebValidationError } from "./effect/web-errors";
+
 type BrowserEnv = Record<string, string | undefined> | undefined;
 export type BrowserRuntimeConfig = {
   backendUrl?: string;
@@ -28,51 +31,70 @@ const readBrowserRuntimeConfig = (): BrowserRuntimeConfig | undefined => {
   return browserRuntimeConfig;
 };
 
-const requireBrowserEnvValue = (env: BrowserEnv, key: string, description: string): string => {
-  const value = env?.[key]?.trim();
-  if (!value) {
-    throw new Error(
-      `OpenDucktor web is missing ${description}. Start the app through @openducktor/web so the launcher can inject ${key}.`,
-    );
-  }
+const requireBrowserEnvValueEffect = (
+  env: BrowserEnv,
+  key: string,
+  description: string,
+): Effect.Effect<string, WebValidationError> =>
+  Effect.gen(function* () {
+    const value = env?.[key]?.trim();
+    if (!value) {
+      return yield* new WebValidationError({
+        field: key,
+        message: `OpenDucktor web is missing ${description}. Start the app through @openducktor/web so the launcher can inject ${key}.`,
+      });
+    }
 
-  return value;
-};
+    return value;
+  });
 
-const parseLoopbackHttpOrigin = (rawUrl: string): URL => {
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch (error) {
-    throw new Error(
-      `OpenDucktor web backend URL is invalid. Start the app through @openducktor/web.`,
-      { cause: error },
-    );
-  }
+const parseLoopbackHttpOriginEffect = (rawUrl: string): Effect.Effect<URL, WebValidationError> =>
+  Effect.gen(function* () {
+    const parsed = yield* Effect.try({
+      try: () => new URL(rawUrl),
+      catch: (cause) =>
+        new WebValidationError({
+          message:
+            "OpenDucktor web backend URL is invalid. Start the app through @openducktor/web.",
+          cause,
+          details: { rawUrl },
+        }),
+    });
 
-  if (parsed.protocol !== "http:") {
-    throw new Error("OpenDucktor web backend URL must use http on a loopback interface.");
-  }
-  if (!LOOPBACK_HOSTS.has(parsed.hostname)) {
-    throw new Error("OpenDucktor web backend URL must target 127.0.0.1, localhost, or [::1].");
-  }
-  if (!parsed.port) {
-    throw new Error("OpenDucktor web backend URL must include an explicit port.");
-  }
-  if (
-    parsed.username ||
-    parsed.password ||
-    parsed.pathname !== "/" ||
-    parsed.search ||
-    parsed.hash
-  ) {
-    throw new Error(
-      "OpenDucktor web backend URL must be an origin only, without credentials, path, query, or fragment.",
-    );
-  }
+    if (parsed.protocol !== "http:") {
+      return yield* new WebValidationError({
+        message: "OpenDucktor web backend URL must use http on a loopback interface.",
+        details: { rawUrl },
+      });
+    }
+    if (!LOOPBACK_HOSTS.has(parsed.hostname)) {
+      return yield* new WebValidationError({
+        message: "OpenDucktor web backend URL must target 127.0.0.1, localhost, or [::1].",
+        details: { rawUrl },
+      });
+    }
+    if (!parsed.port) {
+      return yield* new WebValidationError({
+        message: "OpenDucktor web backend URL must include an explicit port.",
+        details: { rawUrl },
+      });
+    }
+    if (
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== "/" ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return yield* new WebValidationError({
+        message:
+          "OpenDucktor web backend URL must be an origin only, without credentials, path, query, or fragment.",
+        details: { rawUrl },
+      });
+    }
 
-  return parsed;
-};
+    return parsed;
+  });
 
 const hostForOrigin = (hostname: string): string => {
   if (hostname === "::1" || hostname === "[::1]") {
@@ -82,46 +104,79 @@ const hostForOrigin = (hostname: string): string => {
   return hostname;
 };
 
-const alignBackendOriginWithBrowserOrigin = (
+const alignBackendOriginWithBrowserOriginEffect = (
   backendOrigin: URL,
   browserOrigin?: string,
-): string => {
-  if (!browserOrigin) {
-    return backendOrigin.origin;
-  }
+): Effect.Effect<string, WebValidationError> =>
+  Effect.gen(function* () {
+    if (!browserOrigin) {
+      return backendOrigin.origin;
+    }
 
-  let frontendOrigin: URL;
-  try {
-    frontendOrigin = new URL(browserOrigin);
-  } catch {
-    return backendOrigin.origin;
-  }
+    const frontendOrigin = yield* Effect.try({
+      try: () => new URL(browserOrigin),
+      catch: (cause) =>
+        new WebValidationError({
+          message: "OpenDucktor web browser origin is invalid.",
+          cause,
+          details: { browserOrigin },
+        }),
+    });
 
-  if (frontendOrigin.protocol !== "http:" || !LOOPBACK_HOSTS.has(frontendOrigin.hostname)) {
-    return backendOrigin.origin;
-  }
+    if (frontendOrigin.protocol !== "http:" || !LOOPBACK_HOSTS.has(frontendOrigin.hostname)) {
+      return backendOrigin.origin;
+    }
 
-  return new URL(
-    `${frontendOrigin.protocol}//${hostForOrigin(frontendOrigin.hostname)}:${backendOrigin.port}`,
-  ).origin;
-};
+    return new URL(
+      `${frontendOrigin.protocol}//${hostForOrigin(frontendOrigin.hostname)}:${backendOrigin.port}`,
+    ).origin;
+  });
 
-const normalizeLoopbackHttpUrl = (rawUrl: string, browserOrigin?: string): string => {
-  const parsed = parseLoopbackHttpOrigin(rawUrl);
+const normalizeLoopbackHttpUrlEffect = (
+  rawUrl: string,
+  browserOrigin?: string,
+): Effect.Effect<string, WebValidationError> =>
+  Effect.gen(function* () {
+    const parsed = yield* parseLoopbackHttpOriginEffect(rawUrl);
 
-  return alignBackendOriginWithBrowserOrigin(parsed, browserOrigin);
-};
+    return yield* alignBackendOriginWithBrowserOriginEffect(parsed, browserOrigin);
+  });
+
+export const getBrowserBackendUrlEffect = (
+  env: BrowserEnv = readBrowserEnv(),
+  browserOrigin: string | undefined = readBrowserLocationOrigin(),
+): Effect.Effect<string, WebValidationError> =>
+  Effect.gen(function* () {
+    const configuredUrl = readBrowserRuntimeConfig()?.backendUrl?.trim();
+    const rawUrl = configuredUrl
+      ? configuredUrl
+      : yield* requireBrowserEnvValueEffect(
+          env,
+          "VITE_ODT_BROWSER_BACKEND_URL",
+          "the local web host URL",
+        );
+    return yield* normalizeLoopbackHttpUrlEffect(rawUrl, browserOrigin);
+  });
 
 export const getBrowserBackendUrl = (
   env: BrowserEnv = readBrowserEnv(),
   browserOrigin: string | undefined = readBrowserLocationOrigin(),
-): string =>
-  normalizeLoopbackHttpUrl(
-    readBrowserRuntimeConfig()?.backendUrl?.trim() ||
-      requireBrowserEnvValue(env, "VITE_ODT_BROWSER_BACKEND_URL", "the local web host URL"),
-    browserOrigin,
-  );
+): string => runWebSyncBoundary(getBrowserBackendUrlEffect(env, browserOrigin));
+
+export const getBrowserAuthTokenEffect = (
+  env: BrowserEnv = readBrowserEnv(),
+): Effect.Effect<string, WebValidationError> =>
+  Effect.gen(function* () {
+    const configuredToken = readBrowserRuntimeConfig()?.appToken?.trim();
+    if (configuredToken) {
+      return configuredToken;
+    }
+    return yield* requireBrowserEnvValueEffect(
+      env,
+      "VITE_ODT_BROWSER_AUTH_TOKEN",
+      "the local web host app token",
+    );
+  });
 
 export const getBrowserAuthToken = (env: BrowserEnv = readBrowserEnv()): string =>
-  readBrowserRuntimeConfig()?.appToken?.trim() ||
-  requireBrowserEnvValue(env, "VITE_ODT_BROWSER_AUTH_TOKEN", "the local web host app token");
+  runWebSyncBoundary(getBrowserAuthTokenEffect(env));

--- a/packages/openducktor-web/src/browser-shell-bridge.test.ts
+++ b/packages/openducktor-web/src/browser-shell-bridge.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createBrowserShellBridge } from "./browser-shell-bridge";
 import { validateExternalBrowserUrl } from "./browser-url-validation";
 
 describe("browser shell bridge", () => {
@@ -27,5 +28,26 @@ describe("browser shell bridge", () => {
     expect(() => validateExternalBrowserUrl("not a url")).toThrow(
       "OpenDucktor web can only open absolute http or https URLs.",
     );
+  });
+
+  test("does not treat noopener window.open null results as blocked popups", async () => {
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        open: () => null,
+      },
+    });
+
+    try {
+      await expect(
+        createBrowserShellBridge().openExternalUrl("https://example.com/docs"),
+      ).resolves.toBeUndefined();
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
   });
 });

--- a/packages/openducktor-web/src/browser-shell-bridge.test.ts
+++ b/packages/openducktor-web/src/browser-shell-bridge.test.ts
@@ -31,7 +31,7 @@ describe("browser shell bridge", () => {
   });
 
   test("does not treat noopener window.open null results as blocked popups", async () => {
-    const originalWindow = globalThis.window;
+    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
     Object.defineProperty(globalThis, "window", {
       configurable: true,
       value: {
@@ -44,10 +44,11 @@ describe("browser shell bridge", () => {
         createBrowserShellBridge().openExternalUrl("https://example.com/docs"),
       ).resolves.toBeUndefined();
     } finally {
-      Object.defineProperty(globalThis, "window", {
-        configurable: true,
-        value: originalWindow,
-      });
+      if (originalWindowDescriptor) {
+        Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "window");
+      }
     }
   });
 });

--- a/packages/openducktor-web/src/browser-shell-bridge.ts
+++ b/packages/openducktor-web/src/browser-shell-bridge.ts
@@ -4,6 +4,7 @@ import { getBrowserBackendUrlEffect } from "./browser-config";
 import { validateExternalBrowserUrlEffect } from "./browser-url-validation";
 import {
   errorMessage,
+  isWebError,
   runWebBoundary,
   WebDependencyError,
   type WebError,
@@ -21,7 +22,7 @@ import {
 const openExternalUrlEffect = (url: string): Effect.Effect<void, WebError> =>
   Effect.gen(function* () {
     const validatedUrl = yield* validateExternalBrowserUrlEffect(url);
-    const opened = yield* Effect.try({
+    yield* Effect.try({
       try: () => window.open(validatedUrl, "_blank", "noopener,noreferrer"),
       catch: (cause) =>
         new WebDependencyError({
@@ -32,14 +33,6 @@ const openExternalUrlEffect = (url: string): Effect.Effect<void, WebError> =>
           details: { url: validatedUrl },
         }),
     });
-    if (!opened) {
-      return yield* new WebDependencyError({
-        dependency: "browser-window",
-        operation: "open-external-url",
-        message: "Browser blocked the external URL window. Allow popups for OpenDucktor web.",
-        details: { url: validatedUrl },
-      });
-    }
   });
 
 const resolveLocalAttachmentPreviewSrcEffect = (
@@ -50,13 +43,15 @@ const resolveLocalAttachmentPreviewSrcEffect = (
     const resolvedPath = yield* Effect.tryPromise({
       try: () => client.workspaceResolveLocalAttachmentPath({ path }),
       catch: (cause) =>
-        new WebDependencyError({
-          dependency: "local-web-host",
-          operation: "resolve-local-attachment-path",
-          message: errorMessage(cause),
-          cause,
-          details: { path },
-        }),
+        isWebError(cause)
+          ? cause
+          : new WebDependencyError({
+              dependency: "local-web-host",
+              operation: "resolve-local-attachment-path",
+              message: errorMessage(cause),
+              cause,
+              details: { path },
+            }),
     });
     yield* ensureLocalHostSessionDedupedEffect();
     return buildLocalAttachmentPreviewUrl(yield* getBrowserBackendUrlEffect(), resolvedPath.path);

--- a/packages/openducktor-web/src/browser-shell-bridge.ts
+++ b/packages/openducktor-web/src/browser-shell-bridge.ts
@@ -1,15 +1,66 @@
 import type { ShellBridge } from "@openducktor/frontend";
-import { getBrowserBackendUrl } from "./browser-config";
-import { validateExternalBrowserUrl } from "./browser-url-validation";
+import { Effect } from "effect";
+import { getBrowserBackendUrlEffect } from "./browser-config";
+import { validateExternalBrowserUrlEffect } from "./browser-url-validation";
+import {
+  errorMessage,
+  runWebBoundary,
+  WebDependencyError,
+  type WebError,
+} from "./effect/web-errors";
 import {
   buildLocalAttachmentPreviewUrl,
   createLocalHostClient,
-  ensureLocalHostSession,
+  ensureLocalHostSessionDedupedEffect,
   subscribeLocalHostCodexAppServerEvents,
   subscribeLocalHostDevServerEvents,
   subscribeLocalHostRunEvents,
   subscribeLocalHostTaskEvents,
 } from "./local-host-transport";
+
+const openExternalUrlEffect = (url: string): Effect.Effect<void, WebError> =>
+  Effect.gen(function* () {
+    const validatedUrl = yield* validateExternalBrowserUrlEffect(url);
+    const opened = yield* Effect.try({
+      try: () => window.open(validatedUrl, "_blank", "noopener,noreferrer"),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "browser-window",
+          operation: "open-external-url",
+          message: errorMessage(cause),
+          cause,
+          details: { url: validatedUrl },
+        }),
+    });
+    if (!opened) {
+      return yield* new WebDependencyError({
+        dependency: "browser-window",
+        operation: "open-external-url",
+        message: "Browser blocked the external URL window. Allow popups for OpenDucktor web.",
+        details: { url: validatedUrl },
+      });
+    }
+  });
+
+const resolveLocalAttachmentPreviewSrcEffect = (
+  client: ReturnType<typeof createLocalHostClient>,
+  path: string,
+): Effect.Effect<string, WebError> =>
+  Effect.gen(function* () {
+    const resolvedPath = yield* Effect.tryPromise({
+      try: () => client.workspaceResolveLocalAttachmentPath({ path }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "local-web-host",
+          operation: "resolve-local-attachment-path",
+          message: errorMessage(cause),
+          cause,
+          details: { path },
+        }),
+    });
+    yield* ensureLocalHostSessionDedupedEffect();
+    return buildLocalAttachmentPreviewUrl(yield* getBrowserBackendUrlEffect(), resolvedPath.path);
+  });
 
 export const createBrowserShellBridge = (): ShellBridge => {
   const client = createLocalHostClient();
@@ -24,18 +75,8 @@ export const createBrowserShellBridge = (): ShellBridge => {
     subscribeDevServerEvents: subscribeLocalHostDevServerEvents,
     subscribeTaskEvents: subscribeLocalHostTaskEvents,
     subscribeCodexAppServerEvents: subscribeLocalHostCodexAppServerEvents,
-    openExternalUrl: async (url) => {
-      const opened = window.open(validateExternalBrowserUrl(url), "_blank", "noopener,noreferrer");
-      if (!opened) {
-        throw new Error(
-          "Browser blocked the external URL window. Allow popups for OpenDucktor web.",
-        );
-      }
-    },
-    resolveLocalAttachmentPreviewSrc: async (path) => {
-      const resolvedPath = (await client.workspaceResolveLocalAttachmentPath({ path })).path;
-      await ensureLocalHostSession();
-      return buildLocalAttachmentPreviewUrl(getBrowserBackendUrl(), resolvedPath);
-    },
+    openExternalUrl: (url) => runWebBoundary(openExternalUrlEffect(url)),
+    resolveLocalAttachmentPreviewSrc: (path) =>
+      runWebBoundary(resolveLocalAttachmentPreviewSrcEffect(client, path)),
   };
 };

--- a/packages/openducktor-web/src/browser-url-validation.ts
+++ b/packages/openducktor-web/src/browser-url-validation.ts
@@ -1,16 +1,30 @@
-export const validateExternalBrowserUrl = (url: string): string => {
-  const trimmedUrl = url.trim();
-  let parsedUrl: URL;
+import { Effect } from "effect";
+import { runWebSyncBoundary, WebValidationError } from "./effect/web-errors";
 
-  try {
-    parsedUrl = new URL(trimmedUrl);
-  } catch {
-    throw new Error("OpenDucktor web can only open absolute http or https URLs.");
-  }
+export const validateExternalBrowserUrlEffect = (
+  url: string,
+): Effect.Effect<string, WebValidationError> =>
+  Effect.gen(function* () {
+    const trimmedUrl = url.trim();
+    const parsedUrl = yield* Effect.try({
+      try: () => new URL(trimmedUrl),
+      catch: (cause) =>
+        new WebValidationError({
+          message: "OpenDucktor web can only open absolute http or https URLs.",
+          cause,
+          details: { url },
+        }),
+    });
 
-  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-    throw new Error("OpenDucktor web can only open http or https URLs.");
-  }
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      return yield* new WebValidationError({
+        message: "OpenDucktor web can only open http or https URLs.",
+        details: { url },
+      });
+    }
 
-  return parsedUrl.href;
-};
+    return parsedUrl.href;
+  });
+
+export const validateExternalBrowserUrl = (url: string): string =>
+  runWebSyncBoundary(validateExternalBrowserUrlEffect(url));

--- a/packages/openducktor-web/src/cli.test.ts
+++ b/packages/openducktor-web/src/cli.test.ts
@@ -10,16 +10,34 @@ describe("web CLI argument parsing", () => {
   });
 
   test("rejects malformed port values instead of truncating trailing text", () => {
-    expect(() => parseCliArgs(["--backend-port", "14327abc"])).toThrow(
-      "Invalid --backend-port value: 14327abc",
-    );
-    expect(() => parseCliArgs(["--port", "14.20"])).toThrow("Invalid --port value: 14.20");
+    const parseBackendPort = () => parseCliArgs(["--backend-port", "14327abc"]);
+    expect(parseBackendPort).toThrow("Invalid --backend-port value: 14327abc");
+    expect(parseBackendPort).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
+
+    const parseFrontendPort = () => parseCliArgs(["--port", "14.20"]);
+    expect(parseFrontendPort).toThrow("Invalid --port value: 14.20");
+    expect(parseFrontendPort).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
   });
 
   test("rejects ports outside the TCP range", () => {
-    expect(() => parseCliArgs(["--port", "0"])).toThrow("Invalid --port value: 0");
-    expect(() => parseCliArgs(["--backend-port", "65536"])).toThrow(
-      "Invalid --backend-port value: 65536",
+    const parseZeroPort = () => parseCliArgs(["--port", "0"]);
+    expect(parseZeroPort).toThrow("Invalid --port value: 0");
+    expect(parseZeroPort).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
+
+    const parseTooLargeBackendPort = () => parseCliArgs(["--backend-port", "65536"]);
+    expect(parseTooLargeBackendPort).toThrow("Invalid --backend-port value: 65536");
+    expect(parseTooLargeBackendPort).toThrow(
+      expect.objectContaining({ _tag: "WebValidationError" }),
     );
+  });
+
+  test("rejects missing option values and unknown options", () => {
+    const parseMissingPort = () => parseCliArgs(["--port"]);
+    expect(parseMissingPort).toThrow("Missing value for --port.");
+    expect(parseMissingPort).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
+
+    const parseUnknownOption = () => parseCliArgs(["--unexpected"]);
+    expect(parseUnknownOption).toThrow("Unknown option: --unexpected");
+    expect(parseUnknownOption).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
   });
 });

--- a/packages/openducktor-web/src/cli.test.ts
+++ b/packages/openducktor-web/src/cli.test.ts
@@ -36,6 +36,14 @@ describe("web CLI argument parsing", () => {
     expect(parseMissingPort).toThrow("Missing value for --port.");
     expect(parseMissingPort).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
 
+    const parseFlagAsPort = () => parseCliArgs(["--port", "--backend-port", "14328"]);
+    expect(parseFlagAsPort).toThrow("Missing value for --port.");
+    expect(parseFlagAsPort).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
+
+    const parseFlagAsBackendPort = () => parseCliArgs(["--backend-port", "--workspace"]);
+    expect(parseFlagAsBackendPort).toThrow("Missing value for --backend-port.");
+    expect(parseFlagAsBackendPort).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
+
     const parseUnknownOption = () => parseCliArgs(["--unexpected"]);
     expect(parseUnknownOption).toThrow("Unknown option: --unexpected");
     expect(parseUnknownOption).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));

--- a/packages/openducktor-web/src/cli.ts
+++ b/packages/openducktor-web/src/cli.ts
@@ -1,6 +1,14 @@
 #!/usr/bin/env bun
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { Effect } from "effect";
+import {
+  errorMessage,
+  runWebBoundary,
+  runWebSyncBoundary,
+  WebOperationError,
+  WebValidationError,
+} from "./effect/web-errors";
 import { runLauncher } from "./launcher";
 import { logError } from "./logger";
 
@@ -19,61 +27,79 @@ const printHelp = (): void => {
   );
 };
 
-const parsePort = (raw: string | undefined, flag: string): number => {
-  if (!raw) {
-    throw new Error(`Missing value for ${flag}.`);
-  }
-  const trimmed = raw.trim();
-  if (!/^\d+$/.test(trimmed)) {
-    throw new Error(`Invalid ${flag} value: ${raw}. Expected a TCP port between 1 and 65535.`);
-  }
-  const parsed = Number(trimmed);
-  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65_535) {
-    throw new Error(`Invalid ${flag} value: ${raw}. Expected a TCP port between 1 and 65535.`);
-  }
-  return parsed;
-};
+const invalidPortError = (raw: string, flag: string): WebValidationError =>
+  new WebValidationError({
+    message: `Invalid ${flag} value: ${raw}. Expected a TCP port between 1 and 65535.`,
+    field: flag,
+    details: { raw },
+  });
 
-export const parseCliArgs = (args: string[]): CliOptions => {
-  const options: CliOptions = {
-    workspaceMode: false,
-    frontendPort: DEFAULT_FRONTEND_PORT,
-    backendPort: DEFAULT_BACKEND_PORT,
-  };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--workspace") {
-      options.workspaceMode = true;
-      continue;
+const parsePortEffect = (
+  raw: string | undefined,
+  flag: string,
+): Effect.Effect<number, WebValidationError> =>
+  Effect.gen(function* () {
+    if (!raw) {
+      return yield* new WebValidationError({
+        message: `Missing value for ${flag}.`,
+        field: flag,
+      });
     }
-    if (arg === "--port") {
-      options.frontendPort = parsePort(args[index + 1], "--port");
-      index += 1;
-      continue;
+    const trimmed = raw.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      return yield* invalidPortError(raw, flag);
     }
-    if (arg === "--backend-port") {
-      options.backendPort = parsePort(args[index + 1], "--backend-port");
-      index += 1;
-      continue;
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65_535) {
+      return yield* invalidPortError(raw, flag);
     }
-    if (arg === "-h" || arg === "--help") {
-      printHelp();
-      process.exit(0);
+    return parsed;
+  });
+
+export const parseCliArgsEffect = (args: string[]): Effect.Effect<CliOptions, WebValidationError> =>
+  Effect.gen(function* () {
+    const options: CliOptions = {
+      workspaceMode: false,
+      frontendPort: DEFAULT_FRONTEND_PORT,
+      backendPort: DEFAULT_BACKEND_PORT,
+    };
+
+    for (let index = 0; index < args.length; index += 1) {
+      const arg = args[index];
+      if (arg === "--workspace") {
+        options.workspaceMode = true;
+        continue;
+      }
+      if (arg === "--port") {
+        options.frontendPort = yield* parsePortEffect(args[index + 1], "--port");
+        index += 1;
+        continue;
+      }
+      if (arg === "--backend-port") {
+        options.backendPort = yield* parsePortEffect(args[index + 1], "--backend-port");
+        index += 1;
+        continue;
+      }
+      if (arg === "-h" || arg === "--help") {
+        yield* Effect.sync(printHelp);
+        yield* Effect.sync(() => process.exit(0));
+      }
+
+      return yield* new WebValidationError({
+        message: `Unknown option: ${arg}`,
+        field: "option",
+        details: { option: arg },
+      });
     }
 
-    throw new Error(`Unknown option: ${arg}`);
-  }
+    return options;
+  });
 
-  return options;
-};
-
-const runCli = async (): Promise<void> => {
-  const __filename = fileURLToPath(import.meta.url);
-  const packageRoot = path.resolve(path.dirname(__filename), "..");
-
-  try {
-    const cliOptions = parseCliArgs(process.argv.slice(2));
+const runCliEffect = (): Effect.Effect<number, WebOperationError | WebValidationError> =>
+  Effect.gen(function* () {
+    const __filename = fileURLToPath(import.meta.url);
+    const packageRoot = path.resolve(path.dirname(__filename), "..");
+    const cliOptions = yield* parseCliArgsEffect(process.argv.slice(2));
     const launcherOptions = {
       packageRoot,
       ...(cliOptions.workspaceMode ? { workspaceRoot: path.resolve(packageRoot, "../..") } : {}),
@@ -81,13 +107,27 @@ const runCli = async (): Promise<void> => {
       frontendPort: cliOptions.frontendPort,
       backendPort: cliOptions.backendPort,
     };
-    const exitCode = await runLauncher(launcherOptions);
-    process.exit(exitCode);
-  } catch (error) {
-    logError(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  }
+    return yield* Effect.tryPromise({
+      try: () => runLauncher(launcherOptions),
+      catch: (cause) =>
+        new WebOperationError({
+          operation: "web.cli.launch",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+  });
+
+const runCli = async (): Promise<void> => {
+  const exitCode = await runWebBoundary(runCliEffect()).catch((error: unknown) => {
+    logError(errorMessage(error));
+    return 1;
+  });
+  process.exit(exitCode);
 };
+
+export const parseCliArgs = (args: string[]): CliOptions =>
+  runWebSyncBoundary(parseCliArgsEffect(args));
 
 if (import.meta.main) {
   await runCli();

--- a/packages/openducktor-web/src/cli.ts
+++ b/packages/openducktor-web/src/cli.ts
@@ -34,6 +34,13 @@ const invalidPortError = (raw: string, flag: string): WebValidationError =>
     details: { raw },
   });
 
+const isKnownCliFlag = (value: string | undefined): boolean =>
+  value === "--workspace" ||
+  value === "--port" ||
+  value === "--backend-port" ||
+  value === "-h" ||
+  value === "--help";
+
 const parsePortEffect = (
   raw: string | undefined,
   flag: string,
@@ -71,12 +78,26 @@ export const parseCliArgsEffect = (args: string[]): Effect.Effect<CliOptions, We
         continue;
       }
       if (arg === "--port") {
-        options.frontendPort = yield* parsePortEffect(args[index + 1], "--port");
+        const value = args[index + 1];
+        if (isKnownCliFlag(value)) {
+          return yield* new WebValidationError({
+            message: "Missing value for --port.",
+            field: "--port",
+          });
+        }
+        options.frontendPort = yield* parsePortEffect(value, "--port");
         index += 1;
         continue;
       }
       if (arg === "--backend-port") {
-        options.backendPort = yield* parsePortEffect(args[index + 1], "--backend-port");
+        const value = args[index + 1];
+        if (isKnownCliFlag(value)) {
+          return yield* new WebValidationError({
+            message: "Missing value for --backend-port.",
+            field: "--backend-port",
+          });
+        }
+        options.backendPort = yield* parsePortEffect(value, "--backend-port");
         index += 1;
         continue;
       }

--- a/packages/openducktor-web/src/cli.ts
+++ b/packages/openducktor-web/src/cli.ts
@@ -6,10 +6,10 @@ import {
   errorMessage,
   runWebBoundary,
   runWebSyncBoundary,
-  WebOperationError,
+  type WebError,
   WebValidationError,
 } from "./effect/web-errors";
-import { runLauncher } from "./launcher";
+import { runLauncherEffect } from "./launcher";
 import { logError } from "./logger";
 
 type CliOptions = {
@@ -83,6 +83,7 @@ export const parseCliArgsEffect = (args: string[]): Effect.Effect<CliOptions, We
       if (arg === "-h" || arg === "--help") {
         yield* Effect.sync(printHelp);
         yield* Effect.sync(() => process.exit(0));
+        return options;
       }
 
       return yield* new WebValidationError({
@@ -95,7 +96,7 @@ export const parseCliArgsEffect = (args: string[]): Effect.Effect<CliOptions, We
     return options;
   });
 
-const runCliEffect = (): Effect.Effect<number, WebOperationError | WebValidationError> =>
+const runCliEffect = (): Effect.Effect<number, WebError> =>
   Effect.gen(function* () {
     const __filename = fileURLToPath(import.meta.url);
     const packageRoot = path.resolve(path.dirname(__filename), "..");
@@ -107,15 +108,7 @@ const runCliEffect = (): Effect.Effect<number, WebOperationError | WebValidation
       frontendPort: cliOptions.frontendPort,
       backendPort: cliOptions.backendPort,
     };
-    return yield* Effect.tryPromise({
-      try: () => runLauncher(launcherOptions),
-      catch: (cause) =>
-        new WebOperationError({
-          operation: "web.cli.launch",
-          message: errorMessage(cause),
-          cause,
-        }),
-    });
+    return yield* runLauncherEffect(launcherOptions);
   });
 
 const runCli = async (): Promise<void> => {

--- a/packages/openducktor-web/src/effect/web-errors.test.ts
+++ b/packages/openducktor-web/src/effect/web-errors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { Cause, Effect, Exit } from "effect";
+import { causeToWebBoundaryError, WebOperationError, WebValidationError } from "./web-errors";
+
+describe("web Effect boundary errors", () => {
+  test("preserves multiple typed failures on boundary crossing", () => {
+    const firstFailure = new WebValidationError({ field: "first", message: "first failed" });
+    const secondFailure = new WebValidationError({ field: "second", message: "second failed" });
+    const cause = Cause.parallel(Cause.fail(firstFailure), Cause.fail(secondFailure));
+
+    const error = causeToWebBoundaryError(cause);
+
+    expect(error).toBeInstanceOf(WebOperationError);
+    expect(error).toMatchObject({
+      _tag: "WebOperationError",
+      operation: "web.effect.run",
+      message: "Multiple Effect failures crossed the web boundary.",
+      details: { failureMessages: ["first failed", "second failed"] },
+    });
+    expect(Reflect.get(error, "cause")).toEqual({ failures: [firstFailure, secondFailure] });
+  });
+
+  test("returns one typed failure unchanged", () => {
+    const failure = new WebValidationError({ field: "name", message: "name failed" });
+    const exit = Effect.runSyncExit(Effect.fail(failure));
+    if (!Exit.isFailure(exit)) {
+      throw new Error("Expected failed exit");
+    }
+
+    expect(causeToWebBoundaryError(exit.cause)).toBe(failure);
+  });
+});

--- a/packages/openducktor-web/src/effect/web-errors.test.ts
+++ b/packages/openducktor-web/src/effect/web-errors.test.ts
@@ -29,4 +29,18 @@ describe("web Effect boundary errors", () => {
 
     expect(causeToWebBoundaryError(exit.cause)).toBe(failure);
   });
+
+  test("preserves mixed causes instead of unwrapping their typed failure", () => {
+    const failure = new WebValidationError({ field: "name", message: "name failed" });
+    const cause = Cause.sequential(Cause.fail(failure), Cause.die(new Error("unexpected")));
+
+    const error = causeToWebBoundaryError(cause);
+
+    expect(error).toBeInstanceOf(WebOperationError);
+    expect(error).toMatchObject({
+      _tag: "WebOperationError",
+      details: { defect: true, failureMessages: ["name failed"] },
+    });
+    expect(Reflect.get(error, "cause")).toBe(cause);
+  });
 });

--- a/packages/openducktor-web/src/effect/web-errors.ts
+++ b/packages/openducktor-web/src/effect/web-errors.ts
@@ -1,4 +1,4 @@
-import { Cause, Chunk, Data, Effect, Exit, Option } from "effect";
+import { Cause, Data, Effect, Exit } from "effect";
 
 export type WebErrorDetails = Readonly<Record<string, unknown>>;
 
@@ -85,9 +85,17 @@ export const toWebOperationError = (
 export const causeToWebBoundaryError = <Failure>(
   cause: Cause.Cause<Failure>,
 ): Failure | WebOperationError => {
-  const firstFailure = Chunk.head(Cause.failures(cause));
-  if (Option.isSome(firstFailure)) {
-    return firstFailure.value;
+  const failures = Array.from(Cause.failures(cause));
+  if (failures.length === 1) {
+    return failures[0] as Failure;
+  }
+  if (failures.length > 1) {
+    return new WebOperationError({
+      operation: "web.effect.run",
+      message: "Multiple Effect failures crossed the web boundary.",
+      cause: { failures },
+      details: { failureMessages: failures.map(errorMessage) },
+    });
   }
 
   return new WebOperationError({

--- a/packages/openducktor-web/src/effect/web-errors.ts
+++ b/packages/openducktor-web/src/effect/web-errors.ts
@@ -1,0 +1,114 @@
+import { Cause, Chunk, Data, Effect, Exit, Option } from "effect";
+
+export type WebErrorDetails = Readonly<Record<string, unknown>>;
+
+export class WebValidationError extends Data.TaggedError("WebValidationError")<{
+  readonly message: string;
+  readonly field?: string | undefined;
+  readonly cause?: unknown | undefined;
+  readonly details?: WebErrorDetails | undefined;
+}> {}
+
+export class WebDependencyError extends Data.TaggedError("WebDependencyError")<{
+  readonly message: string;
+  readonly dependency: string;
+  readonly operation?: string | undefined;
+  readonly cause?: unknown | undefined;
+  readonly details?: WebErrorDetails | undefined;
+}> {}
+
+export class WebOperationError extends Data.TaggedError("WebOperationError")<{
+  readonly message: string;
+  readonly operation: string;
+  readonly cause?: unknown | undefined;
+  readonly details?: WebErrorDetails | undefined;
+}> {}
+
+export class WebResourceError extends Data.TaggedError("WebResourceError")<{
+  readonly message: string;
+  readonly resource: string;
+  readonly operation?: string | undefined;
+  readonly cause?: unknown | undefined;
+  readonly details?: WebErrorDetails | undefined;
+}> {}
+
+export class WebHostRequestError extends Data.TaggedError("WebHostRequestError")<{
+  readonly message: string;
+  readonly status: number;
+  readonly failureKind?: string | undefined;
+  readonly cause?: unknown | undefined;
+  readonly details?: WebErrorDetails | undefined;
+}> {}
+
+export type WebError =
+  | WebDependencyError
+  | WebHostRequestError
+  | WebOperationError
+  | WebResourceError
+  | WebValidationError;
+
+export const isWebError = (cause: unknown): cause is WebError =>
+  cause instanceof WebDependencyError ||
+  cause instanceof WebHostRequestError ||
+  cause instanceof WebOperationError ||
+  cause instanceof WebResourceError ||
+  cause instanceof WebValidationError;
+
+export const errorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);
+
+export const toWebOperationError = (
+  cause: unknown,
+  operation: string,
+  details?: WebErrorDetails,
+): WebOperationError => {
+  if (cause instanceof WebOperationError) {
+    return cause;
+  }
+  if (isWebError(cause)) {
+    return new WebOperationError({
+      operation,
+      message: cause.message,
+      cause,
+      details,
+    });
+  }
+
+  return new WebOperationError({
+    operation,
+    message: errorMessage(cause),
+    cause,
+    details,
+  });
+};
+
+export const causeToWebBoundaryError = <Failure>(
+  cause: Cause.Cause<Failure>,
+): Failure | WebOperationError => {
+  const firstFailure = Chunk.head(Cause.failures(cause));
+  if (Option.isSome(firstFailure)) {
+    return firstFailure.value;
+  }
+
+  return new WebOperationError({
+    operation: "web.effect.run",
+    message: Cause.pretty(cause),
+    details: { defect: true },
+  });
+};
+
+export const runWebBoundary = async <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throw causeToWebBoundaryError(exit.cause);
+};
+
+export const runWebSyncBoundary = <A, E>(effect: Effect.Effect<A, E>): A => {
+  const exit = Effect.runSyncExit(effect);
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+  throw causeToWebBoundaryError(exit.cause);
+};

--- a/packages/openducktor-web/src/effect/web-errors.ts
+++ b/packages/openducktor-web/src/effect/web-errors.ts
@@ -86,10 +86,14 @@ export const causeToWebBoundaryError = <Failure>(
   cause: Cause.Cause<Failure>,
 ): Failure | WebOperationError => {
   const failures = Array.from(Cause.failures(cause));
-  if (failures.length === 1) {
-    return failures[0] as Failure;
+  const hasOnlyTypedFailures = !Cause.isDie(cause) && !Cause.isInterrupted(cause);
+  if (failures.length === 1 && hasOnlyTypedFailures) {
+    const firstFailure = failures[0];
+    if (firstFailure !== undefined) {
+      return firstFailure;
+    }
   }
-  if (failures.length > 1) {
+  if (failures.length > 1 && hasOnlyTypedFailures) {
     return new WebOperationError({
       operation: "web.effect.run",
       message: "Multiple Effect failures crossed the web boundary.",
@@ -101,7 +105,12 @@ export const causeToWebBoundaryError = <Failure>(
   return new WebOperationError({
     operation: "web.effect.run",
     message: Cause.pretty(cause),
-    details: { defect: true },
+    cause,
+    details: {
+      defect: Cause.isDie(cause),
+      failureMessages: failures.map(errorMessage),
+      interrupted: Cause.isInterrupted(cause),
+    },
   });
 };
 

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -125,6 +125,8 @@ export const closeFrontendServerEffect = (
       return;
     }
 
+    // Capture only synchronous close-call failures here while preserving the
+    // close Promise for Promise.race; async rejections are handled below.
     const closePromise = yield* Effect.try({
       try: () => server.close(),
       catch: (cause) =>

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -341,16 +341,28 @@ export const stopLauncherServices = (
   dependencies: LauncherShutdownDependencies = defaultLauncherShutdownDependencies,
 ): Promise<void> => runWebBoundary(stopLauncherServicesEffect(input, dependencies));
 
-export const keepProcessAliveDuringEffect = <T>(
+export const keepProcessAliveDuringEffect = <T, E>(
+  operation: Effect.Effect<T, E>,
+  dependencies: ProcessKeepAliveDependencies = {
+    clearInterval,
+    setInterval,
+  },
+): Effect.Effect<T, E | WebDependencyError> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => dependencies.setInterval(() => {}, SHUTDOWN_KEEP_ALIVE_INTERVAL_MS)),
+    () => operation,
+    (timer) => Effect.sync(() => dependencies.clearInterval(timer)),
+  );
+
+export const keepProcessAliveDuring = <T>(
   operation: Promise<T>,
   dependencies: ProcessKeepAliveDependencies = {
     clearInterval,
     setInterval,
   },
-): Effect.Effect<T, WebDependencyError> =>
-  Effect.acquireUseRelease(
-    Effect.sync(() => dependencies.setInterval(() => {}, SHUTDOWN_KEEP_ALIVE_INTERVAL_MS)),
-    () =>
+): Promise<T> =>
+  runWebBoundary(
+    keepProcessAliveDuringEffect(
       Effect.tryPromise({
         try: () => operation,
         catch: (cause) =>
@@ -361,13 +373,6 @@ export const keepProcessAliveDuringEffect = <T>(
             cause,
           }),
       }),
-    (timer) => Effect.sync(() => dependencies.clearInterval(timer)),
+      dependencies,
+    ),
   );
-
-export const keepProcessAliveDuring = <T>(
-  operation: Promise<T>,
-  dependencies: ProcessKeepAliveDependencies = {
-    clearInterval,
-    setInterval,
-  },
-): Promise<T> => runWebBoundary(keepProcessAliveDuringEffect(operation, dependencies));

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -347,7 +347,7 @@ export const keepProcessAliveDuringEffect = <T, E>(
     clearInterval,
     setInterval,
   },
-): Effect.Effect<T, E | WebDependencyError> =>
+): Effect.Effect<T, E> =>
   Effect.acquireUseRelease(
     Effect.sync(() => dependencies.setInterval(() => {}, SHUTDOWN_KEEP_ALIVE_INTERVAL_MS)),
     () => operation,

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -1,4 +1,13 @@
 import path from "node:path";
+import { Effect } from "effect";
+import {
+  causeToWebBoundaryError,
+  errorMessage,
+  runWebBoundary,
+  WebDependencyError,
+  type WebError,
+  WebOperationError,
+} from "./effect/web-errors";
 import { logError } from "./logger";
 import type { TypescriptHostBackend } from "./typescript-host-backend";
 
@@ -48,28 +57,58 @@ export const buildFrontendDisplayUrls = (port: number): string[] => [
   `http://${LOCALHOST}:${port}/`,
 ];
 
-const verifyBackendReadiness = async (
+const verifyBackendReadinessEffect = (
   backendUrl: string,
   appToken: string,
   fetchImpl: FetchFunction,
-): Promise<void> => {
-  const healthResponse = await fetchImpl(`${backendUrl}/health`);
-  if (!healthResponse.ok) {
-    throw new Error(`Health endpoint returned ${healthResponse.status}.`);
-  }
+): Effect.Effect<void, WebDependencyError> =>
+  Effect.gen(function* () {
+    const healthResponse = yield* Effect.tryPromise({
+      try: () => fetchImpl(`${backendUrl}/health`),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "typescript-host-backend",
+          operation: "health-check",
+          message: errorMessage(cause),
+          cause,
+          details: { backendUrl },
+        }),
+    });
+    if (!healthResponse.ok) {
+      return yield* new WebDependencyError({
+        dependency: "typescript-host-backend",
+        operation: "health-check",
+        message: `Health endpoint returned ${healthResponse.status}.`,
+        details: { backendUrl, status: healthResponse.status },
+      });
+    }
 
-  const sessionResponse = await fetchImpl(`${backendUrl}/session`, {
-    method: "POST",
-    headers: {
-      [APP_TOKEN_HEADER]: appToken,
-    },
+    const sessionResponse = yield* Effect.tryPromise({
+      try: () =>
+        fetchImpl(`${backendUrl}/session`, {
+          method: "POST",
+          headers: {
+            [APP_TOKEN_HEADER]: appToken,
+          },
+        }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "typescript-host-backend",
+          operation: "session-check",
+          message: errorMessage(cause),
+          cause,
+          details: { backendUrl },
+        }),
+    });
+    if (!sessionResponse.ok) {
+      return yield* new WebDependencyError({
+        dependency: "typescript-host-backend",
+        operation: "session-check",
+        message: `Session endpoint rejected the launcher app token with status ${sessionResponse.status}.`,
+        details: { backendUrl, status: sessionResponse.status },
+      });
+    }
   });
-  if (!sessionResponse.ok) {
-    throw new Error(
-      `Session endpoint rejected the launcher app token with status ${sessionResponse.status}.`,
-    );
-  }
-};
 
 const forceCloseFrontendConnections = (server: FrontendServer): void => {
   const httpServer = (server as FrontendServerWithHttpConnections).httpServer;
@@ -77,64 +116,113 @@ const forceCloseFrontendConnections = (server: FrontendServer): void => {
   httpServer?.closeAllConnections?.();
 };
 
-export const closeFrontendServer = async (
+export const closeFrontendServerEffect = (
   server: FrontendServer | null,
   sleep: SleepFunction = Bun.sleep,
-): Promise<void> => {
-  if (!server) {
-    return;
-  }
+): Effect.Effect<void, WebDependencyError> =>
+  Effect.gen(function* () {
+    if (!server) {
+      return;
+    }
 
-  let closePromise: Promise<void>;
-  try {
-    closePromise = server.close();
-  } finally {
-    forceCloseFrontendConnections(server);
-  }
-  await Promise.race([closePromise, sleep(FRONTEND_CLOSE_TIMEOUT_MS)]);
-};
+    const closePromise = yield* Effect.try({
+      try: () => server.close(),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "frontend-server",
+          operation: "close",
+          message: errorMessage(cause),
+          cause,
+        }),
+    }).pipe(Effect.ensuring(Effect.sync(() => forceCloseFrontendConnections(server))));
+    yield* Effect.tryPromise({
+      try: () => Promise.race([closePromise, sleep(FRONTEND_CLOSE_TIMEOUT_MS)]),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "frontend-server",
+          operation: "close",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+  });
 
-export const waitForBackend = async (
+export const closeFrontendServer = (
+  server: FrontendServer | null,
+  sleep: SleepFunction = Bun.sleep,
+): Promise<void> => runWebBoundary(closeFrontendServerEffect(server, sleep));
+
+export const waitForBackendEffect = (
   backendUrl: string,
   appToken: string,
   timeoutMs: number,
   hostProcess: ManagedHost,
   dependencies: BackendReadinessDependencies = { fetch, sleep: Bun.sleep },
-): Promise<void> => {
-  const startedAt = Date.now();
-  let lastError: unknown;
-  let earlyExitCode: number | null = null;
+): Effect.Effect<void, WebDependencyError | WebOperationError> =>
+  Effect.gen(function* () {
+    const startedAt = Date.now();
+    let lastError: unknown;
+    let earlyExitCode: number | null = null;
 
-  void hostProcess.exited.then((exitCode) => {
-    earlyExitCode = exitCode;
+    yield* Effect.sync(() => {
+      void hostProcess.exited.then((exitCode) => {
+        earlyExitCode = exitCode;
+      });
+    });
+
+    while (Date.now() - startedAt < timeoutMs) {
+      if (earlyExitCode !== null) {
+        return yield* new WebOperationError({
+          operation: "web.launcher.wait-for-backend",
+          message: `OpenDucktor web host exited before startup completed with code ${earlyExitCode}.`,
+          details: { backendUrl, exitCode: earlyExitCode },
+        });
+      }
+
+      const readinessExit = yield* Effect.exit(
+        verifyBackendReadinessEffect(backendUrl, appToken, dependencies.fetch),
+      );
+      if (readinessExit._tag === "Success") {
+        return;
+      }
+      lastError = causeToWebBoundaryError(readinessExit.cause);
+
+      yield* Effect.tryPromise({
+        try: () => dependencies.sleep(250),
+        catch: (cause) =>
+          new WebDependencyError({
+            dependency: "timer",
+            operation: "wait-for-backend",
+            message: errorMessage(cause),
+            cause,
+          }),
+      });
+    }
+
+    if (earlyExitCode !== null) {
+      return yield* new WebOperationError({
+        operation: "web.launcher.wait-for-backend",
+        message: `OpenDucktor web host exited before startup completed with code ${earlyExitCode}.`,
+        details: { backendUrl, exitCode: earlyExitCode },
+      });
+    }
+
+    const detail = lastError instanceof Error ? ` Last error: ${lastError.message}` : "";
+    return yield* new WebOperationError({
+      operation: "web.launcher.wait-for-backend",
+      message: `Timed out waiting for OpenDucktor web host at ${backendUrl}.${detail}`,
+      details: { backendUrl, timeoutMs },
+    });
   });
 
-  while (Date.now() - startedAt < timeoutMs) {
-    if (earlyExitCode !== null) {
-      throw new Error(
-        `OpenDucktor web host exited before startup completed with code ${earlyExitCode}.`,
-      );
-    }
-
-    try {
-      await verifyBackendReadiness(backendUrl, appToken, dependencies.fetch);
-      return;
-    } catch (error) {
-      lastError = error;
-    }
-
-    await dependencies.sleep(250);
-  }
-
-  if (earlyExitCode !== null) {
-    throw new Error(
-      `OpenDucktor web host exited before startup completed with code ${earlyExitCode}.`,
-    );
-  }
-
-  const detail = lastError instanceof Error ? ` Last error: ${lastError.message}` : "";
-  throw new Error(`Timed out waiting for OpenDucktor web host at ${backendUrl}.${detail}`);
-};
+export const waitForBackend = (
+  backendUrl: string,
+  appToken: string,
+  timeoutMs: number,
+  hostProcess: ManagedHost,
+  dependencies: BackendReadinessDependencies = { fetch, sleep: Bun.sleep },
+): Promise<void> =>
+  runWebBoundary(waitForBackendEffect(backendUrl, appToken, timeoutMs, hostProcess, dependencies));
 
 export const buildBrowserRuntimeConfigJson = (backendUrl: string, appToken: string): string =>
   `${JSON.stringify({ backendUrl, appToken })}\n`;
@@ -150,14 +238,23 @@ export const resolveStaticAssetPath = (staticRoot: string, requestPath: string):
   return path.join(staticRoot, normalized);
 };
 
-const throwLauncherShutdownFailures = (failures: unknown[]): void => {
+const launcherShutdownFailure = (failures: unknown[]): WebOperationError | null => {
   if (failures.length === 0) {
-    return;
+    return null;
   }
   if (failures.length === 1) {
-    throw failures[0];
+    const [failure] = failures;
+    return new WebOperationError({
+      operation: "web.launcher.shutdown",
+      message: errorMessage(failure),
+      cause: failure,
+    });
   }
-  throw new AggregateError(failures, "OpenDucktor web shutdown failed.");
+  return new WebOperationError({
+    operation: "web.launcher.shutdown",
+    message: "OpenDucktor web shutdown failed.",
+    details: { failures: failures.map(errorMessage) },
+  });
 };
 
 const defaultLauncherShutdownDependencies: LauncherShutdownDependencies = {
@@ -165,46 +262,112 @@ const defaultLauncherShutdownDependencies: LauncherShutdownDependencies = {
   stopHost: (hostBackend) => hostBackend.stop(),
 };
 
-export const stopLauncherServices = async (
+export const stopLauncherServicesEffect = (
   { frontendServer, hostBackend }: StopLauncherServicesInput,
   { closeServer, stopHost }: LauncherShutdownDependencies = defaultLauncherShutdownDependencies,
-): Promise<void> => {
-  const [frontendCloseResult, hostStopResult] = await Promise.allSettled([
-    closeServer(frontendServer),
-    stopHost(hostBackend),
-  ]);
-  const shutdownFailures = [frontendCloseResult, hostStopResult]
-    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
-    .map((result) => result.reason);
-  for (const failure of shutdownFailures) {
-    logError(failure instanceof Error ? failure.message : failure);
-  }
-  if (hostStopResult.status === "rejected") {
-    throwLauncherShutdownFailures(shutdownFailures);
-    return;
-  }
-
-  const hostExitCode = await hostBackend.exited;
-  if (hostExitCode !== 0) {
-    shutdownFailures.push(
-      new Error(`OpenDucktor TypeScript host shutdown failed with exit code ${hostExitCode}.`),
+): Effect.Effect<void, WebError> =>
+  Effect.gen(function* () {
+    const [frontendCloseExit, hostStopExit] = yield* Effect.all(
+      [
+        Effect.exit(
+          Effect.tryPromise({
+            try: () => closeServer(frontendServer),
+            catch: (cause) =>
+              new WebDependencyError({
+                dependency: "frontend-server",
+                operation: "close",
+                message: errorMessage(cause),
+                cause,
+              }),
+          }),
+        ),
+        Effect.exit(
+          Effect.tryPromise({
+            try: () => stopHost(hostBackend),
+            catch: (cause) =>
+              new WebDependencyError({
+                dependency: "typescript-host-backend",
+                operation: "stop",
+                message: errorMessage(cause),
+                cause,
+              }),
+          }),
+        ),
+      ],
+      { concurrency: "unbounded" },
     );
-  }
+    const shutdownFailures = [frontendCloseExit, hostStopExit]
+      .filter((result) => result._tag === "Failure")
+      .map((result) => causeToWebBoundaryError(result.cause));
+    for (const failure of shutdownFailures) {
+      logError(errorMessage(failure));
+    }
+    if (hostStopExit._tag === "Failure") {
+      const failure = launcherShutdownFailure(shutdownFailures);
+      if (failure) {
+        return yield* failure;
+      }
+      return;
+    }
 
-  throwLauncherShutdownFailures(shutdownFailures);
-};
+    const hostExitCode = yield* Effect.tryPromise({
+      try: () => hostBackend.exited,
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "typescript-host-backend",
+          operation: "await-exit",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+    if (hostExitCode !== 0) {
+      shutdownFailures.push(
+        new WebOperationError({
+          operation: "web.launcher.shutdown",
+          message: `OpenDucktor TypeScript host shutdown failed with exit code ${hostExitCode}.`,
+          details: { hostExitCode },
+        }),
+      );
+    }
 
-export const keepProcessAliveDuring = async <T>(
+    const failure = launcherShutdownFailure(shutdownFailures);
+    if (failure) {
+      return yield* failure;
+    }
+  });
+
+export const stopLauncherServices = (
+  input: StopLauncherServicesInput,
+  dependencies: LauncherShutdownDependencies = defaultLauncherShutdownDependencies,
+): Promise<void> => runWebBoundary(stopLauncherServicesEffect(input, dependencies));
+
+export const keepProcessAliveDuringEffect = <T>(
   operation: Promise<T>,
   dependencies: ProcessKeepAliveDependencies = {
     clearInterval,
     setInterval,
   },
-): Promise<T> => {
-  const timer = dependencies.setInterval(() => {}, SHUTDOWN_KEEP_ALIVE_INTERVAL_MS);
-  try {
-    return await operation;
-  } finally {
-    dependencies.clearInterval(timer);
-  }
-};
+): Effect.Effect<T, WebDependencyError> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => dependencies.setInterval(() => {}, SHUTDOWN_KEEP_ALIVE_INTERVAL_MS)),
+    () =>
+      Effect.tryPromise({
+        try: () => operation,
+        catch: (cause) =>
+          new WebDependencyError({
+            dependency: "launcher-operation",
+            operation: "keep-process-alive",
+            message: errorMessage(cause),
+            cause,
+          }),
+      }),
+    (timer) => Effect.sync(() => dependencies.clearInterval(timer)),
+  );
+
+export const keepProcessAliveDuring = <T>(
+  operation: Promise<T>,
+  dependencies: ProcessKeepAliveDependencies = {
+    clearInterval,
+    setInterval,
+  },
+): Promise<T> => runWebBoundary(keepProcessAliveDuringEffect(operation, dependencies));

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -61,10 +61,11 @@ const verifyBackendReadinessEffect = (
   backendUrl: string,
   appToken: string,
   fetchImpl: FetchFunction,
+  signal?: AbortSignal,
 ): Effect.Effect<void, WebDependencyError> =>
   Effect.gen(function* () {
     const healthResponse = yield* Effect.tryPromise({
-      try: () => fetchImpl(`${backendUrl}/health`),
+      try: () => fetchImpl(`${backendUrl}/health`, signal ? { signal } : undefined),
       catch: (cause) =>
         new WebDependencyError({
           dependency: "typescript-host-backend",
@@ -90,6 +91,7 @@ const verifyBackendReadinessEffect = (
           headers: {
             [APP_TOKEN_HEADER]: appToken,
           },
+          ...(signal ? { signal } : {}),
         }),
       catch: (cause) =>
         new WebDependencyError({
@@ -149,6 +151,23 @@ export const closeFrontendServerEffect = (
     });
   });
 
+const verifyBackendReadinessAttemptEffect = (
+  backendUrl: string,
+  appToken: string,
+  fetchImpl: FetchFunction,
+  timeoutMs: number,
+): Effect.Effect<void, WebDependencyError> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      return { controller, timeout };
+    }),
+    ({ controller }) =>
+      verifyBackendReadinessEffect(backendUrl, appToken, fetchImpl, controller.signal),
+    ({ timeout }) => Effect.sync(() => clearTimeout(timeout)),
+  );
+
 export const closeFrontendServer = (
   server: FrontendServer | null,
   sleep: SleepFunction = Bun.sleep,
@@ -181,8 +200,13 @@ export const waitForBackendEffect = (
         });
       }
 
+      const remainingMs = timeoutMs - (Date.now() - startedAt);
+      if (remainingMs <= 0) {
+        break;
+      }
+
       const readinessExit = yield* Effect.exit(
-        verifyBackendReadinessEffect(backendUrl, appToken, dependencies.fetch),
+        verifyBackendReadinessAttemptEffect(backendUrl, appToken, dependencies.fetch, remainingMs),
       );
       if (readinessExit._tag === "Success") {
         return;

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -190,6 +190,8 @@ export const waitForBackendEffect = (
         earlyExitCode = exitCode;
       });
     });
+    // Let an already-settled host exit promise win before applying the timeout path.
+    yield* Effect.promise(() => Promise.resolve());
 
     while (Date.now() - startedAt < timeoutMs) {
       if (earlyExitCode !== null) {

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -57,6 +57,12 @@ describe("launcher internals", () => {
         sleep: async () => {},
       }),
     ).rejects.toThrow("OpenDucktor web host exited before startup completed with code 9.");
+    await expect(
+      waitForBackend("http://127.0.0.1:14327", "app-token", 1_000, createHostProcess(exited), {
+        fetch: async () => new Response(null, { status: 503 }),
+        sleep: async () => {},
+      }),
+    ).rejects.toMatchObject({ _tag: "WebOperationError" });
   });
 
   test("stops frontend and host services directly", async () => {
@@ -147,7 +153,17 @@ describe("launcher internals", () => {
       },
     };
 
-    await expect(closeFrontendServer(frontendServer)).rejects.toThrow("close failed");
+    const result = await closeFrontendServer(frontendServer).then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+
+    if (result.ok) {
+      throw new Error("Expected closeFrontendServer to reject");
+    }
+
+    expect(result.error).toMatchObject({ _tag: "WebDependencyError" });
+    expect(result.error).toEqual(expect.objectContaining({ message: "close failed" }));
     expect(closeIdleConnectionsCalls).toBe(1);
     expect(closeAllConnectionsCalls).toBe(1);
   });
@@ -221,6 +237,20 @@ describe("launcher internals", () => {
         },
       ),
     ).rejects.toThrow("host stop failed");
+    await expect(
+      stopLauncherServices(
+        {
+          frontendServer: null,
+          hostBackend,
+        },
+        {
+          closeServer: async () => {},
+          stopHost: async () => {
+            throw new Error("host stop failed");
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ _tag: "WebOperationError" });
   });
 
   test("builds runtime config JSON for the browser shell", () => {

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -52,13 +52,13 @@ describe("launcher internals", () => {
     await exited;
 
     await expect(
-      waitForBackend("http://127.0.0.1:14327", "app-token", 1_000, createHostProcess(exited), {
+      waitForBackend("http://127.0.0.1:14327", "app-token", 1, createHostProcess(exited), {
         fetch: async () => new Response(null, { status: 503 }),
         sleep: async () => {},
       }),
     ).rejects.toThrow("OpenDucktor web host exited before startup completed with code 9.");
     await expect(
-      waitForBackend("http://127.0.0.1:14327", "app-token", 1_000, createHostProcess(exited), {
+      waitForBackend("http://127.0.0.1:14327", "app-token", 1, createHostProcess(exited), {
         fetch: async () => new Response(null, { status: 503 }),
         sleep: async () => {},
       }),

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -65,6 +65,31 @@ describe("launcher internals", () => {
     ).rejects.toMatchObject({ _tag: "WebOperationError" });
   });
 
+  test("aborts readiness fetches when the launcher timeout expires", async () => {
+    let aborted = false;
+    const fetchImpl = async (_url: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          aborted = true;
+          reject(new Error("readiness aborted"));
+        });
+      });
+
+    await expect(
+      waitForBackend(
+        "http://127.0.0.1:14327",
+        "app-token",
+        10,
+        createHostProcess(new Promise<number>(() => {})),
+        {
+          fetch: fetchImpl,
+          sleep: async () => {},
+        },
+      ),
+    ).rejects.toThrow("Timed out waiting for OpenDucktor web host");
+    expect(aborted).toBe(true);
+  });
+
   test("stops frontend and host services directly", async () => {
     let stopCalls = 0;
     let frontendCloseCalls = 0;

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -216,6 +216,14 @@ describe("launcher internals", () => {
     expect(source).toContain("OpenDucktor web shutdown is already in progress");
   });
 
+  test("registers launcher resource cleanup in Effect finalizers", async () => {
+    const source = await Bun.file(new URL("./launcher.ts", import.meta.url)).text();
+
+    expect(source).toContain("if (!servicesReleased)");
+    expect(source).toContain("const stopExit = yield* Effect.exit(stopEffect())");
+    expect(source).toContain("Effect.onInterrupt");
+  });
+
   test("does not wait for the host exit code when host stop fails", async () => {
     const hostBackend = {
       exited: new Promise<number>(() => {}),

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -52,13 +52,13 @@ describe("launcher internals", () => {
     await exited;
 
     await expect(
-      waitForBackend("http://127.0.0.1:14327", "app-token", 1, createHostProcess(exited), {
+      waitForBackend("http://127.0.0.1:14327", "app-token", 0, createHostProcess(exited), {
         fetch: async () => new Response(null, { status: 503 }),
         sleep: async () => {},
       }),
     ).rejects.toThrow("OpenDucktor web host exited before startup completed with code 9.");
     await expect(
-      waitForBackend("http://127.0.0.1:14327", "app-token", 1, createHostProcess(exited), {
+      waitForBackend("http://127.0.0.1:14327", "app-token", 0, createHostProcess(exited), {
         fetch: async () => new Response(null, { status: 503 }),
         sleep: async () => {},
       }),

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
-import { Effect } from "effect";
+import { Deferred, Effect } from "effect";
 import type { ViteDevServer } from "vite";
 import {
   causeToWebBoundaryError,
@@ -9,7 +9,6 @@ import {
   runWebBoundary,
   WebDependencyError,
   type WebError,
-  WebOperationError,
   WebResourceError,
 } from "./effect/web-errors";
 import {
@@ -17,9 +16,9 @@ import {
   buildBrowserRuntimeConfigJson,
   buildFrontendDisplayUrls,
   buildFrontendUrl,
-  closeFrontendServer,
+  closeFrontendServerEffect,
   type FrontendServer,
-  keepProcessAliveDuring,
+  keepProcessAliveDuringEffect,
   LOCALHOST,
   resolveStaticAssetPath,
   stopLauncherServicesEffect,
@@ -251,25 +250,34 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
       runtimeDistribution,
     });
     let frontendServer: FrontendServer | null = null;
-    let stopPromise: Promise<void> | null = null;
+    const stopDeferred = yield* Deferred.make<void, WebError>();
+    let stopStarted = false;
     let terminationStarted = false;
     let duplicateTerminationNoticeLogged = false;
 
-    const stop = async (): Promise<void> => {
-      if (stopPromise) {
-        return stopPromise;
-      }
+    const stopEffect = (): Effect.Effect<void, WebError> =>
+      Effect.suspend(() => {
+        if (stopStarted) {
+          return Deferred.await(stopDeferred);
+        }
+        stopStarted = true;
+        return Effect.gen(function* () {
+          const stopExit = yield* Effect.exit(
+            Effect.gen(function* () {
+              logInfo("Stopping OpenDucktor frontend server...");
+              logInfo("Stopping OpenDucktor TypeScript host services...");
 
-      stopPromise = (async () => {
-        logInfo("Stopping OpenDucktor frontend server...");
-        logInfo("Stopping OpenDucktor TypeScript host services...");
+              yield* stopLauncherServicesEffect({ frontendServer, hostBackend });
+              logSuccess("OpenDucktor web stopped.");
+            }),
+          );
+          yield* Deferred.done(stopDeferred, stopExit);
+          return yield* Deferred.await(stopDeferred);
+        });
+      });
 
-        await runWebBoundary(stopLauncherServicesEffect({ frontendServer, hostBackend }));
-        logSuccess("OpenDucktor web stopped.");
-      })();
-
-      return stopPromise;
-    };
+    const stopForSignal = (): Promise<void> =>
+      runWebBoundary(keepProcessAliveDuringEffect(stopEffect()));
 
     const handleTerminationSignal = (signal: NodeJS.Signals, exitCode: number): void => {
       if (terminationStarted) {
@@ -284,7 +292,7 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
       terminationStarted = true;
       logInfo(`Stopping OpenDucktor web after ${signal}...`);
 
-      void keepProcessAliveDuring(stop()).then(
+      void stopForSignal().then(
         () => {
           process.exit(exitCode);
         },
@@ -317,27 +325,11 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
               cause,
             }),
         });
-        if (stopPromise) {
-          yield* Effect.tryPromise({
-            try: () => stop(),
-            catch: (cause) =>
-              new WebOperationError({
-                operation: "web.launcher.stop",
-                message: errorMessage(cause),
-                cause,
-              }),
-          });
+        if (stopStarted) {
+          yield* stopEffect();
         } else {
           logInfo("OpenDucktor TypeScript host exited; stopping frontend server...");
-          yield* Effect.tryPromise({
-            try: () => closeFrontendServer(frontendServer),
-            catch: (cause) =>
-              new WebOperationError({
-                operation: "web.launcher.close-frontend",
-                message: errorMessage(cause),
-                cause,
-              }),
-          });
+          yield* closeFrontendServerEffect(frontendServer);
           logSuccess("OpenDucktor web stopped.");
         }
         return exitCode;
@@ -348,17 +340,7 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
       return launcherExit.value;
     }
 
-    const stopExit = yield* Effect.exit(
-      Effect.tryPromise({
-        try: () => stop(),
-        catch: (cause) =>
-          new WebOperationError({
-            operation: "web.launcher.stop-after-failure",
-            message: errorMessage(cause),
-            cause,
-          }),
-      }),
-    );
+    const stopExit = yield* Effect.exit(stopEffect());
     if (stopExit._tag === "Failure") {
       return yield* causeToWebBoundaryError(stopExit.cause);
     }

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -74,11 +74,19 @@ const contentTypeForPath = (filePath: string): string => {
   }
 };
 
+const cleanupStartedFrontendServerEffect = (server: FrontendServer): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const closeExit = yield* Effect.exit(closeFrontendServerEffect(server));
+    if (closeExit._tag === "Failure") {
+      logError(errorMessage(causeToWebBoundaryError(closeExit.cause)));
+    }
+  });
+
 const startViteServerEffect = (
   options: LauncherOptions,
   backendUrl: string,
   appToken: string,
-): Effect.Effect<ViteDevServer, WebDependencyError> =>
+): Effect.Effect<ViteDevServer, WebError> =>
   Effect.gen(function* () {
     const { createServer } = yield* Effect.tryPromise({
       try: () => import("vite"),
@@ -91,52 +99,67 @@ const startViteServerEffect = (
         }),
     });
     const runtimeConfigJson = buildBrowserRuntimeConfigJson(backendUrl, appToken);
-    const server = yield* Effect.tryPromise({
-      try: () =>
-        createServer({
-          root: options.packageRoot,
-          configFile: path.join(options.packageRoot, "vite.config.ts"),
-          plugins: [
-            {
-              name: "openducktor-runtime-config",
-              configureServer(devServer) {
-                devServer.middlewares.use(RUNTIME_CONFIG_PATH, (_request, response) => {
-                  response.statusCode = 200;
-                  response.setHeader("content-type", "application/json; charset=utf-8");
-                  response.setHeader("cache-control", "no-store");
-                  response.end(runtimeConfigJson);
-                });
-              },
-            },
-          ],
-          server: {
-            host: LOCALHOST,
-            port: options.frontendPort,
-            strictPort: true,
-          },
-        }),
-      catch: (cause) =>
-        new WebDependencyError({
-          dependency: "vite",
-          operation: "create-server",
-          message: errorMessage(cause),
-          cause,
-          details: { frontendPort: options.frontendPort },
-        }),
-    });
 
-    yield* Effect.tryPromise({
-      try: () => server.listen(options.frontendPort),
-      catch: (cause) =>
-        new WebDependencyError({
-          dependency: "vite",
-          operation: "listen",
-          message: errorMessage(cause),
-          cause,
-          details: { frontendPort: options.frontendPort },
-        }),
-    });
-    return server;
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const server = yield* Effect.tryPromise({
+          try: () =>
+            createServer({
+              root: options.packageRoot,
+              configFile: path.join(options.packageRoot, "vite.config.ts"),
+              plugins: [
+                {
+                  name: "openducktor-runtime-config",
+                  configureServer(devServer) {
+                    devServer.middlewares.use(RUNTIME_CONFIG_PATH, (_request, response) => {
+                      response.statusCode = 200;
+                      response.setHeader("content-type", "application/json; charset=utf-8");
+                      response.setHeader("cache-control", "no-store");
+                      response.end(runtimeConfigJson);
+                    });
+                  },
+                },
+              ],
+              server: {
+                host: LOCALHOST,
+                port: options.frontendPort,
+                strictPort: true,
+              },
+            }),
+          catch: (cause) =>
+            new WebDependencyError({
+              dependency: "vite",
+              operation: "create-server",
+              message: errorMessage(cause),
+              cause,
+              details: { frontendPort: options.frontendPort },
+            }),
+        });
+
+        yield* restore(
+          Effect.tryPromise({
+            try: () => server.listen(options.frontendPort),
+            catch: (cause) =>
+              new WebDependencyError({
+                dependency: "vite",
+                operation: "listen",
+                message: errorMessage(cause),
+                cause,
+                details: { frontendPort: options.frontendPort },
+              }),
+          }),
+        ).pipe(
+          Effect.catchAll((error) =>
+            Effect.gen(function* () {
+              yield* cleanupStartedFrontendServerEffect(server);
+              return yield* error;
+            }),
+          ),
+          Effect.onInterrupt(() => cleanupStartedFrontendServerEffect(server)),
+        );
+        return server;
+      }),
+    );
   });
 
 const startStaticFrontendServerEffect = (
@@ -168,55 +191,57 @@ const startStaticFrontendServerEffect = (
     }
 
     const runtimeConfigJson = buildBrowserRuntimeConfigJson(backendUrl, appToken);
-    const server = yield* Effect.try({
-      try: () =>
-        Bun.serve({
-          hostname: LOCALHOST,
-          port: options.frontendPort,
-          fetch(request) {
-            const requestUrl = new URL(request.url);
-            if (requestUrl.pathname === RUNTIME_CONFIG_PATH) {
-              return new Response(runtimeConfigJson, {
+    return yield* Effect.uninterruptible(
+      Effect.try({
+        try: () =>
+          Bun.serve({
+            hostname: LOCALHOST,
+            port: options.frontendPort,
+            fetch(request) {
+              const requestUrl = new URL(request.url);
+              if (requestUrl.pathname === RUNTIME_CONFIG_PATH) {
+                return new Response(runtimeConfigJson, {
+                  headers: {
+                    "cache-control": "no-store",
+                    "content-type": "application/json; charset=utf-8",
+                  },
+                });
+              }
+
+              const assetPath = resolveStaticAssetPath(staticRoot, requestUrl.pathname);
+              if (!assetPath) {
+                return new Response("Not found", { status: 404 });
+              }
+
+              const assetExists = existsSync(assetPath) && statSync(assetPath).isFile();
+              if (!assetExists && path.extname(requestUrl.pathname)) {
+                return new Response("Not found", { status: 404 });
+              }
+
+              const responsePath = assetExists ? assetPath : indexPath;
+              return new Response(Bun.file(responsePath), {
                 headers: {
-                  "cache-control": "no-store",
-                  "content-type": "application/json; charset=utf-8",
+                  "content-type": contentTypeForPath(responsePath),
                 },
               });
-            }
-
-            const assetPath = resolveStaticAssetPath(staticRoot, requestUrl.pathname);
-            if (!assetPath) {
-              return new Response("Not found", { status: 404 });
-            }
-
-            const assetExists = existsSync(assetPath) && statSync(assetPath).isFile();
-            if (!assetExists && path.extname(requestUrl.pathname)) {
-              return new Response("Not found", { status: 404 });
-            }
-
-            const responsePath = assetExists ? assetPath : indexPath;
-            return new Response(Bun.file(responsePath), {
-              headers: {
-                "content-type": contentTypeForPath(responsePath),
-              },
-            });
+            },
+          }),
+        catch: (cause) =>
+          new WebDependencyError({
+            dependency: "bun-server",
+            operation: "start-static-frontend",
+            message: errorMessage(cause),
+            cause,
+            details: { frontendPort: options.frontendPort },
+          }),
+      }).pipe(
+        Effect.map((server) => ({
+          async close() {
+            server.stop(true);
           },
-        }),
-      catch: (cause) =>
-        new WebDependencyError({
-          dependency: "bun-server",
-          operation: "start-static-frontend",
-          message: errorMessage(cause),
-          cause,
-          details: { frontendPort: options.frontendPort },
-        }),
-    });
-
-    return {
-      async close() {
-        server.stop(true);
-      },
-    };
+        })),
+      ),
+    );
   });
 
 const startFrontendServerEffect = (
@@ -241,123 +266,193 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
       ...(options.workspaceRoot ? { workspaceRoot: options.workspaceRoot } : {}),
     });
     const providedToolPaths = yield* resolveWebProvidedToolPathsEffect();
-    const hostBackend = yield* startTypescriptHostBackendEffect({
-      port: options.backendPort,
-      frontendOrigin: frontendUrl,
-      controlToken,
-      appToken,
-      providedToolPaths,
-      runtimeDistribution,
-    });
     let frontendServer: FrontendServer | null = null;
-    const stopDeferred = yield* Deferred.make<void, WebError>();
-    let stopStarted = false;
-    let terminationStarted = false;
-    let duplicateTerminationNoticeLogged = false;
+    let frontendClosed = false;
+    let servicesReleased = false;
+    let stopEffectRef: (() => Effect.Effect<void, WebError>) | null = null;
 
-    const stopServicesWithLogsEffect = (): Effect.Effect<void, WebError> =>
-      Effect.gen(function* () {
-        logInfo("Stopping OpenDucktor frontend server...");
-        logInfo("Stopping OpenDucktor TypeScript host services...");
-
-        yield* stopLauncherServicesEffect({ frontendServer, hostBackend });
-        logSuccess("OpenDucktor web stopped.");
-      });
-
-    const stopEffect = (): Effect.Effect<void, WebError> =>
+    const closeFrontendOnceEffect = (
+      server: FrontendServer | null,
+    ): Effect.Effect<void, WebError> =>
       Effect.suspend(() => {
-        if (stopStarted) {
-          return Deferred.await(stopDeferred);
+        if (!server || frontendClosed) {
+          return Effect.void;
         }
-        stopStarted = true;
-        return Effect.gen(function* () {
-          const stopExit = yield* Effect.exit(stopServicesWithLogsEffect());
-          yield* Deferred.done(stopDeferred, stopExit);
-          return yield* Deferred.await(stopDeferred);
-        });
+        frontendClosed = true;
+        return closeFrontendServerEffect(server);
       });
-
-    const stopForSignal = (): Promise<void> =>
-      runWebBoundary(keepProcessAliveDuringEffect(stopEffect()));
-
-    const handleTerminationSignal = (signal: NodeJS.Signals, exitCode: number): void => {
-      if (terminationStarted) {
-        if (!duplicateTerminationNoticeLogged) {
-          duplicateTerminationNoticeLogged = true;
-          logInfo(
-            "OpenDucktor web shutdown is already in progress; waiting for cleanup to finish.",
-          );
-        }
-        return;
-      }
-      terminationStarted = true;
-      logInfo(`Stopping OpenDucktor web after ${signal}...`);
-
-      void stopForSignal().then(
-        () => {
-          process.exit(exitCode);
-        },
-        (error: unknown) => {
-          logError(errorMessage(error));
-          process.exit(1);
-        },
-      );
-    };
-
-    const handleSigint = (): void => handleTerminationSignal("SIGINT", 130);
-    const handleSigterm = (): void => handleTerminationSignal("SIGTERM", 143);
 
     return yield* Effect.acquireUseRelease(
-      Effect.sync(() => {
-        process.on("SIGINT", handleSigint);
-        process.on("SIGTERM", handleSigterm);
+      startTypescriptHostBackendEffect({
+        port: options.backendPort,
+        frontendOrigin: frontendUrl,
+        controlToken,
+        appToken,
+        providedToolPaths,
+        runtimeDistribution,
       }),
-      () =>
+      (hostBackend) =>
         Effect.gen(function* () {
-          const launcherExit = yield* Effect.exit(
+          const stopDeferred = yield* Deferred.make<void, WebError>();
+          let stopStarted = false;
+          let terminationStarted = false;
+          let duplicateTerminationNoticeLogged = false;
+
+          const stopServicesWithLogsEffect = (): Effect.Effect<void, WebError> =>
             Effect.gen(function* () {
-              logInfo("Starting OpenDucktor TypeScript host...");
-              logInfo("Waiting for OpenDucktor TypeScript host readiness...");
-              yield* waitForBackendEffect(backendUrl, appToken, readinessTimeoutMs, hostBackend);
-              logInfo("Starting OpenDucktor frontend server...");
-              frontendServer = yield* startFrontendServerEffect(options, backendUrl, appToken);
-              logFrontendAvailability(options.frontendPort);
+              logInfo("Stopping OpenDucktor frontend server...");
+              logInfo("Stopping OpenDucktor TypeScript host services...");
 
-              const exitCode = yield* Effect.tryPromise({
-                try: () => hostBackend.exited,
-                catch: (cause) =>
-                  new WebDependencyError({
-                    dependency: "typescript-host-backend",
-                    operation: "await-exit",
-                    message: errorMessage(cause),
-                    cause,
-                  }),
-              });
+              yield* stopLauncherServicesEffect(
+                { frontendServer, hostBackend },
+                {
+                  closeServer: (server) => runWebBoundary(closeFrontendOnceEffect(server)),
+                  stopHost: (backend) => backend.stop(),
+                },
+              );
+              logSuccess("OpenDucktor web stopped.");
+            });
+
+          const stopEffect = (): Effect.Effect<void, WebError> =>
+            Effect.suspend(() => {
               if (stopStarted) {
-                yield* stopEffect();
-              } else {
-                logInfo("OpenDucktor TypeScript host exited; stopping frontend server...");
-                yield* closeFrontendServerEffect(frontendServer);
-                logSuccess("OpenDucktor web stopped.");
+                return Deferred.await(stopDeferred);
               }
-              return exitCode;
+              stopStarted = true;
+              return Effect.gen(function* () {
+                const stopExit = yield* Effect.exit(stopServicesWithLogsEffect());
+                servicesReleased = true;
+                yield* Deferred.done(stopDeferred, stopExit);
+                return yield* Deferred.await(stopDeferred);
+              });
+            });
+          stopEffectRef = stopEffect;
+
+          const stopForSignal = (): Promise<void> =>
+            runWebBoundary(keepProcessAliveDuringEffect(stopEffect()));
+
+          const handleTerminationSignal = (signal: NodeJS.Signals, exitCode: number): void => {
+            if (terminationStarted) {
+              if (!duplicateTerminationNoticeLogged) {
+                duplicateTerminationNoticeLogged = true;
+                logInfo(
+                  "OpenDucktor web shutdown is already in progress; waiting for cleanup to finish.",
+                );
+              }
+              return;
+            }
+            terminationStarted = true;
+            logInfo(`Stopping OpenDucktor web after ${signal}...`);
+
+            void stopForSignal().then(
+              () => {
+                process.exit(exitCode);
+              },
+              (error: unknown) => {
+                logError(errorMessage(error));
+                process.exit(1);
+              },
+            );
+          };
+
+          const handleSigint = (): void => handleTerminationSignal("SIGINT", 130);
+          const handleSigterm = (): void => handleTerminationSignal("SIGTERM", 143);
+
+          return yield* Effect.acquireUseRelease(
+            Effect.sync(() => {
+              process.on("SIGINT", handleSigint);
+              process.on("SIGTERM", handleSigterm);
             }),
+            () =>
+              Effect.gen(function* () {
+                const launcherExit = yield* Effect.exit(
+                  Effect.gen(function* () {
+                    logInfo("Starting OpenDucktor TypeScript host...");
+                    logInfo("Waiting for OpenDucktor TypeScript host readiness...");
+                    yield* waitForBackendEffect(
+                      backendUrl,
+                      appToken,
+                      readinessTimeoutMs,
+                      hostBackend,
+                    );
+                    logInfo("Starting OpenDucktor frontend server...");
+                    return yield* Effect.acquireUseRelease(
+                      startFrontendServerEffect(options, backendUrl, appToken),
+                      (server) =>
+                        Effect.gen(function* () {
+                          frontendServer = server;
+                          logFrontendAvailability(options.frontendPort);
+
+                          const exitCode = yield* Effect.tryPromise({
+                            try: () => hostBackend.exited,
+                            catch: (cause) =>
+                              new WebDependencyError({
+                                dependency: "typescript-host-backend",
+                                operation: "await-exit",
+                                message: errorMessage(cause),
+                                cause,
+                              }),
+                          });
+                          if (stopStarted) {
+                            yield* stopEffect();
+                          } else {
+                            logInfo(
+                              "OpenDucktor TypeScript host exited; stopping frontend server...",
+                            );
+                            yield* closeFrontendOnceEffect(server);
+                            logSuccess("OpenDucktor web stopped.");
+                            servicesReleased = true;
+                          }
+                          return exitCode;
+                        }),
+                      (server) =>
+                        Effect.gen(function* () {
+                          const closeExit = yield* Effect.exit(closeFrontendOnceEffect(server));
+                          if (closeExit._tag === "Failure") {
+                            logError(errorMessage(causeToWebBoundaryError(closeExit.cause)));
+                          }
+                        }),
+                    );
+                  }),
+                );
+
+                if (launcherExit._tag === "Success") {
+                  return launcherExit.value;
+                }
+
+                const stopExit = yield* Effect.exit(stopEffect());
+                if (stopExit._tag === "Failure") {
+                  return yield* causeToWebBoundaryError(stopExit.cause);
+                }
+                return yield* causeToWebBoundaryError(launcherExit.cause);
+              }),
+            () =>
+              Effect.gen(function* () {
+                process.off("SIGINT", handleSigint);
+                process.off("SIGTERM", handleSigterm);
+                if (!servicesReleased) {
+                  const stopExit = yield* Effect.exit(stopEffect());
+                  if (stopExit._tag === "Failure") {
+                    logError(errorMessage(causeToWebBoundaryError(stopExit.cause)));
+                  }
+                }
+              }),
           );
-
-          if (launcherExit._tag === "Success") {
-            return launcherExit.value;
-          }
-
-          const stopExit = yield* Effect.exit(stopEffect());
-          if (stopExit._tag === "Failure") {
-            return yield* causeToWebBoundaryError(stopExit.cause);
-          }
-          return yield* causeToWebBoundaryError(launcherExit.cause);
         }),
-      () =>
-        Effect.sync(() => {
-          process.off("SIGINT", handleSigint);
-          process.off("SIGTERM", handleSigterm);
+      (hostBackend) =>
+        Effect.gen(function* () {
+          if (servicesReleased) {
+            return;
+          }
+          const stopExit = yield* Effect.exit(
+            stopEffectRef
+              ? stopEffectRef()
+              : stopLauncherServicesEffect({ frontendServer, hostBackend }),
+          );
+          servicesReleased = true;
+          if (stopExit._tag === "Failure") {
+            logError(errorMessage(causeToWebBoundaryError(stopExit.cause)));
+          }
         }),
     );
   });

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -304,48 +304,62 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
       );
     };
 
-    process.on("SIGINT", () => handleTerminationSignal("SIGINT", 130));
-    process.on("SIGTERM", () => handleTerminationSignal("SIGTERM", 143));
+    const handleSigint = (): void => handleTerminationSignal("SIGINT", 130);
+    const handleSigterm = (): void => handleTerminationSignal("SIGTERM", 143);
 
-    const launcherExit = yield* Effect.exit(
-      Effect.gen(function* () {
-        logInfo("Starting OpenDucktor TypeScript host...");
-        logInfo("Waiting for OpenDucktor TypeScript host readiness...");
-        yield* waitForBackendEffect(backendUrl, appToken, readinessTimeoutMs, hostBackend);
-        logInfo("Starting OpenDucktor frontend server...");
-        frontendServer = yield* startFrontendServerEffect(options, backendUrl, appToken);
-        logFrontendAvailability(options.frontendPort);
-
-        const exitCode = yield* Effect.tryPromise({
-          try: () => hostBackend.exited,
-          catch: (cause) =>
-            new WebDependencyError({
-              dependency: "typescript-host-backend",
-              operation: "await-exit",
-              message: errorMessage(cause),
-              cause,
-            }),
-        });
-        if (stopStarted) {
-          yield* stopEffect();
-        } else {
-          logInfo("OpenDucktor TypeScript host exited; stopping frontend server...");
-          yield* closeFrontendServerEffect(frontendServer);
-          logSuccess("OpenDucktor web stopped.");
-        }
-        return exitCode;
+    return yield* Effect.acquireUseRelease(
+      Effect.sync(() => {
+        process.on("SIGINT", handleSigint);
+        process.on("SIGTERM", handleSigterm);
       }),
+      () =>
+        Effect.gen(function* () {
+          const launcherExit = yield* Effect.exit(
+            Effect.gen(function* () {
+              logInfo("Starting OpenDucktor TypeScript host...");
+              logInfo("Waiting for OpenDucktor TypeScript host readiness...");
+              yield* waitForBackendEffect(backendUrl, appToken, readinessTimeoutMs, hostBackend);
+              logInfo("Starting OpenDucktor frontend server...");
+              frontendServer = yield* startFrontendServerEffect(options, backendUrl, appToken);
+              logFrontendAvailability(options.frontendPort);
+
+              const exitCode = yield* Effect.tryPromise({
+                try: () => hostBackend.exited,
+                catch: (cause) =>
+                  new WebDependencyError({
+                    dependency: "typescript-host-backend",
+                    operation: "await-exit",
+                    message: errorMessage(cause),
+                    cause,
+                  }),
+              });
+              if (stopStarted) {
+                yield* stopEffect();
+              } else {
+                logInfo("OpenDucktor TypeScript host exited; stopping frontend server...");
+                yield* closeFrontendServerEffect(frontendServer);
+                logSuccess("OpenDucktor web stopped.");
+              }
+              return exitCode;
+            }),
+          );
+
+          if (launcherExit._tag === "Success") {
+            return launcherExit.value;
+          }
+
+          const stopExit = yield* Effect.exit(stopEffect());
+          if (stopExit._tag === "Failure") {
+            return yield* causeToWebBoundaryError(stopExit.cause);
+          }
+          return yield* causeToWebBoundaryError(launcherExit.cause);
+        }),
+      () =>
+        Effect.sync(() => {
+          process.off("SIGINT", handleSigint);
+          process.off("SIGTERM", handleSigterm);
+        }),
     );
-
-    if (launcherExit._tag === "Success") {
-      return launcherExit.value;
-    }
-
-    const stopExit = yield* Effect.exit(stopEffect());
-    if (stopExit._tag === "Failure") {
-      return yield* causeToWebBoundaryError(stopExit.cause);
-    }
-    return yield* causeToWebBoundaryError(launcherExit.cause);
   });
 
 export const runLauncher = (options: LauncherOptions): Promise<number> =>

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -1,7 +1,17 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
+import { Effect } from "effect";
 import type { ViteDevServer } from "vite";
+import {
+  causeToWebBoundaryError,
+  errorMessage,
+  runWebBoundary,
+  WebDependencyError,
+  type WebError,
+  WebOperationError,
+  WebResourceError,
+} from "./effect/web-errors";
 import {
   buildBackendUrl,
   buildBrowserRuntimeConfigJson,
@@ -12,14 +22,14 @@ import {
   keepProcessAliveDuring,
   LOCALHOST,
   resolveStaticAssetPath,
-  stopLauncherServices,
-  waitForBackend,
+  stopLauncherServicesEffect,
+  waitForBackendEffect,
 } from "./launcher-support";
 import { logError, logInfo, logSuccess } from "./logger";
 import { RUNTIME_CONFIG_PATH } from "./runtime-config";
-import { startTypescriptHostBackend } from "./typescript-host-backend";
-import { resolveWebRuntimeDistribution } from "./web-runtime-distribution";
-import { resolveWebProvidedToolPaths } from "./web-tool-discovery";
+import { startTypescriptHostBackendEffect } from "./typescript-host-backend";
+import { resolveWebRuntimeDistributionEffect } from "./web-runtime-distribution";
+import { resolveWebProvidedToolPathsEffect } from "./web-tool-discovery";
 
 export type LauncherOptions = {
   packageRoot: string;
@@ -65,191 +75,295 @@ const contentTypeForPath = (filePath: string): string => {
   }
 };
 
-const startViteServer = async (
+const startViteServerEffect = (
   options: LauncherOptions,
   backendUrl: string,
   appToken: string,
-): Promise<ViteDevServer> => {
-  const { createServer } = await import("vite");
-  const runtimeConfigJson = buildBrowserRuntimeConfigJson(backendUrl, appToken);
-  const server = await createServer({
-    root: options.packageRoot,
-    configFile: path.join(options.packageRoot, "vite.config.ts"),
-    plugins: [
-      {
-        name: "openducktor-runtime-config",
-        configureServer(devServer) {
-          devServer.middlewares.use(RUNTIME_CONFIG_PATH, (_request, response) => {
-            response.statusCode = 200;
-            response.setHeader("content-type", "application/json; charset=utf-8");
-            response.setHeader("cache-control", "no-store");
-            response.end(runtimeConfigJson);
-          });
-        },
-      },
-    ],
-    server: {
-      host: LOCALHOST,
-      port: options.frontendPort,
-      strictPort: true,
-    },
-  });
-
-  await server.listen(options.frontendPort);
-  return server;
-};
-
-const startStaticFrontendServer = async (
-  options: LauncherOptions,
-  backendUrl: string,
-  appToken: string,
-): Promise<FrontendServer> => {
-  const staticRoot = path.join(options.packageRoot, "dist/web-shell");
-  const indexPath = path.join(staticRoot, "index.html");
-  if (!existsSync(indexPath) || !statSync(indexPath).isFile()) {
-    throw new Error(
-      `OpenDucktor web shell assets were not found at ${staticRoot}. Reinstall @openducktor/web or run the package build before starting.`,
-    );
-  }
-
-  const runtimeConfigJson = buildBrowserRuntimeConfigJson(backendUrl, appToken);
-  const server = Bun.serve({
-    hostname: LOCALHOST,
-    port: options.frontendPort,
-    fetch(request) {
-      const requestUrl = new URL(request.url);
-      if (requestUrl.pathname === RUNTIME_CONFIG_PATH) {
-        return new Response(runtimeConfigJson, {
-          headers: {
-            "cache-control": "no-store",
-            "content-type": "application/json; charset=utf-8",
+): Effect.Effect<ViteDevServer, WebDependencyError> =>
+  Effect.gen(function* () {
+    const { createServer } = yield* Effect.tryPromise({
+      try: () => import("vite"),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "vite",
+          operation: "import",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+    const runtimeConfigJson = buildBrowserRuntimeConfigJson(backendUrl, appToken);
+    const server = yield* Effect.tryPromise({
+      try: () =>
+        createServer({
+          root: options.packageRoot,
+          configFile: path.join(options.packageRoot, "vite.config.ts"),
+          plugins: [
+            {
+              name: "openducktor-runtime-config",
+              configureServer(devServer) {
+                devServer.middlewares.use(RUNTIME_CONFIG_PATH, (_request, response) => {
+                  response.statusCode = 200;
+                  response.setHeader("content-type", "application/json; charset=utf-8");
+                  response.setHeader("cache-control", "no-store");
+                  response.end(runtimeConfigJson);
+                });
+              },
+            },
+          ],
+          server: {
+            host: LOCALHOST,
+            port: options.frontendPort,
+            strictPort: true,
           },
-        });
-      }
+        }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "vite",
+          operation: "create-server",
+          message: errorMessage(cause),
+          cause,
+          details: { frontendPort: options.frontendPort },
+        }),
+    });
 
-      const assetPath = resolveStaticAssetPath(staticRoot, requestUrl.pathname);
-      if (!assetPath) {
-        return new Response("Not found", { status: 404 });
-      }
-
-      const assetExists = existsSync(assetPath) && statSync(assetPath).isFile();
-      if (!assetExists && path.extname(requestUrl.pathname)) {
-        return new Response("Not found", { status: 404 });
-      }
-
-      const responsePath = assetExists ? assetPath : indexPath;
-      return new Response(Bun.file(responsePath), {
-        headers: {
-          "content-type": contentTypeForPath(responsePath),
-        },
-      });
-    },
+    yield* Effect.tryPromise({
+      try: () => server.listen(options.frontendPort),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "vite",
+          operation: "listen",
+          message: errorMessage(cause),
+          cause,
+          details: { frontendPort: options.frontendPort },
+        }),
+    });
+    return server;
   });
 
-  return {
-    async close() {
-      server.stop(true);
-    },
-  };
-};
-
-const startFrontendServer = async (
+const startStaticFrontendServerEffect = (
   options: LauncherOptions,
   backendUrl: string,
   appToken: string,
-): Promise<FrontendServer> => {
-  if (options.workspaceMode) {
-    return startViteServer(options, backendUrl, appToken);
-  }
-
-  return startStaticFrontendServer(options, backendUrl, appToken);
-};
-
-export const runLauncher = async (options: LauncherOptions): Promise<number> => {
-  const readinessTimeoutMs = options.readinessTimeoutMs ?? 60_000;
-  const frontendUrl = buildFrontendUrl(options.frontendPort);
-  const backendUrl = buildBackendUrl(options.backendPort);
-  const controlToken = randomUUID();
-  const appToken = randomUUID();
-  const runtimeDistribution = resolveWebRuntimeDistribution({
-    packageRoot: options.packageRoot,
-    workspaceMode: options.workspaceMode,
-    ...(options.workspaceRoot ? { workspaceRoot: options.workspaceRoot } : {}),
-  });
-  const providedToolPaths = resolveWebProvidedToolPaths();
-  const hostBackend = await startTypescriptHostBackend({
-    port: options.backendPort,
-    frontendOrigin: frontendUrl,
-    controlToken,
-    appToken,
-    providedToolPaths,
-    runtimeDistribution,
-  });
-  let frontendServer: FrontendServer | null = null;
-  let stopPromise: Promise<void> | null = null;
-  let terminationStarted = false;
-  let duplicateTerminationNoticeLogged = false;
-
-  const stop = async (): Promise<void> => {
-    if (stopPromise) {
-      return stopPromise;
+): Effect.Effect<FrontendServer, WebDependencyError | WebResourceError> =>
+  Effect.gen(function* () {
+    const staticRoot = path.join(options.packageRoot, "dist/web-shell");
+    const indexPath = path.join(staticRoot, "index.html");
+    const indexFileExists = yield* Effect.try({
+      try: () => existsSync(indexPath) && statSync(indexPath).isFile(),
+      catch: (cause) =>
+        new WebResourceError({
+          resource: "web-shell-assets",
+          operation: "stat",
+          message: errorMessage(cause),
+          cause,
+          details: { indexPath, staticRoot },
+        }),
+    });
+    if (!indexFileExists) {
+      return yield* new WebResourceError({
+        resource: "web-shell-assets",
+        operation: "resolve",
+        message: `OpenDucktor web shell assets were not found at ${staticRoot}. Reinstall @openducktor/web or run the package build before starting.`,
+        details: { indexPath, staticRoot },
+      });
     }
 
-    stopPromise = (async () => {
-      logInfo("Stopping OpenDucktor frontend server...");
-      logInfo("Stopping OpenDucktor TypeScript host services...");
+    const runtimeConfigJson = buildBrowserRuntimeConfigJson(backendUrl, appToken);
+    const server = yield* Effect.try({
+      try: () =>
+        Bun.serve({
+          hostname: LOCALHOST,
+          port: options.frontendPort,
+          fetch(request) {
+            const requestUrl = new URL(request.url);
+            if (requestUrl.pathname === RUNTIME_CONFIG_PATH) {
+              return new Response(runtimeConfigJson, {
+                headers: {
+                  "cache-control": "no-store",
+                  "content-type": "application/json; charset=utf-8",
+                },
+              });
+            }
 
-      await stopLauncherServices({ frontendServer, hostBackend });
-      logSuccess("OpenDucktor web stopped.");
-    })();
+            const assetPath = resolveStaticAssetPath(staticRoot, requestUrl.pathname);
+            if (!assetPath) {
+              return new Response("Not found", { status: 404 });
+            }
 
-    return stopPromise;
-  };
+            const assetExists = existsSync(assetPath) && statSync(assetPath).isFile();
+            if (!assetExists && path.extname(requestUrl.pathname)) {
+              return new Response("Not found", { status: 404 });
+            }
 
-  const handleTerminationSignal = (signal: NodeJS.Signals, exitCode: number): void => {
-    if (terminationStarted) {
-      if (!duplicateTerminationNoticeLogged) {
-        duplicateTerminationNoticeLogged = true;
-        logInfo("OpenDucktor web shutdown is already in progress; waiting for cleanup to finish.");
+            const responsePath = assetExists ? assetPath : indexPath;
+            return new Response(Bun.file(responsePath), {
+              headers: {
+                "content-type": contentTypeForPath(responsePath),
+              },
+            });
+          },
+        }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "bun-server",
+          operation: "start-static-frontend",
+          message: errorMessage(cause),
+          cause,
+          details: { frontendPort: options.frontendPort },
+        }),
+    });
+
+    return {
+      async close() {
+        server.stop(true);
+      },
+    };
+  });
+
+const startFrontendServerEffect = (
+  options: LauncherOptions,
+  backendUrl: string,
+  appToken: string,
+): Effect.Effect<FrontendServer, WebError> =>
+  options.workspaceMode
+    ? startViteServerEffect(options, backendUrl, appToken)
+    : startStaticFrontendServerEffect(options, backendUrl, appToken);
+
+export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<number, WebError> =>
+  Effect.gen(function* () {
+    const readinessTimeoutMs = options.readinessTimeoutMs ?? 60_000;
+    const frontendUrl = buildFrontendUrl(options.frontendPort);
+    const backendUrl = buildBackendUrl(options.backendPort);
+    const controlToken = randomUUID();
+    const appToken = randomUUID();
+    const runtimeDistribution = yield* resolveWebRuntimeDistributionEffect({
+      packageRoot: options.packageRoot,
+      workspaceMode: options.workspaceMode,
+      ...(options.workspaceRoot ? { workspaceRoot: options.workspaceRoot } : {}),
+    });
+    const providedToolPaths = yield* resolveWebProvidedToolPathsEffect();
+    const hostBackend = yield* startTypescriptHostBackendEffect({
+      port: options.backendPort,
+      frontendOrigin: frontendUrl,
+      controlToken,
+      appToken,
+      providedToolPaths,
+      runtimeDistribution,
+    });
+    let frontendServer: FrontendServer | null = null;
+    let stopPromise: Promise<void> | null = null;
+    let terminationStarted = false;
+    let duplicateTerminationNoticeLogged = false;
+
+    const stop = async (): Promise<void> => {
+      if (stopPromise) {
+        return stopPromise;
       }
-      return;
-    }
-    terminationStarted = true;
-    logInfo(`Stopping OpenDucktor web after ${signal}...`);
 
-    void keepProcessAliveDuring(stop()).then(
-      () => {
-        process.exit(exitCode);
-      },
-      (error: unknown) => {
-        logError(error instanceof Error ? error.message : String(error));
-        process.exit(1);
-      },
+      stopPromise = (async () => {
+        logInfo("Stopping OpenDucktor frontend server...");
+        logInfo("Stopping OpenDucktor TypeScript host services...");
+
+        await runWebBoundary(stopLauncherServicesEffect({ frontendServer, hostBackend }));
+        logSuccess("OpenDucktor web stopped.");
+      })();
+
+      return stopPromise;
+    };
+
+    const handleTerminationSignal = (signal: NodeJS.Signals, exitCode: number): void => {
+      if (terminationStarted) {
+        if (!duplicateTerminationNoticeLogged) {
+          duplicateTerminationNoticeLogged = true;
+          logInfo(
+            "OpenDucktor web shutdown is already in progress; waiting for cleanup to finish.",
+          );
+        }
+        return;
+      }
+      terminationStarted = true;
+      logInfo(`Stopping OpenDucktor web after ${signal}...`);
+
+      void keepProcessAliveDuring(stop()).then(
+        () => {
+          process.exit(exitCode);
+        },
+        (error: unknown) => {
+          logError(errorMessage(error));
+          process.exit(1);
+        },
+      );
+    };
+
+    process.on("SIGINT", () => handleTerminationSignal("SIGINT", 130));
+    process.on("SIGTERM", () => handleTerminationSignal("SIGTERM", 143));
+
+    const launcherExit = yield* Effect.exit(
+      Effect.gen(function* () {
+        logInfo("Starting OpenDucktor TypeScript host...");
+        logInfo("Waiting for OpenDucktor TypeScript host readiness...");
+        yield* waitForBackendEffect(backendUrl, appToken, readinessTimeoutMs, hostBackend);
+        logInfo("Starting OpenDucktor frontend server...");
+        frontendServer = yield* startFrontendServerEffect(options, backendUrl, appToken);
+        logFrontendAvailability(options.frontendPort);
+
+        const exitCode = yield* Effect.tryPromise({
+          try: () => hostBackend.exited,
+          catch: (cause) =>
+            new WebDependencyError({
+              dependency: "typescript-host-backend",
+              operation: "await-exit",
+              message: errorMessage(cause),
+              cause,
+            }),
+        });
+        if (stopPromise) {
+          yield* Effect.tryPromise({
+            try: () => stop(),
+            catch: (cause) =>
+              new WebOperationError({
+                operation: "web.launcher.stop",
+                message: errorMessage(cause),
+                cause,
+              }),
+          });
+        } else {
+          logInfo("OpenDucktor TypeScript host exited; stopping frontend server...");
+          yield* Effect.tryPromise({
+            try: () => closeFrontendServer(frontendServer),
+            catch: (cause) =>
+              new WebOperationError({
+                operation: "web.launcher.close-frontend",
+                message: errorMessage(cause),
+                cause,
+              }),
+          });
+          logSuccess("OpenDucktor web stopped.");
+        }
+        return exitCode;
+      }),
     );
-  };
 
-  process.on("SIGINT", () => handleTerminationSignal("SIGINT", 130));
-  process.on("SIGTERM", () => handleTerminationSignal("SIGTERM", 143));
-
-  try {
-    logInfo("Starting OpenDucktor TypeScript host...");
-    logInfo("Waiting for OpenDucktor TypeScript host readiness...");
-    await waitForBackend(backendUrl, appToken, readinessTimeoutMs, hostBackend);
-    logInfo("Starting OpenDucktor frontend server...");
-    frontendServer = await startFrontendServer(options, backendUrl, appToken);
-    logFrontendAvailability(options.frontendPort);
-
-    const exitCode = await hostBackend.exited;
-    if (stopPromise) {
-      await stop();
-    } else {
-      logInfo("OpenDucktor TypeScript host exited; stopping frontend server...");
-      await closeFrontendServer(frontendServer);
-      logSuccess("OpenDucktor web stopped.");
+    if (launcherExit._tag === "Success") {
+      return launcherExit.value;
     }
-    return exitCode;
-  } catch (error) {
-    await stop();
-    throw error;
-  }
-};
+
+    const stopExit = yield* Effect.exit(
+      Effect.tryPromise({
+        try: () => stop(),
+        catch: (cause) =>
+          new WebOperationError({
+            operation: "web.launcher.stop-after-failure",
+            message: errorMessage(cause),
+            cause,
+          }),
+      }),
+    );
+    if (stopExit._tag === "Failure") {
+      return yield* causeToWebBoundaryError(stopExit.cause);
+    }
+    return yield* causeToWebBoundaryError(launcherExit.cause);
+  });
+
+export const runLauncher = (options: LauncherOptions): Promise<number> =>
+  runWebBoundary(runLauncherEffect(options));

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -422,7 +422,7 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
 
                 const stopExit = yield* Effect.exit(stopEffect());
                 if (stopExit._tag === "Failure") {
-                  return yield* causeToWebBoundaryError(stopExit.cause);
+                  logError(errorMessage(causeToWebBoundaryError(stopExit.cause)));
                 }
                 return yield* causeToWebBoundaryError(launcherExit.cause);
               }),

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -255,6 +255,15 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
     let terminationStarted = false;
     let duplicateTerminationNoticeLogged = false;
 
+    const stopServicesWithLogsEffect = (): Effect.Effect<void, WebError> =>
+      Effect.gen(function* () {
+        logInfo("Stopping OpenDucktor frontend server...");
+        logInfo("Stopping OpenDucktor TypeScript host services...");
+
+        yield* stopLauncherServicesEffect({ frontendServer, hostBackend });
+        logSuccess("OpenDucktor web stopped.");
+      });
+
     const stopEffect = (): Effect.Effect<void, WebError> =>
       Effect.suspend(() => {
         if (stopStarted) {
@@ -262,15 +271,7 @@ export const runLauncherEffect = (options: LauncherOptions): Effect.Effect<numbe
         }
         stopStarted = true;
         return Effect.gen(function* () {
-          const stopExit = yield* Effect.exit(
-            Effect.gen(function* () {
-              logInfo("Stopping OpenDucktor frontend server...");
-              logInfo("Stopping OpenDucktor TypeScript host services...");
-
-              yield* stopLauncherServicesEffect({ frontendServer, hostBackend });
-              logSuccess("OpenDucktor web stopped.");
-            }),
-          );
+          const stopExit = yield* Effect.exit(stopServicesWithLogsEffect());
           yield* Deferred.done(stopDeferred, stopExit);
           return yield* Deferred.await(stopDeferred);
         });

--- a/packages/openducktor-web/src/local-host-errors.ts
+++ b/packages/openducktor-web/src/local-host-errors.ts
@@ -1,25 +1,55 @@
-export const readLocalHostErrorPayload = async (
-  response: Response,
-): Promise<{ message: string; payload: unknown | null }> => {
-  const text = await response.text().catch(() => "");
-  const trimmedText = text.trim();
+import { Effect } from "effect";
+import { errorMessage, runWebBoundary, WebDependencyError } from "./effect/web-errors";
 
-  if (trimmedText) {
-    try {
-      const payload = JSON.parse(trimmedText) as { error?: unknown; message?: unknown };
-      if (typeof payload.error === "string" && payload.error.trim()) {
-        return { message: payload.error, payload };
-      }
-      if (typeof payload.message === "string" && payload.message.trim()) {
-        return { message: payload.message, payload };
-      }
-    } catch {}
+export type LocalHostErrorPayload = { message: string; payload: unknown | null };
 
-    return { message: trimmedText, payload: null };
+const parseStructuredErrorPayload = (trimmedText: string): LocalHostErrorPayload | null => {
+  try {
+    const payload = JSON.parse(trimmedText) as { error?: unknown; message?: unknown };
+    if (typeof payload.error === "string" && payload.error.trim()) {
+      return { message: payload.error, payload };
+    }
+    if (typeof payload.message === "string" && payload.message.trim()) {
+      return { message: payload.message, payload };
+    }
+  } catch {
+    return null;
   }
 
-  return {
-    message: `OpenDucktor web host request failed with status ${response.status}.`,
-    payload: null,
-  };
+  return null;
 };
+
+export const readLocalHostErrorPayloadEffect = (
+  response: Response,
+): Effect.Effect<LocalHostErrorPayload, WebDependencyError> =>
+  Effect.gen(function* () {
+    const text = yield* Effect.tryPromise({
+      try: () => response.text(),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "local-web-host",
+          operation: "read-error-response",
+          message: errorMessage(cause),
+          cause,
+          details: { status: response.status },
+        }),
+    });
+    const trimmedText = text.trim();
+
+    if (trimmedText) {
+      const structuredPayload = parseStructuredErrorPayload(trimmedText);
+      if (structuredPayload) {
+        return structuredPayload;
+      }
+
+      return { message: trimmedText, payload: null };
+    }
+
+    return {
+      message: `OpenDucktor web host request failed with status ${response.status}.`,
+      payload: null,
+    };
+  });
+
+export const readLocalHostErrorPayload = (response: Response): Promise<LocalHostErrorPayload> =>
+  runWebBoundary(readLocalHostErrorPayloadEffect(response));

--- a/packages/openducktor-web/src/local-host-transport.test.ts
+++ b/packages/openducktor-web/src/local-host-transport.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { configureBrowserRuntimeConfig } from "./browser-config";
 
 type FakeEventSourceListener = (event: MessageEvent<string>) => void;
 
@@ -79,6 +80,7 @@ beforeEach(async () => {
   localHostTransportImportId += 1;
   localHostTransportImportPath = `./local-host-transport.ts?test=${localHostTransportImportId}`;
   FakeEventSource.reset();
+  configureBrowserRuntimeConfig({ backendUrl: "http://127.0.0.1:14327", appToken: "app-token" });
   process.env.VITE_ODT_BROWSER_BACKEND_URL = "http://127.0.0.1:14327";
   process.env.VITE_ODT_BROWSER_AUTH_TOKEN = "app-token";
   // @ts-expect-error test shim
@@ -88,6 +90,7 @@ beforeEach(async () => {
 afterEach(() => {
   globalThis.EventSource = originalEventSource;
   globalThis.fetch = originalFetch;
+  configureBrowserRuntimeConfig({});
   if (originalBackendUrl === undefined) {
     delete process.env.VITE_ODT_BROWSER_BACKEND_URL;
   } else {
@@ -313,6 +316,33 @@ describe("local host SSE subscriptions", () => {
     });
 
     unsubscribe();
+  });
+
+  test("rejects dev-server subscriptions when EventSource errors before opening", async () => {
+    const { subscribeLocalHostDevServerEvents } = await loadLocalHostTransport();
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const subscription = subscribeLocalHostDevServerEvents(mock(() => {}));
+    const eventSource = await waitForEventSourceInstance();
+
+    eventSource.emit("error", "failed");
+
+    await expect(subscription).rejects.toMatchObject({
+      _tag: "WebDependencyError",
+      dependency: "event-source",
+      operation: "await-ready",
+    });
+    expect(eventSource.closed).toBe(true);
+
+    const retrySubscription = subscribeLocalHostDevServerEvents(mock(() => {}));
+    const retryEventSource = await waitForEventSourceInstance(1);
+    retryEventSource.emit("open", "");
+    const unsubscribe = await retrySubscription;
+    expect(typeof unsubscribe).toBe("function");
+    unsubscribe();
+    expect(retryEventSource.closed).toBe(true);
   });
 
   test("buildLocalAttachmentPreviewUrl normalizes the backend base URL", async () => {

--- a/packages/openducktor-web/src/local-host-transport.test.ts
+++ b/packages/openducktor-web/src/local-host-transport.test.ts
@@ -142,6 +142,22 @@ describe("readLocalHostErrorPayload", () => {
 });
 
 describe("createLocalHostClient", () => {
+  test("rejects local host session failures with a typed web host request error", async () => {
+    const { ensureLocalHostSession } = await loadLocalHostTransport();
+    globalThis.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ error: "Session rejected" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof globalThis.fetch;
+
+    await expect(ensureLocalHostSession()).rejects.toThrow("Session rejected");
+    await expect(ensureLocalHostSession()).rejects.toMatchObject({
+      _tag: "WebHostRequestError",
+    });
+  });
+
   test("preserves structured timeout metadata through local web runtimeEnsure", async () => {
     const { createLocalHostClient } = await loadLocalHostTransport();
     const fetchMock = mock(async (url: string | URL | Request) => {

--- a/packages/openducktor-web/src/local-host-transport.test.ts
+++ b/packages/openducktor-web/src/local-host-transport.test.ts
@@ -155,8 +155,9 @@ describe("createLocalHostClient", () => {
         }),
     ) as unknown as typeof globalThis.fetch;
 
-    await expect(ensureLocalHostSession()).rejects.toThrow("Session rejected");
-    await expect(ensureLocalHostSession()).rejects.toMatchObject({
+    const session = ensureLocalHostSession();
+    await expect(session).rejects.toThrow("Session rejected");
+    await expect(session).rejects.toMatchObject({
       _tag: "WebHostRequestError",
     });
   });

--- a/packages/openducktor-web/src/local-host-transport.ts
+++ b/packages/openducktor-web/src/local-host-transport.ts
@@ -4,8 +4,17 @@ import {
 } from "@openducktor/frontend/lib/browser-live/constants";
 import { browserLiveControlEvent } from "@openducktor/frontend/lib/browser-live-control-events";
 import { createHostClient, type HostClient } from "@openducktor/host-client";
-import { getBrowserAuthToken, getBrowserBackendUrl } from "./browser-config";
-import { readLocalHostErrorPayload } from "./local-host-errors";
+import { Effect } from "effect";
+import { getBrowserAuthTokenEffect, getBrowserBackendUrlEffect } from "./browser-config";
+import {
+  errorMessage,
+  isWebError,
+  runWebBoundary,
+  WebDependencyError,
+  type WebError,
+  WebHostRequestError,
+} from "./effect/web-errors";
+import { readLocalHostErrorPayloadEffect } from "./local-host-errors";
 
 type BrowserSseListener = (payload: unknown) => void;
 
@@ -31,58 +40,132 @@ const sseChannels = new Map<string, BrowserSseChannel>();
 let nextSseListenerId = 0;
 let sessionPromise: Promise<void> | null = null;
 
+const readFailureKind = (payload: unknown): string | undefined => {
+  if (!payload || typeof payload !== "object" || !("failureKind" in payload)) {
+    return undefined;
+  }
+  const failureKind = payload.failureKind;
+  return typeof failureKind === "string" && failureKind.trim() ? failureKind : undefined;
+};
+
+const localHostRequestErrorEffect = (
+  response: Response,
+): Effect.Effect<never, WebDependencyError | WebHostRequestError> =>
+  Effect.gen(function* () {
+    const { message, payload } = yield* readLocalHostErrorPayloadEffect(response);
+    const failureKind = payload !== null ? readFailureKind(payload) : undefined;
+    return yield* new WebHostRequestError({
+      message,
+      status: response.status,
+      ...(payload !== null ? { cause: payload } : {}),
+      ...(failureKind ? { failureKind } : {}),
+    });
+  });
+
+export const ensureLocalHostSessionEffect = (): Effect.Effect<void, WebError> =>
+  Effect.gen(function* () {
+    const baseUrl = (yield* getBrowserBackendUrlEffect()).replace(/\/$/, "");
+    const appToken = yield* getBrowserAuthTokenEffect();
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`${baseUrl}/${SESSION_PATH}`, {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            [APP_TOKEN_HEADER]: appToken,
+          },
+        }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "local-web-host",
+          operation: "session",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+
+    if (!response.ok) {
+      return yield* localHostRequestErrorEffect(response);
+    }
+  });
+
 export const ensureLocalHostSession = (): Promise<void> => {
   if (sessionPromise) {
     return sessionPromise;
   }
 
-  const baseUrl = getBrowserBackendUrl().replace(/\/$/, "");
-  const appToken = getBrowserAuthToken();
-  sessionPromise = fetch(`${baseUrl}/${SESSION_PATH}`, {
-    method: "POST",
-    credentials: "include",
-    headers: {
-      [APP_TOKEN_HEADER]: appToken,
-    },
-  })
-    .then(async (response) => {
-      if (!response.ok) {
-        const { message, payload } = await readLocalHostErrorPayload(response);
-        throw new Error(message, payload ? { cause: payload } : undefined);
-      }
-    })
-    .catch((error) => {
-      sessionPromise = null;
-      throw error;
-    });
+  sessionPromise = runWebBoundary(ensureLocalHostSessionEffect()).catch((error: unknown) => {
+    sessionPromise = null;
+    throw error;
+  });
 
   return sessionPromise;
 };
 
-const createHttpInvoke = () => {
-  const baseUrl = getBrowserBackendUrl().replace(/\/$/, "");
-  const appToken = getBrowserAuthToken();
+export const ensureLocalHostSessionDedupedEffect = (): Effect.Effect<void, WebError> =>
+  Effect.tryPromise({
+    try: () => ensureLocalHostSession(),
+    catch: (cause) =>
+      isWebError(cause)
+        ? cause
+        : new WebDependencyError({
+            dependency: "local-web-host",
+            operation: "session",
+            message: errorMessage(cause),
+            cause,
+          }),
+  });
 
-  return async <T>(command: string, args?: Record<string, unknown>): Promise<T> => {
-    await ensureLocalHostSession();
-    const response = await fetch(`${baseUrl}/invoke/${command}`, {
-      method: "POST",
-      credentials: "include",
-      headers: {
-        "content-type": "application/json",
-        [APP_TOKEN_HEADER]: appToken,
-      },
-      body: JSON.stringify(args ?? {}),
+const invokeLocalHostEffect = <T>(
+  command: string,
+  args?: Record<string, unknown>,
+): Effect.Effect<T, WebError> =>
+  Effect.gen(function* () {
+    const baseUrl = (yield* getBrowserBackendUrlEffect()).replace(/\/$/, "");
+    const appToken = yield* getBrowserAuthTokenEffect();
+    yield* ensureLocalHostSessionDedupedEffect();
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`${baseUrl}/invoke/${command}`, {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "content-type": "application/json",
+            [APP_TOKEN_HEADER]: appToken,
+          },
+          body: JSON.stringify(args ?? {}),
+        }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "local-web-host",
+          operation: "invoke",
+          message: errorMessage(cause),
+          cause,
+          details: { command },
+        }),
     });
 
     if (!response.ok) {
-      const { message, payload } = await readLocalHostErrorPayload(response);
-      throw new Error(message, payload ? { cause: payload } : undefined);
+      return yield* localHostRequestErrorEffect(response);
     }
 
-    return (await response.json()) as T;
-  };
-};
+    return yield* Effect.tryPromise({
+      try: () => response.json() as Promise<T>,
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "local-web-host",
+          operation: "read-invoke-response",
+          message: errorMessage(cause),
+          cause,
+          details: { command },
+        }),
+    });
+  });
+
+const createHttpInvoke =
+  () =>
+  async <T>(command: string, args?: Record<string, unknown>): Promise<T> =>
+    runWebBoundary(invokeLocalHostEffect<T>(command, args));
 
 export const createLocalHostClient = (): HostClient => createHostClient(createHttpInvoke());
 
@@ -108,111 +191,148 @@ const closeSseChannelIfUnused = (path: string, channel: BrowserSseChannel): void
   sseChannels.delete(path);
 };
 
-const subscribeSseChannel = (
+const subscribeSseChannelEffect = (
   path: string,
   listener: BrowserSseListener,
-): BrowserSseSubscription => {
-  const baseUrl = getBrowserBackendUrl().replace(/\/$/, "");
-  let channel = sseChannels.get(path);
+): Effect.Effect<BrowserSseSubscription, WebError> =>
+  Effect.gen(function* () {
+    const baseUrl = (yield* getBrowserBackendUrlEffect()).replace(/\/$/, "");
+    let channel = sseChannels.get(path);
 
-  if (!channel) {
-    const eventSource = new EventSource(`${baseUrl}/${path}`, { withCredentials: true });
-    const listeners = new Map<number, BrowserSseListener>();
-    const shouldEmitControlEvents = CONTROL_EVENT_SSE_PATHS.has(path);
-    let hasOpened = false;
-    let resolveReady: () => void = () => {};
-    const ready = new Promise<void>((resolve) => {
-      resolveReady = resolve;
-    });
-    const handleMessage = (event: MessageEvent<string>): void => {
-      const payload = parseSsePayload(event.data);
-      for (const currentListener of listeners.values()) {
-        currentListener(payload);
-      }
-    };
-    const handleOpen = (): void => {
-      if (!hasOpened) {
-        hasOpened = true;
-        resolveReady();
-        return;
-      }
-      if (!shouldEmitControlEvents) {
-        return;
-      }
-      for (const currentListener of listeners.values()) {
-        currentListener(browserLiveControlEvent(BROWSER_LIVE_RECONNECTED_EVENT_KIND));
-      }
-    };
-    const handleStreamWarning = (event: MessageEvent<string>): void => {
-      if (!shouldEmitControlEvents) {
-        return;
-      }
-      for (const currentListener of listeners.values()) {
-        currentListener(
-          browserLiveControlEvent(BROWSER_LIVE_STREAM_WARNING_EVENT_KIND, event.data),
-        );
-      }
-    };
+    if (!channel) {
+      const eventSource = yield* Effect.try({
+        try: () => new EventSource(`${baseUrl}/${path}`, { withCredentials: true }),
+        catch: (cause) =>
+          new WebDependencyError({
+            dependency: "event-source",
+            operation: "subscribe",
+            message: errorMessage(cause),
+            cause,
+            details: { path },
+          }),
+      });
+      const listeners = new Map<number, BrowserSseListener>();
+      const shouldEmitControlEvents = CONTROL_EVENT_SSE_PATHS.has(path);
+      let hasOpened = false;
+      let resolveReady: () => void = () => {};
+      const ready = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+      });
+      const handleMessage = (event: MessageEvent<string>): void => {
+        const payload = parseSsePayload(event.data);
+        for (const currentListener of listeners.values()) {
+          currentListener(payload);
+        }
+      };
+      const handleOpen = (): void => {
+        if (!hasOpened) {
+          hasOpened = true;
+          resolveReady();
+          return;
+        }
+        if (!shouldEmitControlEvents) {
+          return;
+        }
+        for (const currentListener of listeners.values()) {
+          currentListener(browserLiveControlEvent(BROWSER_LIVE_RECONNECTED_EVENT_KIND));
+        }
+      };
+      const handleStreamWarning = (event: MessageEvent<string>): void => {
+        if (!shouldEmitControlEvents) {
+          return;
+        }
+        for (const currentListener of listeners.values()) {
+          currentListener(
+            browserLiveControlEvent(BROWSER_LIVE_STREAM_WARNING_EVENT_KIND, event.data),
+          );
+        }
+      };
 
-    eventSource.addEventListener("message", handleMessage as EventListener);
-    eventSource.addEventListener("open", handleOpen as EventListener);
-    eventSource.addEventListener("stream-warning", handleStreamWarning as EventListener);
-    channel = {
-      eventSource,
-      listeners,
-      ready,
-      handleMessage,
-      handleOpen,
-      handleStreamWarning,
+      eventSource.addEventListener("message", handleMessage as EventListener);
+      eventSource.addEventListener("open", handleOpen as EventListener);
+      eventSource.addEventListener("stream-warning", handleStreamWarning as EventListener);
+      channel = {
+        eventSource,
+        listeners,
+        ready,
+        handleMessage,
+        handleOpen,
+        handleStreamWarning,
+      };
+      sseChannels.set(path, channel);
+    }
+
+    const listenerId = nextSseListenerId;
+    nextSseListenerId += 1;
+    channel.listeners.set(listenerId, listener);
+
+    return {
+      ready: channel.ready,
+      unsubscribe: () => {
+        const currentChannel = sseChannels.get(path);
+        if (!currentChannel) {
+          return;
+        }
+        currentChannel.listeners.delete(listenerId);
+        closeSseChannelIfUnused(path, currentChannel);
+      },
     };
-    sseChannels.set(path, channel);
-  }
-
-  const listenerId = nextSseListenerId;
-  nextSseListenerId += 1;
-  channel.listeners.set(listenerId, listener);
-
-  return {
-    ready: channel.ready,
-    unsubscribe: () => {
-      const currentChannel = sseChannels.get(path);
-      if (!currentChannel) {
-        return;
-      }
-      currentChannel.listeners.delete(listenerId);
-      closeSseChannelIfUnused(path, currentChannel);
-    },
-  };
-};
+  });
 
 export const subscribeLocalHostRunEvents = async (
   listener: (payload: unknown) => void,
 ): Promise<() => void> => {
-  await ensureLocalHostSession();
-  return subscribeSseChannel("events", listener).unsubscribe;
+  return runWebBoundary(
+    Effect.gen(function* () {
+      yield* ensureLocalHostSessionDedupedEffect();
+      return (yield* subscribeSseChannelEffect("events", listener)).unsubscribe;
+    }),
+  );
 };
 
 export const subscribeLocalHostDevServerEvents = async (
   listener: (payload: unknown) => void,
 ): Promise<() => void> => {
-  await ensureLocalHostSession();
-  const subscription = subscribeSseChannel("dev-server-events", listener);
-  await subscription.ready;
-  return subscription.unsubscribe;
+  return runWebBoundary(
+    Effect.gen(function* () {
+      yield* ensureLocalHostSessionDedupedEffect();
+      const subscription = yield* subscribeSseChannelEffect("dev-server-events", listener);
+      yield* Effect.tryPromise({
+        try: () => subscription.ready,
+        catch: (cause) =>
+          new WebDependencyError({
+            dependency: "event-source",
+            operation: "await-ready",
+            message: errorMessage(cause),
+            cause,
+            details: { path: "dev-server-events" },
+          }),
+      });
+      return subscription.unsubscribe;
+    }),
+  );
 };
 
 export const subscribeLocalHostTaskEvents = async (
   listener: (payload: unknown) => void,
 ): Promise<() => void> => {
-  await ensureLocalHostSession();
-  return subscribeSseChannel("task-events", listener).unsubscribe;
+  return runWebBoundary(
+    Effect.gen(function* () {
+      yield* ensureLocalHostSessionDedupedEffect();
+      return (yield* subscribeSseChannelEffect("task-events", listener)).unsubscribe;
+    }),
+  );
 };
 
 export const subscribeLocalHostCodexAppServerEvents = async (
   listener: (payload: unknown) => void,
 ): Promise<() => void> => {
-  await ensureLocalHostSession();
-  return subscribeSseChannel("codex-app-server-events", listener).unsubscribe;
+  return runWebBoundary(
+    Effect.gen(function* () {
+      yield* ensureLocalHostSessionDedupedEffect();
+      return (yield* subscribeSseChannelEffect("codex-app-server-events", listener)).unsubscribe;
+    }),
+  );
 };
 
 export const buildLocalAttachmentPreviewUrl = (browserBackendUrl: string, path: string): string => {

--- a/packages/openducktor-web/src/local-host-transport.ts
+++ b/packages/openducktor-web/src/local-host-transport.ts
@@ -7,6 +7,7 @@ import { createHostClient, type HostClient } from "@openducktor/host-client";
 import { Effect } from "effect";
 import { getBrowserAuthTokenEffect, getBrowserBackendUrlEffect } from "./browser-config";
 import {
+  causeToWebBoundaryError,
   errorMessage,
   isWebError,
   runWebBoundary,
@@ -21,6 +22,7 @@ type BrowserSseListener = (payload: unknown) => void;
 const CONTROL_EVENT_SSE_PATHS = new Set(["dev-server-events", "task-events"]);
 const APP_TOKEN_HEADER = "x-openducktor-app-token";
 const SESSION_PATH = "session";
+const INITIAL_SSE_READY_TIMEOUT_MS = 10_000;
 
 type BrowserSseChannel = {
   eventSource: EventSource;
@@ -28,6 +30,7 @@ type BrowserSseChannel = {
   ready: Promise<void>;
   handleMessage: (event: MessageEvent<string>) => void;
   handleOpen: () => void;
+  handleError: (event: Event) => void;
   handleStreamWarning: (event: MessageEvent<string>) => void;
 };
 
@@ -183,6 +186,7 @@ const closeSseChannelIfUnused = (path: string, channel: BrowserSseChannel): void
   }
   channel.eventSource.removeEventListener("message", channel.handleMessage as EventListener);
   channel.eventSource.removeEventListener("open", channel.handleOpen as EventListener);
+  channel.eventSource.removeEventListener("error", channel.handleError as EventListener);
   channel.eventSource.removeEventListener(
     "stream-warning",
     channel.handleStreamWarning as EventListener,
@@ -215,9 +219,12 @@ const subscribeSseChannelEffect = (
       const shouldEmitControlEvents = CONTROL_EVENT_SSE_PATHS.has(path);
       let hasOpened = false;
       let resolveReady: () => void = () => {};
-      const ready = new Promise<void>((resolve) => {
+      let rejectReady: (error: unknown) => void = () => {};
+      const ready = new Promise<void>((resolve, reject) => {
         resolveReady = resolve;
+        rejectReady = reject;
       });
+      void ready.catch(() => {});
       const handleMessage = (event: MessageEvent<string>): void => {
         const payload = parseSsePayload(event.data);
         for (const currentListener of listeners.values()) {
@@ -237,6 +244,20 @@ const subscribeSseChannelEffect = (
           currentListener(browserLiveControlEvent(BROWSER_LIVE_RECONNECTED_EVENT_KIND));
         }
       };
+      const handleError = (event: Event): void => {
+        if (hasOpened) {
+          return;
+        }
+        rejectReady(
+          new WebDependencyError({
+            dependency: "event-source",
+            operation: "await-ready",
+            message: `EventSource failed before opening ${path}.`,
+            cause: event,
+            details: { path },
+          }),
+        );
+      };
       const handleStreamWarning = (event: MessageEvent<string>): void => {
         if (!shouldEmitControlEvents) {
           return;
@@ -250,6 +271,7 @@ const subscribeSseChannelEffect = (
 
       eventSource.addEventListener("message", handleMessage as EventListener);
       eventSource.addEventListener("open", handleOpen as EventListener);
+      eventSource.addEventListener("error", handleError as EventListener);
       eventSource.addEventListener("stream-warning", handleStreamWarning as EventListener);
       channel = {
         eventSource,
@@ -257,6 +279,7 @@ const subscribeSseChannelEffect = (
         ready,
         handleMessage,
         handleOpen,
+        handleError,
         handleStreamWarning,
       };
       sseChannels.set(path, channel);
@@ -297,17 +320,51 @@ export const subscribeLocalHostDevServerEvents = async (
     Effect.gen(function* () {
       yield* ensureLocalHostSessionDedupedEffect();
       const subscription = yield* subscribeSseChannelEffect("dev-server-events", listener);
-      yield* Effect.tryPromise({
-        try: () => subscription.ready,
-        catch: (cause) =>
-          new WebDependencyError({
-            dependency: "event-source",
-            operation: "await-ready",
-            message: errorMessage(cause),
-            cause,
-            details: { path: "dev-server-events" },
-          }),
-      });
+      const readyExit = yield* Effect.exit(
+        Effect.tryPromise({
+          try: () => {
+            let timeoutId: ReturnType<typeof setTimeout> | null = null;
+            const timeout = new Promise<never>((_, reject) => {
+              timeoutId = setTimeout(
+                () =>
+                  reject(
+                    new WebDependencyError({
+                      dependency: "event-source",
+                      operation: "await-ready",
+                      message: `Timed out waiting for EventSource dev-server-events subscription to open.`,
+                      details: {
+                        path: "dev-server-events",
+                        timeoutMs: INITIAL_SSE_READY_TIMEOUT_MS,
+                      },
+                    }),
+                  ),
+                INITIAL_SSE_READY_TIMEOUT_MS,
+              );
+            });
+            return Promise.race([subscription.ready, timeout]).finally(() => {
+              if (timeoutId) {
+                clearTimeout(timeoutId);
+              }
+            });
+          },
+          catch: (cause) => {
+            if (isWebError(cause)) {
+              return cause;
+            }
+            return new WebDependencyError({
+              dependency: "event-source",
+              operation: "await-ready",
+              message: errorMessage(cause),
+              cause,
+              details: { path: "dev-server-events" },
+            });
+          },
+        }),
+      );
+      if (readyExit._tag === "Failure") {
+        subscription.unsubscribe();
+        return yield* causeToWebBoundaryError(readyExit.cause);
+      }
       return subscription.unsubscribe;
     }),
   );

--- a/packages/openducktor-web/src/runtime-config.test.ts
+++ b/packages/openducktor-web/src/runtime-config.test.ts
@@ -40,6 +40,9 @@ describe("runtime config loader", () => {
     await expect(loadBrowserRuntimeConfig(fetchImpl)).rejects.toThrow(
       `OpenDucktor web failed to load runtime config from ${RUNTIME_CONFIG_PATH}: HTTP 503.`,
     );
+    await expect(loadBrowserRuntimeConfig(fetchImpl)).rejects.toMatchObject({
+      _tag: "WebDependencyError",
+    });
   });
 
   test("rejects malformed runtime config payloads", async () => {
@@ -51,5 +54,8 @@ describe("runtime config loader", () => {
     await expect(loadBrowserRuntimeConfig(fetchImpl)).rejects.toThrow(
       `OpenDucktor web runtime config from ${RUNTIME_CONFIG_PATH} is missing backendUrl or appToken.`,
     );
+    await expect(loadBrowserRuntimeConfig(fetchImpl)).rejects.toMatchObject({
+      _tag: "WebValidationError",
+    });
   });
 });

--- a/packages/openducktor-web/src/runtime-config.ts
+++ b/packages/openducktor-web/src/runtime-config.ts
@@ -1,4 +1,11 @@
+import { Effect } from "effect";
 import { type BrowserRuntimeConfig, configureBrowserRuntimeConfig } from "./browser-config";
+import {
+  errorMessage,
+  runWebBoundary,
+  WebDependencyError,
+  WebValidationError,
+} from "./effect/web-errors";
 
 export const RUNTIME_CONFIG_PATH = "/openducktor-config.json";
 
@@ -7,24 +14,52 @@ const isRuntimeConfigRecord = (value: unknown): value is BrowserRuntimeConfig =>
     return false;
   }
 
-  const config = value as Record<string, unknown>;
+  const config = value as { backendUrl?: unknown; appToken?: unknown };
   return typeof config.backendUrl === "string" && typeof config.appToken === "string";
 };
 
-export const loadBrowserRuntimeConfig = async (fetchImpl: typeof fetch = fetch): Promise<void> => {
-  const response = await fetchImpl(RUNTIME_CONFIG_PATH, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(
-      `OpenDucktor web failed to load runtime config from ${RUNTIME_CONFIG_PATH}: HTTP ${response.status}.`,
-    );
-  }
+export const loadBrowserRuntimeConfigEffect = (
+  fetchImpl: typeof fetch = fetch,
+): Effect.Effect<void, WebDependencyError | WebValidationError> =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () => fetchImpl(RUNTIME_CONFIG_PATH, { cache: "no-store" }),
+      catch: (cause) =>
+        new WebDependencyError({
+          dependency: "browser-runtime-config",
+          operation: "fetch",
+          message: errorMessage(cause),
+          cause,
+          details: { path: RUNTIME_CONFIG_PATH },
+        }),
+    });
+    if (!response.ok) {
+      return yield* new WebDependencyError({
+        dependency: "browser-runtime-config",
+        operation: "fetch",
+        message: `OpenDucktor web failed to load runtime config from ${RUNTIME_CONFIG_PATH}: HTTP ${response.status}.`,
+        details: { path: RUNTIME_CONFIG_PATH, status: response.status },
+      });
+    }
 
-  const config = (await response.json()) as unknown;
-  if (!isRuntimeConfigRecord(config)) {
-    throw new Error(
-      `OpenDucktor web runtime config from ${RUNTIME_CONFIG_PATH} is missing backendUrl or appToken.`,
-    );
-  }
+    const config = yield* Effect.tryPromise({
+      try: () => response.json() as Promise<unknown>,
+      catch: (cause) =>
+        new WebValidationError({
+          message: `OpenDucktor web runtime config from ${RUNTIME_CONFIG_PATH} is not valid JSON.`,
+          cause,
+          details: { path: RUNTIME_CONFIG_PATH },
+        }),
+    });
+    if (!isRuntimeConfigRecord(config)) {
+      return yield* new WebValidationError({
+        message: `OpenDucktor web runtime config from ${RUNTIME_CONFIG_PATH} is missing backendUrl or appToken.`,
+        details: { path: RUNTIME_CONFIG_PATH },
+      });
+    }
 
-  configureBrowserRuntimeConfig(config);
-};
+    configureBrowserRuntimeConfig(config);
+  });
+
+export const loadBrowserRuntimeConfig = (fetchImpl: typeof fetch = fetch): Promise<void> =>
+  runWebBoundary(loadBrowserRuntimeConfigEffect(fetchImpl));

--- a/packages/openducktor-web/src/typescript-host-backend-support.ts
+++ b/packages/openducktor-web/src/typescript-host-backend-support.ts
@@ -5,6 +5,14 @@ import type {
   HostEventUnsubscribe,
 } from "@openducktor/host";
 import { Cause, Effect } from "effect";
+import {
+  errorMessage,
+  runWebBoundary,
+  runWebSyncBoundary,
+  WebOperationError,
+  WebResourceError,
+  WebValidationError,
+} from "./effect/web-errors";
 import { logError } from "./logger";
 
 export type BufferedHostEvent = {
@@ -109,41 +117,79 @@ export class BufferedHostEventBus implements HostEventBusPort {
         return knownChannel;
       }
     }
-    throw new Error(`Unknown OpenDucktor host event channel: ${channel}`);
+    throw new WebResourceError({
+      resource: "host-event-channel",
+      operation: "browser-event-bus.require-channel",
+      message: `Unknown OpenDucktor host event channel: ${channel}`,
+      details: { channel },
+    });
   }
 }
 
-export const validateWebFrontendOrigin = (origin: string): string => {
-  const trimmed = origin.trim();
-  if (!trimmed) {
-    throw new Error("browser frontend origin cannot be empty");
-  }
+export const validateWebFrontendOriginEffect = (
+  origin: string,
+): Effect.Effect<string, WebValidationError> =>
+  Effect.gen(function* () {
+    const trimmed = origin.trim();
+    if (!trimmed) {
+      return yield* new WebValidationError({
+        field: "frontendOrigin",
+        message: "browser frontend origin cannot be empty",
+      });
+    }
 
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch (error) {
-    throw new Error(`invalid browser frontend origin configured: ${trimmed}`, { cause: error });
-  }
+    const parsed = yield* Effect.try({
+      try: () => new URL(trimmed),
+      catch: (cause) =>
+        new WebValidationError({
+          field: "frontendOrigin",
+          message: `invalid browser frontend origin configured: ${trimmed}`,
+          cause,
+          details: { origin },
+        }),
+    });
 
-  if (parsed.protocol !== "http:") {
-    throw new Error("browser frontend origin must use http");
-  }
-  if (parsed.username || parsed.password) {
-    throw new Error("browser frontend origin must not include credentials");
-  }
-  if (parsed.port.length === 0) {
-    throw new Error("browser frontend origin must include an explicit port");
-  }
-  if (parsed.pathname !== "/" || parsed.search || parsed.hash) {
-    throw new Error("browser frontend origin must not include a path, query string, or fragment");
-  }
-  if (!["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname)) {
-    throw new Error("browser frontend origin must target 127.0.0.1, localhost, or [::1]");
-  }
+    if (parsed.protocol !== "http:") {
+      return yield* new WebValidationError({
+        field: "frontendOrigin",
+        message: "browser frontend origin must use http",
+        details: { origin },
+      });
+    }
+    if (parsed.username || parsed.password) {
+      return yield* new WebValidationError({
+        field: "frontendOrigin",
+        message: "browser frontend origin must not include credentials",
+        details: { origin },
+      });
+    }
+    if (parsed.port.length === 0) {
+      return yield* new WebValidationError({
+        field: "frontendOrigin",
+        message: "browser frontend origin must include an explicit port",
+        details: { origin },
+      });
+    }
+    if (parsed.pathname !== "/" || parsed.search || parsed.hash) {
+      return yield* new WebValidationError({
+        field: "frontendOrigin",
+        message: "browser frontend origin must not include a path, query string, or fragment",
+        details: { origin },
+      });
+    }
+    if (!["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname)) {
+      return yield* new WebValidationError({
+        field: "frontendOrigin",
+        message: "browser frontend origin must target 127.0.0.1, localhost, or [::1]",
+        details: { origin },
+      });
+    }
 
-  return parsed.origin;
-};
+    return parsed.origin;
+  });
+
+export const validateWebFrontendOrigin = (origin: string): string =>
+  runWebSyncBoundary(validateWebFrontendOriginEffect(origin));
 
 export const allowedOriginsForFrontendOrigin = (frontendOrigin: string): Set<string> => {
   const parsed = new URL(frontendOrigin);
@@ -154,20 +200,30 @@ export const allowedOriginsForFrontendOrigin = (frontendOrigin: string): Set<str
   ]);
 };
 
-export const stopTypescriptHostBackendServices = ({
+export const stopTypescriptHostBackendServicesEffect = ({
   disposeHost,
   resolveExited,
   stopServer,
-}: StopTypescriptHostBackendServicesInput): Promise<void> =>
-  Effect.runPromise(
-    Effect.gen(function* () {
-      let exitCode = 0;
-      const disposeExit = yield* Effect.exit(disposeHost());
-      if (disposeExit._tag === "Failure") {
-        exitCode = 1;
-        logError(Cause.pretty(disposeExit.cause));
-      }
-      yield* Effect.sync(stopServer);
-      resolveExited(exitCode);
-    }),
-  );
+}: StopTypescriptHostBackendServicesInput): Effect.Effect<void, WebOperationError> =>
+  Effect.gen(function* () {
+    let exitCode = 0;
+    const disposeExit = yield* Effect.exit(disposeHost());
+    if (disposeExit._tag === "Failure") {
+      exitCode = 1;
+      logError(Cause.pretty(disposeExit.cause));
+    }
+    yield* Effect.try({
+      try: stopServer,
+      catch: (cause) =>
+        new WebOperationError({
+          operation: "web.host.stop-server",
+          message: errorMessage(cause),
+          cause,
+        }),
+    });
+    resolveExited(exitCode);
+  });
+
+export const stopTypescriptHostBackendServices = (
+  input: StopTypescriptHostBackendServicesInput,
+): Promise<void> => runWebBoundary(stopTypescriptHostBackendServicesEffect(input));

--- a/packages/openducktor-web/src/typescript-host-backend-support.ts
+++ b/packages/openducktor-web/src/typescript-host-backend-support.ts
@@ -119,7 +119,7 @@ export class BufferedHostEventBus implements HostEventBusPort {
     }
     throw new WebResourceError({
       resource: "host-event-channel",
-      operation: "browser-event-bus.require-channel",
+      operation: "host-event-bus.require-channel",
       message: `Unknown OpenDucktor host event channel: ${channel}`,
       details: { channel },
     });

--- a/packages/openducktor-web/src/typescript-host-backend-support.ts
+++ b/packages/openducktor-web/src/typescript-host-backend-support.ts
@@ -212,16 +212,34 @@ export const stopTypescriptHostBackendServicesEffect = ({
       exitCode = 1;
       logError(Cause.pretty(disposeExit.cause));
     }
-    yield* Effect.try({
-      try: stopServer,
-      catch: (cause) =>
+    const stopServerExit = yield* Effect.exit(
+      Effect.try({
+        try: stopServer,
+        catch: (cause) =>
+          new WebOperationError({
+            operation: "web.host.stop-server",
+            message: errorMessage(cause),
+            cause,
+          }),
+      }),
+    );
+    let stopServerError: WebOperationError | null = null;
+    if (stopServerExit._tag === "Failure") {
+      stopServerError =
+        Array.from(Cause.failures(stopServerExit.cause))[0] ??
         new WebOperationError({
           operation: "web.host.stop-server",
-          message: errorMessage(cause),
-          cause,
-        }),
-    });
+          message: Cause.pretty(stopServerExit.cause),
+          cause: stopServerExit.cause,
+        });
+    }
+    if (stopServerError) {
+      exitCode = 1;
+    }
     resolveExited(exitCode);
+    if (stopServerError) {
+      return yield* stopServerError;
+    }
   });
 
 export const stopTypescriptHostBackendServices = (

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -39,11 +39,13 @@ class StructuredHostCommandFailure extends Error {
   }
 }
 
+type TestHostCommandInvoke = (
+  command: string,
+  args?: Record<string, unknown>,
+) => Effect.Effect<unknown, unknown>;
+
 const createTestHostCommandRouter = (
-  invoke: (
-    command: string,
-    args?: Record<string, unknown>,
-  ) => Effect.Effect<unknown, unknown> = () => Effect.succeed(null),
+  invoke: TestHostCommandInvoke = () => Effect.succeed(null),
 ): EffectHostCommandRouter => ({
   dispose: () => Effect.void,
   initialize: () => Effect.void,

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { createSourceRuntimeDistribution } from "@openducktor/host";
-import { Effect } from "effect";
 import {
+  createLocalAttachmentAdapter,
+  createSourceRuntimeDistribution,
+  type EffectHostCommandRouter,
+} from "@openducktor/host";
+import { Effect } from "effect";
+import { HostOperationError } from "../../host/src/effect/host-errors";
+import {
+  BufferedHostEventBus,
   stopTypescriptHostBackendServices,
   validateWebFrontendOrigin,
 } from "./typescript-host-backend-support";
@@ -13,7 +19,9 @@ const nativeResponse = await Bun.fetch("data:,");
 (globalThis as typeof globalThis & { Response: typeof Response }).Response =
   nativeResponse.constructor as typeof Response;
 
-const { startTypescriptHostBackend } = await import("./typescript-host-backend");
+const { handleTypescriptHostBackendRequest, startTypescriptHostBackend } = await import(
+  "./typescript-host-backend"
+);
 
 const APP_TOKEN = "app-token";
 const CONTROL_TOKEN = "control-token";
@@ -21,6 +29,37 @@ const FRONTEND_ORIGIN = "http://127.0.0.1:1420";
 const SOURCE_RUNTIME_DISTRIBUTION = createSourceRuntimeDistribution(
   path.resolve(import.meta.dir, "../../.."),
 );
+
+const createTestHostCommandRouter = (
+  invoke: EffectHostCommandRouter["invoke"] = () => Effect.succeed(null),
+): EffectHostCommandRouter => ({
+  dispose: () => Effect.void,
+  initialize: () => Effect.void,
+  invoke,
+});
+
+const handleTestRequest = (
+  request: Request,
+  options: Partial<{
+    appToken: string;
+    controlToken: string;
+    hostCommandRouter: EffectHostCommandRouter;
+    stop: () => Promise<void>;
+  }> = {},
+): Promise<Response> =>
+  Effect.runPromise(
+    handleTypescriptHostBackendRequest({
+      allowedOrigins: new Set(),
+      appToken: options.appToken ?? APP_TOKEN,
+      controlToken: options.controlToken ?? CONTROL_TOKEN,
+      eventBus: new BufferedHostEventBus(),
+      hostCommandRouter: options.hostCommandRouter ?? createTestHostCommandRouter(),
+      localAttachments: createLocalAttachmentAdapter(),
+      request,
+      shutdownStarted: false,
+      stop: options.stop ?? (async () => {}),
+    }),
+  );
 
 describe("TypeScript web host backend", () => {
   test("serves health, session, invoke, and shutdown through the browser HTTP contract", async () => {
@@ -98,6 +137,106 @@ describe("TypeScript web host backend", () => {
     expect(() => validateWebFrontendOrigin("http://example.com:1420")).toThrow(
       "browser frontend origin must target 127.0.0.1, localhost, or [::1]",
     );
+  });
+
+  test("preserves structured host command failure kind in invoke error responses", async () => {
+    const hostCommandRouter = createTestHostCommandRouter((command) =>
+      Effect.fail(
+        new HostOperationError({
+          operation: "host-command-router.invoke",
+          message: `Failed to invoke ${command}.`,
+          details: { command, failureKind: "timeout" },
+        }),
+      ),
+    );
+
+    const response = await handleTestRequest(
+      new Request("http://127.0.0.1/invoke/runtime_ensure", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openducktor-app-token": APP_TOKEN,
+        },
+        body: JSON.stringify({}),
+      }),
+      { hostCommandRouter },
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "Failed to invoke runtime_ensure.",
+      failureKind: "timeout",
+      message: "Failed to invoke runtime_ensure.",
+    });
+  });
+
+  test("rejects missing or invalid backend auth through typed route errors", async () => {
+    const sessionMissing = await handleTestRequest(
+      new Request("http://127.0.0.1/session", { method: "POST" }),
+    );
+    expect(sessionMissing.status).toBe(401);
+    expect(await sessionMissing.json()).toEqual({
+      error: "Missing OpenDucktor web host app token.",
+      message: "Missing OpenDucktor web host app token.",
+    });
+
+    const sessionInvalid = await handleTestRequest(
+      new Request("http://127.0.0.1/session", {
+        method: "POST",
+        headers: { "x-openducktor-app-token": "wrong" },
+      }),
+    );
+    expect(sessionInvalid.status).toBe(403);
+    expect(await sessionInvalid.json()).toEqual({
+      error: "Invalid OpenDucktor web host app token.",
+      message: "Invalid OpenDucktor web host app token.",
+    });
+
+    let stopCalls = 0;
+    const stop = async () => {
+      stopCalls += 1;
+    };
+    const shutdownMissing = await handleTestRequest(
+      new Request("http://127.0.0.1/shutdown", { method: "POST" }),
+      { stop },
+    );
+    expect(shutdownMissing.status).toBe(401);
+    expect(await shutdownMissing.json()).toEqual({
+      error: "Missing OpenDucktor web host control token.",
+      message: "Missing OpenDucktor web host control token.",
+    });
+    expect(stopCalls).toBe(0);
+
+    const shutdownInvalid = await handleTestRequest(
+      new Request("http://127.0.0.1/shutdown", {
+        method: "POST",
+        headers: { "x-openducktor-control-token": "wrong" },
+      }),
+      { stop },
+    );
+    expect(shutdownInvalid.status).toBe(403);
+    expect(await shutdownInvalid.json()).toEqual({
+      error: "Invalid OpenDucktor web host control token.",
+      message: "Invalid OpenDucktor web host control token.",
+    });
+    expect(stopCalls).toBe(0);
+
+    const previewUrl = "http://127.0.0.1/local-attachment-preview?path=/tmp/file";
+    const previewMissing = await handleTestRequest(new Request(previewUrl));
+    expect(previewMissing.status).toBe(401);
+    expect(await previewMissing.json()).toEqual({
+      error: "Missing OpenDucktor web host app token.",
+      message: "Missing OpenDucktor web host app token.",
+    });
+
+    const previewInvalid = await handleTestRequest(
+      new Request(previewUrl, { headers: { cookie: "openducktor_web_session=wrong" } }),
+    );
+    expect(previewInvalid.status).toBe(403);
+    expect(await previewInvalid.json()).toEqual({
+      error: "Invalid OpenDucktor web host app token.",
+      message: "Invalid OpenDucktor web host app token.",
+    });
   });
 
   test("keeps the backend server alive until host disposal finishes", async () => {

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -8,7 +8,6 @@ import {
   type EffectHostCommandRouter,
 } from "@openducktor/host";
 import { Effect } from "effect";
-import { HostOperationError } from "../../host/src/effect/host-errors";
 import {
   BufferedHostEventBus,
   stopTypescriptHostBackendServices,
@@ -30,12 +29,25 @@ const SOURCE_RUNTIME_DISTRIBUTION = createSourceRuntimeDistribution(
   path.resolve(import.meta.dir, "../../.."),
 );
 
+class StructuredHostCommandFailure extends Error {
+  readonly details: { readonly command: string; readonly failureKind: "timeout" };
+
+  constructor(command: string) {
+    super(`Failed to invoke ${command}.`);
+    this.name = "StructuredHostCommandFailure";
+    this.details = { command, failureKind: "timeout" };
+  }
+}
+
 const createTestHostCommandRouter = (
-  invoke: EffectHostCommandRouter["invoke"] = () => Effect.succeed(null),
+  invoke: (
+    command: string,
+    args?: Record<string, unknown>,
+  ) => Effect.Effect<unknown, unknown> = () => Effect.succeed(null),
 ): EffectHostCommandRouter => ({
   dispose: () => Effect.void,
   initialize: () => Effect.void,
-  invoke,
+  invoke: (command, args) => invoke(command, args) as ReturnType<EffectHostCommandRouter["invoke"]>,
 });
 
 const handleTestRequest = (
@@ -141,13 +153,7 @@ describe("TypeScript web host backend", () => {
 
   test("preserves structured host command failure kind in invoke error responses", async () => {
     const hostCommandRouter = createTestHostCommandRouter((command) =>
-      Effect.fail(
-        new HostOperationError({
-          operation: "host-command-router.invoke",
-          message: `Failed to invoke ${command}.`,
-          details: { command, failureKind: "timeout" },
-        }),
-      ),
+      Effect.fail(new StructuredHostCommandFailure(command)),
     );
 
     const response = await handleTestRequest(

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -178,6 +178,42 @@ describe("TypeScript web host backend", () => {
     });
   });
 
+  test("rejects malformed invoke command URI components as typed host request errors", async () => {
+    const response = await handleTestRequest(
+      new Request("http://127.0.0.1/invoke/%E0%A4%A", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openducktor-app-token": APP_TOKEN,
+        },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Invalid command URI component: %E0%A4%A",
+      message: "Invalid command URI component: %E0%A4%A",
+    });
+  });
+
+  test("resolves host backend exit after stop server failures", async () => {
+    const resolvedExitCodes: number[] = [];
+
+    await expect(
+      stopTypescriptHostBackendServices({
+        disposeHost: () => Effect.void,
+        resolveExited: (exitCode) => {
+          resolvedExitCodes.push(exitCode);
+        },
+        stopServer: () => {
+          throw new Error("stop server failed");
+        },
+      }),
+    ).rejects.toMatchObject({ _tag: "WebOperationError" });
+    expect(resolvedExitCodes).toEqual([1]);
+  });
+
   test("rejects missing or invalid backend auth through typed route errors", async () => {
     const sessionMissing = await handleTestRequest(
       new Request("http://127.0.0.1/session", { method: "POST" }),

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -58,6 +58,8 @@ const handleTestRequest = (
     appToken: string;
     controlToken: string;
     hostCommandRouter: EffectHostCommandRouter;
+    beginShutdown: () => void;
+    shutdownStarted: boolean;
     stop: () => Promise<void>;
   }> = {},
 ): Promise<Response> =>
@@ -70,7 +72,8 @@ const handleTestRequest = (
       hostCommandRouter: options.hostCommandRouter ?? createTestHostCommandRouter(),
       localAttachments: createLocalAttachmentAdapter(),
       request,
-      shutdownStarted: false,
+      shutdownStarted: options.shutdownStarted ?? false,
+      beginShutdown: options.beginShutdown ?? (() => {}),
       stop: options.stop ?? (async () => {}),
     }),
   );
@@ -281,6 +284,30 @@ describe("TypeScript web host backend", () => {
       error: "Invalid OpenDucktor web host app token.",
       message: "Invalid OpenDucktor web host app token.",
     });
+  });
+
+  test("marks shutdown as started before deferred host teardown runs", async () => {
+    let shutdownStarted = false;
+    let stopCalls = 0;
+
+    const response = await handleTestRequest(
+      new Request("http://127.0.0.1/shutdown", {
+        method: "POST",
+        headers: { "x-openducktor-control-token": CONTROL_TOKEN },
+      }),
+      {
+        beginShutdown: () => {
+          shutdownStarted = true;
+        },
+        stop: async () => {
+          stopCalls += 1;
+        },
+      },
+    );
+
+    expect(response.status).toBe(202);
+    expect(shutdownStarted).toBe(true);
+    expect(stopCalls).toBe(0);
   });
 
   test("keeps the backend server alive until host disposal finishes", async () => {

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -463,7 +463,9 @@ const routeCorsRequest = ({
       yield* validateControlToken(request, controlToken);
       yield* Effect.sync(() => {
         setTimeout(() => {
-          void stop();
+          void stop().catch((error: unknown) => {
+            logError(errorMessage(error));
+          });
         }, 10);
       });
       return jsonResponse({ ok: true }, { status: 202 }, corsHeaders);
@@ -505,7 +507,15 @@ const routeCorsRequest = ({
       if (!command) {
         return yield* rejectWebHostRequest("Host command is required.", 400);
       }
-      const decodedCommand = decodeURIComponent(command);
+      const decodedCommand = yield* Effect.try({
+        try: () => decodeURIComponent(command),
+        catch: (cause) =>
+          new WebHostRequestError({
+            message: `Invalid command URI component: ${command}`,
+            status: 400,
+            cause,
+          }),
+      });
       const result = yield* hostCommandRouter
         .invoke(decodedCommand, args)
         .pipe(Effect.mapError((error) => hostCommandFailureToWebError(decodedCommand, error)));

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -428,6 +428,7 @@ const routeCorsRequest = ({
   request,
   requestTimeouts,
   shutdownStarted,
+  beginShutdown,
   stop,
 }: {
   appToken: string;
@@ -439,6 +440,7 @@ const routeCorsRequest = ({
   request: Request;
   requestTimeouts?: RequestTimeoutController | undefined;
   shutdownStarted: boolean;
+  beginShutdown: () => void;
   stop: () => Promise<void>;
 }): Effect.Effect<Response, WebHostRequestError> =>
   Effect.gen(function* () {
@@ -463,6 +465,7 @@ const routeCorsRequest = ({
     if (requestUrl.pathname === "/shutdown" && request.method === "POST") {
       yield* validateControlToken(request, controlToken);
       yield* Effect.sync(() => {
+        beginShutdown();
         setTimeout(() => {
           void stop().catch((error: unknown) => {
             logError(errorMessage(error));
@@ -536,6 +539,7 @@ export const handleTypescriptHostBackendRequest = ({
   request,
   requestTimeouts,
   shutdownStarted,
+  beginShutdown,
   stop,
 }: {
   allowedOrigins: Set<string>;
@@ -547,6 +551,7 @@ export const handleTypescriptHostBackendRequest = ({
   request: Request;
   requestTimeouts?: RequestTimeoutController | undefined;
   shutdownStarted: boolean;
+  beginShutdown: () => void;
   stop: () => Promise<void>;
 }): Effect.Effect<Response> =>
   Effect.gen(function* () {
@@ -569,6 +574,7 @@ export const handleTypescriptHostBackendRequest = ({
       request,
       requestTimeouts,
       shutdownStarted,
+      beginShutdown,
       stop,
     }).pipe(
       Effect.catchAll((error) => Effect.succeed(webHostRequestErrorResponse(error, corsHeaders))),
@@ -601,6 +607,9 @@ export const startTypescriptHostBackendEffect = ({
       runtimeDistribution,
     });
     let shutdownStarted = false;
+    const beginShutdown = (): void => {
+      shutdownStarted = true;
+    };
     let stopPromise: Promise<void> | null = null;
     let resolveExited: (exitCode: number) => void = () => {};
     let server: TypescriptHostBackendServer;
@@ -612,7 +621,7 @@ export const startTypescriptHostBackendEffect = ({
       if (stopPromise) {
         return stopPromise;
       }
-      shutdownStarted = true;
+      beginShutdown();
       stopPromise = stopTypescriptHostBackendServices({
         disposeHost: () => hostCommandRouter.dispose(),
         resolveExited,
@@ -654,6 +663,7 @@ export const startTypescriptHostBackendEffect = ({
                     request,
                     requestTimeouts: server,
                     shutdownStarted,
+                    beginShutdown,
                     stop,
                   }),
                 );

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -1,6 +1,7 @@
 import type { Stats } from "node:fs";
 import { stat } from "node:fs/promises";
 import path from "node:path";
+import { failureKindSchema } from "@openducktor/contracts";
 import {
   createLocalAttachmentAdapter,
   createNodeEffectHostCommandRouter,
@@ -128,16 +129,16 @@ const preflightResponse = (request: Request, allowedOrigins: Set<string>): Respo
   });
 };
 
-const HOST_FAILURE_KINDS = new Set<string>(["error", "timeout"]);
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const readUnknownProperty = (value: unknown, property: string): unknown =>
   isRecord(value) ? value[property] : undefined;
 
-const readValidFailureKind = (value: unknown): string | undefined =>
-  typeof value === "string" && HOST_FAILURE_KINDS.has(value) ? value : undefined;
+const readValidFailureKind = (value: unknown): string | undefined => {
+  const parsed = failureKindSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+};
 
 const readStructuredDetails = (value: unknown): Record<string, unknown> | undefined => {
   const details = readUnknownProperty(value, "details");

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -46,6 +46,7 @@ export type TypescriptHostBackend = {
 type RequestTimeoutController = {
   timeout(request: Request, seconds: number): void;
 };
+type TypescriptHostBackendServer = ReturnType<typeof Bun.serve>;
 
 const LOCALHOST = "127.0.0.1";
 const CONTROL_TOKEN_HEADER = "x-openducktor-control-token";
@@ -602,6 +603,7 @@ export const startTypescriptHostBackendEffect = ({
     let shutdownStarted = false;
     let stopPromise: Promise<void> | null = null;
     let resolveExited: (exitCode: number) => void = () => {};
+    let server: TypescriptHostBackendServer;
     const exited = new Promise<number>((resolve) => {
       resolveExited = resolve;
     });
@@ -619,66 +621,79 @@ export const startTypescriptHostBackendEffect = ({
       return stopPromise;
     };
 
-    const server = yield* Effect.try({
-      try: () =>
-        Bun.serve({
-          hostname: LOCALHOST,
-          idleTimeout: HOST_IDLE_TIMEOUT_SECONDS,
-          port,
-          fetch(request, server) {
-            return Effect.runPromise(
-              handleTypescriptHostBackendRequest({
-                allowedOrigins,
-                appToken,
-                controlToken,
-                eventBus,
-                hostCommandRouter,
-                localAttachments,
-                request,
-                requestTimeouts: server,
-                shutdownStarted,
-                stop,
-              }),
-            );
-          },
-        }),
-      catch: (cause) => toWebOperationError(cause, "web.host.start-server", { port }),
-    });
-
-    if (server.port === undefined) {
-      server.stop(true);
-      return yield* new WebOperationError({
-        operation: "web.host.start-server",
-        message: "OpenDucktor TypeScript host did not expose a listening port.",
-        details: { port },
+    const cleanupStartedServerEffect = (): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const disposeExit = yield* Effect.exit(hostCommandRouter.dispose());
+        yield* Effect.sync(() => server.stop(true));
+        if (disposeExit._tag === "Failure") {
+          logError(
+            `Failed to dispose local OpenDucktor host after startup failure: ${Cause.pretty(
+              disposeExit.cause,
+            )}`,
+          );
+        }
       });
-    }
 
-    const initializeExit = yield* Effect.exit(hostCommandRouter.initialize());
-    if (initializeExit._tag === "Failure") {
-      const disposeExit = yield* Effect.exit(hostCommandRouter.dispose());
-      yield* Effect.sync(() => server.stop(true));
-      if (disposeExit._tag === "Failure") {
-        logError(
-          `Failed to dispose local OpenDucktor host after startup failure: ${Cause.pretty(
-            disposeExit.cause,
-          )}`,
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        server = yield* Effect.try({
+          try: () =>
+            Bun.serve({
+              hostname: LOCALHOST,
+              idleTimeout: HOST_IDLE_TIMEOUT_SECONDS,
+              port,
+              fetch(request, server) {
+                return Effect.runPromise(
+                  handleTypescriptHostBackendRequest({
+                    allowedOrigins,
+                    appToken,
+                    controlToken,
+                    eventBus,
+                    hostCommandRouter,
+                    localAttachments,
+                    request,
+                    requestTimeouts: server,
+                    shutdownStarted,
+                    stop,
+                  }),
+                );
+              },
+            }),
+          catch: (cause) => toWebOperationError(cause, "web.host.start-server", { port }),
+        });
+
+        if (server.port === undefined) {
+          yield* cleanupStartedServerEffect();
+          return yield* new WebOperationError({
+            operation: "web.host.start-server",
+            message: "OpenDucktor TypeScript host did not expose a listening port.",
+            details: { port },
+          });
+        }
+
+        yield* restore(hostCommandRouter.initialize()).pipe(
+          Effect.catchAll((error) =>
+            Effect.gen(function* () {
+              yield* cleanupStartedServerEffect();
+              return yield* new WebOperationError({
+                operation: "web.host.initialize",
+                message: `Failed to initialize the local MCP bridge used for external OpenDucktor discovery: ${errorMessage(
+                  error,
+                )}`,
+                cause: error,
+              });
+            }),
+          ),
+          Effect.onInterrupt(cleanupStartedServerEffect),
         );
-      }
-      return yield* new WebOperationError({
-        operation: "web.host.initialize",
-        message: `Failed to initialize the local MCP bridge used for external OpenDucktor discovery: ${Cause.pretty(
-          initializeExit.cause,
-        )}`,
-        cause: initializeExit.cause,
-      });
-    }
 
-    return {
-      exited,
-      port: server.port,
-      stop,
-    };
+        return {
+          exited,
+          port: server.port,
+          stop,
+        };
+      }),
+    );
   });
 
 export const startTypescriptHostBackend = (

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -128,19 +128,76 @@ const preflightResponse = (request: Request, allowedOrigins: Set<string>): Respo
   });
 };
 
+const HOST_FAILURE_KINDS = new Set<string>(["error", "timeout"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readUnknownProperty = (value: unknown, property: string): unknown =>
+  isRecord(value) ? value[property] : undefined;
+
+const readValidFailureKind = (value: unknown): string | undefined =>
+  typeof value === "string" && HOST_FAILURE_KINDS.has(value) ? value : undefined;
+
+const readStructuredDetails = (value: unknown): Record<string, unknown> | undefined => {
+  const details = readUnknownProperty(value, "details");
+  return isRecord(details) ? details : undefined;
+};
+
+const extractHostCommandFailureKind = (
+  value: unknown,
+  visited = new Set<object>(),
+): string | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  if (visited.has(value)) {
+    return undefined;
+  }
+  visited.add(value);
+
+  const direct = readValidFailureKind(readUnknownProperty(value, "failureKind"));
+  if (direct) {
+    return direct;
+  }
+
+  const details = readStructuredDetails(value);
+  const detailsFailureKind = readValidFailureKind(readUnknownProperty(details, "failureKind"));
+  if (detailsFailureKind) {
+    return detailsFailureKind;
+  }
+
+  return extractHostCommandFailureKind(readUnknownProperty(value, "cause"), visited);
+};
+
+const hostCommandFailureToWebError = (command: string, error: unknown): WebHostRequestError => {
+  const failureKind = extractHostCommandFailureKind(error);
+  const details = readStructuredDetails(error);
+  return new WebHostRequestError({
+    message: errorMessage(error),
+    status: 500,
+    cause: error,
+    details: {
+      command,
+      ...(details ? { hostDetails: details } : {}),
+    },
+    ...(failureKind ? { failureKind } : {}),
+  });
+};
+
 const validateExpectedToken = (
   receivedToken: string | null,
   expectedToken: string,
   missingMessage: string,
   invalidMessage: string,
-): Response | null => {
+): Effect.Effect<void, WebHostRequestError> => {
   if (receivedToken === null) {
-    return errorResponse(missingMessage, 401);
+    return Effect.fail(new WebHostRequestError({ message: missingMessage, status: 401 }));
   }
   if (receivedToken !== expectedToken) {
-    return errorResponse(invalidMessage, 403);
+    return Effect.fail(new WebHostRequestError({ message: invalidMessage, status: 403 }));
   }
-  return null;
+  return Effect.void;
 };
 
 const readCookie = (request: Request, name: string): string | null => {
@@ -158,7 +215,10 @@ const readCookie = (request: Request, name: string): string | null => {
   return null;
 };
 
-const validateControlToken = (request: Request, expectedToken: string): Response | null =>
+const validateControlToken = (
+  request: Request,
+  expectedToken: string,
+): Effect.Effect<void, WebHostRequestError> =>
   validateExpectedToken(
     request.headers.get(CONTROL_TOKEN_HEADER),
     expectedToken,
@@ -166,7 +226,10 @@ const validateControlToken = (request: Request, expectedToken: string): Response
     "Invalid OpenDucktor web host control token.",
   );
 
-const validateAppTokenHeader = (request: Request, expectedToken: string): Response | null =>
+const validateAppTokenHeader = (
+  request: Request,
+  expectedToken: string,
+): Effect.Effect<void, WebHostRequestError> =>
   validateExpectedToken(
     request.headers.get(APP_TOKEN_HEADER),
     expectedToken,
@@ -174,7 +237,10 @@ const validateAppTokenHeader = (request: Request, expectedToken: string): Respon
     "Invalid OpenDucktor web host app token.",
   );
 
-const validateAppSessionCookie = (request: Request, expectedToken: string): Response | null =>
+const validateAppSessionCookie = (
+  request: Request,
+  expectedToken: string,
+): Effect.Effect<void, WebHostRequestError> =>
   validateExpectedToken(
     readCookie(request, APP_SESSION_COOKIE_NAME),
     expectedToken,
@@ -182,7 +248,10 @@ const validateAppSessionCookie = (request: Request, expectedToken: string): Resp
     "Invalid OpenDucktor web host app token.",
   );
 
-const validateAppCookieOrHeader = (request: Request, expectedToken: string): Response | null =>
+const validateAppCookieOrHeader = (
+  request: Request,
+  expectedToken: string,
+): Effect.Effect<void, WebHostRequestError> =>
   validateExpectedToken(
     readCookie(request, APP_SESSION_COOKIE_NAME) ?? request.headers.get(APP_TOKEN_HEADER),
     expectedToken,
@@ -245,8 +314,7 @@ const webHostRequestErrorResponse = (
   corsHeaders: HeadersInit,
 ): Response => errorResponse(error.message, error.status, corsHeaders, error.failureKind);
 
-const isJsonObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+const isJsonObject = (value: unknown): value is Record<string, unknown> => isRecord(value);
 
 const parseJsonObjectBody = (
   request: Request,
@@ -378,10 +446,7 @@ const routeCorsRequest = ({
     }
 
     if (requestUrl.pathname === "/session" && request.method === "POST") {
-      const tokenError = validateAppTokenHeader(request, appToken);
-      if (tokenError) {
-        return tokenError;
-      }
+      yield* validateAppTokenHeader(request, appToken);
       return jsonResponse(
         { ok: true },
         {
@@ -394,10 +459,7 @@ const routeCorsRequest = ({
     }
 
     if (requestUrl.pathname === "/shutdown" && request.method === "POST") {
-      const tokenError = validateControlToken(request, controlToken);
-      if (tokenError) {
-        return tokenError;
-      }
+      yield* validateControlToken(request, controlToken);
       yield* Effect.sync(() => {
         setTimeout(() => {
           void stop();
@@ -408,10 +470,7 @@ const routeCorsRequest = ({
 
     const streamChannel = STREAM_PATH_TO_CHANNEL.get(requestUrl.pathname.replace(/^\//, ""));
     if (streamChannel && request.method === "GET") {
-      const tokenError = validateAppCookieOrHeader(request, appToken);
-      if (tokenError) {
-        return tokenError;
-      }
+      yield* validateAppCookieOrHeader(request, appToken);
       if (shutdownStarted) {
         return yield* rejectWebHostRequest(
           "Browser backend is shutting down and is no longer accepting new work.",
@@ -427,19 +486,13 @@ const routeCorsRequest = ({
     }
 
     if (requestUrl.pathname === "/local-attachment-preview" && request.method === "GET") {
-      const tokenError = validateAppSessionCookie(request, appToken);
-      if (tokenError) {
-        return tokenError;
-      }
+      yield* validateAppSessionCookie(request, appToken);
       return yield* localAttachmentPreviewResponse(request, localAttachments, corsHeaders);
     }
 
     const invokeMatch = /^\/invoke\/([^/]+)$/.exec(requestUrl.pathname);
     if (invokeMatch && request.method === "POST") {
-      const tokenError = validateAppTokenHeader(request, appToken);
-      if (tokenError) {
-        return tokenError;
-      }
+      yield* validateAppTokenHeader(request, appToken);
       if (shutdownStarted) {
         return yield* rejectWebHostRequest(
           "Browser backend is shutting down and is no longer accepting new work.",
@@ -451,22 +504,17 @@ const routeCorsRequest = ({
       if (!command) {
         return yield* rejectWebHostRequest("Host command is required.", 400);
       }
-      const result = yield* hostCommandRouter.invoke(decodeURIComponent(command), args).pipe(
-        Effect.mapError(
-          (error) =>
-            new WebHostRequestError({
-              message: errorMessage(error),
-              status: 500,
-            }),
-        ),
-      );
+      const decodedCommand = decodeURIComponent(command);
+      const result = yield* hostCommandRouter
+        .invoke(decodedCommand, args)
+        .pipe(Effect.mapError((error) => hostCommandFailureToWebError(decodedCommand, error)));
       return jsonResponse(result, undefined, corsHeaders);
     }
 
-    return errorResponse("Not found", 404, corsHeaders);
+    return yield* rejectWebHostRequest("Not found", 404);
   });
 
-const handleTypescriptHostBackendRequest = ({
+export const handleTypescriptHostBackendRequest = ({
   allowedOrigins,
   appToken,
   controlToken,

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -8,7 +8,14 @@ import {
   type HostRuntimeDistribution,
   type ToolDiscoveryId,
 } from "@openducktor/host";
-import { Cause, Data, Effect } from "effect";
+import { Cause, Effect } from "effect";
+import {
+  errorMessage,
+  runWebBoundary,
+  toWebOperationError,
+  WebHostRequestError,
+  WebOperationError,
+} from "./effect/web-errors";
 import { logError, logInfo } from "./logger";
 import {
   allowedOriginsForFrontendOrigin,
@@ -17,7 +24,7 @@ import {
   type BufferedHostEventStream,
   STREAM_PATH_TO_CHANNEL,
   stopTypescriptHostBackendServices,
-  validateWebFrontendOrigin,
+  validateWebFrontendOriginEffect,
 } from "./typescript-host-backend-support";
 
 export type TypescriptHostBackendOptions = {
@@ -224,33 +231,17 @@ const isWithinDirectory = (directory: string, candidate: string): boolean => {
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 };
 
-const errorMessage = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error);
-
-class WebHostRequestRejection extends Data.TaggedError("WebHostRequestRejection")<{
-  message: string;
-  status: number;
-  failureKind?: string | undefined;
-}> {}
-
-class WebHostStartupError extends Data.TaggedError("WebHostStartupError")<{
-  message: string;
-  cause?: unknown | undefined;
-}> {}
-
 const rejectWebHostRequest = (
   message: string,
   status: number,
   failureKind?: string,
-): Effect.Effect<never, WebHostRequestRejection> =>
+): Effect.Effect<never, WebHostRequestError> =>
   Effect.fail(
-    new WebHostRequestRejection(
-      failureKind ? { failureKind, message, status } : { message, status },
-    ),
+    new WebHostRequestError(failureKind ? { failureKind, message, status } : { message, status }),
   );
 
 const webHostRequestErrorResponse = (
-  error: WebHostRequestRejection,
+  error: WebHostRequestError,
   corsHeaders: HeadersInit,
 ): Response => errorResponse(error.message, error.status, corsHeaders, error.failureKind);
 
@@ -259,12 +250,12 @@ const isJsonObject = (value: unknown): value is Record<string, unknown> =>
 
 const parseJsonObjectBody = (
   request: Request,
-): Effect.Effect<Record<string, unknown>, WebHostRequestRejection> =>
+): Effect.Effect<Record<string, unknown>, WebHostRequestError> =>
   Effect.gen(function* () {
     const parsed: unknown = yield* Effect.tryPromise({
       try: () => request.json(),
       catch: (error) =>
-        new WebHostRequestRejection({
+        new WebHostRequestError({
           message: error instanceof Error ? error.message : "Malformed JSON request body.",
           status: 400,
         }),
@@ -275,9 +266,7 @@ const parseJsonObjectBody = (
     return parsed;
   });
 
-const parseLastEventId = (
-  request: Request,
-): Effect.Effect<number | null, WebHostRequestRejection> =>
+const parseLastEventId = (request: Request): Effect.Effect<number | null, WebHostRequestError> =>
   Effect.gen(function* () {
     const raw = request.headers.get(LAST_EVENT_ID_HEADER);
     if (raw === null) {
@@ -292,11 +281,11 @@ const parseLastEventId = (
 
 const statLocalAttachmentPreview = (
   requestedPath: string,
-): Effect.Effect<Stats, WebHostRequestRejection> =>
+): Effect.Effect<Stats, WebHostRequestError> =>
   Effect.tryPromise({
     try: () => stat(requestedPath),
     catch: (error) =>
-      new WebHostRequestRejection({
+      new WebHostRequestError({
         message: `Failed to stat local attachment preview: ${errorMessage(error)}`,
         status: 404,
       }),
@@ -306,7 +295,7 @@ const localAttachmentPreviewResponse = (
   request: Request,
   localAttachmentPort: ReturnType<typeof createLocalAttachmentAdapter>,
   corsHeaders: HeadersInit,
-): Effect.Effect<Response, WebHostRequestRejection> =>
+): Effect.Effect<Response, WebHostRequestError> =>
   Effect.gen(function* () {
     const requestUrl = new URL(request.url);
     const requestedPath = requestUrl.searchParams.get("path");
@@ -327,7 +316,7 @@ const localAttachmentPreviewResponse = (
       .pipe(
         Effect.mapError(
           (error) =>
-            new WebHostRequestRejection({
+            new WebHostRequestError({
               message: `Failed to resolve local attachment preview directory: ${errorMessage(error)}`,
               status: 500,
             }),
@@ -336,7 +325,7 @@ const localAttachmentPreviewResponse = (
     const canonicalPath = yield* localAttachmentPort.canonicalizePath(requestedPath).pipe(
       Effect.mapError(
         (error) =>
-          new WebHostRequestRejection({
+          new WebHostRequestError({
             message: `Failed to resolve local attachment preview path: ${errorMessage(error)}`,
             status: 500,
           }),
@@ -381,7 +370,7 @@ const routeCorsRequest = ({
   requestTimeouts?: RequestTimeoutController | undefined;
   shutdownStarted: boolean;
   stop: () => Promise<void>;
-}): Effect.Effect<Response, WebHostRequestRejection> =>
+}): Effect.Effect<Response, WebHostRequestError> =>
   Effect.gen(function* () {
     const requestUrl = new URL(request.url);
     if (requestUrl.pathname === "/health" && request.method === "GET") {
@@ -465,7 +454,7 @@ const routeCorsRequest = ({
       const result = yield* hostCommandRouter.invoke(decodeURIComponent(command), args).pipe(
         Effect.mapError(
           (error) =>
-            new WebHostRequestRejection({
+            new WebHostRequestError({
               message: errorMessage(error),
               status: 500,
             }),
@@ -526,22 +515,18 @@ const handleTypescriptHostBackendRequest = ({
     );
   });
 
-const toWebHostStartupError = (message: string, cause?: unknown): WebHostStartupError =>
-  new WebHostStartupError(cause === undefined ? { message } : { cause, message });
-
-const startTypescriptHostBackendEffect = ({
+export const startTypescriptHostBackendEffect = ({
   port,
   frontendOrigin,
   controlToken,
   appToken,
   providedToolPaths,
   runtimeDistribution,
-}: TypescriptHostBackendOptions): Effect.Effect<TypescriptHostBackend, WebHostStartupError> =>
+}: TypescriptHostBackendOptions): Effect.Effect<TypescriptHostBackend, WebOperationError> =>
   Effect.gen(function* () {
-    const validatedFrontendOrigin = yield* Effect.try({
-      try: () => validateWebFrontendOrigin(frontendOrigin),
-      catch: (error) => toWebHostStartupError(errorMessage(error), error),
-    });
+    const validatedFrontendOrigin = yield* validateWebFrontendOriginEffect(frontendOrigin).pipe(
+      Effect.mapError((cause) => toWebOperationError(cause, "web.host.validate-frontend-origin")),
+    );
     const allowedOrigins = allowedOriginsForFrontendOrigin(validatedFrontendOrigin);
     const eventBus = new BufferedHostEventBus();
     const localAttachments = createLocalAttachmentAdapter();
@@ -575,33 +560,39 @@ const startTypescriptHostBackendEffect = ({
       return stopPromise;
     };
 
-    const server = Bun.serve({
-      hostname: LOCALHOST,
-      idleTimeout: HOST_IDLE_TIMEOUT_SECONDS,
-      port,
-      fetch(request, server) {
-        return Effect.runPromise(
-          handleTypescriptHostBackendRequest({
-            allowedOrigins,
-            appToken,
-            controlToken,
-            eventBus,
-            hostCommandRouter,
-            localAttachments,
-            request,
-            requestTimeouts: server,
-            shutdownStarted,
-            stop,
-          }),
-        );
-      },
+    const server = yield* Effect.try({
+      try: () =>
+        Bun.serve({
+          hostname: LOCALHOST,
+          idleTimeout: HOST_IDLE_TIMEOUT_SECONDS,
+          port,
+          fetch(request, server) {
+            return Effect.runPromise(
+              handleTypescriptHostBackendRequest({
+                allowedOrigins,
+                appToken,
+                controlToken,
+                eventBus,
+                hostCommandRouter,
+                localAttachments,
+                request,
+                requestTimeouts: server,
+                shutdownStarted,
+                stop,
+              }),
+            );
+          },
+        }),
+      catch: (cause) => toWebOperationError(cause, "web.host.start-server", { port }),
     });
 
     if (server.port === undefined) {
       server.stop(true);
-      return yield* Effect.fail(
-        toWebHostStartupError("OpenDucktor TypeScript host did not expose a listening port."),
-      );
+      return yield* new WebOperationError({
+        operation: "web.host.start-server",
+        message: "OpenDucktor TypeScript host did not expose a listening port.",
+        details: { port },
+      });
     }
 
     const initializeExit = yield* Effect.exit(hostCommandRouter.initialize());
@@ -615,14 +606,13 @@ const startTypescriptHostBackendEffect = ({
           )}`,
         );
       }
-      return yield* Effect.fail(
-        toWebHostStartupError(
-          `Failed to initialize the local MCP bridge used for external OpenDucktor discovery: ${Cause.pretty(
-            initializeExit.cause,
-          )}`,
+      return yield* new WebOperationError({
+        operation: "web.host.initialize",
+        message: `Failed to initialize the local MCP bridge used for external OpenDucktor discovery: ${Cause.pretty(
           initializeExit.cause,
-        ),
-      );
+        )}`,
+        cause: initializeExit.cause,
+      });
     }
 
     return {
@@ -634,4 +624,4 @@ const startTypescriptHostBackendEffect = ({
 
 export const startTypescriptHostBackend = (
   options: TypescriptHostBackendOptions,
-): Promise<TypescriptHostBackend> => Effect.runPromise(startTypescriptHostBackendEffect(options));
+): Promise<TypescriptHostBackend> => runWebBoundary(startTypescriptHostBackendEffect(options));

--- a/packages/openducktor-web/src/web-runtime-distribution.test.ts
+++ b/packages/openducktor-web/src/web-runtime-distribution.test.ts
@@ -20,12 +20,15 @@ describe("resolveWebRuntimeDistribution", () => {
   });
 
   test("requires an explicit workspace root in web dev mode", () => {
-    expect(() =>
+    const resolveDistribution = () =>
       resolveWebRuntimeDistribution({
         packageRoot: "/repo/packages/openducktor-web",
         workspaceMode: true,
-      }),
-    ).toThrow("OpenDucktor web workspace mode requires a workspace root.");
+      });
+    expect(resolveDistribution).toThrow(
+      "OpenDucktor web workspace mode requires a workspace root.",
+    );
+    expect(resolveDistribution).toThrow(expect.objectContaining({ _tag: "WebValidationError" }));
   });
 
   test("uses the self-contained package MCP entrypoint in npm package mode", () => {

--- a/packages/openducktor-web/src/web-runtime-distribution.ts
+++ b/packages/openducktor-web/src/web-runtime-distribution.ts
@@ -4,6 +4,8 @@ import {
   createSourceRuntimeDistribution,
   type HostRuntimeDistribution,
 } from "@openducktor/host";
+import { Effect } from "effect";
+import { errorMessage, runWebSyncBoundary, WebValidationError } from "./effect/web-errors";
 
 export type ResolveWebRuntimeDistributionInput = {
   packageRoot: string;
@@ -13,24 +15,54 @@ export type ResolveWebRuntimeDistributionInput = {
 
 export const WEB_PACKAGE_MCP_ENTRYPOINT = "openducktor-mcp.js";
 
-export const resolveWebRuntimeDistribution = ({
+export const resolveWebRuntimeDistributionEffect = ({
   packageRoot,
   workspaceMode,
   workspaceRoot,
-}: ResolveWebRuntimeDistributionInput): HostRuntimeDistribution => {
-  if (workspaceMode) {
-    if (!workspaceRoot) {
-      throw new Error("OpenDucktor web workspace mode requires a workspace root.");
+}: ResolveWebRuntimeDistributionInput): Effect.Effect<
+  HostRuntimeDistribution,
+  WebValidationError
+> =>
+  Effect.gen(function* () {
+    if (workspaceMode) {
+      if (!workspaceRoot) {
+        return yield* new WebValidationError({
+          message: "OpenDucktor web workspace mode requires a workspace root.",
+          field: "workspaceRoot",
+        });
+      }
+      return yield* Effect.try({
+        try: () => createSourceRuntimeDistribution(workspaceRoot),
+        catch: (cause) =>
+          new WebValidationError({
+            field: "workspaceRoot",
+            message: errorMessage(cause),
+            cause,
+            details: { workspaceRoot },
+          }),
+      });
     }
-    return createSourceRuntimeDistribution(workspaceRoot);
-  }
 
-  const mcpEntrypoint = path.join(packageRoot, "dist", WEB_PACKAGE_MCP_ENTRYPOINT);
-  return createArtifactRuntimeDistribution({
-    mcpLauncher: {
-      kind: "toolScript",
-      scriptPath: mcpEntrypoint,
-      toolId: "bun",
-    },
+    const mcpEntrypoint = path.join(packageRoot, "dist", WEB_PACKAGE_MCP_ENTRYPOINT);
+    return yield* Effect.try({
+      try: () =>
+        createArtifactRuntimeDistribution({
+          mcpLauncher: {
+            kind: "toolScript",
+            scriptPath: mcpEntrypoint,
+            toolId: "bun",
+          },
+        }),
+      catch: (cause) =>
+        new WebValidationError({
+          field: "packageRoot",
+          message: errorMessage(cause),
+          cause,
+          details: { mcpEntrypoint, packageRoot },
+        }),
+    });
   });
-};
+
+export const resolveWebRuntimeDistribution = (
+  input: ResolveWebRuntimeDistributionInput,
+): HostRuntimeDistribution => runWebSyncBoundary(resolveWebRuntimeDistributionEffect(input));

--- a/packages/openducktor-web/src/web-tool-discovery.ts
+++ b/packages/openducktor-web/src/web-tool-discovery.ts
@@ -1,17 +1,29 @@
 import type { ToolDiscoveryId } from "@openducktor/host";
+import { Effect } from "effect";
+import { runWebSyncBoundary, WebResourceError } from "./effect/web-errors";
 
 export type WebProvidedToolPaths = Partial<Record<ToolDiscoveryId, string>>;
 
-const currentBunExecutable = (): string => {
-  const executable = Bun.argv[0];
-  if (!executable) {
-    throw new Error("OpenDucktor web requires the current Bun executable path.");
-  }
-  return executable;
-};
+const currentBunExecutableEffect = (): Effect.Effect<string, WebResourceError> =>
+  Effect.gen(function* () {
+    const executable = Bun.argv[0];
+    if (!executable) {
+      return yield* new WebResourceError({
+        resource: "bun-executable",
+        operation: "web-tool-discovery.resolve",
+        message: "OpenDucktor web requires the current Bun executable path.",
+      });
+    }
+    return executable;
+  });
 
-export const resolveWebProvidedToolPaths = (
-  bunExecutable = currentBunExecutable(),
-): WebProvidedToolPaths => ({
-  bun: bunExecutable,
-});
+export const resolveWebProvidedToolPathsEffect = (
+  bunExecutable?: string,
+): Effect.Effect<WebProvidedToolPaths, WebResourceError> =>
+  Effect.gen(function* () {
+    const resolvedBunExecutable = bunExecutable ?? (yield* currentBunExecutableEffect());
+    return { bun: resolvedBunExecutable };
+  });
+
+export const resolveWebProvidedToolPaths = (bunExecutable?: string): WebProvidedToolPaths =>
+  runWebSyncBoundary(resolveWebProvidedToolPathsEffect(bunExecutable));

--- a/packages/openducktor-web/tsconfig.json
+++ b/packages/openducktor-web/tsconfig.json
@@ -8,6 +8,7 @@
     "types": ["vite/client", "node", "bun-types"],
     "paths": {
       "@/*": ["../frontend/src/*", "./src/*"],
+      "@openducktor/contracts": ["../contracts/src/index.ts"],
       "@openducktor/frontend": ["../frontend/src/index.ts"],
       "@openducktor/frontend/styles.css": ["../frontend/src/styles.css"],
       "@openducktor/frontend/lib/*": ["../frontend/src/lib/*"],


### PR DESCRIPTION
## Summary
- Migrates `@openducktor/web` runtime, launcher, local host transport, CLI, config, and build/dev script internals onto Effect boundaries.
- Adds typed web/runtime error helpers so expected failures preserve actionable metadata.
- Updates focused web package tests around config parsing, launcher behavior, transport errors, backend failures, and runtime distribution handling.

## Goal / Context
This prepares the browser runner/web package to follow the repo Effect-native host direction while keeping public contracts stable and failure behavior explicit.

## Technical Choices
- Kept Promise interop at command/script/runtime adapter edges and used Effect internally for fallible sequencing.
- Introduced shared tagged web errors instead of silent defaults or fallback behavior.
- Preserved backend failure metadata through HTTP/SSE boundaries.
- Avoided durable schema or task-store changes.

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Cargo checks not applicable: no `Cargo.toml` exists in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced structured, typed error handling across web CLI, build, dev, and launcher flows, including effect-based validation for browser configuration, runtime config, URL handling, and local-host sessions.

* **Bug Fixes**
  * Improved failure reporting and consistent exit codes/logging for build/dev/launcher processes.
  * Strengthened validation for ports, external URLs, loopback origin rules, and malformed runtime config payloads; improved popup handling and local attachment preview errors.

* **Tests**
  * Expanded assertions to verify structured error tags and boundary behavior across web and host workflows.

* **Chores**
  * Added Knip configuration for the web package and a workspace/contracts dependency alias update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->