### PR TITLE
fix: centralize GitHub CLI invocation env

### DIFF
--- a/packages/host/src/adapters/system/system-command-runner.test.ts
+++ b/packages/host/src/adapters/system/system-command-runner.test.ts
@@ -32,6 +32,38 @@ describe("createSystemCommandRunner", () => {
     expect(result.stdout.trim()).toBe("from-host-env");
   });
 
+  test("per-command environment overrides inherited values", async () => {
+    const port = createSystemCommandRunner({
+      env: {
+        PATH: process.env.PATH,
+        FORCE_COLOR: "1",
+        CLICOLOR_FORCE: "1",
+        NO_COLOR: "0",
+      },
+      platform: process.platform,
+    });
+
+    const result = await Effect.runPromise(
+      port.runCommandAllowFailure(
+        "bun",
+        [
+          "-e",
+          "console.log([process.env.FORCE_COLOR, process.env.CLICOLOR_FORCE, process.env.NO_COLOR].join('|'))",
+        ],
+        {
+          env: {
+            FORCE_COLOR: "0",
+            CLICOLOR_FORCE: "0",
+            NO_COLOR: "1",
+          },
+        },
+      ),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.stdout.trim()).toBe("0|0|1");
+  });
+
   test("fails before spawn when command discovery cannot resolve the executable", async () => {
     const port = createSystemCommandRunner({
       env: { PATH: "" },

--- a/packages/host/src/application/diagnostics/system-diagnostics-service.test.ts
+++ b/packages/host/src/application/diagnostics/system-diagnostics-service.test.ts
@@ -103,24 +103,38 @@ const createRuntimeHealthPort = (
 const createSystemCommandPort = ({
   missingCommands = [],
   ghAuthResult = { ok: true, stdout: "Logged in to github.com account octocat\n", stderr: "" },
+  calls = [],
+  versionCalls = [],
   versionForCommand,
 }: {
   missingCommands?: string[];
   ghAuthResult?: SystemCommandRunResult;
+  calls?: Array<{
+    command: string;
+    args: string[];
+    options: Parameters<SystemCommandPort["runCommandAllowFailure"]>[2];
+  }>;
+  versionCalls?: Array<{
+    command: string;
+    args: string[];
+    options: Parameters<SystemCommandPort["versionCommand"]>[2];
+  }>;
   versionForCommand?: (command: string) => string | null | undefined;
 } = {}): SystemCommandPort => {
   const missing = new Set(missingCommands);
   const port: SystemCommandPort = {
     resolveCommandPath: (command) => Effect.succeed(missing.has(command) ? null : command),
-    versionCommand: (command, _args, _options) => {
+    versionCommand: (command, args, options) => {
+      versionCalls.push({ command, args, options });
       const version = versionForCommand?.(command);
       return Effect.succeed(
         missing.has(command) ? null : version === undefined ? `${command} version 1.0.0` : version,
       );
     },
-    runCommandAllowFailure: (command) =>
+    runCommandAllowFailure: (command, args, options) =>
       Effect.tryPromise({
         try: async () => {
+          calls.push({ command, args, options });
           if (command === "gh") {
             return ghAuthResult;
           }
@@ -189,6 +203,16 @@ const createSystemDiagnosticsServiceForTest = (
   });
 describe("createSystemDiagnosticsService", () => {
   test("runtimeCheck reports CLI, GitHub auth, runtime health, and config enablement", async () => {
+    const commandCalls: Array<{
+      command: string;
+      args: string[];
+      options: Parameters<SystemCommandPort["runCommandAllowFailure"]>[2];
+    }> = [];
+    const versionCommandCalls: Array<{
+      command: string;
+      args: string[];
+      options: Parameters<SystemCommandPort["versionCommand"]>[2];
+    }> = [];
     const service = createSystemDiagnosticsServiceForTest({
       runtimeDefinitionsService: createRuntimeDefinitions(),
       runtimeHealth: createRuntimeHealthPort({
@@ -201,7 +225,10 @@ describe("createSystemDiagnosticsService", () => {
           codex: { ...DEFAULT_AGENT_RUNTIMES.codex, enabled: false },
         },
       }),
-      systemCommands: createSystemCommandPort(),
+      systemCommands: createSystemCommandPort({
+        calls: commandCalls,
+        versionCalls: versionCommandCalls,
+      }),
       repoStoreDiagnostics: createTaskStore(),
     });
     const check = await Effect.runPromise(service.runtimeCheck(true));
@@ -219,6 +246,22 @@ describe("createSystemDiagnosticsService", () => {
       }),
     ]);
     expect(check.errors).toEqual([]);
+    expect(commandCalls.find((call) => call.command === "gh")?.options?.env).toMatchObject({
+      GH_PROMPT_DISABLED: "1",
+      NO_COLOR: "1",
+      CLICOLOR: "0",
+      CLICOLOR_FORCE: "0",
+      FORCE_COLOR: "0",
+    });
+    const ghVersionCall = versionCommandCalls.find((call) => call.command === "gh");
+    expect(ghVersionCall?.args).toEqual(["--version"]);
+    expect(ghVersionCall?.options?.env).toMatchObject({
+      GH_PROMPT_DISABLED: "1",
+      NO_COLOR: "1",
+      CLICOLOR: "0",
+      CLICOLOR_FORCE: "0",
+      FORCE_COLOR: "0",
+    });
   });
   test("runtimeCheck caches fresh results unless force refresh is requested", async () => {
     let version = "1.0.0";

--- a/packages/host/src/application/diagnostics/system-diagnostics-service.ts
+++ b/packages/host/src/application/diagnostics/system-diagnostics-service.ts
@@ -23,6 +23,7 @@ import type {
   ToolDiscoveryId,
   ToolDiscoveryPort,
 } from "../../ports/tool-discovery-port";
+import { readGithubCliVersion, runGithubCliCommand } from "../git/github-cli";
 import type { RuntimeDefinitionsService } from "../runtimes/runtime-definitions-service";
 
 type CachedRuntimeCheck = {
@@ -41,7 +42,6 @@ export type SystemDiagnosticsError =
   | TaskStoreError
   | ToolDiscoveryError;
 const RUNTIME_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
-const GH_NON_INTERACTIVE_ENV = { GH_PROMPT_DISABLED: "1" };
 const loadGlobalConfig = (settingsConfig: SettingsConfigPort) =>
   Effect.gen(function* () {
     return (yield* settingsConfig.readConfig()) ?? createDefaultGlobalConfig();
@@ -58,13 +58,12 @@ const parseGithubAuthLogin = (output: string): string | null => {
 };
 const probeGithubAuthStatus = (systemCommands: SystemCommandPort, ghCommand: string) =>
   Effect.gen(function* () {
-    const result: SystemCommandRunResult = yield* systemCommands.runCommandAllowFailure(
-      ghCommand,
-      ["auth", "status", "--hostname", "github.com"],
-      {
-        env: GH_NON_INTERACTIVE_ENV,
-      },
-    );
+    const result: SystemCommandRunResult = yield* runGithubCliCommand(systemCommands, ghCommand, [
+      "auth",
+      "status",
+      "--hostname",
+      "github.com",
+    ]);
     const stdout = result.stdout.trim();
     const stderr = result.stderr.trim();
     const combined =
@@ -131,14 +130,13 @@ const resolveToolAvailability = (
     ),
   );
 const versionForResolvedTool = (
-  systemCommands: SystemCommandPort,
   toolName: string,
   toolPath: string | null,
-  args: string[],
+  readVersion: (toolPath: string) => ReturnType<SystemCommandPort["versionCommand"]>,
 ) =>
   toolPath === null
     ? Effect.succeed({ error: null, version: null } satisfies ToolVersionAvailability)
-    : Effect.either(systemCommands.versionCommand(toolPath, args)).pipe(
+    : Effect.either(readVersion(toolPath)).pipe(
         Effect.map((result) => {
           if (result._tag === "Left") {
             return {
@@ -175,12 +173,12 @@ export const createSystemDiagnosticsService = ({
     Effect.gen(function* () {
       const gitTool = yield* resolveToolAvailability(toolDiscovery, "git");
       const ghTool = yield* resolveToolAvailability(toolDiscovery, "githubCli");
-      const gitVersion = yield* versionForResolvedTool(systemCommands, "git", gitTool.path, [
-        "--version",
-      ]);
-      const ghVersion = yield* versionForResolvedTool(systemCommands, "gh", ghTool.path, [
-        "--version",
-      ]);
+      const gitVersion = yield* versionForResolvedTool("git", gitTool.path, (path) =>
+        systemCommands.versionCommand(path, ["--version"]),
+      );
+      const ghVersion = yield* versionForResolvedTool("gh", ghTool.path, (path) =>
+        readGithubCliVersion(systemCommands, path),
+      );
       const gitError = gitTool.error ?? gitVersion.error;
       const ghError = ghTool.error ?? ghVersion.error;
       const gitOk = gitError === null;

--- a/packages/host/src/application/git/github-cli.test.ts
+++ b/packages/host/src/application/git/github-cli.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import type {
+  SystemCommandPort,
+  SystemCommandRunOptions,
+  SystemCommandRunResult,
+} from "../../ports/system-command-port";
+import { readGithubCliVersion, runGithubCliCommand } from "./github-cli";
+
+type RunCall = {
+  command: string;
+  args: string[];
+  options: SystemCommandRunOptions | undefined;
+};
+
+type VersionCall = RunCall;
+
+const createSystemCommandPort = ({
+  runResult = { ok: true, stdout: "{}", stderr: "" },
+  versionResult = "gh version 2.95.0",
+}: {
+  runResult?: SystemCommandRunResult;
+  versionResult?: string | null;
+} = {}) => {
+  const runCalls: RunCall[] = [];
+  const versionCalls: VersionCall[] = [];
+  const port: SystemCommandPort = {
+    resolveCommandPath(command) {
+      return Effect.succeed(command);
+    },
+    versionCommand(command, args, options) {
+      versionCalls.push({ command, args, options });
+      return Effect.succeed(versionResult);
+    },
+    runCommandAllowFailure(command, args, options) {
+      runCalls.push({ command, args, options });
+      return Effect.succeed(runResult);
+    },
+  };
+
+  return { port, runCalls, versionCalls };
+};
+
+describe("GitHub CLI command helpers", () => {
+  test("runGithubCliCommand preserves command options and enforces machine-readable env", async () => {
+    const { port, runCalls } = createSystemCommandPort();
+
+    await Effect.runPromise(
+      runGithubCliCommand(port, "gh", ["api", "repos/openai/openducktor/pulls"], {
+        cwd: "/repo",
+        env: {
+          FORCE_COLOR: "1",
+          CLICOLOR_FORCE: "1",
+          CUSTOM_TOKEN: "kept",
+        },
+        timeoutMs: 1234,
+      }),
+    );
+
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0]).toEqual({
+      command: "gh",
+      args: ["api", "repos/openai/openducktor/pulls"],
+      options: {
+        cwd: "/repo",
+        env: {
+          CUSTOM_TOKEN: "kept",
+          GH_PROMPT_DISABLED: "1",
+          NO_COLOR: "1",
+          CLICOLOR: "0",
+          CLICOLOR_FORCE: "0",
+          FORCE_COLOR: "0",
+        },
+        timeoutMs: 1234,
+      },
+    });
+  });
+
+  test("readGithubCliVersion uses the same machine-readable env", async () => {
+    const { port, versionCalls } = createSystemCommandPort();
+
+    await Effect.runPromise(
+      readGithubCliVersion(port, "gh", {
+        env: {
+          FORCE_COLOR: "1",
+          CUSTOM_PATH: "/bin",
+        },
+      }),
+    );
+
+    expect(versionCalls).toEqual([
+      {
+        command: "gh",
+        args: ["--version"],
+        options: {
+          env: {
+            CUSTOM_PATH: "/bin",
+            GH_PROMPT_DISABLED: "1",
+            NO_COLOR: "1",
+            CLICOLOR: "0",
+            CLICOLOR_FORCE: "0",
+            FORCE_COLOR: "0",
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/host/src/application/git/github-cli.ts
+++ b/packages/host/src/application/git/github-cli.ts
@@ -1,0 +1,32 @@
+import type { SystemCommandPort, SystemCommandRunOptions } from "../../ports/system-command-port";
+
+const GITHUB_CLI_MACHINE_ENV = {
+  GH_PROMPT_DISABLED: "1",
+  NO_COLOR: "1",
+  CLICOLOR: "0",
+  CLICOLOR_FORCE: "0",
+  FORCE_COLOR: "0",
+};
+
+const githubCliCommandOptions = (
+  options: SystemCommandRunOptions = {},
+): SystemCommandRunOptions => ({
+  ...options,
+  env: {
+    ...(options.env ?? {}),
+    ...GITHUB_CLI_MACHINE_ENV,
+  },
+});
+
+export const runGithubCliCommand = (
+  systemCommands: SystemCommandPort,
+  ghCommand: string,
+  args: string[],
+  options?: SystemCommandRunOptions,
+) => systemCommands.runCommandAllowFailure(ghCommand, args, githubCliCommandOptions(options));
+
+export const readGithubCliVersion = (
+  systemCommands: SystemCommandPort,
+  ghCommand: string,
+  options?: SystemCommandRunOptions,
+) => systemCommands.versionCommand(ghCommand, ["--version"], githubCliCommandOptions(options));

--- a/packages/host/src/application/tasks/support/github-pull-request-model.ts
+++ b/packages/host/src/application/tasks/support/github-pull-request-model.ts
@@ -3,7 +3,6 @@ import { pullRequestSchema } from "@openducktor/contracts";
 import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 
 export const GITHUB_PROVIDER_ID = "github";
-export const GH_NON_INTERACTIVE_ENV = { GH_PROMPT_DISABLED: "1" };
 
 export const repositoryKey = (repository: { host: string; owner: string; name: string }): string =>
   `${repository.host}/${repository.owner}/${repository.name}`.toLowerCase();

--- a/packages/host/src/application/tasks/support/github-pull-requests.test.ts
+++ b/packages/host/src/application/tasks/support/github-pull-requests.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { PullRequest } from "@openducktor/contracts";
-import { pullRequestRecordsMatch } from "./github-pull-requests";
+import { Effect } from "effect";
+import type { SystemCommandPort } from "../../../ports/system-command-port";
+import type { ToolDiscoveryPort } from "../../../ports/tool-discovery-port";
+import {
+  findGithubPullRequestForBranch,
+  type GithubCommandDependencies,
+  pullRequestRecordsMatch,
+} from "./github-pull-requests";
 
 const pullRequest = (overrides: Partial<PullRequest> = {}): PullRequest => ({
   providerId: "github",
@@ -27,5 +34,73 @@ describe("pullRequestRecordsMatch", () => {
     expect(
       pullRequestRecordsMatch(pullRequest({ state: "open" }), pullRequest({ state: "merged" })),
     ).toBe(false);
+  });
+});
+
+describe("findGithubPullRequestForBranch", () => {
+  test("disables inherited CLI color so gh api stdout remains parseable JSON", async () => {
+    const commandCalls: Array<{
+      args: string[];
+      options: Parameters<SystemCommandPort["runCommandAllowFailure"]>[2];
+    }> = [];
+    const systemCommands: SystemCommandPort = {
+      resolveCommandPath(command) {
+        return Effect.succeed(command);
+      },
+      versionCommand() {
+        return Effect.succeed("gh version 2.95.0");
+      },
+      runCommandAllowFailure(_command, args, options) {
+        commandCalls.push({ args, options });
+        const machineJson =
+          options?.env?.NO_COLOR === "1" &&
+          options.env.FORCE_COLOR === "0" &&
+          options.env.CLICOLOR_FORCE === "0";
+        return Effect.succeed({
+          ok: true,
+          stdout: machineJson ? "[]" : "\u001b[1;37m[\u001b[m\u001b[1;37m]\u001b[m\n",
+          stderr: "",
+        });
+      },
+    };
+    const toolDiscovery: ToolDiscoveryPort = {
+      resolveTool() {
+        return Effect.succeed({
+          displayLabel: "System PATH",
+          path: "gh",
+          sourceCategory: "system_path",
+        });
+      },
+      resolveToolPath() {
+        return Effect.succeed("gh");
+      },
+    };
+    const dependencies: GithubCommandDependencies = {
+      resolveGithubCommand: () => Effect.succeed({ ghCommand: "gh", systemCommands }),
+      systemCommands,
+      toolDiscovery,
+    };
+
+    const pullRequest = await Effect.runPromise(
+      findGithubPullRequestForBranch(
+        dependencies,
+        "/repo",
+        {
+          repository: { host: "github.com", owner: "Maxsky5", name: "openducktor" },
+          remoteName: "origin",
+        },
+        "odt/task-1",
+        "open",
+      ),
+    );
+
+    expect(pullRequest).toBeUndefined();
+    expect(commandCalls[0]?.options?.env).toMatchObject({
+      GH_PROMPT_DISABLED: "1",
+      NO_COLOR: "1",
+      CLICOLOR: "0",
+      CLICOLOR_FORCE: "0",
+      FORCE_COLOR: "0",
+    });
   });
 });

--- a/packages/host/src/application/tasks/support/github-pull-requests.ts
+++ b/packages/host/src/application/tasks/support/github-pull-requests.ts
@@ -10,10 +10,10 @@ import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 import type { GitPort } from "../../../ports/git-port";
 import type { SystemCommandPort, SystemCommandRunResult } from "../../../ports/system-command-port";
 import type { ToolDiscoveryError, ToolDiscoveryPort } from "../../../ports/tool-discovery-port";
+import { runGithubCliCommand } from "../../git/github-cli";
 import { parseGithubRemoteUrl } from "../../git/github-repository-detection-service";
 import {
   combinedCommandOutput,
-  GH_NON_INTERACTIVE_ENV,
   GITHUB_PROVIDER_ID,
   type GithubPullRequestContext,
   type GithubPullRequestSyncPolicy,
@@ -123,11 +123,12 @@ export const githubProviderStatus = (
       };
     }
     const authStatusResult = yield* Effect.either(
-      dependencies.systemCommands.runCommandAllowFailure(
-        ghCommand,
-        ["auth", "status", "--hostname", repository.host],
-        { env: GH_NON_INTERACTIVE_ENV },
-      ),
+      runGithubCliCommand(dependencies.systemCommands, ghCommand, [
+        "auth",
+        "status",
+        "--hostname",
+        repository.host,
+      ]),
     );
     if (authStatusResult._tag === "Left") {
       return {
@@ -178,12 +179,12 @@ const runGithubCommand = (
   Effect.gen(function* () {
     const hostArgs = host.trim() ? ["--hostname", host.trim(), ...args] : args;
     const githubCommand = yield* resolveGithubCommandDependencies(dependencies);
-    const result = yield* githubCommand.systemCommands.runCommandAllowFailure(
+    const result = yield* runGithubCliCommand(
+      githubCommand.systemCommands,
       githubCommand.ghCommand,
       hostArgs,
       {
         cwd: repoPath,
-        env: GH_NON_INTERACTIVE_ENV,
       },
     );
     if (result.ok) {
@@ -241,13 +242,12 @@ const probeResolvedGithubAuthOrThrow = (
   host: string,
 ) =>
   Effect.gen(function* () {
-    const result = yield* dependencies.systemCommands.runCommandAllowFailure(
-      dependencies.ghCommand,
-      ["auth", "status", "--hostname", host],
-      {
-        env: GH_NON_INTERACTIVE_ENV,
-      },
-    );
+    const result = yield* runGithubCliCommand(dependencies.systemCommands, dependencies.ghCommand, [
+      "auth",
+      "status",
+      "--hostname",
+      host,
+    ]);
     if (result.ok) {
       return;
     }

--- a/packages/host/src/application/tasks/task-service-pull-requests.test.ts
+++ b/packages/host/src/application/tasks/task-service-pull-requests.test.ts
@@ -242,6 +242,22 @@ describe("createTaskService pull requests", () => {
         pullRequest: expect.objectContaining({ number: 42, state: "open" }),
       },
     });
+    expect(calls).toContainEqual(
+      expect.objectContaining({
+        type: "command",
+        command: "gh",
+        args: expect.arrayContaining(["api", "state=open"]),
+        options: expect.objectContaining({
+          env: expect.objectContaining({
+            GH_PROMPT_DISABLED: "1",
+            NO_COLOR: "1",
+            CLICOLOR: "0",
+            CLICOLOR_FORCE: "0",
+            FORCE_COLOR: "0",
+          }),
+        }),
+      }),
+    );
   });
   test("detectPullRequest preserves task policy errors for invalid workflow statuses", async () => {
     const calls: unknown[] = [];


### PR DESCRIPTION
Summary

Centralizes every host-side GitHub CLI execution behind a small helper that always disables prompts and colored output before calling `gh`.

Goal

OpenDucktor started failing to parse GitHub pull request responses when the Electron process inherited color-forcing environment variables such as `FORCE_COLOR=1` or `CLICOLOR_FORCE=1`. The immediate failure was in PR detection, but the same risk applied to other `gh` interactions if each caller had to remember the exact environment contract.

Implementation

- Added `packages/host/src/application/git/github-cli.ts` with `runGithubCliCommand` and `readGithubCliVersion`.
- Moved the machine-readable `gh` environment into that helper: `GH_PROMPT_DISABLED=1`, `NO_COLOR=1`, `CLICOLOR=0`, `CLICOLOR_FORCE=0`, and `FORCE_COLOR=0`.
- Updated PR support and diagnostics so `gh api`, `gh auth status`, and `gh --version` all share the same invocation path.
- Kept caller options such as `cwd`, `timeoutMs`, and custom env entries, while forcing the GitHub CLI output-related vars at the helper boundary.
- Added regression coverage for ANSI-colored PR JSON, diagnostics auth/version probes, and command-runner env overriding.

Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `git diff --cached --check`
- GitNexus staged change detection: low risk, no affected execution flows

No Cargo checks were run because this checkout has no `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub CLI commands now run with consistent, non-interactive settings, helping command-line operations behave more reliably.
  * Runtime checks now use a shared approach for reading tool versions and checking GitHub authentication.

* **Bug Fixes**
  * Improved handling of environment overrides so command-specific settings are respected.
  * Expanded coverage around pull request discovery and GitHub CLI behavior to reduce regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->