### PR TITLE
feat: remember left sidebar state

### DIFF
--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
@@ -85,13 +85,30 @@ export function DiagnosticsPanel({
     workspaceRepoPath !== null &&
     model.criticalReasons.length > 0 &&
     !autoOpenedByRepo.has(workspaceRepoPath);
+  const sheetOpen = isOpen || shouldAutoOpen;
 
-  if (shouldAutoOpen) {
+  const markAutoOpenedForWorkspace = (): boolean => {
+    if (!shouldAutoOpen || workspaceRepoPath === null) {
+      return false;
+    }
+
     autoOpenedByRepo.add(workspaceRepoPath);
-    if (!isOpen) {
+    return true;
+  };
+
+  const handleSheetOpenAutoFocus = (): void => {
+    if (markAutoOpenedForWorkspace() && !isOpen) {
       setOpen(true);
     }
-  }
+  };
+
+  const handleSheetOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen) {
+      markAutoOpenedForWorkspace();
+    }
+
+    setOpen(nextOpen);
+  };
 
   const iconTriggerLabel = `Open diagnostics: ${model.summaryState.label}`;
 
@@ -154,8 +171,12 @@ export function DiagnosticsPanel({
   return (
     <>
       {trigger}
-      <Sheet open={isOpen} onOpenChange={setOpen}>
-        <SheetContent side="right" className="overflow-y-auto">
+      <Sheet open={sheetOpen} onOpenChange={handleSheetOpenChange}>
+        <SheetContent
+          side="right"
+          className="overflow-y-auto"
+          onOpenAutoFocus={handleSheetOpenAutoFocus}
+        >
           <SheetHeader className="space-y-3">
             <div className="flex items-center justify-between gap-3">
               <div className="space-y-1">

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
@@ -17,7 +17,15 @@ import {
 import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
 import { DiagnosticsPanelSections } from "./diagnostics-panel-sections";
 
-export function DiagnosticsPanel(): ReactElement {
+type DiagnosticsPanelProps = {
+  triggerClassName?: string;
+  triggerVariant?: "summary" | "icon";
+};
+
+export function DiagnosticsPanel({
+  triggerClassName,
+  triggerVariant = "summary",
+}: DiagnosticsPanelProps): ReactElement {
   const { activeWorkspace, isSwitchingWorkspace } = useWorkspaceState();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
   const {
@@ -82,9 +90,21 @@ export function DiagnosticsPanel(): ReactElement {
     setOpen(true);
   }, [autoOpenedByRepo, workspaceRepoPath, model.criticalReasons.length]);
 
-  return (
-    <>
-      <div className="space-y-1.5">
+  const trigger =
+    triggerVariant === "icon" ? (
+      <Button
+        type="button"
+        size="icon"
+        variant="outline"
+        className={cn("size-8", triggerClassName)}
+        onClick={() => setOpen(true)}
+        aria-label="Open diagnostics"
+        title="Open diagnostics"
+      >
+        <ShieldCheck className={cn("size-4", model.summaryState.iconClass)} />
+      </Button>
+    ) : (
+      <div className={cn("space-y-1.5", triggerClassName)}>
         <div className="flex items-center justify-between gap-2 rounded-lg border border-border bg-card px-2.5 py-2">
           <div className="min-w-0">
             <p className="flex items-center gap-1.5 text-sm font-medium text-foreground">
@@ -120,7 +140,11 @@ export function DiagnosticsPanel(): ReactElement {
           </p>
         ) : null}
       </div>
+    );
 
+  return (
+    <>
+      {trigger}
       <Sheet open={isOpen} onOpenChange={setOpen}>
         <SheetContent side="right" className="overflow-y-auto">
           <SheetHeader className="space-y-3">

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
@@ -90,6 +90,8 @@ export function DiagnosticsPanel({
     setOpen(true);
   }, [autoOpenedByRepo, workspaceRepoPath, model.criticalReasons.length]);
 
+  const iconTriggerLabel = `Open diagnostics: ${model.summaryState.label}`;
+
   const trigger =
     triggerVariant === "icon" ? (
       <Button
@@ -98,8 +100,8 @@ export function DiagnosticsPanel({
         variant="outline"
         className={cn("size-8", triggerClassName)}
         onClick={() => setOpen(true)}
-        aria-label="Open diagnostics"
-        title="Open diagnostics"
+        aria-label={iconTriggerLabel}
+        title={iconTriggerLabel}
       >
         <ShieldCheck className={cn("size-4", model.summaryState.iconClass)} />
       </Button>

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight, RefreshCcw, ShieldCheck } from "lucide-react";
-import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactElement, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -18,11 +18,13 @@ import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
 import { DiagnosticsPanelSections } from "./diagnostics-panel-sections";
 
 type DiagnosticsPanelProps = {
+  autoOpenedByRepo?: Set<string>;
   triggerClassName?: string;
   triggerVariant?: "summary" | "icon";
 };
 
 export function DiagnosticsPanel({
+  autoOpenedByRepo: sharedAutoOpenedByRepo,
   triggerClassName,
   triggerVariant = "summary",
 }: DiagnosticsPanelProps): ReactElement {
@@ -43,11 +45,11 @@ export function DiagnosticsPanel({
   } = useChecksState();
   const { runtimeHealthByRuntime } = useRepoRuntimeHealthContext();
   const [isOpen, setOpen] = useState(false);
-  const autoOpenedByRepoRef = useRef<Set<string> | null>(null);
-  if (autoOpenedByRepoRef.current === null) {
-    autoOpenedByRepoRef.current = new Set();
+  const localAutoOpenedByRepoRef = useRef<Set<string> | null>(null);
+  if (localAutoOpenedByRepoRef.current === null) {
+    localAutoOpenedByRepoRef.current = new Set();
   }
-  const autoOpenedByRepo = autoOpenedByRepoRef.current;
+  const autoOpenedByRepo = sharedAutoOpenedByRepo ?? localAutoOpenedByRepoRef.current;
 
   const model = useMemo(
     () =>
@@ -79,16 +81,17 @@ export function DiagnosticsPanel({
     ],
   );
 
-  useEffect(() => {
-    if (!workspaceRepoPath || model.criticalReasons.length === 0) {
-      return;
-    }
-    if (autoOpenedByRepo.has(workspaceRepoPath)) {
-      return;
-    }
+  const shouldAutoOpen =
+    workspaceRepoPath !== null &&
+    model.criticalReasons.length > 0 &&
+    !autoOpenedByRepo.has(workspaceRepoPath);
+
+  if (shouldAutoOpen) {
     autoOpenedByRepo.add(workspaceRepoPath);
-    setOpen(true);
-  }, [autoOpenedByRepo, workspaceRepoPath, model.criticalReasons.length]);
+    if (!isOpen) {
+      setOpen(true);
+    }
+  }
 
   const iconTriggerLabel = `Open diagnostics: ${model.summaryState.label}`;
 
@@ -103,7 +106,11 @@ export function DiagnosticsPanel({
         aria-label={iconTriggerLabel}
         title={iconTriggerLabel}
       >
-        <ShieldCheck className={cn("size-4", model.summaryState.iconClass)} />
+        {model.isSummaryChecking ? (
+          <RefreshCcw className={cn("size-4 animate-spin", model.summaryState.iconClass)} />
+        ) : (
+          <ShieldCheck className={cn("size-4", model.summaryState.iconClass)} />
+        )}
       </Button>
     ) : (
       <div className={cn("space-y-1.5", triggerClassName)}>

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -135,6 +135,7 @@ const createWorkspaceBranchState = (): WorkspaceBranchStateContextValue => ({
 });
 
 type RenderAppShellForTestOptions = {
+  isLoadingRuntimeDefinitions?: boolean;
   runtimeDefinitionsError?: string | null;
 };
 
@@ -195,7 +196,7 @@ const renderAppShellForTest = (
                       runtimeDefinitions: [],
                       availableRuntimeDefinitions: [],
                       agentRuntimes: settingsSnapshot.agentRuntimes,
-                      isLoadingRuntimeDefinitions: false,
+                      isLoadingRuntimeDefinitions: options.isLoadingRuntimeDefinitions ?? false,
                       runtimeDefinitionsError: options.runtimeDefinitionsError ?? null,
                       refreshRuntimeDefinitions: async () => [],
                       loadRepoRuntimeCatalog: async () => {
@@ -288,6 +289,7 @@ describe("AppShell", () => {
 
     renderAppShellForTest({ runtimeDefinitionsError: "Runtime definitions failed" });
 
+    // Critical diagnostics auto-open the modal sheet, so Radix hides background controls.
     const diagnosticsButton = screen.getByRole("button", {
       hidden: true,
       name: "Open diagnostics: Critical issue",
@@ -300,6 +302,18 @@ describe("AppShell", () => {
     await waitFor(() => expect(screen.getByRole("heading", { name: "Diagnostics" })).toBeTruthy());
   });
 
+  test("shows checking state in the collapsed diagnostics trigger", () => {
+    globalThis.localStorage.setItem(LEFT_SIDEBAR_STORAGE_KEY, "collapsed");
+
+    renderAppShellForTest({ isLoadingRuntimeDefinitions: true });
+
+    const diagnosticsButton = screen.getByRole("button", {
+      name: "Open diagnostics: Checking...",
+    });
+    const diagnosticsIcon = diagnosticsButton.querySelector("svg");
+    expect(diagnosticsIcon?.getAttribute("class")).toContain("animate-spin");
+  });
+
   test("opens diagnostics from the collapsed sidebar trigger", async () => {
     globalThis.localStorage.setItem(LEFT_SIDEBAR_STORAGE_KEY, "collapsed");
 
@@ -308,6 +322,26 @@ describe("AppShell", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Open diagnostics: / }));
 
     await waitFor(() => expect(screen.getByRole("heading", { name: "Diagnostics" })).toBeTruthy());
+  });
+
+  test("does not auto-open diagnostics again after dismissing and toggling the sidebar", async () => {
+    renderAppShellForTest({ runtimeDefinitionsError: "Runtime definitions failed" });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Diagnostics" })).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() => expect(screen.queryByRole("heading", { name: "Diagnostics" })).toBeNull());
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+
+    expect(screen.getByRole("button", { name: "Show sidebar" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Diagnostics" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show sidebar" }));
+
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Diagnostics" })).toBeNull();
   });
 
   test("stores collapsed and restores the collapsed sidebar after remount", () => {

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -1,7 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { WorkspaceRecord } from "@openducktor/contracts";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { createQueryClient } from "@/lib/query-client";
@@ -27,6 +27,8 @@ import type {
 } from "@/types/state-slices";
 import { AppShell } from "./app-shell";
 
+const LEFT_SIDEBAR_STORAGE_KEY = "openducktor:app-shell:left-sidebar";
+
 const activeWorkspace = {
   workspaceId: "workspace-1",
   workspaceName: "OpenDucktor",
@@ -38,6 +40,43 @@ const activeWorkspace = {
   defaultWorktreeBasePath: null,
   effectiveWorktreeBasePath: null,
 } satisfies WorkspaceRecord;
+
+class MemoryStorage implements Storage {
+  readonly #items = new Map<string, string>();
+
+  get length(): number {
+    return this.#items.size;
+  }
+
+  clear(): void {
+    this.#items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.#items.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.#items.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.#items.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.#items.set(key, value);
+  }
+}
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+const installLocalStorage = (storage: Storage): void => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+};
 
 const createWorkspaceState = (): WorkspaceStateContextValue => ({
   isSwitchingWorkspace: false,
@@ -180,6 +219,28 @@ const renderAppShellForTest = (): ReturnType<typeof render> => {
 };
 
 describe("AppShell", () => {
+  beforeEach(() => {
+    installLocalStorage(new MemoryStorage());
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+      return;
+    }
+
+    Reflect.deleteProperty(globalThis, "localStorage");
+  });
+
+  test("opens the sidebar by default when no preference is stored", () => {
+    renderAppShellForTest();
+
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Show sidebar" })).toBeNull();
+    expect(globalThis.localStorage.getItem(LEFT_SIDEBAR_STORAGE_KEY)).toBeNull();
+  });
+
   test("keeps the settings trigger available when the sidebar is collapsed", async () => {
     renderAppShellForTest();
 
@@ -193,5 +254,93 @@ describe("AppShell", () => {
     expect(collapsedSettingsButton.textContent?.trim()).toBe("");
     expect(collapsedSettingsButton.className).toContain("size-8");
     expect(collapsedSettingsButton.className).not.toContain("px-3");
+  });
+
+  test("stores collapsed and restores the collapsed sidebar after remount", () => {
+    const view = renderAppShellForTest();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+
+    expect(screen.getByRole("button", { name: "Show sidebar" })).toBeTruthy();
+    expect(globalThis.localStorage.getItem(LEFT_SIDEBAR_STORAGE_KEY)).toBe("collapsed");
+
+    view.unmount();
+    renderAppShellForTest();
+
+    expect(screen.getByRole("button", { name: "Show sidebar" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Hide sidebar" })).toBeNull();
+  });
+
+  test("stores opened and restores the opened sidebar after remount", () => {
+    globalThis.localStorage.setItem(LEFT_SIDEBAR_STORAGE_KEY, "collapsed");
+    const view = renderAppShellForTest();
+
+    expect(screen.getByRole("button", { name: "Show sidebar" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show sidebar" }));
+
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+    expect(globalThis.localStorage.getItem(LEFT_SIDEBAR_STORAGE_KEY)).toBe("opened");
+
+    view.unmount();
+    renderAppShellForTest();
+
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Show sidebar" })).toBeNull();
+  });
+
+  test("defaults opened when the stored sidebar preference is invalid", () => {
+    globalThis.localStorage.setItem(LEFT_SIDEBAR_STORAGE_KEY, "{bad-json");
+
+    renderAppShellForTest();
+
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Show sidebar" })).toBeNull();
+  });
+
+  test("defaults opened when storage cannot be read", () => {
+    const storage = new MemoryStorage();
+    const getItem = mock(() => {
+      throw new Error("read failed");
+    });
+    storage.getItem = getItem;
+    installLocalStorage(storage);
+    const originalConsoleError = console.error;
+    const consoleError = mock(() => undefined);
+    console.error = consoleError;
+
+    try {
+      renderAppShellForTest();
+
+      expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+      expect(getItem).toHaveBeenCalledWith(LEFT_SIDEBAR_STORAGE_KEY);
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  test("keeps sidebar toggling in memory when storage cannot be written", () => {
+    const storage = new MemoryStorage();
+    const setItem = mock(() => {
+      throw new Error("write failed");
+    });
+    storage.setItem = setItem;
+    installLocalStorage(storage);
+    const originalConsoleError = console.error;
+    const consoleError = mock(() => undefined);
+    console.error = consoleError;
+
+    try {
+      renderAppShellForTest();
+
+      fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+
+      expect(screen.getByRole("button", { name: "Show sidebar" })).toBeTruthy();
+      expect(setItem).toHaveBeenCalledWith(LEFT_SIDEBAR_STORAGE_KEY, "collapsed");
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      console.error = originalConsoleError;
+    }
   });
 });

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -134,6 +134,10 @@ const createWorkspaceBranchState = (): WorkspaceBranchStateContextValue => ({
   switchBranch: async () => undefined,
 });
 
+type RenderAppShellForTestOptions = {
+  runtimeDefinitionsError?: string | null;
+};
+
 const createChecksState = (): ChecksStateContextValue => ({
   runtimeCheck: null,
   taskStoreCheck: null,
@@ -169,7 +173,9 @@ const createTasksState = (): TasksStateContextValue => ({
   humanRequestChangesTask: async () => undefined,
 });
 
-const renderAppShellForTest = (): ReturnType<typeof render> => {
+const renderAppShellForTest = (
+  options: RenderAppShellForTestOptions = {},
+): ReturnType<typeof render> => {
   const queryClient = createQueryClient();
   const settingsSnapshot = createSettingsSnapshotFixture();
   queryClient.setQueryData(settingsSnapshotQueryOptions().queryKey, settingsSnapshot);
@@ -190,7 +196,7 @@ const renderAppShellForTest = (): ReturnType<typeof render> => {
                       availableRuntimeDefinitions: [],
                       agentRuntimes: settingsSnapshot.agentRuntimes,
                       isLoadingRuntimeDefinitions: false,
-                      runtimeDefinitionsError: null,
+                      runtimeDefinitionsError: options.runtimeDefinitionsError ?? null,
                       refreshRuntimeDefinitions: async () => [],
                       loadRepoRuntimeCatalog: async () => {
                         throw new Error("loadRepoRuntimeCatalog is not used in this test");
@@ -275,6 +281,32 @@ describe("AppShell", () => {
     expect(collapsedSettingsButton.textContent?.trim()).toBe("");
     expect(collapsedSettingsButton.className).toContain("size-8");
     expect(collapsedSettingsButton.className).not.toContain("px-3");
+  });
+
+  test("keeps diagnostics available as a status-colored collapsed sidebar trigger", async () => {
+    globalThis.localStorage.setItem(LEFT_SIDEBAR_STORAGE_KEY, "collapsed");
+
+    renderAppShellForTest({ runtimeDefinitionsError: "Runtime definitions failed" });
+
+    const diagnosticsButton = screen.getByRole("button", {
+      hidden: true,
+      name: "Open diagnostics",
+    });
+    const diagnosticsIcon = diagnosticsButton.querySelector("svg");
+    expect(diagnosticsButton.className).toContain("size-8");
+    expect(diagnosticsButton.textContent?.trim()).toBe("");
+    expect(diagnosticsIcon?.getAttribute("class")).toContain("text-destructive-accent");
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Diagnostics" })).toBeTruthy());
+  });
+
+  test("opens diagnostics from the collapsed sidebar trigger", async () => {
+    globalThis.localStorage.setItem(LEFT_SIDEBAR_STORAGE_KEY, "collapsed");
+
+    renderAppShellForTest();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open diagnostics" }));
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Diagnostics" })).toBeTruthy());
   });
 
   test("stores collapsed and restores the collapsed sidebar after remount", () => {

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -41,8 +41,20 @@ const activeWorkspace = {
   effectiveWorktreeBasePath: null,
 } satisfies WorkspaceRecord;
 
+type MemoryStorageOverrides = {
+  getItem?: (key: string) => string | null;
+  setItem?: (key: string, value: string) => void;
+};
+
 class MemoryStorage implements Storage {
   readonly #items = new Map<string, string>();
+  readonly #getItemOverride: MemoryStorageOverrides["getItem"];
+  readonly #setItemOverride: MemoryStorageOverrides["setItem"];
+
+  constructor(overrides: MemoryStorageOverrides = {}) {
+    this.#getItemOverride = overrides.getItem;
+    this.#setItemOverride = overrides.setItem;
+  }
 
   get length(): number {
     return this.#items.size;
@@ -53,6 +65,10 @@ class MemoryStorage implements Storage {
   }
 
   getItem(key: string): string | null {
+    if (this.#getItemOverride) {
+      return this.#getItemOverride(key);
+    }
+
     return this.#items.get(key) ?? null;
   }
 
@@ -65,6 +81,11 @@ class MemoryStorage implements Storage {
   }
 
   setItem(key: string, value: string): void {
+    if (this.#setItemOverride) {
+      this.#setItemOverride(key, value);
+      return;
+    }
+
     this.#items.set(key, value);
   }
 }
@@ -299,12 +320,10 @@ describe("AppShell", () => {
   });
 
   test("defaults opened when storage cannot be read", () => {
-    const storage = new MemoryStorage();
     const getItem = mock(() => {
       throw new Error("read failed");
     });
-    storage.getItem = getItem;
-    installLocalStorage(storage);
+    installLocalStorage(new MemoryStorage({ getItem }));
     const originalConsoleError = console.error;
     const consoleError = mock(() => undefined);
     console.error = consoleError;
@@ -321,12 +340,10 @@ describe("AppShell", () => {
   });
 
   test("keeps sidebar toggling in memory when storage cannot be written", () => {
-    const storage = new MemoryStorage();
     const setItem = mock(() => {
       throw new Error("write failed");
     });
-    storage.setItem = setItem;
-    installLocalStorage(storage);
+    installLocalStorage(new MemoryStorage({ setItem }));
     const originalConsoleError = console.error;
     const consoleError = mock(() => undefined);
     console.error = consoleError;

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -290,10 +290,11 @@ describe("AppShell", () => {
 
     const diagnosticsButton = screen.getByRole("button", {
       hidden: true,
-      name: "Open diagnostics",
+      name: "Open diagnostics: Critical issue",
     });
     const diagnosticsIcon = diagnosticsButton.querySelector("svg");
     expect(diagnosticsButton.className).toContain("size-8");
+    expect(diagnosticsButton.getAttribute("title")).toBe("Open diagnostics: Critical issue");
     expect(diagnosticsButton.textContent?.trim()).toBe("");
     expect(diagnosticsIcon?.getAttribute("class")).toContain("text-destructive-accent");
     await waitFor(() => expect(screen.getByRole("heading", { name: "Diagnostics" })).toBeTruthy());
@@ -304,7 +305,7 @@ describe("AppShell", () => {
 
     renderAppShellForTest();
 
-    fireEvent.click(screen.getByRole("button", { name: "Open diagnostics" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Open diagnostics: / }));
 
     await waitFor(() => expect(screen.getByRole("heading", { name: "Diagnostics" })).toBeTruthy());
   });

--- a/packages/frontend/src/components/layout/app-shell.tsx
+++ b/packages/frontend/src/components/layout/app-shell.tsx
@@ -17,11 +17,53 @@ import { cn } from "@/lib/utils";
 import { useActiveWorkspace, useWorkspacePresence } from "@/state/app-state-provider";
 import { useShellAgentActivity } from "@/state/queries/use-shell-agent-activity";
 
+type AppShellSidebarPreference = "opened" | "collapsed";
+
+const APP_SHELL_LEFT_SIDEBAR_STORAGE_KEY = "openducktor:app-shell:left-sidebar";
+const DEFAULT_APP_SHELL_SIDEBAR_PREFERENCE: AppShellSidebarPreference = "opened";
+
+const isAppShellSidebarPreference = (value: string | null): value is AppShellSidebarPreference =>
+  value === "opened" || value === "collapsed";
+
+const readPersistedLeftSidebarPreference = (): AppShellSidebarPreference => {
+  try {
+    const storage = globalThis.localStorage;
+    if (!storage) {
+      return DEFAULT_APP_SHELL_SIDEBAR_PREFERENCE;
+    }
+
+    const preference = storage.getItem(APP_SHELL_LEFT_SIDEBAR_STORAGE_KEY);
+    if (isAppShellSidebarPreference(preference)) {
+      return preference;
+    }
+
+    return DEFAULT_APP_SHELL_SIDEBAR_PREFERENCE;
+  } catch (error) {
+    console.error("[app-shell] Failed to read persisted sidebar state.", { error });
+    return DEFAULT_APP_SHELL_SIDEBAR_PREFERENCE;
+  }
+};
+
+const persistLeftSidebarPreference = (preference: AppShellSidebarPreference): void => {
+  try {
+    const storage = globalThis.localStorage;
+    if (!storage) {
+      return;
+    }
+
+    storage.setItem(APP_SHELL_LEFT_SIDEBAR_STORAGE_KEY, preference);
+  } catch (error) {
+    console.error("[app-shell] Failed to persist sidebar state.", { preference, error });
+  }
+};
+
 export const AppShell = memo(function AppShell(): ReactElement {
   const activeWorkspace = useActiveWorkspace();
   const { hasWorkspaces } = useWorkspacePresence();
   const [isRepositoryModalOpen, setRepositoryModalOpen] = useState(false);
-  const [isSidebarOpen, setSidebarOpen] = useState(true);
+  const [isSidebarOpen, setSidebarOpen] = useState(
+    () => readPersistedLeftSidebarPreference() === "opened",
+  );
   const hasActiveWorkspace = activeWorkspace !== null;
   const isRepositoryModalBlocking = !hasActiveWorkspace && !hasWorkspaces;
   const agentActivity = useShellAgentActivity(activeWorkspace?.repoPath ?? null);
@@ -48,6 +90,16 @@ export const AppShell = memo(function AppShell(): ReactElement {
     setRepositoryModalOpen(true);
   }, []);
 
+  const handleHideSidebar = useCallback(() => {
+    setSidebarOpen(false);
+    persistLeftSidebarPreference("collapsed");
+  }, []);
+
+  const handleShowSidebar = useCallback(() => {
+    setSidebarOpen(true);
+    persistLeftSidebarPreference("opened");
+  }, []);
+
   return (
     <>
       <div className="h-screen min-h-screen w-full overflow-hidden">
@@ -70,7 +122,7 @@ export const AppShell = memo(function AppShell(): ReactElement {
                       size="icon"
                       variant="ghost"
                       className="mt-0.5 size-8 shrink-0 text-sidebar-muted-foreground hover:text-sidebar-foreground"
-                      onClick={() => setSidebarOpen(false)}
+                      onClick={handleHideSidebar}
                       aria-label="Hide sidebar"
                       title="Hide sidebar"
                     >
@@ -120,7 +172,7 @@ export const AppShell = memo(function AppShell(): ReactElement {
                   size="icon"
                   variant="ghost"
                   className="size-8 text-sidebar-muted-foreground hover:text-sidebar-foreground"
-                  onClick={() => setSidebarOpen(true)}
+                  onClick={handleShowSidebar}
                   aria-label="Show sidebar"
                   title="Show sidebar"
                 >

--- a/packages/frontend/src/components/layout/app-shell.tsx
+++ b/packages/frontend/src/components/layout/app-shell.tsx
@@ -178,6 +178,12 @@ export const AppShell = memo(function AppShell(): ReactElement {
                 >
                   <PanelLeftOpen className="size-4" />
                 </Button>
+                <div className="flex w-full justify-center border-t border-sidebar-border pt-2">
+                  <DiagnosticsPanel
+                    triggerClassName="text-sidebar-muted-foreground hover:text-sidebar-foreground"
+                    triggerVariant="icon"
+                  />
+                </div>
                 <div className="w-full border-t border-sidebar-border pt-2">
                   <SidebarNavigation hasActiveWorkspace={hasActiveWorkspace} compact />
                 </div>

--- a/packages/frontend/src/components/layout/app-shell.tsx
+++ b/packages/frontend/src/components/layout/app-shell.tsx
@@ -1,5 +1,5 @@
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
-import { memo, type ReactElement, useCallback, useEffect, useState } from "react";
+import { memo, type ReactElement, useCallback, useEffect, useRef, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { DiagnosticsPanel } from "@/components/features/diagnostics";
 import { OpenRepositoryModal } from "@/components/features/repository/open-repository-modal";
@@ -64,6 +64,11 @@ export const AppShell = memo(function AppShell(): ReactElement {
   const [isSidebarOpen, setSidebarOpen] = useState(
     () => readPersistedLeftSidebarPreference() === "opened",
   );
+  const diagnosticsAutoOpenedByRepoRef = useRef<Set<string> | null>(null);
+  if (diagnosticsAutoOpenedByRepoRef.current === null) {
+    diagnosticsAutoOpenedByRepoRef.current = new Set();
+  }
+  const diagnosticsAutoOpenedByRepo = diagnosticsAutoOpenedByRepoRef.current;
   const hasActiveWorkspace = activeWorkspace !== null;
   const isRepositoryModalBlocking = !hasActiveWorkspace && !hasWorkspaces;
   const agentActivity = useShellAgentActivity(activeWorkspace?.repoPath ?? null);
@@ -146,7 +151,7 @@ export const AppShell = memo(function AppShell(): ReactElement {
 
                   <BranchSwitcher />
 
-                  <DiagnosticsPanel />
+                  <DiagnosticsPanel autoOpenedByRepo={diagnosticsAutoOpenedByRepo} />
 
                   <SidebarNavigation hasActiveWorkspace={hasActiveWorkspace} />
                   <AgentActivityCard
@@ -180,6 +185,7 @@ export const AppShell = memo(function AppShell(): ReactElement {
                 </Button>
                 <div className="flex w-full justify-center border-t border-sidebar-border pt-2">
                   <DiagnosticsPanel
+                    autoOpenedByRepo={diagnosticsAutoOpenedByRepo}
                     triggerClassName="text-sidebar-muted-foreground hover:text-sidebar-foreground"
                     triggerVariant="icon"
                   />


### PR DESCRIPTION
Summary
This PR remembers the primary left app sidebar state across reloads and keeps diagnostics available and status-accessible when the sidebar is collapsed.

Goal
OpenDucktor already preserves adjacent UI preferences, such as Agent Studio panel state. The primary left sidebar previously reset to opened on reload, forcing users who prefer the collapsed layout to collapse it again every time. This PR persists that local UI preference while keeping the existing default-open behavior for first load and invalid storage.

Technical choices
- Stores a frontend-only raw localStorage value under `openducktor:app-shell:left-sidebar` with the logical values `opened` and `collapsed`.
- Restores the preference through lazy `AppShell` state initialization so the first render uses the stored state without an effect-time flicker.
- Persists only from the existing Hide sidebar and Show sidebar user actions, avoiding default writes on mount and avoiding any backend, task-store, contract, or SQLite change.
- Handles unavailable, invalid, or throwing storage by keeping the shell usable and defaulting opened on read failures.
- Adds a collapsed-sidebar diagnostics shield button using the existing diagnostics status model, with status color plus an accessible `aria-label` and `title` that include the current diagnostics state.
- Extends focused AppShell tests for persistence, storage failure behavior, collapsed settings availability, and collapsed diagnostics availability.

Verification
- Cargo: no `Cargo.toml` exists in this worktree, so cargo checks are not applicable.
- `rtk bun run lint`
- `rtk bun run typecheck`
- `rtk bun run test`
- `rtk bun run build`
- `rtk git diff --check`
- React Doctor on changed React files: `100 / 100`
- GitNexus final change detection: low risk for the final accessibility follow-up.

Target branch freshness
Fetched `origin/main` before creating the PR. `HEAD...origin/main` was `4 0`, so this branch is ahead by four commits and behind by zero; no rebase was required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar open/collapsed preference is now remembered between visits.
  * Diagnostics is now directly accessible from the collapsed sidebar via a compact icon trigger.
* **Bug Fixes**
  * Sidebar preference handling now safely falls back when saved data is missing, invalid, or can’t be read/written.
  * Diagnostics behavior no longer re-auto-opens after it’s been closed.
* **Tests**
  * Expanded app-shell tests to cover sidebar persistence, diagnostics trigger states, and failure/fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->