### PR TITLE
fix: order open tasks by priority

### DIFF
--- a/packages/host/src/adapters/sqlite/sqlite-task-queries.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-queries.ts
@@ -1,8 +1,16 @@
-import { asc, desc, eq, inArray, type SQL } from "drizzle-orm";
+import { asc, desc, eq, inArray, type SQL, sql } from "drizzle-orm";
 import { Effect } from "effect";
 import { HostResourceError } from "../../effect/host-errors";
 import type { SqliteTaskStoreReadError } from "./sqlite-task-store-errors";
 import { type TaskRow, type TaskStoreSession, tasks } from "./sqlite-task-store-schema";
+
+const taskRowsOrderBy = [
+  asc(sql`case when ${tasks.status} = 'open' then 0 else 1 end`),
+  asc(sql`case when ${tasks.status} = 'open' then ${tasks.priority} else 0 end`),
+  desc(sql`case when ${tasks.status} = 'open' then ${tasks.createdAt} else null end`),
+  asc(sql`case when ${tasks.status} != 'open' then ${tasks.updatedAt} else null end`),
+  asc(tasks.id),
+] as const;
 
 export const taskRows = (
   session: TaskStoreSession,
@@ -13,7 +21,10 @@ export const taskRows = (
       where === undefined
         ? yield* session.execute(
             (database) =>
-              database.select().from(tasks).orderBy(desc(tasks.updatedAt), asc(tasks.id)),
+              database
+                .select()
+                .from(tasks)
+                .orderBy(...taskRowsOrderBy),
             "sqliteTaskStore.taskRows.selectTasks",
           )
         : yield* session.execute(
@@ -22,7 +33,7 @@ export const taskRows = (
                 .select()
                 .from(tasks)
                 .where(where)
-                .orderBy(desc(tasks.updatedAt), asc(tasks.id)),
+                .orderBy(...taskRowsOrderBy),
             "sqliteTaskStore.taskRows.selectTasks",
           );
     return rows;

--- a/packages/host/src/adapters/sqlite/sqlite-task-queries.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-queries.ts
@@ -8,8 +8,8 @@ const taskLaneOrderBy = [
   // Open tasks are backlog-priority ordered; every other lane keeps newer activity last.
   asc(sql`case when ${tasks.status} = 'open' then 0 else 1 end`),
   asc(sql`case when ${tasks.status} = 'open' then ${tasks.priority} else 0 end`),
-  desc(sql`case when ${tasks.status} = 'open' then ${tasks.createdAt} else null end`),
-  asc(sql`case when ${tasks.status} <> 'open' then ${tasks.updatedAt} else null end`),
+  desc(sql`case when ${tasks.status} = 'open' then ${tasks.createdAt} else 0 end`),
+  asc(sql`case when ${tasks.status} <> 'open' then ${tasks.updatedAt} else 0 end`),
   asc(tasks.id),
 ] as const;
 

--- a/packages/host/src/adapters/sqlite/sqlite-task-queries.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-queries.ts
@@ -4,11 +4,12 @@ import { HostResourceError } from "../../effect/host-errors";
 import type { SqliteTaskStoreReadError } from "./sqlite-task-store-errors";
 import { type TaskRow, type TaskStoreSession, tasks } from "./sqlite-task-store-schema";
 
-const taskRowsOrderBy = [
+const taskLaneOrderBy = [
+  // Open tasks are backlog-priority ordered; every other lane keeps newer activity last.
   asc(sql`case when ${tasks.status} = 'open' then 0 else 1 end`),
   asc(sql`case when ${tasks.status} = 'open' then ${tasks.priority} else 0 end`),
   desc(sql`case when ${tasks.status} = 'open' then ${tasks.createdAt} else null end`),
-  asc(sql`case when ${tasks.status} != 'open' then ${tasks.updatedAt} else null end`),
+  asc(sql`case when ${tasks.status} <> 'open' then ${tasks.updatedAt} else null end`),
   asc(tasks.id),
 ] as const;
 
@@ -24,7 +25,7 @@ export const taskRows = (
               database
                 .select()
                 .from(tasks)
-                .orderBy(...taskRowsOrderBy),
+                .orderBy(...taskLaneOrderBy),
             "sqliteTaskStore.taskRows.selectTasks",
           )
         : yield* session.execute(
@@ -33,7 +34,7 @@ export const taskRows = (
                 .select()
                 .from(tasks)
                 .where(where)
-                .orderBy(...taskRowsOrderBy),
+                .orderBy(...taskLaneOrderBy),
             "sqliteTaskStore.taskRows.selectTasks",
           );
     return rows;

--- a/packages/host/src/application/mcp/odt-mcp-bridge-service.test.ts
+++ b/packages/host/src/application/mcp/odt-mcp-bridge-service.test.ts
@@ -256,6 +256,57 @@ describe("createOdtMcpBridgeService", () => {
     ).resolves.toMatchObject({ task: { id: "task-new", title: "New task" } });
     expect(events).toEqual([{ repoPath: "/repo", taskId: "task-new" }]);
   });
+  test("orders task search results by recent activity before applying the result limit", async () => {
+    const taskService = createTaskService({
+      listTasks(input: unknown) {
+        expect(input).toEqual({ repoPath: "/repo" });
+        return Effect.succeed([
+          taskCard({
+            id: "open-newer",
+            title: "Open newer",
+            status: "open",
+            updatedAt: "2026-05-10T10:03:00.000Z",
+          }),
+          taskCard({
+            id: "open-middle",
+            title: "Open middle",
+            status: "open",
+            updatedAt: "2026-05-10T10:02:00.000Z",
+          }),
+          taskCard({
+            id: "open-older",
+            title: "Open older",
+            status: "open",
+            updatedAt: "2026-05-10T10:01:00.000Z",
+          }),
+          taskCard({
+            id: "recent-progress",
+            title: "Recent progress",
+            status: "in_progress",
+            updatedAt: "2026-05-10T12:00:00.000Z",
+          }),
+        ]);
+      },
+    });
+    const service = createOdtMcpBridgeServiceForTest({
+      taskService,
+      workspaceSettingsService: createWorkspaceSettingsService(),
+    });
+
+    await expect(
+      Effect.runPromise(
+        service.invoke("odt_search_tasks", {
+          workspaceId: "repo",
+          limit: 2,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      results: [{ task: { id: "recent-progress" } }, { task: { id: "open-newer" } }],
+      limit: 2,
+      totalCount: 4,
+      hasMore: true,
+    });
+  });
   test("links pull requests through the task service provider lookup path", async () => {
     let currentTask = taskCard({ status: "human_review" });
     const linkPullRequestCalls: unknown[] = [];

--- a/packages/host/src/application/mcp/odt-mcp-bridge-service.ts
+++ b/packages/host/src/application/mcp/odt-mcp-bridge-service.ts
@@ -13,6 +13,7 @@ import {
   type SetPlanResult,
   type SetPullRequestResult,
   type SetSpecResult,
+  type TaskCard,
   type TaskDocumentsRead,
   type TaskSummary,
   type WorkspaceScopedOdtToolName,
@@ -41,6 +42,17 @@ import {
 } from "./odt-mcp-bridge-model";
 
 const RESPONSE_SCHEMAS = ODT_HOST_BRIDGE_RESPONSE_SCHEMAS;
+
+const compareTaskSearchResults = (
+  left: Pick<TaskCard, "id" | "updatedAt">,
+  right: Pick<TaskCard, "id" | "updatedAt">,
+): number => {
+  const updatedAtOrder = right.updatedAt.localeCompare(left.updatedAt);
+  if (updatedAtOrder !== 0) {
+    return updatedAtOrder;
+  }
+  return left.id.localeCompare(right.id);
+};
 
 export type OdtMcpBridgeError =
   | HostOperationError
@@ -171,6 +183,7 @@ export const createOdtMcpBridgeService = ({
               }
               return true;
             });
+            tasks.sort(compareTaskSearchResults);
             const results = tasks.slice(0, parsed.limit).map(mapTaskSummary);
             return yield* parseResponse(toolName, RESPONSE_SCHEMAS.odt_search_tasks, {
               results,

--- a/packages/host/src/ports/task-store-port-contract.test-support.ts
+++ b/packages/host/src/ports/task-store-port-contract.test-support.ts
@@ -151,6 +151,60 @@ export const describeTaskStorePortContract = (
       );
     });
 
+    test("orders open tasks by priority then creation date and non-open tasks by update date", async () => {
+      const { repoPath, store } = await createTrackedHarness();
+
+      const olderHighPriorityOpen = await createTask(store, repoPath, {
+        title: "Older high priority open",
+        issueType: "task",
+        priority: 1,
+        aiReviewEnabled: true,
+      });
+      const newerHighPriorityOpen = await createTask(store, repoPath, {
+        title: "Newer high priority open",
+        issueType: "task",
+        priority: 1,
+        aiReviewEnabled: true,
+      });
+      const newestLowPriorityOpen = await createTask(store, repoPath, {
+        title: "Newest low priority open",
+        issueType: "task",
+        priority: 4,
+        aiReviewEnabled: true,
+      });
+      const olderSpecReady = await createTask(store, repoPath, {
+        title: "Older spec ready",
+        issueType: "task",
+        priority: 2,
+        aiReviewEnabled: true,
+      });
+      const newerSpecReady = await createTask(store, repoPath, {
+        title: "Newer spec ready",
+        issueType: "task",
+        priority: 2,
+        aiReviewEnabled: true,
+      });
+
+      await run(
+        store.transitionTask({ repoPath, taskId: olderSpecReady.id, status: "spec_ready" }),
+      );
+      await run(
+        store.transitionTask({ repoPath, taskId: newerSpecReady.id, status: "spec_ready" }),
+      );
+
+      const tasks = await run(store.listTasks({ repoPath }));
+
+      expect(tasks.filter((task) => task.status === "open").map((task) => task.id)).toEqual([
+        newerHighPriorityOpen.id,
+        olderHighPriorityOpen.id,
+        newestLowPriorityOpen.id,
+      ]);
+      expect(tasks.filter((task) => task.status === "spec_ready").map((task) => task.id)).toEqual([
+        olderSpecReady.id,
+        newerSpecReady.id,
+      ]);
+    });
+
     test("stores workflow documents and exposes the current metadata/read-model state", async () => {
       const { repoPath, store } = await createTrackedHarness();
       const task = await createTask(store, repoPath, {

--- a/packages/host/src/ports/task-store-port-contract.test-support.ts
+++ b/packages/host/src/ports/task-store-port-contract.test-support.ts
@@ -203,6 +203,15 @@ export const describeTaskStorePortContract = (
         olderSpecReady.id,
         newerSpecReady.id,
       ]);
+
+      const filteredTasks = await run(store.listTasks({ repoPath, doneVisibleDays: 0 }));
+
+      expect(filteredTasks.filter((task) => task.status === "open").map((task) => task.id)).toEqual(
+        [newerHighPriorityOpen.id, olderHighPriorityOpen.id, newestLowPriorityOpen.id],
+      );
+      expect(
+        filteredTasks.filter((task) => task.status === "spec_ready").map((task) => task.id),
+      ).toEqual([olderSpecReady.id, newerSpecReady.id]);
     });
 
     test("stores workflow documents and exposes the current metadata/read-model state", async () => {


### PR DESCRIPTION
Summary

This PR updates task list ordering so Open tasks are ordered by priority first and then by creation time, while other task statuses retain an activity-oriented update-time order.

Goal

OpenDucktor task lanes currently inherit the SQLite task list order. Before this change, all tasks were sorted by latest update first, so new low-priority Open tasks could appear above older higher-priority work. The goal is to make the backlog/Open lane prioritize the work that should be picked first, while preserving the intended ordering for other workflow statuses. Waiting-for-input and active tasks remain visually prioritized by the existing frontend activity partition; this PR supplies the base ordering within those activity groups.

Technical approach

- Centralized the lane ordering in the SQLite task read query.
- Open tasks sort by ascending numeric priority, then descending creation timestamp, then id for deterministic ties.
- Non-open tasks sort by ascending update timestamp, then id, matching the requested newer-last behavior for other statuses.
- Applied the same ordering to filtered and unfiltered task reads so done-visibility filtering does not diverge from the default task list.
- Added TaskStorePort contract coverage to lock in Open ordering and non-open update-time ordering at the storage boundary.

Verification

- Cargo checks: not applicable; this worktree has no Cargo.toml or Cargo.lock.
- bun run lint
- bun run test
- bun run typecheck
- bun run build

All Bun commands were run through timeout guards and completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task ordering so open items appear in a more predictable priority/creation order, while completed or transitioned items are sorted by recent activity.
  * Search results now return the most recently updated tasks first before applying result limits, making top matches more relevant and consistent.
  * Added stronger ordering consistency across task lists, including when only a limited set of tasks is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->