### PR TITLE
fix(frontend): hide actions on closed kanban cards

### DIFF
--- a/packages/frontend/src/components/features/kanban/kanban-task-card.test.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-task-card.test.tsx
@@ -122,6 +122,57 @@ describe("KanbanTaskCard active sessions", () => {
     expect(html).not.toContain("Sessions");
   });
 
+  test("hides workflow action footer for closed tasks", () => {
+    const task = createTaskCardFixture({
+      id: "TASK-CLOSED",
+      title: "Archived task",
+      status: "closed",
+      availableActions: ["build_start", "open_builder", "open_qa"],
+    });
+    const historicalSessions = [
+      {
+        externalSessionId: "external-spec",
+        role: "spec" as const,
+        startedAt: "2026-01-10T10:00:00.000Z",
+        runtimeKind: "opencode" as const,
+        workingDirectory: "/repo/worktrees/spec",
+        selectedModel: null,
+      },
+      {
+        externalSessionId: "external-builder",
+        role: "build" as const,
+        startedAt: "2026-01-11T10:00:00.000Z",
+        runtimeKind: "opencode" as const,
+        workingDirectory: "/repo/worktrees/build",
+        selectedModel: null,
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      createElement(
+        MemoryRouter,
+        { initialEntries: ["/kanban"] },
+        createElement(KanbanTaskCard, {
+          task,
+          historicalSessions,
+          taskActivityState: "idle",
+          taskSessions: [],
+          onOpenDetails: noop,
+          onDelegate: noop,
+          onPlan: noop,
+          onBuild: noop,
+        }),
+      ),
+    );
+
+    expect(html).toContain("Archived task");
+    expect(html).not.toContain("Start Builder");
+    expect(html).not.toContain("Open Builder");
+    expect(html).not.toContain("Open Spec");
+    expect(html).not.toContain("Open QA");
+    expect(html).not.toContain('data-slot="popover-trigger"');
+  });
+
   test("renders waiting-input active primary style and suppresses the animated ray", () => {
     const task = createTaskCardFixture({ id: "TASK-WAITING", title: "Need approval" });
 

--- a/packages/frontend/src/components/features/kanban/kanban-task-card.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-task-card.tsx
@@ -347,6 +347,10 @@ function TaskActions({
   activeSessionRole?: AgentRole;
   taskActivityState: KanbanTaskActivityState;
 }): ReactElement | null {
+  if (task.status === "closed") {
+    return null;
+  }
+
   const historicalSessionRoles = resolveHistoricalSessionRoles(historicalSessions);
   const workflowActions = resolveTaskCardActions(task, {
     include: TASK_CARD_WORKFLOW_ACTIONS,


### PR DESCRIPTION
Summary
This PR hides the bottom workflow action section on Kanban task cards once a task is closed.

Goal
Closed tasks represent completed work in the Kanban Done lane, so the card should not invite follow-up workflow actions such as starting or opening Builder/QA sessions. The previous card-level rendering still resolved available workflow actions and historical session view actions, which made closed cards show a footer with buttons that were no longer useful in that context.

Technical choices
The fix is scoped to the Kanban card rendering boundary. `TaskActions` now returns `null` for `closed` tasks before resolving available or historical workflow actions. This keeps the shared workflow resolver unchanged, so other surfaces that still need historical session actions, such as task details or Agent Studio, keep their existing behavior.

Tests
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- Cargo checks: not applicable in this worktree because there is no `Cargo.toml` manifest (`rg --files --hidden -g Cargo.toml` returned no matches).

Additional focused verification
- `bun run --filter @openducktor/frontend test src/components/features/kanban/kanban-task-card.test.tsx`
- `bun run --filter @openducktor/frontend test src/components/features/kanban/kanban-task-card.memo.test.tsx`
- React Doctor diff scan: 100/100
- GitNexus detect_changes: low risk, no affected flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closed kanban tasks now hide workflow actions and related popovers, keeping the card view cleaner and preventing unavailable actions from appearing.
  * Added coverage to ensure closed tasks still show the title while action buttons and triggers remain hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->