### PR TITLE
fix(opencode): prevent prompt async idle flicker

### DIFF
--- a/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
@@ -69,6 +69,7 @@ export const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
   runtimeId: "runtime-opencode-1",
   streamTurnStatus: "active",
   isSendingUserMessage: false,
+  isAwaitingRuntimeTurnStart: false,
   activeAssistantMessageId: null,
   completedAssistantMessageIds: new Set<string>(),
   emittedAssistantMessageIds: new Set<string>(),

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -1506,17 +1506,48 @@ describe("event-stream", () => {
     expect(idleEvents).toHaveLength(0);
   });
 
-  test("ignores session.status idle while a user message send is still in flight", async () => {
+  test("ignores session.status idle while waiting for runtime turn start", async () => {
     const { emitted, sessionRecord } = await runEventStreamWithSession(
       [makeSessionStatusIdleEvent()],
       (session) => {
         session.isSendingUserMessage = true;
+        session.isAwaitingRuntimeTurnStart = true;
       },
     );
 
     expect(emitted.filter((event) => event.type === "session_status")).toHaveLength(0);
     expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(0);
     expect(sessionRecord.streamTurnStatus).toBe("active");
+  });
+
+  test("honors session.status idle after runtime turn start while a send is still in flight", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [makeSessionStatusIdleEvent()],
+      (session) => {
+        session.isSendingUserMessage = true;
+        session.isAwaitingRuntimeTurnStart = false;
+      },
+    );
+
+    const statusEvents = emitted.filter((event) => event.type === "session_status");
+    expect(statusEvents).toHaveLength(1);
+    expect(statusEvents[0]).toMatchObject({ status: { type: "idle" } });
+    expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(0);
+    expect(sessionRecord.streamTurnStatus).toBe("idle");
+  });
+
+  test("honors session.idle after runtime turn start while a send is still in flight", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [makeSessionIdleEvent()],
+      (session) => {
+        session.isSendingUserMessage = true;
+        session.isAwaitingRuntimeTurnStart = false;
+      },
+    );
+
+    expect(emitted.filter((event) => event.type === "session_status")).toHaveLength(0);
+    expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(1);
+    expect(sessionRecord.streamTurnStatus).toBe("idle");
   });
 
   test("ignores OpenCode idle events while waiting for runtime turn start", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -1506,6 +1506,56 @@ describe("event-stream", () => {
     expect(idleEvents).toHaveLength(0);
   });
 
+  test("ignores session.status idle while a user message send is still in flight", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [makeSessionStatusIdleEvent()],
+      (session) => {
+        session.isSendingUserMessage = true;
+      },
+    );
+
+    expect(emitted.filter((event) => event.type === "session_status")).toHaveLength(0);
+    expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(0);
+    expect(sessionRecord.streamTurnStatus).toBe("active");
+  });
+
+  test("ignores OpenCode idle events while waiting for runtime turn start", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [makeSessionStatusIdleEvent(), makeSessionIdleEvent()],
+      (session) => {
+        session.isAwaitingRuntimeTurnStart = true;
+      },
+    );
+
+    expect(emitted.filter((event) => event.type === "session_status")).toHaveLength(0);
+    expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(0);
+    expect(sessionRecord.streamTurnStatus).toBe("active");
+    expect(sessionRecord.isAwaitingRuntimeTurnStart).toBe(true);
+  });
+
+  test("terminal assistant events clear pending turn start even when stream status is idle", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [
+        makeAssistantMessageUpdatedEvent({
+          messageId: "assistant-message-pending-terminal",
+          finish: "stop",
+          completedAt: 1,
+          text: "Done after pending turn",
+          partId: "text-pending-terminal-1",
+        }),
+      ],
+      (session) => {
+        session.streamTurnStatus = "idle";
+        session.isAwaitingRuntimeTurnStart = true;
+      },
+    );
+
+    expect(emitted.filter((event) => event.type === "assistant_message")).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(1);
+    expect(sessionRecord.isAwaitingRuntimeTurnStart).toBe(false);
+    expect(sessionRecord.streamTurnStatus).toBe("idle");
+  });
+
   test("keeps late terminal part updates out of assistant_part emission once idle", async () => {
     const { emitted, sessionRecord } = await runEventStreamWithSession([
       makeAssistantMessageUpdatedEvent({
@@ -2764,15 +2814,20 @@ describe("event-stream", () => {
   });
 
   test("normalizes unknown session error payload", async () => {
-    const emitted = await runEventStream([
-      {
-        type: "session.error",
-        properties: {
-          sessionID: "external-session-1",
-          error: { data: {} },
-        },
-      } as unknown as Event,
-    ]);
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [
+        {
+          type: "session.error",
+          properties: {
+            sessionID: "external-session-1",
+            error: { data: {} },
+          },
+        } as unknown as Event,
+      ],
+      (session) => {
+        session.isAwaitingRuntimeTurnStart = true;
+      },
+    );
 
     const errors = emitted.filter((event) => event.type === "session_error");
     expect(errors).toHaveLength(1);
@@ -2780,6 +2835,8 @@ describe("event-stream", () => {
       throw new Error("Expected session_error event");
     }
     expect(errors[0].message).toBe("Unknown session error");
+    expect(sessionRecord.isAwaitingRuntimeTurnStart).toBe(false);
+    expect(sessionRecord.streamTurnStatus).toBe("idle");
   });
 
   test("does not replay duplicate delta after suppressed known user-part update", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -18,7 +18,7 @@ import {
   bindSubagentExternalSession,
   emitSessionIdle,
   flushPendingSubagentInputEventsForSession,
-  isSessionUserMessageTurnStartPending,
+  isSessionAwaitingRuntimeTurnStart,
   markSessionActive,
   markSessionIdle,
   readEventDirectory,
@@ -233,7 +233,7 @@ const handleSessionStatusEvent = (event: Event, runtime: EventStreamRuntime): bo
     if (status.type === "busy") {
       markSessionActive(runtime);
     } else {
-      if (isSessionUserMessageTurnStartPending(runtime)) {
+      if (isSessionAwaitingRuntimeTurnStart(runtime)) {
         return true;
       }
       markSessionIdle(runtime);
@@ -377,7 +377,7 @@ const handleSessionIdleEvent = (event: Event, runtime: EventStreamRuntime): bool
     return false;
   }
 
-  if (isSessionUserMessageTurnStartPending(runtime)) {
+  if (isSessionAwaitingRuntimeTurnStart(runtime)) {
     return true;
   }
   emitSessionIdle(runtime);

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -18,6 +18,7 @@ import {
   bindSubagentExternalSession,
   emitSessionIdle,
   flushPendingSubagentInputEventsForSession,
+  isSessionUserMessageTurnStartPending,
   markSessionActive,
   markSessionIdle,
   readEventDirectory,
@@ -232,6 +233,9 @@ const handleSessionStatusEvent = (event: Event, runtime: EventStreamRuntime): bo
     if (status.type === "busy") {
       markSessionActive(runtime);
     } else {
+      if (isSessionUserMessageTurnStartPending(runtime)) {
+        return true;
+      }
       markSessionIdle(runtime);
       publishUserMessageReadStateChanges(runtime);
     }
@@ -358,6 +362,7 @@ const handleSessionErrorEvent = (event: Event, runtime: EventStreamRuntime): boo
   }
 
   const properties = readEventProperties(event);
+  markSessionIdle(runtime);
   runtime.emit(runtime.externalSessionId, {
     type: "session_error",
     externalSessionId: runtime.externalSessionId,
@@ -372,6 +377,9 @@ const handleSessionIdleEvent = (event: Event, runtime: EventStreamRuntime): bool
     return false;
   }
 
+  if (isSessionUserMessageTurnStartPending(runtime)) {
+    return true;
+  }
   emitSessionIdle(runtime);
   publishUserMessageReadStateChanges(runtime);
   return true;

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -189,6 +189,7 @@ const emitIdleForSession = (
     if (!isAwaitingRuntimeTurnStart(session)) {
       return false;
     }
+    // Covers terminal completion after early idle suppression or seeded/local idle state.
     clearAwaitingRuntimeTurnStart(session);
     emitter.emit(emitter.externalSessionId, {
       type: "session_idle",

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -1,7 +1,13 @@
 import type { Event, Part } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import { asUnknownRecord, readRecordProp, readStringProp } from "../guards";
-import { isStreamTurnIdle, markStreamTurnActive, markStreamTurnIdle } from "../session-activity";
+import {
+  clearUserMessageTurnStartPending,
+  isStreamTurnIdle,
+  isUserMessageTurnStartPending,
+  markStreamTurnActive,
+  markStreamTurnIdle,
+} from "../session-activity";
 import type { SessionInput, SessionRecord } from "../types";
 import { readEventProperties } from "./schemas";
 
@@ -176,8 +182,20 @@ const emitIdleForSession = (
   session: SessionRecord | undefined,
   emitter: SessionIdleEmitter,
 ): boolean => {
-  if (!session || isStreamTurnIdle(session)) {
+  if (!session) {
     return false;
+  }
+  if (isStreamTurnIdle(session)) {
+    if (!isUserMessageTurnStartPending(session)) {
+      return false;
+    }
+    clearUserMessageTurnStartPending(session);
+    emitter.emit(emitter.externalSessionId, {
+      type: "session_idle",
+      externalSessionId: emitter.externalSessionId,
+      timestamp: emitter.now(),
+    });
+    return true;
   }
   markStreamTurnIdle(session);
   emitter.emit(emitter.externalSessionId, {
@@ -204,6 +222,12 @@ export const markSessionIdle = (
   context: Pick<EventStreamContext, "externalSessionId" | "getSession">,
 ): void => {
   markStreamTurnIdle(getSessionRecord(context));
+};
+
+export const isSessionUserMessageTurnStartPending = (
+  context: Pick<EventStreamContext, "externalSessionId" | "getSession">,
+): boolean => {
+  return isUserMessageTurnStartPending(getSessionRecord(context));
 };
 
 export const emitSessionIdle = (

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -2,9 +2,9 @@ import type { Event, Part } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import { asUnknownRecord, readRecordProp, readStringProp } from "../guards";
 import {
-  clearUserMessageTurnStartPending,
+  clearAwaitingRuntimeTurnStart,
+  isAwaitingRuntimeTurnStart,
   isStreamTurnIdle,
-  isUserMessageTurnStartPending,
   markStreamTurnActive,
   markStreamTurnIdle,
 } from "../session-activity";
@@ -186,10 +186,10 @@ const emitIdleForSession = (
     return false;
   }
   if (isStreamTurnIdle(session)) {
-    if (!isUserMessageTurnStartPending(session)) {
+    if (!isAwaitingRuntimeTurnStart(session)) {
       return false;
     }
-    clearUserMessageTurnStartPending(session);
+    clearAwaitingRuntimeTurnStart(session);
     emitter.emit(emitter.externalSessionId, {
       type: "session_idle",
       externalSessionId: emitter.externalSessionId,
@@ -224,10 +224,10 @@ export const markSessionIdle = (
   markStreamTurnIdle(getSessionRecord(context));
 };
 
-export const isSessionUserMessageTurnStartPending = (
+export const isSessionAwaitingRuntimeTurnStart = (
   context: Pick<EventStreamContext, "externalSessionId" | "getSession">,
 ): boolean => {
-  return isUserMessageTurnStartPending(getSessionRecord(context));
+  return isAwaitingRuntimeTurnStart(getSessionRecord(context));
 };
 
 export const emitSessionIdle = (

--- a/packages/adapters-opencode-sdk/src/live-session-snapshots.ts
+++ b/packages/adapters-opencode-sdk/src/live-session-snapshots.ts
@@ -8,7 +8,11 @@ import { formatWorkflowAgentSessionTitle } from "@openducktor/core";
 import { unwrapData } from "./data-utils";
 import { readStringProp } from "./guards";
 import { listOpencodeLiveSessionPendingInput } from "./pending-input-ops";
-import { isLocalSessionBusy, isUserMessageSendInFlight } from "./session-activity";
+import {
+  clearUserMessageTurnStartPending,
+  isLocalSessionBusy,
+  isUserMessageTurnStartPending,
+} from "./session-activity";
 import { toIsoFromEpoch } from "./session-runtime-utils";
 import type { ClientFactory, SessionRecord } from "./types";
 
@@ -122,12 +126,20 @@ export const applyOpencodeInFlightSendToRuntimeSnapshot = ({
   snapshot,
 }: ApplyOpencodeInFlightSendToRuntimeSnapshotInput): OpencodeRuntimeSnapshotSource => {
   const localSession = sessions.get(snapshot.externalSessionId);
-  if (
-    !localSession ||
-    localSession.runtimeId !== runtimeId ||
-    !isUserMessageSendInFlight(localSession) ||
-    snapshot.runtimeActivity !== "idle"
-  ) {
+  if (!localSession || localSession.runtimeId !== runtimeId) {
+    return snapshot;
+  }
+
+  const hasRuntimeTurnStartEvidence =
+    snapshot.runtimeActivity !== "idle" ||
+    snapshot.pendingApprovals.length > 0 ||
+    snapshot.pendingQuestions.length > 0;
+  if (hasRuntimeTurnStartEvidence) {
+    clearUserMessageTurnStartPending(localSession);
+    return snapshot;
+  }
+
+  if (!isUserMessageTurnStartPending(localSession)) {
     return snapshot;
   }
 

--- a/packages/adapters-opencode-sdk/src/live-session-snapshots.ts
+++ b/packages/adapters-opencode-sdk/src/live-session-snapshots.ts
@@ -9,9 +9,9 @@ import { unwrapData } from "./data-utils";
 import { readStringProp } from "./guards";
 import { listOpencodeLiveSessionPendingInput } from "./pending-input-ops";
 import {
-  clearUserMessageTurnStartPending,
+  clearAwaitingRuntimeTurnStart,
+  isAwaitingRuntimeTurnStart,
   isLocalSessionBusy,
-  isUserMessageTurnStartPending,
 } from "./session-activity";
 import { toIsoFromEpoch } from "./session-runtime-utils";
 import type { ClientFactory, SessionRecord } from "./types";
@@ -40,7 +40,7 @@ export type ReadOpencodeLocalRuntimeSnapshotInput = OpencodeLocalRuntimeSnapshot
   externalSessionId: string;
 };
 
-export type ApplyOpencodeInFlightSendToRuntimeSnapshotInput = {
+export type ApplyOpencodeAwaitingTurnStartToRuntimeSnapshotInput = {
   sessions: ReadonlyMap<string, SessionRecord>;
   runtimeId: string;
   snapshot: OpencodeRuntimeSnapshotSource;
@@ -120,11 +120,11 @@ const toOpencodeLocalRuntimeSnapshot = (session: SessionRecord): OpencodeRuntime
   pendingQuestions: [],
 });
 
-export const applyOpencodeInFlightSendToRuntimeSnapshot = ({
+export const applyOpencodeAwaitingTurnStartToRuntimeSnapshot = ({
   sessions,
   runtimeId,
   snapshot,
-}: ApplyOpencodeInFlightSendToRuntimeSnapshotInput): OpencodeRuntimeSnapshotSource => {
+}: ApplyOpencodeAwaitingTurnStartToRuntimeSnapshotInput): OpencodeRuntimeSnapshotSource => {
   const localSession = sessions.get(snapshot.externalSessionId);
   if (!localSession || localSession.runtimeId !== runtimeId) {
     return snapshot;
@@ -135,11 +135,11 @@ export const applyOpencodeInFlightSendToRuntimeSnapshot = ({
     snapshot.pendingApprovals.length > 0 ||
     snapshot.pendingQuestions.length > 0;
   if (hasRuntimeTurnStartEvidence) {
-    clearUserMessageTurnStartPending(localSession);
+    clearAwaitingRuntimeTurnStart(localSession);
     return snapshot;
   }
 
-  if (!isUserMessageTurnStartPending(localSession)) {
+  if (!isAwaitingRuntimeTurnStart(localSession)) {
     return snapshot;
   }
 

--- a/packages/adapters-opencode-sdk/src/message-execution.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.test.ts
@@ -71,6 +71,7 @@ const createSession = (overrides?: {
     pendingQueuedUserMessages: [],
     streamTurnStatus: "idle",
     isSendingUserMessage: false,
+    isAwaitingRuntimeTurnStart: false,
   } as unknown as SessionRecord;
 
   return { session, command, promptAsync };

--- a/packages/adapters-opencode-sdk/src/message-execution.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.ts
@@ -185,6 +185,9 @@ const toSlashCommandExecutionRequest = (
   };
 };
 
+export const usesPromptAsyncTransport = (parts: SendAgentUserMessageInput["parts"]): boolean =>
+  !normalizeAgentUserMessageParts(parts).some((part) => part.kind === "slash_command");
+
 const preparePromptSend = (request: SendAgentUserMessageInput): PreparedUserSend => {
   return {
     execute: async ({ session, messageId, modelInput, tools }) => {

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -1467,6 +1467,125 @@ describe("opencode-sdk-adapter", () => {
     expect(promptAsyncCalls).toHaveLength(1);
   });
 
+  test("sendUserMessage slash command does not hold idle snapshots awaiting prompt async", async () => {
+    const mock = makeMockClient();
+    const commandCalls: unknown[] = [];
+    const slashCommandClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        status: async (input?: unknown) => {
+          mock.statusCalls.push(input);
+          return { data: { "external-session-1": { type: "idle" } }, error: undefined };
+        },
+        command: async (input: unknown) => {
+          commandCalls.push(input);
+          return { data: undefined, error: undefined };
+        },
+      },
+      permission: {
+        ...mock.client.permission,
+        list: async (input?: unknown) => {
+          mock.permissionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      question: {
+        ...mock.client.question,
+        list: async (input?: unknown) => {
+          mock.questionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      mcp: {
+        status: async () => ({ data: { openducktor: { status: "connected" } }, error: undefined }),
+        connect: async () => ({ data: true, error: undefined }),
+      },
+      tool: {
+        ids: async () => ({ data: ["odt_read_task"], error: undefined }),
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => slashCommandClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    await adapter.sendUserMessage({
+      ...sessionRuntimeRef("external-session-1"),
+      parts: [
+        {
+          kind: "slash_command",
+          command: { id: "compact", trigger: "compact", title: "compact", hints: [] },
+        },
+      ],
+    });
+
+    const snapshot = await adapter.readSessionRuntimeSnapshot({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      externalSessionId: "external-session-1",
+    });
+    const session = (adapter as unknown as TestAdapterInternals).sessions.get("external-session-1");
+
+    expect(snapshot).toMatchObject({ availability: "runtime", classification: "idle" });
+    expect(session?.isAwaitingRuntimeTurnStart).toBe(false);
+    expect(commandCalls).toHaveLength(1);
+  });
+
+  test("sendUserMessage queued behind an active assistant preserves an existing await marker", async () => {
+    const mock = makeMockClient();
+    const queuedSendClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        promptAsync: async () => ({ data: undefined, error: undefined }),
+      },
+      mcp: {
+        status: async () => ({ data: { openducktor: { status: "connected" } }, error: undefined }),
+        connect: async () => ({ data: true, error: undefined }),
+      },
+      tool: {
+        ids: async () => ({ data: ["odt_read_task"], error: undefined }),
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => queuedSendClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+    const session = (adapter as unknown as TestAdapterInternals).sessions.get("external-session-1");
+    if (!session) {
+      throw new Error("Expected test session to be registered.");
+    }
+    session.activeAssistantMessageId = "assistant-active";
+    session.isAwaitingRuntimeTurnStart = true;
+
+    await adapter.sendUserMessage({
+      ...sessionRuntimeRef("external-session-1"),
+      parts: [{ kind: "text", text: "Queue behind current answer" }],
+    });
+
+    expect(session.isAwaitingRuntimeTurnStart).toBe(true);
+  });
+
   test("readSessionRuntimeSnapshot does not synthesize local runtime snapshot for another working directory", async () => {
     const mock = makeMockClient();
     const emptyListClient = {
@@ -1554,6 +1673,124 @@ describe("opencode-sdk-adapter", () => {
         pendingQuestions: [],
       },
     ]);
+  });
+
+  test("local-only runtime snapshots preserve the awaiting turn marker", async () => {
+    const mock = makeMockClient();
+    const emptyListClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        list: async (input?: unknown) => {
+          mock.listCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => emptyListClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+    const session = (adapter as unknown as TestAdapterInternals).sessions.get("external-session-1");
+    if (!session) {
+      throw new Error("Expected test session to be registered.");
+    }
+    session.isAwaitingRuntimeTurnStart = true;
+
+    const snapshots = await adapter.listSessionRuntimeSnapshots({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      directories: [defaultWorkingDirectory],
+    });
+    const snapshot = await adapter.readSessionRuntimeSnapshot({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      externalSessionId: "external-session-1",
+    });
+
+    expect(snapshots[0]).toMatchObject({ availability: "runtime", classification: "running" });
+    expect(snapshot).toMatchObject({ availability: "runtime", classification: "running" });
+    expect(session.isAwaitingRuntimeTurnStart).toBe(true);
+  });
+
+  test("live idle runtime snapshots stay suppressed while awaiting turn start", async () => {
+    const mock = makeMockClient();
+    const idleLiveClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        list: async (input?: unknown) => {
+          mock.listCalls.push(input);
+          return {
+            data: [
+              {
+                id: "external-session-1",
+                projectID: "project-1",
+                directory: defaultWorkingDirectory,
+                title: "BUILD task-1",
+                time: { created: Date.parse("2026-02-22T12:00:00.000Z") },
+              },
+            ],
+            error: undefined,
+          };
+        },
+        status: async (input?: unknown) => {
+          mock.statusCalls.push(input);
+          return { data: { "external-session-1": { type: "idle" } }, error: undefined };
+        },
+      },
+      permission: {
+        ...mock.client.permission,
+        list: async (input?: unknown) => {
+          mock.permissionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      question: {
+        ...mock.client.question,
+        list: async (input?: unknown) => {
+          mock.questionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => idleLiveClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+    const session = (adapter as unknown as TestAdapterInternals).sessions.get("external-session-1");
+    if (!session) {
+      throw new Error("Expected test session to be registered.");
+    }
+    session.isAwaitingRuntimeTurnStart = true;
+
+    const snapshots = await adapter.listSessionRuntimeSnapshots({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      directories: [defaultWorkingDirectory],
+    });
+
+    expect(snapshots[0]).toMatchObject({ availability: "runtime", classification: "running" });
+    expect(session.isAwaitingRuntimeTurnStart).toBe(true);
   });
 
   test("listSessionRuntimeSnapshots includes observed existing sessions before runtime list catches up", async () => {

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -1292,6 +1292,181 @@ describe("opencode-sdk-adapter", () => {
     expect(promptAsyncCalls).toHaveLength(1);
   });
 
+  test("sendUserMessage trusts runtime idle after turn start evidence while prompt async is still settling", async () => {
+    const mock = makeMockClient();
+    const promptAsyncStarted = createDeferred<void>();
+    const promptAsyncDeferred = createDeferred<{ data: undefined; error: undefined }>();
+    let runtimeStatus: "idle" | "busy" = "idle";
+    const promptPendingClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        status: async (input?: unknown) => {
+          mock.statusCalls.push(input);
+          return {
+            data: {
+              "external-session-1": { type: runtimeStatus },
+            },
+            error: undefined,
+          };
+        },
+        promptAsync: async () => {
+          promptAsyncStarted.resolve(undefined);
+          return promptAsyncDeferred.promise;
+        },
+      },
+      permission: {
+        ...mock.client.permission,
+        list: async (input?: unknown) => {
+          mock.permissionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      question: {
+        ...mock.client.question,
+        list: async (input?: unknown) => {
+          mock.questionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      mcp: {
+        status: async () => ({ data: { openducktor: { status: "connected" } }, error: undefined }),
+        connect: async () => ({ data: true, error: undefined }),
+      },
+      tool: {
+        ids: async () => ({ data: ["odt_read_task"], error: undefined }),
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => promptPendingClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    const sendPromise = adapter.sendUserMessage({
+      ...sessionRuntimeRef("external-session-1"),
+      parts: [{ kind: "text", text: "Continue" }],
+    });
+    await promptAsyncStarted.promise;
+
+    const readSnapshot = () =>
+      adapter.readSessionRuntimeSnapshot({
+        repoPath: defaultRepoPath,
+        runtimeKind: "opencode",
+        workingDirectory: defaultWorkingDirectory,
+        externalSessionId: "external-session-1",
+      });
+
+    runtimeStatus = "busy";
+    const busySnapshot = await readSnapshot();
+    expect(busySnapshot).toMatchObject({
+      availability: "runtime",
+      classification: "running",
+    });
+
+    runtimeStatus = "idle";
+    const idleSnapshot = await readSnapshot();
+    expect(idleSnapshot).toMatchObject({
+      availability: "runtime",
+      classification: "idle",
+    });
+
+    promptAsyncDeferred.resolve({ data: undefined, error: undefined });
+    await sendPromise;
+  });
+
+  test("sendUserMessage queued behind an active assistant does not hold idle snapshots awaiting a new turn", async () => {
+    const mock = makeMockClient();
+    const promptAsyncCalls: unknown[] = [];
+    const queuedSendClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        status: async (input?: unknown) => {
+          mock.statusCalls.push(input);
+          return {
+            data: {
+              "external-session-1": { type: "idle" },
+            },
+            error: undefined,
+          };
+        },
+        promptAsync: async (input: unknown) => {
+          promptAsyncCalls.push(input);
+          return { data: undefined, error: undefined };
+        },
+      },
+      permission: {
+        ...mock.client.permission,
+        list: async (input?: unknown) => {
+          mock.permissionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      question: {
+        ...mock.client.question,
+        list: async (input?: unknown) => {
+          mock.questionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      mcp: {
+        status: async () => ({ data: { openducktor: { status: "connected" } }, error: undefined }),
+        connect: async () => ({ data: true, error: undefined }),
+      },
+      tool: {
+        ids: async () => ({ data: ["odt_read_task"], error: undefined }),
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => queuedSendClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    const session = (adapter as unknown as TestAdapterInternals).sessions.get("external-session-1");
+    if (!session) {
+      throw new Error("Expected test session to be registered.");
+    }
+    session.activeAssistantMessageId = "assistant-active";
+    session.streamTurnStatus = "active";
+
+    await adapter.sendUserMessage({
+      ...sessionRuntimeRef("external-session-1"),
+      parts: [{ kind: "text", text: "Queue behind current answer" }],
+    });
+
+    const snapshot = await adapter.readSessionRuntimeSnapshot({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      externalSessionId: "external-session-1",
+    });
+
+    expect(snapshot).toMatchObject({
+      availability: "runtime",
+      classification: "idle",
+    });
+    expect(session.isAwaitingRuntimeTurnStart).toBe(false);
+    expect(promptAsyncCalls).toHaveLength(1);
+  });
+
   test("readSessionRuntimeSnapshot does not synthesize local runtime snapshot for another working directory", async () => {
     const mock = makeMockClient();
     const emptyListClient = {

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -1197,6 +1197,101 @@ describe("opencode-sdk-adapter", () => {
     expect(promptAsyncCalls).toHaveLength(1);
   });
 
+  test("sendUserMessage keeps the runtime snapshot active until runtime turn start evidence", async () => {
+    const mock = makeMockClient();
+    const promptAsyncCalls: unknown[] = [];
+    let runtimeStatus: "idle" | "busy" = "idle";
+    const acceptedPromptClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        status: async (input?: unknown) => {
+          mock.statusCalls.push(input);
+          return {
+            data: {
+              "external-session-1": { type: runtimeStatus },
+            },
+            error: undefined,
+          };
+        },
+        promptAsync: async (input: unknown) => {
+          promptAsyncCalls.push(input);
+          return { data: undefined, error: undefined };
+        },
+      },
+      permission: {
+        ...mock.client.permission,
+        list: async (input?: unknown) => {
+          mock.permissionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      question: {
+        ...mock.client.question,
+        list: async (input?: unknown) => {
+          mock.questionListCalls.push(input);
+          return { data: [], error: undefined };
+        },
+      },
+      mcp: {
+        status: async () => ({ data: { openducktor: { status: "connected" } }, error: undefined }),
+        connect: async () => ({ data: true, error: undefined }),
+      },
+      tool: {
+        ids: async () => ({ data: ["odt_read_task"], error: undefined }),
+      },
+    } as unknown as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => acceptedPromptClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await adapter.startSession({
+      repoPath: defaultRepoPath,
+      runtimeKind: "opencode",
+      workingDirectory: defaultWorkingDirectory,
+      taskId: "task-1",
+      role: "build",
+      systemPrompt: "system",
+    });
+
+    await adapter.sendUserMessage({
+      ...sessionRuntimeRef("external-session-1"),
+      parts: [{ kind: "text", text: "Continue" }],
+    });
+
+    const readSnapshot = () =>
+      adapter.readSessionRuntimeSnapshot({
+        repoPath: defaultRepoPath,
+        runtimeKind: "opencode",
+        workingDirectory: defaultWorkingDirectory,
+        externalSessionId: "external-session-1",
+      });
+
+    const snapshot = await readSnapshot();
+
+    expect(snapshot).toMatchObject({
+      availability: "runtime",
+      classification: "running",
+    });
+
+    runtimeStatus = "busy";
+    const busySnapshot = await readSnapshot();
+    expect(busySnapshot).toMatchObject({
+      availability: "runtime",
+      classification: "running",
+    });
+
+    runtimeStatus = "idle";
+    const idleSnapshot = await readSnapshot();
+    expect(idleSnapshot).toMatchObject({
+      availability: "runtime",
+      classification: "idle",
+    });
+
+    expect(promptAsyncCalls).toHaveLength(1);
+  });
+
   test("readSessionRuntimeSnapshot does not synthesize local runtime snapshot for another working directory", async () => {
     const mock = makeMockClient();
     const emptyListClient = {

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -60,7 +60,7 @@ import {
   listOpencodeLocalRuntimeSnapshots,
   listOpencodeRuntimeSnapshotSources,
 } from "./live-session-snapshots";
-import { sendUserMessage } from "./message-execution";
+import { sendUserMessage, usesPromptAsyncTransport } from "./message-execution";
 import { loadAndSeedSessionHistory, loadSessionHistory, loadSessionTodos } from "./message-ops";
 import { replyApproval, replyQuestion } from "./pending-input-ops";
 import {
@@ -405,7 +405,7 @@ export class OpencodeSdkAdapter
       ...(input.directories ? { directories: input.directories } : {}),
       existingExternalSessionIds,
     });
-    return [...snapshots, ...localSnapshots].map((snapshot) =>
+    const liveSnapshots = snapshots.map((snapshot) =>
       toAgentSessionRuntimeSnapshot({
         ref: {
           repoPath: input.repoPath,
@@ -420,6 +420,18 @@ export class OpencodeSdkAdapter
         }),
       }),
     );
+    const localRuntimeSnapshots = localSnapshots.map((snapshot) =>
+      toAgentSessionRuntimeSnapshot({
+        ref: {
+          repoPath: input.repoPath,
+          runtimeKind: input.runtimeKind,
+          workingDirectory: snapshot.workingDirectory,
+          externalSessionId: snapshot.externalSessionId,
+        },
+        snapshot,
+      }),
+    );
+    return [...liveSnapshots, ...localRuntimeSnapshots];
   }
 
   async readSessionRuntimeSnapshot(
@@ -446,7 +458,13 @@ export class OpencodeSdkAdapter
       workingDirectory: input.workingDirectory,
       externalSessionId: input.externalSessionId,
     });
-    const snapshot = scannedSnapshot ?? localSnapshot;
+    const snapshot = scannedSnapshot
+      ? applyOpencodeAwaitingTurnStartToRuntimeSnapshot({
+          sessions: this.sessions,
+          runtimeId: runtimeClientInput.runtimeId,
+          snapshot: scannedSnapshot,
+        })
+      : localSnapshot;
     if (!snapshot) {
       return toAgentSessionRuntimeSnapshot({
         ref: input,
@@ -463,11 +481,7 @@ export class OpencodeSdkAdapter
         ...input,
         workingDirectory: canonicalWorkingDirectory,
       },
-      snapshot: applyOpencodeAwaitingTurnStartToRuntimeSnapshot({
-        sessions: this.sessions,
-        runtimeId: runtimeClientInput.runtimeId,
-        snapshot,
-      }),
+      snapshot,
     });
   }
 
@@ -573,7 +587,8 @@ export class OpencodeSdkAdapter
     const session = requireSession(this.sessions, input.externalSessionId);
     applyRuntimeContextToSession(session, input);
     startUserMessageSend(session, {
-      expectRuntimeTurnStart: session.activeAssistantMessageId === null,
+      expectRuntimeTurnStart:
+        session.activeAssistantMessageId === null && usesPromptAsyncTransport(input.parts),
     });
     this.emit(input.externalSessionId, {
       type: "session_status",

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -55,7 +55,7 @@ import {
 } from "./event-stream/message-events/user-emitter";
 import type { EventStreamRuntime } from "./event-stream/shared";
 import {
-  applyOpencodeInFlightSendToRuntimeSnapshot,
+  applyOpencodeAwaitingTurnStartToRuntimeSnapshot,
   findOpencodeLocalRuntimeSnapshot,
   listOpencodeLocalRuntimeSnapshots,
   listOpencodeRuntimeSnapshotSources,
@@ -413,7 +413,7 @@ export class OpencodeSdkAdapter
           workingDirectory: snapshot.workingDirectory,
           externalSessionId: snapshot.externalSessionId,
         },
-        snapshot: applyOpencodeInFlightSendToRuntimeSnapshot({
+        snapshot: applyOpencodeAwaitingTurnStartToRuntimeSnapshot({
           sessions: this.sessions,
           runtimeId: runtimeClientInput.runtimeId,
           snapshot,
@@ -463,7 +463,7 @@ export class OpencodeSdkAdapter
         ...input,
         workingDirectory: canonicalWorkingDirectory,
       },
-      snapshot: applyOpencodeInFlightSendToRuntimeSnapshot({
+      snapshot: applyOpencodeAwaitingTurnStartToRuntimeSnapshot({
         sessions: this.sessions,
         runtimeId: runtimeClientInput.runtimeId,
         snapshot,
@@ -572,7 +572,9 @@ export class OpencodeSdkAdapter
     }
     const session = requireSession(this.sessions, input.externalSessionId);
     applyRuntimeContextToSession(session, input);
-    startUserMessageSend(session);
+    startUserMessageSend(session, {
+      expectRuntimeTurnStart: session.activeAssistantMessageId === null,
+    });
     this.emit(input.externalSessionId, {
       type: "session_status",
       externalSessionId: input.externalSessionId,

--- a/packages/adapters-opencode-sdk/src/session-activity.ts
+++ b/packages/adapters-opencode-sdk/src/session-activity.ts
@@ -9,6 +9,7 @@ export const markStreamTurnActive = (session: SessionRecord | undefined): void =
     return;
   }
   session.streamTurnStatus = "active";
+  session.isAwaitingRuntimeTurnStart = false;
 };
 
 export const markStreamTurnIdle = (session: SessionRecord | undefined): void => {
@@ -16,11 +17,13 @@ export const markStreamTurnIdle = (session: SessionRecord | undefined): void => 
     return;
   }
   session.streamTurnStatus = "idle";
+  session.isAwaitingRuntimeTurnStart = false;
   session.activeAssistantMessageId = null;
 };
 
 export const startUserMessageSend = (session: SessionRecord): void => {
   session.isSendingUserMessage = true;
+  session.isAwaitingRuntimeTurnStart = true;
 };
 
 export const finishUserMessageSend = (session: SessionRecord): void => {
@@ -31,6 +34,21 @@ export const isUserMessageSendInFlight = (session: SessionRecord | undefined): b
   return session?.isSendingUserMessage === true;
 };
 
+export const isUserMessageTurnStartPending = (session: SessionRecord | undefined): boolean => {
+  return session?.isSendingUserMessage === true || session?.isAwaitingRuntimeTurnStart === true;
+};
+
+export const clearUserMessageTurnStartPending = (session: SessionRecord | undefined): void => {
+  if (!session) {
+    return;
+  }
+  session.isAwaitingRuntimeTurnStart = false;
+};
+
 export const isLocalSessionBusy = (session: SessionRecord): boolean => {
-  return session.isSendingUserMessage || session.streamTurnStatus === "active";
+  return (
+    session.isSendingUserMessage ||
+    session.isAwaitingRuntimeTurnStart ||
+    session.streamTurnStatus === "active"
+  );
 };

--- a/packages/adapters-opencode-sdk/src/session-activity.ts
+++ b/packages/adapters-opencode-sdk/src/session-activity.ts
@@ -21,24 +21,23 @@ export const markStreamTurnIdle = (session: SessionRecord | undefined): void => 
   session.activeAssistantMessageId = null;
 };
 
-export const startUserMessageSend = (session: SessionRecord): void => {
+export const startUserMessageSend = (
+  session: SessionRecord,
+  options: { expectRuntimeTurnStart?: boolean } = {},
+): void => {
   session.isSendingUserMessage = true;
-  session.isAwaitingRuntimeTurnStart = true;
+  session.isAwaitingRuntimeTurnStart = options.expectRuntimeTurnStart !== false;
 };
 
 export const finishUserMessageSend = (session: SessionRecord): void => {
   session.isSendingUserMessage = false;
 };
 
-export const isUserMessageSendInFlight = (session: SessionRecord | undefined): boolean => {
-  return session?.isSendingUserMessage === true;
+export const isAwaitingRuntimeTurnStart = (session: SessionRecord | undefined): boolean => {
+  return session?.isAwaitingRuntimeTurnStart === true;
 };
 
-export const isUserMessageTurnStartPending = (session: SessionRecord | undefined): boolean => {
-  return session?.isSendingUserMessage === true || session?.isAwaitingRuntimeTurnStart === true;
-};
-
-export const clearUserMessageTurnStartPending = (session: SessionRecord | undefined): void => {
+export const clearAwaitingRuntimeTurnStart = (session: SessionRecord | undefined): void => {
   if (!session) {
     return;
   }

--- a/packages/adapters-opencode-sdk/src/session-activity.ts
+++ b/packages/adapters-opencode-sdk/src/session-activity.ts
@@ -26,7 +26,9 @@ export const startUserMessageSend = (
   options: { expectRuntimeTurnStart?: boolean } = {},
 ): void => {
   session.isSendingUserMessage = true;
-  session.isAwaitingRuntimeTurnStart = options.expectRuntimeTurnStart !== false;
+  if (options.expectRuntimeTurnStart === true) {
+    session.isAwaitingRuntimeTurnStart = true;
+  }
 };
 
 export const finishUserMessageSend = (session: SessionRecord): void => {

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -351,6 +351,7 @@ export const registerSession = (
     runtimeId: input.runtimeId,
     streamTurnStatus: startsActive ? "active" : "idle",
     isSendingUserMessage: false,
+    isAwaitingRuntimeTurnStart: false,
     activeAssistantMessageId: null,
     completedAssistantMessageIds: new Set<string>(),
     emittedAssistantMessageIds: new Set<string>(),

--- a/packages/adapters-opencode-sdk/src/types.test.ts
+++ b/packages/adapters-opencode-sdk/src/types.test.ts
@@ -37,6 +37,7 @@ describe("types", () => {
       runtimeId: "runtime-opencode-1",
       streamTurnStatus: "active",
       isSendingUserMessage: false,
+      isAwaitingRuntimeTurnStart: false,
       activeAssistantMessageId: null,
       completedAssistantMessageIds: new Set<string>(),
       emittedAssistantMessageIds: new Set<string>(),

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -51,6 +51,7 @@ export type SessionRecord = {
   runtimeId: string;
   streamTurnStatus: SessionStreamTurnStatus;
   isSendingUserMessage: boolean;
+  isAwaitingRuntimeTurnStart: boolean;
   activeAssistantMessageId: string | null;
   completedAssistantMessageIds: Set<string>;
   emittedAssistantMessageIds: Set<string>;


### PR DESCRIPTION
Summary: Prevents OpenCode prompt_async session starts from briefly settling idle before runtime turn-start evidence arrives.

## Goal

Starting an OpenCode session from Kanban or Agent Studio could show running, briefly flip to idle, then return to running. The race happens because OpenCode prompt_async accepts work immediately, while runtime status can still read as the default idle state until busy, assistant output, pending input, terminal completion, or error evidence arrives.

This PR keeps the UI activity model aligned with the actual prompt lifecycle so early idle snapshots/events cannot regress the session status before the runtime turn has truly started.

## Technical choices

- Added a live-only adapter marker, `isAwaitingRuntimeTurnStart`, to track the short gap after an accepted prompt_async send and before OpenCode provides turn-start evidence. This is transient in-memory adapter state only; no persisted schema or SQLite shape changes.
- Suppress OpenCode idle status/events only while that explicit awaiting-turn-start marker is set. Once runtime busy, retry, pending input, terminal assistant output, or error evidence arrives, later idle is trusted.
- Keep send-admission state separate from runtime turn state: `isSendingUserMessage` means the adapter request is still in flight, while `isAwaitingRuntimeTurnStart` means early idle must not settle the UI yet.
- Avoid setting the awaiting-turn-start marker for sends queued behind an already-active assistant turn, preserving current-turn runtime ownership.
- Added regression tests for early idle suppression, busy-to-idle while prompt_async is still settling, terminal/error marker clearing, and queued-send behavior.

## Verification

- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- Cargo checks: no `Cargo.toml` files were found in this worktree, so Cargo lint/test/typecheck/build were not applicable.

The branch was fetched and compared against `origin/main`; it is ahead by 2 commits and behind by 0, so no rebase was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session handling when waiting for the next runtime turn, keeping status updates and idle states more accurate.
  * Better support for prompt-based message sending, including clearer handling of messages that use async prompt transport.

* **Bug Fixes**
  * Prevented idle indicators from appearing too early while a session is still waiting to start.
  * Preserved the correct running state for live runtime snapshots in edge cases.
  * Improved error recovery so sessions reset cleanly after a session error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->