### PR TITLE
fix(frontend): restore runtime CLI diagnostics

### DIFF
--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model-test-fixtures.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model-test-fixtures.ts
@@ -1,5 +1,11 @@
-import type { RuntimeDescriptor, TaskStoreCheck, WorkspaceRecord } from "@openducktor/contracts";
-import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import type {
+  RuntimeCheck,
+  RuntimeDescriptor,
+  RuntimeHealth,
+  TaskStoreCheck,
+  WorkspaceRecord,
+} from "@openducktor/contracts";
+import { CODEX_RUNTIME_DESCRIPTOR, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { deriveRepoRuntimeHealthState } from "@/lib/repo-runtime-health";
 import {
   createTaskStoreCheckFixture,
@@ -9,6 +15,23 @@ import type { RepoRuntimeDiagnosticInstance, RepoRuntimeHealthCheck } from "@/ty
 
 export const makeRuntimeDefinitions = (): RuntimeDescriptor[] => [
   structuredClone(OPENCODE_RUNTIME_DESCRIPTOR),
+];
+
+export const makeBuiltInRuntimeDefinitions = (): RuntimeDescriptor[] => [
+  ...makeRuntimeDefinitions(),
+  structuredClone(CODEX_RUNTIME_DESCRIPTOR),
+];
+
+export const makeBuiltInRuntimeDiagnostics = (
+  opencode: RuntimeHealth & { kind: "opencode" },
+): RuntimeCheck["runtimes"] => [
+  structuredClone(opencode),
+  {
+    kind: "codex",
+    enabled: false,
+    ok: false,
+    version: null,
+  },
 ];
 
 export const makeRuntimeDiagnosticInstance = (): RepoRuntimeDiagnosticInstance => ({

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.cli-tools.test.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.cli-tools.test.ts
@@ -174,7 +174,7 @@ describe("buildDiagnosticsPanelModel CLI Tools", () => {
         ghAuthOk: false,
         ghAuthLogin: null,
         ghAuthError: "Timed out after 15000ms",
-        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: false, version: null }),
+        runtimes: [{ kind: "opencode", ok: false, version: null }],
         errors: ["Timed out after 15000ms"],
       },
       taskStoreCheck: makeTaskStoreCheck({
@@ -204,8 +204,10 @@ describe("buildDiagnosticsPanelModel CLI Tools", () => {
     expect(model.isSummaryChecking).toBe(false);
     expect(model.summaryState.label).toBe("Critical issue");
     expect(model.criticalReasons).toEqual(expect.arrayContaining(["Timed out after 15000ms"]));
-    expect(model.sections[1]?.badge).toEqual({ label: "Timed out", variant: "warning" });
-    expect(model.sections[1]?.errors[0]).toContain("CLI tools are not yet available");
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+    expect(cliToolsSection?.badge).toEqual({ label: "Timed out", variant: "warning" });
+    expect(cliToolsSection?.errors[0]).toContain("CLI tools are not yet available");
+    expect(cliToolsSection?.rows.map((row) => row.label)).toEqual(["Git", "GitHub CLI"]);
     const taskStoreSection = model.sections.find((section) => section.key === "task-store");
     expect(taskStoreSection?.badge).toEqual({ label: "Timed out", variant: "warning" });
     expect(taskStoreSection?.errors[0]).toContain("Task store is not yet available");
@@ -303,7 +305,8 @@ describe("buildDiagnosticsPanelModel CLI Tools", () => {
     });
 
     expect(model.criticalReasons).not.toContain("gh auth missing");
-    expect(model.sections[1]?.badge).toEqual({ label: "GitHub optional", variant: "warning" });
-    expect(model.sections[1]?.errors).toEqual([]);
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+    expect(cliToolsSection?.badge).toEqual({ label: "GitHub optional", variant: "warning" });
+    expect(cliToolsSection?.errors).toEqual([]);
   });
 });

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.cli-tools.test.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.cli-tools.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CODEX_RUNTIME_DESCRIPTOR,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type RuntimeCheck,
+  type RuntimeDescriptor,
+} from "@openducktor/contracts";
+import { buildDisabledRuntimeHealth } from "@/lib/repo-runtime-health";
+import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
+import {
+  makeBuiltInRuntimeDefinitions,
+  makeBuiltInRuntimeDiagnostics,
+  makeRepoHealth,
+  makeRuntimeDiagnosticInstance,
+  makeTaskStoreCheck,
+  makeWorkspace,
+} from "./diagnostics-panel-model-test-fixtures";
+
+const buildCliToolsModel = ({
+  runtimeDefinitions = makeBuiltInRuntimeDefinitions(),
+  runtimeDefinitionsError = null,
+  runtimes,
+}: {
+  runtimeDefinitions?: RuntimeDescriptor[];
+  runtimeDefinitionsError?: string | null;
+  runtimes: RuntimeCheck["runtimes"];
+}) =>
+  buildDiagnosticsPanelModel({
+    workspaceRepoPath: "/repo",
+    activeWorkspace: makeWorkspace("/repo"),
+    runtimeDefinitions,
+    isLoadingRuntimeDefinitions: false,
+    runtimeDefinitionsError,
+    runtimeCheck: {
+      gitOk: true,
+      gitVersion: "git version 2.50.1",
+      ghOk: true,
+      ghVersion: "gh version 2.73.0",
+      ghAuthOk: true,
+      ghAuthLogin: "octocat",
+      ghAuthError: null,
+      runtimes,
+      errors: [],
+    },
+    taskStoreCheck: makeTaskStoreCheck(),
+    runtimeCheckFailureKind: null,
+    taskStoreCheckFailureKind: null,
+    runtimeHealthByRuntime: {},
+    isLoadingChecks: false,
+  });
+
+describe("buildDiagnosticsPanelModel CLI Tools", () => {
+  test("restores OpenCode and Codex CLI values by runtime kind", () => {
+    const opencodeValue = "1.2.9 (/Users/dev/.opencode/bin/opencode)";
+    const codexValue =
+      "codex-cli 0.42.0 (/Applications/OpenDucktor.app/Contents/Resources/bin/codex)";
+    const model = buildCliToolsModel({
+      runtimes: [
+        { kind: "codex", ok: true, version: codexValue },
+        { kind: "opencode", ok: true, version: opencodeValue },
+      ],
+    });
+
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows).toEqual([
+      { label: "Git", value: "git version 2.50.1" },
+      { label: "GitHub CLI", value: "gh version 2.73.0" },
+      { label: "OpenCode", value: opencodeValue, breakAll: true },
+      { label: "Codex", value: codexValue, breakAll: true },
+    ]);
+  });
+
+  test.each([
+    {
+      name: "missing OpenCode and detected Codex",
+      runtimes: [
+        { kind: "opencode" as const, ok: false, version: null },
+        { kind: "codex" as const, ok: true, version: "codex-cli 0.42.0 (/bin/codex)" },
+      ],
+      expectedValues: ["missing", "codex-cli 0.42.0 (/bin/codex)"],
+    },
+    {
+      name: "detected OpenCode and missing Codex",
+      runtimes: [
+        { kind: "opencode" as const, ok: true, version: "1.2.9 (/bin/opencode)" },
+        { kind: "codex" as const, ok: false, version: null },
+      ],
+      expectedValues: ["1.2.9 (/bin/opencode)", "missing"],
+    },
+  ])("formats $name independently", ({ runtimes, expectedValues }) => {
+    const model = buildCliToolsModel({ runtimes: [...runtimes] });
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows.slice(2).map((row) => row.value)).toEqual([...expectedValues]);
+  });
+
+  test("formats a runtime with no reported version as detected", () => {
+    const model = buildCliToolsModel({
+      runtimes: [
+        { kind: "opencode", ok: true, version: null },
+        { kind: "codex", ok: true, version: null },
+      ],
+    });
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows.slice(2).map((row) => row.value)).toEqual([
+      "detected",
+      "detected",
+    ]);
+  });
+
+  test("fails when a loaded runtime diagnostic omits an expected runtime", () => {
+    expect(() =>
+      buildCliToolsModel({
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+      }),
+    ).toThrow('Missing CLI diagnostic for runtime kind "codex"');
+  });
+
+  test("fails when loaded runtime definitions omit an expected runtime", () => {
+    expect(() =>
+      buildCliToolsModel({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        runtimes: [
+          { kind: "opencode", ok: true, version: "1.2.9" },
+          { kind: "codex", ok: true, version: "codex-cli 0.42.0" },
+        ],
+      }),
+    ).toThrow('Missing runtime definition for runtime kind "codex"');
+  });
+
+  test("keeps runtime definition failures authoritative over CLI row invariants", () => {
+    const model = buildCliToolsModel({
+      runtimeDefinitions: [],
+      runtimeDefinitionsError: "Runtime definitions unavailable",
+      runtimes: [],
+    });
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows.map((row) => row.label)).toEqual(["Git", "GitHub CLI"]);
+    expect(cliToolsSection?.errors).toEqual(["Runtime definitions unavailable"]);
+  });
+
+  test("preserves a detected CLI value before the disabled qualifier", () => {
+    const codexValue = "codex-cli 0.42.0 (/Applications/OpenDucktor.app/bin/codex)";
+    const model = buildCliToolsModel({
+      runtimes: [
+        { kind: "opencode", ok: true, version: "1.2.9" },
+        { kind: "codex", enabled: false, ok: true, version: codexValue },
+      ],
+    });
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows.at(3)).toEqual({
+      label: "Codex",
+      value: `${codexValue} (runtime disabled)`,
+      breakAll: true,
+    });
+  });
+
+  test("shows timeout-specific CLI tools and task-store states", () => {
+    const model = buildDiagnosticsPanelModel({
+      workspaceRepoPath: "/repo",
+      activeWorkspace: makeWorkspace("/repo"),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
+      isLoadingRuntimeDefinitions: false,
+      runtimeDefinitionsError: null,
+      runtimeCheck: {
+        gitOk: false,
+        gitVersion: null,
+        ghOk: false,
+        ghVersion: null,
+        ghAuthOk: false,
+        ghAuthLogin: null,
+        ghAuthError: "Timed out after 15000ms",
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: false, version: null }),
+        errors: ["Timed out after 15000ms"],
+      },
+      taskStoreCheck: makeTaskStoreCheck({
+        taskStoreOk: false,
+        taskStorePath: null,
+        taskStoreError: "Timed out after 15000ms",
+        repoStoreHealth: {
+          category: "database_unavailable",
+          status: "blocking",
+          isReady: false,
+          detail: "Timed out after 15000ms",
+          databasePath: null,
+        },
+      }),
+      runtimeCheckFailureKind: "timeout",
+      taskStoreCheckFailureKind: "timeout",
+      runtimeHealthByRuntime: {
+        opencode: makeRepoHealth({
+          runtime: { instance: makeRuntimeDiagnosticInstance() },
+          mcp: { toolIds: [] },
+        }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
+      },
+      isLoadingChecks: false,
+    });
+
+    expect(model.isSummaryChecking).toBe(false);
+    expect(model.summaryState.label).toBe("Critical issue");
+    expect(model.criticalReasons).toEqual(expect.arrayContaining(["Timed out after 15000ms"]));
+    expect(model.sections[1]?.badge).toEqual({ label: "Timed out", variant: "warning" });
+    expect(model.sections[1]?.errors[0]).toContain("CLI tools are not yet available");
+    const taskStoreSection = model.sections.find((section) => section.key === "task-store");
+    expect(taskStoreSection?.badge).toEqual({ label: "Timed out", variant: "warning" });
+    expect(taskStoreSection?.errors[0]).toContain("Task store is not yet available");
+  });
+
+  test("keeps hard runtime failures ahead of timeout summary state", () => {
+    const model = buildDiagnosticsPanelModel({
+      workspaceRepoPath: "/repo",
+      activeWorkspace: makeWorkspace("/repo"),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
+      isLoadingRuntimeDefinitions: false,
+      runtimeDefinitionsError: null,
+      runtimeCheck: {
+        gitOk: false,
+        gitVersion: null,
+        ghOk: false,
+        ghVersion: null,
+        ghAuthOk: false,
+        ghAuthLogin: null,
+        ghAuthError: "Timed out after 15000ms",
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: false, version: null }),
+        errors: ["Timed out after 15000ms"],
+      },
+      taskStoreCheck: makeTaskStoreCheck(),
+      runtimeCheckFailureKind: "timeout",
+      taskStoreCheckFailureKind: null,
+      runtimeHealthByRuntime: {
+        opencode: makeRepoHealth({
+          status: "error",
+          runtime: {
+            status: "error",
+            stage: "startup_failed",
+            observation: null,
+            instance: makeRuntimeDiagnosticInstance(),
+            startedAt: makeRuntimeDiagnosticInstance().startedAt,
+            updatedAt: "2026-02-22T08:00:00.000Z",
+            elapsedMs: 20_000,
+            attempts: 4,
+            detail: "runtime failed",
+            failureKind: "error",
+            failureReason: null,
+          },
+          mcp: {
+            supported: true,
+            status: "waiting_for_runtime",
+            serverName: "openducktor",
+            serverStatus: null,
+            toolIds: [],
+            detail: "Runtime is unavailable, so MCP cannot be verified.",
+            failureKind: "timeout",
+          },
+        }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
+      },
+      isLoadingChecks: false,
+    });
+
+    expect(model.isSummaryChecking).toBe(false);
+    expect(model.summaryState.label).toBe("Critical issue");
+    expect(model.criticalReasons).toEqual(expect.arrayContaining(["runtime failed"]));
+  });
+
+  test("treats GitHub CLI auth failures as optional warnings", () => {
+    const model = buildDiagnosticsPanelModel({
+      workspaceRepoPath: "/repo",
+      activeWorkspace: makeWorkspace("/repo"),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
+      isLoadingRuntimeDefinitions: false,
+      runtimeDefinitionsError: null,
+      runtimeCheck: {
+        gitOk: true,
+        gitVersion: "git version 2.50.1",
+        ghOk: false,
+        ghVersion: null,
+        ghAuthOk: false,
+        ghAuthLogin: null,
+        ghAuthError: "gh auth missing",
+        runtimes: makeBuiltInRuntimeDiagnostics({
+          kind: "opencode",
+          ok: true,
+          version: "1.2.9",
+        }),
+        errors: ["gh auth missing"],
+      },
+      taskStoreCheck: makeTaskStoreCheck(),
+      runtimeCheckFailureKind: null,
+      taskStoreCheckFailureKind: null,
+      runtimeHealthByRuntime: {
+        opencode: makeRepoHealth({
+          runtime: { instance: makeRuntimeDiagnosticInstance() },
+          mcp: { toolIds: [] },
+        }),
+      },
+      isLoadingChecks: false,
+    });
+
+    expect(model.criticalReasons).not.toContain("gh auth missing");
+    expect(model.sections[1]?.badge).toEqual({ label: "GitHub optional", variant: "warning" });
+    expect(model.sections[1]?.errors).toEqual([]);
+  });
+});

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -1,63 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import {
-  CODEX_RUNTIME_DESCRIPTOR,
-  OPENCODE_RUNTIME_DESCRIPTOR,
-  type RuntimeCheck,
-  type RuntimeDescriptor,
-} from "@openducktor/contracts";
+import { CODEX_RUNTIME_DESCRIPTOR, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { buildDisabledRuntimeHealth } from "@/lib/repo-runtime-health";
 import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
 import {
+  makeBuiltInRuntimeDefinitions,
+  makeBuiltInRuntimeDiagnostics,
   makeRepoHealth,
   makeRuntimeDiagnosticInstance,
   makeTaskStoreCheck,
   makeWorkspace,
 } from "./diagnostics-panel-model-test-fixtures";
-
-const makeDisabledCodexDiagnostic = (): RuntimeCheck["runtimes"][number] => ({
-  kind: "codex",
-  enabled: false,
-  ok: false,
-  version: null,
-});
-
-const makeBuiltInRuntimeDefinitions = (): RuntimeDescriptor[] => [
-  structuredClone(OPENCODE_RUNTIME_DESCRIPTOR),
-  structuredClone(CODEX_RUNTIME_DESCRIPTOR),
-];
-
-const buildCliToolsModel = ({
-  runtimeDefinitions = makeBuiltInRuntimeDefinitions(),
-  runtimeDefinitionsError = null,
-  runtimes,
-}: {
-  runtimeDefinitions?: RuntimeDescriptor[];
-  runtimeDefinitionsError?: string | null;
-  runtimes: RuntimeCheck["runtimes"];
-}) =>
-  buildDiagnosticsPanelModel({
-    workspaceRepoPath: "/repo",
-    activeWorkspace: makeWorkspace("/repo"),
-    runtimeDefinitions,
-    isLoadingRuntimeDefinitions: false,
-    runtimeDefinitionsError,
-    runtimeCheck: {
-      gitOk: true,
-      gitVersion: "git version 2.50.1",
-      ghOk: true,
-      ghVersion: "gh version 2.73.0",
-      ghAuthOk: true,
-      ghAuthLogin: "octocat",
-      ghAuthError: null,
-      runtimes,
-      errors: [],
-    },
-    taskStoreCheck: makeTaskStoreCheck(),
-    runtimeCheckFailureKind: null,
-    taskStoreCheckFailureKind: null,
-    runtimeHealthByRuntime: {},
-    isLoadingChecks: false,
-  });
 
 describe("buildDiagnosticsPanelModel", () => {
   test("returns no-repository summary and empty-state messages when no repository is selected", () => {
@@ -105,98 +57,6 @@ describe("buildDiagnosticsPanelModel", () => {
     expect(cliToolsSection?.emptyMessage).toBe("CLI checks are loading...");
   });
 
-  test("restores OpenCode and Codex CLI values by runtime kind", () => {
-    const opencodeValue = "1.2.9 (/Users/dev/.opencode/bin/opencode)";
-    const codexValue =
-      "codex-cli 0.42.0 (/Applications/OpenDucktor.app/Contents/Resources/bin/codex)";
-    const model = buildCliToolsModel({
-      runtimes: [
-        { kind: "codex", ok: true, version: codexValue },
-        { kind: "opencode", ok: true, version: opencodeValue },
-      ],
-    });
-
-    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
-
-    expect(cliToolsSection?.rows).toEqual([
-      { label: "Git", value: "git version 2.50.1" },
-      { label: "GitHub CLI", value: "gh version 2.73.0" },
-      { label: "OpenCode", value: opencodeValue, breakAll: true },
-      { label: "Codex", value: codexValue, breakAll: true },
-    ]);
-  });
-
-  test.each([
-    {
-      name: "missing OpenCode and detected Codex",
-      runtimes: [
-        { kind: "opencode" as const, ok: false, version: null },
-        { kind: "codex" as const, ok: true, version: "codex-cli 0.42.0 (/bin/codex)" },
-      ],
-      expectedValues: ["missing", "codex-cli 0.42.0 (/bin/codex)"],
-    },
-    {
-      name: "detected OpenCode and missing Codex",
-      runtimes: [
-        { kind: "opencode" as const, ok: true, version: "1.2.9 (/bin/opencode)" },
-        { kind: "codex" as const, ok: false, version: null },
-      ],
-      expectedValues: ["1.2.9 (/bin/opencode)", "missing"],
-    },
-  ])("formats $name independently", ({ runtimes, expectedValues }) => {
-    const model = buildCliToolsModel({ runtimes: [...runtimes] });
-    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
-
-    expect(cliToolsSection?.rows.slice(2).map((row) => row.value)).toEqual([...expectedValues]);
-  });
-
-  test("formats a runtime with no reported version as detected", () => {
-    const model = buildCliToolsModel({
-      runtimes: [
-        { kind: "opencode", ok: true, version: null },
-        { kind: "codex", ok: true, version: null },
-      ],
-    });
-    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
-
-    expect(cliToolsSection?.rows.slice(2).map((row) => row.value)).toEqual([
-      "detected",
-      "detected",
-    ]);
-  });
-
-  test("fails when a loaded runtime diagnostic omits an expected runtime", () => {
-    expect(() =>
-      buildCliToolsModel({
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
-      }),
-    ).toThrow('Missing CLI diagnostic for runtime kind "codex"');
-  });
-
-  test("fails when loaded runtime definitions omit an expected runtime", () => {
-    expect(() =>
-      buildCliToolsModel({
-        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
-        runtimes: [
-          { kind: "opencode", ok: true, version: "1.2.9" },
-          { kind: "codex", ok: true, version: "codex-cli 0.42.0" },
-        ],
-      }),
-    ).toThrow('Missing runtime definition for runtime kind "codex"');
-  });
-
-  test("keeps runtime definition failures authoritative over CLI row invariants", () => {
-    const model = buildCliToolsModel({
-      runtimeDefinitions: [],
-      runtimeDefinitionsError: "Runtime definitions unavailable",
-      runtimes: [],
-    });
-    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
-
-    expect(cliToolsSection?.rows.map((row) => row.label)).toEqual(["Git", "GitHub CLI"]);
-    expect(cliToolsSection?.errors).toEqual(["Runtime definitions unavailable"]);
-  });
-
   test("keeps summary in checking state while runtime health is still pending", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
@@ -212,7 +72,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -241,7 +101,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -290,7 +150,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -341,7 +201,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -374,23 +234,6 @@ describe("buildDiagnosticsPanelModel", () => {
     );
   });
 
-  test("preserves a detected CLI value before the disabled qualifier", () => {
-    const codexValue = "codex-cli 0.42.0 (/Applications/OpenDucktor.app/bin/codex)";
-    const model = buildCliToolsModel({
-      runtimes: [
-        { kind: "opencode", ok: true, version: "1.2.9" },
-        { kind: "codex", enabled: false, ok: true, version: codexValue },
-      ],
-    });
-    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
-
-    expect(cliToolsSection?.rows.at(3)).toEqual({
-      label: "Codex",
-      value: `${codexValue} (runtime disabled)`,
-      breakAll: true,
-    });
-  });
-
   test("returns setup-needed summary when no effective worktree directory is available", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
@@ -411,7 +254,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -451,7 +294,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck({
@@ -510,7 +353,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -557,10 +400,11 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [
-          { kind: "opencode", ok: true, version: "1.2.9 (/Users/dev/.opencode/bin/opencode)" },
-          makeDisabledCodexDiagnostic(),
-        ],
+        runtimes: makeBuiltInRuntimeDiagnostics({
+          kind: "opencode",
+          ok: true,
+          version: "1.2.9 (/Users/dev/.opencode/bin/opencode)",
+        }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck({
@@ -619,7 +463,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: false,
         ghAuthLogin: null,
         ghAuthError: "gh not found in PATH",
-        runtimes: [{ kind: "opencode", ok: false, version: null }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: false, version: null }),
         errors: ["opencode not found in PATH"],
       },
       taskStoreCheck: makeTaskStoreCheck({
@@ -691,7 +535,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -734,7 +578,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -810,7 +654,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -888,7 +732,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -931,7 +775,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -978,7 +822,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
+        runtimes: makeBuiltInRuntimeDiagnostics({ kind: "opencode", ok: true, version: "1.2.9" }),
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -1009,149 +853,5 @@ describe("buildDiagnosticsPanelModel", () => {
     expect(model.summaryState.label).toBe("Critical issue");
     expect(model.criticalReasons).toContain("MCP unavailable");
     expect(mcpSection?.errors).toEqual(["MCP unavailable"]);
-  });
-
-  test("shows timeout-specific cli tools and task-store states instead of leaving them checking", () => {
-    const model = buildDiagnosticsPanelModel({
-      workspaceRepoPath: "/repo",
-      activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
-      isLoadingRuntimeDefinitions: false,
-      runtimeDefinitionsError: null,
-      runtimeCheck: {
-        gitOk: false,
-        gitVersion: null,
-        ghOk: false,
-        ghVersion: null,
-        ghAuthOk: false,
-        ghAuthLogin: null,
-        ghAuthError: "Timed out after 15000ms",
-        runtimes: [{ kind: "opencode", ok: false, version: null }, makeDisabledCodexDiagnostic()],
-        errors: ["Timed out after 15000ms"],
-      },
-      taskStoreCheck: makeTaskStoreCheck({
-        taskStoreOk: false,
-        taskStorePath: null,
-        taskStoreError: "Timed out after 15000ms",
-        repoStoreHealth: {
-          category: "database_unavailable",
-          status: "blocking",
-          isReady: false,
-          detail: "Timed out after 15000ms",
-          databasePath: null,
-        },
-      }),
-      runtimeCheckFailureKind: "timeout",
-      taskStoreCheckFailureKind: "timeout",
-      runtimeHealthByRuntime: {
-        opencode: makeRepoHealth({
-          runtime: { instance: makeRuntimeDiagnosticInstance() },
-          mcp: { toolIds: [] },
-        }),
-        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
-      },
-      isLoadingChecks: false,
-    });
-
-    expect(model.isSummaryChecking).toBe(false);
-    expect(model.summaryState.label).toBe("Critical issue");
-    expect(model.criticalReasons).toEqual(expect.arrayContaining(["Timed out after 15000ms"]));
-    expect(model.sections[1]?.badge).toEqual({ label: "Timed out", variant: "warning" });
-    expect(model.sections[1]?.errors[0]).toContain("CLI tools are not yet available");
-    const taskStoreSection = model.sections.find((section) => section.key === "task-store");
-    expect(taskStoreSection?.badge).toEqual({ label: "Timed out", variant: "warning" });
-    expect(taskStoreSection?.errors[0]).toContain("Task store is not yet available");
-  });
-
-  test("keeps hard failures ahead of timeout summary state", () => {
-    const model = buildDiagnosticsPanelModel({
-      workspaceRepoPath: "/repo",
-      activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
-      isLoadingRuntimeDefinitions: false,
-      runtimeDefinitionsError: null,
-      runtimeCheck: {
-        gitOk: false,
-        gitVersion: null,
-        ghOk: false,
-        ghVersion: null,
-        ghAuthOk: false,
-        ghAuthLogin: null,
-        ghAuthError: "Timed out after 15000ms",
-        runtimes: [{ kind: "opencode", ok: false, version: null }, makeDisabledCodexDiagnostic()],
-        errors: ["Timed out after 15000ms"],
-      },
-      taskStoreCheck: makeTaskStoreCheck(),
-      runtimeCheckFailureKind: "timeout",
-      taskStoreCheckFailureKind: null,
-      runtimeHealthByRuntime: {
-        opencode: makeRepoHealth({
-          status: "error",
-          runtime: {
-            status: "error",
-            stage: "startup_failed",
-            observation: null,
-            instance: makeRuntimeDiagnosticInstance(),
-            startedAt: makeRuntimeDiagnosticInstance().startedAt,
-            updatedAt: "2026-02-22T08:00:00.000Z",
-            elapsedMs: 20_000,
-            attempts: 4,
-            detail: "runtime failed",
-            failureKind: "error",
-            failureReason: null,
-          },
-          mcp: {
-            supported: true,
-            status: "waiting_for_runtime",
-            serverName: "openducktor",
-            serverStatus: null,
-            toolIds: [],
-            detail: "Runtime is unavailable, so MCP cannot be verified.",
-            failureKind: "timeout",
-          },
-        }),
-        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
-      },
-      isLoadingChecks: false,
-    });
-
-    expect(model.isSummaryChecking).toBe(false);
-    expect(model.summaryState.label).toBe("Critical issue");
-    expect(model.criticalReasons).toEqual(expect.arrayContaining(["runtime failed"]));
-  });
-
-  test("treats GitHub CLI auth failures as optional warnings", () => {
-    const model = buildDiagnosticsPanelModel({
-      workspaceRepoPath: "/repo",
-      activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
-      isLoadingRuntimeDefinitions: false,
-      runtimeDefinitionsError: null,
-      runtimeCheck: {
-        gitOk: true,
-        gitVersion: "git version 2.50.1",
-        ghOk: false,
-        ghVersion: null,
-        ghAuthOk: false,
-        ghAuthLogin: null,
-        ghAuthError: "gh auth missing",
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
-        errors: ["gh auth missing"],
-      },
-      taskStoreCheck: makeTaskStoreCheck(),
-      runtimeCheckFailureKind: null,
-      taskStoreCheckFailureKind: null,
-      runtimeHealthByRuntime: {
-        opencode: makeRepoHealth({
-          runtime: { instance: makeRuntimeDiagnosticInstance() },
-          mcp: { toolIds: [] },
-        }),
-      },
-      isLoadingChecks: false,
-    });
-
-    expect(model.criticalReasons).not.toContain("gh auth missing");
-    expect(model.sections[1]?.badge).toEqual({ label: "GitHub optional", variant: "warning" });
-    expect(model.sections[1]?.errors).toEqual([]);
   });
 });

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -127,6 +127,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: null,
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -500,6 +501,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: "error",
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -513,8 +515,9 @@ describe("buildDiagnosticsPanelModel", () => {
       expect.arrayContaining(["runtime failed", "task store failed"]),
     );
     expect(model.criticalReasons).not.toContain("gh not found in PATH");
-    expect(model.sections[1]?.badge).toEqual({ label: "GitHub optional", variant: "warning" });
-    expect(model.sections[1]?.errors).toEqual([]);
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+    expect(cliToolsSection?.badge).toEqual({ label: "GitHub optional", variant: "warning" });
+    expect(cliToolsSection?.errors).toEqual([]);
     expect(runtimeSection?.errors).toEqual(["runtime failed"]);
     expect(mcpSection?.errors).toEqual([]);
     expect(taskStoreSection?.errors).toEqual(["task store failed"]);
@@ -555,6 +558,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: "error",
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -610,6 +614,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: "timeout",
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -686,6 +691,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: null,
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -752,6 +758,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: null,
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -795,6 +802,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: "timeout",
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -1,21 +1,70 @@
 import { describe, expect, test } from "bun:test";
-import { CODEX_RUNTIME_DESCRIPTOR, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import {
+  CODEX_RUNTIME_DESCRIPTOR,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type RuntimeCheck,
+  type RuntimeDescriptor,
+} from "@openducktor/contracts";
 import { buildDisabledRuntimeHealth } from "@/lib/repo-runtime-health";
 import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
 import {
   makeRepoHealth,
-  makeRuntimeDefinitions,
   makeRuntimeDiagnosticInstance,
   makeTaskStoreCheck,
   makeWorkspace,
 } from "./diagnostics-panel-model-test-fixtures";
+
+const makeDisabledCodexDiagnostic = (): RuntimeCheck["runtimes"][number] => ({
+  kind: "codex",
+  enabled: false,
+  ok: false,
+  version: null,
+});
+
+const makeBuiltInRuntimeDefinitions = (): RuntimeDescriptor[] => [
+  structuredClone(OPENCODE_RUNTIME_DESCRIPTOR),
+  structuredClone(CODEX_RUNTIME_DESCRIPTOR),
+];
+
+const buildCliToolsModel = ({
+  runtimeDefinitions = makeBuiltInRuntimeDefinitions(),
+  runtimeDefinitionsError = null,
+  runtimes,
+}: {
+  runtimeDefinitions?: RuntimeDescriptor[];
+  runtimeDefinitionsError?: string | null;
+  runtimes: RuntimeCheck["runtimes"];
+}) =>
+  buildDiagnosticsPanelModel({
+    workspaceRepoPath: "/repo",
+    activeWorkspace: makeWorkspace("/repo"),
+    runtimeDefinitions,
+    isLoadingRuntimeDefinitions: false,
+    runtimeDefinitionsError,
+    runtimeCheck: {
+      gitOk: true,
+      gitVersion: "git version 2.50.1",
+      ghOk: true,
+      ghVersion: "gh version 2.73.0",
+      ghAuthOk: true,
+      ghAuthLogin: "octocat",
+      ghAuthError: null,
+      runtimes,
+      errors: [],
+    },
+    taskStoreCheck: makeTaskStoreCheck(),
+    runtimeCheckFailureKind: null,
+    taskStoreCheckFailureKind: null,
+    runtimeHealthByRuntime: {},
+    isLoadingChecks: false,
+  });
 
 describe("buildDiagnosticsPanelModel", () => {
   test("returns no-repository summary and empty-state messages when no repository is selected", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: null,
       activeWorkspace: null,
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: null,
@@ -38,7 +87,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: null,
@@ -51,13 +100,108 @@ describe("buildDiagnosticsPanelModel", () => {
 
     expect(model.isSummaryChecking).toBe(true);
     expect(model.summaryState.label).toBe("Checking...");
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+    expect(cliToolsSection?.rows).toEqual([]);
+    expect(cliToolsSection?.emptyMessage).toBe("CLI checks are loading...");
+  });
+
+  test("restores OpenCode and Codex CLI values by runtime kind", () => {
+    const opencodeValue = "1.2.9 (/Users/dev/.opencode/bin/opencode)";
+    const codexValue =
+      "codex-cli 0.42.0 (/Applications/OpenDucktor.app/Contents/Resources/bin/codex)";
+    const model = buildCliToolsModel({
+      runtimes: [
+        { kind: "codex", ok: true, version: codexValue },
+        { kind: "opencode", ok: true, version: opencodeValue },
+      ],
+    });
+
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows).toEqual([
+      { label: "Git", value: "git version 2.50.1" },
+      { label: "GitHub CLI", value: "gh version 2.73.0" },
+      { label: "OpenCode", value: opencodeValue, breakAll: true },
+      { label: "Codex", value: codexValue, breakAll: true },
+    ]);
+  });
+
+  test.each([
+    {
+      name: "missing OpenCode and detected Codex",
+      runtimes: [
+        { kind: "opencode" as const, ok: false, version: null },
+        { kind: "codex" as const, ok: true, version: "codex-cli 0.42.0 (/bin/codex)" },
+      ],
+      expectedValues: ["missing", "codex-cli 0.42.0 (/bin/codex)"],
+    },
+    {
+      name: "detected OpenCode and missing Codex",
+      runtimes: [
+        { kind: "opencode" as const, ok: true, version: "1.2.9 (/bin/opencode)" },
+        { kind: "codex" as const, ok: false, version: null },
+      ],
+      expectedValues: ["1.2.9 (/bin/opencode)", "missing"],
+    },
+  ])("formats $name independently", ({ runtimes, expectedValues }) => {
+    const model = buildCliToolsModel({ runtimes: [...runtimes] });
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows.slice(2).map((row) => row.value)).toEqual([...expectedValues]);
+  });
+
+  test("formats a runtime with no reported version as detected", () => {
+    const model = buildCliToolsModel({
+      runtimes: [
+        { kind: "opencode", ok: true, version: null },
+        { kind: "codex", ok: true, version: null },
+      ],
+    });
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows.slice(2).map((row) => row.value)).toEqual([
+      "detected",
+      "detected",
+    ]);
+  });
+
+  test("fails when a loaded runtime diagnostic omits an expected runtime", () => {
+    expect(() =>
+      buildCliToolsModel({
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+      }),
+    ).toThrow('Missing CLI diagnostic for runtime kind "codex"');
+  });
+
+  test("fails when loaded runtime definitions omit an expected runtime", () => {
+    expect(() =>
+      buildCliToolsModel({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        runtimes: [
+          { kind: "opencode", ok: true, version: "1.2.9" },
+          { kind: "codex", ok: true, version: "codex-cli 0.42.0" },
+        ],
+      }),
+    ).toThrow('Missing runtime definition for runtime kind "codex"');
+  });
+
+  test("keeps runtime definition failures authoritative over CLI row invariants", () => {
+    const model = buildCliToolsModel({
+      runtimeDefinitions: [],
+      runtimeDefinitionsError: "Runtime definitions unavailable",
+      runtimes: [],
+    });
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows.map((row) => row.label)).toEqual(["Git", "GitHub CLI"]);
+    expect(cliToolsSection?.errors).toEqual(["Runtime definitions unavailable"]);
   });
 
   test("keeps summary in checking state while runtime health is still pending", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -68,7 +212,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -86,7 +230,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -97,7 +241,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -135,7 +279,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -146,7 +290,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -197,10 +341,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [
-          { kind: "opencode", ok: true, version: "1.2.9" },
-          { kind: "codex", enabled: false, ok: false, version: null },
-        ],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -218,7 +359,12 @@ describe("buildDiagnosticsPanelModel", () => {
 
     expect(model.isSummaryChecking).toBe(false);
     expect(cliToolsSection?.badge.label).toBe("Available");
-    expect(cliToolsSection?.rows.map((row) => row.label)).toEqual(["Git", "GitHub CLI"]);
+    expect(cliToolsSection?.rows).toEqual([
+      { label: "Git", value: "git version 2.50.1" },
+      { label: "GitHub CLI", value: "gh version 2.73.0" },
+      { label: "OpenCode", value: "1.2.9", breakAll: true },
+      { label: "Codex", value: "missing (runtime disabled)", breakAll: true },
+    ]);
     expect(codexRuntimeSection?.badge.label).toBe("Disabled");
     expect(codexRuntimeSection?.rows).toContainEqual(
       expect.objectContaining({
@@ -226,6 +372,23 @@ describe("buildDiagnosticsPanelModel", () => {
         value: "Codex runtime is disabled in Agent Runtime settings.",
       }),
     );
+  });
+
+  test("preserves a detected CLI value before the disabled qualifier", () => {
+    const codexValue = "codex-cli 0.42.0 (/Applications/OpenDucktor.app/bin/codex)";
+    const model = buildCliToolsModel({
+      runtimes: [
+        { kind: "opencode", ok: true, version: "1.2.9" },
+        { kind: "codex", enabled: false, ok: true, version: codexValue },
+      ],
+    });
+    const cliToolsSection = model.sections.find((section) => section.key === "cli-tools");
+
+    expect(cliToolsSection?.rows.at(3)).toEqual({
+      label: "Codex",
+      value: `${codexValue} (runtime disabled)`,
+      breakAll: true,
+    });
   });
 
   test("returns setup-needed summary when no effective worktree directory is available", () => {
@@ -237,7 +400,7 @@ describe("buildDiagnosticsPanelModel", () => {
         defaultWorktreeBasePath: null,
         effectiveWorktreeBasePath: null,
       }),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -248,7 +411,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -259,6 +422,7 @@ describe("buildDiagnosticsPanelModel", () => {
           runtime: { instance: makeRuntimeDiagnosticInstance() },
           mcp: { toolIds: [] },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -276,7 +440,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -287,7 +451,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck({
@@ -335,7 +499,7 @@ describe("buildDiagnosticsPanelModel", () => {
         configuredWorktreeBasePath: null,
         effectiveWorktreeBasePath: "/Users/dev/.openducktor/worktrees/repo",
       }),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -346,7 +510,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -357,6 +521,7 @@ describe("buildDiagnosticsPanelModel", () => {
           runtime: { instance: makeRuntimeDiagnosticInstance() },
           mcp: { toolIds: [] },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -381,7 +546,7 @@ describe("buildDiagnosticsPanelModel", () => {
         defaultWorktreeBasePath: "/Users/dev/.openducktor/worktrees/fairnest",
         effectiveWorktreeBasePath: "/Users/dev/worktrees",
       }),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -394,6 +559,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthError: null,
         runtimes: [
           { kind: "opencode", ok: true, version: "1.2.9 (/Users/dev/.opencode/bin/opencode)" },
+          makeDisabledCodexDiagnostic(),
         ],
         errors: [],
       },
@@ -410,6 +576,7 @@ describe("buildDiagnosticsPanelModel", () => {
           runtime: { instance: makeRuntimeDiagnosticInstance() },
           mcp: { toolIds: ["openducktor_odt_read_task", "openducktor_odt_set_spec"] },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -441,7 +608,7 @@ describe("buildDiagnosticsPanelModel", () => {
         defaultWorktreeBasePath: null,
         effectiveWorktreeBasePath: null,
       }),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -452,7 +619,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: false,
         ghAuthLogin: null,
         ghAuthError: "gh not found in PATH",
-        runtimes: [{ kind: "opencode", ok: false, version: null }],
+        runtimes: [{ kind: "opencode", ok: false, version: null }, makeDisabledCodexDiagnostic()],
         errors: ["opencode not found in PATH"],
       },
       taskStoreCheck: makeTaskStoreCheck({
@@ -513,7 +680,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -524,7 +691,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -556,7 +723,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -567,7 +734,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -632,7 +799,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -643,7 +810,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -710,7 +877,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -721,7 +888,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -753,7 +920,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -764,7 +931,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -800,7 +967,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -811,7 +978,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: true,
         ghAuthLogin: "octocat",
         ghAuthError: null,
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: [],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -831,6 +998,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: "error",
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -847,7 +1015,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -858,7 +1026,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: false,
         ghAuthLogin: null,
         ghAuthError: "Timed out after 15000ms",
-        runtimes: [{ kind: "opencode", ok: false, version: null }],
+        runtimes: [{ kind: "opencode", ok: false, version: null }, makeDisabledCodexDiagnostic()],
         errors: ["Timed out after 15000ms"],
       },
       taskStoreCheck: makeTaskStoreCheck({
@@ -880,6 +1048,7 @@ describe("buildDiagnosticsPanelModel", () => {
           runtime: { instance: makeRuntimeDiagnosticInstance() },
           mcp: { toolIds: [] },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -889,15 +1058,16 @@ describe("buildDiagnosticsPanelModel", () => {
     expect(model.criticalReasons).toEqual(expect.arrayContaining(["Timed out after 15000ms"]));
     expect(model.sections[1]?.badge).toEqual({ label: "Timed out", variant: "warning" });
     expect(model.sections[1]?.errors[0]).toContain("CLI tools are not yet available");
-    expect(model.sections[4]?.badge).toEqual({ label: "Timed out", variant: "warning" });
-    expect(model.sections[4]?.errors[0]).toContain("Task store is not yet available");
+    const taskStoreSection = model.sections.find((section) => section.key === "task-store");
+    expect(taskStoreSection?.badge).toEqual({ label: "Timed out", variant: "warning" });
+    expect(taskStoreSection?.errors[0]).toContain("Task store is not yet available");
   });
 
   test("keeps hard failures ahead of timeout summary state", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -908,7 +1078,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: false,
         ghAuthLogin: null,
         ghAuthError: "Timed out after 15000ms",
-        runtimes: [{ kind: "opencode", ok: false, version: null }],
+        runtimes: [{ kind: "opencode", ok: false, version: null }, makeDisabledCodexDiagnostic()],
         errors: ["Timed out after 15000ms"],
       },
       taskStoreCheck: makeTaskStoreCheck(),
@@ -940,6 +1110,7 @@ describe("buildDiagnosticsPanelModel", () => {
             failureKind: "timeout",
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -953,7 +1124,7 @@ describe("buildDiagnosticsPanelModel", () => {
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/repo",
       activeWorkspace: makeWorkspace("/repo"),
-      runtimeDefinitions: makeRuntimeDefinitions(),
+      runtimeDefinitions: makeBuiltInRuntimeDefinitions(),
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -964,7 +1135,7 @@ describe("buildDiagnosticsPanelModel", () => {
         ghAuthOk: false,
         ghAuthLogin: null,
         ghAuthError: "gh auth missing",
-        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }, makeDisabledCodexDiagnostic()],
         errors: ["gh auth missing"],
       },
       taskStoreCheck: makeTaskStoreCheck(),

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -76,6 +76,35 @@ type BuildDiagnosticsPanelModelInput = {
 
 type RuntimeHealthState = RepoRuntimeHealthMap[string] | undefined;
 
+const CLI_RUNTIME_KINDS = ["opencode", "codex"] as const;
+
+const formatCliRuntimeValue = (cliHealth: RuntimeCheck["runtimes"][number]): string => {
+  const value = cliHealth.ok ? (cliHealth.version ?? "detected") : "missing";
+  return cliHealth.enabled === false ? `${value} (runtime disabled)` : value;
+};
+
+const buildCliRuntimeRows = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeCheck: RuntimeCheck,
+): DiagnosticKeyValueRowModel[] =>
+  CLI_RUNTIME_KINDS.map((runtimeKind) => {
+    const definition = runtimeDefinitions.find((entry) => entry.kind === runtimeKind);
+    if (!definition) {
+      throw new Error(`Missing runtime definition for runtime kind "${runtimeKind}".`);
+    }
+
+    const cliHealth = runtimeCheck.runtimes.find((entry) => entry.kind === runtimeKind);
+    if (!cliHealth) {
+      throw new Error(`Missing CLI diagnostic for runtime kind "${runtimeKind}".`);
+    }
+
+    return {
+      label: definition.label,
+      value: formatCliRuntimeValue(cliHealth),
+      breakAll: true,
+    };
+  });
+
 const getFailureBadge = (
   ok: boolean | null,
   failureKind: RepoRuntimeFailureKind,
@@ -444,6 +473,10 @@ export const buildDiagnosticsPanelModel = (
         error: "Issue",
         checking: "Checking",
       });
+  const cliRuntimeRows =
+    runtimeCheck && !isLoadingRuntimeDefinitions && runtimeDefinitionsError === null
+      ? buildCliRuntimeRows(runtimeDefinitions, runtimeCheck)
+      : [];
 
   const cliToolsSection: DiagnosticsSectionModel = {
     key: "cli-tools",
@@ -453,6 +486,7 @@ export const buildDiagnosticsPanelModel = (
       ? [
           { label: "Git", value: runtimeCheck.gitVersion ?? "missing" },
           { label: "GitHub CLI", value: runtimeCheck.ghVersion ?? "missing" },
+          ...cliRuntimeRows,
         ]
       : [],
     errors:

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -474,7 +474,10 @@ export const buildDiagnosticsPanelModel = (
         checking: "Checking",
       });
   const cliRuntimeRows =
-    runtimeCheck && !isLoadingRuntimeDefinitions && runtimeDefinitionsError === null
+    runtimeCheck &&
+    runtimeCheckFailureKind === null &&
+    !isLoadingRuntimeDefinitions &&
+    runtimeDefinitionsError === null
       ? buildCliRuntimeRows(runtimeDefinitions, runtimeCheck)
       : [];
 

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-sections.test.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-sections.test.ts
@@ -7,7 +7,10 @@ import {
 } from "@openducktor/contracts";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { deriveRepoRuntimeHealthState } from "@/lib/repo-runtime-health";
+import {
+  buildDisabledRuntimeHealth,
+  deriveRepoRuntimeHealthState,
+} from "@/lib/repo-runtime-health";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
 import { DiagnosticsPanelSections } from "./diagnostics-panel-sections";
@@ -156,6 +159,7 @@ describe("DiagnosticsPanelSections", () => {
             failureKind: null,
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });
@@ -240,6 +244,7 @@ describe("DiagnosticsPanelSections", () => {
             failureKind: "error",
           },
         }),
+        codex: buildDisabledRuntimeHealth(CODEX_RUNTIME_DESCRIPTOR),
       },
       isLoadingChecks: false,
     });

--- a/packages/frontend/src/components/features/diagnostics/diagnostics-panel-sections.test.ts
+++ b/packages/frontend/src/components/features/diagnostics/diagnostics-panel-sections.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  CODEX_RUNTIME_DESCRIPTOR,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type TaskStoreCheck,
   type WorkspaceRecord,
@@ -103,10 +104,13 @@ describe("DiagnosticsPanelSections", () => {
   });
 
   test("renders key-value labels consistently across sections", () => {
+    const opencodeValue = "1.2.9 (/Users/dev/.opencode/bin/opencode)";
+    const codexValue =
+      "codex-cli 0.42.0 (/Applications/OpenDucktor.app/Contents/Resources/bin/codex)";
     const model = buildDiagnosticsPanelModel({
       workspaceRepoPath: "/Users/dev/fairnest",
       activeWorkspace: makeWorkspace("/Users/dev/fairnest"),
-      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -118,7 +122,8 @@ describe("DiagnosticsPanelSections", () => {
         ghAuthLogin: "octocat",
         ghAuthError: null,
         runtimes: [
-          { kind: "opencode", ok: true, version: "1.2.9 (/Users/dev/.opencode/bin/opencode)" },
+          { kind: "opencode", ok: true, version: opencodeValue },
+          { kind: "codex", enabled: false, ok: true, version: codexValue },
         ],
         errors: [],
       },
@@ -162,6 +167,10 @@ describe("DiagnosticsPanelSections", () => {
     expect(html).toContain("Worktree directory:");
     expect(html).toContain("Git:");
     expect(html).toContain("GitHub CLI:");
+    expect(html).toContain("OpenCode:");
+    expect(html).toContain("Codex:");
+    expect(html).toContain(opencodeValue);
+    expect(html).toContain(`${codexValue} (runtime disabled)`);
     expect(html).toContain("OpenCode Runtime");
     expect(html).toContain("Working directory:");
     expect(html).toContain("Server name:");
@@ -179,7 +188,7 @@ describe("DiagnosticsPanelSections", () => {
         defaultWorktreeBasePath: null,
         effectiveWorktreeBasePath: null,
       }),
-      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, CODEX_RUNTIME_DESCRIPTOR],
       isLoadingRuntimeDefinitions: false,
       runtimeDefinitionsError: null,
       runtimeCheck: {
@@ -190,7 +199,10 @@ describe("DiagnosticsPanelSections", () => {
         ghAuthOk: false,
         ghAuthLogin: null,
         ghAuthError: "gh not found in PATH",
-        runtimes: [{ kind: "opencode", ok: false, version: null }],
+        runtimes: [
+          { kind: "opencode", ok: false, version: null },
+          { kind: "codex", enabled: false, ok: false, version: null },
+        ],
         errors: ["gh not found in PATH"],
       },
       taskStoreCheck: makeTaskStoreCheck({


### PR DESCRIPTION
## Summary

Restores OpenCode and Codex CLI version and executable-location rows in the Diagnostics panel, with focused regression coverage for the CLI Tools model.

## Goal

The Diagnostics panel accidentally stopped showing which OpenCode and Codex CLI installations OpenDucktor resolved, even though the host still supplied that information. These details are important when diagnosing runtime setup, version mismatches, and PATH selection.

## Implementation

- Builds OpenCode and Codex rows from runtime definitions and successful health checks, matched by runtime kind.
- Preserves host-provided version and executable-path strings for detected tools.
- Represents detected, missing, runtime-disabled, and invalid built-in runtime states explicitly.
- Preserves actionable fail-fast behavior for incomplete successful payloads while keeping failed synthetic checks renderable.
- Enables break-all wrapping for long executable paths in the CLI Tools section.
- Uses complete built-in runtime fixtures and keyed section lookups in focused regression tests.

## Out of scope

- Runtime discovery, probing, startup, cache policy, or settings invalidation.
- CLI Tools badge, severity, and error-routing changes.
- Contract, persistence, or database schema changes.

## Verification

- [x] bun run lint
- [x] bun run test
- [x] bun run typecheck
- [x] bun run build
- [x] React Doctor: 100/100
- [x] Focused diagnostics tests: 31 passed
- [x] Browser-mode validation completed for real OpenCode and Codex paths in light and dark themes at a narrow viewport.

Cargo checks are not applicable because this repository has no Cargo.toml or Rust workspace.

## Related task

OpenDucktor task: openduckto-b3qt

## Breaking changes

None.

## Additional context

The implementation intentionally keeps the approved display value missing (runtime disabled) and does not reclassify missing runtime CLIs as section failures; both behaviors are locked by the task specification.