### PR TITLE
fix: handle opencode background subagent state

### DIFF
--- a/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
@@ -281,21 +281,33 @@ const makeBackgroundTaskResultUserPartUpdatedEvent = (input: {
   state: "completed" | "error";
   summary: string;
   text: string;
-  timestampMs: number;
+  timestampMs?: number;
+  eventTimestampMs?: number;
 }): Event => {
   const resultTag = input.state === "error" ? "task_error" : "task_result";
   return {
     type: "message.part.updated",
     properties: {
+      ...(input.eventTimestampMs !== undefined
+        ? {
+            time: {
+              updated: input.eventTimestampMs,
+            },
+          }
+        : {}),
       part: {
         id: input.partId,
         sessionID: "external-session-1",
         messageID: input.messageId,
         type: "text",
         synthetic: true,
-        time: {
-          end: input.timestampMs,
-        },
+        ...(input.timestampMs !== undefined
+          ? {
+              time: {
+                end: input.timestampMs,
+              },
+            }
+          : {}),
         text: [
           `<task id="${input.childSessionId}" state="${input.state}">`,
           `<summary>${input.summary}</summary>`,
@@ -572,6 +584,45 @@ describe("event-stream subagent correlation", () => {
       endedAtMs: Date.parse("2026-02-22T12:00:47.000Z"),
     });
     expect(subagentEvents[2]?.timestamp).toBe("2026-02-22T12:00:47.000Z");
+  });
+
+  test("uses the message.part.updated event timestamp for synthetic background task results", async () => {
+    const { emitted } = await runEventStreamWithSession([
+      assistantRoleEvent("assistant-background-task-event-time"),
+      makeAssistantSubtaskPartUpdatedEvent({
+        messageId: "assistant-background-task-event-time",
+        partId: "subtask-a",
+        description: "Run tests",
+      }),
+      makeBackgroundTaskRunningPartUpdatedEvent({
+        messageId: "assistant-background-task-event-time",
+        partId: "tool-a",
+        callId: "call-a",
+        childSessionId: "child-a",
+      }),
+      userRoleEvent("user-background-task-event-time"),
+      makeBackgroundTaskResultUserPartUpdatedEvent({
+        messageId: "user-background-task-event-time",
+        partId: "text-background-task-event-time",
+        childSessionId: "child-a",
+        state: "completed",
+        summary: "Background task completed: Run tests",
+        text: "Tests passed.",
+        eventTimestampMs: Date.parse("2026-02-22T12:00:48.000Z"),
+      }),
+    ]);
+
+    const subagentEvents = readSubagentEvents(emitted);
+    const subagentParts = subagentEvents.map((event) => event.part);
+
+    expect(subagentParts).toHaveLength(3);
+    expect(subagentParts[2]).toMatchObject({
+      correlationKey: "part:assistant-background-task-event-time:subtask-a",
+      partId: "text-background-task-event-time",
+      status: "completed",
+      endedAtMs: Date.parse("2026-02-22T12:00:48.000Z"),
+    });
+    expect(subagentEvents[2]?.timestamp).toBe("2026-02-22T12:00:48.000Z");
   });
 
   test("keeps early synthetic background task results queued until the real subagent binding exists", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
@@ -214,6 +214,47 @@ const makeBackgroundTaskRunningPartUpdatedEvent = (input: {
     },
   }) as unknown as Event;
 
+const makeBackgroundTaskResultUserMessageUpdatedEvent = (input: {
+  messageId: string;
+  partId: string;
+  childSessionId: string;
+  state: "completed" | "error";
+  summary: string;
+  text: string;
+}): Event => {
+  const resultTag = input.state === "error" ? "task_error" : "task_result";
+  return {
+    type: "message.updated",
+    properties: {
+      info: {
+        id: input.messageId,
+        role: "user",
+        sessionID: "external-session-1",
+        time: {
+          created: Date.parse("2026-02-22T12:00:45.000Z"),
+        },
+        parts: [
+          {
+            id: input.partId,
+            sessionID: "external-session-1",
+            messageID: input.messageId,
+            type: "text",
+            synthetic: true,
+            text: [
+              `<task id="${input.childSessionId}" state="${input.state}">`,
+              `<summary>${input.summary}</summary>`,
+              `<${resultTag}>`,
+              input.text,
+              `</${resultTag}>`,
+              "</task>",
+            ].join("\n"),
+          },
+        ],
+      },
+    },
+  } as unknown as Event;
+};
+
 describe("event-stream subagent correlation", () => {
   test("binds same-turn sibling subagents to child sessions without fragmenting their cards", async () => {
     const { emitted } = await runEventStreamWithSession([
@@ -388,6 +429,51 @@ describe("event-stream subagent correlation", () => {
     expect(subagentParts[1]).not.toEqual(
       expect.objectContaining({ endedAtMs: expect.any(Number) }),
     );
+  });
+
+  test("updates a running background task when OpenCode emits the synthetic completion result", async () => {
+    const { emitted } = await runEventStreamWithSession([
+      assistantRoleEvent("assistant-background-task-completes"),
+      makeAssistantSubtaskPartUpdatedEvent({
+        messageId: "assistant-background-task-completes",
+        partId: "subtask-a",
+        description: "Run tests",
+      }),
+      makeBackgroundTaskRunningPartUpdatedEvent({
+        messageId: "assistant-background-task-completes",
+        partId: "tool-a",
+        callId: "call-a",
+        childSessionId: "child-a",
+      }),
+      makeBackgroundTaskResultUserMessageUpdatedEvent({
+        messageId: "user-background-task-completed",
+        partId: "text-background-task-completed",
+        childSessionId: "child-a",
+        state: "completed",
+        summary: "Background task completed: Run tests",
+        text: "Tests passed.",
+      }),
+    ]);
+
+    const subagentParts = readSubagentParts(emitted);
+    expect(subagentParts).toHaveLength(3);
+    expect(subagentParts.map((part) => part.correlationKey)).toEqual([
+      "part:assistant-background-task-completes:subtask-a",
+      "part:assistant-background-task-completes:subtask-a",
+      "part:assistant-background-task-completes:subtask-a",
+    ]);
+    expect(subagentParts.map((part) => part.status)).toEqual(["running", "running", "completed"]);
+    expect(subagentParts.map((part) => part.externalSessionId)).toEqual([
+      undefined,
+      "child-a",
+      "child-a",
+    ]);
+    expect(subagentParts[2]).toMatchObject({
+      partId: "text-background-task-completed",
+      description: "Background task completed: Run tests",
+      executionMode: "background",
+      endedAtMs: Date.parse("2026-02-22T12:00:45.000Z"),
+    });
   });
 
   test("clears pending subagent queues once a running task tool update gains a session id", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
@@ -290,9 +290,7 @@ const makeBackgroundTaskResultUserPartUpdatedEvent = (input: {
     properties: {
       ...(input.eventTimestampMs !== undefined
         ? {
-            time: {
-              updated: input.eventTimestampMs,
-            },
+            time: input.eventTimestampMs,
           }
         : {}),
       part: {

--- a/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
@@ -5,6 +5,7 @@ import { runEventStreamWithSession } from "./event-stream.test-support";
 
 type AssistantPartEvent = Extract<AgentEvent, { type: "assistant_part" }>;
 type SubagentPart = Extract<AssistantPartEvent["part"], { kind: "subagent" }>;
+type SubagentPartEvent = AssistantPartEvent & { part: SubagentPart };
 
 const readSubagentParts = (events: AgentEvent[]): SubagentPart[] =>
   events
@@ -14,6 +15,12 @@ const readSubagentParts = (events: AgentEvent[]): SubagentPart[] =>
     )
     .map((event) => event.part as SubagentPart);
 
+const readSubagentEvents = (events: AgentEvent[]): SubagentPartEvent[] =>
+  events.filter(
+    (event): event is SubagentPartEvent =>
+      event.type === "assistant_part" && event.part.kind === "subagent",
+  );
+
 const assistantRoleEvent = (messageId: string): Event =>
   ({
     type: "message.updated",
@@ -21,6 +28,18 @@ const assistantRoleEvent = (messageId: string): Event =>
       info: {
         id: messageId,
         role: "assistant",
+        sessionID: "external-session-1",
+      },
+    },
+  }) as unknown as Event;
+
+const userRoleEvent = (messageId: string): Event =>
+  ({
+    type: "message.updated",
+    properties: {
+      info: {
+        id: messageId,
+        role: "user",
         sessionID: "external-session-1",
       },
     },
@@ -255,6 +274,41 @@ const makeBackgroundTaskResultUserMessageUpdatedEvent = (input: {
   } as unknown as Event;
 };
 
+const makeBackgroundTaskResultUserPartUpdatedEvent = (input: {
+  messageId: string;
+  partId: string;
+  childSessionId: string;
+  state: "completed" | "error";
+  summary: string;
+  text: string;
+  timestampMs: number;
+}): Event => {
+  const resultTag = input.state === "error" ? "task_error" : "task_result";
+  return {
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: input.partId,
+        sessionID: "external-session-1",
+        messageID: input.messageId,
+        type: "text",
+        synthetic: true,
+        time: {
+          end: input.timestampMs,
+        },
+        text: [
+          `<task id="${input.childSessionId}" state="${input.state}">`,
+          `<summary>${input.summary}</summary>`,
+          `<${resultTag}>`,
+          input.text,
+          `</${resultTag}>`,
+          "</task>",
+        ].join("\n"),
+      },
+    },
+  } as unknown as Event;
+};
+
 describe("event-stream subagent correlation", () => {
   test("binds same-turn sibling subagents to child sessions without fragmenting their cards", async () => {
     const { emitted } = await runEventStreamWithSession([
@@ -473,6 +527,127 @@ describe("event-stream subagent correlation", () => {
       description: "Background task completed: Run tests",
       executionMode: "background",
       endedAtMs: Date.parse("2026-02-22T12:00:45.000Z"),
+    });
+  });
+
+  test("updates a running background task when OpenCode emits the synthetic result as a part update", async () => {
+    const { emitted } = await runEventStreamWithSession([
+      assistantRoleEvent("assistant-background-task-part-completes"),
+      makeAssistantSubtaskPartUpdatedEvent({
+        messageId: "assistant-background-task-part-completes",
+        partId: "subtask-a",
+        description: "Run tests",
+      }),
+      makeBackgroundTaskRunningPartUpdatedEvent({
+        messageId: "assistant-background-task-part-completes",
+        partId: "tool-a",
+        callId: "call-a",
+        childSessionId: "child-a",
+      }),
+      userRoleEvent("user-background-task-part-completed"),
+      makeBackgroundTaskResultUserPartUpdatedEvent({
+        messageId: "user-background-task-part-completed",
+        partId: "text-background-task-part-completed",
+        childSessionId: "child-a",
+        state: "completed",
+        summary: "Background task completed: Run tests",
+        text: "Tests passed.",
+        timestampMs: Date.parse("2026-02-22T12:00:47.000Z"),
+      }),
+    ]);
+
+    const subagentEvents = readSubagentEvents(emitted);
+    const subagentParts = subagentEvents.map((event) => event.part);
+
+    expect(subagentParts).toHaveLength(3);
+    expect(subagentParts.map((part) => part.correlationKey)).toEqual([
+      "part:assistant-background-task-part-completes:subtask-a",
+      "part:assistant-background-task-part-completes:subtask-a",
+      "part:assistant-background-task-part-completes:subtask-a",
+    ]);
+    expect(subagentParts.map((part) => part.status)).toEqual(["running", "running", "completed"]);
+    expect(subagentParts[2]).toMatchObject({
+      partId: "text-background-task-part-completed",
+      description: "Background task completed: Run tests",
+      endedAtMs: Date.parse("2026-02-22T12:00:47.000Z"),
+    });
+    expect(subagentEvents[2]?.timestamp).toBe("2026-02-22T12:00:47.000Z");
+  });
+
+  test("keeps early synthetic background task results queued until the real subagent binding exists", async () => {
+    const { emitted } = await runEventStreamWithSession([
+      assistantRoleEvent("assistant-background-task-early-result"),
+      makeBackgroundTaskResultUserMessageUpdatedEvent({
+        messageId: "user-background-task-early-completed",
+        partId: "text-background-task-early-completed",
+        childSessionId: "child-a",
+        state: "completed",
+        summary: "Background task completed: Run tests",
+        text: "Tests passed.",
+      }),
+      makeAssistantSubtaskPartUpdatedEvent({
+        messageId: "assistant-background-task-early-result",
+        partId: "subtask-a",
+        description: "Run tests",
+      }),
+      makeBackgroundTaskRunningPartUpdatedEvent({
+        messageId: "assistant-background-task-early-result",
+        partId: "tool-a",
+        callId: "call-a",
+        childSessionId: "child-a",
+      }),
+    ]);
+
+    const subagentParts = readSubagentParts(emitted);
+
+    expect(subagentParts).toHaveLength(3);
+    expect(subagentParts.map((part) => part.correlationKey)).toEqual([
+      "part:assistant-background-task-early-result:subtask-a",
+      "part:assistant-background-task-early-result:subtask-a",
+      "part:assistant-background-task-early-result:subtask-a",
+    ]);
+    expect(subagentParts.map((part) => part.status)).toEqual(["running", "running", "completed"]);
+    expect(subagentParts[2]).toMatchObject({
+      partId: "text-background-task-early-completed",
+      description: "Background task completed: Run tests",
+      externalSessionId: "child-a",
+    });
+  });
+
+  test("maps synthetic background task errors onto the original subagent card", async () => {
+    const { emitted } = await runEventStreamWithSession([
+      assistantRoleEvent("assistant-background-task-errors"),
+      makeAssistantSubtaskPartUpdatedEvent({
+        messageId: "assistant-background-task-errors",
+        partId: "subtask-a",
+        description: "Run tests",
+      }),
+      makeBackgroundTaskRunningPartUpdatedEvent({
+        messageId: "assistant-background-task-errors",
+        partId: "tool-a",
+        callId: "call-a",
+        childSessionId: "child-a",
+      }),
+      makeBackgroundTaskResultUserMessageUpdatedEvent({
+        messageId: "user-background-task-error",
+        partId: "text-background-task-error",
+        childSessionId: "child-a",
+        state: "error",
+        summary: "Background task failed: Run tests",
+        text: "Tests failed.",
+      }),
+    ]);
+
+    const subagentParts = readSubagentParts(emitted);
+
+    expect(subagentParts).toHaveLength(3);
+    expect(subagentParts[2]).toMatchObject({
+      correlationKey: "part:assistant-background-task-errors:subtask-a",
+      partId: "text-background-task-error",
+      status: "error",
+      description: "Background task failed: Run tests",
+      error: "Tests failed.",
+      externalSessionId: "child-a",
     });
   });
 

--- a/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
@@ -169,6 +169,51 @@ const makeSubagentToolPartUpdatedEvent = (input: {
   } as unknown as Event;
 };
 
+const makeBackgroundTaskRunningPartUpdatedEvent = (input: {
+  messageId: string;
+  partId: string;
+  callId: string;
+  childSessionId: string;
+}): Event =>
+  ({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: input.partId,
+        sessionID: "external-session-1",
+        messageID: input.messageId,
+        callID: input.callId,
+        type: "tool",
+        tool: "task",
+        state: {
+          status: "completed",
+          input: {
+            subagent_type: "build",
+            prompt: "Inspect repo",
+            description: "Starting A",
+          },
+          output: [
+            `<task id="${input.childSessionId}" state="running">`,
+            "<summary>Background task started</summary>",
+            "<task_result>",
+            "The task is running in the background.",
+            "</task_result>",
+            "</task>",
+          ].join("\n"),
+          metadata: {
+            background: true,
+            sessionId: input.childSessionId,
+            jobId: input.childSessionId,
+          },
+          time: {
+            start: 10,
+            end: 40,
+          },
+        },
+      },
+    },
+  }) as unknown as Event;
+
 describe("event-stream subagent correlation", () => {
   test("binds same-turn sibling subagents to child sessions without fragmenting their cards", async () => {
     const { emitted } = await runEventStreamWithSession([
@@ -310,6 +355,39 @@ describe("event-stream subagent correlation", () => {
     ]);
     expect(subagentParts.map((part) => part.externalSessionId)).toEqual([undefined, "child-a"]);
     expect(subagentParts.map((part) => part.agent)).toEqual(["build", "build"]);
+  });
+
+  test("keeps background task tool updates running when OpenCode completes the parent tool", async () => {
+    const { emitted } = await runEventStreamWithSession([
+      assistantRoleEvent("assistant-background-task-tool-running"),
+      makeAssistantSubtaskPartUpdatedEvent({
+        messageId: "assistant-background-task-tool-running",
+        partId: "subtask-a",
+        description: "Starting A",
+      }),
+      makeBackgroundTaskRunningPartUpdatedEvent({
+        messageId: "assistant-background-task-tool-running",
+        partId: "tool-a",
+        callId: "call-a",
+        childSessionId: "child-a",
+      }),
+    ]);
+
+    const subagentParts = readSubagentParts(emitted);
+    expect(subagentParts).toHaveLength(2);
+    expect(subagentParts.map((part) => part.correlationKey)).toEqual([
+      "part:assistant-background-task-tool-running:subtask-a",
+      "part:assistant-background-task-tool-running:subtask-a",
+    ]);
+    expect(subagentParts.map((part) => part.status)).toEqual(["running", "running"]);
+    expect(subagentParts.map((part) => part.externalSessionId)).toEqual([undefined, "child-a"]);
+    expect(subagentParts[1]).toMatchObject({
+      executionMode: "background",
+      startedAtMs: 10,
+    });
+    expect(subagentParts[1]).not.toEqual(
+      expect.objectContaining({ endedAtMs: expect.any(Number) }),
+    );
   });
 
   test("clears pending subagent queues once a running task tool update gains a session id", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
@@ -89,6 +89,7 @@ export const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
   pendingSubagentSessionsByExternalSessionId: new Map(),
   pendingSubagentPartEmissionsByExternalSessionId: new Map(),
   pendingSubagentInputEventsByExternalSessionId: new Map(),
+  pendingBackgroundTaskResultsByExternalSessionId: new Map(),
 });
 
 export const runEventStreamWithSession = async (

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -214,6 +214,7 @@ test("flushPendingSubagentInputEventsForSession preserves original timestamps", 
         ],
       ],
     ]),
+    pendingBackgroundTaskResultsByExternalSessionId: new Map(),
   };
 
   flushPendingSubagentInputEventsForSession(runtime, "external-child-session");

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -177,6 +177,8 @@ export const createEventStreamRuntime = (
       session.pendingSubagentPartEmissionsByExternalSessionId,
     pendingSubagentInputEventsByExternalSessionId:
       session.pendingSubagentInputEventsByExternalSessionId,
+    pendingBackgroundTaskResultsByExternalSessionId:
+      session.pendingBackgroundTaskResultsByExternalSessionId,
   };
 };
 

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/assistant.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/assistant.ts
@@ -13,6 +13,7 @@ import {
   flushPendingSubagentInputEventsForSession,
   markSessionActive,
 } from "../shared";
+import { flushPendingBackgroundTaskResultSubagentParts } from "./background-task-result";
 import {
   getKnownMessageParts,
   hasTerminalStopSignalInParts,
@@ -90,6 +91,11 @@ export const emitAssistantPart = (
     part: nextMapped,
   });
   if (nextMapped.kind === "subagent" && nextMapped.externalSessionId) {
+    flushPendingBackgroundTaskResultSubagentParts(
+      runtime,
+      nextMapped.externalSessionId,
+      nextMapped.correlationKey,
+    );
     flushPendingSubagentInputEventsForSession(runtime, nextMapped.externalSessionId);
   }
   return true;

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/background-task-result.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/background-task-result.ts
@@ -3,6 +3,71 @@ import { mapOpenCodeBackgroundTaskResultPart } from "../../opencode-background-t
 import type { EventStreamRuntime } from "../shared";
 import { bindSubagentExternalSession } from "../shared";
 
+type BackgroundTaskResultSubagentPart = NonNullable<
+  ReturnType<typeof mapOpenCodeBackgroundTaskResultPart>
+>;
+
+const queuePendingBackgroundTaskResult = (
+  runtime: EventStreamRuntime,
+  externalSessionId: string,
+  part: BackgroundTaskResultSubagentPart,
+  timestamp: string,
+): void => {
+  const pending = runtime.pendingBackgroundTaskResultsByExternalSessionId.get(externalSessionId);
+  const next = [
+    ...(pending?.filter((entry) => entry.part.partId !== part.partId) ?? []),
+    { part, timestamp },
+  ];
+  runtime.pendingBackgroundTaskResultsByExternalSessionId.set(externalSessionId, next);
+};
+
+const emitBackgroundTaskResultSubagentPart = (
+  runtime: EventStreamRuntime,
+  input: {
+    part: BackgroundTaskResultSubagentPart;
+    correlationKey: string;
+    timestamp: string;
+  },
+): void => {
+  const externalSessionId = input.part.externalSessionId;
+  if (!externalSessionId) {
+    return;
+  }
+
+  const mapped = {
+    ...input.part,
+    correlationKey: input.correlationKey,
+  };
+  bindSubagentExternalSession(runtime, externalSessionId, mapped.correlationKey, mapped.partId);
+  runtime.emit(runtime.externalSessionId, {
+    type: "assistant_part",
+    externalSessionId: runtime.externalSessionId,
+    timestamp: input.timestamp,
+    part: mapped,
+  });
+};
+
+export const flushPendingBackgroundTaskResultSubagentParts = (
+  runtime: EventStreamRuntime,
+  externalSessionId: string,
+  correlationKey: string,
+): boolean => {
+  const pending = runtime.pendingBackgroundTaskResultsByExternalSessionId.get(externalSessionId);
+  if (!pending || pending.length === 0) {
+    return false;
+  }
+
+  runtime.pendingBackgroundTaskResultsByExternalSessionId.delete(externalSessionId);
+  for (const entry of pending) {
+    emitBackgroundTaskResultSubagentPart(runtime, {
+      part: entry.part,
+      correlationKey,
+      timestamp: entry.timestamp,
+    });
+  }
+  return true;
+};
+
 export const emitBackgroundTaskResultSubagentParts = (
   runtime: EventStreamRuntime,
   input: {
@@ -25,25 +90,16 @@ export const emitBackgroundTaskResultSubagentParts = (
       continue;
     }
 
-    const correlationKey =
-      runtime.subagentCorrelationKeyByExternalSessionId.get(externalSessionId) ??
-      ["session", part.messageID, externalSessionId].join(":");
-    const mapped = {
-      ...initialMapped,
-      correlationKey,
-    };
-
-    const mappedExternalSessionId = mapped.externalSessionId;
-    if (!mappedExternalSessionId) {
+    const correlationKey = runtime.subagentCorrelationKeyByExternalSessionId.get(externalSessionId);
+    if (!correlationKey) {
+      queuePendingBackgroundTaskResult(runtime, externalSessionId, initialMapped, input.timestamp);
       continue;
     }
 
-    bindSubagentExternalSession(runtime, mappedExternalSessionId, mapped.correlationKey, part.id);
-    runtime.emit(runtime.externalSessionId, {
-      type: "assistant_part",
-      externalSessionId: runtime.externalSessionId,
+    emitBackgroundTaskResultSubagentPart(runtime, {
+      part: initialMapped,
+      correlationKey,
       timestamp: input.timestamp,
-      part: mapped,
     });
     emitted = true;
   }

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/background-task-result.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/background-task-result.ts
@@ -1,0 +1,52 @@
+import type { Part } from "@opencode-ai/sdk/v2/client";
+import { mapOpenCodeBackgroundTaskResultPart } from "../../opencode-background-task-result";
+import type { EventStreamRuntime } from "../shared";
+import { bindSubagentExternalSession } from "../shared";
+
+export const emitBackgroundTaskResultSubagentParts = (
+  runtime: EventStreamRuntime,
+  input: {
+    parts: Part[];
+    timestamp: string;
+  },
+): boolean => {
+  let emitted = false;
+
+  for (const part of input.parts) {
+    if (part.type !== "text") {
+      continue;
+    }
+
+    const initialMapped = mapOpenCodeBackgroundTaskResultPart(part, {
+      timestamp: input.timestamp,
+    });
+    const externalSessionId = initialMapped?.externalSessionId;
+    if (!externalSessionId) {
+      continue;
+    }
+
+    const correlationKey =
+      runtime.subagentCorrelationKeyByExternalSessionId.get(externalSessionId) ??
+      ["session", part.messageID, externalSessionId].join(":");
+    const mapped = {
+      ...initialMapped,
+      correlationKey,
+    };
+
+    const mappedExternalSessionId = mapped.externalSessionId;
+    if (!mappedExternalSessionId) {
+      continue;
+    }
+
+    bindSubagentExternalSession(runtime, mappedExternalSessionId, mapped.correlationKey, part.id);
+    runtime.emit(runtime.externalSessionId, {
+      type: "assistant_part",
+      externalSessionId: runtime.externalSessionId,
+      timestamp: input.timestamp,
+      part: mapped,
+    });
+    emitted = true;
+  }
+
+  return emitted;
+};

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/parts.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/parts.ts
@@ -1,5 +1,5 @@
 import type { Event, Part } from "@opencode-ai/sdk/v2/client";
-import { readStringProp, readUnknownProp } from "../../guards";
+import { readNumberProp, readRecordProp, readStringProp, readUnknownProp } from "../../guards";
 import { readEventPart, readEventProperties } from "../schemas";
 import type { EventStreamRuntime } from "../shared";
 import { applyDeltaToPart, isReasoningDeltaField, markSessionActive } from "../shared";
@@ -11,6 +11,20 @@ import {
 import { applyPendingDeltas } from "./helpers";
 import { removeSubagentCorrelationForPart } from "./subagent";
 import { handleUserPartUpdated } from "./user";
+
+const toIsoTimestamp = (timestampMs: number | undefined): string | undefined => {
+  if (timestampMs === undefined) {
+    return undefined;
+  }
+  const timestamp = new Date(timestampMs);
+  return Number.isNaN(timestamp.getTime()) ? undefined : timestamp.toISOString();
+};
+
+const readPartUpdatedTimestamp = (part: unknown): string | undefined => {
+  const time =
+    readRecordProp(part, "time") ?? readRecordProp(readRecordProp(part, "state"), "time");
+  return toIsoTimestamp(readNumberProp(time, ["end", "completed", "updated", "created"]));
+};
 
 export const handleMessagePartDeltaEvent = (event: Event, runtime: EventStreamRuntime): boolean => {
   if (event.type !== "message.part.delta") {
@@ -107,7 +121,7 @@ export const handleMessagePartUpdatedEvent = (
     return true;
   }
   if (role === "user") {
-    handleUserPartUpdated(runtime, messageId);
+    handleUserPartUpdated(runtime, messageId, readPartUpdatedTimestamp(nextPart));
   }
   return true;
 };

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/parts.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/parts.ts
@@ -20,19 +20,22 @@ const toIsoTimestamp = (timestampMs: number | undefined): string | undefined => 
   return Number.isNaN(timestamp.getTime()) ? undefined : timestamp.toISOString();
 };
 
-const readIsoTimestampFromTimeRecord = (time: unknown): string | undefined => {
+const readIsoTimestampFromTime = (time: unknown): string | undefined => {
+  if (typeof time === "number") {
+    return toIsoTimestamp(time);
+  }
   return toIsoTimestamp(readNumberProp(time, ["end", "completed", "updated", "created"]));
 };
 
 const readPartUpdatedTimestamp = (properties: unknown, part: unknown): string | undefined => {
-  const eventTimestamp = readIsoTimestampFromTimeRecord(readRecordProp(properties, "time"));
+  const eventTimestamp = readIsoTimestampFromTime(readUnknownProp(properties, "time"));
   if (eventTimestamp) {
     return eventTimestamp;
   }
 
   const partTime =
     readRecordProp(part, "time") ?? readRecordProp(readRecordProp(part, "state"), "time");
-  return readIsoTimestampFromTimeRecord(partTime);
+  return readIsoTimestampFromTime(partTime);
 };
 
 export const handleMessagePartDeltaEvent = (event: Event, runtime: EventStreamRuntime): boolean => {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/parts.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/parts.ts
@@ -20,10 +20,19 @@ const toIsoTimestamp = (timestampMs: number | undefined): string | undefined => 
   return Number.isNaN(timestamp.getTime()) ? undefined : timestamp.toISOString();
 };
 
-const readPartUpdatedTimestamp = (part: unknown): string | undefined => {
-  const time =
-    readRecordProp(part, "time") ?? readRecordProp(readRecordProp(part, "state"), "time");
+const readIsoTimestampFromTimeRecord = (time: unknown): string | undefined => {
   return toIsoTimestamp(readNumberProp(time, ["end", "completed", "updated", "created"]));
+};
+
+const readPartUpdatedTimestamp = (properties: unknown, part: unknown): string | undefined => {
+  const eventTimestamp = readIsoTimestampFromTimeRecord(readRecordProp(properties, "time"));
+  if (eventTimestamp) {
+    return eventTimestamp;
+  }
+
+  const partTime =
+    readRecordProp(part, "time") ?? readRecordProp(readRecordProp(part, "state"), "time");
+  return readIsoTimestampFromTimeRecord(partTime);
 };
 
 export const handleMessagePartDeltaEvent = (event: Event, runtime: EventStreamRuntime): boolean => {
@@ -121,7 +130,7 @@ export const handleMessagePartUpdatedEvent = (
     return true;
   }
   if (role === "user") {
-    handleUserPartUpdated(runtime, messageId, readPartUpdatedTimestamp(nextPart));
+    handleUserPartUpdated(runtime, messageId, readPartUpdatedTimestamp(properties, nextPart));
   }
   return true;
 };

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
@@ -7,6 +7,7 @@ import {
 } from "../../message-normalizers";
 import type { QueuedUserMessageSend, SessionMessageMetadata } from "../../types";
 import type { EventStreamRuntime } from "../shared";
+import { emitBackgroundTaskResultSubagentParts } from "./background-task-result";
 import { getKnownMessageParts } from "./helpers";
 import { buildVisibleUserMessage } from "./user-display";
 import { emitKnownUserMessage, emitUserMessage, persistUserMessageMetadata } from "./user-emitter";
@@ -96,6 +97,10 @@ export const handleUserMessageUpdated = (
     input.normalizedParts.length > 0
       ? input.normalizedParts
       : getKnownMessageParts(runtime, input.messageId);
+  emitBackgroundTaskResultSubagentParts(runtime, {
+    parts: userParts,
+    timestamp: input.messageTimestamp,
+  });
   const currentMetadata = session?.messageMetadataById.get(input.messageId);
   const normalizedDisplayParts = normalizeUserMessageDisplayParts(userParts);
   const fallbackText = currentMetadata?.text ?? readTextFromMessageInfo(input.infoRecord);
@@ -139,9 +144,12 @@ export const handleUserMessageUpdated = (
 export const handleUserPartUpdated = (runtime: EventStreamRuntime, messageId: string): void => {
   const session = runtime.getSession(runtime.externalSessionId);
   const metadata = session?.messageMetadataById.get(messageId);
-  const normalizedDisplayParts = normalizeUserMessageDisplayParts(
-    getKnownMessageParts(runtime, messageId),
-  );
+  const knownParts = getKnownMessageParts(runtime, messageId);
+  const normalizedDisplayParts = normalizeUserMessageDisplayParts(knownParts);
+  emitBackgroundTaskResultSubagentParts(runtime, {
+    parts: knownParts,
+    timestamp: metadata?.timestamp ?? runtime.now(),
+  });
   const fallbackText = metadata?.text ?? "";
   const { displayParts, matchedQueuedSend, visible } = resolveUserMessageDisplay({
     fallbackText,

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events/user.ts
@@ -141,15 +141,21 @@ export const handleUserMessageUpdated = (
   });
 };
 
-export const handleUserPartUpdated = (runtime: EventStreamRuntime, messageId: string): void => {
+export const handleUserPartUpdated = (
+  runtime: EventStreamRuntime,
+  messageId: string,
+  updatedPartTimestamp?: string,
+): void => {
   const session = runtime.getSession(runtime.externalSessionId);
   const metadata = session?.messageMetadataById.get(messageId);
   const knownParts = getKnownMessageParts(runtime, messageId);
   const normalizedDisplayParts = normalizeUserMessageDisplayParts(knownParts);
-  emitBackgroundTaskResultSubagentParts(runtime, {
-    parts: knownParts,
-    timestamp: metadata?.timestamp ?? runtime.now(),
-  });
+  if (updatedPartTimestamp) {
+    emitBackgroundTaskResultSubagentParts(runtime, {
+      parts: knownParts,
+      timestamp: updatedPartTimestamp,
+    });
+  }
   const fallbackText = metadata?.text ?? "";
   const { displayParts, matchedQueuedSend, visible } = resolveUserMessageDisplay({
     fallbackText,

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -3,6 +3,7 @@ import type { AgentEvent } from "@openducktor/core";
 import { toAgentApprovalRequestFromOpenCodePermission } from "../approval-translation";
 import { normalizeTodoList } from "../todo-normalizers";
 import { emitSubagentPartsForSession, publishUserMessageReadStateChanges } from "./message-events";
+import { flushPendingBackgroundTaskResultSubagentParts } from "./message-events/background-task-result";
 import {
   parsePendingInputReplied,
   parsePermissionAsked,
@@ -89,6 +90,7 @@ const bindPendingSubagentCorrelation = (
   runtime.pendingSubagentSessionsByExternalSessionId.delete(childExternalSessionId);
   removePendingSubagentCorrelationKey(runtime, correlationKey);
   emitSubagentPartsForSession(runtime, childExternalSessionId);
+  flushPendingBackgroundTaskResultSubagentParts(runtime, childExternalSessionId, correlationKey);
   flushPendingSubagentInputEventsForSession(runtime, childExternalSessionId);
   return correlationKey;
 };
@@ -453,6 +455,11 @@ const bindChildSessionCorrelation = (event: Event, runtime: EventStreamRuntime):
       runtime.subagentPartIdByCorrelationKey.get(existingCorrelationKey),
     );
     emitSubagentPartsForSession(runtime, normalizedChildExternalSessionId);
+    flushPendingBackgroundTaskResultSubagentParts(
+      runtime,
+      normalizedChildExternalSessionId,
+      existingCorrelationKey,
+    );
     flushPendingSubagentInputEventsForSession(runtime, normalizedChildExternalSessionId);
     return true;
   }
@@ -497,6 +504,7 @@ const bindChildSessionCorrelation = (event: Event, runtime: EventStreamRuntime):
     runtime.pendingSubagentSessionsByExternalSessionId.delete(externalSessionId);
     removePendingSubagentCorrelationKey(runtime, nextCorrelationKey);
     emitSubagentPartsForSession(runtime, externalSessionId);
+    flushPendingBackgroundTaskResultSubagentParts(runtime, externalSessionId, nextCorrelationKey);
     flushPendingSubagentInputEventsForSession(runtime, externalSessionId);
   }
   return true;

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -1,5 +1,5 @@
 import type { Event, Part } from "@opencode-ai/sdk/v2/client";
-import type { AgentEvent } from "@openducktor/core";
+import type { AgentEvent, AgentStreamPart } from "@openducktor/core";
 import { asUnknownRecord, readRecordProp, readStringProp } from "../guards";
 import {
   clearAwaitingRuntimeTurnStart,
@@ -25,6 +25,11 @@ export type PendingSubagentInputEvent = Extract<
   AgentEvent,
   { type: "approval_required" | "question_required" }
 >;
+
+export type PendingBackgroundTaskResult = {
+  part: Extract<AgentStreamPart, { kind: "subagent" }>;
+  timestamp: string;
+};
 
 export type PendingSubagentSessionBinding = {
   createdAtMs?: number;
@@ -59,6 +64,7 @@ export type EventStreamState = {
   pendingSubagentSessionsByExternalSessionId: Map<string, PendingSubagentSessionBinding>;
   pendingSubagentPartEmissionsByExternalSessionId: Map<string, PendingSubagentPartEmission[]>;
   pendingSubagentInputEventsByExternalSessionId: Map<string, PendingSubagentInputEvent[]>;
+  pendingBackgroundTaskResultsByExternalSessionId: Map<string, PendingBackgroundTaskResult[]>;
 };
 
 export type EventStreamRuntime = EventStreamContext & EventStreamState;

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -54,6 +54,11 @@ type ChildSessionLink = {
   externalSessionId: string;
   createdAtMs: number;
 };
+type HistoryStreamPartNormalizationState = {
+  pendingBySignature: Map<string, string[]>;
+  correlationByExternalSessionId: Map<string, string>;
+  unmatchedChildSessionLinks: ChildSessionLink[];
+};
 
 const CHILD_SESSION_START_TOLERANCE_MS = 5_000;
 
@@ -213,15 +218,20 @@ const removePendingSubagentCorrelationKey = (
   }
 };
 
+const createHistoryStreamPartNormalizationState = (
+  childSessionLinks: ChildSessionLink[],
+): HistoryStreamPartNormalizationState => ({
+  pendingBySignature: new Map<string, string[]>(),
+  correlationByExternalSessionId: new Map<string, string>(),
+  unmatchedChildSessionLinks: [...childSessionLinks],
+});
+
 const normalizeHistoryStreamParts = (
   parts: Part[],
-  childSessionLinks: ChildSessionLink[] = [],
+  state: HistoryStreamPartNormalizationState,
   timestamp?: string,
 ): AgentStreamPart[] => {
-  const pendingBySignature = new Map<string, string[]>();
-  const correlationByExternalSessionId = new Map<string, string>();
   const normalized: AgentStreamPart[] = [];
-  const unmatchedChildSessionLinks = [...childSessionLinks];
 
   for (const rawPart of parts) {
     if (rawPart.type === "patch") {
@@ -233,7 +243,17 @@ const normalizeHistoryStreamParts = (
         ...(timestamp ? { timestamp } : {}),
       });
       if (backgroundTaskResult) {
-        normalized.push(backgroundTaskResult);
+        const externalSessionId = backgroundTaskResult.externalSessionId;
+        const correlationKey = externalSessionId
+          ? state.correlationByExternalSessionId.get(externalSessionId)
+          : undefined;
+        const mapped = correlationKey
+          ? { ...backgroundTaskResult, correlationKey }
+          : backgroundTaskResult;
+        if (externalSessionId && mapped.correlationKey) {
+          state.correlationByExternalSessionId.set(externalSessionId, mapped.correlationKey);
+        }
+        normalized.push(mapped);
       }
       continue;
     }
@@ -248,15 +268,15 @@ const normalizeHistoryStreamParts = (
       continue;
     }
 
-    const mapped = linkSubagentPartToChildSession(rawMapped, unmatchedChildSessionLinks);
+    const mapped = linkSubagentPartToChildSession(rawMapped, state.unmatchedChildSessionLinks);
     const signature = buildSubagentSignature(mapped);
     if (rawPart.type === "subtask") {
       const correlationKey = buildPartScopedSubagentCorrelationKey(mapped, rawPart.id);
       if (signature) {
-        enqueuePendingSubagentCorrelationKey(pendingBySignature, signature, correlationKey);
+        enqueuePendingSubagentCorrelationKey(state.pendingBySignature, signature, correlationKey);
       }
       if (mapped.externalSessionId) {
-        correlationByExternalSessionId.set(mapped.externalSessionId, correlationKey);
+        state.correlationByExternalSessionId.set(mapped.externalSessionId, correlationKey);
       }
 
       normalized.push({
@@ -267,14 +287,14 @@ const normalizeHistoryStreamParts = (
     }
 
     const sessionCorrelationKey = mapped.externalSessionId
-      ? correlationByExternalSessionId.get(mapped.externalSessionId)
+      ? state.correlationByExternalSessionId.get(mapped.externalSessionId)
       : undefined;
     const pendingCorrelationKeys = signature
-      ? peekPendingSubagentCorrelationKeys(pendingBySignature, signature)
+      ? peekPendingSubagentCorrelationKeys(state.pendingBySignature, signature)
       : [];
     const queuedCorrelationKey =
       pendingCorrelationKeys.length === 1 && signature
-        ? dequeuePendingSubagentCorrelationKey(pendingBySignature, signature)
+        ? dequeuePendingSubagentCorrelationKey(state.pendingBySignature, signature)
         : undefined;
     const correlationKey =
       sessionCorrelationKey ??
@@ -284,8 +304,8 @@ const normalizeHistoryStreamParts = (
         : buildPartScopedSubagentCorrelationKey(mapped, rawPart.id));
 
     if (mapped.externalSessionId) {
-      correlationByExternalSessionId.set(mapped.externalSessionId, correlationKey);
-      removePendingSubagentCorrelationKey(pendingBySignature, correlationKey);
+      state.correlationByExternalSessionId.set(mapped.externalSessionId, correlationKey);
+      removePendingSubagentCorrelationKey(state.pendingBySignature, correlationKey);
     }
 
     normalized.push({
@@ -438,26 +458,15 @@ export const loadSessionHistory = async (
       return aTime - bTime;
     });
 
-  const assistantRawParts = normalizedEntries.flatMap((item) =>
-    item.entry.info.role === "assistant" ? item.rawParts : [],
-  );
-  const assistantNormalizedPartsByMessageId = new Map(
-    normalizeHistoryStreamParts(assistantRawParts, childSessionLinks).reduce<
-      Map<string, AgentStreamPart[]>
-    >((byMessageId, part) => {
-      const existing = byMessageId.get(part.messageId) ?? [];
-      existing.push(part);
-      byMessageId.set(part.messageId, existing);
-      return byMessageId;
-    }, new Map()),
-  );
-
+  const historyPartNormalizationState =
+    createHistoryStreamPartNormalizationState(childSessionLinks);
   const entries = normalizedEntries.map((item) => ({
     ...item,
-    parts:
-      item.entry.info.role === "assistant"
-        ? (assistantNormalizedPartsByMessageId.get(item.entry.info.id) ?? [])
-        : normalizeHistoryStreamParts(item.rawParts, [], item.timestamp),
+    parts: normalizeHistoryStreamParts(
+      item.rawParts,
+      historyPartNormalizationState,
+      item.timestamp,
+    ),
   }));
 
   const pendingAssistantReverseIndex = [...entries]

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -19,6 +19,7 @@ import {
   readVisibleUserTextFromDisplayParts,
   sanitizeAssistantMessage,
 } from "./message-normalizers";
+import { mapOpenCodeBackgroundTaskResultPart } from "./opencode-background-task-result";
 import { toOpenCodeRequestError } from "./request-errors";
 import { toIsoFromEpoch } from "./session-runtime-utils";
 import { mapPartToAgentStreamPart } from "./stream-part-mapper";
@@ -215,6 +216,7 @@ const removePendingSubagentCorrelationKey = (
 const normalizeHistoryStreamParts = (
   parts: Part[],
   childSessionLinks: ChildSessionLink[] = [],
+  timestamp?: string,
 ): AgentStreamPart[] => {
   const pendingBySignature = new Map<string, string[]>();
   const correlationByExternalSessionId = new Map<string, string>();
@@ -223,6 +225,16 @@ const normalizeHistoryStreamParts = (
 
   for (const rawPart of parts) {
     if (rawPart.type === "patch") {
+      continue;
+    }
+
+    if (rawPart.type === "text") {
+      const backgroundTaskResult = mapOpenCodeBackgroundTaskResultPart(rawPart, {
+        ...(timestamp ? { timestamp } : {}),
+      });
+      if (backgroundTaskResult) {
+        normalized.push(backgroundTaskResult);
+      }
       continue;
     }
 
@@ -445,7 +457,7 @@ export const loadSessionHistory = async (
     parts:
       item.entry.info.role === "assistant"
         ? (assistantNormalizedPartsByMessageId.get(item.entry.info.id) ?? [])
-        : normalizeHistoryStreamParts(item.rawParts),
+        : normalizeHistoryStreamParts(item.rawParts, [], item.timestamp),
   }));
 
   const pendingAssistantReverseIndex = [...entries]

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -58,6 +58,7 @@ type HistoryStreamPartNormalizationState = {
   pendingBySignature: Map<string, string[]>;
   correlationByExternalSessionId: Map<string, string>;
   unmatchedChildSessionLinks: ChildSessionLink[];
+  pendingBackgroundTaskResultsByExternalSessionId: Map<string, MappedSubagentPart[]>;
 };
 
 const CHILD_SESSION_START_TOLERANCE_MS = 5_000;
@@ -218,12 +219,42 @@ const removePendingSubagentCorrelationKey = (
   }
 };
 
+const queuePendingBackgroundTaskResult = (
+  state: HistoryStreamPartNormalizationState,
+  externalSessionId: string,
+  part: MappedSubagentPart,
+): void => {
+  const pending = state.pendingBackgroundTaskResultsByExternalSessionId.get(externalSessionId);
+  const next = [...(pending?.filter((entry) => entry.partId !== part.partId) ?? []), part];
+  state.pendingBackgroundTaskResultsByExternalSessionId.set(externalSessionId, next);
+};
+
+const flushPendingBackgroundTaskResults = (
+  state: HistoryStreamPartNormalizationState,
+  externalSessionId: string,
+  correlationKey: string,
+): MappedSubagentPart[] => {
+  const pending = state.pendingBackgroundTaskResultsByExternalSessionId.get(externalSessionId);
+  if (!pending || pending.length === 0) {
+    return [];
+  }
+
+  state.pendingBackgroundTaskResultsByExternalSessionId.delete(externalSessionId);
+  state.correlationByExternalSessionId.set(externalSessionId, correlationKey);
+  removePendingSubagentCorrelationKey(state.pendingBySignature, correlationKey);
+  return pending.map((part) => ({
+    ...part,
+    correlationKey,
+  }));
+};
+
 const createHistoryStreamPartNormalizationState = (
   childSessionLinks: ChildSessionLink[],
 ): HistoryStreamPartNormalizationState => ({
   pendingBySignature: new Map<string, string[]>(),
   correlationByExternalSessionId: new Map<string, string>(),
   unmatchedChildSessionLinks: [...childSessionLinks],
+  pendingBackgroundTaskResultsByExternalSessionId: new Map<string, MappedSubagentPart[]>(),
 });
 
 const normalizeHistoryStreamParts = (
@@ -244,15 +275,23 @@ const normalizeHistoryStreamParts = (
       });
       if (backgroundTaskResult) {
         const externalSessionId = backgroundTaskResult.externalSessionId;
-        const correlationKey = externalSessionId
-          ? state.correlationByExternalSessionId.get(externalSessionId)
-          : undefined;
-        const mapped = correlationKey
-          ? { ...backgroundTaskResult, correlationKey }
-          : backgroundTaskResult;
-        if (externalSessionId && mapped.correlationKey) {
-          state.correlationByExternalSessionId.set(externalSessionId, mapped.correlationKey);
+        if (!externalSessionId) {
+          normalized.push(backgroundTaskResult);
+          continue;
         }
+
+        const correlationKey = state.correlationByExternalSessionId.get(externalSessionId);
+        if (!correlationKey) {
+          queuePendingBackgroundTaskResult(state, externalSessionId, backgroundTaskResult);
+          continue;
+        }
+
+        const mapped = {
+          ...backgroundTaskResult,
+          correlationKey,
+        };
+        state.correlationByExternalSessionId.set(externalSessionId, correlationKey);
+        removePendingSubagentCorrelationKey(state.pendingBySignature, correlationKey);
         normalized.push(mapped);
       }
       continue;
@@ -283,6 +322,11 @@ const normalizeHistoryStreamParts = (
         ...mapped,
         correlationKey,
       });
+      if (mapped.externalSessionId) {
+        normalized.push(
+          ...flushPendingBackgroundTaskResults(state, mapped.externalSessionId, correlationKey),
+        );
+      }
       continue;
     }
 
@@ -312,6 +356,11 @@ const normalizeHistoryStreamParts = (
       ...mapped,
       correlationKey,
     });
+    if (mapped.externalSessionId) {
+      normalized.push(
+        ...flushPendingBackgroundTaskResults(state, mapped.externalSessionId, correlationKey),
+      );
+    }
   }
 
   return normalized;

--- a/packages/adapters-opencode-sdk/src/opencode-background-task-result.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-background-task-result.ts
@@ -1,0 +1,156 @@
+import type { Part } from "@opencode-ai/sdk/v2/client";
+import type { AgentStreamPart, AgentSubagentStatus } from "@openducktor/core";
+
+type SubagentStreamPart = Extract<AgentStreamPart, { kind: "subagent" }>;
+type TextPart = Extract<Part, { type: "text" }>;
+
+type ParsedTaskResult = {
+  externalSessionId: string;
+  status: Extract<AgentSubagentStatus, "running" | "completed" | "error">;
+  summary?: string;
+  resultText?: string;
+};
+
+const TASK_OPEN_PREFIX = "<task ";
+const TASK_CLOSE_TAG = "</task>";
+
+const readQuotedAttribute = (tag: string, attributeName: string): string | undefined => {
+  const marker = ` ${attributeName}="`;
+  const markerIndex = tag.indexOf(marker);
+  if (markerIndex < 0) {
+    return undefined;
+  }
+
+  const valueStart = markerIndex + marker.length;
+  const valueEnd = tag.indexOf('"', valueStart);
+  if (valueEnd < 0) {
+    return undefined;
+  }
+
+  const value = tag.slice(valueStart, valueEnd).trim();
+  return value.length > 0 ? value : undefined;
+};
+
+const readInlineElement = (line: string, tagName: string): string | undefined => {
+  const openTag = `<${tagName}>`;
+  const closeTag = `</${tagName}>`;
+  if (!line.startsWith(openTag) || !line.endsWith(closeTag)) {
+    return undefined;
+  }
+
+  const value = line.slice(openTag.length, line.length - closeTag.length).trim();
+  return value.length > 0 ? value : undefined;
+};
+
+const readBlockElement = (lines: string[], tagName: string): string | undefined => {
+  const openTag = `<${tagName}>`;
+  const closeTag = `</${tagName}>`;
+  const openIndex = lines.indexOf(openTag);
+  if (openIndex < 0) {
+    return undefined;
+  }
+
+  const closeIndex = lines.findIndex((line, index) => index > openIndex && line === closeTag);
+  if (closeIndex < 0) {
+    return undefined;
+  }
+
+  const value = lines
+    .slice(openIndex + 1, closeIndex)
+    .join("\n")
+    .trim();
+  return value.length > 0 ? value : undefined;
+};
+
+const toTaskResultStatus = (value: string | undefined): ParsedTaskResult["status"] | undefined => {
+  if (value === "running" || value === "completed" || value === "error") {
+    return value;
+  }
+  return undefined;
+};
+
+export const parseOpenCodeBackgroundTaskResult = (value: string): ParsedTaskResult | null => {
+  const lines = value
+    .trim()
+    .split("\n")
+    .map((line) => {
+      const normalizedLine = line.endsWith("\r") ? line.slice(0, -1) : line;
+      return normalizedLine.trim();
+    })
+    .filter((line) => line.length > 0);
+  const [openTag] = lines;
+  if (!openTag?.startsWith(TASK_OPEN_PREFIX) || !openTag.endsWith(">")) {
+    return null;
+  }
+  if (lines.at(-1) !== TASK_CLOSE_TAG) {
+    return null;
+  }
+
+  const externalSessionId = readQuotedAttribute(openTag, "id");
+  const status = toTaskResultStatus(readQuotedAttribute(openTag, "state"));
+  if (!externalSessionId || !status) {
+    return null;
+  }
+
+  const resultTag = status === "error" ? "task_error" : "task_result";
+  const summaryLine = lines.find((line) => line.startsWith("<summary>"));
+  const summary = summaryLine ? readInlineElement(summaryLine, "summary") : undefined;
+  const resultText = readBlockElement(lines, resultTag);
+
+  return {
+    externalSessionId,
+    status,
+    ...(summary ? { summary } : {}),
+    ...(resultText ? { resultText } : {}),
+  };
+};
+
+const readEndedAtMs = (part: TextPart, timestamp: string | undefined): number | undefined => {
+  if (typeof part.time?.end === "number") {
+    return part.time.end;
+  }
+  if (!timestamp) {
+    return undefined;
+  }
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+export const mapOpenCodeBackgroundTaskResultPart = (
+  part: Part,
+  options: {
+    correlationKey?: string;
+    timestamp?: string;
+  } = {},
+): SubagentStreamPart | null => {
+  if (part.type !== "text" || part.synthetic !== true) {
+    return null;
+  }
+
+  const parsed = parseOpenCodeBackgroundTaskResult(part.text);
+  if (!parsed) {
+    return null;
+  }
+
+  const description = parsed.summary ?? parsed.resultText;
+  let endedAtMs: number | undefined;
+  if (parsed.status !== "running") {
+    endedAtMs = readEndedAtMs(part, options.timestamp);
+  }
+  return {
+    kind: "subagent",
+    messageId: part.messageID,
+    partId: part.id,
+    correlationKey:
+      options.correlationKey ?? ["session", part.messageID, parsed.externalSessionId].join(":"),
+    status: parsed.status,
+    ...(description ? { description } : {}),
+    ...(parsed.status === "error" && parsed.resultText ? { error: parsed.resultText } : {}),
+    externalSessionId: parsed.externalSessionId,
+    executionMode: "background",
+    metadata: {
+      background: true,
+    },
+    ...(typeof endedAtMs === "number" ? { endedAtMs } : {}),
+  };
+};

--- a/packages/adapters-opencode-sdk/src/opencode-background-task-result.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-background-task-result.ts
@@ -14,6 +14,18 @@ type ParsedTaskResult = {
 const TASK_OPEN_PREFIX = "<task ";
 const TASK_CLOSE_TAG = "</task>";
 
+const trimOuterEmptyLines = (lines: string[]): string[] => {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start]?.trim().length === 0) {
+    start += 1;
+  }
+  while (end > start && lines[end - 1]?.trim().length === 0) {
+    end -= 1;
+  }
+  return lines.slice(start, end);
+};
+
 const readQuotedAttribute = (tag: string, attributeName: string): string | undefined => {
   const marker = ` ${attributeName}="`;
   const markerIndex = tag.indexOf(marker);
@@ -31,34 +43,48 @@ const readQuotedAttribute = (tag: string, attributeName: string): string | undef
   return value.length > 0 ? value : undefined;
 };
 
-const readInlineElement = (line: string, tagName: string): string | undefined => {
+const readElement = (
+  lines: string[],
+  tagName: string,
+  closeSearch: "first" | "last",
+): string | undefined => {
   const openTag = `<${tagName}>`;
   const closeTag = `</${tagName}>`;
-  if (!line.startsWith(openTag) || !line.endsWith(closeTag)) {
-    return undefined;
-  }
-
-  const value = line.slice(openTag.length, line.length - closeTag.length).trim();
-  return value.length > 0 ? value : undefined;
-};
-
-const readBlockElement = (lines: string[], tagName: string): string | undefined => {
-  const openTag = `<${tagName}>`;
-  const closeTag = `</${tagName}>`;
-  const openIndex = lines.indexOf(openTag);
+  const openIndex = lines.findIndex((line) => line.trim().startsWith(openTag));
   if (openIndex < 0) {
     return undefined;
   }
 
-  const closeIndex = lines.findIndex((line, index) => index > openIndex && line === closeTag);
-  if (closeIndex < 0) {
+  const openLine = lines[openIndex] ?? "";
+  const trimmedOpenLine = openLine.trim();
+  if (trimmedOpenLine.endsWith(closeTag)) {
+    const inlineValue = trimmedOpenLine.slice(openTag.length, -closeTag.length).trim();
+    return inlineValue.length > 0 ? inlineValue : undefined;
+  }
+
+  const candidateCloseIndexes = lines
+    .map((line, index) => ({ index, line: line.trim() }))
+    .filter((candidate) => candidate.index > openIndex && candidate.line.endsWith(closeTag))
+    .map((candidate) => candidate.index);
+  const closeIndex =
+    closeSearch === "last" ? candidateCloseIndexes.at(-1) : candidateCloseIndexes[0];
+  if (closeIndex === undefined) {
     return undefined;
   }
 
-  const value = lines
-    .slice(openIndex + 1, closeIndex)
-    .join("\n")
-    .trim();
+  const closeLine = lines[closeIndex] ?? "";
+  const trimmedCloseLine = closeLine.trim();
+  const valueLines = lines.slice(openIndex + 1, closeIndex);
+  const inlineOpenValue = trimmedOpenLine.slice(openTag.length);
+  if (inlineOpenValue.length > 0) {
+    valueLines.unshift(inlineOpenValue);
+  }
+  const inlineCloseValue = trimmedCloseLine.slice(0, -closeTag.length);
+  if (inlineCloseValue.length > 0) {
+    valueLines.push(inlineCloseValue);
+  }
+
+  const value = valueLines.join("\n").trim();
   return value.length > 0 ? value : undefined;
 };
 
@@ -69,23 +95,20 @@ const toTaskResultStatus = (value: string | undefined): ParsedTaskResult["status
   return undefined;
 };
 
-export const parseOpenCodeBackgroundTaskResult = (value: string): ParsedTaskResult | null => {
-  const lines = value
-    .trim()
-    .split("\n")
-    .map((line) => {
-      const normalizedLine = line.endsWith("\r") ? line.slice(0, -1) : line;
-      return normalizedLine.trim();
-    })
-    .filter((line) => line.length > 0);
-  const [openTag] = lines;
+const parseOpenCodeBackgroundTaskResult = (value: string): ParsedTaskResult | null => {
+  const lines = trimOuterEmptyLines(
+    value.split("\n").map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line)),
+  );
+  const openTag = lines[0]?.trim();
   if (!openTag?.startsWith(TASK_OPEN_PREFIX) || !openTag.endsWith(">")) {
     return null;
   }
-  if (lines.at(-1) !== TASK_CLOSE_TAG) {
+  if (lines.at(-1)?.trim() !== TASK_CLOSE_TAG) {
     return null;
   }
 
+  const bodyLines = lines.slice(1, -1);
+  const normalizedBodyLines = bodyLines.map((line) => line.trim());
   const externalSessionId = readQuotedAttribute(openTag, "id");
   const status = toTaskResultStatus(readQuotedAttribute(openTag, "state"));
   if (!externalSessionId || !status) {
@@ -93,9 +116,8 @@ export const parseOpenCodeBackgroundTaskResult = (value: string): ParsedTaskResu
   }
 
   const resultTag = status === "error" ? "task_error" : "task_result";
-  const summaryLine = lines.find((line) => line.startsWith("<summary>"));
-  const summary = summaryLine ? readInlineElement(summaryLine, "summary") : undefined;
-  const resultText = readBlockElement(lines, resultTag);
+  const summary = readElement(normalizedBodyLines, "summary", "first");
+  const resultText = readElement(bodyLines, resultTag, "last");
 
   return {
     externalSessionId,

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -160,6 +160,16 @@ const copySubagentCorrelationState = (source: SessionRecord, target: SessionReco
   for (const [signature, pending] of source.pendingSubagentCorrelationKeysBySignature) {
     target.pendingSubagentCorrelationKeysBySignature.set(signature, [...pending]);
   }
+  target.pendingBackgroundTaskResultsByExternalSessionId.clear();
+  for (const [
+    externalSessionId,
+    pending,
+  ] of source.pendingBackgroundTaskResultsByExternalSessionId) {
+    target.pendingBackgroundTaskResultsByExternalSessionId.set(
+      externalSessionId,
+      pending.map((entry) => ({ ...entry })),
+    );
+  }
 };
 
 export class OpencodeSdkAdapter

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -824,6 +824,7 @@ describe("OpencodeSdkAdapter session history", () => {
         kind: "subagent",
         status: "completed",
         externalSessionId: "child-session-a",
+        correlationKey: "part:msg-200:subtask-a",
         description: "Background task completed: Run tests",
         endedAtMs: taskCompletedAtMs,
       }),

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -709,6 +709,127 @@ describe("OpencodeSdkAdapter session history", () => {
     ]);
   });
 
+  test("loadSessionHistory maps synthetic background task completion prompts to subagent updates", async () => {
+    const taskStartedAtMs = Date.parse("2026-02-17T12:00:03.000Z");
+    const taskCompletedAtMs = Date.parse("2026-02-17T12:00:45.000Z");
+    const mock = makeMockClient({
+      messagesResponse: [
+        {
+          info: {
+            id: "msg-200",
+            role: "assistant",
+            time: { created: Date.parse("2026-02-17T12:00:00Z") },
+          },
+          parts: [
+            {
+              id: "subtask-a",
+              sessionID: "session-opencode-1",
+              messageID: "msg-200",
+              type: "subtask",
+              agent: "build",
+              prompt: "Run tests",
+              description: "Run tests",
+            } as unknown as Part,
+            {
+              id: "tool-task-a",
+              sessionID: "session-opencode-1",
+              messageID: "msg-200",
+              callID: "call-a",
+              type: "tool",
+              tool: "task",
+              state: {
+                status: "completed",
+                input: {
+                  subagent_type: "build",
+                  prompt: "Run tests",
+                  description: "Run tests",
+                },
+                output: [
+                  '<task id="child-session-a" state="running">',
+                  "<summary>Background task started</summary>",
+                  "<task_result>",
+                  "The task is running in the background.",
+                  "</task_result>",
+                  "</task>",
+                ].join("\n"),
+                metadata: {
+                  background: true,
+                  sessionId: "child-session-a",
+                  jobId: "child-session-a",
+                },
+                time: {
+                  start: taskStartedAtMs,
+                  end: taskStartedAtMs + 10,
+                },
+              },
+            } as unknown as Part,
+          ],
+        },
+        {
+          info: {
+            id: "msg-201",
+            role: "user",
+            time: { created: taskCompletedAtMs },
+          },
+          parts: [
+            {
+              id: "text-background-task-completed",
+              sessionID: "session-opencode-1",
+              messageID: "msg-201",
+              type: "text",
+              synthetic: true,
+              text: [
+                '<task id="child-session-a" state="completed">',
+                "<summary>Background task completed: Run tests</summary>",
+                "<task_result>",
+                "Tests passed.",
+                "</task_result>",
+                "</task>",
+              ].join("\n"),
+            } as unknown as Part,
+          ],
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const history = await adapter.loadSessionHistory({
+      ...defaultRepoRuntimeInput,
+      externalSessionId: "session-opencode-1",
+      limit: 100,
+    });
+
+    expect(history).toHaveLength(2);
+    if (history[0]?.role !== "assistant" || history[1]?.role !== "user") {
+      throw new Error("Expected assistant history followed by synthetic user task result");
+    }
+    expect(history[0].parts).toEqual([
+      expect.objectContaining({
+        kind: "subagent",
+        status: "running",
+        correlationKey: "part:msg-200:subtask-a",
+      }),
+      expect.objectContaining({
+        kind: "subagent",
+        status: "running",
+        externalSessionId: "child-session-a",
+        correlationKey: "part:msg-200:subtask-a",
+      }),
+    ]);
+    expect(history[1].parts).toEqual([
+      expect.objectContaining({
+        kind: "subagent",
+        status: "completed",
+        externalSessionId: "child-session-a",
+        description: "Background task completed: Run tests",
+        endedAtMs: taskCompletedAtMs,
+      }),
+    ]);
+  });
+
   test("loadSessionHistory seeds live subagent correlation for later task-tool updates", async () => {
     const streamEvents: Event[] = [
       {

--- a/packages/adapters-opencode-sdk/src/session-history.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-history.test.ts
@@ -831,6 +831,128 @@ describe("OpencodeSdkAdapter session history", () => {
     ]);
   });
 
+  test("loadSessionHistory queues early synthetic background task completions until the parent binding exists", async () => {
+    const taskStartedAtMs = Date.parse("2026-02-17T12:00:03.000Z");
+    const taskCompletedAtMs = Date.parse("2026-02-17T12:00:01.000Z");
+    const mock = makeMockClient({
+      messagesResponse: [
+        {
+          info: {
+            id: "msg-201",
+            role: "user",
+            time: { created: taskCompletedAtMs },
+          },
+          parts: [
+            {
+              id: "text-background-task-completed",
+              sessionID: "session-opencode-1",
+              messageID: "msg-201",
+              type: "text",
+              synthetic: true,
+              text: [
+                '<task id="child-session-a" state="completed">',
+                "<summary>Background task completed: Run tests</summary>",
+                "<task_result>",
+                "Tests passed.",
+                "</task_result>",
+                "</task>",
+              ].join("\n"),
+            } as unknown as Part,
+          ],
+        },
+        {
+          info: {
+            id: "msg-200",
+            role: "assistant",
+            time: { created: Date.parse("2026-02-17T12:00:02Z") },
+          },
+          parts: [
+            {
+              id: "subtask-a",
+              sessionID: "session-opencode-1",
+              messageID: "msg-200",
+              type: "subtask",
+              agent: "build",
+              prompt: "Run tests",
+              description: "Run tests",
+            } as unknown as Part,
+            {
+              id: "tool-task-a",
+              sessionID: "session-opencode-1",
+              messageID: "msg-200",
+              callID: "call-a",
+              type: "tool",
+              tool: "task",
+              state: {
+                status: "completed",
+                input: {
+                  subagent_type: "build",
+                  prompt: "Run tests",
+                  description: "Run tests",
+                },
+                output: [
+                  '<task id="child-session-a" state="running">',
+                  "<summary>Background task started</summary>",
+                  "<task_result>",
+                  "The task is running in the background.",
+                  "</task_result>",
+                  "</task>",
+                ].join("\n"),
+                metadata: {
+                  background: true,
+                  sessionId: "child-session-a",
+                  jobId: "child-session-a",
+                },
+                time: {
+                  start: taskStartedAtMs,
+                  end: taskStartedAtMs + 10,
+                },
+              },
+            } as unknown as Part,
+          ],
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const history = await adapter.loadSessionHistory({
+      ...defaultRepoRuntimeInput,
+      externalSessionId: "session-opencode-1",
+      limit: 100,
+    });
+
+    expect(history).toHaveLength(2);
+    if (history[0]?.role !== "user" || history[1]?.role !== "assistant") {
+      throw new Error("Expected early synthetic user result followed by assistant history");
+    }
+    expect(history[0].parts).toEqual([]);
+    expect(history[1].parts).toEqual([
+      expect.objectContaining({
+        kind: "subagent",
+        status: "running",
+        correlationKey: "part:msg-200:subtask-a",
+      }),
+      expect.objectContaining({
+        kind: "subagent",
+        status: "running",
+        externalSessionId: "child-session-a",
+        correlationKey: "part:msg-200:subtask-a",
+      }),
+      expect.objectContaining({
+        kind: "subagent",
+        status: "completed",
+        partId: "text-background-task-completed",
+        externalSessionId: "child-session-a",
+        correlationKey: "part:msg-200:subtask-a",
+        description: "Background task completed: Run tests",
+        endedAtMs: taskCompletedAtMs,
+      }),
+    ]);
+  });
+
   test("loadSessionHistory seeds live subagent correlation for later task-tool updates", async () => {
     const streamEvents: Event[] = [
       {

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -371,6 +371,7 @@ export const registerSession = (
     pendingSubagentSessionsByExternalSessionId: new Map(),
     pendingSubagentPartEmissionsByExternalSessionId: new Map(),
     pendingSubagentInputEventsByExternalSessionId: new Map(),
+    pendingBackgroundTaskResultsByExternalSessionId: new Map(),
   });
 
   if (input.subscribeToEvents !== false) {

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -134,6 +134,57 @@ describe("stream-part-mapper", () => {
     });
   });
 
+  test("keeps completed OpenCode background task results running while the child session is active", () => {
+    const part = createToolPart({
+      id: "tool-background-task-running-1",
+      tool: "task",
+      status: "completed",
+      input: {
+        subagent_type: "build",
+        prompt: "Inspect the repo",
+        description: "Inspect the race",
+      },
+      output: [
+        '<task id="session-child-background-1" state="running">',
+        "<summary>Background task started</summary>",
+        "<task_result>",
+        "The task is running in the background.",
+        "</task_result>",
+        "</task>",
+      ].join("\n"),
+      metadata: {
+        background: true,
+        sessionId: "session-child-background-1",
+        jobId: "session-child-background-1",
+      },
+      time: {
+        start: 10,
+        end: 40,
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "subagent",
+      messageId: "assistant-tool-background-task-running-1",
+      partId: "tool-background-task-running-1",
+      status: "running",
+      agent: "build",
+      prompt: "Inspect the repo",
+      description: "Inspect the race",
+      externalSessionId: "session-child-background-1",
+      executionMode: "background",
+      metadata: {
+        background: true,
+        sessionId: "session-child-background-1",
+        jobId: "session-child-background-1",
+      },
+      startedAtMs: 10,
+    });
+    expect(mapped).not.toEqual(expect.objectContaining({ endedAtMs: expect.any(Number) }));
+  });
+
   test("does not map the unsupported subtask tool alias to a subagent part", () => {
     const part = createToolPart({
       id: "tool-subtask-1",

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Part } from "@opencode-ai/sdk/v2/client";
+import { mapOpenCodeBackgroundTaskResultPart } from "./opencode-background-task-result";
 import { mapPartToAgentStreamPart } from "./stream-part-mapper";
 
 const createToolPart = ({
@@ -56,6 +57,25 @@ const createToolPart = ({
     state,
   } as unknown as Part;
 };
+
+const createSyntheticTextPart = ({
+  id,
+  text,
+  time,
+}: {
+  id: string;
+  text: string;
+  time?: { end?: number };
+}): Part =>
+  ({
+    id,
+    sessionID: "session-1",
+    messageID: `user-${id}`,
+    type: "text",
+    synthetic: true,
+    text,
+    ...(time ? { time } : {}),
+  }) as unknown as Part;
 
 describe("stream-part-mapper", () => {
   test("maps raw subtask parts to canonical subagent parts", () => {
@@ -183,6 +203,158 @@ describe("stream-part-mapper", () => {
       startedAtMs: 10,
     });
     expect(mapped).not.toEqual(expect.objectContaining({ endedAtMs: expect.any(Number) }));
+  });
+
+  test("preserves structured background task failures as terminal errors", () => {
+    const part = createToolPart({
+      id: "tool-background-task-error-1",
+      tool: "task",
+      status: "completed",
+      input: {
+        subagent_type: "build",
+        prompt: "Inspect the repo",
+      },
+      output: {
+        content: [{ type: "text", text: "Task failed" }],
+        isError: true,
+      },
+      metadata: {
+        background: true,
+        sessionId: "session-child-background-error-1",
+      },
+      time: {
+        start: 10,
+        end: 40,
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "subagent",
+      status: "error",
+      error: "Task failed",
+      externalSessionId: "session-child-background-error-1",
+      executionMode: "background",
+      endedAtMs: 40,
+    });
+  });
+
+  test("preserves cancelled background task tool results as terminal", () => {
+    const part = createToolPart({
+      id: "tool-background-task-cancelled-1",
+      tool: "task",
+      status: "cancelled",
+      input: {
+        subagent_type: "build",
+        prompt: "Inspect the repo",
+      },
+      output: [
+        '<task id="session-child-background-cancelled-1" state="running">',
+        "<summary>Background task started</summary>",
+        "<task_result>",
+        "The task is running in the background.",
+        "</task_result>",
+        "</task>",
+      ].join("\n"),
+      metadata: {
+        background: true,
+        sessionId: "session-child-background-cancelled-1",
+      },
+      time: {
+        start: 10,
+        end: 40,
+      },
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+
+    expect(mapped).toMatchObject({
+      kind: "subagent",
+      status: "cancelled",
+      externalSessionId: "session-child-background-cancelled-1",
+      executionMode: "background",
+      endedAtMs: 40,
+    });
+  });
+
+  test("maps synthetic completed background task text without truncating raw result lines", () => {
+    const part = createSyntheticTextPart({
+      id: "text-background-completed-1",
+      text: [
+        '<task id="session-child-completed-1" state="completed">',
+        "<task_result>",
+        "rendered raw line:",
+        "</task_result>",
+        "actual final output",
+        "</task_result>",
+        "</task>",
+      ].join("\n"),
+      time: {
+        end: Date.parse("2026-02-22T12:00:45.000Z"),
+      },
+    });
+
+    const mapped = mapOpenCodeBackgroundTaskResultPart(part, {
+      correlationKey: "part:assistant-background:subtask-a",
+      timestamp: "2026-02-22T12:00:40.000Z",
+    });
+
+    expect(mapped).toMatchObject({
+      kind: "subagent",
+      partId: "text-background-completed-1",
+      correlationKey: "part:assistant-background:subtask-a",
+      status: "completed",
+      description: "rendered raw line:\n</task_result>\nactual final output",
+      externalSessionId: "session-child-completed-1",
+      executionMode: "background",
+      endedAtMs: Date.parse("2026-02-22T12:00:45.000Z"),
+    });
+  });
+
+  test("maps synthetic errored background task text with inline summary", () => {
+    const part = createSyntheticTextPart({
+      id: "text-background-error-1",
+      text: [
+        '<task id="session-child-error-1" state="error">',
+        "<summary>Background task failed: Run tests</summary>",
+        "<task_error>",
+        "Tests failed.",
+        "</task_error>",
+        "</task>",
+      ].join("\n"),
+    });
+
+    const mapped = mapOpenCodeBackgroundTaskResultPart(part, {
+      correlationKey: "part:assistant-background:subtask-a",
+      timestamp: "2026-02-22T12:00:45.000Z",
+    });
+
+    expect(mapped).toMatchObject({
+      kind: "subagent",
+      partId: "text-background-error-1",
+      correlationKey: "part:assistant-background:subtask-a",
+      status: "error",
+      description: "Background task failed: Run tests",
+      error: "Tests failed.",
+      externalSessionId: "session-child-error-1",
+      executionMode: "background",
+      endedAtMs: Date.parse("2026-02-22T12:00:45.000Z"),
+    });
+  });
+
+  test("ignores malformed synthetic background task text", () => {
+    const part = createSyntheticTextPart({
+      id: "text-background-malformed-1",
+      text: [
+        '<task id="session-child-malformed-1" state="completed">',
+        "<task_result>",
+        "missing close task tag",
+        "</task_result>",
+      ].join("\n"),
+    });
+
+    expect(mapOpenCodeBackgroundTaskResultPart(part)).toBeNull();
   });
 
   test("does not map the unsupported subtask tool alias to a subagent part", () => {

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -637,11 +637,10 @@ const buildSubagentFromToolPart = (
   const error = structuredError ?? directError;
   const isBackgroundResultStillRunning = isRunningBackgroundSubagentResult(metadata);
   let status = normalizedStatus;
-  if (isBackgroundResultStillRunning) {
-    status = "running";
-  }
-  if (directError) {
+  if (error) {
     status = "error";
+  } else if (isBackgroundResultStillRunning && status !== "cancelled") {
+    status = "running";
   }
   let mappedTiming = timing;
   if (status === "running" && isBackgroundResultStillRunning) {

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -488,6 +488,34 @@ const resolveSubagentExecutionMode = (
   return undefined;
 };
 
+const OPENCODE_TASK_OUTPUT_STATE_PATTERN = /<task\b[^>]*\bstate="([^"]+)"[^>]*>/i;
+
+const readOpencodeTaskOutputState = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const match = OPENCODE_TASK_OUTPUT_STATE_PATTERN.exec(value);
+  const state = match?.[1]?.trim().toLowerCase();
+  return state && state.length > 0 ? state : undefined;
+};
+
+const isRunningBackgroundSubagentResult = (
+  metadata: Record<string, unknown> | undefined,
+  output: unknown,
+): boolean => {
+  return (
+    resolveSubagentExecutionMode(metadata) === "background" &&
+    readOpencodeTaskOutputState(output) === "running"
+  );
+};
+
+const omitEndedTiming = (
+  timing: ReturnType<typeof extractPartTiming>,
+): ReturnType<typeof extractPartTiming> => ({
+  ...(typeof timing.startedAtMs === "number" ? { startedAtMs: timing.startedAtMs } : {}),
+});
+
 const resolveSubagentExternalSessionId = (...sources: unknown[]): string | undefined => {
   for (const source of sources) {
     const externalSessionId = readTrimmedString(source, [
@@ -616,7 +644,14 @@ const buildSubagentFromToolPart = (
   const prompt = resolveSubagentPrompt(input, metadata, output);
   const directError = toDisplayText(readUnknownProp(toolState, "error"));
   const error = structuredError ?? directError;
-  const status = directError ? "error" : normalizedStatus;
+  const isBackgroundResultStillRunning = isRunningBackgroundSubagentResult(metadata, rawOutput);
+  const status = directError
+    ? "error"
+    : isBackgroundResultStillRunning
+      ? "running"
+      : normalizedStatus;
+  const mappedTiming =
+    status === "running" && isBackgroundResultStillRunning ? omitEndedTiming(timing) : timing;
   const preview = deriveToolPreview({
     tool: part.tool,
     rawInput,
@@ -637,7 +672,7 @@ const buildSubagentFromToolPart = (
     ...(externalSessionId ? { externalSessionId } : {}),
     executionMode: resolveSubagentExecutionMode(metadata, input, output),
     ...(metadata ? { metadata } : {}),
-    ...timing,
+    ...mappedTiming,
   });
 };
 

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -488,25 +488,16 @@ const resolveSubagentExecutionMode = (
   return undefined;
 };
 
-const OPENCODE_TASK_OUTPUT_STATE_PATTERN = /<task\b[^>]*\bstate="([^"]+)"[^>]*>/i;
-
-const readOpencodeTaskOutputState = (value: unknown): string | undefined => {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const match = OPENCODE_TASK_OUTPUT_STATE_PATTERN.exec(value);
-  const state = match?.[1]?.trim().toLowerCase();
-  return state && state.length > 0 ? state : undefined;
-};
+const resolveBackgroundJobId = (
+  metadata: Record<string, unknown> | undefined,
+): string | undefined => readTrimmedString(metadata, ["jobId", "jobID", "job_id"]);
 
 const isRunningBackgroundSubagentResult = (
   metadata: Record<string, unknown> | undefined,
-  output: unknown,
 ): boolean => {
   return (
     resolveSubagentExecutionMode(metadata) === "background" &&
-    readOpencodeTaskOutputState(output) === "running"
+    resolveBackgroundJobId(metadata) !== undefined
   );
 };
 
@@ -644,14 +635,18 @@ const buildSubagentFromToolPart = (
   const prompt = resolveSubagentPrompt(input, metadata, output);
   const directError = toDisplayText(readUnknownProp(toolState, "error"));
   const error = structuredError ?? directError;
-  const isBackgroundResultStillRunning = isRunningBackgroundSubagentResult(metadata, rawOutput);
-  const status = directError
-    ? "error"
-    : isBackgroundResultStillRunning
-      ? "running"
-      : normalizedStatus;
-  const mappedTiming =
-    status === "running" && isBackgroundResultStillRunning ? omitEndedTiming(timing) : timing;
+  const isBackgroundResultStillRunning = isRunningBackgroundSubagentResult(metadata);
+  let status = normalizedStatus;
+  if (isBackgroundResultStillRunning) {
+    status = "running";
+  }
+  if (directError) {
+    status = "error";
+  }
+  let mappedTiming = timing;
+  if (status === "running" && isBackgroundResultStillRunning) {
+    mappedTiming = omitEndedTiming(timing);
+  }
   const preview = deriveToolPreview({
     tool: part.tool,
     rawInput,

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -495,6 +495,7 @@ const resolveBackgroundJobId = (
 const isRunningBackgroundSubagentResult = (
   metadata: Record<string, unknown> | undefined,
 ): boolean => {
+  // OpenCode keeps the parent tool part carrying background job metadata; the synthetic task result is the terminal child update.
   return (
     resolveSubagentExecutionMode(metadata) === "background" &&
     resolveBackgroundJobId(metadata) !== undefined

--- a/packages/adapters-opencode-sdk/src/types.test.ts
+++ b/packages/adapters-opencode-sdk/src/types.test.ts
@@ -57,6 +57,7 @@ describe("types", () => {
       pendingSubagentSessionsByExternalSessionId: new Map(),
       pendingSubagentPartEmissionsByExternalSessionId: new Map(),
       pendingSubagentInputEventsByExternalSessionId: new Map(),
+      pendingBackgroundTaskResultsByExternalSessionId: new Map(),
     };
     const options: OpencodeSdkAdapterOptions = {
       now: () => "2026-02-22T12:00:00.000Z",

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -9,6 +9,7 @@ import type {
   StartAgentSessionInput,
 } from "@openducktor/core";
 import type {
+  PendingBackgroundTaskResult,
   PendingPartDelta,
   PendingSubagentInputEvent,
   PendingSubagentPartEmission,
@@ -71,6 +72,7 @@ export type SessionRecord = {
   pendingSubagentSessionsByExternalSessionId: Map<string, PendingSubagentSessionBinding>;
   pendingSubagentPartEmissionsByExternalSessionId: Map<string, PendingSubagentPartEmission[]>;
   pendingSubagentInputEventsByExternalSessionId: Map<string, PendingSubagentInputEvent[]>;
+  pendingBackgroundTaskResultsByExternalSessionId: Map<string, PendingBackgroundTaskResult[]>;
   /** Cached workflow tool selection (toolId -> enabled). */
   workflowToolSelectionCache?: Record<string, boolean>;
   /** Timestamp when cache was last populated. */

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-assistant-subagents.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-assistant-subagents.test.ts
@@ -118,6 +118,7 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
 
     const sessionsRef = createSessionsRef([buildSession({ role: "build" })]);
     const updateSession = createSessionUpdater(sessionsRef);
+    const recordedActivityTimestamps: Array<string | number> = [];
 
     await listenToAgentSessionEvents({
       adapter,
@@ -125,6 +126,9 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
       externalSessionId: "session-1",
       sessionsRef,
       updateSession,
+      recordTurnActivityTimestamp: (_externalSessionId, timestamp) => {
+        recordedActivityTimestamps.push(timestamp);
+      },
       resolveTurnDurationMs: () => 300,
       clearTurnDuration: () => {},
       refreshTaskData: async () => {},
@@ -155,6 +159,7 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
     });
 
     expect(findSession(sessionsRef, "session-1")?.status).toBe("running");
+    expect(recordedActivityTimestamps).toEqual([Date.parse("2026-02-22T08:00:02.000Z")]);
 
     if (inactiveStatus === "idle") {
       handleEvent({
@@ -171,6 +176,26 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
     }
 
     expect(findSession(sessionsRef, "session-1")?.status).toBe(inactiveStatus);
+
+    handleEvent({
+      type: "assistant_part",
+      externalSessionId: "session-1",
+      timestamp: "2026-02-22T08:00:35.000Z",
+      part: {
+        kind: "subagent",
+        messageId: "assistant-background-task",
+        partId: "tool-background-task-running",
+        correlationKey: "part:assistant-background-task:subtask-background",
+        status: "running",
+        description: "Background task still running",
+        externalSessionId: "child-background-session",
+        executionMode: "background",
+        startedAtMs: Date.parse("2026-02-22T08:00:02.000Z"),
+      },
+    });
+
+    expect(findSession(sessionsRef, "session-1")?.status).toBe(inactiveStatus);
+    expect(recordedActivityTimestamps).toEqual([Date.parse("2026-02-22T08:00:02.000Z")]);
 
     handleEvent({
       type: "assistant_part",
@@ -198,6 +223,8 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
     }
     expect(subagentMessage.meta.status).toBe("completed");
     expect(subagentMessage.meta.externalSessionId).toBe("child-background-session");
+    expect(subagentMessage.meta.endedAtMs).toBe(Date.parse("2026-02-22T08:00:45.000Z"));
+    expect(recordedActivityTimestamps).toEqual([Date.parse("2026-02-22T08:00:02.000Z")]);
   });
 
   test("handles session start and assistant parts matrix", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-assistant-subagents.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-assistant-subagents.test.ts
@@ -100,6 +100,94 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
     expect(clearTurnDurationCalls).toBe(1);
   });
 
+  test("keeps an idle parent session idle when a background subagent completes late", async () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: async (_externalSessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyApproval: async () => {},
+    };
+
+    const sessionsRef = createSessionsRef([buildSession({ role: "build" })]);
+    const updateSession = createSessionUpdater(sessionsRef);
+
+    await listenToAgentSessionEvents({
+      adapter,
+      repoPath: "/tmp/repo",
+      externalSessionId: "session-1",
+      sessionsRef,
+      updateSession,
+      resolveTurnDurationMs: () => 300,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "assistant_part",
+      externalSessionId: "session-1",
+      timestamp: "2026-02-22T08:00:02.000Z",
+      part: {
+        kind: "subagent",
+        messageId: "assistant-background-task",
+        partId: "subtask-background",
+        correlationKey: "part:assistant-background-task:subtask-background",
+        status: "running",
+        agent: "fixer",
+        prompt: "Run build",
+        description: "Run build",
+        externalSessionId: "child-background-session",
+        executionMode: "background",
+        startedAtMs: Date.parse("2026-02-22T08:00:02.000Z"),
+      },
+    });
+
+    expect(findSession(sessionsRef, "session-1")?.status).toBe("running");
+
+    handleEvent({
+      type: "session_idle",
+      externalSessionId: "session-1",
+      timestamp: "2026-02-22T08:00:05.000Z",
+    });
+
+    expect(findSession(sessionsRef, "session-1")?.status).toBe("idle");
+
+    handleEvent({
+      type: "assistant_part",
+      externalSessionId: "session-1",
+      timestamp: "2026-02-22T08:00:45.000Z",
+      part: {
+        kind: "subagent",
+        messageId: "user-background-task-completed",
+        partId: "text-background-task-completed",
+        correlationKey: "part:assistant-background-task:subtask-background",
+        status: "completed",
+        description: "Background task completed: Run build",
+        externalSessionId: "child-background-session",
+        executionMode: "background",
+        endedAtMs: Date.parse("2026-02-22T08:00:45.000Z"),
+      },
+    });
+
+    expect(findSession(sessionsRef, "session-1")?.status).toBe("idle");
+    const subagentMessage = getSessionMessages(sessionsRef).find(
+      (message) => message.role === "system" && message.meta?.kind === "subagent",
+    );
+    if (subagentMessage?.meta?.kind !== "subagent") {
+      throw new Error("Expected subagent message with subagent meta");
+    }
+    expect(subagentMessage.meta.status).toBe("completed");
+    expect(subagentMessage.meta.externalSessionId).toBe("child-background-session");
+  });
+
   test("handles session start and assistant parts matrix", async () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     let refreshCalls = 0;

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-assistant-subagents.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-assistant-subagents.test.ts
@@ -100,7 +100,11 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
     expect(clearTurnDurationCalls).toBe(1);
   });
 
-  test("keeps an idle parent session idle when a background subagent completes late", async () => {
+  test.each([
+    "idle",
+    "stopped",
+    "error",
+  ] as const)("keeps an inactive parent session %s when a background subagent completes late", async (inactiveStatus) => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const adapter: SessionEventAdapter = {
       subscribeEvents: async (_externalSessionId, handler) => {
@@ -152,13 +156,21 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
 
     expect(findSession(sessionsRef, "session-1")?.status).toBe("running");
 
-    handleEvent({
-      type: "session_idle",
-      externalSessionId: "session-1",
-      timestamp: "2026-02-22T08:00:05.000Z",
-    });
+    if (inactiveStatus === "idle") {
+      handleEvent({
+        type: "session_status",
+        externalSessionId: "session-1",
+        status: { type: "idle" },
+        timestamp: "2026-02-22T08:00:05.000Z",
+      });
+    } else {
+      updateSession(getSession(sessionsRef), (current) => ({
+        ...current,
+        status: inactiveStatus,
+      }));
+    }
 
-    expect(findSession(sessionsRef, "session-1")?.status).toBe("idle");
+    expect(findSession(sessionsRef, "session-1")?.status).toBe(inactiveStatus);
 
     handleEvent({
       type: "assistant_part",
@@ -177,7 +189,7 @@ describe("agent-orchestrator session assistant and subagent updates", () => {
       },
     });
 
-    expect(findSession(sessionsRef, "session-1")?.status).toBe("idle");
+    expect(findSession(sessionsRef, "session-1")?.status).toBe(inactiveStatus);
     const subagentMessage = getSessionMessages(sessionsRef).find(
       (message) => message.role === "system" && message.meta?.kind === "subagent",
     );

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
@@ -22,13 +22,8 @@ const markSessionRunning = (context: SessionPartEventContext): void => {
   context.store.updateSession(context.session.identity, (current) => withRunningStatus(current));
 };
 
-const isTerminalBackgroundSubagentPart = (
-  part: Extract<SessionPart, { kind: "subagent" }>,
-): boolean => {
-  if (part.executionMode !== "background") {
-    return false;
-  }
-  return part.status === "completed" || part.status === "cancelled" || part.status === "error";
+const isBackgroundSubagentPart = (part: Extract<SessionPart, { kind: "subagent" }>): boolean => {
+  return part.executionMode === "background";
 };
 
 const isInactiveSessionStatus = (status: AgentSessionState["status"]): boolean => {
@@ -39,14 +34,14 @@ const shouldPreserveInactiveStatusForSubagentPart = (
   session: AgentSessionState,
   part: Extract<SessionPart, { kind: "subagent" }>,
 ): boolean => {
-  return isInactiveSessionStatus(session.status) && isTerminalBackgroundSubagentPart(part);
+  return isInactiveSessionStatus(session.status) && isBackgroundSubagentPart(part);
 };
 
 const shouldRecordPartAsTurnActivity = (
   context: SessionPartEventContext,
   part: SessionPart,
 ): boolean => {
-  if (part.kind !== "subagent" || !isTerminalBackgroundSubagentPart(part)) {
+  if (part.kind !== "subagent" || !isBackgroundSubagentPart(part)) {
     return true;
   }
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
@@ -22,6 +22,34 @@ const markSessionRunning = (context: SessionPartEventContext): void => {
   context.store.updateSession(context.session.identity, (current) => withRunningStatus(current));
 };
 
+const isTerminalBackgroundSubagentPart = (
+  part: Extract<SessionPart, { kind: "subagent" }>,
+): boolean => {
+  if (part.executionMode !== "background") {
+    return false;
+  }
+  return part.status === "completed" || part.status === "cancelled" || part.status === "error";
+};
+
+const shouldPreserveIdleForSubagentPart = (
+  session: AgentSessionState,
+  part: Extract<SessionPart, { kind: "subagent" }>,
+): boolean => {
+  return session.status === "idle" && isTerminalBackgroundSubagentPart(part);
+};
+
+const shouldRecordPartAsTurnActivity = (
+  context: SessionPartEventContext,
+  part: SessionPart,
+): boolean => {
+  if (part.kind !== "subagent" || !isTerminalBackgroundSubagentPart(part)) {
+    return true;
+  }
+
+  const current = context.store.readSession(context.session.identity);
+  return current?.status !== "idle";
+};
+
 const resolvePartModelSelection = (
   context: SessionPartEventContext,
   current: AgentSessionState,
@@ -210,9 +238,10 @@ const handleSubagentPart = (
       ...(typeof part.startedAtMs === "number" ? { startedAtMs: part.startedAtMs } : {}),
       ...(typeof part.endedAtMs === "number" ? { endedAtMs: part.endedAtMs } : {}),
     };
+    const status = shouldPreserveIdleForSubagentPart(prepared, part) ? prepared.status : "running";
     return {
       ...prepared,
-      status: "running",
+      status,
       messages: upsertSubagentMessage({
         owner: prepared,
         incomingMeta,
@@ -259,7 +288,7 @@ export const handleAssistantPart = (
   event: SessionPartEvent,
 ): void => {
   const part = event.part;
-  if (part.kind !== "step") {
+  if (part.kind !== "step" && shouldRecordPartAsTurnActivity(context, part)) {
     const activityTimestamp =
       (part.kind === "tool" || part.kind === "subagent") && typeof part.startedAtMs === "number"
         ? part.startedAtMs

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
@@ -46,6 +46,7 @@ const shouldRecordPartAsTurnActivity = (
   }
 
   const current = context.store.readSession(context.session.identity);
+  // If the live session is unavailable, keep the existing activity path because inactivity cannot be proven.
   return current ? !isInactiveSessionStatus(current.status) : true;
 };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-parts.ts
@@ -31,11 +31,15 @@ const isTerminalBackgroundSubagentPart = (
   return part.status === "completed" || part.status === "cancelled" || part.status === "error";
 };
 
-const shouldPreserveIdleForSubagentPart = (
+const isInactiveSessionStatus = (status: AgentSessionState["status"]): boolean => {
+  return status === "idle" || status === "stopped" || status === "error";
+};
+
+const shouldPreserveInactiveStatusForSubagentPart = (
   session: AgentSessionState,
   part: Extract<SessionPart, { kind: "subagent" }>,
 ): boolean => {
-  return session.status === "idle" && isTerminalBackgroundSubagentPart(part);
+  return isInactiveSessionStatus(session.status) && isTerminalBackgroundSubagentPart(part);
 };
 
 const shouldRecordPartAsTurnActivity = (
@@ -47,7 +51,7 @@ const shouldRecordPartAsTurnActivity = (
   }
 
   const current = context.store.readSession(context.session.identity);
-  return current?.status !== "idle";
+  return current ? !isInactiveSessionStatus(current.status) : true;
 };
 
 const resolvePartModelSelection = (
@@ -238,7 +242,9 @@ const handleSubagentPart = (
       ...(typeof part.startedAtMs === "number" ? { startedAtMs: part.startedAtMs } : {}),
       ...(typeof part.endedAtMs === "number" ? { endedAtMs: part.endedAtMs } : {}),
     };
-    const status = shouldPreserveIdleForSubagentPart(prepared, part) ? prepared.status : "running";
+    const status = shouldPreserveInactiveStatusForSubagentPart(prepared, part)
+      ? prepared.status
+      : "running";
     return {
       ...prepared,
       status,


### PR DESCRIPTION
## Summary

This PR fixes OpenCode background subagent handling so background task cards stay running while their child sessions are active, reconcile correctly when completion notifications arrive, and do not make an inactive parent session appear running again.

## Goal

OpenCode can dispatch background subagents whose parent tool part completes before the child session has finished. OpenDucktor was treating that parent tool completion as the subagent completion, which made active background work look done. Follow-up testing also exposed the opposite edge: once a background subagent completed and notified the parent, late terminal subagent updates could push an already idle, stopped, or errored parent session back to `running` until reload.

The goal is to reflect the real runtime state in both live streams and reconstructed history:

- Background subagents remain visibly running while OpenCode gives us an active background job or child session.
- Synthetic OpenCode background completion messages update the existing subagent row instead of creating a separate orphaned row.
- Parent session status remains terminal or inactive when late background subagent completion updates arrive after the parent turn has settled.

## Technical Choices

The adapter now treats OpenCode background task output as a small structured task-result block with a dedicated parser instead of broad XML regex matching. That parser only accepts the known `<task ...>` envelope, quoted task attributes, and the supported inline/block child elements needed for OpenCode background results.

Live event handling now emits subagent updates from synthetic background task result user-message parts, binding them through the same `externalSessionId` and correlation-key state used by normal subagent tool events. Tool parts that represent background jobs are kept in `running` state and have end timing omitted while the child job is still active.

History reconstruction now uses shared normalization state across sorted history entries. That keeps assistant subtask parts, child session links, and synthetic completion messages on the same canonical part-scoped correlation key, matching the live stream path.

On the frontend, terminal background subagent parts no longer automatically mark the parent session as running when the parent is already inactive (`idle`, `stopped`, or `error`). Those late terminal parts still update the subagent message row, but they no longer count as new parent-turn activity.

## Verification

- `rtk rg --files -g 'Cargo.toml'` found no Cargo manifests in this worktree, so Cargo checks are not applicable here.
- `rtk bun run lint`
- `rtk bun run test`
  - First sandboxed run failed because `@openducktor/build-tools` could not create temp directories under `/var/folders`.
  - Rerun with filesystem permissions passed.
- `rtk bun run typecheck`
- `rtk bun run build`

Notes:
- The root Bun test suite emits existing React multi-renderer warnings in transcript tests, but exits successfully.
- The root Bun build emits existing Vite chunk-size warnings, but exits successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved background task tracking for subagent updates, including running, completed, and error states.
  * Session history now retains background task context and completion timing across both assistant and user updates.

* **Bug Fixes**
  * Background tasks no longer show as finished while the child session is still active.
  * Late background task updates no longer incorrectly alter inactive parent session states.
  * Enhanced correlation and session linking for background task events to keep transcripts consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->