### PR TITLE
perf(host): index staged attachment lookups

### DIFF
--- a/packages/host/src/application/attachments/local-attachment-index.ts
+++ b/packages/host/src/application/attachments/local-attachment-index.ts
@@ -12,6 +12,7 @@ export type IndexedStagedAttachment = {
 export type StagedAttachmentIndex = {
   attachmentDirectory: string;
   byLookupToken: Map<string, IndexedStagedAttachment[]>;
+  directoryModifiedTimeMs: number | null;
 };
 
 export const readStagedAttachmentOriginalName = (entry: LocalAttachmentEntry): string => {
@@ -62,6 +63,25 @@ const compareNewestStagedAttachmentFirst = (
   right: IndexedStagedAttachment,
 ): number => right.modifiedTimeMs - left.modifiedTimeMs;
 
+export const readStagedAttachmentDirectoryModifiedTimeMs = (
+  localAttachmentPort: LocalAttachmentPort,
+  attachmentDirectory: string,
+): Effect.Effect<number | null, HostOperationError> =>
+  localAttachmentPort.modifiedTimeMs(attachmentDirectory).pipe(
+    Effect.catchAll((error) => {
+      if (hasNestedNodeErrorCode(error, "ENOENT")) {
+        return Effect.succeed(null);
+      }
+      return Effect.fail(
+        new HostOperationError({
+          operation: "local_attachment.stat_stage_directory",
+          message: `Failed to inspect attachment staging directory: ${errorMessage(error)}`,
+          cause: error,
+        }),
+      );
+    }),
+  );
+
 export const addIndexedStagedAttachment = (
   index: StagedAttachmentIndex,
   lookupToken: string,
@@ -103,6 +123,10 @@ export const loadStagedAttachmentIndex = (
   attachmentDirectory: string,
 ): Effect.Effect<StagedAttachmentIndex, HostOperationError> =>
   Effect.gen(function* () {
+    const directoryModifiedTimeMs = yield* readStagedAttachmentDirectoryModifiedTimeMs(
+      localAttachmentPort,
+      attachmentDirectory,
+    );
     const entries = yield* localAttachmentPort.readDirectory(attachmentDirectory).pipe(
       Effect.catchAll((error) => {
         if (hasNestedNodeErrorCode(error, "ENOENT")) {
@@ -120,6 +144,7 @@ export const loadStagedAttachmentIndex = (
     const index: StagedAttachmentIndex = {
       attachmentDirectory,
       byLookupToken: new Map(),
+      directoryModifiedTimeMs,
     };
     const indexedAttachments = yield* Effect.all(
       entries.map((entry) =>
@@ -137,6 +162,16 @@ export const loadStagedAttachmentIndex = (
     }
     return index;
   });
+
+export const isStagedAttachmentIndexFresh = (
+  localAttachmentPort: LocalAttachmentPort,
+  index: StagedAttachmentIndex,
+): Effect.Effect<boolean, HostOperationError> =>
+  readStagedAttachmentDirectoryModifiedTimeMs(localAttachmentPort, index.attachmentDirectory).pipe(
+    Effect.map(
+      (directoryModifiedTimeMs) => directoryModifiedTimeMs === index.directoryModifiedTimeMs,
+    ),
+  );
 
 export const resolveIndexedStagedAttachment = (
   localAttachmentPort: LocalAttachmentPort,

--- a/packages/host/src/application/attachments/local-attachment-index.ts
+++ b/packages/host/src/application/attachments/local-attachment-index.ts
@@ -52,7 +52,7 @@ const compareNewestStagedAttachmentFirst = (
   (right.modifiedTimeMs ?? Number.NEGATIVE_INFINITY) -
   (left.modifiedTimeMs ?? Number.NEGATIVE_INFINITY);
 
-export const readStagedAttachmentDirectoryModifiedTimeMs = (
+const readStagedAttachmentDirectoryModifiedTimeMs = (
   localAttachmentPort: LocalAttachmentPort,
   attachmentDirectory: string,
 ): Effect.Effect<number | null, HostOperationError> =>

--- a/packages/host/src/application/attachments/local-attachment-index.ts
+++ b/packages/host/src/application/attachments/local-attachment-index.ts
@@ -15,41 +15,37 @@ export type StagedAttachmentIndex = {
   directoryModifiedTimeMs: number | null;
 };
 
+type StagedAttachmentIndexLoadResult =
+  | {
+      _tag: "indexed";
+      attachment: IndexedStagedAttachment;
+    }
+  | {
+      _tag: "skipped";
+    };
+
 export const readStagedAttachmentOriginalName = (entry: LocalAttachmentEntry): string => {
-  if (entry.fileName.length <= 37) {
+  const uuidPrefixMatch = uuidPrefixPattern.exec(entry.fileName);
+  if (!uuidPrefixMatch) {
     return entry.fileName;
   }
-  if (!uuidPrefixPattern.test(entry.fileName)) {
-    return entry.fileName;
-  }
-  return entry.fileName.slice(37);
+  return entry.fileName.slice(uuidPrefixMatch[0].length);
 };
 
 const hasNestedNodeErrorCode = (error: unknown, code: string): boolean => {
-  if (typeof error !== "object" || error === null) {
-    return false;
+  const visited = new Set<object>();
+  let current: unknown = error;
+  while (typeof current === "object" && current !== null) {
+    if (visited.has(current)) {
+      return false;
+    }
+    visited.add(current);
+    if ("code" in current && current.code === code) {
+      return true;
+    }
+    current = "cause" in current ? current.cause : undefined;
   }
-  if (
-    "code" in error &&
-    (
-      error as {
-        code?: unknown;
-      }
-    ).code === code
-  ) {
-    return true;
-  }
-  return (
-    "cause" in error &&
-    hasNestedNodeErrorCode(
-      (
-        error as {
-          cause?: unknown;
-        }
-      ).cause,
-      code,
-    )
-  );
+  return false;
 };
 
 const createNoStagedAttachmentMatchError = (displayName: string): HostValidationError =>
@@ -118,6 +114,32 @@ const removeIndexedStagedAttachment = (
   index.byLookupToken.set(lookupToken, remainingMatches);
 };
 
+const readIndexedStagedAttachment = (
+  localAttachmentPort: LocalAttachmentPort,
+  entry: LocalAttachmentEntry,
+): Effect.Effect<StagedAttachmentIndexLoadResult, HostOperationError> =>
+  localAttachmentPort.modifiedTimeMs(entry.path).pipe(
+    Effect.map(
+      (modifiedTimeMs): StagedAttachmentIndexLoadResult => ({
+        _tag: "indexed",
+        attachment: { entry, modifiedTimeMs },
+      }),
+    ),
+    Effect.catchAll((error) => {
+      if (hasNestedNodeErrorCode(error, "ENOENT")) {
+        return Effect.succeed({ _tag: "skipped" as const });
+      }
+      return Effect.fail(
+        new HostOperationError({
+          operation: "local_attachment.stat_staged_attachment",
+          message: `Failed to inspect staged attachment entry: ${errorMessage(error)}`,
+          cause: error,
+          details: { path: entry.path },
+        }),
+      );
+    }),
+  );
+
 export const loadStagedAttachmentIndex = (
   localAttachmentPort: LocalAttachmentPort,
   attachmentDirectory: string,
@@ -147,17 +169,17 @@ export const loadStagedAttachmentIndex = (
       directoryModifiedTimeMs,
     };
     const indexedAttachments = yield* Effect.all(
-      entries.map((entry) =>
-        localAttachmentPort
-          .modifiedTimeMs(entry.path)
-          .pipe(Effect.map((modifiedTimeMs) => ({ entry, modifiedTimeMs }))),
-      ),
+      entries.map((entry) => readIndexedStagedAttachment(localAttachmentPort, entry)),
+      { concurrency: "unbounded" },
     );
     for (const attachment of indexedAttachments) {
+      if (attachment._tag === "skipped") {
+        continue;
+      }
       addIndexedStagedAttachment(
         index,
-        readStagedAttachmentOriginalName(attachment.entry),
-        attachment,
+        readStagedAttachmentOriginalName(attachment.attachment.entry),
+        attachment.attachment,
       );
     }
     return index;
@@ -184,6 +206,7 @@ export const resolveIndexedStagedAttachment = (
     if (!matches || matches.length === 0) {
       return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
     }
+    // Stale entries are pruned while scanning, so iterate over a stable snapshot.
     for (const match of [...matches]) {
       const exists = yield* localAttachmentPort.exists(match.entry.path).pipe(
         Effect.mapError(

--- a/packages/host/src/application/attachments/local-attachment-index.ts
+++ b/packages/host/src/application/attachments/local-attachment-index.ts
@@ -1,0 +1,170 @@
+import { Effect } from "effect";
+import { errorMessage, HostOperationError, HostValidationError } from "../../effect/host-errors";
+import type { LocalAttachmentEntry, LocalAttachmentPort } from "../../ports/local-attachment-port";
+
+const uuidPrefixPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-/i;
+
+export type IndexedStagedAttachment = {
+  entry: LocalAttachmentEntry;
+  modifiedTimeMs: number;
+};
+
+export type StagedAttachmentIndex = {
+  attachmentDirectory: string;
+  byLookupToken: Map<string, IndexedStagedAttachment[]>;
+};
+
+export const readStagedAttachmentOriginalName = (entry: LocalAttachmentEntry): string => {
+  if (entry.fileName.length <= 37) {
+    return entry.fileName;
+  }
+  if (!uuidPrefixPattern.test(entry.fileName)) {
+    return entry.fileName;
+  }
+  return entry.fileName.slice(37);
+};
+
+const hasNestedNodeErrorCode = (error: unknown, code: string): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  if (
+    "code" in error &&
+    (
+      error as {
+        code?: unknown;
+      }
+    ).code === code
+  ) {
+    return true;
+  }
+  return (
+    "cause" in error &&
+    hasNestedNodeErrorCode(
+      (
+        error as {
+          cause?: unknown;
+        }
+      ).cause,
+      code,
+    )
+  );
+};
+
+const createNoStagedAttachmentMatchError = (displayName: string): HostValidationError =>
+  new HostValidationError({
+    message: `No staged local attachment matches '${displayName}'.`,
+    field: "path",
+  });
+
+const compareNewestStagedAttachmentFirst = (
+  left: IndexedStagedAttachment,
+  right: IndexedStagedAttachment,
+): number => right.modifiedTimeMs - left.modifiedTimeMs;
+
+export const addIndexedStagedAttachment = (
+  index: StagedAttachmentIndex,
+  lookupToken: string,
+  attachment: IndexedStagedAttachment,
+): void => {
+  const matches = index.byLookupToken.get(lookupToken);
+  if (!matches) {
+    index.byLookupToken.set(lookupToken, [attachment]);
+    return;
+  }
+  const existingIndex = matches.findIndex((match) => match.entry.path === attachment.entry.path);
+  if (existingIndex >= 0) {
+    matches[existingIndex] = attachment;
+  } else {
+    matches.push(attachment);
+  }
+  matches.sort(compareNewestStagedAttachmentFirst);
+};
+
+const removeIndexedStagedAttachment = (
+  index: StagedAttachmentIndex,
+  lookupToken: string,
+  path: string,
+): void => {
+  const matches = index.byLookupToken.get(lookupToken);
+  if (!matches) {
+    return;
+  }
+  const remainingMatches = matches.filter((match) => match.entry.path !== path);
+  if (remainingMatches.length === 0) {
+    index.byLookupToken.delete(lookupToken);
+    return;
+  }
+  index.byLookupToken.set(lookupToken, remainingMatches);
+};
+
+export const loadStagedAttachmentIndex = (
+  localAttachmentPort: LocalAttachmentPort,
+  attachmentDirectory: string,
+): Effect.Effect<StagedAttachmentIndex, HostOperationError> =>
+  Effect.gen(function* () {
+    const entries = yield* localAttachmentPort.readDirectory(attachmentDirectory).pipe(
+      Effect.catchAll((error) => {
+        if (hasNestedNodeErrorCode(error, "ENOENT")) {
+          return Effect.succeed([]);
+        }
+        return Effect.fail(
+          new HostOperationError({
+            operation: "local_attachment.read_stage_directory",
+            message: `Failed to read attachment staging directory: ${errorMessage(error)}`,
+            cause: error,
+          }),
+        );
+      }),
+    );
+    const index: StagedAttachmentIndex = {
+      attachmentDirectory,
+      byLookupToken: new Map(),
+    };
+    const indexedAttachments = yield* Effect.all(
+      entries.map((entry) =>
+        localAttachmentPort
+          .modifiedTimeMs(entry.path)
+          .pipe(Effect.map((modifiedTimeMs) => ({ entry, modifiedTimeMs }))),
+      ),
+    );
+    for (const attachment of indexedAttachments) {
+      addIndexedStagedAttachment(
+        index,
+        readStagedAttachmentOriginalName(attachment.entry),
+        attachment,
+      );
+    }
+    return index;
+  });
+
+export const resolveIndexedStagedAttachment = (
+  localAttachmentPort: LocalAttachmentPort,
+  index: StagedAttachmentIndex,
+  lookupToken: string,
+  displayName: string,
+): Effect.Effect<IndexedStagedAttachment, HostOperationError | HostValidationError> =>
+  Effect.gen(function* () {
+    const matches = index.byLookupToken.get(lookupToken);
+    if (!matches || matches.length === 0) {
+      return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
+    }
+    for (const match of [...matches]) {
+      const exists = yield* localAttachmentPort.exists(match.entry.path).pipe(
+        Effect.mapError(
+          (error) =>
+            new HostOperationError({
+              operation: "local_attachment.verify_index_entry",
+              message: `Failed to verify staged attachment index entry: ${errorMessage(error)}`,
+              cause: error,
+              details: { path: match.entry.path },
+            }),
+        ),
+      );
+      if (exists) {
+        return match;
+      }
+      removeIndexedStagedAttachment(index, lookupToken, match.entry.path);
+    }
+    return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
+  });

--- a/packages/host/src/application/attachments/local-attachment-index.ts
+++ b/packages/host/src/application/attachments/local-attachment-index.ts
@@ -6,7 +6,7 @@ const uuidPrefixPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9
 
 export type IndexedStagedAttachment = {
   entry: LocalAttachmentEntry;
-  modifiedTimeMs: number;
+  modifiedTimeMs: number | null;
 };
 
 export type StagedAttachmentIndex = {
@@ -14,15 +14,6 @@ export type StagedAttachmentIndex = {
   byLookupToken: Map<string, IndexedStagedAttachment[]>;
   directoryModifiedTimeMs: number | null;
 };
-
-type StagedAttachmentIndexLoadResult =
-  | {
-      _tag: "indexed";
-      attachment: IndexedStagedAttachment;
-    }
-  | {
-      _tag: "skipped";
-    };
 
 export const readStagedAttachmentOriginalName = (entry: LocalAttachmentEntry): string => {
   const uuidPrefixMatch = uuidPrefixPattern.exec(entry.fileName);
@@ -57,7 +48,9 @@ const createNoStagedAttachmentMatchError = (displayName: string): HostValidation
 const compareNewestStagedAttachmentFirst = (
   left: IndexedStagedAttachment,
   right: IndexedStagedAttachment,
-): number => right.modifiedTimeMs - left.modifiedTimeMs;
+): number =>
+  (right.modifiedTimeMs ?? Number.NEGATIVE_INFINITY) -
+  (left.modifiedTimeMs ?? Number.NEGATIVE_INFINITY);
 
 export const readStagedAttachmentDirectoryModifiedTimeMs = (
   localAttachmentPort: LocalAttachmentPort,
@@ -114,32 +107,6 @@ const removeIndexedStagedAttachment = (
   index.byLookupToken.set(lookupToken, remainingMatches);
 };
 
-const readIndexedStagedAttachment = (
-  localAttachmentPort: LocalAttachmentPort,
-  entry: LocalAttachmentEntry,
-): Effect.Effect<StagedAttachmentIndexLoadResult, HostOperationError> =>
-  localAttachmentPort.modifiedTimeMs(entry.path).pipe(
-    Effect.map(
-      (modifiedTimeMs): StagedAttachmentIndexLoadResult => ({
-        _tag: "indexed",
-        attachment: { entry, modifiedTimeMs },
-      }),
-    ),
-    Effect.catchAll((error) => {
-      if (hasNestedNodeErrorCode(error, "ENOENT")) {
-        return Effect.succeed({ _tag: "skipped" as const });
-      }
-      return Effect.fail(
-        new HostOperationError({
-          operation: "local_attachment.stat_staged_attachment",
-          message: `Failed to inspect staged attachment entry: ${errorMessage(error)}`,
-          cause: error,
-          details: { path: entry.path },
-        }),
-      );
-    }),
-  );
-
 export const loadStagedAttachmentIndex = (
   localAttachmentPort: LocalAttachmentPort,
   attachmentDirectory: string,
@@ -168,19 +135,11 @@ export const loadStagedAttachmentIndex = (
       byLookupToken: new Map(),
       directoryModifiedTimeMs,
     };
-    const indexedAttachments = yield* Effect.all(
-      entries.map((entry) => readIndexedStagedAttachment(localAttachmentPort, entry)),
-      { concurrency: "unbounded" },
-    );
-    for (const attachment of indexedAttachments) {
-      if (attachment._tag === "skipped") {
-        continue;
-      }
-      addIndexedStagedAttachment(
-        index,
-        readStagedAttachmentOriginalName(attachment.attachment.entry),
-        attachment.attachment,
-      );
+    for (const entry of entries) {
+      addIndexedStagedAttachment(index, readStagedAttachmentOriginalName(entry), {
+        entry,
+        modifiedTimeMs: null,
+      });
     }
     return index;
   });
@@ -219,10 +178,41 @@ export const resolveIndexedStagedAttachment = (
             }),
         ),
       );
-      if (exists) {
-        return match;
+      if (!exists) {
+        removeIndexedStagedAttachment(index, lookupToken, match.entry.path);
+        continue;
       }
-      removeIndexedStagedAttachment(index, lookupToken, match.entry.path);
+      if (match.modifiedTimeMs !== null) {
+        continue;
+      }
+      const modifiedTimeMs = yield* localAttachmentPort.modifiedTimeMs(match.entry.path).pipe(
+        Effect.catchAll((error) => {
+          if (hasNestedNodeErrorCode(error, "ENOENT")) {
+            removeIndexedStagedAttachment(index, lookupToken, match.entry.path);
+            return Effect.succeed(null);
+          }
+          return Effect.fail(
+            new HostOperationError({
+              operation: "local_attachment.stat_staged_attachment",
+              message: `Failed to inspect staged attachment entry: ${errorMessage(error)}`,
+              cause: error,
+              details: { path: match.entry.path },
+            }),
+          );
+        }),
+      );
+      if (modifiedTimeMs !== null) {
+        match.modifiedTimeMs = modifiedTimeMs;
+      }
     }
-    return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
+    const refreshedMatches = index.byLookupToken.get(lookupToken);
+    if (!refreshedMatches || refreshedMatches.length === 0) {
+      return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
+    }
+    refreshedMatches.sort(compareNewestStagedAttachmentFirst);
+    const newestMatch = refreshedMatches[0];
+    if (!newestMatch) {
+      return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
+    }
+    return newestMatch;
   });

--- a/packages/host/src/application/attachments/local-attachment-service.test.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.test.ts
@@ -14,17 +14,35 @@ type FakeLocalAttachmentPortOptions = {
   readDirectoryDelay?: () => Promise<void>;
 };
 const createFakeLocalAttachmentPort = (options: FakeLocalAttachmentPortOptions = {}) => {
+  const attachmentDirectory = "/tmp/openducktor-local-attachments";
   const files = new Map<string, FakeFile>();
-  const directories = new Set<string>(["/tmp/openducktor-local-attachments"]);
+  const directories = new Map<string, number>([[attachmentDirectory, 1]]);
+  const failModifiedTimePaths = new Set<string>();
   const calls = {
     exists: 0,
     modifiedTimeMs: 0,
     readDirectory: 0,
   };
-  let nextModifiedTimeMs = 1;
+  let nextModifiedTimeMs = 2;
+  const nextModifiedTime = (): number => {
+    const modifiedTimeMs = nextModifiedTimeMs;
+    nextModifiedTimeMs += 1;
+    return modifiedTimeMs;
+  };
+  const parentDirectory = (filePath: string): string => {
+    const lastSeparatorIndex = filePath.lastIndexOf("/");
+    return lastSeparatorIndex > 0 ? filePath.slice(0, lastSeparatorIndex) : "/";
+  };
+  const writeFileFixture = (path: string, bytes: Uint8Array): void => {
+    files.set(path, { bytes, modifiedTimeMs: nextModifiedTime() });
+    const directory = parentDirectory(path);
+    if (directories.has(directory)) {
+      directories.set(directory, nextModifiedTime());
+    }
+  };
   const port: LocalAttachmentPort = {
     stageDirectory() {
-      return "/tmp/openducktor-local-attachments";
+      return attachmentDirectory;
     },
     joinPath(...segments) {
       return segments.join("/").replaceAll(/\/+/g, "/");
@@ -60,7 +78,9 @@ const createFakeLocalAttachmentPort = (options: FakeLocalAttachmentPortOptions =
     ensureDirectory(path) {
       return Effect.tryPromise({
         try: async () => {
-          directories.add(path);
+          if (!directories.has(path)) {
+            directories.set(path, nextModifiedTime());
+          }
         },
         catch: (cause) =>
           new HostOperationError({
@@ -73,8 +93,7 @@ const createFakeLocalAttachmentPort = (options: FakeLocalAttachmentPortOptions =
     writeFile(path, bytes) {
       return Effect.tryPromise({
         try: async () => {
-          files.set(path, { bytes, modifiedTimeMs: nextModifiedTimeMs });
-          nextModifiedTimeMs += 1;
+          writeFileFixture(path, bytes);
         },
         catch: (cause) =>
           new HostOperationError({
@@ -118,7 +137,22 @@ const createFakeLocalAttachmentPort = (options: FakeLocalAttachmentPortOptions =
       return Effect.tryPromise({
         try: async () => {
           calls.modifiedTimeMs += 1;
-          return files.get(path)?.modifiedTimeMs ?? 0;
+          if (failModifiedTimePaths.has(path)) {
+            throw new Error(`stat failed for fixture path: ${path}`);
+          }
+          const fileModifiedTimeMs = files.get(path)?.modifiedTimeMs;
+          if (fileModifiedTimeMs !== undefined) {
+            return fileModifiedTimeMs;
+          }
+          const directoryModifiedTimeMs = directories.get(path);
+          if (directoryModifiedTimeMs !== undefined) {
+            return directoryModifiedTimeMs;
+          }
+          const error = new Error(`missing path fixture: ${path}`) as Error & {
+            code: string;
+          };
+          error.code = "ENOENT";
+          throw error;
         },
         catch: (cause) =>
           new HostOperationError({
@@ -135,8 +169,14 @@ const createFakeLocalAttachmentPort = (options: FakeLocalAttachmentPortOptions =
   };
   return {
     calls,
+    failModifiedTimePaths,
     files,
     port: port as LocalAttachmentPort,
+    writeExternalFile(fileName: string, contents: string) {
+      const filePath = `${attachmentDirectory}/${fileName}`;
+      writeFileFixture(filePath, new TextEncoder().encode(contents));
+      return filePath;
+    },
   };
 };
 describe("createLocalAttachmentService", () => {
@@ -171,7 +211,25 @@ describe("createLocalAttachmentService", () => {
     });
     expect(older.path).not.toBe(newer.path);
     expect(calls.readDirectory).toBe(1);
-    expect(calls.modifiedTimeMs).toBe(2);
+    expect(calls.modifiedTimeMs).toBe(4);
+  });
+  test("refreshes a loaded index when another writer stages a newer matching attachment", async () => {
+    const { calls, port, writeExternalFile } = createFakeLocalAttachmentPort();
+    const service = createLocalAttachmentService(port);
+    const older = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "b2xkZXI=" }),
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: older.path,
+    });
+    const externalPath = writeExternalFile(
+      "00000000-0000-0000-0000-000000000999-brief.pdf",
+      "newer",
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: externalPath,
+    });
+    expect(calls.readDirectory).toBe(2);
   });
   test("shares one cold index load across concurrent relative resolves", async () => {
     let markReadDirectoryStarted: () => void = () => {};
@@ -198,10 +256,13 @@ describe("createLocalAttachmentService", () => {
       }),
     );
     await readDirectoryStarted;
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(calls.readDirectory).toBe(1);
-    releaseReadDirectory();
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls.readDirectory).toBe(1);
+    } finally {
+      releaseReadDirectory();
+    }
     await expect(resolving).resolves.toEqual([{ path: staged.path }, { path: staged.path }]);
     expect(calls.readDirectory).toBe(1);
   });
@@ -223,14 +284,21 @@ describe("createLocalAttachmentService", () => {
     const service = createLocalAttachmentService(port);
     const resolving = Effect.runPromise(service.resolve({ path: "brief.pdf" }));
     await readDirectoryStarted;
-    const staged = await Effect.runPromise(
-      service.stage({ name: "brief.pdf", base64Data: "YnJpZWY=" }),
-    );
-    releaseReadDirectory();
+    let staged: { path: string } | undefined;
+    try {
+      staged = await Effect.runPromise(
+        service.stage({ name: "brief.pdf", base64Data: "YnJpZWY=" }),
+      );
+    } finally {
+      releaseReadDirectory();
+    }
+    if (!staged) {
+      throw new Error("Expected the staged attachment to be created.");
+    }
     await expect(resolving).resolves.toEqual({ path: staged.path });
     expect(calls.readDirectory).toBe(1);
   });
-  test("updates the loaded attachment index after staging a newer duplicate", async () => {
+  test("resolves a newer duplicate after staging changes the directory timestamp", async () => {
     const { calls, port } = createFakeLocalAttachmentPort();
     const service = createLocalAttachmentService(port);
     const older = await Effect.runPromise(
@@ -245,8 +313,32 @@ describe("createLocalAttachmentService", () => {
     await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
       path: newer.path,
     });
-    expect(calls.readDirectory).toBe(1);
-    expect(calls.modifiedTimeMs).toBe(2);
+    expect(calls.readDirectory).toBe(2);
+    expect(calls.modifiedTimeMs).toBe(6);
+  });
+  test("staging succeeds when file stat would fail after a loaded index exists", async () => {
+    const firstAttachmentId = "00000000-0000-0000-0000-000000000001";
+    const secondAttachmentId = "00000000-0000-0000-0000-000000000002";
+    const attachmentIds = [firstAttachmentId, secondAttachmentId];
+    const { calls, failModifiedTimePaths, files, port } = createFakeLocalAttachmentPort();
+    const service = createLocalAttachmentService(
+      port,
+      () => attachmentIds.shift() ?? secondAttachmentId,
+    );
+    const older = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "b2xkZXI=" }),
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: older.path,
+    });
+    const expectedPath = `/tmp/openducktor-local-attachments/${secondAttachmentId}-brief.pdf`;
+    failModifiedTimePaths.add(expectedPath);
+    const modifiedTimeCallsBeforeStage = calls.modifiedTimeMs;
+    await expect(
+      Effect.runPromise(service.stage({ name: "brief.pdf", base64Data: "bmV3ZXI=" })),
+    ).resolves.toEqual({ path: expectedPath });
+    expect(files.has(expectedPath)).toBe(true);
+    expect(calls.modifiedTimeMs).toBe(modifiedTimeCallsBeforeStage);
   });
   test("resolves absolute staged paths and rejects outside absolute paths", async () => {
     const { calls, port } = createFakeLocalAttachmentPort();

--- a/packages/host/src/application/attachments/local-attachment-service.test.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.test.ts
@@ -10,7 +10,10 @@ type FakeFile = {
   bytes: Uint8Array;
   modifiedTimeMs: number;
 };
-const createFakeLocalAttachmentPort = () => {
+type FakeLocalAttachmentPortOptions = {
+  readDirectoryDelay?: () => Promise<void>;
+};
+const createFakeLocalAttachmentPort = (options: FakeLocalAttachmentPortOptions = {}) => {
   const files = new Map<string, FakeFile>();
   const directories = new Set<string>(["/tmp/openducktor-local-attachments"]);
   const calls = {
@@ -92,7 +95,7 @@ const createFakeLocalAttachmentPort = () => {
             error.code = "ENOENT";
             throw error;
           }
-          return [...files.keys()]
+          const entries = [...files.keys()]
             .filter((filePath) => filePath.startsWith(`${path}/`))
             .map(
               (filePath): LocalAttachmentEntry => ({
@@ -100,6 +103,8 @@ const createFakeLocalAttachmentPort = () => {
                 fileName: filePath.slice(path.length + 1),
               }),
             );
+          await options.readDirectoryDelay?.();
+          return entries;
         },
         catch: (cause) =>
           new HostOperationError({
@@ -167,6 +172,63 @@ describe("createLocalAttachmentService", () => {
     expect(older.path).not.toBe(newer.path);
     expect(calls.readDirectory).toBe(1);
     expect(calls.modifiedTimeMs).toBe(2);
+  });
+  test("shares one cold index load across concurrent relative resolves", async () => {
+    let markReadDirectoryStarted: () => void = () => {};
+    let releaseReadDirectory: () => void = () => {};
+    const readDirectoryStarted = new Promise<void>((resolve) => {
+      markReadDirectoryStarted = resolve;
+    });
+    const readDirectoryReleased = new Promise<void>((resolve) => {
+      releaseReadDirectory = resolve;
+    });
+    const { calls, port } = createFakeLocalAttachmentPort({
+      readDirectoryDelay: async () => {
+        markReadDirectoryStarted();
+        await readDirectoryReleased;
+      },
+    });
+    const service = createLocalAttachmentService(port);
+    const staged = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "YnJpZWY=" }),
+    );
+    const resolving = Effect.runPromise(
+      Effect.all([service.resolve({ path: "brief.pdf" }), service.resolve({ path: "brief.pdf" })], {
+        concurrency: "unbounded",
+      }),
+    );
+    await readDirectoryStarted;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(calls.readDirectory).toBe(1);
+    releaseReadDirectory();
+    await expect(resolving).resolves.toEqual([{ path: staged.path }, { path: staged.path }]);
+    expect(calls.readDirectory).toBe(1);
+  });
+  test("merges attachments staged while a cold index load is in flight", async () => {
+    let markReadDirectoryStarted: () => void = () => {};
+    let releaseReadDirectory: () => void = () => {};
+    const readDirectoryStarted = new Promise<void>((resolve) => {
+      markReadDirectoryStarted = resolve;
+    });
+    const readDirectoryReleased = new Promise<void>((resolve) => {
+      releaseReadDirectory = resolve;
+    });
+    const { calls, port } = createFakeLocalAttachmentPort({
+      readDirectoryDelay: async () => {
+        markReadDirectoryStarted();
+        await readDirectoryReleased;
+      },
+    });
+    const service = createLocalAttachmentService(port);
+    const resolving = Effect.runPromise(service.resolve({ path: "brief.pdf" }));
+    await readDirectoryStarted;
+    const staged = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "YnJpZWY=" }),
+    );
+    releaseReadDirectory();
+    await expect(resolving).resolves.toEqual({ path: staged.path });
+    expect(calls.readDirectory).toBe(1);
   });
   test("updates the loaded attachment index after staging a newer duplicate", async () => {
     const { calls, port } = createFakeLocalAttachmentPort();

--- a/packages/host/src/application/attachments/local-attachment-service.test.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.test.ts
@@ -11,15 +11,19 @@ type FakeFile = {
   modifiedTimeMs: number;
 };
 type FakeLocalAttachmentPortOptions = {
+  includeStageDirectory?: boolean;
   readDirectoryDelay?: () => Promise<void>;
 };
 const createFakeLocalAttachmentPort = (options: FakeLocalAttachmentPortOptions = {}) => {
   const attachmentDirectory = "/tmp/openducktor-local-attachments";
   const files = new Map<string, FakeFile>();
-  const directories = new Map<string, number>([[attachmentDirectory, 1]]);
+  const directories = new Map<string, number>(
+    options.includeStageDirectory === false ? [] : [[attachmentDirectory, 1]],
+  );
   const failModifiedTimePaths = new Set<string>();
   const calls = {
     exists: 0,
+    existsPaths: [] as string[],
     modifiedTimeMs: 0,
     readDirectory: 0,
   };
@@ -164,6 +168,7 @@ const createFakeLocalAttachmentPort = (options: FakeLocalAttachmentPortOptions =
     },
     exists(path) {
       calls.exists += 1;
+      calls.existsPaths.push(path);
       return Effect.succeed(directories.has(path) || files.has(path));
     },
   };
@@ -230,6 +235,72 @@ describe("createLocalAttachmentService", () => {
       path: externalPath,
     });
     expect(calls.readDirectory).toBe(2);
+  });
+  test("shares one stale index reload across concurrent relative resolves", async () => {
+    let delayReadDirectory = false;
+    let markReadDirectoryStarted: () => void = () => {};
+    let releaseReadDirectory: () => void = () => {};
+    const readDirectoryStarted = new Promise<void>((resolve) => {
+      markReadDirectoryStarted = resolve;
+    });
+    const readDirectoryReleased = new Promise<void>((resolve) => {
+      releaseReadDirectory = resolve;
+    });
+    const { calls, port, writeExternalFile } = createFakeLocalAttachmentPort({
+      readDirectoryDelay: async () => {
+        if (!delayReadDirectory) {
+          return;
+        }
+        markReadDirectoryStarted();
+        await readDirectoryReleased;
+      },
+    });
+    const service = createLocalAttachmentService(port);
+    const older = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "b2xkZXI=" }),
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: older.path,
+    });
+    delayReadDirectory = true;
+    const externalPath = writeExternalFile(
+      "00000000-0000-0000-0000-000000000999-brief.pdf",
+      "newer",
+    );
+    const resolving = Effect.runPromise(
+      Effect.all([service.resolve({ path: "brief.pdf" }), service.resolve({ path: "brief.pdf" })], {
+        concurrency: "unbounded",
+      }),
+    );
+    await readDirectoryStarted;
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls.readDirectory).toBe(2);
+    } finally {
+      releaseReadDirectory();
+    }
+    await expect(resolving).resolves.toEqual([{ path: externalPath }, { path: externalPath }]);
+    expect(calls.readDirectory).toBe(2);
+  });
+  test("skips unrelated entries that vanish while loading the staged index", async () => {
+    let stalePath = "";
+    const { calls, files, port, writeExternalFile } = createFakeLocalAttachmentPort({
+      readDirectoryDelay: async () => {
+        if (stalePath.length > 0) {
+          files.delete(stalePath);
+        }
+      },
+    });
+    const service = createLocalAttachmentService(port);
+    const staged = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "YnJpZWY=" }),
+    );
+    stalePath = writeExternalFile("00000000-0000-0000-0000-000000000111-unrelated.txt", "stale");
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: staged.path,
+    });
+    expect(calls.readDirectory).toBe(1);
   });
   test("shares one cold index load across concurrent relative resolves", async () => {
     let markReadDirectoryStarted: () => void = () => {};
@@ -376,6 +447,15 @@ describe("createLocalAttachmentService", () => {
       "No staged local attachment matches 'brief.pdf'.",
     );
     expect(calls.readDirectory).toBe(1);
+    expect(calls.existsPaths).toEqual([newer.path, newer.path, older.path, older.path]);
+  });
+  test("returns a validation error when resolving a relative token without a staging directory", async () => {
+    const { calls, port } = createFakeLocalAttachmentPort({ includeStageDirectory: false });
+    const service = createLocalAttachmentService(port);
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).rejects.toThrow(
+      "No staged local attachment matches 'brief.pdf'.",
+    );
+    expect(calls.readDirectory).toBe(1);
   });
   test("rejects blank names, blank payloads, and unsafe lookup tokens", async () => {
     const { port } = createFakeLocalAttachmentPort();
@@ -386,7 +466,19 @@ describe("createLocalAttachmentService", () => {
     await expect(
       Effect.runPromise(service.stage({ name: "brief.pdf", base64Data: " " })),
     ).rejects.toThrow("Attachment payload is required.");
+    await expect(Effect.runPromise(service.resolve({ path: " " }))).rejects.toThrow(
+      "Attachment path is required.",
+    );
     await expect(Effect.runPromise(service.resolve({ path: "../brief.pdf" }))).rejects.toThrow(
+      "Attachment path must be a staged attachment filename token.",
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "folder\\brief.pdf" }))).rejects.toThrow(
+      "Attachment path must be a staged attachment filename token.",
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "." }))).rejects.toThrow(
+      "Attachment path must be a staged attachment filename token.",
+    );
+    await expect(Effect.runPromise(service.resolve({ path: ".." }))).rejects.toThrow(
       "Attachment path must be a staged attachment filename token.",
     );
   });

--- a/packages/host/src/application/attachments/local-attachment-service.test.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.test.ts
@@ -13,6 +13,11 @@ type FakeFile = {
 const createFakeLocalAttachmentPort = () => {
   const files = new Map<string, FakeFile>();
   const directories = new Set<string>(["/tmp/openducktor-local-attachments"]);
+  const calls = {
+    exists: 0,
+    modifiedTimeMs: 0,
+    readDirectory: 0,
+  };
   let nextModifiedTimeMs = 1;
   const port: LocalAttachmentPort = {
     stageDirectory() {
@@ -79,6 +84,7 @@ const createFakeLocalAttachmentPort = () => {
     readDirectory(path) {
       return Effect.tryPromise({
         try: async () => {
+          calls.readDirectory += 1;
           if (!directories.has(path)) {
             const error = new Error(`missing directory: ${path}`) as Error & {
               code: string;
@@ -106,6 +112,7 @@ const createFakeLocalAttachmentPort = () => {
     modifiedTimeMs(path) {
       return Effect.tryPromise({
         try: async () => {
+          calls.modifiedTimeMs += 1;
           return files.get(path)?.modifiedTimeMs ?? 0;
         },
         catch: (cause) =>
@@ -117,10 +124,12 @@ const createFakeLocalAttachmentPort = () => {
       });
     },
     exists(path) {
+      calls.exists += 1;
       return Effect.succeed(directories.has(path) || files.has(path));
     },
   };
   return {
+    calls,
     files,
     port: port as LocalAttachmentPort,
   };
@@ -141,7 +150,7 @@ describe("createLocalAttachmentService", () => {
     expect(Buffer.from(files.get(staged.path)?.bytes ?? []).toString("utf8")).toBe("preview-bytes");
   });
   test("resolves relative filename tokens to the newest staged attachment", async () => {
-    const { port } = createFakeLocalAttachmentPort();
+    const { calls, port } = createFakeLocalAttachmentPort();
     const service = createLocalAttachmentService(port);
     const older = await Effect.runPromise(
       service.stage({ name: "brief.pdf", base64Data: "b2xkZXI=" }),
@@ -152,10 +161,33 @@ describe("createLocalAttachmentService", () => {
     await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
       path: newer.path,
     });
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: newer.path,
+    });
     expect(older.path).not.toBe(newer.path);
+    expect(calls.readDirectory).toBe(1);
+    expect(calls.modifiedTimeMs).toBe(2);
+  });
+  test("updates the loaded attachment index after staging a newer duplicate", async () => {
+    const { calls, port } = createFakeLocalAttachmentPort();
+    const service = createLocalAttachmentService(port);
+    const older = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "b2xkZXI=" }),
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: older.path,
+    });
+    const newer = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "bmV3ZXI=" }),
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: newer.path,
+    });
+    expect(calls.readDirectory).toBe(1);
+    expect(calls.modifiedTimeMs).toBe(2);
   });
   test("resolves absolute staged paths and rejects outside absolute paths", async () => {
-    const { port } = createFakeLocalAttachmentPort();
+    const { calls, port } = createFakeLocalAttachmentPort();
     const service = createLocalAttachmentService(port);
     const staged = await Effect.runPromise(
       service.stage({ name: "brief.pdf", base64Data: "YnJpZWY=" }),
@@ -166,6 +198,30 @@ describe("createLocalAttachmentService", () => {
     await expect(
       Effect.runPromise(service.resolve({ path: "/tmp/not-staged.pdf" })),
     ).rejects.toThrow("Failed to resolve staged attachment path:");
+    expect(calls.readDirectory).toBe(0);
+    expect(calls.modifiedTimeMs).toBe(0);
+  });
+  test("prunes stale indexed attachment entries before resolving relative tokens", async () => {
+    const { calls, files, port } = createFakeLocalAttachmentPort();
+    const service = createLocalAttachmentService(port);
+    const older = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "b2xkZXI=" }),
+    );
+    const newer = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "bmV3ZXI=" }),
+    );
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: newer.path,
+    });
+    files.delete(newer.path);
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: older.path,
+    });
+    files.delete(older.path);
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).rejects.toThrow(
+      "No staged local attachment matches 'brief.pdf'.",
+    );
+    expect(calls.readDirectory).toBe(1);
   });
   test("rejects blank names, blank payloads, and unsafe lookup tokens", async () => {
     const { port } = createFakeLocalAttachmentPort();

--- a/packages/host/src/application/attachments/local-attachment-service.test.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.test.ts
@@ -302,6 +302,24 @@ describe("createLocalAttachmentService", () => {
     });
     expect(calls.readDirectory).toBe(1);
   });
+  test("does not let an unrelated stat failure block a matching relative token", async () => {
+    const { failModifiedTimePaths, port, writeExternalFile } = createFakeLocalAttachmentPort();
+    const service = createLocalAttachmentService(port);
+    const staged = await Effect.runPromise(
+      service.stage({ name: "brief.pdf", base64Data: "YnJpZWY=" }),
+    );
+    const brokenPath = writeExternalFile(
+      "00000000-0000-0000-0000-000000000111-broken.txt",
+      "broken",
+    );
+    failModifiedTimePaths.add(brokenPath);
+    await expect(Effect.runPromise(service.resolve({ path: "brief.pdf" }))).resolves.toEqual({
+      path: staged.path,
+    });
+    await expect(Effect.runPromise(service.resolve({ path: "broken.txt" }))).rejects.toThrow(
+      "Failed to inspect staged attachment entry:",
+    );
+  });
   test("shares one cold index load across concurrent relative resolves", async () => {
     let markReadDirectoryStarted: () => void = () => {};
     let releaseReadDirectory: () => void = () => {};
@@ -447,7 +465,7 @@ describe("createLocalAttachmentService", () => {
       "No staged local attachment matches 'brief.pdf'.",
     );
     expect(calls.readDirectory).toBe(1);
-    expect(calls.existsPaths).toEqual([newer.path, newer.path, older.path, older.path]);
+    expect(calls.existsPaths).toEqual([older.path, newer.path, newer.path, older.path, older.path]);
   });
   test("returns a validation error when resolving a relative token without a staging directory", async () => {
     const { calls, port } = createFakeLocalAttachmentPort({ includeStageDirectory: false });

--- a/packages/host/src/application/attachments/local-attachment-service.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.ts
@@ -1,6 +1,13 @@
-import { Effect } from "effect";
+import { Deferred, Effect } from "effect";
 import { errorMessage, HostOperationError, HostValidationError } from "../../effect/host-errors";
-import type { LocalAttachmentEntry, LocalAttachmentPort } from "../../ports/local-attachment-port";
+import type { LocalAttachmentPort } from "../../ports/local-attachment-port";
+import {
+  addIndexedStagedAttachment,
+  loadStagedAttachmentIndex,
+  readStagedAttachmentOriginalName,
+  resolveIndexedStagedAttachment,
+  type StagedAttachmentIndex,
+} from "./local-attachment-index";
 
 export type LocalAttachmentServiceError = HostOperationError | HostValidationError;
 
@@ -19,7 +26,6 @@ export type LocalAttachmentService = {
   ): Effect.Effect<ResolvedLocalAttachment, LocalAttachmentServiceError>;
 };
 const maxAttachmentLookupDisplayLength = 128;
-const uuidPrefixPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-/i;
 export type LocalAttachmentStageInput = {
   base64Data: string;
   name: string;
@@ -27,13 +33,14 @@ export type LocalAttachmentStageInput = {
 export type LocalAttachmentResolveInput = {
   path: string;
 };
-type IndexedStagedAttachment = {
-  entry: LocalAttachmentEntry;
-  modifiedTimeMs: number;
-};
-type StagedAttachmentIndex = {
+type StagedAttachmentIndexFlight = {
   attachmentDirectory: string;
-  byLookupToken: Map<string, IndexedStagedAttachment[]>;
+  deferred: Deferred.Deferred<StagedAttachmentIndex, HostOperationError>;
+};
+type PendingStagedAttachment = {
+  fileName: string;
+  modifiedTimeMs: number;
+  path: string;
 };
 const sanitizeAttachmentFilename = (name: string): string => {
   const sanitized = [...name]
@@ -77,15 +84,6 @@ const formatAttachmentLookupDisplayName = (token: string): string => {
   }
   return `${sanitized.slice(0, maxAttachmentLookupDisplayLength - 3)}...`;
 };
-const readStagedAttachmentOriginalName = (entry: LocalAttachmentEntry): string => {
-  if (entry.fileName.length <= 37) {
-    return entry.fileName;
-  }
-  if (!uuidPrefixPattern.test(entry.fileName)) {
-    return entry.fileName;
-  }
-  return entry.fileName.slice(37);
-};
 const decodeBase64 = (value: string): Uint8Array => {
   const compact = value.trim();
   if (!/^[A-Za-z0-9+/]*={0,2}$/.test(compact) || compact.length % 4 !== 0) {
@@ -117,170 +115,132 @@ const isWithinDirectory = (
     relative === "" || (!relative.startsWith("..") && !localAttachmentPort.isAbsolutePath(relative))
   );
 };
-const hasNestedNodeErrorCode = (error: unknown, code: string): boolean => {
-  if (typeof error !== "object" || error === null) {
-    return false;
-  }
-  if (
-    "code" in error &&
-    (
-      error as {
-        code?: unknown;
-      }
-    ).code === code
-  ) {
-    return true;
-  }
-  return (
-    "cause" in error &&
-    hasNestedNodeErrorCode(
-      (
-        error as {
-          cause?: unknown;
-        }
-      ).cause,
-      code,
-    )
-  );
-};
-const createNoStagedAttachmentMatchError = (displayName: string): HostValidationError =>
-  new HostValidationError({
-    message: `No staged local attachment matches '${displayName}'.`,
-    field: "path",
-  });
-const compareNewestStagedAttachmentFirst = (
-  left: IndexedStagedAttachment,
-  right: IndexedStagedAttachment,
-): number => right.modifiedTimeMs - left.modifiedTimeMs;
-const addIndexedStagedAttachment = (
-  index: StagedAttachmentIndex,
-  lookupToken: string,
-  attachment: IndexedStagedAttachment,
-): void => {
-  const matches = index.byLookupToken.get(lookupToken);
-  if (!matches) {
-    index.byLookupToken.set(lookupToken, [attachment]);
-    return;
-  }
-  const existingIndex = matches.findIndex((match) => match.entry.path === attachment.entry.path);
-  if (existingIndex >= 0) {
-    matches[existingIndex] = attachment;
-  } else {
-    matches.push(attachment);
-  }
-  matches.sort(compareNewestStagedAttachmentFirst);
-};
-const removeIndexedStagedAttachment = (
-  index: StagedAttachmentIndex,
-  lookupToken: string,
-  path: string,
-): void => {
-  const matches = index.byLookupToken.get(lookupToken);
-  if (!matches) {
-    return;
-  }
-  const remainingMatches = matches.filter((match) => match.entry.path !== path);
-  if (remainingMatches.length === 0) {
-    index.byLookupToken.delete(lookupToken);
-    return;
-  }
-  index.byLookupToken.set(lookupToken, remainingMatches);
-};
-const loadStagedAttachmentIndex = (
-  localAttachmentPort: LocalAttachmentPort,
-  attachmentDirectory: string,
-): Effect.Effect<StagedAttachmentIndex, HostOperationError> =>
+const completeIndexLoadFlight = (
+  flight: StagedAttachmentIndexFlight,
+  loadIndex: Effect.Effect<StagedAttachmentIndex, HostOperationError>,
+  setLoadedIndex: (index: StagedAttachmentIndex) => void,
+  clearFlight: (flight: StagedAttachmentIndexFlight) => void,
+): Effect.Effect<void, never> =>
   Effect.gen(function* () {
-    const entries = yield* localAttachmentPort.readDirectory(attachmentDirectory).pipe(
-      Effect.catchAll((error) => {
-        if (hasNestedNodeErrorCode(error, "ENOENT")) {
-          return Effect.succeed([]);
-        }
-        return Effect.fail(
-          new HostOperationError({
-            operation: "local_attachment.read_stage_directory",
-            message: `Failed to read attachment staging directory: ${errorMessage(error)}`,
-            cause: error,
-          }),
-        );
+    const exit = yield* Effect.exit(loadIndex);
+    if (exit._tag === "Success") {
+      setLoadedIndex(exit.value);
+    }
+    yield* Deferred.done(flight.deferred, exit);
+  }).pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        clearFlight(flight);
       }),
-    );
-    const index: StagedAttachmentIndex = {
-      attachmentDirectory,
-      byLookupToken: new Map(),
-    };
-    const indexedAttachments = yield* Effect.all(
-      entries.map((entry) =>
-        localAttachmentPort
-          .modifiedTimeMs(entry.path)
-          .pipe(Effect.map((modifiedTimeMs) => ({ entry, modifiedTimeMs }))),
-      ),
-    );
-    for (const attachment of indexedAttachments) {
-      addIndexedStagedAttachment(
-        index,
-        readStagedAttachmentOriginalName(attachment.entry),
-        attachment,
-      );
-    }
-    return index;
-  });
-const resolveIndexedStagedAttachment = (
-  localAttachmentPort: LocalAttachmentPort,
-  index: StagedAttachmentIndex,
-  lookupToken: string,
-  displayName: string,
-): Effect.Effect<IndexedStagedAttachment, LocalAttachmentServiceError> =>
-  Effect.gen(function* () {
-    const matches = index.byLookupToken.get(lookupToken);
-    if (!matches || matches.length === 0) {
-      return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
-    }
-    for (const match of [...matches]) {
-      const exists = yield* localAttachmentPort.exists(match.entry.path).pipe(
-        Effect.mapError(
-          (error) =>
-            new HostOperationError({
-              operation: "local_attachment.verify_index_entry",
-              message: `Failed to verify staged attachment index entry: ${errorMessage(error)}`,
-              cause: error,
-              details: { path: match.entry.path },
-            }),
-        ),
-      );
-      if (exists) {
-        return match;
-      }
-      removeIndexedStagedAttachment(index, lookupToken, match.entry.path);
-    }
-    return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
-  });
+    ),
+  );
 export const createLocalAttachmentService = (
   localAttachmentPort: LocalAttachmentPort,
   attachmentIdFactory: () => string = () => crypto.randomUUID(),
 ): LocalAttachmentService => {
   let stagedAttachmentIndex: StagedAttachmentIndex | undefined;
+  let stagedAttachmentIndexFlight: StagedAttachmentIndexFlight | undefined;
+  const pendingStagedAttachments = new Map<string, PendingStagedAttachment[]>();
+  const addPendingStagedAttachmentsToIndex = (index: StagedAttachmentIndex): void => {
+    const pendingAttachments = pendingStagedAttachments.get(index.attachmentDirectory);
+    if (!pendingAttachments) {
+      return;
+    }
+    for (const attachment of pendingAttachments) {
+      addIndexedStagedAttachment(
+        index,
+        readStagedAttachmentOriginalName({
+          path: attachment.path,
+          fileName: attachment.fileName,
+        }),
+        {
+          entry: {
+            path: attachment.path,
+            fileName: attachment.fileName,
+          },
+          modifiedTimeMs: attachment.modifiedTimeMs,
+        },
+      );
+    }
+    pendingStagedAttachments.delete(index.attachmentDirectory);
+  };
+  const recordPendingStagedAttachment = (
+    attachmentDirectory: string,
+    attachment: PendingStagedAttachment,
+  ): void => {
+    const pendingAttachments = pendingStagedAttachments.get(attachmentDirectory);
+    if (!pendingAttachments) {
+      pendingStagedAttachments.set(attachmentDirectory, [attachment]);
+      return;
+    }
+    pendingAttachments.push(attachment);
+  };
   const getStagedAttachmentIndex = (
     attachmentDirectory: string,
   ): Effect.Effect<StagedAttachmentIndex, HostOperationError> =>
-    Effect.gen(function* () {
-      if (stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory) {
-        return stagedAttachmentIndex;
-      }
-      const index = yield* loadStagedAttachmentIndex(localAttachmentPort, attachmentDirectory);
-      stagedAttachmentIndex = index;
-      return index;
-    });
+    Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        if (stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory) {
+          return stagedAttachmentIndex;
+        }
+        const reservation = yield* Effect.gen(function* () {
+          if (stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory) {
+            return { _tag: "loaded" as const, index: stagedAttachmentIndex };
+          }
+          if (stagedAttachmentIndexFlight?.attachmentDirectory === attachmentDirectory) {
+            return { _tag: "existing" as const, flight: stagedAttachmentIndexFlight };
+          }
+          const flight = {
+            attachmentDirectory,
+            deferred: yield* Deferred.make<StagedAttachmentIndex, HostOperationError>(),
+          };
+          stagedAttachmentIndexFlight = flight;
+          return { _tag: "created" as const, flight };
+        });
+        if (reservation._tag === "loaded") {
+          return reservation.index;
+        }
+        if (reservation._tag === "created") {
+          yield* Effect.forkDaemon(
+            completeIndexLoadFlight(
+              reservation.flight,
+              loadStagedAttachmentIndex(localAttachmentPort, attachmentDirectory),
+              (index) => {
+                addPendingStagedAttachmentsToIndex(index);
+                stagedAttachmentIndex = index;
+              },
+              (flight) => {
+                if (stagedAttachmentIndexFlight === flight) {
+                  stagedAttachmentIndexFlight = undefined;
+                }
+              },
+            ),
+          );
+        }
+        return yield* restore(Deferred.await(reservation.flight.deferred));
+      }),
+    );
   const addStagedAttachmentToLoadedIndex = (
     attachmentDirectory: string,
     fileName: string,
     stagedPath: string,
   ): Effect.Effect<void, HostOperationError> =>
     Effect.gen(function* () {
-      if (stagedAttachmentIndex?.attachmentDirectory !== attachmentDirectory) {
+      if (
+        stagedAttachmentIndex?.attachmentDirectory !== attachmentDirectory &&
+        stagedAttachmentIndexFlight?.attachmentDirectory !== attachmentDirectory
+      ) {
         return;
       }
       const modifiedTimeMs = yield* localAttachmentPort.modifiedTimeMs(stagedPath);
+      if (stagedAttachmentIndex?.attachmentDirectory !== attachmentDirectory) {
+        recordPendingStagedAttachment(attachmentDirectory, {
+          fileName,
+          modifiedTimeMs,
+          path: stagedPath,
+        });
+        return;
+      }
       addIndexedStagedAttachment(
         stagedAttachmentIndex,
         readStagedAttachmentOriginalName({ path: stagedPath, fileName }),

--- a/packages/host/src/application/attachments/local-attachment-service.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.ts
@@ -178,6 +178,7 @@ export const createLocalAttachmentService = (
         },
       );
     }
+    pendingAttachments.length = 0;
   };
   const getStagedAttachmentIndex = (
     attachmentDirectory: string,

--- a/packages/host/src/application/attachments/local-attachment-service.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.ts
@@ -27,6 +27,14 @@ export type LocalAttachmentStageInput = {
 export type LocalAttachmentResolveInput = {
   path: string;
 };
+type IndexedStagedAttachment = {
+  entry: LocalAttachmentEntry;
+  modifiedTimeMs: number;
+};
+type StagedAttachmentIndex = {
+  attachmentDirectory: string;
+  byLookupToken: Map<string, IndexedStagedAttachment[]>;
+};
 const sanitizeAttachmentFilename = (name: string): string => {
   const sanitized = [...name]
     .map((character) => {
@@ -69,7 +77,7 @@ const formatAttachmentLookupDisplayName = (token: string): string => {
   }
   return `${sanitized.slice(0, maxAttachmentLookupDisplayLength - 3)}...`;
 };
-const readStagedAttachmentOriginalName = (entry: LocalAttachmentEntry): string | undefined => {
+const readStagedAttachmentOriginalName = (entry: LocalAttachmentEntry): string => {
   if (entry.fileName.length <= 37) {
     return entry.fileName;
   }
@@ -135,143 +143,240 @@ const hasNestedNodeErrorCode = (error: unknown, code: string): boolean => {
     )
   );
 };
+const createNoStagedAttachmentMatchError = (displayName: string): HostValidationError =>
+  new HostValidationError({
+    message: `No staged local attachment matches '${displayName}'.`,
+    field: "path",
+  });
+const compareNewestStagedAttachmentFirst = (
+  left: IndexedStagedAttachment,
+  right: IndexedStagedAttachment,
+): number => right.modifiedTimeMs - left.modifiedTimeMs;
+const addIndexedStagedAttachment = (
+  index: StagedAttachmentIndex,
+  lookupToken: string,
+  attachment: IndexedStagedAttachment,
+): void => {
+  const matches = index.byLookupToken.get(lookupToken);
+  if (!matches) {
+    index.byLookupToken.set(lookupToken, [attachment]);
+    return;
+  }
+  const existingIndex = matches.findIndex((match) => match.entry.path === attachment.entry.path);
+  if (existingIndex >= 0) {
+    matches[existingIndex] = attachment;
+  } else {
+    matches.push(attachment);
+  }
+  matches.sort(compareNewestStagedAttachmentFirst);
+};
+const removeIndexedStagedAttachment = (
+  index: StagedAttachmentIndex,
+  lookupToken: string,
+  path: string,
+): void => {
+  const matches = index.byLookupToken.get(lookupToken);
+  if (!matches) {
+    return;
+  }
+  const remainingMatches = matches.filter((match) => match.entry.path !== path);
+  if (remainingMatches.length === 0) {
+    index.byLookupToken.delete(lookupToken);
+    return;
+  }
+  index.byLookupToken.set(lookupToken, remainingMatches);
+};
+const loadStagedAttachmentIndex = (
+  localAttachmentPort: LocalAttachmentPort,
+  attachmentDirectory: string,
+): Effect.Effect<StagedAttachmentIndex, HostOperationError> =>
+  Effect.gen(function* () {
+    const entries = yield* localAttachmentPort.readDirectory(attachmentDirectory).pipe(
+      Effect.catchAll((error) => {
+        if (hasNestedNodeErrorCode(error, "ENOENT")) {
+          return Effect.succeed([]);
+        }
+        return Effect.fail(
+          new HostOperationError({
+            operation: "local_attachment.read_stage_directory",
+            message: `Failed to read attachment staging directory: ${errorMessage(error)}`,
+            cause: error,
+          }),
+        );
+      }),
+    );
+    const index: StagedAttachmentIndex = {
+      attachmentDirectory,
+      byLookupToken: new Map(),
+    };
+    const indexedAttachments = yield* Effect.all(
+      entries.map((entry) =>
+        localAttachmentPort
+          .modifiedTimeMs(entry.path)
+          .pipe(Effect.map((modifiedTimeMs) => ({ entry, modifiedTimeMs }))),
+      ),
+    );
+    for (const attachment of indexedAttachments) {
+      addIndexedStagedAttachment(
+        index,
+        readStagedAttachmentOriginalName(attachment.entry),
+        attachment,
+      );
+    }
+    return index;
+  });
+const resolveIndexedStagedAttachment = (
+  localAttachmentPort: LocalAttachmentPort,
+  index: StagedAttachmentIndex,
+  lookupToken: string,
+  displayName: string,
+): Effect.Effect<IndexedStagedAttachment, LocalAttachmentServiceError> =>
+  Effect.gen(function* () {
+    const matches = index.byLookupToken.get(lookupToken);
+    if (!matches || matches.length === 0) {
+      return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
+    }
+    for (const match of [...matches]) {
+      const exists = yield* localAttachmentPort.exists(match.entry.path).pipe(
+        Effect.mapError(
+          (error) =>
+            new HostOperationError({
+              operation: "local_attachment.verify_index_entry",
+              message: `Failed to verify staged attachment index entry: ${errorMessage(error)}`,
+              cause: error,
+              details: { path: match.entry.path },
+            }),
+        ),
+      );
+      if (exists) {
+        return match;
+      }
+      removeIndexedStagedAttachment(index, lookupToken, match.entry.path);
+    }
+    return yield* Effect.fail(createNoStagedAttachmentMatchError(displayName));
+  });
 export const createLocalAttachmentService = (
   localAttachmentPort: LocalAttachmentPort,
   attachmentIdFactory: () => string = () => crypto.randomUUID(),
-): LocalAttachmentService => ({
-  stage(input) {
-    return Effect.gen(function* () {
-      const { name, base64Data } = yield* Effect.try({
-        try: () => normalizeStageInput(input),
-        catch: (cause) =>
-          new HostValidationError({
-            message: cause instanceof Error ? cause.message : String(cause),
-            cause,
-          }),
-      });
-      const bytes = yield* Effect.try({
-        try: () => decodeBase64(base64Data),
-        catch: (cause) =>
-          new HostValidationError({
-            message: cause instanceof Error ? cause.message : String(cause),
-            cause,
-          }),
-      });
-      const attachmentDirectory = localAttachmentPort.stageDirectory();
-      yield* localAttachmentPort.ensureDirectory(attachmentDirectory);
-      const fileName = `${attachmentIdFactory()}-${sanitizeAttachmentFilename(name)}`;
-      const stagedPath = localAttachmentPort.joinPath(attachmentDirectory, fileName);
-      yield* localAttachmentPort.writeFile(stagedPath, bytes);
-      return { path: stagedPath };
+): LocalAttachmentService => {
+  let stagedAttachmentIndex: StagedAttachmentIndex | undefined;
+  const getStagedAttachmentIndex = (
+    attachmentDirectory: string,
+  ): Effect.Effect<StagedAttachmentIndex, HostOperationError> =>
+    Effect.gen(function* () {
+      if (stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory) {
+        return stagedAttachmentIndex;
+      }
+      const index = yield* loadStagedAttachmentIndex(localAttachmentPort, attachmentDirectory);
+      stagedAttachmentIndex = index;
+      return index;
     });
-  },
-  resolve(input) {
-    return Effect.gen(function* () {
-      const { path } = input;
-      const trimmedPath = path.trim();
-      const attachmentDirectory = localAttachmentPort.stageDirectory();
-      if (localAttachmentPort.isAbsolutePath(trimmedPath)) {
-        const canonicalDirectory = yield* localAttachmentPort
-          .canonicalizePath(attachmentDirectory)
-          .pipe(
+  const addStagedAttachmentToLoadedIndex = (
+    attachmentDirectory: string,
+    fileName: string,
+    stagedPath: string,
+  ): Effect.Effect<void, HostOperationError> =>
+    Effect.gen(function* () {
+      if (stagedAttachmentIndex?.attachmentDirectory !== attachmentDirectory) {
+        return;
+      }
+      const modifiedTimeMs = yield* localAttachmentPort.modifiedTimeMs(stagedPath);
+      addIndexedStagedAttachment(
+        stagedAttachmentIndex,
+        readStagedAttachmentOriginalName({ path: stagedPath, fileName }),
+        {
+          entry: { path: stagedPath, fileName },
+          modifiedTimeMs,
+        },
+      );
+    });
+  return {
+    stage(input) {
+      return Effect.gen(function* () {
+        const { name, base64Data } = yield* Effect.try({
+          try: () => normalizeStageInput(input),
+          catch: (cause) =>
+            new HostValidationError({
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause,
+            }),
+        });
+        const bytes = yield* Effect.try({
+          try: () => decodeBase64(base64Data),
+          catch: (cause) =>
+            new HostValidationError({
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause,
+            }),
+        });
+        const attachmentDirectory = localAttachmentPort.stageDirectory();
+        yield* localAttachmentPort.ensureDirectory(attachmentDirectory);
+        const fileName = `${attachmentIdFactory()}-${sanitizeAttachmentFilename(name)}`;
+        const stagedPath = localAttachmentPort.joinPath(attachmentDirectory, fileName);
+        yield* localAttachmentPort.writeFile(stagedPath, bytes);
+        yield* addStagedAttachmentToLoadedIndex(attachmentDirectory, fileName, stagedPath);
+        return { path: stagedPath };
+      });
+    },
+    resolve(input) {
+      return Effect.gen(function* () {
+        const { path } = input;
+        const trimmedPath = path.trim();
+        const attachmentDirectory = localAttachmentPort.stageDirectory();
+        if (localAttachmentPort.isAbsolutePath(trimmedPath)) {
+          const canonicalDirectory = yield* localAttachmentPort
+            .canonicalizePath(attachmentDirectory)
+            .pipe(
+              Effect.mapError(
+                (error) =>
+                  new HostOperationError({
+                    operation: "local_attachment.resolve_stage_directory",
+                    message: `Failed to resolve staged attachment directory: ${errorMessage(error)}`,
+                    cause: error,
+                  }),
+              ),
+            );
+          const canonicalPath = yield* localAttachmentPort.canonicalizePath(trimmedPath).pipe(
             Effect.mapError(
               (error) =>
                 new HostOperationError({
-                  operation: "local_attachment.resolve_stage_directory",
-                  message: `Failed to resolve staged attachment directory: ${errorMessage(error)}`,
+                  operation: "local_attachment.resolve_path",
+                  message: `Failed to resolve staged attachment path: ${errorMessage(error)}`,
                   cause: error,
                 }),
             ),
           );
-        const canonicalPath = yield* localAttachmentPort.canonicalizePath(trimmedPath).pipe(
-          Effect.mapError(
-            (error) =>
-              new HostOperationError({
-                operation: "local_attachment.resolve_path",
-                message: `Failed to resolve staged attachment path: ${errorMessage(error)}`,
-                cause: error,
-              }),
-          ),
-        );
-        if (isWithinDirectory(localAttachmentPort, canonicalDirectory, canonicalPath)) {
-          return { path: trimmedPath };
-        }
-        return yield* Effect.fail(
-          new HostValidationError({
-            message: "Attachment path is not a staged local attachment.",
-            field: "path",
-          }),
-        );
-      }
-      const lookupToken = yield* Effect.try({
-        try: () => sanitizeAttachmentLookupToken(trimmedPath),
-        catch: (cause) =>
-          new HostValidationError({
-            message: cause instanceof Error ? cause.message : String(cause),
-            cause,
-            details: {
-              field: "path",
-            },
-          }),
-      });
-      const displayName = formatAttachmentLookupDisplayName(lookupToken);
-      const entries = yield* localAttachmentPort.readDirectory(attachmentDirectory).pipe(
-        Effect.mapError((error) => {
-          if (hasNestedNodeErrorCode(error, "ENOENT")) {
-            return new HostValidationError({
-              message: `No staged local attachment matches '${displayName}'.`,
-              field: "path",
-              cause: error,
-            });
+          if (isWithinDirectory(localAttachmentPort, canonicalDirectory, canonicalPath)) {
+            return { path: trimmedPath };
           }
-          return new HostOperationError({
-            operation: "local_attachment.read_stage_directory",
-            message: `Failed to read attachment staging directory: ${errorMessage(error)}`,
-            cause: error,
-          });
-        }),
-      );
-      const matches = entries.filter(
-        (entry) => readStagedAttachmentOriginalName(entry) === lookupToken,
-      );
-      if (matches.length === 0) {
-        return yield* Effect.fail(
-          new HostValidationError({
-            message: `No staged local attachment matches '${displayName}'.`,
-            field: "path",
-          }),
-        );
-      }
-      if (matches.length === 1) {
-        const [match] = matches;
-        if (!match) {
           return yield* Effect.fail(
             new HostValidationError({
-              message: `No staged local attachment matches '${displayName}'.`,
+              message: "Attachment path is not a staged local attachment.",
               field: "path",
             }),
           );
         }
-        return { path: match.path };
-      }
-      const rankedMatches = yield* Effect.all(
-        matches.map((entry) =>
-          localAttachmentPort
-            .modifiedTimeMs(entry.path)
-            .pipe(Effect.map((modifiedTimeMs) => ({ entry, modifiedTimeMs }))),
-        ),
-      );
-      rankedMatches.sort((left, right) => right.modifiedTimeMs - left.modifiedTimeMs);
-      const [newestMatch] = rankedMatches;
-      if (!newestMatch) {
-        return yield* Effect.fail(
-          new HostValidationError({
-            message: `No staged local attachment matches '${displayName}'.`,
-            field: "path",
-          }),
+        const lookupToken = yield* Effect.try({
+          try: () => sanitizeAttachmentLookupToken(trimmedPath),
+          catch: (cause) =>
+            new HostValidationError({
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause,
+              details: {
+                field: "path",
+              },
+            }),
+        });
+        const displayName = formatAttachmentLookupDisplayName(lookupToken);
+        const index = yield* getStagedAttachmentIndex(attachmentDirectory);
+        const match = yield* resolveIndexedStagedAttachment(
+          localAttachmentPort,
+          index,
+          lookupToken,
+          displayName,
         );
-      }
-      return { path: newestMatch.entry.path };
-    });
-  },
-});
+        return { path: match.entry.path };
+      });
+    },
+  };
+};

--- a/packages/host/src/application/attachments/local-attachment-service.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.ts
@@ -1,8 +1,9 @@
-import { Deferred, Effect } from "effect";
+import { Deferred, Effect, FiberId } from "effect";
 import { errorMessage, HostOperationError, HostValidationError } from "../../effect/host-errors";
 import type { LocalAttachmentPort } from "../../ports/local-attachment-port";
 import {
   addIndexedStagedAttachment,
+  isStagedAttachmentIndexFresh,
   loadStagedAttachmentIndex,
   readStagedAttachmentOriginalName,
   resolveIndexedStagedAttachment,
@@ -33,15 +34,23 @@ export type LocalAttachmentStageInput = {
 export type LocalAttachmentResolveInput = {
   path: string;
 };
-type StagedAttachmentIndexFlight = {
-  attachmentDirectory: string;
-  deferred: Deferred.Deferred<StagedAttachmentIndex, HostOperationError>;
-};
 type PendingStagedAttachment = {
   fileName: string;
   modifiedTimeMs: number;
   path: string;
 };
+type StagedAttachmentIndexFlight = {
+  attachmentDirectory: string;
+  deferred: Deferred.Deferred<StagedAttachmentIndex, HostOperationError>;
+  pendingAttachments: PendingStagedAttachment[];
+};
+const makeStagedAttachmentIndexFlight = (
+  attachmentDirectory: string,
+): StagedAttachmentIndexFlight => ({
+  attachmentDirectory,
+  deferred: Deferred.unsafeMake(FiberId.none),
+  pendingAttachments: [],
+});
 const sanitizeAttachmentFilename = (name: string): string => {
   const sanitized = [...name]
     .map((character) => {
@@ -140,10 +149,17 @@ export const createLocalAttachmentService = (
 ): LocalAttachmentService => {
   let stagedAttachmentIndex: StagedAttachmentIndex | undefined;
   let stagedAttachmentIndexFlight: StagedAttachmentIndexFlight | undefined;
-  const pendingStagedAttachments = new Map<string, PendingStagedAttachment[]>();
-  const addPendingStagedAttachmentsToIndex = (index: StagedAttachmentIndex): void => {
-    const pendingAttachments = pendingStagedAttachments.get(index.attachmentDirectory);
-    if (!pendingAttachments) {
+  let latestLocalModifiedTimeMs = 0;
+  const nextLocalModifiedTimeMs = (): number => {
+    const now = Date.now();
+    latestLocalModifiedTimeMs = Math.max(now, latestLocalModifiedTimeMs + 1);
+    return latestLocalModifiedTimeMs;
+  };
+  const addPendingStagedAttachmentsToIndex = (
+    index: StagedAttachmentIndex,
+    pendingAttachments: PendingStagedAttachment[],
+  ): void => {
+    if (pendingAttachments.length === 0) {
       return;
     }
     for (const attachment of pendingAttachments) {
@@ -162,38 +178,35 @@ export const createLocalAttachmentService = (
         },
       );
     }
-    pendingStagedAttachments.delete(index.attachmentDirectory);
-  };
-  const recordPendingStagedAttachment = (
-    attachmentDirectory: string,
-    attachment: PendingStagedAttachment,
-  ): void => {
-    const pendingAttachments = pendingStagedAttachments.get(attachmentDirectory);
-    if (!pendingAttachments) {
-      pendingStagedAttachments.set(attachmentDirectory, [attachment]);
-      return;
-    }
-    pendingAttachments.push(attachment);
   };
   const getStagedAttachmentIndex = (
     attachmentDirectory: string,
   ): Effect.Effect<StagedAttachmentIndex, HostOperationError> =>
     Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
-        if (stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory) {
-          return stagedAttachmentIndex;
+        const loadedIndex =
+          stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory
+            ? stagedAttachmentIndex
+            : undefined;
+        if (loadedIndex) {
+          const fresh = yield* restore(
+            isStagedAttachmentIndexFresh(localAttachmentPort, loadedIndex),
+          );
+          if (fresh && stagedAttachmentIndex === loadedIndex) {
+            return loadedIndex;
+          }
+          if (stagedAttachmentIndex === loadedIndex) {
+            stagedAttachmentIndex = undefined;
+          }
         }
-        const reservation = yield* Effect.gen(function* () {
+        const reservation = yield* Effect.sync(() => {
           if (stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory) {
             return { _tag: "loaded" as const, index: stagedAttachmentIndex };
           }
           if (stagedAttachmentIndexFlight?.attachmentDirectory === attachmentDirectory) {
             return { _tag: "existing" as const, flight: stagedAttachmentIndexFlight };
           }
-          const flight = {
-            attachmentDirectory,
-            deferred: yield* Deferred.make<StagedAttachmentIndex, HostOperationError>(),
-          };
+          const flight = makeStagedAttachmentIndexFlight(attachmentDirectory);
           stagedAttachmentIndexFlight = flight;
           return { _tag: "created" as const, flight };
         });
@@ -206,7 +219,7 @@ export const createLocalAttachmentService = (
               reservation.flight,
               loadStagedAttachmentIndex(localAttachmentPort, attachmentDirectory),
               (index) => {
-                addPendingStagedAttachmentsToIndex(index);
+                addPendingStagedAttachmentsToIndex(index, reservation.flight.pendingAttachments);
                 stagedAttachmentIndex = index;
               },
               (flight) => {
@@ -224,17 +237,17 @@ export const createLocalAttachmentService = (
     attachmentDirectory: string,
     fileName: string,
     stagedPath: string,
-  ): Effect.Effect<void, HostOperationError> =>
-    Effect.gen(function* () {
+  ): Effect.Effect<void> =>
+    Effect.sync(() => {
       if (
         stagedAttachmentIndex?.attachmentDirectory !== attachmentDirectory &&
         stagedAttachmentIndexFlight?.attachmentDirectory !== attachmentDirectory
       ) {
         return;
       }
-      const modifiedTimeMs = yield* localAttachmentPort.modifiedTimeMs(stagedPath);
+      const modifiedTimeMs = nextLocalModifiedTimeMs();
       if (stagedAttachmentIndex?.attachmentDirectory !== attachmentDirectory) {
-        recordPendingStagedAttachment(attachmentDirectory, {
+        stagedAttachmentIndexFlight?.pendingAttachments.push({
           fileName,
           modifiedTimeMs,
           path: stagedPath,

--- a/packages/host/src/application/attachments/local-attachment-service.ts
+++ b/packages/host/src/application/attachments/local-attachment-service.ts
@@ -189,18 +189,19 @@ export const createLocalAttachmentService = (
           stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory
             ? stagedAttachmentIndex
             : undefined;
+        let loadedIndexFresh = false;
         if (loadedIndex) {
-          const fresh = yield* restore(
+          loadedIndexFresh = yield* restore(
             isStagedAttachmentIndexFresh(localAttachmentPort, loadedIndex),
           );
-          if (fresh && stagedAttachmentIndex === loadedIndex) {
-            return loadedIndex;
-          }
-          if (stagedAttachmentIndex === loadedIndex) {
-            stagedAttachmentIndex = undefined;
-          }
         }
         const reservation = yield* Effect.sync(() => {
+          if (loadedIndex && stagedAttachmentIndex === loadedIndex) {
+            if (loadedIndexFresh) {
+              return { _tag: "loaded" as const, index: loadedIndex };
+            }
+            stagedAttachmentIndex = undefined;
+          }
           if (stagedAttachmentIndex?.attachmentDirectory === attachmentDirectory) {
             return { _tag: "loaded" as const, index: stagedAttachmentIndex };
           }


### PR DESCRIPTION
Summary
Adds an indexed host-side lookup path for staged local attachment filename tokens, while preserving absolute staged path validation and duplicate filename newest-wins behavior.

Goal
Relative staged attachment resolution previously scanned the entire shared staging directory for every lookup, then stripped generated UUID prefixes and statted matching duplicates to choose the newest file. That made attachment preview/open behavior scale with the total number of accumulated staged files. This PR makes repeated relative-token resolution use an in-memory index and keeps stale or cross-process changes explicit.

Technical choices
- Builds a staged attachment index keyed by the original/sanitized lookup token and stores candidates sorted newest-first.
- Coalesces concurrent cold index loads with a single Effect Deferred flight.
- Tracks staging directory mtime on loaded indexes so a warm service refreshes when another host/process writes to the shared staging directory.
- Verifies indexed candidates still exist before returning them and prunes stale entries.
- Keeps absolute path resolution unchanged: canonicalize, validate containment in the staging directory, and fail fast otherwise.
- Keeps all state in memory and avoids SQLite/task-store schema changes.
- Avoids treating post-write index bookkeeping as part of stage success, so a successfully written staged file is not reported as failed because optional cache metadata could not be read.

Verification
- bun run typecheck
- bun run lint
- bun run test
- bun run build
- Cargo checks: not applicable; this checkout has no Cargo.toml workspace.