### PR TITLE
fix: keep pull request sync stop nonblocking

### DIFF
--- a/packages/host/src/application/tasks/sync/task-sync-service.test.ts
+++ b/packages/host/src/application/tasks/sync/task-sync-service.test.ts
@@ -247,7 +247,7 @@ describe("createTaskSyncService", () => {
       expect(events).toEqual([]);
       releaseSync();
       await syncFinished;
-      await sleep(10);
+      await Effect.runPromise(Effect.yieldNow());
       expect(events).toEqual([]);
     } finally {
       releaseSync();

--- a/packages/host/src/application/tasks/sync/task-sync-service.test.ts
+++ b/packages/host/src/application/tasks/sync/task-sync-service.test.ts
@@ -186,7 +186,7 @@ describe("createTaskSyncService", () => {
     await Effect.runPromise(loop.stop());
     expect(calls).toEqual([]);
   });
-  test("waits for an in-flight pull request sync iteration during stop", async () => {
+  test("stops without waiting for an in-flight pull request sync iteration", async () => {
     const { eventBus, events } = createEventBus();
     let resolveSyncStarted: () => void = () => {};
     const syncStarted = new Promise<void>((resolve) => {
@@ -195,6 +195,10 @@ describe("createTaskSyncService", () => {
     let releaseSync: () => void = () => {};
     const syncReleased = new Promise<void>((resolve) => {
       releaseSync = resolve;
+    });
+    let resolveSyncFinished: () => void = () => {};
+    const syncFinished = new Promise<void>((resolve) => {
+      resolveSyncFinished = resolve;
     });
     const service = createTaskSyncServiceForTest({
       eventBus,
@@ -205,6 +209,7 @@ describe("createTaskSyncService", () => {
             Effect.gen(function* () {
               resolveSyncStarted();
               yield* Effect.promise(() => syncReleased);
+              resolveSyncFinished();
               return { ran: true, changedTaskIds: ["task-1"] };
             }),
           );
@@ -238,10 +243,11 @@ describe("createTaskSyncService", () => {
         sleep(50).then(() => "waiting" as const),
       ]);
 
-      expect(stopBeforeRelease).toBe("waiting");
+      expect(stopBeforeRelease).toBe("stopped");
       expect(events).toEqual([]);
       releaseSync();
-      await expect(stopPromise).resolves.toBe("stopped");
+      await syncFinished;
+      await sleep(10);
       expect(events).toEqual([]);
     } finally {
       releaseSync();

--- a/packages/host/src/application/tasks/sync/task-sync-service.ts
+++ b/packages/host/src/application/tasks/sync/task-sync-service.ts
@@ -1,5 +1,5 @@
 import type { ExternalTaskSyncEvent } from "@openducktor/contracts";
-import { Effect, Fiber, Ref, Schedule } from "effect";
+import { Effect, Fiber, Ref } from "effect";
 import { HostOperationError } from "../../../effect/host-errors";
 import type { HostEventBusPort } from "../../../events/host-event-bus";
 import type {
@@ -14,6 +14,7 @@ export type TaskSyncLifecycleLogger = {
   error(message: string): void;
 };
 export type TaskSyncLoopHandle = {
+  /** Request loop shutdown without waiting for an active sync iteration to finish. */
   stop(): Effect.Effect<void, never>;
 };
 export type TaskSyncService = {
@@ -131,9 +132,10 @@ export const createTaskSyncService = ({
       ),
     );
   const runPullRequestSyncLoop = (stopped: Ref.Ref<boolean>) =>
-    Effect.sleep(`${intervalMs} millis`).pipe(
-      Effect.zipRight(runPullRequestSyncLoopIteration(stopped)),
-      Effect.repeat({ schedule: Schedule.forever }),
+    Effect.forever(
+      Effect.sleep(`${intervalMs} millis`).pipe(
+        Effect.zipRight(runPullRequestSyncLoopIteration(stopped)),
+      ),
     );
   return {
     publishExternalTaskCreated(repoPath, taskId) {

--- a/packages/host/src/application/tasks/sync/task-sync-service.ts
+++ b/packages/host/src/application/tasks/sync/task-sync-service.ts
@@ -1,5 +1,5 @@
 import type { ExternalTaskSyncEvent } from "@openducktor/contracts";
-import { Effect, Fiber } from "effect";
+import { Effect, Fiber, Ref, Schedule } from "effect";
 import { HostOperationError } from "../../../effect/host-errors";
 import type { HostEventBusPort } from "../../../events/host-event-bus";
 import type {
@@ -34,6 +34,10 @@ export type CreateTaskSyncServiceInput = {
   taskService: Pick<TaskService, "repoPullRequestSyncDetailed">;
   workspaceSettingsService: Pick<WorkspaceSettingsService, "listWorkspaces">;
 };
+type PullRequestSyncResult = {
+  changedTaskIds: string[];
+  repoPath: string;
+} | null;
 const nowIso = (): string => new Date().toISOString();
 const buildExternalTaskCreatedEvent = (
   eventIdFactory: () => string,
@@ -76,23 +80,61 @@ export const createTaskSyncService = ({
           details: { channel: TASK_EVENT_CHANNEL, eventKind: event.kind },
         }),
     });
-  const syncActiveWorkspacePullRequests = () =>
+  const readActiveWorkspacePullRequestSync = (): Effect.Effect<
+    PullRequestSyncResult,
+    TaskSyncError
+  > =>
     Effect.gen(function* () {
       const activeWorkspace = (yield* workspaceSettingsService.listWorkspaces()).find(
         (workspace) => workspace.isActive,
       );
       if (!activeWorkspace) {
-        return;
+        return null;
       }
       const result = yield* taskService.repoPullRequestSyncDetailed({
         repoPath: activeWorkspace.repoPath,
       });
-      if (result.changedTaskIds.length > 0) {
-        yield* publish(
-          buildTasksUpdatedEvent(eventIdFactory, activeWorkspace.repoPath, result.changedTaskIds),
-        );
-      }
+      return {
+        changedTaskIds: result.changedTaskIds,
+        repoPath: activeWorkspace.repoPath,
+      };
     });
+  const publishPullRequestSyncResult = (
+    result: PullRequestSyncResult,
+  ): Effect.Effect<void, HostOperationError> => {
+    if (!result || result.changedTaskIds.length === 0) {
+      return Effect.void;
+    }
+    return publish(buildTasksUpdatedEvent(eventIdFactory, result.repoPath, result.changedTaskIds));
+  };
+  const publishPullRequestSyncResultIfRunning = (
+    stopped: Ref.Ref<boolean>,
+    result: PullRequestSyncResult,
+  ): Effect.Effect<void, HostOperationError> => {
+    return Ref.get(stopped).pipe(
+      Effect.flatMap((isStopped) =>
+        isStopped ? Effect.void : publishPullRequestSyncResult(result),
+      ),
+    );
+  };
+  const syncActiveWorkspacePullRequests = () =>
+    readActiveWorkspacePullRequestSync().pipe(Effect.flatMap(publishPullRequestSyncResult));
+  const runPullRequestSyncLoopIteration = (stopped: Ref.Ref<boolean>) =>
+    readActiveWorkspacePullRequestSync().pipe(
+      Effect.flatMap((result) => publishPullRequestSyncResultIfRunning(stopped, result)),
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          logger.error(
+            `Pull request sync iteration failed; the scheduler will retry on the next interval: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }),
+      ),
+    );
+  const runPullRequestSyncLoop = (stopped: Ref.Ref<boolean>) =>
+    Effect.sleep(`${intervalMs} millis`).pipe(
+      Effect.zipRight(runPullRequestSyncLoopIteration(stopped)),
+      Effect.repeat({ schedule: Schedule.forever }),
+    );
   return {
     publishExternalTaskCreated(repoPath, taskId) {
       return publish(buildExternalTaskCreatedEvent(eventIdFactory, repoPath, taskId));
@@ -105,29 +147,18 @@ export const createTaskSyncService = ({
     },
     syncActiveWorkspacePullRequests,
     startPullRequestSyncLoop() {
-      return Effect.forkDaemon(
-        Effect.forever(
-          Effect.sleep(`${intervalMs} millis`).pipe(
-            Effect.zipRight(
-              syncActiveWorkspacePullRequests().pipe(
-                Effect.catchAll((error) =>
-                  Effect.sync(() => {
-                    logger.error(
-                      `Pull request sync iteration failed; the scheduler will retry on the next interval: ${error instanceof Error ? error.message : String(error)}`,
-                    );
-                  }),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ).pipe(
-        Effect.map((fiber) => ({
+      return Effect.gen(function* () {
+        const stopped = yield* Ref.make(false);
+        const fiber = yield* Effect.forkDaemon(runPullRequestSyncLoop(stopped));
+        return {
           stop() {
-            return Fiber.interrupt(fiber).pipe(Effect.asVoid);
+            return Ref.set(stopped, true).pipe(
+              Effect.zipRight(Fiber.interruptFork(fiber)),
+              Effect.asVoid,
+            );
           },
-        })),
-      );
+        };
+      });
     },
   };
 };


### PR DESCRIPTION
Summary:
Fixes the browser dev-server shutdown regression where host disposal could hang at `Stopping pull request sync loop...`.

Goal:
The previous review fix waited for `Fiber.interrupt` to complete so stopped pull-request sync loops would not publish late `tasks_updated` events. That preserved the event-safety goal but made shutdown wait for any in-flight pull-request sync iteration. In browser dev mode this can take a long time, which blocks the browser dev server stop flow.

Implementation:
- Keep pull-request sync reads separate from task-update event publication.
- Use a loop-scoped `Ref<boolean>` to mark the loop as stopped lazily when `stop()` is executed.
- Use nonblocking `Fiber.interruptFork` so shutdown requests interruption without joining a slow in-flight sync iteration.
- Gate loop-owned `tasks_updated` publication after sync reads complete, so an in-flight loop iteration cannot publish stale updates after stop.
- Keep the public `syncActiveWorkspacePullRequests()` path unconditional so manual sync behavior is unchanged.
- Document the `TaskSyncLoopHandle.stop()` contract as nonblocking for active iterations.

Review cleanup:
- Removed the unnecessary `Schedule.forever` import/use and kept the simpler `Effect.forever` loop expression.
- Replaced the regression test's arbitrary post-sync timer with `Effect.yieldNow()`.
- Left stale review feedback about eager boolean mutation as addressed by the rewrite to `Ref.set(...)` inside the returned `Effect`.

Testing:
- `rtk proxy bun test packages/host/src/application/tasks/sync/task-sync-service.test.ts --timeout 5000`
- `rtk proxy bun run typecheck`
- `rtk proxy bun run lint`
- `rtk proxy bun run test`
- `rtk proxy bun run build`

Breaking changes:
None.

Notes:
No Cargo checks were run because this checkout has no `Cargo.toml` targets.