### PR TITLE
fix(codex): show tool call durations

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
@@ -1096,6 +1096,7 @@ describe("CodexAppServerAdapter history loading", () => {
 
   test("reuses todos discovered while loading Codex session history", async () => {
     const calls: CodexJsonRpcRequest[] = [];
+    const completedAtMs = Date.parse("2026-05-20T10:00:02.000Z");
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         calls.push(request);
@@ -1138,6 +1139,8 @@ describe("CodexAppServerAdapter history loading", () => {
                           { step: "Reuse todos", status: "inProgress" },
                         ],
                       },
+                      durationMs: 25,
+                      completedAtMs,
                     },
                   ],
                 },
@@ -1153,13 +1156,25 @@ describe("CodexAppServerAdapter history loading", () => {
     };
     const adapter = createAdapterWithTransport(transport);
 
-    await adapter.loadSessionHistory({
+    const history = await adapter.loadSessionHistory({
       repoPath: "/repo",
       runtimeKind: "codex",
       workingDirectory: "/repo",
       externalSessionId: "thread-history-todos",
     });
 
+    expect(history).toContainEqual(
+      expect.objectContaining({
+        messageId: "todo-call-1",
+        parts: [
+          expect.objectContaining({
+            kind: "tool",
+            startedAtMs: completedAtMs - 25,
+            endedAtMs: completedAtMs,
+          }),
+        ],
+      }),
+    );
     expect(calls.filter((call) => call.method === "thread/read")).toHaveLength(1);
     expect(calls.some((call) => call.method === "thread/resume")).toBe(false);
     calls.length = 0;

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -165,7 +165,7 @@ describe("CodexAppServerAdapter streaming", () => {
             completedAtMs: 1_777_766_402_500,
             item: {
               type: "commandExecution",
-              id: "cmd-failed-1",
+              id: "cmd-1",
               command: "bun test",
               cwd: "/repo",
               status: "failed",
@@ -338,10 +338,12 @@ describe("CodexAppServerAdapter streaming", () => {
         type: "assistant_part",
         part: expect.objectContaining({
           kind: "tool",
-          partId: "cmd-failed-1",
+          partId: "cmd-1",
           tool: "bash",
           toolType: "bash",
           status: "error",
+          startedAtMs: 1_777_766_401_000,
+          endedAtMs: 1_777_766_402_500,
           error: "exit code 1",
         }),
       }),

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -146,6 +146,15 @@ const consumeSyntheticUserMessage = (
 const normalizeSyntheticUserMessageText = (text: string): string =>
   text.replace(/\s+/g, " ").trim();
 
+const withLifecycleTimestamp = (
+  item: Record<string, unknown>,
+  key: "startedAtMs" | "completedAtMs",
+  timestamp: string,
+): Record<string, unknown> => {
+  const timestampMs = Date.parse(timestamp);
+  return Number.isFinite(timestampMs) ? { ...item, [key]: timestampMs } : item;
+};
+
 let lastAcceptedUserMessageTimestamp = 0;
 let acceptedUserMessageCounter = 0;
 
@@ -240,7 +249,7 @@ const emitStartedItem = (
     return;
   }
   const canonicalEvents = context.eventMapperPipeline.runLive(
-    { kind: "item_started", item },
+    { kind: "item_started", item: withLifecycleTimestamp(item, "startedAtMs", timestamp) },
     { source: "live", runtimeId: session.runtimeId, threadId: session.threadId, timestamp },
   );
   for (const event of projectCodexCanonicalEvents(canonicalEvents)) {
@@ -331,7 +340,7 @@ const emitCompletedItem = (
   }
 
   const canonicalEvents = context.eventMapperPipeline.runLive(
-    { kind: "item_completed", item },
+    { kind: "item_completed", item: withLifecycleTimestamp(item, "completedAtMs", timestamp) },
     {
       source: "live",
       runtimeId: session.runtimeId,

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -354,7 +354,11 @@ const emitCompletedItem = (
     return;
   }
 
-  const parts = toStreamPart(item, itemId, itemId);
+  const parts = toStreamPart(
+    withLifecycleTimestamp(item, "completedAtMs", timestamp),
+    itemId,
+    itemId,
+  );
   for (const part of parts) {
     emitCodexSessionEvent(context, session.threadId, {
       type: "assistant_part",

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -58,6 +58,7 @@ export type CodexStreamingContext = {
   drainNotifications?: (runtimeId: string) => Promise<unknown[]>;
   bufferedNotificationsByThreadId: Map<string, CodexNotificationRecord[]>;
   activeTurnsBySessionId: Map<string, ActiveCodexTurn>;
+  startedItemTimestampsByKey: Map<string, number>;
   syntheticUserMessageTextsByThreadId: Map<string, string[]>;
   completedAgentMessagesByTurnKey: Map<string, CompletedAgentMessage>;
   tokenUsageByTurnKey: Map<string, CodexTokenUsageTotals>;
@@ -155,6 +156,51 @@ const withLifecycleTimestamp = (
   return Number.isFinite(timestampMs) ? { ...item, [key]: timestampMs } : item;
 };
 
+const lifecycleItemKey = (
+  session: CodexSessionState,
+  item: Record<string, unknown>,
+): string | null => {
+  const itemId = extractStringField(item, ["id"]);
+  return itemId ? `${session.runtimeId}:${session.threadId}:${itemId}` : null;
+};
+
+const recordStartedItemTimestamp = (
+  context: CodexStreamingContext,
+  session: CodexSessionState,
+  item: Record<string, unknown>,
+  timestamp: string,
+): void => {
+  const itemKey = lifecycleItemKey(session, item);
+  if (!itemKey) {
+    return;
+  }
+  const startedAtMs = Date.parse(timestamp);
+  if (Number.isFinite(startedAtMs)) {
+    context.startedItemTimestampsByKey.set(itemKey, startedAtMs);
+  }
+};
+
+const withRecordedStartedItemTimestamp = (
+  context: CodexStreamingContext,
+  session: CodexSessionState,
+  item: Record<string, unknown>,
+): Record<string, unknown> => {
+  const itemKey = lifecycleItemKey(session, item);
+  if (!itemKey) {
+    return item;
+  }
+  const startedAtMs = context.startedItemTimestampsByKey.get(itemKey);
+  context.startedItemTimestampsByKey.delete(itemKey);
+  if (
+    typeof startedAtMs !== "number" ||
+    Object.hasOwn(item, "startedAtMs") ||
+    Object.hasOwn(item, "started_at_ms")
+  ) {
+    return item;
+  }
+  return { ...item, startedAtMs };
+};
+
 let lastAcceptedUserMessageTimestamp = 0;
 let acceptedUserMessageCounter = 0;
 
@@ -248,8 +294,10 @@ const emitStartedItem = (
   ) {
     return;
   }
+  const startedItem = withLifecycleTimestamp(item, "startedAtMs", timestamp);
+  recordStartedItemTimestamp(context, session, startedItem, timestamp);
   const canonicalEvents = context.eventMapperPipeline.runLive(
-    { kind: "item_started", item: withLifecycleTimestamp(item, "startedAtMs", timestamp) },
+    { kind: "item_started", item: startedItem },
     { source: "live", runtimeId: session.runtimeId, threadId: session.threadId, timestamp },
   );
   for (const event of projectCodexCanonicalEvents(canonicalEvents)) {
@@ -339,8 +387,13 @@ const emitCompletedItem = (
     return;
   }
 
+  const completedItem = withLifecycleTimestamp(
+    withRecordedStartedItemTimestamp(context, session, item),
+    "completedAtMs",
+    timestamp,
+  );
   const canonicalEvents = context.eventMapperPipeline.runLive(
-    { kind: "item_completed", item: withLifecycleTimestamp(item, "completedAtMs", timestamp) },
+    { kind: "item_completed", item: completedItem },
     {
       source: "live",
       runtimeId: session.runtimeId,
@@ -354,11 +407,7 @@ const emitCompletedItem = (
     return;
   }
 
-  const parts = toStreamPart(
-    withLifecycleTimestamp(item, "completedAtMs", timestamp),
-    itemId,
-    itemId,
-  );
+  const parts = toStreamPart(completedItem, itemId, itemId);
   for (const part of parts) {
     emitCodexSessionEvent(context, session.threadId, {
       type: "assistant_part",

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -5,6 +5,8 @@ import {
   timestampFromCodexTurn,
   toHistoryMessage,
 } from "./codex-app-server-transcript";
+import { projectCodexCanonicalEvents } from "./codex-canonical-projector";
+import { createCodexEventMapperPipeline } from "./codex-event-mapper-pipeline";
 import { codexUserInputListToText, toDisplayParts } from "./codex-user-input-display";
 import {
   codexUserInputsFromItem,
@@ -36,7 +38,7 @@ describe("Codex App Server transcript parsing", () => {
     ).toBeNull();
   });
 
-  test("derives tool timing from Codex duration and the existing item timestamp", () => {
+  test("does not derive tool timing from generic message timestamps", () => {
     const timestamp = "2026-05-07T00:00:10.000Z";
     const message = toHistoryMessage(
       {
@@ -57,12 +59,40 @@ describe("Codex App Server transcript parsing", () => {
     expect(message?.parts).toEqual([
       expect.objectContaining({
         kind: "tool",
-        startedAtMs: Date.parse(timestamp) - 8,
       }),
     ]);
     expect(message?.parts[0]).not.toEqual(
+      expect.objectContaining({ startedAtMs: expect.any(Number) }),
+    );
+    expect(message?.parts[0]).not.toEqual(
       expect.objectContaining({ endedAtMs: expect.any(Number) }),
     );
+  });
+
+  test("derives tool timing from Codex duration and explicit completion timestamp", () => {
+    const completedAtMs = Date.parse("2026-05-07T00:00:10.000Z");
+    const message = toHistoryMessage(
+      {
+        id: "tool-1",
+        type: "mcpToolCall",
+        server: "openducktor",
+        tool: "odt_read_task",
+        status: "completed",
+        arguments: { taskId: "task-1" },
+        result: { content: [{ type: "text", text: "ok" }] },
+        durationMs: 8,
+        completedAtMs,
+      },
+      "fallback-id",
+    );
+
+    expect(message?.parts).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        startedAtMs: completedAtMs - 8,
+        endedAtMs: completedAtMs,
+      }),
+    ]);
   });
 
   test("maps skill message parts to structured Codex skill input", () => {
@@ -873,6 +903,86 @@ describe("Codex App Server transcript parsing", () => {
 
     expect(items).toHaveLength(1);
     expect(items[0]?.model).toBeUndefined();
+  });
+
+  test("prefers item timestamp evidence over turn completion timestamps", () => {
+    const itemTimestampMs = Date.parse("2026-05-20T10:00:02.000Z");
+    const items = codexTurnItemsFromThreadRead({
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            startedAt: 1_779_270_000,
+            completedAt: 1_779_270_030,
+            items: [
+              {
+                id: "tool-1",
+                type: "mcpToolCall",
+                server: "openducktor",
+                tool: "odt_read_task",
+                status: "completed",
+                arguments: { taskId: "task-1" },
+                result: { content: [{ type: "text", text: "ok" }] },
+                timestampMs: itemTimestampMs,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(items[0]?.timestamp).toBe("2026-05-20T10:00:02.000Z");
+    expect(items[0]?.item).not.toEqual(
+      expect.objectContaining({ completedAtMs: expect.any(Number) }),
+    );
+  });
+
+  test("hydrates thread-read tool duration through the canonical event mapper path", () => {
+    const completedAtMs = Date.parse("2026-05-20T10:00:02.000Z");
+    const [threadItem] = codexTurnItemsFromThreadRead({
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            completedAt: 1_779_270_030,
+            items: [
+              {
+                id: "tool-1",
+                type: "mcpToolCall",
+                server: "openducktor",
+                tool: "odt_read_task",
+                status: "completed",
+                arguments: { taskId: "task-1" },
+                result: { content: [{ type: "text", text: "ok" }] },
+                durationMs: 8,
+                completedAtMs,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    if (!threadItem) {
+      throw new Error("Expected Codex thread item");
+    }
+
+    const events = projectCodexCanonicalEvents(
+      createCodexEventMapperPipeline().runThreadItem(
+        { item: threadItem.item, index: 0, timestamp: threadItem.timestamp ?? undefined },
+        { source: "thread_read", threadId: "thread-1" },
+      ),
+    );
+
+    const tool = events.find((event) => event.type === "assistant_part")?.part;
+    expect(tool).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        startedAtMs: completedAtMs - 8,
+        endedAtMs: completedAtMs,
+      }),
+    );
   });
 
   test("hydrates local images as attachment display parts", () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -19,6 +19,10 @@ describe("Codex App Server transcript parsing", () => {
     expect(timestampFromCodexParams({ timestampMs: 0 })).toBe("1970-01-01T00:00:00.000Z");
   });
 
+  test("ignores malformed notification timestamps instead of throwing", () => {
+    expect(timestampFromCodexParams({ timestampMs: Number.MAX_VALUE })).toBeNull();
+  });
+
   test("does not invent timestamps when notification params omit runtime timestamps", () => {
     expect(timestampFromCodexParams({})).toBeNull();
   });
@@ -936,6 +940,77 @@ describe("Codex App Server transcript parsing", () => {
     expect(items[0]?.item).not.toEqual(
       expect.objectContaining({ completedAtMs: expect.any(Number) }),
     );
+  });
+
+  test("ignores malformed item timestamp evidence instead of throwing", () => {
+    const items = codexTurnItemsFromThreadRead({
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            completedAt: 1,
+            items: [
+              {
+                id: "tool-1",
+                type: "mcpToolCall",
+                server: "openducktor",
+                tool: "odt_read_task",
+                status: "completed",
+                arguments: { taskId: "task-1" },
+                result: { content: [{ type: "text", text: "ok" }] },
+                timestampMs: Number.MAX_VALUE,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(items[0]?.timestamp).toBe("1970-01-01T00:00:01.000Z");
+  });
+
+  test("does not hydrate start-only tool timing from item display timestamps", () => {
+    const timestampMs = Date.parse("2026-05-20T10:00:02.000Z");
+    const [threadItem] = codexTurnItemsFromThreadRead({
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            completedAt: 1_779_270_030,
+            items: [
+              {
+                id: "tool-1",
+                type: "mcpToolCall",
+                server: "openducktor",
+                tool: "odt_read_task",
+                status: "completed",
+                arguments: { taskId: "task-1" },
+                result: { content: [{ type: "text", text: "ok" }] },
+                startedAtMs: timestampMs - 1000,
+                timestampMs,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    if (!threadItem) {
+      throw new Error("Expected Codex thread item");
+    }
+
+    const events = projectCodexCanonicalEvents(
+      createCodexEventMapperPipeline().runThreadItem(
+        { item: threadItem.item, index: 0, timestamp: threadItem.timestamp ?? undefined },
+        { source: "thread_read", threadId: "thread-1" },
+      ),
+    );
+
+    const tool = events.find((event) => event.type === "assistant_part")?.part;
+    expect(tool).toEqual(expect.objectContaining({ kind: "tool" }));
+    expect(tool).not.toEqual(expect.objectContaining({ startedAtMs: expect.any(Number) }));
+    expect(tool).not.toEqual(expect.objectContaining({ endedAtMs: expect.any(Number) }));
   });
 
   test("hydrates thread-read tool duration through the canonical event mapper path", () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.test.ts
@@ -36,6 +36,35 @@ describe("Codex App Server transcript parsing", () => {
     ).toBeNull();
   });
 
+  test("derives tool timing from Codex duration and the existing item timestamp", () => {
+    const timestamp = "2026-05-07T00:00:10.000Z";
+    const message = toHistoryMessage(
+      {
+        id: "tool-1",
+        type: "mcpToolCall",
+        server: "openducktor",
+        tool: "odt_read_task",
+        status: "completed",
+        arguments: { taskId: "task-1" },
+        result: { content: [{ type: "text", text: "ok" }] },
+        durationMs: 8,
+      },
+      "fallback-id",
+      undefined,
+      timestamp,
+    );
+
+    expect(message?.parts).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        startedAtMs: Date.parse(timestamp) - 8,
+      }),
+    ]);
+    expect(message?.parts[0]).not.toEqual(
+      expect.objectContaining({ endedAtMs: expect.any(Number) }),
+    );
+  });
+
   test("maps skill message parts to structured Codex skill input", () => {
     const skill = {
       id: "/skills/review/SKILL.md",

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -196,6 +196,14 @@ const selectCodexFinalAgentMessage = (
   );
 };
 
+const withCompletedAtMs = (
+  item: Record<string, unknown>,
+  timestamp: string,
+): Record<string, unknown> => {
+  const completedAtMs = Date.parse(timestamp);
+  return Number.isFinite(completedAtMs) ? { ...item, completedAtMs } : item;
+};
+
 export const shouldReplaceCodexBufferedFinalAgentMessage = (
   current: Record<string, unknown>,
   next: Record<string, unknown>,
@@ -322,7 +330,7 @@ export const toHistoryMessage = (
       ...(model ? { model } : {}),
     };
   }
-  const parts = toStreamPart(item, messageId, messageId);
+  const parts = toStreamPart(withCompletedAtMs(item, messageTimestamp), messageId, messageId);
   if (parts.length > 0) {
     return {
       messageId,

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -35,96 +35,22 @@ import {
   statusFromCodexStatus,
 } from "./codex-tool-normalizer";
 import {
+  type CodexToolTimingOptions,
+  codexItemTimestamp,
+  codexToolTimingFields,
+  safeCodexTimestampFromMilliseconds,
+  withCodexItemCompletedAtMs,
+} from "./codex-tool-timing";
+import {
   codexUserInputListToText,
   codexUserInputsToDisplayParts,
 } from "./codex-user-input-display";
 import { codexUserInputsFromItem } from "./codex-user-inputs";
 import { type CodexTodoUpdate, codexTodosFromThreadRead, todoMapper } from "./event-mappers";
 
-const CODEX_DURATION_MS_KEYS = ["durationMs", "duration_ms"];
-const CODEX_STARTED_MS_KEYS = ["startedAtMs", "started_at_ms"];
-const CODEX_ENDED_MS_KEYS = ["endedAtMs", "ended_at_ms"];
-const CODEX_COMPLETED_MS_KEYS = ["completedAtMs", "completed_at_ms"];
-const CODEX_COMPLETION_MS_KEYS = [...CODEX_COMPLETED_MS_KEYS, ...CODEX_ENDED_MS_KEYS];
-const CODEX_COMPLETION_STRING_KEYS = ["completedAt", "completed_at", "endedAt", "ended_at"];
-const CODEX_DISPLAY_TIMESTAMP_MS_KEYS = [
-  "timestampMs",
-  "timestamp_ms",
-  "occurredAtMs",
-  "occurred_at_ms",
-];
-const CODEX_DISPLAY_TIMESTAMP_STRING_KEYS = [
-  "timestamp",
-  "createdAt",
-  "created_at",
-  "startedAt",
-  "started_at",
-];
-
 export type CodexTokenUsageTotals = {
   totalTokens: number;
   contextWindow?: number;
-};
-
-const extractOptionalFiniteNumberField = (
-  value: Record<string, unknown>,
-  keys: string[],
-  label: string,
-): number | null => {
-  for (const key of keys) {
-    if (!Object.hasOwn(value, key)) {
-      continue;
-    }
-    const candidate = value[key];
-    if (candidate === null || candidate === undefined) {
-      return null;
-    }
-    if (typeof candidate === "number" && Number.isFinite(candidate)) {
-      return candidate;
-    }
-    throw new Error(`Codex tool ${label} must be a finite number when present.`);
-  }
-  return null;
-};
-
-const hasOwnField = (value: Record<string, unknown>, keys: string[]): boolean =>
-  keys.some((key) => Object.hasOwn(value, key));
-
-const codexToolTimingFields = (
-  value: Record<string, unknown>,
-): Pick<NormalizedCodexToolInvocation, "startedAtMs" | "endedAtMs"> => {
-  const durationMs = extractOptionalFiniteNumberField(value, CODEX_DURATION_MS_KEYS, "durationMs");
-  const explicitStartedAtMs = extractOptionalFiniteNumberField(
-    value,
-    CODEX_STARTED_MS_KEYS,
-    "startedAtMs",
-  );
-  const explicitEndedAtMs = extractOptionalFiniteNumberField(
-    value,
-    CODEX_ENDED_MS_KEYS,
-    "endedAtMs",
-  );
-  const completedAtMs = extractOptionalFiniteNumberField(
-    value,
-    CODEX_COMPLETED_MS_KEYS,
-    "completedAtMs",
-  );
-  const endedAtMs =
-    explicitEndedAtMs ??
-    completedAtMs ??
-    (typeof explicitStartedAtMs === "number" && typeof durationMs === "number"
-      ? explicitStartedAtMs + durationMs
-      : null);
-  const startedAtMs =
-    explicitStartedAtMs ??
-    (typeof durationMs === "number" && typeof endedAtMs === "number"
-      ? Math.max(0, endedAtMs - durationMs)
-      : null);
-
-  return {
-    ...(typeof startedAtMs === "number" ? { startedAtMs } : {}),
-    ...(typeof endedAtMs === "number" ? { endedAtMs } : {}),
-  };
 };
 
 export type CodexTurnTiming = {
@@ -159,7 +85,7 @@ export const timestampFromCodexParams = (params: unknown): string | null => {
     "startedAtMs",
     "started_at_ms",
   ]);
-  return millis !== null ? new Date(millis).toISOString() : null;
+  return safeCodexTimestampFromMilliseconds(millis);
 };
 
 const codexTimestampFromSeconds = (seconds: number | null): string | undefined => {
@@ -256,57 +182,6 @@ const selectCodexFinalAgentMessage = (
   );
 };
 
-const parseCodexTimestampString = (timestamp: string | null | undefined): number | null => {
-  if (!timestamp) {
-    return null;
-  }
-  const parsed = Date.parse(timestamp);
-  return Number.isFinite(parsed) ? parsed : null;
-};
-
-const codexItemCompletedAtMs = (item: Record<string, unknown>): number | null => {
-  const millis = extractNumberField(item, CODEX_COMPLETION_MS_KEYS);
-  if (millis !== null) {
-    return millis;
-  }
-
-  const timestamp = extractStringField(item, CODEX_COMPLETION_STRING_KEYS);
-  return parseCodexTimestampString(timestamp);
-};
-
-const codexItemTimestampMs = (item: Record<string, unknown>): number | null => {
-  const completionTimestamp = codexItemCompletedAtMs(item);
-  if (completionTimestamp !== null) {
-    return completionTimestamp;
-  }
-
-  const itemTimestampMs = extractNumberField(item, CODEX_DISPLAY_TIMESTAMP_MS_KEYS);
-  if (itemTimestampMs !== null) {
-    return itemTimestampMs;
-  }
-
-  const startedAtMs = extractNumberField(item, CODEX_STARTED_MS_KEYS);
-  if (startedAtMs !== null) {
-    return startedAtMs;
-  }
-
-  const timestamp = extractStringField(item, CODEX_DISPLAY_TIMESTAMP_STRING_KEYS);
-  return parseCodexTimestampString(timestamp);
-};
-
-const codexItemTimestamp = (item: Record<string, unknown>): string | null => {
-  const millis = codexItemTimestampMs(item);
-  return millis !== null ? new Date(millis).toISOString() : null;
-};
-
-const withItemCompletedAtMs = (item: Record<string, unknown>): Record<string, unknown> => {
-  if (hasOwnField(item, CODEX_COMPLETION_MS_KEYS)) {
-    return item;
-  }
-  const completedAtMs = codexItemCompletedAtMs(item);
-  return completedAtMs !== null ? { ...item, completedAtMs } : item;
-};
-
 export const shouldReplaceCodexBufferedFinalAgentMessage = (
   current: Record<string, unknown>,
   next: Record<string, unknown>,
@@ -363,7 +238,7 @@ export const codexTurnItemsFromThreadRead = (value: unknown): CodexThreadReadIte
       const timestamp =
         codexItemTimestamp(item) ?? codexTimestampFromSeconds(timestampSeconds) ?? null;
       return {
-        item: withItemCompletedAtMs(item),
+        item: withCodexItemCompletedAtMs(item),
         turnId,
         timestamp,
         isFinalAgentMessage: itemIsFinalAgentMessage,
@@ -434,7 +309,7 @@ export const toHistoryMessage = (
       ...(model ? { model } : {}),
     };
   }
-  const parts = toStreamPart(withItemCompletedAtMs(item), messageId, messageId);
+  const parts = toStreamPart(withCodexItemCompletedAtMs(item), messageId, messageId);
   if (parts.length > 0) {
     return {
       messageId,
@@ -779,6 +654,7 @@ const codexCommandExecutionStreamParts = (
   value: Record<string, unknown>,
   messageId: string,
   partId: string,
+  timingOptions?: CodexToolTimingOptions,
 ): AgentStreamPart[] => {
   const command = codexCommandText(value.command) ?? "command";
   const cwd = extractStringField(value, ["cwd"]);
@@ -789,7 +665,7 @@ const codexCommandExecutionStreamParts = (
   const explicitError = stringifyJsonValue(value.error);
   const status = statusFromCodexStatus(value.status);
   const error = explicitError ?? (status === "error" ? output : null);
-  const timing = codexToolTimingFields(value);
+  const timing = codexToolTimingFields(value, timingOptions);
 
   return normalizedCodexToolPart({
     messageId,
@@ -843,6 +719,7 @@ const codexMcpToolCallStreamParts = (
   value: Record<string, unknown>,
   messageId: string,
   partId: string,
+  timingOptions?: CodexToolTimingOptions,
 ): AgentStreamPart[] => {
   const server = extractStringField(value, ["server"]);
   const tool = extractStringField(value, ["tool"]) ?? "mcp_tool";
@@ -858,7 +735,7 @@ const codexMcpToolCallStreamParts = (
     ...(args ? { input: args } : {}),
     output: error ? null : output,
     error,
-    ...codexToolTimingFields(value),
+    ...codexToolTimingFields(value, timingOptions),
     metadata: { codexItem: value, ...(server ? { server } : {}) },
   });
 };
@@ -898,13 +775,14 @@ const codexDynamicToolCallStreamParts = (
   value: Record<string, unknown>,
   messageId: string,
   partId: string,
+  timingOptions?: CodexToolTimingOptions,
 ): AgentStreamPart[] => {
   const todoResult = todoMapper.fromThreadItemObject(value, {
     source: "thread_read",
     threadId: messageId,
   });
   if (todoResult.handled) {
-    const timing = codexToolTimingFields(value);
+    const timing = codexToolTimingFields(value, timingOptions);
     return projectCodexCanonicalEvents(todoResult.events).flatMap((event) =>
       event.type === "assistant_part"
         ? [event.part.kind === "tool" ? { ...event.part, ...timing } : event.part]
@@ -941,7 +819,7 @@ const codexDynamicToolCallStreamParts = (
     output: failed ? null : patch ? patchOutput : output,
     error: error ?? (failed ? output : null),
     fileDiffs,
-    ...codexToolTimingFields(value),
+    ...codexToolTimingFields(value, timingOptions),
     metadata: { codexItem: value },
   });
 };
@@ -950,6 +828,7 @@ const codexWebSearchStreamParts = (
   value: Record<string, unknown>,
   messageId: string,
   partId: string,
+  timingOptions?: CodexToolTimingOptions,
 ): AgentStreamPart[] => {
   const input = webSearchInput(value);
   const output = stringifyJsonValue(
@@ -964,7 +843,7 @@ const codexWebSearchStreamParts = (
     ...(input ? { input } : {}),
     ...(output ? { output } : {}),
     ...(input ? { preview: Object.values(input).join(" ") } : {}),
-    ...codexToolTimingFields(value),
+    ...codexToolTimingFields(value, timingOptions),
     metadata: { codexItem: value },
   });
 };
@@ -973,6 +852,7 @@ export const toStreamPart = (
   value: Record<string, unknown>,
   messageId: string,
   fallbackPartId: string,
+  timingOptions?: CodexToolTimingOptions,
 ): AgentStreamPart[] => {
   const partId = codexItemId(value, fallbackPartId);
   if (codexItemTypeMatches(value, "reasoning")) {
@@ -982,13 +862,13 @@ export const toStreamPart = (
     return codexPlanStreamParts(value, messageId, partId);
   }
   if (codexItemTypeMatches(value, "commandExecution")) {
-    return codexCommandExecutionStreamParts(value, messageId, partId);
+    return codexCommandExecutionStreamParts(value, messageId, partId, timingOptions);
   }
   if (codexItemTypeMatches(value, "fileChange")) {
     return codexFileChangeStreamParts(value, messageId, partId);
   }
   if (codexItemTypeMatches(value, "mcpToolCall")) {
-    return codexMcpToolCallStreamParts(value, messageId, partId);
+    return codexMcpToolCallStreamParts(value, messageId, partId, timingOptions);
   }
   if (
     codexItemTypeMatches(value, "collabAgentToolCall") ||
@@ -997,10 +877,10 @@ export const toStreamPart = (
     return codexCollabAgentToolCallStreamParts(value, messageId, partId);
   }
   if (codexItemTypeMatches(value, "dynamicToolCall")) {
-    return codexDynamicToolCallStreamParts(value, messageId, partId);
+    return codexDynamicToolCallStreamParts(value, messageId, partId, timingOptions);
   }
   if (codexItemTypeMatches(value, "webSearch")) {
-    return codexWebSearchStreamParts(value, messageId, partId);
+    return codexWebSearchStreamParts(value, messageId, partId, timingOptions);
   }
   return [];
 };

--- a/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-transcript.ts
@@ -41,6 +41,26 @@ import {
 import { codexUserInputsFromItem } from "./codex-user-inputs";
 import { type CodexTodoUpdate, codexTodosFromThreadRead, todoMapper } from "./event-mappers";
 
+const CODEX_DURATION_MS_KEYS = ["durationMs", "duration_ms"];
+const CODEX_STARTED_MS_KEYS = ["startedAtMs", "started_at_ms"];
+const CODEX_ENDED_MS_KEYS = ["endedAtMs", "ended_at_ms"];
+const CODEX_COMPLETED_MS_KEYS = ["completedAtMs", "completed_at_ms"];
+const CODEX_COMPLETION_MS_KEYS = [...CODEX_COMPLETED_MS_KEYS, ...CODEX_ENDED_MS_KEYS];
+const CODEX_COMPLETION_STRING_KEYS = ["completedAt", "completed_at", "endedAt", "ended_at"];
+const CODEX_DISPLAY_TIMESTAMP_MS_KEYS = [
+  "timestampMs",
+  "timestamp_ms",
+  "occurredAtMs",
+  "occurred_at_ms",
+];
+const CODEX_DISPLAY_TIMESTAMP_STRING_KEYS = [
+  "timestamp",
+  "createdAt",
+  "created_at",
+  "startedAt",
+  "started_at",
+];
+
 export type CodexTokenUsageTotals = {
   totalTokens: number;
   contextWindow?: number;
@@ -62,9 +82,49 @@ const extractOptionalFiniteNumberField = (
     if (typeof candidate === "number" && Number.isFinite(candidate)) {
       return candidate;
     }
-    throw new Error(`Codex commandExecution ${label} must be a finite number when present.`);
+    throw new Error(`Codex tool ${label} must be a finite number when present.`);
   }
   return null;
+};
+
+const hasOwnField = (value: Record<string, unknown>, keys: string[]): boolean =>
+  keys.some((key) => Object.hasOwn(value, key));
+
+const codexToolTimingFields = (
+  value: Record<string, unknown>,
+): Pick<NormalizedCodexToolInvocation, "startedAtMs" | "endedAtMs"> => {
+  const durationMs = extractOptionalFiniteNumberField(value, CODEX_DURATION_MS_KEYS, "durationMs");
+  const explicitStartedAtMs = extractOptionalFiniteNumberField(
+    value,
+    CODEX_STARTED_MS_KEYS,
+    "startedAtMs",
+  );
+  const explicitEndedAtMs = extractOptionalFiniteNumberField(
+    value,
+    CODEX_ENDED_MS_KEYS,
+    "endedAtMs",
+  );
+  const completedAtMs = extractOptionalFiniteNumberField(
+    value,
+    CODEX_COMPLETED_MS_KEYS,
+    "completedAtMs",
+  );
+  const endedAtMs =
+    explicitEndedAtMs ??
+    completedAtMs ??
+    (typeof explicitStartedAtMs === "number" && typeof durationMs === "number"
+      ? explicitStartedAtMs + durationMs
+      : null);
+  const startedAtMs =
+    explicitStartedAtMs ??
+    (typeof durationMs === "number" && typeof endedAtMs === "number"
+      ? Math.max(0, endedAtMs - durationMs)
+      : null);
+
+  return {
+    ...(typeof startedAtMs === "number" ? { startedAtMs } : {}),
+    ...(typeof endedAtMs === "number" ? { endedAtMs } : {}),
+  };
 };
 
 export type CodexTurnTiming = {
@@ -196,12 +256,55 @@ const selectCodexFinalAgentMessage = (
   );
 };
 
-const withCompletedAtMs = (
-  item: Record<string, unknown>,
-  timestamp: string,
-): Record<string, unknown> => {
-  const completedAtMs = Date.parse(timestamp);
-  return Number.isFinite(completedAtMs) ? { ...item, completedAtMs } : item;
+const parseCodexTimestampString = (timestamp: string | null | undefined): number | null => {
+  if (!timestamp) {
+    return null;
+  }
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const codexItemCompletedAtMs = (item: Record<string, unknown>): number | null => {
+  const millis = extractNumberField(item, CODEX_COMPLETION_MS_KEYS);
+  if (millis !== null) {
+    return millis;
+  }
+
+  const timestamp = extractStringField(item, CODEX_COMPLETION_STRING_KEYS);
+  return parseCodexTimestampString(timestamp);
+};
+
+const codexItemTimestampMs = (item: Record<string, unknown>): number | null => {
+  const completionTimestamp = codexItemCompletedAtMs(item);
+  if (completionTimestamp !== null) {
+    return completionTimestamp;
+  }
+
+  const itemTimestampMs = extractNumberField(item, CODEX_DISPLAY_TIMESTAMP_MS_KEYS);
+  if (itemTimestampMs !== null) {
+    return itemTimestampMs;
+  }
+
+  const startedAtMs = extractNumberField(item, CODEX_STARTED_MS_KEYS);
+  if (startedAtMs !== null) {
+    return startedAtMs;
+  }
+
+  const timestamp = extractStringField(item, CODEX_DISPLAY_TIMESTAMP_STRING_KEYS);
+  return parseCodexTimestampString(timestamp);
+};
+
+const codexItemTimestamp = (item: Record<string, unknown>): string | null => {
+  const millis = codexItemTimestampMs(item);
+  return millis !== null ? new Date(millis).toISOString() : null;
+};
+
+const withItemCompletedAtMs = (item: Record<string, unknown>): Record<string, unknown> => {
+  if (hasOwnField(item, CODEX_COMPLETION_MS_KEYS)) {
+    return item;
+  }
+  const completedAtMs = codexItemCompletedAtMs(item);
+  return completedAtMs !== null ? { ...item, completedAtMs } : item;
 };
 
 export const shouldReplaceCodexBufferedFinalAgentMessage = (
@@ -257,9 +360,10 @@ export const codexTurnItemsFromThreadRead = (value: unknown): CodexThreadReadIte
       } else {
         timestampSeconds = completedAtSeconds ?? startedAtSeconds;
       }
-      const timestamp = codexTimestampFromSeconds(timestampSeconds) ?? null;
+      const timestamp =
+        codexItemTimestamp(item) ?? codexTimestampFromSeconds(timestampSeconds) ?? null;
       return {
-        item,
+        item: withItemCompletedAtMs(item),
         turnId,
         timestamp,
         isFinalAgentMessage: itemIsFinalAgentMessage,
@@ -330,7 +434,7 @@ export const toHistoryMessage = (
       ...(model ? { model } : {}),
     };
   }
-  const parts = toStreamPart(withCompletedAtMs(item, messageTimestamp), messageId, messageId);
+  const parts = toStreamPart(withItemCompletedAtMs(item), messageId, messageId);
   if (parts.length > 0) {
     return {
       messageId,
@@ -685,20 +789,7 @@ const codexCommandExecutionStreamParts = (
   const explicitError = stringifyJsonValue(value.error);
   const status = statusFromCodexStatus(value.status);
   const error = explicitError ?? (status === "error" ? output : null);
-  const startedAtMs = extractOptionalFiniteNumberField(
-    value,
-    ["startedAtMs", "started_at_ms"],
-    "startedAtMs",
-  );
-  const durationMs = extractOptionalFiniteNumberField(
-    value,
-    ["durationMs", "duration_ms"],
-    "durationMs",
-  );
-  const endedAtMs =
-    typeof startedAtMs === "number" && typeof durationMs === "number"
-      ? startedAtMs + durationMs
-      : null;
+  const timing = codexToolTimingFields(value);
 
   return normalizedCodexToolPart({
     messageId,
@@ -710,8 +801,7 @@ const codexCommandExecutionStreamParts = (
     input,
     output,
     error,
-    ...(typeof startedAtMs === "number" ? { startedAtMs } : {}),
-    ...(typeof endedAtMs === "number" ? { endedAtMs } : {}),
+    ...timing,
     metadata: { codexItem: value },
   });
 };
@@ -768,6 +858,7 @@ const codexMcpToolCallStreamParts = (
     ...(args ? { input: args } : {}),
     output: error ? null : output,
     error,
+    ...codexToolTimingFields(value),
     metadata: { codexItem: value, ...(server ? { server } : {}) },
   });
 };
@@ -813,8 +904,11 @@ const codexDynamicToolCallStreamParts = (
     threadId: messageId,
   });
   if (todoResult.handled) {
+    const timing = codexToolTimingFields(value);
     return projectCodexCanonicalEvents(todoResult.events).flatMap((event) =>
-      event.type === "assistant_part" ? [event.part] : [],
+      event.type === "assistant_part"
+        ? [event.part.kind === "tool" ? { ...event.part, ...timing } : event.part]
+        : [],
     );
   }
 
@@ -847,6 +941,7 @@ const codexDynamicToolCallStreamParts = (
     output: failed ? null : patch ? patchOutput : output,
     error: error ?? (failed ? output : null),
     fileDiffs,
+    ...codexToolTimingFields(value),
     metadata: { codexItem: value },
   });
 };
@@ -869,6 +964,7 @@ const codexWebSearchStreamParts = (
     ...(input ? { input } : {}),
     ...(output ? { output } : {}),
     ...(input ? { preview: Object.values(input).join(" ") } : {}),
+    ...codexToolTimingFields(value),
     metadata: { codexItem: value },
   });
 };

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -98,6 +98,7 @@ export class CodexRuntimeSessionEvents {
   private readonly completedAgentMessagesByTurnKey = new Map<string, CompletedAgentMessage>();
   private readonly tokenUsageByTurnKey = new Map<string, CodexTokenUsageTotals>();
   private readonly modelByTurnKey = new Map<string, AgentModelSelection>();
+  private readonly startedItemTimestampsByKey = new Map<string, number>();
   private readonly latestTodosBySessionId = new Map<string, AgentSessionTodoItem[]>();
   private readonly restoredContextCapturesByKey = new Map<string, RestoredContextCapture>();
   private readonly bufferedResolvedServerRequestIdsByThreadId = new Map<
@@ -737,6 +738,7 @@ export class CodexRuntimeSessionEvents {
       ...(this.deps.drainNotifications ? { drainNotifications: this.deps.drainNotifications } : {}),
       bufferedNotificationsByThreadId: this.runtimeEventBuffer.notificationsByThreadId,
       activeTurnsBySessionId: this.deps.activeTurnsBySessionId,
+      startedItemTimestampsByKey: this.startedItemTimestampsByKey,
       syntheticUserMessageTextsByThreadId: this.syntheticUserMessageTextsByThreadId,
       completedAgentMessagesByTurnKey: this.completedAgentMessagesByTurnKey,
       tokenUsageByTurnKey: this.tokenUsageByTurnKey,

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
@@ -459,6 +459,26 @@ function AuthConsumer() {}
     );
   });
 
+  test("keeps start-only timing only when the live start path opts in", () => {
+    const item = {
+      type: "commandExecution",
+      id: "cmd-1",
+      command: "true",
+      cwd: "/repo",
+      status: "running",
+      commandActions: [],
+      aggregatedOutput: "",
+      startedAtMs: 1000,
+    };
+
+    expect(toStreamPart(item, "message-history", "cmd-1")[0]).not.toEqual(
+      expect.objectContaining({ startedAtMs: expect.any(Number) }),
+    );
+    expect(toStreamPart(item, "message-live", "cmd-1", { allowStartedAtOnly: true })[0]).toEqual(
+      expect.objectContaining({ startedAtMs: 1000 }),
+    );
+  });
+
   test("rejects malformed command timing fields when Codex provides them", () => {
     expect(() =>
       toStreamPart(

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.test.ts
@@ -475,7 +475,7 @@ function AuthConsumer() {}
         "message-live",
         "cmd-1",
       ),
-    ).toThrow("Codex commandExecution durationMs must be a finite number when present.");
+    ).toThrow("Codex tool durationMs must be a finite number when present.");
   });
 
   test("uses Codex web search action details when top-level query is absent", () => {

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.ts
@@ -303,9 +303,19 @@ export const normalizeCodexToolInvocation = ({
   const resolvedError = error && error.trim().length > 0 ? error : null;
   const resolvedOutput = output && output.trim().length > 0 ? output : null;
   const resolvedPreview = preview ?? toolPreviewFromInput(toolType, resolvedInput);
+  const item = isPlainObject(metadata?.codexItem) ? metadata.codexItem : {};
+  const durationMs = typeof item.durationMs === "number" ? item.durationMs : item.duration_ms;
+  const endedAtMs = typeof item.endedAtMs === "number" ? item.endedAtMs : item.completedAtMs;
+  const startedAtMs =
+    typeof item.startedAtMs === "number"
+      ? item.startedAtMs
+      : typeof durationMs === "number" && typeof endedAtMs === "number"
+        ? endedAtMs - durationMs
+        : undefined;
   return {
     kind: "tool",
     ...ids,
+    ...(typeof startedAtMs === "number" ? { startedAtMs } : {}),
     tool,
     toolType,
     title: title ?? defaultTitle(tool),

--- a/packages/adapters-codex-app-server/src/codex-tool-normalizer.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-normalizer.ts
@@ -12,6 +12,7 @@ import {
   readPathFromCommand,
   searchInputFromCommand,
 } from "./codex-app-server-shared";
+import { codexToolTimingFields } from "./codex-tool-timing";
 
 /**
  * Canonical boundary for raw Codex tool invocations.
@@ -304,18 +305,11 @@ export const normalizeCodexToolInvocation = ({
   const resolvedOutput = output && output.trim().length > 0 ? output : null;
   const resolvedPreview = preview ?? toolPreviewFromInput(toolType, resolvedInput);
   const item = isPlainObject(metadata?.codexItem) ? metadata.codexItem : {};
-  const durationMs = typeof item.durationMs === "number" ? item.durationMs : item.duration_ms;
-  const endedAtMs = typeof item.endedAtMs === "number" ? item.endedAtMs : item.completedAtMs;
-  const startedAtMs =
-    typeof item.startedAtMs === "number"
-      ? item.startedAtMs
-      : typeof durationMs === "number" && typeof endedAtMs === "number"
-        ? endedAtMs - durationMs
-        : undefined;
+  const metadataTiming = codexToolTimingFields(item);
   return {
     kind: "tool",
+    ...metadataTiming,
     ...ids,
-    ...(typeof startedAtMs === "number" ? { startedAtMs } : {}),
     tool,
     toolType,
     title: title ?? defaultTitle(tool),

--- a/packages/adapters-codex-app-server/src/codex-tool-timing.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-timing.ts
@@ -70,7 +70,7 @@ const parseCodexTimestampString = (timestamp: string | null | undefined): number
   return Number.isFinite(parsed) ? parsed : null;
 };
 
-export const codexItemCompletedAtMs = (item: Record<string, unknown>): number | null => {
+const codexItemCompletedAtMs = (item: Record<string, unknown>): number | null => {
   const millis = extractNumberField(item, CODEX_COMPLETION_MS_KEYS);
   if (millis !== null) {
     return millis;

--- a/packages/adapters-codex-app-server/src/codex-tool-timing.ts
+++ b/packages/adapters-codex-app-server/src/codex-tool-timing.ts
@@ -1,0 +1,156 @@
+import type { AgentStreamPart } from "@openducktor/core";
+import { extractNumberField, extractStringField } from "./codex-app-server-shared";
+
+const CODEX_DURATION_MS_KEYS = ["durationMs", "duration_ms"];
+const CODEX_STARTED_MS_KEYS = ["startedAtMs", "started_at_ms"];
+const CODEX_ENDED_MS_KEYS = ["endedAtMs", "ended_at_ms"];
+const CODEX_COMPLETED_MS_KEYS = ["completedAtMs", "completed_at_ms"];
+const CODEX_COMPLETION_MS_KEYS = [...CODEX_COMPLETED_MS_KEYS, ...CODEX_ENDED_MS_KEYS];
+const CODEX_COMPLETION_STRING_KEYS = ["completedAt", "completed_at", "endedAt", "ended_at"];
+const CODEX_DISPLAY_TIMESTAMP_MS_KEYS = [
+  "timestampMs",
+  "timestamp_ms",
+  "occurredAtMs",
+  "occurred_at_ms",
+];
+const CODEX_DISPLAY_TIMESTAMP_STRING_KEYS = [
+  "timestamp",
+  "createdAt",
+  "created_at",
+  "startedAt",
+  "started_at",
+];
+
+export type CodexToolTimingFields = Pick<
+  Extract<AgentStreamPart, { kind: "tool" }>,
+  "startedAtMs" | "endedAtMs"
+>;
+
+export type CodexToolTimingOptions = {
+  allowStartedAtOnly?: boolean;
+};
+
+const hasOwnField = (value: Record<string, unknown>, keys: string[]): boolean =>
+  keys.some((key) => Object.hasOwn(value, key));
+
+const extractOptionalFiniteNumberField = (
+  value: Record<string, unknown>,
+  keys: string[],
+  label: string,
+): number | null => {
+  for (const key of keys) {
+    if (!Object.hasOwn(value, key)) {
+      continue;
+    }
+    const candidate = value[key];
+    if (candidate === null || candidate === undefined) {
+      return null;
+    }
+    if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      return candidate;
+    }
+    throw new Error(`Codex tool ${label} must be a finite number when present.`);
+  }
+  return null;
+};
+
+export const safeCodexTimestampFromMilliseconds = (millis: number | null): string | null => {
+  if (millis === null || !Number.isFinite(millis)) {
+    return null;
+  }
+  const timestamp = new Date(millis);
+  return Number.isFinite(timestamp.getTime()) ? timestamp.toISOString() : null;
+};
+
+const parseCodexTimestampString = (timestamp: string | null | undefined): number | null => {
+  if (!timestamp) {
+    return null;
+  }
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const codexItemCompletedAtMs = (item: Record<string, unknown>): number | null => {
+  const millis = extractNumberField(item, CODEX_COMPLETION_MS_KEYS);
+  if (millis !== null) {
+    return millis;
+  }
+
+  const timestamp = extractStringField(item, CODEX_COMPLETION_STRING_KEYS);
+  return parseCodexTimestampString(timestamp);
+};
+
+const codexItemTimestampMs = (item: Record<string, unknown>): number | null => {
+  const completionTimestamp = codexItemCompletedAtMs(item);
+  if (completionTimestamp !== null) {
+    return completionTimestamp;
+  }
+
+  const itemTimestampMs = extractNumberField(item, CODEX_DISPLAY_TIMESTAMP_MS_KEYS);
+  if (itemTimestampMs !== null) {
+    return itemTimestampMs;
+  }
+
+  const startedAtMs = extractNumberField(item, CODEX_STARTED_MS_KEYS);
+  if (startedAtMs !== null) {
+    return startedAtMs;
+  }
+
+  const timestamp = extractStringField(item, CODEX_DISPLAY_TIMESTAMP_STRING_KEYS);
+  return parseCodexTimestampString(timestamp);
+};
+
+export const codexItemTimestamp = (item: Record<string, unknown>): string | null =>
+  safeCodexTimestampFromMilliseconds(codexItemTimestampMs(item));
+
+export const withCodexItemCompletedAtMs = (
+  item: Record<string, unknown>,
+): Record<string, unknown> => {
+  if (hasOwnField(item, CODEX_COMPLETION_MS_KEYS)) {
+    return item;
+  }
+  const completedAtMs = codexItemCompletedAtMs(item);
+  return completedAtMs !== null ? { ...item, completedAtMs } : item;
+};
+
+export const codexToolTimingFields = (
+  value: Record<string, unknown>,
+  options: CodexToolTimingOptions = {},
+): CodexToolTimingFields => {
+  const durationMs = extractOptionalFiniteNumberField(value, CODEX_DURATION_MS_KEYS, "durationMs");
+  const explicitStartedAtMs = extractOptionalFiniteNumberField(
+    value,
+    CODEX_STARTED_MS_KEYS,
+    "startedAtMs",
+  );
+  const explicitEndedAtMs = extractOptionalFiniteNumberField(
+    value,
+    CODEX_ENDED_MS_KEYS,
+    "endedAtMs",
+  );
+  const completedAtMs = extractOptionalFiniteNumberField(
+    value,
+    CODEX_COMPLETED_MS_KEYS,
+    "completedAtMs",
+  );
+  const endedAtMs =
+    explicitEndedAtMs ??
+    completedAtMs ??
+    (typeof explicitStartedAtMs === "number" && typeof durationMs === "number"
+      ? explicitStartedAtMs + durationMs
+      : null);
+  const startedAtMs =
+    explicitStartedAtMs ??
+    (typeof durationMs === "number" && typeof endedAtMs === "number"
+      ? Math.max(0, endedAtMs - durationMs)
+      : null);
+
+  const canEmitStartedAtMs =
+    typeof startedAtMs === "number" &&
+    (options.allowStartedAtOnly === true || typeof endedAtMs === "number");
+
+  return {
+    ...(canEmitStartedAtMs ? { startedAtMs } : {}),
+    ...(typeof endedAtMs === "number" ? { endedAtMs } : {}),
+  };
+};

--- a/packages/adapters-codex-app-server/src/event-mappers/stream-parts.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/stream-parts.ts
@@ -4,6 +4,7 @@ import type { CodexMappingContext, CodexMappingResult } from "../codex-canonical
 import { emptyCodexMappingResult } from "../codex-canonical-events";
 import type { CodexEventMapper } from "../codex-event-mapper";
 import { noCodexMapperState } from "../codex-event-mapper";
+import type { CodexToolTimingOptions } from "../codex-tool-timing";
 import { emptyMapper } from "./empty";
 
 const streamPartEvents = (
@@ -14,9 +15,10 @@ const streamPartEvents = (
   messageId: string,
   partId: string,
   timestamp?: string,
+  timingOptions?: CodexToolTimingOptions,
 ): CodexMappingResult => ({
   handled: true,
-  events: toStreamPart(item, messageId, partId).map((part) => {
+  events: toStreamPart(item, messageId, partId, timingOptions).map((part) => {
     const eventTimestamp = ctx.timestamp ?? timestamp;
     return {
       kind: "stream_part",
@@ -43,7 +45,9 @@ const streamPartMapper = (name: string, itemType: string): CodexEventMapper => (
     }
     const itemId =
       typeof input.item.id === "string" ? input.item.id : `${ctx.threadId}-${name}-${Date.now()}`;
-    return streamPartEvents(name, ctx, input.item, input.item, itemId, itemId);
+    return streamPartEvents(name, ctx, input.item, input.item, itemId, itemId, undefined, {
+      allowStartedAtOnly: input.kind === "item_started",
+    });
   },
   fromThreadItem(input, ctx): CodexMappingResult {
     if (!codexItemTypeMatches(input.item, itemType)) {

--- a/packages/adapters-codex-app-server/src/event-mappers/todo.ts
+++ b/packages/adapters-codex-app-server/src/event-mappers/todo.ts
@@ -17,6 +17,7 @@ import { emptyCodexMappingResult } from "../codex-canonical-events";
 import type { CodexEventMapper, CodexLiveInput, CodexThreadItemInput } from "../codex-event-mapper";
 import { codexDynamicToolErrorFromItem } from "../codex-tool-error-extractor";
 import { statusFromCodexStatus } from "../codex-tool-normalizer";
+import { type CodexToolTimingFields, codexToolTimingFields } from "../codex-tool-timing";
 
 const parseJsonObject = (value: unknown): Record<string, unknown> | null => {
   if (isPlainObject(value)) return value;
@@ -156,7 +157,12 @@ const todoToolCanonicalEvents = (
   update: CodexTodoUpdate,
   input: Record<string, unknown>,
   ctx: CodexMappingContext,
-  ids: { messageId: string; partId: string; callId: string; rawToolName: string },
+  ids: {
+    messageId: string;
+    partId: string;
+    callId: string;
+    rawToolName: string;
+  } & CodexToolTimingFields,
   raw: unknown,
 ): CodexCanonicalEvent[] => [
   {
@@ -220,13 +226,14 @@ const completedDynamicToolCallEvents = (
   }
   const displayInput = codexTodoToolInputFromPayload(input) ?? input;
   const partId = codexItemId(item, fallbackId);
+  const timing = codexToolTimingFields(item);
   return {
     handled: true,
     events: todoToolCanonicalEvents(
       update,
       displayInput,
       ctx,
-      { messageId: partId, partId, callId: partId, rawToolName },
+      { messageId: partId, partId, callId: partId, rawToolName, ...timing },
       item,
     ),
   };
@@ -245,13 +252,14 @@ const planItemEvents = (
     return emptyCodexMappingResult();
   }
   const partId = codexItemId(item, `${ctx.threadId}-plan`);
+  const timing = codexToolTimingFields(item);
   return {
     handled: true,
     events: todoToolCanonicalEvents(
       update,
       input,
       ctx,
-      { messageId: partId, partId, callId: partId, rawToolName: "update_plan" },
+      { messageId: partId, partId, callId: partId, rawToolName: "update_plan", ...timing },
       item,
     ),
   };

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -848,6 +848,28 @@ describe("agent-chat-message-card-model", () => {
           "not-a-date",
         ),
       ).toBeNull();
+
+      expect(
+        getToolDuration(
+          createToolMeta({
+            status: "completed",
+            startedAtMs: Number.NaN,
+            endedAtMs: 300,
+          }),
+          "2026-02-22T10:00:00.000Z",
+        ),
+      ).toBeNull();
+
+      expect(
+        getToolDuration(
+          createToolMeta({
+            status: "completed",
+            startedAtMs: 100,
+            endedAtMs: Number.POSITIVE_INFINITY,
+          }),
+          "2026-02-22T10:00:00.000Z",
+        ),
+      ).toBeNull();
     });
   });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/tool-duration.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/tool-duration.ts
@@ -1,22 +1,28 @@
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { getToolLifecyclePhase } from "./tool-lifecycle";
 
+const isFiniteTimestamp = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const parseFiniteTimestamp = (timestamp: string): number | null => {
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
 export const getToolDuration = (meta: ToolMeta, messageTimestamp: string): number | null => {
   const lifecyclePhase = getToolLifecyclePhase(meta);
   if (lifecyclePhase === "queued" || lifecyclePhase === "executing") {
     return null;
   }
 
-  if (typeof meta.startedAtMs !== "number") {
+  if (!isFiniteTimestamp(meta.startedAtMs)) {
     return null;
   }
-  const endedAtMs =
-    typeof meta.endedAtMs === "number"
-      ? meta.endedAtMs
-      : Number.isNaN(Date.parse(messageTimestamp))
-        ? null
-        : Date.parse(messageTimestamp);
-  if (endedAtMs === null || Number.isNaN(endedAtMs) || endedAtMs < meta.startedAtMs) {
+  if (meta.endedAtMs !== undefined && !isFiniteTimestamp(meta.endedAtMs)) {
+    return null;
+  }
+  const endedAtMs = meta.endedAtMs ?? parseFiniteTimestamp(messageTimestamp);
+  if (endedAtMs === null || endedAtMs < meta.startedAtMs) {
     return null;
   }
   return endedAtMs - meta.startedAtMs;


### PR DESCRIPTION
Summary: Display Codex tool-call durations by adapting Codex timing data into OpenDucktor's existing tool timing model.

Goal:
Codex tool calls were missing duration display even though OpenCode tool calls already showed it. Codex app-server items expose duration data for command, MCP, and dynamic tool calls, but the adapter was not consistently projecting that timing into the existing `startedAtMs` / `endedAtMs` fields consumed by the frontend.

Technical choices:
- Kept the fix entirely in `packages/adapters-codex-app-server` without changing frontend, core, or public contracts.
- Added a focused Codex tool timing helper that validates optional timing fields, derives `startedAtMs` / `endedAtMs` from real completion evidence plus duration, and fails fast on malformed timing fields.
- Threaded explicit `completedAtTimestamp` evidence only from live completed item events, avoiding false absolute timestamps from thread-read display timestamps.
- Preserved dynamic todo tool timing through the real mapper pipeline, where `todoMapper` handles `update_plan` / `todo_write` before the generic dynamic tool mapper.
- Whitelisted emitted normalizer fields instead of rest-spreading adapter input into public stream parts.

Verification:
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `bun run --filter @openducktor/adapters-codex-app-server test`
- `bun run --filter @openducktor/adapters-codex-app-server typecheck`
- `bun run --filter @openducktor/adapters-codex-app-server lint`

Cargo:
- No `Cargo.toml` files were found in this repository, so Cargo checks are not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for agent tool activity so timing details are more consistently shown when available.
  * Fixed cases where tool event timing could be missing or inaccurate in history and streaming updates.
  * Added coverage for tool timing calculations to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->