### PR TITLE
fix: preserve Codex stream event receipt time

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.approvals.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.approvals.test.ts
@@ -30,10 +30,10 @@ const withRuntimeReceivedAt = (event: RuntimeEventInput) => ({
   receivedAt: runtimeEventReceivedAt,
 });
 
-const bufferedServerRequest = (message: unknown) => ({
+const bufferedServerRequest = (message: unknown, receivedAt = runtimeEventReceivedAt) => ({
   runtimeId: "runtime-live",
   kind: "server_request" as const,
-  receivedAt: runtimeEventReceivedAt,
+  receivedAt,
   message,
 });
 
@@ -951,16 +951,19 @@ describe("CodexAppServerAdapter approvals", () => {
   test("steers active Codex turns for queued user messages", async () => {
     const { adapter, takeBufferedEvents, transports } = createHarness({}, { deferTurnStart: true });
     takeBufferedEvents.mockImplementationOnce(async () => [
-      bufferedServerRequest({
-        id: 33,
-        method: "item/tool/requestUserInput",
-        params: {
-          threadId: "thread/start-runtime-live",
-          turnId: "turn-active",
-          itemId: "item-1",
-          questions: [{ id: "question-1", header: "Confirm", question: "Continue?" }],
+      bufferedServerRequest(
+        {
+          id: 33,
+          method: "item/tool/requestUserInput",
+          params: {
+            threadId: "thread/start-runtime-live",
+            turnId: "turn-active",
+            itemId: "item-1",
+            questions: [{ id: "question-1", header: "Confirm", question: "Continue?" }],
+          },
         },
-      }),
+        new Date().toISOString(),
+      ),
     ]);
 
     await adapter.startSession(codexStartSessionInput());

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.approvals.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.approvals.test.ts
@@ -15,19 +15,33 @@ import { codexServerRequestKey } from "./codex-app-server-approvals";
 const CURL_NETWORK_COMMAND =
   "curl -I --max-time 5 https://example.com; curl -I --max-time 5 https://1.1.1.1";
 
+const runtimeEventReceivedAt = "2026-07-06T12:00:00.000Z";
+
+type RuntimeEventInput = {
+  runtimeId: string;
+  kind: "notification" | "server_request";
+  message: unknown;
+};
+
+type RuntimeListener = (event: RuntimeEventInput) => void;
+
+const withRuntimeReceivedAt = (event: RuntimeEventInput) => ({
+  ...event,
+  receivedAt: runtimeEventReceivedAt,
+});
+
 const bufferedServerRequest = (message: unknown) => ({
   runtimeId: "runtime-live",
   kind: "server_request" as const,
+  receivedAt: runtimeEventReceivedAt,
   message,
 });
 
 describe("CodexAppServerAdapter approvals", () => {
   test("emits a session error for streamed server requests missing a thread identifier", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "server_request"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const { adapter } = createHarness({ subscribeEvents });
@@ -59,11 +73,9 @@ describe("CodexAppServerAdapter approvals", () => {
   });
 
   test("surfaces legacy exec command approvals routed by conversationId", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "server_request"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const { adapter, respondServerRequest } = createHarness({ subscribeEvents });
@@ -117,11 +129,9 @@ describe("CodexAppServerAdapter approvals", () => {
   });
 
   test("surfaces streamed network command approvals from structured command actions", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "server_request"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const takeBufferedEvents = mock(async () => [] as unknown[]);
@@ -195,15 +205,9 @@ describe("CodexAppServerAdapter approvals", () => {
   });
 
   test("requires a server request to create command approvals", async () => {
-    const streamListeners: Array<
-      (event: {
-        runtimeId: string;
-        kind: "notification" | "server_request";
-        message: unknown;
-      }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const takeBufferedEvents = mock(async () => [] as unknown[]);
@@ -256,11 +260,9 @@ describe("CodexAppServerAdapter approvals", () => {
   });
 
   test("surfaces live command approvals before turn start settles", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "server_request"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const takeBufferedEvents = mock(async () => [] as unknown[]);
@@ -328,11 +330,9 @@ describe("CodexAppServerAdapter approvals", () => {
   });
 
   test("rejects Codex dynamic tool calls because workflow tools use MCP", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "server_request"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const takeBufferedEvents = mock(async () => [] as unknown[]);
@@ -470,11 +470,9 @@ describe("CodexAppServerAdapter approvals", () => {
         requestResolved.resolve();
       }
     });
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "server_request"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const { adapter } = createHarness({ respondServerRequest, subscribeEvents });
@@ -1027,11 +1025,9 @@ describe("CodexAppServerAdapter approvals", () => {
         dynamicToolRejected.resolve();
       }
     });
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "server_request"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const takeBufferedEvents = mock(async () => [] as unknown[]);
@@ -1131,11 +1127,9 @@ describe("CodexAppServerAdapter approvals", () => {
         dynamicToolRejected.resolve();
       }
     });
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "server_request"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const takeBufferedEvents = mock(async () => [] as unknown[]);

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
@@ -14,6 +14,21 @@ import {
 import type { CodexPendingInputState } from "./codex-pending-input-state";
 import type { CodexAppServerAdapter, CodexJsonRpcRequest } from "./index";
 
+const runtimeEventReceivedAt = "2026-07-06T12:00:00.000Z";
+
+type RuntimeEventInput = {
+  runtimeId: string;
+  kind: "notification" | "server_request";
+  message: unknown;
+};
+
+type RuntimeListener = (event: RuntimeEventInput) => void;
+
+const withRuntimeReceivedAt = (event: RuntimeEventInput) => ({
+  ...event,
+  receivedAt: runtimeEventReceivedAt,
+});
+
 class ThreadIdOnlyResumeTransport extends RecordingTransport {
   async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
     if (request.method === "thread/resume") {
@@ -622,7 +637,7 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
     const subscribeEvents = mock(async (runtimeId: string, listener) => {
       await new Promise((resolve) => setTimeout(resolve, 20));
       transport.emitRestoredUsage = (message) =>
-        listener({ runtimeId, kind: "notification", message });
+        listener(withRuntimeReceivedAt({ runtimeId, kind: "notification", message }));
       return () => {};
     });
     const { adapter } = createHarness({
@@ -878,11 +893,9 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
   });
 
   test("streams messages and completion after refresh session preparation", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const takeBufferedEvents = mock(async () => [] as unknown[]);
@@ -962,11 +975,9 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
   });
 
   test("streams child transcript events after read-only subscription materializes inventory thread", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const transport = new ChildThreadListTransport("runtime-live", false);
@@ -1008,11 +1019,9 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
   });
 
   test("streams child transcript events for a learned subagent route absent from inventory", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const transport = new MutableThreadListTransport("runtime-live", false);
@@ -1101,15 +1110,9 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
   });
 
   test("routes child server requests through routes learned from refreshed inventory", async () => {
-    const streamListeners: Array<
-      (event: {
-        runtimeId: string;
-        kind: "notification" | "server_request";
-        message: unknown;
-      }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const transport = new ParentWithChildThreadListTransport("runtime-live", false);
@@ -1206,11 +1209,9 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
   });
 
   test("does not resurrect an idle local session from stale active thread inventory", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const transport = new MutableThreadListTransport("runtime-live", false);
@@ -1291,11 +1292,9 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
   });
 
   test("streams messages and completion after refresh resume stream", async () => {
-    const streamListeners: Array<
-      (event: { runtimeId: string; kind: "notification"; message: unknown }) => void
-    > = [];
+    const streamListeners: RuntimeListener[] = [];
     const subscribeEvents = mock((_runtimeId: string, listener) => {
-      streamListeners.push(listener);
+      streamListeners.push((event) => listener(withRuntimeReceivedAt(event)));
       return () => {};
     });
     const takeBufferedEvents = mock(async () => [] as unknown[]);

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -897,7 +897,12 @@ describe("CodexAppServerAdapter streaming", () => {
     const { adapter, transports } = createHarness({ subscribeEvents }, { deferTurnStart: true });
 
     await adapter.startSession(codexStartSessionInput());
-    const unsubscribe = await observeSessionState(adapter, "thread/start-runtime-live");
+    const events: Array<{ type?: string }> = [];
+    const unsubscribe = await adapter.subscribeEvents(
+      codexSessionRuntimeRef("thread/start-runtime-live"),
+      (event) => events.push(event),
+    );
+    await flushCodexAdapterWork();
 
     await adapter.sendUserMessage(
       codexUserMessageInput({
@@ -928,6 +933,7 @@ describe("CodexAppServerAdapter streaming", () => {
         externalSessionId: "thread/start-runtime-live",
       }),
     ).resolves.toMatchObject({ classification: "idle" });
+    expect(events.some((event) => event.type === "session_idle")).toBe(true);
 
     await adapter.sendUserMessage(
       codexUserMessageInput({
@@ -953,6 +959,7 @@ describe("CodexAppServerAdapter streaming", () => {
           params: {
             threadId: "thread/start-runtime-live",
             status: { type: "idle" },
+            timestampMs: Date.now() + 60_000,
           },
         },
         "runtime-live",
@@ -1006,6 +1013,98 @@ describe("CodexAppServerAdapter streaming", () => {
       },
     });
     unsubscribe();
+  });
+
+  test("does not settle the active turn from idle status before the turn id is bound", async () => {
+    const { subscribeEvents, emitNotification } = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({ subscribeEvents }, { deferTurnStart: true });
+
+    await adapter.startSession(codexStartSessionInput());
+    const unsubscribe = await observeSessionState(adapter, "thread/start-runtime-live");
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Start now" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+
+    emitNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "thread/start-runtime-live",
+        status: { type: "idle" },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    transports.get("runtime-live")?.turnStartDeferred.resolve({
+      turn: { id: "turn-live", status: "running" },
+    });
+    await flushCodexAdapterWork();
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Keep steering" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+
+    const runtimeCalls = transports.get("runtime-live")?.calls ?? [];
+    expect(runtimeCalls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+    expect(runtimeCalls).toContainEqual({
+      method: "turn/steer",
+      params: {
+        threadId: "thread/start-runtime-live",
+        input: [{ type: "text", text: "Keep steering" }],
+        expectedTurnId: "turn-live",
+      },
+    });
+    unsubscribe();
+  });
+
+  test("rejects malformed receivedAt values when checking idle status freshness", async () => {
+    const takeBufferedEvents = mock(async (_runtimeId: string) => []);
+    takeBufferedEvents.mockImplementationOnce(async () => [
+      bufferedNotificationEvent(
+        {
+          method: "thread/status/changed",
+          params: {
+            threadId: "thread/start-runtime-live",
+            status: { type: "idle" },
+          },
+        },
+        "runtime-live",
+        "not-a-timestamp",
+      ),
+    ]);
+    const { adapter, transports } = createHarness({ takeBufferedEvents }, { deferTurnStart: true });
+
+    await adapter.startSession(codexStartSessionInput());
+    const sendUserMessageError = adapter
+      .sendUserMessage(
+        codexUserMessageInput({
+          externalSessionId: "thread/start-runtime-live",
+          parts: [{ kind: "text", text: "Start now" }],
+          model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+        }),
+      )
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+    await flushCodexAdapterWork();
+    transports.get("runtime-live")?.turnStartDeferred.resolve({
+      turn: { id: "turn-live", status: "running" },
+    });
+
+    expect(await sendUserMessageError).toEqual(
+      expect.objectContaining({
+        message: "Codex notification has an unparsable receivedAt timestamp 'not-a-timestamp'.",
+      }),
+    );
   });
 
   test("emits accepted queued Codex user messages into the runtime transcript stream", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -4,10 +4,11 @@ import {
   codexSessionRuntimeRef,
   codexStartSessionInput,
   codexUserMessageInput,
+  createDeferred,
   createHarness,
   flushCodexAdapterWork,
 } from "./codex-app-server-adapter.test-harness";
-import type { CodexAppServerAdapter } from "./index";
+import type { CodexAppServerAdapter, CodexJsonRpcRequest, CodexJsonRpcTransport } from "./index";
 
 const bufferedNotifications = (messages: unknown[]) =>
   messages.map((message) => bufferedNotificationEvent(message));
@@ -949,6 +950,249 @@ describe("CodexAppServerAdapter streaming", () => {
     unsubscribe();
   });
 
+  test("flushes the buffered final assistant message before settling from idle status", async () => {
+    const { subscribeEvents, emitNotification } = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({ subscribeEvents }, { deferTurnStart: true });
+
+    await adapter.startSession(codexStartSessionInput());
+    const events: Array<{ type?: string; message?: string; totalTokens?: number }> = [];
+    const unsubscribe = await adapter.subscribeEvents(
+      codexSessionRuntimeRef("thread/start-runtime-live"),
+      (event) => events.push(event),
+    );
+    await flushCodexAdapterWork();
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Start now" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+    transports.get("runtime-live")?.turnStartDeferred.resolve({
+      turn: { id: "turn-live", status: "running" },
+    });
+    await flushCodexAdapterWork();
+
+    emitNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread/start-runtime-live",
+        turnId: "turn-live",
+        completedAtMs: 1_777_766_420_000,
+        item: {
+          type: "agentMessage",
+          id: "agent-idle-final",
+          phase: "final_answer",
+          text: "Done before idle.",
+        },
+      },
+    });
+    emitNotification({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread/start-runtime-live",
+        turnId: "turn-live",
+        tokenUsage: {
+          total: { totalTokens: 12_345 },
+          last: { totalTokens: 321 },
+          modelContextWindow: 200_000,
+        },
+      },
+    });
+    emitNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "thread/start-runtime-live",
+        status: { type: "idle" },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "assistant_message",
+        message: "Done before idle.",
+        totalTokens: 321,
+      }),
+    );
+    const assistantMessageIndex = events.findIndex((event) => event.type === "assistant_message");
+    const sessionIdleIndex = events.findIndex((event) => event.type === "session_idle");
+    expect(assistantMessageIndex).toBeGreaterThanOrEqual(0);
+    expect(sessionIdleIndex).toBeGreaterThan(assistantMessageIndex);
+    unsubscribe();
+  });
+
+  test("late old turn completion does not clear a newer active turn", async () => {
+    const { subscribeEvents, emitNotification } = createRuntimeStreamSubscription();
+    const firstTurnStart = createDeferred<unknown>();
+    const secondTurnStart = createDeferred<unknown>();
+    const pendingTurnStarts = [firstTurnStart, secondTurnStart];
+    const calls: CodexJsonRpcRequest[] = [];
+    const transport: CodexJsonRpcTransport = {
+      request: mock(async <Response>(request: CodexJsonRpcRequest): Promise<Response> => {
+        calls.push(request);
+        if (request.method === "initialize") {
+          return {} as Response;
+        }
+        if (request.method === "model/list") {
+          return {
+            data: [
+              {
+                id: "gpt-5",
+                model: "gpt-5",
+                displayName: "GPT-5",
+                hidden: false,
+                supportedReasoningEfforts: [
+                  { reasoningEffort: "medium", description: "Balanced reasoning" },
+                ],
+                defaultReasoningEffort: {
+                  reasoningEffort: "medium",
+                  description: "Balanced reasoning",
+                },
+                inputModalities: ["text"],
+                supportsPersonality: true,
+                isDefault: true,
+              },
+            ],
+            nextCursor: null,
+          } as Response;
+        }
+        if (request.method === "thread/start") {
+          return {
+            thread: {
+              id: "thread/start-runtime-live",
+              cwd: "/repo",
+              createdAt: 1_778_112_000,
+              status: { type: "active", activeFlags: [] },
+              turns: [],
+            },
+            startedAt: "2026-05-07T00:00:00.000Z",
+          } as Response;
+        }
+        if (request.method === "thread/name/set") {
+          return {} as Response;
+        }
+        if (request.method === "thread/loaded/list") {
+          return { data: ["thread/start-runtime-live"], nextCursor: null } as Response;
+        }
+        if (request.method === "thread/list") {
+          return {
+            data: [
+              {
+                id: "thread/start-runtime-live",
+                cwd: "/repo",
+                createdAt: 1_778_112_000,
+                status: { type: "active", activeFlags: [] },
+              },
+            ],
+            nextCursor: null,
+            backwardsCursor: null,
+          } as Response;
+        }
+        if (request.method === "thread/read") {
+          return {
+            thread: {
+              id: "thread/start-runtime-live",
+              cwd: "/repo",
+              createdAt: 1_778_112_000,
+              status: { type: "active", activeFlags: [] },
+              turns: [],
+            },
+          } as Response;
+        }
+        if (request.method === "turn/start") {
+          const deferred = pendingTurnStarts.shift();
+          if (!deferred) {
+            throw new Error("Unexpected extra turn/start request.");
+          }
+          return (await deferred.promise) as Response;
+        }
+        if (request.method === "turn/steer") {
+          return { turnId: "turn-steered" } as Response;
+        }
+        throw new Error(`Unexpected method '${request.method}'.`);
+      }),
+    };
+    const { adapter } = createHarness({
+      subscribeEvents,
+      transportFactory: () => transport,
+    });
+
+    await adapter.startSession(codexStartSessionInput());
+    const unsubscribe = await observeSessionState(adapter, "thread/start-runtime-live");
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Start first turn" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+    emitNotification({
+      method: "turn/started",
+      params: {
+        threadId: "thread/start-runtime-live",
+        turn: { id: "turn-old" },
+      },
+    });
+    emitNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "thread/start-runtime-live",
+        status: { type: "idle" },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Start replacement turn" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+    emitNotification({
+      method: "turn/started",
+      params: {
+        threadId: "thread/start-runtime-live",
+        turn: { id: "turn-new" },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    firstTurnStart.resolve({ turn: { id: "turn-old", status: "completed" } });
+    await flushCodexAdapterWork();
+
+    await expect(
+      adapter.readSessionRuntimeSnapshot({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "thread/start-runtime-live",
+      }),
+    ).resolves.toMatchObject({ classification: "running" });
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Steer replacement turn" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+
+    expect(calls.filter((call) => call.method === "turn/start")).toHaveLength(2);
+    expect(calls).toContainEqual({
+      method: "turn/steer",
+      params: {
+        threadId: "thread/start-runtime-live",
+        input: [{ type: "text", text: "Steer replacement turn" }],
+        expectedTurnId: "turn-new",
+      },
+    });
+    unsubscribe();
+  });
+
   test("does not settle the active turn from a stale buffered idle status", async () => {
     const staleReceivedAt = new Date(Date.now() - 60_000).toISOString();
     const takeBufferedEvents = mock(async (_runtimeId: string) => []);
@@ -1165,6 +1409,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/completed",
         params: {
@@ -1219,6 +1464,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/completed",
         params: {
@@ -1280,6 +1526,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/completed",
         params: {
@@ -1357,6 +1604,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/completed",
         params: {
@@ -1467,6 +1715,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/agentMessage/delta",
         params: {
@@ -1480,6 +1729,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/started",
         params: {
@@ -1496,6 +1746,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/completed",
         params: {
@@ -1565,6 +1816,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/started",
         params: {
@@ -1581,6 +1833,7 @@ describe("CodexAppServerAdapter streaming", () => {
     streamListeners[0]?.({
       runtimeId: "runtime-live",
       kind: "notification",
+      receivedAt: new Date().toISOString(),
       message: {
         method: "item/completed",
         params: {
@@ -1638,6 +1891,7 @@ describe("CodexAppServerAdapter streaming", () => {
       streamListeners[0]?.({
         runtimeId: "runtime-live",
         kind: "notification",
+        receivedAt: new Date().toISOString(),
         message: {
           method: "item/started",
           params: {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -24,6 +24,32 @@ const observeSessionState = async (
   return unsubscribe;
 };
 
+type TestRuntimeStreamListener = (event: {
+  runtimeId: string;
+  kind: "notification" | "server_request";
+  receivedAt: string;
+  message: unknown;
+}) => void;
+
+const createRuntimeStreamSubscription = () => {
+  const streamListeners: TestRuntimeStreamListener[] = [];
+  const subscribeEvents = mock((_runtimeId: string, listener: TestRuntimeStreamListener) => {
+    streamListeners.push(listener);
+    return () => {};
+  });
+  const emitNotification = (message: unknown, receivedAt = new Date().toISOString()) => {
+    const listener = streamListeners[0];
+    expect(listener).toBeDefined();
+    listener?.({
+      runtimeId: "runtime-live",
+      kind: "notification",
+      receivedAt,
+      message,
+    });
+  };
+  return { subscribeEvents, emitNotification };
+};
+
 describe("CodexAppServerAdapter streaming", () => {
   test("emits transcript events from Codex notifications", async () => {
     const takeBufferedEvents = mock(async (_runtimeId: string) => []);
@@ -864,6 +890,122 @@ describe("CodexAppServerAdapter streaming", () => {
         expectedTurnId: "turn-active",
       },
     });
+  });
+
+  test("settles the active turn when runtime status changes to idle before turn completion", async () => {
+    const { subscribeEvents, emitNotification } = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({ subscribeEvents }, { deferTurnStart: true });
+
+    await adapter.startSession(codexStartSessionInput());
+    const unsubscribe = await observeSessionState(adapter, "thread/start-runtime-live");
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Start now" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+    transports.get("runtime-live")?.turnStartDeferred.resolve({
+      turn: { id: "turn-live", status: "running" },
+    });
+    await flushCodexAdapterWork();
+
+    emitNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "thread/start-runtime-live",
+        status: { type: "idle" },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    await expect(
+      adapter.readSessionRuntimeSnapshot({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "thread/start-runtime-live",
+      }),
+    ).resolves.toMatchObject({ classification: "idle" });
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Continue after idle" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+
+    const runtimeCalls = transports.get("runtime-live")?.calls ?? [];
+    expect(runtimeCalls.filter((call) => call.method === "turn/steer")).toEqual([]);
+    expect(runtimeCalls.filter((call) => call.method === "turn/start")).toHaveLength(2);
+    unsubscribe();
+  });
+
+  test("does not settle the active turn from a stale buffered idle status", async () => {
+    const staleReceivedAt = new Date(Date.now() - 60_000).toISOString();
+    const takeBufferedEvents = mock(async (_runtimeId: string) => []);
+    takeBufferedEvents.mockImplementationOnce(async () => [
+      bufferedNotificationEvent(
+        {
+          method: "thread/status/changed",
+          params: {
+            threadId: "thread/start-runtime-live",
+            status: { type: "idle" },
+          },
+        },
+        "runtime-live",
+        staleReceivedAt,
+      ),
+    ]);
+    const { adapter, transports } = createHarness({ takeBufferedEvents }, { deferTurnStart: true });
+
+    await adapter.startSession(codexStartSessionInput());
+    const unsubscribe = await observeSessionState(adapter, "thread/start-runtime-live");
+
+    const firstMessage = adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Start now" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+    await flushCodexAdapterWork();
+    transports.get("runtime-live")?.turnStartDeferred.resolve({
+      turn: { id: "turn-live", status: "running" },
+    });
+    await firstMessage;
+    await flushCodexAdapterWork();
+
+    await expect(
+      adapter.readSessionRuntimeSnapshot({
+        repoPath: "/repo",
+        runtimeKind: "codex",
+        workingDirectory: "/repo",
+        externalSessionId: "thread/start-runtime-live",
+      }),
+    ).resolves.toMatchObject({ classification: "running" });
+
+    await adapter.sendUserMessage(
+      codexUserMessageInput({
+        externalSessionId: "thread/start-runtime-live",
+        parts: [{ kind: "text", text: "Keep steering" }],
+        model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+      }),
+    );
+
+    const runtimeCalls = transports.get("runtime-live")?.calls ?? [];
+    expect(runtimeCalls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+    expect(runtimeCalls).toContainEqual({
+      method: "turn/steer",
+      params: {
+        threadId: "thread/start-runtime-live",
+        input: [{ type: "text", text: "Keep steering" }],
+        expectedTurnId: "turn-live",
+      },
+    });
+    unsubscribe();
   });
 
   test("emits accepted queued Codex user messages into the runtime transcript stream", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -1309,7 +1309,7 @@ describe("CodexAppServerAdapter streaming", () => {
     unsubscribe();
   });
 
-  test("rejects malformed receivedAt values when checking idle status freshness", async () => {
+  test("rejects malformed receivedAt values before idle status processing", async () => {
     const takeBufferedEvents = mock(async (_runtimeId: string) => []);
     takeBufferedEvents.mockImplementationOnce(async () => [
       bufferedNotificationEvent(
@@ -1346,7 +1346,8 @@ describe("CodexAppServerAdapter streaming", () => {
 
     expect(await sendUserMessageError).toEqual(
       expect.objectContaining({
-        message: "Codex notification has an unparsable receivedAt timestamp 'not-a-timestamp'.",
+        message:
+          "Codex app-server notification has an unparsable receivedAt timestamp 'not-a-timestamp'.",
       }),
     );
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -31,15 +31,25 @@ export const makeRuntimeSummary = (runtimeId: string): RuntimeInstanceSummary =>
   descriptor: CODEX_RUNTIME_DESCRIPTOR,
 });
 
-export const bufferedNotificationEvent = (message: unknown, runtimeId = "runtime-live") => ({
+export const bufferedNotificationEvent = (
+  message: unknown,
+  runtimeId = "runtime-live",
+  receivedAt = new Date().toISOString(),
+) => ({
   runtimeId,
   kind: "notification" as const,
+  receivedAt,
   message,
 });
 
-export const bufferedServerRequestEvent = (message: unknown, runtimeId = "runtime-live") => ({
+export const bufferedServerRequestEvent = (
+  message: unknown,
+  runtimeId = "runtime-live",
+  receivedAt = new Date().toISOString(),
+) => ({
   runtimeId,
   kind: "server_request" as const,
+  receivedAt,
   message,
 });
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -768,8 +768,8 @@ export class CodexAppServerAdapter
       validateModel: (client, runtimeId, model) => this.models.validate(client, runtimeId, model),
       ensureRuntimeEventSubscription: (runtimeId) =>
         this.runtimeEvents.ensureRuntimeEventSubscription(runtimeId),
-      bindActiveTurnId: (activeTurn, turnId) =>
-        this.runtimeEvents.bindActiveTurnId(activeTurn, turnId),
+      bindActiveTurnId: (activeTurn, turnId, startedAtMs) =>
+        this.runtimeEvents.bindActiveTurnId(activeTurn, turnId, startedAtMs),
       bindPendingInputToActiveTurn: (externalSessionId, activeTurn) =>
         this.runtimeEvents.bindPendingInputToActiveTurn(externalSessionId, activeTurn),
       setSessionLiveStatus: (session, liveStatus) =>

--- a/packages/adapters-codex-app-server/src/codex-app-server-requests.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-requests.test.ts
@@ -367,4 +367,14 @@ describe("Codex App Server notification parsing", () => {
       ),
     ).toThrow("Codex app-server notification is missing receivedAt.");
   });
+
+  test("rejects unparsable receivedAt timestamps", () => {
+    expect(() =>
+      parseNotificationRecord({
+        method: "thread/tokenUsage/updated",
+        params: { threadId: "thread-1" },
+        receivedAt: "not-a-date",
+      }),
+    ).toThrow("Codex app-server notification has an unparsable receivedAt timestamp 'not-a-date'.");
+  });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-requests.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-requests.test.ts
@@ -346,4 +346,25 @@ describe("Codex App Server notification parsing", () => {
       ).receivedAt,
     ).toBe("2026-06-23T10:00:01.000Z");
   });
+
+  test("rejects notifications without a receivedAt timestamp", () => {
+    expect(() =>
+      parseNotificationRecord({
+        method: "thread/tokenUsage/updated",
+        params: { threadId: "thread-1" },
+      }),
+    ).toThrow("Codex app-server notification is missing receivedAt.");
+  });
+
+  test("rejects empty explicit receivedAt arguments", () => {
+    expect(() =>
+      parseNotificationRecord(
+        {
+          method: "thread/tokenUsage/updated",
+          receivedAt: "2026-06-23T10:00:00.000Z",
+        },
+        "",
+      ),
+    ).toThrow("Codex app-server notification is missing receivedAt.");
+  });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-requests.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-requests.ts
@@ -401,6 +401,14 @@ export const extractThreadIdFromParams = (value: unknown): string | null => {
 
 export const codexTurnKey = (threadId: string, turnId: string): string => `${threadId}:${turnId}`;
 
+const assertParseableNotificationReceivedAt = (receivedAt: string): void => {
+  if (!Number.isFinite(Date.parse(receivedAt))) {
+    throw new Error(
+      `Codex app-server notification has an unparsable receivedAt timestamp '${receivedAt}'.`,
+    );
+  }
+};
+
 export const isTerminalTurnStatus = (value: unknown): boolean => {
   if (!isPlainObject(value)) {
     return false;
@@ -511,6 +519,7 @@ export const parseNotificationRecord = (
   if (typeof parsedReceivedAt !== "string" || parsedReceivedAt.trim().length === 0) {
     throw new Error("Codex app-server notification is missing receivedAt.");
   }
+  assertParseableNotificationReceivedAt(parsedReceivedAt);
   return {
     method: method.trim(),
     ...(params !== undefined ? { params } : {}),

--- a/packages/adapters-codex-app-server/src/codex-app-server-requests.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-requests.ts
@@ -507,9 +507,10 @@ export const parseNotificationRecord = (
   if (typeof method !== "string" || method.trim().length === 0) {
     throw new Error("Codex app-server notification is missing method.");
   }
-  const parsedReceivedAt =
-    receivedAt ??
-    (typeof value.receivedAt === "string" ? value.receivedAt : new Date().toISOString());
+  const parsedReceivedAt = receivedAt ?? value.receivedAt;
+  if (typeof parsedReceivedAt !== "string" || parsedReceivedAt.trim().length === 0) {
+    throw new Error("Codex app-server notification is missing receivedAt.");
+  }
   return {
     method: method.trim(),
     ...(params !== undefined ? { params } : {}),

--- a/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-server-requests.ts
@@ -61,7 +61,7 @@ export type CodexServerRequestHandlerContext = {
   activeTurnsBySessionId: Map<string, ActiveCodexTurn>;
   subagents: CodexSubagentLinkState;
   sessionForThreadId(threadId: string): CodexSessionState | undefined;
-  bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean;
+  bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string, startedAtMs?: number): boolean;
   flushQueuedUserMessagesLater(activeTurn: ActiveCodexTurn): void;
   emitSessionEvent(externalSessionId: string, event: AgentEvent): void;
 };
@@ -142,6 +142,7 @@ export const handleCodexServerRequest = async (
   session: CodexSessionState,
   rawRequest: CodexServerRequestRecord,
   handledRequestKeys: Set<string>,
+  requestReceivedAtMs?: number,
 ): Promise<boolean> => {
   const requestId = rawRequest.id;
   const requestKey = requestId !== undefined ? codexServerRequestKey(requestId) : undefined;
@@ -169,7 +170,11 @@ export const handleCodexServerRequest = async (
     (routeContext.ownerThreadId === routeContext.policySession.threadId
       ? context.activeTurnsBySessionId.get(routeContext.policySession.threadId)
       : undefined);
-  if (requestTurnId && activeTurn && context.bindActiveTurnId(activeTurn, requestTurnId)) {
+  if (
+    requestTurnId &&
+    activeTurn &&
+    context.bindActiveTurnId(activeTurn, requestTurnId, requestReceivedAtMs)
+  ) {
     context.flushQueuedUserMessagesLater(activeTurn);
   }
 
@@ -226,7 +231,7 @@ export const handleCodexServerRequest = async (
         `Codex question request thread '${parsed.threadId}' does not match request owner '${routeContext.ownerThreadId}'.`,
       );
     }
-    if (activeTurn && context.bindActiveTurnId(activeTurn, parsed.turnId)) {
+    if (activeTurn && context.bindActiveTurnId(activeTurn, parsed.turnId, requestReceivedAtMs)) {
       context.flushQueuedUserMessagesLater(activeTurn);
     }
     const questionInput = {

--- a/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
@@ -14,7 +14,7 @@ export const CODEX_USER_INPUT_REQUEST_METHOD = "item/tool/requestUserInput";
 export type ActiveCodexTurn = {
   session: CodexSessionState;
   startedAtMs: number;
-  turnEvidenceMinReceivedAtMs: number;
+  turnStartRequestSentAtMs: number | null;
   turnStartPromise: Promise<CodexTurnStartResult>;
   isTurnSettled: () => boolean;
   markTurnSettled: () => void;

--- a/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
@@ -14,6 +14,7 @@ export const CODEX_USER_INPUT_REQUEST_METHOD = "item/tool/requestUserInput";
 export type ActiveCodexTurn = {
   session: CodexSessionState;
   startedAtMs: number;
+  turnEvidenceMinReceivedAtMs: number;
   turnStartPromise: Promise<CodexTurnStartResult>;
   isTurnSettled: () => boolean;
   markTurnSettled: () => void;

--- a/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
@@ -13,6 +13,7 @@ export const CODEX_USER_INPUT_REQUEST_METHOD = "item/tool/requestUserInput";
 
 export type ActiveCodexTurn = {
   session: CodexSessionState;
+  startedAtMs: number;
   turnStartPromise: Promise<CodexTurnStartResult>;
   isTurnSettled: () => boolean;
   markTurnSettled: () => void;

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -477,6 +477,37 @@ const isNotificationAtOrAfterActiveTurnStart = (
   return receivedAtMs >= activeTurn.startedAtMs;
 };
 
+const clearTurnScopedStreamingState = (
+  context: CodexStreamingContext,
+  threadId: string,
+  turnId: string,
+): void => {
+  const turnKey = codexTurnKey(threadId, turnId);
+  context.completedAgentMessagesByTurnKey.delete(turnKey);
+  context.tokenUsageByTurnKey.delete(turnKey);
+  context.modelByTurnKey.delete(turnKey);
+};
+
+const flushBufferedFinalAgentMessage = (
+  context: CodexStreamingContext,
+  session: CodexSessionState,
+  turnId: string,
+): void => {
+  const turnKey = codexTurnKey(session.threadId, turnId);
+  const bufferedAgentMessage = context.completedAgentMessagesByTurnKey.get(turnKey);
+  if (!bufferedAgentMessage) {
+    return;
+  }
+  emitFinalAgentMessage(
+    context,
+    bufferedAgentMessage.session,
+    bufferedAgentMessage.item,
+    bufferedAgentMessage.timestamp,
+    context.tokenUsageByTurnKey.get(turnKey),
+    bufferedAgentMessage.model ?? modelForTurn(context, session, turnId),
+  );
+};
+
 export const handleCodexPendingNotifications = async (
   context: CodexStreamingContext,
   session: CodexSessionState,
@@ -548,6 +579,10 @@ export const handleCodexPendingNotifications = async (
         const liveStatus = codexThreadStatusSnapshot(notification.params.status);
         context.setSessionLiveStatus(session, liveStatus);
         if (activeTurn && isIdleStatus) {
+          if (activeTurn.turnId) {
+            flushBufferedFinalAgentMessage(context, session, activeTurn.turnId);
+            clearTurnScopedStreamingState(context, session.threadId, activeTurn.turnId);
+          }
           emitCodexSessionEvent(context, session.threadId, {
             type: "session_idle",
             externalSessionId: session.threadId,
@@ -625,26 +660,10 @@ export const handleCodexPendingNotifications = async (
       const turn = isPlainObject(notification.params) ? notification.params.turn : null;
       const turnId = isPlainObject(turn) ? extractStringField(turn, ["id", "turnId"]) : null;
       if (turnId && isPlainObject(turn) && turn.status === "completed") {
-        const turnKey = codexTurnKey(session.threadId, turnId);
-        const bufferedAgentMessage = context.completedAgentMessagesByTurnKey.get(turnKey);
-        if (bufferedAgentMessage) {
-          emitFinalAgentMessage(
-            context,
-            bufferedAgentMessage.session,
-            bufferedAgentMessage.item,
-            bufferedAgentMessage.timestamp,
-            context.tokenUsageByTurnKey.get(turnKey),
-            bufferedAgentMessage.model ?? modelForTurn(context, session, turnId),
-          );
-          context.completedAgentMessagesByTurnKey.delete(turnKey);
-        }
-        context.tokenUsageByTurnKey.delete(turnKey);
-        context.modelByTurnKey.delete(turnKey);
+        flushBufferedFinalAgentMessage(context, session, turnId);
+        clearTurnScopedStreamingState(context, session.threadId, turnId);
       } else if (turnId) {
-        const turnKey = codexTurnKey(session.threadId, turnId);
-        context.completedAgentMessagesByTurnKey.delete(turnKey);
-        context.tokenUsageByTurnKey.delete(turnKey);
-        context.modelByTurnKey.delete(turnKey);
+        clearTurnScopedStreamingState(context, session.threadId, turnId);
       }
       const shouldSettleActiveTurn = activeTurn && (!turnId || activeTurn.turnId === turnId);
       if (shouldSettleActiveTurn) {

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -64,7 +64,7 @@ export type CodexStreamingContext = {
   latestTodosBySessionId: Map<string, AgentSessionTodoItem[]>;
   eventMapperPipeline: CodexEventMapperPipeline;
   emitSessionEvent(externalSessionId: string, event: AgentEvent): void;
-  bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean;
+  bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string, startedAtMs?: number): boolean;
   flushQueuedUserMessagesLater(activeTurn: ActiveCodexTurn): void;
   bufferNotification(notification: CodexNotificationRecord): void;
   setSessionLiveStatus(session: CodexSessionState, liveStatus: CodexThreadStatusSnapshot): void;
@@ -461,12 +461,20 @@ const isCodexIdleThreadStatus = (status: unknown): boolean => {
   return type?.toLowerCase() === "idle";
 };
 
+const receivedAtMsFromCodexNotification = (receivedAt: string): number => {
+  const receivedAtMs = Date.parse(receivedAt);
+  if (!Number.isFinite(receivedAtMs)) {
+    throw new Error(`Codex notification has an unparsable receivedAt timestamp '${receivedAt}'.`);
+  }
+  return receivedAtMs;
+};
+
 const isNotificationAtOrAfterActiveTurnStart = (
-  timestamp: string,
+  receivedAt: string,
   activeTurn: ActiveCodexTurn,
 ): boolean => {
-  const receivedAtMs = Date.parse(timestamp);
-  return Number.isFinite(receivedAtMs) && receivedAtMs >= activeTurn.startedAtMs;
+  const receivedAtMs = receivedAtMsFromCodexNotification(receivedAt);
+  return receivedAtMs >= activeTurn.startedAtMs;
 };
 
 export const handleCodexPendingNotifications = async (
@@ -498,7 +506,11 @@ export const handleCodexPendingNotifications = async (
     if (
       notificationTurnId &&
       activeTurn &&
-      context.bindActiveTurnId(activeTurn, notificationTurnId)
+      context.bindActiveTurnId(
+        activeTurn,
+        notificationTurnId,
+        receivedAtMsFromCodexNotification(notification.receivedAt),
+      )
     ) {
       context.flushQueuedUserMessagesLater(activeTurn);
     }
@@ -509,7 +521,15 @@ export const handleCodexPendingNotifications = async (
       });
       const turn = isPlainObject(notification.params) ? notification.params.turn : null;
       const turnId = isPlainObject(turn) ? extractStringField(turn, ["id", "turnId"]) : null;
-      if (turnId && activeTurn && context.bindActiveTurnId(activeTurn, turnId)) {
+      if (
+        turnId &&
+        activeTurn &&
+        context.bindActiveTurnId(
+          activeTurn,
+          turnId,
+          receivedAtMsFromCodexNotification(notification.receivedAt),
+        )
+      ) {
         context.flushQueuedUserMessagesLater(activeTurn);
       }
       continue;
@@ -521,13 +541,18 @@ export const handleCodexPendingNotifications = async (
         if (
           activeTurn &&
           isIdleStatus &&
-          !isNotificationAtOrAfterActiveTurnStart(timestamp, activeTurn)
+          !isNotificationAtOrAfterActiveTurnStart(notification.receivedAt, activeTurn)
         ) {
           continue;
         }
         const liveStatus = codexThreadStatusSnapshot(notification.params.status);
         context.setSessionLiveStatus(session, liveStatus);
         if (activeTurn && isIdleStatus) {
+          emitCodexSessionEvent(context, session.threadId, {
+            type: "session_idle",
+            externalSessionId: session.threadId,
+            timestamp: notification.receivedAt,
+          });
           activeTurn.markTurnSettled();
         }
       }

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -452,6 +452,23 @@ const timestampFromCodexNotification = (notification: CodexNotificationRecord): 
   return notification.receivedAt;
 };
 
+const isCodexIdleThreadStatus = (status: unknown): boolean => {
+  const type = isPlainObject(status)
+    ? extractStringField(status, ["type"])
+    : typeof status === "string"
+      ? status
+      : null;
+  return type?.toLowerCase() === "idle";
+};
+
+const isNotificationAtOrAfterActiveTurnStart = (
+  timestamp: string,
+  activeTurn: ActiveCodexTurn,
+): boolean => {
+  const receivedAtMs = Date.parse(timestamp);
+  return Number.isFinite(receivedAtMs) && receivedAtMs >= activeTurn.startedAtMs;
+};
+
 export const handleCodexPendingNotifications = async (
   context: CodexStreamingContext,
   session: CodexSessionState,
@@ -500,10 +517,19 @@ export const handleCodexPendingNotifications = async (
 
     if (notification.method === "thread/status/changed") {
       if (isPlainObject(notification.params)) {
-        context.setSessionLiveStatus(
-          session,
-          codexThreadStatusSnapshot(notification.params.status),
-        );
+        const isIdleStatus = isCodexIdleThreadStatus(notification.params.status);
+        if (
+          activeTurn &&
+          isIdleStatus &&
+          !isNotificationAtOrAfterActiveTurnStart(timestamp, activeTurn)
+        ) {
+          continue;
+        }
+        const liveStatus = codexThreadStatusSnapshot(notification.params.status);
+        context.setSessionLiveStatus(session, liveStatus);
+        if (activeTurn && isIdleStatus) {
+          activeTurn.markTurnSettled();
+        }
       }
       continue;
     }

--- a/packages/adapters-codex-app-server/src/codex-runtime-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-events.test.ts
@@ -42,10 +42,10 @@ describe("CodexRuntimeEventBuffer", () => {
     });
 
     expect(buffer.takeServerRequests("child-thread", "runtime-1")).toEqual([
-      request(1, "child-thread"),
+      { request: request(1, "child-thread"), receivedAt },
     ]);
     expect(buffer.takeServerRequests("child-thread", "runtime-2")).toEqual([
-      request(2, "child-thread"),
+      { request: request(2, "child-thread"), receivedAt },
     ]);
   });
 
@@ -68,7 +68,7 @@ describe("CodexRuntimeEventBuffer", () => {
 
     expect(buffer.takeServerRequests("child-thread", "runtime-1")).toEqual([]);
     expect(buffer.takeServerRequests("child-thread", "runtime-2")).toEqual([
-      request(2, "child-thread"),
+      { request: request(2, "child-thread"), receivedAt },
     ]);
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-runtime-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-events.test.ts
@@ -6,6 +6,7 @@ const request = (id: number, threadId: string) => ({
   method: "item/tool/requestUserInput",
   params: { threadId, turnId: `turn-${id}` },
 });
+const receivedAt = "2026-07-06T12:00:00.000Z";
 
 describe("CodexRuntimeEventSubscriptions", () => {
   test("removes a failed synchronous subscription so the runtime can retry", async () => {
@@ -30,11 +31,13 @@ describe("CodexRuntimeEventBuffer", () => {
     buffer.bufferRuntimeStreamEvent("child-thread", {
       runtimeId: "runtime-1",
       kind: "server_request",
+      receivedAt,
       message: request(1, "child-thread"),
     });
     buffer.bufferRuntimeStreamEvent("child-thread", {
       runtimeId: "runtime-2",
       kind: "server_request",
+      receivedAt,
       message: request(2, "child-thread"),
     });
 
@@ -51,11 +54,13 @@ describe("CodexRuntimeEventBuffer", () => {
     buffer.bufferRuntimeStreamEvent("child-thread", {
       runtimeId: "runtime-1",
       kind: "server_request",
+      receivedAt,
       message: request(1, "child-thread"),
     });
     buffer.bufferRuntimeStreamEvent("child-thread", {
       runtimeId: "runtime-2",
       kind: "server_request",
+      receivedAt,
       message: request(2, "child-thread"),
     });
 

--- a/packages/adapters-codex-app-server/src/codex-runtime-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-events.ts
@@ -23,13 +23,23 @@ export type CodexRuntimeStreamEvent = {
   message: unknown;
 };
 
+export type BufferedCodexServerRequest = {
+  request: CodexServerRequestRecord;
+  receivedAt: string;
+};
+
 export type BufferedCodexRuntimeEvent =
   | { kind: "notification"; notification: CodexNotificationRecord }
-  | { kind: "server_request"; runtimeId: string; request: CodexServerRequestRecord };
+  | {
+      kind: "server_request";
+      runtimeId: string;
+      request: CodexServerRequestRecord;
+      receivedAt: string;
+    };
 
 export class CodexRuntimeEventBuffer {
   readonly notificationsByThreadId = new Map<string, CodexNotificationRecord[]>();
-  readonly serverRequestsByRuntimeId = new Map<string, Map<string, CodexServerRequestRecord[]>>();
+  readonly serverRequestsByRuntimeId = new Map<string, Map<string, BufferedCodexServerRequest[]>>();
 
   takeNotifications(threadId: string): CodexNotificationRecord[] {
     const notifications = this.notificationsByThreadId.get(threadId) ?? [];
@@ -37,12 +47,12 @@ export class CodexRuntimeEventBuffer {
     return notifications;
   }
 
-  takeServerRequests(threadId: string, runtimeId?: string): CodexServerRequestRecord[] {
+  takeServerRequests(threadId: string, runtimeId?: string): BufferedCodexServerRequest[] {
     if (runtimeId) {
       return this.takeServerRequestsForRuntime(threadId, runtimeId);
     }
 
-    const requests: CodexServerRequestRecord[] = [];
+    const requests: BufferedCodexServerRequest[] = [];
     for (const runtime of [...this.serverRequestsByRuntimeId.keys()]) {
       requests.push(...this.takeServerRequestsForRuntime(threadId, runtime));
     }
@@ -52,7 +62,7 @@ export class CodexRuntimeEventBuffer {
   private takeServerRequestsForRuntime(
     threadId: string,
     runtimeId: string,
-  ): CodexServerRequestRecord[] {
+  ): BufferedCodexServerRequest[] {
     const requestsByThreadId = this.serverRequestsByRuntimeId.get(runtimeId);
     const requests = requestsByThreadId?.get(threadId) ?? [];
     requestsByThreadId?.delete(threadId);
@@ -104,8 +114,16 @@ export class CodexRuntimeEventBuffer {
     }
 
     const request = parseServerRequestRecord(event.message);
-    this.bufferServerRequestForThread(threadId, event.runtimeId, request);
-    return { kind: "server_request", runtimeId: event.runtimeId, request };
+    this.bufferServerRequestForThread(threadId, event.runtimeId, {
+      request,
+      receivedAt: event.receivedAt,
+    });
+    return {
+      kind: "server_request",
+      runtimeId: event.runtimeId,
+      request,
+      receivedAt: event.receivedAt,
+    };
   }
 
   private bufferNotificationForThread(threadId: string, notification: CodexNotificationRecord) {
@@ -117,7 +135,7 @@ export class CodexRuntimeEventBuffer {
   private bufferServerRequestForThread(
     threadId: string,
     runtimeId: string,
-    request: CodexServerRequestRecord,
+    request: BufferedCodexServerRequest,
   ) {
     const requestsByThreadId = this.serverRequestsByRuntimeId.get(runtimeId) ?? new Map();
     const buffered = requestsByThreadId.get(threadId) ?? [];

--- a/packages/adapters-codex-app-server/src/codex-runtime-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-events.ts
@@ -19,6 +19,7 @@ import type {
 export type CodexRuntimeStreamEvent = {
   runtimeId: string;
   kind: "notification" | "server_request";
+  receivedAt: string;
   message: unknown;
 };
 
@@ -94,10 +95,10 @@ export class CodexRuntimeEventBuffer {
 
   bufferRuntimeStreamEvent(
     threadId: string,
-    event: Pick<CodexRuntimeStreamEvent, "runtimeId" | "kind" | "message">,
+    event: Pick<CodexRuntimeStreamEvent, "runtimeId" | "kind" | "receivedAt" | "message">,
   ): BufferedCodexRuntimeEvent {
     if (event.kind === "notification") {
-      const notification = parseNotificationRecord(event.message);
+      const notification = parseNotificationRecord(event.message, event.receivedAt);
       this.bufferNotificationForThread(threadId, notification);
       return { kind: "notification", notification };
     }

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -70,6 +70,7 @@ const createActiveTurn = (
   turnModel: AgentModelSelection = model,
 ): ActiveCodexTurn => ({
   session: createSession(threadId),
+  startedAtMs: Date.now(),
   turnStartPromise: Promise.resolve({}),
   isTurnSettled: () => false,
   markTurnSettled: () => undefined,

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -102,7 +102,7 @@ const createActiveTurn = (
 ): ActiveCodexTurn => ({
   session: createSession(threadId),
   startedAtMs: Date.now(),
-  turnEvidenceMinReceivedAtMs: 0,
+  turnStartRequestSentAtMs: 0,
   turnStartPromise: Promise.resolve({}),
   isTurnSettled: () => false,
   markTurnSettled: () => undefined,
@@ -377,6 +377,18 @@ describe("CodexRuntimeSessionEvents", () => {
     );
   });
 
+  test("does not first-bind before the turn start request is sent", () => {
+    const session = createSession("thread-unstarted-turn");
+    const runtimeEvents = createRuntimeEvents();
+    const activeTurn = createActiveTurn(session.threadId);
+    activeTurn.turnStartRequestSentAtMs = null;
+
+    const didBind = runtimeEvents.bindActiveTurnId(activeTurn, "turn-too-early");
+
+    expect(didBind).toBe(false);
+    expect(activeTurn.turnId).toBeUndefined();
+  });
+
   test("does not first-bind an active turn from old buffered turn evidence", async () => {
     const staleTurnStartedReceivedAt = "2000-01-01T00:00:00.000Z";
     const staleIdleReceivedAt = "2000-01-01T00:00:01.000Z";
@@ -386,7 +398,7 @@ describe("CodexRuntimeSessionEvents", () => {
     const emittedEvents: unknown[] = [];
     const { activeTurn, isSettled } = createSettlingActiveTurn(session.threadId);
     activeTurn.startedAtMs = Number.POSITIVE_INFINITY;
-    activeTurn.turnEvidenceMinReceivedAtMs = Date.parse("2000-01-01T00:00:02.000Z");
+    activeTurn.turnStartRequestSentAtMs = Date.parse("2000-01-01T00:00:02.000Z");
     const activeTurnsBySessionId = new Map([[session.threadId, activeTurn]]);
     sessionEvents.subscribe(codexSessionRef(session), (event) => emittedEvents.push(event));
     const runtimeEvents = createRuntimeEvents({

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -17,11 +17,34 @@ const flushRuntimeEvents = async (): Promise<void> => {
   await waitForRuntimeEvent();
 };
 
-type RuntimeListener = (event: {
+const runtimeEventReceivedAt = "2026-07-06T12:00:00.000Z";
+
+type RuntimeEventInput = {
   runtimeId: string;
   kind: "notification" | "server_request";
   message: unknown;
-}) => void;
+};
+
+type RuntimeListener = (event: RuntimeEventInput) => void;
+
+const withRuntimeReceivedAt = (event: RuntimeEventInput) => ({
+  ...event,
+  receivedAt: runtimeEventReceivedAt,
+});
+
+const bufferedServerRequestEvent = (message: unknown, runtimeId = "runtime-1") => ({
+  runtimeId,
+  kind: "server_request" as const,
+  receivedAt: runtimeEventReceivedAt,
+  message,
+});
+
+const bufferedNotificationEvent = (message: unknown, runtimeId = "runtime-1") => ({
+  runtimeId,
+  kind: "notification" as const,
+  receivedAt: runtimeEventReceivedAt,
+  message,
+});
 
 const createRuntimeEvents = (
   overrides: Partial<ConstructorParameters<typeof CodexRuntimeSessionEvents>[0]> = {},
@@ -129,7 +152,7 @@ describe("CodexRuntimeSessionEvents", () => {
     });
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
-        listener = next;
+        listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
       sessions,
@@ -179,7 +202,7 @@ describe("CodexRuntimeSessionEvents", () => {
     sessionEvents.subscribe(codexSessionRef(session), (event) => emittedEvents.push(event));
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
-        listener = next;
+        listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
       sessions,
@@ -234,31 +257,23 @@ describe("CodexRuntimeSessionEvents", () => {
     const pendingInput = new CodexPendingInputState();
     const runtimeEvents = createRuntimeEvents({
       takeBufferedEvents: async () => [
-        {
-          runtimeId: "runtime-1",
-          kind: "server_request",
-          message: {
-            id: "buffered-approval-1",
-            method: CODEX_APP_SERVER_SERVER_REQUEST_METHOD.ITEM_COMMAND_EXECUTION_REQUEST_APPROVAL,
-            params: {
-              threadId: "thread-buffered-order",
-              turnId: "turn-buffered-order",
-              itemId: "call-buffered-order",
-              command: "curl -I https://example.com",
-            },
+        bufferedServerRequestEvent({
+          id: "buffered-approval-1",
+          method: CODEX_APP_SERVER_SERVER_REQUEST_METHOD.ITEM_COMMAND_EXECUTION_REQUEST_APPROVAL,
+          params: {
+            threadId: "thread-buffered-order",
+            turnId: "turn-buffered-order",
+            itemId: "call-buffered-order",
+            command: "curl -I https://example.com",
           },
-        },
-        {
-          runtimeId: "runtime-1",
-          kind: "notification",
-          message: {
-            method: "serverRequest/resolved",
-            params: {
-              threadId: "thread-buffered-order",
-              requestId: "buffered-approval-1",
-            },
+        }),
+        bufferedNotificationEvent({
+          method: "serverRequest/resolved",
+          params: {
+            threadId: "thread-buffered-order",
+            requestId: "buffered-approval-1",
           },
-        },
+        }),
       ],
       sessions,
       pendingInput,
@@ -277,47 +292,35 @@ describe("CodexRuntimeSessionEvents", () => {
     const pendingInput = new CodexPendingInputState();
     const runtimeEvents = createRuntimeEvents({
       takeBufferedEvents: async () => [
-        {
-          runtimeId: "runtime-1",
-          kind: "server_request",
-          message: {
-            id: "drained-approval-1",
-            method: CODEX_APP_SERVER_SERVER_REQUEST_METHOD.ITEM_COMMAND_EXECUTION_REQUEST_APPROVAL,
-            params: {
-              threadId: "thread-drained-resolution",
-              turnId: "turn-drained-resolution",
-              itemId: "call-drained-resolution",
-              command: "curl -I https://example.com",
+        bufferedServerRequestEvent({
+          id: "drained-approval-1",
+          method: CODEX_APP_SERVER_SERVER_REQUEST_METHOD.ITEM_COMMAND_EXECUTION_REQUEST_APPROVAL,
+          params: {
+            threadId: "thread-drained-resolution",
+            turnId: "turn-drained-resolution",
+            itemId: "call-drained-resolution",
+            command: "curl -I https://example.com",
+          },
+        }),
+        bufferedNotificationEvent({
+          method: "serverRequest/resolved",
+          params: {
+            threadId: "thread-drained-resolution",
+            requestId: "drained-approval-1",
+          },
+        }),
+        bufferedNotificationEvent({
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-drained-resolution",
+            turnId: "turn-drained-resolution",
+            tokenUsage: {
+              total: { totalTokens: 1_000 },
+              last: { totalTokens: 100 },
+              modelContextWindow: 200_000,
             },
           },
-        },
-        {
-          runtimeId: "runtime-1",
-          kind: "notification",
-          message: {
-            method: "serverRequest/resolved",
-            params: {
-              threadId: "thread-drained-resolution",
-              requestId: "drained-approval-1",
-            },
-          },
-        },
-        {
-          runtimeId: "runtime-1",
-          kind: "notification",
-          message: {
-            method: "thread/tokenUsage/updated",
-            params: {
-              threadId: "thread-drained-resolution",
-              turnId: "turn-drained-resolution",
-              tokenUsage: {
-                total: { totalTokens: 1_000 },
-                last: { totalTokens: 100 },
-                modelContextWindow: 200_000,
-              },
-            },
-          },
-        },
+        }),
       ],
       sessions,
       pendingInput,
@@ -349,7 +352,7 @@ describe("CodexRuntimeSessionEvents", () => {
     const subagents = new CodexSubagentLinkState();
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
-        listener = next;
+        listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
       sessions,
@@ -432,7 +435,7 @@ describe("CodexRuntimeSessionEvents", () => {
     const pendingInput = new CodexPendingInputState();
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
-        listener = next;
+        listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
       sessions,
@@ -498,7 +501,7 @@ describe("CodexRuntimeSessionEvents", () => {
     const subagents = new CodexSubagentLinkState();
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
-        listener = next;
+        listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
       sessions,
@@ -564,7 +567,7 @@ describe("CodexRuntimeSessionEvents", () => {
     const pendingInput = new CodexPendingInputState();
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
-        listener = next;
+        listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
       sessions,
@@ -620,7 +623,7 @@ describe("CodexRuntimeSessionEvents", () => {
     });
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
-        listener = next;
+        listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
       sessions,
@@ -669,7 +672,7 @@ describe("CodexRuntimeSessionEvents", () => {
     const subagents = new CodexSubagentLinkState();
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (runtimeId, next) => {
-        listeners.set(runtimeId, next);
+        listeners.set(runtimeId, (event) => next(withRuntimeReceivedAt(event)));
         return () => undefined;
       },
       sessions,
@@ -745,7 +748,7 @@ describe("CodexRuntimeSessionEvents", () => {
     const subagents = new CodexSubagentLinkState();
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
-        listener = next;
+        listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
       sessions,

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -102,6 +102,7 @@ const createActiveTurn = (
 ): ActiveCodexTurn => ({
   session: createSession(threadId),
   startedAtMs: Date.now(),
+  turnEvidenceMinReceivedAtMs: 0,
   turnStartPromise: Promise.resolve({}),
   isTurnSettled: () => false,
   markTurnSettled: () => undefined,
@@ -372,6 +373,60 @@ describe("CodexRuntimeSessionEvents", () => {
         type: "session_idle",
         externalSessionId: session.threadId,
         timestamp: idleReceivedAt,
+      }),
+    );
+  });
+
+  test("does not first-bind an active turn from old buffered turn evidence", async () => {
+    const staleTurnStartedReceivedAt = "2000-01-01T00:00:00.000Z";
+    const staleIdleReceivedAt = "2000-01-01T00:00:01.000Z";
+    const session = createSession("thread-stale-turn-start");
+    const sessions = new Map([[session.threadId, session]]);
+    const sessionEvents = new CodexSessionEventBus();
+    const emittedEvents: unknown[] = [];
+    const { activeTurn, isSettled } = createSettlingActiveTurn(session.threadId);
+    activeTurn.startedAtMs = Number.POSITIVE_INFINITY;
+    activeTurn.turnEvidenceMinReceivedAtMs = Date.parse("2000-01-01T00:00:02.000Z");
+    const activeTurnsBySessionId = new Map([[session.threadId, activeTurn]]);
+    sessionEvents.subscribe(codexSessionRef(session), (event) => emittedEvents.push(event));
+    const runtimeEvents = createRuntimeEvents({
+      takeBufferedEvents: async () => [
+        bufferedNotificationEvent(
+          {
+            method: "turn/started",
+            params: {
+              threadId: session.threadId,
+              turn: { id: "turn-old" },
+            },
+          },
+          session.runtimeId,
+          staleTurnStartedReceivedAt,
+        ),
+        bufferedNotificationEvent(
+          {
+            method: "thread/status/changed",
+            params: {
+              threadId: session.threadId,
+              status: { type: "idle" },
+            },
+          },
+          session.runtimeId,
+          staleIdleReceivedAt,
+        ),
+      ],
+      sessions,
+      sessionEvents,
+      activeTurnsBySessionId,
+    });
+
+    await runtimeEvents.handleBufferedRuntimeEvents(session, new Set());
+
+    expect(activeTurn.turnId).toBeUndefined();
+    expect(activeTurn.startedAtMs).toBe(Number.POSITIVE_INFINITY);
+    expect(isSettled()).toBe(false);
+    expect(emittedEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "session_idle",
       }),
     );
   });

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -32,17 +32,25 @@ const withRuntimeReceivedAt = (event: RuntimeEventInput) => ({
   receivedAt: runtimeEventReceivedAt,
 });
 
-const bufferedServerRequestEvent = (message: unknown, runtimeId = "runtime-1") => ({
+const bufferedServerRequestEvent = (
+  message: unknown,
+  runtimeId = "runtime-1",
+  receivedAt = runtimeEventReceivedAt,
+) => ({
   runtimeId,
   kind: "server_request" as const,
-  receivedAt: runtimeEventReceivedAt,
+  receivedAt,
   message,
 });
 
-const bufferedNotificationEvent = (message: unknown, runtimeId = "runtime-1") => ({
+const bufferedNotificationEvent = (
+  message: unknown,
+  runtimeId = "runtime-1",
+  receivedAt = runtimeEventReceivedAt,
+) => ({
   runtimeId,
   kind: "notification" as const,
-  receivedAt: runtimeEventReceivedAt,
+  receivedAt,
   message,
 });
 
@@ -101,6 +109,23 @@ const createActiveTurn = (
   queuedUserMessages: [],
   model: turnModel,
 });
+
+const createSettlingActiveTurn = (
+  threadId: string,
+  turnModel: AgentModelSelection = model,
+): { activeTurn: ActiveCodexTurn; isSettled: () => boolean } => {
+  let settled = false;
+  return {
+    activeTurn: {
+      ...createActiveTurn(threadId, turnModel),
+      isTurnSettled: () => settled,
+      markTurnSettled: () => {
+        settled = true;
+      },
+    },
+    isSettled: () => settled,
+  };
+};
 
 const createChildThreadSnapshot = (
   childThreadId: string,
@@ -284,6 +309,127 @@ describe("CodexRuntimeSessionEvents", () => {
     expect(hasPendingInput).toBe(false);
     expect(pendingInput.approval("buffered-approval-1")).toBeUndefined();
     expect(pendingInput.pendingApprovalEventsForSession("thread-buffered-order")).toHaveLength(0);
+  });
+
+  test("uses server-request receipt time when binding a buffered active turn", async () => {
+    const requestReceivedAt = "2000-01-01T00:00:00.000Z";
+    const idleReceivedAt = "2000-01-01T00:00:01.000Z";
+    const session = createSession("thread-server-request-receipt");
+    const sessions = new Map([[session.threadId, session]]);
+    const pendingInput = new CodexPendingInputState();
+    const sessionEvents = new CodexSessionEventBus();
+    const emittedEvents: unknown[] = [];
+    const { activeTurn, isSettled } = createSettlingActiveTurn(session.threadId);
+    const activeTurnsBySessionId = new Map([[session.threadId, activeTurn]]);
+    sessionEvents.subscribe(codexSessionRef(session), (event) => emittedEvents.push(event));
+    const runtimeEvents = createRuntimeEvents({
+      takeBufferedEvents: async () => [
+        bufferedServerRequestEvent(
+          {
+            id: "question-receipt-1",
+            method: "item/tool/requestUserInput",
+            params: {
+              threadId: session.threadId,
+              turnId: "turn-receipt",
+              questions: [
+                {
+                  id: "question-item-1",
+                  header: "Choose",
+                  question: "Proceed?",
+                  options: ["Yes", "No"],
+                },
+              ],
+            },
+          },
+          session.runtimeId,
+          requestReceivedAt,
+        ),
+        bufferedNotificationEvent(
+          {
+            method: "thread/status/changed",
+            params: {
+              threadId: session.threadId,
+              status: { type: "idle" },
+            },
+          },
+          session.runtimeId,
+          idleReceivedAt,
+        ),
+      ],
+      sessions,
+      sessionEvents,
+      pendingInput,
+      activeTurnsBySessionId,
+    });
+
+    await runtimeEvents.handleBufferedRuntimeEvents(session, new Set());
+
+    expect(activeTurn.turnId).toBe("turn-receipt");
+    expect(activeTurn.startedAtMs).toBe(Date.parse(requestReceivedAt));
+    expect(isSettled()).toBe(true);
+    expect(emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "session_idle",
+        externalSessionId: session.threadId,
+        timestamp: idleReceivedAt,
+      }),
+    );
+  });
+
+  test("lowers the active-turn cutoff when same-turn start evidence is older", async () => {
+    const originalStartedAtMs = Date.parse("2100-01-01T00:00:00.000Z");
+    const turnStartedReceivedAt = "2000-01-01T00:00:00.000Z";
+    const idleReceivedAt = "2000-01-01T00:00:01.000Z";
+    const session = createSession("thread-same-turn-cutoff");
+    const sessions = new Map([[session.threadId, session]]);
+    const sessionEvents = new CodexSessionEventBus();
+    const emittedEvents: unknown[] = [];
+    const { activeTurn, isSettled } = createSettlingActiveTurn(session.threadId);
+    const activeTurnsBySessionId = new Map([[session.threadId, activeTurn]]);
+    sessionEvents.subscribe(codexSessionRef(session), (event) => emittedEvents.push(event));
+    const runtimeEvents = createRuntimeEvents({
+      takeBufferedEvents: async () => [
+        bufferedNotificationEvent(
+          {
+            method: "turn/started",
+            params: {
+              threadId: session.threadId,
+              turn: { id: "turn-same" },
+            },
+          },
+          session.runtimeId,
+          turnStartedReceivedAt,
+        ),
+        bufferedNotificationEvent(
+          {
+            method: "thread/status/changed",
+            params: {
+              threadId: session.threadId,
+              status: { type: "idle" },
+            },
+          },
+          session.runtimeId,
+          idleReceivedAt,
+        ),
+      ],
+      sessions,
+      sessionEvents,
+      activeTurnsBySessionId,
+    });
+    runtimeEvents.bindActiveTurnId(activeTurn, "turn-same", originalStartedAtMs);
+
+    await runtimeEvents.handleBufferedRuntimeEvents(session, new Set());
+
+    expect(activeTurn.turnId).toBe("turn-same");
+    expect(activeTurn.startedAtMs).toBe(Date.parse(turnStartedReceivedAt));
+    expect(isSettled()).toBe(true);
+    expect(emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "session_idle",
+        externalSessionId: session.threadId,
+        timestamp: idleReceivedAt,
+      }),
+    );
   });
 
   test("does not replay token-usage drained requests resolved in the same batch", async () => {

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -215,6 +215,14 @@ export class CodexRuntimeSessionEvents {
     }
 
     const didBind = !activeTurn.turnId;
+    if (
+      didBind &&
+      startedAtMs !== undefined &&
+      startedAtMs < activeTurn.turnEvidenceMinReceivedAtMs
+    ) {
+      return false;
+    }
+
     activeTurn.turnId = turnId;
     if (startedAtMs !== undefined && (didBind || startedAtMs < activeTurn.startedAtMs)) {
       activeTurn.startedAtMs = startedAtMs;

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -367,7 +367,7 @@ export class CodexRuntimeSessionEvents {
       return;
     }
     if (event.kind === "notification") {
-      const notification = parseNotificationRecord(event.message);
+      const notification = parseNotificationRecord(event.message, event.receivedAt);
       if (notification.method === "serverRequest/resolved") {
         this.handleServerRequestResolvedNotification(event.runtimeId, notification);
         return;
@@ -567,7 +567,7 @@ export class CodexRuntimeSessionEvents {
 
   private bufferRuntimeStreamEvent(
     threadId: string,
-    event: { runtimeId: string; kind: "notification" | "server_request"; message: unknown },
+    event: Pick<CodexRuntimeStreamEvent, "runtimeId" | "kind" | "receivedAt" | "message">,
   ): void {
     this.runtimeEventBuffer.bufferRuntimeStreamEvent(threadId, event);
   }
@@ -627,10 +627,12 @@ export class CodexRuntimeSessionEvents {
 
   private async processRuntimeStreamEventForSession(
     session: CodexSessionState,
-    event: { kind: "notification" | "server_request"; message: unknown },
+    event: Pick<CodexRuntimeStreamEvent, "kind" | "receivedAt" | "message">,
   ): Promise<void> {
     if (event.kind === "notification") {
-      await this.handlePendingNotifications(session, [parseNotificationRecord(event.message)]);
+      await this.handlePendingNotifications(session, [
+        parseNotificationRecord(event.message, event.receivedAt),
+      ]);
       return;
     }
     await this.processServerRequestsForSession(session, [parseServerRequestRecord(event.message)]);
@@ -700,7 +702,7 @@ export class CodexRuntimeSessionEvents {
     threadId: string | null,
     event: CodexRuntimeStreamEvent,
   ): Promise<void> {
-    const notification = parseNotificationRecord(event.message);
+    const notification = parseNotificationRecord(event.message, event.receivedAt);
     if (notification.method === "serverRequest/resolved") {
       this.handleServerRequestResolvedNotification(event.runtimeId, notification);
       return;
@@ -809,7 +811,7 @@ export class CodexRuntimeSessionEvents {
     if (event.kind !== "notification") {
       return null;
     }
-    const notification = parseNotificationRecord(event.message);
+    const notification = parseNotificationRecord(event.message, event.receivedAt);
     if (notification.method !== "serverRequest/resolved") {
       return null;
     }
@@ -832,6 +834,7 @@ export class CodexRuntimeSessionEvents {
   private bufferUnprocessedServerRequest(
     runtimeId: string,
     request: CodexServerRequestRecord,
+    receivedAt: string,
   ): void {
     const threadId = extractThreadIdFromParams(request.params);
     if (!threadId) {
@@ -841,6 +844,7 @@ export class CodexRuntimeSessionEvents {
     this.bufferRuntimeStreamEvent(threadId, {
       runtimeId,
       kind: "server_request",
+      receivedAt,
       message: request,
     });
   }
@@ -963,11 +967,11 @@ export class CodexRuntimeSessionEvents {
           const request = parseServerRequestRecord(event.message);
           const requestKey = this.serverRequestBatchKey(event.runtimeId, request);
           if (!requestKey || !resolvedRequestKeys.has(requestKey)) {
-            this.bufferUnprocessedServerRequest(event.runtimeId, request);
+            this.bufferUnprocessedServerRequest(event.runtimeId, request, event.receivedAt);
           }
           continue;
         }
-        const notification = parseNotificationRecord(event.message);
+        const notification = parseNotificationRecord(event.message, event.receivedAt);
         if (notification.method === "serverRequest/resolved") {
           this.handleServerRequestResolvedNotification(event.runtimeId, notification);
           continue;

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -215,12 +215,14 @@ export class CodexRuntimeSessionEvents {
     }
 
     const didBind = !activeTurn.turnId;
-    if (
-      didBind &&
-      startedAtMs !== undefined &&
-      startedAtMs < activeTurn.turnEvidenceMinReceivedAtMs
-    ) {
-      return false;
+    if (didBind) {
+      const turnStartRequestSentAtMs = activeTurn.turnStartRequestSentAtMs;
+      if (turnStartRequestSentAtMs === null) {
+        return false;
+      }
+      if (startedAtMs !== undefined && startedAtMs < turnStartRequestSentAtMs) {
+        return false;
+      }
     }
 
     activeTurn.turnId = turnId;

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -365,6 +365,7 @@ export class CodexRuntimeSessionEvents {
   }
 
   private async handleRuntimeStreamEvent(event: CodexRuntimeStreamEvent): Promise<void> {
+    this.assertRuntimeStreamEventReceivedAt(event);
     const threadId = threadIdFromRuntimeStreamEvent(event);
     if (!threadId) {
       if (event.kind === "server_request") {
@@ -674,6 +675,7 @@ export class CodexRuntimeSessionEvents {
     preferredHandledRequestKeys: Set<string>,
     event: CodexRuntimeStreamEvent,
   ): Promise<void> {
+    this.assertRuntimeStreamEventReceivedAt(event);
     const threadId = threadIdFromRuntimeStreamEvent(event);
     if (event.kind === "notification") {
       await this.processBufferedNotification(preferredSession, threadId, event);
@@ -1081,6 +1083,15 @@ export class CodexRuntimeSessionEvents {
 
   private errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
+  }
+
+  private assertRuntimeStreamEventReceivedAt(
+    event: Pick<CodexRuntimeStreamEvent, "receivedAt">,
+  ): void {
+    const receivedAt = (event as { receivedAt?: unknown }).receivedAt;
+    if (typeof receivedAt !== "string" || receivedAt.trim().length === 0) {
+      throw new Error("Codex app-server stream event is missing receivedAt.");
+    }
   }
 
   private emitSessionEvent(externalSessionId: string, event: AgentEvent): void {

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -35,6 +35,7 @@ import { createCodexEventMapperPipeline } from "./codex-event-mapper-pipeline";
 import type { CodexSessionLookup } from "./codex-local-session-state";
 import type { CodexPendingInputState } from "./codex-pending-input-state";
 import {
+  type BufferedCodexServerRequest,
   CodexRuntimeEventBuffer,
   CodexRuntimeEventSubscriptions,
   type CodexRuntimeStreamEvent,
@@ -90,6 +91,23 @@ const waitForRestoredUsageReplayTick = (): Promise<void> =>
 
 const restoredContextCaptureKey = (runtimeId: string, threadId: string): string =>
   `${runtimeId}:${threadId}`;
+
+const receivedAtMsFromRuntimeStreamEvent = (receivedAt: string): number => {
+  const receivedAtMs = Date.parse(receivedAt);
+  if (!Number.isFinite(receivedAtMs)) {
+    throw new Error(
+      `Codex app-server stream event has an unparsable receivedAt timestamp '${receivedAt}'.`,
+    );
+  }
+  return receivedAtMs;
+};
+
+const serverRequestFromRuntimeEvent = (
+  event: Pick<CodexRuntimeStreamEvent, "message" | "receivedAt">,
+): BufferedCodexServerRequest => ({
+  request: parseServerRequestRecord(event.message),
+  receivedAt: event.receivedAt,
+});
 
 export class CodexRuntimeSessionEvents {
   private readonly runtimeEventBuffer = new CodexRuntimeEventBuffer();
@@ -192,13 +210,16 @@ export class CodexRuntimeSessionEvents {
       return false;
     }
 
+    if (startedAtMs !== undefined && !Number.isFinite(startedAtMs)) {
+      throw new Error("Codex active turn was bound with an invalid start timestamp.");
+    }
+
     const didBind = !activeTurn.turnId;
     activeTurn.turnId = turnId;
-    if (didBind) {
-      if (startedAtMs !== undefined && !Number.isFinite(startedAtMs)) {
-        throw new Error("Codex active turn was bound with an invalid start timestamp.");
-      }
-      activeTurn.startedAtMs = startedAtMs ?? Date.now();
+    if (startedAtMs !== undefined && (didBind || startedAtMs < activeTurn.startedAtMs)) {
+      activeTurn.startedAtMs = startedAtMs;
+    } else if (didBind) {
+      activeTurn.startedAtMs = Date.now();
     }
     this.modelByTurnKey.set(codexTurnKey(activeTurn.session.threadId, turnId), activeTurn.model);
     return didBind;
@@ -642,16 +663,16 @@ export class CodexRuntimeSessionEvents {
       ]);
       return;
     }
-    await this.processServerRequestsForSession(session, [parseServerRequestRecord(event.message)]);
+    await this.processServerRequestsForSession(session, [serverRequestFromRuntimeEvent(event)]);
   }
 
   private async processServerRequestsForSession(
     session: CodexSessionState,
-    requests: CodexServerRequestRecord[],
+    requests: BufferedCodexServerRequest[],
     handledRequestKeysOverride?: Set<string>,
   ): Promise<boolean> {
     const ownerThreadIds = new Set(
-      requests.map((request) => extractThreadIdFromParams(request.params) ?? session.threadId),
+      requests.map(({ request }) => extractThreadIdFromParams(request.params) ?? session.threadId),
     );
     const activeTurn = this.deps.activeTurnsBySessionId.get(session.threadId);
     const handledRequestKeys =
@@ -700,7 +721,7 @@ export class CodexRuntimeSessionEvents {
         : undefined;
     await this.processServerRequestsForSession(
       targetSession,
-      [parseServerRequestRecord(event.message)],
+      [serverRequestFromRuntimeEvent(event)],
       handledRequestKeys,
     );
   }
@@ -774,15 +795,16 @@ export class CodexRuntimeSessionEvents {
   private async handleServerRequests(
     session: CodexSessionState,
     handledRequestKeys: Set<string>,
-    requests: unknown[],
+    requests: BufferedCodexServerRequest[],
   ): Promise<boolean> {
     let hasPendingInput = false;
-    for (const request of requests) {
+    for (const { request, receivedAt } of requests) {
       hasPendingInput =
         (await this.handleServerRequest(
           session,
-          parseServerRequestRecord(request),
+          request,
           handledRequestKeys,
+          receivedAtMsFromRuntimeStreamEvent(receivedAt),
         )) || hasPendingInput;
     }
     return hasPendingInput;
@@ -935,12 +957,14 @@ export class CodexRuntimeSessionEvents {
     session: CodexSessionState,
     rawRequest: CodexServerRequestRecord,
     handledRequestKeys: Set<string>,
+    requestReceivedAtMs?: number,
   ): Promise<boolean> {
     return handleCodexServerRequest(
       this.serverRequestContext(),
       session,
       rawRequest,
       handledRequestKeys,
+      requestReceivedAtMs,
     );
   }
 
@@ -951,7 +975,8 @@ export class CodexRuntimeSessionEvents {
       activeTurnsBySessionId: this.deps.activeTurnsBySessionId,
       subagents: this.deps.subagents,
       sessionForThreadId: (threadId) => this.deps.sessions.get(threadId),
-      bindActiveTurnId: (activeTurn, turnId) => this.bindActiveTurnId(activeTurn, turnId),
+      bindActiveTurnId: (activeTurn, turnId, startedAtMs) =>
+        this.bindActiveTurnId(activeTurn, turnId, startedAtMs),
       flushQueuedUserMessagesLater: (activeTurn) =>
         this.deps.flushQueuedUserMessagesLater(activeTurn),
       emitSessionEvent: (externalSessionId, event) =>

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -187,13 +187,19 @@ export class CodexRuntimeSessionEvents {
     this.clearBufferedResolvedServerRequests(externalSessionId, runtimeId);
   }
 
-  bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean {
+  bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string, startedAtMs?: number): boolean {
     if (activeTurn.turnId && activeTurn.turnId !== turnId) {
       return false;
     }
 
     const didBind = !activeTurn.turnId;
     activeTurn.turnId = turnId;
+    if (didBind) {
+      if (startedAtMs !== undefined && !Number.isFinite(startedAtMs)) {
+        throw new Error("Codex active turn was bound with an invalid start timestamp.");
+      }
+      activeTurn.startedAtMs = startedAtMs ?? Date.now();
+    }
     this.modelByTurnKey.set(codexTurnKey(activeTurn.session.threadId, turnId), activeTurn.model);
     return didBind;
   }
@@ -913,7 +919,8 @@ export class CodexRuntimeSessionEvents {
       eventMapperPipeline: this.eventMapperPipeline,
       emitSessionEvent: (externalSessionId, event) =>
         this.emitSessionEvent(externalSessionId, event),
-      bindActiveTurnId: (activeTurn, turnId) => this.bindActiveTurnId(activeTurn, turnId),
+      bindActiveTurnId: (activeTurn, turnId, startedAtMs) =>
+        this.bindActiveTurnId(activeTurn, turnId, startedAtMs),
       flushQueuedUserMessagesLater: (activeTurn) =>
         this.deps.flushQueuedUserMessagesLater(activeTurn),
       bufferNotification: (notification) =>

--- a/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
@@ -33,7 +33,7 @@ export type CodexTurnLifecycleContext = {
     model: AgentModelSelection,
   ): Promise<void>;
   ensureRuntimeEventSubscription(runtimeId: string): Promise<void>;
-  bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string): boolean;
+  bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string, startedAtMs?: number): boolean;
   bindPendingInputToActiveTurn(externalSessionId: string, activeTurn: ActiveCodexTurn): void;
   setSessionLiveStatus(session: CodexSessionState, liveStatus: CodexThreadStatusSnapshot): void;
   handleBufferedRuntimeEvents(
@@ -173,7 +173,7 @@ export const startCodexTurnForSession = async (
   const handledRequestKeys = new Set<string>();
   const activeTurnState: ActiveCodexTurn = {
     session,
-    startedAtMs: Date.now(),
+    startedAtMs: Number.POSITIVE_INFINITY,
     turnStartPromise: Promise.resolve({}),
     isTurnSettled: () => turnSettled,
     markTurnSettled: () => {
@@ -228,9 +228,10 @@ export const startCodexTurnForSession = async (
       effort: toTransportModelSelection(model).effort,
     })
     .then((result) => {
+      const turnStartedAtMs = Date.now();
       const turnId = extractTurnId(result);
       if (turnId) {
-        context.bindActiveTurnId(activeTurnState, turnId);
+        context.bindActiveTurnId(activeTurnState, turnId, turnStartedAtMs);
       }
       flushQueuedUserMessagesLater(context, activeTurnState);
       if (isPlainObject(result.turn) && isTerminalTurnStatus(result.turn)) {

--- a/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
@@ -173,6 +173,7 @@ export const startCodexTurnForSession = async (
   const handledRequestKeys = new Set<string>();
   const activeTurnState: ActiveCodexTurn = {
     session,
+    startedAtMs: Date.now(),
     turnStartPromise: Promise.resolve({}),
     isTurnSettled: () => turnSettled,
     markTurnSettled: () => {

--- a/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
@@ -178,7 +178,9 @@ export const startCodexTurnForSession = async (
     isTurnSettled: () => turnSettled,
     markTurnSettled: () => {
       turnSettled = true;
-      context.activeTurnsBySessionId.delete(session.threadId);
+      if (context.activeTurnsBySessionId.get(session.threadId) === activeTurnState) {
+        context.activeTurnsBySessionId.delete(session.threadId);
+      }
     },
     handledRequestKeys,
     queuedUserMessages: [],
@@ -235,7 +237,10 @@ export const startCodexTurnForSession = async (
       }
       flushQueuedUserMessagesLater(context, activeTurnState);
       if (isPlainObject(result.turn) && isTerminalTurnStatus(result.turn)) {
-        context.setSessionLiveStatus(session, codexThreadStatusSnapshot("idle"));
+        const currentActiveTurn = context.activeTurnsBySessionId.get(session.threadId);
+        if (!currentActiveTurn || currentActiveTurn === activeTurnState) {
+          context.setSessionLiveStatus(session, codexThreadStatusSnapshot("idle"));
+        }
         activeTurnState.markTurnSettled();
       }
       return result;

--- a/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
@@ -174,6 +174,7 @@ export const startCodexTurnForSession = async (
   const activeTurnState: ActiveCodexTurn = {
     session,
     startedAtMs: Number.POSITIVE_INFINITY,
+    turnEvidenceMinReceivedAtMs: Number.POSITIVE_INFINITY,
     turnStartPromise: Promise.resolve({}),
     isTurnSettled: () => turnSettled,
     markTurnSettled: () => {
@@ -219,6 +220,7 @@ export const startCodexTurnForSession = async (
     }),
   );
 
+  activeTurnState.turnEvidenceMinReceivedAtMs = Date.now();
   const turnStartPromise = client
     .turnStart({
       approvalPolicy: policy.approvalPolicy,

--- a/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
+++ b/packages/adapters-codex-app-server/src/codex-turn-lifecycle.ts
@@ -174,7 +174,7 @@ export const startCodexTurnForSession = async (
   const activeTurnState: ActiveCodexTurn = {
     session,
     startedAtMs: Number.POSITIVE_INFINITY,
-    turnEvidenceMinReceivedAtMs: Number.POSITIVE_INFINITY,
+    turnStartRequestSentAtMs: null,
     turnStartPromise: Promise.resolve({}),
     isTurnSettled: () => turnSettled,
     markTurnSettled: () => {
@@ -220,7 +220,7 @@ export const startCodexTurnForSession = async (
     }),
   );
 
-  activeTurnState.turnEvidenceMinReceivedAtMs = Date.now();
+  activeTurnState.turnStartRequestSentAtMs = Date.now();
   const turnStartPromise = client
     .turnStart({
       approvalPolicy: policy.approvalPolicy,

--- a/packages/adapters-codex-app-server/src/types.ts
+++ b/packages/adapters-codex-app-server/src/types.ts
@@ -62,6 +62,7 @@ export type CodexServerRequestResponder = (
 export type CodexAppServerStreamEvent = {
   runtimeId: string;
   kind: "notification" | "server_request";
+  receivedAt: string;
   message: unknown;
 };
 

--- a/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.test.ts
+++ b/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.test.ts
@@ -276,9 +276,14 @@ describe("createCodexAppServerRuntimeAdapter", () => {
       },
     });
 
+    const originalConsoleError = console.error;
     try {
       const adapter = createCodexAppServerRuntimeAdapter();
       const events: Array<{ type?: string }> = [];
+      const consoleErrors: unknown[][] = [];
+      console.error = mock((...args: unknown[]) => {
+        consoleErrors.push(args);
+      }) as typeof console.error;
       const unsubscribe = await adapter.subscribeEvents(
         {
           repoPath: "/repo",
@@ -310,6 +315,17 @@ describe("createCodexAppServerRuntimeAdapter", () => {
 
       emitCodexEvent({
         runtimeId: "runtime-codex-live",
+        kind: "server_request",
+        message: { method: "item/tool/requestUserInput" },
+      });
+      expect(events).toEqual([]);
+      expect(consoleErrors).toContainEqual([
+        "Dropping Codex app-server event with invalid receivedAt",
+        "server_request",
+      ]);
+
+      emitCodexEvent({
+        runtimeId: "runtime-codex-live",
         kind: "notification",
         receivedAt: "2026-02-22T09:00:01.000Z",
         message: {
@@ -337,6 +353,7 @@ describe("createCodexAppServerRuntimeAdapter", () => {
       expect(appQueryClient.getQueryState(runtimeSkillKey)?.isInvalidated).toBe(true);
       unsubscribe();
     } finally {
+      console.error = originalConsoleError;
       host.runtimeRequire = originalRuntimeRequire;
       host.codexAppServerRequest = originalCodexAppServerRequest;
       host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;

--- a/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.test.ts
+++ b/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.test.ts
@@ -311,6 +311,7 @@ describe("createCodexAppServerRuntimeAdapter", () => {
       emitCodexEvent({
         runtimeId: "runtime-codex-live",
         kind: "notification",
+        receivedAt: "2026-02-22T09:00:01.000Z",
         message: {
           method: "turn/completed",
           params: {
@@ -326,6 +327,7 @@ describe("createCodexAppServerRuntimeAdapter", () => {
       emitCodexEvent({
         runtimeId: "runtime-codex-live",
         kind: "notification",
+        receivedAt: "2026-02-22T09:00:02.000Z",
         message: {
           method: "skills/changed",
           params: { cwd: "/repo" },

--- a/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.test.ts
+++ b/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.test.ts
@@ -83,6 +83,19 @@ const waitForSessionIdleEvent = async (
   await waitForSessionIdleEvent(events, deadline);
 };
 
+const waitForSessionEvent = async (
+  events: Array<{ type?: string }>,
+  type: string,
+  deadline = Date.now() + 1_000,
+): Promise<void> => {
+  if (events.some((event) => event.type === type) || Date.now() >= deadline) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  await waitForSessionEvent(events, type, deadline);
+};
+
 const waitForCodexEventListener = async (
   bridge: { listener?: (payload: unknown) => void },
   deadline = Date.now() + 1_000,
@@ -276,14 +289,9 @@ describe("createCodexAppServerRuntimeAdapter", () => {
       },
     });
 
-    const originalConsoleError = console.error;
     try {
       const adapter = createCodexAppServerRuntimeAdapter();
       const events: Array<{ type?: string }> = [];
-      const consoleErrors: unknown[][] = [];
-      console.error = mock((...args: unknown[]) => {
-        consoleErrors.push(args);
-      }) as typeof console.error;
       const unsubscribe = await adapter.subscribeEvents(
         {
           repoPath: "/repo",
@@ -318,11 +326,13 @@ describe("createCodexAppServerRuntimeAdapter", () => {
         kind: "server_request",
         message: { method: "item/tool/requestUserInput" },
       });
-      expect(events).toEqual([]);
-      expect(consoleErrors).toContainEqual([
-        "Dropping Codex app-server event with invalid receivedAt",
-        "server_request",
-      ]);
+      await waitForSessionEvent(events, "session_error");
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "session_error",
+          message: "Codex app-server stream event is missing receivedAt.",
+        }),
+      );
 
       emitCodexEvent({
         runtimeId: "runtime-codex-live",
@@ -353,7 +363,6 @@ describe("createCodexAppServerRuntimeAdapter", () => {
       expect(appQueryClient.getQueryState(runtimeSkillKey)?.isInvalidated).toBe(true);
       unsubscribe();
     } finally {
-      console.error = originalConsoleError;
       host.runtimeRequire = originalRuntimeRequire;
       host.codexAppServerRequest = originalCodexAppServerRequest;
       host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;

--- a/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.ts
+++ b/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.ts
@@ -70,6 +70,7 @@ export const createCodexAppServerRuntimeAdapter = (): AgentRuntimeAdapter =>
           return;
         }
         if (typeof event.receivedAt !== "string" || event.receivedAt.trim().length === 0) {
+          console.error("Dropping Codex app-server event with invalid receivedAt", event.kind);
           return;
         }
         if (event.kind === "notification" && isSkillsChangedNotification(event.message)) {

--- a/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.ts
+++ b/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.ts
@@ -57,17 +57,30 @@ export const createCodexAppServerRuntimeAdapter = (): AgentRuntimeAdapter =>
         if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
           return;
         }
-        const event = payload as { runtimeId?: unknown; kind?: unknown; message?: unknown };
+        const event = payload as {
+          runtimeId?: unknown;
+          kind?: unknown;
+          message?: unknown;
+          receivedAt?: unknown;
+        };
         if (event.runtimeId !== runtimeId) {
           return;
         }
         if (event.kind !== "notification" && event.kind !== "server_request") {
           return;
         }
+        if (typeof event.receivedAt !== "string" || event.receivedAt.trim().length === 0) {
+          return;
+        }
         if (event.kind === "notification" && isSkillsChangedNotification(event.message)) {
           invalidateSkillCatalogQueries();
         }
-        listener({ runtimeId, kind: event.kind, message: event.message });
+        listener({
+          runtimeId,
+          kind: event.kind,
+          message: event.message,
+          receivedAt: event.receivedAt,
+        });
       });
     },
     respondServerRequest: async (

--- a/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.ts
+++ b/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.ts
@@ -69,10 +69,6 @@ export const createCodexAppServerRuntimeAdapter = (): AgentRuntimeAdapter =>
         if (event.kind !== "notification" && event.kind !== "server_request") {
           return;
         }
-        if (typeof event.receivedAt !== "string" || event.receivedAt.trim().length === 0) {
-          console.error("Dropping Codex app-server event with invalid receivedAt", event.kind);
-          return;
-        }
         if (event.kind === "notification" && isSkillsChangedNotification(event.message)) {
           invalidateSkillCatalogQueries();
         }
@@ -80,7 +76,7 @@ export const createCodexAppServerRuntimeAdapter = (): AgentRuntimeAdapter =>
           runtimeId,
           kind: event.kind,
           message: event.message,
-          receivedAt: event.receivedAt,
+          receivedAt: event.receivedAt as string,
         });
       });
     },

--- a/packages/host-client/src/build-runtime-client.ts
+++ b/packages/host-client/src/build-runtime-client.ts
@@ -45,6 +45,7 @@ export type CodexAppServerBufferedEvent = {
   runtimeId: string;
   kind: "notification" | "server_request";
   message: unknown;
+  receivedAt: string;
 };
 
 type RuntimeEnsureErrorInit = {
@@ -287,12 +288,20 @@ const parseCodexAppServerBufferedEvent = (value: unknown): CodexAppServerBuffere
     throw new Error("Expected Codex app-server buffered event payload");
   }
 
-  const event = value as { runtimeId?: unknown; kind?: unknown; message?: unknown };
+  const event = value as {
+    runtimeId?: unknown;
+    kind?: unknown;
+    message?: unknown;
+    receivedAt?: unknown;
+  };
   if (typeof event.runtimeId !== "string" || event.runtimeId.trim().length === 0) {
     throw new Error("Expected Codex app-server buffered event runtimeId");
   }
   if (event.kind !== "notification" && event.kind !== "server_request") {
     throw new Error("Expected Codex app-server buffered event kind");
+  }
+  if (typeof event.receivedAt !== "string" || event.receivedAt.trim().length === 0) {
+    throw new Error("Expected Codex app-server buffered event receivedAt");
   }
   if (!("message" in value)) {
     throw new Error("Expected Codex app-server buffered event message");
@@ -302,6 +311,7 @@ const parseCodexAppServerBufferedEvent = (value: unknown): CodexAppServerBuffere
     runtimeId: event.runtimeId,
     kind: event.kind,
     message: event.message,
+    receivedAt: event.receivedAt,
   };
 };
 

--- a/packages/host-client/src/index.test.ts
+++ b/packages/host-client/src/index.test.ts
@@ -1584,6 +1584,7 @@ describe("HostClient", () => {
               runtimeId: "runtime-1",
               kind: "notification",
               message: { method: "codex/app-server/ready" },
+              receivedAt: "2026-02-22T09:00:00.000Z",
             },
           ];
         default:

--- a/packages/host-client/src/index.test.ts
+++ b/packages/host-client/src/index.test.ts
@@ -1635,16 +1635,35 @@ describe("HostClient", () => {
   });
 
   test("codex app-server buffered events reject malformed host payloads", async () => {
-    const { client } = createClient((command) => {
-      if (command === "codex_app_server_take_buffered_events") {
-        return [{ runtimeId: "runtime-1", kind: "invalid", message: {} }];
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    });
+    const cases = [
+      {
+        payload: [{ runtimeId: "runtime-1", kind: "invalid", message: {} }],
+        expected: "Expected Codex app-server buffered event kind",
+      },
+      {
+        payload: [{ runtimeId: "runtime-1", kind: "notification", message: {} }],
+        expected: "Expected Codex app-server buffered event receivedAt",
+      },
+      {
+        payload: [{ runtimeId: "runtime-1", kind: "notification", message: {}, receivedAt: "" }],
+        expected: "Expected Codex app-server buffered event receivedAt",
+      },
+      {
+        payload: [{ runtimeId: "runtime-1", kind: "notification", message: {}, receivedAt: 123 }],
+        expected: "Expected Codex app-server buffered event receivedAt",
+      },
+    ];
 
-    await expect(client.takeCodexAppServerBufferedEvents("runtime-1")).rejects.toThrow(
-      "Expected Codex app-server buffered event kind",
-    );
+    for (const { payload, expected } of cases) {
+      const { client } = createClient((command) => {
+        if (command === "codex_app_server_take_buffered_events") {
+          return payload;
+        }
+        throw new Error(`Unexpected command: ${command}`);
+      });
+
+      await expect(client.takeCodexAppServerBufferedEvents("runtime-1")).rejects.toThrow(expected);
+    }
   });
 
   test("runtime and session ack commands reject malformed host payloads", async () => {

--- a/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
@@ -21,6 +21,8 @@ const codexApprovalRequest = {
   },
 } satisfies CodexAppServerProtocolMessage;
 
+const receivedAt = "2026-07-06T12:00:00.000Z";
+
 describe("createCodexAppServerTransportRegistry", () => {
   test("routes app-server operations to the registered runtime transport", async () => {
     const calls: unknown[] = [];
@@ -69,11 +71,13 @@ describe("createCodexAppServerTransportRegistry", () => {
           {
             runtimeId: "runtime-1",
             kind: "notification" as const,
+            receivedAt,
             message: codexStatusNotification,
           },
           {
             runtimeId: "runtime-1",
             kind: "server_request" as const,
+            receivedAt,
             message: codexApprovalRequest,
           },
         ]);
@@ -93,8 +97,18 @@ describe("createCodexAppServerTransportRegistry", () => {
       ),
     ).resolves.toEqual({ data: [], nextCursor: null });
     await expect(Effect.runPromise(port.takeBufferedEvents("runtime-1"))).resolves.toEqual([
-      { runtimeId: "runtime-1", kind: "notification", message: codexStatusNotification },
-      { runtimeId: "runtime-1", kind: "server_request", message: codexApprovalRequest },
+      {
+        runtimeId: "runtime-1",
+        kind: "notification",
+        receivedAt,
+        message: codexStatusNotification,
+      },
+      {
+        runtimeId: "runtime-1",
+        kind: "server_request",
+        receivedAt,
+        message: codexApprovalRequest,
+      },
     ]);
     await expect(
       Effect.runPromise(

--- a/packages/host/src/adapters/codex/codex-app-server-transport.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.test.ts
@@ -2,7 +2,10 @@ import type { ChildProcessByStdio } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
 import { Effect, Fiber } from "effect";
-import type { CodexAppServerProtocolMessage } from "../../ports/codex-app-server-port";
+import type {
+  CodexAppServerProtocolMessage,
+  CodexAppServerStreamEvent,
+} from "../../ports/codex-app-server-port";
 import { createCodexAppServerTransport } from "./codex-app-server-transport";
 
 const createChild = (
@@ -16,6 +19,25 @@ const createChild = (
 };
 
 const waitForStreamEvents = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+const notificationEvent = (message: unknown) =>
+  expect.objectContaining({
+    runtimeId: "runtime-1",
+    kind: "notification" as const,
+    receivedAt: expect.any(String),
+    message,
+  });
+
+const serverRequestEvent = (message: unknown) =>
+  expect.objectContaining({
+    runtimeId: "runtime-1",
+    kind: "server_request" as const,
+    receivedAt: expect.any(String),
+    message,
+  });
+
+const receivedAtFrom = (event: unknown): string =>
+  (event as Pick<CodexAppServerStreamEvent, "receivedAt">).receivedAt;
 
 const recordClearTimeouts = () => {
   const originalClearTimeout = globalThis.clearTimeout;
@@ -78,12 +100,10 @@ describe("createCodexAppServerTransport", () => {
     child.stdout.write(`${JSON.stringify(notification)}\n`);
 
     await expect(response).resolves.toEqual({ data: [], nextCursor: null });
-    expect(emitted).toEqual([
-      { runtimeId: "runtime-1", kind: "notification", message: notification },
-    ]);
-    await expect(Effect.runPromise(transport.takeBufferedEvents())).resolves.toEqual([
-      { runtimeId: "runtime-1", kind: "notification", message: notification },
-    ]);
+    expect(emitted).toEqual([notificationEvent(notification)]);
+    const bufferedEvents = await Effect.runPromise(transport.takeBufferedEvents());
+    expect(bufferedEvents).toEqual([notificationEvent(notification)]);
+    expect(bufferedEvents[0]?.receivedAt).toBe(receivedAtFrom(emitted[0]));
 
     await Effect.runPromise(transport.close());
   });
@@ -107,11 +127,9 @@ describe("createCodexAppServerTransport", () => {
     child.stdout.write(`${JSON.stringify(notification)}\n`);
     await waitForStreamEvents();
 
-    expect(emitted).toEqual([
-      { runtimeId: "runtime-1", kind: "notification", message: notification },
-    ]);
+    expect(emitted).toEqual([notificationEvent(notification)]);
     await expect(Effect.runPromise(transport.takeBufferedEvents())).resolves.toEqual([
-      { runtimeId: "runtime-1", kind: "notification", message: notification },
+      notificationEvent(notification),
     ]);
 
     await Effect.runPromise(transport.close());
@@ -139,9 +157,9 @@ describe("createCodexAppServerTransport", () => {
 
     child.stdout.write(`${JSON.stringify(request)}\n`);
 
-    expect(emitted).toEqual([{ runtimeId: "runtime-1", kind: "server_request", message: request }]);
+    expect(emitted).toEqual([serverRequestEvent(request)]);
     await expect(Effect.runPromise(transport.takeBufferedEvents())).resolves.toEqual([
-      { runtimeId: "runtime-1", kind: "server_request", message: request },
+      serverRequestEvent(request),
     ]);
 
     child.stdout.write(`${JSON.stringify(request)}\n`);
@@ -187,12 +205,9 @@ describe("createCodexAppServerTransport", () => {
     child.stdout.write(`${JSON.stringify(resolved)}\n`);
     await waitForStreamEvents();
 
-    expect(emitted).toEqual([
-      { runtimeId: "runtime-1", kind: "server_request", message: request },
-      { runtimeId: "runtime-1", kind: "notification", message: resolved },
-    ]);
+    expect(emitted).toEqual([serverRequestEvent(request), notificationEvent(resolved)]);
     await expect(Effect.runPromise(transport.takeBufferedEvents())).resolves.toEqual([
-      { runtimeId: "runtime-1", kind: "notification", message: resolved },
+      notificationEvent(resolved),
     ]);
 
     await Effect.runPromise(transport.close());
@@ -240,8 +255,8 @@ describe("createCodexAppServerTransport", () => {
     await waitForStreamEvents();
 
     await expect(Effect.runPromise(transport.takeBufferedEvents())).resolves.toEqual([
-      { runtimeId: "runtime-1", kind: "server_request", message: stringRequest },
-      { runtimeId: "runtime-1", kind: "notification", message: resolvedNumericRequest },
+      serverRequestEvent(stringRequest),
+      notificationEvent(resolvedNumericRequest),
     ]);
 
     await Effect.runPromise(transport.close());
@@ -271,7 +286,7 @@ describe("createCodexAppServerTransport", () => {
 
     child.stdout.write(`${JSON.stringify(request)}\n`);
 
-    expect(emitted).toEqual([{ runtimeId: "runtime-1", kind: "server_request", message: request }]);
+    expect(emitted).toEqual([serverRequestEvent(request)]);
 
     await Effect.runPromise(transport.close());
   });

--- a/packages/host/src/adapters/codex/codex-app-server-transport.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport.ts
@@ -195,13 +195,17 @@ export const createCodexAppServerTransport = (
     }
     request.resolve(parsedResult.right);
   };
-  const emitBufferedEvent = (event: CodexAppServerStreamEvent) => {
-    pushBoundedMessage(bufferedEvents, event);
+  const emitBufferedEvent = (event: Omit<CodexAppServerStreamEvent, "receivedAt">) => {
+    const receivedEvent: CodexAppServerStreamEvent = {
+      ...event,
+      receivedAt: new Date().toISOString(),
+    };
+    pushBoundedMessage(bufferedEvents, receivedEvent);
     if (!eventEmitter) {
       return;
     }
     try {
-      eventEmitter(event);
+      eventEmitter(receivedEvent);
     } catch (error) {
       failFast(
         new HostOperationError({

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.test.ts
@@ -734,6 +734,7 @@ describe("createCodexWorkspaceRuntimeStarter", () => {
         {
           runtimeId: "runtime-events",
           kind: "notification",
+          receivedAt: expect.any(String),
           message: {
             method: "thread/status/changed",
             params: { threadId: "thread-1", status: { type: "idle" } },
@@ -742,6 +743,7 @@ describe("createCodexWorkspaceRuntimeStarter", () => {
         {
           runtimeId: "runtime-events",
           kind: "server_request",
+          receivedAt: expect.any(String),
           message: {
             id: 99,
             method: "execCommandApproval",
@@ -763,6 +765,7 @@ describe("createCodexWorkspaceRuntimeStarter", () => {
         {
           runtimeId: "runtime-events",
           kind: "notification",
+          receivedAt: expect.any(String),
           message: {
             method: "thread/status/changed",
             params: { threadId: "thread-1", status: { type: "idle" } },
@@ -771,6 +774,7 @@ describe("createCodexWorkspaceRuntimeStarter", () => {
         {
           runtimeId: "runtime-events",
           kind: "server_request",
+          receivedAt: expect.any(String),
           message: {
             id: 99,
             method: "execCommandApproval",

--- a/packages/host/src/application/runtimes/codex-app-server-service.test.ts
+++ b/packages/host/src/application/runtimes/codex-app-server-service.test.ts
@@ -24,6 +24,8 @@ const codexApprovalRequest = {
   },
 } satisfies CodexAppServerProtocolMessage;
 
+const receivedAt = "2026-07-06T12:00:00.000Z";
+
 const createCodexAppServerService = (
   ...args: Parameters<typeof createEffectCodexAppServerService>
 ) => createEffectCodexAppServerService(...args);
@@ -54,8 +56,13 @@ const createPort = (): {
       takeBufferedEvents(runtimeId) {
         calls.push({ method: "takeBufferedEvents", runtimeId });
         return Effect.succeed([
-          { runtimeId, kind: "notification" as const, message: codexStatusNotification },
-          { runtimeId, kind: "server_request" as const, message: codexApprovalRequest },
+          {
+            runtimeId,
+            kind: "notification" as const,
+            receivedAt,
+            message: codexStatusNotification,
+          },
+          { runtimeId, kind: "server_request" as const, receivedAt, message: codexApprovalRequest },
         ]);
       },
       respond(input) {
@@ -81,8 +88,18 @@ describe("createCodexAppServerService", () => {
     await expect(
       Effect.runPromise(service.takeBufferedEvents({ runtimeId: "runtime-1" })),
     ).resolves.toEqual([
-      { runtimeId: "runtime-1", kind: "notification", message: codexStatusNotification },
-      { runtimeId: "runtime-1", kind: "server_request", message: codexApprovalRequest },
+      {
+        runtimeId: "runtime-1",
+        kind: "notification",
+        receivedAt,
+        message: codexStatusNotification,
+      },
+      {
+        runtimeId: "runtime-1",
+        kind: "server_request",
+        receivedAt,
+        message: codexApprovalRequest,
+      },
     ]);
     await expect(
       Effect.runPromise(

--- a/packages/host/src/interface/commands/codex-app-server-command-handlers.test.ts
+++ b/packages/host/src/interface/commands/codex-app-server-command-handlers.test.ts
@@ -21,6 +21,8 @@ const codexStatusNotification = {
   params: { threadId: "thread-1", status: { type: "idle" } },
 } satisfies CodexAppServerProtocolMessage;
 
+const receivedAt = "2026-07-06T12:00:00.000Z";
+
 describe("createCodexAppServerCommandHandlers", () => {
   test("logs Codex policy-bearing requests through the host logger", async () => {
     const infos: string[] = [];
@@ -174,6 +176,7 @@ describe("createCodexAppServerCommandHandlers", () => {
           {
             runtimeId: input.runtimeId,
             kind: "notification" as const,
+            receivedAt,
             message: codexStatusNotification,
           },
         ]);
@@ -224,7 +227,12 @@ describe("createCodexAppServerCommandHandlers", () => {
     await expect(
       router.invoke("codex_app_server_take_buffered_events", { runtimeId: "runtime-1" }),
     ).resolves.toEqual([
-      { runtimeId: "runtime-1", kind: "notification", message: codexStatusNotification },
+      {
+        runtimeId: "runtime-1",
+        kind: "notification",
+        receivedAt,
+        message: codexStatusNotification,
+      },
     ]);
     await expect(
       router.invoke("codex_app_server_respond", {

--- a/packages/host/src/ports/codex-app-server-port.ts
+++ b/packages/host/src/ports/codex-app-server-port.ts
@@ -62,6 +62,7 @@ export type CodexSessionStatus = "active" | "idle" | "notLoaded" | "systemError"
 export type CodexAppServerStreamEvent = {
   runtimeId: string;
   kind: "notification" | "server_request";
+  receivedAt: string;
   message: CodexAppServerProtocolMessage;
 };
 export type CodexAppServerThreadEntry = {


### PR DESCRIPTION
## Summary

- Stamp Codex app-server stream envelopes with host receipt time before buffering or emitting.
- Use that receipt time to ignore stale thread-scoped idle notifications replayed before an active turn.
- Carry receivedAt through host-client and frontend subscription boundaries, with regression coverage for buffered/live events.

## Verification

- `rtk proxy gtimeout 900 bun run lint`
- `rtk proxy gtimeout 900 bun run typecheck`
- `rtk proxy gtimeout 900 bun run test`
- `rtk proxy gtimeout 1200 bun run build`
- `rtk proxy git diff --check`
- GitNexus `detect_changes`: CRITICAL impact; expected live Codex send/resume/reply flows affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream, buffered stream, and runtime session events now include a required `receivedAt` timestamp end-to-end for improved traceability.

* **Bug Fixes**
  * Improved active turn settling: `idle` status only takes effect when it is newer than the active turn start, preventing stale idle signals from settling the wrong turn.
  * Buffered final assistant output is now flushed at the correct times (e.g., when settling from idle/completed).
  * Clear session errors are returned for missing/empty/unparsable `receivedAt`.

* **Tests**
  * Expanded streaming and runtime event timing scenarios to validate the new `receivedAt` behavior and turn settling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->