### PR TITLE
fix: keep settings available in collapsed sidebar

### DIFF
--- a/packages/frontend/src/components/features/settings/settings-modal.tsx
+++ b/packages/frontend/src/components/features/settings/settings-modal.tsx
@@ -48,7 +48,7 @@ const INITIAL_NAVIGATION_STATE: SettingsModalNavigationState = {
 export function SettingsModal({
   triggerClassName,
   triggerIconOnly = false,
-  triggerSize = "sm",
+  triggerSize = triggerIconOnly ? "icon" : "sm",
 }: SettingsModalProps): ReactElement {
   const [open, setOpen] = useState(false);
   const [navigation, setNavigation] =

--- a/packages/frontend/src/components/features/settings/settings-modal.tsx
+++ b/packages/frontend/src/components/features/settings/settings-modal.tsx
@@ -22,6 +22,7 @@ import { useSettingsModalController } from "./use-settings-modal-controller";
 
 type SettingsModalProps = {
   triggerClassName?: string;
+  triggerIconOnly?: boolean;
   triggerSize?: "default" | "sm" | "lg" | "icon";
 };
 
@@ -46,6 +47,7 @@ const INITIAL_NAVIGATION_STATE: SettingsModalNavigationState = {
 
 export function SettingsModal({
   triggerClassName,
+  triggerIconOnly = false,
   triggerSize = "sm",
 }: SettingsModalProps): ReactElement {
   const [open, setOpen] = useState(false);
@@ -98,9 +100,16 @@ export function SettingsModal({
       }}
     >
       <DialogTrigger asChild>
-        <Button type="button" variant="outline" size={triggerSize} className={cn(triggerClassName)}>
+        <Button
+          type="button"
+          variant="outline"
+          size={triggerSize}
+          className={cn(triggerClassName)}
+          aria-label={triggerIconOnly ? "Settings" : undefined}
+          title={triggerIconOnly ? "Settings" : undefined}
+        >
           <Settings2 className="size-4" />
-          Settings
+          {triggerIconOnly ? null : "Settings"}
         </Button>
       </DialogTrigger>
 

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { WorkspaceRecord } from "@openducktor/contracts";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { PropsWithChildren, ReactElement } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ThemeProvider } from "@/components/layout/theme-provider";
+import { createQueryClient } from "@/lib/query-client";
+import { createAgentSessionsStore } from "@/state/agent-sessions-store";
+import {
+  ActiveWorkspaceContext,
+  AgentSessionsContext,
+  ChecksStateContext,
+  RepoRuntimeHealthContext,
+  RuntimeDefinitionsContext,
+  TasksStateContext,
+  WorkspaceBranchStateContext,
+  WorkspacePresenceContext,
+  WorkspaceStateContext,
+} from "@/state/app-state-contexts";
+import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
+import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+import { createSettingsSnapshotFixture } from "@/test-utils/shared-test-fixtures";
+import type {
+  ChecksStateContextValue,
+  TasksStateContextValue,
+  WorkspaceBranchStateContextValue,
+  WorkspaceStateContextValue,
+} from "@/types/state-slices";
+
+const actualSettingsModalModule = await import("@/components/features/settings/settings-modal");
+
+type SettingsModalTriggerProps = {
+  triggerClassName?: string;
+  triggerSize?: "default" | "sm" | "lg" | "icon";
+  triggerIconOnly?: boolean;
+};
+
+const activeWorkspace = {
+  workspaceId: "workspace-1",
+  workspaceName: "OpenDucktor",
+  repoPath: "/repo",
+  iconDataUrl: undefined,
+  isActive: true,
+  hasConfig: true,
+  configuredWorktreeBasePath: null,
+  defaultWorktreeBasePath: null,
+  effectiveWorktreeBasePath: null,
+} satisfies WorkspaceRecord;
+
+const createWorkspaceState = (): WorkspaceStateContextValue => ({
+  isSwitchingWorkspace: false,
+  isLoadingBranches: false,
+  isSwitchingBranch: false,
+  branchSyncDegraded: false,
+  workspaces: [activeWorkspace],
+  activeWorkspace,
+  branches: [],
+  activeBranch: null,
+  addWorkspace: async () => undefined,
+  selectWorkspace: async () => undefined,
+  reorderWorkspaces: async () => undefined,
+  refreshBranches: async () => undefined,
+  switchBranch: async () => undefined,
+  loadRepoSettings: async () => {
+    throw new Error("loadRepoSettings is not used in this test");
+  },
+  saveRepoSettings: async () => undefined,
+  loadSettingsSnapshot: async () => createSettingsSnapshotFixture(),
+  detectGithubRepository: async () => null,
+  saveGlobalGitConfig: async () => undefined,
+  saveSettingsSnapshot: async () => undefined,
+});
+
+const createWorkspaceBranchState = (): WorkspaceBranchStateContextValue => ({
+  activeWorkspace,
+  branches: [],
+  activeBranch: null,
+  isSwitchingWorkspace: false,
+  isLoadingBranches: false,
+  isSwitchingBranch: false,
+  branchSyncDegraded: false,
+  switchBranch: async () => undefined,
+});
+
+const createChecksState = (): ChecksStateContextValue => ({
+  runtimeCheck: null,
+  taskStoreCheck: null,
+  runtimeCheckFailureKind: null,
+  taskStoreCheckFailureKind: null,
+  isLoadingChecks: false,
+  refreshChecks: async () => undefined,
+});
+
+const createTasksState = (): TasksStateContextValue => ({
+  isForegroundLoadingTasks: false,
+  isRefreshingTasksInBackground: false,
+  isLoadingTasks: false,
+  detectingPullRequestTaskId: null,
+  linkingMergedPullRequestTaskId: null,
+  unlinkingPullRequestTaskId: null,
+  pendingMergedPullRequest: null,
+  tasks: [],
+  refreshTasks: async () => undefined,
+  syncPullRequests: async () => undefined,
+  linkMergedPullRequest: async () => undefined,
+  cancelLinkMergedPullRequest: () => undefined,
+  unlinkPullRequest: async () => undefined,
+  createTask: async () => undefined,
+  updateTask: async () => undefined,
+  setTaskTargetBranch: async () => undefined,
+  deleteTask: async () => undefined,
+  closeTask: async () => undefined,
+  resetTaskImplementation: async () => undefined,
+  resetTask: async () => undefined,
+  transitionTask: async () => undefined,
+  humanApproveTask: async () => undefined,
+  humanRequestChangesTask: async () => undefined,
+});
+
+function AppShellTestProviders({ children }: PropsWithChildren): ReactElement {
+  const queryClient = createQueryClient();
+  const settingsSnapshot = createSettingsSnapshotFixture();
+  queryClient.setQueryData(settingsSnapshotQueryOptions().queryKey, settingsSnapshot);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <ActiveWorkspaceContext.Provider
+          value={{ activeWorkspace, setActiveWorkspace: () => undefined }}
+        >
+          <WorkspacePresenceContext.Provider value={{ hasWorkspaces: true }}>
+            <WorkspaceStateContext.Provider value={createWorkspaceState()}>
+              <WorkspaceBranchStateContext.Provider value={createWorkspaceBranchState()}>
+                <RuntimeDefinitionsContext.Provider
+                  value={{
+                    runtimeDefinitions: [],
+                    availableRuntimeDefinitions: [],
+                    agentRuntimes: settingsSnapshot.agentRuntimes,
+                    isLoadingRuntimeDefinitions: false,
+                    runtimeDefinitionsError: null,
+                    refreshRuntimeDefinitions: async () => [],
+                    loadRepoRuntimeCatalog: async () => {
+                      throw new Error("loadRepoRuntimeCatalog is not used in this test");
+                    },
+                    loadRepoRuntimeSlashCommands: async () => {
+                      throw new Error("loadRepoRuntimeSlashCommands is not used in this test");
+                    },
+                    loadRepoRuntimeSkills: async () => {
+                      throw new Error("loadRepoRuntimeSkills is not used in this test");
+                    },
+                    loadRepoRuntimeSubagents: async () => {
+                      throw new Error("loadRepoRuntimeSubagents is not used in this test");
+                    },
+                    loadRepoRuntimeFileSearch: async () => {
+                      throw new Error("loadRepoRuntimeFileSearch is not used in this test");
+                    },
+                  }}
+                >
+                  <RepoRuntimeHealthContext.Provider
+                    value={{
+                      runtimeHealthByRuntime: {},
+                      isLoadingRepoRuntimeHealth: false,
+                      refreshRepoRuntimeHealth: async () => ({}),
+                    }}
+                  >
+                    <ChecksStateContext.Provider value={createChecksState()}>
+                      <TasksStateContext.Provider value={createTasksState()}>
+                        <AgentSessionsContext.Provider value={createAgentSessionsStore("/repo")}>
+                          {children}
+                        </AgentSessionsContext.Provider>
+                      </TasksStateContext.Provider>
+                    </ChecksStateContext.Provider>
+                  </RepoRuntimeHealthContext.Provider>
+                </RuntimeDefinitionsContext.Provider>
+              </WorkspaceBranchStateContext.Provider>
+            </WorkspaceStateContext.Provider>
+          </WorkspacePresenceContext.Provider>
+        </ActiveWorkspaceContext.Provider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+const restoreSettingsModalMock = async (): Promise<void> => {
+  await restoreMockedModules([
+    ["@/components/features/settings/settings-modal", async () => actualSettingsModalModule],
+  ]);
+};
+
+const importAppShell = async (): Promise<typeof import("./app-shell").AppShell> => {
+  const { AppShell } = await import("./app-shell");
+  return AppShell;
+};
+
+describe("AppShell", () => {
+  beforeEach(() => {
+    mock.module("@/components/features/settings/settings-modal", () => ({
+      SettingsModal: ({
+        triggerClassName,
+        triggerIconOnly = false,
+        triggerSize,
+      }: SettingsModalTriggerProps) => (
+        <button
+          type="button"
+          aria-label={triggerIconOnly ? "Settings" : undefined}
+          className={triggerClassName}
+          data-settings-modal-trigger="true"
+          data-trigger-icon-only={triggerIconOnly ? "true" : "false"}
+          data-trigger-size={triggerSize ?? ""}
+          title={triggerIconOnly ? "Settings" : undefined}
+        >
+          {triggerIconOnly ? null : "Settings"}
+        </button>
+      ),
+    }));
+  });
+
+  afterEach(async () => {
+    await restoreSettingsModalMock();
+  });
+
+  test("keeps the settings trigger available when the sidebar is collapsed", async () => {
+    const AppShell = await importAppShell();
+
+    render(
+      <MemoryRouter initialEntries={["/kanban"]} useTransitions>
+        <AppShellTestProviders>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/kanban" element={<main>Kanban</main>} />
+            </Route>
+          </Routes>
+        </AppShellTestProviders>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Settings" }).dataset.settingsModalTrigger).toBe(
+        "true",
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+
+    const collapsedSettingsButton = screen.getByRole("button", { name: "Settings" });
+    expect(collapsedSettingsButton.dataset.settingsModalTrigger).toBe("true");
+    expect(collapsedSettingsButton.dataset.triggerIconOnly).toBe("true");
+    expect(collapsedSettingsButton.dataset.triggerSize).toBe("icon");
+  });
+});

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { WorkspaceRecord } from "@openducktor/contracts";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -18,7 +18,6 @@ import {
   WorkspaceStateContext,
 } from "@/state/app-state-contexts";
 import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
-import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import { createSettingsSnapshotFixture } from "@/test-utils/shared-test-fixtures";
 import type {
   ChecksStateContextValue,
@@ -26,14 +25,7 @@ import type {
   WorkspaceBranchStateContextValue,
   WorkspaceStateContextValue,
 } from "@/types/state-slices";
-
-const actualSettingsModalModule = await import("@/components/features/settings/settings-modal");
-
-type SettingsModalTriggerProps = {
-  triggerClassName?: string;
-  triggerSize?: "default" | "sm" | "lg" | "icon";
-  triggerIconOnly?: boolean;
-};
+import { AppShell } from "./app-shell";
 
 const activeWorkspace = {
   workspaceId: "workspace-1",
@@ -117,8 +109,7 @@ const createTasksState = (): TasksStateContextValue => ({
   humanRequestChangesTask: async () => undefined,
 });
 
-const renderAppShellForTest = async (): Promise<ReturnType<typeof render>> => {
-  const AppShell = await importAppShell();
+const renderAppShellForTest = (): ReturnType<typeof render> => {
   const queryClient = createQueryClient();
   const settingsSnapshot = createSettingsSnapshotFixture();
   queryClient.setQueryData(settingsSnapshotQueryOptions().queryKey, settingsSnapshot);
@@ -188,58 +179,19 @@ const renderAppShellForTest = async (): Promise<ReturnType<typeof render>> => {
   );
 };
 
-const restoreSettingsModalMock = async (): Promise<void> => {
-  await restoreMockedModules([
-    ["@/components/features/settings/settings-modal", async () => actualSettingsModalModule],
-  ]);
-};
-
-const importAppShell = async (): Promise<typeof import("./app-shell").AppShell> => {
-  const { AppShell } = await import("./app-shell");
-  return AppShell;
-};
-
 describe("AppShell", () => {
-  beforeEach(() => {
-    mock.module("@/components/features/settings/settings-modal", () => ({
-      SettingsModal: ({
-        triggerClassName,
-        triggerIconOnly = false,
-        triggerSize,
-      }: SettingsModalTriggerProps) => (
-        <button
-          type="button"
-          aria-label={triggerIconOnly ? "Settings" : undefined}
-          className={triggerClassName}
-          data-settings-modal-trigger="true"
-          data-trigger-icon-only={triggerIconOnly ? "true" : "false"}
-          data-trigger-size={triggerSize ?? ""}
-          title={triggerIconOnly ? "Settings" : undefined}
-        >
-          {triggerIconOnly ? null : "Settings"}
-        </button>
-      ),
-    }));
-  });
-
-  afterEach(async () => {
-    await restoreSettingsModalMock();
-  });
-
   test("keeps the settings trigger available when the sidebar is collapsed", async () => {
-    await renderAppShellForTest();
+    renderAppShellForTest();
 
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Settings" }).dataset.settingsModalTrigger).toBe(
-        "true",
-      ),
-    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "Settings" })).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
 
     const collapsedSettingsButton = screen.getByRole("button", { name: "Settings" });
-    expect(collapsedSettingsButton.dataset.settingsModalTrigger).toBe("true");
-    expect(collapsedSettingsButton.dataset.triggerIconOnly).toBe("true");
-    expect(collapsedSettingsButton.dataset.triggerSize).toBe("icon");
+    expect(collapsedSettingsButton.getAttribute("aria-label")).toBe("Settings");
+    expect(collapsedSettingsButton.getAttribute("title")).toBe("Settings");
+    expect(collapsedSettingsButton.textContent?.trim()).toBe("");
+    expect(collapsedSettingsButton.className).toContain("size-8");
+    expect(collapsedSettingsButton.className).not.toContain("px-3");
   });
 });

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { WorkspaceRecord } from "@openducktor/contracts";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type { PropsWithChildren, ReactElement } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { createQueryClient } from "@/lib/query-client";
@@ -118,69 +117,76 @@ const createTasksState = (): TasksStateContextValue => ({
   humanRequestChangesTask: async () => undefined,
 });
 
-function AppShellTestProviders({ children }: PropsWithChildren): ReactElement {
+const renderAppShellForTest = async (): Promise<ReturnType<typeof render>> => {
+  const AppShell = await importAppShell();
   const queryClient = createQueryClient();
   const settingsSnapshot = createSettingsSnapshotFixture();
   queryClient.setQueryData(settingsSnapshotQueryOptions().queryKey, settingsSnapshot);
 
-  return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <ActiveWorkspaceContext.Provider
-          value={{ activeWorkspace, setActiveWorkspace: () => undefined }}
-        >
-          <WorkspacePresenceContext.Provider value={{ hasWorkspaces: true }}>
-            <WorkspaceStateContext.Provider value={createWorkspaceState()}>
-              <WorkspaceBranchStateContext.Provider value={createWorkspaceBranchState()}>
-                <RuntimeDefinitionsContext.Provider
-                  value={{
-                    runtimeDefinitions: [],
-                    availableRuntimeDefinitions: [],
-                    agentRuntimes: settingsSnapshot.agentRuntimes,
-                    isLoadingRuntimeDefinitions: false,
-                    runtimeDefinitionsError: null,
-                    refreshRuntimeDefinitions: async () => [],
-                    loadRepoRuntimeCatalog: async () => {
-                      throw new Error("loadRepoRuntimeCatalog is not used in this test");
-                    },
-                    loadRepoRuntimeSlashCommands: async () => {
-                      throw new Error("loadRepoRuntimeSlashCommands is not used in this test");
-                    },
-                    loadRepoRuntimeSkills: async () => {
-                      throw new Error("loadRepoRuntimeSkills is not used in this test");
-                    },
-                    loadRepoRuntimeSubagents: async () => {
-                      throw new Error("loadRepoRuntimeSubagents is not used in this test");
-                    },
-                    loadRepoRuntimeFileSearch: async () => {
-                      throw new Error("loadRepoRuntimeFileSearch is not used in this test");
-                    },
-                  }}
-                >
-                  <RepoRuntimeHealthContext.Provider
+  return render(
+    <MemoryRouter initialEntries={["/kanban"]} useTransitions>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <ActiveWorkspaceContext.Provider
+            value={{ activeWorkspace, setActiveWorkspace: () => undefined }}
+          >
+            <WorkspacePresenceContext.Provider value={{ hasWorkspaces: true }}>
+              <WorkspaceStateContext.Provider value={createWorkspaceState()}>
+                <WorkspaceBranchStateContext.Provider value={createWorkspaceBranchState()}>
+                  <RuntimeDefinitionsContext.Provider
                     value={{
-                      runtimeHealthByRuntime: {},
-                      isLoadingRepoRuntimeHealth: false,
-                      refreshRepoRuntimeHealth: async () => ({}),
+                      runtimeDefinitions: [],
+                      availableRuntimeDefinitions: [],
+                      agentRuntimes: settingsSnapshot.agentRuntimes,
+                      isLoadingRuntimeDefinitions: false,
+                      runtimeDefinitionsError: null,
+                      refreshRuntimeDefinitions: async () => [],
+                      loadRepoRuntimeCatalog: async () => {
+                        throw new Error("loadRepoRuntimeCatalog is not used in this test");
+                      },
+                      loadRepoRuntimeSlashCommands: async () => {
+                        throw new Error("loadRepoRuntimeSlashCommands is not used in this test");
+                      },
+                      loadRepoRuntimeSkills: async () => {
+                        throw new Error("loadRepoRuntimeSkills is not used in this test");
+                      },
+                      loadRepoRuntimeSubagents: async () => {
+                        throw new Error("loadRepoRuntimeSubagents is not used in this test");
+                      },
+                      loadRepoRuntimeFileSearch: async () => {
+                        throw new Error("loadRepoRuntimeFileSearch is not used in this test");
+                      },
                     }}
                   >
-                    <ChecksStateContext.Provider value={createChecksState()}>
-                      <TasksStateContext.Provider value={createTasksState()}>
-                        <AgentSessionsContext.Provider value={createAgentSessionsStore("/repo")}>
-                          {children}
-                        </AgentSessionsContext.Provider>
-                      </TasksStateContext.Provider>
-                    </ChecksStateContext.Provider>
-                  </RepoRuntimeHealthContext.Provider>
-                </RuntimeDefinitionsContext.Provider>
-              </WorkspaceBranchStateContext.Provider>
-            </WorkspaceStateContext.Provider>
-          </WorkspacePresenceContext.Provider>
-        </ActiveWorkspaceContext.Provider>
-      </ThemeProvider>
-    </QueryClientProvider>
+                    <RepoRuntimeHealthContext.Provider
+                      value={{
+                        runtimeHealthByRuntime: {},
+                        isLoadingRepoRuntimeHealth: false,
+                        refreshRepoRuntimeHealth: async () => ({}),
+                      }}
+                    >
+                      <ChecksStateContext.Provider value={createChecksState()}>
+                        <TasksStateContext.Provider value={createTasksState()}>
+                          <AgentSessionsContext.Provider value={createAgentSessionsStore("/repo")}>
+                            <Routes>
+                              <Route element={<AppShell />}>
+                                <Route path="/kanban" element={<main>Kanban</main>} />
+                              </Route>
+                            </Routes>
+                          </AgentSessionsContext.Provider>
+                        </TasksStateContext.Provider>
+                      </ChecksStateContext.Provider>
+                    </RepoRuntimeHealthContext.Provider>
+                  </RuntimeDefinitionsContext.Provider>
+                </WorkspaceBranchStateContext.Provider>
+              </WorkspaceStateContext.Provider>
+            </WorkspacePresenceContext.Provider>
+          </ActiveWorkspaceContext.Provider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
   );
-}
+};
 
 const restoreSettingsModalMock = async (): Promise<void> => {
   await restoreMockedModules([
@@ -221,19 +227,7 @@ describe("AppShell", () => {
   });
 
   test("keeps the settings trigger available when the sidebar is collapsed", async () => {
-    const AppShell = await importAppShell();
-
-    render(
-      <MemoryRouter initialEntries={["/kanban"]} useTransitions>
-        <AppShellTestProviders>
-          <Routes>
-            <Route element={<AppShell />}>
-              <Route path="/kanban" element={<main>Kanban</main>} />
-            </Route>
-          </Routes>
-        </AppShellTestProviders>
-      </MemoryRouter>,
-    );
+    await renderAppShellForTest();
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Settings" }).dataset.settingsModalTrigger).toBe(

--- a/packages/frontend/src/components/layout/app-shell.tsx
+++ b/packages/frontend/src/components/layout/app-shell.tsx
@@ -1,8 +1,9 @@
-import { PanelLeftClose, PanelLeftOpen, Settings2 } from "lucide-react";
-import { lazy, memo, type ReactElement, Suspense, useCallback, useEffect, useState } from "react";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { memo, type ReactElement, useCallback, useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { DiagnosticsPanel } from "@/components/features/diagnostics";
 import { OpenRepositoryModal } from "@/components/features/repository/open-repository-modal";
+import { SettingsModal } from "@/components/features/settings/settings-modal";
 import {
   AgentActivityCard,
   AppBrand,
@@ -15,11 +16,6 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useActiveWorkspace, useWorkspacePresence } from "@/state/app-state-provider";
 import { useShellAgentActivity } from "@/state/queries/use-shell-agent-activity";
-
-const SettingsModal = lazy(async () => {
-  const module = await import("@/components/features/settings/settings-modal");
-  return { default: module.SettingsModal };
-});
 
 export const AppShell = memo(function AppShell(): ReactElement {
   const activeWorkspace = useActiveWorkspace();
@@ -114,21 +110,7 @@ export const AppShell = memo(function AppShell(): ReactElement {
                 </div>
 
                 <div className="border-t border-sidebar-border p-3">
-                  <Suspense
-                    fallback={
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className="w-full justify-start"
-                        disabled
-                      >
-                        <Settings2 className="size-4" />
-                        Settings
-                      </Button>
-                    }
-                  >
-                    <SettingsModal triggerClassName="w-full justify-start" triggerSize="default" />
-                  </Suspense>
+                  <SettingsModal triggerClassName="w-full justify-start" triggerSize="default" />
                 </div>
               </>
             ) : (
@@ -148,27 +130,10 @@ export const AppShell = memo(function AppShell(): ReactElement {
                   <SidebarNavigation hasActiveWorkspace={hasActiveWorkspace} compact />
                 </div>
                 <div className="mt-auto flex w-full justify-center border-t border-sidebar-border pt-2">
-                  <Suspense
-                    fallback={
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        className="size-8 text-sidebar-muted-foreground hover:text-sidebar-foreground"
-                        disabled
-                        aria-label="Settings"
-                        title="Settings"
-                      >
-                        <Settings2 className="size-4" />
-                      </Button>
-                    }
-                  >
-                    <SettingsModal
-                      triggerClassName="size-8 text-sidebar-muted-foreground hover:text-sidebar-foreground"
-                      triggerIconOnly
-                      triggerSize="icon"
-                    />
-                  </Suspense>
+                  <SettingsModal
+                    triggerClassName="size-8 text-sidebar-muted-foreground hover:text-sidebar-foreground"
+                    triggerIconOnly
+                  />
                 </div>
               </div>
             )}

--- a/packages/frontend/src/components/layout/app-shell.tsx
+++ b/packages/frontend/src/components/layout/app-shell.tsx
@@ -147,6 +147,29 @@ export const AppShell = memo(function AppShell(): ReactElement {
                 <div className="w-full border-t border-sidebar-border pt-2">
                   <SidebarNavigation hasActiveWorkspace={hasActiveWorkspace} compact />
                 </div>
+                <div className="mt-auto flex w-full justify-center border-t border-sidebar-border pt-2">
+                  <Suspense
+                    fallback={
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="size-8 text-sidebar-muted-foreground hover:text-sidebar-foreground"
+                        disabled
+                        aria-label="Settings"
+                        title="Settings"
+                      >
+                        <Settings2 className="size-4" />
+                      </Button>
+                    }
+                  >
+                    <SettingsModal
+                      triggerClassName="size-8 text-sidebar-muted-foreground hover:text-sidebar-foreground"
+                      triggerIconOnly
+                      triggerSize="icon"
+                    />
+                  </Suspense>
+                </div>
               </div>
             )}
           </aside>

--- a/packages/frontend/src/components/ui/markdown-syntax-block.test.tsx
+++ b/packages/frontend/src/components/ui/markdown-syntax-block.test.tsx
@@ -13,6 +13,8 @@ type Theme = "dark" | "light";
 const LIGHT_THEME = { themeName: "light" };
 const DARK_THEME = { themeName: "dark" };
 
+const actualThemeProviderModule = await import("@/components/layout/theme-provider");
+
 let currentTheme: Theme = "light";
 let yamlLanguageShouldFail = false;
 const registerLanguageMock = mock((_language: string, _grammar: unknown) => {});
@@ -85,7 +87,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await restoreMockedModules([
-    ["@/components/layout/theme-provider", () => import("@/components/layout/theme-provider")],
+    ["@/components/layout/theme-provider", async () => actualThemeProviderModule],
     ["react-syntax-highlighter", () => import("react-syntax-highlighter")],
     [
       "react-syntax-highlighter/dist/esm/languages/prism/javascript",

--- a/packages/frontend/src/components/ui/markdown-syntax-block.test.tsx
+++ b/packages/frontend/src/components/ui/markdown-syntax-block.test.tsx
@@ -13,7 +13,7 @@ type Theme = "dark" | "light";
 const LIGHT_THEME = { themeName: "light" };
 const DARK_THEME = { themeName: "dark" };
 
-const actualThemeProviderModule = await import("@/components/layout/theme-provider");
+const actualThemeProviderModule = { ...(await import("@/components/layout/theme-provider")) };
 
 let currentTheme: Theme = "light";
 let yamlLanguageShouldFail = false;


### PR DESCRIPTION
Summary:
Adds a settings trigger to the collapsed left sidebar so Settings remains available without reopening the full sidebar.

Goal:
The expanded sidebar had a Settings button in its footer, but the collapsed sidebar rendered only the expand control and compact navigation. This PR keeps the Settings entry point available at the bottom of the collapsed sidebar, matching the expected shell affordance.

Technical choices:
- Added an icon-only trigger mode to `SettingsModal` so the same modal trigger can fit the collapsed rail while preserving the existing expanded trigger.
- Rendered the icon-only settings trigger in a collapsed sidebar footer with the same lazy-loading boundary and an accessible fallback.
- Added an AppShell regression test that collapses the sidebar and asserts the settings trigger remains available.
- Extracted the AppShell test render harness so the regression stays focused on behavior.
- Fixed a `theme-provider` module mock restore leak exposed by the full frontend suite.

Verification:
- `timeout 600 bun run lint`
- `timeout 600 bun run test`
- `timeout 600 bun run typecheck`
- `timeout 900 bun run build`
- Cargo checks: not applicable; no `Cargo.toml` or `Cargo.lock` exists in this repo.