### PR TITLE
fix: make sidebar route feedback immediate

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -21,7 +21,7 @@ type AppProps = {
   routerMode?: AppRouterMode;
 };
 
-type RouterComponent = ComponentType<{ children?: ReactNode }>;
+type RouterComponent = ComponentType<{ children?: ReactNode; useTransitions?: boolean }>;
 
 const ROUTERS: Record<AppRouterMode, RouterComponent> = {
   browser: BrowserRouter,
@@ -60,7 +60,7 @@ export function App({ routerMode = "browser" }: AppProps): ReactElement {
   const Router = ROUTERS[routerMode];
 
   return (
-    <Router>
+    <Router useTransitions>
       <QueryProvider>
         <ThemeProvider>
           <AppStateProvider>

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation-styles.ts
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation-styles.ts
@@ -3,17 +3,17 @@ import { cn } from "@/lib/utils";
 type SidebarNavLinkClassNameArgs = {
   compact: boolean;
   isActive: boolean;
+  isActivated: boolean;
   isDisabled: boolean;
-  isPending: boolean;
 };
 
 export const sidebarNavLinkClassName = ({
   compact,
   isActive,
+  isActivated,
   isDisabled,
-  isPending,
 }: SidebarNavLinkClassNameArgs): string => {
-  const isSelected = !isDisabled && (isActive || isPending);
+  const isSelected = !isDisabled && (isActive || isActivated);
 
   return cn(
     compact

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation-styles.ts
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation-styles.ts
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+type SidebarNavLinkClassNameArgs = {
+  compact: boolean;
+  isActive: boolean;
+  isDisabled: boolean;
+  isPending: boolean;
+};
+
+export const sidebarNavLinkClassName = ({
+  compact,
+  isActive,
+  isDisabled,
+  isPending,
+}: SidebarNavLinkClassNameArgs): string => {
+  const isSelected = !isDisabled && (isActive || isPending);
+
+  return cn(
+    compact
+      ? "flex items-center justify-center rounded-lg p-2.5 text-sm font-medium transition"
+      : "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium",
+    isDisabled ? "cursor-not-allowed opacity-50" : "",
+    isSelected
+      ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
+      : "text-sidebar-foreground hover:bg-accent hover:text-accent-foreground",
+  );
+};

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation.test.tsx
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation.test.tsx
@@ -134,6 +134,19 @@ describe("SidebarNavigation", () => {
     expect(className).not.toContain("hover:bg-accent");
   });
 
+  test("keeps disabled links disabled-looking even when the router marks them active", () => {
+    const className = sidebarNavLinkClassName({
+      compact: false,
+      isActive: true,
+      isActivated: false,
+      isDisabled: true,
+    });
+
+    expect(className).toContain("cursor-not-allowed");
+    expect(className).toContain("opacity-50");
+    expect(className).not.toContain("bg-sidebar-accent");
+  });
+
   test("shows Agents as selected immediately while declarative routing to Agents is still suspended", () => {
     renderSidebarRoutingScenario({ initialRoute: "/kanban", suspendedRoute: "/agents" });
 
@@ -191,6 +204,33 @@ describe("SidebarNavigation", () => {
     expect(screen.getByRole("link", { name: "Agents" }).className).not.toContain(
       "bg-sidebar-accent",
     );
+  });
+
+  test("clears optimistic selection when clicking the currently active route", () => {
+    renderSidebarRoutingScenario({ initialRoute: "/kanban", suspendedRoute: "/agents" });
+
+    fireEvent.click(screen.getByRole("link", { name: "Agents" }));
+    expect(screen.getByRole("link", { name: "Agents" }).className).toContain("bg-sidebar-accent");
+
+    fireEvent.click(screen.getByRole("link", { name: "Kanban" }));
+
+    expect(screen.getByRole("link", { name: "Kanban" }).className).toContain("bg-sidebar-accent");
+    expect(screen.getByRole("link", { name: "Agents" }).className).not.toContain(
+      "bg-sidebar-accent",
+    );
+  });
+
+  test("keeps focus while optimistic selection waits on a suspended target route", () => {
+    renderSidebarRoutingScenario({ initialRoute: "/kanban", suspendedRoute: "/agents" });
+
+    const agentsLink = screen.getByRole("link", { name: "Agents" });
+    agentsLink.focus();
+    fireEvent.click(agentsLink);
+
+    expect(screen.getByLabelText("Current route").textContent).toBe("/kanban");
+    expect(agentsLink.isConnected).toBe(true);
+    expect(document.activeElement).toBe(agentsLink);
+    expect(agentsLink.className).toContain("bg-sidebar-accent");
   });
 
   test("keeps focus when route commit replaces optimistic selection with active selection", async () => {

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation.test.tsx
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { createElement, lazy, type ReactElement, Suspense } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createElement, lazy, type MouseEvent, type ReactElement, Suspense } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { SidebarNavigation } from "./sidebar-navigation";
 import { sidebarNavLinkClassName } from "./sidebar-navigation-styles";
 
@@ -17,16 +17,44 @@ function CurrentRouteProbe(): ReactElement {
   return <output aria-label="Current route">{location.pathname}</output>;
 }
 
+function BackButton(): ReactElement {
+  const navigate = useNavigate();
+
+  return (
+    <button type="button" onClick={() => navigate(-1)}>
+      Back
+    </button>
+  );
+}
+
 const routeTestId = (route: RoutePath): string => `${route.slice(1)}-route`;
 
-function renderSidebarWithSuspendedTarget(
-  initialRoute: RoutePath,
-  suspendedRoute: RoutePath,
-): void {
-  const SuspendedRoute = createSuspendedRoute();
+const MODIFIED_CLICK_CASES = [
+  { label: "Alt", eventInit: { altKey: true } },
+  { label: "Control", eventInit: { ctrlKey: true } },
+  { label: "Meta", eventInit: { metaKey: true } },
+  { label: "Shift", eventInit: { shiftKey: true } },
+] as const;
+
+type RenderSidebarRoutingScenarioOptions = {
+  initialRoute: RoutePath;
+  onSidebarClickCapture?: (event: MouseEvent<HTMLDivElement>) => void;
+  suspendedRoute?: RoutePath;
+};
+
+function renderSidebarRoutingScenario({
+  initialRoute,
+  onSidebarClickCapture,
+  suspendedRoute,
+}: RenderSidebarRoutingScenarioOptions): void {
+  const SuspendedRoute = suspendedRoute ? createSuspendedRoute() : null;
 
   const routeElement = (route: RoutePath): ReactElement => {
     if (route === suspendedRoute) {
+      if (!SuspendedRoute) {
+        throw new Error(`Missing suspended route component for ${route}`);
+      }
+
       return <SuspendedRoute />;
     }
 
@@ -35,7 +63,10 @@ function renderSidebarWithSuspendedTarget(
 
   render(
     <MemoryRouter initialEntries={[initialRoute]} useTransitions>
-      <SidebarNavigation hasActiveWorkspace />
+      <div onClickCapture={onSidebarClickCapture}>
+        <SidebarNavigation hasActiveWorkspace />
+      </div>
+      <BackButton />
       <CurrentRouteProbe />
       <Suspense fallback={<div data-testid="route-loading" />}>
         <Routes>
@@ -104,7 +135,7 @@ describe("SidebarNavigation", () => {
   });
 
   test("shows Agents as selected immediately while declarative routing to Agents is still suspended", () => {
-    renderSidebarWithSuspendedTarget("/kanban", "/agents");
+    renderSidebarRoutingScenario({ initialRoute: "/kanban", suspendedRoute: "/agents" });
 
     fireEvent.click(screen.getByRole("link", { name: "Agents" }));
 
@@ -114,12 +145,80 @@ describe("SidebarNavigation", () => {
   });
 
   test("shows Kanban as selected immediately while declarative routing to Kanban is still suspended", () => {
-    renderSidebarWithSuspendedTarget("/agents", "/kanban");
+    renderSidebarRoutingScenario({ initialRoute: "/agents", suspendedRoute: "/kanban" });
 
     fireEvent.click(screen.getByRole("link", { name: "Kanban" }));
 
     expect(screen.getByLabelText("Current route").textContent).toBe("/agents");
     expect(screen.getByTestId("agents-route")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Kanban" }).className).toContain("bg-sidebar-accent");
+  });
+
+  for (const modifiedClickCase of MODIFIED_CLICK_CASES) {
+    test(`does not show optimistic selection for ${modifiedClickCase.label} clicks handled by the browser`, () => {
+      renderSidebarRoutingScenario({ initialRoute: "/kanban", suspendedRoute: "/agents" });
+
+      fireEvent.click(screen.getByRole("link", { name: "Agents" }), modifiedClickCase.eventInit);
+
+      expect(screen.getByLabelText("Current route").textContent).toBe("/kanban");
+      expect(screen.getByRole("link", { name: "Agents" }).className).not.toContain(
+        "bg-sidebar-accent",
+      );
+    });
+  }
+
+  test("does not show optimistic selection for non-left clicks handled by the browser", () => {
+    renderSidebarRoutingScenario({ initialRoute: "/kanban", suspendedRoute: "/agents" });
+
+    fireEvent.click(screen.getByRole("link", { name: "Agents" }), { button: 1 });
+
+    expect(screen.getByLabelText("Current route").textContent).toBe("/kanban");
+    expect(screen.getByRole("link", { name: "Agents" }).className).not.toContain(
+      "bg-sidebar-accent",
+    );
+  });
+
+  test("does not show optimistic selection when another handler prevents navigation", () => {
+    renderSidebarRoutingScenario({
+      initialRoute: "/kanban",
+      onSidebarClickCapture: (event) => event.preventDefault(),
+      suspendedRoute: "/agents",
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: "Agents" }));
+
+    expect(screen.getByLabelText("Current route").textContent).toBe("/kanban");
+    expect(screen.getByRole("link", { name: "Agents" }).className).not.toContain(
+      "bg-sidebar-accent",
+    );
+  });
+
+  test("keeps focus when route commit replaces optimistic selection with active selection", async () => {
+    renderSidebarRoutingScenario({ initialRoute: "/kanban" });
+
+    const agentsLink = screen.getByRole("link", { name: "Agents" });
+    agentsLink.focus();
+    fireEvent.click(agentsLink);
+
+    await waitFor(() => expect(screen.getByLabelText("Current route").textContent).toBe("/agents"));
+
+    expect(agentsLink.isConnected).toBe(true);
+    expect(document.activeElement).toBe(agentsLink);
+    expect(agentsLink.className).toContain("bg-sidebar-accent");
+  });
+
+  test("does not revive stale optimistic selection after browser back restores the source entry", async () => {
+    renderSidebarRoutingScenario({ initialRoute: "/kanban" });
+
+    fireEvent.click(screen.getByRole("link", { name: "Agents" }));
+    await waitFor(() => expect(screen.getByLabelText("Current route").textContent).toBe("/agents"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() => expect(screen.getByLabelText("Current route").textContent).toBe("/kanban"));
+
+    expect(screen.getByRole("link", { name: "Kanban" }).className).toContain("bg-sidebar-accent");
+    expect(screen.getByRole("link", { name: "Agents" }).className).not.toContain(
+      "bg-sidebar-accent",
+    );
   });
 });

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation.test.tsx
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation.test.tsx
@@ -3,6 +3,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import { SidebarNavigation } from "./sidebar-navigation";
+import { sidebarNavLinkClassName } from "./sidebar-navigation-styles";
 
 describe("SidebarNavigation", () => {
   test("renders text labels in default mode", () => {
@@ -45,5 +46,18 @@ describe("SidebarNavigation", () => {
 
     expect(html).toContain('href="/kanban"');
     expect(html).toContain('aria-disabled="true"');
+  });
+
+  test("uses selected styles while navigation is pending", () => {
+    const className = sidebarNavLinkClassName({
+      compact: false,
+      isActive: false,
+      isDisabled: false,
+      isPending: true,
+    });
+
+    expect(className).toContain("bg-sidebar-accent");
+    expect(className).toContain("text-sidebar-accent-foreground");
+    expect(className).not.toContain("hover:bg-accent");
   });
 });

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation.test.tsx
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation.test.tsx
@@ -1,9 +1,51 @@
 import { describe, expect, test } from "bun:test";
-import { createElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createElement, lazy, type ReactElement, Suspense } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { SidebarNavigation } from "./sidebar-navigation";
 import { sidebarNavLinkClassName } from "./sidebar-navigation-styles";
+
+type RoutePath = "/agents" | "/kanban";
+
+const createSuspendedRoute = () =>
+  lazy(() => new Promise<{ default: () => ReactElement }>(() => {}));
+
+function CurrentRouteProbe(): ReactElement {
+  const location = useLocation();
+
+  return <output aria-label="Current route">{location.pathname}</output>;
+}
+
+const routeTestId = (route: RoutePath): string => `${route.slice(1)}-route`;
+
+function renderSidebarWithSuspendedTarget(
+  initialRoute: RoutePath,
+  suspendedRoute: RoutePath,
+): void {
+  const SuspendedRoute = createSuspendedRoute();
+
+  const routeElement = (route: RoutePath): ReactElement => {
+    if (route === suspendedRoute) {
+      return <SuspendedRoute />;
+    }
+
+    return <div data-testid={routeTestId(route)} />;
+  };
+
+  render(
+    <MemoryRouter initialEntries={[initialRoute]} useTransitions>
+      <SidebarNavigation hasActiveWorkspace />
+      <CurrentRouteProbe />
+      <Suspense fallback={<div data-testid="route-loading" />}>
+        <Routes>
+          <Route path="/kanban" element={routeElement("/kanban")} />
+          <Route path="/agents" element={routeElement("/agents")} />
+        </Routes>
+      </Suspense>
+    </MemoryRouter>,
+  );
+}
 
 describe("SidebarNavigation", () => {
   test("renders text labels in default mode", () => {
@@ -48,16 +90,36 @@ describe("SidebarNavigation", () => {
     expect(html).toContain('aria-disabled="true"');
   });
 
-  test("uses selected styles while navigation is pending", () => {
+  test("uses selected styles while navigation is activated", () => {
     const className = sidebarNavLinkClassName({
       compact: false,
       isActive: false,
+      isActivated: true,
       isDisabled: false,
-      isPending: true,
     });
 
     expect(className).toContain("bg-sidebar-accent");
     expect(className).toContain("text-sidebar-accent-foreground");
     expect(className).not.toContain("hover:bg-accent");
+  });
+
+  test("shows Agents as selected immediately while declarative routing to Agents is still suspended", () => {
+    renderSidebarWithSuspendedTarget("/kanban", "/agents");
+
+    fireEvent.click(screen.getByRole("link", { name: "Agents" }));
+
+    expect(screen.getByLabelText("Current route").textContent).toBe("/kanban");
+    expect(screen.getByTestId("kanban-route")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Agents" }).className).toContain("bg-sidebar-accent");
+  });
+
+  test("shows Kanban as selected immediately while declarative routing to Kanban is still suspended", () => {
+    renderSidebarWithSuspendedTarget("/agents", "/kanban");
+
+    fireEvent.click(screen.getByRole("link", { name: "Kanban" }));
+
+    expect(screen.getByLabelText("Current route").textContent).toBe("/agents");
+    expect(screen.getByTestId("agents-route")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Kanban" }).className).toContain("bg-sidebar-accent");
   });
 });

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation.tsx
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation.tsx
@@ -1,6 +1,6 @@
 import { Bot, Columns3 } from "lucide-react";
-import type { ReactElement } from "react";
-import { NavLink } from "react-router-dom";
+import { type ReactElement, useState } from "react";
+import { NavLink, useLocation } from "react-router-dom";
 import { preloadAgentsPage, preloadKanbanPage } from "@/pages";
 import { sidebarNavLinkClassName } from "./sidebar-navigation-styles";
 
@@ -9,7 +9,9 @@ const NAV_ITEMS = [
   { to: "/agents", icon: Bot, label: "Agents", requiresRepo: true },
 ] as const;
 
-const ROUTE_PRELOADERS: Record<(typeof NAV_ITEMS)[number]["to"], () => void> = {
+type NavigationRoute = (typeof NAV_ITEMS)[number]["to"];
+
+const ROUTE_PRELOADERS: Record<NavigationRoute, () => void> = {
   "/agents": preloadAgentsPage,
   "/kanban": preloadKanbanPage,
 };
@@ -23,12 +25,37 @@ export function SidebarNavigation({
   hasActiveWorkspace,
   compact = false,
 }: SidebarNavigationProps): ReactElement {
+  const location = useLocation();
+
+  return (
+    <SidebarNavigationLinks
+      key={location.pathname}
+      compact={compact}
+      currentPathname={location.pathname}
+      hasActiveWorkspace={hasActiveWorkspace}
+    />
+  );
+}
+
+type SidebarNavigationLinksProps = SidebarNavigationProps & {
+  currentPathname: string;
+};
+
+function SidebarNavigationLinks({
+  compact = false,
+  currentPathname,
+  hasActiveWorkspace,
+}: SidebarNavigationLinksProps): ReactElement {
+  const [activatedRoute, setActivatedRoute] = useState<NavigationRoute | null>(null);
+
   return (
     <nav className="space-y-1">
       {NAV_ITEMS.map((item) => {
         const Icon = item.icon;
         const isDisabled = item.requiresRepo && !hasActiveWorkspace;
         const preloadRoute = isDisabled ? undefined : ROUTE_PRELOADERS[item.to];
+        const activateRoute =
+          isDisabled || currentPathname === item.to ? undefined : () => setActivatedRoute(item.to);
         return (
           <NavLink
             key={item.to}
@@ -38,8 +65,14 @@ export function SidebarNavigation({
             prefetch={isDisabled ? "none" : "intent"}
             onFocus={preloadRoute}
             onPointerEnter={preloadRoute}
-            className={({ isActive, isPending }) =>
-              sidebarNavLinkClassName({ compact, isActive, isDisabled, isPending })
+            onClick={activateRoute}
+            className={({ isActive }) =>
+              sidebarNavLinkClassName({
+                compact,
+                isActive,
+                isActivated: activatedRoute === item.to,
+                isDisabled,
+              })
             }
             aria-disabled={isDisabled}
           >

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation.tsx
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation.tsx
@@ -35,7 +35,7 @@ type ShouldActivateSidebarNavigationArgs = {
   currentPathname: string;
   event: MouseEvent<HTMLAnchorElement>;
   isDisabled: boolean;
-  targetPathname: NavigationRoute;
+  linkTarget: NavigationRoute;
 };
 
 const isModifiedEvent = (event: MouseEvent<HTMLAnchorElement>): boolean =>
@@ -45,9 +45,9 @@ const shouldActivateSidebarNavigation = ({
   currentPathname,
   event,
   isDisabled,
-  targetPathname,
+  linkTarget,
 }: ShouldActivateSidebarNavigationArgs): boolean => {
-  if (isDisabled || currentPathname === targetPathname || event.defaultPrevented) {
+  if (isDisabled || currentPathname === linkTarget || event.defaultPrevented) {
     return false;
   }
 
@@ -78,11 +78,10 @@ export function SidebarNavigation({
 
   const activateRoute = (
     event: MouseEvent<HTMLAnchorElement>,
-    item: (typeof NAV_ITEMS)[number],
+    linkTarget: NavigationRoute,
+    isDisabled: boolean,
   ): void => {
-    const isDisabled = item.requiresRepo && !hasActiveWorkspace;
-
-    if (currentPathname === item.to) {
+    if (currentPathname === linkTarget) {
       setNavigationState({ activatedNavigation: null, committedLocationKey: currentLocationKey });
       return;
     }
@@ -92,11 +91,11 @@ export function SidebarNavigation({
         currentPathname,
         event,
         isDisabled,
-        targetPathname: item.to,
+        linkTarget,
       })
     ) {
       setNavigationState({
-        activatedNavigation: { route: item.to, sourceLocationKey: currentLocationKey },
+        activatedNavigation: { route: linkTarget, sourceLocationKey: currentLocationKey },
         committedLocationKey: currentLocationKey,
       });
     }
@@ -107,20 +106,20 @@ export function SidebarNavigation({
       {NAV_ITEMS.map((item) => {
         const Icon = item.icon;
         const isDisabled = item.requiresRepo && !hasActiveWorkspace;
+        const linkTarget: NavigationRoute = isDisabled ? "/kanban" : item.to;
         const preloadRoute = isDisabled ? undefined : ROUTE_PRELOADERS[item.to];
         const isActivated =
-          activatedNavigation?.route === item.to &&
+          activatedNavigation?.route === linkTarget &&
           activatedNavigation.sourceLocationKey === currentLocationKey;
         return (
           <NavLink
             key={item.to}
-            to={isDisabled ? "/kanban" : item.to}
+            to={linkTarget}
             title={item.label}
             aria-label={item.label}
-            prefetch={isDisabled ? "none" : "intent"}
             onFocus={preloadRoute}
             onPointerEnter={preloadRoute}
-            onClick={(event) => activateRoute(event, item)}
+            onClick={(event) => activateRoute(event, linkTarget, isDisabled)}
             className={({ isActive }) =>
               sidebarNavLinkClassName({
                 compact,

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation.tsx
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation.tsx
@@ -1,12 +1,18 @@
 import { Bot, Columns3 } from "lucide-react";
 import type { ReactElement } from "react";
 import { NavLink } from "react-router-dom";
-import { cn } from "@/lib/utils";
+import { preloadAgentsPage, preloadKanbanPage } from "@/pages";
+import { sidebarNavLinkClassName } from "./sidebar-navigation-styles";
 
 const NAV_ITEMS = [
   { to: "/kanban", icon: Columns3, label: "Kanban", requiresRepo: false },
   { to: "/agents", icon: Bot, label: "Agents", requiresRepo: true },
 ] as const;
+
+const ROUTE_PRELOADERS: Record<(typeof NAV_ITEMS)[number]["to"], () => void> = {
+  "/agents": preloadAgentsPage,
+  "/kanban": preloadKanbanPage,
+};
 
 type SidebarNavigationProps = {
   hasActiveWorkspace: boolean;
@@ -22,22 +28,18 @@ export function SidebarNavigation({
       {NAV_ITEMS.map((item) => {
         const Icon = item.icon;
         const isDisabled = item.requiresRepo && !hasActiveWorkspace;
+        const preloadRoute = isDisabled ? undefined : ROUTE_PRELOADERS[item.to];
         return (
           <NavLink
             key={item.to}
             to={isDisabled ? "/kanban" : item.to}
             title={item.label}
             aria-label={item.label}
-            className={({ isActive }) =>
-              cn(
-                compact
-                  ? "flex items-center justify-center rounded-lg p-2.5 text-sm font-medium transition"
-                  : "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium",
-                isDisabled ? "cursor-not-allowed opacity-50" : "",
-                isActive
-                  ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
-                  : "text-sidebar-foreground hover:bg-accent hover:text-accent-foreground",
-              )
+            prefetch={isDisabled ? "none" : "intent"}
+            onFocus={preloadRoute}
+            onPointerEnter={preloadRoute}
+            className={({ isActive, isPending }) =>
+              sidebarNavLinkClassName({ compact, isActive, isDisabled, isPending })
             }
             aria-disabled={isDisabled}
           >

--- a/packages/frontend/src/components/layout/sidebar/sidebar-navigation.tsx
+++ b/packages/frontend/src/components/layout/sidebar/sidebar-navigation.tsx
@@ -1,5 +1,5 @@
 import { Bot, Columns3 } from "lucide-react";
-import { type ReactElement, useState } from "react";
+import { type MouseEvent, type ReactElement, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { preloadAgentsPage, preloadKanbanPage } from "@/pages";
 import { sidebarNavLinkClassName } from "./sidebar-navigation-styles";
@@ -11,6 +11,16 @@ const NAV_ITEMS = [
 
 type NavigationRoute = (typeof NAV_ITEMS)[number]["to"];
 
+type ActivatedNavigation = {
+  route: NavigationRoute;
+  sourceLocationKey: string;
+};
+
+type SidebarNavigationState = {
+  activatedNavigation: ActivatedNavigation | null;
+  committedLocationKey: string;
+};
+
 const ROUTE_PRELOADERS: Record<NavigationRoute, () => void> = {
   "/agents": preloadAgentsPage,
   "/kanban": preloadKanbanPage,
@@ -21,32 +31,76 @@ type SidebarNavigationProps = {
   compact?: boolean;
 };
 
+type ShouldActivateSidebarNavigationArgs = {
+  currentPathname: string;
+  event: MouseEvent<HTMLAnchorElement>;
+  isDisabled: boolean;
+  targetPathname: NavigationRoute;
+};
+
+const isModifiedEvent = (event: MouseEvent<HTMLAnchorElement>): boolean =>
+  event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+
+const shouldActivateSidebarNavigation = ({
+  currentPathname,
+  event,
+  isDisabled,
+  targetPathname,
+}: ShouldActivateSidebarNavigationArgs): boolean => {
+  if (isDisabled || currentPathname === targetPathname || event.defaultPrevented) {
+    return false;
+  }
+
+  const target = event.currentTarget.getAttribute("target");
+
+  return event.button === 0 && (!target || target === "_self") && !isModifiedEvent(event);
+};
+
 export function SidebarNavigation({
   hasActiveWorkspace,
   compact = false,
 }: SidebarNavigationProps): ReactElement {
   const location = useLocation();
 
-  return (
-    <SidebarNavigationLinks
-      key={location.pathname}
-      compact={compact}
-      currentPathname={location.pathname}
-      hasActiveWorkspace={hasActiveWorkspace}
-    />
-  );
-}
+  const currentPathname = location.pathname;
+  const currentLocationKey = location.key;
+  const [navigationState, setNavigationState] = useState<SidebarNavigationState>(() => ({
+    activatedNavigation: null,
+    committedLocationKey: currentLocationKey,
+  }));
+  let activatedNavigation = navigationState.activatedNavigation;
 
-type SidebarNavigationLinksProps = SidebarNavigationProps & {
-  currentPathname: string;
-};
+  if (navigationState.committedLocationKey !== currentLocationKey) {
+    // Reset during render so restored history entries cannot revive stale optimistic feedback.
+    activatedNavigation = null;
+    setNavigationState({ activatedNavigation: null, committedLocationKey: currentLocationKey });
+  }
 
-function SidebarNavigationLinks({
-  compact = false,
-  currentPathname,
-  hasActiveWorkspace,
-}: SidebarNavigationLinksProps): ReactElement {
-  const [activatedRoute, setActivatedRoute] = useState<NavigationRoute | null>(null);
+  const activateRoute = (
+    event: MouseEvent<HTMLAnchorElement>,
+    item: (typeof NAV_ITEMS)[number],
+  ): void => {
+    const isDisabled = item.requiresRepo && !hasActiveWorkspace;
+
+    if (currentPathname === item.to) {
+      setNavigationState({ activatedNavigation: null, committedLocationKey: currentLocationKey });
+      return;
+    }
+
+    if (
+      shouldActivateSidebarNavigation({
+        currentPathname,
+        event,
+        isDisabled,
+        targetPathname: item.to,
+      })
+    ) {
+      setNavigationState({
+        activatedNavigation: { route: item.to, sourceLocationKey: currentLocationKey },
+        committedLocationKey: currentLocationKey,
+      });
+    }
+  };
 
   return (
     <nav className="space-y-1">
@@ -54,8 +108,9 @@ function SidebarNavigationLinks({
         const Icon = item.icon;
         const isDisabled = item.requiresRepo && !hasActiveWorkspace;
         const preloadRoute = isDisabled ? undefined : ROUTE_PRELOADERS[item.to];
-        const activateRoute =
-          isDisabled || currentPathname === item.to ? undefined : () => setActivatedRoute(item.to);
+        const isActivated =
+          activatedNavigation?.route === item.to &&
+          activatedNavigation.sourceLocationKey === currentLocationKey;
         return (
           <NavLink
             key={item.to}
@@ -65,12 +120,12 @@ function SidebarNavigationLinks({
             prefetch={isDisabled ? "none" : "intent"}
             onFocus={preloadRoute}
             onPointerEnter={preloadRoute}
-            onClick={activateRoute}
+            onClick={(event) => activateRoute(event, item)}
             className={({ isActive }) =>
               sidebarNavLinkClassName({
                 compact,
                 isActive,
-                isActivated: activatedRoute === item.to,
+                isActivated,
                 isDisabled,
               })
             }

--- a/packages/frontend/src/pages/index.test.ts
+++ b/packages/frontend/src/pages/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ComponentType } from "react";
+import { createCachedPageLoader } from "./index";
+
+const TestPage = (() => null) as ComponentType;
+
+describe("createCachedPageLoader", () => {
+  test("retries after a rejected load instead of returning a poisoned cached promise", async () => {
+    const failedImport = new Error("chunk load failed");
+    let attempts = 0;
+    const loadPage = mock(async () => {
+      attempts += 1;
+
+      if (attempts === 1) {
+        throw failedImport;
+      }
+
+      return { default: TestPage };
+    });
+    const loadCachedPage = createCachedPageLoader(loadPage);
+
+    await expect(loadCachedPage()).rejects.toThrow(failedImport);
+    await expect(loadCachedPage()).resolves.toEqual({ default: TestPage });
+
+    expect(loadPage).toHaveBeenCalledTimes(2);
+  });
+
+  test("reuses the in-flight successful load promise", () => {
+    const loadPage = mock(async () => ({ default: TestPage }));
+    const loadCachedPage = createCachedPageLoader(loadPage);
+
+    const firstLoad = loadCachedPage();
+    const secondLoad = loadCachedPage();
+
+    expect(secondLoad).toBe(firstLoad);
+    expect(loadPage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/src/pages/index.ts
+++ b/packages/frontend/src/pages/index.ts
@@ -1,14 +1,49 @@
-export const loadAgentsPage = async () => {
-  const module = await import("./agents/agents-page");
-  return { default: module.AgentsPage };
+import type { ComponentType } from "react";
+
+type PageModule = {
+  default: ComponentType;
 };
 
-export const loadKanbanPage = async () => {
-  const module = await import("./kanban/kanban-page");
-  return { default: module.KanbanPage };
+let agentsPageLoad: Promise<PageModule> | null = null;
+let kanbanPageLoad: Promise<PageModule> | null = null;
+let notFoundPageLoad: Promise<PageModule> | null = null;
+
+const reportRoutePreloadError = (pageName: string, error: unknown): void => {
+  console.error(`[route-preload] Failed to preload ${pageName} page.`, error);
 };
 
-export const loadNotFoundPage = async () => {
-  const module = await import("./not-found-page");
-  return { default: module.NotFoundPage };
+const preloadRoutePage = (pageName: string, loadPage: () => Promise<PageModule>): void => {
+  void loadPage().catch((error) => reportRoutePreloadError(pageName, error));
+};
+
+export const loadAgentsPage = (): Promise<PageModule> => {
+  agentsPageLoad ??= import("./agents/agents-page").then((module) => ({
+    default: module.AgentsPage,
+  }));
+
+  return agentsPageLoad;
+};
+
+export const preloadAgentsPage = (): void => {
+  preloadRoutePage("Agent Studio", loadAgentsPage);
+};
+
+export const loadKanbanPage = (): Promise<PageModule> => {
+  kanbanPageLoad ??= import("./kanban/kanban-page").then((module) => ({
+    default: module.KanbanPage,
+  }));
+
+  return kanbanPageLoad;
+};
+
+export const preloadKanbanPage = (): void => {
+  preloadRoutePage("Kanban", loadKanbanPage);
+};
+
+export const loadNotFoundPage = (): Promise<PageModule> => {
+  notFoundPageLoad ??= import("./not-found-page").then((module) => ({
+    default: module.NotFoundPage,
+  }));
+
+  return notFoundPageLoad;
 };

--- a/packages/frontend/src/pages/index.ts
+++ b/packages/frontend/src/pages/index.ts
@@ -4,46 +4,55 @@ type PageModule = {
   default: ComponentType;
 };
 
-let agentsPageLoad: Promise<PageModule> | null = null;
-let kanbanPageLoad: Promise<PageModule> | null = null;
-let notFoundPageLoad: Promise<PageModule> | null = null;
+type PageLoader = () => Promise<PageModule>;
+
+export const createCachedPageLoader = (loadPage: PageLoader): PageLoader => {
+  let cachedPageLoad: Promise<PageModule> | null = null;
+
+  return () => {
+    cachedPageLoad ??= loadPage().catch((error) => {
+      cachedPageLoad = null;
+      throw error;
+    });
+
+    return cachedPageLoad;
+  };
+};
 
 const reportRoutePreloadError = (pageName: string, error: unknown): void => {
   console.error(`[route-preload] Failed to preload ${pageName} page.`, error);
 };
 
-const preloadRoutePage = (pageName: string, loadPage: () => Promise<PageModule>): void => {
+const preloadRoutePage = (pageName: string, loadPage: PageLoader): void => {
   void loadPage().catch((error) => reportRoutePreloadError(pageName, error));
 };
 
-export const loadAgentsPage = (): Promise<PageModule> => {
-  agentsPageLoad ??= import("./agents/agents-page").then((module) => ({
+export const loadAgentsPage = createCachedPageLoader(() =>
+  import("./agents/agents-page").then((module) => ({
     default: module.AgentsPage,
-  }));
-
-  return agentsPageLoad;
-};
+  })),
+);
 
 export const preloadAgentsPage = (): void => {
   preloadRoutePage("Agent Studio", loadAgentsPage);
 };
 
-export const loadKanbanPage = (): Promise<PageModule> => {
-  kanbanPageLoad ??= import("./kanban/kanban-page").then((module) => ({
+export const loadKanbanPage = createCachedPageLoader(() =>
+  import("./kanban/kanban-page").then((module) => ({
     default: module.KanbanPage,
-  }));
-
-  return kanbanPageLoad;
-};
+  })),
+);
 
 export const preloadKanbanPage = (): void => {
   preloadRoutePage("Kanban", loadKanbanPage);
 };
 
-export const loadNotFoundPage = (): Promise<PageModule> => {
-  notFoundPageLoad ??= import("./not-found-page").then((module) => ({
+export const loadNotFoundPage = createCachedPageLoader(() =>
+  import("./not-found-page").then((module) => ({
     default: module.NotFoundPage,
-  }));
+  })),
+);
 
-  return notFoundPageLoad;
+export const preloadNotFoundPage = (): void => {
+  preloadRoutePage("Not Found", loadNotFoundPage);
 };


### PR DESCRIPTION
Summary: This PR makes Kanban ↔ Agent Studio sidebar navigation feel immediate by giving the clicked route synchronous visual feedback, while keeping the router and lazy page loading architecture intact.

## Goal

Switching between Kanban and Agent Studio could feel inert for 1–2 seconds because the declarative router can keep the old route visible while lazy route chunks and page mount work are still pending. The product requirement is that sidebar clicks must never appear blocked or unresponsive.

## Technical approach

- Enable React Router transition-aware declarative navigation in the app shell.
- Cache lazy route imports for Kanban, Agent Studio, and Not Found pages.
- Preload Kanban and Agent Studio route chunks on sidebar focus and pointer intent.
- Add app-owned sidebar activation state instead of relying on `NavLink.isPending`, which is not available in this app's declarative BrowserRouter/HashRouter mode.
- Mirror React Router click semantics before optimistic activation: left click only, same-tab target only, no modifier keys, not prevented, not disabled, and not same path.
- Tie optimistic activation to the current history entry and clear it on committed location-key changes so browser Back/POP cannot revive stale feedback.
- Preserve link DOM identity and focus across route commits instead of resetting state with a keyed remount.
- Add behavioral tests for suspended bidirectional navigation, modified/prevented/non-left clicks, focus preservation, and browser-back stale activation.

## Verification

- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- Cargo checks: not applicable; no `Cargo.toml` exists in this worktree.

Note: the full frontend test suite still emits existing unrelated React act/context warnings, but all tests pass.