### PR TITLE
fix: stabilize dev server log streams

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { AgentStudioDevServerTerminal } from "./agent-studio-dev-server-terminal";
 
 if (typeof document === "undefined") {
@@ -10,6 +10,8 @@ if (typeof document === "undefined") {
 afterEach(() => {
   document.body.innerHTML = "";
 });
+
+const TERMINAL_WRITE_ACK_TIMEOUT_MS = 50;
 
 const createQueuedWriteTerminalHarness = (queuedData: string) => {
   const open = mock((_container: HTMLElement) => {});
@@ -60,6 +62,53 @@ const createQueuedWriteTerminalHarness = (queuedData: string) => {
     createTerminalBinding,
     queuedWrites,
     readScreen: () => screen,
+  };
+};
+
+const installTerminalWriteAckTimeoutControl = () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const callbacks = new Map<number, () => void>();
+  let nextTimeoutId = 1;
+
+  globalThis.setTimeout = ((handler: TimerHandler, delay?: number, ...args: unknown[]) => {
+    if (delay === TERMINAL_WRITE_ACK_TIMEOUT_MS && typeof handler === "function") {
+      const timeoutId = -nextTimeoutId;
+      nextTimeoutId += 1;
+      callbacks.set(timeoutId, () => {
+        handler(...args);
+      });
+      return timeoutId as unknown as ReturnType<typeof globalThis.setTimeout>;
+    }
+
+    return originalSetTimeout(handler, delay, ...args);
+  }) as typeof globalThis.setTimeout;
+  globalThis.clearTimeout = ((timeoutId?: ReturnType<typeof globalThis.setTimeout>) => {
+    if (typeof timeoutId === "number" && callbacks.delete(timeoutId)) {
+      return;
+    }
+
+    originalClearTimeout(timeoutId);
+  }) as typeof globalThis.clearTimeout;
+
+  return {
+    restore: () => {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    },
+    runNext: async (): Promise<void> => {
+      const nextCallbackEntry = callbacks.entries().next().value;
+      if (!nextCallbackEntry) {
+        throw new Error("Expected a terminal write acknowledgement timeout to be scheduled.");
+      }
+
+      const [timeoutId, callback] = nextCallbackEntry;
+      callbacks.delete(timeoutId);
+      await act(async () => {
+        callback();
+        await Promise.resolve();
+      });
+    },
   };
 };
 
@@ -721,55 +770,62 @@ describe("AgentStudioDevServerTerminal", () => {
   test("drops timed-out replay writes when switching scripts", async () => {
     const onRendererError = () => {};
     const terminalHarness = createQueuedWriteTerminalHarness("stale replay\r\n");
+    const timeoutControl = installTerminalWriteAckTimeoutControl();
 
-    const view = render(
-      <AgentStudioDevServerTerminal
-        scriptId="frontend"
-        terminalBuffer={{
-          entries: [
-            {
-              scriptId: "frontend",
-              sequence: 0,
-              data: "stale replay\r\n",
-              timestamp: "2026-03-19T15:30:00.000Z",
-            },
-          ],
-          lastSequence: 0,
-          resetToken: 0,
-        }}
-        onRendererError={onRendererError}
-        createTerminalBinding={terminalHarness.createTerminalBinding}
-      />,
-    );
+    let view: ReturnType<typeof render>;
+    try {
+      view = render(
+        <AgentStudioDevServerTerminal
+          scriptId="frontend"
+          terminalBuffer={{
+            entries: [
+              {
+                scriptId: "frontend",
+                sequence: 0,
+                data: "stale replay\r\n",
+                timestamp: "2026-03-19T15:30:00.000Z",
+              },
+            ],
+            lastSequence: 0,
+            resetToken: 0,
+          }}
+          onRendererError={onRendererError}
+          createTerminalBinding={terminalHarness.createTerminalBinding}
+        />,
+      );
 
-    await waitFor(() => {
+      await act(async () => {
+        await Promise.resolve();
+      });
       expect(terminalHarness.queuedWrites).toHaveLength(1);
-    });
-    await new Promise((resolve) => setTimeout(resolve, 70));
+      await timeoutControl.runNext();
+    } finally {
+      timeoutControl.restore();
+    }
 
-    view.rerender(
-      <AgentStudioDevServerTerminal
-        scriptId="backend"
-        terminalBuffer={{
-          entries: [
-            {
-              scriptId: "backend",
-              sequence: 0,
-              data: "backend ready\r\n",
-              timestamp: "2026-03-19T15:30:01.000Z",
-            },
-          ],
-          lastSequence: 0,
-          resetToken: 0,
-        }}
-        onRendererError={onRendererError}
-        createTerminalBinding={terminalHarness.createTerminalBinding}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
+    await act(async () => {
+      view.rerender(
+        <AgentStudioDevServerTerminal
+          scriptId="backend"
+          terminalBuffer={{
+            entries: [
+              {
+                scriptId: "backend",
+                sequence: 0,
+                data: "backend ready\r\n",
+                timestamp: "2026-03-19T15:30:01.000Z",
+              },
+            ],
+            lastSequence: 0,
+            resetToken: 0,
+          }}
+          onRendererError={onRendererError}
+          createTerminalBinding={terminalHarness.createTerminalBinding}
+        />,
+      );
+      await Promise.resolve();
     });
+    expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
 
     terminalHarness.queuedWrites[0]?.();
     expect(terminalHarness.readScreen()).toBe("backend ready\r\n");

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -580,6 +580,134 @@ describe("AgentStudioDevServerTerminal", () => {
     });
   });
 
+  test("drops queued incremental writes when switching scripts", async () => {
+    const open = mock((_container: HTMLElement) => {});
+    const loadAddon = mock((_addon: unknown) => {});
+    const fit = mock(() => {});
+    const onRendererError = () => {};
+    let screen = "";
+    const queuedWrites: Array<() => void> = [];
+    const createTerminalBinding = (container: HTMLElement) => {
+      let active = true;
+      const reset = mock(() => {
+        if (active) {
+          screen = "";
+        }
+      });
+      const clear = mock(() => {
+        if (active) {
+          screen = "";
+        }
+      });
+      const dispose = mock(() => {
+        active = false;
+      });
+      const write = mock((data: string, callback?: () => void) => {
+        if (data === "stale frontend\r\n") {
+          queuedWrites.push(() => {
+            if (active) {
+              screen += data;
+            }
+            callback?.();
+          });
+          return;
+        }
+
+        if (active) {
+          screen += data;
+        }
+        callback?.();
+      });
+      open(container);
+      loadAddon({});
+      return {
+        terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
+        fitAddon: { dispose: mock(() => {}), fit },
+      };
+    };
+
+    const view = render(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "frontend ready\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+          lastSequence: 0,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("frontend ready\r\n");
+    });
+
+    view.rerender(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "frontend ready\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+            {
+              scriptId: "frontend",
+              sequence: 1,
+              data: "stale frontend\r\n",
+              timestamp: "2026-03-19T15:30:01.000Z",
+            },
+          ],
+          lastSequence: 1,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(queuedWrites).toHaveLength(1);
+    });
+
+    view.rerender(
+      <AgentStudioDevServerTerminal
+        scriptId="backend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "backend",
+              sequence: 0,
+              data: "backend ready\r\n",
+              timestamp: "2026-03-19T15:30:02.000Z",
+            },
+          ],
+          lastSequence: 0,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("backend ready\r\n");
+    });
+
+    queuedWrites[0]?.();
+    expect(screen).toBe("backend ready\r\n");
+  });
+
   test("surfaces renderer initialization failures", async () => {
     const onRendererError = mock(() => {});
 

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -11,6 +11,58 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
+const createQueuedWriteTerminalHarness = (queuedData: string) => {
+  const open = mock((_container: HTMLElement) => {});
+  const loadAddon = mock((_addon: unknown) => {});
+  const fit = mock(() => {});
+  let screen = "";
+  const queuedWrites: Array<() => void> = [];
+  const createTerminalBinding = (container: HTMLElement) => {
+    let active = true;
+    const reset = mock(() => {
+      if (active) {
+        screen = "";
+      }
+    });
+    const clear = mock(() => {
+      if (active) {
+        screen = "";
+      }
+    });
+    const dispose = mock(() => {
+      active = false;
+    });
+    const write = mock((data: string, callback?: () => void) => {
+      if (data === queuedData) {
+        queuedWrites.push(() => {
+          if (active) {
+            screen += data;
+          }
+          callback?.();
+        });
+        return;
+      }
+
+      if (active) {
+        screen += data;
+      }
+      callback?.();
+    });
+    open(container);
+    loadAddon({});
+    return {
+      terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
+      fitAddon: { dispose: mock(() => {}), fit },
+    };
+  };
+
+  return {
+    createTerminalBinding,
+    queuedWrites,
+    readScreen: () => screen,
+  };
+};
+
 describe("AgentStudioDevServerTerminal", () => {
   test("creates a read-only terminal and replays buffered chunks", async () => {
     const open = mock((_container: HTMLElement) => {});
@@ -581,50 +633,8 @@ describe("AgentStudioDevServerTerminal", () => {
   });
 
   test("drops queued incremental writes when switching scripts", async () => {
-    const open = mock((_container: HTMLElement) => {});
-    const loadAddon = mock((_addon: unknown) => {});
-    const fit = mock(() => {});
     const onRendererError = () => {};
-    let screen = "";
-    const queuedWrites: Array<() => void> = [];
-    const createTerminalBinding = (container: HTMLElement) => {
-      let active = true;
-      const reset = mock(() => {
-        if (active) {
-          screen = "";
-        }
-      });
-      const clear = mock(() => {
-        if (active) {
-          screen = "";
-        }
-      });
-      const dispose = mock(() => {
-        active = false;
-      });
-      const write = mock((data: string, callback?: () => void) => {
-        if (data === "stale frontend\r\n") {
-          queuedWrites.push(() => {
-            if (active) {
-              screen += data;
-            }
-            callback?.();
-          });
-          return;
-        }
-
-        if (active) {
-          screen += data;
-        }
-        callback?.();
-      });
-      open(container);
-      loadAddon({});
-      return {
-        terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
-        fitAddon: { dispose: mock(() => {}), fit },
-      };
-    };
+    const terminalHarness = createQueuedWriteTerminalHarness("stale frontend\r\n");
 
     const view = render(
       <AgentStudioDevServerTerminal
@@ -642,12 +652,12 @@ describe("AgentStudioDevServerTerminal", () => {
           resetToken: 0,
         }}
         onRendererError={onRendererError}
-        createTerminalBinding={createTerminalBinding}
+        createTerminalBinding={terminalHarness.createTerminalBinding}
       />,
     );
 
     await waitFor(() => {
-      expect(screen).toBe("frontend ready\r\n");
+      expect(terminalHarness.readScreen()).toBe("frontend ready\r\n");
     });
 
     view.rerender(
@@ -672,12 +682,12 @@ describe("AgentStudioDevServerTerminal", () => {
           resetToken: 0,
         }}
         onRendererError={onRendererError}
-        createTerminalBinding={createTerminalBinding}
+        createTerminalBinding={terminalHarness.createTerminalBinding}
       />,
     );
 
     await waitFor(() => {
-      expect(queuedWrites).toHaveLength(1);
+      expect(terminalHarness.queuedWrites).toHaveLength(1);
     });
 
     view.rerender(
@@ -696,63 +706,21 @@ describe("AgentStudioDevServerTerminal", () => {
           resetToken: 0,
         }}
         onRendererError={onRendererError}
-        createTerminalBinding={createTerminalBinding}
+        createTerminalBinding={terminalHarness.createTerminalBinding}
       />,
     );
 
     await waitFor(() => {
-      expect(screen).toBe("backend ready\r\n");
+      expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
     });
 
-    queuedWrites[0]?.();
-    expect(screen).toBe("backend ready\r\n");
+    terminalHarness.queuedWrites[0]?.();
+    expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
   });
 
   test("drops timed-out replay writes when switching scripts", async () => {
-    const open = mock((_container: HTMLElement) => {});
-    const loadAddon = mock((_addon: unknown) => {});
-    const fit = mock(() => {});
     const onRendererError = () => {};
-    let screen = "";
-    const queuedReplayWrites: Array<() => void> = [];
-    const createTerminalBinding = (container: HTMLElement) => {
-      let active = true;
-      const reset = mock(() => {
-        if (active) {
-          screen = "";
-        }
-      });
-      const clear = mock(() => {
-        if (active) {
-          screen = "";
-        }
-      });
-      const dispose = mock(() => {
-        active = false;
-      });
-      const write = mock((data: string, callback?: () => void) => {
-        if (data === "stale replay\r\n") {
-          queuedReplayWrites.push(() => {
-            if (active) {
-              screen += data;
-            }
-            callback?.();
-          });
-          return;
-        }
-
-        if (active) {
-          screen += data;
-        }
-        callback?.();
-      });
-      open(container);
-      loadAddon({});
-      return {
-        terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
-        fitAddon: { dispose: mock(() => {}), fit },
-      };
-    };
+    const terminalHarness = createQueuedWriteTerminalHarness("stale replay\r\n");
 
     const view = render(
       <AgentStudioDevServerTerminal
@@ -770,12 +738,12 @@ describe("AgentStudioDevServerTerminal", () => {
           resetToken: 0,
         }}
         onRendererError={onRendererError}
-        createTerminalBinding={createTerminalBinding}
+        createTerminalBinding={terminalHarness.createTerminalBinding}
       />,
     );
 
     await waitFor(() => {
-      expect(queuedReplayWrites).toHaveLength(1);
+      expect(terminalHarness.queuedWrites).toHaveLength(1);
     });
     await new Promise((resolve) => setTimeout(resolve, 70));
 
@@ -795,16 +763,16 @@ describe("AgentStudioDevServerTerminal", () => {
           resetToken: 0,
         }}
         onRendererError={onRendererError}
-        createTerminalBinding={createTerminalBinding}
+        createTerminalBinding={terminalHarness.createTerminalBinding}
       />,
     );
 
     await waitFor(() => {
-      expect(screen).toBe("backend ready\r\n");
+      expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
     });
 
-    queuedReplayWrites[0]?.();
-    expect(screen).toBe("backend ready\r\n");
+    terminalHarness.queuedWrites[0]?.();
+    expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
   });
 
   test("surfaces renderer initialization failures", async () => {

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -168,6 +168,129 @@ describe("AgentStudioDevServerTerminal", () => {
     expect(reset).toHaveBeenCalledTimes(2);
   });
 
+  test("continues rendering live chunks when an incremental write callback stalls", async () => {
+    const open = mock((_container: HTMLElement) => {});
+    const loadAddon = mock((_addon: unknown) => {});
+    const fit = mock(() => {});
+    const reset = mock(() => {});
+    const clear = mock(() => {});
+    const writes: string[] = [];
+    let screen = "";
+    const write = mock((data: string, callback?: () => void) => {
+      writes.push(data);
+      screen += data;
+      if (data === "stalled\r\n") {
+        return;
+      }
+
+      callback?.();
+    });
+    const dispose = mock(() => {});
+    const onRendererError = () => {};
+    const createTerminalBinding = (container: HTMLElement) => {
+      open(container);
+      loadAddon({});
+      return {
+        terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
+        fitAddon: { dispose, fit },
+      };
+    };
+
+    const view = render(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "ready\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+          lastSequence: 0,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("ready\r\n");
+    });
+
+    view.rerender(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "ready\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+            {
+              scriptId: "frontend",
+              sequence: 1,
+              data: "stalled\r\n",
+              timestamp: "2026-03-19T15:30:01.000Z",
+            },
+          ],
+          lastSequence: 1,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("ready\r\nstalled\r\n");
+    });
+
+    view.rerender(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "ready\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+            {
+              scriptId: "frontend",
+              sequence: 1,
+              data: "stalled\r\n",
+              timestamp: "2026-03-19T15:30:01.000Z",
+            },
+            {
+              scriptId: "frontend",
+              sequence: 2,
+              data: "still live\r\n",
+              timestamp: "2026-03-19T15:30:02.000Z",
+            },
+          ],
+          lastSequence: 2,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(
+      () => {
+        expect(screen).toBe("ready\r\nstalled\r\nstill live\r\n");
+      },
+      { timeout: 200 },
+    );
+    expect(writes).toEqual(["ready\r\n", "stalled\r\n", "still live\r\n"]);
+  });
+
   test("clears stale terminal rows before replaying a reset window", async () => {
     const open = mock((_container: HTMLElement) => {});
     const loadAddon = mock((_addon: unknown) => {});

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act, render, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { AgentStudioDevServerTerminal } from "./agent-studio-dev-server-terminal";
 
 if (typeof document === "undefined") {
@@ -10,8 +10,6 @@ if (typeof document === "undefined") {
 afterEach(() => {
   document.body.innerHTML = "";
 });
-
-const TERMINAL_WRITE_ACK_TIMEOUT_MS = 50;
 
 const createQueuedWriteTerminalHarness = (queuedData: string) => {
   const open = mock((_container: HTMLElement) => {});
@@ -62,53 +60,6 @@ const createQueuedWriteTerminalHarness = (queuedData: string) => {
     createTerminalBinding,
     queuedWrites,
     readScreen: () => screen,
-  };
-};
-
-const installTerminalWriteAckTimeoutControl = () => {
-  const originalSetTimeout = globalThis.setTimeout;
-  const originalClearTimeout = globalThis.clearTimeout;
-  const callbacks = new Map<number, () => void>();
-  let nextTimeoutId = 1;
-
-  globalThis.setTimeout = ((handler: TimerHandler, delay?: number, ...args: unknown[]) => {
-    if (delay === TERMINAL_WRITE_ACK_TIMEOUT_MS && typeof handler === "function") {
-      const timeoutId = -nextTimeoutId;
-      nextTimeoutId += 1;
-      callbacks.set(timeoutId, () => {
-        handler(...args);
-      });
-      return timeoutId as unknown as ReturnType<typeof globalThis.setTimeout>;
-    }
-
-    return originalSetTimeout(handler, delay, ...args);
-  }) as typeof globalThis.setTimeout;
-  globalThis.clearTimeout = ((timeoutId?: ReturnType<typeof globalThis.setTimeout>) => {
-    if (typeof timeoutId === "number" && callbacks.delete(timeoutId)) {
-      return;
-    }
-
-    originalClearTimeout(timeoutId);
-  }) as typeof globalThis.clearTimeout;
-
-  return {
-    restore: () => {
-      globalThis.setTimeout = originalSetTimeout;
-      globalThis.clearTimeout = originalClearTimeout;
-    },
-    runNext: async (): Promise<void> => {
-      const nextCallbackEntry = callbacks.entries().next().value;
-      if (!nextCallbackEntry) {
-        throw new Error("Expected a terminal write acknowledgement timeout to be scheduled.");
-      }
-
-      const [timeoutId, callback] = nextCallbackEntry;
-      callbacks.delete(timeoutId);
-      await act(async () => {
-        callback();
-        await Promise.resolve();
-      });
-    },
   };
 };
 
@@ -383,12 +334,9 @@ describe("AgentStudioDevServerTerminal", () => {
       />,
     );
 
-    await waitFor(
-      () => {
-        expect(screen).toBe("ready\r\nstalled\r\nstill live\r\n");
-      },
-      { timeout: 200 },
-    );
+    await waitFor(() => {
+      expect(screen).toBe("ready\r\nstalled\r\nstill live\r\n");
+    });
     expect(writes).toEqual(["ready\r\n", "stalled\r\n", "still live\r\n"]);
   });
 
@@ -603,34 +551,9 @@ describe("AgentStudioDevServerTerminal", () => {
     expect(reset).toHaveBeenCalledTimes(2);
   });
 
-  test("drops stale pending writes when switching scripts", async () => {
-    const open = mock((_container: HTMLElement) => {});
-    const loadAddon = mock((_addon: unknown) => {});
-    const fit = mock(() => {});
-    const dispose = mock(() => {});
+  test("drops queued replay writes when switching scripts", async () => {
     const onRendererError = () => {};
-    let screen = "";
-    const reset = mock(() => {
-      screen = "";
-    });
-    const clear = mock(() => {
-      screen = "";
-    });
-    const write = mock((data: string, callback?: () => void) => {
-      const delay = data.includes("frontend") ? 20 : 0;
-      setTimeout(() => {
-        screen += data;
-        callback?.();
-      }, delay);
-    });
-    const createTerminalBinding = (container: HTMLElement) => {
-      open(container);
-      loadAddon({});
-      return {
-        terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
-        fitAddon: { dispose, fit },
-      };
-    };
+    const terminalHarness = createQueuedWriteTerminalHarness("frontend\r\n");
 
     const view = render(
       <AgentStudioDevServerTerminal
@@ -648,12 +571,12 @@ describe("AgentStudioDevServerTerminal", () => {
           resetToken: 0,
         }}
         onRendererError={onRendererError}
-        createTerminalBinding={createTerminalBinding}
+        createTerminalBinding={terminalHarness.createTerminalBinding}
       />,
     );
 
     await waitFor(() => {
-      expect(open).toHaveBeenCalled();
+      expect(terminalHarness.queuedWrites).toHaveLength(1);
     });
 
     view.rerender(
@@ -672,13 +595,16 @@ describe("AgentStudioDevServerTerminal", () => {
           resetToken: 0,
         }}
         onRendererError={onRendererError}
-        createTerminalBinding={createTerminalBinding}
+        createTerminalBinding={terminalHarness.createTerminalBinding}
       />,
     );
 
     await waitFor(() => {
-      expect(screen).toBe("backend\r\n");
+      expect(terminalHarness.readScreen()).toBe("backend\r\n");
     });
+
+    terminalHarness.queuedWrites[0]?.();
+    expect(terminalHarness.readScreen()).toBe("backend\r\n");
   });
 
   test("drops queued incremental writes when switching scripts", async () => {
@@ -762,70 +688,6 @@ describe("AgentStudioDevServerTerminal", () => {
     await waitFor(() => {
       expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
     });
-
-    terminalHarness.queuedWrites[0]?.();
-    expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
-  });
-
-  test("drops timed-out replay writes when switching scripts", async () => {
-    const onRendererError = () => {};
-    const terminalHarness = createQueuedWriteTerminalHarness("stale replay\r\n");
-    const timeoutControl = installTerminalWriteAckTimeoutControl();
-
-    let view: ReturnType<typeof render>;
-    try {
-      view = render(
-        <AgentStudioDevServerTerminal
-          scriptId="frontend"
-          terminalBuffer={{
-            entries: [
-              {
-                scriptId: "frontend",
-                sequence: 0,
-                data: "stale replay\r\n",
-                timestamp: "2026-03-19T15:30:00.000Z",
-              },
-            ],
-            lastSequence: 0,
-            resetToken: 0,
-          }}
-          onRendererError={onRendererError}
-          createTerminalBinding={terminalHarness.createTerminalBinding}
-        />,
-      );
-
-      await act(async () => {
-        await Promise.resolve();
-      });
-      expect(terminalHarness.queuedWrites).toHaveLength(1);
-      await timeoutControl.runNext();
-    } finally {
-      timeoutControl.restore();
-    }
-
-    await act(async () => {
-      view.rerender(
-        <AgentStudioDevServerTerminal
-          scriptId="backend"
-          terminalBuffer={{
-            entries: [
-              {
-                scriptId: "backend",
-                sequence: 0,
-                data: "backend ready\r\n",
-                timestamp: "2026-03-19T15:30:01.000Z",
-              },
-            ],
-            lastSequence: 0,
-            resetToken: 0,
-          }}
-          onRendererError={onRendererError}
-          createTerminalBinding={terminalHarness.createTerminalBinding}
-        />,
-      );
-      await Promise.resolve();
-    });
-    expect(terminalHarness.readScreen()).toBe("backend ready\r\n");
 
     terminalHarness.queuedWrites[0]?.();
     expect(terminalHarness.readScreen()).toBe("backend ready\r\n");

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -708,6 +708,105 @@ describe("AgentStudioDevServerTerminal", () => {
     expect(screen).toBe("backend ready\r\n");
   });
 
+  test("drops timed-out replay writes when switching scripts", async () => {
+    const open = mock((_container: HTMLElement) => {});
+    const loadAddon = mock((_addon: unknown) => {});
+    const fit = mock(() => {});
+    const onRendererError = () => {};
+    let screen = "";
+    const queuedReplayWrites: Array<() => void> = [];
+    const createTerminalBinding = (container: HTMLElement) => {
+      let active = true;
+      const reset = mock(() => {
+        if (active) {
+          screen = "";
+        }
+      });
+      const clear = mock(() => {
+        if (active) {
+          screen = "";
+        }
+      });
+      const dispose = mock(() => {
+        active = false;
+      });
+      const write = mock((data: string, callback?: () => void) => {
+        if (data === "stale replay\r\n") {
+          queuedReplayWrites.push(() => {
+            if (active) {
+              screen += data;
+            }
+            callback?.();
+          });
+          return;
+        }
+
+        if (active) {
+          screen += data;
+        }
+        callback?.();
+      });
+      open(container);
+      loadAddon({});
+      return {
+        terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
+        fitAddon: { dispose: mock(() => {}), fit },
+      };
+    };
+
+    const view = render(
+      <AgentStudioDevServerTerminal
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "stale replay\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+          lastSequence: 0,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(queuedReplayWrites).toHaveLength(1);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 70));
+
+    view.rerender(
+      <AgentStudioDevServerTerminal
+        scriptId="backend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "backend",
+              sequence: 0,
+              data: "backend ready\r\n",
+              timestamp: "2026-03-19T15:30:01.000Z",
+            },
+          ],
+          lastSequence: 0,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("backend ready\r\n");
+    });
+
+    queuedReplayWrites[0]?.();
+    expect(screen).toBe("backend ready\r\n");
+  });
+
   test("surfaces renderer initialization failures", async () => {
     const onRendererError = mock(() => {});
 

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -29,7 +29,6 @@ type TerminalRenderController = {
   renderedStateRef: { current: RenderedTerminalState };
   renderQueueRef: { current: Promise<void> | null };
   renderGenerationRef: { current: number };
-  pendingTerminalWritesRef: PendingTerminalWritesRef;
   recreateTerminalBinding: () => TerminalBinding | null;
 };
 
@@ -44,10 +43,6 @@ type UseDevServerTerminalRenderingArgs = TerminalRenderController & {
   terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   onRendererError: (message: string | null) => void;
 };
-
-type PendingTerminalWritesRef = { current: Set<symbol> };
-
-const TERMINAL_WRITE_ACK_TIMEOUT_MS = 50;
 
 const readCssVariable = (element: HTMLElement, name: string): string => {
   return getComputedStyle(element).getPropertyValue(name).trim();
@@ -86,70 +81,12 @@ const terminalOptions = (container: HTMLElement): ITerminalOptions => ({
   theme: buildTerminalTheme(container),
 });
 
-const trackPendingTerminalWrite = (
-  pendingTerminalWritesRef: PendingTerminalWritesRef,
-): (() => void) => {
-  const pendingWrite = Symbol();
-  pendingTerminalWritesRef.current.add(pendingWrite);
-  let isFinished = false;
-
-  return () => {
-    if (isFinished) {
-      return;
-    }
-
-    isFinished = true;
-    pendingTerminalWritesRef.current.delete(pendingWrite);
-  };
-};
-
-const writeTerminalOutput = (
-  terminal: TerminalBinding["terminal"],
-  data: string,
-  waitForAcknowledgement: boolean,
-  pendingTerminalWritesRef: PendingTerminalWritesRef,
-): Promise<void> => {
+const writeTerminalOutput = (terminal: TerminalBinding["terminal"], data: string): void => {
   if (data.length === 0) {
-    return Promise.resolve();
+    return;
   }
 
-  const finishPendingWrite = trackPendingTerminalWrite(pendingTerminalWritesRef);
-
-  if (!waitForAcknowledgement) {
-    try {
-      terminal.write(data, finishPendingWrite);
-    } catch (error) {
-      finishPendingWrite();
-      throw error;
-    }
-    return Promise.resolve();
-  }
-
-  return new Promise((resolve) => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    const resolveWrite = (): void => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-      resolve();
-    };
-    const finishAcknowledgedWrite = (): void => {
-      finishPendingWrite();
-      resolveWrite();
-    };
-
-    timeoutId = setTimeout(resolveWrite, TERMINAL_WRITE_ACK_TIMEOUT_MS);
-    try {
-      terminal.write(data, finishAcknowledgedWrite);
-    } catch (error) {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
-      finishPendingWrite();
-      throw error;
-    }
-  });
+  terminal.write(data);
 };
 
 const readTerminalErrorMessage = (action: "initialize" | "render", error: unknown): string => {
@@ -283,21 +220,19 @@ const readAppendedTerminalOutput = (
   return output;
 };
 
-const renderTerminalBuffer = async ({
+const renderTerminalBuffer = ({
   binding,
   scriptId,
   terminalBuffer,
   renderedStateRef,
-  pendingTerminalWritesRef,
   recreateTerminalBinding,
 }: {
   binding: TerminalBinding;
   scriptId: string;
   terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   renderedStateRef: { current: RenderedTerminalState };
-  pendingTerminalWritesRef: PendingTerminalWritesRef;
   recreateTerminalBinding: () => TerminalBinding | null;
-}): Promise<void> => {
+}): void => {
   const entries = terminalBuffer?.entries ?? [];
   const nextResetToken = terminalBuffer?.resetToken ?? 0;
   const nextLastSequence = terminalBuffer?.lastSequence ?? null;
@@ -305,20 +240,15 @@ const renderTerminalBuffer = async ({
   const didResetTokenChange = renderedStateRef.current.resetToken !== nextResetToken;
 
   if (didScriptChange || didResetTokenChange) {
-    const activeBinding =
-      pendingTerminalWritesRef.current.size > 0 ? recreateTerminalBinding() : binding;
+    const hasRenderedCurrentBinding = renderedStateRef.current.scriptId !== null;
+    const activeBinding = hasRenderedCurrentBinding ? recreateTerminalBinding() : binding;
     if (!activeBinding) {
       throw new Error("Cannot recreate dev server terminal before replay without a container");
     }
 
     activeBinding.terminal.reset();
     activeBinding.terminal.clear();
-    await writeTerminalOutput(
-      activeBinding.terminal,
-      readTerminalReplayOutput(entries),
-      true,
-      pendingTerminalWritesRef,
-    );
+    writeTerminalOutput(activeBinding.terminal, readTerminalReplayOutput(entries));
     activeBinding.fitAddon.fit();
     renderedStateRef.current = {
       scriptId,
@@ -328,11 +258,9 @@ const renderTerminalBuffer = async ({
     return;
   }
 
-  await writeTerminalOutput(
+  writeTerminalOutput(
     binding.terminal,
     readAppendedTerminalOutput(entries, renderedStateRef.current.lastSequence),
-    false,
-    pendingTerminalWritesRef,
   );
   renderedStateRef.current.lastSequence = nextLastSequence;
 };
@@ -353,7 +281,6 @@ export const useDevServerTerminalBinding = ({
     renderQueueRef.current = Promise.resolve();
   }
   const renderGenerationRef = useRef(0);
-  const pendingTerminalWritesRef = useRef<Set<symbol>>(new Set());
   const terminalObserversCleanupRef = useRef<(() => void) | null>(null);
 
   const recreateTerminalBinding = useCallback((): TerminalBinding | null => {
@@ -367,7 +294,6 @@ export const useDevServerTerminalBinding = ({
     bindingRef.current?.terminal.dispose();
     bindingRef.current?.fitAddon.dispose();
     bindingRef.current = null;
-    pendingTerminalWritesRef.current = new Set();
 
     const binding = createTerminalBinding(container, terminalOptions(container));
     wireTerminalSelectionCopy(binding);
@@ -389,7 +315,6 @@ export const useDevServerTerminalBinding = ({
       return () => {
         terminalObserversCleanupRef.current?.();
         terminalObserversCleanupRef.current = null;
-        pendingTerminalWritesRef.current = new Set();
         disposeTerminalBinding(bindingRef, renderedStateRef, renderQueueRef, renderGenerationRef);
       };
     } catch (error) {
@@ -402,7 +327,6 @@ export const useDevServerTerminalBinding = ({
     renderedStateRef,
     renderQueueRef,
     renderGenerationRef,
-    pendingTerminalWritesRef,
     recreateTerminalBinding,
   };
 };
@@ -412,7 +336,6 @@ export const useDevServerTerminalRendering = ({
   renderedStateRef,
   renderQueueRef,
   renderGenerationRef,
-  pendingTerminalWritesRef,
   recreateTerminalBinding,
   scriptId,
   terminalBuffer,
@@ -429,18 +352,17 @@ export const useDevServerTerminalRendering = ({
 
     renderQueueRef.current = (renderQueueRef.current ?? Promise.resolve())
       .catch(() => {})
-      .then(async () => {
+      .then(() => {
         const queuedBinding = bindingRef.current;
         if (!queuedBinding || renderGeneration !== renderGenerationRef.current) {
           return;
         }
 
-        await renderTerminalBuffer({
+        renderTerminalBuffer({
           binding: queuedBinding,
           scriptId,
           terminalBuffer,
           renderedStateRef,
-          pendingTerminalWritesRef,
           recreateTerminalBinding,
         });
         if (bindingRef.current && renderGeneration === renderGenerationRef.current) {
@@ -458,7 +380,6 @@ export const useDevServerTerminalRendering = ({
     renderGenerationRef,
     renderQueueRef,
     renderedStateRef,
-    pendingTerminalWritesRef,
     recreateTerminalBinding,
     scriptId,
     terminalBuffer,

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -94,17 +94,17 @@ const writeTerminalOutput = (
     return Promise.resolve();
   }
 
-  if (!waitForAcknowledgement) {
-    const pendingWrite = Symbol();
-    pendingTerminalWritesRef.current.add(pendingWrite);
-    const finish = (): void => {
-      pendingTerminalWritesRef.current.delete(pendingWrite);
-    };
+  const pendingWrite = Symbol();
+  pendingTerminalWritesRef.current.add(pendingWrite);
+  const finishPendingWrite = (): void => {
+    pendingTerminalWritesRef.current.delete(pendingWrite);
+  };
 
+  if (!waitForAcknowledgement) {
     try {
-      terminal.write(data, finish);
+      terminal.write(data, finishPendingWrite);
     } catch (error) {
-      finish();
+      finishPendingWrite();
       throw error;
     }
     return Promise.resolve();
@@ -112,21 +112,26 @@ const writeTerminalOutput = (
 
   return new Promise((resolve) => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    const finish = (): void => {
+    const resolveWrite = (): void => {
       if (timeoutId !== null) {
         clearTimeout(timeoutId);
         timeoutId = null;
       }
       resolve();
     };
+    const finishAcknowledgedWrite = (): void => {
+      finishPendingWrite();
+      resolveWrite();
+    };
 
-    timeoutId = setTimeout(finish, TERMINAL_WRITE_ACK_TIMEOUT_MS);
+    timeoutId = setTimeout(resolveWrite, TERMINAL_WRITE_ACK_TIMEOUT_MS);
     try {
-      terminal.write(data, finish);
+      terminal.write(data, finishAcknowledgedWrite);
     } catch (error) {
       if (timeoutId !== null) {
         clearTimeout(timeoutId);
       }
+      finishPendingWrite();
       throw error;
     }
   });

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -43,6 +43,8 @@ type UseDevServerTerminalRenderingArgs = TerminalRenderController & {
   onRendererError: (message: string | null) => void;
 };
 
+const TERMINAL_WRITE_ACK_TIMEOUT_MS = 50;
+
 const readCssVariable = (element: HTMLElement, name: string): string => {
   return getComputedStyle(element).getPropertyValue(name).trim();
 };
@@ -83,13 +85,36 @@ const terminalOptions = (container: HTMLElement): ITerminalOptions => ({
 const writeTerminalOutput = (
   terminal: TerminalBinding["terminal"],
   data: string,
+  waitForAcknowledgement: boolean,
 ): Promise<void> => {
   if (data.length === 0) {
     return Promise.resolve();
   }
 
+  if (!waitForAcknowledgement) {
+    terminal.write(data);
+    return Promise.resolve();
+  }
+
   return new Promise((resolve) => {
-    terminal.write(data, resolve);
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const finish = (): void => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      resolve();
+    };
+
+    timeoutId = setTimeout(finish, TERMINAL_WRITE_ACK_TIMEOUT_MS);
+    try {
+      terminal.write(data, finish);
+    } catch (error) {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+      throw error;
+    }
   });
 };
 
@@ -244,7 +269,7 @@ const renderTerminalBuffer = async ({
   if (didScriptChange || didResetTokenChange) {
     binding.terminal.reset();
     binding.terminal.clear();
-    await writeTerminalOutput(binding.terminal, readTerminalReplayOutput(entries));
+    await writeTerminalOutput(binding.terminal, readTerminalReplayOutput(entries), true);
     binding.fitAddon.fit();
     renderedStateRef.current = {
       scriptId,
@@ -257,6 +282,7 @@ const renderTerminalBuffer = async ({
   await writeTerminalOutput(
     binding.terminal,
     readAppendedTerminalOutput(entries, renderedStateRef.current.lastSequence),
+    false,
   );
   renderedStateRef.current.lastSequence = nextLastSequence;
 };

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -29,7 +29,7 @@ type TerminalRenderController = {
   renderedStateRef: { current: RenderedTerminalState };
   renderQueueRef: { current: Promise<void> | null };
   renderGenerationRef: { current: number };
-  pendingTerminalWritesRef: { current: Set<symbol> };
+  pendingTerminalWritesRef: PendingTerminalWritesRef;
   recreateTerminalBinding: () => TerminalBinding | null;
 };
 
@@ -44,6 +44,8 @@ type UseDevServerTerminalRenderingArgs = TerminalRenderController & {
   terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   onRendererError: (message: string | null) => void;
 };
+
+type PendingTerminalWritesRef = { current: Set<symbol> };
 
 const TERMINAL_WRITE_ACK_TIMEOUT_MS = 50;
 
@@ -84,21 +86,34 @@ const terminalOptions = (container: HTMLElement): ITerminalOptions => ({
   theme: buildTerminalTheme(container),
 });
 
+const trackPendingTerminalWrite = (
+  pendingTerminalWritesRef: PendingTerminalWritesRef,
+): (() => void) => {
+  const pendingWrite = Symbol();
+  pendingTerminalWritesRef.current.add(pendingWrite);
+  let isFinished = false;
+
+  return () => {
+    if (isFinished) {
+      return;
+    }
+
+    isFinished = true;
+    pendingTerminalWritesRef.current.delete(pendingWrite);
+  };
+};
+
 const writeTerminalOutput = (
   terminal: TerminalBinding["terminal"],
   data: string,
   waitForAcknowledgement: boolean,
-  pendingTerminalWritesRef: { current: Set<symbol> },
+  pendingTerminalWritesRef: PendingTerminalWritesRef,
 ): Promise<void> => {
   if (data.length === 0) {
     return Promise.resolve();
   }
 
-  const pendingWrite = Symbol();
-  pendingTerminalWritesRef.current.add(pendingWrite);
-  const finishPendingWrite = (): void => {
-    pendingTerminalWritesRef.current.delete(pendingWrite);
-  };
+  const finishPendingWrite = trackPendingTerminalWrite(pendingTerminalWritesRef);
 
   if (!waitForAcknowledgement) {
     try {
@@ -280,7 +295,7 @@ const renderTerminalBuffer = async ({
   scriptId: string;
   terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   renderedStateRef: { current: RenderedTerminalState };
-  pendingTerminalWritesRef: { current: Set<symbol> };
+  pendingTerminalWritesRef: PendingTerminalWritesRef;
   recreateTerminalBinding: () => TerminalBinding | null;
 }): Promise<void> => {
   const entries = terminalBuffer?.entries ?? [];

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -1,6 +1,6 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { type ITerminalOptions, type ITheme, Terminal } from "@xterm/xterm";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 
 export type TerminalBinding = {
@@ -29,6 +29,8 @@ type TerminalRenderController = {
   renderedStateRef: { current: RenderedTerminalState };
   renderQueueRef: { current: Promise<void> | null };
   renderGenerationRef: { current: number };
+  pendingTerminalWritesRef: { current: Set<symbol> };
+  recreateTerminalBinding: () => TerminalBinding | null;
 };
 
 type UseDevServerTerminalBindingArgs = {
@@ -86,13 +88,25 @@ const writeTerminalOutput = (
   terminal: TerminalBinding["terminal"],
   data: string,
   waitForAcknowledgement: boolean,
+  pendingTerminalWritesRef: { current: Set<symbol> },
 ): Promise<void> => {
   if (data.length === 0) {
     return Promise.resolve();
   }
 
   if (!waitForAcknowledgement) {
-    terminal.write(data);
+    const pendingWrite = Symbol();
+    pendingTerminalWritesRef.current.add(pendingWrite);
+    const finish = (): void => {
+      pendingTerminalWritesRef.current.delete(pendingWrite);
+    };
+
+    try {
+      terminal.write(data, finish);
+    } catch (error) {
+      finish();
+      throw error;
+    }
     return Promise.resolve();
   }
 
@@ -254,11 +268,15 @@ const renderTerminalBuffer = async ({
   scriptId,
   terminalBuffer,
   renderedStateRef,
+  pendingTerminalWritesRef,
+  recreateTerminalBinding,
 }: {
   binding: TerminalBinding;
   scriptId: string;
   terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   renderedStateRef: { current: RenderedTerminalState };
+  pendingTerminalWritesRef: { current: Set<symbol> };
+  recreateTerminalBinding: () => TerminalBinding | null;
 }): Promise<void> => {
   const entries = terminalBuffer?.entries ?? [];
   const nextResetToken = terminalBuffer?.resetToken ?? 0;
@@ -267,10 +285,21 @@ const renderTerminalBuffer = async ({
   const didResetTokenChange = renderedStateRef.current.resetToken !== nextResetToken;
 
   if (didScriptChange || didResetTokenChange) {
-    binding.terminal.reset();
-    binding.terminal.clear();
-    await writeTerminalOutput(binding.terminal, readTerminalReplayOutput(entries), true);
-    binding.fitAddon.fit();
+    const activeBinding =
+      pendingTerminalWritesRef.current.size > 0 ? recreateTerminalBinding() : binding;
+    if (!activeBinding) {
+      throw new Error("Cannot recreate dev server terminal before replay without a container");
+    }
+
+    activeBinding.terminal.reset();
+    activeBinding.terminal.clear();
+    await writeTerminalOutput(
+      activeBinding.terminal,
+      readTerminalReplayOutput(entries),
+      true,
+      pendingTerminalWritesRef,
+    );
+    activeBinding.fitAddon.fit();
     renderedStateRef.current = {
       scriptId,
       resetToken: nextResetToken,
@@ -283,6 +312,7 @@ const renderTerminalBuffer = async ({
     binding.terminal,
     readAppendedTerminalOutput(entries, renderedStateRef.current.lastSequence),
     false,
+    pendingTerminalWritesRef,
   );
   renderedStateRef.current.lastSequence = nextLastSequence;
 };
@@ -303,6 +333,28 @@ export const useDevServerTerminalBinding = ({
     renderQueueRef.current = Promise.resolve();
   }
   const renderGenerationRef = useRef(0);
+  const pendingTerminalWritesRef = useRef<Set<symbol>>(new Set());
+  const terminalObserversCleanupRef = useRef<(() => void) | null>(null);
+
+  const recreateTerminalBinding = useCallback((): TerminalBinding | null => {
+    const container = containerRef.current;
+    if (!container) {
+      return null;
+    }
+
+    terminalObserversCleanupRef.current?.();
+    terminalObserversCleanupRef.current = null;
+    bindingRef.current?.terminal.dispose();
+    bindingRef.current?.fitAddon.dispose();
+    bindingRef.current = null;
+    pendingTerminalWritesRef.current = new Set();
+
+    const binding = createTerminalBinding(container, terminalOptions(container));
+    wireTerminalSelectionCopy(binding);
+    bindingRef.current = binding;
+    terminalObserversCleanupRef.current = createTerminalObserversCleanup(container, binding);
+    return binding;
+  }, [containerRef, createTerminalBinding]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -311,26 +363,27 @@ export const useDevServerTerminalBinding = ({
     }
 
     try {
-      const binding = createTerminalBinding(container, terminalOptions(container));
-      wireTerminalSelectionCopy(binding);
-      bindingRef.current = binding;
+      recreateTerminalBinding();
       onRendererError(null);
-      const cleanupObservers = createTerminalObserversCleanup(container, binding);
 
       return () => {
-        cleanupObservers();
+        terminalObserversCleanupRef.current?.();
+        terminalObserversCleanupRef.current = null;
+        pendingTerminalWritesRef.current = new Set();
         disposeTerminalBinding(bindingRef, renderedStateRef, renderQueueRef, renderGenerationRef);
       };
     } catch (error) {
       onRendererError(readTerminalErrorMessage("initialize", error));
     }
-  }, [containerRef, createTerminalBinding, onRendererError]);
+  }, [containerRef, onRendererError, recreateTerminalBinding]);
 
   return {
     bindingRef,
     renderedStateRef,
     renderQueueRef,
     renderGenerationRef,
+    pendingTerminalWritesRef,
+    recreateTerminalBinding,
   };
 };
 
@@ -339,6 +392,8 @@ export const useDevServerTerminalRendering = ({
   renderedStateRef,
   renderQueueRef,
   renderGenerationRef,
+  pendingTerminalWritesRef,
+  recreateTerminalBinding,
   scriptId,
   terminalBuffer,
   onRendererError,
@@ -365,6 +420,8 @@ export const useDevServerTerminalRendering = ({
           scriptId,
           terminalBuffer,
           renderedStateRef,
+          pendingTerminalWritesRef,
+          recreateTerminalBinding,
         });
         if (bindingRef.current && renderGeneration === renderGenerationRef.current) {
           onRendererError(null);
@@ -381,6 +438,8 @@ export const useDevServerTerminalRendering = ({
     renderGenerationRef,
     renderQueueRef,
     renderedStateRef,
+    pendingTerminalWritesRef,
+    recreateTerminalBinding,
     scriptId,
     terminalBuffer,
   ]);

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -103,6 +103,27 @@ describe("dev-server-log-buffer", () => {
     expect(buffer?.entries[0]?.data).toBe("latest");
   });
 
+  test("accepts later live chunks after host byte trimming preserves sequence order", () => {
+    const store = createDevServerTerminalBufferStore();
+
+    appendDevServerTerminalChunk(store, {
+      scriptId: "frontend",
+      sequence: 1,
+      data: "oversized-live",
+      timestamp: "2026-03-25T10:00:00.000Z",
+    });
+    appendDevServerTerminalChunk(store, {
+      scriptId: "frontend",
+      sequence: 2,
+      data: "later-live",
+      timestamp: "2026-03-25T10:00:01.000Z",
+    });
+
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual(["oversized-live", "later-live"]);
+  });
+
   test("returned buffer snapshots stay stable after later appends", () => {
     const store = createDevServerTerminalBufferStore();
 

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -103,7 +103,7 @@ describe("dev-server-log-buffer", () => {
     expect(buffer?.entries[0]?.data).toBe("latest");
   });
 
-  test("accepts later live chunks after host byte trimming preserves sequence order", () => {
+  test("accepts sequential live chunks after replay gaps", () => {
     const store = createDevServerTerminalBufferStore();
 
     appendDevServerTerminalChunk(store, {

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -753,6 +753,126 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
+  test("preserves live shutdown output when a stop mutation returns an empty replay", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const runningState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "ready\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const stoppedState = buildState({
+      updatedAt: "2026-03-19T15:31:00.000Z",
+      scripts: [
+        buildScript({
+          status: "stopped",
+          pid: null,
+          startedAt: null,
+          bufferedTerminalChunks: [],
+        }),
+      ],
+    });
+    const stoppedScript = stoppedState.scripts[0];
+    if (!stoppedScript) {
+      throw new Error("Expected stopped dev server script fixture.");
+    }
+    const stopDeferred = createDeferred<DevServerGroupState>();
+    devServerGetState = async () => runningState;
+    devServerStop = async () => stopDeferred.promise;
+
+    let latest: HookResult | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe("ready\r\n");
+      });
+      await waitFor(() => {
+        expect(devServerEventListener).not.toBeNull();
+      });
+
+      await act(async () => {
+        getLatest().onStop();
+      });
+
+      await act(async () => {
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            sequence: 1,
+            data: "closing dev server\r\n",
+            timestamp: "2026-03-19T15:30:01.000Z",
+          },
+        });
+        devServerEventListener?.({
+          type: "script_status_changed",
+          repoPath: "/repo",
+          taskId: "task-7",
+          updatedAt: "2026-03-19T15:30:02.000Z",
+          script: stoppedScript,
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
+        ).toEqual(["closing dev server\r\n"]);
+      });
+
+      stopDeferred.resolve(stoppedState);
+
+      await waitFor(() => {
+        expect(getLatest().isStopPending).toBe(false);
+      });
+      expect(getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data)).toEqual([
+        "closing dev server\r\n",
+      ]);
+      expect(getLatest().scripts[0]?.status).toBe("stopped");
+    } finally {
+      view.unmount();
+    }
+  });
+
   test("replaces mixed old and new replay when mutation state returns the reset window", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -1577,6 +1577,182 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
+  test("clears old live-only output when restart emits a starting status before low-sequence chunks", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const initialState = buildState({
+      scripts: [
+        buildScript({
+          status: "failed",
+          pid: null,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          lastError: "Command failed.",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "Starting `bun run dev`\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const restartDeferred = createDeferred<DevServerGroupState>();
+    devServerGetState = async () => initialState;
+    devServerRestart = async () => restartDeferred.promise;
+
+    let latest: HookResult | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(
+          getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
+        ).toEqual(["Starting `bun run dev`\r\n"]);
+      });
+      await waitFor(() => {
+        expect(devServerEventListener).not.toBeNull();
+      });
+
+      act(() => {
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            sequence: 1,
+            data: "old failed output\r\n",
+            timestamp: "2026-03-19T15:30:01.000Z",
+          },
+        });
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            sequence: 2,
+            data: "ELIFECYCLE Command failed.\r\n",
+            timestamp: "2026-03-19T15:30:02.000Z",
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
+        ).toEqual([
+          "Starting `bun run dev`\r\n",
+          "old failed output\r\n",
+          "ELIFECYCLE Command failed.\r\n",
+        ]);
+      });
+
+      await act(async () => {
+        getLatest().onRestart();
+      });
+      act(() => {
+        devServerEventListener?.({
+          type: "script_status_changed",
+          repoPath: "/repo",
+          taskId: "task-7",
+          updatedAt: "2026-03-19T15:31:00.000Z",
+          script: buildScript({
+            status: "starting",
+            pid: null,
+            startedAt: "2026-03-19T15:31:00.000Z",
+            bufferedTerminalChunks: [],
+          }),
+        });
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            sequence: 0,
+            data: "Starting `bun run dev`\r\n",
+            timestamp: "2026-03-19T15:31:00.000Z",
+          },
+        });
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            sequence: 1,
+            data: "new dev server ready\r\n",
+            timestamp: "2026-03-19T15:31:01.000Z",
+          },
+        });
+      });
+
+      expect(getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data)).toEqual([
+        "Starting `bun run dev`\r\n",
+        "new dev server ready\r\n",
+      ]);
+
+      restartDeferred.resolve(
+        buildState({
+          scripts: [
+            buildScript({
+              status: "running",
+              pid: 4343,
+              startedAt: "2026-03-19T15:31:00.000Z",
+              bufferedTerminalChunks: [
+                {
+                  scriptId: "frontend",
+                  sequence: 0,
+                  data: "Starting `bun run dev`\r\n",
+                  timestamp: "2026-03-19T15:31:00.000Z",
+                },
+                {
+                  scriptId: "frontend",
+                  sequence: 1,
+                  data: "new dev server ready\r\n",
+                  timestamp: "2026-03-19T15:31:01.000Z",
+                },
+              ],
+            }),
+          ],
+        }),
+      );
+      await waitFor(() => {
+        expect(getLatest().isRestartPending).toBe(false);
+      });
+    } finally {
+      view.unmount();
+    }
+  });
+
   test("clears stale task state when switching to another task while enabled", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -1604,31 +1604,13 @@ describe("useAgentStudioDevServerPanel", () => {
     devServerGetState = async () => initialState;
     devServerRestart = async () => restartDeferred.promise;
 
-    let latest: HookResult | null = null;
-    const getLatest = (): HookResult => {
-      if (latest === null) {
-        throw new Error("Hook result not ready");
-      }
-      return latest;
-    };
-
-    const Harness = ({ args }: { args: HookArgs }) => {
-      latest = useAgentStudioDevServerPanel(args);
-      return null;
-    };
-
-    const view = render(
-      <QueryProvider useIsolatedClient>
-        <Harness
-          args={{
-            repoPath: "/repo",
-            taskId: "task-7",
-            repoSettings,
-            enabled: true,
-          }}
-        />
-      </QueryProvider>,
-    );
+    const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
+      repoPath: "/repo",
+      taskId: "task-7",
+      repoSettings,
+      enabled: true,
+    });
+    const getLatest = harness.getLatest;
 
     try {
       await waitFor(() => {
@@ -1749,7 +1731,7 @@ describe("useAgentStudioDevServerPanel", () => {
         expect(getLatest().isRestartPending).toBe(false);
       });
     } finally {
-      view.unmount();
+      harness.unmount();
     }
   });
 

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -794,31 +794,13 @@ describe("useAgentStudioDevServerPanel", () => {
     devServerGetState = async () => runningState;
     devServerStop = async () => stopDeferred.promise;
 
-    let latest: HookResult | null = null;
-    const getLatest = (): HookResult => {
-      if (latest === null) {
-        throw new Error("Hook result not ready");
-      }
-      return latest;
-    };
-
-    const Harness = ({ args }: { args: HookArgs }) => {
-      latest = useAgentStudioDevServerPanel(args);
-      return null;
-    };
-
-    const view = render(
-      <QueryProvider useIsolatedClient>
-        <Harness
-          args={{
-            repoPath: "/repo",
-            taskId: "task-7",
-            repoSettings,
-            enabled: true,
-          }}
-        />
-      </QueryProvider>,
-    );
+    const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
+      repoPath: "/repo",
+      taskId: "task-7",
+      repoSettings,
+      enabled: true,
+    });
+    const getLatest = harness.getLatest;
 
     try {
       await waitFor(() => {
@@ -869,7 +851,7 @@ describe("useAgentStudioDevServerPanel", () => {
       ]);
       expect(getLatest().scripts[0]?.status).toBe("stopped");
     } finally {
-      view.unmount();
+      harness.unmount();
     }
   });
 

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -185,8 +185,15 @@ export const useAgentStudioDevServerTerminalBuffers =
         }
 
         if (event.type === "script_status_changed") {
+          const replacementContext =
+            event.script.status === "starting"
+              ? null
+              : getDevServerTerminalBufferReplacementContext(
+                  terminalBuffers,
+                  event.script.scriptId,
+                );
           const replacement = getDevServerTerminalBufferReplacement(
-            getDevServerTerminalBufferReplacementContext(terminalBuffers, event.script.scriptId),
+            replacementContext,
             event.script,
           );
           if (replacement === null) {

--- a/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
@@ -26,6 +26,7 @@ const repoConfig: RepoConfig = {
 const createRuntime = (): DevServerGroupRuntime => ({
   processes: new Map(),
   state: buildGroupState(repoConfig, "task-1", "/worktrees/task-1", "2026-05-24T00:00:00.000Z"),
+  terminalNextSequenceByScriptId: new Map(),
 });
 
 const updateScriptState: UpdateScriptState = (runtime, scriptId, update) => {

--- a/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
@@ -26,6 +26,7 @@ const repoConfig: RepoConfig = {
 const createRuntime = (): DevServerGroupRuntime => ({
   processes: new Map(),
   state: buildGroupState(repoConfig, "task-1", "/worktrees/task-1", "2026-05-24T00:00:00.000Z"),
+  terminalBufferedBytesByScriptId: new Map(),
   terminalNextSequenceByScriptId: new Map(),
 });
 

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -273,6 +273,50 @@ describe("createDevServerService", () => {
     expect(chunks.map((chunk) => chunk.sequence)).toEqual([2, 3]);
     expect(chunks.reduce((total, chunk) => total + chunk.data.length, 0)).toBe(512 * 1024);
   });
+  test("keeps terminal sequences increasing after an oversized chunk empties replay", async () => {
+    const { eventBus, events } = createEventBus();
+    const oversizedChunk = "x".repeat(600 * 1024);
+    const processPort: DevServerProcessPort = {
+      start(input) {
+        input.onOutput({ data: oversizedChunk });
+        input.onOutput({ data: "still live\n" });
+
+        return Effect.succeed({
+          pid: 413,
+          stop: () => Effect.succeed(undefined),
+        });
+      },
+    };
+    const service = createDevServerService({
+      eventBus,
+      processPort,
+      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+      workspaceSettingsService: createWorkspaceSettingsService(repoConfig()),
+    });
+
+    const state = await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    const terminalChunks = events
+      .map((event) => (event as { payload?: unknown }).payload)
+      .filter(
+        (payload): payload is { terminalChunk: { data: string; sequence: number }; type: string } =>
+          typeof payload === "object" &&
+          payload !== null &&
+          "type" in payload &&
+          payload.type === "terminal_chunk" &&
+          "terminalChunk" in payload,
+      )
+      .map((payload) => payload.terminalChunk);
+
+    expect(terminalChunks.map((chunk) => chunk.sequence)).toEqual([0, 1, 2]);
+    expect(terminalChunks.map((chunk) => chunk.data)).toEqual([
+      "Starting `bun run dev`\r\n",
+      oversizedChunk,
+      "still live\r\n",
+    ]);
+    expect(state.scripts[0]?.bufferedTerminalChunks.map((chunk) => chunk.data)).toEqual([
+      "still live\r\n",
+    ]);
+  });
   test("rejects duplicate starts while a script is running", async () => {
     const { processPort } = createProcessPort();
     const service = createDevServerService({

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -221,6 +221,58 @@ describe("createDevServerService", () => {
       ]),
     );
   });
+  test("trims buffered terminal output to the chunk limit", async () => {
+    const processPort: DevServerProcessPort = {
+      start(input) {
+        for (let index = 0; index < 2_005; index += 1) {
+          input.onOutput({ data: `line-${index}\n` });
+        }
+
+        return Effect.succeed({
+          pid: 410,
+          stop: () => Effect.succeed(undefined),
+        });
+      },
+    };
+    const service = createDevServerService({
+      processPort,
+      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+      workspaceSettingsService: createWorkspaceSettingsService(repoConfig()),
+    });
+
+    const state = await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    const chunks = state.scripts[0]?.bufferedTerminalChunks ?? [];
+
+    expect(chunks).toHaveLength(2_000);
+    expect(chunks[0]).toMatchObject({ sequence: 6, data: "line-5\r\n" });
+    expect(chunks.at(-1)).toMatchObject({ sequence: 2005, data: "line-2004\r\n" });
+  });
+  test("trims buffered terminal output to the byte limit", async () => {
+    const halfLimitChunk = "x".repeat(256 * 1024);
+    const processPort: DevServerProcessPort = {
+      start(input) {
+        input.onOutput({ data: halfLimitChunk });
+        input.onOutput({ data: halfLimitChunk });
+        input.onOutput({ data: halfLimitChunk });
+
+        return Effect.succeed({
+          pid: 411,
+          stop: () => Effect.succeed(undefined),
+        });
+      },
+    };
+    const service = createDevServerService({
+      processPort,
+      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+      workspaceSettingsService: createWorkspaceSettingsService(repoConfig()),
+    });
+
+    const state = await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    const chunks = state.scripts[0]?.bufferedTerminalChunks ?? [];
+
+    expect(chunks.map((chunk) => chunk.sequence)).toEqual([2, 3]);
+    expect(chunks.reduce((total, chunk) => total + chunk.data.length, 0)).toBe(512 * 1024);
+  });
   test("rejects duplicate starts while a script is running", async () => {
     const { processPort } = createProcessPort();
     const service = createDevServerService({
@@ -464,6 +516,40 @@ describe("createDevServerService", () => {
       scripts: [{ scriptId: "web", status: "stopped", pid: null }],
     });
     expect(stoppedPids).toEqual([400]);
+  });
+  test("preserves existing and shutdown terminal output when stopping", async () => {
+    const stoppedPids: number[] = [];
+    const processPort: DevServerProcessPort = {
+      start(input) {
+        input.onOutput({ data: "ready\n" });
+
+        return Effect.succeed({
+          pid: 412,
+          stop: () =>
+            Effect.sync(() => {
+              stoppedPids.push(412);
+              input.onOutput({ data: "closing dev server\n" });
+              input.onExit({ pid: 412, exitCode: 0, signal: null, error: null });
+            }),
+        });
+      },
+    };
+    const service = createDevServerService({
+      processPort,
+      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+      workspaceSettingsService: createWorkspaceSettingsService(repoConfig()),
+    });
+
+    await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    const state = await Effect.runPromise(service.stop({ repoPath: "/repo", taskId: "task-1" }));
+
+    expect(stoppedPids).toEqual([412]);
+    expect(state.scripts[0]?.bufferedTerminalChunks.map((chunk) => chunk.data)).toEqual([
+      "Starting `bun run dev`\r\n",
+      "ready\r\n",
+      "closing dev server\r\n",
+    ]);
+    expect(state.scripts[0]).toMatchObject({ status: "stopped", pid: null });
   });
   test("stops all running task dev server groups during host shutdown", async () => {
     const { processPort, stoppedPids } = createProcessPort();

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -45,6 +45,7 @@ import {
   resetTerminalChunks,
   scriptHasLiveProcess,
   syncGroupState,
+  syncRuntimeTerminalBufferByteCounts,
 } from "./dev-server-state";
 
 export type {
@@ -91,11 +92,13 @@ export const createDevServerService = ({
       const existing = groups.get(key);
       if (existing) {
         syncGroupState(existing.state, repoConfig, taskId, worktreePath);
+        syncRuntimeTerminalBufferByteCounts(existing);
         return existing;
       }
       const runtime = {
         processes: new Map<string, DevServerProcessHandle>(),
         state: buildGroupState(repoConfig, taskId, worktreePath, nowIso()),
+        terminalBufferedBytesByScriptId: new Map<string, number>(),
         terminalNextSequenceByScriptId: new Map<string, number>(),
       };
       groups.set(key, runtime);
@@ -149,7 +152,7 @@ export const createDevServerService = ({
       data,
       timestamp: nowIso(),
     };
-    appendTerminalChunk(script.bufferedTerminalChunks, terminalChunk);
+    appendTerminalChunk(runtime, script, terminalChunk);
     runtime.state.updatedAt = nowIso();
     publish({
       type: "terminal_chunk",

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -96,6 +96,7 @@ export const createDevServerService = ({
       const runtime = {
         processes: new Map<string, DevServerProcessHandle>(),
         state: buildGroupState(repoConfig, taskId, worktreePath, nowIso()),
+        terminalNextSequenceByScriptId: new Map<string, number>(),
       };
       groups.set(key, runtime);
       return runtime;
@@ -144,7 +145,7 @@ export const createDevServerService = ({
     }
     const terminalChunk = {
       scriptId,
-      sequence: nextTerminalSequence(script),
+      sequence: nextTerminalSequence(runtime, script),
       data,
       timestamp: nowIso(),
     };
@@ -232,7 +233,7 @@ export const createDevServerService = ({
         script.startedAt = null;
         script.exitCode = null;
         script.lastError = null;
-        resetTerminalChunks(script);
+        resetTerminalChunks(runtime, script);
       });
       appendTerminalSystemMessage(runtime, scriptConfig.id, `Starting \`${scriptConfig.command}\``);
       const handle = yield* processPort

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -146,14 +146,15 @@ export const createDevServerService = ({
     if (!script) {
       return;
     }
+    const timestamp = nowIso();
     const terminalChunk = {
       scriptId,
       sequence: nextTerminalSequence(runtime, script),
       data,
-      timestamp: nowIso(),
+      timestamp,
     };
     appendTerminalChunk(runtime, script, terminalChunk);
-    runtime.state.updatedAt = nowIso();
+    runtime.state.updatedAt = timestamp;
     publish({
       type: "terminal_chunk",
       repoPath: runtime.state.repoPath,

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -31,6 +31,7 @@ import type {
   StoppedDevServerScript,
 } from "./dev-server-service-types";
 import {
+  appendTerminalChunk,
   buildGroupState,
   DEV_SERVER_CLICOLOR_FORCE,
   DEV_SERVER_COLORTERM,
@@ -41,9 +42,9 @@ import {
   formatTerminalProcessOutput,
   formatTerminalSystemMessage,
   nextTerminalSequence,
+  resetTerminalChunks,
   scriptHasLiveProcess,
   syncGroupState,
-  trimTerminalChunks,
 } from "./dev-server-state";
 
 export type {
@@ -147,8 +148,7 @@ export const createDevServerService = ({
       data,
       timestamp: nowIso(),
     };
-    script.bufferedTerminalChunks.push(terminalChunk);
-    trimTerminalChunks(script.bufferedTerminalChunks);
+    appendTerminalChunk(script.bufferedTerminalChunks, terminalChunk);
     runtime.state.updatedAt = nowIso();
     publish({
       type: "terminal_chunk",
@@ -232,7 +232,7 @@ export const createDevServerService = ({
         script.startedAt = null;
         script.exitCode = null;
         script.lastError = null;
-        script.bufferedTerminalChunks = [];
+        resetTerminalChunks(script);
       });
       appendTerminalSystemMessage(runtime, scriptConfig.id, `Starting \`${scriptConfig.command}\``);
       const handle = yield* processPort
@@ -301,7 +301,6 @@ export const createDevServerService = ({
       }> = [];
       const errors: string[] = [];
       for (const script of runtime.state.scripts) {
-        script.bufferedTerminalChunks = [];
         if (script.pid === null) {
           if (
             script.status !== "stopped" ||

--- a/packages/host/src/application/dev-servers/dev-server-state.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.test.ts
@@ -1,0 +1,51 @@
+import type { RepoConfig } from "@openducktor/contracts";
+import {
+  buildGroupState,
+  type DevServerGroupRuntime,
+  syncRuntimeTerminalBufferByteCounts,
+} from "./dev-server-state";
+
+const repoConfig: RepoConfig = {
+  workspaceId: "repo",
+  workspaceName: "Repo",
+  repoPath: "/canonical/repo",
+  defaultRuntimeKind: "opencode",
+  branchPrefix: "odt",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  git: { providers: {} },
+  hooks: { preStart: [], postComplete: [] },
+  devServers: [
+    { id: "web", name: "Web", command: "bun run dev" },
+    { id: "api", name: "API", command: "bun run api" },
+  ],
+  worktreeCopyPaths: [],
+  promptOverrides: {},
+  agentDefaults: {},
+};
+
+const createRuntime = (): DevServerGroupRuntime => ({
+  processes: new Map(),
+  state: buildGroupState(repoConfig, "task-1", "/worktrees/task-1", "2026-05-24T00:00:00.000Z"),
+  terminalBufferedBytesByScriptId: new Map(),
+  terminalNextSequenceByScriptId: new Map(),
+});
+
+describe("dev-server state helpers", () => {
+  test("prunes terminal runtime accounting for inactive scripts", () => {
+    const runtime = createRuntime();
+    runtime.state.scripts = runtime.state.scripts.filter((script) => script.scriptId === "web");
+    runtime.terminalBufferedBytesByScriptId.set("web", 12);
+    runtime.terminalBufferedBytesByScriptId.set("api", 24);
+    runtime.terminalNextSequenceByScriptId.set("web", 3);
+    runtime.terminalNextSequenceByScriptId.set("api", 9);
+    runtime.terminalNextSequenceByScriptId.set("removed-sequence-only", 17);
+
+    syncRuntimeTerminalBufferByteCounts(runtime);
+
+    expect(runtime.terminalBufferedBytesByScriptId.has("api")).toBe(false);
+    expect(runtime.terminalNextSequenceByScriptId.has("api")).toBe(false);
+    expect(runtime.terminalNextSequenceByScriptId.has("removed-sequence-only")).toBe(false);
+    expect(runtime.terminalBufferedBytesByScriptId.get("web")).toBe(12);
+    expect(runtime.terminalNextSequenceByScriptId.get("web")).toBe(3);
+  });
+});

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -10,6 +10,7 @@ import type { DevServerProcessHandle } from "../../ports/dev-server-process-port
 export type DevServerGroupRuntime = {
   processes: Map<string, DevServerProcessHandle>;
   state: DevServerGroupState;
+  terminalNextSequenceByScriptId: Map<string, number>;
 };
 
 export const DEV_SERVER_EVENT_CHANNEL = "openducktor://dev-server-event";
@@ -82,9 +83,20 @@ export const syncGroupState = (
   state.updatedAt = nowIso();
 };
 
-export const nextTerminalSequence = (script: DevServerScriptState): number => {
+const nextTerminalSequenceFromReplay = (script: DevServerScriptState): number => {
   const lastChunk = script.bufferedTerminalChunks.at(-1);
   return lastChunk ? lastChunk.sequence + 1 : 0;
+};
+
+export const nextTerminalSequence = (
+  runtime: DevServerGroupRuntime,
+  script: DevServerScriptState,
+): number => {
+  const nextSequence =
+    runtime.terminalNextSequenceByScriptId.get(script.scriptId) ??
+    nextTerminalSequenceFromReplay(script);
+  runtime.terminalNextSequenceByScriptId.set(script.scriptId, nextSequence + 1);
+  return nextSequence;
 };
 
 const readTerminalBufferByteCount = (chunks: DevServerTerminalChunk[]): number => {
@@ -135,9 +147,13 @@ export const appendTerminalChunk = (
   trimTerminalChunksWithByteCount(chunks, totalBytes);
 };
 
-export const resetTerminalChunks = (script: DevServerScriptState): void => {
+export const resetTerminalChunks = (
+  runtime: DevServerGroupRuntime,
+  script: DevServerScriptState,
+): void => {
   script.bufferedTerminalChunks = [];
   terminalBufferByteCounts.set(script.bufferedTerminalChunks, 0);
+  runtime.terminalNextSequenceByScriptId.set(script.scriptId, 0);
 };
 
 export const trimTerminalChunks = (chunks: DevServerTerminalChunk[]): void => {

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -89,6 +89,11 @@ export const syncRuntimeTerminalBufferByteCounts = (runtime: DevServerGroupRunti
       runtime.terminalBufferedBytesByScriptId.delete(scriptId);
     }
   }
+  for (const scriptId of runtime.terminalNextSequenceByScriptId.keys()) {
+    if (!activeScriptIds.has(scriptId)) {
+      runtime.terminalNextSequenceByScriptId.delete(scriptId);
+    }
+  }
 
   for (const script of runtime.state.scripts) {
     if (!runtime.terminalBufferedBytesByScriptId.has(script.scriptId)) {
@@ -173,10 +178,6 @@ export const resetTerminalChunks = (
   script.bufferedTerminalChunks = [];
   runtime.terminalBufferedBytesByScriptId.set(script.scriptId, 0);
   runtime.terminalNextSequenceByScriptId.set(script.scriptId, 0);
-};
-
-export const trimTerminalChunks = (chunks: DevServerTerminalChunk[]): void => {
-  trimTerminalChunksWithByteCount(chunks, readTerminalBufferByteCount(chunks));
 };
 
 export const formatTerminalSystemMessage = (message: string): string => {

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -21,6 +21,8 @@ export const DEV_SERVER_TERM = "xterm-256color";
 const TERMINAL_BUFFER_CHUNK_LIMIT = 2_000;
 const TERMINAL_BUFFER_BYTE_LIMIT = 512 * 1024;
 
+const terminalBufferByteCounts = new WeakMap<DevServerTerminalChunk[], number>();
+
 const nowIso = (): string => new Date().toISOString();
 
 const scriptStateFromConfig = (script: RepoConfig["devServers"][number]): DevServerScriptState => ({
@@ -85,9 +87,26 @@ export const nextTerminalSequence = (script: DevServerScriptState): number => {
   return lastChunk ? lastChunk.sequence + 1 : 0;
 };
 
-export const trimTerminalChunks = (chunks: DevServerTerminalChunk[]): void => {
+const readTerminalBufferByteCount = (chunks: DevServerTerminalChunk[]): number => {
+  const cachedByteCount = terminalBufferByteCounts.get(chunks);
+  if (cachedByteCount !== undefined) {
+    return cachedByteCount;
+  }
+
+  let totalBytes = 0;
+  for (const chunk of chunks) {
+    totalBytes += chunk.data.length;
+  }
+  terminalBufferByteCounts.set(chunks, totalBytes);
+  return totalBytes;
+};
+
+const trimTerminalChunksWithByteCount = (
+  chunks: DevServerTerminalChunk[],
+  initialByteCount: number,
+): void => {
   let removeCount = 0;
-  let totalBytes = chunks.reduce((total, chunk) => total + chunk.data.length, 0);
+  let totalBytes = initialByteCount;
 
   while (
     chunks.length - removeCount > TERMINAL_BUFFER_CHUNK_LIMIT ||
@@ -104,6 +123,25 @@ export const trimTerminalChunks = (chunks: DevServerTerminalChunk[]): void => {
   if (removeCount > 0) {
     chunks.splice(0, removeCount);
   }
+  terminalBufferByteCounts.set(chunks, totalBytes);
+};
+
+export const appendTerminalChunk = (
+  chunks: DevServerTerminalChunk[],
+  chunk: DevServerTerminalChunk,
+): void => {
+  const totalBytes = readTerminalBufferByteCount(chunks) + chunk.data.length;
+  chunks.push(chunk);
+  trimTerminalChunksWithByteCount(chunks, totalBytes);
+};
+
+export const resetTerminalChunks = (script: DevServerScriptState): void => {
+  script.bufferedTerminalChunks = [];
+  terminalBufferByteCounts.set(script.bufferedTerminalChunks, 0);
+};
+
+export const trimTerminalChunks = (chunks: DevServerTerminalChunk[]): void => {
+  trimTerminalChunksWithByteCount(chunks, readTerminalBufferByteCount(chunks));
 };
 
 export const formatTerminalSystemMessage = (message: string): string => {

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -10,6 +10,7 @@ import type { DevServerProcessHandle } from "../../ports/dev-server-process-port
 export type DevServerGroupRuntime = {
   processes: Map<string, DevServerProcessHandle>;
   state: DevServerGroupState;
+  terminalBufferedBytesByScriptId: Map<string, number>;
   terminalNextSequenceByScriptId: Map<string, number>;
 };
 
@@ -21,8 +22,6 @@ export const DEV_SERVER_TERM = "xterm-256color";
 
 const TERMINAL_BUFFER_CHUNK_LIMIT = 2_000;
 const TERMINAL_BUFFER_BYTE_LIMIT = 512 * 1024;
-
-const terminalBufferByteCounts = new WeakMap<DevServerTerminalChunk[], number>();
 
 const nowIso = (): string => new Date().toISOString();
 
@@ -83,6 +82,24 @@ export const syncGroupState = (
   state.updatedAt = nowIso();
 };
 
+export const syncRuntimeTerminalBufferByteCounts = (runtime: DevServerGroupRuntime): void => {
+  const activeScriptIds = new Set(runtime.state.scripts.map((script) => script.scriptId));
+  for (const scriptId of runtime.terminalBufferedBytesByScriptId.keys()) {
+    if (!activeScriptIds.has(scriptId)) {
+      runtime.terminalBufferedBytesByScriptId.delete(scriptId);
+    }
+  }
+
+  for (const script of runtime.state.scripts) {
+    if (!runtime.terminalBufferedBytesByScriptId.has(script.scriptId)) {
+      runtime.terminalBufferedBytesByScriptId.set(
+        script.scriptId,
+        readTerminalBufferByteCount(script.bufferedTerminalChunks),
+      );
+    }
+  }
+};
+
 const nextTerminalSequenceFromReplay = (script: DevServerScriptState): number => {
   const lastChunk = script.bufferedTerminalChunks.at(-1);
   return lastChunk ? lastChunk.sequence + 1 : 0;
@@ -100,23 +117,17 @@ export const nextTerminalSequence = (
 };
 
 const readTerminalBufferByteCount = (chunks: DevServerTerminalChunk[]): number => {
-  const cachedByteCount = terminalBufferByteCounts.get(chunks);
-  if (cachedByteCount !== undefined) {
-    return cachedByteCount;
-  }
-
   let totalBytes = 0;
   for (const chunk of chunks) {
     totalBytes += chunk.data.length;
   }
-  terminalBufferByteCounts.set(chunks, totalBytes);
   return totalBytes;
 };
 
 const trimTerminalChunksWithByteCount = (
   chunks: DevServerTerminalChunk[],
   initialByteCount: number,
-): void => {
+): number => {
   let removeCount = 0;
   let totalBytes = initialByteCount;
 
@@ -135,16 +146,24 @@ const trimTerminalChunksWithByteCount = (
   if (removeCount > 0) {
     chunks.splice(0, removeCount);
   }
-  terminalBufferByteCounts.set(chunks, totalBytes);
+  return totalBytes;
 };
 
 export const appendTerminalChunk = (
-  chunks: DevServerTerminalChunk[],
+  runtime: DevServerGroupRuntime,
+  script: DevServerScriptState,
   chunk: DevServerTerminalChunk,
 ): void => {
-  const totalBytes = readTerminalBufferByteCount(chunks) + chunk.data.length;
+  const chunks = script.bufferedTerminalChunks;
+  const currentBytes =
+    runtime.terminalBufferedBytesByScriptId.get(script.scriptId) ??
+    readTerminalBufferByteCount(chunks);
+  const totalBytes = currentBytes + chunk.data.length;
   chunks.push(chunk);
-  trimTerminalChunksWithByteCount(chunks, totalBytes);
+  runtime.terminalBufferedBytesByScriptId.set(
+    script.scriptId,
+    trimTerminalChunksWithByteCount(chunks, totalBytes),
+  );
 };
 
 export const resetTerminalChunks = (
@@ -152,7 +171,7 @@ export const resetTerminalChunks = (
   script: DevServerScriptState,
 ): void => {
   script.bufferedTerminalChunks = [];
-  terminalBufferByteCounts.set(script.bufferedTerminalChunks, 0);
+  runtime.terminalBufferedBytesByScriptId.set(script.scriptId, 0);
   runtime.terminalNextSequenceByScriptId.set(script.scriptId, 0);
 };
 

--- a/packages/openducktor-web/src/browser-config.test.ts
+++ b/packages/openducktor-web/src/browser-config.test.ts
@@ -76,4 +76,10 @@ describe("browser web host config", () => {
       ),
     ).toBe("http://127.0.0.1:14327");
   });
+
+  test("keeps the injected backend hostname for opaque browser origins", () => {
+    expect(
+      getBrowserBackendUrl({ VITE_ODT_BROWSER_BACKEND_URL: "http://127.0.0.1:14327" }, "null"),
+    ).toBe("http://127.0.0.1:14327");
+  });
 });

--- a/packages/openducktor-web/src/browser-config.ts
+++ b/packages/openducktor-web/src/browser-config.ts
@@ -24,7 +24,8 @@ const readBrowserLocationOrigin = (): string | undefined => {
     return undefined;
   }
 
-  return window.location.origin;
+  const origin = window.location.origin;
+  return origin === "null" ? undefined : origin;
 };
 
 const readBrowserRuntimeConfig = (): BrowserRuntimeConfig | undefined => {
@@ -109,7 +110,7 @@ const alignBackendOriginWithBrowserOriginEffect = (
   browserOrigin?: string,
 ): Effect.Effect<string, WebValidationError> =>
   Effect.gen(function* () {
-    if (!browserOrigin) {
+    if (!browserOrigin || browserOrigin === "null") {
       return backendOrigin.origin;
     }
 

--- a/packages/openducktor-web/src/browser-config.ts
+++ b/packages/openducktor-web/src/browser-config.ts
@@ -18,6 +18,10 @@ const readBrowserEnv = (): BrowserEnv =>
   (typeof process !== "undefined" ? process.env : undefined);
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
+const OPAQUE_BROWSER_ORIGIN = "null";
+
+const isUsableBrowserOrigin = (origin: string | undefined): origin is string =>
+  typeof origin === "string" && origin.length > 0 && origin !== OPAQUE_BROWSER_ORIGIN;
 
 const readBrowserLocationOrigin = (): string | undefined => {
   if (typeof window === "undefined") {
@@ -25,7 +29,7 @@ const readBrowserLocationOrigin = (): string | undefined => {
   }
 
   const origin = window.location.origin;
-  return origin === "null" ? undefined : origin;
+  return isUsableBrowserOrigin(origin) ? origin : undefined;
 };
 
 const readBrowserRuntimeConfig = (): BrowserRuntimeConfig | undefined => {
@@ -110,7 +114,7 @@ const alignBackendOriginWithBrowserOriginEffect = (
   browserOrigin?: string,
 ): Effect.Effect<string, WebValidationError> =>
   Effect.gen(function* () {
-    if (!browserOrigin || browserOrigin === "null") {
+    if (!isUsableBrowserOrigin(browserOrigin)) {
       return backendOrigin.origin;
     }
 

--- a/packages/openducktor-web/src/local-host-transport.test.ts
+++ b/packages/openducktor-web/src/local-host-transport.test.ts
@@ -346,6 +346,45 @@ describe("local host SSE subscriptions", () => {
     expect(retryEventSource.closed).toBe(true);
   });
 
+  test("emits a stream-warning control payload when dev-server EventSource errors after opening", async () => {
+    const { subscribeLocalHostDevServerEvents } = await loadLocalHostTransport();
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+    const listener = mock(() => {});
+
+    const subscription = subscribeLocalHostDevServerEvents(listener);
+    const eventSource = await waitForEventSourceInstance();
+    eventSource.emit("open", "");
+    const unsubscribe = await subscription;
+
+    eventSource.emit("error", "lost connection");
+
+    expect(listener).toHaveBeenNthCalledWith(1, {
+      __openducktorBrowserLive: true,
+      kind: "stream-warning",
+      message: "EventSource dev-server-events reported an error after opening.",
+    });
+
+    eventSource.emit("error", "still disconnected");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    eventSource.emit("open", "");
+    expect(listener).toHaveBeenNthCalledWith(2, {
+      __openducktorBrowserLive: true,
+      kind: "reconnected",
+    });
+
+    eventSource.emit("error", "lost again");
+    expect(listener).toHaveBeenNthCalledWith(3, {
+      __openducktorBrowserLive: true,
+      kind: "stream-warning",
+      message: "EventSource dev-server-events reported an error after opening.",
+    });
+
+    unsubscribe();
+  });
+
   test("buildLocalAttachmentPreviewUrl normalizes the backend base URL", async () => {
     const { buildLocalAttachmentPreviewUrl } = await loadLocalHostTransport();
 

--- a/packages/openducktor-web/src/local-host-transport.test.ts
+++ b/packages/openducktor-web/src/local-host-transport.test.ts
@@ -385,6 +385,36 @@ describe("local host SSE subscriptions", () => {
     unsubscribe();
   });
 
+  test("isolates post-open dev-server stream-warning listener failures", async () => {
+    const { subscribeLocalHostDevServerEvents } = await loadLocalHostTransport();
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+    const throwingListener = mock(() => {
+      throw new Error("listener failed");
+    });
+    const listener = mock(() => {});
+
+    const throwingSubscription = subscribeLocalHostDevServerEvents(throwingListener);
+    const eventSource = await waitForEventSourceInstance();
+    eventSource.emit("open", "");
+    const unsubscribeThrowing = await throwingSubscription;
+    const unsubscribe = await subscribeLocalHostDevServerEvents(listener);
+
+    expect(() => eventSource.emit("error", "lost connection")).toThrow("listener failed");
+    expect(listener).toHaveBeenNthCalledWith(1, {
+      __openducktorBrowserLive: true,
+      kind: "stream-warning",
+      message: "EventSource dev-server-events reported an error after opening.",
+    });
+
+    eventSource.emit("error", "still disconnected");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribeThrowing();
+    unsubscribe();
+  });
+
   test("buildLocalAttachmentPreviewUrl normalizes the backend base URL", async () => {
     const { buildLocalAttachmentPreviewUrl } = await loadLocalHostTransport();
 

--- a/packages/openducktor-web/src/local-host-transport.ts
+++ b/packages/openducktor-web/src/local-host-transport.ts
@@ -218,6 +218,7 @@ const subscribeSseChannelEffect = (
       const listeners = new Map<number, BrowserSseListener>();
       const shouldEmitControlEvents = CONTROL_EVENT_SSE_PATHS.has(path);
       let hasOpened = false;
+      let hasReportedPostOpenError = false;
       let resolveReady: () => void = () => {};
       let rejectReady: (error: unknown) => void = () => {};
       const ready = new Promise<void>((resolve, reject) => {
@@ -234,9 +235,11 @@ const subscribeSseChannelEffect = (
       const handleOpen = (): void => {
         if (!hasOpened) {
           hasOpened = true;
+          hasReportedPostOpenError = false;
           resolveReady();
           return;
         }
+        hasReportedPostOpenError = false;
         if (!shouldEmitControlEvents) {
           return;
         }
@@ -246,6 +249,18 @@ const subscribeSseChannelEffect = (
       };
       const handleError = (event: Event): void => {
         if (hasOpened) {
+          if (!shouldEmitControlEvents || hasReportedPostOpenError) {
+            return;
+          }
+          hasReportedPostOpenError = true;
+          for (const currentListener of listeners.values()) {
+            currentListener(
+              browserLiveControlEvent(
+                BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+                `EventSource ${path} reported an error after opening.`,
+              ),
+            );
+          }
           return;
         }
         rejectReady(

--- a/packages/openducktor-web/src/local-host-transport.ts
+++ b/packages/openducktor-web/src/local-host-transport.ts
@@ -252,14 +252,25 @@ const subscribeSseChannelEffect = (
           if (!shouldEmitControlEvents || hasReportedPostOpenError) {
             return;
           }
-          hasReportedPostOpenError = true;
+          const warningPayload = browserLiveControlEvent(
+            BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+            `EventSource ${path} reported an error after opening.`,
+          );
+          let hasListenerError = false;
+          let listenerError: unknown;
           for (const currentListener of listeners.values()) {
-            currentListener(
-              browserLiveControlEvent(
-                BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
-                `EventSource ${path} reported an error after opening.`,
-              ),
-            );
+            try {
+              currentListener(warningPayload);
+            } catch (error) {
+              if (!hasListenerError) {
+                listenerError = error;
+              }
+              hasListenerError = true;
+            }
+          }
+          hasReportedPostOpenError = true;
+          if (hasListenerError) {
+            throw listenerError;
           }
           return;
         }

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -44,6 +44,23 @@ type TestHostCommandInvoke = (
   args?: Record<string, unknown>,
 ) => Effect.Effect<unknown, unknown>;
 
+const PENDING_STREAM_READ = Symbol("pending-stream-read");
+type StreamReadResult = Awaited<ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]>>;
+
+const readImmediateStreamChunk = async (
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<StreamReadResult> => {
+  const readPromise = reader.read().then((value): StreamReadResult => value);
+  await Promise.resolve();
+  const result = await Promise.race([readPromise, Promise.resolve(PENDING_STREAM_READ)]);
+  if (result === PENDING_STREAM_READ) {
+    await reader.cancel();
+    throw new Error("Expected the SSE response to flush an initial frame immediately.");
+  }
+
+  return result;
+};
+
 const createTestHostCommandRouter = (
   invoke: TestHostCommandInvoke = () => Effect.succeed(null),
 ): EffectHostCommandRouter => ({
@@ -208,11 +225,38 @@ describe("TypeScript web host backend", () => {
       throw new Error("Expected SSE response body.");
     }
     try {
-      const chunk = await reader.read();
+      const readyChunk = await readImmediateStreamChunk(reader);
+      expect(readyChunk.done).toBe(false);
+      expect(new TextDecoder().decode(readyChunk.value)).toBe(": openducktor-ready\n\n");
+
+      const chunk = await readImmediateStreamChunk(reader);
       expect(chunk.done).toBe(false);
       expect(new TextDecoder().decode(chunk.value)).toContain(
         'data: {"runtimeId":"runtime-live","kind":"server_request"',
       );
+    } finally {
+      await reader.cancel();
+    }
+  });
+
+  test("flushes an initial SSE frame for idle dev-server streams", async () => {
+    const response = await handleTestRequest(
+      new Request("http://127.0.0.1/dev-server-events", {
+        method: "GET",
+        headers: { "x-openducktor-app-token": APP_TOKEN },
+      }),
+      { eventBus: new BufferedHostEventBus() },
+    );
+
+    expect(response.status).toBe(200);
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Expected SSE response body.");
+    }
+    try {
+      const chunk = await readImmediateStreamChunk(reader);
+      expect(chunk.done).toBe(false);
+      expect(new TextDecoder().decode(chunk.value)).toBe(": openducktor-ready\n\n");
     } finally {
       await reader.cancel();
     }

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -266,6 +266,7 @@ const writeSseEvent = (event: BufferedHostEvent): string =>
   [`id: ${event.id}`, ...event.payload.split(/\r?\n/).map((line) => `data: ${line}`), "", ""].join(
     "\n",
   );
+const SSE_READY_COMMENT = ": openducktor-ready\n\n";
 
 const createSseResponse = (
   stream: BufferedHostEventStream,
@@ -277,6 +278,7 @@ const createSseResponse = (
   let unsubscribe: (() => void) | null = null;
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
+      controller.enqueue(encoder.encode(SSE_READY_COMMENT));
       for (const event of stream.replayAfter(lastEventId, options)) {
         controller.enqueue(encoder.encode(writeSseEvent(event)));
       }


### PR DESCRIPTION
Summary:
Fixes dev-server terminal live sync so logs remain current during noisy output, restart, stop, and browser stream recovery paths without requiring tab switching.

Goal:
The dev-server panel could show initial output and then appear frozen until the user switched tabs or remounted the terminal. Stop and restart paths also risked replacing newer live shutdown output with stale or empty replay data. This PR makes the terminal output pipeline resilient across the host buffer, frontend terminal renderer, and browser SSE transport.

Technical choices:
- Keep terminal output as live event-stream state instead of moving it into polling or a request cache.
- Preserve monotonic terminal chunk ordering and avoid stale snapshot or mutation responses overwriting newer live chunks.
- Replace host-side terminal buffer trimming with runtime-local incremental byte accounting instead of reducing the whole buffer on every append.
- Remove the frontend test timer fallback and make terminal replay behavior deterministic around xterm write callbacks and replay boundaries.
- Teach the browser EventSource transport to surface post-open dev-server stream errors as existing browser-live stream-warning control events, with one warning per broken connection stretch until reconnect.
- Keep contracts and durable storage schemas unchanged.

Verification:
- Cargo: no Cargo.toml, Cargo.lock, or .rs files exist in this checkout, so there is no Cargo workspace to run.
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
- bun run build

Notes:
Root tests emitted existing React multiple-renderer warnings in frontend tests, but all suites completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal output now stays consistent during live updates, restarts, and stop actions, with better handling of buffered output and script switching.
  * SSE connections now send an immediate ready signal and support clearer reconnect/error notifications.

* **Bug Fixes**
  * Fixed terminal output ordering issues when chunks arrive out of sequence or after buffer trimming.
  * Improved browser URL handling for opaque origins so the backend address stays stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->