### PR TITLE
chore: add repo-wide format gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check formatting
+        run: bun run format:check
+
       - name: Lint workspaces
         run: bun run lint
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -eu
 
+bun run format:check
 bun run lint
 bun run typecheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,11 +80,17 @@ The browser command starts the TypeScript host on `127.0.0.1`, serves the shared
 Run the main workspace checks from the repository root:
 
 ```sh
+bun run format:check
 bun run lint
 bun run typecheck
 bun run test
 bun run build
 ```
+
+Use `bun run format` to apply Biome formatting across the repository. The `format:check`
+command is intentionally repo-wide and runs before linting in both CI and the local pre-commit
+hook. Biome is configured to honor Git ignore files, so generated outputs such as `dist`, `build`,
+`coverage`, and `.vite` are excluded from this gate.
 
 Useful focused commands:
 
@@ -101,7 +107,7 @@ bun run --filter @openducktor/host test
 
 Shared local Git hooks run on every commit once you have run `bun install`.
 
-- `pre-commit` runs `bun run lint` and `bun run typecheck` in that order.
+- `pre-commit` runs `bun run format:check`, `bun run lint`, and `bun run typecheck` in that order.
 - `commit-msg` enforces Conventional Commits.
 - `bun run test` does not run during `pre-commit`.
 - `git commit --no-verify` still bypasses local hooks; this repository does not try to prevent that.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,10 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "css": {
     "parser": {
       "tailwindDirectives": true

--- a/docs/contracts/opencode-runtime-descriptor.fixture.json
+++ b/docs/contracts/opencode-runtime-descriptor.fixture.json
@@ -2,30 +2,15 @@
   "kind": "opencode",
   "label": "OpenCode",
   "description": "Local OpenCode runtime connected through the OpenDucktor MCP bridge.",
-  "readOnlyRoleBlockedTools": [
-    "edit",
-    "write",
-    "apply_patch",
-    "ast_grep_replace",
-    "lsp_rename"
-  ],
+  "readOnlyRoleBlockedTools": ["edit", "write", "apply_patch", "ast_grep_replace", "lsp_rename"],
   "workflowToolAliasesByCanonical": {
-    "odt_read_task": [
-      "openducktor_odt_read_task",
-      "functions.openducktor_odt_read_task"
-    ],
+    "odt_read_task": ["openducktor_odt_read_task", "functions.openducktor_odt_read_task"],
     "odt_read_task_documents": [
       "openducktor_odt_read_task_documents",
       "functions.openducktor_odt_read_task_documents"
     ],
-    "odt_set_spec": [
-      "openducktor_odt_set_spec",
-      "functions.openducktor_odt_set_spec"
-    ],
-    "odt_set_plan": [
-      "openducktor_odt_set_plan",
-      "functions.openducktor_odt_set_plan"
-    ],
+    "odt_set_spec": ["openducktor_odt_set_spec", "functions.openducktor_odt_set_spec"],
+    "odt_set_plan": ["openducktor_odt_set_plan", "functions.openducktor_odt_set_plan"],
     "odt_build_blocked": [
       "openducktor_odt_build_blocked",
       "functions.openducktor_odt_build_blocked"
@@ -42,35 +27,19 @@
       "openducktor_odt_set_pull_request",
       "functions.openducktor_odt_set_pull_request"
     ],
-    "odt_qa_approved": [
-      "openducktor_odt_qa_approved",
-      "functions.openducktor_odt_qa_approved"
-    ],
-    "odt_qa_rejected": [
-      "openducktor_odt_qa_rejected",
-      "functions.openducktor_odt_qa_rejected"
-    ]
+    "odt_qa_approved": ["openducktor_odt_qa_approved", "functions.openducktor_odt_qa_approved"],
+    "odt_qa_rejected": ["openducktor_odt_qa_rejected", "functions.openducktor_odt_qa_rejected"]
   },
   "capabilities": {
     "provisioningMode": "host_managed",
     "workflow": {
       "supportsOdtWorkflowTools": true,
-      "supportedScopes": [
-        "workspace",
-        "task",
-        "build"
-      ]
+      "supportedScopes": ["workspace", "task", "build"]
     },
     "sessionLifecycle": {
-      "supportedStartModes": [
-        "fresh",
-        "reuse",
-        "fork"
-      ],
+      "supportedStartModes": ["fresh", "reuse", "fork"],
       "supportsSessionFork": true,
-      "forkTargets": [
-        "session"
-      ],
+      "forkTargets": ["session"],
       "supportsListLiveSessions": true,
       "supportsQueuedUserMessages": true,
       "supportsPendingInputSnapshots": true
@@ -82,51 +51,29 @@
       "stableItemIds": false,
       "stableItemOrder": true,
       "exposesCompletionState": false,
-      "limitations": [
-        "OpenCode session history is loaded at message-level fidelity."
-      ]
+      "limitations": ["OpenCode session history is loaded at message-level fidelity."]
     },
     "approvals": {
-      "supportedRequestTypes": [
-        "permission_grant",
-        "runtime_tool"
-      ],
-      "supportedReplyOutcomes": [
-        "approve_once",
-        "approve_session",
-        "reject"
-      ],
+      "supportedRequestTypes": ["permission_grant", "runtime_tool"],
+      "supportedReplyOutcomes": ["approve_once", "approve_session", "reject"],
       "omittedPermissionBehavior": "deny",
-      "pendingVisibility": [
-        "live_snapshot"
-      ],
+      "pendingVisibility": ["live_snapshot"],
       "canClassifyMutatingRequests": true,
       "readOnlyAutoRejectSafe": true
     },
     "structuredInput": {
       "supportsQuestions": true,
       "supportsMultipleQuestions": true,
-      "supportedAnswerModes": [
-        "free_text",
-        "single_select",
-        "multi_select"
-      ],
+      "supportedAnswerModes": ["free_text", "single_select", "multi_select"],
       "supportsRequiredQuestions": true,
       "supportsDefaultValues": false,
       "supportsSecretInput": false,
       "supportsCustomAnswers": true,
       "supportsQuestionResolution": true,
-      "pendingVisibility": [
-        "live_snapshot"
-      ]
+      "pendingVisibility": ["live_snapshot"]
     },
     "promptInput": {
-      "supportedParts": [
-        "text",
-        "slash_command",
-        "file_reference",
-        "folder_reference"
-      ],
+      "supportedParts": ["text", "slash_command", "file_reference", "folder_reference"],
       "supportsSlashCommands": true,
       "supportsFileSearch": true,
       "supportsSkillReferences": false
@@ -139,10 +86,7 @@
       "supportsFileStatus": true,
       "supportsMcpStatus": true,
       "supportsSubagents": true,
-      "supportedSubagentExecutionModes": [
-        "foreground",
-        "background"
-      ]
+      "supportedSubagentExecutionModes": ["foreground", "background"]
     }
   }
 }

--- a/docs/contracts/workflow-contract-fixture.json
+++ b/docs/contracts/workflow-contract-fixture.json
@@ -87,9 +87,32 @@
   ],
   "setPlanAllowedStatuses": {
     "epic": ["spec_ready", "ready_for_dev", "in_progress", "blocked", "ai_review", "human_review"],
-    "feature": ["spec_ready", "ready_for_dev", "in_progress", "blocked", "ai_review", "human_review"],
-    "task": ["open", "spec_ready", "ready_for_dev", "in_progress", "blocked", "ai_review", "human_review"],
-    "bug": ["open", "spec_ready", "ready_for_dev", "in_progress", "blocked", "ai_review", "human_review"]
+    "feature": [
+      "spec_ready",
+      "ready_for_dev",
+      "in_progress",
+      "blocked",
+      "ai_review",
+      "human_review"
+    ],
+    "task": [
+      "open",
+      "spec_ready",
+      "ready_for_dev",
+      "in_progress",
+      "blocked",
+      "ai_review",
+      "human_review"
+    ],
+    "bug": [
+      "open",
+      "spec_ready",
+      "ready_for_dev",
+      "in_progress",
+      "blocked",
+      "ai_review",
+      "human_review"
+    ]
   },
   "resetImplementationAllowedStatuses": ["in_progress", "blocked", "ai_review", "human_review"],
   "resetTaskAllowedStatuses": [

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -40,10 +40,7 @@
       },
       {
         "files": ["src/pages/agents/query-sync/use-navigation-url-sync.ts"],
-        "rules": [
-          "react-doctor/no-derived-state",
-          "react-doctor/no-pass-live-state-to-parent"
-        ]
+        "rules": ["react-doctor/no-derived-state", "react-doctor/no-pass-live-state-to-parent"]
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "build": "bun run --workspaces build",
     "typecheck": "bun run --workspaces typecheck",
     "test": "bun run --workspaces test && bun run test:scripts",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
     "lint": "bun run frontend:boundary-guard && bun run host:architecture-guard && bun run --workspaces lint",
     "frontend:boundary-guard": "bun run scripts/frontend-boundary-guard.ts",
     "host:architecture-guard": "bun run scripts/host-architecture-guard.ts",

--- a/scripts/frontend-boundary-guard.ts
+++ b/scripts/frontend-boundary-guard.ts
@@ -13,7 +13,8 @@ const ALLOWED_ELECTRON_RENDERER_FILES = new Set([
 
 const SHARED_FRONTEND_BANNED_PATTERNS = [
   {
-    pattern: /(?:^|\n)\s*(?:import\s+(?:type\s+)?(?:[\s\S]*?\s+from\s+)?|export\s+(?:type\s+)?[\s\S]*?\s+from\s+|await\s+import\(|import\()\s*["'][^"']*(?:apps\/electron|packages\/openducktor-web)/,
+    pattern:
+      /(?:^|\n)\s*(?:import\s+(?:type\s+)?(?:[\s\S]*?\s+from\s+)?|export\s+(?:type\s+)?[\s\S]*?\s+from\s+|await\s+import\(|import\()\s*["'][^"']*(?:apps\/electron|packages\/openducktor-web)/,
     message: "Shared frontend code must not import shell internals; use the shell bridge instead.",
   },
 ];
@@ -59,7 +60,8 @@ const walkFiles = (root: string): string[] => {
   return files.sort((left, right) => left.localeCompare(right));
 };
 
-const lineForIndex = (source: string, index: number): number => source.slice(0, index).split("\n").length;
+const lineForIndex = (source: string, index: number): number =>
+  source.slice(0, index).split("\n").length;
 
 const findSharedFrontendViolations = (): Violation[] => {
   const violations: Violation[] = [];
@@ -86,11 +88,15 @@ const findSharedFrontendViolations = (): Violation[] => {
 
 const findElectronRendererShellViolations = (): Violation[] => {
   return walkFiles(ELECTRON_RENDERER_ROOT)
-    .filter((filePath) => !ALLOWED_ELECTRON_RENDERER_FILES.has(relative(ELECTRON_RENDERER_ROOT, filePath)))
+    .filter(
+      (filePath) =>
+        !ALLOWED_ELECTRON_RENDERER_FILES.has(relative(ELECTRON_RENDERER_ROOT, filePath)),
+    )
     .map((filePath) => ({
       filePath,
       line: 1,
-      message: "Electron renderer source must stay a thin shell. Move shared UI/runtime code to packages/frontend/src.",
+      message:
+        "Electron renderer source must stay a thin shell. Move shared UI/runtime code to packages/frontend/src.",
       snippet: "",
     }));
 };
@@ -98,7 +104,9 @@ const findElectronRendererShellViolations = (): Violation[] => {
 const violations = [...findSharedFrontendViolations(), ...findElectronRendererShellViolations()];
 
 if (violations.length > 0) {
-  console.error(`[frontend-boundary-guard] Found ${violations.length} frontend boundary violation(s).`);
+  console.error(
+    `[frontend-boundary-guard] Found ${violations.length} frontend boundary violation(s).`,
+  );
   for (const violation of violations) {
     console.error(
       `[frontend-boundary-guard] ${violation.filePath}:${violation.line} ${violation.message} ${violation.snippet}`,
@@ -107,4 +115,6 @@ if (violations.length > 0) {
   process.exit(1);
 }
 
-console.log("[frontend-boundary-guard] Shared frontend and Electron renderer shell boundaries are clean.");
+console.log(
+  "[frontend-boundary-guard] Shared frontend and Electron renderer shell boundaries are clean.",
+);


### PR DESCRIPTION
Summary:
Adds a repo-wide Biome format gate and wires it into local and CI quality checks.

Goal:
Biome formatting was enabled, but the repository did not expose root formatting commands or a blocking repo-wide format check. This PR makes formatting drift visible and blocking through the same quality workflow reviewers already use.

Technical choices:
- Added root `format` and `format:check` scripts that call Biome directly.
- Runs `format:check` before lint/typecheck in `.husky/pre-commit` so local commits fail on formatting drift early.
- Runs `format:check` before the workspace lint step in CI so pull requests cannot merge formatting drift.
- Applied Biome once to the existing files reported by the new gate so the gate starts from a clean baseline.

Verification:
- Cargo: not applicable because this checkout has no `Cargo.toml` or `Cargo.lock`.
- `bun run format:check`
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`

All Bun verification commands were run with hard timeouts.