### PR TITLE
fix(frontend): remove unsafe launch action casts

### DIFF
--- a/packages/frontend/src/lib/session-launch-actions.test.ts
+++ b/packages/frontend/src/lib/session-launch-actions.test.ts
@@ -22,9 +22,12 @@ describe("session-launch-actions", () => {
     }
 
     expect(isSessionLaunchActionId(null)).toBe(false);
+    expect(isSessionLaunchActionId(undefined)).toBe(false);
     expect(isSessionLaunchActionId("")).toBe(false);
     expect(isSessionLaunchActionId("qa_review ")).toBe(false);
     expect(isSessionLaunchActionId("unknown")).toBe(false);
+    expect(isSessionLaunchActionId(123)).toBe(false);
+    expect(isSessionLaunchActionId({})).toBe(false);
   });
 
   test("checks allowed start modes for each launch action", () => {

--- a/packages/frontend/src/lib/session-launch-actions.test.ts
+++ b/packages/frontend/src/lib/session-launch-actions.test.ts
@@ -34,11 +34,4 @@ describe("session-launch-actions", () => {
     expect(isLaunchStartModeAllowed("build_pull_request_generation", "fork")).toBe(true);
     expect(isLaunchStartModeAllowed("build_pull_request_generation", "fresh")).toBe(false);
   });
-
-  test("does not reintroduce unsafe launch-action casts", async () => {
-    const source = await Bun.file(new URL("./session-launch-actions.ts", import.meta.url)).text();
-
-    expect(source).not.toContain("value as SessionLaunchActionId");
-    expect(source).not.toContain("as SessionLaunchAction).allowedStartModes");
-  });
 });

--- a/packages/frontend/src/lib/session-launch-actions.test.ts
+++ b/packages/frontend/src/lib/session-launch-actions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getSessionLaunchAction,
+  isLaunchStartModeAllowed,
+  isSessionLaunchActionId,
+  SESSION_LAUNCH_ACTIONS,
+  sessionLaunchActionIds,
+} from "./session-launch-actions";
+
+describe("session-launch-actions", () => {
+  test("keeps launch action ids aligned with action definitions", () => {
+    expect(Object.keys(SESSION_LAUNCH_ACTIONS).sort()).toEqual([...sessionLaunchActionIds].sort());
+
+    for (const id of sessionLaunchActionIds) {
+      expect(getSessionLaunchAction(id).id).toBe(id);
+    }
+  });
+
+  test("recognizes only configured launch action ids", () => {
+    for (const id of sessionLaunchActionIds) {
+      expect(isSessionLaunchActionId(id)).toBe(true);
+    }
+
+    expect(isSessionLaunchActionId(null)).toBe(false);
+    expect(isSessionLaunchActionId("")).toBe(false);
+    expect(isSessionLaunchActionId("qa_review ")).toBe(false);
+    expect(isSessionLaunchActionId("unknown")).toBe(false);
+  });
+
+  test("checks allowed start modes for each launch action", () => {
+    expect(isLaunchStartModeAllowed("build_implementation_start", "fresh")).toBe(true);
+    expect(isLaunchStartModeAllowed("build_implementation_start", "reuse")).toBe(false);
+    expect(isLaunchStartModeAllowed("build_pull_request_generation", "reuse")).toBe(true);
+    expect(isLaunchStartModeAllowed("build_pull_request_generation", "fork")).toBe(true);
+    expect(isLaunchStartModeAllowed("build_pull_request_generation", "fresh")).toBe(false);
+  });
+
+  test("does not reintroduce unsafe launch-action casts", async () => {
+    const source = await Bun.file(new URL("./session-launch-actions.ts", import.meta.url)).text();
+
+    expect(source).not.toContain("value as SessionLaunchActionId");
+    expect(source).not.toContain("as SessionLaunchAction).allowedStartModes");
+  });
+});

--- a/packages/frontend/src/lib/session-launch-actions.ts
+++ b/packages/frontend/src/lib/session-launch-actions.ts
@@ -20,6 +20,8 @@ export const sessionLaunchActionIds = [
 
 export type SessionLaunchActionId = (typeof sessionLaunchActionIds)[number];
 
+const sessionLaunchActionIdSet: ReadonlySet<string> = new Set(sessionLaunchActionIds);
+
 export type SessionLaunchAction = {
   id: SessionLaunchActionId;
   role: AgentRole;
@@ -118,13 +120,12 @@ export const defaultSessionLaunchActionForRole = (role: AgentRole): SessionLaunc
 };
 
 export const isSessionLaunchActionId = (value: string | null): value is SessionLaunchActionId =>
-  value !== null && sessionLaunchActionIds.includes(value as SessionLaunchActionId);
+  value !== null && sessionLaunchActionIdSet.has(value);
 
 export const isLaunchStartModeAllowed = (
   actionId: SessionLaunchActionId,
   startMode: AgentSessionStartMode,
-): boolean =>
-  (SESSION_LAUNCH_ACTIONS[actionId] as SessionLaunchAction).allowedStartModes.includes(startMode);
+): boolean => getSessionLaunchAction(actionId).allowedStartModes.includes(startMode);
 
 export const resolveBuildContinuationLaunchAction = (
   task: TaskCard | null | undefined,

--- a/packages/frontend/src/lib/session-launch-actions.ts
+++ b/packages/frontend/src/lib/session-launch-actions.ts
@@ -119,8 +119,8 @@ export const defaultSessionLaunchActionForRole = (role: AgentRole): SessionLaunc
   return action.id;
 };
 
-export const isSessionLaunchActionId = (value: string | null): value is SessionLaunchActionId =>
-  value !== null && sessionLaunchActionIdSet.has(value);
+export const isSessionLaunchActionId = (value: unknown): value is SessionLaunchActionId =>
+  typeof value === "string" && sessionLaunchActionIdSet.has(value);
 
 export const isLaunchStartModeAllowed = (
   actionId: SessionLaunchActionId,


### PR DESCRIPTION
Summary: This PR removes unsafe assertion casts from frontend session launch-action guards and keeps launch-action validation covered by behavioral tests.

Goal:
The launch-action helpers previously used assertion casts to make includes checks and action-map indexing type-check. That could hide drift between sessionLaunchActionIds and SESSION_LAUNCH_ACTIONS, which is the contract these helpers should protect.

Technical choices:
- Added a ReadonlySet<string> built from sessionLaunchActionIds so isSessionLaunchActionId checks raw string membership without casting the input into the target union.
- Updated isLaunchStartModeAllowed to use getSessionLaunchAction(actionId) and rely on the typed Record<SessionLaunchActionId, SessionLaunchAction> contract.
- Added focused tests for action id/action map alignment, guard behavior, and allowed start modes.
- Removed a brittle source-string test in a follow-up cleanup; the remaining tests assert behavior and contract shape.

Verification:
- gtimeout 300 bun run lint
- gtimeout 600 bun run test
- gtimeout 600 bun run typecheck
- gtimeout 900 bun run build
- Cargo checks: not applicable; no Cargo.toml exists in this worktree.
- Branch sync: fetched origin; HEAD...origin/main was 2 0 and origin/main is an ancestor of HEAD.