### PR TITLE
feat(frontend): persist chat composer drafts

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -10,6 +10,7 @@ import {
 import {
   flushAgentChatDraft,
   resetAgentChatDraftStoreForTests,
+  setAgentChatDraftAttachmentStagerForTests,
   setAgentChatDraftStorageForTests,
 } from "./agent-chat-draft-store";
 import { buildModelSelection } from "./agent-chat-test-fixtures";
@@ -109,6 +110,17 @@ const sessionIdentity = (externalSessionId: string): AgentChatDraftSessionIdenti
   workspaceId: "workspace-repo",
   externalSessionId,
 });
+
+const createDeferred = <T,>() => {
+  let resolve: ((value: T) => void) | null = null;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return {
+    promise,
+    resolve: (value: T) => resolve?.(value),
+  };
+};
 
 const getEditorRoot = (container: HTMLElement): HTMLElement => {
   const editorRoot = container.querySelector('[contenteditable="true"]');
@@ -313,6 +325,71 @@ describe("AgentChatComposer attachments", () => {
 
     await waitFor(() => {
       expect(onSend).toHaveBeenCalledTimes(1);
+      expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+    });
+  });
+
+  test("clears a successfully sent attachment draft when staging resolves during send", async () => {
+    const storage = createMemoryStorage();
+    const identity = sessionIdentity("session-a");
+    const stagedPath = createDeferred<string>();
+    const sendResult = createDeferred<boolean>();
+    const onSend = mock(() => sendResult.promise);
+    const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftAttachmentStagerForTests(mock(() => stagedPath.promise));
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          onSend,
+          displayedSessionKey: "session-a",
+          draftStateKey: "draft-a",
+          draftPersistenceIdentity: identity,
+          selectedModelDescriptor: {
+            id: "openai/gpt-5.3-codex",
+            providerId: "openai",
+            providerName: "OpenAI",
+            modelId: "gpt-5.3-codex",
+            modelName: "GPT-5.3 Codex",
+            variants: ["high"],
+            contextWindow: 400_000,
+            outputLimit: 128_000,
+            attachmentSupport: {
+              image: false,
+              audio: false,
+              video: false,
+              pdf: true,
+            },
+          },
+        }}
+      />,
+    );
+
+    const attachmentInput = container.querySelector('input[type="file"]');
+    if (!(attachmentInput instanceof HTMLInputElement)) {
+      throw new Error("Expected hidden attachment input");
+    }
+    fireEvent.change(attachmentInput, {
+      target: { files: [file] },
+    });
+    typeIntoComposer(container, "send with attachment");
+    const flushPromise = flushAgentChatDraft(identity);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+
+    stagedPath.resolve("/tmp/staged/brief.pdf");
+    await flushPromise;
+    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toContain(
+      "/tmp/staged/brief.pdf",
+    );
+
+    sendResult.resolve(true);
+
+    await waitFor(() => {
       expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
     });
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -1,8 +1,20 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createRef } from "react";
 import { AgentChatComposer } from "./agent-chat-composer";
+import {
+  type AgentChatDraftSessionIdentity,
+  toAgentChatDraftStorageKey,
+  writeAgentChatDraftToStorage,
+} from "./agent-chat-draft-storage";
+import {
+  flushAgentChatDraft,
+  resetAgentChatDraftStoreForTests,
+  setAgentChatDraftStorageForTests,
+} from "./agent-chat-draft-store";
 import { buildModelSelection } from "./agent-chat-test-fixtures";
+
+type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
 
 const SHARED_CALLBACKS = {
   onSend: async () => true,
@@ -22,6 +34,7 @@ const buildModel = () => ({
   busySendBlockedReason: null,
   pendingInlineCommentCount: 0,
   draftStateKey: "draft-1",
+  draftPersistenceIdentity: null,
   onSend: SHARED_CALLBACKS.onSend,
   isSending: false,
   isStarting: false,
@@ -70,6 +83,31 @@ const buildModel = () => ({
   onComposerEditorInput: SHARED_CALLBACKS.onComposerEditorInput,
   scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
   syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
+});
+
+const createMemoryStorage = (spies?: { getItem?: (key: string) => void }): TestStorage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    getItem: (key) => {
+      spies?.getItem?.(key);
+      return store.get(key) ?? null;
+    },
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+};
+
+const sessionIdentity = (externalSessionId: string): AgentChatDraftSessionIdentity => ({
+  workspaceId: "workspace-repo",
+  externalSessionId,
 });
 
 const getEditorRoot = (container: HTMLElement): HTMLElement => {
@@ -123,6 +161,198 @@ const createClipboardData = ({ itemFile, files }: { itemFile?: File; files?: Fil
 });
 
 describe("AgentChatComposer attachments", () => {
+  afterEach(() => {
+    resetAgentChatDraftStoreForTests();
+  });
+
+  test("restores independent in-memory drafts when switching sessions", async () => {
+    const storage = createMemoryStorage();
+    setAgentChatDraftStorageForTests(storage);
+    const sessionA = sessionIdentity("session-a");
+    const sessionB = sessionIdentity("session-b");
+    const { container, rerender } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          displayedSessionKey: "session-a",
+          draftStateKey: "draft-a",
+          draftPersistenceIdentity: sessionA,
+        }}
+      />,
+    );
+
+    typeIntoComposer(container, "hello A");
+    rerender(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          displayedSessionKey: "session-b",
+          draftStateKey: "draft-b",
+          draftPersistenceIdentity: sessionB,
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.textContent).not.toContain("hello A");
+    });
+
+    typeIntoComposer(container, "hello B");
+    rerender(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          displayedSessionKey: "session-a",
+          draftStateKey: "draft-a",
+          draftPersistenceIdentity: sessionA,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("hello A");
+    });
+    expect(container.textContent).not.toContain("hello B");
+  });
+
+  test("does not reread localStorage after a session has hydrated into memory", async () => {
+    const getItem = mock((_key: string) => {});
+    const storage = createMemoryStorage({ getItem });
+    setAgentChatDraftStorageForTests(storage);
+    const sessionA = sessionIdentity("session-a");
+    const sessionB = sessionIdentity("session-b");
+
+    const { rerender } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          displayedSessionKey: "session-a",
+          draftStateKey: "draft-a",
+          draftPersistenceIdentity: sessionA,
+        }}
+      />,
+    );
+    rerender(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          displayedSessionKey: "session-b",
+          draftStateKey: "draft-b",
+          draftPersistenceIdentity: sessionB,
+        }}
+      />,
+    );
+    rerender(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          displayedSessionKey: "session-a",
+          draftStateKey: "draft-a",
+          draftPersistenceIdentity: sessionA,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      const sessionAReads = getItem.mock.calls.filter(
+        ([key]) => key === toAgentChatDraftStorageKey(sessionA),
+      );
+      expect(sessionAReads).toHaveLength(1);
+    });
+  });
+
+  test("restores a persisted draft when the selected session loads", async () => {
+    const storage = createMemoryStorage();
+    const identity = sessionIdentity("session-a");
+    setAgentChatDraftStorageForTests(storage);
+    writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft: { segments: [{ id: "text-1", kind: "text", text: "restored" }], attachments: [] },
+      updatedAt: new Date().toISOString(),
+    });
+
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          displayedSessionKey: "session-a",
+          draftStateKey: "draft-a",
+          draftPersistenceIdentity: identity,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("restored");
+    });
+  });
+
+  test("clears the submitted session draft after a successful send", async () => {
+    const storage = createMemoryStorage();
+    const identity = sessionIdentity("session-a");
+    const onSend = mock(async () => true);
+    setAgentChatDraftStorageForTests(storage);
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          onSend,
+          displayedSessionKey: "session-a",
+          draftStateKey: "draft-a",
+          draftPersistenceIdentity: identity,
+        }}
+      />,
+    );
+
+    typeIntoComposer(container, "send me");
+    await flushAgentChatDraft(identity);
+    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+      expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+    });
+  });
+
+  test("restores the submitted draft when send returns false", async () => {
+    let resolveSend: (didSend: boolean) => void = () => {};
+    const onSend = mock(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSend = resolve;
+        }),
+    );
+    const storage = createMemoryStorage();
+    const identity = sessionIdentity("session-a");
+    setAgentChatDraftStorageForTests(storage);
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          onSend,
+          displayedSessionKey: "session-a",
+          draftStateKey: "draft-a",
+          draftPersistenceIdentity: identity,
+        }}
+      />,
+    );
+
+    typeIntoComposer(container, "keep me");
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => {
+      expect(container.textContent).not.toContain("keep me");
+    });
+
+    resolveSend(false);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("keep me");
+    });
+  });
+
   test("stages attachments, revalidates on model changes, and removes them", async () => {
     const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
     const { container, rerender } = render(<AgentChatComposer model={buildModel()} />);

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -106,9 +106,14 @@ const createMemoryStorage = (spies?: { getItem?: (key: string) => void }): TestS
   };
 };
 
-const sessionIdentity = (externalSessionId: string): AgentChatDraftSessionIdentity => ({
+const sessionIdentity = (
+  externalSessionId: string,
+  workingDirectory = "/repo",
+): AgentChatDraftSessionIdentity => ({
   workspaceId: "workspace-repo",
   externalSessionId,
+  runtimeKind: "opencode",
+  workingDirectory,
 });
 
 const createDeferred = <T,>() => {
@@ -180,8 +185,8 @@ describe("AgentChatComposer attachments", () => {
   test("restores independent in-memory drafts when switching sessions", async () => {
     const storage = createMemoryStorage();
     setAgentChatDraftStorageForTests(storage);
-    const sessionA = sessionIdentity("session-a");
-    const sessionB = sessionIdentity("session-b");
+    const sessionA = sessionIdentity("session-shared", "/repo-a");
+    const sessionB = sessionIdentity("session-shared", "/repo-b");
     const { container, rerender } = render(
       <AgentChatComposer
         model={{

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
@@ -13,6 +13,7 @@ const buildModel = () => ({
   busySendBlockedReason: null,
   pendingInlineCommentCount: 0,
   draftStateKey: "draft-1",
+  draftPersistenceIdentity: null,
   onSend: async () => true,
   isSending: false,
   isStarting: false,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -17,7 +17,6 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
 } from "react";
 import { toast } from "sonner";
 import { BorderRay } from "@/components/ui/border-ray";
@@ -49,6 +48,7 @@ import {
   setCaretOffsetWithinElement,
 } from "./agent-chat-composer-selection";
 import { AgentContextUsageIndicator } from "./agent-context-usage-indicator";
+import { useAgentChatComposerDraftState } from "./use-agent-chat-composer-draft-state";
 
 export type AgentChatComposerHandle = {
   addFiles: (files: File[]) => void;
@@ -540,6 +540,7 @@ export function AgentChatComposer({
     busySendBlockedReason,
     pendingInlineCommentCount,
     draftStateKey,
+    draftPersistenceIdentity,
     onSend,
     isSending,
     isStarting,
@@ -559,17 +560,19 @@ export function AgentChatComposer({
     syncBottomAfterComposerLayoutRef,
   } = model;
 
-  const [draftState, setDraftState] = useState(() => ({
-    key: draftStateKey,
-    draft: createEmptyComposerDraft(),
-  }));
-  const latestDraftRef = useRef<AgentChatComposerDraft>(draftState.draft);
-  let draft = draftState.draft;
-  if (draftState.key !== draftStateKey) {
-    draft = createEmptyComposerDraft();
-    latestDraftRef.current = draft;
-    setDraftState({ key: draftStateKey, draft });
-  }
+  const {
+    draft,
+    commitDraft,
+    setDisplayedDraft,
+    createSubmittedDraftSnapshot,
+    clearSubmittedDraft,
+    restoreSubmittedDraft,
+  } = useAgentChatComposerDraftState({
+    draftStateKey,
+    persistenceIdentity: draftPersistenceIdentity,
+    taskId,
+  });
+  const latestDraftRef = useRef<AgentChatComposerDraft>(draft);
   const latestSendDisabledRef = useRef(false);
   const latestOnSendRef = useRef(onSend);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
@@ -585,9 +588,9 @@ export function AgentChatComposer({
   const handleDraftChange = useCallback(
     (nextDraft: AgentChatComposerDraft) => {
       latestDraftRef.current = nextDraft;
-      setDraftState({ key: draftStateKey, draft: nextDraft });
+      commitDraft(nextDraft);
     },
-    [draftStateKey],
+    [commitDraft],
   );
 
   const handleRemoveAttachment = useCallback(
@@ -619,14 +622,10 @@ export function AgentChatComposer({
       if (attachments.length === 0) {
         return;
       }
-      setDraftState((currentState) => {
-        const nextDraft = appendAttachmentsToDraft(currentState.draft, attachments);
-        latestDraftRef.current = nextDraft;
-        return { key: currentState.key, draft: nextDraft };
-      });
+      handleDraftChange(appendAttachmentsToDraft(latestDraftRef.current, attachments));
       onComposerEditorInput();
     },
-    [attachmentIntakeDisabled, onComposerEditorInput],
+    [attachmentIntakeDisabled, handleDraftChange, onComposerEditorInput],
   );
 
   useImperativeHandle(
@@ -710,42 +709,38 @@ export function AgentChatComposer({
     if (latestSendDisabledRef.current) {
       return;
     }
-    const submitKey = draftStateKey;
     const submittedDraft = latestDraftRef.current;
-    setDraftState({ key: submitKey, draft: createEmptyComposerDraft() });
+    const submittedSnapshot = createSubmittedDraftSnapshot(submittedDraft);
+    setDisplayedDraft(createEmptyComposerDraft());
     onComposerEditorInput();
     scheduleComposerFocus();
     try {
       const didSend = await latestOnSendRef.current(submittedDraft);
       if (!didSend) {
-        setDraftState((currentState) => ({
-          key: currentState.key,
-          draft:
-            currentState.key !== submitKey || draftHasMeaningfulContent(currentState.draft)
-              ? currentState.draft
-              : submittedDraft,
-        }));
+        restoreSubmittedDraft(submittedSnapshot);
         onComposerEditorInput();
         scheduleComposerFocus();
         return;
       }
+      clearSubmittedDraft(submittedSnapshot);
       scheduleComposerFocus();
     } catch (error) {
       const description = error instanceof Error ? error.message : String(error);
       toast.error("Unable to send message", {
         description,
       });
-      setDraftState((currentState) => ({
-        key: currentState.key,
-        draft:
-          currentState.key !== submitKey || draftHasMeaningfulContent(currentState.draft)
-            ? currentState.draft
-            : submittedDraft,
-      }));
+      restoreSubmittedDraft(submittedSnapshot);
       onComposerEditorInput();
       scheduleComposerFocus();
     }
-  }, [draftStateKey, onComposerEditorInput, scheduleComposerFocus]);
+  }, [
+    clearSubmittedDraft,
+    createSubmittedDraftSnapshot,
+    onComposerEditorInput,
+    restoreSubmittedDraft,
+    scheduleComposerFocus,
+    setDisplayedDraft,
+  ]);
   const submitComposerAction = useCallback((): void => {
     void handleSubmit();
   }, [handleSubmit]);

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.test.ts
@@ -240,6 +240,27 @@ describe("agent chat draft storage", () => {
     expect(storage.getItem(key)).toBeNull();
   });
 
+  test("removes drafts with future update dates during restore", () => {
+    const storage = createMemoryStorage();
+    const key = toAgentChatDraftStorageKey(identity);
+    writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft: { segments: [createTextSegment("future", "text-1")], attachments: [] },
+      updatedAt: "2026-07-09T10:00:01.000Z",
+    });
+
+    const result = readAgentChatDraftFromStorage({
+      storage,
+      identity,
+      now: new Date("2026-07-09T10:00:00.000Z"),
+    });
+
+    expect(result.status).toBe("invalid");
+    expect(storage.getItem(key)).toBeNull();
+  });
+
   test("persists payloads at the size boundary and removes stale payloads above it", () => {
     const storage = createMemoryStorage();
     const key = toAgentChatDraftStorageKey(identity);

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.test.ts
@@ -154,6 +154,37 @@ describe("agent chat draft storage", () => {
     expect(storage.getItem("unrelated")).toBe("kept");
   });
 
+  test("removes payloads with malformed nested reference segments", () => {
+    const storage = createMemoryStorage();
+    const key = toAgentChatDraftStorageKey(identity);
+    storage.setItem(
+      key,
+      JSON.stringify({
+        version: 1,
+        workspaceId: identity.workspaceId,
+        externalSessionId: identity.externalSessionId,
+        taskId: "task-1",
+        updatedAt: "2026-07-01T10:00:00.000Z",
+        draft: {
+          segments: [
+            { id: "text-1", kind: "text", text: "Use " },
+            { id: "skill-1", kind: "skill_mention", skill: {} },
+          ],
+          attachments: [],
+        },
+      }),
+    );
+
+    const result = readAgentChatDraftFromStorage({
+      storage,
+      identity,
+      now: new Date("2026-07-02T10:00:00.000Z"),
+    });
+
+    expect(result.status).toBe("invalid");
+    expect(storage.getItem(key)).toBeNull();
+  });
+
   test("removes drafts older than seven days during restore", () => {
     const storage = createMemoryStorage();
     const key = toAgentChatDraftStorageKey(identity);

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.test.ts
@@ -41,6 +41,8 @@ const createMemoryStorage = (): TestStorage => {
 const identity: AgentChatDraftSessionIdentity = {
   workspaceId: "workspace:one",
   externalSessionId: "session/one",
+  runtimeKind: "opencode",
+  workingDirectory: "/workspace/one",
 };
 
 const command = {
@@ -94,9 +96,9 @@ const buildStructuredDraft = (): AgentChatComposerDraft => ({
 });
 
 describe("agent chat draft storage", () => {
-  test("builds storage keys from workspace and external session identity", () => {
+  test("builds storage keys from workspace and canonical session identity", () => {
     expect(toAgentChatDraftStorageKey(identity)).toBe(
-      "openducktor:agent-chat:draft:v1:workspace%3Aone:session%2Fone",
+      "openducktor:agent-chat:draft:v2:workspace%3Aone:session%2Fone|opencode|%2Fworkspace%2Fone",
     );
   });
 
@@ -160,9 +162,11 @@ describe("agent chat draft storage", () => {
     storage.setItem(
       key,
       JSON.stringify({
-        version: 1,
+        version: 2,
         workspaceId: identity.workspaceId,
         externalSessionId: identity.externalSessionId,
+        runtimeKind: identity.runtimeKind,
+        workingDirectory: identity.workingDirectory,
         taskId: "task-1",
         updatedAt: "2026-07-01T10:00:00.000Z",
         draft: {
@@ -170,6 +174,36 @@ describe("agent chat draft storage", () => {
             { id: "text-1", kind: "text", text: "Use " },
             { id: "skill-1", kind: "skill_mention", skill: {} },
           ],
+          attachments: [],
+        },
+      }),
+    );
+
+    const result = readAgentChatDraftFromStorage({
+      storage,
+      identity,
+      now: new Date("2026-07-02T10:00:00.000Z"),
+    });
+
+    expect(result.status).toBe("invalid");
+    expect(storage.getItem(key)).toBeNull();
+  });
+
+  test("removes payloads whose canonical session identity does not match the key", () => {
+    const storage = createMemoryStorage();
+    const key = toAgentChatDraftStorageKey(identity);
+    storage.setItem(
+      key,
+      JSON.stringify({
+        version: 2,
+        workspaceId: identity.workspaceId,
+        externalSessionId: identity.externalSessionId,
+        runtimeKind: identity.runtimeKind,
+        workingDirectory: "/another/workspace",
+        taskId: "task-1",
+        updatedAt: "2026-07-01T10:00:00.000Z",
+        draft: {
+          segments: [{ id: "text-1", kind: "text", text: "wrong workspace" }],
           attachments: [],
         },
       }),
@@ -262,8 +296,18 @@ describe("agent chat draft storage", () => {
 
   test("cleanup scans only chat draft keys", () => {
     const storage = createMemoryStorage();
-    const expiredIdentity = { workspaceId: "workspace", externalSessionId: "expired" };
-    const freshIdentity = { workspaceId: "workspace", externalSessionId: "fresh" };
+    const expiredIdentity = {
+      workspaceId: "workspace",
+      externalSessionId: "expired",
+      runtimeKind: "opencode" as const,
+      workingDirectory: "/repo",
+    };
+    const freshIdentity = {
+      workspaceId: "workspace",
+      externalSessionId: "fresh",
+      runtimeKind: "opencode" as const,
+      workingDirectory: "/repo",
+    };
     writeAgentChatDraftToStorage({
       storage,
       identity: expiredIdentity,
@@ -278,6 +322,7 @@ describe("agent chat draft storage", () => {
       draft: { segments: [createTextSegment("fresh", "text-1")], attachments: [] },
       updatedAt: "2026-07-08T09:00:00.000Z",
     });
+    storage.setItem("openducktor:agent-chat:draft:v1:workspace:legacy-session", "legacy");
     storage.setItem("openducktor:other-feature", "keep");
 
     cleanupExpiredAgentChatDraftStorage({
@@ -287,6 +332,7 @@ describe("agent chat draft storage", () => {
 
     expect(storage.getItem(toAgentChatDraftStorageKey(expiredIdentity))).toBeNull();
     expect(storage.getItem(toAgentChatDraftStorageKey(freshIdentity))).not.toBeNull();
+    expect(storage.getItem("openducktor:agent-chat:draft:v1:workspace:legacy-session")).toBeNull();
     expect(storage.getItem("openducktor:other-feature")).toBe("keep");
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AgentChatComposerDraft,
+  createComposerAttachment,
+  createFileReferenceSegment,
+  createSkillReferenceSegment,
+  createSlashCommandSegment,
+  createSubagentReferenceSegment,
+  createTextSegment,
+} from "./agent-chat-composer-draft";
+import {
+  AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES,
+  type AgentChatDraftSessionIdentity,
+  cleanupExpiredAgentChatDraftStorage,
+  measureAgentChatDraftPayloadBytes,
+  readAgentChatDraftFromStorage,
+  serializeAgentChatDraftPayload,
+  toAgentChatDraftStorageKey,
+  writeAgentChatDraftToStorage,
+} from "./agent-chat-draft-storage";
+
+type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
+
+const createMemoryStorage = (): TestStorage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+};
+
+const identity: AgentChatDraftSessionIdentity = {
+  workspaceId: "workspace:one",
+  externalSessionId: "session/one",
+};
+
+const command = {
+  id: "compact",
+  trigger: "compact",
+  title: "Compact",
+  hints: ["compact"],
+};
+
+const file = {
+  id: "src/main.ts",
+  path: "src/main.ts",
+  name: "main.ts",
+  kind: "code" as const,
+};
+
+const skill = {
+  id: "/skills/review/SKILL.md",
+  name: "review",
+  path: "/skills/review/SKILL.md",
+};
+
+const subagent = {
+  id: "reviewer",
+  name: "reviewer",
+  label: "Reviewer",
+};
+
+const buildStructuredDraft = (): AgentChatComposerDraft => ({
+  segments: [
+    createTextSegment("Please ", "text-1"),
+    createSlashCommandSegment(command, "slash-1"),
+    createTextSegment(" inspect ", "text-2"),
+    createFileReferenceSegment(file, "file-1"),
+    createTextSegment(" with ", "text-3"),
+    createSkillReferenceSegment(skill, "skill-1"),
+    createTextSegment(" and ", "text-4"),
+    createSubagentReferenceSegment(subagent, "subagent-1"),
+  ],
+  attachments: [
+    createComposerAttachment(
+      {
+        name: "brief.pdf",
+        kind: "pdf",
+        mime: "application/pdf",
+        path: "/tmp/brief.pdf",
+      },
+      "attachment-1",
+    ),
+  ],
+});
+
+describe("agent chat draft storage", () => {
+  test("builds storage keys from workspace and external session identity", () => {
+    expect(toAgentChatDraftStorageKey(identity)).toBe(
+      "openducktor:agent-chat:draft:v1:workspace%3Aone:session%2Fone",
+    );
+  });
+
+  test("round-trips structured segments and path-backed attachment metadata", () => {
+    const storage = createMemoryStorage();
+    const draft = buildStructuredDraft();
+
+    const writeResult = writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft,
+      updatedAt: "2026-07-01T10:00:00.000Z",
+    });
+
+    expect(writeResult.status).toBe("serialized");
+    const readResult = readAgentChatDraftFromStorage({
+      storage,
+      identity,
+      now: new Date("2026-07-02T10:00:00.000Z"),
+    });
+
+    expect(readResult.status).toBe("restored");
+    if (readResult.status !== "restored") {
+      throw new Error("Expected restored draft");
+    }
+    expect(readResult.value.draft.segments).toEqual(draft.segments);
+    expect(readResult.value.draft.attachments).toEqual([
+      expect.objectContaining({
+        id: "attachment-1",
+        path: "/tmp/brief.pdf",
+        name: "brief.pdf",
+        kind: "pdf",
+        mime: "application/pdf",
+      }),
+    ]);
+    expect(readResult.value.draft.attachments?.[0]?.file).toBeUndefined();
+    expect(readResult.value.draft.attachments?.[0]?.previewUrl).toBeUndefined();
+  });
+
+  test("removes invalid stored payloads for only the affected key", () => {
+    const storage = createMemoryStorage();
+    const key = toAgentChatDraftStorageKey(identity);
+    storage.setItem(key, "{not-json");
+    storage.setItem("unrelated", "kept");
+
+    const result = readAgentChatDraftFromStorage({
+      storage,
+      identity,
+      now: new Date("2026-07-02T10:00:00.000Z"),
+    });
+
+    expect(result.status).toBe("invalid");
+    expect(storage.getItem(key)).toBeNull();
+    expect(storage.getItem("unrelated")).toBe("kept");
+  });
+
+  test("removes drafts older than seven days during restore", () => {
+    const storage = createMemoryStorage();
+    const key = toAgentChatDraftStorageKey(identity);
+    writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft: { segments: [createTextSegment("old", "text-1")], attachments: [] },
+      updatedAt: "2026-07-01T10:00:00.000Z",
+    });
+
+    const result = readAgentChatDraftFromStorage({
+      storage,
+      identity,
+      now: new Date("2026-07-08T10:00:00.000Z"),
+    });
+
+    expect(result.status).toBe("expired");
+    expect(storage.getItem(key)).toBeNull();
+  });
+
+  test("persists payloads at the size boundary and removes stale payloads above it", () => {
+    const storage = createMemoryStorage();
+    const key = toAgentChatDraftStorageKey(identity);
+    const buildDraft = (textLength: number): AgentChatComposerDraft => ({
+      segments: [createTextSegment("x".repeat(textLength), "text-1")],
+      attachments: [],
+    });
+    const byteLengthForText = (textLength: number): number => {
+      const result = serializeAgentChatDraftPayload({
+        identity,
+        taskId: "task-1",
+        draft: buildDraft(textLength),
+        updatedAt: "2026-07-01T10:00:00.000Z",
+      });
+      return result.status === "serialized" || result.status === "oversized"
+        ? result.byteLength
+        : 0;
+    };
+
+    let low = 1;
+    let high = AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES;
+    while (low < high) {
+      const mid = Math.ceil((low + high) / 2);
+      if (byteLengthForText(mid) <= AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES) {
+        low = mid;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    const boundaryResult = writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft: buildDraft(low),
+      updatedAt: "2026-07-01T10:00:00.000Z",
+    });
+    expect(boundaryResult.status).toBe("serialized");
+    expect(storage.getItem(key)).not.toBeNull();
+    expect(measureAgentChatDraftPayloadBytes(storage.getItem(key) ?? "")).toBeLessThanOrEqual(
+      AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES,
+    );
+
+    const oversizedResult = writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft: buildDraft(low + 1),
+      updatedAt: "2026-07-01T10:00:00.000Z",
+    });
+    expect(oversizedResult.status).toBe("oversized");
+    expect(storage.getItem(key)).toBeNull();
+  });
+
+  test("cleanup scans only chat draft keys", () => {
+    const storage = createMemoryStorage();
+    const expiredIdentity = { workspaceId: "workspace", externalSessionId: "expired" };
+    const freshIdentity = { workspaceId: "workspace", externalSessionId: "fresh" };
+    writeAgentChatDraftToStorage({
+      storage,
+      identity: expiredIdentity,
+      taskId: "task-1",
+      draft: { segments: [createTextSegment("old", "text-1")], attachments: [] },
+      updatedAt: "2026-07-01T10:00:00.000Z",
+    });
+    writeAgentChatDraftToStorage({
+      storage,
+      identity: freshIdentity,
+      taskId: "task-2",
+      draft: { segments: [createTextSegment("fresh", "text-1")], attachments: [] },
+      updatedAt: "2026-07-08T09:00:00.000Z",
+    });
+    storage.setItem("openducktor:other-feature", "keep");
+
+    cleanupExpiredAgentChatDraftStorage({
+      storage,
+      now: new Date("2026-07-08T10:00:00.000Z"),
+    });
+
+    expect(storage.getItem(toAgentChatDraftStorageKey(expiredIdentity))).toBeNull();
+    expect(storage.getItem(toAgentChatDraftStorageKey(freshIdentity))).not.toBeNull();
+    expect(storage.getItem("openducktor:other-feature")).toBe("keep");
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.ts
@@ -57,6 +57,8 @@ export const AGENT_CHAT_DRAFT_STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 const encoder = new TextEncoder();
 const ATTACHMENT_KINDS = new Set<AgentAttachmentKind>(["image", "audio", "video", "pdf"]);
+const FILE_REFERENCE_KINDS = new Set(["directory", "css", "code", "image", "video", "default"]);
+const SLASH_COMMAND_SOURCES = new Set(["command", "mcp", "skill", "custom"]);
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -66,6 +68,12 @@ const isNonEmptyString = (value: unknown): value is string =>
 
 const optionalString = (value: unknown): value is string | undefined =>
   typeof value === "undefined" || typeof value === "string";
+
+const optionalNonEmptyString = (value: unknown): value is string | undefined =>
+  typeof value === "undefined" || isNonEmptyString(value);
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string");
 
 export const toAgentChatDraftStorageKey = ({
   workspaceId,
@@ -80,6 +88,61 @@ export const isAgentChatDraftStorageKey = (key: string): boolean =>
 
 export const measureAgentChatDraftPayloadBytes = (payload: string): number =>
   encoder.encode(payload).byteLength;
+
+const isValidSlashCommand = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    isNonEmptyString(value.id) &&
+    isNonEmptyString(value.trigger) &&
+    isNonEmptyString(value.title) &&
+    optionalString(value.description) &&
+    (typeof value.source === "undefined" ||
+      (typeof value.source === "string" && SLASH_COMMAND_SOURCES.has(value.source))) &&
+    (typeof value.hints === "undefined" || isStringArray(value.hints))
+  );
+};
+
+const isValidFileReference = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    isNonEmptyString(value.id) &&
+    isNonEmptyString(value.path) &&
+    isNonEmptyString(value.name) &&
+    typeof value.kind === "string" &&
+    FILE_REFERENCE_KINDS.has(value.kind)
+  );
+};
+
+const isValidSkillReference = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    isNonEmptyString(value.id) &&
+    isNonEmptyString(value.name) &&
+    isNonEmptyString(value.path) &&
+    optionalNonEmptyString(value.title) &&
+    optionalNonEmptyString(value.displayName) &&
+    optionalString(value.description) &&
+    optionalString(value.color)
+  );
+};
+
+const isValidSubagentReference = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    isNonEmptyString(value.id) &&
+    isNonEmptyString(value.name) &&
+    optionalNonEmptyString(value.label) &&
+    optionalString(value.description)
+  );
+};
 
 const toPersistedAttachment = (
   attachment: AgentChatComposerAttachment,
@@ -150,13 +213,13 @@ const isValidSegment = (segment: unknown): segment is AgentChatComposerSegment =
     case "text":
       return typeof segment.text === "string";
     case "slash_command":
-      return isRecord(segment.command);
+      return isValidSlashCommand(segment.command);
     case "file_reference":
-      return isRecord(segment.file);
+      return isValidFileReference(segment.file);
     case "skill_mention":
-      return isRecord(segment.skill);
+      return isValidSkillReference(segment.skill);
     case "subagent_reference":
-      return isRecord(segment.subagent);
+      return isValidSubagentReference(segment.subagent);
     default:
       return false;
   }

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.ts
@@ -323,7 +323,11 @@ export const parseAgentChatDraftPayload = ({
   if (!Number.isFinite(updatedAtMs)) {
     return { status: "invalid", reason: "Stored chat draft update date is invalid." };
   }
-  if (now.getTime() - updatedAtMs >= AGENT_CHAT_DRAFT_STORAGE_TTL_MS) {
+  const ageMs = now.getTime() - updatedAtMs;
+  if (ageMs < 0) {
+    return { status: "invalid", reason: "Stored chat draft update date is in the future." };
+  }
+  if (ageMs >= AGENT_CHAT_DRAFT_STORAGE_TTL_MS) {
     return { status: "expired" };
   }
   if (!isRecord(parsed.draft) || !Array.isArray(parsed.draft.segments)) {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.ts
@@ -1,0 +1,386 @@
+import type { AgentAttachmentKind } from "@openducktor/core";
+import { buildComposerAttachmentFromPath } from "./agent-chat-attachments";
+import {
+  type AgentChatComposerAttachment,
+  type AgentChatComposerDraft,
+  type AgentChatComposerSegment,
+  draftHasMeaningfulContent,
+} from "./agent-chat-composer-draft";
+
+export type AgentChatDraftSessionIdentity = {
+  workspaceId: string;
+  externalSessionId: string;
+};
+
+export type PersistedAgentChatDraftAttachment = {
+  id: string;
+  path: string;
+  name: string;
+  kind: AgentAttachmentKind;
+  mime?: string;
+};
+
+export type PersistedAgentChatDraftPayload = {
+  version: 1;
+  workspaceId: string;
+  externalSessionId: string;
+  taskId: string;
+  updatedAt: string;
+  draft: {
+    segments: AgentChatComposerSegment[];
+    attachments: PersistedAgentChatDraftAttachment[];
+  };
+};
+
+export type SerializedAgentChatDraftResult =
+  | { status: "empty" }
+  | { status: "unpersistable_attachments" }
+  | { status: "oversized"; byteLength: number }
+  | { status: "serialized"; payload: string; byteLength: number };
+
+export type RestoredAgentChatDraft = {
+  taskId: string;
+  updatedAt: string;
+  draft: AgentChatComposerDraft;
+};
+
+export type AgentChatDraftStorageReadResult =
+  | { status: "empty" }
+  | { status: "restored"; value: RestoredAgentChatDraft }
+  | { status: "invalid"; reason: string }
+  | { status: "expired" }
+  | { status: "oversized"; byteLength: number };
+
+export const AGENT_CHAT_DRAFT_STORAGE_PREFIX = "openducktor:agent-chat:draft:v1";
+export const AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES = 20_480;
+export const AGENT_CHAT_DRAFT_STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const encoder = new TextEncoder();
+const ATTACHMENT_KINDS = new Set<AgentAttachmentKind>(["image", "audio", "video", "pdf"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const optionalString = (value: unknown): value is string | undefined =>
+  typeof value === "undefined" || typeof value === "string";
+
+export const toAgentChatDraftStorageKey = ({
+  workspaceId,
+  externalSessionId,
+}: AgentChatDraftSessionIdentity): string =>
+  `${AGENT_CHAT_DRAFT_STORAGE_PREFIX}:${encodeURIComponent(workspaceId)}:${encodeURIComponent(
+    externalSessionId,
+  )}`;
+
+export const isAgentChatDraftStorageKey = (key: string): boolean =>
+  key.startsWith(`${AGENT_CHAT_DRAFT_STORAGE_PREFIX}:`);
+
+export const measureAgentChatDraftPayloadBytes = (payload: string): number =>
+  encoder.encode(payload).byteLength;
+
+const toPersistedAttachment = (
+  attachment: AgentChatComposerAttachment,
+): PersistedAgentChatDraftAttachment | null => {
+  if (!attachment.path) {
+    return null;
+  }
+
+  return {
+    id: attachment.id,
+    path: attachment.path,
+    name: attachment.name,
+    kind: attachment.kind,
+    ...(attachment.mime ? { mime: attachment.mime } : {}),
+  };
+};
+
+export const serializeAgentChatDraftPayload = ({
+  identity,
+  taskId,
+  draft,
+  updatedAt,
+}: {
+  identity: AgentChatDraftSessionIdentity;
+  taskId: string;
+  draft: AgentChatComposerDraft;
+  updatedAt: string;
+}): SerializedAgentChatDraftResult => {
+  if (!draftHasMeaningfulContent(draft)) {
+    return { status: "empty" };
+  }
+
+  const attachments: PersistedAgentChatDraftAttachment[] = [];
+  for (const attachment of draft.attachments ?? []) {
+    const persistedAttachment = toPersistedAttachment(attachment);
+    if (!persistedAttachment) {
+      return { status: "unpersistable_attachments" };
+    }
+    attachments.push(persistedAttachment);
+  }
+
+  const payload: PersistedAgentChatDraftPayload = {
+    version: 1,
+    workspaceId: identity.workspaceId,
+    externalSessionId: identity.externalSessionId,
+    taskId,
+    updatedAt,
+    draft: {
+      segments: draft.segments,
+      attachments,
+    },
+  };
+  const serialized = JSON.stringify(payload);
+  const byteLength = measureAgentChatDraftPayloadBytes(serialized);
+  if (byteLength > AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES) {
+    return { status: "oversized", byteLength };
+  }
+
+  return { status: "serialized", payload: serialized, byteLength };
+};
+
+const isValidSegment = (segment: unknown): segment is AgentChatComposerSegment => {
+  if (!isRecord(segment) || !isNonEmptyString(segment.id)) {
+    return false;
+  }
+
+  switch (segment.kind) {
+    case "text":
+      return typeof segment.text === "string";
+    case "slash_command":
+      return isRecord(segment.command);
+    case "file_reference":
+      return isRecord(segment.file);
+    case "skill_mention":
+      return isRecord(segment.skill);
+    case "subagent_reference":
+      return isRecord(segment.subagent);
+    default:
+      return false;
+  }
+};
+
+const parseAttachment = (value: unknown): AgentChatComposerAttachment | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    !isNonEmptyString(value.id) ||
+    !isNonEmptyString(value.path) ||
+    !isNonEmptyString(value.name) ||
+    typeof value.kind !== "string" ||
+    !ATTACHMENT_KINDS.has(value.kind as AgentAttachmentKind) ||
+    !optionalString(value.mime)
+  ) {
+    return null;
+  }
+
+  const attachment = buildComposerAttachmentFromPath(value.path, {
+    name: value.name,
+    kind: value.kind as AgentAttachmentKind,
+    ...(value.mime ? { mime: value.mime } : {}),
+  });
+  return attachment ? { ...attachment, id: value.id } : null;
+};
+
+export const parseAgentChatDraftPayload = ({
+  raw,
+  identity,
+  now,
+}: {
+  raw: string | null;
+  identity: AgentChatDraftSessionIdentity;
+  now: Date;
+}): AgentChatDraftStorageReadResult => {
+  if (!raw) {
+    return { status: "empty" };
+  }
+
+  const byteLength = measureAgentChatDraftPayloadBytes(raw);
+  if (byteLength > AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES) {
+    return { status: "oversized", byteLength };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: "invalid", reason: "Stored chat draft is not valid JSON." };
+  }
+
+  if (!isRecord(parsed)) {
+    return { status: "invalid", reason: "Stored chat draft is not an object." };
+  }
+  if (parsed.version !== 1) {
+    return { status: "invalid", reason: "Stored chat draft uses an unsupported version." };
+  }
+  if (
+    parsed.workspaceId !== identity.workspaceId ||
+    parsed.externalSessionId !== identity.externalSessionId
+  ) {
+    return { status: "invalid", reason: "Stored chat draft identity does not match the key." };
+  }
+  if (!isNonEmptyString(parsed.taskId)) {
+    return { status: "invalid", reason: "Stored chat draft is missing a task id." };
+  }
+  if (!isNonEmptyString(parsed.updatedAt)) {
+    return { status: "invalid", reason: "Stored chat draft is missing an update date." };
+  }
+  const updatedAtMs = Date.parse(parsed.updatedAt);
+  if (!Number.isFinite(updatedAtMs)) {
+    return { status: "invalid", reason: "Stored chat draft update date is invalid." };
+  }
+  if (now.getTime() - updatedAtMs >= AGENT_CHAT_DRAFT_STORAGE_TTL_MS) {
+    return { status: "expired" };
+  }
+  if (!isRecord(parsed.draft) || !Array.isArray(parsed.draft.segments)) {
+    return { status: "invalid", reason: "Stored chat draft body is invalid." };
+  }
+
+  const segments: AgentChatComposerSegment[] = [];
+  for (const segment of parsed.draft.segments) {
+    if (!isValidSegment(segment)) {
+      return { status: "invalid", reason: "Stored chat draft contains an invalid segment." };
+    }
+    segments.push(segment);
+  }
+
+  if (!Array.isArray(parsed.draft.attachments)) {
+    return { status: "invalid", reason: "Stored chat draft attachments are invalid." };
+  }
+  const attachments: AgentChatComposerAttachment[] = [];
+  for (const attachmentValue of parsed.draft.attachments) {
+    const attachment = parseAttachment(attachmentValue);
+    if (!attachment) {
+      return { status: "invalid", reason: "Stored chat draft contains an invalid attachment." };
+    }
+    attachments.push(attachment);
+  }
+
+  return {
+    status: "restored",
+    value: {
+      taskId: parsed.taskId,
+      updatedAt: parsed.updatedAt,
+      draft: { segments, attachments },
+    },
+  };
+};
+
+const readDraftStoragePayload = (storage: Pick<Storage, "getItem">, key: string): string | null => {
+  try {
+    return storage.getItem(key);
+  } catch (cause) {
+    throw new Error(`Failed to read chat draft storage key "${key}".`, { cause });
+  }
+};
+
+const removeDraftStoragePayload = (storage: Pick<Storage, "removeItem">, key: string): void => {
+  try {
+    storage.removeItem(key);
+  } catch (cause) {
+    throw new Error(`Failed to remove chat draft storage key "${key}".`, { cause });
+  }
+};
+
+export const writeAgentChatDraftToStorage = ({
+  storage,
+  identity,
+  taskId,
+  draft,
+  updatedAt,
+}: {
+  storage: Pick<Storage, "setItem" | "removeItem">;
+  identity: AgentChatDraftSessionIdentity;
+  taskId: string;
+  draft: AgentChatComposerDraft;
+  updatedAt: string;
+}): SerializedAgentChatDraftResult => {
+  const key = toAgentChatDraftStorageKey(identity);
+  const result = serializeAgentChatDraftPayload({ identity, taskId, draft, updatedAt });
+  if (result.status !== "serialized") {
+    removeDraftStoragePayload(storage, key);
+    return result;
+  }
+
+  try {
+    storage.setItem(key, result.payload);
+  } catch (cause) {
+    throw new Error(`Failed to persist chat draft storage key "${key}".`, { cause });
+  }
+
+  return result;
+};
+
+export const readAgentChatDraftFromStorage = ({
+  storage,
+  identity,
+  now = new Date(),
+}: {
+  storage: Pick<Storage, "getItem" | "removeItem">;
+  identity: AgentChatDraftSessionIdentity;
+  now?: Date;
+}): AgentChatDraftStorageReadResult => {
+  const key = toAgentChatDraftStorageKey(identity);
+  const raw = readDraftStoragePayload(storage, key);
+  const result = parseAgentChatDraftPayload({ raw, identity, now });
+  if (result.status === "invalid" || result.status === "expired" || result.status === "oversized") {
+    removeDraftStoragePayload(storage, key);
+  }
+  return result;
+};
+
+export const removeAgentChatDraftFromStorage = ({
+  storage,
+  identity,
+}: {
+  storage: Pick<Storage, "removeItem">;
+  identity: AgentChatDraftSessionIdentity;
+}): void => {
+  removeDraftStoragePayload(storage, toAgentChatDraftStorageKey(identity));
+};
+
+export const cleanupExpiredAgentChatDraftStorage = ({
+  storage,
+  now = new Date(),
+}: {
+  storage: Pick<Storage, "length" | "key" | "getItem" | "removeItem">;
+  now?: Date;
+}): void => {
+  const keys: string[] = [];
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+    if (key && isAgentChatDraftStorageKey(key)) {
+      keys.push(key);
+    }
+  }
+
+  for (const key of keys) {
+    const raw = readDraftStoragePayload(storage, key);
+    const parts = key.split(":");
+    const workspaceId = parts.at(-2);
+    const externalSessionId = parts.at(-1);
+    if (!workspaceId || !externalSessionId) {
+      removeDraftStoragePayload(storage, key);
+      continue;
+    }
+
+    const result = parseAgentChatDraftPayload({
+      raw,
+      identity: {
+        workspaceId: decodeURIComponent(workspaceId),
+        externalSessionId: decodeURIComponent(externalSessionId),
+      },
+      now,
+    });
+    if (
+      result.status === "invalid" ||
+      result.status === "expired" ||
+      result.status === "oversized"
+    ) {
+      removeDraftStoragePayload(storage, key);
+    }
+  }
+};

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-storage.ts
@@ -1,4 +1,11 @@
+import { runtimeKindSchema } from "@openducktor/contracts";
 import type { AgentAttachmentKind } from "@openducktor/core";
+import {
+  type AgentSessionIdentityLike,
+  agentSessionIdentityKey,
+  parseAgentSessionIdentityKey,
+} from "@/lib/agent-session-identity";
+import { normalizeWorkingDirectory } from "@/lib/working-directory";
 import { buildComposerAttachmentFromPath } from "./agent-chat-attachments";
 import {
   type AgentChatComposerAttachment,
@@ -7,9 +14,8 @@ import {
   draftHasMeaningfulContent,
 } from "./agent-chat-composer-draft";
 
-export type AgentChatDraftSessionIdentity = {
+export type AgentChatDraftSessionIdentity = AgentSessionIdentityLike & {
   workspaceId: string;
-  externalSessionId: string;
 };
 
 export type PersistedAgentChatDraftAttachment = {
@@ -21,9 +27,11 @@ export type PersistedAgentChatDraftAttachment = {
 };
 
 export type PersistedAgentChatDraftPayload = {
-  version: 1;
+  version: 2;
   workspaceId: string;
   externalSessionId: string;
+  runtimeKind: AgentChatDraftSessionIdentity["runtimeKind"];
+  workingDirectory: string;
   taskId: string;
   updatedAt: string;
   draft: {
@@ -51,7 +59,8 @@ export type AgentChatDraftStorageReadResult =
   | { status: "expired" }
   | { status: "oversized"; byteLength: number };
 
-export const AGENT_CHAT_DRAFT_STORAGE_PREFIX = "openducktor:agent-chat:draft:v1";
+export const AGENT_CHAT_DRAFT_STORAGE_PREFIX = "openducktor:agent-chat:draft:v2";
+const LEGACY_AGENT_CHAT_DRAFT_STORAGE_PREFIX = "openducktor:agent-chat:draft:v1";
 export const AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES = 20_480;
 export const AGENT_CHAT_DRAFT_STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -75,16 +84,14 @@ const optionalNonEmptyString = (value: unknown): value is string | undefined =>
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((entry) => typeof entry === "string");
 
-export const toAgentChatDraftStorageKey = ({
-  workspaceId,
-  externalSessionId,
-}: AgentChatDraftSessionIdentity): string =>
-  `${AGENT_CHAT_DRAFT_STORAGE_PREFIX}:${encodeURIComponent(workspaceId)}:${encodeURIComponent(
-    externalSessionId,
-  )}`;
+export const toAgentChatDraftStorageKey = (identity: AgentChatDraftSessionIdentity): string =>
+  `${AGENT_CHAT_DRAFT_STORAGE_PREFIX}:${encodeURIComponent(
+    identity.workspaceId,
+  )}:${agentSessionIdentityKey(identity)}`;
 
 export const isAgentChatDraftStorageKey = (key: string): boolean =>
-  key.startsWith(`${AGENT_CHAT_DRAFT_STORAGE_PREFIX}:`);
+  key.startsWith(`${AGENT_CHAT_DRAFT_STORAGE_PREFIX}:`) ||
+  key.startsWith(`${LEGACY_AGENT_CHAT_DRAFT_STORAGE_PREFIX}:`);
 
 export const measureAgentChatDraftPayloadBytes = (payload: string): number =>
   encoder.encode(payload).byteLength;
@@ -185,9 +192,11 @@ export const serializeAgentChatDraftPayload = ({
   }
 
   const payload: PersistedAgentChatDraftPayload = {
-    version: 1,
+    version: 2,
     workspaceId: identity.workspaceId,
     externalSessionId: identity.externalSessionId,
+    runtimeKind: identity.runtimeKind,
+    workingDirectory: normalizeWorkingDirectory(identity.workingDirectory),
     taskId,
     updatedAt,
     draft: {
@@ -276,12 +285,31 @@ export const parseAgentChatDraftPayload = ({
   if (!isRecord(parsed)) {
     return { status: "invalid", reason: "Stored chat draft is not an object." };
   }
-  if (parsed.version !== 1) {
+  if (parsed.version !== 2) {
     return { status: "invalid", reason: "Stored chat draft uses an unsupported version." };
   }
+  if (!isNonEmptyString(parsed.workspaceId)) {
+    return { status: "invalid", reason: "Stored chat draft is missing a workspace id." };
+  }
+  const parsedRuntimeKind = runtimeKindSchema.safeParse(parsed.runtimeKind);
+  if (!parsedRuntimeKind.success) {
+    return { status: "invalid", reason: "Stored chat draft runtime kind is invalid." };
+  }
+  if (!isNonEmptyString(parsed.workingDirectory)) {
+    return { status: "invalid", reason: "Stored chat draft is missing a working directory." };
+  }
+  if (!isNonEmptyString(parsed.externalSessionId)) {
+    return { status: "invalid", reason: "Stored chat draft is missing a session id." };
+  }
+  const parsedIdentity: AgentChatDraftSessionIdentity = {
+    workspaceId: parsed.workspaceId,
+    externalSessionId: parsed.externalSessionId,
+    runtimeKind: parsedRuntimeKind.data,
+    workingDirectory: parsed.workingDirectory,
+  };
   if (
-    parsed.workspaceId !== identity.workspaceId ||
-    parsed.externalSessionId !== identity.externalSessionId
+    parsedIdentity.workspaceId !== identity.workspaceId ||
+    agentSessionIdentityKey(parsedIdentity) !== agentSessionIdentityKey(identity)
   ) {
     return { status: "invalid", reason: "Stored chat draft identity does not match the key." };
   }
@@ -346,6 +374,38 @@ const removeDraftStoragePayload = (storage: Pick<Storage, "removeItem">, key: st
   } catch (cause) {
     throw new Error(`Failed to remove chat draft storage key "${key}".`, { cause });
   }
+};
+
+const decodeDraftKeyPart = (value: string): string | null => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+};
+
+const parseDraftStorageKeyIdentity = (key: string): AgentChatDraftSessionIdentity | null => {
+  const keyPrefix = `${AGENT_CHAT_DRAFT_STORAGE_PREFIX}:`;
+  if (!key.startsWith(keyPrefix)) {
+    return null;
+  }
+
+  const suffix = key.slice(keyPrefix.length);
+  const workspaceSeparatorIndex = suffix.indexOf(":");
+  if (workspaceSeparatorIndex === -1) {
+    return null;
+  }
+
+  const workspaceId = decodeDraftKeyPart(suffix.slice(0, workspaceSeparatorIndex));
+  const sessionIdentity = parseAgentSessionIdentityKey(suffix.slice(workspaceSeparatorIndex + 1));
+  if (!workspaceId || !sessionIdentity) {
+    return null;
+  }
+
+  return {
+    workspaceId,
+    ...sessionIdentity,
+  };
 };
 
 export const writeAgentChatDraftToStorage = ({
@@ -421,21 +481,21 @@ export const cleanupExpiredAgentChatDraftStorage = ({
   }
 
   for (const key of keys) {
+    if (key.startsWith(`${LEGACY_AGENT_CHAT_DRAFT_STORAGE_PREFIX}:`)) {
+      removeDraftStoragePayload(storage, key);
+      continue;
+    }
+
     const raw = readDraftStoragePayload(storage, key);
-    const parts = key.split(":");
-    const workspaceId = parts.at(-2);
-    const externalSessionId = parts.at(-1);
-    if (!workspaceId || !externalSessionId) {
+    const identity = parseDraftStorageKeyIdentity(key);
+    if (!identity) {
       removeDraftStoragePayload(storage, key);
       continue;
     }
 
     const result = parseAgentChatDraftPayload({
       raw,
-      identity: {
-        workspaceId: decodeURIComponent(workspaceId),
-        externalSessionId: decodeURIComponent(externalSessionId),
-      },
+      identity,
       now,
     });
     if (

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
@@ -98,6 +98,8 @@ const installManualTimers = () => {
 const identity: AgentChatDraftSessionIdentity = {
   workspaceId: "workspace",
   externalSessionId: "session-a",
+  runtimeKind: "opencode",
+  workingDirectory: "/repo",
 };
 
 const buildDraft = (text: string): AgentChatComposerDraft => ({
@@ -250,8 +252,18 @@ describe("agent chat draft store", () => {
 
   test("runs expired draft cleanup during first hydration only", () => {
     const storage = createMemoryStorage();
-    const expiredIdentity = { workspaceId: "workspace", externalSessionId: "expired" };
-    const freshIdentity = { workspaceId: "workspace", externalSessionId: "fresh" };
+    const expiredIdentity = {
+      workspaceId: "workspace",
+      externalSessionId: "expired",
+      runtimeKind: "opencode" as const,
+      workingDirectory: "/repo",
+    };
+    const freshIdentity = {
+      workspaceId: "workspace",
+      externalSessionId: "fresh",
+      runtimeKind: "opencode" as const,
+      workingDirectory: "/repo",
+    };
     setAgentChatDraftStorageForTests(storage);
     setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:00.000Z"));
     writeAgentChatDraftToStorage({

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  type AgentChatComposerDraft,
+  createComposerAttachment,
+  createTextSegment,
+} from "./agent-chat-composer-draft";
+import {
+  type AgentChatDraftSessionIdentity,
+  toAgentChatDraftStorageKey,
+  writeAgentChatDraftToStorage,
+} from "./agent-chat-draft-storage";
+import {
+  clearAgentChatDraft,
+  flushAgentChatDraft,
+  hydrateAgentChatDraft,
+  resetAgentChatDraftStoreForTests,
+  setAgentChatDraft,
+  setAgentChatDraftAttachmentStagerForTests,
+  setAgentChatDraftNowProviderForTests,
+  setAgentChatDraftPersistenceErrorReporter,
+  setAgentChatDraftStorageForTests,
+} from "./agent-chat-draft-store";
+
+type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
+
+const createMemoryStorage = (spies?: {
+  getItem?: (key: string) => void;
+  setItem?: (key: string, value: string) => void;
+  removeItem?: (key: string) => void;
+}): TestStorage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    getItem: (key) => {
+      spies?.getItem?.(key);
+      return store.get(key) ?? null;
+    },
+    setItem: (key, value) => {
+      spies?.setItem?.(key, value);
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      spies?.removeItem?.(key);
+      store.delete(key);
+    },
+  };
+};
+
+const installManualTimers = () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let nextTimerId = 1;
+  const timers = new Map<number, { handler: () => void; delay: number; cleared: boolean }>();
+
+  globalThis.setTimeout = ((handler: TimerHandler, delay?: number) => {
+    const timerId = nextTimerId;
+    nextTimerId += 1;
+    timers.set(timerId, {
+      handler: () => {
+        if (typeof handler === "function") {
+          handler();
+        }
+      },
+      delay: delay ?? 0,
+      cleared: false,
+    });
+    return timerId as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as unknown as typeof globalThis.setTimeout;
+
+  globalThis.clearTimeout = ((timerId?: ReturnType<typeof globalThis.setTimeout>) => {
+    const timer = timers.get(Number(timerId));
+    if (timer) {
+      timer.cleared = true;
+    }
+  }) as typeof globalThis.clearTimeout;
+
+  return {
+    runNextByDelay: (delay: number) => {
+      const timer = Array.from(timers.entries()).find(
+        ([, value]) => value.delay === delay && !value.cleared,
+      );
+      if (!timer) {
+        throw new Error(`Expected timer with delay ${delay}`);
+      }
+      timer[1].cleared = true;
+      timer[1].handler();
+    },
+    restore: () => {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    },
+  };
+};
+
+const identity: AgentChatDraftSessionIdentity = {
+  workspaceId: "workspace",
+  externalSessionId: "session-a",
+};
+
+const buildDraft = (text: string): AgentChatComposerDraft => ({
+  segments: [createTextSegment(text, "text-1")],
+  attachments: [],
+});
+
+afterEach(() => {
+  resetAgentChatDraftStoreForTests();
+});
+
+describe("agent chat draft store", () => {
+  test("hydrates a session from storage once and then reads from memory", () => {
+    const getItem = mock((_key: string) => {});
+    const storage = createMemoryStorage({ getItem });
+    setAgentChatDraftStorageForTests(storage);
+    writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft: buildDraft("persisted"),
+      updatedAt: "2026-07-08T10:00:00.000Z",
+    });
+    setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:01.000Z"));
+
+    const firstHydration = hydrateAgentChatDraft(identity, "task-1");
+    const secondHydration = hydrateAgentChatDraft(identity, "task-1");
+
+    expect(firstHydration.segments).toEqual(secondHydration.segments);
+    expect(getItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("coalesces dirty writes instead of writing on every draft change", async () => {
+    const setItem = mock((_key: string, _value: string) => {});
+    const storage = createMemoryStorage({ setItem });
+    const timers = installManualTimers();
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:00.000Z"));
+
+    try {
+      setAgentChatDraft(identity, "task-1", buildDraft("one"));
+      setAgentChatDraft(identity, "task-1", buildDraft("two"));
+      setAgentChatDraft(identity, "task-1", buildDraft("three"));
+
+      expect(setItem).not.toHaveBeenCalled();
+      timers.runNextByDelay(1_000);
+      await Promise.resolve();
+
+      expect(setItem).toHaveBeenCalledTimes(1);
+      const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
+      expect(raw).toContain("three");
+    } finally {
+      timers.restore();
+    }
+  });
+
+  test("persists the latest draft when the max wait timer fires", async () => {
+    const setItem = mock((_key: string, _value: string) => {});
+    const storage = createMemoryStorage({ setItem });
+    const timers = installManualTimers();
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:00.000Z"));
+
+    try {
+      setAgentChatDraft(identity, "task-1", buildDraft("first"));
+      setAgentChatDraft(identity, "task-1", buildDraft("latest"));
+
+      timers.runNextByDelay(2_000);
+      await Promise.resolve();
+
+      expect(setItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toContain("latest");
+    } finally {
+      timers.restore();
+    }
+  });
+
+  test("stages file-backed attachments asynchronously before durable persistence", async () => {
+    const storage = createMemoryStorage();
+    const stagedFile = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:00.000Z"));
+    setAgentChatDraftAttachmentStagerForTests(mock(async () => "/tmp/staged/brief.pdf"));
+
+    setAgentChatDraft(identity, "task-1", {
+      segments: [createTextSegment("with file", "text-1")],
+      attachments: [
+        createComposerAttachment(
+          {
+            name: "brief.pdf",
+            kind: "pdf",
+            mime: "application/pdf",
+            file: stagedFile,
+          },
+          "attachment-1",
+        ),
+      ],
+    });
+
+    await flushAgentChatDraft(identity);
+    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+
+    await flushAgentChatDraft(identity);
+    const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
+    expect(raw).toContain("/tmp/staged/brief.pdf");
+    expect(raw).not.toContain("base64");
+  });
+
+  test("removes stale storage and reports staging failures without dropping memory", async () => {
+    const errors: Error[] = [];
+    const storage = createMemoryStorage();
+    const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftPersistenceErrorReporter((error) => {
+      errors.push(error);
+    });
+    setAgentChatDraftAttachmentStagerForTests(
+      mock(async () => {
+        throw new Error("stage failed");
+      }),
+    );
+    writeAgentChatDraftToStorage({
+      storage,
+      identity,
+      taskId: "task-1",
+      draft: buildDraft("old"),
+      updatedAt: "2026-07-08T10:00:00.000Z",
+    });
+
+    setAgentChatDraft(identity, "task-1", {
+      segments: [createTextSegment("with file", "text-1")],
+      attachments: [
+        createComposerAttachment(
+          {
+            name: "brief.pdf",
+            kind: "pdf",
+            mime: "application/pdf",
+            file,
+          },
+          "attachment-1",
+        ),
+      ],
+    });
+
+    await flushAgentChatDraft(identity);
+
+    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+    expect(errors[0]?.message).toBe("stage failed");
+    expect(hydrateAgentChatDraft(identity, "task-1").attachments?.[0]?.file).toBe(file);
+  });
+
+  test("clears storage only when the submitted draft version is still current", () => {
+    const storage = createMemoryStorage();
+    setAgentChatDraftStorageForTests(storage);
+    const submittedVersion = setAgentChatDraft(identity, "task-1", buildDraft("submitted"));
+    setAgentChatDraft(identity, "task-1", buildDraft("new draft"));
+
+    const didClear = clearAgentChatDraft(identity, { onlyIfVersion: submittedVersion });
+
+    expect(didClear).toBe(false);
+    expect(hydrateAgentChatDraft(identity, "task-1").segments[0]).toEqual(
+      expect.objectContaining({ text: "new draft" }),
+    );
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
@@ -124,10 +124,11 @@ describe("agent chat draft store", () => {
     setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:01.000Z"));
 
     const firstHydration = hydrateAgentChatDraft(identity, "task-1");
+    const getItemCallsAfterFirstHydration = getItem.mock.calls.length;
     const secondHydration = hydrateAgentChatDraft(identity, "task-1");
 
     expect(firstHydration.segments).toEqual(secondHydration.segments);
-    expect(getItem).toHaveBeenCalledTimes(1);
+    expect(getItem.mock.calls.length).toBe(getItemCallsAfterFirstHydration);
   });
 
   test("coalesces dirty writes instead of writing on every draft change", async () => {
@@ -198,12 +199,37 @@ describe("agent chat draft store", () => {
     });
 
     await flushAgentChatDraft(identity);
-    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
-
-    await flushAgentChatDraft(identity);
     const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
     expect(raw).toContain("/tmp/staged/brief.pdf");
     expect(raw).not.toContain("base64");
+  });
+
+  test("runs expired draft cleanup during first hydration only", () => {
+    const storage = createMemoryStorage();
+    const expiredIdentity = { workspaceId: "workspace", externalSessionId: "expired" };
+    const freshIdentity = { workspaceId: "workspace", externalSessionId: "fresh" };
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:00.000Z"));
+    writeAgentChatDraftToStorage({
+      storage,
+      identity: expiredIdentity,
+      taskId: "task-1",
+      draft: buildDraft("expired"),
+      updatedAt: "2026-07-01T09:59:59.000Z",
+    });
+    writeAgentChatDraftToStorage({
+      storage,
+      identity: freshIdentity,
+      taskId: "task-2",
+      draft: buildDraft("fresh"),
+      updatedAt: "2026-07-08T09:00:00.000Z",
+    });
+
+    hydrateAgentChatDraft(freshIdentity, "task-2");
+    hydrateAgentChatDraft(freshIdentity, "task-2");
+
+    expect(storage.getItem(toAgentChatDraftStorageKey(expiredIdentity))).toBeNull();
+    expect(storage.getItem(toAgentChatDraftStorageKey(freshIdentity))).not.toBeNull();
   });
 
   test("removes stale storage and reports staging failures without dropping memory", async () => {
@@ -247,6 +273,28 @@ describe("agent chat draft store", () => {
     expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
     expect(errors[0]?.message).toBe("stage failed");
     expect(hydrateAgentChatDraft(identity, "task-1").attachments?.[0]?.file).toBe(file);
+  });
+
+  test("does not mark failed storage writes as persisted", async () => {
+    const errors: Error[] = [];
+    const setItem = mock((_key: string, _value: string) => {
+      throw new Error("quota exceeded");
+    });
+    const storage = createMemoryStorage({ setItem });
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftPersistenceErrorReporter((error) => {
+      errors.push(error);
+    });
+
+    setAgentChatDraft(identity, "task-1", buildDraft("retry me"));
+    await flushAgentChatDraft(identity);
+    await flushAgentChatDraft(identity);
+
+    expect(setItem).toHaveBeenCalledTimes(2);
+    expect(errors.map((error) => error.message)).toEqual([
+      expect.stringContaining("Failed to persist chat draft storage key"),
+      expect.stringContaining("Failed to persist chat draft storage key"),
+    ]);
   });
 
   test("clears storage only when the submitted draft version is still current", () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
@@ -204,6 +204,50 @@ describe("agent chat draft store", () => {
     expect(raw).not.toContain("base64");
   });
 
+  test("reuses a staged path for the same file attachment after later text edits", async () => {
+    const storage = createMemoryStorage();
+    const stagedFile = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    let stageCount = 0;
+    const stager = mock(async () => {
+      stageCount += 1;
+      return `/tmp/staged/brief-${stageCount}.pdf`;
+    });
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:00.000Z"));
+    setAgentChatDraftAttachmentStagerForTests(stager);
+
+    const buildDraftWithFile = (text: string, file: File): AgentChatComposerDraft => ({
+      segments: [createTextSegment(text, "text-1")],
+      attachments: [
+        createComposerAttachment(
+          {
+            name: "brief.pdf",
+            kind: "pdf",
+            mime: "application/pdf",
+            file,
+          },
+          "attachment-1",
+        ),
+      ],
+    });
+
+    setAgentChatDraft(identity, "task-1", buildDraftWithFile("with file", stagedFile));
+    await flushAgentChatDraft(identity);
+
+    setAgentChatDraft(identity, "task-1", buildDraftWithFile("edited text", stagedFile));
+    await flushAgentChatDraft(identity);
+
+    const replacementFile = new File(["updated"], "brief.pdf", { type: "application/pdf" });
+    setAgentChatDraft(identity, "task-1", buildDraftWithFile("replaced file", replacementFile));
+    await flushAgentChatDraft(identity);
+
+    const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
+    expect(stager).toHaveBeenCalledTimes(2);
+    expect(raw).toContain("replaced file");
+    expect(raw).toContain("/tmp/staged/brief-2.pdf");
+    expect(raw).not.toContain("/tmp/staged/brief-3.pdf");
+  });
+
   test("runs expired draft cleanup during first hydration only", () => {
     const storage = createMemoryStorage();
     const expiredIdentity = { workspaceId: "workspace", externalSessionId: "expired" };

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.test.ts
@@ -5,6 +5,7 @@ import {
   createTextSegment,
 } from "./agent-chat-composer-draft";
 import {
+  AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES,
   type AgentChatDraftSessionIdentity,
   toAgentChatDraftStorageKey,
   writeAgentChatDraftToStorage,
@@ -92,6 +93,20 @@ const installManualTimers = () => {
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;
     },
+  };
+};
+
+const createDeferred = <T>() => {
+  let resolveValue: (value: T) => void = () => {};
+  let rejectValue: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveValue = resolve;
+    rejectValue = reject;
+  });
+  return {
+    promise,
+    resolve: resolveValue,
+    reject: rejectValue,
   };
 };
 
@@ -288,7 +303,7 @@ describe("agent chat draft store", () => {
     expect(storage.getItem(toAgentChatDraftStorageKey(freshIdentity))).not.toBeNull();
   });
 
-  test("removes stale storage and reports staging failures without dropping memory", async () => {
+  test("preserves stale storage and reports staging failures without dropping memory", async () => {
     const errors: Error[] = [];
     const storage = createMemoryStorage();
     const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
@@ -326,9 +341,47 @@ describe("agent chat draft store", () => {
 
     await flushAgentChatDraft(identity);
 
-    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toContain("old");
     expect(errors[0]?.message).toBe("stage failed");
     expect(hydrateAgentChatDraft(identity, "task-1").attachments?.[0]?.file).toBe(file);
+  });
+
+  test("abandons in-flight staging when the draft entry is replaced", async () => {
+    const storage = createMemoryStorage();
+    const staging = createDeferred<string>();
+    const stagedFile = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    const stager = mock(() => staging.promise);
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftNowProviderForTests(() => new Date("2026-07-08T10:00:00.000Z"));
+    setAgentChatDraftAttachmentStagerForTests(stager);
+
+    setAgentChatDraft(identity, "task-1", {
+      segments: [createTextSegment("with file", "text-1")],
+      attachments: [
+        createComposerAttachment(
+          {
+            name: "brief.pdf",
+            kind: "pdf",
+            mime: "application/pdf",
+            file: stagedFile,
+          },
+          "attachment-1",
+        ),
+      ],
+    });
+    const staleFlush = flushAgentChatDraft(identity);
+    await Promise.resolve();
+
+    clearAgentChatDraft(identity);
+    setAgentChatDraft(identity, "task-1", buildDraft("replacement"));
+    staging.resolve("/tmp/staged/brief.pdf");
+    await staleFlush;
+    await flushAgentChatDraft(identity);
+
+    const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
+    expect(stager).toHaveBeenCalledTimes(1);
+    expect(raw).toContain("replacement");
+    expect(raw).not.toContain("/tmp/staged/brief.pdf");
   });
 
   test("does not mark failed storage writes as persisted", async () => {
@@ -351,6 +404,47 @@ describe("agent chat draft store", () => {
       expect.stringContaining("Failed to persist chat draft storage key"),
       expect.stringContaining("Failed to persist chat draft storage key"),
     ]);
+  });
+
+  test("does not mark oversized drafts as persisted", async () => {
+    const errors: Error[] = [];
+    const storage = createMemoryStorage();
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraftPersistenceErrorReporter((error) => {
+      errors.push(error);
+    });
+    setAgentChatDraft(
+      identity,
+      "task-1",
+      buildDraft("x".repeat(AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES)),
+    );
+
+    await flushAgentChatDraft(identity);
+    await flushAgentChatDraft(identity);
+
+    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+    expect(errors.map((error) => error.message)).toEqual([
+      expect.stringContaining("Chat draft is too large to persist"),
+      expect.stringContaining("Chat draft is too large to persist"),
+    ]);
+  });
+
+  test("keeps memory when throwing storage cleanup fails", () => {
+    const storage = createMemoryStorage({
+      removeItem: () => {
+        throw new Error("remove failed");
+      },
+    });
+    setAgentChatDraftStorageForTests(storage);
+    setAgentChatDraft(identity, "task-1", buildDraft("keep me"));
+
+    expect(() => clearAgentChatDraft(identity, { throwOnStorageError: true })).toThrow(
+      "Failed to remove chat draft storage key",
+    );
+
+    expect(hydrateAgentChatDraft(identity, "task-1").segments[0]).toEqual(
+      expect.objectContaining({ text: "keep me" }),
+    );
   });
 
   test("clears storage only when the submitted draft version is still current", () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
@@ -1,0 +1,408 @@
+import { stageLocalAttachmentFile } from "@/lib/local-attachment-files";
+import {
+  type AgentChatComposerAttachment,
+  type AgentChatComposerDraft,
+  createEmptyComposerDraft,
+} from "./agent-chat-composer-draft";
+import {
+  type AgentChatDraftSessionIdentity,
+  cleanupExpiredAgentChatDraftStorage as cleanupExpiredDraftStorage,
+  readAgentChatDraftFromStorage,
+  removeAgentChatDraftFromStorage,
+  toAgentChatDraftStorageKey,
+  writeAgentChatDraftToStorage,
+} from "./agent-chat-draft-storage";
+
+type DraftTimerId = ReturnType<typeof globalThis.setTimeout>;
+type DraftStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
+type AttachmentStager = (file: File) => Promise<string>;
+type PersistenceErrorReporter = (error: Error) => void;
+
+type DraftMemoryEntry = {
+  identity: AgentChatDraftSessionIdentity;
+  taskId: string;
+  draft: AgentChatComposerDraft;
+  version: number;
+  persistedVersion: number;
+  maxTimeoutId: DraftTimerId | null;
+  trailingTimeoutId: DraftTimerId | null;
+  isFlushing: boolean;
+  flushRequestedAfterCurrent: boolean;
+  flushPromise: Promise<void> | null;
+  stagingAttachmentIds: Set<string>;
+};
+
+export type AgentChatDraftCleanupTarget = AgentChatDraftSessionIdentity & {
+  taskId: string;
+};
+
+const MAX_WAIT_MS = 2_000;
+const TRAILING_WAIT_MS = 1_000;
+const draftEntries = new Map<string, DraftMemoryEntry>();
+
+let storageOverride: DraftStorage | null = null;
+let attachmentStager: AttachmentStager = stageLocalAttachmentFile;
+let nowProvider = (): Date => new Date();
+let persistenceErrorReporter: PersistenceErrorReporter = (error) => {
+  console.error(error);
+};
+
+const getDraftStorage = (): DraftStorage => {
+  if (storageOverride) {
+    return storageOverride;
+  }
+  if (typeof globalThis.localStorage === "undefined") {
+    throw new Error("Chat draft persistence is unavailable because localStorage is missing.");
+  }
+  return globalThis.localStorage;
+};
+
+const reportPersistenceError = (error: unknown): void => {
+  persistenceErrorReporter(error instanceof Error ? error : new Error(String(error)));
+};
+
+const createEntry = (
+  identity: AgentChatDraftSessionIdentity,
+  taskId: string,
+  draft: AgentChatComposerDraft,
+): DraftMemoryEntry => ({
+  identity,
+  taskId,
+  draft,
+  version: 0,
+  persistedVersion: 0,
+  maxTimeoutId: null,
+  trailingTimeoutId: null,
+  isFlushing: false,
+  flushRequestedAfterCurrent: false,
+  flushPromise: null,
+  stagingAttachmentIds: new Set(),
+});
+
+const clearEntryTimers = (entry: DraftMemoryEntry): void => {
+  if (entry.maxTimeoutId !== null) {
+    globalThis.clearTimeout(entry.maxTimeoutId);
+    entry.maxTimeoutId = null;
+  }
+  if (entry.trailingTimeoutId !== null) {
+    globalThis.clearTimeout(entry.trailingTimeoutId);
+    entry.trailingTimeoutId = null;
+  }
+};
+
+const readEntry = (identity: AgentChatDraftSessionIdentity): DraftMemoryEntry | null =>
+  draftEntries.get(toAgentChatDraftStorageKey(identity)) ?? null;
+
+const upsertEntry = (
+  identity: AgentChatDraftSessionIdentity,
+  taskId: string,
+  draft: AgentChatComposerDraft,
+): DraftMemoryEntry => {
+  const key = toAgentChatDraftStorageKey(identity);
+  const existing = draftEntries.get(key);
+  if (existing) {
+    existing.taskId = taskId;
+    existing.draft = draft;
+    return existing;
+  }
+
+  const entry = createEntry(identity, taskId, draft);
+  draftEntries.set(key, entry);
+  return entry;
+};
+
+const scheduleEntryFlush = (entry: DraftMemoryEntry): void => {
+  if (entry.isFlushing) {
+    entry.flushRequestedAfterCurrent = true;
+    return;
+  }
+
+  if (entry.maxTimeoutId === null) {
+    entry.maxTimeoutId = globalThis.setTimeout(() => {
+      void flushAgentChatDraft(entry.identity);
+    }, MAX_WAIT_MS);
+  }
+
+  if (entry.trailingTimeoutId !== null) {
+    globalThis.clearTimeout(entry.trailingTimeoutId);
+  }
+  entry.trailingTimeoutId = globalThis.setTimeout(() => {
+    void flushAgentChatDraft(entry.identity);
+  }, TRAILING_WAIT_MS);
+};
+
+const toPathBackedAttachment = (
+  attachment: AgentChatComposerAttachment,
+  path: string,
+): AgentChatComposerAttachment => {
+  const { file: _file, previewUrl: _previewUrl, ...metadata } = attachment;
+  return { ...metadata, path };
+};
+
+const findUnpersistableAttachment = (
+  draft: AgentChatComposerDraft,
+): AgentChatComposerAttachment | null => {
+  for (const attachment of draft.attachments ?? []) {
+    if (!attachment.path) {
+      return attachment;
+    }
+  }
+  return null;
+};
+
+const stageAttachmentForEntry = async (
+  entry: DraftMemoryEntry,
+  attachment: AgentChatComposerAttachment,
+): Promise<void> => {
+  if (!attachment.file || entry.stagingAttachmentIds.has(attachment.id)) {
+    return;
+  }
+
+  entry.stagingAttachmentIds.add(attachment.id);
+  try {
+    const stagedPath = await attachmentStager(attachment.file);
+    const currentEntry = readEntry(entry.identity);
+    if (!currentEntry) {
+      return;
+    }
+
+    let didUpdateAttachment = false;
+    const nextAttachments = (currentEntry.draft.attachments ?? []).map((currentAttachment) => {
+      if (
+        currentAttachment.id !== attachment.id ||
+        currentAttachment.path ||
+        currentAttachment.file !== attachment.file
+      ) {
+        return currentAttachment;
+      }
+
+      didUpdateAttachment = true;
+      return toPathBackedAttachment(currentAttachment, stagedPath);
+    });
+
+    if (!didUpdateAttachment) {
+      return;
+    }
+
+    currentEntry.draft = {
+      ...currentEntry.draft,
+      attachments: nextAttachments,
+    };
+    currentEntry.version += 1;
+    scheduleEntryFlush(currentEntry);
+  } catch (error) {
+    reportPersistenceError(
+      error instanceof Error
+        ? error
+        : new Error(`Failed to stage chat draft attachment "${attachment.name}".`),
+    );
+  } finally {
+    entry.stagingAttachmentIds.delete(attachment.id);
+  }
+};
+
+const persistEntrySnapshot = async (entry: DraftMemoryEntry, version: number): Promise<void> => {
+  const storage = getDraftStorage();
+  const unpersistableAttachment = findUnpersistableAttachment(entry.draft);
+  if (unpersistableAttachment) {
+    removeAgentChatDraftFromStorage({ storage, identity: entry.identity });
+    entry.persistedVersion = version;
+    if (!unpersistableAttachment.file) {
+      reportPersistenceError(
+        new Error(
+          `Attachment "${unpersistableAttachment.name}" cannot be persisted because it has no local file path.`,
+        ),
+      );
+      return;
+    }
+    await stageAttachmentForEntry(entry, unpersistableAttachment);
+    return;
+  }
+
+  writeAgentChatDraftToStorage({
+    storage,
+    identity: entry.identity,
+    taskId: entry.taskId,
+    draft: entry.draft,
+    updatedAt: nowProvider().toISOString(),
+  });
+  entry.persistedVersion = version;
+};
+
+export const hydrateAgentChatDraft = (
+  identity: AgentChatDraftSessionIdentity,
+  taskId: string,
+): AgentChatComposerDraft => {
+  const existing = readEntry(identity);
+  if (existing) {
+    existing.taskId = taskId;
+    return existing.draft;
+  }
+
+  let draft = createEmptyComposerDraft();
+  try {
+    const result = readAgentChatDraftFromStorage({
+      storage: getDraftStorage(),
+      identity,
+      now: nowProvider(),
+    });
+    if (result.status === "restored") {
+      draft = result.value.draft;
+    }
+  } catch (error) {
+    reportPersistenceError(error);
+  }
+
+  const entry = createEntry(identity, taskId, draft);
+  draftEntries.set(toAgentChatDraftStorageKey(identity), entry);
+  return draft;
+};
+
+export const setAgentChatDraft = (
+  identity: AgentChatDraftSessionIdentity,
+  taskId: string,
+  draft: AgentChatComposerDraft,
+): number => {
+  const entry = upsertEntry(identity, taskId, draft);
+  entry.version += 1;
+  scheduleEntryFlush(entry);
+  return entry.version;
+};
+
+export const readAgentChatDraftVersion = (identity: AgentChatDraftSessionIdentity): number | null =>
+  readEntry(identity)?.version ?? null;
+
+export const clearAgentChatDraft = (
+  identity: AgentChatDraftSessionIdentity,
+  options?: {
+    onlyIfVersion?: number | null;
+    throwOnStorageError?: boolean;
+  },
+): boolean => {
+  const key = toAgentChatDraftStorageKey(identity);
+  const entry = draftEntries.get(key);
+  if (
+    typeof options?.onlyIfVersion === "number" &&
+    entry &&
+    entry.version !== options.onlyIfVersion
+  ) {
+    return false;
+  }
+
+  if (entry) {
+    clearEntryTimers(entry);
+    draftEntries.delete(key);
+  }
+
+  try {
+    removeAgentChatDraftFromStorage({ storage: getDraftStorage(), identity });
+  } catch (error) {
+    if (options?.throwOnStorageError) {
+      throw error;
+    }
+    reportPersistenceError(error);
+  }
+
+  return true;
+};
+
+export const flushAgentChatDraft = (identity: AgentChatDraftSessionIdentity): Promise<void> => {
+  const entry = readEntry(identity);
+  if (!entry) {
+    return Promise.resolve();
+  }
+
+  if (entry.isFlushing) {
+    entry.flushRequestedAfterCurrent = true;
+    return entry.flushPromise ?? Promise.resolve();
+  }
+
+  clearEntryTimers(entry);
+  entry.isFlushing = true;
+  entry.flushRequestedAfterCurrent = false;
+  const version = entry.version;
+  const flushPromise = persistEntrySnapshot(entry, version)
+    .catch((error) => {
+      entry.persistedVersion = version;
+      reportPersistenceError(error);
+    })
+    .finally(() => {
+      entry.isFlushing = false;
+      entry.flushPromise = null;
+      if (entry.version !== entry.persistedVersion || entry.flushRequestedAfterCurrent) {
+        entry.flushRequestedAfterCurrent = false;
+        scheduleEntryFlush(entry);
+      }
+    });
+
+  entry.flushPromise = flushPromise;
+  return flushPromise;
+};
+
+export const flushAllAgentChatDrafts = async (): Promise<void> => {
+  await Promise.all(
+    Array.from(draftEntries.values(), (entry) => flushAgentChatDraft(entry.identity)),
+  );
+};
+
+export const clearAgentChatDraftsForTargets = (targets: AgentChatDraftCleanupTarget[]): void => {
+  const uniqueIdentities = new Map<string, AgentChatDraftSessionIdentity>();
+  for (const target of targets) {
+    uniqueIdentities.set(toAgentChatDraftStorageKey(target), {
+      workspaceId: target.workspaceId,
+      externalSessionId: target.externalSessionId,
+    });
+  }
+
+  const errors: Error[] = [];
+  for (const identity of uniqueIdentities.values()) {
+    try {
+      clearAgentChatDraft(identity, { throwOnStorageError: true });
+    } catch (error) {
+      errors.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Failed to clean ${errors.length} chat draft storage key(s).`, {
+      cause: errors[0],
+    });
+  }
+};
+
+export const cleanupExpiredAgentChatDrafts = (): void => {
+  cleanupExpiredDraftStorage({ storage: getDraftStorage(), now: nowProvider() });
+};
+
+export const setAgentChatDraftPersistenceErrorReporter = (
+  reporter: PersistenceErrorReporter,
+): void => {
+  persistenceErrorReporter = reporter;
+};
+
+export const setAgentChatDraftStorageForTests = (storage: DraftStorage | null): void => {
+  storageOverride = storage;
+};
+
+export const setAgentChatDraftAttachmentStagerForTests = (
+  stager: AttachmentStager | null,
+): void => {
+  attachmentStager = stager ?? stageLocalAttachmentFile;
+};
+
+export const setAgentChatDraftNowProviderForTests = (provider: (() => Date) | null): void => {
+  nowProvider = provider ?? (() => new Date());
+};
+
+export const resetAgentChatDraftStoreForTests = (): void => {
+  for (const entry of draftEntries.values()) {
+    clearEntryTimers(entry);
+  }
+  draftEntries.clear();
+  storageOverride = null;
+  attachmentStager = stageLocalAttachmentFile;
+  nowProvider = () => new Date();
+  persistenceErrorReporter = (error) => {
+    console.error(error);
+  };
+};

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
@@ -5,6 +5,7 @@ import {
   createEmptyComposerDraft,
 } from "./agent-chat-composer-draft";
 import {
+  AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES,
   type AgentChatDraftSessionIdentity,
   cleanupExpiredAgentChatDraftStorage as cleanupExpiredDraftStorage,
   readAgentChatDraftFromStorage,
@@ -197,7 +198,7 @@ const stageAttachmentForEntry = async (
   try {
     const stagedPath = await attachmentStager(attachment.file);
     const currentEntry = readEntry(entry.identity);
-    if (!currentEntry) {
+    if (currentEntry !== entry) {
       return false;
     }
 
@@ -242,7 +243,6 @@ const persistEntrySnapshot = async (entry: DraftMemoryEntry): Promise<void> => {
       break;
     }
 
-    removeAgentChatDraftFromStorage({ storage, identity: entry.identity });
     if (!unpersistableAttachment.file) {
       throw new Error(
         `Attachment "${unpersistableAttachment.name}" cannot be persisted because it has no local file path.`,
@@ -251,7 +251,7 @@ const persistEntrySnapshot = async (entry: DraftMemoryEntry): Promise<void> => {
 
     const didStage = await stageAttachmentForEntry(entry, unpersistableAttachment);
     const currentEntry = readEntry(entry.identity);
-    if (!currentEntry) {
+    if (currentEntry !== entry) {
       return;
     }
     if (
@@ -265,13 +265,22 @@ const persistEntrySnapshot = async (entry: DraftMemoryEntry): Promise<void> => {
   }
 
   const version = entry.version;
-  writeAgentChatDraftToStorage({
+  const writeResult = writeAgentChatDraftToStorage({
     storage,
     identity: entry.identity,
     taskId: entry.taskId,
     draft: entry.draft,
     updatedAt: nowProvider().toISOString(),
   });
+  if (writeResult.status === "oversized") {
+    throw new Error(
+      `Chat draft is too large to persist (${writeResult.byteLength} bytes, maximum ${AGENT_CHAT_DRAFT_STORAGE_MAX_BYTES} bytes).`,
+    );
+  }
+  if (writeResult.status === "unpersistable_attachments") {
+    throw new Error("Chat draft contains attachments that cannot be persisted.");
+  }
+
   entry.persistedVersion = version;
 };
 
@@ -354,6 +363,15 @@ export const clearAgentChatDraft = (
     return false;
   }
 
+  if (options?.throwOnStorageError) {
+    removeAgentChatDraftFromStorage({ storage: getDraftStorage(), identity });
+    if (entry) {
+      clearEntryTimers(entry);
+      draftEntries.delete(key);
+    }
+    return true;
+  }
+
   if (entry) {
     clearEntryTimers(entry);
     draftEntries.delete(key);
@@ -362,9 +380,6 @@ export const clearAgentChatDraft = (
   try {
     removeAgentChatDraftFromStorage({ storage: getDraftStorage(), identity });
   } catch (error) {
-    if (options?.throwOnStorageError) {
-      throw error;
-    }
     reportPersistenceError(error);
   }
 
@@ -393,6 +408,9 @@ export const flushAgentChatDraft = (identity: AgentChatDraftSessionIdentity): Pr
       reportPersistenceError(error);
     })
     .finally(() => {
+      if (readEntry(entry.identity) !== entry) {
+        return;
+      }
       entry.isFlushing = false;
       entry.flushPromise = null;
       const hasNewUserChanges = entry.userVersion !== userVersion;

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
@@ -424,6 +424,8 @@ export const clearAgentChatDraftsForTargets = (targets: AgentChatDraftCleanupTar
     uniqueIdentities.set(toAgentChatDraftStorageKey(target), {
       workspaceId: target.workspaceId,
       externalSessionId: target.externalSessionId,
+      runtimeKind: target.runtimeKind,
+      workingDirectory: target.workingDirectory,
     });
   }
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
@@ -23,6 +23,7 @@ type DraftMemoryEntry = {
   taskId: string;
   draft: AgentChatComposerDraft;
   version: number;
+  userVersion: number;
   persistedVersion: number;
   maxTimeoutId: DraftTimerId | null;
   trailingTimeoutId: DraftTimerId | null;
@@ -46,6 +47,7 @@ let nowProvider = (): Date => new Date();
 let persistenceErrorReporter: PersistenceErrorReporter = (error) => {
   console.error(error);
 };
+let didRunExpiredCleanup = false;
 
 const getDraftStorage = (): DraftStorage => {
   if (storageOverride) {
@@ -70,6 +72,7 @@ const createEntry = (
   taskId,
   draft,
   version: 0,
+  userVersion: 0,
   persistedVersion: 0,
   maxTimeoutId: null,
   trailingTimeoutId: null,
@@ -153,9 +156,9 @@ const findUnpersistableAttachment = (
 const stageAttachmentForEntry = async (
   entry: DraftMemoryEntry,
   attachment: AgentChatComposerAttachment,
-): Promise<void> => {
+): Promise<boolean> => {
   if (!attachment.file || entry.stagingAttachmentIds.has(attachment.id)) {
-    return;
+    return false;
   }
 
   entry.stagingAttachmentIds.add(attachment.id);
@@ -163,7 +166,7 @@ const stageAttachmentForEntry = async (
     const stagedPath = await attachmentStager(attachment.file);
     const currentEntry = readEntry(entry.identity);
     if (!currentEntry) {
-      return;
+      return false;
     }
 
     let didUpdateAttachment = false;
@@ -181,7 +184,7 @@ const stageAttachmentForEntry = async (
     });
 
     if (!didUpdateAttachment) {
-      return;
+      return false;
     }
 
     currentEntry.draft = {
@@ -189,36 +192,43 @@ const stageAttachmentForEntry = async (
       attachments: nextAttachments,
     };
     currentEntry.version += 1;
-    scheduleEntryFlush(currentEntry);
-  } catch (error) {
-    reportPersistenceError(
-      error instanceof Error
-        ? error
-        : new Error(`Failed to stage chat draft attachment "${attachment.name}".`),
-    );
+    return true;
   } finally {
     entry.stagingAttachmentIds.delete(attachment.id);
   }
 };
 
-const persistEntrySnapshot = async (entry: DraftMemoryEntry, version: number): Promise<void> => {
+const persistEntrySnapshot = async (entry: DraftMemoryEntry): Promise<void> => {
   const storage = getDraftStorage();
-  const unpersistableAttachment = findUnpersistableAttachment(entry.draft);
-  if (unpersistableAttachment) {
+  while (true) {
+    const unpersistableAttachment = findUnpersistableAttachment(entry.draft);
+    if (!unpersistableAttachment) {
+      break;
+    }
+
     removeAgentChatDraftFromStorage({ storage, identity: entry.identity });
-    entry.persistedVersion = version;
     if (!unpersistableAttachment.file) {
-      reportPersistenceError(
-        new Error(
-          `Attachment "${unpersistableAttachment.name}" cannot be persisted because it has no local file path.`,
-        ),
+      throw new Error(
+        `Attachment "${unpersistableAttachment.name}" cannot be persisted because it has no local file path.`,
       );
+    }
+
+    const didStage = await stageAttachmentForEntry(entry, unpersistableAttachment);
+    const currentEntry = readEntry(entry.identity);
+    if (!currentEntry) {
       return;
     }
-    await stageAttachmentForEntry(entry, unpersistableAttachment);
-    return;
+    if (
+      !didStage &&
+      findUnpersistableAttachment(currentEntry.draft)?.id === unpersistableAttachment.id
+    ) {
+      throw new Error(
+        `Attachment "${unpersistableAttachment.name}" could not be prepared for chat draft persistence.`,
+      );
+    }
   }
 
+  const version = entry.version;
   writeAgentChatDraftToStorage({
     storage,
     identity: entry.identity,
@@ -227,6 +237,22 @@ const persistEntrySnapshot = async (entry: DraftMemoryEntry, version: number): P
     updatedAt: nowProvider().toISOString(),
   });
   entry.persistedVersion = version;
+};
+
+const cleanupExpiredAgentChatDraftsOnce = (): void => {
+  if (didRunExpiredCleanup) {
+    return;
+  }
+  didRunExpiredCleanup = true;
+  try {
+    cleanupExpiredAgentChatDrafts();
+  } catch (error) {
+    reportPersistenceError(
+      error instanceof Error
+        ? error
+        : new Error("Failed to clean expired chat drafts from storage.", { cause: error }),
+    );
+  }
 };
 
 export const hydrateAgentChatDraft = (
@@ -238,6 +264,8 @@ export const hydrateAgentChatDraft = (
     existing.taskId = taskId;
     return existing.draft;
   }
+
+  cleanupExpiredAgentChatDraftsOnce();
 
   let draft = createEmptyComposerDraft();
   try {
@@ -265,12 +293,13 @@ export const setAgentChatDraft = (
 ): number => {
   const entry = upsertEntry(identity, taskId, draft);
   entry.version += 1;
+  entry.userVersion += 1;
   scheduleEntryFlush(entry);
-  return entry.version;
+  return entry.userVersion;
 };
 
 export const readAgentChatDraftVersion = (identity: AgentChatDraftSessionIdentity): number | null =>
-  readEntry(identity)?.version ?? null;
+  readEntry(identity)?.userVersion ?? null;
 
 export const clearAgentChatDraft = (
   identity: AgentChatDraftSessionIdentity,
@@ -284,7 +313,7 @@ export const clearAgentChatDraft = (
   if (
     typeof options?.onlyIfVersion === "number" &&
     entry &&
-    entry.version !== options.onlyIfVersion
+    entry.userVersion !== options.onlyIfVersion
   ) {
     return false;
   }
@@ -320,17 +349,25 @@ export const flushAgentChatDraft = (identity: AgentChatDraftSessionIdentity): Pr
   clearEntryTimers(entry);
   entry.isFlushing = true;
   entry.flushRequestedAfterCurrent = false;
-  const version = entry.version;
-  const flushPromise = persistEntrySnapshot(entry, version)
+  const userVersion = entry.userVersion;
+  let didFail = false;
+  const flushPromise = persistEntrySnapshot(entry)
     .catch((error) => {
-      entry.persistedVersion = version;
+      didFail = true;
       reportPersistenceError(error);
     })
     .finally(() => {
       entry.isFlushing = false;
       entry.flushPromise = null;
-      if (entry.version !== entry.persistedVersion || entry.flushRequestedAfterCurrent) {
-        entry.flushRequestedAfterCurrent = false;
+      const hasNewUserChanges = entry.userVersion !== userVersion;
+      entry.flushRequestedAfterCurrent = false;
+      if (didFail) {
+        if (hasNewUserChanges) {
+          scheduleEntryFlush(entry);
+        }
+        return;
+      }
+      if (entry.version !== entry.persistedVersion) {
         scheduleEntryFlush(entry);
       }
     });
@@ -402,6 +439,7 @@ export const resetAgentChatDraftStoreForTests = (): void => {
   storageOverride = null;
   attachmentStager = stageLocalAttachmentFile;
   nowProvider = () => new Date();
+  didRunExpiredCleanup = false;
   persistenceErrorReporter = (error) => {
     console.error(error);
   };

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-draft-store.ts
@@ -17,6 +17,10 @@ type DraftTimerId = ReturnType<typeof globalThis.setTimeout>;
 type DraftStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
 type AttachmentStager = (file: File) => Promise<string>;
 type PersistenceErrorReporter = (error: Error) => void;
+type StagedAttachment = {
+  file: File;
+  path: string;
+};
 
 type DraftMemoryEntry = {
   identity: AgentChatDraftSessionIdentity;
@@ -31,6 +35,7 @@ type DraftMemoryEntry = {
   flushRequestedAfterCurrent: boolean;
   flushPromise: Promise<void> | null;
   stagingAttachmentIds: Set<string>;
+  stagedAttachmentsById: Map<string, StagedAttachment>;
 };
 
 export type AgentChatDraftCleanupTarget = AgentChatDraftSessionIdentity & {
@@ -80,6 +85,7 @@ const createEntry = (
   flushRequestedAfterCurrent: false,
   flushPromise: null,
   stagingAttachmentIds: new Set(),
+  stagedAttachmentsById: new Map(),
 });
 
 const clearEntryTimers = (entry: DraftMemoryEntry): void => {
@@ -105,7 +111,7 @@ const upsertEntry = (
   const existing = draftEntries.get(key);
   if (existing) {
     existing.taskId = taskId;
-    existing.draft = draft;
+    existing.draft = preserveStagedAttachmentPaths(existing, draft);
     return existing;
   }
 
@@ -140,6 +146,32 @@ const toPathBackedAttachment = (
 ): AgentChatComposerAttachment => {
   const { file: _file, previewUrl: _previewUrl, ...metadata } = attachment;
   return { ...metadata, path };
+};
+
+const preserveStagedAttachmentPaths = (
+  entry: DraftMemoryEntry,
+  draft: AgentChatComposerDraft,
+): AgentChatComposerDraft => {
+  if (!draft.attachments?.length || entry.stagedAttachmentsById.size === 0) {
+    return draft;
+  }
+
+  let didPreserveStagedPath = false;
+  const attachments = draft.attachments.map((attachment) => {
+    if (attachment.path || !attachment.file) {
+      return attachment;
+    }
+
+    const stagedAttachment = entry.stagedAttachmentsById.get(attachment.id);
+    if (!stagedAttachment || stagedAttachment.file !== attachment.file) {
+      return attachment;
+    }
+
+    didPreserveStagedPath = true;
+    return toPathBackedAttachment(attachment, stagedAttachment.path);
+  });
+
+  return didPreserveStagedPath ? { ...draft, attachments } : draft;
 };
 
 const findUnpersistableAttachment = (
@@ -187,6 +219,10 @@ const stageAttachmentForEntry = async (
       return false;
     }
 
+    currentEntry.stagedAttachmentsById.set(attachment.id, {
+      file: attachment.file,
+      path: stagedPath,
+    });
     currentEntry.draft = {
       ...currentEntry.draft,
       attachments: nextAttachments,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
@@ -52,6 +52,7 @@ const buildModel = () => ({
     busySendBlockedReason: null,
     pendingInlineCommentCount: 0,
     draftStateKey: "draft-1",
+    draftPersistenceIdentity: null,
     onSend: async () => true,
     isSending: false,
     isStarting: false,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -55,6 +55,7 @@ const buildModel = () => ({
     busySendBlockedReason: null,
     pendingInlineCommentCount: 0,
     draftStateKey: "draft-1",
+    draftPersistenceIdentity: null,
     onSend: async () => true,
     isSending: false,
     isStarting: false,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -25,6 +25,7 @@ import type {
   SessionMessagesState,
 } from "@/types/agent-orchestrator";
 import type { AgentSessionActivityState } from "@/types/agent-session-activity";
+import type { AgentChatDraftSessionIdentity } from "./agent-chat-draft-storage";
 
 export type AgentRoleOption = {
   role: AgentRole;
@@ -107,6 +108,7 @@ export type AgentChatComposerModel = {
   busySendBlockedReason: string | null;
   pendingInlineCommentCount: number;
   draftStateKey: string;
+  draftPersistenceIdentity: AgentChatDraftSessionIdentity | null;
   onSend: (draft: import("./agent-chat-composer-draft").AgentChatComposerDraft) => Promise<boolean>;
   isSending: boolean;
   isStarting: boolean;

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHookHarness } from "@/test-utils/react-hook-harness";
+import {
+  type AgentChatComposerDraft,
+  createEmptyComposerDraft,
+  createTextSegment,
+} from "./agent-chat-composer-draft";
+import {
+  type AgentChatDraftSessionIdentity,
+  toAgentChatDraftStorageKey,
+} from "./agent-chat-draft-storage";
+import {
+  flushAgentChatDraft,
+  resetAgentChatDraftStoreForTests,
+  setAgentChatDraftStorageForTests,
+} from "./agent-chat-draft-store";
+import { useAgentChatComposerDraftState } from "./use-agent-chat-composer-draft-state";
+
+type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
+type HookArgs = Parameters<typeof useAgentChatComposerDraftState>[0];
+type HookResult = ReturnType<typeof useAgentChatComposerDraftState>;
+
+const createMemoryStorage = (): TestStorage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+};
+
+const identity: AgentChatDraftSessionIdentity = {
+  workspaceId: "workspace",
+  externalSessionId: "session-a",
+  runtimeKind: "opencode",
+  workingDirectory: "/repo",
+};
+
+const buildDraft = (text: string): AgentChatComposerDraft => ({
+  segments: [createTextSegment(text, "text-1")],
+  attachments: [],
+});
+
+const mountHarness = async (args: Partial<HookArgs> = {}) => {
+  const harness = createHookHarness<HookArgs, HookResult>(useAgentChatComposerDraftState, {
+    draftStateKey: "composer-key",
+    persistenceIdentity: identity,
+    taskId: "task-1",
+    ...args,
+  });
+  await harness.mount();
+  return harness;
+};
+
+afterEach(() => {
+  resetAgentChatDraftStoreForTests();
+});
+
+describe("useAgentChatComposerDraftState", () => {
+  test("rehydrates the draft entry when only the task id changes", async () => {
+    const storage = createMemoryStorage();
+    setAgentChatDraftStorageForTests(storage);
+    const harness = await mountHarness();
+
+    await harness.run((value) => {
+      value.commitDraft(buildDraft("same session"));
+    });
+    await harness.update({
+      draftStateKey: "composer-key",
+      persistenceIdentity: identity,
+      taskId: "task-2",
+    });
+    await flushAgentChatDraft(identity);
+
+    const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw ?? "{}")).toEqual(expect.objectContaining({ taskId: "task-2" }));
+    await harness.unmount();
+  });
+
+  test("persists a failed-send restoration when the visible draft is empty", async () => {
+    const storage = createMemoryStorage();
+    setAgentChatDraftStorageForTests(storage);
+    const harness = await mountHarness();
+    const submittedDraft = buildDraft("restore me");
+    let snapshot: ReturnType<HookResult["createSubmittedDraftSnapshot"]> | null = null;
+
+    await harness.run((value) => {
+      value.commitDraft(submittedDraft);
+      const nextSnapshot = value.createSubmittedDraftSnapshot(submittedDraft);
+      snapshot = nextSnapshot;
+      value.clearSubmittedDraft(nextSnapshot);
+      value.setDisplayedDraft(createEmptyComposerDraft());
+    });
+
+    expect(storage.getItem(toAgentChatDraftStorageKey(identity))).toBeNull();
+    await harness.run((value) => {
+      if (!snapshot) {
+        throw new Error("Expected submitted draft snapshot");
+      }
+      value.restoreSubmittedDraft(snapshot);
+    });
+    await flushAgentChatDraft(identity);
+
+    const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
+    expect(harness.getLatest().draft.segments[0]).toEqual(
+      expect.objectContaining({ text: "restore me" }),
+    );
+    expect(raw).toContain("restore me");
+    await harness.unmount();
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  type AgentChatComposerDraft,
+  createEmptyComposerDraft,
+  draftHasMeaningfulContent,
+} from "./agent-chat-composer-draft";
+import {
+  type AgentChatDraftSessionIdentity,
+  toAgentChatDraftStorageKey,
+} from "./agent-chat-draft-storage";
+import {
+  clearAgentChatDraft,
+  flushAgentChatDraft,
+  flushAllAgentChatDrafts,
+  hydrateAgentChatDraft,
+  readAgentChatDraftVersion,
+  setAgentChatDraft,
+} from "./agent-chat-draft-store";
+
+type ComposerDraftState = {
+  key: string;
+  identity: AgentChatDraftSessionIdentity | null;
+  draft: AgentChatComposerDraft;
+};
+
+type UseAgentChatComposerDraftStateArgs = {
+  draftStateKey: string;
+  persistenceIdentity: AgentChatDraftSessionIdentity | null;
+  taskId: string;
+};
+
+type SubmittedDraftSnapshot = {
+  key: string;
+  identity: AgentChatDraftSessionIdentity | null;
+  version: number | null;
+  draft: AgentChatComposerDraft;
+};
+
+type UseAgentChatComposerDraftStateResult = {
+  draft: AgentChatComposerDraft;
+  commitDraft: (draft: AgentChatComposerDraft) => void;
+  setDisplayedDraft: (draft: AgentChatComposerDraft) => void;
+  createSubmittedDraftSnapshot: (draft: AgentChatComposerDraft) => SubmittedDraftSnapshot;
+  clearSubmittedDraft: (snapshot: SubmittedDraftSnapshot) => void;
+  restoreSubmittedDraft: (snapshot: SubmittedDraftSnapshot) => void;
+};
+
+const toComposerDraftStateKey = (
+  draftStateKey: string,
+  identity: AgentChatDraftSessionIdentity | null,
+): string => (identity ? toAgentChatDraftStorageKey(identity) : draftStateKey);
+
+const areIdentitiesEqual = (
+  left: AgentChatDraftSessionIdentity | null,
+  right: AgentChatDraftSessionIdentity | null,
+): boolean =>
+  left?.workspaceId === right?.workspaceId && left?.externalSessionId === right?.externalSessionId;
+
+const createInitialDraftState = ({
+  draftStateKey,
+  persistenceIdentity,
+  taskId,
+}: UseAgentChatComposerDraftStateArgs): ComposerDraftState => ({
+  key: toComposerDraftStateKey(draftStateKey, persistenceIdentity),
+  identity: persistenceIdentity,
+  draft: persistenceIdentity
+    ? hydrateAgentChatDraft(persistenceIdentity, taskId)
+    : createEmptyComposerDraft(),
+});
+
+export function useAgentChatComposerDraftState({
+  draftStateKey,
+  persistenceIdentity,
+  taskId,
+}: UseAgentChatComposerDraftStateArgs): UseAgentChatComposerDraftStateResult {
+  const [state, setState] = useState<ComposerDraftState>(() =>
+    createInitialDraftState({ draftStateKey, persistenceIdentity, taskId }),
+  );
+  const latestStateRef = useRef(state);
+  const nextStateKey = toComposerDraftStateKey(draftStateKey, persistenceIdentity);
+
+  latestStateRef.current = state;
+
+  useLayoutEffect(() => {
+    const current = latestStateRef.current;
+    if (current.key === nextStateKey && areIdentitiesEqual(current.identity, persistenceIdentity)) {
+      return;
+    }
+
+    if (current.identity) {
+      void flushAgentChatDraft(current.identity);
+    }
+
+    const nextDraft = persistenceIdentity
+      ? hydrateAgentChatDraft(persistenceIdentity, taskId)
+      : createEmptyComposerDraft();
+    setState({
+      key: nextStateKey,
+      identity: persistenceIdentity,
+      draft: nextDraft,
+    });
+  }, [nextStateKey, persistenceIdentity, taskId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const flushDrafts = (): void => {
+      void flushAllAgentChatDrafts();
+    };
+    const handleVisibilityChange = (): void => {
+      if (document.visibilityState === "hidden") {
+        flushDrafts();
+      }
+    };
+
+    window.addEventListener("pagehide", flushDrafts);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("pagehide", flushDrafts);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      flushDrafts();
+    };
+  }, []);
+
+  const commitDraft = useCallback(
+    (nextDraft: AgentChatComposerDraft): void => {
+      const activeIdentity = latestStateRef.current.identity;
+      const activeKey = latestStateRef.current.key;
+      if (activeIdentity) {
+        setAgentChatDraft(activeIdentity, taskId, nextDraft);
+      }
+      setState({
+        key: activeKey,
+        identity: activeIdentity,
+        draft: nextDraft,
+      });
+    },
+    [taskId],
+  );
+
+  const setDisplayedDraft = useCallback((nextDraft: AgentChatComposerDraft): void => {
+    const current = latestStateRef.current;
+    setState({
+      key: current.key,
+      identity: current.identity,
+      draft: nextDraft,
+    });
+  }, []);
+
+  const createSubmittedDraftSnapshot = useCallback(
+    (draft: AgentChatComposerDraft): SubmittedDraftSnapshot => {
+      const current = latestStateRef.current;
+      return {
+        key: current.key,
+        identity: current.identity,
+        version: current.identity ? readAgentChatDraftVersion(current.identity) : null,
+        draft,
+      };
+    },
+    [],
+  );
+
+  const clearSubmittedDraft = useCallback((snapshot: SubmittedDraftSnapshot): void => {
+    if (!snapshot.identity) {
+      return;
+    }
+    clearAgentChatDraft(snapshot.identity, { onlyIfVersion: snapshot.version });
+  }, []);
+
+  const restoreSubmittedDraft = useCallback((snapshot: SubmittedDraftSnapshot): void => {
+    setState((current) => {
+      if (current.key !== snapshot.key || draftHasMeaningfulContent(current.draft)) {
+        return current;
+      }
+
+      return {
+        key: current.key,
+        identity: current.identity,
+        draft: snapshot.draft,
+      };
+    });
+  }, []);
+
+  return useMemo(
+    () => ({
+      draft: state.key === nextStateKey ? state.draft : createEmptyComposerDraft(),
+      commitDraft,
+      setDisplayedDraft,
+      createSubmittedDraftSnapshot,
+      clearSubmittedDraft,
+      restoreSubmittedDraft,
+    }),
+    [
+      clearSubmittedDraft,
+      commitDraft,
+      createSubmittedDraftSnapshot,
+      nextStateKey,
+      restoreSubmittedDraft,
+      setDisplayedDraft,
+      state.draft,
+      state.key,
+    ],
+  );
+}

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -20,6 +20,7 @@ import {
 type ComposerDraftState = {
   key: string;
   identity: AgentChatDraftSessionIdentity | null;
+  taskId: string;
   draft: AgentChatComposerDraft;
 };
 
@@ -32,6 +33,7 @@ type UseAgentChatComposerDraftStateArgs = {
 type SubmittedDraftSnapshot = {
   key: string;
   identity: AgentChatDraftSessionIdentity | null;
+  taskId: string;
   version: number | null;
   draft: AgentChatComposerDraft;
 };
@@ -66,6 +68,7 @@ const createInitialDraftState = ({
 }: UseAgentChatComposerDraftStateArgs): ComposerDraftState => ({
   key: toComposerDraftStateKey(draftStateKey, persistenceIdentity),
   identity: persistenceIdentity,
+  taskId,
   draft: persistenceIdentity
     ? hydrateAgentChatDraft(persistenceIdentity, taskId)
     : createEmptyComposerDraft(),
@@ -86,7 +89,11 @@ export function useAgentChatComposerDraftState({
 
   useLayoutEffect(() => {
     const current = latestStateRef.current;
-    if (current.key === nextStateKey && areIdentitiesEqual(current.identity, persistenceIdentity)) {
+    if (
+      current.key === nextStateKey &&
+      current.taskId === taskId &&
+      areIdentitiesEqual(current.identity, persistenceIdentity)
+    ) {
       return;
     }
 
@@ -100,6 +107,7 @@ export function useAgentChatComposerDraftState({
     setState({
       key: nextStateKey,
       identity: persistenceIdentity,
+      taskId,
       draft: nextDraft,
     });
   }, [nextStateKey, persistenceIdentity, taskId]);
@@ -128,27 +136,27 @@ export function useAgentChatComposerDraftState({
     };
   }, []);
 
-  const commitDraft = useCallback(
-    (nextDraft: AgentChatComposerDraft): void => {
-      const activeIdentity = latestStateRef.current.identity;
-      const activeKey = latestStateRef.current.key;
-      if (activeIdentity) {
-        setAgentChatDraft(activeIdentity, taskId, nextDraft);
-      }
-      setState({
-        key: activeKey,
-        identity: activeIdentity,
-        draft: nextDraft,
-      });
-    },
-    [taskId],
-  );
+  const commitDraft = useCallback((nextDraft: AgentChatComposerDraft): void => {
+    const activeIdentity = latestStateRef.current.identity;
+    const activeKey = latestStateRef.current.key;
+    const activeTaskId = latestStateRef.current.taskId;
+    if (activeIdentity) {
+      setAgentChatDraft(activeIdentity, activeTaskId, nextDraft);
+    }
+    setState({
+      key: activeKey,
+      identity: activeIdentity,
+      taskId: activeTaskId,
+      draft: nextDraft,
+    });
+  }, []);
 
   const setDisplayedDraft = useCallback((nextDraft: AgentChatComposerDraft): void => {
     const current = latestStateRef.current;
     setState({
       key: current.key,
       identity: current.identity,
+      taskId: current.taskId,
       draft: nextDraft,
     });
   }, []);
@@ -159,6 +167,7 @@ export function useAgentChatComposerDraftState({
       return {
         key: current.key,
         identity: current.identity,
+        taskId: current.taskId,
         version: current.identity ? readAgentChatDraftVersion(current.identity) : null,
         draft,
       };
@@ -174,16 +183,23 @@ export function useAgentChatComposerDraftState({
   }, []);
 
   const restoreSubmittedDraft = useCallback((snapshot: SubmittedDraftSnapshot): void => {
-    setState((current) => {
-      if (current.key !== snapshot.key || draftHasMeaningfulContent(current.draft)) {
-        return current;
-      }
+    const current = latestStateRef.current;
+    if (
+      current.key !== snapshot.key ||
+      current.taskId !== snapshot.taskId ||
+      draftHasMeaningfulContent(current.draft)
+    ) {
+      return;
+    }
 
-      return {
-        key: current.key,
-        identity: current.identity,
-        draft: snapshot.draft,
-      };
+    if (current.identity) {
+      setAgentChatDraft(current.identity, current.taskId, snapshot.draft);
+    }
+    setState({
+      key: current.key,
+      identity: current.identity,
+      taskId: current.taskId,
+      draft: snapshot.draft,
     });
   }, []);
 

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -54,7 +54,10 @@ const areIdentitiesEqual = (
   left: AgentChatDraftSessionIdentity | null,
   right: AgentChatDraftSessionIdentity | null,
 ): boolean =>
-  left?.workspaceId === right?.workspaceId && left?.externalSessionId === right?.externalSessionId;
+  left === right ||
+  (left !== null &&
+    right !== null &&
+    toAgentChatDraftStorageKey(left) === toAgentChatDraftStorageKey(right));
 
 const createInitialDraftState = ({
   draftStateKey,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
@@ -22,6 +22,7 @@ import {
   type AgentChatDraftScope,
   didAgentChatDraftScopeSwitchSessionOnly,
 } from "./agent-chat-draft-scope";
+import type { AgentChatDraftSessionIdentity } from "./agent-chat-draft-storage";
 
 type StopAgentSession = (session: AgentSessionIdentity) => Promise<void>;
 type AgentChatComposerSelectedSession = AgentSessionIdentity & {
@@ -53,6 +54,7 @@ export type AgentChatComposerConfig = {
   readOnlyReason: string | null;
   draftStateKey: string;
   draftScope: AgentChatDraftScope;
+  draftPersistenceIdentity: AgentChatDraftSessionIdentity | null;
   onSend: (draft: AgentChatComposerDraft) => Promise<boolean>;
   isSending: boolean;
   isStarting: boolean;
@@ -210,6 +212,7 @@ export function useAgentChatComposerModel({
       busySendBlockedReason: composer.busySendBlockedReason,
       pendingInlineCommentCount,
       draftStateKey: composer.draftStateKey,
+      draftPersistenceIdentity: composer.draftPersistenceIdentity,
       onSend: (draft) => submitComposerDraft(draft, composer.onSend),
       isSending: composer.isSending,
       isStarting: composer.isStarting,

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
@@ -66,14 +66,20 @@ export function useAgentsPageOrchestrationShellModel({
   const { selection, scheduleQueryUpdate, selectAgentStudioSelection } = routeSession;
 
   const composer = useMemo(
-    (): { draftScope: AgentChatDraftScope } => ({
+    (): { draftScope: AgentChatDraftScope; workspaceId: string | null } => ({
+      workspaceId: activeWorkspaceId,
       draftScope: {
         taskId: selection.view.taskId,
         role: selection.view.role,
         session: selection.view.selectedSession.identity,
       },
     }),
-    [selection.view.role, selection.view.selectedSession.identity, selection.view.taskId],
+    [
+      activeWorkspaceId,
+      selection.view.role,
+      selection.view.selectedSession.identity,
+      selection.view.taskId,
+    ],
   );
 
   const orchestrationSelection = useMemo<

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -11,6 +11,7 @@ import {
   type AgentChatDraftScope,
   agentChatDraftScopeKey,
 } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
+import type { AgentChatDraftSessionIdentity } from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
 import { useAgentChatSurfaceModel } from "@/components/features/agents/agent-chat/use-agent-chat-surface-model";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentStudioContextUsage } from "@/features/agent-chat-composer/context-usage/context-usage-resolution";
@@ -71,6 +72,7 @@ export type AgentStudioChatModelSelectionContext = {
 
 export type AgentStudioChatComposerContext = {
   draftScope: AgentChatDraftScope;
+  workspaceId: string | null;
 };
 
 type UseAgentStudioChatModelArgs = {
@@ -172,6 +174,16 @@ export function useAgentStudioChatModel({
   const selectedSessionKey = selectedSessionIdentity
     ? agentSessionIdentityKey(selectedSessionIdentity)
     : null;
+  const draftPersistenceIdentity = useMemo<AgentChatDraftSessionIdentity | null>(() => {
+    if (!composer.workspaceId || !selectedSessionIdentity?.externalSessionId) {
+      return null;
+    }
+
+    return {
+      workspaceId: composer.workspaceId,
+      externalSessionId: selectedSessionIdentity.externalSessionId,
+    };
+  }, [composer.workspaceId, selectedSessionIdentity?.externalSessionId]);
   const surfaceState = useMemo(
     () =>
       deriveAgentStudioChatSurfaceState({
@@ -240,6 +252,7 @@ export function useAgentStudioChatModel({
       readOnlyReason: surfaceState.composerReadOnlyReason,
       draftStateKey: agentChatDraftScopeKey(composer.draftScope),
       draftScope: composer.draftScope,
+      draftPersistenceIdentity,
       onSend: sessionActions.onSend,
       isSending: sessionActions.isSending,
       isStarting: sessionActions.isStarting,
@@ -276,6 +289,7 @@ export function useAgentStudioChatModel({
     [
       chatContextUsage,
       composer.draftScope,
+      draftPersistenceIdentity,
       modelSelection.agentOptions,
       modelSelection.isSelectionCatalogLoading,
       modelSelection.isSlashCommandsLoading,

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -175,15 +175,17 @@ export function useAgentStudioChatModel({
     ? agentSessionIdentityKey(selectedSessionIdentity)
     : null;
   const draftPersistenceIdentity = useMemo<AgentChatDraftSessionIdentity | null>(() => {
-    if (!composer.workspaceId || !selectedSessionIdentity?.externalSessionId) {
+    if (!composer.workspaceId || !selectedSessionIdentity) {
       return null;
     }
 
     return {
       workspaceId: composer.workspaceId,
       externalSessionId: selectedSessionIdentity.externalSessionId,
+      runtimeKind: selectedSessionIdentity.runtimeKind,
+      workingDirectory: selectedSessionIdentity.workingDirectory,
     };
-  }, [composer.workspaceId, selectedSessionIdentity?.externalSessionId]);
+  }, [composer.workspaceId, selectedSessionIdentity]);
   const surfaceState = useMemo(
     () =>
       deriveAgentStudioChatSurfaceState({

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -157,6 +157,7 @@ const baseArgs: BuildArgs = {
   },
   chatSettings: baseChatSettings,
   composer: {
+    workspaceId: "workspace-repo",
     draftScope: {
       taskId: "task-1",
       role: "planner",

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -413,6 +413,8 @@ describe("useAgentStudioPageModels", () => {
     expect(state.agentChatModel.composer.draftPersistenceIdentity).toEqual({
       workspaceId: "workspace-repo",
       externalSessionId: "external-1",
+      runtimeKind: "opencode",
+      workingDirectory: "/repo",
     });
     expect(state.agentChatModel.thread.runtimeReadiness.state).toBe("ready");
     expect(state.agentChatModel.thread.isSessionWorking).toBe(true);

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -290,6 +290,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
   };
   const chatSettings = createChatSettingsFixture(overrides.chatSettings);
   const composer = {
+    workspaceId: "workspace-repo",
     draftScope: {
       taskId: selectedSessionCore.taskId,
       role: selectedSessionCore.role,
@@ -408,6 +409,10 @@ describe("useAgentStudioPageModels", () => {
     expect(state.agentChatModel.composer.contextUsage).toEqual({
       totalTokens: 12,
       contextWindow: 100,
+    });
+    expect(state.agentChatModel.composer.draftPersistenceIdentity).toEqual({
+      workspaceId: "workspace-repo",
+      externalSessionId: "external-1",
     });
     expect(state.agentChatModel.thread.runtimeReadiness.state).toBe("ready");
     expect(state.agentChatModel.thread.isSessionWorking).toBe(true);

--- a/packages/frontend/src/pages/kanban/task-approval-flow-direct-merge.ts
+++ b/packages/frontend/src/pages/kanban/task-approval-flow-direct-merge.ts
@@ -133,24 +133,24 @@ export async function completeDirectMergeApproval({
   const approvalContext = approval.approvalContext;
   const publishTarget = approvalContext.publishTarget;
 
-  if (publishTarget) {
-    if (!publishTarget.remote) {
-      throw new Error("The configured target branch does not have a publish remote.");
-    }
-    const pushResult = await host.gitPushBranch(repoPath, checkoutTargetBranch(publishTarget), {
-      remote: publishTarget.remote,
-    });
-    if (pushResult.outcome !== "pushed") {
-      throw new Error(pushResult.output.trim() || DIRECT_MERGE_PUSH_FAILURE_MESSAGE);
-    }
-  }
-
   await runTaskMutationWithChatDraftCleanup({
     queryClient,
     repoPath,
     workspaceId,
     taskIds: [approval.taskId],
     mutation: async () => {
+      if (publishTarget) {
+        if (!publishTarget.remote) {
+          throw new Error("The configured target branch does not have a publish remote.");
+        }
+        const pushResult = await host.gitPushBranch(repoPath, checkoutTargetBranch(publishTarget), {
+          remote: publishTarget.remote,
+        });
+        if (pushResult.outcome !== "pushed") {
+          throw new Error(pushResult.output.trim() || DIRECT_MERGE_PUSH_FAILURE_MESSAGE);
+        }
+      }
+
       await host.taskDirectMergeComplete(repoPath, approval.taskId);
     },
   });

--- a/packages/frontend/src/pages/kanban/task-approval-flow-direct-merge.ts
+++ b/packages/frontend/src/pages/kanban/task-approval-flow-direct-merge.ts
@@ -3,6 +3,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import type { GitConflict } from "@/features/agent-studio-git";
 import { canonicalTargetBranch, checkoutTargetBranch } from "@/lib/target-branch";
 import { host } from "@/state/operations/shared/host";
+import { runTaskMutationWithChatDraftCleanup } from "@/state/operations/tasks/task-chat-draft-cleanup";
 import {
   invalidateTaskApprovalContextQuery,
   loadTaskApprovalContextFromQuery,
@@ -16,12 +17,15 @@ type SubmitDirectMergeApprovalArgs = {
   queryClient: QueryClient;
   repoPath: string;
   refreshTasks: () => Promise<void>;
+  workspaceId: string | null;
 };
 
 type CompleteDirectMergeApprovalArgs = {
   approval: TaskApprovalFlowReadyState;
+  queryClient: QueryClient;
   repoPath: string;
   refreshTasks: () => Promise<void>;
+  workspaceId: string | null;
 };
 
 export type SubmitDirectMergeApprovalResult =
@@ -57,14 +61,23 @@ export async function submitDirectMergeApproval({
   queryClient,
   repoPath,
   refreshTasks,
+  workspaceId,
 }: SubmitDirectMergeApprovalArgs): Promise<SubmitDirectMergeApprovalResult> {
   const approvalContext = approval.approvalContext;
-  const directMergeResult = await host.taskDirectMerge(repoPath, approval.taskId, {
-    mergeMethod: approval.mergeMethod,
-    squashCommitMessage:
-      approval.mergeMethod === "squash"
-        ? approval.squashCommitMessage.trim() || undefined
-        : undefined,
+  const directMergeResult = await runTaskMutationWithChatDraftCleanup({
+    queryClient,
+    repoPath,
+    workspaceId,
+    taskIds: [approval.taskId],
+    mutation: async () =>
+      host.taskDirectMerge(repoPath, approval.taskId, {
+        mergeMethod: approval.mergeMethod,
+        squashCommitMessage:
+          approval.mergeMethod === "squash"
+            ? approval.squashCommitMessage.trim() || undefined
+            : undefined,
+      }),
+    shouldCleanup: (result) => result.outcome !== "conflicts" && result.task.status === "closed",
   });
 
   if (directMergeResult.outcome === "conflicts") {
@@ -112,8 +125,10 @@ export async function submitDirectMergeApproval({
 
 export async function completeDirectMergeApproval({
   approval,
+  queryClient,
   repoPath,
   refreshTasks,
+  workspaceId,
 }: CompleteDirectMergeApprovalArgs): Promise<{ successDescription: string }> {
   const approvalContext = approval.approvalContext;
   const publishTarget = approvalContext.publishTarget;
@@ -130,7 +145,15 @@ export async function completeDirectMergeApproval({
     }
   }
 
-  await host.taskDirectMergeComplete(repoPath, approval.taskId);
+  await runTaskMutationWithChatDraftCleanup({
+    queryClient,
+    repoPath,
+    workspaceId,
+    taskIds: [approval.taskId],
+    mutation: async () => {
+      await host.taskDirectMergeComplete(repoPath, approval.taskId);
+    },
+  });
   await refreshTasks();
 
   return {

--- a/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -1160,7 +1160,7 @@ describe("useTaskApprovalFlow", () => {
     });
   });
 
-  test("blocks direct merge when cleanup target lookup fails", async () => {
+  test("reports cleanup target lookup failure after direct merge succeeds", async () => {
     agentSessionsListMock.mockImplementationOnce(async () => {
       throw new Error("session lookup failed");
     });
@@ -1198,20 +1198,21 @@ describe("useTaskApprovalFlow", () => {
     });
 
     expect(agentSessionsListMock).toHaveBeenCalledWith("/repo", "TASK-1");
-    expect(taskDirectMergeMock).not.toHaveBeenCalled();
-    expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBe("session lookup failed");
-    expect(toastErrorMock).toHaveBeenCalledWith(
-      "Approval failed",
-      expect.objectContaining({ description: "session lookup failed" }),
-    );
+    expect(taskDirectMergeMock).toHaveBeenCalledWith("/repo", "TASK-1", {
+      mergeMethod: "merge_commit",
+      squashCommitMessage: undefined,
+    });
+    await waitForTaskApprovalModalClosed();
+    expect(toastErrorMock).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
+      description: "session lookup failed",
+    });
 
     await act(async () => {
       await harness.unmount();
     });
   });
 
-  test("blocks direct merge completion when cleanup target lookup fails", async () => {
+  test("reports cleanup target lookup failure after direct merge completion succeeds", async () => {
     agentSessionsListMock.mockImplementationOnce(async () => {
       throw new Error("session lookup failed");
     });
@@ -1258,15 +1259,14 @@ describe("useTaskApprovalFlow", () => {
     });
 
     expect(agentSessionsListMock).toHaveBeenCalledWith("/repo", "TASK-1");
-    expect(gitPushBranchMock).not.toHaveBeenCalled();
-    expect(taskDirectMergeCompleteMock).not.toHaveBeenCalled();
-    expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
-    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBe("session lookup failed");
-    expect(toastErrorMock).toHaveBeenCalledWith(
-      "Failed to finish direct merge",
-      expect.objectContaining({ description: "session lookup failed" }),
-    );
+    expect(gitPushBranchMock).toHaveBeenCalledWith("/repo", "main", {
+      remote: "origin",
+    });
+    expect(taskDirectMergeCompleteMock).toHaveBeenCalledWith("/repo", "TASK-1");
+    await waitForTaskApprovalModalClosed();
+    expect(toastErrorMock).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
+      description: "session lookup failed",
+    });
 
     await act(async () => {
       await harness.unmount();

--- a/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -61,6 +61,24 @@ const defaultGitPushBranch = async () => ({
 const defaultGitAbortConflict = async () => {};
 const defaultHumanApproveTask = async () => {};
 const defaultOpenResetImplementation = (_taskId: string) => true;
+const defaultAgentSessionsList = async () => [
+  {
+    ...createAgentSessionFixture({
+      externalSessionId: "builder-session-old",
+      taskId: "TASK-1",
+      role: "build",
+      startedAt: "2026-03-12T11:59:00Z",
+    }),
+  },
+  {
+    ...createAgentSessionFixture({
+      externalSessionId: "builder-session",
+      taskId: "TASK-1",
+      role: "build",
+      startedAt: "2026-03-12T12:00:00Z",
+    }),
+  },
+];
 
 const taskApprovalContextGetMock = mock(defaultTaskApprovalContextGet);
 const taskDirectMergeMock = mock(defaultTaskDirectMerge);
@@ -70,6 +88,7 @@ const gitPushBranchMock = mock(defaultGitPushBranch);
 const gitAbortConflictMock = mock(defaultGitAbortConflict);
 const humanApproveTaskMock = mock(defaultHumanApproveTask);
 const openResetImplementationMock = mock(defaultOpenResetImplementation);
+const agentSessionsListMock = mock(defaultAgentSessionsList);
 const toastLoadingMock = mock(() => "toast-id");
 const toastSuccessMock = mock(() => {});
 const toastErrorMock = mock(() => {});
@@ -123,24 +142,7 @@ const buildMockedHost = () => ({
   taskPullRequestUpsert: taskPullRequestUpsertMock,
   gitPushBranch: gitPushBranchMock,
   gitAbortConflict: gitAbortConflictMock,
-  agentSessionsList: async () => [
-    {
-      ...createAgentSessionFixture({
-        externalSessionId: "builder-session-old",
-        taskId: "TASK-1",
-        role: "build",
-        startedAt: "2026-03-12T11:59:00Z",
-      }),
-    },
-    {
-      ...createAgentSessionFixture({
-        externalSessionId: "builder-session",
-        taskId: "TASK-1",
-        role: "build",
-        startedAt: "2026-03-12T12:00:00Z",
-      }),
-    },
-  ],
+  agentSessionsList: agentSessionsListMock,
   specGet: async () => ({ markdown: "", updatedAt: null }),
   planGet: async () => ({ markdown: "", updatedAt: null }),
   qaGetReport: async () => ({ markdown: "", updatedAt: null }),
@@ -360,6 +362,8 @@ describe("useTaskApprovalFlow", () => {
     humanApproveTaskMock.mockImplementation(defaultHumanApproveTask);
     openResetImplementationMock.mockClear();
     openResetImplementationMock.mockImplementation(defaultOpenResetImplementation);
+    agentSessionsListMock.mockClear();
+    agentSessionsListMock.mockImplementation(defaultAgentSessionsList);
   });
 
   afterAll(async () => {
@@ -1147,6 +1151,119 @@ describe("useTaskApprovalFlow", () => {
     expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).toBeNull();
     await waitForTaskApprovalModalClosed();
     expect(latestHarnessValue?.taskApprovalModal).toBeNull();
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("blocks direct merge when cleanup target lookup fails", async () => {
+    agentSessionsListMock.mockImplementationOnce(async () => {
+      throw new Error("session lookup failed");
+    });
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createReadyTaskApprovalContextResult({ publishTarget: undefined }) as unknown as never,
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeWorkspace: {
+            workspaceId: "workspace-repo",
+            workspaceName: "Repo",
+            repoPath: "/repo",
+          },
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      expectApprovalModal().onConfirm();
+      await Promise.resolve();
+    });
+
+    expect(agentSessionsListMock).toHaveBeenCalledWith("/repo", "TASK-1");
+    expect(taskDirectMergeMock).not.toHaveBeenCalled();
+    expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
+    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBe("session lookup failed");
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Approval failed",
+      expect.objectContaining({ description: "session lookup failed" }),
+    );
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("blocks direct merge completion when cleanup target lookup fails", async () => {
+    agentSessionsListMock.mockImplementationOnce(async () => {
+      throw new Error("session lookup failed");
+    });
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createReadyTaskApprovalContextResult({
+        publishTarget: { remote: "origin", branch: "main" },
+        directMerge: {
+          method: "merge_commit",
+          sourceBranch: "odt/TASK-1",
+          targetBranch: { remote: "origin", branch: "main" },
+          mergedAt: "2026-03-12T12:00:00Z",
+        },
+      }) as unknown as never,
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeWorkspace: {
+            workspaceId: "workspace-repo",
+            workspaceName: "Repo",
+            repoPath: "/repo",
+          },
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
+
+    await act(async () => {
+      expectCompletionModal().onCompleteDirectMerge();
+      await Promise.resolve();
+    });
+
+    expect(agentSessionsListMock).toHaveBeenCalledWith("/repo", "TASK-1");
+    expect(gitPushBranchMock).not.toHaveBeenCalled();
+    expect(taskDirectMergeCompleteMock).not.toHaveBeenCalled();
+    expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
+    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
+    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBe("session lookup failed");
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Failed to finish direct merge",
+      expect.objectContaining({ description: "session lookup failed" }),
+    );
 
     await act(async () => {
       await harness.unmount();

--- a/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -5,6 +5,16 @@ import { waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { act } from "react";
 import { toast } from "sonner";
+import { createTextSegment } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
+import {
+  type AgentChatDraftSessionIdentity,
+  toAgentChatDraftStorageKey,
+  writeAgentChatDraftToStorage,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
+import {
+  resetAgentChatDraftStoreForTests,
+  setAgentChatDraftStorageForTests,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-store";
 import { QueryProvider } from "@/lib/query-provider";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
 import { createSettingsSnapshotFixture } from "@/test-utils/shared-test-fixtures";
@@ -66,6 +76,39 @@ const toastErrorMock = mock(() => {});
 const originalToastLoading = toast.loading;
 const originalToastSuccess = toast.success;
 const originalToastError = toast.error;
+
+type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
+
+const createMemoryStorage = (): TestStorage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+};
+
+const writeTestDraft = (
+  storage: TestStorage,
+  identity: AgentChatDraftSessionIdentity,
+  text: string,
+): void => {
+  writeAgentChatDraftToStorage({
+    storage,
+    identity,
+    taskId: "TASK-1",
+    draft: { segments: [createTextSegment(text, "text-1")], attachments: [] },
+    updatedAt: "2026-07-08T10:00:00.000Z",
+  });
+};
 
 const createUnavailableHostClient = () =>
   createHostClient(async () => {
@@ -289,6 +332,7 @@ const expectMissingBuilderWorktreeModal = (): TaskApprovalMissingBuilderWorktree
 
 describe("useTaskApprovalFlow", () => {
   beforeEach(async () => {
+    resetAgentChatDraftStoreForTests();
     await applyHostMocks();
     latestHarnessValue = null;
     (toast as { loading: typeof toast.loading }).loading =
@@ -980,6 +1024,14 @@ describe("useTaskApprovalFlow", () => {
       }) as unknown as never,
     );
 
+    const storage = createMemoryStorage();
+    setAgentChatDraftStorageForTests(storage);
+    const draftIdentity = {
+      workspaceId: "workspace-repo",
+      externalSessionId: "builder-session",
+    };
+    writeTestDraft(storage, draftIdentity, "pending direct merge draft");
+
     const Harness = (): ReactElement | null => {
       latestHarnessValue = useTaskApprovalFlow(
         createUseTaskApprovalFlowArgs({
@@ -1018,6 +1070,7 @@ describe("useTaskApprovalFlow", () => {
     await waitFor(() => {
       expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
     });
+    expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).not.toBeNull();
 
     await act(async () => {
       expectCompletionModal().onCompleteDirectMerge();
@@ -1032,6 +1085,7 @@ describe("useTaskApprovalFlow", () => {
       remote: "upstream",
     });
     expect(taskDirectMergeCompleteMock).toHaveBeenCalledWith("/repo", "TASK-1");
+    expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).toBeNull();
 
     await act(async () => {
       await harness.unmount();
@@ -1040,6 +1094,13 @@ describe("useTaskApprovalFlow", () => {
 
   test("closes after direct merge without offering a push step for local-only target branches", async () => {
     const refreshTasksMock = mock(async () => {});
+    const storage = createMemoryStorage();
+    setAgentChatDraftStorageForTests(storage);
+    const draftIdentity = {
+      workspaceId: "workspace-repo",
+      externalSessionId: "builder-session",
+    };
+    writeTestDraft(storage, draftIdentity, "direct merge draft");
     taskApprovalContextGetMock.mockResolvedValueOnce(
       createReadyTaskApprovalContextResult({
         targetBranch: { branch: "release/2026.03" },
@@ -1083,6 +1144,7 @@ describe("useTaskApprovalFlow", () => {
     expect(gitPushBranchMock).not.toHaveBeenCalled();
     expect(refreshTasksMock).toHaveBeenCalledTimes(1);
     expect(taskDirectMergeCompleteMock).not.toHaveBeenCalled();
+    expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).toBeNull();
     await waitForTaskApprovalModalClosed();
     expect(latestHarnessValue?.taskApprovalModal).toBeNull();
 

--- a/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -67,6 +67,7 @@ const defaultAgentSessionsList = async () => [
       externalSessionId: "builder-session-old",
       taskId: "TASK-1",
       role: "build",
+      workingDirectory: "/repo",
       startedAt: "2026-03-12T11:59:00Z",
     }),
   },
@@ -75,6 +76,7 @@ const defaultAgentSessionsList = async () => [
       externalSessionId: "builder-session",
       taskId: "TASK-1",
       role: "build",
+      workingDirectory: "/repo",
       startedAt: "2026-03-12T12:00:00Z",
     }),
   },
@@ -128,6 +130,13 @@ const writeTestDraft = (
     updatedAt: "2026-07-08T10:00:00.000Z",
   });
 };
+
+const createDraftIdentity = (externalSessionId: string): AgentChatDraftSessionIdentity => ({
+  workspaceId: "workspace-repo",
+  externalSessionId,
+  runtimeKind: "opencode",
+  workingDirectory: "/repo",
+});
 
 const createUnavailableHostClient = () =>
   createHostClient(async () => {
@@ -1030,10 +1039,7 @@ describe("useTaskApprovalFlow", () => {
 
     const storage = createMemoryStorage();
     setAgentChatDraftStorageForTests(storage);
-    const draftIdentity = {
-      workspaceId: "workspace-repo",
-      externalSessionId: "builder-session",
-    };
+    const draftIdentity = createDraftIdentity("builder-session");
     writeTestDraft(storage, draftIdentity, "pending direct merge draft");
 
     const Harness = (): ReactElement | null => {
@@ -1100,10 +1106,7 @@ describe("useTaskApprovalFlow", () => {
     const refreshTasksMock = mock(async () => {});
     const storage = createMemoryStorage();
     setAgentChatDraftStorageForTests(storage);
-    const draftIdentity = {
-      workspaceId: "workspace-repo",
-      externalSessionId: "builder-session",
-    };
+    const draftIdentity = createDraftIdentity("builder-session");
     writeTestDraft(storage, draftIdentity, "direct merge draft");
     taskApprovalContextGetMock.mockResolvedValueOnce(
       createReadyTaskApprovalContextResult({

--- a/packages/frontend/src/pages/kanban/use-task-approval-flow.ts
+++ b/packages/frontend/src/pages/kanban/use-task-approval-flow.ts
@@ -65,6 +65,7 @@ export function useTaskApprovalFlow({
 }: UseTaskApprovalFlowArgs): UseTaskApprovalFlowResult {
   const queryClient = useQueryClient();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
+  const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
   const [state, dispatch] = useReducer(taskApprovalFlowReducer, CLOSED_TASK_APPROVAL_STATE);
   const approvalRequestVersionRef = useRef(0);
 
@@ -199,6 +200,7 @@ export function useTaskApprovalFlow({
             queryClient,
             repoPath,
             refreshTasks,
+            workspaceId: activeWorkspaceId,
           });
           if (directMergeResult.outcome === "conflicts") {
             reset();
@@ -260,6 +262,7 @@ export function useTaskApprovalFlow({
     })();
   }, [
     workspaceRepoPath,
+    activeWorkspaceId,
     humanApproveTask,
     queryClient,
     openGitConflictDialog,
@@ -291,8 +294,10 @@ export function useTaskApprovalFlow({
       try {
         const result = await completeDirectMergeApproval({
           approval: approvalState,
+          queryClient,
           repoPath: workspaceRepoPath,
           refreshTasks,
+          workspaceId: activeWorkspaceId,
         });
         reset();
         toast.success("Task moved to Done", {
@@ -306,7 +311,7 @@ export function useTaskApprovalFlow({
         });
       }
     })();
-  }, [workspaceRepoPath, refreshTasks, reset, state]);
+  }, [workspaceRepoPath, activeWorkspaceId, queryClient, refreshTasks, reset, state]);
 
   if (!isTaskApprovalOpen(state)) {
     return {

--- a/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
+++ b/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
@@ -7,6 +7,14 @@ import {
 import { errorMessage } from "@/lib/errors";
 import { loadAgentSessionListsFromQuery } from "../../queries/agent-sessions";
 
+export type TaskChatDraftCleanupPlan = {
+  targets: AgentChatDraftCleanupTarget[];
+  error: Error | null;
+};
+
+const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
 export const prepareTaskChatDraftCleanupTargets = async ({
   queryClient,
   repoPath,
@@ -17,37 +25,47 @@ export const prepareTaskChatDraftCleanupTargets = async ({
   repoPath: string;
   workspaceId: string | null;
   taskIds: string[];
-}): Promise<AgentChatDraftCleanupTarget[]> => {
-  if (!workspaceId) {
-    throw new Error("Cannot clean chat drafts without an active workspace id.");
-  }
-
-  const sessionListsByTaskId = await loadAgentSessionListsFromQuery(
-    queryClient,
-    repoPath,
-    taskIds,
-    {
-      forceFresh: true,
-    },
-  );
-  const targets = new Map<string, AgentChatDraftCleanupTarget>();
-
-  for (const [taskId, sessions] of Object.entries(sessionListsByTaskId)) {
-    for (const session of sessions) {
-      targets.set(`${workspaceId}:${session.externalSessionId}`, {
-        workspaceId,
-        externalSessionId: session.externalSessionId,
-        taskId,
-      });
+}): Promise<TaskChatDraftCleanupPlan> => {
+  try {
+    if (!workspaceId) {
+      throw new Error("Cannot clean chat drafts without an active workspace id.");
     }
-  }
 
-  return Array.from(targets.values());
+    const sessionListsByTaskId = await loadAgentSessionListsFromQuery(
+      queryClient,
+      repoPath,
+      taskIds,
+      {
+        forceFresh: true,
+      },
+    );
+    const targets = new Map<string, AgentChatDraftCleanupTarget>();
+
+    for (const [taskId, sessions] of Object.entries(sessionListsByTaskId)) {
+      for (const session of sessions) {
+        targets.set(`${workspaceId}:${session.externalSessionId}`, {
+          workspaceId,
+          externalSessionId: session.externalSessionId,
+          taskId,
+        });
+      }
+    }
+
+    return { targets: Array.from(targets.values()), error: null };
+  } catch (error) {
+    return { targets: [], error: toError(error) };
+  }
 };
 
-export const runTaskChatDraftCleanupAfterSuccess = (
-  targets: AgentChatDraftCleanupTarget[],
-): boolean => {
+export const runTaskChatDraftCleanupAfterSuccess = (plan: TaskChatDraftCleanupPlan): boolean => {
+  if (plan.error) {
+    toast.error("Task updated, but chat draft cleanup failed", {
+      description: errorMessage(plan.error),
+    });
+    return false;
+  }
+
+  const { targets } = plan;
   if (targets.length === 0) {
     return true;
   }

--- a/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
+++ b/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
@@ -9,7 +9,6 @@ import { loadAgentSessionListsFromQuery } from "../../queries/agent-sessions";
 
 export type TaskChatDraftCleanupPlan = {
   targets: AgentChatDraftCleanupTarget[];
-  error: Error | null;
 };
 
 type TaskChatDraftCleanupInput = {
@@ -24,9 +23,6 @@ type RunTaskMutationWithChatDraftCleanupInput<TResult> = TaskChatDraftCleanupInp
   shouldCleanup?: (result: TResult) => boolean;
 };
 
-const toError = (error: unknown): Error =>
-  error instanceof Error ? error : new Error(String(error));
-
 const reportTaskChatDraftCleanupFailure = (error: unknown): void => {
   toast.error("Task updated, but chat draft cleanup failed", {
     description: errorMessage(error),
@@ -39,43 +35,34 @@ export const prepareTaskChatDraftCleanupTargets = async ({
   workspaceId,
   taskIds,
 }: TaskChatDraftCleanupInput): Promise<TaskChatDraftCleanupPlan> => {
-  try {
-    if (!workspaceId) {
-      throw new Error("Cannot clean chat drafts without an active workspace id.");
-    }
-
-    const sessionListsByTaskId = await loadAgentSessionListsFromQuery(
-      queryClient,
-      repoPath,
-      taskIds,
-      {
-        forceFresh: true,
-      },
-    );
-    const targets = new Map<string, AgentChatDraftCleanupTarget>();
-
-    for (const [taskId, sessions] of Object.entries(sessionListsByTaskId)) {
-      for (const session of sessions) {
-        targets.set(`${workspaceId}:${session.externalSessionId}`, {
-          workspaceId,
-          externalSessionId: session.externalSessionId,
-          taskId,
-        });
-      }
-    }
-
-    return { targets: Array.from(targets.values()), error: null };
-  } catch (error) {
-    return { targets: [], error: toError(error) };
+  if (!workspaceId) {
+    throw new Error("Cannot clean chat drafts without an active workspace id.");
   }
+
+  const sessionListsByTaskId = await loadAgentSessionListsFromQuery(
+    queryClient,
+    repoPath,
+    taskIds,
+    {
+      forceFresh: true,
+    },
+  );
+  const targets = new Map<string, AgentChatDraftCleanupTarget>();
+
+  for (const [taskId, sessions] of Object.entries(sessionListsByTaskId)) {
+    for (const session of sessions) {
+      targets.set(`${workspaceId}:${session.externalSessionId}`, {
+        workspaceId,
+        externalSessionId: session.externalSessionId,
+        taskId,
+      });
+    }
+  }
+
+  return { targets: Array.from(targets.values()) };
 };
 
 export const runTaskChatDraftCleanupAfterSuccess = (plan: TaskChatDraftCleanupPlan): boolean => {
-  if (plan.error) {
-    reportTaskChatDraftCleanupFailure(plan.error);
-    return false;
-  }
-
   const { targets } = plan;
   if (targets.length === 0) {
     return true;

--- a/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
+++ b/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
@@ -15,6 +15,12 @@ export type TaskChatDraftCleanupPlan = {
 const toError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
 
+const reportTaskChatDraftCleanupFailure = (error: unknown): void => {
+  toast.error("Task updated, but chat draft cleanup failed", {
+    description: errorMessage(error),
+  });
+};
+
 export const prepareTaskChatDraftCleanupTargets = async ({
   queryClient,
   repoPath,
@@ -59,9 +65,7 @@ export const prepareTaskChatDraftCleanupTargets = async ({
 
 export const runTaskChatDraftCleanupAfterSuccess = (plan: TaskChatDraftCleanupPlan): boolean => {
   if (plan.error) {
-    toast.error("Task updated, but chat draft cleanup failed", {
-      description: errorMessage(plan.error),
-    });
+    reportTaskChatDraftCleanupFailure(plan.error);
     return false;
   }
 
@@ -74,9 +78,7 @@ export const runTaskChatDraftCleanupAfterSuccess = (plan: TaskChatDraftCleanupPl
     clearAgentChatDraftsForTargets(targets);
     return true;
   } catch (error) {
-    toast.error("Task updated, but chat draft cleanup failed", {
-      description: errorMessage(error),
-    });
+    reportTaskChatDraftCleanupFailure(error);
     return false;
   }
 };

--- a/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
+++ b/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { toAgentChatDraftStorageKey } from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
 import {
   type AgentChatDraftCleanupTarget,
   clearAgentChatDraftsForTargets,
@@ -51,11 +52,14 @@ export const prepareTaskChatDraftCleanupTargets = async ({
 
   for (const [taskId, sessions] of Object.entries(sessionListsByTaskId)) {
     for (const session of sessions) {
-      targets.set(`${workspaceId}:${session.externalSessionId}`, {
+      const target: AgentChatDraftCleanupTarget = {
         workspaceId,
         externalSessionId: session.externalSessionId,
+        runtimeKind: session.runtimeKind,
+        workingDirectory: session.workingDirectory,
         taskId,
-      });
+      };
+      targets.set(toAgentChatDraftStorageKey(target), target);
     }
   }
 

--- a/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
+++ b/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
@@ -12,6 +12,18 @@ export type TaskChatDraftCleanupPlan = {
   error: Error | null;
 };
 
+type TaskChatDraftCleanupInput = {
+  queryClient: QueryClient;
+  repoPath: string;
+  workspaceId: string | null;
+  taskIds: string[];
+};
+
+type RunTaskMutationWithChatDraftCleanupInput<TResult> = TaskChatDraftCleanupInput & {
+  mutation: () => Promise<TResult>;
+  shouldCleanup?: (result: TResult) => boolean;
+};
+
 const toError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
 
@@ -26,12 +38,7 @@ export const prepareTaskChatDraftCleanupTargets = async ({
   repoPath,
   workspaceId,
   taskIds,
-}: {
-  queryClient: QueryClient;
-  repoPath: string;
-  workspaceId: string | null;
-  taskIds: string[];
-}): Promise<TaskChatDraftCleanupPlan> => {
+}: TaskChatDraftCleanupInput): Promise<TaskChatDraftCleanupPlan> => {
   try {
     if (!workspaceId) {
       throw new Error("Cannot clean chat drafts without an active workspace id.");
@@ -81,4 +88,25 @@ export const runTaskChatDraftCleanupAfterSuccess = (plan: TaskChatDraftCleanupPl
     reportTaskChatDraftCleanupFailure(error);
     return false;
   }
+};
+
+export const runTaskMutationWithChatDraftCleanup = async <TResult>({
+  queryClient,
+  repoPath,
+  workspaceId,
+  taskIds,
+  mutation,
+  shouldCleanup = () => true,
+}: RunTaskMutationWithChatDraftCleanupInput<TResult>): Promise<TResult> => {
+  const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
+    queryClient,
+    repoPath,
+    workspaceId,
+    taskIds,
+  });
+  const result = await mutation();
+  if (shouldCleanup(result)) {
+    runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
+  }
+  return result;
 };

--- a/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
+++ b/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
@@ -1,0 +1,64 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  type AgentChatDraftCleanupTarget,
+  clearAgentChatDraftsForTargets,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-store";
+import { errorMessage } from "@/lib/errors";
+import { loadAgentSessionListsFromQuery } from "../../queries/agent-sessions";
+
+export const prepareTaskChatDraftCleanupTargets = async ({
+  queryClient,
+  repoPath,
+  workspaceId,
+  taskIds,
+}: {
+  queryClient: QueryClient;
+  repoPath: string;
+  workspaceId: string | null;
+  taskIds: string[];
+}): Promise<AgentChatDraftCleanupTarget[]> => {
+  if (!workspaceId) {
+    throw new Error("Cannot clean chat drafts without an active workspace id.");
+  }
+
+  const sessionListsByTaskId = await loadAgentSessionListsFromQuery(
+    queryClient,
+    repoPath,
+    taskIds,
+    {
+      forceFresh: true,
+    },
+  );
+  const targets = new Map<string, AgentChatDraftCleanupTarget>();
+
+  for (const [taskId, sessions] of Object.entries(sessionListsByTaskId)) {
+    for (const session of sessions) {
+      targets.set(`${workspaceId}:${session.externalSessionId}`, {
+        workspaceId,
+        externalSessionId: session.externalSessionId,
+        taskId,
+      });
+    }
+  }
+
+  return Array.from(targets.values());
+};
+
+export const runTaskChatDraftCleanupAfterSuccess = (
+  targets: AgentChatDraftCleanupTarget[],
+): boolean => {
+  if (targets.length === 0) {
+    return true;
+  }
+
+  try {
+    clearAgentChatDraftsForTargets(targets);
+    return true;
+  } catch (error) {
+    toast.error("Task updated, but chat draft cleanup failed", {
+      description: errorMessage(error),
+    });
+    return false;
+  }
+};

--- a/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
+++ b/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
@@ -89,15 +89,26 @@ export const runTaskMutationWithChatDraftCleanup = async <TResult>({
   mutation,
   shouldCleanup = () => true,
 }: RunTaskMutationWithChatDraftCleanupInput<TResult>): Promise<TResult> => {
-  const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
-    queryClient,
-    repoPath,
-    workspaceId,
-    taskIds,
-  });
+  let cleanupTargets: TaskChatDraftCleanupPlan | null = null;
+  let cleanupTargetLookupError: unknown = null;
+  try {
+    cleanupTargets = await prepareTaskChatDraftCleanupTargets({
+      queryClient,
+      repoPath,
+      workspaceId,
+      taskIds,
+    });
+  } catch (error) {
+    cleanupTargetLookupError = error;
+  }
+
   const result = await mutation();
   if (shouldCleanup(result)) {
-    runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
+    if (cleanupTargetLookupError) {
+      reportTaskChatDraftCleanupFailure(cleanupTargetLookupError);
+    } else if (cleanupTargets) {
+      runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
+    }
   }
   return result;
 };

--- a/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
@@ -11,6 +11,7 @@ import { host } from "../shared/host";
 import {
   prepareTaskChatDraftCleanupTargets,
   runTaskChatDraftCleanupAfterSuccess,
+  type TaskChatDraftCleanupPlan,
 } from "./task-chat-draft-cleanup";
 import { collectTaskDeletionIds } from "./task-deletion-ids";
 import type { TaskMutationRunner } from "./task-mutation-runner";
@@ -26,6 +27,11 @@ type UseTaskMutationCommandsArgs = {
   tasks: TaskCard[];
   runTaskMutation: TaskMutationRunner["runTaskMutation"];
 };
+
+const emptyTaskChatDraftCleanupPlan = (): TaskChatDraftCleanupPlan => ({
+  targets: [],
+  error: null,
+});
 
 export type TaskMutationCommands = {
   createTask: (input: TaskCreateInput) => Promise<void>;
@@ -155,7 +161,7 @@ export function useTaskMutationCommands({
                   workspaceId: activeWorkspaceId,
                   taskIds: [taskId],
                 })
-              : [];
+              : emptyTaskChatDraftCleanupPlan();
           await host.taskTransition(repoPath, taskId, status, reason);
           runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },

--- a/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
@@ -8,11 +8,7 @@ import type {
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { host } from "../shared/host";
-import {
-  prepareTaskChatDraftCleanupTargets,
-  runTaskChatDraftCleanupAfterSuccess,
-  type TaskChatDraftCleanupPlan,
-} from "./task-chat-draft-cleanup";
+import { runTaskMutationWithChatDraftCleanup } from "./task-chat-draft-cleanup";
 import { collectTaskDeletionIds } from "./task-deletion-ids";
 import type { TaskMutationRunner } from "./task-mutation-runner";
 import {
@@ -27,11 +23,6 @@ type UseTaskMutationCommandsArgs = {
   tasks: TaskCard[];
   runTaskMutation: TaskMutationRunner["runTaskMutation"];
 };
-
-const emptyTaskChatDraftCleanupPlan = (): TaskChatDraftCleanupPlan => ({
-  targets: [],
-  error: null,
-});
 
 export type TaskMutationCommands = {
   createTask: (input: TaskCreateInput) => Promise<void>;
@@ -51,32 +42,6 @@ export function useTaskMutationCommands({
   runTaskMutation,
 }: UseTaskMutationCommandsArgs): TaskMutationCommands {
   const queryClient = useQueryClient();
-
-  const prepareCleanupTargets = useCallback(
-    async (repoPath: string, taskIds: string[]): Promise<TaskChatDraftCleanupPlan> =>
-      prepareTaskChatDraftCleanupTargets({
-        queryClient,
-        repoPath,
-        workspaceId: activeWorkspaceId,
-        taskIds,
-      }),
-    [activeWorkspaceId, queryClient],
-  );
-
-  const prepareClosingCleanupTargets = useCallback(
-    async (
-      repoPath: string,
-      taskId: string,
-      status: TaskStatus,
-    ): Promise<TaskChatDraftCleanupPlan> => {
-      if (status !== "closed") {
-        return emptyTaskChatDraftCleanupPlan();
-      }
-
-      return prepareCleanupTargets(repoPath, [taskId]);
-    },
-    [prepareCleanupTargets],
-  );
 
   const createTask = useCallback(
     async (input: TaskCreateInput): Promise<void> => {
@@ -135,16 +100,22 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "remove-task", taskIds: taskIdsToRemove },
         run: async (repoPath) => {
-          const cleanupTargets = await prepareCleanupTargets(repoPath, taskIdsToRemove);
-          await host.taskDelete(repoPath, taskId, deleteSubtasks);
-          runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
+          await runTaskMutationWithChatDraftCleanup({
+            queryClient,
+            repoPath,
+            workspaceId: activeWorkspaceId,
+            taskIds: taskIdsToRemove,
+            mutation: async () => {
+              await host.taskDelete(repoPath, taskId, deleteSubtasks);
+            },
+          });
         },
         successTitle: "Task deleted",
         successDescription: taskId,
         failureTitle: "Failed to delete task",
       });
     },
-    [prepareCleanupTargets, runTaskMutation, tasks],
+    [activeWorkspaceId, queryClient, runTaskMutation, tasks],
   );
 
   const closeTask = useCallback(
@@ -152,16 +123,22 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
-          const cleanupTargets = await prepareCleanupTargets(repoPath, [taskId]);
-          await host.taskClose(repoPath, taskId);
-          runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
+          await runTaskMutationWithChatDraftCleanup({
+            queryClient,
+            repoPath,
+            workspaceId: activeWorkspaceId,
+            taskIds: [taskId],
+            mutation: async () => {
+              await host.taskClose(repoPath, taskId);
+            },
+          });
         },
         successTitle: "Task closed",
         successDescription: taskId,
         failureTitle: "Failed to close task",
       });
     },
-    [prepareCleanupTargets, runTaskMutation],
+    [activeWorkspaceId, queryClient, runTaskMutation],
   );
 
   const transitionTask = useCallback(
@@ -169,15 +146,26 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
-          const cleanupTargets = await prepareClosingCleanupTargets(repoPath, taskId, status);
-          await host.taskTransition(repoPath, taskId, status, reason);
-          runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
+          if (status !== "closed") {
+            await host.taskTransition(repoPath, taskId, status, reason);
+            return;
+          }
+
+          await runTaskMutationWithChatDraftCleanup({
+            queryClient,
+            repoPath,
+            workspaceId: activeWorkspaceId,
+            taskIds: [taskId],
+            mutation: async () => {
+              await host.taskTransition(repoPath, taskId, status, reason);
+            },
+          });
         },
         successDescription: taskId,
         failureTitle: "Failed to transition task",
       });
     },
-    [prepareClosingCleanupTargets, runTaskMutation],
+    [activeWorkspaceId, queryClient, runTaskMutation],
   );
 
   const humanApproveTask = useCallback(
@@ -185,16 +173,22 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
-          const cleanupTargets = await prepareCleanupTargets(repoPath, [taskId]);
-          await host.humanApprove(repoPath, taskId);
-          runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
+          await runTaskMutationWithChatDraftCleanup({
+            queryClient,
+            repoPath,
+            workspaceId: activeWorkspaceId,
+            taskIds: [taskId],
+            mutation: async () => {
+              await host.humanApprove(repoPath, taskId);
+            },
+          });
         },
         successTitle: "Task approved",
         successDescription: taskId,
         failureTitle: "Failed to approve task",
       });
     },
-    [prepareCleanupTargets, runTaskMutation],
+    [activeWorkspaceId, queryClient, runTaskMutation],
   );
 
   const humanRequestChangesTask = useCallback(

--- a/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
@@ -5,8 +5,13 @@ import type {
   TaskStatus,
   TaskUpdatePatch,
 } from "@openducktor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { host } from "../shared/host";
+import {
+  prepareTaskChatDraftCleanupTargets,
+  runTaskChatDraftCleanupAfterSuccess,
+} from "./task-chat-draft-cleanup";
 import { collectTaskDeletionIds } from "./task-deletion-ids";
 import type { TaskMutationRunner } from "./task-mutation-runner";
 import {
@@ -17,6 +22,7 @@ import {
 
 type UseTaskMutationCommandsArgs = {
   activeRepoPath: string | null;
+  activeWorkspaceId: string | null;
   tasks: TaskCard[];
   runTaskMutation: TaskMutationRunner["runTaskMutation"];
 };
@@ -34,9 +40,12 @@ export type TaskMutationCommands = {
 
 export function useTaskMutationCommands({
   activeRepoPath,
+  activeWorkspaceId,
   tasks,
   runTaskMutation,
 }: UseTaskMutationCommandsArgs): TaskMutationCommands {
+  const queryClient = useQueryClient();
+
   const createTask = useCallback(
     async (input: TaskCreateInput): Promise<void> => {
       requireActiveRepo(activeRepoPath);
@@ -94,14 +103,21 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "remove-task", taskIds: taskIdsToRemove },
         run: async (repoPath) => {
+          const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
+            queryClient,
+            repoPath,
+            workspaceId: activeWorkspaceId,
+            taskIds: taskIdsToRemove,
+          });
           await host.taskDelete(repoPath, taskId, deleteSubtasks);
+          runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },
         successTitle: "Task deleted",
         successDescription: taskId,
         failureTitle: "Failed to delete task",
       });
     },
-    [runTaskMutation, tasks],
+    [activeWorkspaceId, queryClient, runTaskMutation, tasks],
   );
 
   const closeTask = useCallback(
@@ -109,14 +125,21 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
+          const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
+            queryClient,
+            repoPath,
+            workspaceId: activeWorkspaceId,
+            taskIds: [taskId],
+          });
           await host.taskClose(repoPath, taskId);
+          runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },
         successTitle: "Task closed",
         successDescription: taskId,
         failureTitle: "Failed to close task",
       });
     },
-    [runTaskMutation],
+    [activeWorkspaceId, queryClient, runTaskMutation],
   );
 
   const transitionTask = useCallback(
@@ -124,13 +147,23 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
+          const cleanupTargets =
+            status === "closed"
+              ? await prepareTaskChatDraftCleanupTargets({
+                  queryClient,
+                  repoPath,
+                  workspaceId: activeWorkspaceId,
+                  taskIds: [taskId],
+                })
+              : [];
           await host.taskTransition(repoPath, taskId, status, reason);
+          runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },
         successDescription: taskId,
         failureTitle: "Failed to transition task",
       });
     },
-    [runTaskMutation],
+    [activeWorkspaceId, queryClient, runTaskMutation],
   );
 
   const humanApproveTask = useCallback(
@@ -138,14 +171,21 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
+          const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
+            queryClient,
+            repoPath,
+            workspaceId: activeWorkspaceId,
+            taskIds: [taskId],
+          });
           await host.humanApprove(repoPath, taskId);
+          runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },
         successTitle: "Task approved",
         successDescription: taskId,
         failureTitle: "Failed to approve task",
       });
     },
-    [runTaskMutation],
+    [activeWorkspaceId, queryClient, runTaskMutation],
   );
 
   const humanRequestChangesTask = useCallback(

--- a/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
@@ -52,6 +52,32 @@ export function useTaskMutationCommands({
 }: UseTaskMutationCommandsArgs): TaskMutationCommands {
   const queryClient = useQueryClient();
 
+  const prepareCleanupTargets = useCallback(
+    async (repoPath: string, taskIds: string[]): Promise<TaskChatDraftCleanupPlan> =>
+      prepareTaskChatDraftCleanupTargets({
+        queryClient,
+        repoPath,
+        workspaceId: activeWorkspaceId,
+        taskIds,
+      }),
+    [activeWorkspaceId, queryClient],
+  );
+
+  const prepareClosingCleanupTargets = useCallback(
+    async (
+      repoPath: string,
+      taskId: string,
+      status: TaskStatus,
+    ): Promise<TaskChatDraftCleanupPlan> => {
+      if (status !== "closed") {
+        return emptyTaskChatDraftCleanupPlan();
+      }
+
+      return prepareCleanupTargets(repoPath, [taskId]);
+    },
+    [prepareCleanupTargets],
+  );
+
   const createTask = useCallback(
     async (input: TaskCreateInput): Promise<void> => {
       requireActiveRepo(activeRepoPath);
@@ -109,12 +135,7 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "remove-task", taskIds: taskIdsToRemove },
         run: async (repoPath) => {
-          const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
-            queryClient,
-            repoPath,
-            workspaceId: activeWorkspaceId,
-            taskIds: taskIdsToRemove,
-          });
+          const cleanupTargets = await prepareCleanupTargets(repoPath, taskIdsToRemove);
           await host.taskDelete(repoPath, taskId, deleteSubtasks);
           runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },
@@ -123,7 +144,7 @@ export function useTaskMutationCommands({
         failureTitle: "Failed to delete task",
       });
     },
-    [activeWorkspaceId, queryClient, runTaskMutation, tasks],
+    [prepareCleanupTargets, runTaskMutation, tasks],
   );
 
   const closeTask = useCallback(
@@ -131,12 +152,7 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
-          const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
-            queryClient,
-            repoPath,
-            workspaceId: activeWorkspaceId,
-            taskIds: [taskId],
-          });
+          const cleanupTargets = await prepareCleanupTargets(repoPath, [taskId]);
           await host.taskClose(repoPath, taskId);
           runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },
@@ -145,7 +161,7 @@ export function useTaskMutationCommands({
         failureTitle: "Failed to close task",
       });
     },
-    [activeWorkspaceId, queryClient, runTaskMutation],
+    [prepareCleanupTargets, runTaskMutation],
   );
 
   const transitionTask = useCallback(
@@ -153,15 +169,7 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
-          const cleanupTargets =
-            status === "closed"
-              ? await prepareTaskChatDraftCleanupTargets({
-                  queryClient,
-                  repoPath,
-                  workspaceId: activeWorkspaceId,
-                  taskIds: [taskId],
-                })
-              : emptyTaskChatDraftCleanupPlan();
+          const cleanupTargets = await prepareClosingCleanupTargets(repoPath, taskId, status);
           await host.taskTransition(repoPath, taskId, status, reason);
           runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },
@@ -169,7 +177,7 @@ export function useTaskMutationCommands({
         failureTitle: "Failed to transition task",
       });
     },
-    [activeWorkspaceId, queryClient, runTaskMutation],
+    [prepareClosingCleanupTargets, runTaskMutation],
   );
 
   const humanApproveTask = useCallback(
@@ -177,12 +185,7 @@ export function useTaskMutationCommands({
       await runTaskMutation({
         refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
-          const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
-            queryClient,
-            repoPath,
-            workspaceId: activeWorkspaceId,
-            taskIds: [taskId],
-          });
+          const cleanupTargets = await prepareCleanupTargets(repoPath, [taskId]);
           await host.humanApprove(repoPath, taskId);
           runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
         },
@@ -191,7 +194,7 @@ export function useTaskMutationCommands({
         failureTitle: "Failed to approve task",
       });
     },
-    [activeWorkspaceId, queryClient, runTaskMutation],
+    [prepareCleanupTargets, runTaskMutation],
   );
 
   const humanRequestChangesTask = useCallback(

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -1967,6 +1967,60 @@ describe("use-task-operations", () => {
     }
   });
 
+  test("deleteTask does not block host deletion when chat draft cleanup target lookup fails", async () => {
+    let isDeleted = false;
+    const taskDelete = mock(async () => {
+      isDeleted = true;
+      return { ok: true };
+    });
+    const agentSessionsList = mock(async () => {
+      throw new Error("session lookup failed");
+    });
+    const tasksList = mock(async () => (isDeleted ? [] : [makeTask("A", "open")]));
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+
+    const original = {
+      taskDelete: host.taskDelete,
+      agentSessionsList: host.agentSessionsList,
+      tasksList: host.tasksList,
+      runsList: legacyHost.runsList,
+      toastError: toast.error,
+    };
+    host.taskDelete = taskDelete;
+    host.agentSessionsList = agentSessionsList;
+    host.tasksList = tasksList;
+    legacyHost.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+
+      await harness.run(async (value) => {
+        await value.deleteTask("A");
+      });
+
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(taskDelete).toHaveBeenCalledWith("/repo", "A", false);
+      expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
+        description: "session lookup failed",
+      });
+    } finally {
+      await harness.unmount();
+      host.taskDelete = original.taskDelete;
+      host.agentSessionsList = original.agentSessionsList;
+      host.tasksList = original.tasksList;
+      legacyHost.runsList = original.runsList;
+      toast.error = original.toastError;
+    }
+  });
+
   test("closeTask calls the host close route and refreshes the task", async () => {
     let isClosed = false;
     const taskClose = mock(async () => {

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -1,8 +1,23 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { TaskCard, TaskCreateInput, TaskStoreCheck } from "@openducktor/contracts";
+import type {
+  AgentSessionRecord,
+  TaskCard,
+  TaskCreateInput,
+  TaskStoreCheck,
+} from "@openducktor/contracts";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import type { PropsWithChildren, ReactElement } from "react";
 import { toast } from "sonner";
+import { createTextSegment } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
+import {
+  type AgentChatDraftSessionIdentity,
+  toAgentChatDraftStorageKey,
+  writeAgentChatDraftToStorage,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-storage";
+import {
+  resetAgentChatDraftStoreForTests,
+  setAgentChatDraftStorageForTests,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-store";
 import { useTaskDocuments } from "@/components/features/task-details/use-task-documents";
 import { createQueryClient } from "@/lib/query-client";
 import { QueryProvider } from "@/lib/query-provider";
@@ -53,6 +68,7 @@ const legacyHost = host as typeof host & {
 };
 
 type RunSummary = LegacyRunSummary;
+type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
 
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -79,6 +95,37 @@ const createDeferred = <T,>() => {
     resolve: (value: T) => resolve?.(value),
     reject: (reason?: unknown) => reject?.(reason),
   };
+};
+
+const createMemoryStorage = (): TestStorage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+};
+
+const writeTestDraft = (
+  storage: TestStorage,
+  identity: AgentChatDraftSessionIdentity,
+  text: string,
+): void => {
+  writeAgentChatDraftToStorage({
+    storage,
+    identity,
+    taskId: "task-1",
+    draft: { segments: [createTextSegment(text, "text-1")], attachments: [] },
+    updatedAt: "2026-07-08T10:00:00.000Z",
+  });
 };
 
 const makeTask = (id: string, status: TaskCard["status"]): TaskCard => ({
@@ -122,6 +169,18 @@ const buildAgentSession = (overrides: Partial<AgentSessionState> = {}): AgentSes
   selectedModel: null,
   ...overrides,
   historyLoadState: overrides.historyLoadState ?? "not_requested",
+});
+
+const buildAgentSessionRecord = (
+  overrides: Partial<AgentSessionRecord> = {},
+): AgentSessionRecord => ({
+  runtimeKind: "opencode",
+  externalSessionId: "external-1",
+  role: "build",
+  startedAt: "2026-02-22T08:00:00.000Z",
+  workingDirectory: "/repo",
+  selectedModel: null,
+  ...overrides,
 });
 
 const makeTaskStoreCheck = (overrides: TaskStoreCheckFixtureOverrides = {}): TaskStoreCheck =>
@@ -394,6 +453,7 @@ describe("use-task-operations", () => {
     console.warn = originalConsoleWarn;
     toast.success = originalToastSuccess;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+    resetAgentChatDraftStoreForTests();
   });
 
   test("refreshTaskData keeps host task results intact", async () => {
@@ -1745,6 +1805,15 @@ describe("use-task-operations", () => {
       isDeleted = true;
       return { ok: true };
     });
+    const agentSessionsList = mock(async (_repoPath: string, taskId: string) => {
+      if (taskId === "A") {
+        return [buildAgentSessionRecord({ externalSessionId: "session-a" })];
+      }
+      if (taskId === "B") {
+        return [buildAgentSessionRecord({ externalSessionId: "session-b" })];
+      }
+      return [];
+    });
     const tasksList = mock(async () =>
       isDeleted ? [] : [{ ...makeTask("A", "open"), subtaskIds: ["B"] }, makeTask("B", "open")],
     );
@@ -1752,10 +1821,12 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
+      agentSessionsList: host.agentSessionsList,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskDelete = taskDelete;
+    host.agentSessionsList = agentSessionsList;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -1783,6 +1854,15 @@ describe("use-task-operations", () => {
     );
 
     try {
+      const storage = createMemoryStorage();
+      setAgentChatDraftStorageForTests(storage);
+      const parentDraftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+      const childDraftIdentity = { workspaceId: "repo", externalSessionId: "session-b" };
+      const unrelatedDraftIdentity = { workspaceId: "repo", externalSessionId: "session-c" };
+      writeTestDraft(storage, parentDraftIdentity, "parent draft");
+      writeTestDraft(storage, childDraftIdentity, "child draft");
+      writeTestDraft(storage, unrelatedDraftIdentity, "unrelated draft");
+
       queryClient.setQueryData(taskQueryKeys.repoData("/repo", 1), {
         tasks: [{ ...makeTask("A", "open"), subtaskIds: ["B"] }, makeTask("B", "open")],
         runs: [] satisfies RunSummary[],
@@ -1815,13 +1895,75 @@ describe("use-task-operations", () => {
       );
 
       expect(taskDelete).toHaveBeenCalledWith("/repo", "A", true);
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "B");
+      expect(storage.getItem(toAgentChatDraftStorageKey(parentDraftIdentity))).toBeNull();
+      expect(storage.getItem(toAgentChatDraftStorageKey(childDraftIdentity))).toBeNull();
+      expect(storage.getItem(toAgentChatDraftStorageKey(unrelatedDraftIdentity))).not.toBeNull();
       expect(queryClient.getQueryData(documentQueryKeys.spec("/repo", "A"))).toBeUndefined();
       expect(queryClient.getQueryData(documentQueryKeys.plan("/repo", "B"))).toBeUndefined();
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
+      host.agentSessionsList = original.agentSessionsList;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
+    }
+  });
+
+  test("deleteTask leaves chat drafts intact when the host deletion fails", async () => {
+    const taskDelete = mock(async () => {
+      throw new Error("delete failed");
+    });
+    const agentSessionsList = mock(async () => [
+      buildAgentSessionRecord({ externalSessionId: "session-a" }),
+    ]);
+    const tasksList = mock(async () => [makeTask("A", "open")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+
+    const original = {
+      taskDelete: host.taskDelete,
+      agentSessionsList: host.agentSessionsList,
+      tasksList: host.tasksList,
+      runsList: legacyHost.runsList,
+      toastError: toast.error,
+    };
+    host.taskDelete = taskDelete;
+    host.agentSessionsList = agentSessionsList;
+    host.tasksList = tasksList;
+    legacyHost.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const storage = createMemoryStorage();
+    setAgentChatDraftStorageForTests(storage);
+    const draftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+    writeTestDraft(storage, draftIdentity, "parent draft");
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+
+      await expect(
+        harness.run(async (value) => {
+          await value.deleteTask("A");
+        }),
+      ).rejects.toThrow("delete failed");
+
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).not.toBeNull();
+    } finally {
+      await harness.unmount();
+      host.taskDelete = original.taskDelete;
+      host.agentSessionsList = original.agentSessionsList;
+      host.tasksList = original.tasksList;
+      legacyHost.runsList = original.runsList;
+      toast.error = original.toastError;
     }
   });
 
@@ -1831,15 +1973,20 @@ describe("use-task-operations", () => {
       isClosed = true;
       return makeTask("A", "closed");
     });
+    const agentSessionsList = mock(async () => [
+      buildAgentSessionRecord({ externalSessionId: "session-a" }),
+    ]);
     const tasksList = mock(async () => [makeTask("A", isClosed ? "closed" : "in_progress")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
 
     const original = {
       taskClose: host.taskClose,
+      agentSessionsList: host.agentSessionsList,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskClose = taskClose;
+    host.agentSessionsList = agentSessionsList;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -1867,6 +2014,11 @@ describe("use-task-operations", () => {
     );
 
     try {
+      const storage = createMemoryStorage();
+      setAgentChatDraftStorageForTests(storage);
+      const draftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+      writeTestDraft(storage, draftIdentity, "close draft");
+
       await harness.mount();
       await harness.waitFor(() => latest?.tasks[0]?.status === "in_progress");
       await harness.run(async () => {
@@ -1886,9 +2038,12 @@ describe("use-task-operations", () => {
       );
 
       expect(taskClose).toHaveBeenCalledWith("/repo", "A");
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).toBeNull();
     } finally {
       await harness.unmount();
       host.taskClose = original.taskClose;
+      host.agentSessionsList = original.agentSessionsList;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
     }
@@ -2341,17 +2496,22 @@ describe("use-task-operations", () => {
       },
     }));
     const taskPullRequestLinkMerged = mock(async () => makeTask("A", "closed"));
+    const agentSessionsList = mock(async () => [
+      buildAgentSessionRecord({ externalSessionId: "session-a" }),
+    ]);
     const tasksList = mock(async () => [makeTask("A", "closed")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
 
     const original = {
       taskPullRequestDetect: host.taskPullRequestDetect,
       taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
+      agentSessionsList: host.agentSessionsList,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
+    host.agentSessionsList = agentSessionsList;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -2366,6 +2526,11 @@ describe("use-task-operations", () => {
     });
 
     try {
+      const storage = createMemoryStorage();
+      setAgentChatDraftStorageForTests(storage);
+      const draftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+      writeTestDraft(storage, draftIdentity, "merged draft");
+
       await harness.mount();
       await harness.waitFor((value) => value.tasks.length === 1);
       tasksList.mockClear();
@@ -2389,6 +2554,8 @@ describe("use-task-operations", () => {
         closedAt: "2026-02-20T10:00:00Z",
       });
       expect(tasksList).toHaveBeenCalledWith("/repo", 1);
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).toBeNull();
       expect(harness.getLatest().pendingMergedPullRequest).toBeNull();
       expect(harness.getLatest().linkingMergedPullRequestTaskId).toBeNull();
       expect(toastSuccess).toHaveBeenCalledWith("Merged pull request linked", {
@@ -2398,6 +2565,7 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
+      host.agentSessionsList = original.agentSessionsList;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.success = originalToastSuccess;
@@ -2425,17 +2593,20 @@ describe("use-task-operations", () => {
       currentStatus = "closed";
       return makeTask("A", currentStatus);
     });
+    const agentSessionsList = mock(async () => []);
     const tasksList = mock(async () => [makeTask("A", currentStatus)]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
 
     const original = {
       taskPullRequestDetect: host.taskPullRequestDetect,
       taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
+      agentSessionsList: host.agentSessionsList,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
+    host.agentSessionsList = agentSessionsList;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -2494,6 +2665,7 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
+      host.agentSessionsList = original.agentSessionsList;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
     }

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -132,6 +132,16 @@ const writeTestDraft = (
   });
 };
 
+const createDraftIdentity = (
+  externalSessionId: string,
+  workingDirectory = "/repo",
+): AgentChatDraftSessionIdentity => ({
+  workspaceId: "repo",
+  externalSessionId,
+  runtimeKind: "opencode",
+  workingDirectory,
+});
+
 const makeTask = (id: string, status: TaskCard["status"]): TaskCard => ({
   id,
   title: id,
@@ -1811,10 +1821,20 @@ describe("use-task-operations", () => {
     });
     const agentSessionsList = mock(async (_repoPath: string, taskId: string) => {
       if (taskId === "A") {
-        return [buildAgentSessionRecord({ externalSessionId: "session-a" })];
+        return [
+          buildAgentSessionRecord({
+            externalSessionId: "session-shared",
+            workingDirectory: "/repo/parent",
+          }),
+        ];
       }
       if (taskId === "B") {
-        return [buildAgentSessionRecord({ externalSessionId: "session-b" })];
+        return [
+          buildAgentSessionRecord({
+            externalSessionId: "session-b",
+            workingDirectory: "/repo/child",
+          }),
+        ];
       }
       return [];
     });
@@ -1860,9 +1880,9 @@ describe("use-task-operations", () => {
     try {
       const storage = createMemoryStorage();
       setAgentChatDraftStorageForTests(storage);
-      const parentDraftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
-      const childDraftIdentity = { workspaceId: "repo", externalSessionId: "session-b" };
-      const unrelatedDraftIdentity = { workspaceId: "repo", externalSessionId: "session-c" };
+      const parentDraftIdentity = createDraftIdentity("session-shared", "/repo/parent");
+      const childDraftIdentity = createDraftIdentity("session-b", "/repo/child");
+      const unrelatedDraftIdentity = createDraftIdentity("session-shared", "/repo/unrelated");
       writeTestDraft(storage, parentDraftIdentity, "parent draft");
       writeTestDraft(storage, childDraftIdentity, "child draft");
       writeTestDraft(storage, unrelatedDraftIdentity, "unrelated draft");
@@ -1941,7 +1961,7 @@ describe("use-task-operations", () => {
 
     const storage = createMemoryStorage();
     setAgentChatDraftStorageForTests(storage);
-    const draftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+    const draftIdentity = createDraftIdentity("session-a");
     writeTestDraft(storage, draftIdentity, "parent draft");
 
     const harness = createHookHarness({
@@ -2003,7 +2023,7 @@ describe("use-task-operations", () => {
       },
     });
     setAgentChatDraftStorageForTests(storage);
-    const draftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+    const draftIdentity = createDraftIdentity("session-a");
     writeTestDraft(storage, draftIdentity, "parent draft");
 
     const harness = createHookHarness({
@@ -2202,7 +2222,7 @@ describe("use-task-operations", () => {
     try {
       const storage = createMemoryStorage();
       setAgentChatDraftStorageForTests(storage);
-      const draftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+      const draftIdentity = createDraftIdentity("session-a");
       writeTestDraft(storage, draftIdentity, "close draft");
 
       await harness.mount();
@@ -2714,7 +2734,7 @@ describe("use-task-operations", () => {
     try {
       const storage = createMemoryStorage();
       setAgentChatDraftStorageForTests(storage);
-      const draftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+      const draftIdentity = createDraftIdentity("session-a");
       writeTestDraft(storage, draftIdentity, "merged draft");
 
       await harness.mount();

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -2054,7 +2054,7 @@ describe("use-task-operations", () => {
     }
   });
 
-  test("deleteTask blocks host deletion when chat draft cleanup target lookup fails", async () => {
+  test("deleteTask reports cleanup target lookup failure after host deletion succeeds", async () => {
     const taskDelete = mock(async () => {
       return { ok: true };
     });
@@ -2087,15 +2087,13 @@ describe("use-task-operations", () => {
       await harness.mount();
       await harness.waitFor((value) => value.tasks[0]?.id === "A");
 
-      await expect(
-        harness.run(async (value) => {
-          await value.deleteTask("A");
-        }),
-      ).rejects.toThrow("session lookup failed");
+      await harness.run(async (value) => {
+        await value.deleteTask("A");
+      });
 
       expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
-      expect(taskDelete).not.toHaveBeenCalled();
-      expect(toastError).toHaveBeenCalledWith("Failed to delete task", {
+      expect(taskDelete).toHaveBeenCalledWith("/repo", "A", false);
+      expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
         description: "session lookup failed",
       });
     } finally {
@@ -2108,7 +2106,7 @@ describe("use-task-operations", () => {
     }
   });
 
-  test("close and approval completion routes block host mutation when cleanup target lookup fails", async () => {
+  test("close and approval completion routes report cleanup lookup failures after host mutation succeeds", async () => {
     const taskClose = mock(async () => makeTask("A", "closed"));
     const humanApprove = mock(async () => makeTask("A", "closed"));
     const taskTransition = mock(async () => makeTask("A", "closed"));
@@ -2117,6 +2115,7 @@ describe("use-task-operations", () => {
     });
     const tasksList = mock(async () => [makeTask("A", "human_review")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
 
     const original = {
       taskClose: host.taskClose,
@@ -2125,6 +2124,7 @@ describe("use-task-operations", () => {
       agentSessionsList: host.agentSessionsList,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
+      toastError: toast.error,
     };
     host.taskClose = taskClose;
     host.humanApprove = humanApprove;
@@ -2132,6 +2132,7 @@ describe("use-task-operations", () => {
     host.agentSessionsList = agentSessionsList;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
 
     const harness = createHookHarness({
       activeRepo: "/repo",
@@ -2142,26 +2143,24 @@ describe("use-task-operations", () => {
       await harness.mount();
       await harness.waitFor((value) => value.tasks[0]?.id === "A");
 
-      await expect(
-        harness.run(async (value) => {
-          await value.closeTask("A");
-        }),
-      ).rejects.toThrow("session lookup failed");
-      await expect(
-        harness.run(async (value) => {
-          await value.humanApproveTask("A");
-        }),
-      ).rejects.toThrow("session lookup failed");
-      await expect(
-        harness.run(async (value) => {
-          await value.transitionTask("A", "closed");
-        }),
-      ).rejects.toThrow("session lookup failed");
+      await harness.run(async (value) => {
+        await value.closeTask("A");
+      });
+      await harness.run(async (value) => {
+        await value.humanApproveTask("A");
+      });
+      await harness.run(async (value) => {
+        await value.transitionTask("A", "closed");
+      });
 
       expect(agentSessionsList).toHaveBeenCalledTimes(3);
-      expect(taskClose).not.toHaveBeenCalled();
-      expect(humanApprove).not.toHaveBeenCalled();
-      expect(taskTransition).not.toHaveBeenCalled();
+      expect(taskClose).toHaveBeenCalledWith("/repo", "A");
+      expect(humanApprove).toHaveBeenCalledWith("/repo", "A");
+      expect(taskTransition).toHaveBeenCalledWith("/repo", "A", "closed", undefined);
+      expect(toastError).toHaveBeenCalledTimes(3);
+      expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
+        description: "session lookup failed",
+      });
     } finally {
       await harness.unmount();
       host.taskClose = original.taskClose;
@@ -2170,6 +2169,7 @@ describe("use-task-operations", () => {
       host.agentSessionsList = original.agentSessionsList;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
+      toast.error = original.toastError;
     }
   });
 
@@ -2778,7 +2778,7 @@ describe("use-task-operations", () => {
     }
   });
 
-  test("linkMergedPullRequest blocks merged-link mutation when cleanup target lookup fails", async () => {
+  test("linkMergedPullRequest reports cleanup lookup failure after merged-link mutation succeeds", async () => {
     const mergedPullRequest = {
       providerId: "github" as const,
       number: 17,
@@ -2833,14 +2833,11 @@ describe("use-task-operations", () => {
       });
 
       expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
-      expect(taskPullRequestLinkMerged).not.toHaveBeenCalled();
-      expect(toastError).toHaveBeenCalledWith("Failed to link merged pull request", {
+      expect(taskPullRequestLinkMerged).toHaveBeenCalledWith("/repo", "A", mergedPullRequest);
+      expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
         description: "session lookup failed",
       });
-      expect(harness.getLatest().pendingMergedPullRequest).toEqual({
-        taskId: "A",
-        pullRequest: mergedPullRequest,
-      });
+      expect(harness.getLatest().pendingMergedPullRequest).toBeNull();
     } finally {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -69,6 +69,9 @@ const legacyHost = host as typeof host & {
 
 type RunSummary = LegacyRunSummary;
 type TestStorage = Pick<Storage, "length" | "key" | "getItem" | "setItem" | "removeItem">;
+type TestStorageSpies = {
+  removeItem?: (key: string) => void;
+};
 
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -97,7 +100,7 @@ const createDeferred = <T,>() => {
   };
 };
 
-const createMemoryStorage = (): TestStorage => {
+const createMemoryStorage = (spies?: TestStorageSpies): TestStorage => {
   const store = new Map<string, string>();
   return {
     get length() {
@@ -109,6 +112,7 @@ const createMemoryStorage = (): TestStorage => {
       store.set(key, value);
     },
     removeItem: (key) => {
+      spies?.removeItem?.(key);
       store.delete(key);
     },
   };
@@ -1967,16 +1971,77 @@ describe("use-task-operations", () => {
     }
   });
 
-  test("deleteTask does not block host deletion when chat draft cleanup target lookup fails", async () => {
+  test("deleteTask reports chat draft cleanup storage failures without blocking host deletion", async () => {
     let isDeleted = false;
     const taskDelete = mock(async () => {
       isDeleted = true;
       return { ok: true };
     });
+    const agentSessionsList = mock(async () => [
+      buildAgentSessionRecord({ externalSessionId: "session-a" }),
+    ]);
+    const tasksList = mock(async () => (isDeleted ? [] : [makeTask("A", "open")]));
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+
+    const original = {
+      taskDelete: host.taskDelete,
+      agentSessionsList: host.agentSessionsList,
+      tasksList: host.tasksList,
+      runsList: legacyHost.runsList,
+      toastError: toast.error,
+    };
+    host.taskDelete = taskDelete;
+    host.agentSessionsList = agentSessionsList;
+    host.tasksList = tasksList;
+    legacyHost.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const storage = createMemoryStorage({
+      removeItem: () => {
+        throw new Error("storage remove failed");
+      },
+    });
+    setAgentChatDraftStorageForTests(storage);
+    const draftIdentity = { workspaceId: "repo", externalSessionId: "session-a" };
+    writeTestDraft(storage, draftIdentity, "parent draft");
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+
+      await harness.run(async (value) => {
+        await value.deleteTask("A");
+      });
+
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(taskDelete).toHaveBeenCalledWith("/repo", "A", false);
+      expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
+        description: "Failed to clean 1 chat draft storage key(s).",
+      });
+    } finally {
+      await harness.unmount();
+      host.taskDelete = original.taskDelete;
+      host.agentSessionsList = original.agentSessionsList;
+      host.tasksList = original.tasksList;
+      legacyHost.runsList = original.runsList;
+      toast.error = original.toastError;
+    }
+  });
+
+  test("deleteTask blocks host deletion when chat draft cleanup target lookup fails", async () => {
+    const taskDelete = mock(async () => {
+      return { ok: true };
+    });
     const agentSessionsList = mock(async () => {
       throw new Error("session lookup failed");
     });
-    const tasksList = mock(async () => (isDeleted ? [] : [makeTask("A", "open")]));
+    const tasksList = mock(async () => [makeTask("A", "open")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
     const toastError = mock((_message: string, _options?: { description?: string }) => "");
 
@@ -2002,13 +2067,15 @@ describe("use-task-operations", () => {
       await harness.mount();
       await harness.waitFor((value) => value.tasks[0]?.id === "A");
 
-      await harness.run(async (value) => {
-        await value.deleteTask("A");
-      });
+      await expect(
+        harness.run(async (value) => {
+          await value.deleteTask("A");
+        }),
+      ).rejects.toThrow("session lookup failed");
 
       expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
-      expect(taskDelete).toHaveBeenCalledWith("/repo", "A", false);
-      expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
+      expect(taskDelete).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith("Failed to delete task", {
         description: "session lookup failed",
       });
     } finally {
@@ -2018,6 +2085,71 @@ describe("use-task-operations", () => {
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
+    }
+  });
+
+  test("close and approval completion routes block host mutation when cleanup target lookup fails", async () => {
+    const taskClose = mock(async () => makeTask("A", "closed"));
+    const humanApprove = mock(async () => makeTask("A", "closed"));
+    const taskTransition = mock(async () => makeTask("A", "closed"));
+    const agentSessionsList = mock(async () => {
+      throw new Error("session lookup failed");
+    });
+    const tasksList = mock(async () => [makeTask("A", "human_review")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+
+    const original = {
+      taskClose: host.taskClose,
+      humanApprove: host.humanApprove,
+      taskTransition: host.taskTransition,
+      agentSessionsList: host.agentSessionsList,
+      tasksList: host.tasksList,
+      runsList: legacyHost.runsList,
+    };
+    host.taskClose = taskClose;
+    host.humanApprove = humanApprove;
+    host.taskTransition = taskTransition;
+    host.agentSessionsList = agentSessionsList;
+    host.tasksList = tasksList;
+    legacyHost.runsList = runsList;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+
+      await expect(
+        harness.run(async (value) => {
+          await value.closeTask("A");
+        }),
+      ).rejects.toThrow("session lookup failed");
+      await expect(
+        harness.run(async (value) => {
+          await value.humanApproveTask("A");
+        }),
+      ).rejects.toThrow("session lookup failed");
+      await expect(
+        harness.run(async (value) => {
+          await value.transitionTask("A", "closed");
+        }),
+      ).rejects.toThrow("session lookup failed");
+
+      expect(agentSessionsList).toHaveBeenCalledTimes(3);
+      expect(taskClose).not.toHaveBeenCalled();
+      expect(humanApprove).not.toHaveBeenCalled();
+      expect(taskTransition).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+      host.taskClose = original.taskClose;
+      host.humanApprove = original.humanApprove;
+      host.taskTransition = original.taskTransition;
+      host.agentSessionsList = original.agentSessionsList;
+      host.tasksList = original.tasksList;
+      legacyHost.runsList = original.runsList;
     }
   });
 
@@ -2623,6 +2755,80 @@ describe("use-task-operations", () => {
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.success = originalToastSuccess;
+    }
+  });
+
+  test("linkMergedPullRequest blocks merged-link mutation when cleanup target lookup fails", async () => {
+    const mergedPullRequest = {
+      providerId: "github" as const,
+      number: 17,
+      url: "https://github.com/openai/openducktor/pull/17",
+      state: "merged" as const,
+      createdAt: "2026-02-20T10:00:00Z",
+      updatedAt: "2026-02-20T10:00:00Z",
+      lastSyncedAt: "2026-02-20T10:00:00Z",
+      mergedAt: "2026-02-20T10:00:00Z",
+      closedAt: "2026-02-20T10:00:00Z",
+    };
+    const taskPullRequestDetect = mock(async () => ({
+      outcome: "merged" as const,
+      pullRequest: mergedPullRequest,
+    }));
+    const taskPullRequestLinkMerged = mock(async () => makeTask("A", "closed"));
+    const agentSessionsList = mock(async () => {
+      throw new Error("session lookup failed");
+    });
+    const tasksList = mock(async () => [makeTask("A", "human_review")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+
+    const original = {
+      taskPullRequestDetect: host.taskPullRequestDetect,
+      taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
+      agentSessionsList: host.agentSessionsList,
+      tasksList: host.tasksList,
+      runsList: legacyHost.runsList,
+      toastError: toast.error,
+    };
+    host.taskPullRequestDetect = taskPullRequestDetect;
+    host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
+    host.agentSessionsList = agentSessionsList;
+    host.tasksList = tasksList;
+    legacyHost.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks.length === 1);
+      await harness.run(async (value) => {
+        await value.syncPullRequests("A");
+      });
+      await harness.run(async (value) => {
+        await value.linkMergedPullRequest();
+      });
+
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(taskPullRequestLinkMerged).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith("Failed to link merged pull request", {
+        description: "session lookup failed",
+      });
+      expect(harness.getLatest().pendingMergedPullRequest).toEqual({
+        taskId: "A",
+        pullRequest: mergedPullRequest,
+      });
+    } finally {
+      await harness.unmount();
+      host.taskPullRequestDetect = original.taskPullRequestDetect;
+      host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
+      host.agentSessionsList = original.agentSessionsList;
+      host.tasksList = original.tasksList;
+      legacyHost.runsList = original.runsList;
+      toast.error = original.toastError;
     }
   });
 

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.ts
@@ -10,10 +10,12 @@ export function useTaskOperations({
   activeWorkspace,
 }: UseTaskOperationsArgs): UseTaskOperationsResult {
   const activeRepoPath = activeWorkspace?.repoPath ?? null;
+  const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
   const taskReadFlow = useTaskReadFlow({ activeRepoPath });
   const mutationRunner = useTaskMutationRunner({ activeRepoPath });
   const mutationCommands = useTaskMutationCommands({
     activeRepoPath,
+    activeWorkspaceId,
     tasks: taskReadFlow.tasks,
     runTaskMutation: mutationRunner.runTaskMutation,
   });
@@ -23,6 +25,7 @@ export function useTaskOperations({
   });
   const pullRequestOperations = useTaskPullRequestOperations({
     activeRepoPath,
+    activeWorkspaceId,
     refreshTaskData: taskReadFlow.refreshTaskData,
     runTaskMutation: mutationRunner.runTaskMutation,
   });

--- a/packages/frontend/src/state/operations/tasks/use-task-pull-request-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-pull-request-operations.ts
@@ -4,10 +4,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { host } from "../shared/host";
-import {
-  prepareTaskChatDraftCleanupTargets,
-  runTaskChatDraftCleanupAfterSuccess,
-} from "./task-chat-draft-cleanup";
+import { runTaskMutationWithChatDraftCleanup } from "./task-chat-draft-cleanup";
 import type { TaskMutationRunner } from "./task-mutation-runner";
 import { requireActiveRepo } from "./task-operations-model";
 import type { UseTaskOperationsResult } from "./task-operations-types";
@@ -146,18 +143,19 @@ export function useTaskPullRequestOperations({
     const { repoPath, taskId, pullRequest } = pendingMergedPullRequestState;
     setLinkingMergedPullRequestTaskId(taskId);
     try {
-      const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
+      await runTaskMutationWithChatDraftCleanup({
         queryClient,
         repoPath,
         workspaceId: activeWorkspaceId,
         taskIds: [taskId],
+        mutation: async () => {
+          await host.taskPullRequestLinkMerged(repoPath, taskId, pullRequest);
+        },
       });
-      await host.taskPullRequestLinkMerged(repoPath, taskId, pullRequest);
       setPendingMergedPullRequestState((current) =>
         current?.repoPath === repoPath && current.taskId === taskId ? null : current,
       );
       await refreshTaskData(repoPath, taskId);
-      runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
       toast.success("Merged pull request linked", {
         description: `PR #${pullRequest.number}; task moved to Done.`,
       });

--- a/packages/frontend/src/state/operations/tasks/use-task-pull-request-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-pull-request-operations.ts
@@ -1,14 +1,20 @@
 import type { PullRequest } from "@openducktor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { host } from "../shared/host";
+import {
+  prepareTaskChatDraftCleanupTargets,
+  runTaskChatDraftCleanupAfterSuccess,
+} from "./task-chat-draft-cleanup";
 import type { TaskMutationRunner } from "./task-mutation-runner";
 import { requireActiveRepo } from "./task-operations-model";
 import type { UseTaskOperationsResult } from "./task-operations-types";
 
 type UseTaskPullRequestOperationsArgs = {
   activeRepoPath: string | null;
+  activeWorkspaceId: string | null;
   refreshTaskData: UseTaskOperationsResult["refreshTaskData"];
   runTaskMutation: TaskMutationRunner["runTaskMutation"];
 };
@@ -38,9 +44,11 @@ export type TaskPullRequestOperations = {
 
 export function useTaskPullRequestOperations({
   activeRepoPath,
+  activeWorkspaceId,
   refreshTaskData,
   runTaskMutation,
 }: UseTaskPullRequestOperationsArgs): TaskPullRequestOperations {
+  const queryClient = useQueryClient();
   const [detectingPullRequestState, setDetectingPullRequestState] = useState<TaskRepoState | null>(
     null,
   );
@@ -138,11 +146,18 @@ export function useTaskPullRequestOperations({
     const { repoPath, taskId, pullRequest } = pendingMergedPullRequestState;
     setLinkingMergedPullRequestTaskId(taskId);
     try {
+      const cleanupTargets = await prepareTaskChatDraftCleanupTargets({
+        queryClient,
+        repoPath,
+        workspaceId: activeWorkspaceId,
+        taskIds: [taskId],
+      });
       await host.taskPullRequestLinkMerged(repoPath, taskId, pullRequest);
       setPendingMergedPullRequestState((current) =>
         current?.repoPath === repoPath && current.taskId === taskId ? null : current,
       );
       await refreshTaskData(repoPath, taskId);
+      runTaskChatDraftCleanupAfterSuccess(cleanupTargets);
       toast.success("Merged pull request linked", {
         description: `PR #${pullRequest.number}; task moved to Done.`,
       });
@@ -153,7 +168,7 @@ export function useTaskPullRequestOperations({
         currentTaskId === taskId ? null : currentTaskId,
       );
     }
-  }, [pendingMergedPullRequestState, refreshTaskData]);
+  }, [activeWorkspaceId, pendingMergedPullRequestState, queryClient, refreshTaskData]);
 
   const unlinkPullRequest = useCallback(
     async (taskId: string): Promise<void> => {

--- a/packages/host/src/ports/task-store-port-contract.test-support.ts
+++ b/packages/host/src/ports/task-store-port-contract.test-support.ts
@@ -80,6 +80,8 @@ export const createDirectMergeRecord = (
 
 const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> => Effect.runPromise(effect);
 
+const SQLITE_ORDERING_CONTRACT_TEST_TIMEOUT_MS = 20_000;
+
 const createTask = (
   store: TaskStorePort,
   repoPath: string,
@@ -151,68 +153,71 @@ export const describeTaskStorePortContract = (
       );
     });
 
-    test("orders open tasks by priority then creation date and non-open tasks by update date", async () => {
-      const { repoPath, store } = await createTrackedHarness();
+    test(
+      "orders open tasks by priority then creation date and non-open tasks by update date",
+      async () => {
+        const { repoPath, store } = await createTrackedHarness();
 
-      const olderHighPriorityOpen = await createTask(store, repoPath, {
-        title: "Older high priority open",
-        issueType: "task",
-        priority: 1,
-        aiReviewEnabled: true,
-      });
-      const newerHighPriorityOpen = await createTask(store, repoPath, {
-        title: "Newer high priority open",
-        issueType: "task",
-        priority: 1,
-        aiReviewEnabled: true,
-      });
-      const newestLowPriorityOpen = await createTask(store, repoPath, {
-        title: "Newest low priority open",
-        issueType: "task",
-        priority: 4,
-        aiReviewEnabled: true,
-      });
-      const olderSpecReady = await createTask(store, repoPath, {
-        title: "Older spec ready",
-        issueType: "task",
-        priority: 2,
-        aiReviewEnabled: true,
-      });
-      const newerSpecReady = await createTask(store, repoPath, {
-        title: "Newer spec ready",
-        issueType: "task",
-        priority: 2,
-        aiReviewEnabled: true,
-      });
+        const olderHighPriorityOpen = await createTask(store, repoPath, {
+          title: "Older high priority open",
+          issueType: "task",
+          priority: 1,
+          aiReviewEnabled: true,
+        });
+        const newerHighPriorityOpen = await createTask(store, repoPath, {
+          title: "Newer high priority open",
+          issueType: "task",
+          priority: 1,
+          aiReviewEnabled: true,
+        });
+        const newestLowPriorityOpen = await createTask(store, repoPath, {
+          title: "Newest low priority open",
+          issueType: "task",
+          priority: 4,
+          aiReviewEnabled: true,
+        });
+        const olderSpecReady = await createTask(store, repoPath, {
+          title: "Older spec ready",
+          issueType: "task",
+          priority: 2,
+          aiReviewEnabled: true,
+        });
+        const newerSpecReady = await createTask(store, repoPath, {
+          title: "Newer spec ready",
+          issueType: "task",
+          priority: 2,
+          aiReviewEnabled: true,
+        });
 
-      await run(
-        store.transitionTask({ repoPath, taskId: olderSpecReady.id, status: "spec_ready" }),
-      );
-      await run(
-        store.transitionTask({ repoPath, taskId: newerSpecReady.id, status: "spec_ready" }),
-      );
+        await run(
+          store.transitionTask({ repoPath, taskId: olderSpecReady.id, status: "spec_ready" }),
+        );
+        await run(
+          store.transitionTask({ repoPath, taskId: newerSpecReady.id, status: "spec_ready" }),
+        );
 
-      const tasks = await run(store.listTasks({ repoPath }));
+        const tasks = await run(store.listTasks({ repoPath }));
 
-      expect(tasks.filter((task) => task.status === "open").map((task) => task.id)).toEqual([
-        newerHighPriorityOpen.id,
-        olderHighPriorityOpen.id,
-        newestLowPriorityOpen.id,
-      ]);
-      expect(tasks.filter((task) => task.status === "spec_ready").map((task) => task.id)).toEqual([
-        olderSpecReady.id,
-        newerSpecReady.id,
-      ]);
+        expect(tasks.filter((task) => task.status === "open").map((task) => task.id)).toEqual([
+          newerHighPriorityOpen.id,
+          olderHighPriorityOpen.id,
+          newestLowPriorityOpen.id,
+        ]);
+        expect(tasks.filter((task) => task.status === "spec_ready").map((task) => task.id)).toEqual(
+          [olderSpecReady.id, newerSpecReady.id],
+        );
 
-      const filteredTasks = await run(store.listTasks({ repoPath, doneVisibleDays: 0 }));
+        const filteredTasks = await run(store.listTasks({ repoPath, doneVisibleDays: 0 }));
 
-      expect(filteredTasks.filter((task) => task.status === "open").map((task) => task.id)).toEqual(
-        [newerHighPriorityOpen.id, olderHighPriorityOpen.id, newestLowPriorityOpen.id],
-      );
-      expect(
-        filteredTasks.filter((task) => task.status === "spec_ready").map((task) => task.id),
-      ).toEqual([olderSpecReady.id, newerSpecReady.id]);
-    });
+        expect(
+          filteredTasks.filter((task) => task.status === "open").map((task) => task.id),
+        ).toEqual([newerHighPriorityOpen.id, olderHighPriorityOpen.id, newestLowPriorityOpen.id]);
+        expect(
+          filteredTasks.filter((task) => task.status === "spec_ready").map((task) => task.id),
+        ).toEqual([olderSpecReady.id, newerSpecReady.id]);
+      },
+      SQLITE_ORDERING_CONTRACT_TEST_TIMEOUT_MS,
+    );
 
     test("stores workflow documents and exposes the current metadata/read-model state", async () => {
       const { repoPath, store } = await createTrackedHarness();


### PR DESCRIPTION
Summary: This PR preserves in-progress Agent Studio chat composer drafts across session switching and app reloads, and removes related drafts when task lifecycle operations close or delete the owning sessions.

## Goal

Users could lose a partially written chat composer message after switching away from a session and coming back. The goal is to make draft persistence invisible and session-scoped: typing remains instant, valid drafts survive reload within the retention window, failed sends keep the draft, successful sends clear only the submitted session draft, and task close/delete flows clean up related drafts.

## Context

The implementation keeps draft state frontend-owned. Drafts are transient UI state, so the solution does not change SQLite, task-store records, host contracts, or backend schemas. A later QA pass found that using only `workspaceId + externalSessionId` was too narrow for the repository session model, so the final version keys drafts by the canonical selectable session identity.

## Technical Choices

- Added a memory-first draft store with coalesced localStorage persistence so composer input updates synchronously while durable writes are delayed and bounded.
- Persisted v2 draft payloads with `workspaceId`, `externalSessionId`, `runtimeKind`, normalized `workingDirectory`, `taskId`, `updatedAt`, and structured draft content.
- Keyed drafts by `workspaceId + externalSessionId + runtimeKind + normalized workingDirectory`, matching the repository canonical session identity and avoiding same-external-id collisions across runtimes or worktrees.
- Preserved structured composer content, including text, slash commands, file references, skill mentions, subagent references, and path-backed attachment metadata. Raw File objects, bytes, base64, and preview URLs are not serialized.
- Reused staged attachment paths for unchanged file attachments after later text-only edits.
- Added a common task cleanup path that prepares session cleanup targets before destructive task mutations and clears drafts after successful delete, close, merged-PR close, direct merge, and direct-merge completion. Post-success localStorage cleanup failures remain visible but do not roll back the successful task mutation.
- Treated legacy two-field draft keys as unsafe aliases: they are not restored and are removed by bounded draft cleanup.

## Verification

- Cargo checks: not applicable in this checkout; no tracked `Cargo.toml` files exist.
- `gtimeout 600s bun run lint`
- `gtimeout 900s bun run test`
- `gtimeout 600s bun run typecheck`
- `gtimeout 900s bun run build`

All Bun checks passed locally before PR creation. The branch was fetched and verified against `origin/main`: 6 commits ahead, 0 behind, with no rebase required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent chat drafts now persist across sessions and restore when you return to the same workspace/session.
  * Drafts with attachments are saved more reliably, including after changes and app refreshes.

* **Bug Fixes**
  * Sending a message now properly clears the draft, and failed sends restore it instead of losing your text.
  * Drafts are cleaned up automatically during related task actions, reducing stale or cross-session draft carryover.
  * Improved handling for hidden-page/background transitions so drafts are less likely to be lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->