### PR TITLE
feat: support Codex subagents

### DIFF
--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -150,7 +150,7 @@ Canonical capability schema: `packages/contracts/src/agent-runtime-schemas.ts`
 | `optionalSurfaces.supportsProfiles` / `supportsVariants` | Optional enhancement | Runtime supports named profiles or model variants | Session start flow and repo settings | Profile and variant selectors should read these before showing choices |
 | `optionalSurfaces.supportsTodos` / `supportsDiff` / `supportsFileStatus` | Optional enhancement | Runtime can list session todos, diff, and file-status data | Session warmup and inspection views | Runtime-adapter consumers should gate these calls on descriptor support; current Agent Studio git diff/file-status views primarily use host git worktree queries rather than these adapter surfaces |
 | `optionalSurfaces.supportsMcpStatus` | Optional enhancement | Runtime exposes MCP status info | Diagnostics and health checks | Diagnostics and MCP health checks read this before querying MCP status |
-| `optionalSurfaces.supportsSubagents` / `supportedSubagentExecutionModes` | Optional enhancement | Runtime can run subagents and declares supported execution modes | Agent orchestration surfaces | Subagent support must include at least one execution mode; disabled support must leave the mode list empty |
+| `optionalSurfaces.supportsSubagents` / `supportedSubagentExecutionModes` | Optional enhancement | Runtime can surface subagents and may declare supported execution modes when it has real mode controls | Agent orchestration surfaces | Runtimes with subagent support may leave the mode list empty when no mode choice exists; disabled support must leave the mode list empty |
 
 The current codebase treats runtime integration in these categories:
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
@@ -9,6 +9,7 @@ import {
   RecordingTransport,
   waitForEvent,
 } from "./codex-app-server-adapter.test-harness";
+import type { CodexPendingInputState } from "./codex-pending-input-state";
 import type { CodexAppServerAdapter, CodexJsonRpcRequest } from "./index";
 
 class ThreadIdOnlyResumeTransport extends RecordingTransport {
@@ -107,6 +108,28 @@ class ParentWithChildThreadListTransport extends RecordingTransport {
             preview: "Child subagent",
             status: { type: "active", activeFlags: [] },
             parentThreadId: "parent-thread",
+          },
+        ],
+        nextCursor: null,
+        backwardsCursor: null,
+      } as Response;
+    }
+    return super.request<Response>(request);
+  }
+}
+
+class IdleParentThreadListTransport extends RecordingTransport {
+  async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
+    if (request.method === "thread/list") {
+      this.calls.push(request);
+      return {
+        data: [
+          {
+            id: "parent-thread",
+            cwd: "/repo",
+            createdAt: 1_778_112_000,
+            preview: "Idle parent session",
+            status: { type: "idle" },
           },
         ],
         nextCursor: null,
@@ -1127,6 +1150,54 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
         (event as { childExternalSessionId?: unknown }).childExternalSessionId === "child-thread",
     );
     unsubscribe();
+  });
+
+  test("replays mirrored pending input when subscribing an idle parent without a local session", async () => {
+    const { adapter } = createHarness({
+      transportFactory: mock(() => new IdleParentThreadListTransport("runtime-live", false)),
+    });
+    const adapterState = adapter as unknown as { pendingInput: CodexPendingInputState };
+    adapterState.pendingInput.addQuestion({
+      runtimeId: "runtime-live",
+      threadId: "child-thread",
+      request: {
+        requestId: "question-1",
+        questions: [
+          {
+            id: "question-item-1",
+            header: "Choose",
+            question: "Proceed?",
+            options: ["Yes", "No"],
+          },
+        ],
+      },
+      questionIds: ["question-item-1"],
+      input: { requestId: "question-1" },
+      route: {
+        runtimeId: "runtime-live",
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+        subagentCorrelationKey: "codex-subagent:parent-thread:spawn-1",
+      },
+    });
+    const events: unknown[] = [];
+
+    const unsubscribe = await adapter.subscribeEvents(
+      codexSessionRuntimeRef("parent-thread"),
+      (event) => events.push(event),
+    );
+
+    try {
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "question_required",
+          externalSessionId: "parent-thread",
+          childExternalSessionId: "child-thread",
+        }),
+      );
+    } finally {
+      unsubscribe();
+    }
   });
 
   test("does not resurrect an idle local session from stale active thread inventory", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import {
   codexSessionRef,
   codexSessionRuntimeRef,
+  codexUserMessageInput,
   createDeferred,
   createHarness,
   flushCodexAdapterWork,
@@ -618,6 +619,31 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
     expect(transport.calls.some((call) => call.method === "thread/resume")).toBe(false);
   });
 
+  test("resumes a stored main session before sending after an idle event subscription", async () => {
+    const transport = new StoredIdleHistoryTransport("runtime-live", false);
+    const subscribeEvents = mock((_runtimeId: string, _listener) => () => {});
+    const { adapter } = createHarness({
+      subscribeEvents,
+      transportFactory: mock(() => transport),
+    });
+
+    const unsubscribe = await adapter.subscribeEvents(codexSessionRef("thread-idle"), () => {});
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread-idle",
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+        parts: [{ kind: "text", text: "Continue" }],
+      }),
+    );
+    unsubscribe();
+
+    const resumeIndex = transport.calls.findIndex((call) => call.method === "thread/resume");
+    const turnStartIndex = transport.calls.findIndex((call) => call.method === "turn/start");
+    expect(resumeIndex).toBeGreaterThanOrEqual(0);
+    expect(turnStartIndex).toBeGreaterThanOrEqual(0);
+    expect(resumeIndex).toBeLessThan(turnStartIndex);
+  });
+
   test("lists loaded Codex sessions from App Server", async () => {
     const { adapter } = createHarness();
 
@@ -919,6 +945,100 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
     );
     expect(transport.calls.some((call) => call.method === "thread/resume")).toBe(false);
     unsubscribe();
+  });
+
+  test("streams child transcript events for a learned subagent route absent from inventory", async () => {
+    const streamListeners: Array<
+      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
+    > = [];
+    const subscribeEvents = mock((_runtimeId: string, listener) => {
+      streamListeners.push(listener);
+      return () => {};
+    });
+    const transport = new MutableThreadListTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      drainNotifications: mock(async () => [] as unknown[]),
+      drainServerRequests: mock(async () => [] as unknown[]),
+      subscribeEvents,
+      transportFactory: mock(() => transport),
+    });
+
+    const parentEvents: unknown[] = [];
+    const unsubscribeParent = await adapter.subscribeEvents(
+      codexSessionRuntimeRef("thread-saved"),
+      (event) => parentEvents.push(event),
+    );
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-saved",
+          turnId: "turn-live",
+          completedAtMs: 1_777_766_452_000,
+          item: {
+            type: "collabAgentToolCall",
+            id: "spawn-live",
+            tool: "spawnAgent",
+            status: "completed",
+            senderThreadId: "thread-saved",
+            receiverThreadIds: ["child-thread"],
+            prompt: "Inspect child work",
+            agentsStates: {
+              "child-thread": { status: "running", message: null },
+            },
+          },
+        },
+      },
+    });
+    await waitForEvent(
+      parentEvents,
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        (event as { type?: unknown }).type === "assistant_part" &&
+        (event as { part?: { kind?: unknown; externalSessionId?: unknown } }).part?.kind ===
+          "subagent" &&
+        (event as { part?: { externalSessionId?: unknown } }).part?.externalSessionId ===
+          "child-thread",
+    );
+
+    const events: unknown[] = [];
+    const unsubscribe = await adapter.subscribeEvents(
+      codexSessionRuntimeRef("child-thread"),
+      (event) => events.push(event),
+    );
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-live",
+          itemId: "agent-live",
+          delta: "child route text",
+        },
+      },
+    });
+
+    await waitForEvent(
+      events,
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        (event as { type?: unknown; delta?: unknown }).type === "assistant_delta" &&
+        (event as { delta?: unknown }).delta === "child route text",
+    );
+    expect(transport.calls).toContainEqual(
+      expect.objectContaining({
+        method: "thread/resume",
+        params: expect.objectContaining({ threadId: "child-thread" }),
+      }),
+    );
+    unsubscribe();
+    unsubscribeParent();
   });
 
   test("does not resurrect an idle local session from stale active thread inventory", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
@@ -63,6 +63,29 @@ class MutableThreadListTransport extends RecordingTransport {
   }
 }
 
+class ChildThreadListTransport extends RecordingTransport {
+  async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
+    if (request.method === "thread/list") {
+      this.calls.push(request);
+      return {
+        data: [
+          {
+            id: "child-thread",
+            cwd: "/repo",
+            createdAt: 1_778_112_020,
+            preview: "Child subagent",
+            status: { type: "idle" },
+            parentThreadId: "parent-thread",
+          },
+        ],
+        nextCursor: null,
+        backwardsCursor: null,
+      } as Response;
+    }
+    return super.request<Response>(request);
+  }
+}
+
 class IdleThreadResumeActiveListTransport extends MutableThreadListTransport {
   async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
     if (request.method === "thread/resume") {
@@ -848,6 +871,53 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
     ).resolves.toMatchObject({ classification: "idle" });
     expect(drainNotifications).not.toHaveBeenCalled();
     expect(drainServerRequests).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  test("streams child transcript events after read-only subscription materializes inventory thread", async () => {
+    const streamListeners: Array<
+      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
+    > = [];
+    const subscribeEvents = mock((_runtimeId: string, listener) => {
+      streamListeners.push(listener);
+      return () => {};
+    });
+    const transport = new ChildThreadListTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      drainNotifications: mock(async () => [] as unknown[]),
+      drainServerRequests: mock(async () => [] as unknown[]),
+      subscribeEvents,
+      transportFactory: mock(() => transport),
+    });
+
+    const events: unknown[] = [];
+    const unsubscribe = await adapter.subscribeEvents(
+      codexSessionRuntimeRef("child-thread"),
+      (event) => events.push(event),
+    );
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-live",
+          itemId: "agent-live",
+          delta: "new child text",
+        },
+      },
+    });
+
+    await waitForEvent(
+      events,
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        (event as { type?: unknown; delta?: unknown }).type === "assistant_delta" &&
+        (event as { delta?: unknown }).delta === "new child text",
+    );
+    expect(transport.calls.some((call) => call.method === "thread/resume")).toBe(false);
     unsubscribe();
   });
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
@@ -87,6 +87,36 @@ class ChildThreadListTransport extends RecordingTransport {
   }
 }
 
+class ParentWithChildThreadListTransport extends RecordingTransport {
+  async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
+    if (request.method === "thread/list") {
+      this.calls.push(request);
+      return {
+        data: [
+          {
+            id: "parent-thread",
+            cwd: "/repo",
+            createdAt: 1_778_112_000,
+            preview: "Parent session",
+            status: { type: "active", activeFlags: [] },
+          },
+          {
+            id: "child-thread",
+            cwd: "/repo",
+            createdAt: 1_778_112_020,
+            preview: "Child subagent",
+            status: { type: "active", activeFlags: [] },
+            parentThreadId: "parent-thread",
+          },
+        ],
+        nextCursor: null,
+        backwardsCursor: null,
+      } as Response;
+    }
+    return super.request<Response>(request);
+  }
+}
+
 class IdleThreadResumeActiveListTransport extends MutableThreadListTransport {
   async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
     if (request.method === "thread/resume") {
@@ -1039,6 +1069,64 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
     );
     unsubscribe();
     unsubscribeParent();
+  });
+
+  test("routes child server requests through routes learned from refreshed inventory", async () => {
+    const streamListeners: Array<
+      (event: {
+        runtimeId: string;
+        kind: "notification" | "server_request";
+        message: unknown;
+      }) => void
+    > = [];
+    const subscribeEvents = mock((_runtimeId: string, listener) => {
+      streamListeners.push(listener);
+      return () => {};
+    });
+    const transport = new ParentWithChildThreadListTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      drainNotifications: mock(async () => [] as unknown[]),
+      drainServerRequests: mock(async () => [] as unknown[]),
+      subscribeEvents,
+      transportFactory: mock(() => transport),
+    });
+
+    const events: unknown[] = [];
+    const unsubscribe = await adapter.subscribeEvents(
+      codexSessionRuntimeRef("parent-thread"),
+      (event) => events.push(event),
+    );
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "server_request",
+      message: {
+        id: 64,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+          questions: [
+            {
+              id: "question-item-1",
+              header: "Choose",
+              question: "Proceed?",
+              options: ["Yes", "No"],
+            },
+          ],
+        },
+      },
+    });
+
+    await waitForEvent(
+      events,
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        (event as { type?: unknown; externalSessionId?: unknown }).type === "question_required" &&
+        (event as { externalSessionId?: unknown }).externalSessionId === "parent-thread" &&
+        (event as { childExternalSessionId?: unknown }).childExternalSessionId === "child-thread",
+    );
+    unsubscribe();
   });
 
   test("does not resurrect an idle local session from stale active thread inventory", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -1486,6 +1486,62 @@ describe("CodexAppServerAdapter streaming", () => {
     unsubscribe();
   });
 
+  test("emits live subagent rows from started collab items", async () => {
+    const streamListeners: Array<
+      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
+    > = [];
+    const subscribeEvents = mock((_runtimeId: string, listener) => {
+      streamListeners.push(listener);
+      return () => {};
+    });
+    const { adapter } = createHarness({ subscribeEvents });
+    const events: unknown[] = [];
+
+    await observeSessionState(adapter, "thread-saved");
+    const unsubscribe = await adapter.subscribeEvents(
+      codexSessionRuntimeRef("thread-saved"),
+      (event) => events.push(event),
+    );
+
+    streamListeners[0]?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      message: {
+        method: "item/started",
+        params: {
+          threadId: "thread-saved",
+          turnId: "turn-live",
+          startedAtMs: 1_777_766_452_000,
+          item: {
+            type: "collabAgentToolCall",
+            id: "spawn-live",
+            tool: "spawnAgent",
+            status: "inProgress",
+            senderThreadId: "thread-saved",
+            receiverThreadIds: [],
+            prompt: "Review this change",
+            agentsStates: {},
+          },
+        },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        externalSessionId: "thread-saved",
+        part: expect.objectContaining({
+          kind: "subagent",
+          correlationKey: "codex-subagent:thread-saved:spawn-live",
+          status: "running",
+          prompt: "Review this change",
+        }),
+      }),
+    );
+    unsubscribe();
+  });
+
   test("maps completed update_plan dynamic tool calls into live session todos", async () => {
     const drainNotifications = mock(async (_runtimeId: string) => [] as unknown[]);
     const { adapter, transports } = createHarness({ drainNotifications }, { deferTurnStart: true });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -1497,49 +1497,53 @@ describe("CodexAppServerAdapter streaming", () => {
     const { adapter } = createHarness({ subscribeEvents });
     const events: unknown[] = [];
 
-    await observeSessionState(adapter, "thread-saved");
+    const setupUnsubscribe = await observeSessionState(adapter, "thread-saved");
     const unsubscribe = await adapter.subscribeEvents(
       codexSessionRuntimeRef("thread-saved"),
       (event) => events.push(event),
     );
 
-    streamListeners[0]?.({
-      runtimeId: "runtime-live",
-      kind: "notification",
-      message: {
-        method: "item/started",
-        params: {
-          threadId: "thread-saved",
-          turnId: "turn-live",
-          startedAtMs: 1_777_766_452_000,
-          item: {
-            type: "collabAgentToolCall",
-            id: "spawn-live",
-            tool: "spawnAgent",
-            status: "inProgress",
-            senderThreadId: "thread-saved",
-            receiverThreadIds: [],
-            prompt: "Review this change",
-            agentsStates: {},
+    try {
+      streamListeners[0]?.({
+        runtimeId: "runtime-live",
+        kind: "notification",
+        message: {
+          method: "item/started",
+          params: {
+            threadId: "thread-saved",
+            turnId: "turn-live",
+            startedAtMs: 1_777_766_452_000,
+            item: {
+              type: "collabAgentToolCall",
+              id: "spawn-live",
+              tool: "spawnAgent",
+              status: "inProgress",
+              senderThreadId: "thread-saved",
+              receiverThreadIds: [],
+              prompt: "Review this change",
+              agentsStates: {},
+            },
           },
         },
-      },
-    });
-    await flushCodexAdapterWork();
+      });
+      await flushCodexAdapterWork();
 
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: "assistant_part",
-        externalSessionId: "thread-saved",
-        part: expect.objectContaining({
-          kind: "subagent",
-          correlationKey: "codex-subagent:thread-saved:spawn-live",
-          status: "running",
-          prompt: "Review this change",
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "assistant_part",
+          externalSessionId: "thread-saved",
+          part: expect.objectContaining({
+            kind: "subagent",
+            correlationKey: "codex-subagent:thread-saved:spawn-live",
+            status: "running",
+            prompt: "Review this change",
+          }),
         }),
-      }),
-    );
-    unsubscribe();
+      );
+    } finally {
+      unsubscribe();
+      setupUnsubscribe();
+    }
   });
 
   test("maps completed update_plan dynamic tool calls into live session todos", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -47,6 +47,7 @@ import {
   unsupported,
 } from "./codex-app-server-shared";
 import { createCodexAcceptedUserMessage } from "./codex-app-server-streaming";
+import type { CodexThreadInventory } from "./codex-app-server-threads";
 import { codexTodosFromThreadRead } from "./codex-app-server-transcript";
 import { toFileDiffs } from "./codex-file-diffs";
 import { CodexLocalSessionState } from "./codex-local-session-state";
@@ -154,6 +155,19 @@ export class CodexAppServerAdapter
 
   private clearThreadInventory(runtimeId: string): void {
     this.threadInventory.clearInventory(runtimeId);
+  }
+
+  private recordInventorySubagentRoutes(
+    inventory: CodexThreadInventory,
+    runtimeId: string,
+    workingDirectory: string,
+  ): void {
+    for (const thread of inventory.threadsById.values()) {
+      if (thread.cwd !== workingDirectory) {
+        continue;
+      }
+      this.subagents.recordThread(thread, runtimeId);
+    }
   }
 
   async startSession(input: StartAgentSessionInput): Promise<AgentSessionSummary> {
@@ -620,6 +634,7 @@ export class CodexAppServerAdapter
     );
     await this.runtimeEvents.ensureRuntimeEventSubscription(runtimeId);
     const inventory = await this.threadInventory.refresh(client, runtimeId);
+    this.recordInventorySubagentRoutes(inventory, runtimeId, input.workingDirectory);
     const thread = inventory.threadsById.get(input.externalSessionId);
     if (!thread) {
       if (this.subagents.routeForChild(input.externalSessionId, runtimeId)) {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -127,6 +127,7 @@ export class CodexAppServerAdapter
     this.localSessions = new CodexLocalSessionState({
       activeTurnsBySessionId: this.activeTurnsBySessionId,
       pendingInput: this.pendingInput,
+      subagents: this.subagents,
       threadStatusOverrides: {
         clear: (runtimeId, threadId) => this.threadInventory.clearThreadStatus(runtimeId, threadId),
       },

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -72,6 +72,7 @@ import {
   listCodexSessionRuntimeSnapshots,
   readCodexSessionRuntimeSnapshot,
 } from "./codex-session-runtime-snapshot-reader";
+import { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import { CodexThreadInventoryReader } from "./codex-thread-inventory";
 import { requireNormalizedCodexToolInvocation } from "./codex-tool-normalizer";
 import {
@@ -102,6 +103,7 @@ export class CodexAppServerAdapter
   private readonly runtimeEvents: CodexRuntimeSessionEvents;
   private readonly models = new CodexModels();
   private readonly threadInventory = new CodexThreadInventoryReader();
+  private readonly subagents = new CodexSubagentLinkState();
 
   constructor(private readonly options: CodexAppServerAdapterOptions) {
     this.runtimeClients = new CodexRuntimeClientResolver(options);
@@ -117,6 +119,7 @@ export class CodexAppServerAdapter
       activeTurnsBySessionId: this.activeTurnsBySessionId,
       sessionEvents: this.sessionEvents,
       pendingInput: this.pendingInput,
+      subagents: this.subagents,
       updateThreadStatus: (runtimeId, threadId, status) =>
         this.threadInventory.updateThreadStatus(runtimeId, threadId, status),
       flushQueuedUserMessagesLater: (activeTurn) => this.flushQueuedUserMessagesLater(activeTurn),
@@ -578,23 +581,41 @@ export class CodexAppServerAdapter
     }
 
     const unsubscribe = this.sessionEvents.subscribe(registeredSessionRef, listener);
-    for (const approval of this.pendingInput.pendingApprovalsForSession(externalSessionId)) {
+    for (const { request: approval, route } of this.pendingInput.pendingApprovalEventsForSession(
+      externalSessionId,
+    )) {
       listener(
         withAgentSessionRef(registeredSessionRef, {
           ...approval,
           type: "approval_required",
           externalSessionId,
           timestamp: new Date().toISOString(),
+          ...(route
+            ? {
+                parentExternalSessionId: route.parentExternalSessionId,
+                childExternalSessionId: route.childExternalSessionId,
+                subagentCorrelationKey: route.subagentCorrelationKey,
+              }
+            : {}),
         }),
       );
     }
-    for (const question of this.pendingInput.pendingQuestionsForSession(externalSessionId)) {
+    for (const { request: question, route } of this.pendingInput.pendingQuestionEventsForSession(
+      externalSessionId,
+    )) {
       listener(
         withAgentSessionRef(registeredSessionRef, {
           ...question,
           type: "question_required",
           externalSessionId,
           timestamp: new Date().toISOString(),
+          ...(route
+            ? {
+                parentExternalSessionId: route.parentExternalSessionId,
+                childExternalSessionId: route.childExternalSessionId,
+                subagentCorrelationKey: route.subagentCorrelationKey,
+              }
+            : {}),
         }),
       );
     }
@@ -642,6 +663,7 @@ export class CodexAppServerAdapter
       threadInventory: this.threadInventory,
       sessions: this.localSessions,
       pendingInput: this.pendingInput,
+      subagents: this.subagents,
       hasActiveTurn: (externalSessionId: string) => {
         const activeTurn = this.activeTurnsBySessionId.get(externalSessionId);
         return Boolean(activeTurn && !activeTurn.isTurnSettled());

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -586,11 +586,8 @@ export class CodexAppServerAdapter
     }
 
     const session = this.localSessions.get(externalSessionId);
-    if (!session) {
-      return this.sessionEvents.subscribe(input, listener);
-    }
-    const registeredSessionRef = codexSessionRef(session);
-    if (!agentSessionRefsEqual(registeredSessionRef, input)) {
+    const registeredSessionRef = session ? codexSessionRef(session) : input;
+    if (session && !agentSessionRefsEqual(registeredSessionRef, input)) {
       throw new Error(
         `Cannot subscribe Codex session events for '${externalSessionId}' from repo '${input.repoPath}' and working directory '${input.workingDirectory}' because the registered session belongs to repo '${registeredSessionRef.repoPath}' and working directory '${registeredSessionRef.workingDirectory}'.`,
       );

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -73,7 +73,7 @@ import {
   listCodexSessionRuntimeSnapshots,
   readCodexSessionRuntimeSnapshot,
 } from "./codex-session-runtime-snapshot-reader";
-import { CodexSubagentLinkState } from "./codex-subagent-link-state";
+import { CodexSubagentLinkState, codexSubagentRouteEventFields } from "./codex-subagent-link-state";
 import { CodexThreadInventoryReader } from "./codex-thread-inventory";
 import { requireNormalizedCodexToolInvocation } from "./codex-tool-normalizer";
 import {
@@ -592,13 +592,7 @@ export class CodexAppServerAdapter
           type: "approval_required",
           externalSessionId,
           timestamp: new Date().toISOString(),
-          ...(route
-            ? {
-                parentExternalSessionId: route.parentExternalSessionId,
-                childExternalSessionId: route.childExternalSessionId,
-                subagentCorrelationKey: route.subagentCorrelationKey,
-              }
-            : {}),
+          ...codexSubagentRouteEventFields(route),
         }),
       );
     }
@@ -611,13 +605,7 @@ export class CodexAppServerAdapter
           type: "question_required",
           externalSessionId,
           timestamp: new Date().toISOString(),
-          ...(route
-            ? {
-                parentExternalSessionId: route.parentExternalSessionId,
-                childExternalSessionId: route.childExternalSessionId,
-                subagentCorrelationKey: route.subagentCorrelationKey,
-              }
-            : {}),
+          ...codexSubagentRouteEventFields(route),
         }),
       );
     }
@@ -683,7 +671,6 @@ export class CodexAppServerAdapter
       threadInventory: this.threadInventory,
       sessions: this.localSessions,
       pendingInput: this.pendingInput,
-      subagents: this.subagents,
       hasActiveTurn: (externalSessionId: string) => {
         const activeTurn = this.activeTurnsBySessionId.get(externalSessionId);
         return Boolean(activeTurn && !activeTurn.isTurnSettled());

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -634,12 +634,20 @@ export class CodexAppServerAdapter
     const inventory = await this.threadInventory.refresh(client, runtimeId);
     const thread = inventory.threadsById.get(input.externalSessionId);
     if (!thread) {
+      if (this.subagents.routeForChild(input.externalSessionId, runtimeId)) {
+        await this.ensureSessionState(input);
+        this.clearThreadInventory(runtimeId);
+      }
       return;
     }
     if (thread.cwd !== input.workingDirectory) {
       return;
     }
+    this.subagents.recordThread(thread, runtimeId);
     if (thread.status.classification === "idle") {
+      if (!this.subagents.routeForChild(input.externalSessionId, runtimeId)) {
+        return;
+      }
       const session = sessionStateFromThreadSnapshot(input, runtimeId, thread);
       this.localSessions.remember(
         preserveRuntimeContextForExistingThread(

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -61,6 +61,7 @@ import {
   sessionStateFromExistingThread,
   sessionStateFromThreadFork,
   sessionStateFromThreadResume,
+  sessionStateFromThreadSnapshot,
   sessionStateFromThreadStart,
 } from "./codex-session-lifecycle";
 import {
@@ -635,7 +636,17 @@ export class CodexAppServerAdapter
     if (!thread) {
       return;
     }
-    if (thread.cwd !== input.workingDirectory || thread.status.classification === "idle") {
+    if (thread.cwd !== input.workingDirectory) {
+      return;
+    }
+    if (thread.status.classification === "idle") {
+      const session = sessionStateFromThreadSnapshot(input, runtimeId, thread);
+      this.localSessions.remember(
+        preserveRuntimeContextForExistingThread(
+          session,
+          this.localSessions.get(session.summary.externalSessionId),
+        ),
+      );
       return;
     }
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-runtime-snapshot.test.ts
@@ -214,6 +214,37 @@ describe("resolveCodexRuntimeSnapshotSource", () => {
     });
   });
 
+  test("keeps proven parent linkage when pending input uses the local snapshot path", () => {
+    expect(
+      toRefreshedRuntimeSnapshot({
+        session: {
+          ...createSession(),
+          threadId: "child-thread",
+          summary: {
+            ...createSession().summary,
+            externalSessionId: "child-thread",
+          },
+        },
+        inventory: createInventory({
+          thread: {
+            ...createThread("active"),
+            id: "child-thread",
+            parentThreadId: "parent-thread",
+          },
+        }),
+        pendingApprovals: [],
+        pendingQuestions: [{ requestId: "question-1", questions: [] }],
+        hasActiveTurn: false,
+      }),
+    ).toMatchObject({
+      availability: "runtime",
+      parentExternalSessionId: "parent-thread",
+      ref: {
+        externalSessionId: "child-thread",
+      },
+    });
+  });
+
   test("returns missing only when neither inventory nor local runtime state can prove a runtime snapshot", () => {
     expect(
       toRefreshedRuntimeSnapshot({

--- a/packages/adapters-codex-app-server/src/codex-app-server-runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-runtime-snapshot.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { agentSessionStatusFromActivity } from "@openducktor/core";
-import { toRefreshedRuntimeSnapshot } from "./codex-app-server-runtime-snapshot";
+import {
+  toRefreshedRuntimeSnapshot,
+  toRuntimeSnapshotFromThread,
+} from "./codex-app-server-runtime-snapshot";
 import {
   type CodexThreadInventory,
   type CodexThreadSnapshot,
@@ -31,6 +34,10 @@ const createThread = (status: "active" | "idle" = "active"): CodexThreadSnapshot
   cwd: "/repo",
   startedAt: "2026-05-07T00:00:00.000Z",
   status: codexThreadStatusSnapshot(status),
+  parentThreadId: null,
+  agentNickname: null,
+  agentRole: null,
+  subAgentSource: null,
 });
 
 const createInventory = ({
@@ -101,6 +108,59 @@ describe("toRuntimeSnapshot", () => {
     ).toMatchObject({
       availability: "runtime",
       classification: "waiting_for_question",
+    });
+  });
+
+  test("adds parent linkage for Codex child threads only when thread metadata proves it", () => {
+    expect(
+      toRuntimeSnapshotFromThread(
+        {
+          ...createThread("active"),
+          id: "child-thread",
+          parentThreadId: "parent-thread",
+        },
+        { repoPath: "/repo" },
+      ),
+    ).toMatchObject({
+      availability: "runtime",
+      parentExternalSessionId: "parent-thread",
+      ref: {
+        externalSessionId: "child-thread",
+      },
+    });
+    expect(
+      toRuntimeSnapshotFromThread(createThread("active"), { repoPath: "/repo" }),
+    ).not.toHaveProperty("parentExternalSessionId");
+  });
+
+  test("includes pending input owned by a Codex child thread snapshot", () => {
+    expect(
+      toRuntimeSnapshotFromThread(
+        {
+          ...createThread("active"),
+          id: "child-thread",
+          parentThreadId: "parent-thread",
+        },
+        { repoPath: "/repo" },
+        {
+          pendingApprovals: [
+            {
+              requestId: "approval-1",
+              requestType: "permission_grant",
+              title: "Approve write",
+            },
+          ],
+        },
+      ),
+    ).toMatchObject({
+      classification: "waiting_for_permission",
+      parentExternalSessionId: "parent-thread",
+      pendingApprovals: [
+        {
+          requestId: "approval-1",
+          requestType: "permission_grant",
+        },
+      ],
     });
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-runtime-snapshot.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-runtime-snapshot.ts
@@ -75,20 +75,34 @@ const toRuntimeSnapshot = (
 export const toRuntimeSnapshotFromThread = (
   thread: CodexThreadSnapshot,
   ref: { repoPath: string; externalSessionId?: string },
-): AgentSessionRuntimeSnapshot => ({
-  availability: "runtime",
-  classification: thread.status.classification,
-  ref: {
-    externalSessionId: ref.externalSessionId ?? thread.id,
-    repoPath: ref.repoPath,
-    runtimeKind: "codex",
-    workingDirectory: thread.cwd,
-  },
-  title: thread.title,
-  startedAt: thread.startedAt,
-  pendingApprovals: [],
-  pendingQuestions: [],
-});
+  pendingInput: {
+    pendingApprovals?: AgentPendingApprovalRequest[];
+    pendingQuestions?: AgentPendingQuestionRequest[];
+  } = {},
+): AgentSessionRuntimeSnapshot => {
+  const parentExternalSessionId = thread.parentThreadId ?? thread.subAgentSource?.parentThreadId;
+  const pendingApprovals = pendingInput.pendingApprovals ?? [];
+  const pendingQuestions = pendingInput.pendingQuestions ?? [];
+  return {
+    availability: "runtime",
+    classification: classifyAgentSessionActivity({
+      runtimeActivity: thread.status.classification,
+      pendingApprovals,
+      pendingQuestions,
+    }),
+    ref: {
+      externalSessionId: ref.externalSessionId ?? thread.id,
+      repoPath: ref.repoPath,
+      runtimeKind: "codex",
+      workingDirectory: thread.cwd,
+    },
+    ...(parentExternalSessionId ? { parentExternalSessionId } : {}),
+    title: thread.title,
+    startedAt: thread.startedAt,
+    pendingApprovals,
+    pendingQuestions,
+  };
+};
 
 const codexRuntimeSnapshotRef = (session: CodexSessionState): ReadSessionRuntimeSnapshotInput => ({
   externalSessionId: session.threadId,

--- a/packages/adapters-codex-app-server/src/codex-app-server-runtime-snapshot.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-runtime-snapshot.ts
@@ -50,6 +50,7 @@ const toRuntimeSnapshot = (
   session: CodexSessionState,
   pendingApprovals: AgentPendingApprovalRequest[],
   pendingQuestions: AgentPendingQuestionRequest[],
+  parentExternalSessionId?: string,
 ): AgentSessionRuntimeSnapshot => {
   const classification = classifyAgentSessionActivity({
     runtimeActivity: session.liveStatus?.classification ?? "idle",
@@ -65,6 +66,7 @@ const toRuntimeSnapshot = (
       runtimeKind: "codex",
       workingDirectory: session.workingDirectory,
     },
+    ...(parentExternalSessionId ? { parentExternalSessionId } : {}),
     title: session.summary.title ?? (session.role ? `Codex ${session.role}` : "Codex"),
     startedAt: session.summary.startedAt,
     pendingApprovals,
@@ -111,6 +113,16 @@ const codexRuntimeSnapshotRef = (session: CodexSessionState): ReadSessionRuntime
   workingDirectory: session.workingDirectory,
 });
 
+const parentExternalSessionIdFromThread = (
+  session: CodexSessionState,
+  thread: CodexThreadSnapshot | null,
+): string | undefined => {
+  if (!thread || thread.cwd !== session.workingDirectory) {
+    return undefined;
+  }
+  return thread.parentThreadId ?? thread.subAgentSource?.parentThreadId ?? undefined;
+};
+
 export const toRefreshedRuntimeSnapshot = ({
   session,
   inventory,
@@ -138,7 +150,12 @@ export const toRefreshedRuntimeSnapshot = ({
   });
 
   if (runtimeSnapshotSource.type === "local") {
-    return toRuntimeSnapshot(session, pendingApprovals, pendingQuestions);
+    return toRuntimeSnapshot(
+      session,
+      pendingApprovals,
+      pendingQuestions,
+      parentExternalSessionIdFromThread(session, thread),
+    );
   }
   if (runtimeSnapshotSource.type === "missing") {
     return missingRuntimeSnapshot(ref);

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.test.ts
@@ -5,6 +5,7 @@ import {
   handleCodexServerRequest,
 } from "./codex-app-server-server-requests";
 import { CodexPendingInputState } from "./codex-pending-input-state";
+import { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import type { CodexServerRequestRecord, CodexSessionState } from "./types";
 
 const createSession = (
@@ -30,32 +31,44 @@ const createRequestContext = ({
   events,
   pendingInput = new CodexPendingInputState(),
   respondServerRequest = mock(async () => {}),
+  subagents = new CodexSubagentLinkState(),
+  sessions = new Map<string, CodexSessionState>(),
 }: {
   events: unknown[];
   pendingInput?: CodexPendingInputState;
   respondServerRequest?: CodexServerRequestHandlerContext["respondServerRequest"];
+  subagents?: CodexSubagentLinkState;
+  sessions?: Map<string, CodexSessionState>;
 }): CodexServerRequestHandlerContext => ({
   respondServerRequest,
   pendingInput,
   activeTurnsBySessionId: new Map(),
+  subagents,
+  sessionForThreadId: (threadId) => sessions.get(threadId),
   bindActiveTurnId: () => false,
   flushQueuedUserMessagesLater: () => {},
-  emitSessionEvent: (_externalSessionId: string, event: unknown) => events.push(event),
+  emitSessionEvent: (externalSessionId: string, event: unknown) =>
+    events.push({
+      ...(event as Record<string, unknown>),
+      emittedExternalSessionId: externalSessionId,
+    }),
 });
 
 const mcpToolApprovalRequest = ({
   id,
   serverName,
   toolName,
+  threadId = "thread-spec",
 }: {
   id: number;
   serverName: string;
   toolName: string;
+  threadId?: string;
 }): CodexServerRequestRecord => ({
   id,
   method: CODEX_APP_SERVER_SERVER_REQUEST_METHOD.MCP_SERVER_ELICITATION_REQUEST,
   params: {
-    threadId: "thread-spec",
+    threadId,
     turnId: "turn-spec",
     serverName,
     mode: "form",
@@ -200,6 +213,125 @@ describe("handleCodexServerRequest", () => {
       expect.objectContaining({
         type: "session_error",
         message: expect.stringContaining("role 'spec' is not allowed to use odt_set_plan"),
+      }),
+    );
+  });
+
+  test("mirrors child MCP approvals to the linked parent while keeping the child as owner", async () => {
+    const parentSession = createSession("build", "parent-thread");
+    const childSession = createSession("build", "child-thread");
+    const sessions = new Map([
+      [parentSession.threadId, parentSession],
+      [childSession.threadId, childSession],
+    ]);
+    const subagents = new CodexSubagentLinkState();
+    subagents.upsertLink({
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    const pendingInput = new CodexPendingInputState();
+    const events: unknown[] = [];
+
+    await expect(
+      handleCodexServerRequest(
+        createRequestContext({ events, pendingInput, sessions, subagents }),
+        parentSession,
+        mcpToolApprovalRequest({
+          id: 40,
+          serverName: "semble",
+          toolName: "search",
+          threadId: "child-thread",
+        }),
+        new Set(),
+      ),
+    ).resolves.toBe(true);
+
+    expect(pendingInput.approval("40")).toMatchObject({
+      threadId: "child-thread",
+      route: {
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      },
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        emittedExternalSessionId: "child-thread",
+        type: "approval_required",
+        externalSessionId: "child-thread",
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        emittedExternalSessionId: "parent-thread",
+        type: "approval_required",
+        externalSessionId: "parent-thread",
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      }),
+    );
+  });
+
+  test("accepts child question requests when parent linkage proves the owner", async () => {
+    const parentSession = createSession("build", "parent-thread");
+    const sessions = new Map([[parentSession.threadId, parentSession]]);
+    const subagents = new CodexSubagentLinkState();
+    subagents.upsertLink({
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    const pendingInput = new CodexPendingInputState();
+    const events: unknown[] = [];
+
+    await expect(
+      handleCodexServerRequest(
+        createRequestContext({ events, pendingInput, sessions, subagents }),
+        parentSession,
+        {
+          id: 41,
+          method: CODEX_APP_SERVER_SERVER_REQUEST_METHOD.ITEM_TOOL_REQUEST_USER_INPUT,
+          params: {
+            threadId: "child-thread",
+            turnId: "child-turn",
+            questions: [
+              {
+                id: "question-item-1",
+                header: "Choose",
+                question: "Proceed?",
+                options: ["Yes", "No"],
+              },
+            ],
+          },
+        },
+        new Set(),
+      ),
+    ).resolves.toBe(true);
+
+    expect(pendingInput.question("41")).toMatchObject({
+      threadId: "child-thread",
+      route: {
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      },
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        emittedExternalSessionId: "parent-thread",
+        type: "question_required",
+        externalSessionId: "parent-thread",
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        emittedExternalSessionId: "child-thread",
+        type: "question_required",
       }),
     );
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.test.ts
@@ -188,6 +188,29 @@ describe("handleCodexServerRequest", () => {
     expect(pendingInput.approval("33")?.request.tool?.name).toBe("odt_set_plan");
   });
 
+  test("rejects request owners that are neither the current session nor a known child route", async () => {
+    const parentSession = createSession("build", "parent-thread");
+    const pendingInput = new CodexPendingInputState();
+    const events: unknown[] = [];
+
+    await expect(
+      handleCodexServerRequest(
+        createRequestContext({ events, pendingInput }),
+        parentSession,
+        mcpToolApprovalRequest({
+          id: 34,
+          serverName: "semble",
+          toolName: "search",
+          threadId: "unknown-child-thread",
+        }),
+        new Set(),
+      ),
+    ).rejects.toThrow("no known session or subagent route");
+
+    expect(pendingInput.approval("34")).toBeUndefined();
+    expect(events).toEqual([]);
+  });
+
   test("rejects disallowed OpenDucktor workflow MCP approvals by role", async () => {
     const respondServerRequest = mock(async () => {});
     const pendingInput = new CodexPendingInputState();

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.test.ts
@@ -33,20 +33,26 @@ const createRequestContext = ({
   respondServerRequest = mock(async () => {}),
   subagents = new CodexSubagentLinkState(),
   sessions = new Map<string, CodexSessionState>(),
+  activeTurnsBySessionId = new Map(),
+  bindActiveTurnId = () => false,
+  flushQueuedUserMessagesLater = () => {},
 }: {
   events: unknown[];
   pendingInput?: CodexPendingInputState;
   respondServerRequest?: CodexServerRequestHandlerContext["respondServerRequest"];
   subagents?: CodexSubagentLinkState;
   sessions?: Map<string, CodexSessionState>;
+  activeTurnsBySessionId?: CodexServerRequestHandlerContext["activeTurnsBySessionId"];
+  bindActiveTurnId?: CodexServerRequestHandlerContext["bindActiveTurnId"];
+  flushQueuedUserMessagesLater?: CodexServerRequestHandlerContext["flushQueuedUserMessagesLater"];
 }): CodexServerRequestHandlerContext => ({
   respondServerRequest,
   pendingInput,
-  activeTurnsBySessionId: new Map(),
+  activeTurnsBySessionId,
   subagents,
   sessionForThreadId: (threadId) => sessions.get(threadId),
-  bindActiveTurnId: () => false,
-  flushQueuedUserMessagesLater: () => {},
+  bindActiveTurnId,
+  flushQueuedUserMessagesLater,
   emitSessionEvent: (externalSessionId: string, event: unknown) =>
     events.push({
       ...(event as Record<string, unknown>),
@@ -310,10 +316,21 @@ describe("handleCodexServerRequest", () => {
     });
     const pendingInput = new CodexPendingInputState();
     const events: unknown[] = [];
+    const parentActiveTurn = { session: parentSession };
+    const bindActiveTurnId = mock(() => true);
+    const flushQueuedUserMessagesLater = mock(() => undefined);
 
     await expect(
       handleCodexServerRequest(
-        createRequestContext({ events, pendingInput, sessions, subagents }),
+        createRequestContext({
+          events,
+          pendingInput,
+          sessions,
+          subagents,
+          activeTurnsBySessionId: new Map([[parentSession.threadId, parentActiveTurn as never]]),
+          bindActiveTurnId,
+          flushQueuedUserMessagesLater,
+        }),
         parentSession,
         {
           id: 41,
@@ -357,5 +374,7 @@ describe("handleCodexServerRequest", () => {
         type: "question_required",
       }),
     );
+    expect(bindActiveTurnId).not.toHaveBeenCalled();
+    expect(flushQueuedUserMessagesLater).not.toHaveBeenCalled();
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
@@ -164,8 +164,10 @@ export const handleCodexServerRequest = async (
   }
   const requestTurnId = extractTurnId(rawRequest.params);
   const activeTurn =
-    context.activeTurnsBySessionId.get(routeContext.policySession.threadId) ??
-    context.activeTurnsBySessionId.get(routeContext.ownerThreadId);
+    context.activeTurnsBySessionId.get(routeContext.ownerThreadId) ??
+    (routeContext.ownerThreadId === routeContext.policySession.threadId
+      ? context.activeTurnsBySessionId.get(routeContext.policySession.threadId)
+      : undefined);
   if (requestTurnId && activeTurn && context.bindActiveTurnId(activeTurn, requestTurnId)) {
     context.flushQueuedUserMessagesLater(activeTurn);
   }

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
@@ -6,6 +6,7 @@ import {
 import {
   classifyCodexRequestMutation,
   codexApprovalResponseForRequest,
+  extractThreadIdFromParams,
   extractTurnId,
   parseQuestionRequest,
   toApprovalRequest,
@@ -14,6 +15,7 @@ import {
 import { type ActiveCodexTurn, CODEX_USER_INPUT_REQUEST_METHOD } from "./codex-app-server-shared";
 import type { CodexPendingInputState } from "./codex-pending-input-state";
 import { READ_ONLY_ROLES } from "./codex-session-policy";
+import type { CodexSubagentLinkState, CodexSubagentRoute } from "./codex-subagent-link-state";
 import { requireNormalizedCodexToolInvocation } from "./codex-tool-normalizer";
 import type {
   CodexServerRequestRecord,
@@ -52,9 +54,76 @@ export type CodexServerRequestHandlerContext = {
   respondServerRequest: CodexServerRequestResponder;
   pendingInput: CodexPendingInputState;
   activeTurnsBySessionId: Map<string, ActiveCodexTurn>;
+  subagents: CodexSubagentLinkState;
+  sessionForThreadId(threadId: string): CodexSessionState | undefined;
   bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean;
   flushQueuedUserMessagesLater(activeTurn: ActiveCodexTurn): void;
   emitSessionEvent(externalSessionId: string, event: AgentEvent): void;
+};
+
+type RequestRouteContext = {
+  ownerThreadId: string;
+  ownerSession?: CodexSessionState;
+  policySession: CodexSessionState;
+  runtimeId: string;
+  route: CodexSubagentRoute | null;
+};
+
+const eventRouteFields = (route: CodexSubagentRoute | null) =>
+  route
+    ? {
+        parentExternalSessionId: route.parentExternalSessionId,
+        childExternalSessionId: route.childExternalSessionId,
+        subagentCorrelationKey: route.subagentCorrelationKey,
+      }
+    : {};
+
+const resolveRequestRouteContext = (
+  context: CodexServerRequestHandlerContext,
+  session: CodexSessionState,
+  rawRequest: CodexServerRequestRecord,
+): RequestRouteContext => {
+  const ownerThreadId = extractThreadIdFromParams(rawRequest.params) ?? session.threadId;
+  const ownerSession =
+    context.sessionForThreadId(ownerThreadId) ??
+    (ownerThreadId === session.threadId ? session : undefined);
+  const route = context.subagents.routeForChild(ownerThreadId);
+  const parentSession = route
+    ? (context.sessionForThreadId(route.parentExternalSessionId) ??
+      (route.parentExternalSessionId === session.threadId ? session : undefined))
+    : undefined;
+  const policySession = parentSession ?? ownerSession ?? session;
+  return {
+    ownerThreadId,
+    ...(ownerSession ? { ownerSession } : {}),
+    policySession,
+    runtimeId: ownerSession?.runtimeId ?? policySession.runtimeId,
+    route,
+  };
+};
+
+const emitPendingEvent = (
+  context: CodexServerRequestHandlerContext,
+  routeContext: RequestRouteContext,
+  event: AgentEvent,
+): void => {
+  if (routeContext.ownerSession) {
+    context.emitSessionEvent(routeContext.ownerThreadId, {
+      ...event,
+      externalSessionId: routeContext.ownerThreadId,
+      ...eventRouteFields(routeContext.route),
+    });
+  }
+  if (
+    routeContext.route &&
+    context.sessionForThreadId(routeContext.route.parentExternalSessionId)
+  ) {
+    context.emitSessionEvent(routeContext.route.parentExternalSessionId, {
+      ...event,
+      externalSessionId: routeContext.route.parentExternalSessionId,
+      ...eventRouteFields(routeContext.route),
+    });
+  }
 };
 
 export const handleCodexServerRequest = async (
@@ -77,8 +146,11 @@ export const handleCodexServerRequest = async (
     throw new Error("Codex app-server server request is missing method.");
   }
 
+  const routeContext = resolveRequestRouteContext(context, session, rawRequest);
   const requestTurnId = extractTurnId(rawRequest.params);
-  const activeTurn = context.activeTurnsBySessionId.get(session.threadId);
+  const activeTurn =
+    context.activeTurnsBySessionId.get(routeContext.policySession.threadId) ??
+    context.activeTurnsBySessionId.get(routeContext.ownerThreadId);
   if (requestTurnId && activeTurn && context.bindActiveTurnId(activeTurn, requestTurnId)) {
     context.flushQueuedUserMessagesLater(activeTurn);
   }
@@ -90,13 +162,13 @@ export const handleCodexServerRequest = async (
     }
 
     const roleRejection = odtWorkflowToolRoleRejection(
-      session,
+      routeContext.policySession,
       mcpElicitationApproval.metadata?.serverName,
       mcpElicitationApproval.tool?.name,
     );
     if (roleRejection) {
       await context.respondServerRequest(
-        session.runtimeId,
+        routeContext.runtimeId,
         requestId,
         codexApprovalResponseForRequest({
           outcome: "reject",
@@ -105,9 +177,9 @@ export const handleCodexServerRequest = async (
         }),
         undefined,
       );
-      context.emitSessionEvent(session.threadId, {
+      context.emitSessionEvent(routeContext.policySession.threadId, {
         type: "session_error",
-        externalSessionId: session.threadId,
+        externalSessionId: routeContext.policySession.threadId,
         timestamp: new Date().toISOString(),
         message: `Rejected Codex MCP request '${mcpElicitationApproval.tool?.name}' because ${roleRejection}.`,
       });
@@ -115,14 +187,15 @@ export const handleCodexServerRequest = async (
     }
 
     context.pendingInput.addApproval({
-      runtimeId: session.runtimeId,
-      threadId: session.threadId,
+      runtimeId: routeContext.runtimeId,
+      threadId: routeContext.ownerThreadId,
       request: mcpElicitationApproval,
+      ...(routeContext.route ? { route: routeContext.route } : {}),
     });
-    context.emitSessionEvent(session.threadId, {
+    emitPendingEvent(context, routeContext, {
       ...mcpElicitationApproval,
       type: "approval_required",
-      externalSessionId: session.threadId,
+      externalSessionId: routeContext.ownerThreadId,
       timestamp: new Date().toISOString(),
     });
     return true;
@@ -130,9 +203,9 @@ export const handleCodexServerRequest = async (
 
   if (rawRequest.method === CODEX_USER_INPUT_REQUEST_METHOD) {
     const parsed = parseQuestionRequest(rawRequest);
-    if (parsed.threadId !== session.threadId) {
+    if (parsed.threadId !== routeContext.ownerThreadId) {
       throw new Error(
-        `Codex question request thread '${parsed.threadId}' does not match active session '${session.threadId}'.`,
+        `Codex question request thread '${parsed.threadId}' does not match request owner '${routeContext.ownerThreadId}'.`,
       );
     }
     if (activeTurn && context.bindActiveTurnId(activeTurn, parsed.turnId)) {
@@ -143,21 +216,22 @@ export const handleCodexServerRequest = async (
       questions: parsed.request.questions,
     };
     context.pendingInput.addQuestion({
-      runtimeId: session.runtimeId,
-      threadId: session.threadId,
+      runtimeId: routeContext.runtimeId,
+      threadId: routeContext.ownerThreadId,
       request: parsed.request,
       questionIds: parsed.questionIds,
       input: questionInput,
+      ...(routeContext.route ? { route: routeContext.route } : {}),
     });
-    context.emitSessionEvent(session.threadId, {
+    emitPendingEvent(context, routeContext, {
       ...parsed.request,
       type: "question_required",
-      externalSessionId: session.threadId,
+      externalSessionId: routeContext.ownerThreadId,
       timestamp: new Date().toISOString(),
     });
-    context.emitSessionEvent(session.threadId, {
+    emitPendingEvent(context, routeContext, {
       type: "assistant_part",
-      externalSessionId: session.threadId,
+      externalSessionId: routeContext.ownerThreadId,
       timestamp: new Date().toISOString(),
       part: requireNormalizedCodexToolInvocation({
         messageId: `codex-question-${parsed.request.requestId}`,
@@ -184,9 +258,13 @@ export const handleCodexServerRequest = async (
       throw new Error(`Codex app-server server request '${rawRequest.method}' is missing an id.`);
     }
     const requestMutation = classifyCodexRequestMutation(rawRequest);
-    if (session.role && READ_ONLY_ROLES.has(session.role) && requestMutation === "read_only") {
+    if (
+      routeContext.policySession.role &&
+      READ_ONLY_ROLES.has(routeContext.policySession.role) &&
+      requestMutation === "read_only"
+    ) {
       await context.respondServerRequest(
-        session.runtimeId,
+        routeContext.runtimeId,
         requestId,
         codexApprovalResponseForRequest({ outcome: "approve_once", request: rawRequest }),
         undefined,
@@ -196,13 +274,14 @@ export const handleCodexServerRequest = async (
 
     const isMutatingRequest = requestMutation === "mutating";
     const shouldRejectForRole =
-      !session.role || (isMutatingRequest && READ_ONLY_ROLES.has(session.role));
+      !routeContext.policySession.role ||
+      (isMutatingRequest && READ_ONLY_ROLES.has(routeContext.policySession.role));
     if (shouldRejectForRole) {
-      const roleReason = session.role
-        ? `role '${session.role}' is read-only`
+      const roleReason = routeContext.policySession.role
+        ? `role '${routeContext.policySession.role}' is read-only`
         : "the session role is unknown";
       await context.respondServerRequest(
-        session.runtimeId,
+        routeContext.runtimeId,
         requestId,
         codexApprovalResponseForRequest({
           outcome: "reject",
@@ -211,29 +290,30 @@ export const handleCodexServerRequest = async (
         }),
         undefined,
       );
-      context.emitSessionEvent(session.threadId, {
+      context.emitSessionEvent(routeContext.policySession.threadId, {
         type: "session_error",
-        externalSessionId: session.threadId,
+        externalSessionId: routeContext.policySession.threadId,
         timestamp: new Date().toISOString(),
         message: `Rejected ${isMutatingRequest ? "mutating " : ""}Codex request '${rawRequest.method}' because ${roleReason}.`,
       });
       return false;
     }
 
-    const role = session.role;
+    const role = routeContext.policySession.role;
     if (!role) {
       throw new Error("Codex approval request cannot be created without a session role.");
     }
     const approval = toApprovalRequest(rawRequest, role);
     context.pendingInput.addApproval({
-      runtimeId: session.runtimeId,
-      threadId: session.threadId,
+      runtimeId: routeContext.runtimeId,
+      threadId: routeContext.ownerThreadId,
       request: approval,
+      ...(routeContext.route ? { route: routeContext.route } : {}),
     });
-    context.emitSessionEvent(session.threadId, {
+    emitPendingEvent(context, routeContext, {
       ...approval,
       type: "approval_required",
-      externalSessionId: session.threadId,
+      externalSessionId: routeContext.ownerThreadId,
       timestamp: new Date().toISOString(),
     });
     return true;
@@ -246,7 +326,7 @@ export const handleCodexServerRequest = async (
   // Dynamic Codex tool calls are never approved here; OpenDucktor workflow tools are exposed
   // through MCP so role-specific approval handling is intentionally bypassed for this method.
   await context.respondServerRequest(
-    session.runtimeId,
+    routeContext.runtimeId,
     requestId,
     {
       contentItems: [
@@ -259,9 +339,9 @@ export const handleCodexServerRequest = async (
     },
     undefined,
   );
-  context.emitSessionEvent(session.threadId, {
+  context.emitSessionEvent(routeContext.policySession.threadId, {
     type: "session_error",
-    externalSessionId: session.threadId,
+    externalSessionId: routeContext.policySession.threadId,
     timestamp: new Date().toISOString(),
     message: "Rejected Codex dynamic tool request because OpenDucktor workflow tools must use MCP.",
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
@@ -87,11 +87,26 @@ const resolveRequestRouteContext = (
   const ownerSession =
     context.sessionForThreadId(ownerThreadId) ??
     (ownerThreadId === session.threadId ? session : undefined);
-  const route = context.subagents.routeForChild(ownerThreadId);
+  const route = context.subagents.routeForChild(ownerThreadId, session.runtimeId);
+  if (route?.runtimeId && route.runtimeId !== session.runtimeId) {
+    throw new Error(
+      `Cannot handle Codex server request for thread '${ownerThreadId}' from runtime '${session.runtimeId}' because its subagent route belongs to runtime '${route.runtimeId}'.`,
+    );
+  }
   const parentSession = route
     ? (context.sessionForThreadId(route.parentExternalSessionId) ??
       (route.parentExternalSessionId === session.threadId ? session : undefined))
     : undefined;
+  if (ownerSession && ownerSession.runtimeId !== session.runtimeId) {
+    throw new Error(
+      `Cannot handle Codex server request for thread '${ownerThreadId}' from runtime '${session.runtimeId}' because the owner session belongs to runtime '${ownerSession.runtimeId}'.`,
+    );
+  }
+  if (parentSession && parentSession.runtimeId !== session.runtimeId) {
+    throw new Error(
+      `Cannot handle Codex server request for thread '${ownerThreadId}' from runtime '${session.runtimeId}' because the parent session belongs to runtime '${parentSession.runtimeId}'.`,
+    );
+  }
   const policySession = parentSession ?? ownerSession ?? session;
   return {
     ownerThreadId,

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
@@ -15,7 +15,11 @@ import {
 import { type ActiveCodexTurn, CODEX_USER_INPUT_REQUEST_METHOD } from "./codex-app-server-shared";
 import type { CodexPendingInputState } from "./codex-pending-input-state";
 import { READ_ONLY_ROLES } from "./codex-session-policy";
-import type { CodexSubagentLinkState, CodexSubagentRoute } from "./codex-subagent-link-state";
+import {
+  type CodexSubagentLinkState,
+  type CodexSubagentRoute,
+  codexSubagentRouteEventFields,
+} from "./codex-subagent-link-state";
 import { requireNormalizedCodexToolInvocation } from "./codex-tool-normalizer";
 import type {
   CodexServerRequestRecord,
@@ -69,15 +73,6 @@ type RequestRouteContext = {
   route: CodexSubagentRoute | null;
 };
 
-const eventRouteFields = (route: CodexSubagentRoute | null) =>
-  route
-    ? {
-        parentExternalSessionId: route.parentExternalSessionId,
-        childExternalSessionId: route.childExternalSessionId,
-        subagentCorrelationKey: route.subagentCorrelationKey,
-      }
-    : {};
-
 const resolveRequestRouteContext = (
   context: CodexServerRequestHandlerContext,
   session: CodexSessionState,
@@ -126,7 +121,7 @@ const emitPendingEvent = (
     context.emitSessionEvent(routeContext.ownerThreadId, {
       ...event,
       externalSessionId: routeContext.ownerThreadId,
-      ...eventRouteFields(routeContext.route),
+      ...codexSubagentRouteEventFields(routeContext.route),
     });
   }
   if (
@@ -136,7 +131,7 @@ const emitPendingEvent = (
     context.emitSessionEvent(routeContext.route.parentExternalSessionId, {
       ...event,
       externalSessionId: routeContext.route.parentExternalSessionId,
-      ...eventRouteFields(routeContext.route),
+      ...codexSubagentRouteEventFields(routeContext.route),
     });
   }
 };

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
@@ -147,6 +147,11 @@ export const handleCodexServerRequest = async (
   }
 
   const routeContext = resolveRequestRouteContext(context, session, rawRequest);
+  if (!routeContext.ownerSession && !routeContext.route) {
+    throw new Error(
+      `Cannot handle Codex server request '${rawRequest.method}' for thread '${routeContext.ownerThreadId}' from session '${session.threadId}' because there is no known session or subagent route for the request owner.`,
+    );
+  }
   const requestTurnId = extractTurnId(rawRequest.params);
   const activeTurn =
     context.activeTurnsBySessionId.get(routeContext.policySession.threadId) ??

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -241,7 +241,7 @@ const emitStartedItem = (
   }
   const canonicalEvents = context.eventMapperPipeline.runLive(
     { kind: "item_started", item },
-    { source: "live", threadId: session.threadId, timestamp },
+    { source: "live", runtimeId: session.runtimeId, threadId: session.threadId, timestamp },
   );
   for (const event of projectCodexCanonicalEvents(canonicalEvents)) {
     if (event.type !== "assistant_part") {
@@ -334,6 +334,7 @@ const emitCompletedItem = (
     { kind: "item_completed", item },
     {
       source: "live",
+      runtimeId: session.runtimeId,
       threadId: session.threadId,
       ...(turnId ? { turnId } : {}),
       timestamp,
@@ -469,7 +470,13 @@ export const handleCodexPendingNotifications = async (
           context,
           context.eventMapperPipeline.runLive(
             { kind: "notification", notification },
-            { source: "live", threadId: session.threadId, turnId: usageTurnId, timestamp },
+            {
+              source: "live",
+              runtimeId: session.runtimeId,
+              threadId: session.threadId,
+              turnId: usageTurnId,
+              timestamp,
+            },
           ),
         );
       }
@@ -483,7 +490,13 @@ export const handleCodexPendingNotifications = async (
           context,
           context.eventMapperPipeline.runLive(
             { kind: "notification", notification },
-            { source: "live", threadId: session.threadId, turnId: todoTurnId, timestamp },
+            {
+              source: "live",
+              runtimeId: session.runtimeId,
+              threadId: session.threadId,
+              turnId: todoTurnId,
+              timestamp,
+            },
           ),
         );
       }
@@ -495,6 +508,7 @@ export const handleCodexPendingNotifications = async (
         { kind: "notification", notification },
         {
           source: "live",
+          runtimeId: session.runtimeId,
           threadId: session.threadId,
           ...(notificationTurnId ? { turnId: notificationTurnId } : {}),
           timestamp,
@@ -549,6 +563,7 @@ export const handleCodexPendingNotifications = async (
           { kind: "notification", notification },
           {
             source: "live",
+            runtimeId: session.runtimeId,
             threadId: session.threadId,
             ...(turnId ? { turnId } : {}),
             timestamp,

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -249,6 +249,7 @@ const emitStartedItem = (
       continue;
     }
     if (event.part.kind !== "tool") {
+      emitCodexSessionEvent(context, session.threadId, event);
       continue;
     }
     emitCodexSessionEvent(context, session.threadId, {

--- a/packages/adapters-codex-app-server/src/codex-app-server-threads.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-threads.ts
@@ -120,9 +120,7 @@ const codexThreadSnapshot = (thread: unknown): CodexThreadSnapshot | null => {
   };
 };
 
-export const codexSubAgentSourceMetadata = (
-  source: unknown,
-): CodexSubAgentSourceMetadata | null => {
+const codexSubAgentSourceMetadata = (source: unknown): CodexSubAgentSourceMetadata | null => {
   if (!isPlainObject(source)) {
     return null;
   }

--- a/packages/adapters-codex-app-server/src/codex-app-server-threads.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-threads.ts
@@ -52,6 +52,18 @@ export type CodexThreadSnapshot = {
   startedAt: string;
   title: string;
   status: CodexThreadStatusSnapshot;
+  parentThreadId: string | null;
+  agentNickname: string | null;
+  agentRole: string | null;
+  subAgentSource: CodexSubAgentSourceMetadata | null;
+};
+
+export type CodexSubAgentSourceMetadata = {
+  parentThreadId: string;
+  depth: number;
+  agentPath: unknown;
+  agentNickname: string | null;
+  agentRole: string | null;
 };
 
 const codexTimestampFromUnknownSeconds = (value: unknown): string =>
@@ -91,12 +103,48 @@ const codexThreadSnapshot = (thread: unknown): CodexThreadSnapshot | null => {
   if (!id || !cwd) {
     return null;
   }
+  const subAgentSource = codexSubAgentSourceMetadata(thread.source);
   return {
     id,
     cwd,
     startedAt: codexTimestampFromUnknownSeconds(thread.createdAt ?? thread.created_at),
     title: extractStringField(thread, ["name", "preview"]) ?? `Codex ${id}`,
     status: codexThreadStatusSnapshot(thread.status),
+    parentThreadId:
+      extractStringField(thread, ["parentThreadId", "parent_thread_id"]) ??
+      subAgentSource?.parentThreadId ??
+      null,
+    agentNickname: extractStringField(thread, ["agentNickname", "agent_nickname"]),
+    agentRole: extractStringField(thread, ["agentRole", "agent_role"]),
+    subAgentSource,
+  };
+};
+
+export const codexSubAgentSourceMetadata = (
+  source: unknown,
+): CodexSubAgentSourceMetadata | null => {
+  if (!isPlainObject(source)) {
+    return null;
+  }
+  const subAgent = source.subAgent ?? source.sub_agent;
+  if (!isPlainObject(subAgent)) {
+    return null;
+  }
+  const threadSpawn = subAgent.thread_spawn ?? subAgent.threadSpawn;
+  if (!isPlainObject(threadSpawn)) {
+    return null;
+  }
+  const parentThreadId = extractStringField(threadSpawn, ["parent_thread_id", "parentThreadId"]);
+  const depth = typeof threadSpawn.depth === "number" ? threadSpawn.depth : null;
+  if (!parentThreadId || depth === null || !Number.isFinite(depth)) {
+    return null;
+  }
+  return {
+    parentThreadId,
+    depth,
+    agentPath: threadSpawn.agent_path ?? threadSpawn.agentPath ?? null,
+    agentNickname: extractStringField(threadSpawn, ["agent_nickname", "agentNickname"]),
+    agentRole: extractStringField(threadSpawn, ["agent_role", "agentRole"]),
   };
 };
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -771,9 +771,13 @@ const codexCollabAgentToolCallStreamParts = (
 ): AgentStreamPart[] => {
   const tool = extractStringField(value, ["tool"]) ?? "collab_agent";
   const prompt = extractStringField(value, ["prompt"]);
-  const receivers = arrayFromUnknown(value.receiverThreadIds ?? value.receiver_thread_ids).filter(
-    (entry): entry is string => typeof entry === "string",
-  );
+  const receivers = [
+    ...arrayFromUnknown(value.receiverThreadIds ?? value.receiver_thread_ids).filter(
+      (entry): entry is string => typeof entry === "string",
+    ),
+    extractStringField(value, ["receiverThreadId", "receiver_thread_id"]),
+    extractStringField(value, ["newThreadId", "new_thread_id"]),
+  ].filter((entry): entry is string => Boolean(entry));
   return [
     syntheticToolPart({
       kind: "tool",
@@ -882,7 +886,10 @@ export const toStreamPart = (
   if (codexItemTypeMatches(value, "mcpToolCall")) {
     return codexMcpToolCallStreamParts(value, messageId, partId);
   }
-  if (codexItemTypeMatches(value, "collabAgentToolCall")) {
+  if (
+    codexItemTypeMatches(value, "collabAgentToolCall") ||
+    codexItemTypeMatches(value, "collabToolCall")
+  ) {
     return codexCollabAgentToolCallStreamParts(value, messageId, partId);
   }
   if (codexItemTypeMatches(value, "dynamicToolCall")) {

--- a/packages/adapters-codex-app-server/src/codex-canonical-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-canonical-events.ts
@@ -92,6 +92,7 @@ export type CodexCanonicalEvent =
 
 export type CodexMappingContext = {
   source: CodexCanonicalSource;
+  runtimeId?: string;
   threadId: string;
   turnId?: string;
   timestamp?: string;

--- a/packages/adapters-codex-app-server/src/codex-event-mapper-catalog.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mapper-catalog.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { CODEX_EVENT_MAPPERS } from "./event-mappers";
+import { CodexSubagentLinkState } from "./codex-subagent-link-state";
+import { createCodexEventMappers } from "./event-mappers";
 
 describe("Codex event mapper catalog", () => {
+  const createMappers = () => createCodexEventMappers(new CodexSubagentLinkState());
+
   test("every mapper implements the live/thread contract", () => {
-    expect(CODEX_EVENT_MAPPERS.length).toBeGreaterThan(0);
-    for (const mapper of CODEX_EVENT_MAPPERS) {
+    const mappers = createMappers();
+    expect(mappers.length).toBeGreaterThan(0);
+    for (const mapper of mappers) {
       expect(mapper.name).toBeTruthy();
       expect(mapper.createState).toBeFunction();
       expect(mapper.fromLive).toBeFunction();
@@ -13,7 +17,7 @@ describe("Codex event mapper catalog", () => {
   });
 
   test("specific mappers run before generic fallbacks", () => {
-    const names = CODEX_EVENT_MAPPERS.map((mapper) => mapper.name);
+    const names = createMappers().map((mapper) => mapper.name);
     expect(names.indexOf("todo")).toBeLessThan(names.indexOf("dynamic_tool"));
     expect(names.indexOf("web_search")).toBeLessThan(names.indexOf("dynamic_tool"));
     expect(names[names.length - 1]).toBe("hidden_item");

--- a/packages/adapters-codex-app-server/src/codex-event-mapper-catalog.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mapper-catalog.test.ts
@@ -20,6 +20,7 @@ describe("Codex event mapper catalog", () => {
     const names = createMappers().map((mapper) => mapper.name);
     expect(names.indexOf("todo")).toBeLessThan(names.indexOf("dynamic_tool"));
     expect(names.indexOf("web_search")).toBeLessThan(names.indexOf("dynamic_tool"));
+    expect(names.indexOf("subagent")).toBeLessThan(names.indexOf("collab_tool"));
     expect(names[names.length - 1]).toBe("hidden_item");
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-event-mapper-pipeline.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mapper-pipeline.ts
@@ -11,6 +11,7 @@ import type {
   CodexThreadItemInput,
   RegisteredCodexEventMapper,
 } from "./codex-event-mapper";
+import { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import { createCodexEventMappers } from "./event-mappers";
 
 export type CodexEventMapperPipeline = {
@@ -45,7 +46,7 @@ const runFirstHandled = <Input>(
 };
 
 export const createCodexEventMapperPipeline = (
-  mappers: RegisteredCodexEventMapper[] = createCodexEventMappers(),
+  mappers: RegisteredCodexEventMapper[] = createCodexEventMappers(new CodexSubagentLinkState()),
 ): CodexEventMapperPipeline => {
   const states = createMapperStates(mappers);
   return {

--- a/packages/adapters-codex-app-server/src/codex-event-mapper-pipeline.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mapper-pipeline.ts
@@ -11,7 +11,7 @@ import type {
   CodexThreadItemInput,
   RegisteredCodexEventMapper,
 } from "./codex-event-mapper";
-import { CODEX_EVENT_MAPPERS } from "./event-mappers";
+import { createCodexEventMappers } from "./event-mappers";
 
 export type CodexEventMapperPipeline = {
   runLive(input: CodexLiveInput, ctx: CodexMappingContext): CodexCanonicalEvent[];
@@ -45,7 +45,7 @@ const runFirstHandled = <Input>(
 };
 
 export const createCodexEventMapperPipeline = (
-  mappers: RegisteredCodexEventMapper[] = CODEX_EVENT_MAPPERS,
+  mappers: RegisteredCodexEventMapper[] = createCodexEventMappers(),
 ): CodexEventMapperPipeline => {
   const states = createMapperStates(mappers);
   return {

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -458,6 +458,32 @@ describe("Codex subagent event mapper", () => {
     ]);
   });
 
+  test("rejects terminal receiver updates without child agent state", () => {
+    const pipeline = createCodexEventMapperPipeline();
+
+    expect(() =>
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "wait-1",
+            tool: "wait",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            agentsStates: {},
+          },
+        },
+        {
+          source: "live",
+          threadId: "parent-thread",
+          timestamp: "2026-05-09T00:00:00.000Z",
+        },
+      ),
+    ).toThrow("missing collab agent state");
+  });
+
   test("lets later source-backed child errors override earlier completed state", () => {
     const pipeline = createCodexEventMapperPipeline();
     const ctx = {
@@ -511,6 +537,39 @@ describe("Codex subagent event mapper", () => {
         externalSessionId: "child-thread",
       }),
     ]);
+  });
+
+  test("keeps cancelled subagent status after idle inventory refresh", () => {
+    const subagents = new CodexSubagentLinkState();
+    const cancelled = subagents.upsertLink({
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "activity-1",
+      status: "cancelled",
+    });
+
+    expect(cancelled).toEqual(expect.objectContaining({ status: "cancelled" }));
+
+    subagents.recordThread({
+      id: "child-thread",
+      cwd: "/repo",
+      startedAt: "2026-05-09T00:00:00.000Z",
+      title: "Child",
+      status: { classification: "idle" },
+      parentThreadId: "parent-thread",
+      agentNickname: null,
+      agentRole: null,
+      subAgentSource: null,
+    });
+
+    expect(
+      subagents.upsertLink({
+        parentThreadId: "parent-thread",
+        childThreadId: "child-thread",
+        itemId: "probe-1",
+        status: "running",
+      }),
+    ).toEqual(expect.objectContaining({ status: "cancelled" }));
   });
 
   test("fails fast when one Codex child is linked to two parents", () => {

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -26,6 +26,16 @@ const projectedTool = (events: ReturnType<typeof projectCodexCanonicalEvents>) =
 const projectedTodos = (events: ReturnType<typeof projectCodexCanonicalEvents>) =>
   events.find((event) => event.type === "session_todos_updated");
 
+const projectedSubagents = (events: ReturnType<typeof projectCodexCanonicalEvents>) =>
+  events
+    .filter((event) => event.type === "assistant_part" && event.part.kind === "subagent")
+    .map((event) => {
+      if (event.type !== "assistant_part" || event.part.kind !== "subagent") {
+        throw new Error("Expected subagent part event");
+      }
+      return event.part;
+    });
+
 describe("Codex todo event mapper", () => {
   test("keeps live and thread-read todo updates in canonical parity", () => {
     const live = projectCodexCanonicalEvents(
@@ -182,6 +192,190 @@ describe("Codex todo event mapper", () => {
 
     expect(result.handled).toBe(false);
     expect(result.events).toEqual([]);
+  });
+});
+
+describe("Codex subagent event mapper", () => {
+  test("merges live spawn begin and completed events into one linked subagent row", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const ctx = {
+      source: "live" as const,
+      threadId: "parent-thread",
+      turnId: "turn-1",
+      timestamp: "2026-05-09T00:00:00.000Z",
+    };
+    const started = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_started",
+          item: {
+            type: "collabAgentToolCall",
+            id: "spawn-1",
+            tool: "spawnAgent",
+            status: "inProgress",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: [],
+            prompt: "Review the adapter",
+            agentsStates: {},
+          },
+        },
+        ctx,
+      ),
+    );
+    const completed = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "spawn-1",
+            tool: "spawnAgent",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            prompt: "Review the adapter",
+            agentsStates: {
+              "child-thread": { status: "running", message: null },
+            },
+          },
+        },
+        ctx,
+      ),
+    );
+
+    const [startedPart] = projectedSubagents(started);
+    const [completedPart] = projectedSubagents(completed);
+    expect(startedPart).toMatchObject({
+      kind: "subagent",
+      correlationKey: "codex-subagent:parent-thread:spawn-1",
+      status: "running",
+      prompt: "Review the adapter",
+    });
+    expect(startedPart?.externalSessionId).toBeUndefined();
+    expect(completedPart).toMatchObject({
+      kind: "subagent",
+      correlationKey: startedPart?.correlationKey,
+      status: "running",
+      externalSessionId: "child-thread",
+      executionMode: "background",
+    });
+  });
+
+  test("maps per-child agent states before aggregate collab status", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const events = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "wait-1",
+            tool: "wait",
+            status: "failed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-ok", "child-failed"],
+            prompt: null,
+            agentsStates: {
+              "child-ok": { status: "completed", message: null },
+              "child-failed": { status: "errored", message: "Tests failed" },
+            },
+          },
+        },
+        {
+          source: "live",
+          threadId: "parent-thread",
+          timestamp: "2026-05-09T00:00:00.000Z",
+        },
+      ),
+    );
+
+    expect(projectedSubagents(events)).toEqual([
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:child-ok",
+        status: "completed",
+        externalSessionId: "child-ok",
+      }),
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:child-failed",
+        status: "error",
+        error: "Tests failed",
+        externalSessionId: "child-failed",
+      }),
+    ]);
+  });
+
+  test("projects thread-read collab items to subagent history instead of generic collab tools", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const result = pipeline.runThreadItemResult(
+      {
+        index: 0,
+        timestamp: "2026-05-09T00:00:00.000Z",
+        item: {
+          type: "collabAgentToolCall",
+          id: "spawn-history",
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          prompt: "Summarize the failing tests",
+          agentsStates: {
+            "child-thread": { status: "completed", message: "Done" },
+          },
+        },
+      },
+      {
+        source: "thread_read",
+        threadId: "parent-thread",
+        timestamp: "2026-05-09T00:00:00.000Z",
+      },
+    );
+
+    expect(result.handled).toBe(true);
+    const [message] = projectCodexCanonicalEventsToHistory(result.events);
+    expect(message?.parts).toEqual([
+      expect.objectContaining({
+        kind: "subagent",
+        correlationKey: "codex-subagent:parent-thread:child-thread",
+        status: "completed",
+        externalSessionId: "child-thread",
+        description: "Done",
+      }),
+    ]);
+    expect(message?.parts).not.toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        tool: "collab.spawnAgent",
+      }),
+    ]);
+  });
+
+  test("fails fast on unknown Codex subagent statuses", () => {
+    const pipeline = createCodexEventMapperPipeline();
+
+    expect(() =>
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "wait-bad",
+            tool: "wait",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            prompt: null,
+            agentsStates: {
+              "child-thread": { status: "mystery", message: "Unknown" },
+            },
+          },
+        },
+        {
+          source: "live",
+          threadId: "parent-thread",
+          timestamp: "2026-05-09T00:00:00.000Z",
+        },
+      ),
+    ).toThrow("unknown collab agent status");
   });
 });
 

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
 import { createCodexEventMapperPipeline } from "./codex-event-mapper-pipeline";
 import { projectCodexCanonicalEventsToHistory } from "./codex-history-projector";
+import { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import { todoMapper } from "./event-mappers";
 
 const TODO_PAYLOAD = {
@@ -335,7 +336,7 @@ describe("Codex subagent event mapper", () => {
     expect(message?.parts).toEqual([
       expect.objectContaining({
         kind: "subagent",
-        correlationKey: "codex-subagent:parent-thread:child-thread",
+        correlationKey: "codex-subagent:parent-thread:spawn-history",
         status: "completed",
         externalSessionId: "child-thread",
         description: "Done",
@@ -376,6 +377,104 @@ describe("Codex subagent event mapper", () => {
         },
       ),
     ).toThrow("unknown collab agent status");
+  });
+
+  test("does not mark linked children completed from aggregate-only sendInput updates", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const ctx = {
+      source: "live" as const,
+      threadId: "parent-thread",
+      timestamp: "2026-05-09T00:00:00.000Z",
+    };
+    pipeline.runLive(
+      {
+        kind: "item_completed",
+        item: {
+          type: "collabAgentToolCall",
+          id: "spawn-1",
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          agentsStates: {
+            "child-thread": { status: "running" },
+          },
+        },
+      },
+      ctx,
+    );
+
+    const sendInputEvents = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "send-1",
+            tool: "sendInput",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            agentsStates: {},
+          },
+        },
+        ctx,
+      ),
+    );
+    const erroredEvents = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "wait-1",
+            tool: "wait",
+            status: "failed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            agentsStates: {
+              "child-thread": { status: "errored", message: "Child failed" },
+            },
+          },
+        },
+        ctx,
+      ),
+    );
+
+    expect(projectedSubagents(sendInputEvents)).toEqual([
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:spawn-1",
+        status: "running",
+        externalSessionId: "child-thread",
+      }),
+    ]);
+    expect(projectedSubagents(erroredEvents)).toEqual([
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:spawn-1",
+        status: "error",
+        error: "Child failed",
+        externalSessionId: "child-thread",
+      }),
+    ]);
+  });
+
+  test("fails fast when one Codex child is linked to two parents", () => {
+    const subagents = new CodexSubagentLinkState();
+    subagents.upsertLink({
+      parentThreadId: "parent-a",
+      childThreadId: "child-thread",
+      itemId: "spawn-a",
+      status: "running",
+    });
+
+    expect(() =>
+      subagents.upsertLink({
+        parentThreadId: "parent-b",
+        childThreadId: "child-thread",
+        itemId: "spawn-b",
+        status: "running",
+      }),
+    ).toThrow("already linked to parent");
   });
 });
 

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -458,6 +458,61 @@ describe("Codex subagent event mapper", () => {
     ]);
   });
 
+  test("lets later source-backed child errors override earlier completed state", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const ctx = {
+      source: "live" as const,
+      threadId: "parent-thread",
+      timestamp: "2026-05-09T00:00:00.000Z",
+    };
+    pipeline.runLive(
+      {
+        kind: "item_completed",
+        item: {
+          type: "collabAgentToolCall",
+          id: "spawn-1",
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          agentsStates: {
+            "child-thread": { status: "completed", message: "Spawned" },
+          },
+        },
+      },
+      ctx,
+    );
+
+    const erroredEvents = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "wait-1",
+            tool: "wait",
+            status: "failed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            agentsStates: {
+              "child-thread": { status: "errored", message: "Tests failed" },
+            },
+          },
+        },
+        ctx,
+      ),
+    );
+
+    expect(projectedSubagents(erroredEvents)).toEqual([
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:spawn-1",
+        status: "error",
+        error: "Tests failed",
+        externalSessionId: "child-thread",
+      }),
+    ]);
+  });
+
   test("fails fast when one Codex child is linked to two parents", () => {
     const subagents = new CodexSubagentLinkState();
     subagents.upsertLink({

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -421,6 +421,44 @@ describe("Codex subagent event mapper", () => {
     ]);
   });
 
+  test("leaves receiverless wait collab items to the generic collab mapper", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const events = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_started",
+          item: {
+            type: "collabAgentToolCall",
+            id: "wait-any",
+            tool: "wait",
+            status: "inProgress",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: [],
+            prompt: null,
+            agentsStates: {},
+          },
+        },
+        {
+          source: "live",
+          threadId: "parent-thread",
+          timestamp: "2026-05-09T00:00:00.000Z",
+        },
+      ),
+    );
+
+    expect(projectedSubagents(events)).toEqual([]);
+    expect(projectedTool(events)).toEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          tool: "collab.wait",
+          status: "running",
+        }),
+      }),
+    );
+  });
+
   test("keeps interrupted Codex subagents resumable", () => {
     const pipeline = createCodexEventMapperPipeline();
     const ctx = {

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -305,6 +305,73 @@ describe("Codex subagent event mapper", () => {
     ]);
   });
 
+  test("keeps interrupted Codex subagents resumable", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const ctx = {
+      source: "live" as const,
+      threadId: "parent-thread",
+      timestamp: "2026-05-09T00:00:00.000Z",
+    };
+    const interruptedEvents = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "wait-1",
+            tool: "wait",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            prompt: null,
+            agentsStates: {
+              "child-thread": { status: "interrupted", message: "Paused for input" },
+            },
+          },
+        },
+        ctx,
+      ),
+    );
+
+    expect(projectedSubagents(interruptedEvents)).toEqual([
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:child-thread",
+        status: "running",
+        description: "Paused for input",
+        externalSessionId: "child-thread",
+      }),
+    ]);
+
+    const resumedEvents = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "resume-1",
+            tool: "resumeAgent",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            prompt: null,
+            agentsStates: {
+              "child-thread": { status: "running", message: null },
+            },
+          },
+        },
+        ctx,
+      ),
+    );
+
+    expect(projectedSubagents(resumedEvents)).toEqual([
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:child-thread",
+        status: "running",
+        externalSessionId: "child-thread",
+      }),
+    ]);
+  });
+
   test("projects thread-read collab items to subagent history instead of generic collab tools", () => {
     const pipeline = createCodexEventMapperPipeline();
     const result = pipeline.runThreadItemResult(

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -260,8 +260,8 @@ describe("Codex subagent event mapper", () => {
       status: "running",
       externalSessionId: "child-thread",
       description: "Review the adapter",
-      executionMode: "background",
     });
+    expect(completedPart?.executionMode).toBeUndefined();
   });
 
   test("keeps subagent description short and tied to the creation prompt", () => {

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -264,6 +264,46 @@ describe("Codex subagent event mapper", () => {
     expect(completedPart?.executionMode).toBeUndefined();
   });
 
+  test("maps documented collabToolCall spawn fields to a linked subagent row", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const ctx = {
+      source: "live" as const,
+      threadId: "parent-thread",
+      turnId: "turn-1",
+      timestamp: "2026-05-09T00:00:00.000Z",
+    };
+
+    const started = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_started",
+          item: {
+            type: "collabToolCall",
+            id: "spawn-1",
+            tool: "spawnAgent",
+            status: "inProgress",
+            senderThreadId: "parent-thread",
+            newThreadId: "child-thread",
+            receiverThreadId: "child-thread",
+            prompt: "Review the adapter",
+            agentStatus: "running",
+          },
+        },
+        ctx,
+      ),
+    );
+
+    const [startedPart] = projectedSubagents(started);
+    expect(startedPart).toMatchObject({
+      kind: "subagent",
+      correlationKey: "codex-subagent:parent-thread:spawn-1",
+      status: "running",
+      externalSessionId: "child-thread",
+      prompt: "Review the adapter",
+      description: "Review the adapter",
+    });
+  });
+
   test("keeps subagent description short and tied to the creation prompt", () => {
     const pipeline = createCodexEventMapperPipeline();
     const ctx = {
@@ -434,6 +474,44 @@ describe("Codex subagent event mapper", () => {
             status: "inProgress",
             senderThreadId: "parent-thread",
             receiverThreadIds: [],
+            prompt: null,
+            agentsStates: {},
+          },
+        },
+        {
+          source: "live",
+          threadId: "parent-thread",
+          timestamp: "2026-05-09T00:00:00.000Z",
+        },
+      ),
+    );
+
+    expect(projectedSubagents(events)).toEqual([]);
+    expect(projectedTool(events)).toEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          tool: "collab.wait",
+          status: "running",
+        }),
+      }),
+    );
+  });
+
+  test("leaves null receiver wait collab items to the generic collab mapper", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const events = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_started",
+          item: {
+            type: "collabAgentToolCall",
+            id: "wait-any",
+            tool: "wait",
+            status: "inProgress",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: null,
             prompt: null,
             agentsStates: {},
           },
@@ -755,6 +833,58 @@ describe("Codex subagent event mapper", () => {
         correlationKey: "codex-subagent:parent-thread:spawn-1",
         status: "error",
         error: "Tests failed",
+        externalSessionId: "child-thread",
+      }),
+    ]);
+  });
+
+  test("keeps completed subagent status after later close cleanup", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const ctx = {
+      source: "live" as const,
+      threadId: "parent-thread",
+      timestamp: "2026-05-09T00:00:00.000Z",
+    };
+    pipeline.runLive(
+      {
+        kind: "item_completed",
+        item: {
+          type: "collabAgentToolCall",
+          id: "spawn-1",
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          agentsStates: {
+            "child-thread": { status: "completed", message: "Done" },
+          },
+        },
+      },
+      ctx,
+    );
+
+    const closeEvents = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "close-1",
+            tool: "closeAgent",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            agentsStates: {},
+          },
+        },
+        ctx,
+      ),
+    );
+
+    expect(projectedSubagents(closeEvents)).toEqual([
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:spawn-1",
+        status: "completed",
         externalSessionId: "child-thread",
       }),
     ]);

--- a/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-event-mappers.test.ts
@@ -251,6 +251,7 @@ describe("Codex subagent event mapper", () => {
       correlationKey: "codex-subagent:parent-thread:spawn-1",
       status: "running",
       prompt: "Review the adapter",
+      description: "Review the adapter",
     });
     expect(startedPart?.externalSessionId).toBeUndefined();
     expect(completedPart).toMatchObject({
@@ -258,8 +259,123 @@ describe("Codex subagent event mapper", () => {
       correlationKey: startedPart?.correlationKey,
       status: "running",
       externalSessionId: "child-thread",
+      description: "Review the adapter",
       executionMode: "background",
     });
+  });
+
+  test("keeps subagent description short and tied to the creation prompt", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const ctx = {
+      source: "live" as const,
+      threadId: "parent-thread",
+      timestamp: "2026-05-09T00:00:00.000Z",
+    };
+    const prompt =
+      "Read the file `~/maxsky5.omp.json` and report back the file contents or, if it is large, a concise summary of the key fields. This is read-only.";
+    const fullResponse =
+      "`/Users/maxsky5/maxsky5.omp.json` exists and is a Oh My Posh theme config.\n\nKey fields:\n- `$schema`: https://example.test/schema.json\n- `version`: 4";
+
+    pipeline.runLive(
+      {
+        kind: "item_started",
+        item: {
+          type: "collabAgentToolCall",
+          id: "spawn-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: [],
+          prompt,
+          agentsStates: {},
+        },
+      },
+      ctx,
+    );
+    const completed = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "spawn-1",
+            tool: "spawnAgent",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            prompt,
+            agentsStates: {
+              "child-thread": { status: "completed", message: fullResponse },
+            },
+          },
+        },
+        ctx,
+      ),
+    );
+
+    const [completedPart] = projectedSubagents(completed);
+    expect(completedPart).toMatchObject({
+      status: "completed",
+      prompt,
+      externalSessionId: "child-thread",
+    });
+    expect(completedPart?.description).toBeDefined();
+    expect(completedPart?.description?.length ?? 0).toBeLessThanOrEqual(140);
+    expect(completedPart?.description?.startsWith("Read the file")).toBe(true);
+    expect(completedPart?.description).not.toContain("Key fields");
+  });
+
+  test("marks failed provisional spawn rows as error without losing creation description", () => {
+    const pipeline = createCodexEventMapperPipeline();
+    const ctx = {
+      source: "live" as const,
+      threadId: "parent-thread",
+      timestamp: "2026-05-09T00:00:00.000Z",
+    };
+    pipeline.runLive(
+      {
+        kind: "item_started",
+        item: {
+          type: "collabAgentToolCall",
+          id: "spawn-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: [],
+          prompt: "Inspect config safely",
+          agentsStates: {},
+        },
+      },
+      ctx,
+    );
+
+    const failed = projectCodexCanonicalEvents(
+      pipeline.runLive(
+        {
+          kind: "item_completed",
+          item: {
+            type: "collabAgentToolCall",
+            id: "spawn-1",
+            tool: "spawnAgent",
+            status: "failed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: [],
+            prompt: "Inspect config safely",
+            agentsStates: {},
+          },
+        },
+        ctx,
+      ),
+    );
+
+    expect(projectedSubagents(failed)).toEqual([
+      expect.objectContaining({
+        correlationKey: "codex-subagent:parent-thread:spawn-1",
+        status: "error",
+        description: "Inspect config safely",
+        error: "Codex spawnAgent subagent call failed.",
+      }),
+    ]);
   });
 
   test("maps per-child agent states before aggregate collab status", () => {
@@ -337,10 +453,10 @@ describe("Codex subagent event mapper", () => {
       expect.objectContaining({
         correlationKey: "codex-subagent:parent-thread:child-thread",
         status: "running",
-        description: "Paused for input",
         externalSessionId: "child-thread",
       }),
     ]);
+    expect(projectedSubagents(interruptedEvents)[0]?.description).toBeUndefined();
 
     const resumedEvents = projectCodexCanonicalEvents(
       pipeline.runLive(
@@ -406,7 +522,7 @@ describe("Codex subagent event mapper", () => {
         correlationKey: "codex-subagent:parent-thread:spawn-history",
         status: "completed",
         externalSessionId: "child-thread",
-        description: "Done",
+        description: "Summarize the failing tests",
       }),
     ]);
     expect(message?.parts).not.toEqual([

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
@@ -24,6 +24,7 @@ const createStore = () => {
   const clearedSessionEvents: string[] = [];
   const clearedPendingInput: string[] = [];
   const clearedRuntimeEvents: string[] = [];
+  const clearedSubagents: string[] = [];
   const clearedThreadStatusOverrides: Array<{ runtimeId: string; threadId: string }> = [];
   const drainedRuntimeEvents: string[] = [];
   const stoppedRuntimeSubscriptions: string[] = [];
@@ -35,6 +36,9 @@ const createStore = () => {
     activeTurnsBySessionId,
     pendingInput: {
       clearSession: (externalSessionId) => clearedPendingInput.push(externalSessionId),
+    },
+    subagents: {
+      clearSession: (externalSessionId) => clearedSubagents.push(externalSessionId),
     },
     threadStatusOverrides: {
       clear: (runtimeId, threadId) => clearedThreadStatusOverrides.push({ runtimeId, threadId }),
@@ -53,6 +57,7 @@ const createStore = () => {
     clearedSessionEvents,
     clearedPendingInput,
     clearedRuntimeEvents,
+    clearedSubagents,
     clearedThreadStatusOverrides,
     drainedRuntimeEvents,
     stoppedRuntimeSubscriptions,
@@ -79,6 +84,7 @@ describe("CodexLocalSessionState", () => {
       clearedSessionEvents,
       clearedPendingInput,
       clearedRuntimeEvents,
+      clearedSubagents,
       clearedThreadStatusOverrides,
       stoppedRuntimeSubscriptions,
     } = createStore();
@@ -97,6 +103,7 @@ describe("CodexLocalSessionState", () => {
     expect(clearedSessionEvents).toEqual(["thread-1"]);
     expect(clearedPendingInput).toEqual(["thread-1"]);
     expect(clearedRuntimeEvents).toEqual(["thread-1"]);
+    expect(clearedSubagents).toEqual(["thread-1"]);
     expect(clearedThreadStatusOverrides).toEqual([
       { runtimeId: "runtime-1", threadId: "thread-1" },
     ]);

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
@@ -23,8 +23,8 @@ const session = (threadId: string, runtimeId = "runtime-1"): CodexSessionState =
 const createStore = () => {
   const clearedSessionEvents: string[] = [];
   const clearedPendingInput: string[] = [];
-  const clearedRuntimeEvents: string[] = [];
-  const clearedSubagents: string[] = [];
+  const clearedRuntimeEvents: Array<{ externalSessionId: string; runtimeId?: string }> = [];
+  const clearedSubagents: Array<{ externalSessionId: string; runtimeId?: string }> = [];
   const clearedThreadStatusOverrides: Array<{ runtimeId: string; threadId: string }> = [];
   const drainedRuntimeEvents: string[] = [];
   const stoppedRuntimeSubscriptions: string[] = [];
@@ -38,13 +38,15 @@ const createStore = () => {
       clearSession: (externalSessionId) => clearedPendingInput.push(externalSessionId),
     },
     subagents: {
-      clearSession: (externalSessionId) => clearedSubagents.push(externalSessionId),
+      clearSession: (externalSessionId, runtimeId) =>
+        clearedSubagents.push({ externalSessionId, runtimeId }),
     },
     threadStatusOverrides: {
       clear: (runtimeId, threadId) => clearedThreadStatusOverrides.push({ runtimeId, threadId }),
     },
     runtimeEvents: {
-      clearSession: (externalSessionId) => clearedRuntimeEvents.push(externalSessionId),
+      clearSession: (externalSessionId, runtimeId) =>
+        clearedRuntimeEvents.push({ externalSessionId, runtimeId }),
       drainBufferedStreamEvents: async (externalSessionId) => {
         drainedRuntimeEvents.push(externalSessionId);
       },
@@ -102,8 +104,10 @@ describe("CodexLocalSessionState", () => {
     expect(activeTurnsBySessionId.has("thread-2")).toBe(true);
     expect(clearedSessionEvents).toEqual(["thread-1"]);
     expect(clearedPendingInput).toEqual(["thread-1"]);
-    expect(clearedRuntimeEvents).toEqual(["thread-1"]);
-    expect(clearedSubagents).toEqual(["thread-1"]);
+    expect(clearedRuntimeEvents).toEqual([
+      { externalSessionId: "thread-1", runtimeId: "runtime-1" },
+    ]);
+    expect(clearedSubagents).toEqual([{ externalSessionId: "thread-1", runtimeId: "runtime-1" }]);
     expect(clearedThreadStatusOverrides).toEqual([
       { runtimeId: "runtime-1", threadId: "thread-1" },
     ]);

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.ts
@@ -9,6 +9,7 @@ type CodexLocalSessionStateDeps = {
   sessionEvents: { clear(session: CodexSessionState): void };
   activeTurnsBySessionId: { delete(externalSessionId: string): boolean };
   pendingInput: { clearSession(externalSessionId: string): void };
+  subagents: { clearSession(externalSessionId: string): void };
   threadStatusOverrides: { clear(runtimeId: string, threadId: string): void };
   runtimeEvents: {
     clearSession(externalSessionId: string): void;
@@ -56,6 +57,7 @@ export class CodexLocalSessionState implements CodexSessionLookup {
     }
     this.deps.activeTurnsBySessionId.delete(externalSessionId);
     this.deps.pendingInput.clearSession(externalSessionId);
+    this.deps.subagents.clearSession(externalSessionId);
     this.deps.runtimeEvents.clearSession(externalSessionId);
     return session;
   }

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.ts
@@ -9,10 +9,10 @@ type CodexLocalSessionStateDeps = {
   sessionEvents: { clear(session: CodexSessionState): void };
   activeTurnsBySessionId: { delete(externalSessionId: string): boolean };
   pendingInput: { clearSession(externalSessionId: string): void };
-  subagents: { clearSession(externalSessionId: string): void };
+  subagents: { clearSession(externalSessionId: string, runtimeId?: string): void };
   threadStatusOverrides: { clear(runtimeId: string, threadId: string): void };
   runtimeEvents: {
-    clearSession(externalSessionId: string): void;
+    clearSession(externalSessionId: string, runtimeId?: string): void;
     drainBufferedStreamEvents(externalSessionId: string): Promise<void>;
     stopRuntimeEventSubscription(runtimeId: string): void;
   };
@@ -57,8 +57,8 @@ export class CodexLocalSessionState implements CodexSessionLookup {
     }
     this.deps.activeTurnsBySessionId.delete(externalSessionId);
     this.deps.pendingInput.clearSession(externalSessionId);
-    this.deps.subagents.clearSession(externalSessionId);
-    this.deps.runtimeEvents.clearSession(externalSessionId);
+    this.deps.subagents.clearSession(externalSessionId, session?.runtimeId);
+    this.deps.runtimeEvents.clearSession(externalSessionId, session?.runtimeId);
     return session;
   }
 

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.test.ts
@@ -91,7 +91,7 @@ describe("CodexPendingInputState", () => {
     );
   });
 
-  test("mirrors child pending input to the parent without changing reply ownership", () => {
+  test("mirrors child pending input to the parent while preserving reply ownership", () => {
     const pendingInput = new CodexPendingInputState();
     const route = {
       parentExternalSessionId: "parent-thread",
@@ -121,9 +121,12 @@ describe("CodexPendingInputState", () => {
     expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toEqual([
       { request: questionRequest("question-1"), route },
     ]);
-    expect(() => pendingInput.requireApprovalForSession("approval-1", "parent-thread")).toThrow(
-      "belongs to session 'child-thread', not 'parent-thread'",
-    );
+    expect(pendingInput.requireApprovalForSession("approval-1", "parent-thread")).toMatchObject({
+      threadId: "child-thread",
+    });
+    expect(pendingInput.requireQuestionForSession("question-1", "parent-thread")).toMatchObject({
+      threadId: "child-thread",
+    });
     expect(pendingInput.requireApprovalForSession("approval-1", "child-thread")).toMatchObject({
       threadId: "child-thread",
     });

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { ActiveCodexTurn } from "./codex-app-server-shared";
 import { CodexPendingInputState } from "./codex-pending-input-state";
 
 const approvalRequest = (requestId: string) => ({
@@ -132,6 +133,69 @@ describe("CodexPendingInputState", () => {
 
     expect(pendingInput.pendingApprovalEventsForSession("parent-thread")).toEqual([]);
     expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toEqual([]);
+  });
+
+  test("adds a learned child route to existing owner-scoped pending input", () => {
+    const pendingInput = new CodexPendingInputState();
+    const route = {
+      parentExternalSessionId: "parent-thread",
+      childExternalSessionId: "child-thread",
+      subagentCorrelationKey: "codex-subagent:parent-thread:child-thread",
+    };
+    pendingInput.addApproval({
+      runtimeId: "runtime-1",
+      threadId: "child-thread",
+      request: approvalRequest("approval-1"),
+    });
+    pendingInput.addQuestion({
+      runtimeId: "runtime-1",
+      threadId: "child-thread",
+      request: questionRequest("question-1"),
+      questionIds: ["question-item-1"],
+      input: { requestId: "question-1" },
+    });
+
+    expect(pendingInput.pendingApprovalEventsForSession("parent-thread")).toEqual([]);
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toEqual([]);
+
+    expect(pendingInput.applyRouteToPendingInput(route)).toEqual({
+      approvals: [expect.objectContaining({ request: approvalRequest("approval-1"), route })],
+      questions: [expect.objectContaining({ request: questionRequest("question-1"), route })],
+    });
+
+    expect(pendingInput.approval("approval-1")).toMatchObject({ route });
+    expect(pendingInput.question("question-1")).toMatchObject({ route });
+    expect(pendingInput.pendingApprovalEventsForSession("parent-thread")).toEqual([
+      { request: approvalRequest("approval-1"), route },
+    ]);
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toEqual([
+      { request: questionRequest("question-1"), route },
+    ]);
+  });
+
+  test("binds parent active turns to mirrored child pending input", () => {
+    const pendingInput = new CodexPendingInputState();
+    const route = {
+      parentExternalSessionId: "parent-thread",
+      childExternalSessionId: "child-thread",
+      subagentCorrelationKey: "codex-subagent:parent-thread:child-thread",
+    };
+    const activeTurn = {
+      session: { threadId: "parent-thread" },
+    } as unknown as ActiveCodexTurn;
+
+    pendingInput.addQuestion({
+      runtimeId: "runtime-1",
+      threadId: "child-thread",
+      request: questionRequest("question-1"),
+      questionIds: ["question-item-1"],
+      input: { requestId: "question-1" },
+      route,
+    });
+
+    pendingInput.bindActiveTurn("parent-thread", activeTurn);
+
+    expect(pendingInput.resolveQuestion("question-1")).toBe(activeTurn);
   });
 
   test("clears all pending input for one session only", () => {

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.test.ts
@@ -90,6 +90,50 @@ describe("CodexPendingInputState", () => {
     );
   });
 
+  test("mirrors child pending input to the parent without changing reply ownership", () => {
+    const pendingInput = new CodexPendingInputState();
+    const route = {
+      parentExternalSessionId: "parent-thread",
+      childExternalSessionId: "child-thread",
+      subagentCorrelationKey: "codex-subagent:parent-thread:child-thread",
+    };
+    pendingInput.addApproval({
+      runtimeId: "runtime-1",
+      threadId: "child-thread",
+      request: approvalRequest("approval-1"),
+      route,
+    });
+    pendingInput.addQuestion({
+      runtimeId: "runtime-1",
+      threadId: "child-thread",
+      request: questionRequest("question-1"),
+      questionIds: ["question-item-1"],
+      input: { requestId: "question-1" },
+      route,
+    });
+
+    expect(pendingInput.pendingApprovalsForSession("parent-thread")).toEqual([]);
+    expect(pendingInput.pendingQuestionsForSession("parent-thread")).toEqual([]);
+    expect(pendingInput.pendingApprovalEventsForSession("parent-thread")).toEqual([
+      { request: approvalRequest("approval-1"), route },
+    ]);
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toEqual([
+      { request: questionRequest("question-1"), route },
+    ]);
+    expect(() => pendingInput.requireApprovalForSession("approval-1", "parent-thread")).toThrow(
+      "belongs to session 'child-thread', not 'parent-thread'",
+    );
+    expect(pendingInput.requireApprovalForSession("approval-1", "child-thread")).toMatchObject({
+      threadId: "child-thread",
+    });
+
+    pendingInput.resolveApproval("approval-1");
+    pendingInput.resolveQuestion("question-1");
+
+    expect(pendingInput.pendingApprovalEventsForSession("parent-thread")).toEqual([]);
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toEqual([]);
+  });
+
   test("clears all pending input for one session only", () => {
     const pendingInput = new CodexPendingInputState();
     pendingInput.addApproval({

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.test.ts
@@ -176,7 +176,7 @@ describe("CodexPendingInputState", () => {
     ]);
   });
 
-  test("binds parent active turns to mirrored child pending input", () => {
+  test("does not bind parent active turns to mirrored child pending input", () => {
     const pendingInput = new CodexPendingInputState();
     const route = {
       parentExternalSessionId: "parent-thread",
@@ -197,6 +197,32 @@ describe("CodexPendingInputState", () => {
     });
 
     pendingInput.bindActiveTurn("parent-thread", activeTurn);
+
+    expect(pendingInput.resolveQuestion("question-1")).toBeUndefined();
+  });
+
+  test("clearing a parent mirror preserves child pending input turn ownership", () => {
+    const pendingInput = new CodexPendingInputState();
+    const route = {
+      parentExternalSessionId: "parent-thread",
+      childExternalSessionId: "child-thread",
+      subagentCorrelationKey: "codex-subagent:parent-thread:child-thread",
+    };
+    const activeTurn = {
+      session: { threadId: "child-thread" },
+    } as unknown as ActiveCodexTurn;
+
+    pendingInput.addQuestion({
+      runtimeId: "runtime-1",
+      threadId: "child-thread",
+      request: questionRequest("question-1"),
+      questionIds: ["question-item-1"],
+      input: { requestId: "question-1" },
+      route,
+    });
+
+    pendingInput.bindActiveTurn("child-thread", activeTurn);
+    pendingInput.clearSession("parent-thread");
 
     expect(pendingInput.resolveQuestion("question-1")).toBe(activeTurn);
   });

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
@@ -34,6 +34,7 @@ export type PendingInputRouteApplication = {
 };
 
 const sameRoute = (a: CodexSubagentRoute, b: CodexSubagentRoute): boolean =>
+  a.runtimeId === b.runtimeId &&
   a.parentExternalSessionId === b.parentExternalSessionId &&
   a.childExternalSessionId === b.childExternalSessionId &&
   a.subagentCorrelationKey === b.subagentCorrelationKey;
@@ -293,6 +294,7 @@ export class CodexPendingInputState {
     return this.applyRoute(
       "approval",
       entry.request.requestId,
+      entry.runtimeId,
       entry.threadId,
       entry.route,
       route,
@@ -307,6 +309,7 @@ export class CodexPendingInputState {
     return this.applyRoute(
       "question",
       entry.request.requestId,
+      entry.runtimeId,
       entry.threadId,
       entry.route,
       route,
@@ -320,12 +323,16 @@ export class CodexPendingInputState {
   private applyRoute(
     kind: "approval" | "question",
     requestId: string,
+    runtimeId: string,
     ownerThreadId: string,
     existingRoute: CodexSubagentRoute | undefined,
     route: CodexSubagentRoute,
     setRoute: (route: CodexSubagentRoute) => void,
     mirrorIndex: Map<string, Set<string>>,
   ): boolean {
+    if (route.runtimeId && route.runtimeId !== runtimeId) {
+      return false;
+    }
     if (ownerThreadId !== route.childExternalSessionId) {
       return false;
     }

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
@@ -87,7 +87,13 @@ export class CodexPendingInputState {
     if (!approval) {
       throw new Error(`Unknown Codex approval request '${requestId}'.`);
     }
-    this.requireRequestSession("approval", requestId, approval.threadId, externalSessionId);
+    this.requireRequestSession(
+      "approval",
+      requestId,
+      approval.threadId,
+      externalSessionId,
+      approval.route,
+    );
     return approval;
   }
 
@@ -96,7 +102,13 @@ export class CodexPendingInputState {
     if (!question) {
       throw new Error(`Unknown Codex question request '${requestId}'.`);
     }
-    this.requireRequestSession("question", requestId, question.threadId, externalSessionId);
+    this.requireRequestSession(
+      "question",
+      requestId,
+      question.threadId,
+      externalSessionId,
+      question.route,
+    );
     return question;
   }
 
@@ -334,8 +346,16 @@ export class CodexPendingInputState {
     requestId: string,
     ownerSessionId: string,
     externalSessionId: string,
+    route: CodexSubagentRoute | undefined,
   ): void {
     if (ownerSessionId === externalSessionId) {
+      return;
+    }
+    if (
+      route &&
+      route.childExternalSessionId === ownerSessionId &&
+      route.parentExternalSessionId === externalSessionId
+    ) {
       return;
     }
     throw new Error(

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
@@ -189,8 +189,6 @@ export class CodexPendingInputState {
     const approvalEntries = this.pendingApprovalEntriesForIndex(
       this.pendingApprovalIdsBySessionId,
       externalSessionId,
-    ).concat(
-      this.pendingApprovalEntriesForIndex(this.mirroredApprovalIdsBySessionId, externalSessionId),
     );
     for (const approval of approvalEntries) {
       this.activeTurnsByApprovalRequestId.set(approval.request.requestId, activeTurn);
@@ -199,8 +197,6 @@ export class CodexPendingInputState {
     const questionEntries = this.pendingQuestionEntriesForIndex(
       this.pendingQuestionIdsBySessionId,
       externalSessionId,
-    ).concat(
-      this.pendingQuestionEntriesForIndex(this.mirroredQuestionIdsBySessionId, externalSessionId),
     );
     for (const question of questionEntries) {
       this.activeTurnsByQuestionRequestId.set(question.request.requestId, activeTurn);

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
@@ -28,6 +28,16 @@ export type PendingQuestionEventEntry = {
   route?: CodexSubagentRoute;
 };
 
+export type PendingInputRouteApplication = {
+  approvals: PendingApprovalEventEntry[];
+  questions: PendingQuestionEventEntry[];
+};
+
+const sameRoute = (a: CodexSubagentRoute, b: CodexSubagentRoute): boolean =>
+  a.parentExternalSessionId === b.parentExternalSessionId &&
+  a.childExternalSessionId === b.childExternalSessionId &&
+  a.subagentCorrelationKey === b.subagentCorrelationKey;
+
 export class CodexPendingInputState {
   private readonly pendingApprovalsByRequestId = new Map<string, PendingApprovalEntry>();
   private readonly pendingApprovalIdsBySessionId = new Map<string, Set<string>>();
@@ -138,12 +148,49 @@ export class CodexPendingInputState {
       }));
   }
 
-  bindActiveTurn(externalSessionId: string, activeTurn: ActiveCodexTurn): void {
-    for (const approval of this.pendingApprovalsForSession(externalSessionId)) {
-      this.activeTurnsByApprovalRequestId.set(approval.requestId, activeTurn);
+  applyRouteToPendingInput(route: CodexSubagentRoute): PendingInputRouteApplication {
+    const approvals: PendingApprovalEventEntry[] = [];
+    for (const entry of this.pendingApprovalEntriesForIndex(
+      this.pendingApprovalIdsBySessionId,
+      route.childExternalSessionId,
+    )) {
+      if (this.applyApprovalRoute(entry, route)) {
+        approvals.push({ request: entry.request, route });
+      }
     }
-    for (const question of this.pendingQuestionsForSession(externalSessionId)) {
-      this.activeTurnsByQuestionRequestId.set(question.requestId, activeTurn);
+
+    const questions: PendingQuestionEventEntry[] = [];
+    for (const entry of this.pendingQuestionEntriesForIndex(
+      this.pendingQuestionIdsBySessionId,
+      route.childExternalSessionId,
+    )) {
+      if (this.applyQuestionRoute(entry, route)) {
+        questions.push({ request: entry.request, route });
+      }
+    }
+
+    return { approvals, questions };
+  }
+
+  bindActiveTurn(externalSessionId: string, activeTurn: ActiveCodexTurn): void {
+    const approvalEntries = this.pendingApprovalEntriesForIndex(
+      this.pendingApprovalIdsBySessionId,
+      externalSessionId,
+    ).concat(
+      this.pendingApprovalEntriesForIndex(this.mirroredApprovalIdsBySessionId, externalSessionId),
+    );
+    for (const approval of approvalEntries) {
+      this.activeTurnsByApprovalRequestId.set(approval.request.requestId, activeTurn);
+    }
+
+    const questionEntries = this.pendingQuestionEntriesForIndex(
+      this.pendingQuestionIdsBySessionId,
+      externalSessionId,
+    ).concat(
+      this.pendingQuestionEntriesForIndex(this.mirroredQuestionIdsBySessionId, externalSessionId),
+    );
+    for (const question of questionEntries) {
+      this.activeTurnsByQuestionRequestId.set(question.request.requestId, activeTurn);
     }
   }
 
@@ -228,6 +275,58 @@ export class CodexPendingInputState {
         index.delete(threadId);
       }
     }
+  }
+
+  private applyApprovalRoute(entry: PendingApprovalEntry, route: CodexSubagentRoute): boolean {
+    return this.applyRoute(
+      "approval",
+      entry.request.requestId,
+      entry.threadId,
+      entry.route,
+      route,
+      (nextRoute) => {
+        entry.route = nextRoute;
+      },
+      this.mirroredApprovalIdsBySessionId,
+    );
+  }
+
+  private applyQuestionRoute(entry: PendingQuestionEntry, route: CodexSubagentRoute): boolean {
+    return this.applyRoute(
+      "question",
+      entry.request.requestId,
+      entry.threadId,
+      entry.route,
+      route,
+      (nextRoute) => {
+        entry.route = nextRoute;
+      },
+      this.mirroredQuestionIdsBySessionId,
+    );
+  }
+
+  private applyRoute(
+    kind: "approval" | "question",
+    requestId: string,
+    ownerThreadId: string,
+    existingRoute: CodexSubagentRoute | undefined,
+    route: CodexSubagentRoute,
+    setRoute: (route: CodexSubagentRoute) => void,
+    mirrorIndex: Map<string, Set<string>>,
+  ): boolean {
+    if (ownerThreadId !== route.childExternalSessionId) {
+      return false;
+    }
+    if (existingRoute && !sameRoute(existingRoute, route)) {
+      throw new Error(
+        `Codex ${kind} request '${requestId}' already has route '${existingRoute.parentExternalSessionId}' -> '${existingRoute.childExternalSessionId}', not '${route.parentExternalSessionId}' -> '${route.childExternalSessionId}'.`,
+      );
+    }
+
+    const wasMirrored = mirrorIndex.get(route.parentExternalSessionId)?.has(requestId) ?? false;
+    setRoute(route);
+    this.addSessionRequestId(mirrorIndex, route.parentExternalSessionId, requestId);
+    return !wasMirrored;
   }
 
   private requireRequestSession(

--- a/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-pending-input-state.ts
@@ -1,10 +1,12 @@
 import type { AgentPendingApprovalRequest, AgentPendingQuestionRequest } from "@openducktor/core";
 import type { ActiveCodexTurn } from "./codex-app-server-shared";
+import type { CodexSubagentRoute } from "./codex-subagent-link-state";
 
 export type PendingApprovalEntry = {
   runtimeId: string;
   threadId: string;
   request: AgentPendingApprovalRequest;
+  route?: CodexSubagentRoute;
 };
 
 export type PendingQuestionEntry = {
@@ -13,13 +15,26 @@ export type PendingQuestionEntry = {
   request: AgentPendingQuestionRequest;
   questionIds: string[];
   input: Record<string, unknown>;
+  route?: CodexSubagentRoute;
+};
+
+export type PendingApprovalEventEntry = {
+  request: AgentPendingApprovalRequest;
+  route?: CodexSubagentRoute;
+};
+
+export type PendingQuestionEventEntry = {
+  request: AgentPendingQuestionRequest;
+  route?: CodexSubagentRoute;
 };
 
 export class CodexPendingInputState {
   private readonly pendingApprovalsByRequestId = new Map<string, PendingApprovalEntry>();
   private readonly pendingApprovalIdsBySessionId = new Map<string, Set<string>>();
+  private readonly mirroredApprovalIdsBySessionId = new Map<string, Set<string>>();
   private readonly pendingQuestionsByRequestId = new Map<string, PendingQuestionEntry>();
   private readonly pendingQuestionIdsBySessionId = new Map<string, Set<string>>();
+  private readonly mirroredQuestionIdsBySessionId = new Map<string, Set<string>>();
   private readonly activeTurnsByApprovalRequestId = new Map<string, ActiveCodexTurn>();
   private readonly activeTurnsByQuestionRequestId = new Map<string, ActiveCodexTurn>();
 
@@ -27,12 +42,26 @@ export class CodexPendingInputState {
     const requestId = entry.request.requestId;
     this.pendingApprovalsByRequestId.set(requestId, entry);
     this.addSessionRequestId(this.pendingApprovalIdsBySessionId, entry.threadId, requestId);
+    if (entry.route) {
+      this.addSessionRequestId(
+        this.mirroredApprovalIdsBySessionId,
+        entry.route.parentExternalSessionId,
+        requestId,
+      );
+    }
   }
 
   addQuestion(entry: PendingQuestionEntry): void {
     const requestId = entry.request.requestId;
     this.pendingQuestionsByRequestId.set(requestId, entry);
     this.addSessionRequestId(this.pendingQuestionIdsBySessionId, entry.threadId, requestId);
+    if (entry.route) {
+      this.addSessionRequestId(
+        this.mirroredQuestionIdsBySessionId,
+        entry.route.parentExternalSessionId,
+        requestId,
+      );
+    }
   }
 
   approval(requestId: string): PendingApprovalEntry | undefined {
@@ -71,6 +100,20 @@ export class CodexPendingInputState {
       .filter((request): request is AgentPendingApprovalRequest => Boolean(request));
   }
 
+  pendingApprovalEventsForSession(externalSessionId: string): PendingApprovalEventEntry[] {
+    return this.pendingApprovalEntriesForIndex(
+      this.pendingApprovalIdsBySessionId,
+      externalSessionId,
+    )
+      .concat(
+        this.pendingApprovalEntriesForIndex(this.mirroredApprovalIdsBySessionId, externalSessionId),
+      )
+      .map((entry) => ({
+        request: entry.request,
+        ...(entry.route ? { route: entry.route } : {}),
+      }));
+  }
+
   pendingQuestionsForSession(externalSessionId: string): AgentPendingQuestionRequest[] {
     const requestIds = this.pendingQuestionIdsBySessionId.get(externalSessionId);
     if (!requestIds) {
@@ -79,6 +122,20 @@ export class CodexPendingInputState {
     return [...requestIds]
       .map((requestId) => this.pendingQuestionsByRequestId.get(requestId)?.request)
       .filter((request): request is AgentPendingQuestionRequest => Boolean(request));
+  }
+
+  pendingQuestionEventsForSession(externalSessionId: string): PendingQuestionEventEntry[] {
+    return this.pendingQuestionEntriesForIndex(
+      this.pendingQuestionIdsBySessionId,
+      externalSessionId,
+    )
+      .concat(
+        this.pendingQuestionEntriesForIndex(this.mirroredQuestionIdsBySessionId, externalSessionId),
+      )
+      .map((entry) => ({
+        request: entry.request,
+        ...(entry.route ? { route: entry.route } : {}),
+      }));
   }
 
   bindActiveTurn(externalSessionId: string, activeTurn: ActiveCodexTurn): void {
@@ -95,6 +152,7 @@ export class CodexPendingInputState {
     this.pendingApprovalsByRequestId.delete(requestId);
     this.activeTurnsByApprovalRequestId.delete(requestId);
     this.deleteSessionRequestId(this.pendingApprovalIdsBySessionId, requestId);
+    this.deleteSessionRequestId(this.mirroredApprovalIdsBySessionId, requestId);
     return activeTurn;
   }
 
@@ -103,6 +161,7 @@ export class CodexPendingInputState {
     this.pendingQuestionsByRequestId.delete(requestId);
     this.activeTurnsByQuestionRequestId.delete(requestId);
     this.deleteSessionRequestId(this.pendingQuestionIdsBySessionId, requestId);
+    this.deleteSessionRequestId(this.mirroredQuestionIdsBySessionId, requestId);
     return activeTurn;
   }
 
@@ -111,15 +170,45 @@ export class CodexPendingInputState {
     for (const requestId of approvalRequestIds) {
       this.pendingApprovalsByRequestId.delete(requestId);
       this.activeTurnsByApprovalRequestId.delete(requestId);
+      this.deleteSessionRequestId(this.mirroredApprovalIdsBySessionId, requestId);
     }
     this.pendingApprovalIdsBySessionId.delete(externalSessionId);
+    this.mirroredApprovalIdsBySessionId.delete(externalSessionId);
 
     const questionRequestIds = this.pendingQuestionIdsBySessionId.get(externalSessionId) ?? [];
     for (const requestId of questionRequestIds) {
       this.pendingQuestionsByRequestId.delete(requestId);
       this.activeTurnsByQuestionRequestId.delete(requestId);
+      this.deleteSessionRequestId(this.mirroredQuestionIdsBySessionId, requestId);
     }
     this.pendingQuestionIdsBySessionId.delete(externalSessionId);
+    this.mirroredQuestionIdsBySessionId.delete(externalSessionId);
+  }
+
+  private pendingApprovalEntriesForIndex(
+    index: Map<string, Set<string>>,
+    externalSessionId: string,
+  ): PendingApprovalEntry[] {
+    const requestIds = index.get(externalSessionId);
+    if (!requestIds) {
+      return [];
+    }
+    return [...requestIds]
+      .map((requestId) => this.pendingApprovalsByRequestId.get(requestId))
+      .filter((entry): entry is PendingApprovalEntry => Boolean(entry));
+  }
+
+  private pendingQuestionEntriesForIndex(
+    index: Map<string, Set<string>>,
+    externalSessionId: string,
+  ): PendingQuestionEntry[] {
+    const requestIds = index.get(externalSessionId);
+    if (!requestIds) {
+      return [];
+    }
+    return [...requestIds]
+      .map((requestId) => this.pendingQuestionsByRequestId.get(requestId))
+      .filter((entry): entry is PendingQuestionEntry => Boolean(entry));
   }
 
   private addSessionRequestId(

--- a/packages/adapters-codex-app-server/src/codex-runtime-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-events.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { CodexRuntimeEventSubscriptions } from "./codex-runtime-events";
+import { CodexRuntimeEventBuffer, CodexRuntimeEventSubscriptions } from "./codex-runtime-events";
+
+const request = (id: number, threadId: string) => ({
+  id,
+  method: "item/tool/requestUserInput",
+  params: { threadId, turnId: `turn-${id}` },
+});
 
 describe("CodexRuntimeEventSubscriptions", () => {
   test("removes a failed synchronous subscription so the runtime can retry", async () => {
@@ -15,5 +21,49 @@ describe("CodexRuntimeEventSubscriptions", () => {
     expect(() => subscriptions.ensure("runtime-1", () => undefined)).toThrow("subscribe failed");
     await expect(subscriptions.ensure("runtime-1", () => undefined)).resolves.toBeUndefined();
     expect(subscribeAttempts).toBe(2);
+  });
+});
+
+describe("CodexRuntimeEventBuffer", () => {
+  test("keeps buffered server requests isolated by runtime", () => {
+    const buffer = new CodexRuntimeEventBuffer();
+    buffer.bufferRuntimeStreamEvent("child-thread", {
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: request(1, "child-thread"),
+    });
+    buffer.bufferRuntimeStreamEvent("child-thread", {
+      runtimeId: "runtime-2",
+      kind: "server_request",
+      message: request(2, "child-thread"),
+    });
+
+    expect(buffer.takeServerRequests("child-thread", "runtime-1")).toEqual([
+      request(1, "child-thread"),
+    ]);
+    expect(buffer.takeServerRequests("child-thread", "runtime-2")).toEqual([
+      request(2, "child-thread"),
+    ]);
+  });
+
+  test("clears buffered server requests for one runtime only", () => {
+    const buffer = new CodexRuntimeEventBuffer();
+    buffer.bufferRuntimeStreamEvent("child-thread", {
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: request(1, "child-thread"),
+    });
+    buffer.bufferRuntimeStreamEvent("child-thread", {
+      runtimeId: "runtime-2",
+      kind: "server_request",
+      message: request(2, "child-thread"),
+    });
+
+    buffer.clearSession("child-thread", "runtime-1");
+
+    expect(buffer.takeServerRequests("child-thread", "runtime-1")).toEqual([]);
+    expect(buffer.takeServerRequests("child-thread", "runtime-2")).toEqual([
+      request(2, "child-thread"),
+    ]);
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-runtime-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-events.ts
@@ -26,14 +26,9 @@ export type BufferedCodexRuntimeEvent =
   | { kind: "notification"; notification: CodexNotificationRecord }
   | { kind: "server_request"; runtimeId: string; request: CodexServerRequestRecord };
 
-type BufferedCodexServerRequest = {
-  runtimeId: string;
-  request: CodexServerRequestRecord;
-};
-
 export class CodexRuntimeEventBuffer {
   readonly notificationsByThreadId = new Map<string, CodexNotificationRecord[]>();
-  readonly serverRequestsByThreadId = new Map<string, BufferedCodexServerRequest[]>();
+  readonly serverRequestsByRuntimeId = new Map<string, Map<string, CodexServerRequestRecord[]>>();
 
   takeNotifications(threadId: string): CodexNotificationRecord[] {
     const notifications = this.notificationsByThreadId.get(threadId) ?? [];
@@ -42,37 +37,51 @@ export class CodexRuntimeEventBuffer {
   }
 
   takeServerRequests(threadId: string, runtimeId?: string): CodexServerRequestRecord[] {
-    const entries = this.serverRequestsByThreadId.get(threadId) ?? [];
-    if (!runtimeId) {
-      this.serverRequestsByThreadId.delete(threadId);
-      return entries.map((entry) => entry.request);
+    if (runtimeId) {
+      return this.takeServerRequestsForRuntime(threadId, runtimeId);
     }
 
     const requests: CodexServerRequestRecord[] = [];
-    const remaining: BufferedCodexServerRequest[] = [];
-    for (const entry of entries) {
-      if (entry.runtimeId === runtimeId) {
-        requests.push(entry.request);
-      } else {
-        remaining.push(entry);
-      }
+    for (const runtime of [...this.serverRequestsByRuntimeId.keys()]) {
+      requests.push(...this.takeServerRequestsForRuntime(threadId, runtime));
     }
-    if (remaining.length > 0) {
-      this.serverRequestsByThreadId.set(threadId, remaining);
-    } else {
-      this.serverRequestsByThreadId.delete(threadId);
+    return requests;
+  }
+
+  private takeServerRequestsForRuntime(
+    threadId: string,
+    runtimeId: string,
+  ): CodexServerRequestRecord[] {
+    const requestsByThreadId = this.serverRequestsByRuntimeId.get(runtimeId);
+    const requests = requestsByThreadId?.get(threadId) ?? [];
+    requestsByThreadId?.delete(threadId);
+    if (requestsByThreadId?.size === 0) {
+      this.serverRequestsByRuntimeId.delete(runtimeId);
     }
     return requests;
   }
 
   hasServerRequests(threadId: string, runtimeId?: string): boolean {
-    const entries = this.serverRequestsByThreadId.get(threadId) ?? [];
-    return runtimeId ? entries.some((entry) => entry.runtimeId === runtimeId) : entries.length > 0;
+    if (runtimeId) {
+      return Boolean(this.serverRequestsByRuntimeId.get(runtimeId)?.has(threadId));
+    }
+    for (const requestsByThreadId of this.serverRequestsByRuntimeId.values()) {
+      if (requestsByThreadId.has(threadId)) {
+        return true;
+      }
+    }
+    return false;
   }
 
-  clearSession(threadId: string): void {
+  clearSession(threadId: string, runtimeId?: string): void {
     this.notificationsByThreadId.delete(threadId);
-    this.serverRequestsByThreadId.delete(threadId);
+    if (runtimeId) {
+      this.takeServerRequestsForRuntime(threadId, runtimeId);
+      return;
+    }
+    for (const runtime of [...this.serverRequestsByRuntimeId.keys()]) {
+      this.takeServerRequestsForRuntime(threadId, runtime);
+    }
   }
 
   bufferNotification(notification: CodexNotificationRecord): void {
@@ -109,9 +118,12 @@ export class CodexRuntimeEventBuffer {
     runtimeId: string,
     request: CodexServerRequestRecord,
   ) {
-    const buffered = this.serverRequestsByThreadId.get(threadId) ?? [];
-    buffered.push({ runtimeId, request });
-    this.trimAndStore(this.serverRequestsByThreadId, threadId, buffered);
+    const requestsByThreadId = this.serverRequestsByRuntimeId.get(runtimeId) ?? new Map();
+    const buffered = requestsByThreadId.get(threadId) ?? [];
+    buffered.push(request);
+    this.trimAndStore(requestsByThreadId, threadId, buffered);
+    this.serverRequestsByRuntimeId.set(runtimeId, requestsByThreadId);
+    trimOldestMapKeys(this.serverRequestsByRuntimeId, MAX_CODEX_BUFFERED_THREAD_COUNT);
   }
 
   private trimAndStore<T>(buffer: Map<string, T[]>, threadId: string, entries: T[]): void {

--- a/packages/adapters-codex-app-server/src/codex-runtime-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-events.ts
@@ -24,11 +24,16 @@ export type CodexRuntimeStreamEvent = {
 
 export type BufferedCodexRuntimeEvent =
   | { kind: "notification"; notification: CodexNotificationRecord }
-  | { kind: "server_request"; request: CodexServerRequestRecord };
+  | { kind: "server_request"; runtimeId: string; request: CodexServerRequestRecord };
+
+type BufferedCodexServerRequest = {
+  runtimeId: string;
+  request: CodexServerRequestRecord;
+};
 
 export class CodexRuntimeEventBuffer {
   readonly notificationsByThreadId = new Map<string, CodexNotificationRecord[]>();
-  readonly serverRequestsByThreadId = new Map<string, CodexServerRequestRecord[]>();
+  readonly serverRequestsByThreadId = new Map<string, BufferedCodexServerRequest[]>();
 
   takeNotifications(threadId: string): CodexNotificationRecord[] {
     const notifications = this.notificationsByThreadId.get(threadId) ?? [];
@@ -36,14 +41,33 @@ export class CodexRuntimeEventBuffer {
     return notifications;
   }
 
-  takeServerRequests(threadId: string): CodexServerRequestRecord[] {
-    const requests = this.serverRequestsByThreadId.get(threadId) ?? [];
-    this.serverRequestsByThreadId.delete(threadId);
+  takeServerRequests(threadId: string, runtimeId?: string): CodexServerRequestRecord[] {
+    const entries = this.serverRequestsByThreadId.get(threadId) ?? [];
+    if (!runtimeId) {
+      this.serverRequestsByThreadId.delete(threadId);
+      return entries.map((entry) => entry.request);
+    }
+
+    const requests: CodexServerRequestRecord[] = [];
+    const remaining: BufferedCodexServerRequest[] = [];
+    for (const entry of entries) {
+      if (entry.runtimeId === runtimeId) {
+        requests.push(entry.request);
+      } else {
+        remaining.push(entry);
+      }
+    }
+    if (remaining.length > 0) {
+      this.serverRequestsByThreadId.set(threadId, remaining);
+    } else {
+      this.serverRequestsByThreadId.delete(threadId);
+    }
     return requests;
   }
 
-  hasServerRequests(threadId: string): boolean {
-    return (this.serverRequestsByThreadId.get(threadId)?.length ?? 0) > 0;
+  hasServerRequests(threadId: string, runtimeId?: string): boolean {
+    const entries = this.serverRequestsByThreadId.get(threadId) ?? [];
+    return runtimeId ? entries.some((entry) => entry.runtimeId === runtimeId) : entries.length > 0;
   }
 
   clearSession(threadId: string): void {
@@ -61,7 +85,7 @@ export class CodexRuntimeEventBuffer {
 
   bufferRuntimeStreamEvent(
     threadId: string,
-    event: Pick<CodexRuntimeStreamEvent, "kind" | "message">,
+    event: Pick<CodexRuntimeStreamEvent, "runtimeId" | "kind" | "message">,
   ): BufferedCodexRuntimeEvent {
     if (event.kind === "notification") {
       const notification = parseNotificationRecord(event.message);
@@ -70,8 +94,8 @@ export class CodexRuntimeEventBuffer {
     }
 
     const request = parseServerRequestRecord(event.message);
-    this.bufferServerRequestForThread(threadId, request);
-    return { kind: "server_request", request };
+    this.bufferServerRequestForThread(threadId, event.runtimeId, request);
+    return { kind: "server_request", runtimeId: event.runtimeId, request };
   }
 
   private bufferNotificationForThread(threadId: string, notification: CodexNotificationRecord) {
@@ -80,9 +104,13 @@ export class CodexRuntimeEventBuffer {
     this.trimAndStore(this.notificationsByThreadId, threadId, buffered);
   }
 
-  private bufferServerRequestForThread(threadId: string, request: CodexServerRequestRecord) {
+  private bufferServerRequestForThread(
+    threadId: string,
+    runtimeId: string,
+    request: CodexServerRequestRecord,
+  ) {
     const buffered = this.serverRequestsByThreadId.get(threadId) ?? [];
-    buffered.push(request);
+    buffered.push({ runtimeId, request });
     this.trimAndStore(this.serverRequestsByThreadId, threadId, buffered);
   }
 

--- a/packages/adapters-codex-app-server/src/codex-runtime-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-events.ts
@@ -42,6 +42,10 @@ export class CodexRuntimeEventBuffer {
     return requests;
   }
 
+  hasServerRequests(threadId: string): boolean {
+    return (this.serverRequestsByThreadId.get(threadId)?.length ?? 0) > 0;
+  }
+
   clearSession(threadId: string): void {
     this.notificationsByThreadId.delete(threadId);
     this.serverRequestsByThreadId.delete(threadId);

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -173,6 +173,9 @@ describe("CodexRuntimeSessionEvents", () => {
     let listener: RuntimeListener | null = null;
     const parentSession = createSession("parent-thread");
     const sessions = new Map([[parentSession.threadId, parentSession]]);
+    const sessionEvents = new CodexSessionEventBus();
+    const emittedEvents: unknown[] = [];
+    sessionEvents.subscribe(codexSessionRef(parentSession), (event) => emittedEvents.push(event));
     const pendingInput = new CodexPendingInputState();
     const subagents = new CodexSubagentLinkState();
     const runtimeEvents = createRuntimeEvents({
@@ -181,6 +184,7 @@ describe("CodexRuntimeSessionEvents", () => {
         return () => undefined;
       },
       sessions,
+      sessionEvents,
       pendingInput,
       subagents,
     });
@@ -210,6 +214,12 @@ describe("CodexRuntimeSessionEvents", () => {
 
     expect(pendingInput.question("51")).toBeUndefined();
     expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(0);
+    expect(emittedEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("Cannot route Codex server request"),
+      }),
+    );
 
     listener?.({
       runtimeId: "runtime-1",
@@ -375,7 +385,7 @@ describe("CodexRuntimeSessionEvents", () => {
     expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(0);
   });
 
-  test("emits an error for subscribed server requests with no known session or child route", async () => {
+  test("emits an error for subscribed server requests missing an owner thread id", async () => {
     let listener: RuntimeListener | null = null;
     const parentSession = createSession("parent-thread");
     const sessions = new Map([[parentSession.threadId, parentSession]]);
@@ -401,7 +411,6 @@ describe("CodexRuntimeSessionEvents", () => {
         id: 54,
         method: "item/tool/requestUserInput",
         params: {
-          threadId: "unknown-thread",
           turnId: "turn-child",
           questions: [
             {
@@ -421,7 +430,7 @@ describe("CodexRuntimeSessionEvents", () => {
       expect.objectContaining({
         type: "session_error",
         externalSessionId: "parent-thread",
-        message: expect.stringContaining("Cannot route Codex server request"),
+        message: expect.stringContaining("missing params.threadId"),
       }),
     );
   });
@@ -556,13 +565,7 @@ describe("CodexRuntimeSessionEvents", () => {
     await flushRuntimeEvents();
 
     expect(pendingInput.question("60")).toBeUndefined();
-    expect(runtimeTwoEvents).toContainEqual(
-      expect.objectContaining({
-        type: "session_error",
-        externalSessionId: "runtime-two-thread",
-        message: expect.stringContaining("belongs to runtime 'runtime-1'"),
-      }),
-    );
+    expect(runtimeTwoEvents).toEqual([]);
   });
 
   test("drains buffered child approvals when an inventory route is known before parent load", async () => {

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { CODEX_APP_SERVER_SERVER_REQUEST_METHOD } from "@openducktor/contracts";
 import type { AgentModelSelection } from "@openducktor/core";
 import { codexTurnKey } from "./codex-app-server-requests";
 import type { ActiveCodexTurn } from "./codex-app-server-shared";
+import type { CodexThreadSnapshot } from "./codex-app-server-threads";
 import { CodexPendingInputState } from "./codex-pending-input-state";
 import { CodexRuntimeSessionEvents } from "./codex-runtime-session-events";
 import { CodexSessionEventBus } from "./codex-session-event-bus";
@@ -9,6 +11,16 @@ import { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import type { CodexSessionState } from "./types";
 
 const waitForRuntimeEvent = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+const flushRuntimeEvents = async (): Promise<void> => {
+  await waitForRuntimeEvent();
+  await waitForRuntimeEvent();
+};
+
+type RuntimeListener = (event: {
+  runtimeId: string;
+  kind: "notification" | "server_request";
+  message: unknown;
+}) => void;
 
 const createRuntimeEvents = (
   overrides: Partial<ConstructorParameters<typeof CodexRuntimeSessionEvents>[0]> = {},
@@ -61,6 +73,27 @@ const createActiveTurn = (
   model: turnModel,
 });
 
+const createChildThreadSnapshot = (
+  childThreadId: string,
+  parentThreadId: string,
+): CodexThreadSnapshot => ({
+  id: childThreadId,
+  cwd: "/repo",
+  startedAt: "2026-06-13T00:00:00.000Z",
+  title: childThreadId,
+  status: { classification: "running" },
+  parentThreadId,
+  agentNickname: null,
+  agentRole: null,
+  subAgentSource: {
+    parentThreadId,
+    depth: 1,
+    agentPath: ["agent"],
+    agentNickname: null,
+    agentRole: null,
+  },
+});
+
 describe("CodexRuntimeSessionEvents", () => {
   test("clears turn-scoped stream metadata for one session only", () => {
     const runtimeEvents = createRuntimeEvents();
@@ -77,13 +110,7 @@ describe("CodexRuntimeSessionEvents", () => {
   });
 
   test("routes buffered child server requests through a loaded linked parent", async () => {
-    let listener:
-      | ((event: {
-          runtimeId: string;
-          kind: "notification" | "server_request";
-          message: unknown;
-        }) => void)
-      | null = null;
+    let listener: RuntimeListener | null = null;
     const parentSession = createSession("parent-thread");
     const sessions = new Map([[parentSession.threadId, parentSession]]);
     const pendingInput = new CodexPendingInputState();
@@ -134,5 +161,140 @@ describe("CodexRuntimeSessionEvents", () => {
         childExternalSessionId: "child-thread",
       },
     });
+  });
+
+  test("reprocesses child server requests buffered before a parent subagent link is learned", async () => {
+    let listener: RuntimeListener | null = null;
+    const parentSession = createSession("parent-thread");
+    const sessions = new Map([[parentSession.threadId, parentSession]]);
+    const pendingInput = new CodexPendingInputState();
+    const subagents = new CodexSubagentLinkState();
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (_runtimeId, next) => {
+        listener = next;
+        return () => undefined;
+      },
+      sessions,
+      pendingInput,
+      subagents,
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: {
+        id: 51,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+          questions: [
+            {
+              id: "question-item-1",
+              header: "Choose",
+              question: "Proceed?",
+              options: ["Yes", "No"],
+            },
+          ],
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    expect(pendingInput.question("51")).toBeUndefined();
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(0);
+
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "notification",
+      message: {
+        method: "item/completed",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-parent",
+          completedAtMs: 1_777_766_401_000,
+          item: {
+            type: "collabAgentToolCall",
+            id: "spawn-1",
+            tool: "spawnAgent",
+            status: "completed",
+            senderThreadId: "parent-thread",
+            receiverThreadIds: ["child-thread"],
+            agentsStates: {
+              "child-thread": { status: "running" },
+            },
+          },
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    expect(pendingInput.question("51")).toMatchObject({
+      threadId: "child-thread",
+      route: {
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      },
+    });
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(1);
+  });
+
+  test("drains buffered child approvals when an inventory route is known before parent load", async () => {
+    let listener: RuntimeListener | null = null;
+    const parentSession = createSession("parent-thread");
+    const sessions = new Map<string, CodexSessionState>();
+    const pendingInput = new CodexPendingInputState();
+    const subagents = new CodexSubagentLinkState();
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (_runtimeId, next) => {
+        listener = next;
+        return () => undefined;
+      },
+      sessions,
+      pendingInput,
+      subagents,
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: {
+        id: 52,
+        method: CODEX_APP_SERVER_SERVER_REQUEST_METHOD.MCP_SERVER_ELICITATION_REQUEST,
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+          serverName: "semble",
+          mode: "form",
+          message: 'Allow the semble MCP server to run tool "search"?',
+          requestedSchema: { type: "object", properties: {} },
+          _meta: {
+            codex_approval_kind: "mcp_tool_call",
+            tool_name: "search",
+            persist: ["session"],
+          },
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    subagents.recordThread(createChildThreadSnapshot("child-thread", "parent-thread"));
+    await flushRuntimeEvents();
+
+    expect(pendingInput.approval("52")).toBeUndefined();
+
+    sessions.set(parentSession.threadId, parentSession);
+    await runtimeEvents.drainBufferedStreamEvents(parentSession.threadId);
+
+    expect(pendingInput.approval("52")).toMatchObject({
+      threadId: "child-thread",
+      route: {
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      },
+    });
+    expect(pendingInput.pendingApprovalEventsForSession("parent-thread")).toHaveLength(1);
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -5,9 +5,14 @@ import type { ActiveCodexTurn } from "./codex-app-server-shared";
 import { CodexPendingInputState } from "./codex-pending-input-state";
 import { CodexRuntimeSessionEvents } from "./codex-runtime-session-events";
 import { CodexSessionEventBus } from "./codex-session-event-bus";
+import { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import type { CodexSessionState } from "./types";
 
-const createRuntimeEvents = () =>
+const waitForRuntimeEvent = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+const createRuntimeEvents = (
+  overrides: Partial<ConstructorParameters<typeof CodexRuntimeSessionEvents>[0]> = {},
+) =>
   new CodexRuntimeSessionEvents({
     subscribeEvents: undefined,
     drainServerRequests: async () => [],
@@ -17,8 +22,10 @@ const createRuntimeEvents = () =>
     activeTurnsBySessionId: new Map(),
     sessionEvents: new CodexSessionEventBus(),
     pendingInput: new CodexPendingInputState(),
+    subagents: new CodexSubagentLinkState(),
     updateThreadStatus: () => undefined,
     flushQueuedUserMessagesLater: () => undefined,
+    ...overrides,
   });
 
 const model = { providerId: "openai", modelId: "gpt-5", variant: "medium" } as const;
@@ -67,5 +74,65 @@ describe("CodexRuntimeSessionEvents", () => {
 
     expect(modelByTurnKey.has(stoppedSessionTurnKey)).toBe(false);
     expect(modelByTurnKey.has(otherSessionTurnKey)).toBe(true);
+  });
+
+  test("routes buffered child server requests through a loaded linked parent", async () => {
+    let listener:
+      | ((event: {
+          runtimeId: string;
+          kind: "notification" | "server_request";
+          message: unknown;
+        }) => void)
+      | null = null;
+    const parentSession = createSession("parent-thread");
+    const sessions = new Map([[parentSession.threadId, parentSession]]);
+    const pendingInput = new CodexPendingInputState();
+    const subagents = new CodexSubagentLinkState();
+    subagents.upsertLink({
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (_runtimeId, next) => {
+        listener = next;
+        return () => undefined;
+      },
+      sessions,
+      pendingInput,
+      subagents,
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: {
+        id: 50,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+          questions: [
+            {
+              id: "question-item-1",
+              header: "Choose",
+              question: "Proceed?",
+              options: ["Yes", "No"],
+            },
+          ],
+        },
+      },
+    });
+    await waitForRuntimeEvent();
+
+    expect(pendingInput.question("50")).toMatchObject({
+      threadId: "child-thread",
+      route: {
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      },
+    });
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -297,4 +297,49 @@ describe("CodexRuntimeSessionEvents", () => {
     });
     expect(pendingInput.pendingApprovalEventsForSession("parent-thread")).toHaveLength(1);
   });
+
+  test("mirrors already-processed child pending input when a route is learned later", async () => {
+    const parentSession = createSession("parent-thread");
+    const childSession = createSession("child-thread");
+    const sessions = new Map([
+      [parentSession.threadId, parentSession],
+      [childSession.threadId, childSession],
+    ]);
+    const pendingInput = new CodexPendingInputState();
+    const subagents = new CodexSubagentLinkState();
+    createRuntimeEvents({
+      sessions,
+      pendingInput,
+      subagents,
+    });
+
+    pendingInput.addQuestion({
+      runtimeId: "runtime-1",
+      threadId: "child-thread",
+      request: {
+        requestId: "question-1",
+        questions: [{ header: "Choose", question: "Proceed?", options: ["Yes", "No"] }],
+      },
+      questionIds: ["question-item-1"],
+      input: { requestId: "question-1" },
+    });
+
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(0);
+
+    subagents.upsertLink({
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    await flushRuntimeEvents();
+
+    expect(pendingInput.question("question-1")).toMatchObject({
+      route: {
+        parentExternalSessionId: "parent-thread",
+        childExternalSessionId: "child-thread",
+      },
+    });
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(1);
+  });
 });

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -7,6 +7,7 @@ import type { CodexThreadSnapshot } from "./codex-app-server-threads";
 import { CodexPendingInputState } from "./codex-pending-input-state";
 import { CodexRuntimeSessionEvents } from "./codex-runtime-session-events";
 import { CodexSessionEventBus } from "./codex-session-event-bus";
+import { codexSessionRef } from "./codex-session-ref";
 import { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import type { CodexSessionState } from "./types";
 
@@ -302,6 +303,57 @@ describe("CodexRuntimeSessionEvents", () => {
 
     expect(pendingInput.question("53")).toBeUndefined();
     expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(0);
+  });
+
+  test("emits an error for subscribed server requests with no known session or child route", async () => {
+    let listener: RuntimeListener | null = null;
+    const parentSession = createSession("parent-thread");
+    const sessions = new Map([[parentSession.threadId, parentSession]]);
+    const sessionEvents = new CodexSessionEventBus();
+    const emittedEvents: unknown[] = [];
+    sessionEvents.subscribe(codexSessionRef(parentSession), (event) => emittedEvents.push(event));
+    const pendingInput = new CodexPendingInputState();
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (_runtimeId, next) => {
+        listener = next;
+        return () => undefined;
+      },
+      sessions,
+      sessionEvents,
+      pendingInput,
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: {
+        id: 54,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "unknown-thread",
+          turnId: "turn-child",
+          questions: [
+            {
+              id: "question-item-1",
+              header: "Choose",
+              question: "Proceed?",
+              options: ["Yes", "No"],
+            },
+          ],
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    expect(pendingInput.question("54")).toBeUndefined();
+    expect(emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        externalSessionId: "parent-thread",
+        message: expect.stringContaining("Cannot route Codex server request"),
+      }),
+    );
   });
 
   test("drains buffered child approvals when an inventory route is known before parent load", async () => {

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -61,6 +61,11 @@ const createSession = (threadId: string): CodexSessionState => ({
   model,
 });
 
+const createSessionForRuntime = (threadId: string, runtimeId: string): CodexSessionState => ({
+  ...createSession(threadId),
+  runtimeId,
+});
+
 const createActiveTurn = (
   threadId: string,
   turnModel: AgentModelSelection = model,
@@ -241,6 +246,71 @@ describe("CodexRuntimeSessionEvents", () => {
     expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(1);
   });
 
+  test("does not let history projection drain live buffered child requests", async () => {
+    let listener: RuntimeListener | null = null;
+    const parentSession = createSession("parent-thread");
+    const sessions = new Map([[parentSession.threadId, parentSession]]);
+    const pendingInput = new CodexPendingInputState();
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (_runtimeId, next) => {
+        listener = next;
+        return () => undefined;
+      },
+      sessions,
+      pendingInput,
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: {
+        id: 57,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+          questions: [
+            {
+              id: "question-item-1",
+              header: "Choose",
+              question: "Proceed?",
+              options: ["Yes", "No"],
+            },
+          ],
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    runtimeEvents.historyLoadContext().eventMapperPipeline.runThreadItem(
+      {
+        index: 0,
+        timestamp: "2026-06-13T00:00:00.000Z",
+        item: {
+          type: "collabAgentToolCall",
+          id: "spawn-history",
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          agentsStates: {
+            "child-thread": { status: "running" },
+          },
+        },
+      },
+      {
+        source: "thread_read",
+        threadId: "parent-thread",
+        timestamp: "2026-06-13T00:00:00.000Z",
+      },
+    );
+    await flushRuntimeEvents();
+
+    expect(pendingInput.question("57")).toBeUndefined();
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(0);
+  });
+
   test("applies buffered child request resolutions after route-learned request replay", async () => {
     let listener: RuntimeListener | null = null;
     const parentSession = createSession("parent-thread");
@@ -352,6 +422,145 @@ describe("CodexRuntimeSessionEvents", () => {
         type: "session_error",
         externalSessionId: "parent-thread",
         message: expect.stringContaining("Cannot route Codex server request"),
+      }),
+    );
+  });
+
+  test("emits routed child request processing errors on the loaded parent session", async () => {
+    let listener: RuntimeListener | null = null;
+    const parentSession = createSession("parent-thread");
+    const sessions = new Map([[parentSession.threadId, parentSession]]);
+    const sessionEvents = new CodexSessionEventBus();
+    const emittedEvents: unknown[] = [];
+    sessionEvents.subscribe(codexSessionRef(parentSession), (event) => emittedEvents.push(event));
+    const subagents = new CodexSubagentLinkState();
+    subagents.upsertLink({
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (_runtimeId, next) => {
+        listener = next;
+        return () => undefined;
+      },
+      sessions,
+      sessionEvents,
+      subagents,
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: {
+        id: 58,
+        method: "",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    expect(emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        externalSessionId: "parent-thread",
+        message: "Codex app-server server request is missing method.",
+      }),
+    );
+  });
+
+  test("does not drain buffered child requests across runtimes", async () => {
+    const listeners = new Map<string, RuntimeListener>();
+    const parentSession = createSessionForRuntime("parent-thread", "runtime-1");
+    const runtimeTwoSession = createSessionForRuntime("runtime-two-thread", "runtime-2");
+    const sessions = new Map([
+      [parentSession.threadId, parentSession],
+      [runtimeTwoSession.threadId, runtimeTwoSession],
+    ]);
+    const sessionEvents = new CodexSessionEventBus();
+    const runtimeTwoEvents: unknown[] = [];
+    sessionEvents.subscribe(codexSessionRef(runtimeTwoSession), (event) =>
+      runtimeTwoEvents.push(event),
+    );
+    const pendingInput = new CodexPendingInputState();
+    const subagents = new CodexSubagentLinkState();
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (runtimeId, next) => {
+        listeners.set(runtimeId, next);
+        return () => undefined;
+      },
+      sessions,
+      sessionEvents,
+      pendingInput,
+      subagents,
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-2");
+    listeners.get("runtime-2")?.({
+      runtimeId: "runtime-2",
+      kind: "server_request",
+      message: {
+        id: 59,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+          questions: [
+            {
+              id: "question-item-1",
+              header: "Choose",
+              question: "Proceed?",
+              options: ["Yes", "No"],
+            },
+          ],
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    subagents.upsertLink({
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    await flushRuntimeEvents();
+
+    expect(pendingInput.question("59")).toBeUndefined();
+
+    listeners.get("runtime-2")?.({
+      runtimeId: "runtime-2",
+      kind: "server_request",
+      message: {
+        id: 60,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+          questions: [
+            {
+              id: "question-item-2",
+              header: "Choose",
+              question: "Proceed again?",
+              options: ["Yes", "No"],
+            },
+          ],
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    expect(pendingInput.question("60")).toBeUndefined();
+    expect(runtimeTwoEvents).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        externalSessionId: "runtime-two-thread",
+        message: expect.stringContaining("belongs to runtime 'runtime-1'"),
       }),
     );
   });

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -240,6 +240,70 @@ describe("CodexRuntimeSessionEvents", () => {
     expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(1);
   });
 
+  test("applies buffered child request resolutions after route-learned request replay", async () => {
+    let listener: RuntimeListener | null = null;
+    const parentSession = createSession("parent-thread");
+    const sessions = new Map([[parentSession.threadId, parentSession]]);
+    const pendingInput = new CodexPendingInputState();
+    const subagents = new CodexSubagentLinkState();
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (_runtimeId, next) => {
+        listener = next;
+        return () => undefined;
+      },
+      sessions,
+      pendingInput,
+      subagents,
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "server_request",
+      message: {
+        id: 53,
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "child-thread",
+          turnId: "turn-child",
+          questions: [
+            {
+              id: "question-item-1",
+              header: "Choose",
+              question: "Proceed?",
+              options: ["Yes", "No"],
+            },
+          ],
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "notification",
+      message: {
+        method: "serverRequest/resolved",
+        params: {
+          threadId: "child-thread",
+          requestId: 53,
+        },
+      },
+    });
+    await flushRuntimeEvents();
+
+    subagents.upsertLink({
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    await flushRuntimeEvents();
+
+    expect(pendingInput.question("53")).toBeUndefined();
+    expect(pendingInput.pendingQuestionEventsForSession("parent-thread")).toHaveLength(0);
+  });
+
   test("drains buffered child approvals when an inventory route is known before parent load", async () => {
     let listener: RuntimeListener | null = null;
     const parentSession = createSession("parent-thread");

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -18,7 +18,7 @@ import {
   type CodexServerRequestHandlerContext,
   handleCodexServerRequest,
 } from "./codex-app-server-server-requests";
-import type { ActiveCodexTurn } from "./codex-app-server-shared";
+import { type ActiveCodexTurn, isPlainObject } from "./codex-app-server-shared";
 import {
   type CodexStreamingContext,
   type CompletedAgentMessage,
@@ -41,6 +41,8 @@ import {
 } from "./codex-runtime-events";
 import type { CodexSessionEventBus } from "./codex-session-event-bus";
 import { codexSessionRef } from "./codex-session-ref";
+import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
+import { createCodexEventMappers } from "./event-mappers";
 import type {
   CodexAppServerAdapterOptions,
   CodexNotificationRecord,
@@ -57,6 +59,7 @@ type CodexRuntimeSessionEventsDeps = {
   activeTurnsBySessionId: Map<string, ActiveCodexTurn>;
   sessionEvents: CodexSessionEventBus;
   pendingInput: CodexPendingInputState;
+  subagents: CodexSubagentLinkState;
   updateThreadStatus(runtimeId: string, threadId: string, status: CodexThreadStatusSnapshot): void;
   flushQueuedUserMessagesLater(activeTurn: ActiveCodexTurn): void;
 };
@@ -93,10 +96,13 @@ export class CodexRuntimeSessionEvents {
   private readonly modelByTurnKey = new Map<string, AgentModelSelection>();
   private readonly latestTodosBySessionId = new Map<string, AgentSessionTodoItem[]>();
   private readonly restoredContextCapturesByKey = new Map<string, RestoredContextCapture>();
-  private readonly eventMapperPipeline = createCodexEventMapperPipeline();
+  private readonly eventMapperPipeline: ReturnType<typeof createCodexEventMapperPipeline>;
   private readonly runtimeEventSubscriptions: CodexRuntimeEventSubscriptions;
 
   constructor(private readonly deps: CodexRuntimeSessionEventsDeps) {
+    this.eventMapperPipeline = createCodexEventMapperPipeline(
+      createCodexEventMappers(deps.subagents),
+    );
     this.runtimeEventSubscriptions = new CodexRuntimeEventSubscriptions(deps.subscribeEvents);
   }
 
@@ -246,21 +252,98 @@ export class CodexRuntimeSessionEvents {
       }
       return;
     }
-    if (
-      event.kind === "notification" &&
-      this.captureRestoredContextNotification(
-        event.runtimeId,
-        parseNotificationRecord(event.message),
-      )
-    ) {
-      return;
+    if (event.kind === "notification") {
+      const notification = parseNotificationRecord(event.message);
+      if (notification.method === "serverRequest/resolved") {
+        this.handleServerRequestResolvedNotification(notification);
+        return;
+      }
+      if (this.captureRestoredContextNotification(event.runtimeId, notification)) {
+        return;
+      }
     }
     const session = this.deps.sessions.get(threadId);
     if (!session) {
+      if (event.kind === "server_request") {
+        const route = this.deps.subagents.routeForChild(threadId);
+        const parentSession = route
+          ? this.deps.sessions.get(route.parentExternalSessionId)
+          : undefined;
+        if (parentSession) {
+          await this.processRuntimeStreamEventForSession(parentSession, event);
+          return;
+        }
+      }
       this.bufferRuntimeStreamEvent(threadId, event);
       return;
     }
     await this.processRuntimeStreamEventForSession(session, event);
+  }
+
+  private handleServerRequestResolvedNotification(notification: CodexNotificationRecord): void {
+    const threadId = extractThreadIdFromParams(notification.params);
+    const requestId = this.resolvedServerRequestId(notification);
+    if (!threadId || !requestId) {
+      throw new Error(
+        "Codex serverRequest/resolved notification is missing threadId or requestId.",
+      );
+    }
+    const approval = this.deps.pendingInput.approval(requestId);
+    const question = this.deps.pendingInput.question(requestId);
+    const entry = approval ?? question;
+    if (!entry) {
+      return;
+    }
+    if (entry.threadId !== threadId) {
+      throw new Error(
+        `Codex serverRequest/resolved request '${requestId}' belongs to session '${entry.threadId}', not '${threadId}'.`,
+      );
+    }
+    const route = entry.route ?? this.deps.subagents.routeForChild(threadId);
+    const eventBase = {
+      externalSessionId: threadId,
+      timestamp: new Date().toISOString(),
+      requestId,
+      ...(route
+        ? {
+            parentExternalSessionId: route.parentExternalSessionId,
+            childExternalSessionId: route.childExternalSessionId,
+            subagentCorrelationKey: route.subagentCorrelationKey,
+          }
+        : {}),
+    };
+    const activeTurn = approval
+      ? this.deps.pendingInput.resolveApproval(requestId)
+      : this.deps.pendingInput.resolveQuestion(requestId);
+    const type = approval ? "approval_resolved" : "question_resolved";
+    if (this.deps.sessions.get(threadId)) {
+      this.emitSessionEvent(threadId, {
+        ...eventBase,
+        type,
+      });
+    }
+    if (route && this.deps.sessions.get(route.parentExternalSessionId)) {
+      this.emitSessionEvent(route.parentExternalSessionId, {
+        ...eventBase,
+        type,
+        externalSessionId: route.parentExternalSessionId,
+      });
+    }
+    if (activeTurn && !activeTurn.isTurnSettled()) {
+      void this.continueTurnAfterPendingInput(activeTurn);
+    }
+  }
+
+  private resolvedServerRequestId(notification: CodexNotificationRecord): string | null {
+    if (!isPlainObject(notification.params)) {
+      return null;
+    }
+    const params = notification.params;
+    const requestId = params.requestId ?? params.request_id;
+    if (typeof requestId === "number" || typeof requestId === "string") {
+      return String(requestId);
+    }
+    return null;
   }
 
   private bufferRuntimeStreamEvent(
@@ -427,6 +510,8 @@ export class CodexRuntimeSessionEvents {
       respondServerRequest: this.deps.respondServerRequest,
       pendingInput: this.deps.pendingInput,
       activeTurnsBySessionId: this.deps.activeTurnsBySessionId,
+      subagents: this.deps.subagents,
+      sessionForThreadId: (threadId) => this.deps.sessions.get(threadId),
       bindActiveTurnId: (activeTurn, turnId) => this.bindActiveTurnId(activeTurn, turnId),
       flushQueuedUserMessagesLater: (activeTurn) =>
         this.deps.flushQueuedUserMessagesLater(activeTurn),

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -96,7 +96,10 @@ export class CodexRuntimeSessionEvents {
   private readonly modelByTurnKey = new Map<string, AgentModelSelection>();
   private readonly latestTodosBySessionId = new Map<string, AgentSessionTodoItem[]>();
   private readonly restoredContextCapturesByKey = new Map<string, RestoredContextCapture>();
-  private readonly bufferedResolvedServerRequestIdsByThreadId = new Map<string, Set<string>>();
+  private readonly bufferedResolvedServerRequestIdsByThreadId = new Map<
+    string,
+    Map<string, Set<string>>
+  >();
   private readonly eventMapperPipeline: ReturnType<typeof createCodexEventMapperPipeline>;
   private readonly runtimeEventSubscriptions: CodexRuntimeEventSubscriptions;
 
@@ -116,11 +119,7 @@ export class CodexRuntimeSessionEvents {
         try {
           await this.handleRuntimeStreamEvent(event);
         } catch (error) {
-          const threadId = threadIdFromRuntimeStreamEvent(event);
-          if (!threadId) {
-            return;
-          }
-          this.emitSessionError(threadId, error);
+          this.emitRuntimeStreamEventError(event, error);
         }
       })();
     });
@@ -132,7 +131,7 @@ export class CodexRuntimeSessionEvents {
 
   historyLoadContext(): CodexRuntimeSessionHistoryContext {
     return {
-      eventMapperPipeline: this.eventMapperPipeline,
+      eventMapperPipeline: createCodexEventMapperPipeline(),
       modelByTurnKey: this.modelByTurnKey,
       tokenUsageByTurnKey: this.tokenUsageByTurnKey,
       drainThreadReadTokenUsage: (runtimeId: string, threadId: string) =>
@@ -245,7 +244,10 @@ export class CodexRuntimeSessionEvents {
       return;
     }
     await this.handlePendingNotifications(session, []);
-    const bufferedRequests = this.runtimeEventBuffer.takeServerRequests(session.threadId);
+    const bufferedRequests = this.runtimeEventBuffer.takeServerRequests(
+      session.threadId,
+      session.runtimeId,
+    );
     await this.processServerRequestsForSession(session, bufferedRequests);
     await this.drainBufferedSubagentServerRequestsForParent(session);
   }
@@ -258,13 +260,22 @@ export class CodexRuntimeSessionEvents {
   }
 
   private applyRouteToPendingInput(route: CodexSubagentRoute): void {
+    const parentSession = this.deps.sessions.get(route.parentExternalSessionId);
+    if (route.runtimeId && parentSession && parentSession.runtimeId !== route.runtimeId) {
+      this.emitCrossRuntimeRouteError(
+        route.runtimeId,
+        route.childExternalSessionId,
+        parentSession.runtimeId,
+      );
+      return;
+    }
     const routed = this.deps.pendingInput.applyRouteToPendingInput(route);
     const activeTurn = this.deps.activeTurnsBySessionId.get(route.parentExternalSessionId);
     if (activeTurn && !activeTurn.isTurnSettled()) {
       this.deps.pendingInput.bindActiveTurn(route.parentExternalSessionId, activeTurn);
     }
 
-    if (!this.deps.sessions.get(route.parentExternalSessionId)) {
+    if (!parentSession) {
       return;
     }
 
@@ -296,7 +307,10 @@ export class CodexRuntimeSessionEvents {
   private async drainBufferedSubagentServerRequestsForParent(
     parentSession: CodexSessionState,
   ): Promise<void> {
-    for (const route of this.deps.subagents.routesForParent(parentSession.threadId)) {
+    for (const route of this.deps.subagents.routesForParent(
+      parentSession.threadId,
+      parentSession.runtimeId,
+    )) {
       await this.drainBufferedSubagentServerRequests(route);
     }
   }
@@ -308,9 +322,19 @@ export class CodexRuntimeSessionEvents {
     if (!session) {
       return;
     }
+    if (route.runtimeId && session.runtimeId !== route.runtimeId) {
+      this.emitCrossRuntimeRouteError(
+        route.runtimeId,
+        route.childExternalSessionId,
+        session.runtimeId,
+      );
+      return;
+    }
 
+    const routeRuntimeId = route.runtimeId ?? session.runtimeId;
     const bufferedRequests = this.runtimeEventBuffer.takeServerRequests(
       route.childExternalSessionId,
+      routeRuntimeId,
     );
     if (bufferedRequests.length === 0) {
       return;
@@ -341,7 +365,7 @@ export class CodexRuntimeSessionEvents {
     if (event.kind === "notification") {
       const notification = parseNotificationRecord(event.message);
       if (notification.method === "serverRequest/resolved") {
-        this.handleServerRequestResolvedNotification(notification);
+        this.handleServerRequestResolvedNotification(event.runtimeId, notification);
         return;
       }
       if (this.captureRestoredContextNotification(event.runtimeId, notification)) {
@@ -351,11 +375,21 @@ export class CodexRuntimeSessionEvents {
     const session = this.deps.sessions.get(threadId);
     if (!session) {
       if (event.kind === "server_request") {
-        const route = this.deps.subagents.routeForChild(threadId);
+        const route = this.deps.subagents.routeForChild(threadId, event.runtimeId);
+        if (route?.runtimeId && route.runtimeId !== event.runtimeId) {
+          this.emitCrossRuntimeRouteError(event.runtimeId, threadId, route.runtimeId);
+          this.bufferRuntimeStreamEvent(threadId, event);
+          return;
+        }
         const parentSession = route
           ? this.deps.sessions.get(route.parentExternalSessionId)
           : undefined;
         if (parentSession) {
+          if (parentSession.runtimeId !== event.runtimeId) {
+            this.emitCrossRuntimeRouteError(event.runtimeId, threadId, parentSession.runtimeId);
+            this.bufferRuntimeStreamEvent(threadId, event);
+            return;
+          }
           await this.processRuntimeStreamEventForSession(parentSession, event);
           return;
         }
@@ -367,10 +401,20 @@ export class CodexRuntimeSessionEvents {
       this.bufferRuntimeStreamEvent(threadId, event);
       return;
     }
+    if (session.runtimeId !== event.runtimeId) {
+      if (event.kind === "server_request") {
+        this.emitCrossRuntimeRouteError(event.runtimeId, threadId, session.runtimeId);
+        this.bufferRuntimeStreamEvent(threadId, event);
+      }
+      return;
+    }
     await this.processRuntimeStreamEventForSession(session, event);
   }
 
-  private handleServerRequestResolvedNotification(notification: CodexNotificationRecord): void {
+  private handleServerRequestResolvedNotification(
+    runtimeId: string,
+    notification: CodexNotificationRecord,
+  ): void {
     const threadId = extractThreadIdFromParams(notification.params);
     const requestId = this.resolvedServerRequestId(notification);
     if (!threadId || !requestId) {
@@ -378,18 +422,25 @@ export class CodexRuntimeSessionEvents {
         "Codex serverRequest/resolved notification is missing threadId or requestId.",
       );
     }
-    if (!this.resolvePendingServerRequest(threadId, requestId)) {
-      if (this.runtimeEventBuffer.hasServerRequests(threadId)) {
-        this.bufferResolvedServerRequest(threadId, requestId);
+    if (!this.resolvePendingServerRequest(threadId, requestId, runtimeId)) {
+      if (this.runtimeEventBuffer.hasServerRequests(threadId, runtimeId)) {
+        this.bufferResolvedServerRequest(threadId, runtimeId, requestId);
       }
     }
   }
 
-  private resolvePendingServerRequest(threadId: string, requestId: string): boolean {
+  private resolvePendingServerRequest(
+    threadId: string,
+    requestId: string,
+    runtimeId?: string,
+  ): boolean {
     const approval = this.deps.pendingInput.approval(requestId);
     const question = this.deps.pendingInput.question(requestId);
     const entry = approval ?? question;
     if (!entry) {
+      return false;
+    }
+    if (runtimeId && entry.runtimeId !== runtimeId) {
       return false;
     }
     if (entry.threadId !== threadId) {
@@ -397,7 +448,7 @@ export class CodexRuntimeSessionEvents {
         `Codex serverRequest/resolved request '${requestId}' belongs to session '${entry.threadId}', not '${threadId}'.`,
       );
     }
-    const route = entry.route ?? this.deps.subagents.routeForChild(threadId);
+    const route = entry.route ?? this.deps.subagents.routeForChild(threadId, entry.runtimeId);
     const eventBase = {
       externalSessionId: threadId,
       timestamp: new Date().toISOString(),
@@ -430,34 +481,53 @@ export class CodexRuntimeSessionEvents {
     if (activeTurn && !activeTurn.isTurnSettled()) {
       void this.continueTurnAfterPendingInput(activeTurn);
     }
-    this.deleteBufferedResolvedServerRequest(threadId, requestId);
+    this.deleteBufferedResolvedServerRequest(threadId, entry.runtimeId, requestId);
     return true;
   }
 
-  private bufferResolvedServerRequest(threadId: string, requestId: string): void {
-    const requestIds = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId) ?? new Set();
+  private bufferResolvedServerRequest(
+    threadId: string,
+    runtimeId: string,
+    requestId: string,
+  ): void {
+    const requestIdsByRuntimeId =
+      this.bufferedResolvedServerRequestIdsByThreadId.get(threadId) ?? new Map();
+    const requestIds = requestIdsByRuntimeId.get(runtimeId) ?? new Set();
     requestIds.add(requestId);
-    this.bufferedResolvedServerRequestIdsByThreadId.set(threadId, requestIds);
+    requestIdsByRuntimeId.set(runtimeId, requestIds);
+    this.bufferedResolvedServerRequestIdsByThreadId.set(threadId, requestIdsByRuntimeId);
   }
 
-  private resolveBufferedServerRequests(threadId: string): void {
-    const requestIds = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId);
+  private resolveBufferedServerRequests(threadId: string, runtimeId: string): void {
+    const requestIdsByRuntimeId = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId);
+    const requestIds = requestIdsByRuntimeId?.get(runtimeId);
     if (!requestIds) {
       return;
     }
-    this.bufferedResolvedServerRequestIdsByThreadId.delete(threadId);
+    requestIdsByRuntimeId?.delete(runtimeId);
+    if (requestIdsByRuntimeId?.size === 0) {
+      this.bufferedResolvedServerRequestIdsByThreadId.delete(threadId);
+    }
     for (const requestId of requestIds) {
-      this.resolvePendingServerRequest(threadId, requestId);
+      this.resolvePendingServerRequest(threadId, requestId, runtimeId);
     }
   }
 
-  private deleteBufferedResolvedServerRequest(threadId: string, requestId: string): void {
-    const requestIds = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId);
+  private deleteBufferedResolvedServerRequest(
+    threadId: string,
+    runtimeId: string,
+    requestId: string,
+  ): void {
+    const requestIdsByRuntimeId = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId);
+    const requestIds = requestIdsByRuntimeId?.get(runtimeId);
     if (!requestIds) {
       return;
     }
     requestIds.delete(requestId);
     if (requestIds.size === 0) {
+      requestIdsByRuntimeId?.delete(runtimeId);
+    }
+    if (requestIdsByRuntimeId?.size === 0) {
       this.bufferedResolvedServerRequestIdsByThreadId.delete(threadId);
     }
   }
@@ -476,9 +546,42 @@ export class CodexRuntimeSessionEvents {
 
   private bufferRuntimeStreamEvent(
     threadId: string,
-    event: { kind: "notification" | "server_request"; message: unknown },
+    event: { runtimeId: string; kind: "notification" | "server_request"; message: unknown },
   ): void {
     this.runtimeEventBuffer.bufferRuntimeStreamEvent(threadId, event);
+  }
+
+  private emitRuntimeStreamEventError(event: CodexRuntimeStreamEvent, error: unknown): void {
+    const threadId = threadIdFromRuntimeStreamEvent(event);
+    if (!threadId) {
+      if (event.kind === "server_request") {
+        this.emitUnroutableRuntimeServerRequest(event.runtimeId, this.errorMessage(error));
+      }
+      return;
+    }
+    const session = this.deps.sessions.get(threadId);
+    if (session?.runtimeId === event.runtimeId) {
+      this.emitSessionError(threadId, error);
+      return;
+    }
+    const route = this.deps.subagents.routeForChild(threadId, event.runtimeId);
+    const parentSession = route ? this.deps.sessions.get(route.parentExternalSessionId) : undefined;
+    if (parentSession?.runtimeId === event.runtimeId) {
+      this.emitSessionError(parentSession.threadId, error);
+      return;
+    }
+    this.emitUnroutableRuntimeServerRequest(event.runtimeId, this.errorMessage(error));
+  }
+
+  private emitCrossRuntimeRouteError(
+    runtimeId: string,
+    threadId: string,
+    ownerRuntimeId: string,
+  ): void {
+    this.emitUnroutableRuntimeServerRequest(
+      runtimeId,
+      `Cannot route Codex server request for thread '${threadId}' because the known session or subagent route belongs to runtime '${ownerRuntimeId}', not '${runtimeId}'.`,
+    );
   }
 
   private emitUnroutableRuntimeServerRequest(
@@ -522,7 +625,7 @@ export class CodexRuntimeSessionEvents {
     this.handledStreamRequestKeysByThreadId.set(session.threadId, handledRequestKeys);
     const hasPendingInput = await this.handleServerRequests(session, handledRequestKeys, requests);
     for (const ownerThreadId of ownerThreadIds) {
-      this.resolveBufferedServerRequests(ownerThreadId);
+      this.resolveBufferedServerRequests(ownerThreadId, session.runtimeId);
     }
     if (hasPendingInput && activeTurn && !activeTurn.isTurnSettled()) {
       this.bindPendingInputToActiveTurn(session.threadId, activeTurn);
@@ -761,8 +864,12 @@ export class CodexRuntimeSessionEvents {
       type: "session_error",
       externalSessionId,
       timestamp: new Date().toISOString(),
-      message: error instanceof Error ? error.message : String(error),
+      message: this.errorMessage(error),
     });
+  }
+
+  private errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 
   private emitSessionEvent(externalSessionId: string, event: AgentEvent): void {

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -41,7 +41,11 @@ import {
 } from "./codex-runtime-events";
 import type { CodexSessionEventBus } from "./codex-session-event-bus";
 import { codexSessionRef } from "./codex-session-ref";
-import type { CodexSubagentLinkState, CodexSubagentRoute } from "./codex-subagent-link-state";
+import {
+  type CodexSubagentLinkState,
+  type CodexSubagentRoute,
+  codexSubagentRouteEventFields,
+} from "./codex-subagent-link-state";
 import { createCodexEventMappers } from "./event-mappers";
 import type {
   CodexAppServerAdapterOptions,
@@ -285,9 +289,7 @@ export class CodexRuntimeSessionEvents {
         type: "approval_required",
         externalSessionId: route.parentExternalSessionId,
         timestamp: new Date().toISOString(),
-        parentExternalSessionId: route.parentExternalSessionId,
-        childExternalSessionId: route.childExternalSessionId,
-        subagentCorrelationKey: route.subagentCorrelationKey,
+        ...codexSubagentRouteEventFields(route),
       });
     }
 
@@ -297,9 +299,7 @@ export class CodexRuntimeSessionEvents {
         type: "question_required",
         externalSessionId: route.parentExternalSessionId,
         timestamp: new Date().toISOString(),
-        parentExternalSessionId: route.parentExternalSessionId,
-        childExternalSessionId: route.childExternalSessionId,
-        subagentCorrelationKey: route.subagentCorrelationKey,
+        ...codexSubagentRouteEventFields(route),
       });
     }
   }
@@ -453,13 +453,7 @@ export class CodexRuntimeSessionEvents {
       externalSessionId: threadId,
       timestamp: new Date().toISOString(),
       requestId,
-      ...(route
-        ? {
-            parentExternalSessionId: route.parentExternalSessionId,
-            childExternalSessionId: route.childExternalSessionId,
-            subagentCorrelationKey: route.subagentCorrelationKey,
-          }
-        : {}),
+      ...codexSubagentRouteEventFields(route),
     };
     const activeTurn = approval
       ? this.deps.pendingInput.resolveApproval(requestId)

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -250,8 +250,45 @@ export class CodexRuntimeSessionEvents {
 
   private scheduleBufferedSubagentServerRequestDrain(route: CodexSubagentRoute): void {
     void Promise.resolve()
+      .then(() => this.applyRouteToPendingInput(route))
       .then(() => this.drainBufferedSubagentServerRequests(route))
       .catch((error) => this.emitBufferedSubagentServerRequestError(route, error));
+  }
+
+  private applyRouteToPendingInput(route: CodexSubagentRoute): void {
+    const routed = this.deps.pendingInput.applyRouteToPendingInput(route);
+    const activeTurn = this.deps.activeTurnsBySessionId.get(route.parentExternalSessionId);
+    if (activeTurn && !activeTurn.isTurnSettled()) {
+      this.deps.pendingInput.bindActiveTurn(route.parentExternalSessionId, activeTurn);
+    }
+
+    if (!this.deps.sessions.get(route.parentExternalSessionId)) {
+      return;
+    }
+
+    for (const entry of routed.approvals) {
+      this.emitSessionEvent(route.parentExternalSessionId, {
+        ...entry.request,
+        type: "approval_required",
+        externalSessionId: route.parentExternalSessionId,
+        timestamp: new Date().toISOString(),
+        parentExternalSessionId: route.parentExternalSessionId,
+        childExternalSessionId: route.childExternalSessionId,
+        subagentCorrelationKey: route.subagentCorrelationKey,
+      });
+    }
+
+    for (const entry of routed.questions) {
+      this.emitSessionEvent(route.parentExternalSessionId, {
+        ...entry.request,
+        type: "question_required",
+        externalSessionId: route.parentExternalSessionId,
+        timestamp: new Date().toISOString(),
+        parentExternalSessionId: route.parentExternalSessionId,
+        childExternalSessionId: route.childExternalSessionId,
+        subagentCorrelationKey: route.subagentCorrelationKey,
+      });
+    }
   }
 
   private async drainBufferedSubagentServerRequestsForParent(

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -41,7 +41,7 @@ import {
 } from "./codex-runtime-events";
 import type { CodexSessionEventBus } from "./codex-session-event-bus";
 import { codexSessionRef } from "./codex-session-ref";
-import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
+import type { CodexSubagentLinkState, CodexSubagentRoute } from "./codex-subagent-link-state";
 import { createCodexEventMappers } from "./event-mappers";
 import type {
   CodexAppServerAdapterOptions,
@@ -104,6 +104,9 @@ export class CodexRuntimeSessionEvents {
       createCodexEventMappers(deps.subagents),
     );
     this.runtimeEventSubscriptions = new CodexRuntimeEventSubscriptions(deps.subscribeEvents);
+    deps.subagents.onRouteLearned((route) => {
+      this.scheduleBufferedSubagentServerRequestDrain(route);
+    });
   }
 
   ensureRuntimeEventSubscription(runtimeId: string): Promise<void> {
@@ -242,6 +245,50 @@ export class CodexRuntimeSessionEvents {
     await this.handlePendingNotifications(session, []);
     const bufferedRequests = this.runtimeEventBuffer.takeServerRequests(session.threadId);
     await this.processServerRequestsForSession(session, bufferedRequests);
+    await this.drainBufferedSubagentServerRequestsForParent(session);
+  }
+
+  private scheduleBufferedSubagentServerRequestDrain(route: CodexSubagentRoute): void {
+    void Promise.resolve()
+      .then(() => this.drainBufferedSubagentServerRequests(route))
+      .catch((error) => this.emitBufferedSubagentServerRequestError(route, error));
+  }
+
+  private async drainBufferedSubagentServerRequestsForParent(
+    parentSession: CodexSessionState,
+  ): Promise<void> {
+    for (const route of this.deps.subagents.routesForParent(parentSession.threadId)) {
+      await this.drainBufferedSubagentServerRequests(route);
+    }
+  }
+
+  private async drainBufferedSubagentServerRequests(route: CodexSubagentRoute): Promise<void> {
+    const parentSession = this.deps.sessions.get(route.parentExternalSessionId);
+    const childSession = this.deps.sessions.get(route.childExternalSessionId);
+    const session = parentSession ?? childSession;
+    if (!session) {
+      return;
+    }
+
+    const bufferedRequests = this.runtimeEventBuffer.takeServerRequests(
+      route.childExternalSessionId,
+    );
+    if (bufferedRequests.length === 0) {
+      return;
+    }
+    await this.processServerRequestsForSession(session, bufferedRequests);
+  }
+
+  private emitBufferedSubagentServerRequestError(route: CodexSubagentRoute, error: unknown): void {
+    const externalSessionId = this.deps.sessions.get(route.parentExternalSessionId)
+      ? route.parentExternalSessionId
+      : this.deps.sessions.get(route.childExternalSessionId)
+        ? route.childExternalSessionId
+        : null;
+    if (!externalSessionId) {
+      return;
+    }
+    this.emitSessionError(externalSessionId, error);
   }
 
   private async handleRuntimeStreamEvent(event: CodexRuntimeStreamEvent): Promise<void> {

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -175,15 +175,15 @@ export class CodexRuntimeSessionEvents {
     this.latestTodosBySessionId.set(externalSessionId, todos);
   }
 
-  clearSession(externalSessionId: string): void {
-    this.runtimeEventBuffer.clearSession(externalSessionId);
+  clearSession(externalSessionId: string, runtimeId?: string): void {
+    this.runtimeEventBuffer.clearSession(externalSessionId, runtimeId);
     this.handledStreamRequestKeysByThreadId.delete(externalSessionId);
     this.syntheticUserMessageTextsByThreadId.delete(externalSessionId);
     this.latestTodosBySessionId.delete(externalSessionId);
     this.clearTurnScopedMap(this.completedAgentMessagesByTurnKey, externalSessionId);
     this.clearTurnScopedMap(this.tokenUsageByTurnKey, externalSessionId);
     this.clearTurnScopedMap(this.modelByTurnKey, externalSessionId);
-    this.bufferedResolvedServerRequestIdsByThreadId.delete(externalSessionId);
+    this.clearBufferedResolvedServerRequests(externalSessionId, runtimeId);
   }
 
   bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean {
@@ -534,6 +534,18 @@ export class CodexRuntimeSessionEvents {
     if (requestIds.size === 0) {
       requestIdsByRuntimeId?.delete(runtimeId);
     }
+    if (requestIdsByRuntimeId?.size === 0) {
+      this.bufferedResolvedServerRequestIdsByThreadId.delete(threadId);
+    }
+  }
+
+  private clearBufferedResolvedServerRequests(threadId: string, runtimeId?: string): void {
+    if (!runtimeId) {
+      this.bufferedResolvedServerRequestIdsByThreadId.delete(threadId);
+      return;
+    }
+    const requestIdsByRuntimeId = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId);
+    requestIdsByRuntimeId?.delete(runtimeId);
     if (requestIdsByRuntimeId?.size === 0) {
       this.bufferedResolvedServerRequestIdsByThreadId.delete(threadId);
     }

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -270,6 +270,7 @@ export class CodexRuntimeSessionEvents {
         route.runtimeId,
         route.childExternalSessionId,
         parentSession.runtimeId,
+        parentSession.threadId,
       );
       return;
     }
@@ -327,6 +328,7 @@ export class CodexRuntimeSessionEvents {
         route.runtimeId,
         route.childExternalSessionId,
         session.runtimeId,
+        session.threadId,
       );
       return;
     }
@@ -376,34 +378,45 @@ export class CodexRuntimeSessionEvents {
     if (!session) {
       if (event.kind === "server_request") {
         const route = this.deps.subagents.routeForChild(threadId, event.runtimeId);
-        if (route?.runtimeId && route.runtimeId !== event.runtimeId) {
-          this.emitCrossRuntimeRouteError(event.runtimeId, threadId, route.runtimeId);
-          this.bufferRuntimeStreamEvent(threadId, event);
-          return;
-        }
         const parentSession = route
           ? this.deps.sessions.get(route.parentExternalSessionId)
           : undefined;
+        if (route?.runtimeId && route.runtimeId !== event.runtimeId) {
+          this.emitCrossRuntimeRouteError(
+            event.runtimeId,
+            threadId,
+            route.runtimeId,
+            parentSession?.threadId,
+          );
+          this.bufferRuntimeStreamEvent(threadId, event);
+          return;
+        }
         if (parentSession) {
           if (parentSession.runtimeId !== event.runtimeId) {
-            this.emitCrossRuntimeRouteError(event.runtimeId, threadId, parentSession.runtimeId);
+            this.emitCrossRuntimeRouteError(
+              event.runtimeId,
+              threadId,
+              parentSession.runtimeId,
+              parentSession.threadId,
+            );
             this.bufferRuntimeStreamEvent(threadId, event);
             return;
           }
           await this.processRuntimeStreamEventForSession(parentSession, event);
           return;
         }
-        this.emitUnroutableRuntimeServerRequest(
-          event.runtimeId,
-          `Cannot route Codex server request for thread '${threadId}' because there is no known session or subagent route for the request owner.`,
-        );
       }
       this.bufferRuntimeStreamEvent(threadId, event);
       return;
     }
     if (session.runtimeId !== event.runtimeId) {
       if (event.kind === "server_request") {
-        this.emitCrossRuntimeRouteError(event.runtimeId, threadId, session.runtimeId);
+        this.emitCrossRuntimeRouteError(
+          event.runtimeId,
+          threadId,
+          session.runtimeId,
+          session.threadId,
+        );
         this.bufferRuntimeStreamEvent(threadId, event);
       }
       return;
@@ -564,16 +577,19 @@ export class CodexRuntimeSessionEvents {
       this.emitSessionError(parentSession.threadId, error);
       return;
     }
-    this.emitUnroutableRuntimeServerRequest(event.runtimeId, this.errorMessage(error));
   }
 
   private emitCrossRuntimeRouteError(
     runtimeId: string,
     threadId: string,
     ownerRuntimeId: string,
+    targetExternalSessionId?: string,
   ): void {
-    this.emitUnroutableRuntimeServerRequest(
-      runtimeId,
+    if (!targetExternalSessionId) {
+      return;
+    }
+    this.emitSessionError(
+      targetExternalSessionId,
       `Cannot route Codex server request for thread '${threadId}' because the known session or subagent route belongs to runtime '${ownerRuntimeId}', not '${runtimeId}'.`,
     );
   }

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -96,6 +96,7 @@ export class CodexRuntimeSessionEvents {
   private readonly modelByTurnKey = new Map<string, AgentModelSelection>();
   private readonly latestTodosBySessionId = new Map<string, AgentSessionTodoItem[]>();
   private readonly restoredContextCapturesByKey = new Map<string, RestoredContextCapture>();
+  private readonly bufferedResolvedServerRequestIdsByThreadId = new Map<string, Set<string>>();
   private readonly eventMapperPipeline: ReturnType<typeof createCodexEventMapperPipeline>;
   private readonly runtimeEventSubscriptions: CodexRuntimeEventSubscriptions;
 
@@ -179,6 +180,7 @@ export class CodexRuntimeSessionEvents {
     this.clearTurnScopedMap(this.completedAgentMessagesByTurnKey, externalSessionId);
     this.clearTurnScopedMap(this.tokenUsageByTurnKey, externalSessionId);
     this.clearTurnScopedMap(this.modelByTurnKey, externalSessionId);
+    this.bufferedResolvedServerRequestIdsByThreadId.delete(externalSessionId);
   }
 
   bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean {
@@ -372,11 +374,19 @@ export class CodexRuntimeSessionEvents {
         "Codex serverRequest/resolved notification is missing threadId or requestId.",
       );
     }
+    if (!this.resolvePendingServerRequest(threadId, requestId)) {
+      if (this.runtimeEventBuffer.hasServerRequests(threadId)) {
+        this.bufferResolvedServerRequest(threadId, requestId);
+      }
+    }
+  }
+
+  private resolvePendingServerRequest(threadId: string, requestId: string): boolean {
     const approval = this.deps.pendingInput.approval(requestId);
     const question = this.deps.pendingInput.question(requestId);
     const entry = approval ?? question;
     if (!entry) {
-      return;
+      return false;
     }
     if (entry.threadId !== threadId) {
       throw new Error(
@@ -415,6 +425,36 @@ export class CodexRuntimeSessionEvents {
     }
     if (activeTurn && !activeTurn.isTurnSettled()) {
       void this.continueTurnAfterPendingInput(activeTurn);
+    }
+    this.deleteBufferedResolvedServerRequest(threadId, requestId);
+    return true;
+  }
+
+  private bufferResolvedServerRequest(threadId: string, requestId: string): void {
+    const requestIds = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId) ?? new Set();
+    requestIds.add(requestId);
+    this.bufferedResolvedServerRequestIdsByThreadId.set(threadId, requestIds);
+  }
+
+  private resolveBufferedServerRequests(threadId: string): void {
+    const requestIds = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId);
+    if (!requestIds) {
+      return;
+    }
+    this.bufferedResolvedServerRequestIdsByThreadId.delete(threadId);
+    for (const requestId of requestIds) {
+      this.resolvePendingServerRequest(threadId, requestId);
+    }
+  }
+
+  private deleteBufferedResolvedServerRequest(threadId: string, requestId: string): void {
+    const requestIds = this.bufferedResolvedServerRequestIdsByThreadId.get(threadId);
+    if (!requestIds) {
+      return;
+    }
+    requestIds.delete(requestId);
+    if (requestIds.size === 0) {
+      this.bufferedResolvedServerRequestIdsByThreadId.delete(threadId);
     }
   }
 
@@ -466,11 +506,17 @@ export class CodexRuntimeSessionEvents {
     session: CodexSessionState,
     requests: CodexServerRequestRecord[],
   ): Promise<void> {
+    const ownerThreadIds = new Set(
+      requests.map((request) => extractThreadIdFromParams(request.params) ?? session.threadId),
+    );
     const activeTurn = this.deps.activeTurnsBySessionId.get(session.threadId);
     const handledRequestKeys =
       this.handledStreamRequestKeysByThreadId.get(session.threadId) ?? new Set();
     this.handledStreamRequestKeysByThreadId.set(session.threadId, handledRequestKeys);
     const hasPendingInput = await this.handleServerRequests(session, handledRequestKeys, requests);
+    for (const ownerThreadId of ownerThreadIds) {
+      this.resolveBufferedServerRequests(ownerThreadId);
+    }
     if (hasPendingInput && activeTurn && !activeTurn.isTurnSettled()) {
       this.bindPendingInputToActiveTurn(session.threadId, activeTurn);
     }

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -359,6 +359,10 @@ export class CodexRuntimeSessionEvents {
           await this.processRuntimeStreamEventForSession(parentSession, event);
           return;
         }
+        this.emitUnroutableRuntimeServerRequest(
+          event.runtimeId,
+          `Cannot route Codex server request for thread '${threadId}' because there is no known session or subagent route for the request owner.`,
+        );
       }
       this.bufferRuntimeStreamEvent(threadId, event);
       return;
@@ -477,7 +481,10 @@ export class CodexRuntimeSessionEvents {
     this.runtimeEventBuffer.bufferRuntimeStreamEvent(threadId, event);
   }
 
-  private emitUnroutableRuntimeServerRequest(runtimeId: string): void {
+  private emitUnroutableRuntimeServerRequest(
+    runtimeId: string,
+    message = "Cannot route Codex app-server request because it is missing params.threadId.",
+  ): void {
     for (const session of this.deps.sessions.values()) {
       if (session.runtimeId !== runtimeId) {
         continue;
@@ -486,7 +493,7 @@ export class CodexRuntimeSessionEvents {
         type: "session_error",
         externalSessionId: session.threadId,
         timestamp: new Date().toISOString(),
-        message: "Cannot route Codex app-server request because it is missing params.threadId.",
+        message,
       });
     }
   }

--- a/packages/adapters-codex-app-server/src/codex-session-history.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-history.ts
@@ -93,6 +93,7 @@ const projectCodexThreadReadToHistory = ({
   eventMapperPipeline,
   modelByTurnKey,
   tokenUsageByTurnKey,
+  runtimeId,
 }: {
   input: LoadAgentSessionHistoryInput;
   session: CodexSessionState | undefined;
@@ -101,6 +102,7 @@ const projectCodexThreadReadToHistory = ({
   eventMapperPipeline: ReturnType<typeof createCodexEventMapperPipeline>;
   modelByTurnKey: ReadonlyMap<string, AgentModelSelection>;
   tokenUsageByTurnKey: ReadonlyMap<string, CodexTokenUsageTotals>;
+  runtimeId: string;
 }): AgentSessionHistoryMessage[] => {
   const projectedHistory = codexTurnItemsFromThreadRead(response)
     .flatMap(({ item, turnId, timestamp, isFinalAgentMessage, turnTiming, model }, index) => {
@@ -123,6 +125,7 @@ const projectCodexThreadReadToHistory = ({
         },
         {
           source: "thread_read",
+          runtimeId,
           threadId: input.externalSessionId,
           ...(timestamp ? { timestamp } : {}),
         },
@@ -188,5 +191,6 @@ export const loadCodexSessionHistory = async ({
     eventMapperPipeline,
     modelByTurnKey,
     tokenUsageByTurnKey,
+    runtimeId,
   });
 };

--- a/packages/adapters-codex-app-server/src/codex-session-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-lifecycle.ts
@@ -10,6 +10,7 @@ import type {
 } from "@openducktor/core";
 import { agentSessionStatusFromActivity } from "@openducktor/core";
 import {
+  type CodexThreadSnapshot,
   codexThreadStatusSnapshot,
   extractThreadId,
   requireThreadSnapshotFromReadResponse,
@@ -122,6 +123,22 @@ export const sessionStateFromExistingThread = (
   const session = sessionStateFromThreadResumeResponse(input, runtimeId, model, response);
   delete session.liveStatus;
   return session;
+};
+
+export const sessionStateFromThreadSnapshot = (
+  input: AgentSessionRef | AgentSessionRuntimeRef,
+  runtimeId: string,
+  threadSnapshot: CodexThreadSnapshot,
+): CodexSessionState => {
+  const summary = toSessionSummary({
+    externalSessionId: threadSnapshot.id,
+    workingDirectory: input.workingDirectory,
+    startedAt: threadSnapshot.startedAt,
+    title: threadSnapshot.title,
+    role: "role" in input ? input.role : null,
+    status: agentSessionStatusFromActivity(threadSnapshot.status.classification),
+  });
+  return buildSessionState(input, summary, runtimeId, undefined);
 };
 
 export const preserveRuntimeContextForExistingThread = (

--- a/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.test.ts
@@ -4,7 +4,6 @@ import { codexThreadStatusSnapshot } from "./codex-app-server-threads";
 import { CodexPendingInputState } from "./codex-pending-input-state";
 import type { CodexSessionRuntimeSnapshotReaderDeps } from "./codex-session-runtime-snapshot-reader";
 import { readCodexSessionRuntimeSnapshot } from "./codex-session-runtime-snapshot-reader";
-import { CodexSubagentLinkState } from "./codex-subagent-link-state";
 
 const createChildThread = (): CodexThreadSnapshot => ({
   id: "child-thread",
@@ -45,12 +44,6 @@ const createDeps = (inventory: CodexThreadInventory): CodexSessionRuntimeSnapsho
 
 describe("Codex session runtime snapshot reader", () => {
   test("reads child parent metadata without learning a live route", async () => {
-    const subagents = new CodexSubagentLinkState();
-    let learnedRoutes = 0;
-    subagents.onRouteLearned(() => {
-      learnedRoutes += 1;
-    });
-
     await expect(
       readCodexSessionRuntimeSnapshot(createDeps(createInventory(createChildThread())), {
         repoPath: "/repo",
@@ -62,6 +55,5 @@ describe("Codex session runtime snapshot reader", () => {
       availability: "runtime",
       parentExternalSessionId: "parent-thread",
     });
-    expect(learnedRoutes).toBe(0);
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import type { CodexThreadInventory, CodexThreadSnapshot } from "./codex-app-server-threads";
+import { codexThreadStatusSnapshot } from "./codex-app-server-threads";
+import { CodexPendingInputState } from "./codex-pending-input-state";
+import type { CodexSessionRuntimeSnapshotReaderDeps } from "./codex-session-runtime-snapshot-reader";
+import { readCodexSessionRuntimeSnapshot } from "./codex-session-runtime-snapshot-reader";
+import { CodexSubagentLinkState } from "./codex-subagent-link-state";
+
+const createChildThread = (): CodexThreadSnapshot => ({
+  id: "child-thread",
+  cwd: "/repo",
+  startedAt: "2026-06-26T08:00:00.000Z",
+  title: "Child thread",
+  status: codexThreadStatusSnapshot("active"),
+  parentThreadId: "parent-thread",
+  agentNickname: null,
+  agentRole: null,
+  subAgentSource: null,
+});
+
+const createInventory = (thread: CodexThreadSnapshot): CodexThreadInventory => ({
+  runtimeId: "runtime-1",
+  loadedIds: new Set([thread.id]),
+  threadsById: new Map([[thread.id, thread]]),
+});
+
+const createDeps = (inventory: CodexThreadInventory): CodexSessionRuntimeSnapshotReaderDeps => ({
+  runtimeClients: {
+    clientForRuntime: () => ({}) as never,
+    resolve: async () => ({ runtimeId: "runtime-1", client: {} as never }),
+  },
+  threadInventory: {
+    read: async () => inventory,
+    refresh: async () => inventory,
+  } as never,
+  sessions: {
+    get: () => undefined,
+    values: function* () {
+      yield* [];
+    },
+  },
+  pendingInput: new CodexPendingInputState(),
+  hasActiveTurn: () => false,
+});
+
+describe("Codex session runtime snapshot reader", () => {
+  test("reads child parent metadata without learning a live route", async () => {
+    const subagents = new CodexSubagentLinkState();
+    let learnedRoutes = 0;
+    subagents.onRouteLearned(() => {
+      learnedRoutes += 1;
+    });
+
+    await expect(
+      readCodexSessionRuntimeSnapshot(createDeps(createInventory(createChildThread())), {
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "child-thread",
+      }),
+    ).resolves.toMatchObject({
+      availability: "runtime",
+      parentExternalSessionId: "parent-thread",
+    });
+    expect(learnedRoutes).toBe(0);
+  });
+});

--- a/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.ts
@@ -34,9 +34,10 @@ const threadMatchesDirectories = (thread: CodexThreadSnapshot, directories: Set<
 const recordInventorySubagentLinks = (
   deps: CodexSessionRuntimeSnapshotReaderDeps,
   inventory: CodexThreadInventory,
+  runtimeId: string,
 ): CodexThreadInventory => {
   for (const thread of inventory.threadsById.values()) {
-    deps.subagents.recordThread(thread);
+    deps.subagents.recordThread(thread, runtimeId);
   }
   return inventory;
 };
@@ -52,6 +53,7 @@ const toLocalRuntimeSnapshot = async (
       deps.runtimeClients.clientForRuntime(session.runtimeId),
       session.runtimeId,
     ),
+    session.runtimeId,
   );
   return toRefreshedRuntimeSnapshot({
     session,
@@ -96,6 +98,7 @@ export const listCodexSessionRuntimeSnapshots = async (
         inventory: recordInventorySubagentLinks(
           deps,
           await readRuntimeInventoryOnce(deps, inventoryByRuntimeId, session.runtimeId),
+          session.runtimeId,
         ),
         pendingApprovals: deps.pendingInput.pendingApprovalsForSession(session.threadId),
         pendingQuestions: deps.pendingInput.pendingQuestionsForSession(session.threadId),
@@ -111,6 +114,7 @@ export const listCodexSessionRuntimeSnapshots = async (
   const inventory = recordInventorySubagentLinks(
     deps,
     await deps.threadInventory.refresh(client, runtimeId),
+    runtimeId,
   );
   const remoteSnapshots = [...inventory.threadsById.values()]
     .filter((thread) => inventory.loadedIds.has(thread.id))
@@ -141,6 +145,7 @@ export const readCodexSessionRuntimeSnapshot = async (
   const inventory = recordInventorySubagentLinks(
     deps,
     await deps.threadInventory.refresh(client, runtimeId),
+    runtimeId,
   );
   if (!inventory.loadedIds.has(input.externalSessionId)) {
     return missingRuntimeSnapshot(input);

--- a/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.ts
@@ -12,7 +12,6 @@ import type { CodexThreadInventory, CodexThreadSnapshot } from "./codex-app-serv
 import type { CodexSessionLookup } from "./codex-local-session-state";
 import type { CodexPendingInputState } from "./codex-pending-input-state";
 import type { CodexRuntimeClientResolver } from "./codex-runtime-client-resolver";
-import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import type { CodexThreadInventoryReader } from "./codex-thread-inventory";
 import type { CodexSessionState } from "./types";
 
@@ -21,7 +20,6 @@ export type CodexSessionRuntimeSnapshotReaderDeps = {
   threadInventory: CodexThreadInventoryReader;
   sessions: CodexSessionLookup;
   pendingInput: CodexPendingInputState;
-  subagents: CodexSubagentLinkState;
   hasActiveTurn: (externalSessionId: string) => boolean;
 };
 
@@ -31,28 +29,13 @@ const directoriesFromInput = (directories: readonly string[] | undefined): Set<s
 const threadMatchesDirectories = (thread: CodexThreadSnapshot, directories: Set<string>): boolean =>
   directories.size === 0 || directories.has(thread.cwd);
 
-const recordInventorySubagentLinks = (
-  deps: CodexSessionRuntimeSnapshotReaderDeps,
-  inventory: CodexThreadInventory,
-  runtimeId: string,
-): CodexThreadInventory => {
-  for (const thread of inventory.threadsById.values()) {
-    deps.subagents.recordThread(thread, runtimeId);
-  }
-  return inventory;
-};
-
 const toLocalRuntimeSnapshot = async (
   deps: CodexSessionRuntimeSnapshotReaderDeps,
   session: CodexSessionState,
   input?: ReadSessionRuntimeSnapshotInput,
 ): Promise<AgentSessionRuntimeSnapshot> => {
-  const inventory = recordInventorySubagentLinks(
-    deps,
-    await deps.threadInventory.read(
-      deps.runtimeClients.clientForRuntime(session.runtimeId),
-      session.runtimeId,
-    ),
+  const inventory = await deps.threadInventory.read(
+    deps.runtimeClients.clientForRuntime(session.runtimeId),
     session.runtimeId,
   );
   return toRefreshedRuntimeSnapshot({
@@ -95,11 +78,7 @@ export const listCodexSessionRuntimeSnapshots = async (
     localSessions.map(async (session) =>
       toRefreshedRuntimeSnapshot({
         session,
-        inventory: recordInventorySubagentLinks(
-          deps,
-          await readRuntimeInventoryOnce(deps, inventoryByRuntimeId, session.runtimeId),
-          session.runtimeId,
-        ),
+        inventory: await readRuntimeInventoryOnce(deps, inventoryByRuntimeId, session.runtimeId),
         pendingApprovals: deps.pendingInput.pendingApprovalsForSession(session.threadId),
         pendingQuestions: deps.pendingInput.pendingQuestionsForSession(session.threadId),
         hasActiveTurn: deps.hasActiveTurn(session.threadId),
@@ -111,11 +90,7 @@ export const listCodexSessionRuntimeSnapshots = async (
     input,
     "list session runtime snapshots",
   );
-  const inventory = recordInventorySubagentLinks(
-    deps,
-    await deps.threadInventory.refresh(client, runtimeId),
-    runtimeId,
-  );
+  const inventory = await deps.threadInventory.refresh(client, runtimeId);
   const remoteSnapshots = [...inventory.threadsById.values()]
     .filter((thread) => inventory.loadedIds.has(thread.id))
     .filter((thread) => !localThreadIds.has(thread.id))
@@ -142,11 +117,7 @@ export const readCodexSessionRuntimeSnapshot = async (
     input,
     "read session runtime snapshot",
   );
-  const inventory = recordInventorySubagentLinks(
-    deps,
-    await deps.threadInventory.refresh(client, runtimeId),
-    runtimeId,
-  );
+  const inventory = await deps.threadInventory.refresh(client, runtimeId);
   if (!inventory.loadedIds.has(input.externalSessionId)) {
     return missingRuntimeSnapshot(input);
   }

--- a/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.ts
+++ b/packages/adapters-codex-app-server/src/codex-session-runtime-snapshot-reader.ts
@@ -12,6 +12,7 @@ import type { CodexThreadInventory, CodexThreadSnapshot } from "./codex-app-serv
 import type { CodexSessionLookup } from "./codex-local-session-state";
 import type { CodexPendingInputState } from "./codex-pending-input-state";
 import type { CodexRuntimeClientResolver } from "./codex-runtime-client-resolver";
+import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import type { CodexThreadInventoryReader } from "./codex-thread-inventory";
 import type { CodexSessionState } from "./types";
 
@@ -20,6 +21,7 @@ export type CodexSessionRuntimeSnapshotReaderDeps = {
   threadInventory: CodexThreadInventoryReader;
   sessions: CodexSessionLookup;
   pendingInput: CodexPendingInputState;
+  subagents: CodexSubagentLinkState;
   hasActiveTurn: (externalSessionId: string) => boolean;
 };
 
@@ -29,14 +31,27 @@ const directoriesFromInput = (directories: readonly string[] | undefined): Set<s
 const threadMatchesDirectories = (thread: CodexThreadSnapshot, directories: Set<string>): boolean =>
   directories.size === 0 || directories.has(thread.cwd);
 
+const recordInventorySubagentLinks = (
+  deps: CodexSessionRuntimeSnapshotReaderDeps,
+  inventory: CodexThreadInventory,
+): CodexThreadInventory => {
+  for (const thread of inventory.threadsById.values()) {
+    deps.subagents.recordThread(thread);
+  }
+  return inventory;
+};
+
 const toLocalRuntimeSnapshot = async (
   deps: CodexSessionRuntimeSnapshotReaderDeps,
   session: CodexSessionState,
   input?: ReadSessionRuntimeSnapshotInput,
 ): Promise<AgentSessionRuntimeSnapshot> => {
-  const inventory = await deps.threadInventory.read(
-    deps.runtimeClients.clientForRuntime(session.runtimeId),
-    session.runtimeId,
+  const inventory = recordInventorySubagentLinks(
+    deps,
+    await deps.threadInventory.read(
+      deps.runtimeClients.clientForRuntime(session.runtimeId),
+      session.runtimeId,
+    ),
   );
   return toRefreshedRuntimeSnapshot({
     session,
@@ -78,7 +93,10 @@ export const listCodexSessionRuntimeSnapshots = async (
     localSessions.map(async (session) =>
       toRefreshedRuntimeSnapshot({
         session,
-        inventory: await readRuntimeInventoryOnce(deps, inventoryByRuntimeId, session.runtimeId),
+        inventory: recordInventorySubagentLinks(
+          deps,
+          await readRuntimeInventoryOnce(deps, inventoryByRuntimeId, session.runtimeId),
+        ),
         pendingApprovals: deps.pendingInput.pendingApprovalsForSession(session.threadId),
         pendingQuestions: deps.pendingInput.pendingQuestionsForSession(session.threadId),
         hasActiveTurn: deps.hasActiveTurn(session.threadId),
@@ -90,12 +108,20 @@ export const listCodexSessionRuntimeSnapshots = async (
     input,
     "list session runtime snapshots",
   );
-  const inventory = await deps.threadInventory.refresh(client, runtimeId);
+  const inventory = recordInventorySubagentLinks(
+    deps,
+    await deps.threadInventory.refresh(client, runtimeId),
+  );
   const remoteSnapshots = [...inventory.threadsById.values()]
     .filter((thread) => inventory.loadedIds.has(thread.id))
     .filter((thread) => !localThreadIds.has(thread.id))
     .filter((thread) => threadMatchesDirectories(thread, directories))
-    .map((thread) => toRuntimeSnapshotFromThread(thread, input));
+    .map((thread) =>
+      toRuntimeSnapshotFromThread(thread, input, {
+        pendingApprovals: deps.pendingInput.pendingApprovalsForSession(thread.id),
+        pendingQuestions: deps.pendingInput.pendingQuestionsForSession(thread.id),
+      }),
+    );
   return [...localSnapshots, ...remoteSnapshots];
 };
 
@@ -112,7 +138,10 @@ export const readCodexSessionRuntimeSnapshot = async (
     input,
     "read session runtime snapshot",
   );
-  const inventory = await deps.threadInventory.refresh(client, runtimeId);
+  const inventory = recordInventorySubagentLinks(
+    deps,
+    await deps.threadInventory.refresh(client, runtimeId),
+  );
   if (!inventory.loadedIds.has(input.externalSessionId)) {
     return missingRuntimeSnapshot(input);
   }
@@ -120,5 +149,8 @@ export const readCodexSessionRuntimeSnapshot = async (
   if (!snapshot || snapshot.cwd !== input.workingDirectory) {
     return missingRuntimeSnapshot(input);
   }
-  return toRuntimeSnapshotFromThread(snapshot, input);
+  return toRuntimeSnapshotFromThread(snapshot, input, {
+    pendingApprovals: deps.pendingInput.pendingApprovalsForSession(snapshot.id),
+    pendingQuestions: deps.pendingInput.pendingQuestionsForSession(snapshot.id),
+  });
 };

--- a/packages/adapters-codex-app-server/src/codex-subagent-items.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-items.ts
@@ -1,0 +1,296 @@
+import type { AgentStreamPart, AgentSubagentStatus } from "@openducktor/core";
+import { arrayFromUnknown, extractStringField, isPlainObject } from "./codex-app-server-shared";
+import type { CodexMappingContext } from "./codex-canonical-events";
+import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
+
+type CodexCollabTool = "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+type CodexCollabCallStatus = "inProgress" | "completed" | "failed";
+type CodexCollabAgentStatus =
+  | "pendingInit"
+  | "running"
+  | "interrupted"
+  | "completed"
+  | "errored"
+  | "shutdown"
+  | "notFound";
+type CodexSubagentActivityKind = "started" | "interacted" | "interrupted";
+
+type StatusMapping = {
+  status: AgentSubagentStatus;
+  description?: string;
+  error?: string;
+};
+
+export class CodexSubagentItemError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexSubagentItemError";
+  }
+}
+
+const COLLAB_TOOLS = new Set<CodexCollabTool>([
+  "spawnAgent",
+  "sendInput",
+  "resumeAgent",
+  "wait",
+  "closeAgent",
+]);
+
+const COLLAB_CALL_STATUSES = new Set<CodexCollabCallStatus>(["inProgress", "completed", "failed"]);
+
+const COLLAB_AGENT_STATUSES = new Set<CodexCollabAgentStatus>([
+  "pendingInit",
+  "running",
+  "interrupted",
+  "completed",
+  "errored",
+  "shutdown",
+  "notFound",
+]);
+
+const ACTIVITY_KINDS = new Set<CodexSubagentActivityKind>(["started", "interacted", "interrupted"]);
+
+const itemError = (
+  item: Record<string, unknown>,
+  message: string,
+  context: Record<string, unknown> = {},
+): CodexSubagentItemError => {
+  const id = extractStringField(item, ["id"]) ?? "<missing>";
+  const type = extractStringField(item, ["type"]) ?? "<missing>";
+  return new CodexSubagentItemError(
+    `Malformed Codex subagent item '${id}' of type '${type}': ${message}. Context: ${JSON.stringify(
+      context,
+    )}`,
+  );
+};
+
+const requireStringField = (
+  item: Record<string, unknown>,
+  keys: string[],
+  label: string,
+): string => {
+  const value = extractStringField(item, keys);
+  if (!value) {
+    throw itemError(item, `missing ${label}`);
+  }
+  return value;
+};
+
+const collabTool = (item: Record<string, unknown>): CodexCollabTool => {
+  const tool = requireStringField(item, ["tool"], "tool");
+  if (!COLLAB_TOOLS.has(tool as CodexCollabTool)) {
+    throw itemError(item, "unknown collab tool", { tool });
+  }
+  return tool as CodexCollabTool;
+};
+
+const collabCallStatus = (item: Record<string, unknown>): CodexCollabCallStatus => {
+  const status = requireStringField(item, ["status"], "status");
+  if (!COLLAB_CALL_STATUSES.has(status as CodexCollabCallStatus)) {
+    throw itemError(item, "unknown collab tool-call status", { status });
+  }
+  return status as CodexCollabCallStatus;
+};
+
+const receiverThreadIds = (item: Record<string, unknown>): string[] =>
+  arrayFromUnknown(item.receiverThreadIds ?? item.receiver_thread_ids).filter(
+    (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
+  );
+
+const agentsStates = (item: Record<string, unknown>): Record<string, unknown> => {
+  const states = item.agentsStates ?? item.agents_states;
+  return isPlainObject(states) ? states : {};
+};
+
+const mapAgentStatus = (
+  item: Record<string, unknown>,
+  status: unknown,
+  message: unknown,
+  childThreadId: string,
+): StatusMapping => {
+  if (typeof status !== "string" || !COLLAB_AGENT_STATUSES.has(status as CodexCollabAgentStatus)) {
+    throw itemError(item, "unknown collab agent status", { status, childThreadId });
+  }
+  const text = typeof message === "string" && message.trim().length > 0 ? message : undefined;
+  switch (status as CodexCollabAgentStatus) {
+    case "pendingInit":
+      return text ? { status: "pending", description: text } : { status: "pending" };
+    case "running":
+      return text ? { status: "running", description: text } : { status: "running" };
+    case "completed":
+      return text ? { status: "completed", description: text } : { status: "completed" };
+    case "interrupted":
+    case "shutdown":
+      return text ? { status: "cancelled", description: text } : { status: "cancelled" };
+    case "errored":
+    case "notFound":
+      return {
+        status: "error",
+        error: text ?? `Codex subagent '${childThreadId}' status is ${status}.`,
+      };
+  }
+};
+
+const mapAggregateStatus = (
+  status: CodexCollabCallStatus,
+  tool: CodexCollabTool,
+): StatusMapping => {
+  if (status === "inProgress") {
+    return { status: "running" };
+  }
+  if (status === "failed") {
+    return { status: "error", error: `Codex ${tool} subagent call failed.` };
+  }
+  if (tool === "closeAgent") {
+    return { status: "cancelled" };
+  }
+  return { status: "completed" };
+};
+
+const statusForChild = (
+  item: Record<string, unknown>,
+  tool: CodexCollabTool,
+  aggregateStatus: CodexCollabCallStatus,
+  childThreadId: string,
+): StatusMapping => {
+  const state = agentsStates(item)[childThreadId];
+  if (!isPlainObject(state)) {
+    return mapAggregateStatus(aggregateStatus, tool);
+  }
+  return mapAgentStatus(item, state.status, state.message, childThreadId);
+};
+
+const activityKind = (item: Record<string, unknown>): CodexSubagentActivityKind => {
+  const kind = requireStringField(item, ["kind"], "kind");
+  if (!ACTIVITY_KINDS.has(kind as CodexSubagentActivityKind)) {
+    throw itemError(item, "unknown subagent activity kind", { kind });
+  }
+  return kind as CodexSubagentActivityKind;
+};
+
+const mapActivityStatus = (kind: CodexSubagentActivityKind): StatusMapping => {
+  if (kind === "interrupted") {
+    return { status: "cancelled", description: "Subagent interrupted." };
+  }
+  if (kind === "started") {
+    return { status: "running", description: "Subagent started." };
+  }
+  return { status: "running", description: "Subagent activity updated." };
+};
+
+const collabMetadata = (
+  item: Record<string, unknown>,
+  parentThreadId: string,
+  childThreadId?: string,
+): Record<string, unknown> => ({
+  codexSubagent: {
+    source: "collabAgentToolCall",
+    itemId: extractStringField(item, ["id"]),
+    tool: extractStringField(item, ["tool"]),
+    parentThreadId,
+    ...(childThreadId ? { childThreadId } : {}),
+  },
+});
+
+const activityMetadata = (
+  item: Record<string, unknown>,
+  parentThreadId: string,
+  childThreadId: string,
+): Record<string, unknown> => ({
+  codexSubagent: {
+    source: "subAgentActivity",
+    itemId: extractStringField(item, ["id"]),
+    kind: extractStringField(item, ["kind"]),
+    parentThreadId,
+    childThreadId,
+    ...(extractStringField(item, ["agentPath", "agent_path"])
+      ? { agentPath: extractStringField(item, ["agentPath", "agent_path"]) }
+      : {}),
+  },
+});
+
+export const codexSubagentPartsFromItem = (
+  item: Record<string, unknown>,
+  ctx: CodexMappingContext,
+  linkState: CodexSubagentLinkState,
+): AgentStreamPart[] => {
+  const type = extractStringField(item, ["type"]);
+  if (type === "collabAgentToolCall") {
+    const itemId = requireStringField(item, ["id"], "id");
+    const tool = collabTool(item);
+    const aggregateStatus = collabCallStatus(item);
+    const parentThreadId = requireStringField(
+      item,
+      ["senderThreadId", "sender_thread_id"],
+      "senderThreadId",
+    );
+    const prompt = extractStringField(item, ["prompt"]) ?? undefined;
+    const receivers = receiverThreadIds(item);
+    if (receivers.length === 0) {
+      if (tool !== "spawnAgent") {
+        throw itemError(item, "missing receiverThreadIds for linked collab tool", {
+          tool,
+          parentThreadId,
+        });
+      }
+      const mapped = mapAggregateStatus(aggregateStatus, tool);
+      return [
+        linkState.upsertLink({
+          parentThreadId,
+          itemId,
+          status: mapped.status,
+          ...(prompt ? { prompt } : {}),
+          ...(mapped.description ? { description: mapped.description } : {}),
+          ...(mapped.error ? { error: mapped.error } : {}),
+          metadata: collabMetadata(item, parentThreadId),
+          executionMode: "background",
+        }),
+      ];
+    }
+    return receivers.map((childThreadId) => {
+      const mapped = statusForChild(item, tool, aggregateStatus, childThreadId);
+      return linkState.upsertLink({
+        parentThreadId,
+        childThreadId,
+        itemId,
+        status: mapped.status,
+        ...(prompt ? { prompt } : {}),
+        ...(mapped.description ? { description: mapped.description } : {}),
+        ...(mapped.error ? { error: mapped.error } : {}),
+        metadata: collabMetadata(item, parentThreadId, childThreadId),
+        executionMode: "background",
+      });
+    });
+  }
+
+  if (type === "subAgentActivity") {
+    const itemId = requireStringField(item, ["id"], "id");
+    const childThreadId = requireStringField(
+      item,
+      ["agentThreadId", "agent_thread_id"],
+      "agentThreadId",
+    );
+    const parentThreadId = ctx.threadId;
+    if (parentThreadId === childThreadId) {
+      throw itemError(item, "subAgentActivity parent thread matches child thread", {
+        parentThreadId,
+        childThreadId,
+      });
+    }
+    const mapped = mapActivityStatus(activityKind(item));
+    return [
+      linkState.upsertLink({
+        parentThreadId,
+        childThreadId,
+        itemId,
+        status: mapped.status,
+        ...(mapped.description ? { description: mapped.description } : {}),
+        ...(mapped.error ? { error: mapped.error } : {}),
+        metadata: activityMetadata(item, parentThreadId, childThreadId),
+        executionMode: "background",
+      }),
+    ];
+  }
+
+  return [];
+};

--- a/packages/adapters-codex-app-server/src/codex-subagent-items.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-items.ts
@@ -158,6 +158,16 @@ const statusForChild = (
     if (tool === "closeAgent" && aggregateStatus === "completed") {
       return { status: "cancelled" };
     }
+    if (aggregateStatus === "failed") {
+      return mapAggregateStatus(aggregateStatus, tool);
+    }
+    if (tool === "wait" && aggregateStatus !== "inProgress") {
+      throw itemError(item, "missing collab agent state", {
+        aggregateStatus,
+        childThreadId,
+        tool,
+      });
+    }
     return { status: "running" };
   }
   return mapAgentStatus(item, state.status, state.message, childThreadId);

--- a/packages/adapters-codex-app-server/src/codex-subagent-items.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-items.ts
@@ -271,7 +271,6 @@ export const codexSubagentPartsFromItem = (
           ...(creationDescription ? { description: creationDescription } : {}),
           ...(mapped.error ? { error: mapped.error } : {}),
           metadata: collabMetadata(item, parentThreadId),
-          executionMode: "background",
         }),
       ];
     }
@@ -287,7 +286,6 @@ export const codexSubagentPartsFromItem = (
         ...(creationDescription ? { description: creationDescription } : {}),
         ...(mapped.error ? { error: mapped.error } : {}),
         metadata: collabMetadata(item, parentThreadId, childThreadId),
-        executionMode: "background",
         preferItemCorrelationKey: tool === "spawnAgent",
       });
     });
@@ -317,7 +315,6 @@ export const codexSubagentPartsFromItem = (
         status: mapped.status,
         ...(mapped.error ? { error: mapped.error } : {}),
         metadata: activityMetadata(item, parentThreadId, childThreadId),
-        executionMode: "background",
       }),
     ];
   }

--- a/packages/adapters-codex-app-server/src/codex-subagent-items.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-items.ts
@@ -22,7 +22,7 @@ type StatusMapping = {
 
 type CodexCollabItemType = "collabAgentToolCall" | "collabToolCall";
 
-export class CodexSubagentItemError extends Error {
+class CodexSubagentItemError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "CodexSubagentItemError";

--- a/packages/adapters-codex-app-server/src/codex-subagent-items.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-items.ts
@@ -120,6 +120,7 @@ const mapAgentStatus = (
     case "completed":
       return text ? { status: "completed", description: text } : { status: "completed" };
     case "interrupted":
+      return text ? { status: "running", description: text } : { status: "running" };
     case "shutdown":
       return text ? { status: "cancelled", description: text } : { status: "cancelled" };
     case "errored":
@@ -183,7 +184,7 @@ const activityKind = (item: Record<string, unknown>): CodexSubagentActivityKind 
 
 const mapActivityStatus = (kind: CodexSubagentActivityKind): StatusMapping => {
   if (kind === "interrupted") {
-    return { status: "cancelled", description: "Subagent interrupted." };
+    return { status: "running", description: "Subagent interrupted." };
   }
   if (kind === "started") {
     return { status: "running", description: "Subagent started." };
@@ -249,6 +250,7 @@ export const codexSubagentPartsFromItem = (
       const mapped = mapAggregateStatus(aggregateStatus, tool);
       return [
         linkState.upsertLink({
+          ...(ctx.runtimeId ? { runtimeId: ctx.runtimeId } : {}),
           parentThreadId,
           itemId,
           status: mapped.status,
@@ -263,6 +265,7 @@ export const codexSubagentPartsFromItem = (
     return receivers.map((childThreadId) => {
       const mapped = statusForChild(item, tool, aggregateStatus, childThreadId);
       return linkState.upsertLink({
+        ...(ctx.runtimeId ? { runtimeId: ctx.runtimeId } : {}),
         parentThreadId,
         childThreadId,
         itemId,
@@ -294,6 +297,7 @@ export const codexSubagentPartsFromItem = (
     const mapped = mapActivityStatus(activityKind(item));
     return [
       linkState.upsertLink({
+        ...(ctx.runtimeId ? { runtimeId: ctx.runtimeId } : {}),
         parentThreadId,
         childThreadId,
         itemId,

--- a/packages/adapters-codex-app-server/src/codex-subagent-items.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-items.ts
@@ -155,7 +155,10 @@ const statusForChild = (
 ): StatusMapping => {
   const state = agentsStates(item)[childThreadId];
   if (!isPlainObject(state)) {
-    return mapAggregateStatus(aggregateStatus, tool);
+    if (tool === "closeAgent" && aggregateStatus === "completed") {
+      return { status: "cancelled" };
+    }
+    return { status: "running" };
   }
   return mapAgentStatus(item, state.status, state.message, childThreadId);
 };
@@ -259,6 +262,7 @@ export const codexSubagentPartsFromItem = (
         ...(mapped.error ? { error: mapped.error } : {}),
         metadata: collabMetadata(item, parentThreadId, childThreadId),
         executionMode: "background",
+        preferItemCorrelationKey: tool === "spawnAgent",
       });
     });
   }

--- a/packages/adapters-codex-app-server/src/codex-subagent-items.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-items.ts
@@ -20,6 +20,8 @@ type StatusMapping = {
   error?: string;
 };
 
+type CodexCollabItemType = "collabAgentToolCall" | "collabToolCall";
+
 export class CodexSubagentItemError extends Error {
   constructor(message: string) {
     super(message);
@@ -91,15 +93,44 @@ const collabCallStatus = (item: Record<string, unknown>): CodexCollabCallStatus 
   return status as CodexCollabCallStatus;
 };
 
-const receiverThreadIds = (item: Record<string, unknown>): string[] =>
-  arrayFromUnknown(item.receiverThreadIds ?? item.receiver_thread_ids).filter(
+const stringArrayField = (value: unknown): string[] =>
+  arrayFromUnknown(value).filter(
     (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
   );
+
+const receiverThreadIds = (item: Record<string, unknown>): string[] => {
+  const receivers = [
+    ...stringArrayField(item.receiverThreadIds ?? item.receiver_thread_ids),
+    extractStringField(item, ["receiverThreadId", "receiver_thread_id"]),
+    extractStringField(item, ["newThreadId", "new_thread_id"]),
+  ].filter((entry): entry is string => Boolean(entry));
+  return [...new Set(receivers)];
+};
 
 const agentsStates = (item: Record<string, unknown>): Record<string, unknown> => {
   const states = item.agentsStates ?? item.agents_states;
   return isPlainObject(states) ? states : {};
 };
+
+const agentStateForChild = (
+  item: Record<string, unknown>,
+  childThreadId: string,
+): Record<string, unknown> | null => {
+  const state = agentsStates(item)[childThreadId];
+  if (isPlainObject(state)) {
+    return state;
+  }
+  const status = extractStringField(item, ["agentStatus", "agent_status"]);
+  if (!status) {
+    return null;
+  }
+  return {
+    status,
+    message: extractStringField(item, ["agentMessage", "agent_message"]),
+  };
+};
+
+const assertNever = (value: never): never => value;
 
 const mapAgentStatus = (
   item: Record<string, unknown>,
@@ -111,7 +142,8 @@ const mapAgentStatus = (
     throw itemError(item, "unknown collab agent status", { status, childThreadId });
   }
   const text = typeof message === "string" && message.trim().length > 0 ? message : undefined;
-  switch (status as CodexCollabAgentStatus) {
+  const agentStatus = status as CodexCollabAgentStatus;
+  switch (agentStatus) {
     case "pendingInit":
       return { status: "pending" };
     case "running":
@@ -126,8 +158,10 @@ const mapAgentStatus = (
     case "notFound":
       return {
         status: "error",
-        error: text ?? `Codex subagent '${childThreadId}' status is ${status}.`,
+        error: text ?? `Codex subagent '${childThreadId}' status is ${agentStatus}.`,
       };
+    default:
+      return assertNever(agentStatus);
   }
 };
 
@@ -153,8 +187,8 @@ const statusForChild = (
   aggregateStatus: CodexCollabCallStatus,
   childThreadId: string,
 ): StatusMapping => {
-  const state = agentsStates(item)[childThreadId];
-  if (!isPlainObject(state)) {
+  const state = agentStateForChild(item, childThreadId);
+  if (!state) {
     if (tool === "closeAgent" && aggregateStatus === "completed") {
       return { status: "cancelled" };
     }
@@ -206,11 +240,12 @@ const creationDescriptionForPrompt = (
 
 const collabMetadata = (
   item: Record<string, unknown>,
+  source: CodexCollabItemType,
   parentThreadId: string,
   childThreadId?: string,
 ): Record<string, unknown> => ({
   codexSubagent: {
-    source: "collabAgentToolCall",
+    source,
     itemId: extractStringField(item, ["id"]),
     tool: extractStringField(item, ["tool"]),
     parentThreadId,
@@ -222,18 +257,19 @@ const activityMetadata = (
   item: Record<string, unknown>,
   parentThreadId: string,
   childThreadId: string,
-): Record<string, unknown> => ({
-  codexSubagent: {
-    source: "subAgentActivity",
-    itemId: extractStringField(item, ["id"]),
-    kind: extractStringField(item, ["kind"]),
-    parentThreadId,
-    childThreadId,
-    ...(extractStringField(item, ["agentPath", "agent_path"])
-      ? { agentPath: extractStringField(item, ["agentPath", "agent_path"]) }
-      : {}),
-  },
-});
+): Record<string, unknown> => {
+  const agentPath = extractStringField(item, ["agentPath", "agent_path"]);
+  return {
+    codexSubagent: {
+      source: "subAgentActivity",
+      itemId: extractStringField(item, ["id"]),
+      kind: extractStringField(item, ["kind"]),
+      parentThreadId,
+      childThreadId,
+      ...(agentPath ? { agentPath } : {}),
+    },
+  };
+};
 
 export const codexSubagentPartsFromItem = (
   item: Record<string, unknown>,
@@ -241,7 +277,7 @@ export const codexSubagentPartsFromItem = (
   linkState: CodexSubagentLinkState,
 ): AgentStreamPart[] => {
   const type = extractStringField(item, ["type"]);
-  if (type === "collabAgentToolCall") {
+  if (type === "collabAgentToolCall" || type === "collabToolCall") {
     const itemId = requireStringField(item, ["id"], "id");
     const tool = collabTool(item);
     const aggregateStatus = collabCallStatus(item);
@@ -270,7 +306,7 @@ export const codexSubagentPartsFromItem = (
           ...(prompt ? { prompt } : {}),
           ...(creationDescription ? { description: creationDescription } : {}),
           ...(mapped.error ? { error: mapped.error } : {}),
-          metadata: collabMetadata(item, parentThreadId),
+          metadata: collabMetadata(item, type, parentThreadId),
         }),
       ];
     }
@@ -285,7 +321,7 @@ export const codexSubagentPartsFromItem = (
         ...(prompt ? { prompt } : {}),
         ...(creationDescription ? { description: creationDescription } : {}),
         ...(mapped.error ? { error: mapped.error } : {}),
-        metadata: collabMetadata(item, parentThreadId, childThreadId),
+        metadata: collabMetadata(item, type, parentThreadId, childThreadId),
         preferItemCorrelationKey: tool === "spawnAgent",
       });
     });

--- a/packages/adapters-codex-app-server/src/codex-subagent-items.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-items.ts
@@ -17,7 +17,6 @@ type CodexSubagentActivityKind = "started" | "interacted" | "interrupted";
 
 type StatusMapping = {
   status: AgentSubagentStatus;
-  description?: string;
   error?: string;
 };
 
@@ -114,15 +113,15 @@ const mapAgentStatus = (
   const text = typeof message === "string" && message.trim().length > 0 ? message : undefined;
   switch (status as CodexCollabAgentStatus) {
     case "pendingInit":
-      return text ? { status: "pending", description: text } : { status: "pending" };
+      return { status: "pending" };
     case "running":
-      return text ? { status: "running", description: text } : { status: "running" };
+      return { status: "running" };
     case "completed":
-      return text ? { status: "completed", description: text } : { status: "completed" };
+      return { status: "completed" };
     case "interrupted":
-      return text ? { status: "running", description: text } : { status: "running" };
+      return { status: "running" };
     case "shutdown":
-      return text ? { status: "cancelled", description: text } : { status: "cancelled" };
+      return { status: "cancelled" };
     case "errored":
     case "notFound":
       return {
@@ -182,14 +181,27 @@ const activityKind = (item: Record<string, unknown>): CodexSubagentActivityKind 
   return kind as CodexSubagentActivityKind;
 };
 
-const mapActivityStatus = (kind: CodexSubagentActivityKind): StatusMapping => {
-  if (kind === "interrupted") {
-    return { status: "running", description: "Subagent interrupted." };
+const mapActivityStatus = (_kind: CodexSubagentActivityKind): StatusMapping => {
+  return { status: "running" };
+};
+
+const SUBAGENT_DESCRIPTION_MAX_LENGTH = 140;
+
+const creationDescriptionForPrompt = (
+  tool: CodexCollabTool,
+  prompt: string | undefined,
+): string | undefined => {
+  if (tool !== "spawnAgent") {
+    return undefined;
   }
-  if (kind === "started") {
-    return { status: "running", description: "Subagent started." };
+  const text = prompt?.replace(/\s+/g, " ").trim();
+  if (!text) {
+    return undefined;
   }
-  return { status: "running", description: "Subagent activity updated." };
+  if (text.length <= SUBAGENT_DESCRIPTION_MAX_LENGTH) {
+    return text;
+  }
+  return `${text.slice(0, SUBAGENT_DESCRIPTION_MAX_LENGTH - 3).trimEnd()}...`;
 };
 
 const collabMetadata = (
@@ -239,6 +251,7 @@ export const codexSubagentPartsFromItem = (
       "senderThreadId",
     );
     const prompt = extractStringField(item, ["prompt"]) ?? undefined;
+    const creationDescription = creationDescriptionForPrompt(tool, prompt);
     const receivers = receiverThreadIds(item);
     if (receivers.length === 0) {
       if (tool !== "spawnAgent") {
@@ -255,7 +268,7 @@ export const codexSubagentPartsFromItem = (
           itemId,
           status: mapped.status,
           ...(prompt ? { prompt } : {}),
-          ...(mapped.description ? { description: mapped.description } : {}),
+          ...(creationDescription ? { description: creationDescription } : {}),
           ...(mapped.error ? { error: mapped.error } : {}),
           metadata: collabMetadata(item, parentThreadId),
           executionMode: "background",
@@ -271,7 +284,7 @@ export const codexSubagentPartsFromItem = (
         itemId,
         status: mapped.status,
         ...(prompt ? { prompt } : {}),
-        ...(mapped.description ? { description: mapped.description } : {}),
+        ...(creationDescription ? { description: creationDescription } : {}),
         ...(mapped.error ? { error: mapped.error } : {}),
         metadata: collabMetadata(item, parentThreadId, childThreadId),
         executionMode: "background",
@@ -302,7 +315,6 @@ export const codexSubagentPartsFromItem = (
         childThreadId,
         itemId,
         status: mapped.status,
-        ...(mapped.description ? { description: mapped.description } : {}),
         ...(mapped.error ? { error: mapped.error } : {}),
         metadata: activityMetadata(item, parentThreadId, childThreadId),
         executionMode: "background",

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { CodexSubagentLinkState } from "./codex-subagent-link-state";
+
+describe("CodexSubagentLinkState", () => {
+  test("clears links for one runtime without deleting matching thread ids in another runtime", () => {
+    const subagents = new CodexSubagentLinkState();
+    subagents.upsertLink({
+      runtimeId: "runtime-1",
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    subagents.upsertLink({
+      runtimeId: "runtime-2",
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-2",
+      status: "running",
+    });
+
+    subagents.clearSession("parent-thread", "runtime-1");
+
+    expect(subagents.routeForChild("child-thread", "runtime-1")).toBeNull();
+    expect(subagents.routeForChild("child-thread", "runtime-2")).toMatchObject({
+      parentExternalSessionId: "parent-thread",
+      childExternalSessionId: "child-thread",
+      runtimeId: "runtime-2",
+    });
+  });
+});

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -69,8 +69,8 @@ const provisionalCorrelationKey = (parentThreadId: string, itemId: string): stri
 const STATUS_PRECEDENCE: Record<AgentSubagentStatus, number> = {
   pending: 0,
   running: 1,
-  completed: 2,
-  cancelled: 3,
+  cancelled: 2,
+  completed: 3,
   error: 4,
 };
 
@@ -155,6 +155,7 @@ export class CodexSubagentLinkState {
       return;
     }
     const agent = preferredAgentLabel(thread);
+    const existing = this.linkForChild(thread.id, runtimeId);
     this.upsertLink({
       ...(runtimeId ? { runtimeId } : {}),
       parentThreadId,
@@ -164,7 +165,9 @@ export class CodexSubagentLinkState {
         thread.status.classification === "running"
           ? "running"
           : thread.status.classification === "idle"
-            ? "completed"
+            ? existing?.status === "cancelled"
+              ? "cancelled"
+              : "completed"
             : "running",
       ...(agent ? { agent } : {}),
       metadata: {

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -8,6 +8,15 @@ export type CodexSubagentRoute = {
   subagentCorrelationKey: string;
 };
 
+export const codexSubagentRouteEventFields = (route: CodexSubagentRoute | null | undefined) =>
+  route
+    ? {
+        parentExternalSessionId: route.parentExternalSessionId,
+        childExternalSessionId: route.childExternalSessionId,
+        subagentCorrelationKey: route.subagentCorrelationKey,
+      }
+    : {};
+
 export type CodexSubagentLinkInput = {
   runtimeId?: string;
   parentThreadId: string;

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -176,7 +176,6 @@ export class CodexSubagentLinkState {
           ...(thread.subAgentSource ? { subAgentSource: thread.subAgentSource } : {}),
         },
       },
-      executionMode: "background",
     });
   }
 

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -49,8 +49,8 @@ const STATUS_PRECEDENCE: Record<AgentSubagentStatus, number> = {
   pending: 0,
   running: 1,
   cancelled: 2,
-  error: 3,
-  completed: 4,
+  completed: 3,
+  error: 4,
 };
 
 const resolveStatus = (

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -33,6 +33,8 @@ type CodexStoredSubagentLink = {
   executionMode?: "background";
 };
 
+type CodexSubagentRouteListener = (route: CodexSubagentRoute) => void;
+
 const subagentKey = (parentThreadId: string, childThreadId: string): string =>
   `${parentThreadId}\u0000${childThreadId}`;
 
@@ -77,11 +79,33 @@ const mergeDefined = <T extends Record<string, unknown>>(
   return incoming ?? existing;
 };
 
+const routeFromLink = (link: CodexStoredSubagentLink): CodexSubagentRoute | null =>
+  link.childThreadId
+    ? {
+        parentExternalSessionId: link.parentThreadId,
+        childExternalSessionId: link.childThreadId,
+        subagentCorrelationKey: link.correlationKey,
+      }
+    : null;
+
+const sameRoute = (previous: CodexSubagentRoute | null, next: CodexSubagentRoute | null): boolean =>
+  previous?.parentExternalSessionId === next?.parentExternalSessionId &&
+  previous?.childExternalSessionId === next?.childExternalSessionId &&
+  previous?.subagentCorrelationKey === next?.subagentCorrelationKey;
+
 export class CodexSubagentLinkState {
   private readonly linksByParentChildKey = new Map<string, CodexStoredSubagentLink>();
   private readonly linksByChildThreadId = new Map<string, CodexStoredSubagentLink>();
   private readonly linksByCorrelationKey = new Map<string, CodexStoredSubagentLink>();
   private readonly provisionalByParentItemKey = new Map<string, CodexStoredSubagentLink>();
+  private readonly routeListeners = new Set<CodexSubagentRouteListener>();
+
+  onRouteLearned(listener: CodexSubagentRouteListener): () => void {
+    this.routeListeners.add(listener);
+    return () => {
+      this.routeListeners.delete(listener);
+    };
+  }
 
   recordThread(thread: CodexThreadSnapshot): void {
     const parentThreadId = thread.parentThreadId ?? thread.subAgentSource?.parentThreadId;
@@ -114,6 +138,7 @@ export class CodexSubagentLinkState {
   }
 
   upsertLink(input: CodexSubagentLinkInput): AgentStreamPart {
+    const previousRoute = input.childThreadId ? this.routeForChild(input.childThreadId) : null;
     const parentItemKey = subagentKey(input.parentThreadId, input.itemId);
     const existingProvisional = this.provisionalByParentItemKey.get(parentItemKey);
     const parentChildKey = input.childThreadId
@@ -153,6 +178,10 @@ export class CodexSubagentLinkState {
       ...(executionMode ? { executionMode } : {}),
     };
     this.storeLink(link, parentItemKey);
+    const route = routeFromLink(link);
+    if (route && !sameRoute(previousRoute, route)) {
+      this.emitRouteLearned(route);
+    }
     return this.toPart(link);
   }
 
@@ -161,11 +190,27 @@ export class CodexSubagentLinkState {
     if (!link?.childThreadId) {
       return null;
     }
-    return {
-      parentExternalSessionId: link.parentThreadId,
-      childExternalSessionId: link.childThreadId,
-      subagentCorrelationKey: link.correlationKey,
-    };
+    return routeFromLink(link);
+  }
+
+  routesForParent(parentThreadId: string): CodexSubagentRoute[] {
+    const routes: CodexSubagentRoute[] = [];
+    for (const link of this.linksByChildThreadId.values()) {
+      if (link.parentThreadId !== parentThreadId) {
+        continue;
+      }
+      const route = routeFromLink(link);
+      if (route) {
+        routes.push(route);
+      }
+    }
+    return routes;
+  }
+
+  private emitRouteLearned(route: CodexSubagentRoute): void {
+    for (const listener of this.routeListeners) {
+      listener(route);
+    }
   }
 
   private storeLink(link: CodexStoredSubagentLink, parentItemKey: string): void {

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -1,0 +1,200 @@
+import type { AgentStreamPart, AgentSubagentStatus } from "@openducktor/core";
+import type { CodexThreadSnapshot } from "./codex-app-server-threads";
+
+export type CodexSubagentRoute = {
+  parentExternalSessionId: string;
+  childExternalSessionId: string;
+  subagentCorrelationKey: string;
+};
+
+export type CodexSubagentLinkInput = {
+  parentThreadId: string;
+  childThreadId?: string;
+  itemId: string;
+  status: AgentSubagentStatus;
+  prompt?: string;
+  description?: string;
+  error?: string;
+  agent?: string;
+  metadata?: Record<string, unknown>;
+  executionMode?: "background";
+};
+
+type CodexStoredSubagentLink = {
+  parentThreadId: string;
+  childThreadId?: string;
+  correlationKey: string;
+  status: AgentSubagentStatus;
+  prompt?: string;
+  description?: string;
+  error?: string;
+  agent?: string;
+  metadata?: Record<string, unknown>;
+  executionMode?: "background";
+};
+
+const subagentKey = (parentThreadId: string, childThreadId: string): string =>
+  `${parentThreadId}\u0000${childThreadId}`;
+
+const linkedCorrelationKey = (parentThreadId: string, childThreadId: string): string =>
+  `codex-subagent:${parentThreadId}:${childThreadId}`;
+
+const provisionalCorrelationKey = (parentThreadId: string, itemId: string): string =>
+  `codex-subagent:${parentThreadId}:${itemId}`;
+
+const STATUS_PRECEDENCE: Record<AgentSubagentStatus, number> = {
+  pending: 0,
+  running: 1,
+  cancelled: 2,
+  error: 3,
+  completed: 4,
+};
+
+const resolveStatus = (
+  existing: AgentSubagentStatus | undefined,
+  incoming: AgentSubagentStatus,
+): AgentSubagentStatus => {
+  if (!existing) {
+    return incoming;
+  }
+  return STATUS_PRECEDENCE[incoming] > STATUS_PRECEDENCE[existing] ? incoming : existing;
+};
+
+const preferredAgentLabel = (thread: CodexThreadSnapshot): string | undefined =>
+  thread.agentNickname ??
+  thread.agentRole ??
+  thread.subAgentSource?.agentNickname ??
+  thread.subAgentSource?.agentRole ??
+  undefined;
+
+const mergeDefined = <T extends Record<string, unknown>>(
+  existing: T | undefined,
+  incoming: T | undefined,
+): T | undefined => {
+  if (existing && incoming) {
+    return { ...existing, ...incoming };
+  }
+  return incoming ?? existing;
+};
+
+export class CodexSubagentLinkState {
+  private readonly linksByParentChildKey = new Map<string, CodexStoredSubagentLink>();
+  private readonly linksByChildThreadId = new Map<string, CodexStoredSubagentLink>();
+  private readonly linksByCorrelationKey = new Map<string, CodexStoredSubagentLink>();
+  private readonly provisionalByParentItemKey = new Map<string, CodexStoredSubagentLink>();
+
+  recordThread(thread: CodexThreadSnapshot): void {
+    const parentThreadId = thread.parentThreadId ?? thread.subAgentSource?.parentThreadId;
+    if (!parentThreadId || parentThreadId === thread.id) {
+      return;
+    }
+    const agent = preferredAgentLabel(thread);
+    this.upsertLink({
+      parentThreadId,
+      childThreadId: thread.id,
+      itemId: thread.id,
+      status:
+        thread.status.classification === "running"
+          ? "running"
+          : thread.status.classification === "idle"
+            ? "completed"
+            : "running",
+      ...(agent ? { agent } : {}),
+      metadata: {
+        codexThread: {
+          parentThreadId,
+          childThreadId: thread.id,
+          ...(thread.agentNickname ? { agentNickname: thread.agentNickname } : {}),
+          ...(thread.agentRole ? { agentRole: thread.agentRole } : {}),
+          ...(thread.subAgentSource ? { subAgentSource: thread.subAgentSource } : {}),
+        },
+      },
+      executionMode: "background",
+    });
+  }
+
+  upsertLink(input: CodexSubagentLinkInput): AgentStreamPart {
+    const parentItemKey = subagentKey(input.parentThreadId, input.itemId);
+    const existingProvisional = this.provisionalByParentItemKey.get(parentItemKey);
+    const parentChildKey = input.childThreadId
+      ? subagentKey(input.parentThreadId, input.childThreadId)
+      : null;
+    const existingLinked =
+      input.childThreadId && parentChildKey
+        ? (this.linksByParentChildKey.get(parentChildKey) ??
+          this.linksByChildThreadId.get(input.childThreadId))
+        : undefined;
+    const correlationKey =
+      existingLinked?.correlationKey ??
+      existingProvisional?.correlationKey ??
+      (input.childThreadId
+        ? linkedCorrelationKey(input.parentThreadId, input.childThreadId)
+        : provisionalCorrelationKey(input.parentThreadId, input.itemId));
+    const existing =
+      existingLinked ?? existingProvisional ?? this.linksByCorrelationKey.get(correlationKey);
+    const status = resolveStatus(existing?.status, input.status);
+    const childThreadId = input.childThreadId ?? existing?.childThreadId;
+    const prompt = input.prompt ?? existing?.prompt;
+    const description = input.description ?? existing?.description;
+    const error = input.error ?? existing?.error;
+    const agent = input.agent ?? existing?.agent;
+    const metadata = mergeDefined(existing?.metadata, input.metadata);
+    const executionMode = input.executionMode ?? existing?.executionMode;
+    const link: CodexStoredSubagentLink = {
+      parentThreadId: input.parentThreadId,
+      ...(childThreadId ? { childThreadId } : {}),
+      correlationKey,
+      status,
+      ...(prompt ? { prompt } : {}),
+      ...(description ? { description } : {}),
+      ...(error ? { error } : {}),
+      ...(agent ? { agent } : {}),
+      ...(metadata ? { metadata } : {}),
+      ...(executionMode ? { executionMode } : {}),
+    };
+    this.storeLink(link, parentItemKey);
+    return this.toPart(link);
+  }
+
+  routeForChild(childThreadId: string): CodexSubagentRoute | null {
+    const link = this.linksByChildThreadId.get(childThreadId);
+    if (!link?.childThreadId) {
+      return null;
+    }
+    return {
+      parentExternalSessionId: link.parentThreadId,
+      childExternalSessionId: link.childThreadId,
+      subagentCorrelationKey: link.correlationKey,
+    };
+  }
+
+  private storeLink(link: CodexStoredSubagentLink, parentItemKey: string): void {
+    const hadProvisionalBridge = this.provisionalByParentItemKey.has(parentItemKey);
+    this.linksByCorrelationKey.set(link.correlationKey, link);
+    if (!link.childThreadId || hadProvisionalBridge) {
+      this.provisionalByParentItemKey.set(parentItemKey, link);
+    }
+    if (!link.childThreadId) {
+      return;
+    }
+    this.linksByParentChildKey.set(subagentKey(link.parentThreadId, link.childThreadId), link);
+    this.linksByChildThreadId.set(link.childThreadId, link);
+  }
+
+  private toPart(link: CodexStoredSubagentLink): AgentStreamPart {
+    return {
+      kind: "subagent",
+      messageId: link.correlationKey,
+      partId: link.correlationKey,
+      correlationKey: link.correlationKey,
+      status: link.status,
+      ...(link.agent ? { agent: link.agent } : {}),
+      ...(link.prompt ? { prompt: link.prompt } : {}),
+      ...(link.description ? { description: link.description } : {}),
+      ...(link.error ? { error: link.error } : {}),
+      ...(link.childThreadId ? { externalSessionId: link.childThreadId } : {}),
+      ...(link.executionMode ? { executionMode: link.executionMode } : {}),
+      ...(link.metadata ? { metadata: link.metadata } : {}),
+    };
+  }
+}

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -91,7 +91,7 @@ const preferredAgentLabel = (thread: CodexThreadSnapshot): string | undefined =>
   thread.subAgentSource?.agentRole ??
   undefined;
 
-export class CodexSubagentLinkError extends Error {
+class CodexSubagentLinkError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "CodexSubagentLinkError";
@@ -273,10 +273,13 @@ export class CodexSubagentLinkState {
     return routes;
   }
 
-  clearSession(externalSessionId: string): void {
+  clearSession(externalSessionId: string, runtimeId?: string): void {
     const linksToClear = new Set<CodexStoredSubagentLink>();
     for (const link of this.linksByCorrelationKey.values()) {
-      if (link.parentThreadId === externalSessionId || link.childThreadId === externalSessionId) {
+      if (
+        (runtimeId === undefined || link.runtimeId === runtimeId) &&
+        (link.parentThreadId === externalSessionId || link.childThreadId === externalSessionId)
+      ) {
         linksToClear.add(link);
       }
     }

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -2,12 +2,14 @@ import type { AgentStreamPart, AgentSubagentStatus } from "@openducktor/core";
 import type { CodexThreadSnapshot } from "./codex-app-server-threads";
 
 export type CodexSubagentRoute = {
+  runtimeId?: string;
   parentExternalSessionId: string;
   childExternalSessionId: string;
   subagentCorrelationKey: string;
 };
 
 export type CodexSubagentLinkInput = {
+  runtimeId?: string;
   parentThreadId: string;
   childThreadId?: string;
   itemId: string;
@@ -22,6 +24,7 @@ export type CodexSubagentLinkInput = {
 };
 
 type CodexStoredSubagentLink = {
+  runtimeId?: string;
   parentThreadId: string;
   childThreadId?: string;
   correlationKey: string;
@@ -36,8 +39,17 @@ type CodexStoredSubagentLink = {
 
 type CodexSubagentRouteListener = (route: CodexSubagentRoute) => void;
 
-const subagentKey = (parentThreadId: string, childThreadId: string): string =>
-  `${parentThreadId}\u0000${childThreadId}`;
+const scopedKey = (runtimeId: string | undefined, ...parts: string[]): string =>
+  [runtimeId ?? "", ...parts].join("\u0000");
+
+const subagentKey = (
+  runtimeId: string | undefined,
+  parentThreadId: string,
+  childThreadId: string,
+): string => scopedKey(runtimeId, parentThreadId, childThreadId);
+
+const childThreadKey = (runtimeId: string | undefined, childThreadId: string): string =>
+  scopedKey(runtimeId, childThreadId);
 
 const linkedCorrelationKey = (parentThreadId: string, childThreadId: string): string =>
   `codex-subagent:${parentThreadId}:${childThreadId}`;
@@ -90,6 +102,7 @@ const mergeDefined = <T extends Record<string, unknown>>(
 const routeFromLink = (link: CodexStoredSubagentLink): CodexSubagentRoute | null =>
   link.childThreadId
     ? {
+        ...(link.runtimeId ? { runtimeId: link.runtimeId } : {}),
         parentExternalSessionId: link.parentThreadId,
         childExternalSessionId: link.childThreadId,
         subagentCorrelationKey: link.correlationKey,
@@ -97,6 +110,7 @@ const routeFromLink = (link: CodexStoredSubagentLink): CodexSubagentRoute | null
     : null;
 
 const sameRoute = (previous: CodexSubagentRoute | null, next: CodexSubagentRoute | null): boolean =>
+  previous?.runtimeId === next?.runtimeId &&
   previous?.parentExternalSessionId === next?.parentExternalSessionId &&
   previous?.childExternalSessionId === next?.childExternalSessionId &&
   previous?.subagentCorrelationKey === next?.subagentCorrelationKey;
@@ -115,7 +129,7 @@ export class CodexSubagentLinkState {
     };
   }
 
-  recordThread(thread: CodexThreadSnapshot): void {
+  recordThread(thread: CodexThreadSnapshot, runtimeId?: string): void {
     const parentThreadIds = [thread.parentThreadId, thread.subAgentSource?.parentThreadId].filter(
       (parentThreadId): parentThreadId is string => Boolean(parentThreadId),
     );
@@ -133,6 +147,7 @@ export class CodexSubagentLinkState {
     }
     const agent = preferredAgentLabel(thread);
     this.upsertLink({
+      ...(runtimeId ? { runtimeId } : {}),
       parentThreadId,
       childThreadId: thread.id,
       itemId: thread.id,
@@ -157,14 +172,16 @@ export class CodexSubagentLinkState {
   }
 
   upsertLink(input: CodexSubagentLinkInput): AgentStreamPart {
-    const previousRoute = input.childThreadId ? this.routeForChild(input.childThreadId) : null;
-    const parentItemKey = subagentKey(input.parentThreadId, input.itemId);
+    const previousRoute = input.childThreadId
+      ? this.routeForChild(input.childThreadId, input.runtimeId)
+      : null;
+    const parentItemKey = subagentKey(input.runtimeId, input.parentThreadId, input.itemId);
     const existingProvisional = this.provisionalByParentItemKey.get(parentItemKey);
     const parentChildKey = input.childThreadId
-      ? subagentKey(input.parentThreadId, input.childThreadId)
+      ? subagentKey(input.runtimeId, input.parentThreadId, input.childThreadId)
       : null;
     const existingByChildThreadId = input.childThreadId
-      ? this.linksByChildThreadId.get(input.childThreadId)
+      ? this.linksByChildThreadId.get(childThreadKey(input.runtimeId, input.childThreadId))
       : undefined;
     if (
       input.childThreadId &&
@@ -188,7 +205,9 @@ export class CodexSubagentLinkState {
           : linkedCorrelationKey(input.parentThreadId, input.childThreadId)
         : provisionalCorrelationKey(input.parentThreadId, input.itemId));
     const existing =
-      existingLinked ?? existingProvisional ?? this.linksByCorrelationKey.get(correlationKey);
+      existingLinked ??
+      existingProvisional ??
+      this.linksByCorrelationKey.get(scopedKey(input.runtimeId, correlationKey));
     const status = resolveStatus(existing?.status, input.status);
     const childThreadId = input.childThreadId ?? existing?.childThreadId;
     const prompt = input.prompt ?? existing?.prompt;
@@ -198,6 +217,7 @@ export class CodexSubagentLinkState {
     const metadata = mergeDefined(existing?.metadata, input.metadata);
     const executionMode = input.executionMode ?? existing?.executionMode;
     const link: CodexStoredSubagentLink = {
+      ...(input.runtimeId ? { runtimeId: input.runtimeId } : {}),
       parentThreadId: input.parentThreadId,
       ...(childThreadId ? { childThreadId } : {}),
       correlationKey,
@@ -217,18 +237,21 @@ export class CodexSubagentLinkState {
     return this.toPart(link);
   }
 
-  routeForChild(childThreadId: string): CodexSubagentRoute | null {
-    const link = this.linksByChildThreadId.get(childThreadId);
+  routeForChild(childThreadId: string, runtimeId?: string): CodexSubagentRoute | null {
+    const link = this.linkForChild(childThreadId, runtimeId);
     if (!link?.childThreadId) {
       return null;
     }
     return routeFromLink(link);
   }
 
-  routesForParent(parentThreadId: string): CodexSubagentRoute[] {
+  routesForParent(parentThreadId: string, runtimeId?: string): CodexSubagentRoute[] {
     const routes: CodexSubagentRoute[] = [];
     for (const link of this.linksByChildThreadId.values()) {
       if (link.parentThreadId !== parentThreadId) {
+        continue;
+      }
+      if (runtimeId && link.runtimeId && link.runtimeId !== runtimeId) {
         continue;
       }
       const route = routeFromLink(link);
@@ -259,28 +282,62 @@ export class CodexSubagentLinkState {
 
   private storeLink(link: CodexStoredSubagentLink, parentItemKey: string): void {
     const hadProvisionalBridge = this.provisionalByParentItemKey.has(parentItemKey);
-    this.linksByCorrelationKey.set(link.correlationKey, link);
+    this.linksByCorrelationKey.set(scopedKey(link.runtimeId, link.correlationKey), link);
     if (!link.childThreadId || hadProvisionalBridge) {
       this.provisionalByParentItemKey.set(parentItemKey, link);
     }
     if (!link.childThreadId) {
       return;
     }
-    this.linksByParentChildKey.set(subagentKey(link.parentThreadId, link.childThreadId), link);
-    this.linksByChildThreadId.set(link.childThreadId, link);
+    this.linksByParentChildKey.set(
+      subagentKey(link.runtimeId, link.parentThreadId, link.childThreadId),
+      link,
+    );
+    this.linksByChildThreadId.set(childThreadKey(link.runtimeId, link.childThreadId), link);
   }
 
   private deleteLink(link: CodexStoredSubagentLink): void {
-    this.linksByCorrelationKey.delete(link.correlationKey);
+    this.linksByCorrelationKey.delete(scopedKey(link.runtimeId, link.correlationKey));
     if (link.childThreadId) {
-      this.linksByParentChildKey.delete(subagentKey(link.parentThreadId, link.childThreadId));
-      this.linksByChildThreadId.delete(link.childThreadId);
+      this.linksByParentChildKey.delete(
+        subagentKey(link.runtimeId, link.parentThreadId, link.childThreadId),
+      );
+      this.linksByChildThreadId.delete(childThreadKey(link.runtimeId, link.childThreadId));
     }
     for (const [key, provisional] of this.provisionalByParentItemKey) {
       if (provisional.correlationKey === link.correlationKey) {
         this.provisionalByParentItemKey.delete(key);
       }
     }
+  }
+
+  private linkForChild(
+    childThreadId: string,
+    runtimeId: string | undefined,
+  ): CodexStoredSubagentLink | undefined {
+    if (runtimeId) {
+      return (
+        this.linksByChildThreadId.get(childThreadKey(runtimeId, childThreadId)) ??
+        this.linksByChildThreadId.get(childThreadKey(undefined, childThreadId))
+      );
+    }
+    const unscoped = this.linksByChildThreadId.get(childThreadKey(undefined, childThreadId));
+    if (unscoped) {
+      return unscoped;
+    }
+    let match: CodexStoredSubagentLink | undefined;
+    for (const link of this.linksByChildThreadId.values()) {
+      if (link.childThreadId !== childThreadId) {
+        continue;
+      }
+      if (match && match.correlationKey !== link.correlationKey) {
+        throw new CodexSubagentLinkError(
+          `Codex child thread '${childThreadId}' is linked in multiple runtimes; runtimeId is required to route it.`,
+        );
+      }
+      match = link;
+    }
+    return match;
   }
 
   private toPart(link: CodexStoredSubagentLink): AgentStreamPart {

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -18,6 +18,7 @@ export type CodexSubagentLinkInput = {
   agent?: string;
   metadata?: Record<string, unknown>;
   executionMode?: "background";
+  preferItemCorrelationKey?: boolean;
 };
 
 type CodexStoredSubagentLink = {
@@ -69,6 +70,13 @@ const preferredAgentLabel = (thread: CodexThreadSnapshot): string | undefined =>
   thread.subAgentSource?.agentRole ??
   undefined;
 
+export class CodexSubagentLinkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexSubagentLinkError";
+  }
+}
+
 const mergeDefined = <T extends Record<string, unknown>>(
   existing: T | undefined,
   incoming: T | undefined,
@@ -108,7 +116,18 @@ export class CodexSubagentLinkState {
   }
 
   recordThread(thread: CodexThreadSnapshot): void {
-    const parentThreadId = thread.parentThreadId ?? thread.subAgentSource?.parentThreadId;
+    const parentThreadIds = [thread.parentThreadId, thread.subAgentSource?.parentThreadId].filter(
+      (parentThreadId): parentThreadId is string => Boolean(parentThreadId),
+    );
+    const uniqueParentThreadIds = new Set(parentThreadIds);
+    if (uniqueParentThreadIds.size > 1) {
+      throw new CodexSubagentLinkError(
+        `Codex child thread '${thread.id}' has conflicting parent metadata: ${parentThreadIds.join(
+          ", ",
+        )}.`,
+      );
+    }
+    const parentThreadId = parentThreadIds[0];
     if (!parentThreadId || parentThreadId === thread.id) {
       return;
     }
@@ -144,16 +163,29 @@ export class CodexSubagentLinkState {
     const parentChildKey = input.childThreadId
       ? subagentKey(input.parentThreadId, input.childThreadId)
       : null;
+    const existingByChildThreadId = input.childThreadId
+      ? this.linksByChildThreadId.get(input.childThreadId)
+      : undefined;
+    if (
+      input.childThreadId &&
+      existingByChildThreadId &&
+      existingByChildThreadId.parentThreadId !== input.parentThreadId
+    ) {
+      throw new CodexSubagentLinkError(
+        `Codex child thread '${input.childThreadId}' is already linked to parent '${existingByChildThreadId.parentThreadId}', not '${input.parentThreadId}'.`,
+      );
+    }
     const existingLinked =
       input.childThreadId && parentChildKey
-        ? (this.linksByParentChildKey.get(parentChildKey) ??
-          this.linksByChildThreadId.get(input.childThreadId))
+        ? (this.linksByParentChildKey.get(parentChildKey) ?? existingByChildThreadId)
         : undefined;
     const correlationKey =
       existingLinked?.correlationKey ??
       existingProvisional?.correlationKey ??
       (input.childThreadId
-        ? linkedCorrelationKey(input.parentThreadId, input.childThreadId)
+        ? input.preferItemCorrelationKey
+          ? provisionalCorrelationKey(input.parentThreadId, input.itemId)
+          : linkedCorrelationKey(input.parentThreadId, input.childThreadId)
         : provisionalCorrelationKey(input.parentThreadId, input.itemId));
     const existing =
       existingLinked ?? existingProvisional ?? this.linksByCorrelationKey.get(correlationKey);

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -48,8 +48,8 @@ const provisionalCorrelationKey = (parentThreadId: string, itemId: string): stri
 const STATUS_PRECEDENCE: Record<AgentSubagentStatus, number> = {
   pending: 0,
   running: 1,
-  cancelled: 2,
-  completed: 3,
+  completed: 2,
+  cancelled: 3,
   error: 4,
 };
 
@@ -239,6 +239,18 @@ export class CodexSubagentLinkState {
     return routes;
   }
 
+  clearSession(externalSessionId: string): void {
+    const linksToClear = new Set<CodexStoredSubagentLink>();
+    for (const link of this.linksByCorrelationKey.values()) {
+      if (link.parentThreadId === externalSessionId || link.childThreadId === externalSessionId) {
+        linksToClear.add(link);
+      }
+    }
+    for (const link of linksToClear) {
+      this.deleteLink(link);
+    }
+  }
+
   private emitRouteLearned(route: CodexSubagentRoute): void {
     for (const listener of this.routeListeners) {
       listener(route);
@@ -256,6 +268,19 @@ export class CodexSubagentLinkState {
     }
     this.linksByParentChildKey.set(subagentKey(link.parentThreadId, link.childThreadId), link);
     this.linksByChildThreadId.set(link.childThreadId, link);
+  }
+
+  private deleteLink(link: CodexStoredSubagentLink): void {
+    this.linksByCorrelationKey.delete(link.correlationKey);
+    if (link.childThreadId) {
+      this.linksByParentChildKey.delete(subagentKey(link.parentThreadId, link.childThreadId));
+      this.linksByChildThreadId.delete(link.childThreadId);
+    }
+    for (const [key, provisional] of this.provisionalByParentItemKey) {
+      if (provisional.correlationKey === link.correlationKey) {
+        this.provisionalByParentItemKey.delete(key);
+      }
+    }
   }
 
   private toPart(link: CodexStoredSubagentLink): AgentStreamPart {

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
@@ -9,6 +9,7 @@ const threadListResponse = (
   preview: string,
   cwd = "/repo",
   status: Record<string, unknown> = { type: "idle" },
+  extra: Record<string, unknown> = {},
 ): unknown => ({
   data: [
     {
@@ -17,6 +18,7 @@ const threadListResponse = (
       createdAt: 1,
       preview,
       status,
+      ...extra,
     },
   ],
   nextCursor: null,
@@ -27,6 +29,7 @@ const threadReadResponse = (
   cwd = "/repo",
   status: Record<string, unknown> = { type: "idle" },
   turns: unknown[] = [{ id: "turn-1", status: "completed", items: [] }],
+  extra: Record<string, unknown> = {},
 ): unknown => ({
   thread: {
     id,
@@ -35,6 +38,7 @@ const threadReadResponse = (
     preview: "Stored thread",
     status,
     turns,
+    ...extra,
   },
 });
 
@@ -124,6 +128,51 @@ describe("CodexThreadInventoryReader", () => {
 
     const cached = await reader.read(client, "runtime-1");
     expect(cached.threadsById.get("thread-1")?.status).toEqual({ classification: "idle" });
+  });
+
+  test("extracts Codex subagent parent and label metadata from thread list", async () => {
+    const reader = new CodexThreadInventoryReader();
+    const client = {
+      threadLoadedList: async () => ({ data: ["child-thread"], nextCursor: null }),
+      threadList: async () =>
+        threadListResponse(
+          "child-thread",
+          "Child inventory",
+          "/repo",
+          { type: "idle" },
+          {
+            parentThreadId: "parent-thread",
+            agentNickname: "reviewer",
+            agentRole: "review",
+            source: {
+              subAgent: {
+                thread_spawn: {
+                  parent_thread_id: "parent-thread",
+                  depth: 1,
+                  agent_path: "/root/reviewer",
+                  agent_nickname: "reviewer",
+                  agent_role: "review",
+                },
+              },
+            },
+          },
+        ),
+    } as unknown as CodexAppServerClient;
+
+    const inventory = await reader.refresh(client, "runtime-1");
+
+    expect(inventory.threadsById.get("child-thread")).toMatchObject({
+      parentThreadId: "parent-thread",
+      agentNickname: "reviewer",
+      agentRole: "review",
+      subAgentSource: {
+        parentThreadId: "parent-thread",
+        depth: 1,
+        agentPath: "/root/reviewer",
+        agentNickname: "reviewer",
+        agentRole: "review",
+      },
+    });
   });
 
   test("clears a runtime status override without refetching inventory", async () => {

--- a/packages/adapters-codex-app-server/src/event-mappers/index.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/index.ts
@@ -1,4 +1,5 @@
 import type { RegisteredCodexEventMapper } from "../codex-event-mapper";
+import { CodexSubagentLinkState } from "../codex-subagent-link-state";
 import { emptyMapper } from "./empty";
 import { compactionMapper, deltaMapper, lifecycleMapper, tokenUsageMapper } from "./lifecycle";
 import { assistantMessageMapper, userMessageMapper } from "./messages";
@@ -13,6 +14,7 @@ import {
   reasoningMapper,
   webSearchMapper,
 } from "./stream-parts";
+import { createSubagentMapper } from "./subagents";
 import { todoMapper } from "./todo";
 
 export {
@@ -21,7 +23,9 @@ export {
   todoMapper,
 } from "./todo";
 
-export const CODEX_EVENT_MAPPERS = [
+export const createCodexEventMappers = (
+  subagents: CodexSubagentLinkState = new CodexSubagentLinkState(),
+): RegisteredCodexEventMapper[] => [
   compactionMapper,
   lifecycleMapper,
   tokenUsageMapper,
@@ -36,7 +40,10 @@ export const CODEX_EVENT_MAPPERS = [
   fileChangeMapper,
   mcpToolMapper,
   webSearchMapper,
+  createSubagentMapper(subagents),
   collabToolMapper,
   dynamicToolMapper,
   hiddenItemMapper,
-] satisfies RegisteredCodexEventMapper[];
+];
+
+export const CODEX_EVENT_MAPPERS = createCodexEventMappers();

--- a/packages/adapters-codex-app-server/src/event-mappers/index.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/index.ts
@@ -1,5 +1,5 @@
 import type { RegisteredCodexEventMapper } from "../codex-event-mapper";
-import { CodexSubagentLinkState } from "../codex-subagent-link-state";
+import type { CodexSubagentLinkState } from "../codex-subagent-link-state";
 import { emptyMapper } from "./empty";
 import { compactionMapper, deltaMapper, lifecycleMapper, tokenUsageMapper } from "./lifecycle";
 import { assistantMessageMapper, userMessageMapper } from "./messages";
@@ -24,7 +24,7 @@ export {
 } from "./todo";
 
 export const createCodexEventMappers = (
-  subagents: CodexSubagentLinkState = new CodexSubagentLinkState(),
+  subagents: CodexSubagentLinkState,
 ): RegisteredCodexEventMapper[] => [
   compactionMapper,
   lifecycleMapper,
@@ -45,5 +45,3 @@ export const createCodexEventMappers = (
   dynamicToolMapper,
   hiddenItemMapper,
 ];
-
-export const CODEX_EVENT_MAPPERS = createCodexEventMappers();

--- a/packages/adapters-codex-app-server/src/event-mappers/subagents.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/subagents.ts
@@ -1,0 +1,59 @@
+import { codexItemTypeMatches } from "../codex-app-server-transcript";
+import type { CodexMappingContext, CodexMappingResult } from "../codex-canonical-events";
+import { emptyCodexMappingResult } from "../codex-canonical-events";
+import type { CodexEventMapper } from "../codex-event-mapper";
+import { noCodexMapperState } from "../codex-event-mapper";
+import { codexSubagentPartsFromItem } from "../codex-subagent-items";
+import type { CodexSubagentLinkState } from "../codex-subagent-link-state";
+
+const subagentEvents = (
+  item: Record<string, unknown>,
+  ctx: CodexMappingContext,
+  linkState: CodexSubagentLinkState,
+  timestamp?: string,
+): CodexMappingResult => {
+  const parts = codexSubagentPartsFromItem(item, ctx, linkState);
+  if (parts.length === 0) {
+    return emptyCodexMappingResult();
+  }
+  const eventTimestamp = ctx.timestamp ?? timestamp;
+  return {
+    handled: true,
+    events: parts.map((part) => ({
+      kind: "stream_part",
+      source: ctx.source,
+      mapper: "subagent",
+      threadId: ctx.threadId,
+      ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+      ...(eventTimestamp ? { timestamp: eventTimestamp } : {}),
+      raw: item,
+      part,
+    })),
+  };
+};
+
+export const createSubagentMapper = (linkState: CodexSubagentLinkState): CodexEventMapper => ({
+  name: "subagent",
+  createState: noCodexMapperState,
+  fromLive(input, ctx): CodexMappingResult {
+    if (input.kind !== "item_completed" && input.kind !== "item_started") {
+      return emptyCodexMappingResult();
+    }
+    if (
+      !codexItemTypeMatches(input.item, "collabAgentToolCall") &&
+      !codexItemTypeMatches(input.item, "subAgentActivity")
+    ) {
+      return emptyCodexMappingResult();
+    }
+    return subagentEvents(input.item, ctx, linkState);
+  },
+  fromThreadItem(input, ctx): CodexMappingResult {
+    if (
+      !codexItemTypeMatches(input.item, "collabAgentToolCall") &&
+      !codexItemTypeMatches(input.item, "subAgentActivity")
+    ) {
+      return emptyCodexMappingResult();
+    }
+    return subagentEvents(input.item, ctx, linkState, input.timestamp);
+  },
+});

--- a/packages/adapters-codex-app-server/src/event-mappers/subagents.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/subagents.ts
@@ -33,19 +33,30 @@ const subagentEvents = (
 };
 
 const shouldMapAsSubagentItem = (item: Record<string, unknown>): boolean => {
-  if (!codexItemTypeMatches(item, "collabAgentToolCall")) {
+  const isCollabToolCall =
+    codexItemTypeMatches(item, "collabAgentToolCall") ||
+    codexItemTypeMatches(item, "collabToolCall");
+  if (!isCollabToolCall) {
     return codexItemTypeMatches(item, "subAgentActivity");
   }
 
   const tool = item.tool;
   const receiverThreadIds = item.receiverThreadIds ?? item.receiver_thread_ids;
+  const receiverThreadId =
+    item.receiverThreadId ?? item.receiver_thread_id ?? item.newThreadId ?? item.new_thread_id;
   if (tool === "spawnAgent") {
     return true;
   }
-  if (receiverThreadIds !== undefined && !Array.isArray(receiverThreadIds)) {
+  if (Array.isArray(receiverThreadIds)) {
+    return receiverThreadIds.length > 0;
+  }
+  if (receiverThreadIds !== undefined && receiverThreadIds !== null) {
     return true;
   }
-  return Array.isArray(receiverThreadIds) && receiverThreadIds.length > 0;
+  if (typeof receiverThreadId === "string") {
+    return receiverThreadId.trim().length > 0;
+  }
+  return receiverThreadId !== undefined && receiverThreadId !== null;
 };
 
 export const createSubagentMapper = (linkState: CodexSubagentLinkState): CodexEventMapper => ({

--- a/packages/adapters-codex-app-server/src/event-mappers/subagents.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/subagents.ts
@@ -32,6 +32,22 @@ const subagentEvents = (
   };
 };
 
+const shouldMapAsSubagentItem = (item: Record<string, unknown>): boolean => {
+  if (!codexItemTypeMatches(item, "collabAgentToolCall")) {
+    return codexItemTypeMatches(item, "subAgentActivity");
+  }
+
+  const tool = item.tool;
+  const receiverThreadIds = item.receiverThreadIds ?? item.receiver_thread_ids;
+  if (tool === "spawnAgent") {
+    return true;
+  }
+  if (receiverThreadIds !== undefined && !Array.isArray(receiverThreadIds)) {
+    return true;
+  }
+  return Array.isArray(receiverThreadIds) && receiverThreadIds.length > 0;
+};
+
 export const createSubagentMapper = (linkState: CodexSubagentLinkState): CodexEventMapper => ({
   name: "subagent",
   createState: noCodexMapperState,
@@ -39,19 +55,13 @@ export const createSubagentMapper = (linkState: CodexSubagentLinkState): CodexEv
     if (input.kind !== "item_completed" && input.kind !== "item_started") {
       return emptyCodexMappingResult();
     }
-    if (
-      !codexItemTypeMatches(input.item, "collabAgentToolCall") &&
-      !codexItemTypeMatches(input.item, "subAgentActivity")
-    ) {
+    if (!shouldMapAsSubagentItem(input.item)) {
       return emptyCodexMappingResult();
     }
     return subagentEvents(input.item, ctx, linkState);
   },
   fromThreadItem(input, ctx): CodexMappingResult {
-    if (
-      !codexItemTypeMatches(input.item, "collabAgentToolCall") &&
-      !codexItemTypeMatches(input.item, "subAgentActivity")
-    ) {
+    if (!shouldMapAsSubagentItem(input.item)) {
       return emptyCodexMappingResult();
     }
     return subagentEvents(input.item, ctx, linkState, input.timestamp);

--- a/packages/contracts/src/agent-runtime-schemas.ts
+++ b/packages/contracts/src/agent-runtime-schemas.ts
@@ -502,16 +502,6 @@ export const runtimeCapabilitiesSchema = z
     }
 
     if (
-      capabilities.optionalSurfaces.supportsSubagents &&
-      capabilities.optionalSurfaces.supportedSubagentExecutionModes.length === 0
-    ) {
-      addIssue(
-        ["optionalSurfaces", "supportedSubagentExecutionModes"],
-        "Runtime descriptors that support subagents must declare at least one supported subagent execution mode.",
-      );
-    }
-
-    if (
       !capabilities.optionalSurfaces.supportsSubagents &&
       capabilities.optionalSurfaces.supportedSubagentExecutionModes.length > 0
     ) {

--- a/packages/contracts/src/codex-app-server-protocol.test.ts
+++ b/packages/contracts/src/codex-app-server-protocol.test.ts
@@ -206,19 +206,16 @@ describe("Codex app-server protocol", () => {
 
   test("represents Codex collab and subagent activity thread items", () => {
     const collabItem = {
-      type: "collabAgentToolCall",
+      type: "collabToolCall",
       id: "collab-1",
       tool: "wait",
       status: "failed",
       senderThreadId: "parent-thread",
-      receiverThreadIds: ["child-ok", "child-failed"],
+      receiverThreadId: "child-failed",
       prompt: null,
       model: null,
       reasoningEffort: null,
-      agentsStates: {
-        "child-ok": { status: "completed", message: null },
-        "child-failed": { status: "errored", message: "Tests failed" },
-      },
+      agentStatus: "errored",
     } satisfies CodexAppServerCollabAgentToolCallThreadItem;
     const activityItem = {
       type: "subAgentActivity",
@@ -228,7 +225,7 @@ describe("Codex app-server protocol", () => {
       agentPath: "/root/worker",
     } satisfies CodexAppServerSubAgentActivityThreadItem;
 
-    expect(collabItem.agentsStates["child-failed"]?.status).toBe("errored");
+    expect(collabItem.agentStatus).toBe("errored");
     expect(activityItem.agentThreadId).toBe("child-failed");
   });
 });

--- a/packages/contracts/src/codex-app-server-protocol.test.ts
+++ b/packages/contracts/src/codex-app-server-protocol.test.ts
@@ -6,6 +6,9 @@ import {
   CODEX_APP_SERVER_SERVER_REQUEST_METHOD,
   CODEX_APP_SERVER_SERVER_REQUEST_METHODS,
   type CodexAppServerClientRequest,
+  type CodexAppServerCollabAgentToolCallThreadItem,
+  type CodexAppServerSubAgentActivityThreadItem,
+  type CodexAppServerThread,
   isCodexAppServerCommandRequestMethod,
   isCodexAppServerFileMutationRequestMethod,
   isCodexAppServerJsonValue,
@@ -151,5 +154,81 @@ describe("Codex app-server protocol", () => {
         requestedSchema: { type: "object", properties: {} },
       }),
     ).toBe(false);
+  });
+
+  test("represents Codex subagent thread metadata from the app-server protocol", () => {
+    const thread = {
+      id: "child-thread",
+      sessionId: "session-tree",
+      forkedFromId: null,
+      parentThreadId: "parent-thread",
+      preview: "Review the code",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 2,
+      status: { type: "idle" },
+      path: null,
+      cwd: "/repo",
+      cliVersion: "0.0.0",
+      source: {
+        subAgent: {
+          thread_spawn: {
+            parent_thread_id: "parent-thread",
+            depth: 1,
+            agent_path: null,
+            agent_nickname: "reviewer",
+            agent_role: "review",
+          },
+        },
+      },
+      threadSource: "subagent",
+      agentNickname: "reviewer",
+      agentRole: "review",
+      gitInfo: null,
+      name: null,
+      turns: [],
+    } satisfies CodexAppServerThread;
+
+    expect(thread.parentThreadId).toBe("parent-thread");
+    expect(thread.source).toEqual({
+      subAgent: {
+        thread_spawn: {
+          parent_thread_id: "parent-thread",
+          depth: 1,
+          agent_path: null,
+          agent_nickname: "reviewer",
+          agent_role: "review",
+        },
+      },
+    });
+  });
+
+  test("represents Codex collab and subagent activity thread items", () => {
+    const collabItem = {
+      type: "collabAgentToolCall",
+      id: "collab-1",
+      tool: "wait",
+      status: "failed",
+      senderThreadId: "parent-thread",
+      receiverThreadIds: ["child-ok", "child-failed"],
+      prompt: null,
+      model: null,
+      reasoningEffort: null,
+      agentsStates: {
+        "child-ok": { status: "completed", message: null },
+        "child-failed": { status: "errored", message: "Tests failed" },
+      },
+    } satisfies CodexAppServerCollabAgentToolCallThreadItem;
+    const activityItem = {
+      type: "subAgentActivity",
+      id: "activity-1",
+      kind: "interrupted",
+      agentThreadId: "child-failed",
+      agentPath: "/root/worker",
+    } satisfies CodexAppServerSubAgentActivityThreadItem;
+
+    expect(collabItem.agentsStates["child-failed"]?.status).toBe("errored");
+    expect(activityItem.agentThreadId).toBe("child-failed");
   });
 });

--- a/packages/contracts/src/codex-app-server-protocol.ts
+++ b/packages/contracts/src/codex-app-server-protocol.ts
@@ -31,6 +31,19 @@ export type CodexAppServerThreadStatus =
   | { type: "systemError" };
 export type CodexAppServerThreadSource = "memory_consolidation" | "subagent" | "user";
 export type CodexAppServerThreadStartSource = "clear" | "startup";
+export type CodexAppServerSubAgentThreadSpawnSource = {
+  parent_thread_id: string;
+  depth: number;
+  agent_path: CodexAppServerJsonValue | null;
+  agent_nickname: string | null;
+  agent_role: string | null;
+};
+export type CodexAppServerSubAgentSource =
+  | "review"
+  | "compact"
+  | "memory_consolidation"
+  | { other: string }
+  | { thread_spawn: CodexAppServerSubAgentThreadSpawnSource };
 export type CodexAppServerSessionSource =
   | "appServer"
   | "cli"
@@ -38,7 +51,49 @@ export type CodexAppServerSessionSource =
   | "unknown"
   | "vscode"
   | { custom: string }
-  | { subAgent: CodexAppServerJsonValue };
+  | { subAgent: CodexAppServerSubAgentSource };
+export type CodexAppServerCollabAgentTool =
+  | "spawnAgent"
+  | "sendInput"
+  | "resumeAgent"
+  | "wait"
+  | "closeAgent";
+export type CodexAppServerCollabAgentToolCallStatus = "inProgress" | "completed" | "failed";
+export type CodexAppServerCollabAgentStatus =
+  | "pendingInit"
+  | "running"
+  | "interrupted"
+  | "completed"
+  | "errored"
+  | "shutdown"
+  | "notFound";
+export type CodexAppServerCollabAgentState = {
+  status: CodexAppServerCollabAgentStatus;
+  message: string | null;
+};
+export type CodexAppServerCollabAgentToolCallThreadItem = {
+  type: "collabAgentToolCall";
+  id: string;
+  tool: CodexAppServerCollabAgentTool;
+  status: CodexAppServerCollabAgentToolCallStatus;
+  senderThreadId: string;
+  receiverThreadIds: string[];
+  prompt: string | null;
+  model: string | null;
+  reasoningEffort: CodexAppServerReasoningEffort | null;
+  agentsStates: { [key in string]?: CodexAppServerCollabAgentState };
+};
+export type CodexAppServerSubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type CodexAppServerSubAgentActivityThreadItem = {
+  type: "subAgentActivity";
+  id: string;
+  kind: CodexAppServerSubAgentActivityKind;
+  agentThreadId: string;
+  agentPath: string;
+};
+export type CodexAppServerSubagentThreadItem =
+  | CodexAppServerCollabAgentToolCallThreadItem
+  | CodexAppServerSubAgentActivityThreadItem;
 export type CodexAppServerAskForApproval =
   | "never"
   | "on-failure"
@@ -101,6 +156,7 @@ export type CodexAppServerThread = {
   id: string;
   modelProvider: string;
   name: string | null;
+  parentThreadId: string | null;
   path: string | null;
   preview: string;
   sessionId: string;

--- a/packages/contracts/src/codex-app-server-protocol.ts
+++ b/packages/contracts/src/codex-app-server-protocol.ts
@@ -72,16 +72,19 @@ export type CodexAppServerCollabAgentState = {
   message: string | null;
 };
 export type CodexAppServerCollabAgentToolCallThreadItem = {
-  type: "collabAgentToolCall";
+  type: "collabAgentToolCall" | "collabToolCall";
   id: string;
   tool: CodexAppServerCollabAgentTool;
   status: CodexAppServerCollabAgentToolCallStatus;
   senderThreadId: string;
-  receiverThreadIds: string[];
-  prompt: string | null;
-  model: string | null;
-  reasoningEffort: CodexAppServerReasoningEffort | null;
-  agentsStates: { [key in string]?: CodexAppServerCollabAgentState };
+  receiverThreadIds?: string[];
+  receiverThreadId?: string | null;
+  newThreadId?: string | null;
+  prompt?: string | null;
+  model?: string | null;
+  reasoningEffort?: CodexAppServerReasoningEffort | null;
+  agentsStates?: { [key in string]?: CodexAppServerCollabAgentState };
+  agentStatus?: CodexAppServerCollabAgentStatus | null;
 };
 export type CodexAppServerSubAgentActivityKind = "started" | "interacted" | "interrupted";
 export type CodexAppServerSubAgentActivityThreadItem = {

--- a/packages/contracts/src/runtime-descriptors.ts
+++ b/packages/contracts/src/runtime-descriptors.ts
@@ -160,8 +160,8 @@ export const CODEX_RUNTIME_CAPABILITIES = {
     supportsDiff: true,
     supportsFileStatus: false,
     supportsMcpStatus: true,
-    supportsSubagents: false,
-    supportedSubagentExecutionModes: [],
+    supportsSubagents: true,
+    supportedSubagentExecutionModes: ["background"],
   },
 } as const satisfies RuntimeCapabilities;
 

--- a/packages/contracts/src/runtime-descriptors.ts
+++ b/packages/contracts/src/runtime-descriptors.ts
@@ -161,7 +161,7 @@ export const CODEX_RUNTIME_CAPABILITIES = {
     supportsFileStatus: false,
     supportsMcpStatus: true,
     supportsSubagents: true,
-    supportedSubagentExecutionModes: ["background"],
+    supportedSubagentExecutionModes: [],
   },
 } as const satisfies RuntimeCapabilities;
 

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -150,6 +150,13 @@ describe("runtime schemas", () => {
     });
   });
 
+  test("Codex descriptor advertises background subagent support", () => {
+    expect(CODEX_RUNTIME_DESCRIPTOR.capabilities.optionalSurfaces).toMatchObject({
+      supportsSubagents: true,
+      supportedSubagentExecutionModes: ["background"],
+    });
+  });
+
   test("Codex descriptor enables file search with structured file and folder references", () => {
     expect(CODEX_RUNTIME_DESCRIPTOR.capabilities.promptInput.supportsFileSearch).toBe(true);
     expect(CODEX_RUNTIME_DESCRIPTOR.capabilities.promptInput.supportedParts).toEqual(

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -150,10 +150,10 @@ describe("runtime schemas", () => {
     });
   });
 
-  test("Codex descriptor advertises background subagent support", () => {
+  test("Codex descriptor advertises subagent support without execution modes", () => {
     expect(CODEX_RUNTIME_DESCRIPTOR.capabilities.optionalSurfaces).toMatchObject({
       supportsSubagents: true,
-      supportedSubagentExecutionModes: ["background"],
+      supportedSubagentExecutionModes: [],
     });
   });
 
@@ -1163,22 +1163,7 @@ describe("runtime schemas", () => {
     ).toThrow();
   });
 
-  test("runtime capabilities require execution modes only when subagents are supported", () => {
-    expect(() =>
-      runtimeDescriptorSchema.parse({
-        ...OPENCODE_RUNTIME_DESCRIPTOR,
-        capabilities: withRuntimeCapabilities({
-          optionalSurfaces: {
-            ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.optionalSurfaces,
-            supportsSubagents: true,
-            supportedSubagentExecutionModes: [],
-          },
-        }),
-      }),
-    ).toThrow(
-      "Runtime descriptors that support subagents must declare at least one supported subagent execution mode.",
-    );
-
+  test("runtime capabilities reject execution modes when subagents are unsupported", () => {
     expect(() =>
       runtimeDescriptorSchema.parse({
         ...OPENCODE_RUNTIME_DESCRIPTOR,

--- a/packages/frontend/src/lib/agent-runtime.test.ts
+++ b/packages/frontend/src/lib/agent-runtime.test.ts
@@ -219,20 +219,6 @@ describe("agent-runtime capability policies", () => {
     ]);
   });
 
-  test("classifies subagent execution mode schema issues as optional enhancements", () => {
-    const descriptor = withCapabilities({
-      optionalSurfaces: {
-        ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities.optionalSurfaces,
-        supportsSubagents: true,
-        supportedSubagentExecutionModes: [],
-      },
-    });
-
-    expect(validateRuntimeDefinitionForOpenDucktor(descriptor)).toEqual([
-      "[optional_enhancement] runtime descriptor schema violation at capabilities.optionalSurfaces.supportedSubagentExecutionModes: Runtime descriptors that support subagents must declare at least one supported subagent execution mode.",
-    ]);
-  });
-
   test("reports runtimes that only cover a partial role-specific workflow scope set", () => {
     const workspaceOnly = withCapabilities({
       workflow: {

--- a/packages/frontend/src/state/operations/agent-orchestrator/handlers/session-actions-send.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/handlers/session-actions-send.test.ts
@@ -9,6 +9,10 @@ import {
   sessionMessagesToArray,
 } from "@/test-utils/session-message-test-helpers";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import {
+  createSessionUpdater as createEventSessionUpdater,
+  listenToAgentSessionEvents,
+} from "../events/session-events-test-harness";
 import { createTaskCardFixture } from "../test-utils";
 import {
   buildSession,
@@ -82,6 +86,71 @@ describe("agent-orchestrator/handlers/session-actions send", () => {
       ]);
     } finally {
       adapter.sendUserMessage = originalSendUserMessage;
+    }
+  });
+
+  test("stores a live accepted user message only once when send returns the same event", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalSendUserMessage = adapter.sendUserMessage;
+    const originalSubscribeEvents = adapter.subscribeEvents;
+    const handlers: Parameters<typeof adapter.subscribeEvents>[1][] = [];
+    adapter.subscribeEvents = async (_sessionRef, handler) => {
+      handlers.push(handler);
+      return () => {};
+    };
+    adapter.sendUserMessage = async (input) => {
+      const event = acceptedUserMessage(input);
+      for (const handler of handlers) {
+        handler(event);
+      }
+      return event;
+    };
+
+    const sessionsRef = createSessionsRef([
+      buildSession({
+        status: "idle",
+        historyLoadState: "loaded",
+      }),
+    ]);
+
+    const unsubscribe = await listenToAgentSessionEvents({
+      adapter,
+      sessionsRef,
+      updateSession: createEventSessionUpdater(sessionsRef),
+      externalSessionId: "session-1",
+      repoPath: "/tmp/repo",
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+    const actions = createSessionActions({
+      adapter,
+      sessionsRef,
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeKind: "opencode",
+        workingDirectory: "/tmp/repo",
+      }),
+    });
+
+    try {
+      await actions.sendAgentMessage(getSession(sessionsRef), [{ kind: "text", text: "hello" }]);
+
+      const userMessages = sessionMessagesToArray(getSession(sessionsRef)).filter(
+        (message) => message.role === "user",
+      );
+      expect(userMessages).toHaveLength(1);
+      expect(userMessages[0]).toEqual(
+        expect.objectContaining({
+          id: "accepted-user-message",
+          role: "user",
+          content: "hello",
+        }),
+      );
+    } finally {
+      unsubscribe();
+      adapter.sendUserMessage = originalSendUserMessage;
+      adapter.subscribeEvents = originalSubscribeEvents;
     }
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-loader.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-loader.test.ts
@@ -471,6 +471,71 @@ describe("session history loader", () => {
     ]);
   });
 
+  test("reconciles a local accepted user send when baseline history confirms it", async () => {
+    let resolveHistory!: (history: AgentSessionHistoryMessage[]) => void;
+    const historyPromise = new Promise<AgentSessionHistoryMessage[]>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const harness = createHistoryLoadHarness();
+
+    const loadPromise = loadSelectedSessionBaselineHistoryIntoStore({
+      repoPath: "/repo",
+      adapter: {
+        loadSessionHistory: async () => historyPromise,
+      },
+      readSessionSnapshot: harness.readSessionSnapshot,
+      updateSession: harness.updateSession,
+      identity: sessionTarget,
+      isStaleRepoOperation: () => false,
+    });
+
+    expect(harness.session.historyLoadState).toBe("loading");
+
+    harness.updateSession(sessionTarget, (current) => ({
+      ...current,
+      messages: createSessionMessagesState(sessionTarget.externalSessionId, [
+        {
+          id: "accepted-user-message",
+          role: "user",
+          content: "Hi",
+          timestamp: "2026-06-12T08:00:01.000Z",
+          meta: {
+            kind: "user",
+            state: "read",
+            parts: [{ kind: "text", text: "Hi" }],
+          },
+        },
+      ]),
+    }));
+
+    resolveHistory([
+      {
+        messageId: "runtime-user-confirmed",
+        role: "user",
+        timestamp: "2026-06-12T08:00:01.000Z",
+        text: "Hi",
+        displayParts: [{ kind: "text", text: "Hi" }],
+        state: "read",
+        parts: [],
+      },
+    ]);
+
+    const loadedSession = await loadPromise;
+    const userMessages = sessionMessagesToArray(harness.session).filter(
+      (message) => message.role === "user",
+    );
+
+    expect(loadedSession?.historyLoadState).toBe("loaded");
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0]).toEqual(
+      expect.objectContaining({
+        id: "accepted-user-message",
+        role: "user",
+        content: "Hi",
+      }),
+    );
+  });
+
   test("does not wait for selected session observation before loading baseline history", async () => {
     const observedSessions: AgentSessionRef[] = [];
     const harness = createHistoryLoadHarness();

--- a/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-loader.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-loader.test.ts
@@ -498,7 +498,7 @@ describe("session history loader", () => {
           id: "accepted-user-message",
           role: "user",
           content: "Hi",
-          timestamp: "2026-06-12T08:00:01.000Z",
+          timestamp: "2026-06-12T08:00:01.123Z",
           meta: {
             kind: "user",
             state: "read",

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/history-message-merge.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/history-message-merge.test.ts
@@ -927,6 +927,94 @@ describe("agent-orchestrator/support/history-message-merge", () => {
     );
   });
 
+  test("reconciles a local accepted user send when history confirms it with a nearby timestamp", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "runtime-user-confirmed",
+          role: "user",
+          content: "Hi",
+          timestamp: "2026-03-01T09:00:01.000Z",
+          meta: {
+            kind: "user",
+            state: "read",
+            parts: [{ kind: "text", text: "Hi" }],
+          },
+        },
+      ],
+      [
+        {
+          id: "codex-user-1772355601123-1",
+          role: "user",
+          content: "Hi",
+          timestamp: "2026-03-01T09:00:01.123Z",
+          meta: {
+            kind: "user",
+            state: "read",
+            parts: [{ kind: "text", text: "Hi" }],
+          },
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toEqual(
+      expect.objectContaining({
+        id: "codex-user-1772355601123-1",
+        role: "user",
+        content: "Hi",
+        timestamp: "2026-03-01T09:00:01.123Z",
+      }),
+    );
+  });
+
+  test("matches the nearest local accepted user send when repeated text exists", () => {
+    const merged = mergedMessages(
+      [
+        {
+          id: "runtime-user-confirmed",
+          role: "user",
+          content: "ok",
+          timestamp: "2026-03-01T09:00:00.000Z",
+          meta: {
+            kind: "user",
+            state: "read",
+            parts: [{ kind: "text", text: "ok" }],
+          },
+        },
+      ],
+      [
+        {
+          id: "codex-user-1772355600120-1",
+          role: "user",
+          content: "ok",
+          timestamp: "2026-03-01T09:00:00.120Z",
+          meta: {
+            kind: "user",
+            state: "read",
+            parts: [{ kind: "text", text: "ok" }],
+          },
+        },
+        {
+          id: "codex-user-1772355600900-1",
+          role: "user",
+          content: "ok",
+          timestamp: "2026-03-01T09:00:00.900Z",
+          meta: {
+            kind: "user",
+            state: "read",
+            parts: [{ kind: "text", text: "ok" }],
+          },
+        },
+      ],
+    );
+
+    expect(merged.map((message) => message.id)).toEqual([
+      "codex-user-1772355600120-1",
+      "codex-user-1772355600900-1",
+    ]);
+  });
+
   test("keeps different runtime user message ids distinct even when text matches", () => {
     const merged = mergedMessages(
       [

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/history-message-merge.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/history-message-merge.ts
@@ -76,14 +76,36 @@ const isUserMessage = (
   meta: Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "user" }>;
 } => message.role === "user" && message.meta?.kind === "user";
 
+const LOCAL_ACCEPTED_USER_CONFIRMATION_WINDOW_MS = 2_000;
+
+const timestampMs = (timestamp: string): number | null => {
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
 const confirmsLocalAcceptedUserMessage = (
   loadedMessage: AgentChatMessage,
   currentMessage: AgentChatMessage,
-): boolean =>
-  isUserMessage(loadedMessage) &&
-  isUserMessage(currentMessage) &&
-  loadedMessage.content === currentMessage.content &&
-  loadedMessage.timestamp === currentMessage.timestamp;
+): number | null => {
+  if (
+    !isUserMessage(loadedMessage) ||
+    !isUserMessage(currentMessage) ||
+    loadedMessage.meta.state !== "read" ||
+    currentMessage.meta.state !== "read" ||
+    loadedMessage.content !== currentMessage.content
+  ) {
+    return null;
+  }
+
+  const loadedTimestampMs = timestampMs(loadedMessage.timestamp);
+  const currentTimestampMs = timestampMs(currentMessage.timestamp);
+  if (loadedTimestampMs === null || currentTimestampMs === null) {
+    return null;
+  }
+
+  const distanceMs = Math.abs(loadedTimestampMs - currentTimestampMs);
+  return distanceMs <= LOCAL_ACCEPTED_USER_CONFIRMATION_WINDOW_MS ? distanceMs : null;
+};
 
 const findConfirmedLocalAcceptedUserMessage = ({
   currentOwner,
@@ -102,14 +124,23 @@ const findConfirmedLocalAcceptedUserMessage = ({
   }
 
   const currentSlice = getSessionMessagesSlice(currentOwner, 0);
+  let nearestMatch: { message: AgentChatMessage; distanceMs: number } | null = null;
   for (let index = currentSlice.length - 1; index >= 0; index -= 1) {
     const candidate = currentSlice[index];
     if (!candidate || absorbedCurrentMessageIds.has(candidate.id)) {
       continue;
     }
-    if (confirmsLocalAcceptedUserMessage(loadedMessage, candidate)) {
-      return [candidate];
+    const distanceMs = confirmsLocalAcceptedUserMessage(loadedMessage, candidate);
+    if (distanceMs === null) {
+      continue;
     }
+    if (!nearestMatch || distanceMs < nearestMatch.distanceMs) {
+      nearestMatch = { message: candidate, distanceMs };
+    }
+  }
+
+  if (nearestMatch) {
+    return [nearestMatch.message];
   }
 
   return [];

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/history-message-merge.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/history-message-merge.ts
@@ -69,6 +69,52 @@ const findMatchingCurrentToolMessages = ({
   return matches;
 };
 
+const isUserMessage = (
+  message: AgentChatMessage,
+): message is AgentChatMessage & {
+  role: "user";
+  meta: Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "user" }>;
+} => message.role === "user" && message.meta?.kind === "user";
+
+const confirmsLocalAcceptedUserMessage = (
+  loadedMessage: AgentChatMessage,
+  currentMessage: AgentChatMessage,
+): boolean =>
+  isUserMessage(loadedMessage) &&
+  isUserMessage(currentMessage) &&
+  loadedMessage.content === currentMessage.content &&
+  loadedMessage.timestamp === currentMessage.timestamp;
+
+const findConfirmedLocalAcceptedUserMessage = ({
+  currentOwner,
+  loadedMessage,
+  sameIdCurrentMessage,
+  absorbedCurrentMessageIds,
+}: {
+  currentOwner: Pick<AgentSessionState, "externalSessionId" | "messages">;
+  loadedMessage: AgentChatMessage;
+  sameIdCurrentMessage: AgentChatMessage | undefined;
+  absorbedCurrentMessageIds: ReadonlySet<string>;
+}): AgentChatMessage[] => {
+  const matches = sameIdCurrentMessageOrEmpty(sameIdCurrentMessage, absorbedCurrentMessageIds);
+  if (matches.length > 0) {
+    return matches;
+  }
+
+  const currentSlice = getSessionMessagesSlice(currentOwner, 0);
+  for (let index = currentSlice.length - 1; index >= 0; index -= 1) {
+    const candidate = currentSlice[index];
+    if (!candidate || absorbedCurrentMessageIds.has(candidate.id)) {
+      continue;
+    }
+    if (confirmsLocalAcceptedUserMessage(loadedMessage, candidate)) {
+      return [candidate];
+    }
+  }
+
+  return [];
+};
+
 const findMatchingCurrentMessages = ({
   currentOwner,
   loadedMessage,
@@ -82,6 +128,15 @@ const findMatchingCurrentMessages = ({
 }): AgentChatMessage[] => {
   if (isSubagentMessage(loadedMessage)) {
     return findCurrentSubagentMessagesForLoadedHistory({
+      currentOwner,
+      loadedMessage,
+      sameIdCurrentMessage,
+      absorbedCurrentMessageIds,
+    });
+  }
+
+  if (isUserMessage(loadedMessage)) {
+    return findConfirmedLocalAcceptedUserMessage({
       currentOwner,
       loadedMessage,
       sameIdCurrentMessage,

--- a/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
@@ -132,9 +132,32 @@ describe("createCodexAppServerTransportRegistry", () => {
   });
   test("fails fast when a runtime transport is missing or duplicated", async () => {
     const port = createCodexAppServerTransportRegistry();
+    await expect(
+      Effect.runPromise(port.request({ runtimeId: "runtime-1", method: "model/list", params: {} })),
+    ).rejects.toThrow("Codex app-server transport not found for runtime runtime-1");
     await expect(Effect.runPromise(port.drainNotifications("runtime-1"))).rejects.toThrow(
       "Codex app-server transport not found for runtime runtime-1",
     );
+    await expect(
+      Effect.runPromise(
+        port.listLoadedThreads({ runtimeId: "runtime-1", cursor: null, limit: 100 }),
+      ),
+    ).rejects.toThrow("Codex app-server transport not found for runtime runtime-1");
+    await expect(
+      Effect.runPromise(port.listThreads({ runtimeId: "runtime-1", cursor: null, limit: 100 })),
+    ).rejects.toThrow("Codex app-server transport not found for runtime runtime-1");
+    await expect(Effect.runPromise(port.drainServerRequests("runtime-1"))).rejects.toThrow(
+      "Codex app-server transport not found for runtime runtime-1",
+    );
+    await expect(
+      Effect.runPromise(
+        port.respond({
+          runtimeId: "runtime-1",
+          requestId: 7,
+          result: { decision: "approved" },
+        }),
+      ),
+    ).rejects.toThrow("Codex app-server transport not found for runtime runtime-1");
     const transport = {
       request() {
         return Effect.succeed({ data: [], nextCursor: null });

--- a/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
@@ -38,6 +38,7 @@ describe("createCodexAppServerTransportRegistry", () => {
                 id: "session-1",
                 sessionId: "session-1",
                 forkedFromId: null,
+                parentThreadId: null,
                 preview: "Preview",
                 ephemeral: false,
                 modelProvider: "openai",


### PR DESCRIPTION
Summary:
Adds Codex subagent support so parent transcripts show source-backed subagent rows, child transcript sessions can be opened live, and child approvals/questions route through the correct Codex thread without changing OpenCode behavior.

Goal:
Codex can spawn child agent threads, but OpenDucktor previously treated those runtime events as generic collaboration/tool activity. This PR exposes Codex subagents through the existing shared subagent UI model so reviewers can inspect the child transcript, see lifecycle state, and respond to child-owned approvals or questions from the transcript modal.

The implementation also fixes the regressions found during review: failed spawns no longer stay visually running, subagent descriptions remain the short creation prompt instead of drifting into the final answer, live transcript modals receive new child messages while open, and main-session user messages are not emitted twice.

Technical choices:
- Normalize Codex `collabAgentToolCall` and `subAgentActivity` events inside the Codex adapter, using runtime-provided parent/child thread identifiers rather than frontend inference.
- Keep Codex subagent routing state adapter-local and live-only; task-store schemas and persisted session records are unchanged.
- Route child approvals and questions through the child transcript session, while mirroring parent-visible pending inputs only after the parent/child link is known.
- Reconcile locally accepted Codex user sends with runtime-confirmed history at the send/history boundary, without adding broad message deduplication.
- Omit the subagent execution-mode badge for Codex rows because Codex spawn has no foreground/background mode; blocking is controlled by whether the orchestrator waits.
- Preserve OpenCode subagent behavior and descriptor capabilities.

Verification:
- `rtk bun run lint`
- `rtk bun run test`
- `rtk bun run typecheck`
- `rtk bun run build`
- Cargo checks are not applicable in this checkout because no `Cargo.toml` exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subagent-aware session and thread handling, including parent/child linkage and richer subagent activity details in streaming output.
  * Enhanced runtime snapshot generation and runtime capability discovery to support subagents (background mode).
  * Improved request/pending flows with route-aware approval/question metadata.

* **Bug Fixes**
  * Fixed resume/turn event ordering and ensured approvals/questions attach to the correct parent/child external session.
  * Improved pending input mirroring and history reconciliation to avoid duplications or incorrect ownership.
  * Fixed runtime buffering so server requests/resolved notifications are scoped and drained correctly per runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->