### PR TITLE
fix: make dev server logs task scoped

### DIFF
--- a/apps/electron/src/renderer/electron-shell-bridge.test.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.test.ts
@@ -63,7 +63,7 @@ describe("electron shell bridge", () => {
     const bridge = createElectronShellBridge();
     const listener = mock(() => {});
     const unsubscribeRunEvents = await bridge.subscribeRunEvents(listener);
-    const unsubscribeDevServerEvents = await bridge.subscribeDevServerEvents(listener);
+    const devServerSubscription = await bridge.subscribeDevServerEvents(listener);
     const unsubscribeTaskEvents = await bridge.subscribeTaskEvents(listener);
     const unsubscribeCodexAppServerEvents = await bridge.subscribeCodexAppServerEvents(listener);
 
@@ -80,7 +80,8 @@ describe("electron shell bridge", () => {
     );
 
     unsubscribeRunEvents();
-    unsubscribeDevServerEvents();
+    expect(devServerSubscription.transportEpoch).toMatch(/^electron:\d+$/);
+    devServerSubscription.unsubscribe();
     unsubscribeTaskEvents();
     unsubscribeCodexAppServerEvents();
     expect(unsubscribeSpy).toHaveBeenCalledTimes(4);

--- a/apps/electron/src/renderer/electron-shell-bridge.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.ts
@@ -6,6 +6,7 @@ const RUN_EVENT_CHANNEL = "openducktor://run-event";
 const DEV_SERVER_EVENT_CHANNEL = "openducktor://dev-server-event";
 const TASK_EVENT_CHANNEL = "openducktor://task-event";
 const CODEX_APP_SERVER_EVENT_CHANNEL = "openducktor://codex-app-server-event";
+let nextDevServerTransportEpoch = 0;
 
 export class ElectronPreloadBridgeUnavailableError extends Error {
   constructor() {
@@ -41,7 +42,12 @@ export const createElectronShellBridge = (): ShellBridge => {
       canPreviewLocalAttachments: true,
     },
     subscribeRunEvents: subscribeElectronEvent(electronApi, RUN_EVENT_CHANNEL),
-    subscribeDevServerEvents: subscribeElectronEvent(electronApi, DEV_SERVER_EVENT_CHANNEL),
+    subscribeDevServerEvents: async (listener) => {
+      const unsubscribe = electronApi.subscribe(DEV_SERVER_EVENT_CHANNEL, listener);
+      const transportEpoch = `electron:${nextDevServerTransportEpoch}`;
+      nextDevServerTransportEpoch += 1;
+      return { transportEpoch, unsubscribe };
+    },
     subscribeTaskEvents: subscribeElectronEvent(electronApi, TASK_EVENT_CHANNEL),
     subscribeCodexAppServerEvents: subscribeElectronEvent(
       electronApi,

--- a/packages/contracts/src/dev-server-schemas.test.ts
+++ b/packages/contracts/src/dev-server-schemas.test.ts
@@ -9,6 +9,7 @@ describe("dev-server-schemas", () => {
       taskId: "task-7",
       terminalChunk: {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 12,
         data: "\u001b[32mready\u001b[0m\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -46,5 +47,6 @@ describe("dev-server-schemas", () => {
     });
 
     expect(parsed.scripts[0]?.bufferedTerminalChunks).toEqual([]);
+    expect(parsed.scripts[0]?.runId).toBeNull();
   });
 });

--- a/packages/contracts/src/dev-server-schemas.test.ts
+++ b/packages/contracts/src/dev-server-schemas.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { devServerEventSchema, devServerGroupStateSchema } from "./dev-server-schemas";
+import {
+  devServerEventSchema,
+  devServerGroupStateSchema,
+  devServerScriptStateSchema,
+} from "./dev-server-schemas";
 
 describe("dev-server-schemas", () => {
   test("parses terminal chunk events with ordered replay metadata", () => {
@@ -50,6 +54,63 @@ describe("dev-server-schemas", () => {
         updatedAt: "2026-03-25T10:00:00.000Z",
       }),
     ).toThrow();
+  });
+
+  for (const status of ["starting", "stopping"] as const) {
+    test(`rejects ${status} scripts with missing run ownership`, () => {
+      const parsed = devServerScriptStateSchema.safeParse({
+        scriptId: "frontend",
+        name: "Frontend",
+        command: "bun run dev",
+        status,
+        runIdentity: null,
+        pid: null,
+        startedAt: null,
+        exitCode: null,
+        lastError: null,
+        bufferedTerminalChunks: [],
+      });
+
+      expect(parsed.success).toBe(false);
+      if (parsed.success) {
+        throw new Error(`Expected ${status} script without run ownership to be rejected.`);
+      }
+      expect(parsed.error.issues).toHaveLength(1);
+      expect(parsed.error.issues[0]?.path).toEqual(["runIdentity"]);
+    });
+  }
+
+  test("reports only the root ownership issue for failed scripts with buffered output", () => {
+    const parsed = devServerScriptStateSchema.safeParse({
+      scriptId: "frontend",
+      name: "Frontend",
+      command: "bun run dev",
+      status: "failed",
+      runIdentity: null,
+      pid: null,
+      startedAt: null,
+      exitCode: 1,
+      lastError: "Process exited",
+      bufferedTerminalChunks: [
+        {
+          scriptId: "frontend",
+          runIdentity: {
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
+          },
+          sequence: 0,
+          data: "Process exited\r\n",
+          timestamp: "2026-03-25T10:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) {
+      throw new Error("Expected failed script with buffered output and no owner to be rejected.");
+    }
+    expect(parsed.error.issues).toHaveLength(1);
+    expect(parsed.error.issues[0]?.path).toEqual(["runIdentity"]);
   });
 
   test("requires stopped scripts to state null ownership explicitly", () => {

--- a/packages/contracts/src/dev-server-schemas.test.ts
+++ b/packages/contracts/src/dev-server-schemas.test.ts
@@ -9,8 +9,10 @@ describe("dev-server-schemas", () => {
       taskId: "task-7",
       terminalChunk: {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 12,
         data: "\u001b[32mready\u001b[0m\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -61,8 +63,7 @@ describe("dev-server-schemas", () => {
           name: "Frontend",
           command: "bun run dev",
           status: "stopped",
-          runId: null,
-          runOrder: null,
+          runIdentity: null,
           pid: null,
           startedAt: null,
           exitCode: null,
@@ -72,9 +73,32 @@ describe("dev-server-schemas", () => {
       updatedAt: "2026-03-25T10:00:00.000Z",
     });
 
-    expect(parsed.scripts[0]?.runId).toBeNull();
-    expect(parsed.scripts[0]?.runOrder).toBeNull();
+    expect(parsed.scripts[0]?.runIdentity).toBeNull();
     expect(parsed.scripts[0]?.bufferedTerminalChunks).toEqual([]);
+  });
+
+  test("rejects structurally incomplete run identity", () => {
+    expect(() =>
+      devServerGroupStateSchema.parse({
+        repoPath: "/repo",
+        taskId: "task-7",
+        worktreePath: "/tmp/worktree/task-7",
+        scripts: [
+          {
+            scriptId: "frontend",
+            name: "Frontend",
+            command: "bun run dev",
+            status: "running",
+            runIdentity: { runId: "frontend:1" },
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            exitCode: null,
+            lastError: null,
+          },
+        ],
+        updatedAt: "2026-03-25T10:00:00.000Z",
+      }),
+    ).toThrow();
   });
 
   test("rejects buffered output that does not match script run ownership", () => {
@@ -89,8 +113,10 @@ describe("dev-server-schemas", () => {
             name: "Frontend",
             command: "bun run dev",
             status: "stopped",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             pid: null,
             startedAt: null,
             exitCode: 0,
@@ -98,8 +124,10 @@ describe("dev-server-schemas", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
-                runId: "frontend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 sequence: 0,
                 data: "old output",
                 timestamp: "2026-03-25T10:00:00.000Z",

--- a/packages/contracts/src/dev-server-schemas.test.ts
+++ b/packages/contracts/src/dev-server-schemas.test.ts
@@ -10,6 +10,7 @@ describe("dev-server-schemas", () => {
       terminalChunk: {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 12,
         data: "\u001b[32mready\u001b[0m\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -26,7 +27,30 @@ describe("dev-server-schemas", () => {
     expect(parsed.terminalChunk.data).toContain("\r\n");
   });
 
-  test("defaults missing buffered terminal chunks to an empty replay", () => {
+  test("rejects active scripts with missing run ownership", () => {
+    expect(() =>
+      devServerGroupStateSchema.parse({
+        repoPath: "/repo",
+        taskId: "task-7",
+        worktreePath: "/tmp/worktree/task-7",
+        scripts: [
+          {
+            scriptId: "frontend",
+            name: "Frontend",
+            command: "bun run dev",
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            exitCode: null,
+            lastError: null,
+          },
+        ],
+        updatedAt: "2026-03-25T10:00:00.000Z",
+      }),
+    ).toThrow();
+  });
+
+  test("requires stopped scripts to state null ownership explicitly", () => {
     const parsed = devServerGroupStateSchema.parse({
       repoPath: "/repo",
       taskId: "task-7",
@@ -36,9 +60,11 @@ describe("dev-server-schemas", () => {
           scriptId: "frontend",
           name: "Frontend",
           command: "bun run dev",
-          status: "running",
-          pid: 4242,
-          startedAt: "2026-03-25T10:00:00.000Z",
+          status: "stopped",
+          runId: null,
+          runOrder: null,
+          pid: null,
+          startedAt: null,
           exitCode: null,
           lastError: null,
         },
@@ -46,7 +72,43 @@ describe("dev-server-schemas", () => {
       updatedAt: "2026-03-25T10:00:00.000Z",
     });
 
-    expect(parsed.scripts[0]?.bufferedTerminalChunks).toEqual([]);
     expect(parsed.scripts[0]?.runId).toBeNull();
+    expect(parsed.scripts[0]?.runOrder).toBeNull();
+    expect(parsed.scripts[0]?.bufferedTerminalChunks).toEqual([]);
+  });
+
+  test("rejects buffered output that does not match script run ownership", () => {
+    expect(() =>
+      devServerGroupStateSchema.parse({
+        repoPath: "/repo",
+        taskId: "task-7",
+        worktreePath: "/tmp/worktree/task-7",
+        scripts: [
+          {
+            scriptId: "frontend",
+            name: "Frontend",
+            command: "bun run dev",
+            status: "stopped",
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            pid: null,
+            startedAt: null,
+            exitCode: 0,
+            lastError: null,
+            bufferedTerminalChunks: [
+              {
+                scriptId: "frontend",
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                sequence: 0,
+                data: "old output",
+                timestamp: "2026-03-25T10:00:00.000Z",
+              },
+            ],
+          },
+        ],
+        updatedAt: "2026-03-25T10:00:00.000Z",
+      }),
+    ).toThrow("Buffered terminal chunks must belong to the script's current run.");
   });
 });

--- a/packages/contracts/src/dev-server-schemas.ts
+++ b/packages/contracts/src/dev-server-schemas.ts
@@ -15,10 +15,15 @@ export const devServerRunOrderSchema = z.object({
 });
 export type DevServerRunOrder = z.infer<typeof devServerRunOrderSchema>;
 
-export const devServerTerminalChunkSchema = z.object({
-  scriptId: z.string().min(1),
+export const devServerRunIdentitySchema = z.object({
   runId: z.string().min(1),
   runOrder: devServerRunOrderSchema,
+});
+export type DevServerRunIdentity = z.infer<typeof devServerRunIdentitySchema>;
+
+export const devServerTerminalChunkSchema = z.object({
+  scriptId: z.string().min(1),
+  runIdentity: devServerRunIdentitySchema,
   sequence: z.number().int().nonnegative(),
   data: z.string(),
   timestamp: z.string(),
@@ -31,8 +36,7 @@ export const devServerScriptStateSchema = z
     name: z.string().min(1),
     command: z.string().min(1),
     status: devServerScriptStatusSchema,
-    runId: z.string().min(1).nullable(),
-    runOrder: devServerRunOrderSchema.nullable(),
+    runIdentity: devServerRunIdentitySchema.nullable(),
     pid: z.number().int().positive().nullable(),
     startedAt: z.string().nullable(),
     exitCode: z.number().int().nullable(),
@@ -40,35 +44,25 @@ export const devServerScriptStateSchema = z
     bufferedTerminalChunks: z.array(devServerTerminalChunkSchema).default([]),
   })
   .superRefine((script, context) => {
-    const hasRunId = script.runId !== null;
-    const hasRunOrder = script.runOrder !== null;
-    if (hasRunId !== hasRunOrder) {
-      context.addIssue({
-        code: "custom",
-        message: "Dev server run id and run order must either both be present or both be null.",
-        path: hasRunId ? ["runOrder"] : ["runId"],
-      });
-    }
-
     const requiresRunOwnership =
       script.status === "starting" ||
       script.status === "running" ||
       script.status === "stopping" ||
       script.bufferedTerminalChunks.length > 0;
-    if (requiresRunOwnership && (!hasRunId || !hasRunOrder)) {
+    if (requiresRunOwnership && script.runIdentity === null) {
       context.addIssue({
         code: "custom",
         message: `Dev server script status ${script.status} requires explicit run ownership.`,
-        path: ["runId"],
+        path: ["runIdentity"],
       });
     }
 
     for (const [index, chunk] of script.bufferedTerminalChunks.entries()) {
       if (
         chunk.scriptId !== script.scriptId ||
-        chunk.runId !== script.runId ||
-        chunk.runOrder.hostInstanceId !== script.runOrder?.hostInstanceId ||
-        chunk.runOrder.generation !== script.runOrder?.generation
+        chunk.runIdentity.runId !== script.runIdentity?.runId ||
+        chunk.runIdentity.runOrder.hostInstanceId !== script.runIdentity?.runOrder.hostInstanceId ||
+        chunk.runIdentity.runOrder.generation !== script.runIdentity?.runOrder.generation
       ) {
         context.addIssue({
           code: "custom",

--- a/packages/contracts/src/dev-server-schemas.ts
+++ b/packages/contracts/src/dev-server-schemas.ts
@@ -11,6 +11,7 @@ export type DevServerScriptStatus = z.infer<typeof devServerScriptStatusSchema>;
 
 export const devServerTerminalChunkSchema = z.object({
   scriptId: z.string().min(1),
+  runId: z.string().min(1),
   sequence: z.number().int().nonnegative(),
   data: z.string(),
   timestamp: z.string(),
@@ -22,6 +23,7 @@ export const devServerScriptStateSchema = z.object({
   name: z.string().min(1),
   command: z.string().min(1),
   status: devServerScriptStatusSchema,
+  runId: z.string().min(1).nullable().default(null),
   pid: z.number().int().positive().nullable(),
   startedAt: z.string().nullable(),
   exitCode: z.number().int().nullable(),

--- a/packages/contracts/src/dev-server-schemas.ts
+++ b/packages/contracts/src/dev-server-schemas.ts
@@ -55,6 +55,7 @@ export const devServerScriptStateSchema = z
         message: `Dev server script status ${script.status} requires explicit run ownership.`,
         path: ["runIdentity"],
       });
+      return;
     }
 
     for (const [index, chunk] of script.bufferedTerminalChunks.entries()) {

--- a/packages/contracts/src/dev-server-schemas.ts
+++ b/packages/contracts/src/dev-server-schemas.ts
@@ -9,27 +9,75 @@ export const devServerScriptStatusSchema = z.enum([
 ]);
 export type DevServerScriptStatus = z.infer<typeof devServerScriptStatusSchema>;
 
+export const devServerRunOrderSchema = z.object({
+  hostInstanceId: z.string().min(1),
+  generation: z.number().int().positive(),
+});
+export type DevServerRunOrder = z.infer<typeof devServerRunOrderSchema>;
+
 export const devServerTerminalChunkSchema = z.object({
   scriptId: z.string().min(1),
   runId: z.string().min(1),
+  runOrder: devServerRunOrderSchema,
   sequence: z.number().int().nonnegative(),
   data: z.string(),
   timestamp: z.string(),
 });
 export type DevServerTerminalChunk = z.infer<typeof devServerTerminalChunkSchema>;
 
-export const devServerScriptStateSchema = z.object({
-  scriptId: z.string().min(1),
-  name: z.string().min(1),
-  command: z.string().min(1),
-  status: devServerScriptStatusSchema,
-  runId: z.string().min(1).nullable().default(null),
-  pid: z.number().int().positive().nullable(),
-  startedAt: z.string().nullable(),
-  exitCode: z.number().int().nullable(),
-  lastError: z.string().nullable(),
-  bufferedTerminalChunks: z.array(devServerTerminalChunkSchema).default([]),
-});
+export const devServerScriptStateSchema = z
+  .object({
+    scriptId: z.string().min(1),
+    name: z.string().min(1),
+    command: z.string().min(1),
+    status: devServerScriptStatusSchema,
+    runId: z.string().min(1).nullable(),
+    runOrder: devServerRunOrderSchema.nullable(),
+    pid: z.number().int().positive().nullable(),
+    startedAt: z.string().nullable(),
+    exitCode: z.number().int().nullable(),
+    lastError: z.string().nullable(),
+    bufferedTerminalChunks: z.array(devServerTerminalChunkSchema).default([]),
+  })
+  .superRefine((script, context) => {
+    const hasRunId = script.runId !== null;
+    const hasRunOrder = script.runOrder !== null;
+    if (hasRunId !== hasRunOrder) {
+      context.addIssue({
+        code: "custom",
+        message: "Dev server run id and run order must either both be present or both be null.",
+        path: hasRunId ? ["runOrder"] : ["runId"],
+      });
+    }
+
+    const requiresRunOwnership =
+      script.status === "starting" ||
+      script.status === "running" ||
+      script.status === "stopping" ||
+      script.bufferedTerminalChunks.length > 0;
+    if (requiresRunOwnership && (!hasRunId || !hasRunOrder)) {
+      context.addIssue({
+        code: "custom",
+        message: `Dev server script status ${script.status} requires explicit run ownership.`,
+        path: ["runId"],
+      });
+    }
+
+    for (const [index, chunk] of script.bufferedTerminalChunks.entries()) {
+      if (
+        chunk.scriptId !== script.scriptId ||
+        chunk.runId !== script.runId ||
+        chunk.runOrder.hostInstanceId !== script.runOrder?.hostInstanceId ||
+        chunk.runOrder.generation !== script.runOrder?.generation
+      ) {
+        context.addIssue({
+          code: "custom",
+          message: "Buffered terminal chunks must belong to the script's current run.",
+          path: ["bufferedTerminalChunks", index],
+        });
+      }
+    }
+  });
 export type DevServerScriptState = z.infer<typeof devServerScriptStateSchema>;
 
 export const devServerGroupStateSchema = z.object({

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -249,6 +249,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "KANBAN_EMPTY_COLUMN_DISPLAY_VALUES",
   "devServerEventSchema",
   "devServerGroupStateSchema",
+  "devServerRunIdentitySchema",
   "devServerRunOrderSchema",
   "devServerTerminalChunkSchema",
   "devServerScriptStateSchema",

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -249,6 +249,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "KANBAN_EMPTY_COLUMN_DISPLAY_VALUES",
   "devServerEventSchema",
   "devServerGroupStateSchema",
+  "devServerRunOrderSchema",
   "devServerTerminalChunkSchema",
   "devServerScriptStateSchema",
   "devServerScriptStatusSchema",

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
@@ -16,7 +16,10 @@ const configureAttachmentPreviewShellBridge = (
   configureShellBridge({
     client: {} as ShellBridge["client"],
     subscribeRunEvents: async () => () => {},
-    subscribeDevServerEvents: async () => () => {},
+    subscribeDevServerEvents: async () => ({
+      transportEpoch: "test:0",
+      unsubscribe: () => {},
+    }),
     subscribeTaskEvents: async () => () => {},
     capabilities: {
       canOpenExternalUrls: true,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.test.tsx
@@ -19,7 +19,10 @@ const configureAttachmentPreviewShellBridge = (
   configureShellBridge({
     client: {} as ShellBridge["client"],
     subscribeRunEvents: async () => () => {},
-    subscribeDevServerEvents: async () => () => {},
+    subscribeDevServerEvents: async () => ({
+      transportEpoch: "test:0",
+      unsubscribe: () => {},
+    }),
     subscribeTaskEvents: async () => () => {},
     capabilities: {
       canOpenExternalUrls: true,

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -52,6 +52,7 @@ const runningScript: DevServerScriptState = {
   name: "Frontend",
   command: "bun run dev",
   status: "running",
+  runId: "frontend:1",
   pid: 4321,
   startedAt: "2026-03-19T15:30:00.000Z",
   exitCode: null,
@@ -59,12 +60,14 @@ const runningScript: DevServerScriptState = {
   bufferedTerminalChunks: [
     {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 0,
       data: "Starting `bun run dev`\r\n",
       timestamp: "2026-03-19T15:30:00.000Z",
     },
     {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 1,
       data: "ready on http://localhost:5173\r\n",
       timestamp: "2026-03-19T15:30:01.000Z",
@@ -77,6 +80,7 @@ const backendScript: DevServerScriptState = {
   name: "Backend",
   command: "bun run api",
   status: "running",
+  runId: "backend:1",
   pid: 999,
   startedAt: "2026-03-19T15:31:00.000Z",
   exitCode: null,
@@ -84,6 +88,7 @@ const backendScript: DevServerScriptState = {
   bufferedTerminalChunks: [
     {
       scriptId: "backend",
+      runId: "backend:1",
       sequence: 0,
       data: "api ready\r\n",
       timestamp: "2026-03-19T15:31:01.000Z",
@@ -96,6 +101,7 @@ const failedScript: DevServerScriptState = {
   name: "Failed server",
   command: "bun run broken",
   status: "failed",
+  runId: "failed:1",
   pid: null,
   startedAt: null,
   exitCode: 1,
@@ -103,6 +109,7 @@ const failedScript: DevServerScriptState = {
   bufferedTerminalChunks: [
     {
       scriptId: "failed",
+      runId: "failed:1",
       sequence: 0,
       data: "Process exited\r\n",
       timestamp: "2026-03-19T15:32:01.000Z",

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -53,6 +53,7 @@ const runningScript: DevServerScriptState = {
   command: "bun run dev",
   status: "running",
   runId: "frontend:1",
+  runOrder: { hostInstanceId: "host-1", generation: 1 },
   pid: 4321,
   startedAt: "2026-03-19T15:30:00.000Z",
   exitCode: null,
@@ -61,6 +62,7 @@ const runningScript: DevServerScriptState = {
     {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 0,
       data: "Starting `bun run dev`\r\n",
       timestamp: "2026-03-19T15:30:00.000Z",
@@ -68,6 +70,7 @@ const runningScript: DevServerScriptState = {
     {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 1,
       data: "ready on http://localhost:5173\r\n",
       timestamp: "2026-03-19T15:30:01.000Z",
@@ -81,6 +84,7 @@ const backendScript: DevServerScriptState = {
   command: "bun run api",
   status: "running",
   runId: "backend:1",
+  runOrder: { hostInstanceId: "host-1", generation: 1 },
   pid: 999,
   startedAt: "2026-03-19T15:31:00.000Z",
   exitCode: null,
@@ -89,6 +93,7 @@ const backendScript: DevServerScriptState = {
     {
       scriptId: "backend",
       runId: "backend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 0,
       data: "api ready\r\n",
       timestamp: "2026-03-19T15:31:01.000Z",
@@ -102,6 +107,7 @@ const failedScript: DevServerScriptState = {
   command: "bun run broken",
   status: "failed",
   runId: "failed:1",
+  runOrder: { hostInstanceId: "host-1", generation: 1 },
   pid: null,
   startedAt: null,
   exitCode: 1,
@@ -110,6 +116,7 @@ const failedScript: DevServerScriptState = {
     {
       scriptId: "failed",
       runId: "failed:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 0,
       data: "Process exited\r\n",
       timestamp: "2026-03-19T15:32:01.000Z",

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -52,8 +52,10 @@ const runningScript: DevServerScriptState = {
   name: "Frontend",
   command: "bun run dev",
   status: "running",
-  runId: "frontend:1",
-  runOrder: { hostInstanceId: "host-1", generation: 1 },
+  runIdentity: {
+    runId: "frontend:1",
+    runOrder: { hostInstanceId: "host-1", generation: 1 },
+  },
   pid: 4321,
   startedAt: "2026-03-19T15:30:00.000Z",
   exitCode: null,
@@ -61,16 +63,20 @@ const runningScript: DevServerScriptState = {
   bufferedTerminalChunks: [
     {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 0,
       data: "Starting `bun run dev`\r\n",
       timestamp: "2026-03-19T15:30:00.000Z",
     },
     {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 1,
       data: "ready on http://localhost:5173\r\n",
       timestamp: "2026-03-19T15:30:01.000Z",
@@ -83,8 +89,10 @@ const backendScript: DevServerScriptState = {
   name: "Backend",
   command: "bun run api",
   status: "running",
-  runId: "backend:1",
-  runOrder: { hostInstanceId: "host-1", generation: 1 },
+  runIdentity: {
+    runId: "backend:1",
+    runOrder: { hostInstanceId: "host-1", generation: 1 },
+  },
   pid: 999,
   startedAt: "2026-03-19T15:31:00.000Z",
   exitCode: null,
@@ -92,8 +100,10 @@ const backendScript: DevServerScriptState = {
   bufferedTerminalChunks: [
     {
       scriptId: "backend",
-      runId: "backend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "backend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 0,
       data: "api ready\r\n",
       timestamp: "2026-03-19T15:31:01.000Z",
@@ -106,8 +116,10 @@ const failedScript: DevServerScriptState = {
   name: "Failed server",
   command: "bun run broken",
   status: "failed",
-  runId: "failed:1",
-  runOrder: { hostInstanceId: "host-1", generation: 1 },
+  runIdentity: {
+    runId: "failed:1",
+    runOrder: { hostInstanceId: "host-1", generation: 1 },
+  },
   pid: null,
   startedAt: null,
   exitCode: 1,
@@ -115,8 +127,10 @@ const failedScript: DevServerScriptState = {
   bufferedTerminalChunks: [
     {
       scriptId: "failed",
-      runId: "failed:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "failed:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 0,
       data: "Process exited\r\n",
       timestamp: "2026-03-19T15:32:01.000Z",

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -138,6 +138,8 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
   const hasExpandedActions = model.isExpanded;
   const selectedTabsValue = model.selectedScriptId ?? model.scripts[0]?.scriptId ?? "__none__";
   const selectedScriptContent = selectedScript ?? model.scripts[0] ?? null;
+  const terminalScopeKey =
+    model.repoPath && model.taskId ? `${model.repoPath}::${model.taskId}` : "__no-task__";
   const selectedScriptTerminalBuffer =
     model.selectedScriptTerminalBuffer ??
     (selectedScriptContent
@@ -356,6 +358,7 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
 
                 <div className="relative min-h-0 flex-1 overflow-hidden bg-[var(--dev-server-terminal-panel)]">
                   <AgentStudioDevServerTerminal
+                    scopeKey={terminalScopeKey}
                     scriptId={selectedScriptContent.scriptId}
                     terminalBuffer={selectedScriptTerminalBuffer}
                     onRendererError={setRendererError}

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -145,15 +145,20 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
   const terminalScopeKey = formatDevServerTaskScopeKey(
     createDevServerTaskScope(model.repoPath, model.taskId),
   );
-  const selectedScriptTerminalBuffer =
-    model.selectedScriptTerminalBuffer ??
-    (selectedScriptContent
-      ? {
-          entries: selectedScriptContent.bufferedTerminalChunks,
-          lastSequence: selectedScriptContent.bufferedTerminalChunks.at(-1)?.sequence ?? null,
-          resetToken: 0,
-        }
-      : null);
+  const selectedScriptTerminalBuffer = useMemo(() => {
+    if (model.selectedScriptTerminalBuffer !== null) {
+      return model.selectedScriptTerminalBuffer;
+    }
+    if (selectedScriptContent === null) {
+      return null;
+    }
+
+    return {
+      entries: selectedScriptContent.bufferedTerminalChunks,
+      lastSequence: selectedScriptContent.bufferedTerminalChunks.at(-1)?.sequence ?? null,
+      resetToken: 0,
+    };
+  }, [model.selectedScriptTerminalBuffer, selectedScriptContent]);
   const selectedScriptTerminalChunkCount = selectedScriptTerminalBuffer?.entries.length ?? 0;
   const panelError = model.error ?? rendererError;
   const disabledReasonId = useId();

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -16,6 +16,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
+import {
+  createDevServerTaskScope,
+  formatDevServerTaskScopeKey,
+} from "@/types/dev-server-task-scope";
 
 export type AgentStudioDevServerPanelMode = "loading" | "empty" | "disabled" | "stopped" | "active";
 
@@ -138,8 +142,9 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
   const hasExpandedActions = model.isExpanded;
   const selectedTabsValue = model.selectedScriptId ?? model.scripts[0]?.scriptId ?? "__none__";
   const selectedScriptContent = selectedScript ?? model.scripts[0] ?? null;
-  const terminalScopeKey =
-    model.repoPath && model.taskId ? `${model.repoPath}::${model.taskId}` : "__no-task__";
+  const terminalScopeKey = formatDevServerTaskScopeKey(
+    createDevServerTaskScope(model.repoPath, model.taskId),
+  );
   const selectedScriptTerminalBuffer =
     model.selectedScriptTerminalBuffer ??
     (selectedScriptContent

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -97,6 +97,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -150,6 +151,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "first\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -176,6 +178,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "first\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -183,6 +186,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "second\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -210,6 +214,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 4,
               data: "rehydrated\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -266,6 +271,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -292,6 +298,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -299,6 +306,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "stalled\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -325,6 +333,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -332,6 +341,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "stalled\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -339,6 +349,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 2,
               data: "still live\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -391,6 +402,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "old failed output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -417,6 +429,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -472,6 +485,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 7,
               data: "task one output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -498,6 +512,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "task two output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -563,6 +578,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "\u001b[38;2;255;0",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -570,6 +586,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: ";0mready",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -597,6 +614,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "\u001b[38;2;255;0",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -604,6 +622,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: ";0mready",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -611,6 +630,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 2,
               data: "\u001b[0m\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -638,6 +658,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "\u001b[38;2;255;0;0mready\u001b[0m\r\n",
               timestamp: "2026-03-19T15:30:03.000Z",
@@ -675,6 +696,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "frontend\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -701,6 +723,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "backend",
               runId: "backend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "backend\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -735,6 +758,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "frontend ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -761,6 +785,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "frontend ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -768,6 +793,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "stale frontend\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -794,6 +820,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "backend",
               runId: "backend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "backend ready\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -871,6 +898,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -898,6 +926,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -905,6 +934,7 @@ describe("AgentStudioDevServerTerminal", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "broken\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -976,6 +1006,7 @@ describe("AgentStudioDevServerTerminal", () => {
               {
                 scriptId: "frontend",
                 runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
                 sequence: 0,
                 data: "ready\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -96,8 +96,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -150,8 +152,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "first\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -177,16 +181,20 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "first\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "second\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -213,8 +221,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 4,
               data: "rehydrated\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -270,8 +280,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -297,16 +309,20 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "stalled\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -332,24 +348,30 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "stalled\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 2,
               data: "still live\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -401,8 +423,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "old failed output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -428,8 +452,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -484,8 +510,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 7,
               data: "task one output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -511,8 +539,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "task two output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -577,16 +607,20 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "\u001b[38;2;255;0",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: ";0mready",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -613,24 +647,30 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "\u001b[38;2;255;0",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: ";0mready",
               timestamp: "2026-03-19T15:30:01.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 2,
               data: "\u001b[0m\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -657,8 +697,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "\u001b[38;2;255;0;0mready\u001b[0m\r\n",
               timestamp: "2026-03-19T15:30:03.000Z",
@@ -695,8 +737,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "frontend\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -722,8 +766,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "backend",
-              runId: "backend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "backend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "backend\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -757,8 +803,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "frontend ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -784,16 +832,20 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "frontend ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "stale frontend\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -819,8 +871,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "backend",
-              runId: "backend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "backend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "backend ready\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -897,8 +951,10 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -925,16 +981,20 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "broken\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -1005,8 +1065,10 @@ describe("AgentStudioDevServerTerminal", () => {
             entries: [
               {
                 scriptId: "frontend",
-                runId: "frontend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 sequence: 0,
                 data: "ready\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -90,6 +90,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -141,6 +142,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     const view = render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -165,6 +167,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -196,6 +199,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -250,6 +254,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     const view = render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -274,6 +279,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -304,6 +310,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -366,6 +373,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     const view = render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -390,6 +398,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -412,6 +421,84 @@ describe("AgentStudioDevServerTerminal", () => {
       expect(screen).toBe("Starting `cd apps/web && pnpm dev`\r\n");
     });
     expect(clear).toHaveBeenCalledTimes(2);
+    expect(reset).toHaveBeenCalledTimes(2);
+  });
+
+  test("replays from scratch when the task scope changes with the same script id", async () => {
+    const open = mock((_container: HTMLElement) => {});
+    const loadAddon = mock((_addon: unknown) => {});
+    const fit = mock(() => {});
+    let screen = "";
+    const reset = mock(() => {
+      screen = "";
+    });
+    const clear = mock(() => {
+      screen = "";
+    });
+    const write = mock((data: string, callback?: () => void) => {
+      screen += data;
+      callback?.();
+    });
+    const dispose = mock(() => {});
+    const onRendererError = () => {};
+    const createTerminalBinding = (container: HTMLElement) => {
+      open(container);
+      loadAddon({});
+      return {
+        terminal: { clear, dispose, loadAddon, open, options: {}, reset, write },
+        fitAddon: { dispose, fit },
+      };
+    };
+
+    const view = render(
+      <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 7,
+              data: "task one output\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+          lastSequence: 7,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("task one output\r\n");
+    });
+
+    view.rerender(
+      <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-2"
+        scriptId="frontend"
+        terminalBuffer={{
+          entries: [
+            {
+              scriptId: "frontend",
+              sequence: 0,
+              data: "task two output\r\n",
+              timestamp: "2026-03-19T15:31:00.000Z",
+            },
+          ],
+          lastSequence: 0,
+          resetToken: 0,
+        }}
+        onRendererError={onRendererError}
+        createTerminalBinding={createTerminalBinding}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen).toBe("task two output\r\n");
+    });
     expect(reset).toHaveBeenCalledTimes(2);
   });
 
@@ -454,6 +541,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     const view = render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -485,6 +573,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -522,6 +611,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -557,6 +647,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     const view = render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -581,6 +672,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="backend"
         terminalBuffer={{
           entries: [
@@ -613,6 +705,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     const view = render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -637,6 +730,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -667,6 +761,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="backend"
         terminalBuffer={{
           entries: [
@@ -698,6 +793,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={null}
         onRendererError={onRendererError}
@@ -741,6 +837,7 @@ describe("AgentStudioDevServerTerminal", () => {
 
     const view = render(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -766,6 +863,7 @@ describe("AgentStudioDevServerTerminal", () => {
     shouldThrow = true;
     view.rerender(
       <AgentStudioDevServerTerminal
+        scopeKey="/repo::task-1"
         scriptId="frontend"
         terminalBuffer={{
           entries: [
@@ -841,6 +939,7 @@ describe("AgentStudioDevServerTerminal", () => {
     try {
       render(
         <AgentStudioDevServerTerminal
+          scopeKey="/repo::task-1"
           scriptId="frontend"
           terminalBuffer={{
             entries: [

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.test.tsx
@@ -96,6 +96,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -148,6 +149,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "first\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -173,12 +175,14 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "first\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "second\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -205,6 +209,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 4,
               data: "rehydrated\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -260,6 +265,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -285,12 +291,14 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "stalled\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -316,18 +324,21 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "stalled\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 2,
               data: "still live\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -379,6 +390,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "old failed output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -404,6 +416,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -458,6 +471,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 7,
               data: "task one output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -483,6 +497,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "task two output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -547,12 +562,14 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "\u001b[38;2;255;0",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: ";0mready",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -579,18 +596,21 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "\u001b[38;2;255;0",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: ";0mready",
               timestamp: "2026-03-19T15:30:01.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 2,
               data: "\u001b[0m\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -617,6 +637,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "\u001b[38;2;255;0;0mready\u001b[0m\r\n",
               timestamp: "2026-03-19T15:30:03.000Z",
@@ -653,6 +674,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "frontend\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -678,6 +700,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "backend",
+              runId: "backend:1",
               sequence: 0,
               data: "backend\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -711,6 +734,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "frontend ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -736,12 +760,14 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "frontend ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "stale frontend\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -767,6 +793,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "backend",
+              runId: "backend:1",
               sequence: 0,
               data: "backend ready\r\n",
               timestamp: "2026-03-19T15:30:02.000Z",
@@ -843,6 +870,7 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -869,12 +897,14 @@ describe("AgentStudioDevServerTerminal", () => {
           entries: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
             },
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "broken\r\n",
               timestamp: "2026-03-19T15:30:01.000Z",
@@ -945,6 +975,7 @@ describe("AgentStudioDevServerTerminal", () => {
             entries: [
               {
                 scriptId: "frontend",
+                runId: "frontend:1",
                 sequence: 0,
                 data: "ready\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.tsx
@@ -9,6 +9,7 @@ import {
 } from "./use-agent-studio-dev-server-terminal";
 
 type AgentStudioDevServerTerminalProps = {
+  scopeKey: string;
   scriptId: string;
   terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   onRendererError: (message: string | null) => void;
@@ -16,6 +17,7 @@ type AgentStudioDevServerTerminalProps = {
 };
 
 export const AgentStudioDevServerTerminal = memo(function AgentStudioDevServerTerminal({
+  scopeKey,
   scriptId,
   terminalBuffer,
   onRendererError,
@@ -30,7 +32,7 @@ export const AgentStudioDevServerTerminal = memo(function AgentStudioDevServerTe
 
   useDevServerTerminalRendering({
     ...terminalRenderController,
-    scriptId,
+    terminalIdentityKey: `${scopeKey}::${scriptId}`,
     terminalBuffer,
     onRendererError,
   });

--- a/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-dev-server-terminal.tsx
@@ -1,6 +1,7 @@
 import "@xterm/xterm/css/xterm.css";
 import { memo, type ReactElement, useRef } from "react";
 import type { AgentStudioDevServerTerminalBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
+import { formatDevServerTerminalIdentityKey } from "@/types/dev-server-task-scope";
 import {
   type CreateTerminalBinding,
   defaultCreateTerminalBinding,
@@ -32,7 +33,7 @@ export const AgentStudioDevServerTerminal = memo(function AgentStudioDevServerTe
 
   useDevServerTerminalRendering({
     ...terminalRenderController,
-    terminalIdentityKey: `${scopeKey}::${scriptId}`,
+    terminalIdentityKey: formatDevServerTerminalIdentityKey(scopeKey, scriptId),
     terminalBuffer,
     onRendererError,
   });

--- a/packages/frontend/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -106,8 +106,10 @@ const selectedScript: DevServerScriptState = {
   name: "Frontend",
   command: "bun run dev",
   status: "running",
-  runId: "frontend:1",
-  runOrder: { hostInstanceId: "host-1", generation: 1 },
+  runIdentity: {
+    runId: "frontend:1",
+    runOrder: { hostInstanceId: "host-1", generation: 1 },
+  },
   pid: 123,
   startedAt: "2026-03-19T10:00:00.000Z",
   exitCode: null,
@@ -115,8 +117,10 @@ const selectedScript: DevServerScriptState = {
   bufferedTerminalChunks: [
     {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 0,
       data: "ready in 120ms\r\n",
       timestamp: "2026-03-19T10:00:01.000Z",

--- a/packages/frontend/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -107,6 +107,7 @@ const selectedScript: DevServerScriptState = {
   command: "bun run dev",
   status: "running",
   runId: "frontend:1",
+  runOrder: { hostInstanceId: "host-1", generation: 1 },
   pid: 123,
   startedAt: "2026-03-19T10:00:00.000Z",
   exitCode: null,
@@ -115,6 +116,7 @@ const selectedScript: DevServerScriptState = {
     {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 0,
       data: "ready in 120ms\r\n",
       timestamp: "2026-03-19T10:00:01.000Z",

--- a/packages/frontend/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -106,6 +106,7 @@ const selectedScript: DevServerScriptState = {
   name: "Frontend",
   command: "bun run dev",
   status: "running",
+  runId: "frontend:1",
   pid: 123,
   startedAt: "2026-03-19T10:00:00.000Z",
   exitCode: null,
@@ -113,6 +114,7 @@ const selectedScript: DevServerScriptState = {
   bufferedTerminalChunks: [
     {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 0,
       data: "ready in 120ms\r\n",
       timestamp: "2026-03-19T10:00:01.000Z",

--- a/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
+++ b/packages/frontend/src/components/features/agents/use-agent-studio-dev-server-terminal.ts
@@ -19,7 +19,7 @@ export type CreateTerminalBinding = (
 ) => TerminalBinding;
 
 type RenderedTerminalState = {
-  scriptId: string | null;
+  terminalIdentityKey: string | null;
   resetToken: number | null;
   lastSequence: number | null;
 };
@@ -39,7 +39,7 @@ type UseDevServerTerminalBindingArgs = {
 };
 
 type UseDevServerTerminalRenderingArgs = TerminalRenderController & {
-  scriptId: string;
+  terminalIdentityKey: string;
   terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   onRendererError: (message: string | null) => void;
 };
@@ -122,7 +122,7 @@ const wireTerminalSelectionCopy = (binding: TerminalBinding): void => {
 
 const resetRenderedTerminalState = (renderedStateRef: { current: RenderedTerminalState }): void => {
   renderedStateRef.current = {
-    scriptId: null,
+    terminalIdentityKey: null,
     resetToken: null,
     lastSequence: null,
   };
@@ -222,13 +222,13 @@ const readAppendedTerminalOutput = (
 
 const renderTerminalBuffer = ({
   binding,
-  scriptId,
+  terminalIdentityKey,
   terminalBuffer,
   renderedStateRef,
   recreateTerminalBinding,
 }: {
   binding: TerminalBinding;
-  scriptId: string;
+  terminalIdentityKey: string;
   terminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   renderedStateRef: { current: RenderedTerminalState };
   recreateTerminalBinding: () => TerminalBinding | null;
@@ -236,11 +236,12 @@ const renderTerminalBuffer = ({
   const entries = terminalBuffer?.entries ?? [];
   const nextResetToken = terminalBuffer?.resetToken ?? 0;
   const nextLastSequence = terminalBuffer?.lastSequence ?? null;
-  const didScriptChange = renderedStateRef.current.scriptId !== scriptId;
+  const didTerminalIdentityChange =
+    renderedStateRef.current.terminalIdentityKey !== terminalIdentityKey;
   const didResetTokenChange = renderedStateRef.current.resetToken !== nextResetToken;
 
-  if (didScriptChange || didResetTokenChange) {
-    const hasRenderedCurrentBinding = renderedStateRef.current.scriptId !== null;
+  if (didTerminalIdentityChange || didResetTokenChange) {
+    const hasRenderedCurrentBinding = renderedStateRef.current.terminalIdentityKey !== null;
     const activeBinding = hasRenderedCurrentBinding ? recreateTerminalBinding() : binding;
     if (!activeBinding) {
       throw new Error("Cannot recreate dev server terminal before replay without a container");
@@ -251,7 +252,7 @@ const renderTerminalBuffer = ({
     writeTerminalOutput(activeBinding.terminal, readTerminalReplayOutput(entries));
     activeBinding.fitAddon.fit();
     renderedStateRef.current = {
-      scriptId,
+      terminalIdentityKey,
       resetToken: nextResetToken,
       lastSequence: nextLastSequence,
     };
@@ -272,7 +273,7 @@ export const useDevServerTerminalBinding = ({
 }: UseDevServerTerminalBindingArgs): TerminalRenderController => {
   const bindingRef = useRef<TerminalBinding | null>(null);
   const renderedStateRef = useRef<RenderedTerminalState>({
-    scriptId: null,
+    terminalIdentityKey: null,
     resetToken: null,
     lastSequence: null,
   });
@@ -337,7 +338,7 @@ export const useDevServerTerminalRendering = ({
   renderQueueRef,
   renderGenerationRef,
   recreateTerminalBinding,
-  scriptId,
+  terminalIdentityKey,
   terminalBuffer,
   onRendererError,
 }: UseDevServerTerminalRenderingArgs): void => {
@@ -360,7 +361,7 @@ export const useDevServerTerminalRendering = ({
 
         renderTerminalBuffer({
           binding: queuedBinding,
-          scriptId,
+          terminalIdentityKey,
           terminalBuffer,
           renderedStateRef,
           recreateTerminalBinding,
@@ -381,7 +382,7 @@ export const useDevServerTerminalRendering = ({
     renderQueueRef,
     renderedStateRef,
     recreateTerminalBinding,
-    scriptId,
+    terminalIdentityKey,
     terminalBuffer,
   ]);
 };

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -257,6 +257,52 @@ describe("dev-server-log-buffer", () => {
     ).toBe(false);
   });
 
+  test("merges a delayed same-run replay prefix with an already observed live suffix", () => {
+    const store = createDevServerTerminalBufferStore();
+    appendDevServerTerminalChunk(store, {
+      scriptId: "frontend",
+      sequence: 10,
+      data: "live-10\r\n",
+      timestamp: "2026-03-25T10:00:10.000Z",
+    });
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) => ({
+              scriptId: "frontend",
+              sequence,
+              data: `replay-${sequence}\r\n`,
+              timestamp: `2026-03-25T10:00:${String(sequence).padStart(2, "0")}.000Z`,
+            })),
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual([
+      "replay-0\r\n",
+      "replay-1\r\n",
+      "replay-2\r\n",
+      "replay-3\r\n",
+      "replay-4\r\n",
+      "replay-5\r\n",
+      "replay-6\r\n",
+      "replay-7\r\n",
+      "replay-8\r\n",
+      "replay-9\r\n",
+      "live-10\r\n",
+    ]);
+  });
+
   test("replaces a populated buffer when an authoritative snapshot clears replay", () => {
     const store = createDevServerTerminalBufferStore();
     replaceDevServerTerminalBuffer(store, "frontend", [

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -347,6 +347,41 @@ describe("dev-server-log-buffer", () => {
     expect(getDevServerTerminalBuffer(store, "frontend")?.entries).toEqual([]);
   });
 
+  test("clears old snapshot and live output when a newer run has no replay yet", () => {
+    const store = createDevServerTerminalBufferStore();
+    replaceDevServerTerminalBuffer(store, "frontend", [
+      {
+        scriptId: "frontend",
+        sequence: 3_999,
+        data: "old-snapshot\r\n",
+        timestamp: "2026-03-25T10:00:00.000Z",
+      },
+    ]);
+    appendDevServerTerminalChunk(store, {
+      scriptId: "frontend",
+      sequence: 4_000,
+      data: "old-live-only\r\n",
+      timestamp: "2026-03-25T10:00:01.000Z",
+    });
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 5252,
+            startedAt: "2026-03-25T10:31:00.000Z",
+            bufferedTerminalChunks: [],
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    expect(getDevServerTerminalBuffer(store, "frontend")?.entries).toEqual([]);
+  });
+
   test("drops a stale snapshot prefix while preserving a newer live-only suffix", () => {
     const store = createDevServerTerminalBufferStore();
     replaceDevServerTerminalBuffer(store, "frontend", [

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -278,6 +278,75 @@ describe("dev-server-log-buffer", () => {
     ).toBe(true);
   });
 
+  test("replaces a lower-sequence snapshot from a newer trimmed restart", () => {
+    const store = createDevServerTerminalBufferStore();
+    replaceDevServerTerminalBuffer(
+      store,
+      "frontend",
+      Array.from({ length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS }, (_, offset) => ({
+        scriptId: "frontend",
+        sequence: 4_000 + offset,
+        data: `old-run-${offset}\r\n`,
+        timestamp: `2026-03-25T10:00:${String(offset % 60).padStart(2, "0")}.000Z`,
+      })),
+    );
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 5252,
+            startedAt: "2026-03-25T10:31:00.000Z",
+            bufferedTerminalChunks: Array.from(
+              { length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS },
+              (_, offset) => ({
+                scriptId: "frontend",
+                sequence: 150 + offset,
+                data: `new-run-${offset}\r\n`,
+                timestamp: `2026-03-25T10:31:${String(offset % 60).padStart(2, "0")}.000Z`,
+              }),
+            ),
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    const buffer = getDevServerTerminalBuffer(store, "frontend");
+    expect(buffer?.entries[0]?.sequence).toBe(150);
+    expect(buffer?.entries[0]?.data).toBe("new-run-0\r\n");
+    expect(buffer?.entries.at(-1)?.sequence).toBe(2_149);
+  });
+
+  test("clears live-only output when a newer run has no replay yet", () => {
+    const store = createDevServerTerminalBufferStore();
+    appendDevServerTerminalChunk(store, {
+      scriptId: "frontend",
+      sequence: 4_000,
+      data: "old-live-only\r\n",
+      timestamp: "2026-03-25T10:00:00.000Z",
+    });
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 5252,
+            startedAt: "2026-03-25T10:31:00.000Z",
+            bufferedTerminalChunks: [],
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    expect(getDevServerTerminalBuffer(store, "frontend")?.entries).toEqual([]);
+  });
+
   test("drops a stale snapshot prefix while preserving a newer live-only suffix", () => {
     const store = createDevServerTerminalBufferStore();
     replaceDevServerTerminalBuffer(store, "frontend", [

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -568,7 +568,7 @@ describe("dev-server-log-buffer", () => {
     ).toEqual(["new-run\r\n"]);
   });
 
-  test("accepts a replacement host epoch once and rejects delayed state from the retired host", () => {
+  test("rejects foreign host state until transport ownership is explicitly reset", () => {
     const store = createDevServerTerminalBufferStore();
     syncDevServerTerminalBufferStore(
       store,
@@ -604,7 +604,13 @@ describe("dev-server-log-buffer", () => {
         }),
       ],
     });
-    expect(reconcileDevServerTerminalBufferStore(store, replacementState)).toBe(true);
+    expect(reconcileDevServerTerminalBufferStore(store, replacementState)).toBe(false);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual(["old-host\r\n"]);
+
+    store.clear();
+    syncDevServerTerminalBufferStore(store, replacementState);
 
     const delayedOldState = buildState({
       scripts: [

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -22,6 +22,7 @@ const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerSc
   name: "Frontend",
   command: "bun run dev",
   status: "stopped",
+  runId: overrides.pid === null || overrides.pid === undefined ? null : "frontend:1",
   pid: null,
   startedAt: null,
   exitCode: null,
@@ -44,6 +45,7 @@ const buildChunk = (
   overrides: Partial<DevServerTerminalChunk> = {},
 ): DevServerTerminalChunk => ({
   scriptId: "frontend",
+  runId: "frontend:1",
   sequence,
   data: `line-${sequence}\r\n`,
   timestamp: `2026-03-25T10:00:${String(sequence % 60).padStart(2, "0")}.000Z`,
@@ -56,6 +58,7 @@ describe("dev-server-log-buffer", () => {
       { length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS + 2 },
       (_, index) => ({
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -74,6 +77,7 @@ describe("dev-server-log-buffer", () => {
 
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 0,
       data: "\u001b[32mready\u001b[0m\r\n",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -85,6 +89,7 @@ describe("dev-server-log-buffer", () => {
     for (let index = 1; index <= MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS; index += 1) {
       appendDevServerTerminalChunk(store, {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -102,12 +107,14 @@ describe("dev-server-log-buffer", () => {
 
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 4,
       data: "latest",
       timestamp: "2026-03-25T10:00:00.000Z",
     });
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 3,
       data: "older",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -118,17 +125,43 @@ describe("dev-server-log-buffer", () => {
     expect(buffer?.entries[0]?.data).toBe("latest");
   });
 
+  test("accepts lower sequence chunks from a new run after resetting old output", () => {
+    const store = createDevServerTerminalBufferStore();
+
+    appendDevServerTerminalChunk(store, {
+      scriptId: "frontend",
+      runId: "frontend:1",
+      sequence: 100,
+      data: "old-run",
+      timestamp: "2026-03-25T10:00:00.000Z",
+    });
+    appendDevServerTerminalChunk(store, {
+      scriptId: "frontend",
+      runId: "frontend:2",
+      sequence: 0,
+      data: "new-run",
+      timestamp: "2026-03-25T10:01:00.000Z",
+    });
+
+    const buffer = getDevServerTerminalBuffer(store, "frontend");
+    expect(buffer?.entries).toHaveLength(1);
+    expect(buffer?.entries[0]?.data).toBe("new-run");
+    expect(buffer?.lastSequence).toBe(0);
+  });
+
   test("accepts sequential live chunks after replay gaps", () => {
     const store = createDevServerTerminalBufferStore();
 
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 1,
       data: "oversized-live",
       timestamp: "2026-03-25T10:00:00.000Z",
     });
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 2,
       data: "later-live",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -145,6 +178,7 @@ describe("dev-server-log-buffer", () => {
     for (let index = 0; index < MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS; index += 1) {
       appendDevServerTerminalChunk(store, {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -154,6 +188,7 @@ describe("dev-server-log-buffer", () => {
     const previousSnapshot = getDevServerTerminalBuffer(store, "frontend");
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS,
       data: "latest",
       timestamp: "2026-03-25T10:01:00.000Z",
@@ -169,6 +204,7 @@ describe("dev-server-log-buffer", () => {
     const store = createDevServerTerminalBufferStore();
     appendDevServerTerminalChunk(store, {
       scriptId: "stale",
+      runId: "stale:1",
       sequence: 0,
       data: "stale",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -183,6 +219,7 @@ describe("dev-server-log-buffer", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
+                runId: "frontend:1",
                 sequence: 7,
                 data: "frontend failed\r\n",
                 timestamp: "2026-03-25T10:01:00.000Z",
@@ -201,6 +238,7 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 8,
         data: "restarted\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
@@ -217,6 +255,7 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 0,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -227,6 +266,7 @@ describe("dev-server-log-buffer", () => {
       bufferedTerminalChunks: [
         {
           scriptId: "frontend",
+          runId: "frontend:1",
           sequence: 1,
           data: "fresh\r\n",
           timestamp: "2026-03-25T10:01:00.000Z",
@@ -247,6 +287,7 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 2,
         data: "local-live\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
@@ -257,6 +298,7 @@ describe("dev-server-log-buffer", () => {
       bufferedTerminalChunks: [
         {
           scriptId: "frontend",
+          runId: "frontend:1",
           sequence: 1,
           data: "stale\r\n",
           timestamp: "2026-03-25T10:01:00.000Z",
@@ -327,6 +369,93 @@ describe("dev-server-log-buffer", () => {
     ]);
   });
 
+  test("merges same-run replay after a live chunk arrives before state hydration", () => {
+    const store = createDevServerTerminalBufferStore();
+    appendDevServerTerminalChunk(
+      store,
+      buildChunk(10, {
+        data: "live-10\r\n",
+        timestamp: "2026-03-25T10:00:10.000Z",
+      }),
+    );
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            runId: "frontend:1",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
+              buildChunk(sequence, { data: `replay-${sequence}\r\n` }),
+            ),
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual([
+      "replay-0\r\n",
+      "replay-1\r\n",
+      "replay-2\r\n",
+      "replay-3\r\n",
+      "replay-4\r\n",
+      "replay-5\r\n",
+      "replay-6\r\n",
+      "replay-7\r\n",
+      "replay-8\r\n",
+      "replay-9\r\n",
+      "live-10\r\n",
+    ]);
+  });
+
+  test("rejects stale previous-run replay after a new-run live chunk arrives before state", () => {
+    const store = createDevServerTerminalBufferStore();
+    appendDevServerTerminalChunk(
+      store,
+      buildChunk(5, {
+        runId: "frontend:2",
+        data: "new-run-5\r\n",
+        timestamp: "2026-03-25T10:10:05.000Z",
+      }),
+    );
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            runId: "frontend:1",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: Array.from({ length: 101 }, (_, sequence) =>
+              buildChunk(sequence, { data: `old-run-${sequence}\r\n` }),
+            ),
+          }),
+        ],
+      }),
+    );
+    appendDevServerTerminalChunk(
+      store,
+      buildChunk(6, {
+        runId: "frontend:2",
+        data: "new-run-6\r\n",
+        timestamp: "2026-03-25T10:10:06.000Z",
+      }),
+    );
+
+    expect(didChange).toBe(false);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual(["new-run-5\r\n", "new-run-6\r\n"]);
+  });
+
   test("keeps current-run live output when a delayed previous-run replay arrives", () => {
     const store = createDevServerTerminalBufferStore();
     syncDevServerTerminalBufferStore(
@@ -335,10 +464,12 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
+            runId: "frontend:2",
             pid: 5252,
             startedAt: "2026-03-25T10:10:00.000Z",
             bufferedTerminalChunks: [
               buildChunk(10, {
+                runId: "frontend:2",
                 data: "new-run-10\r\n",
                 timestamp: "2026-03-25T10:10:10.000Z",
               }),
@@ -354,6 +485,7 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
+            runId: "frontend:1",
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
@@ -378,10 +510,12 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
+            runId: "frontend:2",
             pid: 5252,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: [
               buildChunk(10, {
+                runId: "frontend:2",
                 data: "current-run-10\r\n",
                 timestamp: "2026-03-25T10:00:10.000Z",
               }),
@@ -397,6 +531,7 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
+            runId: "frontend:1",
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
@@ -519,6 +654,7 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 2,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
@@ -542,6 +678,7 @@ describe("dev-server-log-buffer", () => {
       "frontend",
       Array.from({ length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS }, (_, offset) => ({
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 4_000 + offset,
         data: `old-run-${offset}\r\n`,
         timestamp: `2026-03-25T10:00:${String(offset % 60).padStart(2, "0")}.000Z`,
@@ -560,6 +697,7 @@ describe("dev-server-log-buffer", () => {
               { length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS },
               (_, offset) => ({
                 scriptId: "frontend",
+                runId: "frontend:1",
                 sequence: 150 + offset,
                 data: `new-run-${offset}\r\n`,
                 timestamp: `2026-03-25T10:31:${String(offset % 60).padStart(2, "0")}.000Z`,
@@ -581,6 +719,7 @@ describe("dev-server-log-buffer", () => {
     const store = createDevServerTerminalBufferStore();
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 4_000,
       data: "old-live-only\r\n",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -609,6 +748,7 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 3_999,
         data: "old-snapshot\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -616,6 +756,7 @@ describe("dev-server-log-buffer", () => {
     ]);
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 4_000,
       data: "old-live-only\r\n",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -644,6 +785,7 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 0,
         data: "snapshot\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -651,6 +793,7 @@ describe("dev-server-log-buffer", () => {
     ]);
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: 1,
       data: "live-only\r\n",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -667,6 +810,7 @@ describe("dev-server-log-buffer", () => {
     expect(getDevServerTerminalBuffer(store, "frontend")?.entries).toEqual([
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 1,
         data: "live-only\r\n",
         timestamp: "2026-03-25T10:00:01.000Z",
@@ -691,12 +835,14 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 2,
         data: "latest\r\n",
         timestamp: "2026-03-25T10:00:02.000Z",
       },
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 1,
         data: "older\r\n",
         timestamp: "2026-03-25T10:00:01.000Z",
@@ -725,6 +871,7 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 0,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -733,6 +880,7 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "removed", [
       {
         scriptId: "removed",
+        runId: "removed:1",
         sequence: 0,
         data: "removed\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -747,6 +895,7 @@ describe("dev-server-log-buffer", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
+                runId: "frontend:1",
                 sequence: 2,
                 data: "fresh\r\n",
                 timestamp: "2026-03-25T10:02:00.000Z",

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -17,19 +17,32 @@ import {
   trimDevServerTerminalChunks,
 } from "./dev-server-log-buffer";
 
-const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => ({
-  scriptId: "frontend",
-  name: "Frontend",
-  command: "bun run dev",
-  status: "stopped",
-  runId: overrides.pid === null || overrides.pid === undefined ? null : "frontend:1",
-  pid: null,
-  startedAt: null,
-  exitCode: null,
-  lastError: null,
-  bufferedTerminalChunks: [],
-  ...overrides,
+const testRunOrder = (runId: string) => ({
+  hostInstanceId: "host-1",
+  generation: Number(runId.split(":").at(-1)),
 });
+
+const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => {
+  const bufferedRun = overrides.bufferedTerminalChunks?.[0];
+  const runId =
+    overrides.runId ??
+    bufferedRun?.runId ??
+    (overrides.pid === null || overrides.pid === undefined ? null : "frontend:1");
+  return {
+    scriptId: "frontend",
+    name: "Frontend",
+    command: "bun run dev",
+    status: "stopped",
+    runId,
+    runOrder: bufferedRun?.runOrder ?? (runId === null ? null : testRunOrder(runId)),
+    pid: null,
+    startedAt: null,
+    exitCode: null,
+    lastError: null,
+    bufferedTerminalChunks: [],
+    ...overrides,
+  };
+};
 
 const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGroupState => ({
   repoPath: "/repo",
@@ -43,14 +56,18 @@ const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGrou
 const buildChunk = (
   sequence: number,
   overrides: Partial<DevServerTerminalChunk> = {},
-): DevServerTerminalChunk => ({
-  scriptId: "frontend",
-  runId: "frontend:1",
-  sequence,
-  data: `line-${sequence}\r\n`,
-  timestamp: `2026-03-25T10:00:${String(sequence % 60).padStart(2, "0")}.000Z`,
-  ...overrides,
-});
+): DevServerTerminalChunk => {
+  const runId = overrides.runId ?? "frontend:1";
+  return {
+    scriptId: "frontend",
+    runId,
+    runOrder: testRunOrder(runId),
+    sequence,
+    data: `line-${sequence}\r\n`,
+    timestamp: `2026-03-25T10:00:${String(sequence % 60).padStart(2, "0")}.000Z`,
+    ...overrides,
+  };
+};
 
 describe("dev-server-log-buffer", () => {
   test("trims snapshots to the configured maximum", () => {
@@ -59,6 +76,7 @@ describe("dev-server-log-buffer", () => {
       (_, index) => ({
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -78,6 +96,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 0,
       data: "\u001b[32mready\u001b[0m\r\n",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -90,6 +109,7 @@ describe("dev-server-log-buffer", () => {
       appendDevServerTerminalChunk(store, {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -108,6 +128,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 4,
       data: "latest",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -115,6 +136,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 3,
       data: "older",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -131,6 +153,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 100,
       data: "old-run",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -138,6 +161,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:2",
+      runOrder: { hostInstanceId: "host-1", generation: 2 },
       sequence: 0,
       data: "new-run",
       timestamp: "2026-03-25T10:01:00.000Z",
@@ -155,6 +179,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 1,
       data: "oversized-live",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -162,6 +187,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 2,
       data: "later-live",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -179,6 +205,7 @@ describe("dev-server-log-buffer", () => {
       appendDevServerTerminalChunk(store, {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -189,6 +216,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS,
       data: "latest",
       timestamp: "2026-03-25T10:01:00.000Z",
@@ -205,6 +233,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "stale",
       runId: "stale:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 0,
       data: "stale",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -220,6 +249,7 @@ describe("dev-server-log-buffer", () => {
               {
                 scriptId: "frontend",
                 runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
                 sequence: 7,
                 data: "frontend failed\r\n",
                 timestamp: "2026-03-25T10:01:00.000Z",
@@ -239,6 +269,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 8,
         data: "restarted\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
@@ -256,6 +287,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 0,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -267,6 +299,7 @@ describe("dev-server-log-buffer", () => {
         {
           scriptId: "frontend",
           runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
           sequence: 1,
           data: "fresh\r\n",
           timestamp: "2026-03-25T10:01:00.000Z",
@@ -282,12 +315,13 @@ describe("dev-server-log-buffer", () => {
     ).toBe(true);
   });
 
-  test("keeps a populated buffer when the local stream is newer than the snapshot", () => {
+  test("accepts a missing same-run replay prefix without replacing newer local output", () => {
     const store = createDevServerTerminalBufferStore();
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 2,
         data: "local-live\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
@@ -299,6 +333,7 @@ describe("dev-server-log-buffer", () => {
         {
           scriptId: "frontend",
           runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
           sequence: 1,
           data: "stale\r\n",
           timestamp: "2026-03-25T10:01:00.000Z",
@@ -311,7 +346,7 @@ describe("dev-server-log-buffer", () => {
         getDevServerTerminalBufferReplacementContext(store, "frontend"),
         staleScript,
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test("merges a delayed same-run replay prefix with an already observed live suffix", () => {
@@ -386,6 +421,7 @@ describe("dev-server-log-buffer", () => {
           buildScript({
             status: "running",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
@@ -420,6 +456,7 @@ describe("dev-server-log-buffer", () => {
       store,
       buildChunk(5, {
         runId: "frontend:2",
+        runOrder: { hostInstanceId: "host-1", generation: 2 },
         data: "new-run-5\r\n",
         timestamp: "2026-03-25T10:10:05.000Z",
       }),
@@ -432,6 +469,7 @@ describe("dev-server-log-buffer", () => {
           buildScript({
             status: "running",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 101 }, (_, sequence) =>
@@ -445,6 +483,7 @@ describe("dev-server-log-buffer", () => {
       store,
       buildChunk(6, {
         runId: "frontend:2",
+        runOrder: { hostInstanceId: "host-1", generation: 2 },
         data: "new-run-6\r\n",
         timestamp: "2026-03-25T10:10:06.000Z",
       }),
@@ -465,11 +504,13 @@ describe("dev-server-log-buffer", () => {
           buildScript({
             status: "running",
             runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
             pid: 5252,
             startedAt: "2026-03-25T10:10:00.000Z",
             bufferedTerminalChunks: [
               buildChunk(10, {
                 runId: "frontend:2",
+                runOrder: { hostInstanceId: "host-1", generation: 2 },
                 data: "new-run-10\r\n",
                 timestamp: "2026-03-25T10:10:10.000Z",
               }),
@@ -486,6 +527,7 @@ describe("dev-server-log-buffer", () => {
           buildScript({
             status: "running",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
@@ -502,6 +544,143 @@ describe("dev-server-log-buffer", () => {
     ).toEqual(["new-run-10\r\n"]);
   });
 
+  test("rejects a delayed previous-run live chunk after a newer run is visible", () => {
+    const store = createDevServerTerminalBufferStore();
+    appendDevServerTerminalChunk(
+      store,
+      buildChunk(0, {
+        runId: "frontend:2",
+        runOrder: testRunOrder("frontend:2"),
+        data: "new-run\r\n",
+      }),
+    );
+    appendDevServerTerminalChunk(
+      store,
+      buildChunk(100, {
+        runId: "frontend:1",
+        runOrder: testRunOrder("frontend:1"),
+        data: "delayed-old-run\r\n",
+      }),
+    );
+
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual(["new-run\r\n"]);
+  });
+
+  test("accepts a replacement host epoch once and rejects delayed state from the retired host", () => {
+    const store = createDevServerTerminalBufferStore();
+    syncDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            runId: "host-1-run",
+            runOrder: { hostInstanceId: "host-1", generation: 8 },
+            bufferedTerminalChunks: [
+              buildChunk(8, {
+                runId: "host-1-run",
+                runOrder: { hostInstanceId: "host-1", generation: 8 },
+                data: "old-host\r\n",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const replacementState = buildState({
+      scripts: [
+        buildScript({
+          runId: "host-2-run",
+          runOrder: { hostInstanceId: "host-2", generation: 1 },
+          bufferedTerminalChunks: [
+            buildChunk(0, {
+              runId: "host-2-run",
+              runOrder: { hostInstanceId: "host-2", generation: 1 },
+              data: "replacement-host\r\n",
+            }),
+          ],
+        }),
+      ],
+    });
+    expect(reconcileDevServerTerminalBufferStore(store, replacementState)).toBe(true);
+
+    const delayedOldState = buildState({
+      scripts: [
+        buildScript({
+          runId: "host-1-delayed-run",
+          runOrder: { hostInstanceId: "host-1", generation: 9 },
+          bufferedTerminalChunks: [
+            buildChunk(9, {
+              runId: "host-1-delayed-run",
+              runOrder: { hostInstanceId: "host-1", generation: 9 },
+              data: "delayed-old-host\r\n",
+            }),
+          ],
+        }),
+      ],
+    });
+    expect(reconcileDevServerTerminalBufferStore(store, delayedOldState)).toBe(false);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual(["replacement-host\r\n"]);
+  });
+
+  test("replaces an old run with a newer authoritative run when its clock moved backward", () => {
+    const store = createDevServerTerminalBufferStore();
+    syncDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: [
+              buildChunk(100, {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                data: "old-run-100\r\n",
+                timestamp: "2026-03-25T10:00:00.000Z",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            pid: 4242,
+            startedAt: "2026-03-25T09:59:59.000Z",
+            bufferedTerminalChunks: [
+              buildChunk(0, {
+                runId: "frontend:2",
+                runOrder: { hostInstanceId: "host-1", generation: 2 },
+                data: "new-run-0\r\n",
+                timestamp: "2026-03-25T09:59:59.000Z",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual(["new-run-0\r\n"]);
+  });
+
   test("does not merge equal-startedAt replay from a different process run", () => {
     const store = createDevServerTerminalBufferStore();
     syncDevServerTerminalBufferStore(
@@ -511,11 +690,13 @@ describe("dev-server-log-buffer", () => {
           buildScript({
             status: "running",
             runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
             pid: 5252,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: [
               buildChunk(10, {
                 runId: "frontend:2",
+                runOrder: { hostInstanceId: "host-1", generation: 2 },
                 data: "current-run-10\r\n",
                 timestamp: "2026-03-25T10:00:10.000Z",
               }),
@@ -532,6 +713,7 @@ describe("dev-server-log-buffer", () => {
           buildScript({
             status: "running",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
@@ -655,13 +837,18 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 2,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
       },
     ]);
 
-    const clearedScript = buildScript({ bufferedTerminalChunks: [] });
+    const clearedScript = buildScript({
+      runId: "frontend:1",
+      runOrder: testRunOrder("frontend:1"),
+      bufferedTerminalChunks: [],
+    });
 
     expect(
       shouldReplaceDevServerTerminalBufferFromScript(
@@ -679,6 +866,7 @@ describe("dev-server-log-buffer", () => {
       Array.from({ length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS }, (_, offset) => ({
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 4_000 + offset,
         data: `old-run-${offset}\r\n`,
         timestamp: `2026-03-25T10:00:${String(offset % 60).padStart(2, "0")}.000Z`,
@@ -697,7 +885,8 @@ describe("dev-server-log-buffer", () => {
               { length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS },
               (_, offset) => ({
                 scriptId: "frontend",
-                runId: "frontend:1",
+                runId: "frontend:2",
+                runOrder: { hostInstanceId: "host-1", generation: 2 },
                 sequence: 150 + offset,
                 data: `new-run-${offset}\r\n`,
                 timestamp: `2026-03-25T10:31:${String(offset % 60).padStart(2, "0")}.000Z`,
@@ -720,6 +909,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 4_000,
       data: "old-live-only\r\n",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -731,6 +921,8 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
+            runId: "frontend:2",
+            runOrder: testRunOrder("frontend:2"),
             pid: 5252,
             startedAt: "2026-03-25T10:31:00.000Z",
             bufferedTerminalChunks: [],
@@ -749,6 +941,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 3_999,
         data: "old-snapshot\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -757,6 +950,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 4_000,
       data: "old-live-only\r\n",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -768,6 +962,8 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
+            runId: "frontend:2",
+            runOrder: testRunOrder("frontend:2"),
             pid: 5252,
             startedAt: "2026-03-25T10:31:00.000Z",
             bufferedTerminalChunks: [],
@@ -786,6 +982,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 0,
         data: "snapshot\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -794,6 +991,7 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: 1,
       data: "live-only\r\n",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -802,7 +1000,13 @@ describe("dev-server-log-buffer", () => {
     const didChange = reconcileDevServerTerminalBufferStore(
       store,
       buildState({
-        scripts: [buildScript({ bufferedTerminalChunks: [] })],
+        scripts: [
+          buildScript({
+            runId: "frontend:1",
+            runOrder: testRunOrder("frontend:1"),
+            bufferedTerminalChunks: [],
+          }),
+        ],
       }),
     );
 
@@ -811,6 +1015,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 1,
         data: "live-only\r\n",
         timestamp: "2026-03-25T10:00:01.000Z",
@@ -819,7 +1024,11 @@ describe("dev-server-log-buffer", () => {
     expect(
       shouldReplaceDevServerTerminalBufferFromScript(
         getDevServerTerminalBufferReplacementContext(store, "frontend"),
-        buildScript({ bufferedTerminalChunks: [] }),
+        buildScript({
+          runId: "frontend:1",
+          runOrder: testRunOrder("frontend:1"),
+          bufferedTerminalChunks: [],
+        }),
       ),
     ).toBe(false);
     expect(getDevServerTerminalBufferReplacementContext(store, "frontend")?.snapshot).toEqual({
@@ -836,6 +1045,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 2,
         data: "latest\r\n",
         timestamp: "2026-03-25T10:00:02.000Z",
@@ -843,6 +1053,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 1,
         data: "older\r\n",
         timestamp: "2026-03-25T10:00:01.000Z",
@@ -872,6 +1083,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 0,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -881,6 +1093,7 @@ describe("dev-server-log-buffer", () => {
       {
         scriptId: "removed",
         runId: "removed:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 0,
         data: "removed\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -896,6 +1109,7 @@ describe("dev-server-log-buffer", () => {
               {
                 scriptId: "frontend",
                 runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
                 sequence: 2,
                 data: "fresh\r\n",
                 timestamp: "2026-03-25T10:02:00.000Z",

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -23,18 +23,21 @@ const testRunOrder = (runId: string) => ({
 });
 
 const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => {
-  const bufferedRun = overrides.bufferedTerminalChunks?.[0];
-  const runId =
-    overrides.runId ??
-    bufferedRun?.runId ??
-    (overrides.pid === null || overrides.pid === undefined ? null : "frontend:1");
+  const bufferedRunIdentity = overrides.bufferedTerminalChunks?.[0]?.runIdentity;
+  const defaultRunIdentity =
+    overrides.pid === null || overrides.pid === undefined
+      ? null
+      : { runId: "frontend:1", runOrder: testRunOrder("frontend:1") };
+  const runIdentity =
+    overrides.runIdentity === undefined
+      ? (bufferedRunIdentity ?? defaultRunIdentity)
+      : overrides.runIdentity;
   return {
     scriptId: "frontend",
     name: "Frontend",
     command: "bun run dev",
     status: "stopped",
-    runId,
-    runOrder: bufferedRun?.runOrder ?? (runId === null ? null : testRunOrder(runId)),
+    runIdentity,
     pid: null,
     startedAt: null,
     exitCode: null,
@@ -57,11 +60,13 @@ const buildChunk = (
   sequence: number,
   overrides: Partial<DevServerTerminalChunk> = {},
 ): DevServerTerminalChunk => {
-  const runId = overrides.runId ?? "frontend:1";
+  const runIdentity = overrides.runIdentity ?? {
+    runId: "frontend:1",
+    runOrder: testRunOrder("frontend:1"),
+  };
   return {
     scriptId: "frontend",
-    runId,
-    runOrder: testRunOrder(runId),
+    runIdentity,
     sequence,
     data: `line-${sequence}\r\n`,
     timestamp: `2026-03-25T10:00:${String(sequence % 60).padStart(2, "0")}.000Z`,
@@ -75,8 +80,10 @@ describe("dev-server-log-buffer", () => {
       { length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS + 2 },
       (_, index) => ({
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -95,8 +102,10 @@ describe("dev-server-log-buffer", () => {
 
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 0,
       data: "\u001b[32mready\u001b[0m\r\n",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -108,8 +117,10 @@ describe("dev-server-log-buffer", () => {
     for (let index = 1; index <= MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS; index += 1) {
       appendDevServerTerminalChunk(store, {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -127,16 +138,20 @@ describe("dev-server-log-buffer", () => {
 
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 4,
       data: "latest",
       timestamp: "2026-03-25T10:00:00.000Z",
     });
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 3,
       data: "older",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -152,16 +167,20 @@ describe("dev-server-log-buffer", () => {
 
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 100,
       data: "old-run",
       timestamp: "2026-03-25T10:00:00.000Z",
     });
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:2",
-      runOrder: { hostInstanceId: "host-1", generation: 2 },
+      runIdentity: {
+        runId: "frontend:2",
+        runOrder: { hostInstanceId: "host-1", generation: 2 },
+      },
       sequence: 0,
       data: "new-run",
       timestamp: "2026-03-25T10:01:00.000Z",
@@ -178,16 +197,20 @@ describe("dev-server-log-buffer", () => {
 
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 1,
       data: "oversized-live",
       timestamp: "2026-03-25T10:00:00.000Z",
     });
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 2,
       data: "later-live",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -204,8 +227,10 @@ describe("dev-server-log-buffer", () => {
     for (let index = 0; index < MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS; index += 1) {
       appendDevServerTerminalChunk(store, {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: index,
         data: `line-${index}`,
         timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -215,8 +240,10 @@ describe("dev-server-log-buffer", () => {
     const previousSnapshot = getDevServerTerminalBuffer(store, "frontend");
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS,
       data: "latest",
       timestamp: "2026-03-25T10:01:00.000Z",
@@ -232,8 +259,10 @@ describe("dev-server-log-buffer", () => {
     const store = createDevServerTerminalBufferStore();
     appendDevServerTerminalChunk(store, {
       scriptId: "stale",
-      runId: "stale:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "stale:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 0,
       data: "stale",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -248,8 +277,10 @@ describe("dev-server-log-buffer", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
-                runId: "frontend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 sequence: 7,
                 data: "frontend failed\r\n",
                 timestamp: "2026-03-25T10:01:00.000Z",
@@ -268,8 +299,10 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 8,
         data: "restarted\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
@@ -286,8 +319,10 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 0,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -298,8 +333,10 @@ describe("dev-server-log-buffer", () => {
       bufferedTerminalChunks: [
         {
           scriptId: "frontend",
-          runId: "frontend:1",
-          runOrder: { hostInstanceId: "host-1", generation: 1 },
+          runIdentity: {
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
+          },
           sequence: 1,
           data: "fresh\r\n",
           timestamp: "2026-03-25T10:01:00.000Z",
@@ -320,8 +357,10 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 2,
         data: "local-live\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
@@ -332,8 +371,10 @@ describe("dev-server-log-buffer", () => {
       bufferedTerminalChunks: [
         {
           scriptId: "frontend",
-          runId: "frontend:1",
-          runOrder: { hostInstanceId: "host-1", generation: 1 },
+          runIdentity: {
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
+          },
           sequence: 1,
           data: "stale\r\n",
           timestamp: "2026-03-25T10:01:00.000Z",
@@ -420,8 +461,10 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
@@ -455,8 +498,10 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(
       store,
       buildChunk(5, {
-        runId: "frontend:2",
-        runOrder: { hostInstanceId: "host-1", generation: 2 },
+        runIdentity: {
+          runId: "frontend:2",
+          runOrder: { hostInstanceId: "host-1", generation: 2 },
+        },
         data: "new-run-5\r\n",
         timestamp: "2026-03-25T10:10:05.000Z",
       }),
@@ -468,8 +513,10 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 101 }, (_, sequence) =>
@@ -482,8 +529,10 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(
       store,
       buildChunk(6, {
-        runId: "frontend:2",
-        runOrder: { hostInstanceId: "host-1", generation: 2 },
+        runIdentity: {
+          runId: "frontend:2",
+          runOrder: { hostInstanceId: "host-1", generation: 2 },
+        },
         data: "new-run-6\r\n",
         timestamp: "2026-03-25T10:10:06.000Z",
       }),
@@ -503,14 +552,18 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             pid: 5252,
             startedAt: "2026-03-25T10:10:00.000Z",
             bufferedTerminalChunks: [
               buildChunk(10, {
-                runId: "frontend:2",
-                runOrder: { hostInstanceId: "host-1", generation: 2 },
+                runIdentity: {
+                  runId: "frontend:2",
+                  runOrder: { hostInstanceId: "host-1", generation: 2 },
+                },
                 data: "new-run-10\r\n",
                 timestamp: "2026-03-25T10:10:10.000Z",
               }),
@@ -526,8 +579,10 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
@@ -549,16 +604,20 @@ describe("dev-server-log-buffer", () => {
     appendDevServerTerminalChunk(
       store,
       buildChunk(0, {
-        runId: "frontend:2",
-        runOrder: testRunOrder("frontend:2"),
+        runIdentity: {
+          runId: "frontend:2",
+          runOrder: testRunOrder("frontend:2"),
+        },
         data: "new-run\r\n",
       }),
     );
     appendDevServerTerminalChunk(
       store,
       buildChunk(100, {
-        runId: "frontend:1",
-        runOrder: testRunOrder("frontend:1"),
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: testRunOrder("frontend:1"),
+        },
         data: "delayed-old-run\r\n",
       }),
     );
@@ -575,12 +634,16 @@ describe("dev-server-log-buffer", () => {
       buildState({
         scripts: [
           buildScript({
-            runId: "host-1-run",
-            runOrder: { hostInstanceId: "host-1", generation: 8 },
+            runIdentity: {
+              runId: "host-1-run",
+              runOrder: { hostInstanceId: "host-1", generation: 8 },
+            },
             bufferedTerminalChunks: [
               buildChunk(8, {
-                runId: "host-1-run",
-                runOrder: { hostInstanceId: "host-1", generation: 8 },
+                runIdentity: {
+                  runId: "host-1-run",
+                  runOrder: { hostInstanceId: "host-1", generation: 8 },
+                },
                 data: "old-host\r\n",
               }),
             ],
@@ -592,12 +655,16 @@ describe("dev-server-log-buffer", () => {
     const replacementState = buildState({
       scripts: [
         buildScript({
-          runId: "host-2-run",
-          runOrder: { hostInstanceId: "host-2", generation: 1 },
+          runIdentity: {
+            runId: "host-2-run",
+            runOrder: { hostInstanceId: "host-2", generation: 1 },
+          },
           bufferedTerminalChunks: [
             buildChunk(0, {
-              runId: "host-2-run",
-              runOrder: { hostInstanceId: "host-2", generation: 1 },
+              runIdentity: {
+                runId: "host-2-run",
+                runOrder: { hostInstanceId: "host-2", generation: 1 },
+              },
               data: "replacement-host\r\n",
             }),
           ],
@@ -615,12 +682,16 @@ describe("dev-server-log-buffer", () => {
     const delayedOldState = buildState({
       scripts: [
         buildScript({
-          runId: "host-1-delayed-run",
-          runOrder: { hostInstanceId: "host-1", generation: 9 },
+          runIdentity: {
+            runId: "host-1-delayed-run",
+            runOrder: { hostInstanceId: "host-1", generation: 9 },
+          },
           bufferedTerminalChunks: [
             buildChunk(9, {
-              runId: "host-1-delayed-run",
-              runOrder: { hostInstanceId: "host-1", generation: 9 },
+              runIdentity: {
+                runId: "host-1-delayed-run",
+                runOrder: { hostInstanceId: "host-1", generation: 9 },
+              },
               data: "delayed-old-host\r\n",
             }),
           ],
@@ -641,14 +712,18 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: [
               buildChunk(100, {
-                runId: "frontend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 data: "old-run-100\r\n",
                 timestamp: "2026-03-25T10:00:00.000Z",
               }),
@@ -664,14 +739,18 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             pid: 4242,
             startedAt: "2026-03-25T09:59:59.000Z",
             bufferedTerminalChunks: [
               buildChunk(0, {
-                runId: "frontend:2",
-                runOrder: { hostInstanceId: "host-1", generation: 2 },
+                runIdentity: {
+                  runId: "frontend:2",
+                  runOrder: { hostInstanceId: "host-1", generation: 2 },
+                },
                 data: "new-run-0\r\n",
                 timestamp: "2026-03-25T09:59:59.000Z",
               }),
@@ -695,14 +774,18 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             pid: 5252,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: [
               buildChunk(10, {
-                runId: "frontend:2",
-                runOrder: { hostInstanceId: "host-1", generation: 2 },
+                runIdentity: {
+                  runId: "frontend:2",
+                  runOrder: { hostInstanceId: "host-1", generation: 2 },
+                },
                 data: "current-run-10\r\n",
                 timestamp: "2026-03-25T10:00:10.000Z",
               }),
@@ -718,8 +801,10 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
             bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
@@ -842,8 +927,10 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 2,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:02:00.000Z",
@@ -851,8 +938,10 @@ describe("dev-server-log-buffer", () => {
     ]);
 
     const clearedScript = buildScript({
-      runId: "frontend:1",
-      runOrder: testRunOrder("frontend:1"),
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: testRunOrder("frontend:1"),
+      },
       bufferedTerminalChunks: [],
     });
 
@@ -871,8 +960,10 @@ describe("dev-server-log-buffer", () => {
       "frontend",
       Array.from({ length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS }, (_, offset) => ({
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 4_000 + offset,
         data: `old-run-${offset}\r\n`,
         timestamp: `2026-03-25T10:00:${String(offset % 60).padStart(2, "0")}.000Z`,
@@ -891,8 +982,10 @@ describe("dev-server-log-buffer", () => {
               { length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS },
               (_, offset) => ({
                 scriptId: "frontend",
-                runId: "frontend:2",
-                runOrder: { hostInstanceId: "host-1", generation: 2 },
+                runIdentity: {
+                  runId: "frontend:2",
+                  runOrder: { hostInstanceId: "host-1", generation: 2 },
+                },
                 sequence: 150 + offset,
                 data: `new-run-${offset}\r\n`,
                 timestamp: `2026-03-25T10:31:${String(offset % 60).padStart(2, "0")}.000Z`,
@@ -914,8 +1007,10 @@ describe("dev-server-log-buffer", () => {
     const store = createDevServerTerminalBufferStore();
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 4_000,
       data: "old-live-only\r\n",
       timestamp: "2026-03-25T10:00:00.000Z",
@@ -927,8 +1022,10 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:2",
-            runOrder: testRunOrder("frontend:2"),
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: testRunOrder("frontend:2"),
+            },
             pid: 5252,
             startedAt: "2026-03-25T10:31:00.000Z",
             bufferedTerminalChunks: [],
@@ -946,8 +1043,10 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 3_999,
         data: "old-snapshot\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -955,8 +1054,10 @@ describe("dev-server-log-buffer", () => {
     ]);
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 4_000,
       data: "old-live-only\r\n",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -968,8 +1069,10 @@ describe("dev-server-log-buffer", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:2",
-            runOrder: testRunOrder("frontend:2"),
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: testRunOrder("frontend:2"),
+            },
             pid: 5252,
             startedAt: "2026-03-25T10:31:00.000Z",
             bufferedTerminalChunks: [],
@@ -987,8 +1090,10 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 0,
         data: "snapshot\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -996,8 +1101,10 @@ describe("dev-server-log-buffer", () => {
     ]);
     appendDevServerTerminalChunk(store, {
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: 1,
       data: "live-only\r\n",
       timestamp: "2026-03-25T10:00:01.000Z",
@@ -1008,8 +1115,10 @@ describe("dev-server-log-buffer", () => {
       buildState({
         scripts: [
           buildScript({
-            runId: "frontend:1",
-            runOrder: testRunOrder("frontend:1"),
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: testRunOrder("frontend:1"),
+            },
             bufferedTerminalChunks: [],
           }),
         ],
@@ -1020,8 +1129,10 @@ describe("dev-server-log-buffer", () => {
     expect(getDevServerTerminalBuffer(store, "frontend")?.entries).toEqual([
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 1,
         data: "live-only\r\n",
         timestamp: "2026-03-25T10:00:01.000Z",
@@ -1031,8 +1142,10 @@ describe("dev-server-log-buffer", () => {
       shouldReplaceDevServerTerminalBufferFromScript(
         getDevServerTerminalBufferReplacementContext(store, "frontend"),
         buildScript({
-          runId: "frontend:1",
-          runOrder: testRunOrder("frontend:1"),
+          runIdentity: {
+            runId: "frontend:1",
+            runOrder: testRunOrder("frontend:1"),
+          },
           bufferedTerminalChunks: [],
         }),
       ),
@@ -1050,16 +1163,20 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 2,
         data: "latest\r\n",
         timestamp: "2026-03-25T10:00:02.000Z",
       },
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 1,
         data: "older\r\n",
         timestamp: "2026-03-25T10:00:01.000Z",
@@ -1088,8 +1205,10 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "frontend", [
       {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 0,
         data: "stale\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -1098,8 +1217,10 @@ describe("dev-server-log-buffer", () => {
     replaceDevServerTerminalBuffer(store, "removed", [
       {
         scriptId: "removed",
-        runId: "removed:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "removed:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 0,
         data: "removed\r\n",
         timestamp: "2026-03-25T10:00:00.000Z",
@@ -1114,8 +1235,10 @@ describe("dev-server-log-buffer", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
-                runId: "frontend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 sequence: 2,
                 data: "fresh\r\n",
                 timestamp: "2026-03-25T10:02:00.000Z",

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import type { DevServerGroupState, DevServerScriptState } from "@openducktor/contracts";
+import type {
+  DevServerGroupState,
+  DevServerScriptState,
+  DevServerTerminalChunk,
+} from "@openducktor/contracts";
 import {
   appendDevServerTerminalChunk,
   createDevServerTerminalBufferStore,
@@ -32,6 +36,17 @@ const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGrou
   worktreePath: "/tmp/worktree/task-7",
   scripts: [buildScript()],
   updatedAt: "2026-03-25T10:00:00.000Z",
+  ...overrides,
+});
+
+const buildChunk = (
+  sequence: number,
+  overrides: Partial<DevServerTerminalChunk> = {},
+): DevServerTerminalChunk => ({
+  scriptId: "frontend",
+  sequence,
+  data: `line-${sequence}\r\n`,
+  timestamp: `2026-03-25T10:00:${String(sequence % 60).padStart(2, "0")}.000Z`,
   ...overrides,
 });
 
@@ -259,12 +274,24 @@ describe("dev-server-log-buffer", () => {
 
   test("merges a delayed same-run replay prefix with an already observed live suffix", () => {
     const store = createDevServerTerminalBufferStore();
-    appendDevServerTerminalChunk(store, {
-      scriptId: "frontend",
-      sequence: 10,
-      data: "live-10\r\n",
-      timestamp: "2026-03-25T10:00:10.000Z",
-    });
+    syncDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: [
+              buildChunk(10, {
+                data: "live-10\r\n",
+                timestamp: "2026-03-25T10:00:10.000Z",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
 
     const didChange = reconcileDevServerTerminalBufferStore(
       store,
@@ -274,12 +301,9 @@ describe("dev-server-log-buffer", () => {
             status: "running",
             pid: 4242,
             startedAt: "2026-03-25T10:00:00.000Z",
-            bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) => ({
-              scriptId: "frontend",
-              sequence,
-              data: `replay-${sequence}\r\n`,
-              timestamp: `2026-03-25T10:00:${String(sequence).padStart(2, "0")}.000Z`,
-            })),
+            bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
+              buildChunk(sequence, { data: `replay-${sequence}\r\n` }),
+            ),
           }),
         ],
       }),
@@ -301,6 +325,193 @@ describe("dev-server-log-buffer", () => {
       "replay-9\r\n",
       "live-10\r\n",
     ]);
+  });
+
+  test("keeps current-run live output when a delayed previous-run replay arrives", () => {
+    const store = createDevServerTerminalBufferStore();
+    syncDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 5252,
+            startedAt: "2026-03-25T10:10:00.000Z",
+            bufferedTerminalChunks: [
+              buildChunk(10, {
+                data: "new-run-10\r\n",
+                timestamp: "2026-03-25T10:10:10.000Z",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
+              buildChunk(sequence, { data: `old-run-${sequence}\r\n` }),
+            ),
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(false);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual(["new-run-10\r\n"]);
+  });
+
+  test("does not merge equal-startedAt replay from a different process run", () => {
+    const store = createDevServerTerminalBufferStore();
+    syncDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 5252,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: [
+              buildChunk(10, {
+                data: "current-run-10\r\n",
+                timestamp: "2026-03-25T10:00:10.000Z",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
+              buildChunk(sequence, { data: `same-time-old-run-${sequence}\r\n` }),
+            ),
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(false);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => entry.data),
+    ).toEqual(["current-run-10\r\n"]);
+  });
+
+  test("deduplicates overlapping same-run replay while preserving the live suffix", () => {
+    const store = createDevServerTerminalBufferStore();
+    syncDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: Array.from({ length: 6 }, (_, offset) =>
+              buildChunk(5 + offset, { data: `live-${5 + offset}\r\n` }),
+            ),
+          }),
+        ],
+      }),
+    );
+
+    const didChange = reconcileDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: Array.from({ length: 10 }, (_, sequence) =>
+              buildChunk(sequence, { data: `replay-${sequence}\r\n` }),
+            ),
+          }),
+        ],
+      }),
+    );
+
+    expect(didChange).toBe(true);
+    expect(
+      getDevServerTerminalBuffer(store, "frontend")?.entries.map((entry) => [
+        entry.sequence,
+        entry.data,
+      ]),
+    ).toEqual([
+      [0, "replay-0\r\n"],
+      [1, "replay-1\r\n"],
+      [2, "replay-2\r\n"],
+      [3, "replay-3\r\n"],
+      [4, "replay-4\r\n"],
+      [5, "live-5\r\n"],
+      [6, "live-6\r\n"],
+      [7, "live-7\r\n"],
+      [8, "live-8\r\n"],
+      [9, "live-9\r\n"],
+      [10, "live-10\r\n"],
+    ]);
+  });
+
+  test("does not reset again when a capped replay merge is already reflected locally", () => {
+    const store = createDevServerTerminalBufferStore();
+    syncDevServerTerminalBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T10:00:00.000Z",
+            bufferedTerminalChunks: [
+              buildChunk(MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS, {
+                data: "live-2000\r\n",
+                timestamp: "2026-03-25T10:40:00.000Z",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    const cappedReplay = Array.from(
+      { length: MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS },
+      (_, sequence) => buildChunk(sequence, { data: `replay-${sequence}\r\n` }),
+    );
+    const replayState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-25T10:00:00.000Z",
+          bufferedTerminalChunks: cappedReplay,
+        }),
+      ],
+    });
+
+    expect(reconcileDevServerTerminalBufferStore(store, replayState)).toBe(true);
+    const resetTokenAfterMerge = getDevServerTerminalBuffer(store, "frontend")?.resetToken;
+
+    expect(reconcileDevServerTerminalBufferStore(store, replayState)).toBe(false);
+    const buffer = getDevServerTerminalBuffer(store, "frontend");
+    expect(buffer?.resetToken).toBe(resetTokenAfterMerge);
+    expect(buffer?.entries).toHaveLength(MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS);
+    expect(buffer?.entries[0]?.sequence).toBe(1);
+    expect(buffer?.entries.at(-1)?.sequence).toBe(MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS);
   });
 
   test("replaces a populated buffer when an authoritative snapshot clears replay", () => {

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -104,11 +104,7 @@ const EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW: DevServerTerminalSequenceWindow
 const readDevServerScriptRunIdentity = (
   script: DevServerScriptState,
 ): DevServerTerminalRunIdentity => {
-  if (script.startedAt === null || script.pid === null) {
-    return null;
-  }
-
-  return JSON.stringify([script.startedAt, script.pid]);
+  return script.runId;
 };
 
 const readSnapshotBufferWindow = (
@@ -142,6 +138,7 @@ const areTerminalChunksEqual = (
     return (
       other !== undefined &&
       chunk.scriptId === other.scriptId &&
+      chunk.runId === other.runId &&
       chunk.sequence === other.sequence &&
       chunk.data === other.data &&
       chunk.timestamp === other.timestamp
@@ -181,7 +178,14 @@ export const appendDevServerTerminalChunk = (
   store: DevServerTerminalBufferStore,
   terminalChunk: DevServerTerminalChunk,
 ): void => {
-  const buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
+  let buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
+  if (buffer.runIdentity !== null && buffer.runIdentity !== terminalChunk.runId) {
+    replaceDevServerTerminalBuffer(store, terminalChunk.scriptId, [], terminalChunk.runId);
+    buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
+  } else {
+    buffer.runIdentity = terminalChunk.runId;
+  }
+
   if (buffer.lastSequence !== null && terminalChunk.sequence <= buffer.lastSequence) {
     return;
   }

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -29,7 +29,6 @@ type DevServerTerminalRunIdentity = {
 export type DevServerTerminalBufferReplacementContext = {
   current: DevServerTerminalSequenceWindow;
   currentEntries: readonly AgentStudioDevServerTerminalChunkEntry[];
-  retiredHostInstanceIds: ReadonlySet<string>;
   runIdentity: DevServerTerminalRunIdentity;
   snapshot: DevServerTerminalSequenceWindow;
 };
@@ -48,7 +47,6 @@ type DevServerTerminalBufferState = {
   size: number;
   lastSequence: number | null;
   resetToken: number;
-  retiredHostInstanceIds: Set<string>;
   runIdentity: DevServerTerminalRunIdentity;
   snapshotEntryCount: number;
 };
@@ -194,7 +192,6 @@ const createDevServerTerminalBufferState = (): DevServerTerminalBufferState => (
   size: 0,
   lastSequence: null,
   resetToken: 0,
-  retiredHostInstanceIds: new Set(),
   runIdentity: null,
   snapshotEntryCount: 0,
 });
@@ -218,13 +215,17 @@ export const createDevServerTerminalBufferStore = (): DevServerTerminalBufferSto
 export const appendDevServerTerminalChunk = (
   store: DevServerTerminalBufferStore,
   terminalChunk: DevServerTerminalChunk,
-): void => {
-  let buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
+): boolean => {
   const nextRunIdentity = readDevServerTerminalChunkRunIdentity(terminalChunk);
+  if (!canApplyDevServerHostInstanceId(store, nextRunIdentity.runOrder.hostInstanceId)) {
+    return false;
+  }
+
+  let buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
   if (!areRunIdentitiesEqual(buffer.runIdentity, nextRunIdentity)) {
     const runOrder = compareDevServerRunIdentity(buffer, nextRunIdentity);
     if (runOrder !== "newer") {
-      return;
+      return false;
     }
     replaceDevServerTerminalBuffer(store, terminalChunk.scriptId, [], nextRunIdentity);
     buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
@@ -233,7 +234,7 @@ export const appendDevServerTerminalChunk = (
   }
 
   if (buffer.lastSequence !== null && terminalChunk.sequence <= buffer.lastSequence) {
-    return;
+    return false;
   }
 
   if (buffer.size < MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS) {
@@ -246,6 +247,7 @@ export const appendDevServerTerminalChunk = (
   }
 
   buffer.lastSequence = terminalChunk.sequence;
+  return true;
 };
 
 export const replaceDevServerTerminalBuffer = (
@@ -266,13 +268,6 @@ export const replaceDevServerTerminalBuffer = (
   buffer.lastSequence = null;
   buffer.firstSnapshotSequence = null;
   buffer.lastSnapshotSequence = null;
-  if (
-    buffer.runIdentity !== null &&
-    runIdentity !== null &&
-    buffer.runIdentity.runOrder.hostInstanceId !== runIdentity.runOrder.hostInstanceId
-  ) {
-    buffer.retiredHostInstanceIds.add(buffer.runIdentity.runOrder.hostInstanceId);
-  }
   buffer.runIdentity = runIdentity;
   if (shouldResetTerminal) {
     buffer.resetToken += 1;
@@ -346,7 +341,6 @@ export const getDevServerTerminalBufferReplacementContext = (
   return {
     current: readCurrentBufferWindow(buffer),
     currentEntries: readCurrentBufferEntries(buffer),
-    retiredHostInstanceIds: new Set(buffer.retiredHostInstanceIds),
     runIdentity: buffer.runIdentity,
     snapshot: readSnapshotBufferWindow(buffer),
   };
@@ -372,13 +366,10 @@ export const getDevServerTerminalBuffer = (
   };
 };
 
-type DevServerRunOrderRelation = "newer" | "older" | "same";
+type DevServerRunOrderRelation = "foreign" | "newer" | "older" | "same";
 
 const compareDevServerRunIdentity = (
-  context: {
-    retiredHostInstanceIds: ReadonlySet<string>;
-    runIdentity: DevServerTerminalRunIdentity;
-  },
+  context: { runIdentity: DevServerTerminalRunIdentity },
   candidate: DevServerTerminalRunIdentity,
 ): DevServerRunOrderRelation => {
   const current = context.runIdentity;
@@ -391,11 +382,8 @@ const compareDevServerRunIdentity = (
   if (current === null) {
     return "newer";
   }
-  if (context.retiredHostInstanceIds.has(candidate.runOrder.hostInstanceId)) {
-    return "older";
-  }
   if (candidate.runOrder.hostInstanceId !== current.runOrder.hostInstanceId) {
-    return "newer";
+    return "foreign";
   }
   if (candidate.runOrder.generation === current.runOrder.generation) {
     throw new Error(
@@ -403,6 +391,87 @@ const compareDevServerRunIdentity = (
     );
   }
   return candidate.runOrder.generation > current.runOrder.generation ? "newer" : "older";
+};
+
+export const canApplyDevServerScriptState = (
+  currentContext: DevServerTerminalBufferReplacementContext | null,
+  script: DevServerScriptState,
+): boolean => {
+  if (currentContext === null) {
+    return true;
+  }
+
+  const relation = compareDevServerRunIdentity(
+    currentContext,
+    readDevServerScriptRunIdentity(script),
+  );
+  return relation === "same" || relation === "newer";
+};
+
+const readDevServerStoreHostInstanceId = (store: DevServerTerminalBufferStore): string | null => {
+  const hostInstanceIds = new Set<string>();
+  for (const buffer of store.values()) {
+    if (buffer.runIdentity !== null) {
+      hostInstanceIds.add(buffer.runIdentity.runOrder.hostInstanceId);
+    }
+  }
+
+  if (hostInstanceIds.size > 1) {
+    throw new Error("Dev server terminal buffers contain conflicting host ownership.");
+  }
+
+  return hostInstanceIds.values().next().value ?? null;
+};
+
+const canApplyDevServerHostInstanceId = (
+  store: DevServerTerminalBufferStore,
+  candidateHostInstanceId: string,
+): boolean => {
+  const currentHostInstanceId = readDevServerStoreHostInstanceId(store);
+  return currentHostInstanceId === null || currentHostInstanceId === candidateHostInstanceId;
+};
+
+export const canApplyDevServerScriptStateToStore = (
+  store: DevServerTerminalBufferStore,
+  script: DevServerScriptState,
+): boolean => {
+  if (
+    script.runOrder !== null &&
+    !canApplyDevServerHostInstanceId(store, script.runOrder.hostInstanceId)
+  ) {
+    return false;
+  }
+
+  return canApplyDevServerScriptState(
+    getDevServerTerminalBufferReplacementContext(store, script.scriptId),
+    script,
+  );
+};
+
+export const canApplyDevServerGroupState = (
+  store: DevServerTerminalBufferStore,
+  state: DevServerGroupState,
+): boolean => {
+  const candidateHostInstanceIds = new Set<string>();
+  for (const script of state.scripts) {
+    if (script.runOrder !== null) {
+      candidateHostInstanceIds.add(script.runOrder.hostInstanceId);
+    }
+  }
+
+  if (candidateHostInstanceIds.size > 1) {
+    throw new Error("Dev server group state contains conflicting host ownership.");
+  }
+
+  const candidateHostInstanceId = candidateHostInstanceIds.values().next().value ?? null;
+  if (
+    candidateHostInstanceId !== null &&
+    !canApplyDevServerHostInstanceId(store, candidateHostInstanceId)
+  ) {
+    return false;
+  }
+
+  return state.scripts.every((script) => canApplyDevServerScriptStateToStore(store, script));
 };
 
 const shouldMergeSameRunReplayPrefix = (
@@ -486,7 +555,7 @@ export const getDevServerTerminalBufferReplacement = (
   }
 
   const runOrder = compareDevServerRunIdentity(currentContext, nextRunIdentity);
-  if (runOrder === "older") {
+  if (runOrder === "older" || runOrder === "foreign") {
     return null;
   }
   if (runOrder === "newer") {
@@ -597,6 +666,10 @@ export const reconcileDevServerTerminalBufferStore = (
   store: DevServerTerminalBufferStore,
   state: DevServerGroupState,
 ): boolean => {
+  if (!canApplyDevServerGroupState(store, state)) {
+    return false;
+  }
+
   let didChange = false;
   const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
 

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -1,5 +1,6 @@
 import type {
   DevServerGroupState,
+  DevServerRunOrder,
   DevServerScriptState,
   DevServerTerminalChunk,
 } from "@openducktor/contracts";
@@ -20,11 +21,15 @@ type DevServerTerminalSequenceWindow = {
   lastSequence: number | null;
 };
 
-type DevServerTerminalRunIdentity = string | null;
+type DevServerTerminalRunIdentity = {
+  runId: string;
+  runOrder: DevServerRunOrder;
+} | null;
 
 export type DevServerTerminalBufferReplacementContext = {
   current: DevServerTerminalSequenceWindow;
   currentEntries: readonly AgentStudioDevServerTerminalChunkEntry[];
+  retiredHostInstanceIds: ReadonlySet<string>;
   runIdentity: DevServerTerminalRunIdentity;
   snapshot: DevServerTerminalSequenceWindow;
 };
@@ -43,6 +48,7 @@ type DevServerTerminalBufferState = {
   size: number;
   lastSequence: number | null;
   resetToken: number;
+  retiredHostInstanceIds: Set<string>;
   runIdentity: DevServerTerminalRunIdentity;
   snapshotEntryCount: number;
 };
@@ -104,7 +110,39 @@ const EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW: DevServerTerminalSequenceWindow
 const readDevServerScriptRunIdentity = (
   script: DevServerScriptState,
 ): DevServerTerminalRunIdentity => {
-  return script.runId;
+  if (script.runId === null && script.runOrder === null) {
+    return null;
+  }
+  if (script.runId === null || script.runOrder === null) {
+    throw new Error(`Dev server script ${script.scriptId} has incomplete run ownership.`);
+  }
+  return { runId: script.runId, runOrder: script.runOrder };
+};
+
+const readDevServerTerminalChunkRunIdentity = (
+  chunk: DevServerTerminalChunk,
+): Exclude<DevServerTerminalRunIdentity, null> => ({
+  runId: chunk.runId,
+  runOrder: chunk.runOrder,
+});
+
+const areRunIdentitiesEqual = (
+  left: DevServerTerminalRunIdentity,
+  right: DevServerTerminalRunIdentity,
+): boolean => {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  if (left.runId !== right.runId) {
+    return false;
+  }
+  if (
+    left.runOrder.hostInstanceId !== right.runOrder.hostInstanceId ||
+    left.runOrder.generation !== right.runOrder.generation
+  ) {
+    throw new Error(`Dev server run ${left.runId} has conflicting order metadata.`);
+  }
+  return true;
 };
 
 const readSnapshotBufferWindow = (
@@ -139,6 +177,8 @@ const areTerminalChunksEqual = (
       other !== undefined &&
       chunk.scriptId === other.scriptId &&
       chunk.runId === other.runId &&
+      chunk.runOrder.hostInstanceId === other.runOrder.hostInstanceId &&
+      chunk.runOrder.generation === other.runOrder.generation &&
       chunk.sequence === other.sequence &&
       chunk.data === other.data &&
       chunk.timestamp === other.timestamp
@@ -154,6 +194,7 @@ const createDevServerTerminalBufferState = (): DevServerTerminalBufferState => (
   size: 0,
   lastSequence: null,
   resetToken: 0,
+  retiredHostInstanceIds: new Set(),
   runIdentity: null,
   snapshotEntryCount: 0,
 });
@@ -179,11 +220,16 @@ export const appendDevServerTerminalChunk = (
   terminalChunk: DevServerTerminalChunk,
 ): void => {
   let buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
-  if (buffer.runIdentity !== null && buffer.runIdentity !== terminalChunk.runId) {
-    replaceDevServerTerminalBuffer(store, terminalChunk.scriptId, [], terminalChunk.runId);
+  const nextRunIdentity = readDevServerTerminalChunkRunIdentity(terminalChunk);
+  if (!areRunIdentitiesEqual(buffer.runIdentity, nextRunIdentity)) {
+    const runOrder = compareDevServerRunIdentity(buffer, nextRunIdentity);
+    if (runOrder !== "newer") {
+      return;
+    }
+    replaceDevServerTerminalBuffer(store, terminalChunk.scriptId, [], nextRunIdentity);
     buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
   } else {
-    buffer.runIdentity = terminalChunk.runId;
+    buffer.runIdentity = nextRunIdentity;
   }
 
   if (buffer.lastSequence !== null && terminalChunk.sequence <= buffer.lastSequence) {
@@ -206,7 +252,9 @@ export const replaceDevServerTerminalBuffer = (
   store: DevServerTerminalBufferStore,
   scriptId: string,
   terminalChunks: DevServerTerminalChunk[],
-  runIdentity: DevServerTerminalRunIdentity = null,
+  runIdentity: DevServerTerminalRunIdentity = terminalChunks[0]
+    ? readDevServerTerminalChunkRunIdentity(terminalChunks[0])
+    : null,
 ): void => {
   const buffer = getOrCreateDevServerTerminalBufferState(store, scriptId);
   const trimmedChunks = trimDevServerTerminalChunks(terminalChunks);
@@ -218,6 +266,13 @@ export const replaceDevServerTerminalBuffer = (
   buffer.lastSequence = null;
   buffer.firstSnapshotSequence = null;
   buffer.lastSnapshotSequence = null;
+  if (
+    buffer.runIdentity !== null &&
+    runIdentity !== null &&
+    buffer.runIdentity.runOrder.hostInstanceId !== runIdentity.runOrder.hostInstanceId
+  ) {
+    buffer.retiredHostInstanceIds.add(buffer.runIdentity.runOrder.hostInstanceId);
+  }
   buffer.runIdentity = runIdentity;
   if (shouldResetTerminal) {
     buffer.resetToken += 1;
@@ -291,6 +346,7 @@ export const getDevServerTerminalBufferReplacementContext = (
   return {
     current: readCurrentBufferWindow(buffer),
     currentEntries: readCurrentBufferEntries(buffer),
+    retiredHostInstanceIds: new Set(buffer.retiredHostInstanceIds),
     runIdentity: buffer.runIdentity,
     snapshot: readSnapshotBufferWindow(buffer),
   };
@@ -316,21 +372,37 @@ export const getDevServerTerminalBuffer = (
   };
 };
 
-const isLaterTimestamp = (candidate: string | null, baseline: string | null): boolean => {
-  return candidate !== null && baseline !== null && candidate > baseline;
-};
+type DevServerRunOrderRelation = "newer" | "older" | "same";
 
-const isNewerRunSnapshot = (
-  currentContext: DevServerTerminalBufferReplacementContext,
-  script: DevServerScriptState,
-  nextChunks: readonly DevServerTerminalChunk[],
-): boolean => {
-  const currentLastTimestamp = currentContext.currentEntries.at(-1)?.timestamp ?? null;
-  const nextFirstTimestamp = nextChunks[0]?.timestamp ?? null;
-  return (
-    isLaterTimestamp(nextFirstTimestamp, currentLastTimestamp) ||
-    isLaterTimestamp(script.startedAt, currentLastTimestamp)
-  );
+const compareDevServerRunIdentity = (
+  context: {
+    retiredHostInstanceIds: ReadonlySet<string>;
+    runIdentity: DevServerTerminalRunIdentity;
+  },
+  candidate: DevServerTerminalRunIdentity,
+): DevServerRunOrderRelation => {
+  const current = context.runIdentity;
+  if (areRunIdentitiesEqual(current, candidate)) {
+    return "same";
+  }
+  if (candidate === null) {
+    return "older";
+  }
+  if (current === null) {
+    return "newer";
+  }
+  if (context.retiredHostInstanceIds.has(candidate.runOrder.hostInstanceId)) {
+    return "older";
+  }
+  if (candidate.runOrder.hostInstanceId !== current.runOrder.hostInstanceId) {
+    return "newer";
+  }
+  if (candidate.runOrder.generation === current.runOrder.generation) {
+    throw new Error(
+      `Dev server runs ${current.runId} and ${candidate.runId} share generation ${candidate.runOrder.generation}.`,
+    );
+  }
+  return candidate.runOrder.generation > current.runOrder.generation ? "newer" : "older";
 };
 
 const shouldMergeSameRunReplayPrefix = (
@@ -341,7 +413,7 @@ const shouldMergeSameRunReplayPrefix = (
   if (
     currentContext.runIdentity === null ||
     nextRunIdentity === null ||
-    currentContext.runIdentity !== nextRunIdentity
+    !areRunIdentitiesEqual(currentContext.runIdentity, nextRunIdentity)
   ) {
     return false;
   }
@@ -382,7 +454,7 @@ const createDevServerTerminalBufferReplacement = (
 ): DevServerTerminalBufferReplacement | null => {
   if (
     currentContext &&
-    currentContext.runIdentity === runIdentity &&
+    areRunIdentitiesEqual(currentContext.runIdentity, runIdentity) &&
     areSequenceWindowsEqual(currentContext.snapshot, snapshotWindow) &&
     areTerminalChunksEqual(terminalChunks, currentContext.currentEntries)
   ) {
@@ -413,6 +485,19 @@ export const getDevServerTerminalBufferReplacement = (
     );
   }
 
+  const runOrder = compareDevServerRunIdentity(currentContext, nextRunIdentity);
+  if (runOrder === "older") {
+    return null;
+  }
+  if (runOrder === "newer") {
+    return createDevServerTerminalBufferReplacement(
+      currentContext,
+      nextWindow,
+      nextChunks,
+      nextRunIdentity,
+    );
+  }
+
   const currentWindow = currentContext.current;
   const currentBufferMirrorsSnapshot =
     currentWindow.count === currentContext.snapshot.count &&
@@ -420,15 +505,6 @@ export const getDevServerTerminalBufferReplacement = (
     currentWindow.lastSequence === currentContext.snapshot.lastSequence;
 
   if (nextWindow.lastSequence === null) {
-    if (isNewerRunSnapshot(currentContext, script, nextChunks)) {
-      return createDevServerTerminalBufferReplacement(
-        currentContext,
-        nextWindow,
-        nextChunks,
-        nextRunIdentity,
-      );
-    }
-
     if (currentWindow.count === 0 || currentContext.snapshot.lastSequence === null) {
       return null;
     }
@@ -473,14 +549,6 @@ export const getDevServerTerminalBufferReplacement = (
   }
 
   if (nextWindow.lastSequence > currentWindow.lastSequence) {
-    if (
-      currentContext.runIdentity !== null &&
-      currentContext.runIdentity !== nextRunIdentity &&
-      !isNewerRunSnapshot(currentContext, script, nextChunks)
-    ) {
-      return null;
-    }
-
     return createDevServerTerminalBufferReplacement(
       currentContext,
       nextWindow,
@@ -490,15 +558,6 @@ export const getDevServerTerminalBufferReplacement = (
   }
 
   if (nextWindow.lastSequence < currentWindow.lastSequence) {
-    if (isNewerRunSnapshot(currentContext, script, nextChunks)) {
-      return createDevServerTerminalBufferReplacement(
-        currentContext,
-        nextWindow,
-        nextChunks,
-        nextRunIdentity,
-      );
-    }
-
     if (shouldMergeSameRunReplayPrefix(currentContext, nextRunIdentity, nextWindow)) {
       return createDevServerTerminalBufferReplacement(
         currentContext,
@@ -514,16 +573,8 @@ export const getDevServerTerminalBufferReplacement = (
   if (
     nextWindow.count !== currentWindow.count ||
     nextWindow.firstSequence !== currentWindow.firstSequence ||
-    nextRunIdentity !== currentContext.runIdentity
+    !areRunIdentitiesEqual(nextRunIdentity, currentContext.runIdentity)
   ) {
-    if (
-      currentContext.runIdentity !== null &&
-      currentContext.runIdentity !== nextRunIdentity &&
-      !isNewerRunSnapshot(currentContext, script, nextChunks)
-    ) {
-      return null;
-    }
-
     return createDevServerTerminalBufferReplacement(
       currentContext,
       nextWindow,

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -258,21 +258,11 @@ const isLaterTimestamp = (candidate: string | null, baseline: string | null): bo
   return candidate !== null && baseline !== null && candidate > baseline;
 };
 
-const isLaterSequenceResetSnapshot = (
+const isNewerRunSnapshot = (
   currentContext: DevServerTerminalBufferReplacementContext,
   script: DevServerScriptState,
   nextChunks: readonly DevServerTerminalChunk[],
-  nextWindow: DevServerTerminalSequenceWindow,
 ): boolean => {
-  if (
-    nextWindow.firstSequence !== 0 ||
-    nextWindow.lastSequence === null ||
-    currentContext.current.lastSequence === null ||
-    nextWindow.lastSequence >= currentContext.current.lastSequence
-  ) {
-    return false;
-  }
-
   const currentLastTimestamp = currentContext.currentEntries.at(-1)?.timestamp ?? null;
   const nextFirstTimestamp = nextChunks[0]?.timestamp ?? null;
   return (
@@ -303,6 +293,13 @@ export const getDevServerTerminalBufferReplacement = (
 
   if (nextWindow.lastSequence === null) {
     if (currentWindow.count === 0 || currentContext.snapshot.lastSequence === null) {
+      if (isNewerRunSnapshot(currentContext, script, nextChunks)) {
+        return {
+          snapshotWindow: nextWindow,
+          terminalChunks: nextChunks,
+        };
+      }
+
       return null;
     }
 
@@ -345,7 +342,7 @@ export const getDevServerTerminalBufferReplacement = (
   }
 
   if (nextWindow.lastSequence < currentWindow.lastSequence) {
-    if (isLaterSequenceResetSnapshot(currentContext, script, nextChunks, nextWindow)) {
+    if (isNewerRunSnapshot(currentContext, script, nextChunks)) {
       return {
         snapshotWindow: nextWindow,
         terminalChunks: nextChunks,

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -271,6 +271,43 @@ const isNewerRunSnapshot = (
   );
 };
 
+const shouldMergeSameRunReplayPrefix = (
+  currentContext: DevServerTerminalBufferReplacementContext,
+  script: DevServerScriptState,
+  nextWindow: DevServerTerminalSequenceWindow,
+): boolean => {
+  if (script.startedAt === null) {
+    return false;
+  }
+
+  if (
+    nextWindow.firstSequence === null ||
+    nextWindow.lastSequence === null ||
+    currentContext.current.firstSequence === null
+  ) {
+    return false;
+  }
+
+  return nextWindow.firstSequence <= currentContext.current.firstSequence;
+};
+
+const mergeReplayPrefixWithCurrentEntries = (
+  nextChunks: readonly DevServerTerminalChunk[],
+  currentEntries: readonly AgentStudioDevServerTerminalChunkEntry[],
+): DevServerTerminalChunk[] => {
+  const chunksBySequence = new Map<number, DevServerTerminalChunk>();
+  for (const chunk of nextChunks) {
+    chunksBySequence.set(chunk.sequence, chunk);
+  }
+  for (const chunk of currentEntries) {
+    chunksBySequence.set(chunk.sequence, chunk);
+  }
+
+  return trimDevServerTerminalChunks(
+    [...chunksBySequence.values()].sort((left, right) => left.sequence - right.sequence),
+  );
+};
+
 export const getDevServerTerminalBufferReplacement = (
   currentContext: DevServerTerminalBufferReplacementContext | null,
   script: DevServerScriptState,
@@ -346,6 +383,16 @@ export const getDevServerTerminalBufferReplacement = (
       return {
         snapshotWindow: nextWindow,
         terminalChunks: nextChunks,
+      };
+    }
+
+    if (shouldMergeSameRunReplayPrefix(currentContext, script, nextWindow)) {
+      return {
+        snapshotWindow: nextWindow,
+        terminalChunks: mergeReplayPrefixWithCurrentEntries(
+          nextChunks,
+          currentContext.currentEntries,
+        ),
       };
     }
 

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -20,13 +20,17 @@ type DevServerTerminalSequenceWindow = {
   lastSequence: number | null;
 };
 
+type DevServerTerminalRunIdentity = string | null;
+
 export type DevServerTerminalBufferReplacementContext = {
   current: DevServerTerminalSequenceWindow;
   currentEntries: readonly AgentStudioDevServerTerminalChunkEntry[];
+  runIdentity: DevServerTerminalRunIdentity;
   snapshot: DevServerTerminalSequenceWindow;
 };
 
 export type DevServerTerminalBufferReplacement = {
+  runIdentity: DevServerTerminalRunIdentity;
   snapshotWindow: DevServerTerminalSequenceWindow;
   terminalChunks: readonly DevServerTerminalChunk[];
 };
@@ -39,6 +43,7 @@ type DevServerTerminalBufferState = {
   size: number;
   lastSequence: number | null;
   resetToken: number;
+  runIdentity: DevServerTerminalRunIdentity;
   snapshotEntryCount: number;
 };
 
@@ -96,6 +101,16 @@ const EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW: DevServerTerminalSequenceWindow
   lastSequence: null,
 };
 
+const readDevServerScriptRunIdentity = (
+  script: DevServerScriptState,
+): DevServerTerminalRunIdentity => {
+  if (script.startedAt === null || script.pid === null) {
+    return null;
+  }
+
+  return JSON.stringify([script.startedAt, script.pid]);
+};
+
 const readSnapshotBufferWindow = (
   buffer: DevServerTerminalBufferState,
 ): DevServerTerminalSequenceWindow => {
@@ -106,6 +121,34 @@ const readSnapshotBufferWindow = (
   };
 };
 
+const areSequenceWindowsEqual = (
+  left: DevServerTerminalSequenceWindow,
+  right: DevServerTerminalSequenceWindow,
+): boolean =>
+  left.count === right.count &&
+  left.firstSequence === right.firstSequence &&
+  left.lastSequence === right.lastSequence;
+
+const areTerminalChunksEqual = (
+  left: readonly DevServerTerminalChunk[],
+  right: readonly AgentStudioDevServerTerminalChunkEntry[],
+): boolean => {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((chunk, index) => {
+    const other = right[index];
+    return (
+      other !== undefined &&
+      chunk.scriptId === other.scriptId &&
+      chunk.sequence === other.sequence &&
+      chunk.data === other.data &&
+      chunk.timestamp === other.timestamp
+    );
+  });
+};
+
 const createDevServerTerminalBufferState = (): DevServerTerminalBufferState => ({
   entries: [],
   firstSnapshotSequence: null,
@@ -114,6 +157,7 @@ const createDevServerTerminalBufferState = (): DevServerTerminalBufferState => (
   size: 0,
   lastSequence: null,
   resetToken: 0,
+  runIdentity: null,
   snapshotEntryCount: 0,
 });
 
@@ -158,6 +202,7 @@ export const replaceDevServerTerminalBuffer = (
   store: DevServerTerminalBufferStore,
   scriptId: string,
   terminalChunks: DevServerTerminalChunk[],
+  runIdentity: DevServerTerminalRunIdentity = null,
 ): void => {
   const buffer = getOrCreateDevServerTerminalBufferState(store, scriptId);
   const trimmedChunks = trimDevServerTerminalChunks(terminalChunks);
@@ -169,6 +214,7 @@ export const replaceDevServerTerminalBuffer = (
   buffer.lastSequence = null;
   buffer.firstSnapshotSequence = null;
   buffer.lastSnapshotSequence = null;
+  buffer.runIdentity = runIdentity;
   if (shouldResetTerminal) {
     buffer.resetToken += 1;
   }
@@ -189,11 +235,17 @@ export const applyDevServerTerminalBufferReplacement = (
   scriptId: string,
   replacement: DevServerTerminalBufferReplacement,
 ): void => {
-  replaceDevServerTerminalBuffer(store, scriptId, [...replacement.terminalChunks]);
+  replaceDevServerTerminalBuffer(
+    store,
+    scriptId,
+    [...replacement.terminalChunks],
+    replacement.runIdentity,
+  );
 
   const buffer = getOrCreateDevServerTerminalBufferState(store, scriptId);
   buffer.firstSnapshotSequence = replacement.snapshotWindow.firstSequence;
   buffer.lastSnapshotSequence = replacement.snapshotWindow.lastSequence;
+  buffer.runIdentity = replacement.runIdentity;
   buffer.snapshotEntryCount = replacement.snapshotWindow.count;
 };
 
@@ -214,7 +266,12 @@ export const syncDevServerTerminalBufferStore = (
   }
 
   for (const script of state.scripts) {
-    replaceDevServerTerminalBuffer(store, script.scriptId, script.bufferedTerminalChunks);
+    replaceDevServerTerminalBuffer(
+      store,
+      script.scriptId,
+      script.bufferedTerminalChunks,
+      readDevServerScriptRunIdentity(script),
+    );
   }
 };
 
@@ -230,6 +287,7 @@ export const getDevServerTerminalBufferReplacementContext = (
   return {
     current: readCurrentBufferWindow(buffer),
     currentEntries: readCurrentBufferEntries(buffer),
+    runIdentity: buffer.runIdentity,
     snapshot: readSnapshotBufferWindow(buffer),
   };
 };
@@ -273,10 +331,14 @@ const isNewerRunSnapshot = (
 
 const shouldMergeSameRunReplayPrefix = (
   currentContext: DevServerTerminalBufferReplacementContext,
-  script: DevServerScriptState,
+  nextRunIdentity: DevServerTerminalRunIdentity,
   nextWindow: DevServerTerminalSequenceWindow,
 ): boolean => {
-  if (script.startedAt === null) {
+  if (
+    currentContext.runIdentity === null ||
+    nextRunIdentity === null ||
+    currentContext.runIdentity !== nextRunIdentity
+  ) {
     return false;
   }
 
@@ -308,18 +370,43 @@ const mergeReplayPrefixWithCurrentEntries = (
   );
 };
 
+const createDevServerTerminalBufferReplacement = (
+  currentContext: DevServerTerminalBufferReplacementContext | null,
+  snapshotWindow: DevServerTerminalSequenceWindow,
+  terminalChunks: readonly DevServerTerminalChunk[],
+  runIdentity: DevServerTerminalRunIdentity,
+): DevServerTerminalBufferReplacement | null => {
+  if (
+    currentContext &&
+    currentContext.runIdentity === runIdentity &&
+    areSequenceWindowsEqual(currentContext.snapshot, snapshotWindow) &&
+    areTerminalChunksEqual(terminalChunks, currentContext.currentEntries)
+  ) {
+    return null;
+  }
+
+  return {
+    runIdentity,
+    snapshotWindow,
+    terminalChunks,
+  };
+};
+
 export const getDevServerTerminalBufferReplacement = (
   currentContext: DevServerTerminalBufferReplacementContext | null,
   script: DevServerScriptState,
 ): DevServerTerminalBufferReplacement | null => {
   const nextChunks = trimDevServerTerminalChunks(script.bufferedTerminalChunks);
   const nextWindow = readBufferedSequenceWindow(nextChunks);
+  const nextRunIdentity = readDevServerScriptRunIdentity(script);
 
   if (currentContext === null) {
-    return {
-      snapshotWindow: nextWindow,
-      terminalChunks: nextChunks,
-    };
+    return createDevServerTerminalBufferReplacement(
+      currentContext,
+      nextWindow,
+      nextChunks,
+      nextRunIdentity,
+    );
   }
 
   const currentWindow = currentContext.current;
@@ -330,10 +417,12 @@ export const getDevServerTerminalBufferReplacement = (
 
   if (nextWindow.lastSequence === null) {
     if (isNewerRunSnapshot(currentContext, script, nextChunks)) {
-      return {
-        snapshotWindow: nextWindow,
-        terminalChunks: nextChunks,
-      };
+      return createDevServerTerminalBufferReplacement(
+        currentContext,
+        nextWindow,
+        nextChunks,
+        nextRunIdentity,
+      );
     }
 
     if (currentWindow.count === 0 || currentContext.snapshot.lastSequence === null) {
@@ -345,55 +434,74 @@ export const getDevServerTerminalBufferReplacement = (
       (chunk) => chunk.sequence > snapshotLastSequence,
     );
     if (liveOnlyChunks.length > 0) {
-      return {
-        snapshotWindow: EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW,
-        terminalChunks: trimDevServerTerminalChunks([...liveOnlyChunks]),
-      };
+      return createDevServerTerminalBufferReplacement(
+        currentContext,
+        EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW,
+        trimDevServerTerminalChunks([...liveOnlyChunks]),
+        currentContext.runIdentity,
+      );
     }
 
     if (!currentBufferMirrorsSnapshot) {
-      return {
-        snapshotWindow: EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW,
-        terminalChunks: [],
-      };
+      return createDevServerTerminalBufferReplacement(
+        currentContext,
+        EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW,
+        [],
+        currentContext.runIdentity,
+      );
     }
 
-    return {
-      snapshotWindow: nextWindow,
-      terminalChunks: nextChunks,
-    };
+    return createDevServerTerminalBufferReplacement(
+      currentContext,
+      nextWindow,
+      nextChunks,
+      nextRunIdentity,
+    );
   }
 
   if (currentWindow.lastSequence === null) {
-    return {
-      snapshotWindow: nextWindow,
-      terminalChunks: nextChunks,
-    };
+    return createDevServerTerminalBufferReplacement(
+      currentContext,
+      nextWindow,
+      nextChunks,
+      nextRunIdentity,
+    );
   }
 
   if (nextWindow.lastSequence > currentWindow.lastSequence) {
-    return {
-      snapshotWindow: nextWindow,
-      terminalChunks: nextChunks,
-    };
+    if (
+      currentContext.runIdentity !== null &&
+      currentContext.runIdentity !== nextRunIdentity &&
+      !isNewerRunSnapshot(currentContext, script, nextChunks)
+    ) {
+      return null;
+    }
+
+    return createDevServerTerminalBufferReplacement(
+      currentContext,
+      nextWindow,
+      nextChunks,
+      nextRunIdentity,
+    );
   }
 
   if (nextWindow.lastSequence < currentWindow.lastSequence) {
     if (isNewerRunSnapshot(currentContext, script, nextChunks)) {
-      return {
-        snapshotWindow: nextWindow,
-        terminalChunks: nextChunks,
-      };
+      return createDevServerTerminalBufferReplacement(
+        currentContext,
+        nextWindow,
+        nextChunks,
+        nextRunIdentity,
+      );
     }
 
-    if (shouldMergeSameRunReplayPrefix(currentContext, script, nextWindow)) {
-      return {
-        snapshotWindow: nextWindow,
-        terminalChunks: mergeReplayPrefixWithCurrentEntries(
-          nextChunks,
-          currentContext.currentEntries,
-        ),
-      };
+    if (shouldMergeSameRunReplayPrefix(currentContext, nextRunIdentity, nextWindow)) {
+      return createDevServerTerminalBufferReplacement(
+        currentContext,
+        nextWindow,
+        mergeReplayPrefixWithCurrentEntries(nextChunks, currentContext.currentEntries),
+        nextRunIdentity,
+      );
     }
 
     return null;
@@ -401,12 +509,23 @@ export const getDevServerTerminalBufferReplacement = (
 
   if (
     nextWindow.count !== currentWindow.count ||
-    nextWindow.firstSequence !== currentWindow.firstSequence
+    nextWindow.firstSequence !== currentWindow.firstSequence ||
+    nextRunIdentity !== currentContext.runIdentity
   ) {
-    return {
-      snapshotWindow: nextWindow,
-      terminalChunks: nextChunks,
-    };
+    if (
+      currentContext.runIdentity !== null &&
+      currentContext.runIdentity !== nextRunIdentity &&
+      !isNewerRunSnapshot(currentContext, script, nextChunks)
+    ) {
+      return null;
+    }
+
+    return createDevServerTerminalBufferReplacement(
+      currentContext,
+      nextWindow,
+      nextChunks,
+      nextRunIdentity,
+    );
   }
 
   return null;

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -292,14 +292,14 @@ export const getDevServerTerminalBufferReplacement = (
     currentWindow.lastSequence === currentContext.snapshot.lastSequence;
 
   if (nextWindow.lastSequence === null) {
-    if (currentWindow.count === 0 || currentContext.snapshot.lastSequence === null) {
-      if (isNewerRunSnapshot(currentContext, script, nextChunks)) {
-        return {
-          snapshotWindow: nextWindow,
-          terminalChunks: nextChunks,
-        };
-      }
+    if (isNewerRunSnapshot(currentContext, script, nextChunks)) {
+      return {
+        snapshotWindow: nextWindow,
+        terminalChunks: nextChunks,
+      };
+    }
 
+    if (currentWindow.count === 0 || currentContext.snapshot.lastSequence === null) {
       return null;
     }
 

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -1,9 +1,15 @@
 import type {
   DevServerGroupState,
-  DevServerRunOrder,
+  DevServerRunIdentity,
   DevServerScriptState,
   DevServerTerminalChunk,
 } from "@openducktor/contracts";
+import {
+  areDevServerRunIdentitiesEqual,
+  canApplyDevServerGroupState,
+  canApplyDevServerRunIdentityToStore,
+  compareDevServerRunIdentity,
+} from "./dev-server-run-ownership";
 
 export const MAX_BUFFERED_DEV_SERVER_TERMINAL_CHUNKS = 2_000;
 
@@ -21,20 +27,15 @@ type DevServerTerminalSequenceWindow = {
   lastSequence: number | null;
 };
 
-type DevServerTerminalRunIdentity = {
-  runId: string;
-  runOrder: DevServerRunOrder;
-} | null;
-
 export type DevServerTerminalBufferReplacementContext = {
   current: DevServerTerminalSequenceWindow;
   currentEntries: readonly AgentStudioDevServerTerminalChunkEntry[];
-  runIdentity: DevServerTerminalRunIdentity;
+  runIdentity: DevServerRunIdentity | null;
   snapshot: DevServerTerminalSequenceWindow;
 };
 
 export type DevServerTerminalBufferReplacement = {
-  runIdentity: DevServerTerminalRunIdentity;
+  runIdentity: DevServerRunIdentity | null;
   snapshotWindow: DevServerTerminalSequenceWindow;
   terminalChunks: readonly DevServerTerminalChunk[];
 };
@@ -47,7 +48,7 @@ type DevServerTerminalBufferState = {
   size: number;
   lastSequence: number | null;
   resetToken: number;
-  runIdentity: DevServerTerminalRunIdentity;
+  runIdentity: DevServerRunIdentity | null;
   snapshotEntryCount: number;
 };
 
@@ -105,44 +106,6 @@ const EMPTY_DEV_SERVER_TERMINAL_SEQUENCE_WINDOW: DevServerTerminalSequenceWindow
   lastSequence: null,
 };
 
-const readDevServerScriptRunIdentity = (
-  script: DevServerScriptState,
-): DevServerTerminalRunIdentity => {
-  if (script.runId === null && script.runOrder === null) {
-    return null;
-  }
-  if (script.runId === null || script.runOrder === null) {
-    throw new Error(`Dev server script ${script.scriptId} has incomplete run ownership.`);
-  }
-  return { runId: script.runId, runOrder: script.runOrder };
-};
-
-const readDevServerTerminalChunkRunIdentity = (
-  chunk: DevServerTerminalChunk,
-): Exclude<DevServerTerminalRunIdentity, null> => ({
-  runId: chunk.runId,
-  runOrder: chunk.runOrder,
-});
-
-const areRunIdentitiesEqual = (
-  left: DevServerTerminalRunIdentity,
-  right: DevServerTerminalRunIdentity,
-): boolean => {
-  if (left === null || right === null) {
-    return left === right;
-  }
-  if (left.runId !== right.runId) {
-    return false;
-  }
-  if (
-    left.runOrder.hostInstanceId !== right.runOrder.hostInstanceId ||
-    left.runOrder.generation !== right.runOrder.generation
-  ) {
-    throw new Error(`Dev server run ${left.runId} has conflicting order metadata.`);
-  }
-  return true;
-};
-
 const readSnapshotBufferWindow = (
   buffer: DevServerTerminalBufferState,
 ): DevServerTerminalSequenceWindow => {
@@ -174,9 +137,7 @@ const areTerminalChunksEqual = (
     return (
       other !== undefined &&
       chunk.scriptId === other.scriptId &&
-      chunk.runId === other.runId &&
-      chunk.runOrder.hostInstanceId === other.runOrder.hostInstanceId &&
-      chunk.runOrder.generation === other.runOrder.generation &&
+      areDevServerRunIdentitiesEqual(chunk.runIdentity, other.runIdentity) &&
       chunk.sequence === other.sequence &&
       chunk.data === other.data &&
       chunk.timestamp === other.timestamp
@@ -216,14 +177,14 @@ export const appendDevServerTerminalChunk = (
   store: DevServerTerminalBufferStore,
   terminalChunk: DevServerTerminalChunk,
 ): boolean => {
-  const nextRunIdentity = readDevServerTerminalChunkRunIdentity(terminalChunk);
-  if (!canApplyDevServerHostInstanceId(store, nextRunIdentity.runOrder.hostInstanceId)) {
+  const nextRunIdentity = terminalChunk.runIdentity;
+  if (!canApplyDevServerRunIdentityToStore(store, nextRunIdentity)) {
     return false;
   }
 
   let buffer = getOrCreateDevServerTerminalBufferState(store, terminalChunk.scriptId);
-  if (!areRunIdentitiesEqual(buffer.runIdentity, nextRunIdentity)) {
-    const runOrder = compareDevServerRunIdentity(buffer, nextRunIdentity);
+  if (!areDevServerRunIdentitiesEqual(buffer.runIdentity, nextRunIdentity)) {
+    const runOrder = compareDevServerRunIdentity(buffer.runIdentity, nextRunIdentity);
     if (runOrder !== "newer") {
       return false;
     }
@@ -254,9 +215,7 @@ export const replaceDevServerTerminalBuffer = (
   store: DevServerTerminalBufferStore,
   scriptId: string,
   terminalChunks: DevServerTerminalChunk[],
-  runIdentity: DevServerTerminalRunIdentity = terminalChunks[0]
-    ? readDevServerTerminalChunkRunIdentity(terminalChunks[0])
-    : null,
+  runIdentity: DevServerRunIdentity | null = terminalChunks[0]?.runIdentity ?? null,
 ): void => {
   const buffer = getOrCreateDevServerTerminalBufferState(store, scriptId);
   const trimmedChunks = trimDevServerTerminalChunks(terminalChunks);
@@ -324,7 +283,7 @@ export const syncDevServerTerminalBufferStore = (
       store,
       script.scriptId,
       script.bufferedTerminalChunks,
-      readDevServerScriptRunIdentity(script),
+      script.runIdentity,
     );
   }
 };
@@ -366,123 +325,15 @@ export const getDevServerTerminalBuffer = (
   };
 };
 
-type DevServerRunOrderRelation = "foreign" | "newer" | "older" | "same";
-
-const compareDevServerRunIdentity = (
-  context: { runIdentity: DevServerTerminalRunIdentity },
-  candidate: DevServerTerminalRunIdentity,
-): DevServerRunOrderRelation => {
-  const current = context.runIdentity;
-  if (areRunIdentitiesEqual(current, candidate)) {
-    return "same";
-  }
-  if (candidate === null) {
-    return "older";
-  }
-  if (current === null) {
-    return "newer";
-  }
-  if (candidate.runOrder.hostInstanceId !== current.runOrder.hostInstanceId) {
-    return "foreign";
-  }
-  if (candidate.runOrder.generation === current.runOrder.generation) {
-    throw new Error(
-      `Dev server runs ${current.runId} and ${candidate.runId} share generation ${candidate.runOrder.generation}.`,
-    );
-  }
-  return candidate.runOrder.generation > current.runOrder.generation ? "newer" : "older";
-};
-
-export const canApplyDevServerScriptState = (
-  currentContext: DevServerTerminalBufferReplacementContext | null,
-  script: DevServerScriptState,
-): boolean => {
-  if (currentContext === null) {
-    return true;
-  }
-
-  const relation = compareDevServerRunIdentity(
-    currentContext,
-    readDevServerScriptRunIdentity(script),
-  );
-  return relation === "same" || relation === "newer";
-};
-
-const readDevServerStoreHostInstanceId = (store: DevServerTerminalBufferStore): string | null => {
-  const hostInstanceIds = new Set<string>();
-  for (const buffer of store.values()) {
-    if (buffer.runIdentity !== null) {
-      hostInstanceIds.add(buffer.runIdentity.runOrder.hostInstanceId);
-    }
-  }
-
-  if (hostInstanceIds.size > 1) {
-    throw new Error("Dev server terminal buffers contain conflicting host ownership.");
-  }
-
-  return hostInstanceIds.values().next().value ?? null;
-};
-
-const canApplyDevServerHostInstanceId = (
-  store: DevServerTerminalBufferStore,
-  candidateHostInstanceId: string,
-): boolean => {
-  const currentHostInstanceId = readDevServerStoreHostInstanceId(store);
-  return currentHostInstanceId === null || currentHostInstanceId === candidateHostInstanceId;
-};
-
-export const canApplyDevServerScriptStateToStore = (
-  store: DevServerTerminalBufferStore,
-  script: DevServerScriptState,
-): boolean => {
-  if (
-    script.runOrder !== null &&
-    !canApplyDevServerHostInstanceId(store, script.runOrder.hostInstanceId)
-  ) {
-    return false;
-  }
-
-  return canApplyDevServerScriptState(
-    getDevServerTerminalBufferReplacementContext(store, script.scriptId),
-    script,
-  );
-};
-
-export const canApplyDevServerGroupState = (
-  store: DevServerTerminalBufferStore,
-  state: DevServerGroupState,
-): boolean => {
-  const candidateHostInstanceIds = new Set<string>();
-  for (const script of state.scripts) {
-    if (script.runOrder !== null) {
-      candidateHostInstanceIds.add(script.runOrder.hostInstanceId);
-    }
-  }
-
-  if (candidateHostInstanceIds.size > 1) {
-    throw new Error("Dev server group state contains conflicting host ownership.");
-  }
-
-  const candidateHostInstanceId = candidateHostInstanceIds.values().next().value ?? null;
-  if (
-    candidateHostInstanceId !== null &&
-    !canApplyDevServerHostInstanceId(store, candidateHostInstanceId)
-  ) {
-    return false;
-  }
-
-  return state.scripts.every((script) => canApplyDevServerScriptStateToStore(store, script));
-};
-
 const shouldMergeSameRunReplayPrefix = (
   currentContext: DevServerTerminalBufferReplacementContext,
-  nextRunIdentity: DevServerTerminalRunIdentity,
+  nextRunIdentity: DevServerRunIdentity | null,
   nextWindow: DevServerTerminalSequenceWindow,
 ): boolean => {
   if (
     currentContext.runIdentity === null ||
     nextRunIdentity === null ||
-    !areRunIdentitiesEqual(currentContext.runIdentity, nextRunIdentity)
+    !areDevServerRunIdentitiesEqual(currentContext.runIdentity, nextRunIdentity)
   ) {
     return false;
   }
@@ -519,11 +370,11 @@ const createDevServerTerminalBufferReplacement = (
   currentContext: DevServerTerminalBufferReplacementContext | null,
   snapshotWindow: DevServerTerminalSequenceWindow,
   terminalChunks: readonly DevServerTerminalChunk[],
-  runIdentity: DevServerTerminalRunIdentity,
+  runIdentity: DevServerRunIdentity | null,
 ): DevServerTerminalBufferReplacement | null => {
   if (
     currentContext &&
-    areRunIdentitiesEqual(currentContext.runIdentity, runIdentity) &&
+    areDevServerRunIdentitiesEqual(currentContext.runIdentity, runIdentity) &&
     areSequenceWindowsEqual(currentContext.snapshot, snapshotWindow) &&
     areTerminalChunksEqual(terminalChunks, currentContext.currentEntries)
   ) {
@@ -543,7 +394,7 @@ export const getDevServerTerminalBufferReplacement = (
 ): DevServerTerminalBufferReplacement | null => {
   const nextChunks = trimDevServerTerminalChunks(script.bufferedTerminalChunks);
   const nextWindow = readBufferedSequenceWindow(nextChunks);
-  const nextRunIdentity = readDevServerScriptRunIdentity(script);
+  const nextRunIdentity = script.runIdentity;
 
   if (currentContext === null) {
     return createDevServerTerminalBufferReplacement(
@@ -554,7 +405,7 @@ export const getDevServerTerminalBufferReplacement = (
     );
   }
 
-  const runOrder = compareDevServerRunIdentity(currentContext, nextRunIdentity);
+  const runOrder = compareDevServerRunIdentity(currentContext.runIdentity, nextRunIdentity);
   if (runOrder === "older" || runOrder === "foreign") {
     return null;
   }
@@ -642,7 +493,7 @@ export const getDevServerTerminalBufferReplacement = (
   if (
     nextWindow.count !== currentWindow.count ||
     nextWindow.firstSequence !== currentWindow.firstSequence ||
-    !areRunIdentitiesEqual(nextRunIdentity, currentContext.runIdentity)
+    !areDevServerRunIdentitiesEqual(nextRunIdentity, currentContext.runIdentity)
   ) {
     return createDevServerTerminalBufferReplacement(
       currentContext,

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -254,6 +254,33 @@ export const getDevServerTerminalBuffer = (
   };
 };
 
+const isLaterTimestamp = (candidate: string | null, baseline: string | null): boolean => {
+  return candidate !== null && baseline !== null && candidate > baseline;
+};
+
+const isLaterSequenceResetSnapshot = (
+  currentContext: DevServerTerminalBufferReplacementContext,
+  script: DevServerScriptState,
+  nextChunks: readonly DevServerTerminalChunk[],
+  nextWindow: DevServerTerminalSequenceWindow,
+): boolean => {
+  if (
+    nextWindow.firstSequence !== 0 ||
+    nextWindow.lastSequence === null ||
+    currentContext.current.lastSequence === null ||
+    nextWindow.lastSequence >= currentContext.current.lastSequence
+  ) {
+    return false;
+  }
+
+  const currentLastTimestamp = currentContext.currentEntries.at(-1)?.timestamp ?? null;
+  const nextFirstTimestamp = nextChunks[0]?.timestamp ?? null;
+  return (
+    isLaterTimestamp(nextFirstTimestamp, currentLastTimestamp) ||
+    isLaterTimestamp(script.startedAt, currentLastTimestamp)
+  );
+};
+
 export const getDevServerTerminalBufferReplacement = (
   currentContext: DevServerTerminalBufferReplacementContext | null,
   script: DevServerScriptState,
@@ -318,6 +345,13 @@ export const getDevServerTerminalBufferReplacement = (
   }
 
   if (nextWindow.lastSequence < currentWindow.lastSequence) {
+    if (isLaterSequenceResetSnapshot(currentContext, script, nextChunks, nextWindow)) {
+      return {
+        snapshotWindow: nextWindow,
+        terminalChunks: nextChunks,
+      };
+    }
+
     return null;
   }
 

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-run-ownership.test.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-run-ownership.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  DevServerGroupState,
+  DevServerRunIdentity,
+  DevServerScriptState,
+} from "@openducktor/contracts";
+import {
+  areDevServerRunIdentitiesEqual,
+  canApplyDevServerGroupState,
+  canApplyDevServerRunIdentityToStore,
+  canApplyDevServerScriptStateToStore,
+  compareDevServerRunIdentity,
+} from "./dev-server-run-ownership";
+
+const runIdentity = (
+  runId: string,
+  generation: number,
+  hostInstanceId = "host-1",
+): DevServerRunIdentity => ({
+  runId,
+  runOrder: { hostInstanceId, generation },
+});
+
+const scriptState = (
+  scriptId: string,
+  identity: DevServerRunIdentity | null,
+): DevServerScriptState => ({
+  scriptId,
+  name: scriptId,
+  command: `run ${scriptId}`,
+  status: identity === null ? "stopped" : "running",
+  runIdentity: identity,
+  pid: identity === null ? null : 1,
+  startedAt: identity === null ? null : "2026-07-10T10:00:00.000Z",
+  exitCode: null,
+  lastError: null,
+  bufferedTerminalChunks: [],
+});
+
+const ownershipStore = (entries: readonly (readonly [string, DevServerRunIdentity | null])[]) =>
+  new Map(entries.map(([scriptId, identity]) => [scriptId, { runIdentity: identity }]));
+
+describe("dev-server-run-ownership", () => {
+  test("compares runs within one host and rejects foreign hosts", () => {
+    const current = runIdentity("frontend:2", 2);
+
+    expect(compareDevServerRunIdentity(current, runIdentity("frontend:3", 3))).toBe("newer");
+    expect(compareDevServerRunIdentity(current, runIdentity("frontend:1", 1))).toBe("older");
+    expect(compareDevServerRunIdentity(current, runIdentity("frontend:3", 3, "host-2"))).toBe(
+      "foreign",
+    );
+  });
+
+  test("rejects conflicting order metadata for one run id", () => {
+    expect(() =>
+      areDevServerRunIdentitiesEqual(runIdentity("frontend:1", 1), runIdentity("frontend:1", 2)),
+    ).toThrow("conflicting order metadata");
+  });
+
+  test("rejects a foreign host before it can own one script or a group", () => {
+    const store = ownershipStore([["frontend", runIdentity("frontend:1", 1)]]);
+    const foreignIdentity = runIdentity("backend:1", 1, "host-2");
+    const foreignScript = scriptState("backend", foreignIdentity);
+    const foreignGroup: DevServerGroupState = {
+      repoPath: "/repo",
+      taskId: "task-7",
+      worktreePath: "/worktree",
+      scripts: [foreignScript],
+      updatedAt: "2026-07-10T10:00:00.000Z",
+    };
+
+    expect(canApplyDevServerRunIdentityToStore(store, foreignIdentity)).toBe(false);
+    expect(canApplyDevServerScriptStateToStore(store, foreignScript)).toBe(false);
+    expect(canApplyDevServerGroupState(store, foreignGroup)).toBe(false);
+  });
+
+  test("accepts a newer run owned by the current host", () => {
+    const store = ownershipStore([["frontend", runIdentity("frontend:1", 1)]]);
+
+    expect(
+      canApplyDevServerScriptStateToStore(
+        store,
+        scriptState("frontend", runIdentity("frontend:2", 2)),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/frontend/src/features/agent-studio-build-tools/dev-server-run-ownership.ts
+++ b/packages/frontend/src/features/agent-studio-build-tools/dev-server-run-ownership.ts
@@ -1,0 +1,129 @@
+import type {
+  DevServerGroupState,
+  DevServerRunIdentity,
+  DevServerScriptState,
+} from "@openducktor/contracts";
+
+type DevServerRunOwner = {
+  runIdentity: DevServerRunIdentity | null;
+};
+
+type DevServerRunOwnershipStore = ReadonlyMap<string, DevServerRunOwner>;
+
+export type DevServerRunOrderRelation = "foreign" | "newer" | "older" | "same";
+
+export const areDevServerRunIdentitiesEqual = (
+  left: DevServerRunIdentity | null,
+  right: DevServerRunIdentity | null,
+): boolean => {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  if (left.runId !== right.runId) {
+    return false;
+  }
+  if (
+    left.runOrder.hostInstanceId !== right.runOrder.hostInstanceId ||
+    left.runOrder.generation !== right.runOrder.generation
+  ) {
+    throw new Error(`Dev server run ${left.runId} has conflicting order metadata.`);
+  }
+  return true;
+};
+
+export const compareDevServerRunIdentity = (
+  current: DevServerRunIdentity | null,
+  candidate: DevServerRunIdentity | null,
+): DevServerRunOrderRelation => {
+  if (areDevServerRunIdentitiesEqual(current, candidate)) {
+    return "same";
+  }
+  if (candidate === null) {
+    return "older";
+  }
+  if (current === null) {
+    return "newer";
+  }
+  if (candidate.runOrder.hostInstanceId !== current.runOrder.hostInstanceId) {
+    return "foreign";
+  }
+  if (candidate.runOrder.generation === current.runOrder.generation) {
+    throw new Error(
+      `Dev server runs ${current.runId} and ${candidate.runId} share generation ${candidate.runOrder.generation}.`,
+    );
+  }
+  return candidate.runOrder.generation > current.runOrder.generation ? "newer" : "older";
+};
+
+const readDevServerStoreHostInstanceId = (store: DevServerRunOwnershipStore): string | null => {
+  const hostInstanceIds = new Set<string>();
+  for (const owner of store.values()) {
+    if (owner.runIdentity !== null) {
+      hostInstanceIds.add(owner.runIdentity.runOrder.hostInstanceId);
+    }
+  }
+
+  if (hostInstanceIds.size > 1) {
+    throw new Error("Dev server terminal buffers contain conflicting host ownership.");
+  }
+
+  return hostInstanceIds.values().next().value ?? null;
+};
+
+export const canApplyDevServerRunIdentityToStore = (
+  store: DevServerRunOwnershipStore,
+  candidate: DevServerRunIdentity,
+): boolean => {
+  const currentHostInstanceId = readDevServerStoreHostInstanceId(store);
+  return (
+    currentHostInstanceId === null || currentHostInstanceId === candidate.runOrder.hostInstanceId
+  );
+};
+
+export const canApplyDevServerScriptStateToStore = (
+  store: DevServerRunOwnershipStore,
+  script: DevServerScriptState,
+): boolean => {
+  if (
+    script.runIdentity !== null &&
+    !canApplyDevServerRunIdentityToStore(store, script.runIdentity)
+  ) {
+    return false;
+  }
+
+  const current = store.get(script.scriptId);
+  if (!current) {
+    return true;
+  }
+
+  const relation = compareDevServerRunIdentity(current.runIdentity, script.runIdentity);
+  return relation === "same" || relation === "newer";
+};
+
+export const canApplyDevServerGroupState = (
+  store: DevServerRunOwnershipStore,
+  state: DevServerGroupState,
+): boolean => {
+  const candidateHostInstanceIds = new Set<string>();
+  for (const script of state.scripts) {
+    if (script.runIdentity !== null) {
+      candidateHostInstanceIds.add(script.runIdentity.runOrder.hostInstanceId);
+    }
+  }
+
+  if (candidateHostInstanceIds.size > 1) {
+    throw new Error("Dev server group state contains conflicting host ownership.");
+  }
+
+  const candidateHostInstanceId = candidateHostInstanceIds.values().next().value ?? null;
+  const currentHostInstanceId = readDevServerStoreHostInstanceId(store);
+  if (
+    candidateHostInstanceId !== null &&
+    currentHostInstanceId !== null &&
+    candidateHostInstanceId !== currentHostInstanceId
+  ) {
+    return false;
+  }
+
+  return state.scripts.every((script) => canApplyDevServerScriptStateToStore(store, script));
+};

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -1,4 +1,9 @@
-export type { HostBridge, ShellBridge, ShellCapabilities } from "./lib/shell-bridge";
+export type {
+  DevServerEventSubscription,
+  HostBridge,
+  ShellBridge,
+  ShellCapabilities,
+} from "./lib/shell-bridge";
 export {
   bootstrapOpenDucktorShell,
   type OpenDucktorShellBootstrapOptions,

--- a/packages/frontend/src/lib/browser-live-control-events.test.ts
+++ b/packages/frontend/src/lib/browser-live-control-events.test.ts
@@ -19,8 +19,18 @@ describe("browser-live-control-events", () => {
       isBrowserLiveControlEvent({
         __openducktorBrowserLive: true,
         kind: BROWSER_LIVE_RECONNECTED_EVENT_KIND,
+        transportEpoch: "test:1",
       }),
     ).toBe(true);
+  });
+
+  test("rejects reconnect events without a transport epoch", () => {
+    expect(
+      isBrowserLiveControlEvent({
+        __openducktorBrowserLive: true,
+        kind: BROWSER_LIVE_RECONNECTED_EVENT_KIND,
+      }),
+    ).toBe(false);
   });
 
   test("rejects control events with non-string messages", () => {

--- a/packages/frontend/src/lib/browser-live-control-events.ts
+++ b/packages/frontend/src/lib/browser-live-control-events.ts
@@ -4,14 +4,35 @@ import {
 } from "@/lib/browser-live/constants";
 import type { BrowserLiveControlEvent, BrowserLiveControlEventKind } from "@/types";
 
-export const browserLiveControlEvent = (
-  kind: BrowserLiveControlEventKind,
+export function browserLiveControlEvent(
+  kind: typeof BROWSER_LIVE_RECONNECTED_EVENT_KIND,
+  transportEpoch: string,
+): BrowserLiveControlEvent;
+export function browserLiveControlEvent(
+  kind: typeof BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
   message?: string,
-): BrowserLiveControlEvent => ({
-  __openducktorBrowserLive: true,
-  kind,
-  ...(message !== undefined ? { message } : {}),
-});
+): BrowserLiveControlEvent;
+export function browserLiveControlEvent(
+  kind: BrowserLiveControlEventKind,
+  detail?: string,
+): BrowserLiveControlEvent {
+  if (kind === BROWSER_LIVE_RECONNECTED_EVENT_KIND) {
+    if (!detail) {
+      throw new Error("Browser live reconnect events require a transport epoch.");
+    }
+    return {
+      __openducktorBrowserLive: true,
+      kind,
+      transportEpoch: detail,
+    };
+  }
+
+  return {
+    __openducktorBrowserLive: true,
+    kind,
+    ...(detail !== undefined ? { message: detail } : {}),
+  };
+}
 
 export const isBrowserLiveControlEvent = (payload: unknown): payload is BrowserLiveControlEvent => {
   if (!payload || typeof payload !== "object") {
@@ -19,10 +40,16 @@ export const isBrowserLiveControlEvent = (payload: unknown): payload is BrowserL
   }
 
   const record = payload as Record<string, unknown>;
+  if (record.__openducktorBrowserLive !== true) {
+    return false;
+  }
+
+  if (record.kind === BROWSER_LIVE_RECONNECTED_EVENT_KIND) {
+    return typeof record.transportEpoch === "string" && record.transportEpoch.length > 0;
+  }
+
   return (
-    record.__openducktorBrowserLive === true &&
-    (record.kind === BROWSER_LIVE_RECONNECTED_EVENT_KIND ||
-      record.kind === BROWSER_LIVE_STREAM_WARNING_EVENT_KIND) &&
+    record.kind === BROWSER_LIVE_STREAM_WARNING_EVENT_KIND &&
     (record.message === undefined || typeof record.message === "string")
   );
 };

--- a/packages/frontend/src/lib/host-client.test.ts
+++ b/packages/frontend/src/lib/host-client.test.ts
@@ -25,7 +25,10 @@ const createRuntimeInstanceSummary = (runtimeId: string): RuntimeInstanceSummary
 const createTestShellBridge = (overrides: Partial<ShellBridge> = {}): ShellBridge => ({
   client: {} as HostClient,
   subscribeRunEvents: async () => () => {},
-  subscribeDevServerEvents: async () => () => {},
+  subscribeDevServerEvents: async () => ({
+    transportEpoch: "test:0",
+    unsubscribe: () => {},
+  }),
   subscribeTaskEvents: async () => () => {},
   capabilities: {
     canOpenExternalUrls: true,

--- a/packages/frontend/src/lib/local-attachment-files.test.ts
+++ b/packages/frontend/src/lib/local-attachment-files.test.ts
@@ -10,7 +10,10 @@ import {
 const createTestShellBridge = (overrides: Partial<ShellBridge> = {}): ShellBridge => ({
   client: {} as HostClient,
   subscribeRunEvents: async () => () => {},
-  subscribeDevServerEvents: async () => () => {},
+  subscribeDevServerEvents: async () => ({
+    transportEpoch: "test:0",
+    unsubscribe: () => {},
+  }),
   subscribeTaskEvents: async () => () => {},
   capabilities: {
     canOpenExternalUrls: true,

--- a/packages/frontend/src/lib/shell-bridge.ts
+++ b/packages/frontend/src/lib/shell-bridge.ts
@@ -2,10 +2,15 @@ import { createHostClient, type HostClient } from "@openducktor/host-client";
 
 export type HostEventListener = (payload: unknown) => void;
 
+export type DevServerEventSubscription = {
+  transportEpoch: string;
+  unsubscribe: () => void;
+};
+
 export type HostBridge = {
   client: HostClient;
   subscribeRunEvents: (listener: HostEventListener) => Promise<() => void>;
-  subscribeDevServerEvents: (listener: HostEventListener) => Promise<() => void>;
+  subscribeDevServerEvents: (listener: HostEventListener) => Promise<DevServerEventSubscription>;
   subscribeTaskEvents: (listener: HostEventListener) => Promise<() => void>;
   subscribeCodexAppServerEvents?: (listener: HostEventListener) => Promise<() => void>;
 };

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
@@ -28,21 +28,6 @@ const trimBufferedTerminalReplay = (script: DevServerScriptState): DevServerScri
   bufferedTerminalChunks: trimDevServerTerminalChunks(script.bufferedTerminalChunks),
 });
 
-export const buildOptimisticStartingState = (state: DevServerGroupState): DevServerGroupState => ({
-  ...state,
-  updatedAt: new Date().toISOString(),
-  scripts: state.scripts.map((script) => ({
-    ...script,
-    status: "starting",
-    runId: null,
-    pid: null,
-    startedAt: null,
-    exitCode: null,
-    lastError: null,
-    bufferedTerminalChunks: [],
-  })),
-});
-
 export const isDevServerSubscriptionControlEvent = isBrowserLiveControlEvent;
 
 export const applyDevServerEventToState = (

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
@@ -5,11 +5,15 @@ import type {
 } from "@openducktor/contracts";
 import { trimDevServerTerminalChunks } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import { isBrowserLiveControlEvent } from "@/lib/browser-live-control-events";
+import {
+  createDevServerTaskScope,
+  formatDevServerTaskScopeKey,
+} from "@/types/dev-server-task-scope";
 
 export type { BrowserLiveControlEvent as DevServerSubscriptionControlEvent } from "@/types";
 
 export const buildTaskMemoryKey = (repoPath: string, taskId: string): string => {
-  return `${repoPath}::${taskId}`;
+  return formatDevServerTaskScopeKey(createDevServerTaskScope(repoPath, taskId));
 };
 
 const replaceScript = (

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
@@ -34,6 +34,7 @@ export const buildOptimisticStartingState = (state: DevServerGroupState): DevSer
   scripts: state.scripts.map((script) => ({
     ...script,
     status: "starting",
+    runId: null,
     pid: null,
     startedAt: null,
     exitCode: null,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
@@ -15,6 +15,11 @@ import { renderDevServerPanelHook } from "./use-agent-studio-dev-server-panel-te
 
 const actualHostClientModule = await import("@/lib/host-client");
 
+type TestDevServerEventSubscription = {
+  transportEpoch: string;
+  unsubscribe: () => void;
+};
+
 if (typeof document === "undefined") {
   GlobalRegistrator.register();
 }
@@ -28,12 +33,16 @@ let devServerStop = async (_repoPath: string, _taskId: string): Promise<DevServe
 let devServerRestart = async (_repoPath: string, _taskId: string): Promise<DevServerGroupState> =>
   buildState();
 let devServerEventListener: ((payload: unknown) => void) | null = null;
+let subscriptionTransportEpoch = "test:0";
 let subscribeDevServerEventsMock = async (
   listener: (payload: unknown) => void,
-): Promise<() => void> => {
+): Promise<TestDevServerEventSubscription> => {
   devServerEventListener = listener;
-  return () => {
-    devServerEventListener = null;
+  return {
+    transportEpoch: subscriptionTransportEpoch,
+    unsubscribe: () => {
+      devServerEventListener = null;
+    },
   };
 };
 
@@ -57,10 +66,14 @@ beforeEach(() => {
   devServerRestart = async (_repoPath: string, _taskId: string): Promise<DevServerGroupState> =>
     buildState();
   devServerEventListener = null;
+  subscriptionTransportEpoch = "test:0";
   subscribeDevServerEventsMock = async (listener: (payload: unknown) => void) => {
     devServerEventListener = listener;
-    return () => {
-      devServerEventListener = null;
+    return {
+      transportEpoch: subscriptionTransportEpoch,
+      unsubscribe: () => {
+        devServerEventListener = null;
+      },
     };
   };
 });
@@ -173,7 +186,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     }
   });
 
-  test("rehydrates full buffered terminal replay when the dev-server subscription first becomes ready", async () => {
+  test("hydrates full buffered terminal replay after the dev-server subscription becomes ready", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
     type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
@@ -186,15 +199,6 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       data: `subscription-gap output ${sequence}\r\n`,
       timestamp: "2026-03-19T15:31:00.000Z",
     }));
-    const initialState = buildState({
-      scripts: [
-        buildScript({
-          status: "running",
-          pid: 4242,
-          startedAt: "2026-03-19T15:30:00.000Z",
-        }),
-      ],
-    });
     const refreshedState = buildState({
       updatedAt: "2026-03-19T15:31:00.000Z",
       scripts: [
@@ -209,9 +213,9 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     let getStateCalls = 0;
     devServerGetState = async () => {
       getStateCalls += 1;
-      return getStateCalls === 1 ? initialState : refreshedState;
+      return refreshedState;
     };
-    const subscriptionReady = createDeferred<() => void>();
+    const subscriptionReady = createDeferred<TestDevServerEventSubscription>();
     subscribeDevServerEventsMock = async (listener: (payload: unknown) => void) => {
       devServerEventListener = listener;
       return subscriptionReady.promise;
@@ -225,13 +229,14 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     });
 
     try {
-      await waitFor(() => {
-        expect(harness.getLatest().mode).toBe("active");
-      });
-      expect(getStateCalls).toBe(1);
+      expect(harness.getLatest().mode).toBe("loading");
+      expect(getStateCalls).toBe(0);
 
-      subscriptionReady.resolve(() => {
-        devServerEventListener = null;
+      subscriptionReady.resolve({
+        transportEpoch: "test:0",
+        unsubscribe: () => {
+          devServerEventListener = null;
+        },
       });
 
       await waitFor(() => {
@@ -243,7 +248,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       expect(harness.getLatest().selectedScriptTerminalBuffer?.entries.at(-1)?.data).toBe(
         "subscription-gap output 299\r\n",
       );
-      expect(getStateCalls).toBe(2);
+      expect(getStateCalls).toBe(1);
     } finally {
       harness.unmount();
     }
@@ -299,12 +304,6 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       getStateCalls += 1;
       return getStateCalls === 1 ? initialState : staleRehydrate.promise;
     };
-    const subscriptionReady = createDeferred<() => void>();
-    subscribeDevServerEventsMock = async (listener: (payload: unknown) => void) => {
-      devServerEventListener = listener;
-      return subscriptionReady.promise;
-    };
-
     const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
       repoPath: "/repo",
       taskId: "task-7",
@@ -1046,6 +1045,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         devServerEventListener?.({
           __openducktorBrowserLive: true,
           kind: "reconnected",
+          transportEpoch: "test:1",
         });
       });
 
@@ -1060,7 +1060,133 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     }
   });
 
-  test("binds query and mutation results to the browser transport generation", async () => {
+  test("rejects retired cache and callbacks when a fresh subscription opens on a new host", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+
+    const retiredHostState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          runId: "retired-run",
+          runOrder: { hostInstanceId: "host-retired", generation: 1 },
+          pid: 4141,
+          startedAt: "2026-03-19T15:30:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              runId: "retired-run",
+              runOrder: { hostInstanceId: "host-retired", generation: 1 },
+              sequence: 0,
+              data: "retired host\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const currentHostState = buildState({
+      updatedAt: "2026-03-19T15:31:00.000Z",
+      scripts: [
+        buildScript({
+          status: "running",
+          runId: "current-run",
+          runOrder: { hostInstanceId: "host-current", generation: 1 },
+          pid: 5151,
+          startedAt: "2026-03-19T15:31:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              runId: "current-run",
+              runOrder: { hostInstanceId: "host-current", generation: 1 },
+              sequence: 0,
+              data: "current host\r\n",
+              timestamp: "2026-03-19T15:31:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    const retiredRestart = createDeferred<DevServerGroupState>();
+    const queryClient = createQueryClient();
+    let activeHostState = retiredHostState;
+    devServerGetState = async () => activeHostState;
+    devServerRestart = async () => retiredRestart.promise;
+
+    const retiredHarness = renderDevServerPanelHook(
+      useAgentStudioDevServerPanel,
+      {
+        repoPath: "/repo",
+        taskId: "task-7",
+        repoSettings,
+        enabled: true,
+      },
+      { queryClient },
+    );
+
+    await waitFor(() => {
+      expect(retiredHarness.getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
+        "retired host\r\n",
+      );
+    });
+    act(() => {
+      retiredHarness.getLatest().onRestart();
+    });
+    const retiredHostListener = devServerEventListener;
+    retiredHarness.unmount();
+
+    activeHostState = currentHostState;
+    subscriptionTransportEpoch = "test:1";
+    const currentHarness = renderDevServerPanelHook(
+      useAgentStudioDevServerPanel,
+      {
+        repoPath: "/repo",
+        taskId: "task-7",
+        repoSettings,
+        enabled: true,
+      },
+      { queryClient },
+    );
+
+    try {
+      expect(currentHarness.getLatest().selectedScriptTerminalBuffer).toBeNull();
+      await waitFor(() => {
+        expect(currentHarness.getLatest().scripts[0]?.runOrder?.hostInstanceId).toBe(
+          "host-current",
+        );
+        expect(currentHarness.getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
+          "current host\r\n",
+        );
+      });
+
+      await act(async () => {
+        retiredRestart.resolve(retiredHostState);
+        retiredHostListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "frontend",
+            runId: "retired-run",
+            runOrder: { hostInstanceId: "host-retired", generation: 1 },
+            sequence: 1,
+            data: "late retired output\r\n",
+            timestamp: "2026-03-19T15:32:00.000Z",
+          },
+        });
+        await retiredRestart.promise;
+        await Promise.resolve();
+      });
+
+      expect(currentHarness.getLatest().scripts[0]?.runOrder?.hostInstanceId).toBe("host-current");
+      expect(
+        currentHarness.getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
+      ).toEqual(["current host\r\n"]);
+    } finally {
+      currentHarness.unmount();
+    }
+  });
+
+  test("binds query and mutation results to the browser transport epoch", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
 
     const staleInitialQuery = createDeferred<DevServerGroupState>();
@@ -1125,6 +1251,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         devServerEventListener?.({
           __openducktorBrowserLive: true,
           kind: "reconnected",
+          transportEpoch: "test:1",
         });
       });
 
@@ -1141,6 +1268,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         devServerEventListener?.({
           __openducktorBrowserLive: true,
           kind: "reconnected",
+          transportEpoch: "test:2",
         });
         staleRestart.resolve(
           buildState({
@@ -1174,7 +1302,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
 
       await waitFor(() => {
         const staleQuery = queryClient.getQueryCache().find({
-          queryKey: devServerQueryKeys.state("/repo", "task-7", 0),
+          queryKey: devServerQueryKeys.state("/repo", "task-7", "test:0"),
           exact: true,
         });
         const hasSettledStaleMutation = queryClient

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
@@ -477,6 +477,63 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     }
   });
 
+  test("does not expose the previous task terminal buffer after the task scope changes", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    devServerGetState = async (_repoPath, taskId) =>
+      buildState({
+        taskId,
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-19T15:30:00.000Z",
+            bufferedTerminalChunks:
+              taskId === "task-7"
+                ? [
+                    {
+                      scriptId: "frontend",
+                      sequence: 7,
+                      data: "previous task output\r\n",
+                      timestamp: "2026-03-19T15:30:00.000Z",
+                    },
+                  ]
+                : [],
+          }),
+        ],
+      });
+
+    const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
+      repoPath: "/repo",
+      taskId: "task-7",
+      repoSettings,
+      enabled: true,
+    });
+
+    try {
+      await waitFor(() => {
+        expect(harness.getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
+          "previous task output\r\n",
+        );
+      });
+
+      act(() => {
+        harness.update({
+          repoPath: "/repo",
+          taskId: "task-8",
+          repoSettings,
+          enabled: true,
+        });
+      });
+
+      expect(harness.getLatest().selectedScriptTerminalBuffer).toBeNull();
+    } finally {
+      harness.unmount();
+    }
+  });
+
   test("rehydrates buffered terminal replay after a browser-live reconnect", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
@@ -534,6 +534,211 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     }
   });
 
+  test("ignores a mutation result that resolves after the active task changes", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    devServerGetState = async (_repoPath, taskId) =>
+      buildState({
+        taskId,
+        worktreePath: `/tmp/worktree/${taskId}`,
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-19T15:30:00.000Z",
+          }),
+        ],
+      });
+    const restartDeferred = createDeferred<DevServerGroupState>();
+    devServerRestart = async () => restartDeferred.promise;
+
+    const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
+      repoPath: "/repo",
+      taskId: "task-7",
+      repoSettings,
+      enabled: true,
+    });
+
+    try {
+      await waitFor(() => {
+        expect(harness.getLatest().worktreePath).toBe("/tmp/worktree/task-7");
+      });
+
+      await act(async () => {
+        harness.getLatest().onRestart();
+      });
+
+      act(() => {
+        harness.update({
+          repoPath: "/repo",
+          taskId: "task-8",
+          repoSettings,
+          enabled: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(harness.getLatest().worktreePath).toBe("/tmp/worktree/task-8");
+      });
+
+      await act(async () => {
+        restartDeferred.resolve(
+          buildState({
+            taskId: "task-7",
+            worktreePath: "/tmp/worktree/task-7",
+            updatedAt: "2026-03-19T15:31:00.000Z",
+            scripts: [
+              buildScript({
+                status: "running",
+                pid: 5252,
+                startedAt: "2026-03-19T15:31:00.000Z",
+                bufferedTerminalChunks: [
+                  {
+                    scriptId: "frontend",
+                    sequence: 0,
+                    data: "task seven restarted output\r\n",
+                    timestamp: "2026-03-19T15:31:00.000Z",
+                  },
+                ],
+              }),
+            ],
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(harness.getLatest().worktreePath).toBe("/tmp/worktree/task-8");
+      });
+      expect(harness.getLatest().selectedScriptTerminalBuffer?.entries).toEqual([]);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("replaces a returned task terminal buffer after its sequence resets while inactive", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const taskStateByTaskId = new Map<string, DevServerGroupState>([
+      [
+        "task-7",
+        buildState({
+          taskId: "task-7",
+          worktreePath: "/tmp/worktree/task-7",
+          scripts: [
+            buildScript({
+              status: "running",
+              pid: 4242,
+              startedAt: "2026-03-19T15:30:00.000Z",
+              bufferedTerminalChunks: [
+                {
+                  scriptId: "frontend",
+                  sequence: 7,
+                  data: "old task seven output\r\n",
+                  timestamp: "2026-03-19T15:30:00.000Z",
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+      [
+        "task-8",
+        buildState({
+          taskId: "task-8",
+          worktreePath: "/tmp/worktree/task-8",
+          scripts: [
+            buildScript({
+              status: "running",
+              pid: 5252,
+              startedAt: "2026-03-19T15:30:30.000Z",
+            }),
+          ],
+        }),
+      ],
+    ]);
+    devServerGetState = async (_repoPath, taskId) => {
+      const state = taskStateByTaskId.get(taskId);
+      if (!state) {
+        throw new Error(`Missing test state for ${taskId}.`);
+      }
+
+      return state;
+    };
+
+    const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
+      repoPath: "/repo",
+      taskId: "task-7",
+      repoSettings,
+      enabled: true,
+    });
+
+    try {
+      await waitFor(() => {
+        expect(harness.getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
+          "old task seven output\r\n",
+        );
+      });
+
+      act(() => {
+        harness.update({
+          repoPath: "/repo",
+          taskId: "task-8",
+          repoSettings,
+          enabled: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(harness.getLatest().worktreePath).toBe("/tmp/worktree/task-8");
+      });
+
+      taskStateByTaskId.set(
+        "task-7",
+        buildState({
+          taskId: "task-7",
+          worktreePath: "/tmp/worktree/task-7",
+          updatedAt: "2026-03-19T15:31:00.000Z",
+          scripts: [
+            buildScript({
+              status: "running",
+              pid: 6262,
+              startedAt: "2026-03-19T15:31:00.000Z",
+              bufferedTerminalChunks: [
+                {
+                  scriptId: "frontend",
+                  sequence: 0,
+                  data: "new task seven output\r\n",
+                  timestamp: "2026-03-19T15:31:00.000Z",
+                },
+              ],
+            }),
+          ],
+        }),
+      );
+
+      act(() => {
+        harness.update({
+          repoPath: "/repo",
+          taskId: "task-7",
+          repoSettings,
+          enabled: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          harness.getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
+        ).toEqual(["new task seven output\r\n"]);
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
   test("rehydrates buffered terminal replay after a browser-live reconnect", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
@@ -129,8 +129,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 4,
               data: "rehydrated output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -193,8 +195,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
 
     const bufferedTerminalChunks = Array.from({ length: 300 }, (_, sequence) => ({
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence,
       data: `subscription-gap output ${sequence}\r\n`,
       timestamp: "2026-03-19T15:31:00.000Z",
@@ -268,8 +272,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -288,8 +294,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -339,8 +347,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 1,
             data: "$ cd apps/web && pnpm dev\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -352,8 +362,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 2,
             data: "ELIFECYCLE Command failed.\r\n",
             timestamp: "2026-03-19T15:30:02.000Z",
@@ -394,8 +406,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             pid: 4242,
             startedAt: "2026-03-19T15:30:00.000Z",
           }),
@@ -416,8 +430,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         taskId: "task-7",
         terminalChunk: {
           scriptId: "frontend",
-          runId: "frontend:2",
-          runOrder: { hostInstanceId: "host-1", generation: 2 },
+          runIdentity: {
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
+          },
           sequence: 1,
           data: "$ cd apps/web && pnpm dev\r\n",
           timestamp: "2026-03-19T15:30:01.000Z",
@@ -429,8 +445,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         taskId: "task-7",
         terminalChunk: {
           scriptId: "frontend",
-          runId: "frontend:2",
-          runOrder: { hostInstanceId: "host-1", generation: 2 },
+          runIdentity: {
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
+          },
           sequence: 2,
           data: "ELIFECYCLE Command failed.\r\n",
           timestamp: "2026-03-19T15:30:02.000Z",
@@ -442,7 +460,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         expect(
           harness.getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
         ).toEqual(["$ cd apps/web && pnpm dev\r\n", "ELIFECYCLE Command failed.\r\n"]);
-        expect(harness.getLatest().scripts[0]?.runId).toBe("frontend:2");
+        expect(harness.getLatest().scripts[0]?.runIdentity?.runId).toBe("frontend:2");
       });
     };
     const staleStartingScript = buildScript({
@@ -452,8 +470,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       bufferedTerminalChunks: [
         {
           scriptId: "frontend",
-          runId: "frontend:1",
-          runOrder: { hostInstanceId: "host-1", generation: 1 },
+          runIdentity: {
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
+          },
           sequence: 0,
           data: "Starting `cd apps/web && pnpm dev`\r\n",
           timestamp: "2026-03-19T15:30:00.000Z",
@@ -462,13 +482,17 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     });
     const staleForeignStartingScript = buildScript({
       status: "starting",
-      runId: "retired-host-run",
-      runOrder: { hostInstanceId: "retired-host", generation: 99 },
+      runIdentity: {
+        runId: "retired-host-run",
+        runOrder: { hostInstanceId: "retired-host", generation: 99 },
+      },
       bufferedTerminalChunks: [
         {
           scriptId: "frontend",
-          runId: "retired-host-run",
-          runOrder: { hostInstanceId: "retired-host", generation: 99 },
+          runIdentity: {
+            runId: "retired-host-run",
+            runOrder: { hostInstanceId: "retired-host", generation: 99 },
+          },
           sequence: 0,
           data: "Retired host starting\r\n",
           timestamp: "2026-03-19T15:29:00.000Z",
@@ -534,8 +558,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         scripts: [
           buildScript({
             status: "running",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-current", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-current", generation: 1 },
+            },
             pid: 4242,
             startedAt: "2026-03-19T15:30:00.000Z",
           }),
@@ -577,8 +603,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
             name: "Backend",
             command: "bun run api",
             status: "starting",
-            runId: "backend:foreign",
-            runOrder: { hostInstanceId: "host-foreign", generation: 99 },
+            runIdentity: {
+              runId: "backend:foreign",
+              runOrder: { hostInstanceId: "host-foreign", generation: 99 },
+            },
           }),
         });
         devServerEventListener?.({
@@ -587,8 +615,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "backend",
-            runId: "backend:foreign",
-            runOrder: { hostInstanceId: "host-foreign", generation: 99 },
+            runIdentity: {
+              runId: "backend:foreign",
+              runOrder: { hostInstanceId: "host-foreign", generation: 99 },
+            },
             sequence: 0,
             data: "foreign backend output\r\n",
             timestamp: "2026-03-19T15:31:00.000Z",
@@ -598,8 +628,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
 
       const backend = harness.getLatest().scripts.find((script) => script.scriptId === "backend");
       expect(backend?.status).toBe("stopped");
-      expect(backend?.runId).toBeNull();
-      expect(backend?.runOrder).toBeNull();
+      expect(backend?.runIdentity).toBeNull();
 
       act(() => {
         harness.getLatest().onSelectScript("backend");
@@ -628,8 +657,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
                 ? [
                     {
                       scriptId: "frontend",
-                      runId: "frontend:1",
-                      runOrder: { hostInstanceId: "host-1", generation: 1 },
+                      runIdentity: {
+                        runId: "frontend:1",
+                        runOrder: { hostInstanceId: "host-1", generation: 1 },
+                      },
                       sequence: 7,
                       data: "previous task output\r\n",
                       timestamp: "2026-03-19T15:30:00.000Z",
@@ -732,8 +763,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
                 bufferedTerminalChunks: [
                   {
                     scriptId: "frontend",
-                    runId: "frontend:1",
-                    runOrder: { hostInstanceId: "host-1", generation: 1 },
+                    runIdentity: {
+                      runId: "frontend:1",
+                      runOrder: { hostInstanceId: "host-1", generation: 1 },
+                    },
                     sequence: 0,
                     data: "task seven restarted output\r\n",
                     timestamp: "2026-03-19T15:31:00.000Z",
@@ -865,8 +898,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
-                  runId: "frontend:1",
-                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                  runIdentity: {
+                    runId: "frontend:1",
+                    runOrder: { hostInstanceId: "host-1", generation: 1 },
+                  },
                   sequence: 7,
                   data: "old task seven output\r\n",
                   timestamp: "2026-03-19T15:30:00.000Z",
@@ -941,8 +976,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
-                  runId: "frontend:2",
-                  runOrder: { hostInstanceId: "host-1", generation: 2 },
+                  runIdentity: {
+                    runId: "frontend:2",
+                    runOrder: { hostInstanceId: "host-1", generation: 2 },
+                  },
                   sequence: 0,
                   data: "new task seven output\r\n",
                   timestamp: "2026-03-19T15:31:00.000Z",
@@ -986,8 +1023,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1001,15 +1040,19 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       scripts: [
         buildScript({
           status: "running",
-          runId: "frontend:2",
-          runOrder: { hostInstanceId: "host-2", generation: 1 },
+          runIdentity: {
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-2", generation: 1 },
+          },
           pid: 4242,
           startedAt: "2026-03-19T15:30:00.000Z",
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:2",
-              runOrder: { hostInstanceId: "host-2", generation: 1 },
+              runIdentity: {
+                runId: "frontend:2",
+                runOrder: { hostInstanceId: "host-2", generation: 1 },
+              },
               sequence: 2,
               data: "reconnected output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -1067,15 +1110,19 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       scripts: [
         buildScript({
           status: "running",
-          runId: "retired-run",
-          runOrder: { hostInstanceId: "host-retired", generation: 1 },
+          runIdentity: {
+            runId: "retired-run",
+            runOrder: { hostInstanceId: "host-retired", generation: 1 },
+          },
           pid: 4141,
           startedAt: "2026-03-19T15:30:00.000Z",
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "retired-run",
-              runOrder: { hostInstanceId: "host-retired", generation: 1 },
+              runIdentity: {
+                runId: "retired-run",
+                runOrder: { hostInstanceId: "host-retired", generation: 1 },
+              },
               sequence: 0,
               data: "retired host\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1089,15 +1136,19 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       scripts: [
         buildScript({
           status: "running",
-          runId: "current-run",
-          runOrder: { hostInstanceId: "host-current", generation: 1 },
+          runIdentity: {
+            runId: "current-run",
+            runOrder: { hostInstanceId: "host-current", generation: 1 },
+          },
           pid: 5151,
           startedAt: "2026-03-19T15:31:00.000Z",
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "current-run",
-              runOrder: { hostInstanceId: "host-current", generation: 1 },
+              runIdentity: {
+                runId: "current-run",
+                runOrder: { hostInstanceId: "host-current", generation: 1 },
+              },
               sequence: 0,
               data: "current host\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -1150,7 +1201,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     try {
       expect(currentHarness.getLatest().selectedScriptTerminalBuffer).toBeNull();
       await waitFor(() => {
-        expect(currentHarness.getLatest().scripts[0]?.runOrder?.hostInstanceId).toBe(
+        expect(currentHarness.getLatest().scripts[0]?.runIdentity?.runOrder.hostInstanceId).toBe(
           "host-current",
         );
         expect(currentHarness.getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
@@ -1166,8 +1217,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "retired-run",
-            runOrder: { hostInstanceId: "host-retired", generation: 1 },
+            runIdentity: {
+              runId: "retired-run",
+              runOrder: { hostInstanceId: "host-retired", generation: 1 },
+            },
             sequence: 1,
             data: "late retired output\r\n",
             timestamp: "2026-03-19T15:32:00.000Z",
@@ -1177,7 +1230,9 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         await Promise.resolve();
       });
 
-      expect(currentHarness.getLatest().scripts[0]?.runOrder?.hostInstanceId).toBe("host-current");
+      expect(currentHarness.getLatest().scripts[0]?.runIdentity?.runOrder.hostInstanceId).toBe(
+        "host-current",
+      );
       expect(
         currentHarness.getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
       ).toEqual(["current host\r\n"]);
@@ -1195,15 +1250,19 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       scripts: [
         buildScript({
           status: "running",
-          runId: "host-current-run",
-          runOrder: { hostInstanceId: "host-current", generation: 1 },
+          runIdentity: {
+            runId: "host-current-run",
+            runOrder: { hostInstanceId: "host-current", generation: 1 },
+          },
           pid: 5252,
           startedAt: "2026-03-19T15:31:00.000Z",
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "host-current-run",
-              runOrder: { hostInstanceId: "host-current", generation: 1 },
+              runIdentity: {
+                runId: "host-current-run",
+                runOrder: { hostInstanceId: "host-current", generation: 1 },
+              },
               sequence: 0,
               data: "current host\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -1257,7 +1316,9 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
 
       await waitFor(() => {
         expect(getStateCalls).toBe(2);
-        expect(harness.getLatest().scripts[0]?.runOrder?.hostInstanceId).toBe("host-current");
+        expect(harness.getLatest().scripts[0]?.runIdentity?.runOrder.hostInstanceId).toBe(
+          "host-current",
+        );
       });
 
       act(() => {
@@ -1275,8 +1336,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
             scripts: [
               buildScript({
                 status: "running",
-                runId: "host-stale-run",
-                runOrder: { hostInstanceId: "host-stale", generation: 99 },
+                runIdentity: {
+                  runId: "host-stale-run",
+                  runOrder: { hostInstanceId: "host-stale", generation: 99 },
+                },
                 pid: 4242,
                 startedAt: "2026-03-19T15:29:00.000Z",
               }),
@@ -1288,8 +1351,10 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
             scripts: [
               buildScript({
                 status: "running",
-                runId: "host-initial-stale-run",
-                runOrder: { hostInstanceId: "host-initial-stale", generation: 50 },
+                runIdentity: {
+                  runId: "host-initial-stale-run",
+                  runOrder: { hostInstanceId: "host-initial-stale", generation: 50 },
+                },
                 pid: 3131,
                 startedAt: "2026-03-19T15:28:00.000Z",
               }),
@@ -1311,7 +1376,8 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           .some((mutation) => {
             const data = mutation.state.data as DevServerGroupState | undefined;
             return (
-              mutation.state.status === "success" && data?.scripts[0]?.runId === "host-stale-run"
+              mutation.state.status === "success" &&
+              data?.scripts[0]?.runIdentity?.runId === "host-stale-run"
             );
           });
         expect(staleQuery?.state.status).toBe("success");
@@ -1319,7 +1385,9 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         expect(hasSettledStaleMutation).toBe(true);
         expect(staleRestartSettled).toBe(true);
         expect(staleInitialQuerySettled).toBe(true);
-        expect(harness.getLatest().scripts[0]?.runOrder?.hostInstanceId).toBe("host-current");
+        expect(harness.getLatest().scripts[0]?.runIdentity?.runOrder.hostInstanceId).toBe(
+          "host-current",
+        );
         expect(harness.getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
           "current host\r\n",
         );

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
@@ -114,6 +114,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 4,
               data: "rehydrated output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -176,6 +177,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
 
     const bufferedTerminalChunks = Array.from({ length: 300 }, (_, sequence) => ({
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence,
       data: `subscription-gap output ${sequence}\r\n`,
       timestamp: "2026-03-19T15:31:00.000Z",
@@ -257,6 +259,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -275,6 +278,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -330,6 +334,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 1,
             data: "$ cd apps/web && pnpm dev\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -341,6 +346,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 2,
             data: "ELIFECYCLE Command failed.\r\n",
             timestamp: "2026-03-19T15:30:02.000Z",
@@ -401,6 +407,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         taskId: "task-7",
         terminalChunk: {
           scriptId: "frontend",
+          runId: "frontend:1",
           sequence: 1,
           data: "$ cd apps/web && pnpm dev\r\n",
           timestamp: "2026-03-19T15:30:01.000Z",
@@ -412,6 +419,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         taskId: "task-7",
         terminalChunk: {
           scriptId: "frontend",
+          runId: "frontend:1",
           sequence: 2,
           data: "ELIFECYCLE Command failed.\r\n",
           timestamp: "2026-03-19T15:30:02.000Z",
@@ -433,6 +441,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       bufferedTerminalChunks: [
         {
           scriptId: "frontend",
+          runId: "frontend:1",
           sequence: 0,
           data: "Starting `cd apps/web && pnpm dev`\r\n",
           timestamp: "2026-03-19T15:30:00.000Z",
@@ -495,6 +504,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
                 ? [
                     {
                       scriptId: "frontend",
+                      runId: "frontend:1",
                       sequence: 7,
                       data: "previous task output\r\n",
                       timestamp: "2026-03-19T15:30:00.000Z",
@@ -597,6 +607,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
                 bufferedTerminalChunks: [
                   {
                     scriptId: "frontend",
+                    runId: "frontend:1",
                     sequence: 0,
                     data: "task seven restarted output\r\n",
                     timestamp: "2026-03-19T15:31:00.000Z",
@@ -728,6 +739,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
+                  runId: "frontend:1",
                   sequence: 7,
                   data: "old task seven output\r\n",
                   timestamp: "2026-03-19T15:30:00.000Z",
@@ -802,6 +814,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
+                  runId: "frontend:1",
                   sequence: 0,
                   data: "new task seven output\r\n",
                   timestamp: "2026-03-19T15:31:00.000Z",
@@ -845,6 +858,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -863,6 +877,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 2,
               data: "reconnected output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { DevServerGroupState } from "@openducktor/contracts";
 import { act, waitFor } from "@testing-library/react";
+import { createQueryClient } from "@/lib/query-client";
+import { devServerQueryKeys } from "@/state/queries/dev-servers";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import {
   buildScript,
@@ -441,13 +443,13 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         expect(
           harness.getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
         ).toEqual(["$ cd apps/web && pnpm dev\r\n", "ELIFECYCLE Command failed.\r\n"]);
+        expect(harness.getLatest().scripts[0]?.runId).toBe("frontend:2");
       });
     };
     const staleStartingScript = buildScript({
-      status: "failed",
+      status: "starting",
       pid: null,
       startedAt: null,
-      lastError: "Command failed.",
       bufferedTerminalChunks: [
         {
           scriptId: "frontend",
@@ -456,6 +458,21 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           sequence: 0,
           data: "Starting `cd apps/web && pnpm dev`\r\n",
           timestamp: "2026-03-19T15:30:00.000Z",
+        },
+      ],
+    });
+    const staleForeignStartingScript = buildScript({
+      status: "starting",
+      runId: "retired-host-run",
+      runOrder: { hostInstanceId: "retired-host", generation: 99 },
+      bufferedTerminalChunks: [
+        {
+          scriptId: "frontend",
+          runId: "retired-host-run",
+          runOrder: { hostInstanceId: "retired-host", generation: 99 },
+          sequence: 0,
+          data: "Retired host starting\r\n",
+          timestamp: "2026-03-19T15:29:00.000Z",
         },
       ],
     });
@@ -484,6 +501,17 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
 
       act(() => {
         devServerEventListener?.({
+          type: "script_status_changed",
+          repoPath: "/repo",
+          taskId: "task-7",
+          updatedAt: "2026-03-19T15:30:03.500Z",
+          script: staleForeignStartingScript,
+        });
+      });
+      await expectLiveFailureOutput();
+
+      act(() => {
+        devServerEventListener?.({
           type: "snapshot",
           state: buildState({
             updatedAt: "2026-03-19T15:30:04.000Z",
@@ -492,6 +520,92 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         });
       });
       await expectLiveFailureOutput();
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("rejects foreign host events for an unowned script in an owned group", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    devServerGetState = async () =>
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-current", generation: 1 },
+            pid: 4242,
+            startedAt: "2026-03-19T15:30:00.000Z",
+          }),
+          buildScript({
+            scriptId: "backend",
+            name: "Backend",
+            command: "bun run api",
+          }),
+        ],
+      });
+
+    const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
+      repoPath: "/repo",
+      taskId: "task-7",
+      repoSettings: {
+        ...repoSettings,
+        devServers: [
+          ...repoSettings.devServers,
+          { id: "backend", name: "Backend", command: "bun run api" },
+        ],
+      },
+      enabled: true,
+    });
+
+    try {
+      await waitFor(() => {
+        expect(harness.getLatest().scripts).toHaveLength(2);
+        expect(devServerEventListener).not.toBeNull();
+      });
+
+      act(() => {
+        devServerEventListener?.({
+          type: "script_status_changed",
+          repoPath: "/repo",
+          taskId: "task-7",
+          updatedAt: "2026-03-19T15:31:00.000Z",
+          script: buildScript({
+            scriptId: "backend",
+            name: "Backend",
+            command: "bun run api",
+            status: "starting",
+            runId: "backend:foreign",
+            runOrder: { hostInstanceId: "host-foreign", generation: 99 },
+          }),
+        });
+        devServerEventListener?.({
+          type: "terminal_chunk",
+          repoPath: "/repo",
+          taskId: "task-7",
+          terminalChunk: {
+            scriptId: "backend",
+            runId: "backend:foreign",
+            runOrder: { hostInstanceId: "host-foreign", generation: 99 },
+            sequence: 0,
+            data: "foreign backend output\r\n",
+            timestamp: "2026-03-19T15:31:00.000Z",
+          },
+        });
+      });
+
+      const backend = harness.getLatest().scripts.find((script) => script.scriptId === "backend");
+      expect(backend?.status).toBe("stopped");
+      expect(backend?.runId).toBeNull();
+      expect(backend?.runOrder).toBeNull();
+
+      act(() => {
+        harness.getLatest().onSelectScript("backend");
+      });
+      expect(harness.getLatest().selectedScriptTerminalBuffer?.entries).toEqual([]);
     } finally {
       harness.unmount();
     }
@@ -888,13 +1002,15 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
       scripts: [
         buildScript({
           status: "running",
+          runId: "frontend:2",
+          runOrder: { hostInstanceId: "host-2", generation: 1 },
           pid: 4242,
           startedAt: "2026-03-19T15:30:00.000Z",
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-2", generation: 1 },
               sequence: 2,
               data: "reconnected output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -939,6 +1055,147 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         );
       });
       expect(getStateCalls).toBe(2);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("binds query and mutation results to the browser transport generation", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+
+    const staleInitialQuery = createDeferred<DevServerGroupState>();
+    const staleRestart = createDeferred<DevServerGroupState>();
+    const currentHostState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          runId: "host-current-run",
+          runOrder: { hostInstanceId: "host-current", generation: 1 },
+          pid: 5252,
+          startedAt: "2026-03-19T15:31:00.000Z",
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              runId: "host-current-run",
+              runOrder: { hostInstanceId: "host-current", generation: 1 },
+              sequence: 0,
+              data: "current host\r\n",
+              timestamp: "2026-03-19T15:31:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+    let getStateCalls = 0;
+    let staleInitialQuerySettled = false;
+    let staleRestartSettled = false;
+    devServerGetState = async () => {
+      getStateCalls += 1;
+      if (getStateCalls !== 1) {
+        return currentHostState;
+      }
+      const result = await staleInitialQuery.promise;
+      staleInitialQuerySettled = true;
+      return result;
+    };
+    devServerRestart = async () => {
+      const result = await staleRestart.promise;
+      staleRestartSettled = true;
+      return result;
+    };
+
+    const queryClient = createQueryClient();
+    const harness = renderDevServerPanelHook(
+      useAgentStudioDevServerPanel,
+      {
+        repoPath: "/repo",
+        taskId: "task-7",
+        repoSettings,
+        enabled: true,
+      },
+      { queryClient },
+    );
+
+    try {
+      await waitFor(() => {
+        expect(devServerEventListener).not.toBeNull();
+      });
+
+      act(() => {
+        devServerEventListener?.({
+          __openducktorBrowserLive: true,
+          kind: "reconnected",
+        });
+      });
+
+      await waitFor(() => {
+        expect(getStateCalls).toBe(2);
+        expect(harness.getLatest().scripts[0]?.runOrder?.hostInstanceId).toBe("host-current");
+      });
+
+      act(() => {
+        harness.getLatest().onRestart();
+      });
+
+      await act(async () => {
+        devServerEventListener?.({
+          __openducktorBrowserLive: true,
+          kind: "reconnected",
+        });
+        staleRestart.resolve(
+          buildState({
+            scripts: [
+              buildScript({
+                status: "running",
+                runId: "host-stale-run",
+                runOrder: { hostInstanceId: "host-stale", generation: 99 },
+                pid: 4242,
+                startedAt: "2026-03-19T15:29:00.000Z",
+              }),
+            ],
+          }),
+        );
+        staleInitialQuery.resolve(
+          buildState({
+            scripts: [
+              buildScript({
+                status: "running",
+                runId: "host-initial-stale-run",
+                runOrder: { hostInstanceId: "host-initial-stale", generation: 50 },
+                pid: 3131,
+                startedAt: "2026-03-19T15:28:00.000Z",
+              }),
+            ],
+          }),
+        );
+        await Promise.all([staleRestart.promise, staleInitialQuery.promise]);
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        const staleQuery = queryClient.getQueryCache().find({
+          queryKey: devServerQueryKeys.state("/repo", "task-7", 0),
+          exact: true,
+        });
+        const hasSettledStaleMutation = queryClient
+          .getMutationCache()
+          .getAll()
+          .some((mutation) => {
+            const data = mutation.state.data as DevServerGroupState | undefined;
+            return (
+              mutation.state.status === "success" && data?.scripts[0]?.runId === "host-stale-run"
+            );
+          });
+        expect(staleQuery?.state.status).toBe("success");
+        expect(staleQuery?.state.fetchStatus).toBe("idle");
+        expect(hasSettledStaleMutation).toBe(true);
+        expect(staleRestartSettled).toBe(true);
+        expect(staleInitialQuerySettled).toBe(true);
+        expect(harness.getLatest().scripts[0]?.runOrder?.hostInstanceId).toBe("host-current");
+        expect(harness.getLatest().selectedScriptTerminalBuffer?.entries[0]?.data).toBe(
+          "current host\r\n",
+        );
+      });
     } finally {
       harness.unmount();
     }

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
@@ -617,6 +617,98 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     }
   });
 
+  test("does not expose a pending dev-server mutation after the active task changes", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    devServerGetState = async (_repoPath, taskId) =>
+      buildState({
+        taskId,
+        worktreePath: `/tmp/worktree/${taskId}`,
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: taskId === "task-7" ? 4242 : 5252,
+            startedAt: "2026-03-19T15:30:00.000Z",
+          }),
+        ],
+      });
+    const stopDeferred = createDeferred<DevServerGroupState>();
+    devServerStop = async () => stopDeferred.promise;
+
+    const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
+      repoPath: "/repo",
+      taskId: "task-7",
+      repoSettings,
+      enabled: true,
+    });
+
+    try {
+      await waitFor(() => {
+        expect(harness.getLatest().worktreePath).toBe("/tmp/worktree/task-7");
+      });
+
+      act(() => {
+        harness.getLatest().onStop();
+      });
+
+      await waitFor(() => {
+        expect(harness.getLatest().isStopPending).toBe(true);
+      });
+
+      act(() => {
+        harness.update({
+          repoPath: "/repo",
+          taskId: "task-8",
+          repoSettings,
+          enabled: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(harness.getLatest().worktreePath).toBe("/tmp/worktree/task-8");
+      });
+      expect(harness.getLatest().isStopPending).toBe(false);
+      expect(harness.getLatest().isStartPending).toBe(false);
+      expect(harness.getLatest().isRestartPending).toBe(false);
+
+      stopDeferred.resolve(
+        buildState({
+          taskId: "task-7",
+          worktreePath: "/tmp/worktree/task-7",
+        }),
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("surfaces dev-server actions without an active task as actionable errors", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const harness = renderDevServerPanelHook<HookArgs, HookResult>(useAgentStudioDevServerPanel, {
+      repoPath: null,
+      taskId: "task-7",
+      repoSettings,
+      enabled: true,
+    });
+
+    try {
+      act(() => {
+        harness.getLatest().onStart();
+      });
+
+      expect(harness.getLatest().error).toBe(
+        "Builder dev servers require an active repository and task.",
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
   test("replaces a returned task terminal buffer after its sequence resets while inactive", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-subscription.test.tsx
@@ -115,6 +115,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 4,
               data: "rehydrated output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -178,6 +179,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
     const bufferedTerminalChunks = Array.from({ length: 300 }, (_, sequence) => ({
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence,
       data: `subscription-gap output ${sequence}\r\n`,
       timestamp: "2026-03-19T15:31:00.000Z",
@@ -260,6 +262,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -279,6 +282,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "Starting `cd apps/web && pnpm dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -335,6 +339,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 1,
             data: "$ cd apps/web && pnpm dev\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -347,6 +352,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 2,
             data: "ELIFECYCLE Command failed.\r\n",
             timestamp: "2026-03-19T15:30:02.000Z",
@@ -387,6 +393,8 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         scripts: [
           buildScript({
             status: "running",
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
             pid: 4242,
             startedAt: "2026-03-19T15:30:00.000Z",
           }),
@@ -407,7 +415,8 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         taskId: "task-7",
         terminalChunk: {
           scriptId: "frontend",
-          runId: "frontend:1",
+          runId: "frontend:2",
+          runOrder: { hostInstanceId: "host-1", generation: 2 },
           sequence: 1,
           data: "$ cd apps/web && pnpm dev\r\n",
           timestamp: "2026-03-19T15:30:01.000Z",
@@ -419,7 +428,8 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         taskId: "task-7",
         terminalChunk: {
           scriptId: "frontend",
-          runId: "frontend:1",
+          runId: "frontend:2",
+          runOrder: { hostInstanceId: "host-1", generation: 2 },
           sequence: 2,
           data: "ELIFECYCLE Command failed.\r\n",
           timestamp: "2026-03-19T15:30:02.000Z",
@@ -442,6 +452,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
         {
           scriptId: "frontend",
           runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
           sequence: 0,
           data: "Starting `cd apps/web && pnpm dev`\r\n",
           timestamp: "2026-03-19T15:30:00.000Z",
@@ -505,6 +516,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
                     {
                       scriptId: "frontend",
                       runId: "frontend:1",
+                      runOrder: { hostInstanceId: "host-1", generation: 1 },
                       sequence: 7,
                       data: "previous task output\r\n",
                       timestamp: "2026-03-19T15:30:00.000Z",
@@ -608,6 +620,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
                   {
                     scriptId: "frontend",
                     runId: "frontend:1",
+                    runOrder: { hostInstanceId: "host-1", generation: 1 },
                     sequence: 0,
                     data: "task seven restarted output\r\n",
                     timestamp: "2026-03-19T15:31:00.000Z",
@@ -740,6 +753,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
                 {
                   scriptId: "frontend",
                   runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
                   sequence: 7,
                   data: "old task seven output\r\n",
                   timestamp: "2026-03-19T15:30:00.000Z",
@@ -814,7 +828,8 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
-                  runId: "frontend:1",
+                  runId: "frontend:2",
+                  runOrder: { hostInstanceId: "host-1", generation: 2 },
                   sequence: 0,
                   data: "new task seven output\r\n",
                   timestamp: "2026-03-19T15:31:00.000Z",
@@ -859,6 +874,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -878,6 +894,7 @@ describe("useAgentStudioDevServerPanel subscriptions", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 2,
               data: "reconnected output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
@@ -19,20 +19,24 @@ export const createDeferred = <T>() => {
 export const buildScript = (
   overrides: Partial<DevServerScriptState> = {},
 ): DevServerScriptState => {
-  const bufferedRun = overrides.bufferedTerminalChunks?.[0];
-  const runId =
-    overrides.runId ??
-    bufferedRun?.runId ??
-    (overrides.pid === null || overrides.pid === undefined ? null : "frontend:1");
+  const bufferedRunIdentity = overrides.bufferedTerminalChunks?.[0]?.runIdentity;
+  const defaultRunIdentity =
+    overrides.pid === null || overrides.pid === undefined
+      ? null
+      : {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        };
+  const runIdentity =
+    overrides.runIdentity === undefined
+      ? (bufferedRunIdentity ?? defaultRunIdentity)
+      : overrides.runIdentity;
   return {
     scriptId: "frontend",
     name: "Frontend",
     command: "bun run dev",
     status: "stopped",
-    runId,
-    runOrder:
-      bufferedRun?.runOrder ??
-      (runId === null ? null : { hostInstanceId: "host-1", generation: 1 }),
+    runIdentity,
     pid: null,
     startedAt: null,
     exitCode: null,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
@@ -18,19 +18,29 @@ export const createDeferred = <T>() => {
 
 export const buildScript = (
   overrides: Partial<DevServerScriptState> = {},
-): DevServerScriptState => ({
-  scriptId: "frontend",
-  name: "Frontend",
-  command: "bun run dev",
-  status: "stopped",
-  runId: overrides.pid === null || overrides.pid === undefined ? null : "frontend:1",
-  pid: null,
-  startedAt: null,
-  exitCode: null,
-  lastError: null,
-  bufferedTerminalChunks: [],
-  ...overrides,
-});
+): DevServerScriptState => {
+  const bufferedRun = overrides.bufferedTerminalChunks?.[0];
+  const runId =
+    overrides.runId ??
+    bufferedRun?.runId ??
+    (overrides.pid === null || overrides.pid === undefined ? null : "frontend:1");
+  return {
+    scriptId: "frontend",
+    name: "Frontend",
+    command: "bun run dev",
+    status: "stopped",
+    runId,
+    runOrder:
+      bufferedRun?.runOrder ??
+      (runId === null ? null : { hostInstanceId: "host-1", generation: 1 }),
+    pid: null,
+    startedAt: null,
+    exitCode: null,
+    lastError: null,
+    bufferedTerminalChunks: [],
+    ...overrides,
+  };
+};
 
 export const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGroupState => ({
   repoPath: "/repo",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-test-fixtures.ts
@@ -23,6 +23,7 @@ export const buildScript = (
   name: "Frontend",
   command: "bun run dev",
   status: "stopped",
+  runId: overrides.pid === null || overrides.pid === undefined ? null : "frontend:1",
   pid: null,
   startedAt: null,
   exitCode: null,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -256,6 +256,7 @@ describe("useAgentStudioDevServerPanel", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
+                runId: "frontend:1",
                 sequence: 0,
                 data: "Starting `bun run dev`\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -378,6 +379,7 @@ describe("useAgentStudioDevServerPanel", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
+                runId: "frontend:1",
                 sequence: 0,
                 data: "Starting `bun run dev`\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -405,6 +407,7 @@ describe("useAgentStudioDevServerPanel", () => {
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
+                  runId: "frontend:1",
                   sequence: 0,
                   data: "Starting `bun run dev`\r\n",
                   timestamp: "2026-03-19T15:30:00.000Z",
@@ -491,6 +494,7 @@ describe("useAgentStudioDevServerPanel", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
+                runId: "frontend:1",
                 sequence: 0,
                 data: "ready\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -507,6 +511,7 @@ describe("useAgentStudioDevServerPanel", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "backend",
+                runId: "backend:1",
                 sequence: 0,
                 data: "Dev server exited with code 1.\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -578,6 +583,7 @@ describe("useAgentStudioDevServerPanel", () => {
       scripts: [
         buildScript({
           status: "running",
+          runId: "frontend:1",
           pid: 4242,
           startedAt: "2026-03-19T15:30:00.000Z",
         }),
@@ -640,6 +646,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 0,
             data: "\u001b[32mready\u001b[0m\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -731,6 +738,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 0,
             data: "fresh-line",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -767,6 +775,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -821,6 +830,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 1,
             data: "closing dev server\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -869,6 +879,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 3,
               data: "old run output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -882,11 +893,13 @@ describe("useAgentStudioDevServerPanel", () => {
       scripts: [
         buildScript({
           status: "running",
+          runId: "frontend:2",
           pid: 4343,
           startedAt: "2026-03-19T15:31:00.000Z",
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:2",
               sequence: 4,
               data: "new run output\r\n",
               timestamp: "2026-03-19T15:31:01.000Z",
@@ -947,6 +960,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:2",
             sequence: 4,
             data: "new run output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -955,7 +969,7 @@ describe("useAgentStudioDevServerPanel", () => {
       });
 
       await waitFor(() => {
-        expect(getLatest().selectedScriptTerminalBuffer?.entries).toHaveLength(2);
+        expect(getLatest().selectedScriptTerminalBuffer?.entries).toHaveLength(1);
       });
 
       restartDeferred.resolve(restartedState);
@@ -993,6 +1007,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "Dev server exited with code 1.\r\n",
               timestamp: "2026-03-19T15:35:00.000Z",
@@ -1100,6 +1115,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1118,6 +1134,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "fresh output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -1205,6 +1222,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1304,6 +1322,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1377,6 +1396,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 1,
             data: "live output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1404,6 +1424,7 @@ describe("useAgentStudioDevServerPanel", () => {
         expect(getLatest().selectedScriptTerminalBuffer?.entries).toEqual([
           {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 1,
             data: "live output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1431,6 +1452,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1530,6 +1552,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 0,
             data: "new run output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1574,6 +1597,7 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 0,
               data: "Starting `bun run dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1611,6 +1635,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 1,
             data: "old failed output\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -1622,6 +1647,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 2,
             data: "ELIFECYCLE Command failed.\r\n",
             timestamp: "2026-03-19T15:30:02.000Z",
@@ -1661,6 +1687,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 0,
             data: "Starting `bun run dev`\r\n",
             timestamp: "2026-03-19T15:31:00.000Z",
@@ -1672,6 +1699,7 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
+            runId: "frontend:1",
             sequence: 1,
             data: "new dev server ready\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1694,12 +1722,14 @@ describe("useAgentStudioDevServerPanel", () => {
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
+                  runId: "frontend:1",
                   sequence: 0,
                   data: "Starting `bun run dev`\r\n",
                   timestamp: "2026-03-19T15:31:00.000Z",
                 },
                 {
                   scriptId: "frontend",
+                  runId: "frontend:1",
                   sequence: 1,
                   data: "new dev server ready\r\n",
                   timestamp: "2026-03-19T15:31:01.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -268,8 +268,10 @@ describe("useAgentStudioDevServerPanel", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
-                runId: "frontend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 sequence: 0,
                 data: "Starting `bun run dev`\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -392,8 +394,10 @@ describe("useAgentStudioDevServerPanel", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
-                runId: "frontend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 sequence: 0,
                 data: "Starting `bun run dev`\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -421,8 +425,10 @@ describe("useAgentStudioDevServerPanel", () => {
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
-                  runId: "frontend:1",
-                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                  runIdentity: {
+                    runId: "frontend:1",
+                    runOrder: { hostInstanceId: "host-1", generation: 1 },
+                  },
                   sequence: 0,
                   data: "Starting `bun run dev`\r\n",
                   timestamp: "2026-03-19T15:30:00.000Z",
@@ -445,13 +451,17 @@ describe("useAgentStudioDevServerPanel", () => {
     const stoppedState = buildState({
       scripts: [
         buildScript({
-          runId: "frontend:1",
-          runOrder: { hostInstanceId: "host-1", generation: 1 },
+          runIdentity: {
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
+          },
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 3,
               data: "stopped replay\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -522,8 +532,10 @@ describe("useAgentStudioDevServerPanel", () => {
           updatedAt: "2026-03-19T15:31:00.000Z",
           script: buildScript({
             status: "starting",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
           }),
         });
       });
@@ -554,8 +566,10 @@ describe("useAgentStudioDevServerPanel", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "frontend",
-                runId: "frontend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 sequence: 0,
                 data: "ready\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -572,8 +586,10 @@ describe("useAgentStudioDevServerPanel", () => {
             bufferedTerminalChunks: [
               {
                 scriptId: "backend",
-                runId: "backend:1",
-                runOrder: { hostInstanceId: "host-1", generation: 1 },
+                runIdentity: {
+                  runId: "backend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
+                },
                 sequence: 0,
                 data: "Dev server exited with code 1.\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -645,8 +661,10 @@ describe("useAgentStudioDevServerPanel", () => {
       scripts: [
         buildScript({
           status: "running",
-          runId: "frontend:1",
-          runOrder: { hostInstanceId: "host-1", generation: 1 },
+          runIdentity: {
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
+          },
           pid: 4242,
           startedAt: "2026-03-19T15:30:00.000Z",
         }),
@@ -709,8 +727,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 0,
             data: "\u001b[32mready\u001b[0m\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -802,8 +822,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 0,
             data: "fresh-line",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -840,8 +862,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -855,8 +879,10 @@ describe("useAgentStudioDevServerPanel", () => {
       scripts: [
         buildScript({
           status: "stopped",
-          runId: "frontend:1",
-          runOrder: { hostInstanceId: "host-1", generation: 1 },
+          runIdentity: {
+            runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
+          },
           pid: null,
           startedAt: null,
           bufferedTerminalChunks: [],
@@ -898,8 +924,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 1,
             data: "closing dev server\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -948,8 +976,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 3,
               data: "old run output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -963,15 +993,19 @@ describe("useAgentStudioDevServerPanel", () => {
       scripts: [
         buildScript({
           status: "running",
-          runId: "frontend:2",
-          runOrder: { hostInstanceId: "host-1", generation: 2 },
+          runIdentity: {
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
+          },
           pid: 4343,
           startedAt: "2026-03-19T15:31:00.000Z",
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:2",
-              runOrder: { hostInstanceId: "host-1", generation: 2 },
+              runIdentity: {
+                runId: "frontend:2",
+                runOrder: { hostInstanceId: "host-1", generation: 2 },
+              },
               sequence: 4,
               data: "new run output\r\n",
               timestamp: "2026-03-19T15:31:01.000Z",
@@ -1032,8 +1066,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             sequence: 4,
             data: "new run output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1080,8 +1116,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "Dev server exited with code 1.\r\n",
               timestamp: "2026-03-19T15:35:00.000Z",
@@ -1184,8 +1222,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1204,8 +1244,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "fresh output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -1293,8 +1335,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1394,8 +1438,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1469,8 +1515,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 1,
             data: "live output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1498,8 +1546,10 @@ describe("useAgentStudioDevServerPanel", () => {
         expect(getLatest().selectedScriptTerminalBuffer?.entries).toEqual([
           {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 1,
             data: "live output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1527,8 +1577,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1628,8 +1680,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 0,
             data: "new run output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1674,8 +1728,10 @@ describe("useAgentStudioDevServerPanel", () => {
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 0,
               data: "Starting `bun run dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1713,8 +1769,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 1,
             data: "old failed output\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -1726,8 +1784,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
-            runOrder: { hostInstanceId: "host-1", generation: 1 },
+            runIdentity: {
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+            },
             sequence: 2,
             data: "ELIFECYCLE Command failed.\r\n",
             timestamp: "2026-03-19T15:30:02.000Z",
@@ -1756,8 +1816,10 @@ describe("useAgentStudioDevServerPanel", () => {
           updatedAt: "2026-03-19T15:31:00.000Z",
           script: buildScript({
             status: "starting",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             pid: null,
             startedAt: "2026-03-19T15:31:00.000Z",
             bufferedTerminalChunks: [],
@@ -1769,8 +1831,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             sequence: 0,
             data: "Starting `bun run dev`\r\n",
             timestamp: "2026-03-19T15:31:00.000Z",
@@ -1782,8 +1846,10 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:2",
-            runOrder: { hostInstanceId: "host-1", generation: 2 },
+            runIdentity: {
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
+            },
             sequence: 1,
             data: "new dev server ready\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1801,23 +1867,29 @@ describe("useAgentStudioDevServerPanel", () => {
           scripts: [
             buildScript({
               status: "running",
-              runId: "frontend:2",
-              runOrder: { hostInstanceId: "host-1", generation: 2 },
+              runIdentity: {
+                runId: "frontend:2",
+                runOrder: { hostInstanceId: "host-1", generation: 2 },
+              },
               pid: 4343,
               startedAt: "2026-03-19T15:31:00.000Z",
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
-                  runId: "frontend:2",
-                  runOrder: { hostInstanceId: "host-1", generation: 2 },
+                  runIdentity: {
+                    runId: "frontend:2",
+                    runOrder: { hostInstanceId: "host-1", generation: 2 },
+                  },
                   sequence: 0,
                   data: "Starting `bun run dev`\r\n",
                   timestamp: "2026-03-19T15:31:00.000Z",
                 },
                 {
                   scriptId: "frontend",
-                  runId: "frontend:2",
-                  runOrder: { hostInstanceId: "host-1", generation: 2 },
+                  runIdentity: {
+                    runId: "frontend:2",
+                    runOrder: { hostInstanceId: "host-1", generation: 2 },
+                  },
                   sequence: 1,
                   data: "new dev server ready\r\n",
                   timestamp: "2026-03-19T15:31:01.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -30,12 +30,18 @@ let devServerStop = async (_repoPath: string, _taskId: string): Promise<DevServe
 let devServerRestart = async (_repoPath: string, _taskId: string): Promise<DevServerGroupState> =>
   buildState();
 let devServerEventListener: ((payload: unknown) => void) | null = null;
+let nextSubscriptionTransportEpoch = 0;
 let subscribeDevServerEventsMock = async (
   listener: (payload: unknown) => void,
-): Promise<() => void> => {
+): Promise<{ transportEpoch: string; unsubscribe: () => void }> => {
   devServerEventListener = listener;
-  return () => {
-    devServerEventListener = null;
+  const transportEpoch = `test:${nextSubscriptionTransportEpoch}`;
+  nextSubscriptionTransportEpoch += 1;
+  return {
+    transportEpoch,
+    unsubscribe: () => {
+      devServerEventListener = null;
+    },
   };
 };
 
@@ -59,10 +65,16 @@ beforeEach(() => {
   devServerRestart = async (_repoPath: string, _taskId: string): Promise<DevServerGroupState> =>
     buildState();
   devServerEventListener = null;
+  nextSubscriptionTransportEpoch = 0;
   subscribeDevServerEventsMock = async (listener: (payload: unknown) => void) => {
     devServerEventListener = listener;
-    return () => {
-      devServerEventListener = null;
+    const transportEpoch = `test:${nextSubscriptionTransportEpoch}`;
+    nextSubscriptionTransportEpoch += 1;
+    return {
+      transportEpoch,
+      unsubscribe: () => {
+        devServerEventListener = null;
+      },
     };
   };
 });
@@ -1045,7 +1057,7 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
-  test("reopens with cached dev-server state while a fresh refetch completes", async () => {
+  test("does not reuse cached dev-server state across subscription sessions", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
     type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
@@ -1079,15 +1091,11 @@ describe("useAgentStudioDevServerPanel", () => {
       ],
     });
     const reopenFetch = createDeferred<DevServerGroupState>();
-    let phase: "initial" | "reopen" | "steady" = "initial";
+    let phase: "initial" | "reopen" = "initial";
 
     devServerGetState = async () => {
       if (phase === "reopen") {
         return reopenFetch.promise;
-      }
-
-      if (phase === "steady") {
-        return refreshedState;
       }
 
       return initialState;
@@ -1145,12 +1153,11 @@ describe("useAgentStudioDevServerPanel", () => {
       );
 
       await waitFor(() => {
-        expect(getLatest().scripts[0]?.status).toBe("running");
+        expect(getLatest().scripts).toHaveLength(0);
+        expect(getLatest().mode).toBe("loading");
+        expect(getLatest().isLoading).toBe(true);
       });
-      expect(getLatest().mode).toBe("active");
-      expect(getLatest().isLoading).toBe(false);
 
-      phase = "steady";
       reopenFetch.resolve(refreshedState);
 
       await waitFor(() => {
@@ -1257,7 +1264,7 @@ describe("useAgentStudioDevServerPanel", () => {
 
       await act(async () => {
         await queryClient?.refetchQueries({
-          queryKey: devServerQueryKeys.state("/repo", "task-7"),
+          queryKey: devServerQueryKeys.state("/repo", "task-7", "test:0"),
           exact: true,
           type: "active",
         });
@@ -1357,7 +1364,7 @@ describe("useAgentStudioDevServerPanel", () => {
 
       await act(async () => {
         await queryClient?.refetchQueries({
-          queryKey: devServerQueryKeys.state("/repo", "task-7"),
+          queryKey: devServerQueryKeys.state("/repo", "task-7", "test:0"),
           exact: true,
           type: "active",
         });
@@ -1481,7 +1488,7 @@ describe("useAgentStudioDevServerPanel", () => {
 
       await act(async () => {
         await queryClient?.refetchQueries({
-          queryKey: devServerQueryKeys.state("/repo", "task-7"),
+          queryKey: devServerQueryKeys.state("/repo", "task-7", "test:0"),
           exact: true,
           type: "active",
         });
@@ -1636,7 +1643,7 @@ describe("useAgentStudioDevServerPanel", () => {
 
       await act(async () => {
         await queryClient?.refetchQueries({
-          queryKey: devServerQueryKeys.state("/repo", "task-7"),
+          queryKey: devServerQueryKeys.state("/repo", "task-7", "test:0"),
           exact: true,
           type: "active",
         });
@@ -1930,9 +1937,13 @@ describe("useAgentStudioDevServerPanel", () => {
     const taskTwoFetch = createDeferred<DevServerGroupState>();
     let didStartTaskTwoFetch = false;
 
-    queryClient.setQueryData(devServerQueryKeys.state("/repo-b", "task-2"), cachedTaskTwoState, {
-      updatedAt: 1,
-    });
+    queryClient.setQueryData(
+      devServerQueryKeys.state("/repo-b", "task-2", "test:1"),
+      cachedTaskTwoState,
+      {
+        updatedAt: 1,
+      },
+    );
     devServerGetState = async (repoPath, taskId) => {
       if (repoPath === "/repo-a" && taskId === "task-1") {
         return taskOneState;
@@ -1960,16 +1971,16 @@ describe("useAgentStudioDevServerPanel", () => {
       currentArgs = { ...currentArgs, repoPath: "/repo-b", taskId: "task-2" };
       harness.update(currentArgs);
 
-      expect(harness.getLatest().scripts[0]?.pid).toBe(2221);
-      expect(harness.getLatest().mode).toBe("active");
-      expect(harness.getLatest().isLoading).toBe(false);
+      expect(harness.getLatest().scripts).toEqual([]);
+      expect(harness.getLatest().mode).toBe("loading");
+      expect(harness.getLatest().isLoading).toBe(true);
 
       await waitFor(() => {
         expect(harness.getLatest().scripts[0]?.pid).toBe(2221);
+        expect(didStartTaskTwoFetch).toBe(true);
       });
       expect(harness.getLatest().mode).toBe("active");
       expect(harness.getLatest().isLoading).toBe(false);
-      expect(didStartTaskTwoFetch).toBe(true);
 
       taskTwoFetch.resolve(freshTaskTwoState);
       await waitFor(() => {

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -257,6 +257,7 @@ describe("useAgentStudioDevServerPanel", () => {
               {
                 scriptId: "frontend",
                 runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
                 sequence: 0,
                 data: "Starting `bun run dev`\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -380,6 +381,7 @@ describe("useAgentStudioDevServerPanel", () => {
               {
                 scriptId: "frontend",
                 runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
                 sequence: 0,
                 data: "Starting `bun run dev`\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -408,6 +410,7 @@ describe("useAgentStudioDevServerPanel", () => {
                 {
                   scriptId: "frontend",
                   runId: "frontend:1",
+                  runOrder: { hostInstanceId: "host-1", generation: 1 },
                   sequence: 0,
                   data: "Starting `bun run dev`\r\n",
                   timestamp: "2026-03-19T15:30:00.000Z",
@@ -495,6 +498,7 @@ describe("useAgentStudioDevServerPanel", () => {
               {
                 scriptId: "frontend",
                 runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
                 sequence: 0,
                 data: "ready\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -512,6 +516,7 @@ describe("useAgentStudioDevServerPanel", () => {
               {
                 scriptId: "backend",
                 runId: "backend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
                 sequence: 0,
                 data: "Dev server exited with code 1.\r\n",
                 timestamp: "2026-03-19T15:30:00.000Z",
@@ -584,6 +589,7 @@ describe("useAgentStudioDevServerPanel", () => {
         buildScript({
           status: "running",
           runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
           pid: 4242,
           startedAt: "2026-03-19T15:30:00.000Z",
         }),
@@ -647,6 +653,7 @@ describe("useAgentStudioDevServerPanel", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 0,
             data: "\u001b[32mready\u001b[0m\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -739,6 +746,7 @@ describe("useAgentStudioDevServerPanel", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 0,
             data: "fresh-line",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -776,6 +784,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "ready\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -789,6 +798,8 @@ describe("useAgentStudioDevServerPanel", () => {
       scripts: [
         buildScript({
           status: "stopped",
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
           pid: null,
           startedAt: null,
           bufferedTerminalChunks: [],
@@ -831,6 +842,7 @@ describe("useAgentStudioDevServerPanel", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 1,
             data: "closing dev server\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -880,6 +892,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 3,
               data: "old run output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -894,12 +907,14 @@ describe("useAgentStudioDevServerPanel", () => {
         buildScript({
           status: "running",
           runId: "frontend:2",
+          runOrder: { hostInstanceId: "host-1", generation: 2 },
           pid: 4343,
           startedAt: "2026-03-19T15:31:00.000Z",
           bufferedTerminalChunks: [
             {
               scriptId: "frontend",
               runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
               sequence: 4,
               data: "new run output\r\n",
               timestamp: "2026-03-19T15:31:01.000Z",
@@ -961,6 +976,7 @@ describe("useAgentStudioDevServerPanel", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
             sequence: 4,
             data: "new run output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1008,6 +1024,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "Dev server exited with code 1.\r\n",
               timestamp: "2026-03-19T15:35:00.000Z",
@@ -1116,6 +1133,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1135,6 +1153,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "fresh output\r\n",
               timestamp: "2026-03-19T15:31:00.000Z",
@@ -1223,6 +1242,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1323,6 +1343,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1397,6 +1418,7 @@ describe("useAgentStudioDevServerPanel", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 1,
             data: "live output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1425,6 +1447,7 @@ describe("useAgentStudioDevServerPanel", () => {
           {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 1,
             data: "live output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1453,6 +1476,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "stale output\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1553,6 +1577,7 @@ describe("useAgentStudioDevServerPanel", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 0,
             data: "new run output\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1598,6 +1623,7 @@ describe("useAgentStudioDevServerPanel", () => {
             {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 0,
               data: "Starting `bun run dev`\r\n",
               timestamp: "2026-03-19T15:30:00.000Z",
@@ -1636,6 +1662,7 @@ describe("useAgentStudioDevServerPanel", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 1,
             data: "old failed output\r\n",
             timestamp: "2026-03-19T15:30:01.000Z",
@@ -1648,6 +1675,7 @@ describe("useAgentStudioDevServerPanel", () => {
           terminalChunk: {
             scriptId: "frontend",
             runId: "frontend:1",
+            runOrder: { hostInstanceId: "host-1", generation: 1 },
             sequence: 2,
             data: "ELIFECYCLE Command failed.\r\n",
             timestamp: "2026-03-19T15:30:02.000Z",
@@ -1676,6 +1704,8 @@ describe("useAgentStudioDevServerPanel", () => {
           updatedAt: "2026-03-19T15:31:00.000Z",
           script: buildScript({
             status: "starting",
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
             pid: null,
             startedAt: "2026-03-19T15:31:00.000Z",
             bufferedTerminalChunks: [],
@@ -1687,7 +1717,8 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
             sequence: 0,
             data: "Starting `bun run dev`\r\n",
             timestamp: "2026-03-19T15:31:00.000Z",
@@ -1699,7 +1730,8 @@ describe("useAgentStudioDevServerPanel", () => {
           taskId: "task-7",
           terminalChunk: {
             scriptId: "frontend",
-            runId: "frontend:1",
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
             sequence: 1,
             data: "new dev server ready\r\n",
             timestamp: "2026-03-19T15:31:01.000Z",
@@ -1717,19 +1749,23 @@ describe("useAgentStudioDevServerPanel", () => {
           scripts: [
             buildScript({
               status: "running",
+              runId: "frontend:2",
+              runOrder: { hostInstanceId: "host-1", generation: 2 },
               pid: 4343,
               startedAt: "2026-03-19T15:31:00.000Z",
               bufferedTerminalChunks: [
                 {
                   scriptId: "frontend",
-                  runId: "frontend:1",
+                  runId: "frontend:2",
+                  runOrder: { hostInstanceId: "host-1", generation: 2 },
                   sequence: 0,
                   data: "Starting `bun run dev`\r\n",
                   timestamp: "2026-03-19T15:31:00.000Z",
                 },
                 {
                   scriptId: "frontend",
-                  runId: "frontend:1",
+                  runId: "frontend:2",
+                  runOrder: { hostInstanceId: "host-1", generation: 2 },
                   sequence: 1,
                   data: "new dev server ready\r\n",
                   timestamp: "2026-03-19T15:31:01.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -425,14 +425,36 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
-  test("applies a starting state immediately when start is clicked", async () => {
+  test("starts from a stopped owned run without clearing replay before host ownership arrives", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
     type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
 
+    const stoppedState = buildState({
+      scripts: [
+        buildScript({
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+          bufferedTerminalChunks: [
+            {
+              scriptId: "frontend",
+              runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              sequence: 3,
+              data: "stopped replay\r\n",
+              timestamp: "2026-03-19T15:30:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
     const startDeferred = createDeferred<DevServerGroupState>();
-    devServerGetState = async () => buildState();
-    devServerStart = async () => startDeferred.promise;
+    let startCalls = 0;
+    devServerGetState = async () => stoppedState;
+    devServerStart = async () => {
+      startCalls += 1;
+      return startDeferred.promise;
+    };
 
     let latest: HookResult | null = null;
     const getLatest = (): HookResult => {
@@ -469,10 +491,33 @@ describe("useAgentStudioDevServerPanel", () => {
         getLatest().onStart();
       });
 
-      expect(getLatest().mode).toBe("active");
-      expect(getLatest().isExpanded).toBe(true);
-      expect(getLatest().scripts[0]?.status).toBe("starting");
+      expect(getLatest().scripts[0]?.status).toBe("stopped");
       expect(getLatest().selectedScript?.scriptId).toBe("frontend");
+      expect(getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data)).toEqual([
+        "stopped replay\r\n",
+      ]);
+      await waitFor(() => {
+        expect(startCalls).toBe(1);
+        expect(getLatest().mode).toBe("active");
+        expect(getLatest().isExpanded).toBe(true);
+      });
+
+      act(() => {
+        devServerEventListener?.({
+          type: "script_status_changed",
+          repoPath: "/repo",
+          taskId: "task-7",
+          updatedAt: "2026-03-19T15:31:00.000Z",
+          script: buildScript({
+            status: "starting",
+            runId: "frontend:2",
+            runOrder: { hostInstanceId: "host-1", generation: 2 },
+          }),
+        });
+      });
+
+      expect(getLatest().scripts[0]?.status).toBe("starting");
+      expect(getLatest().selectedScriptTerminalBuffer?.entries).toEqual([]);
     } finally {
       startDeferred.resolve(buildState());
       view.unmount();

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
@@ -1,52 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import type {
-  DevServerEvent,
-  DevServerGroupState,
-  DevServerScriptState,
-} from "@openducktor/contracts";
+import type { DevServerEvent } from "@openducktor/contracts";
 import {
   applyDevServerEventToState,
   buildTaskMemoryKey,
   isDevServerPanelExpanded,
   selectDefaultDevServerTab,
 } from "./use-agent-studio-dev-server-panel-helpers";
-
-const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => {
-  const bufferedRunIdentity = overrides.bufferedTerminalChunks?.[0]?.runIdentity;
-  const defaultRunIdentity =
-    overrides.pid === null || overrides.pid === undefined
-      ? null
-      : {
-          runId: "frontend:1",
-          runOrder: { hostInstanceId: "host-1", generation: 1 },
-        };
-  const runIdentity =
-    overrides.runIdentity === undefined
-      ? (bufferedRunIdentity ?? defaultRunIdentity)
-      : overrides.runIdentity;
-  return {
-    scriptId: "frontend",
-    name: "Frontend",
-    command: "bun run dev",
-    status: "stopped",
-    runIdentity,
-    pid: null,
-    startedAt: null,
-    exitCode: null,
-    lastError: null,
-    bufferedTerminalChunks: [],
-    ...overrides,
-  };
-};
-
-const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGroupState => ({
-  repoPath: "/repo",
-  taskId: "task-7",
-  worktreePath: "/tmp/worktree/task-7",
-  scripts: [buildScript()],
-  updatedAt: "2026-03-19T15:30:00.000Z",
-  ...overrides,
-});
+import { buildScript, buildState } from "./use-agent-studio-dev-server-panel-test-fixtures";
 
 describe("useAgentStudioDevServerPanel helpers", () => {
   test("builds task memory keys without delimiter collisions", () => {

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
@@ -6,9 +6,10 @@ import type {
 } from "@openducktor/contracts";
 import {
   applyDevServerEventToState,
+  buildTaskMemoryKey,
   isDevServerPanelExpanded,
   selectDefaultDevServerTab,
-} from "./use-agent-studio-dev-server-panel";
+} from "./use-agent-studio-dev-server-panel-helpers";
 
 const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => ({
   scriptId: "frontend",
@@ -33,6 +34,12 @@ const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGrou
 });
 
 describe("useAgentStudioDevServerPanel helpers", () => {
+  test("builds task memory keys without delimiter collisions", () => {
+    expect(buildTaskMemoryKey("/repo::task-b", "task-c")).not.toBe(
+      buildTaskMemoryKey("/repo", "task-b::task-c"),
+    );
+  });
+
   test("applies terminal chunk events without cloning buffered replay into query state", () => {
     const initialChunks = Array.from({ length: 2_000 }, (_, index) => ({
       scriptId: "frontend",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
@@ -12,20 +12,24 @@ import {
 } from "./use-agent-studio-dev-server-panel-helpers";
 
 const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => {
-  const bufferedRun = overrides.bufferedTerminalChunks?.[0];
-  const runId =
-    overrides.runId ??
-    bufferedRun?.runId ??
-    (overrides.pid === null || overrides.pid === undefined ? null : "frontend:1");
+  const bufferedRunIdentity = overrides.bufferedTerminalChunks?.[0]?.runIdentity;
+  const defaultRunIdentity =
+    overrides.pid === null || overrides.pid === undefined
+      ? null
+      : {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        };
+  const runIdentity =
+    overrides.runIdentity === undefined
+      ? (bufferedRunIdentity ?? defaultRunIdentity)
+      : overrides.runIdentity;
   return {
     scriptId: "frontend",
     name: "Frontend",
     command: "bun run dev",
     status: "stopped",
-    runId,
-    runOrder:
-      bufferedRun?.runOrder ??
-      (runId === null ? null : { hostInstanceId: "host-1", generation: 1 }),
+    runIdentity,
     pid: null,
     startedAt: null,
     exitCode: null,
@@ -54,8 +58,10 @@ describe("useAgentStudioDevServerPanel helpers", () => {
   test("applies terminal chunk events without cloning buffered replay into query state", () => {
     const initialChunks = Array.from({ length: 2_000 }, (_, index) => ({
       scriptId: "frontend",
-      runId: "frontend:1",
-      runOrder: { hostInstanceId: "host-1", generation: 1 },
+      runIdentity: {
+        runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
+      },
       sequence: index,
       data: `line-${index}`,
       timestamp: `2026-03-19T15:30:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -69,8 +75,10 @@ describe("useAgentStudioDevServerPanel helpers", () => {
       taskId: "task-7",
       terminalChunk: {
         scriptId: "frontend",
-        runId: "frontend:1",
-        runOrder: { hostInstanceId: "host-1", generation: 1 },
+        runIdentity: {
+          runId: "frontend:1",
+          runOrder: { hostInstanceId: "host-1", generation: 1 },
+        },
         sequence: 2000,
         data: "latest-chunk",
         timestamp: "2026-03-19T15:31:00.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
@@ -11,19 +11,29 @@ import {
   selectDefaultDevServerTab,
 } from "./use-agent-studio-dev-server-panel-helpers";
 
-const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => ({
-  scriptId: "frontend",
-  name: "Frontend",
-  command: "bun run dev",
-  status: "stopped",
-  runId: overrides.pid === null || overrides.pid === undefined ? null : "frontend:1",
-  pid: null,
-  startedAt: null,
-  exitCode: null,
-  lastError: null,
-  bufferedTerminalChunks: [],
-  ...overrides,
-});
+const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => {
+  const bufferedRun = overrides.bufferedTerminalChunks?.[0];
+  const runId =
+    overrides.runId ??
+    bufferedRun?.runId ??
+    (overrides.pid === null || overrides.pid === undefined ? null : "frontend:1");
+  return {
+    scriptId: "frontend",
+    name: "Frontend",
+    command: "bun run dev",
+    status: "stopped",
+    runId,
+    runOrder:
+      bufferedRun?.runOrder ??
+      (runId === null ? null : { hostInstanceId: "host-1", generation: 1 }),
+    pid: null,
+    startedAt: null,
+    exitCode: null,
+    lastError: null,
+    bufferedTerminalChunks: [],
+    ...overrides,
+  };
+};
 
 const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGroupState => ({
   repoPath: "/repo",
@@ -45,6 +55,7 @@ describe("useAgentStudioDevServerPanel helpers", () => {
     const initialChunks = Array.from({ length: 2_000 }, (_, index) => ({
       scriptId: "frontend",
       runId: "frontend:1",
+      runOrder: { hostInstanceId: "host-1", generation: 1 },
       sequence: index,
       data: `line-${index}`,
       timestamp: `2026-03-19T15:30:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -59,6 +70,7 @@ describe("useAgentStudioDevServerPanel helpers", () => {
       terminalChunk: {
         scriptId: "frontend",
         runId: "frontend:1",
+        runOrder: { hostInstanceId: "host-1", generation: 1 },
         sequence: 2000,
         data: "latest-chunk",
         timestamp: "2026-03-19T15:31:00.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
@@ -16,6 +16,7 @@ const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerSc
   name: "Frontend",
   command: "bun run dev",
   status: "stopped",
+  runId: overrides.pid === null || overrides.pid === undefined ? null : "frontend:1",
   pid: null,
   startedAt: null,
   exitCode: null,
@@ -43,6 +44,7 @@ describe("useAgentStudioDevServerPanel helpers", () => {
   test("applies terminal chunk events without cloning buffered replay into query state", () => {
     const initialChunks = Array.from({ length: 2_000 }, (_, index) => ({
       scriptId: "frontend",
+      runId: "frontend:1",
       sequence: index,
       data: `line-${index}`,
       timestamp: `2026-03-19T15:30:${String(index % 60).padStart(2, "0")}.000Z`,
@@ -56,6 +58,7 @@ describe("useAgentStudioDevServerPanel helpers", () => {
       taskId: "task-7",
       terminalChunk: {
         scriptId: "frontend",
+        runId: "frontend:1",
         sequence: 2000,
         data: "latest-chunk",
         timestamp: "2026-03-19T15:31:00.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -110,7 +110,7 @@ export function useAgentStudioDevServerPanel({
     selectedScriptTerminalBuffer,
     syncSelectedScriptTerminalBuffer,
     syncTerminalBuffersFromMutationState,
-  } = useAgentStudioDevServerTerminalBuffers();
+  } = useAgentStudioDevServerTerminalBuffers(taskMemoryKey);
 
   const { effectiveState, isAwaitingFreshState, queryData, stateQuery } =
     useAgentStudioDevServerStateQuery({
@@ -182,7 +182,6 @@ export function useAgentStudioDevServerPanel({
     previousTaskMemoryKeyRef.current = taskMemoryKey;
 
     if (scopeChanged) {
-      clearTerminalBuffers();
       resetSelectedScript();
       dispatchLocalState({ type: "scopeReset" });
     }

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -49,19 +49,20 @@ type DevServerMutationOptions = {
 };
 
 type DevServerMutationContext = {
-  transportGeneration: number;
+  transportEpoch: string | null;
 };
 
 type DevServerPanelLocalState = {
   liveState: DevServerGroupState | null;
   actionError: string | null;
   subscriptionError: string | null;
-  transportGeneration: number;
+  subscriptionTaskMemoryKey: string | null;
+  transportEpoch: string | null;
 };
 
 type DevServerPanelAction =
   | { type: "scopeReset" }
-  | { type: "transportReconnected"; generation: number }
+  | { type: "transportReconnected"; transportEpoch: string }
   | { type: "liveStateChanged"; state: DevServerGroupState | null }
   | {
       type: "liveStateUpdated";
@@ -71,7 +72,7 @@ type DevServerPanelAction =
   | { type: "actionFailed"; error: string }
   | { type: "subscriptionFailed"; error: string }
   | { type: "eventsSynced" }
-  | { type: "subscriptionReady" };
+  | { type: "subscriptionReady"; taskMemoryKey: string; transportEpoch: string };
 
 const devServerPanelReducer = (
   state: DevServerPanelLocalState,
@@ -79,13 +80,20 @@ const devServerPanelReducer = (
 ): DevServerPanelLocalState => {
   switch (action.type) {
     case "scopeReset":
-      return { ...state, liveState: null, actionError: null, subscriptionError: null };
+      return {
+        ...state,
+        liveState: null,
+        actionError: null,
+        subscriptionError: null,
+        subscriptionTaskMemoryKey: null,
+        transportEpoch: null,
+      };
     case "transportReconnected":
       return {
         ...state,
         liveState: null,
         subscriptionError: null,
-        transportGeneration: action.generation,
+        transportEpoch: action.transportEpoch,
       };
     case "liveStateChanged":
       return { ...state, liveState: action.state };
@@ -100,7 +108,12 @@ const devServerPanelReducer = (
     case "eventsSynced":
       return { ...state, actionError: null, subscriptionError: null };
     case "subscriptionReady":
-      return { ...state, subscriptionError: null };
+      return {
+        ...state,
+        subscriptionError: null,
+        subscriptionTaskMemoryKey: action.taskMemoryKey,
+        transportEpoch: action.transportEpoch,
+      };
   }
 };
 
@@ -116,15 +129,23 @@ export function useAgentStudioDevServerPanel({
     liveState: null,
     actionError: null,
     subscriptionError: null,
-    transportGeneration: 0,
+    subscriptionTaskMemoryKey: null,
+    transportEpoch: null,
   });
-  const { liveState, actionError, subscriptionError, transportGeneration } = localState;
-  const transportGenerationRef = useRef(transportGeneration);
+  const { liveState, actionError, subscriptionError, subscriptionTaskMemoryKey, transportEpoch } =
+    localState;
+  const transportEpochRef = useRef(transportEpoch);
 
   const configuredScripts = repoSettings?.devServers ?? [];
   const hasConfiguredScripts = configuredScripts.length > 0;
-  const queryEnabled = enabled && hasConfiguredScripts && repoPath !== null && taskId !== null;
+  const subscriptionEnabled =
+    enabled && hasConfiguredScripts && repoPath !== null && taskId !== null;
   const taskMemoryKey = repoPath && taskId ? buildTaskMemoryKey(repoPath, taskId) : null;
+  const queryEnabled =
+    subscriptionEnabled &&
+    taskMemoryKey !== null &&
+    taskMemoryKey === subscriptionTaskMemoryKey &&
+    transportEpoch !== null;
   const activeTaskScope = useMemo(
     () => createDevServerTaskScope(repoPath, taskId),
     [repoPath, taskId],
@@ -149,7 +170,7 @@ export function useAgentStudioDevServerPanel({
       taskId,
       queryEnabled,
       liveState,
-      transportGeneration,
+      transportEpoch,
     });
 
   const { effectiveSelectedScriptId, onSelectScript, resetSelectedScript, selectedScriptIdRef } =
@@ -160,20 +181,22 @@ export function useAgentStudioDevServerPanel({
     });
 
   const requestTerminalRehydrate = useCallback((): void => {
-    if (!repoPath || !taskId) {
+    const activeTransportEpoch = transportEpochRef.current;
+    if (!repoPath || !taskId || !activeTransportEpoch) {
       return;
     }
 
     void queryClient.refetchQueries({
-      queryKey: devServerQueryKeys.state(repoPath, taskId, transportGeneration),
+      queryKey: devServerQueryKeys.state(repoPath, taskId, activeTransportEpoch),
       exact: true,
       type: "active",
     });
-  }, [queryClient, repoPath, taskId, transportGeneration]);
+  }, [queryClient, repoPath, taskId]);
 
   const syncStateFromEvent = useCallback(
     (event: DevServerEvent): void => {
-      if (!repoPath || !taskId) {
+      const activeTransportEpoch = transportEpochRef.current;
+      if (!repoPath || !taskId || !activeTransportEpoch) {
         return;
       }
 
@@ -183,7 +206,7 @@ export function useAgentStudioDevServerPanel({
       markMutationReplayObserved(event);
 
       if (event.type !== "terminal_chunk") {
-        const queryKey = devServerQueryKeys.state(repoPath, taskId, transportGeneration);
+        const queryKey = devServerQueryKeys.state(repoPath, taskId, activeTransportEpoch);
         const cachedState = queryClient.getQueryData<DevServerGroupState>(queryKey) ?? null;
         dispatchLocalState({
           type: "liveStateUpdated",
@@ -208,7 +231,6 @@ export function useAgentStudioDevServerPanel({
       repoPath,
       selectedScriptIdRef,
       taskId,
-      transportGeneration,
     ],
   );
 
@@ -217,18 +239,20 @@ export function useAgentStudioDevServerPanel({
     previousTaskMemoryKeyRef.current = taskMemoryKey;
 
     if (scopeChanged) {
+      transportEpochRef.current = null;
       resetSelectedScript();
       dispatchLocalState({ type: "scopeReset" });
     }
 
-    if (!queryEnabled) {
+    if (!subscriptionEnabled) {
+      transportEpochRef.current = null;
       clearTerminalBuffers();
       resetSelectedScript();
       dispatchLocalState({ type: "scopeReset" });
       return;
     }
 
-    if (queryData) {
+    if (queryEnabled && queryData) {
       if (hydrateTerminalBuffersFromState(queryData, effectiveSelectedScriptId)) {
         dispatchLocalState({ type: "liveStateChanged", state: queryData });
       }
@@ -240,6 +264,7 @@ export function useAgentStudioDevServerPanel({
     queryData,
     queryEnabled,
     resetSelectedScript,
+    subscriptionEnabled,
     taskMemoryKey,
   ]);
 
@@ -262,49 +287,45 @@ export function useAgentStudioDevServerPanel({
   );
 
   const syncMutationSuccessState = useCallback(
-    (nextState: DevServerGroupState): void => {
+    (nextState: DevServerGroupState, mutationTransportEpoch: string): void => {
       const isActiveState = nextState.repoPath === repoPath && nextState.taskId === taskId;
       if (isActiveState && !syncQueryState(nextState)) {
         return;
       }
       queryClient.setQueryData(
-        devServerQueryKeys.state(nextState.repoPath, nextState.taskId, transportGeneration),
+        devServerQueryKeys.state(nextState.repoPath, nextState.taskId, mutationTransportEpoch),
         nextState,
       );
     },
-    [queryClient, repoPath, syncQueryState, taskId, transportGeneration],
+    [queryClient, repoPath, syncQueryState, taskId],
   );
 
-  const restoreCachedState = useCallback((): void => {
-    if (!repoPath || !taskId) {
-      return;
-    }
+  const restoreCachedState = useCallback(
+    (mutationTransportEpoch: string): void => {
+      if (!repoPath || !taskId) {
+        return;
+      }
 
-    const cachedState =
-      queryClient.getQueryData<DevServerGroupState>(
-        devServerQueryKeys.state(repoPath, taskId, transportGeneration),
-      ) ?? null;
-    if (replaceTerminalBuffersFromState(cachedState, selectedScriptIdRef.current)) {
-      dispatchLocalState({ type: "liveStateChanged", state: cachedState });
-    }
-  }, [
-    queryClient,
-    repoPath,
-    replaceTerminalBuffersFromState,
-    selectedScriptIdRef,
-    taskId,
-    transportGeneration,
-  ]);
+      const cachedState =
+        queryClient.getQueryData<DevServerGroupState>(
+          devServerQueryKeys.state(repoPath, taskId, mutationTransportEpoch),
+        ) ?? null;
+      if (replaceTerminalBuffersFromState(cachedState, selectedScriptIdRef.current)) {
+        dispatchLocalState({ type: "liveStateChanged", state: cachedState });
+      }
+    },
+    [queryClient, repoPath, replaceTerminalBuffersFromState, selectedScriptIdRef, taskId],
+  );
 
   const invalidateState = useCallback(
-    (scope: DevServerTaskScope): void => {
+    (scope: DevServerTaskScope, mutationTransportEpoch: string): void => {
       void queryClient.invalidateQueries({
-        queryKey: devServerQueryKeys.state(scope.repoPath, scope.taskId, transportGeneration),
+        queryKey: devServerQueryKeys.state(scope.repoPath, scope.taskId, mutationTransportEpoch),
         exact: true,
         refetchType: "active",
       });
     },
-    [queryClient, transportGeneration],
+    [queryClient],
   );
 
   const createScopedMutationOptions = useCallback(
@@ -316,7 +337,7 @@ export function useAgentStudioDevServerPanel({
           beginMutationReplaySync(effectiveState);
         }
         return {
-          transportGeneration: transportGenerationRef.current,
+          transportEpoch: transportEpochRef.current,
         } satisfies DevServerMutationContext;
       },
       onSuccess: (
@@ -324,23 +345,23 @@ export function useAgentStudioDevServerPanel({
         _scope: DevServerTaskScope,
         context: DevServerMutationContext | undefined,
       ) => {
-        if (context?.transportGeneration !== transportGenerationRef.current) {
+        if (!context?.transportEpoch || context.transportEpoch !== transportEpochRef.current) {
           return;
         }
-        syncMutationSuccessState(data);
+        syncMutationSuccessState(data, context.transportEpoch);
       },
       onError: (
         error: unknown,
         scope: DevServerTaskScope,
         context: DevServerMutationContext | undefined,
       ) => {
-        if (context?.transportGeneration !== transportGenerationRef.current) {
+        if (!context?.transportEpoch || context.transportEpoch !== transportEpochRef.current) {
           return;
         }
         if (isActiveMutationScope(scope)) {
           cancelMutationReplaySync();
           if (options.restoreCachedStateOnError) {
-            restoreCachedState();
+            restoreCachedState(context.transportEpoch);
           }
           dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
         }
@@ -351,8 +372,12 @@ export function useAgentStudioDevServerPanel({
         scope: DevServerTaskScope,
         context: DevServerMutationContext | undefined,
       ) => {
-        if (error && context?.transportGeneration === transportGenerationRef.current) {
-          invalidateState(scope);
+        if (
+          error &&
+          context?.transportEpoch &&
+          context.transportEpoch === transportEpochRef.current
+        ) {
+          invalidateState(scope, context.transportEpoch);
         }
       },
     }),
@@ -405,7 +430,7 @@ export function useAgentStudioDevServerPanel({
   );
 
   useEffect(() => {
-    if (!queryEnabled || repoPath === null || taskId === null) {
+    if (!subscriptionEnabled || repoPath === null || taskId === null || taskMemoryKey === null) {
       return;
     }
 
@@ -413,14 +438,17 @@ export function useAgentStudioDevServerPanel({
     let unsubscribe: (() => void) | null = null;
 
     void subscribeDevServerEvents((payload) => {
+      if (cancelled) {
+        return;
+      }
+
       if (isDevServerSubscriptionControlEvent(payload)) {
         if (payload.kind === BROWSER_LIVE_RECONNECTED_EVENT_KIND) {
-          const nextTransportGeneration = transportGenerationRef.current + 1;
-          transportGenerationRef.current = nextTransportGeneration;
+          transportEpochRef.current = payload.transportEpoch;
           clearTerminalBuffers();
           dispatchLocalState({
             type: "transportReconnected",
-            generation: nextTransportGeneration,
+            transportEpoch: payload.transportEpoch,
           });
           return;
         }
@@ -458,15 +486,20 @@ export function useAgentStudioDevServerPanel({
       syncStateFromEvent(event);
       dispatchLocalState({ type: "eventsSynced" });
     })
-      .then((cleanup) => {
+      .then((subscription) => {
         if (cancelled) {
-          cleanup();
+          subscription.unsubscribe();
           return;
         }
 
-        unsubscribe = cleanup;
-        dispatchLocalState({ type: "subscriptionReady" });
-        requestTerminalRehydrate();
+        unsubscribe = subscription.unsubscribe;
+        transportEpochRef.current = subscription.transportEpoch;
+        clearTerminalBuffers();
+        dispatchLocalState({
+          type: "subscriptionReady",
+          taskMemoryKey,
+          transportEpoch: subscription.transportEpoch,
+        });
       })
       .catch((error: unknown) => {
         if (!cancelled) {
@@ -480,39 +513,41 @@ export function useAgentStudioDevServerPanel({
     };
   }, [
     clearTerminalBuffers,
-    queryEnabled,
     repoPath,
     requestTerminalRehydrate,
+    subscriptionEnabled,
     syncStateFromEvent,
     taskId,
+    taskMemoryKey,
   ]);
 
   const selectedScript =
     effectiveState?.scripts.find((script) => script.scriptId === effectiveSelectedScriptId) ?? null;
   const isStartPending =
     startMutation.isPending &&
-    startMutation.context?.transportGeneration === transportGeneration &&
+    startMutation.context?.transportEpoch === transportEpoch &&
     isActiveMutationScope(startMutation.variables);
   const isStopPending =
     stopMutation.isPending &&
-    stopMutation.context?.transportGeneration === transportGeneration &&
+    stopMutation.context?.transportEpoch === transportEpoch &&
     isActiveMutationScope(stopMutation.variables);
   const isRestartPending =
     restartMutation.isPending &&
-    restartMutation.context?.transportGeneration === transportGeneration &&
+    restartMutation.context?.transportEpoch === transportEpoch &&
     isActiveMutationScope(restartMutation.variables);
   const isExpanded = isDevServerPanelExpanded(
     effectiveState?.scripts ?? [],
     isStartPending || isRestartPending,
   );
   const hasAvailableScripts = (effectiveState?.scripts.length ?? 0) > 0 || hasConfiguredScripts;
+  const isAwaitingSubscription = subscriptionEnabled && !queryEnabled && subscriptionError === null;
 
   const mode: AgentStudioDevServerPanelMode = useMemo(() => {
     if (!hasAvailableScripts) {
       return "empty";
     }
 
-    if (isAwaitingFreshState) {
+    if (isAwaitingSubscription || isAwaitingFreshState) {
       return "loading";
     }
 
@@ -525,7 +560,13 @@ export function useAgentStudioDevServerPanel({
     }
 
     return "stopped";
-  }, [effectiveState, hasAvailableScripts, isAwaitingFreshState, isExpanded]);
+  }, [
+    effectiveState,
+    hasAvailableScripts,
+    isAwaitingFreshState,
+    isAwaitingSubscription,
+    isExpanded,
+  ]);
 
   const error =
     actionError ?? subscriptionError ?? (stateQuery.error ? errorMessage(stateQuery.error) : null);
@@ -540,7 +581,7 @@ export function useAgentStudioDevServerPanel({
   return {
     mode,
     isExpanded,
-    isLoading: isAwaitingFreshState || stateQuery.isLoading,
+    isLoading: isAwaitingSubscription || isAwaitingFreshState || stateQuery.isLoading,
     disabledReason,
     repoPath,
     taskId,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -11,6 +11,12 @@ import {
 import { errorMessage } from "@/lib/errors";
 import { hostClient, subscribeDevServerEvents } from "@/lib/host-client";
 import { devServerQueryKeys } from "@/state/queries/dev-servers";
+import {
+  createDevServerTaskScope,
+  type DevServerTaskScope,
+  isSameDevServerTaskScope,
+  MISSING_DEV_SERVER_TASK_SCOPE_MESSAGE,
+} from "@/types/dev-server-task-scope";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   applyDevServerEventToState,
@@ -36,12 +42,7 @@ type UseAgentStudioDevServerPanelArgs = {
   enabled: boolean;
 };
 
-type DevServerMutationVariables = {
-  repoPath: string;
-  taskId: string;
-};
-
-type DevServerMutationCommand = (scope: DevServerMutationVariables) => Promise<DevServerGroupState>;
+type DevServerMutationCommand = (scope: DevServerTaskScope) => Promise<DevServerGroupState>;
 
 type DevServerMutationOptions = {
   restoreCachedStateOnError?: boolean;
@@ -109,8 +110,8 @@ export function useAgentStudioDevServerPanel({
   const hasConfiguredScripts = configuredScripts.length > 0;
   const queryEnabled = enabled && hasConfiguredScripts && repoPath !== null && taskId !== null;
   const taskMemoryKey = repoPath && taskId ? buildTaskMemoryKey(repoPath, taskId) : null;
-  const terminalBufferScope = useMemo(
-    () => (repoPath && taskId ? { repoPath, taskId } : null),
+  const activeTaskScope = useMemo(
+    () => createDevServerTaskScope(repoPath, taskId),
     [repoPath, taskId],
   );
 
@@ -125,7 +126,7 @@ export function useAgentStudioDevServerPanel({
     selectedScriptTerminalBuffer,
     syncSelectedScriptTerminalBuffer,
     syncTerminalBuffersFromMutationState,
-  } = useAgentStudioDevServerTerminalBuffers(terminalBufferScope);
+  } = useAgentStudioDevServerTerminalBuffers(activeTaskScope);
 
   const { effectiveState, isAwaitingFreshState, queryData, stateQuery } =
     useAgentStudioDevServerStateQuery({
@@ -231,10 +232,10 @@ export function useAgentStudioDevServerPanel({
   );
 
   const isActiveMutationScope = useCallback(
-    (scope: DevServerMutationVariables): boolean => {
-      return scope.repoPath === repoPath && scope.taskId === taskId;
+    (scope: DevServerTaskScope | null | undefined): boolean => {
+      return isSameDevServerTaskScope(scope ?? null, activeTaskScope);
     },
-    [repoPath, taskId],
+    [activeTaskScope],
   );
 
   const syncMutationSuccessState = useCallback(
@@ -264,7 +265,7 @@ export function useAgentStudioDevServerPanel({
   }, [queryClient, repoPath, replaceTerminalBuffersFromState, selectedScriptIdRef, taskId]);
 
   const invalidateState = useCallback(
-    (scope: DevServerMutationVariables): void => {
+    (scope: DevServerTaskScope): void => {
       void queryClient.invalidateQueries({
         queryKey: devServerQueryKeys.state(scope.repoPath, scope.taskId),
         exact: true,
@@ -277,7 +278,7 @@ export function useAgentStudioDevServerPanel({
   const createScopedMutationOptions = useCallback(
     (mutationFn: DevServerMutationCommand, options: DevServerMutationOptions = {}) => ({
       mutationFn,
-      onMutate: (scope: DevServerMutationVariables) => {
+      onMutate: (scope: DevServerTaskScope) => {
         if (isActiveMutationScope(scope)) {
           dispatchLocalState({ type: "actionStarted" });
           beginMutationReplaySync(effectiveState);
@@ -286,7 +287,7 @@ export function useAgentStudioDevServerPanel({
       onSuccess: (data: DevServerGroupState) => {
         syncMutationSuccessState(data);
       },
-      onError: (error: unknown, scope: DevServerMutationVariables) => {
+      onError: (error: unknown, scope: DevServerTaskScope) => {
         if (isActiveMutationScope(scope)) {
           cancelMutationReplaySync();
           if (options.restoreCachedStateOnError) {
@@ -298,7 +299,7 @@ export function useAgentStudioDevServerPanel({
       onSettled: (
         _data: DevServerGroupState | undefined,
         error: unknown,
-        scope: DevServerMutationVariables,
+        scope: DevServerTaskScope,
       ) => {
         if (error) {
           invalidateState(scope);
@@ -316,7 +317,7 @@ export function useAgentStudioDevServerPanel({
     ],
   );
 
-  const startMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>(
+  const startMutation = useMutation<DevServerGroupState, unknown, DevServerTaskScope>(
     createScopedMutationOptions(
       async (scope): Promise<DevServerGroupState> =>
         hostClient.devServerStart(scope.repoPath, scope.taskId),
@@ -324,14 +325,14 @@ export function useAgentStudioDevServerPanel({
     ),
   );
 
-  const stopMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>(
+  const stopMutation = useMutation<DevServerGroupState, unknown, DevServerTaskScope>(
     createScopedMutationOptions(
       async (scope): Promise<DevServerGroupState> =>
         hostClient.devServerStop(scope.repoPath, scope.taskId),
     ),
   );
 
-  const restartMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>(
+  const restartMutation = useMutation<DevServerGroupState, unknown, DevServerTaskScope>(
     createScopedMutationOptions(
       async (scope): Promise<DevServerGroupState> =>
         hostClient.devServerRestart(scope.repoPath, scope.taskId),
@@ -406,9 +407,13 @@ export function useAgentStudioDevServerPanel({
 
   const selectedScript =
     effectiveState?.scripts.find((script) => script.scriptId === effectiveSelectedScriptId) ?? null;
+  const isStartPending = startMutation.isPending && isActiveMutationScope(startMutation.variables);
+  const isStopPending = stopMutation.isPending && isActiveMutationScope(stopMutation.variables);
+  const isRestartPending =
+    restartMutation.isPending && isActiveMutationScope(restartMutation.variables);
   const isExpanded = isDevServerPanelExpanded(
     effectiveState?.scripts ?? [],
-    startMutation.isPending || restartMutation.isPending,
+    isStartPending || isRestartPending,
   );
   const hasAvailableScripts = (effectiveState?.scripts.length ?? 0) > 0 || hasConfiguredScripts;
 
@@ -455,12 +460,13 @@ export function useAgentStudioDevServerPanel({
     selectedScript,
     selectedScriptTerminalBuffer,
     error,
-    isStartPending: startMutation.isPending,
-    isStopPending: stopMutation.isPending,
-    isRestartPending: restartMutation.isPending,
+    isStartPending,
+    isStopPending,
+    isRestartPending,
     onSelectScript,
     onStart: () => {
-      if (!repoPath || !taskId) {
+      if (!activeTaskScope) {
+        dispatchLocalState({ type: "actionFailed", error: MISSING_DEV_SERVER_TASK_SCOPE_MESSAGE });
         return;
       }
 
@@ -470,21 +476,23 @@ export function useAgentStudioDevServerPanel({
         replaceTerminalBuffersFromState(optimisticState, selectedScriptIdRef.current);
         dispatchLocalState({ type: "liveStateChanged", state: optimisticState });
       }
-      startMutation.mutate({ repoPath, taskId });
+      startMutation.mutate(activeTaskScope);
     },
     onStop: () => {
-      if (!repoPath || !taskId) {
+      if (!activeTaskScope) {
+        dispatchLocalState({ type: "actionFailed", error: MISSING_DEV_SERVER_TASK_SCOPE_MESSAGE });
         return;
       }
 
-      stopMutation.mutate({ repoPath, taskId });
+      stopMutation.mutate(activeTaskScope);
     },
     onRestart: () => {
-      if (!repoPath || !taskId) {
+      if (!activeTaskScope) {
+        dispatchLocalState({ type: "actionFailed", error: MISSING_DEV_SERVER_TASK_SCOPE_MESSAGE });
         return;
       }
 
-      restartMutation.mutate({ repoPath, taskId });
+      restartMutation.mutate(activeTaskScope);
     },
   };
 }

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -36,6 +36,11 @@ type UseAgentStudioDevServerPanelArgs = {
   enabled: boolean;
 };
 
+type DevServerMutationVariables = {
+  repoPath: string;
+  taskId: string;
+};
+
 type DevServerPanelLocalState = {
   liveState: DevServerGroupState | null;
   actionError: string | null;
@@ -194,16 +199,16 @@ export function useAgentStudioDevServerPanel({
     }
 
     if (queryData) {
-      hydrateTerminalBuffersFromState(queryData, selectedScriptIdRef.current);
+      hydrateTerminalBuffersFromState(queryData, effectiveSelectedScriptId);
       dispatchLocalState({ type: "liveStateChanged", state: queryData });
     }
   }, [
     clearTerminalBuffers,
+    effectiveSelectedScriptId,
     hydrateTerminalBuffersFromState,
     queryData,
     queryEnabled,
     resetSelectedScript,
-    selectedScriptIdRef,
     taskMemoryKey,
   ]);
 
@@ -213,6 +218,27 @@ export function useAgentStudioDevServerPanel({
       dispatchLocalState({ type: "liveStateChanged", state: nextState });
     },
     [selectedScriptIdRef, syncTerminalBuffersFromMutationState],
+  );
+
+  const isActiveMutationScope = useCallback(
+    (scope: DevServerMutationVariables): boolean => {
+      return scope.repoPath === repoPath && scope.taskId === taskId;
+    },
+    [repoPath, taskId],
+  );
+
+  const syncMutationSuccessState = useCallback(
+    (nextState: DevServerGroupState): void => {
+      queryClient.setQueryData(
+        devServerQueryKeys.state(nextState.repoPath, nextState.taskId),
+        nextState,
+      );
+
+      if (nextState.repoPath === repoPath && nextState.taskId === taskId) {
+        syncQueryState(nextState);
+      }
+    },
+    [queryClient, repoPath, syncQueryState, taskId],
   );
 
   const restoreCachedState = useCallback((): void => {
@@ -227,102 +253,92 @@ export function useAgentStudioDevServerPanel({
     dispatchLocalState({ type: "liveStateChanged", state: cachedState });
   }, [queryClient, repoPath, replaceTerminalBuffersFromState, selectedScriptIdRef, taskId]);
 
-  const invalidateState = useCallback((): void => {
-    if (!repoPath || !taskId) {
-      return;
-    }
-
-    void queryClient.invalidateQueries({
-      queryKey: devServerQueryKeys.state(repoPath, taskId),
-      exact: true,
-      refetchType: "active",
-    });
-  }, [queryClient, repoPath, taskId]);
-
-  const startMutation = useMutation({
-    mutationFn: async (): Promise<DevServerGroupState> => {
-      if (!repoPath || !taskId) {
-        throw new Error("Builder dev servers require an active repository and task.");
-      }
-
-      return hostClient.devServerStart(repoPath, taskId);
+  const invalidateState = useCallback(
+    (scope: DevServerMutationVariables): void => {
+      void queryClient.invalidateQueries({
+        queryKey: devServerQueryKeys.state(scope.repoPath, scope.taskId),
+        exact: true,
+        refetchType: "active",
+      });
     },
-    onMutate: () => {
-      dispatchLocalState({ type: "actionStarted" });
-      beginMutationReplaySync(effectiveState);
+    [queryClient],
+  );
+
+  const startMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>({
+    mutationFn: async (scope): Promise<DevServerGroupState> => {
+      return hostClient.devServerStart(scope.repoPath, scope.taskId);
+    },
+    onMutate: (scope) => {
+      if (isActiveMutationScope(scope)) {
+        dispatchLocalState({ type: "actionStarted" });
+        beginMutationReplaySync(effectiveState);
+      }
     },
     onSuccess: (data) => {
-      if (repoPath && taskId) {
-        queryClient.setQueryData(devServerQueryKeys.state(repoPath, taskId), data);
+      syncMutationSuccessState(data);
+    },
+    onError: (error: unknown, scope) => {
+      if (isActiveMutationScope(scope)) {
+        cancelMutationReplaySync();
+        restoreCachedState();
+        dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
       }
-      syncQueryState(data);
     },
-    onError: (error: unknown) => {
-      cancelMutationReplaySync();
-      restoreCachedState();
-      dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
-    },
-    onSettled: (_data, error) => {
+    onSettled: (_data, error, scope) => {
       if (error) {
-        invalidateState();
+        invalidateState(scope);
       }
     },
   });
 
-  const stopMutation = useMutation({
-    mutationFn: async (): Promise<DevServerGroupState> => {
-      if (!repoPath || !taskId) {
-        throw new Error("Builder dev servers require an active repository and task.");
-      }
-
-      return hostClient.devServerStop(repoPath, taskId);
+  const stopMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>({
+    mutationFn: async (scope): Promise<DevServerGroupState> => {
+      return hostClient.devServerStop(scope.repoPath, scope.taskId);
     },
-    onMutate: () => {
-      dispatchLocalState({ type: "actionStarted" });
-      beginMutationReplaySync(effectiveState);
+    onMutate: (scope) => {
+      if (isActiveMutationScope(scope)) {
+        dispatchLocalState({ type: "actionStarted" });
+        beginMutationReplaySync(effectiveState);
+      }
     },
     onSuccess: (data) => {
-      if (repoPath && taskId) {
-        queryClient.setQueryData(devServerQueryKeys.state(repoPath, taskId), data);
+      syncMutationSuccessState(data);
+    },
+    onError: (error: unknown, scope) => {
+      if (isActiveMutationScope(scope)) {
+        cancelMutationReplaySync();
+        dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
       }
-      syncQueryState(data);
     },
-    onError: (error: unknown) => {
-      cancelMutationReplaySync();
-      dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
-    },
-    onSettled: (_data, error) => {
+    onSettled: (_data, error, scope) => {
       if (error) {
-        invalidateState();
+        invalidateState(scope);
       }
     },
   });
 
-  const restartMutation = useMutation({
-    mutationFn: async (): Promise<DevServerGroupState> => {
-      if (!repoPath || !taskId) {
-        throw new Error("Builder dev servers require an active repository and task.");
-      }
-
-      return hostClient.devServerRestart(repoPath, taskId);
+  const restartMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>({
+    mutationFn: async (scope): Promise<DevServerGroupState> => {
+      return hostClient.devServerRestart(scope.repoPath, scope.taskId);
     },
-    onMutate: () => {
-      dispatchLocalState({ type: "actionStarted" });
-      beginMutationReplaySync(effectiveState);
+    onMutate: (scope) => {
+      if (isActiveMutationScope(scope)) {
+        dispatchLocalState({ type: "actionStarted" });
+        beginMutationReplaySync(effectiveState);
+      }
     },
     onSuccess: (data) => {
-      if (repoPath && taskId) {
-        queryClient.setQueryData(devServerQueryKeys.state(repoPath, taskId), data);
+      syncMutationSuccessState(data);
+    },
+    onError: (error: unknown, scope) => {
+      if (isActiveMutationScope(scope)) {
+        cancelMutationReplaySync();
+        dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
       }
-      syncQueryState(data);
     },
-    onError: (error: unknown) => {
-      cancelMutationReplaySync();
-      dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
-    },
-    onSettled: (_data, error) => {
+    onSettled: (_data, error, scope) => {
       if (error) {
-        invalidateState();
+        invalidateState(scope);
       }
     },
   });
@@ -449,19 +465,31 @@ export function useAgentStudioDevServerPanel({
     isRestartPending: restartMutation.isPending,
     onSelectScript,
     onStart: () => {
+      if (!repoPath || !taskId) {
+        return;
+      }
+
       dispatchLocalState({ type: "actionStarted" });
       if (effectiveState) {
         const optimisticState = buildOptimisticStartingState(effectiveState);
         replaceTerminalBuffersFromState(optimisticState, selectedScriptIdRef.current);
         dispatchLocalState({ type: "liveStateChanged", state: optimisticState });
       }
-      startMutation.mutate();
+      startMutation.mutate({ repoPath, taskId });
     },
     onStop: () => {
-      stopMutation.mutate();
+      if (!repoPath || !taskId) {
+        return;
+      }
+
+      stopMutation.mutate({ repoPath, taskId });
     },
     onRestart: () => {
-      restartMutation.mutate();
+      if (!repoPath || !taskId) {
+        return;
+      }
+
+      restartMutation.mutate({ repoPath, taskId });
     },
   };
 }

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -41,6 +41,12 @@ type DevServerMutationVariables = {
   taskId: string;
 };
 
+type DevServerMutationCommand = (scope: DevServerMutationVariables) => Promise<DevServerGroupState>;
+
+type DevServerMutationOptions = {
+  restoreCachedStateOnError?: boolean;
+};
+
 type DevServerPanelLocalState = {
   liveState: DevServerGroupState | null;
   actionError: string | null;
@@ -103,6 +109,10 @@ export function useAgentStudioDevServerPanel({
   const hasConfiguredScripts = configuredScripts.length > 0;
   const queryEnabled = enabled && hasConfiguredScripts && repoPath !== null && taskId !== null;
   const taskMemoryKey = repoPath && taskId ? buildTaskMemoryKey(repoPath, taskId) : null;
+  const terminalBufferScope = useMemo(
+    () => (repoPath && taskId ? { repoPath, taskId } : null),
+    [repoPath, taskId],
+  );
 
   const {
     applyTerminalBuffersFromEvent,
@@ -115,7 +125,7 @@ export function useAgentStudioDevServerPanel({
     selectedScriptTerminalBuffer,
     syncSelectedScriptTerminalBuffer,
     syncTerminalBuffersFromMutationState,
-  } = useAgentStudioDevServerTerminalBuffers(taskMemoryKey);
+  } = useAgentStudioDevServerTerminalBuffers(terminalBufferScope);
 
   const { effectiveState, isAwaitingFreshState, queryData, stateQuery } =
     useAgentStudioDevServerStateQuery({
@@ -264,84 +274,69 @@ export function useAgentStudioDevServerPanel({
     [queryClient],
   );
 
-  const startMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>({
-    mutationFn: async (scope): Promise<DevServerGroupState> => {
-      return hostClient.devServerStart(scope.repoPath, scope.taskId);
-    },
-    onMutate: (scope) => {
-      if (isActiveMutationScope(scope)) {
-        dispatchLocalState({ type: "actionStarted" });
-        beginMutationReplaySync(effectiveState);
-      }
-    },
-    onSuccess: (data) => {
-      syncMutationSuccessState(data);
-    },
-    onError: (error: unknown, scope) => {
-      if (isActiveMutationScope(scope)) {
-        cancelMutationReplaySync();
-        restoreCachedState();
-        dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
-      }
-    },
-    onSettled: (_data, error, scope) => {
-      if (error) {
-        invalidateState(scope);
-      }
-    },
-  });
+  const createScopedMutationOptions = useCallback(
+    (mutationFn: DevServerMutationCommand, options: DevServerMutationOptions = {}) => ({
+      mutationFn,
+      onMutate: (scope: DevServerMutationVariables) => {
+        if (isActiveMutationScope(scope)) {
+          dispatchLocalState({ type: "actionStarted" });
+          beginMutationReplaySync(effectiveState);
+        }
+      },
+      onSuccess: (data: DevServerGroupState) => {
+        syncMutationSuccessState(data);
+      },
+      onError: (error: unknown, scope: DevServerMutationVariables) => {
+        if (isActiveMutationScope(scope)) {
+          cancelMutationReplaySync();
+          if (options.restoreCachedStateOnError) {
+            restoreCachedState();
+          }
+          dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
+        }
+      },
+      onSettled: (
+        _data: DevServerGroupState | undefined,
+        error: unknown,
+        scope: DevServerMutationVariables,
+      ) => {
+        if (error) {
+          invalidateState(scope);
+        }
+      },
+    }),
+    [
+      beginMutationReplaySync,
+      cancelMutationReplaySync,
+      effectiveState,
+      invalidateState,
+      isActiveMutationScope,
+      restoreCachedState,
+      syncMutationSuccessState,
+    ],
+  );
 
-  const stopMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>({
-    mutationFn: async (scope): Promise<DevServerGroupState> => {
-      return hostClient.devServerStop(scope.repoPath, scope.taskId);
-    },
-    onMutate: (scope) => {
-      if (isActiveMutationScope(scope)) {
-        dispatchLocalState({ type: "actionStarted" });
-        beginMutationReplaySync(effectiveState);
-      }
-    },
-    onSuccess: (data) => {
-      syncMutationSuccessState(data);
-    },
-    onError: (error: unknown, scope) => {
-      if (isActiveMutationScope(scope)) {
-        cancelMutationReplaySync();
-        dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
-      }
-    },
-    onSettled: (_data, error, scope) => {
-      if (error) {
-        invalidateState(scope);
-      }
-    },
-  });
+  const startMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>(
+    createScopedMutationOptions(
+      async (scope): Promise<DevServerGroupState> =>
+        hostClient.devServerStart(scope.repoPath, scope.taskId),
+      { restoreCachedStateOnError: true },
+    ),
+  );
 
-  const restartMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>({
-    mutationFn: async (scope): Promise<DevServerGroupState> => {
-      return hostClient.devServerRestart(scope.repoPath, scope.taskId);
-    },
-    onMutate: (scope) => {
-      if (isActiveMutationScope(scope)) {
-        dispatchLocalState({ type: "actionStarted" });
-        beginMutationReplaySync(effectiveState);
-      }
-    },
-    onSuccess: (data) => {
-      syncMutationSuccessState(data);
-    },
-    onError: (error: unknown, scope) => {
-      if (isActiveMutationScope(scope)) {
-        cancelMutationReplaySync();
-        dispatchLocalState({ type: "actionFailed", error: errorMessage(error) });
-      }
-    },
-    onSettled: (_data, error, scope) => {
-      if (error) {
-        invalidateState(scope);
-      }
-    },
-  });
+  const stopMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>(
+    createScopedMutationOptions(
+      async (scope): Promise<DevServerGroupState> =>
+        hostClient.devServerStop(scope.repoPath, scope.taskId),
+    ),
+  );
+
+  const restartMutation = useMutation<DevServerGroupState, unknown, DevServerMutationVariables>(
+    createScopedMutationOptions(
+      async (scope): Promise<DevServerGroupState> =>
+        hostClient.devServerRestart(scope.repoPath, scope.taskId),
+    ),
+  );
 
   useEffect(() => {
     if (!queryEnabled || repoPath === null || taskId === null) {

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -8,6 +8,7 @@ import {
   DEV_SERVER_DISABLED_REASON,
   DEV_SERVER_EMPTY_REASON,
 } from "@/components/features/agents/agent-studio-dev-server-panel";
+import { BROWSER_LIVE_RECONNECTED_EVENT_KIND } from "@/lib/browser-live/constants";
 import { errorMessage } from "@/lib/errors";
 import { hostClient, subscribeDevServerEvents } from "@/lib/host-client";
 import { devServerQueryKeys } from "@/state/queries/dev-servers";
@@ -20,7 +21,6 @@ import {
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   applyDevServerEventToState,
-  buildOptimisticStartingState,
   buildTaskMemoryKey,
   isDevServerPanelExpanded,
   isDevServerSubscriptionControlEvent,
@@ -48,14 +48,20 @@ type DevServerMutationOptions = {
   restoreCachedStateOnError?: boolean;
 };
 
+type DevServerMutationContext = {
+  transportGeneration: number;
+};
+
 type DevServerPanelLocalState = {
   liveState: DevServerGroupState | null;
   actionError: string | null;
   subscriptionError: string | null;
+  transportGeneration: number;
 };
 
 type DevServerPanelAction =
   | { type: "scopeReset" }
+  | { type: "transportReconnected"; generation: number }
   | { type: "liveStateChanged"; state: DevServerGroupState | null }
   | {
       type: "liveStateUpdated";
@@ -73,7 +79,14 @@ const devServerPanelReducer = (
 ): DevServerPanelLocalState => {
   switch (action.type) {
     case "scopeReset":
-      return { liveState: null, actionError: null, subscriptionError: null };
+      return { ...state, liveState: null, actionError: null, subscriptionError: null };
+    case "transportReconnected":
+      return {
+        ...state,
+        liveState: null,
+        subscriptionError: null,
+        transportGeneration: action.generation,
+      };
     case "liveStateChanged":
       return { ...state, liveState: action.state };
     case "liveStateUpdated":
@@ -103,8 +116,10 @@ export function useAgentStudioDevServerPanel({
     liveState: null,
     actionError: null,
     subscriptionError: null,
+    transportGeneration: 0,
   });
-  const { liveState, actionError, subscriptionError } = localState;
+  const { liveState, actionError, subscriptionError, transportGeneration } = localState;
+  const transportGenerationRef = useRef(transportGeneration);
 
   const configuredScripts = repoSettings?.devServers ?? [];
   const hasConfiguredScripts = configuredScripts.length > 0;
@@ -134,6 +149,7 @@ export function useAgentStudioDevServerPanel({
       taskId,
       queryEnabled,
       liveState,
+      transportGeneration,
     });
 
   const { effectiveSelectedScriptId, onSelectScript, resetSelectedScript, selectedScriptIdRef } =
@@ -149,11 +165,11 @@ export function useAgentStudioDevServerPanel({
     }
 
     void queryClient.refetchQueries({
-      queryKey: devServerQueryKeys.state(repoPath, taskId),
+      queryKey: devServerQueryKeys.state(repoPath, taskId, transportGeneration),
       exact: true,
       type: "active",
     });
-  }, [queryClient, repoPath, taskId]);
+  }, [queryClient, repoPath, taskId, transportGeneration]);
 
   const syncStateFromEvent = useCallback(
     (event: DevServerEvent): void => {
@@ -161,11 +177,13 @@ export function useAgentStudioDevServerPanel({
         return;
       }
 
+      if (!applyTerminalBuffersFromEvent(event, selectedScriptIdRef.current)) {
+        return;
+      }
       markMutationReplayObserved(event);
-      applyTerminalBuffersFromEvent(event, selectedScriptIdRef.current);
 
       if (event.type !== "terminal_chunk") {
-        const queryKey = devServerQueryKeys.state(repoPath, taskId);
+        const queryKey = devServerQueryKeys.state(repoPath, taskId, transportGeneration);
         const cachedState = queryClient.getQueryData<DevServerGroupState>(queryKey) ?? null;
         dispatchLocalState({
           type: "liveStateUpdated",
@@ -190,6 +208,7 @@ export function useAgentStudioDevServerPanel({
       repoPath,
       selectedScriptIdRef,
       taskId,
+      transportGeneration,
     ],
   );
 
@@ -210,8 +229,9 @@ export function useAgentStudioDevServerPanel({
     }
 
     if (queryData) {
-      hydrateTerminalBuffersFromState(queryData, effectiveSelectedScriptId);
-      dispatchLocalState({ type: "liveStateChanged", state: queryData });
+      if (hydrateTerminalBuffersFromState(queryData, effectiveSelectedScriptId)) {
+        dispatchLocalState({ type: "liveStateChanged", state: queryData });
+      }
     }
   }, [
     clearTerminalBuffers,
@@ -224,9 +244,12 @@ export function useAgentStudioDevServerPanel({
   ]);
 
   const syncQueryState = useCallback(
-    (nextState: DevServerGroupState): void => {
-      syncTerminalBuffersFromMutationState(nextState, selectedScriptIdRef.current);
+    (nextState: DevServerGroupState): boolean => {
+      if (!syncTerminalBuffersFromMutationState(nextState, selectedScriptIdRef.current)) {
+        return false;
+      }
       dispatchLocalState({ type: "liveStateChanged", state: nextState });
+      return true;
     },
     [selectedScriptIdRef, syncTerminalBuffersFromMutationState],
   );
@@ -240,16 +263,16 @@ export function useAgentStudioDevServerPanel({
 
   const syncMutationSuccessState = useCallback(
     (nextState: DevServerGroupState): void => {
+      const isActiveState = nextState.repoPath === repoPath && nextState.taskId === taskId;
+      if (isActiveState && !syncQueryState(nextState)) {
+        return;
+      }
       queryClient.setQueryData(
-        devServerQueryKeys.state(nextState.repoPath, nextState.taskId),
+        devServerQueryKeys.state(nextState.repoPath, nextState.taskId, transportGeneration),
         nextState,
       );
-
-      if (nextState.repoPath === repoPath && nextState.taskId === taskId) {
-        syncQueryState(nextState);
-      }
     },
-    [queryClient, repoPath, syncQueryState, taskId],
+    [queryClient, repoPath, syncQueryState, taskId, transportGeneration],
   );
 
   const restoreCachedState = useCallback((): void => {
@@ -258,21 +281,30 @@ export function useAgentStudioDevServerPanel({
     }
 
     const cachedState =
-      queryClient.getQueryData<DevServerGroupState>(devServerQueryKeys.state(repoPath, taskId)) ??
-      null;
-    replaceTerminalBuffersFromState(cachedState, selectedScriptIdRef.current);
-    dispatchLocalState({ type: "liveStateChanged", state: cachedState });
-  }, [queryClient, repoPath, replaceTerminalBuffersFromState, selectedScriptIdRef, taskId]);
+      queryClient.getQueryData<DevServerGroupState>(
+        devServerQueryKeys.state(repoPath, taskId, transportGeneration),
+      ) ?? null;
+    if (replaceTerminalBuffersFromState(cachedState, selectedScriptIdRef.current)) {
+      dispatchLocalState({ type: "liveStateChanged", state: cachedState });
+    }
+  }, [
+    queryClient,
+    repoPath,
+    replaceTerminalBuffersFromState,
+    selectedScriptIdRef,
+    taskId,
+    transportGeneration,
+  ]);
 
   const invalidateState = useCallback(
     (scope: DevServerTaskScope): void => {
       void queryClient.invalidateQueries({
-        queryKey: devServerQueryKeys.state(scope.repoPath, scope.taskId),
+        queryKey: devServerQueryKeys.state(scope.repoPath, scope.taskId, transportGeneration),
         exact: true,
         refetchType: "active",
       });
     },
-    [queryClient],
+    [queryClient, transportGeneration],
   );
 
   const createScopedMutationOptions = useCallback(
@@ -283,11 +315,28 @@ export function useAgentStudioDevServerPanel({
           dispatchLocalState({ type: "actionStarted" });
           beginMutationReplaySync(effectiveState);
         }
+        return {
+          transportGeneration: transportGenerationRef.current,
+        } satisfies DevServerMutationContext;
       },
-      onSuccess: (data: DevServerGroupState) => {
+      onSuccess: (
+        data: DevServerGroupState,
+        _scope: DevServerTaskScope,
+        context: DevServerMutationContext | undefined,
+      ) => {
+        if (context?.transportGeneration !== transportGenerationRef.current) {
+          return;
+        }
         syncMutationSuccessState(data);
       },
-      onError: (error: unknown, scope: DevServerTaskScope) => {
+      onError: (
+        error: unknown,
+        scope: DevServerTaskScope,
+        context: DevServerMutationContext | undefined,
+      ) => {
+        if (context?.transportGeneration !== transportGenerationRef.current) {
+          return;
+        }
         if (isActiveMutationScope(scope)) {
           cancelMutationReplaySync();
           if (options.restoreCachedStateOnError) {
@@ -300,8 +349,9 @@ export function useAgentStudioDevServerPanel({
         _data: DevServerGroupState | undefined,
         error: unknown,
         scope: DevServerTaskScope,
+        context: DevServerMutationContext | undefined,
       ) => {
-        if (error) {
+        if (error && context?.transportGeneration === transportGenerationRef.current) {
           invalidateState(scope);
         }
       },
@@ -317,7 +367,12 @@ export function useAgentStudioDevServerPanel({
     ],
   );
 
-  const startMutation = useMutation<DevServerGroupState, unknown, DevServerTaskScope>(
+  const startMutation = useMutation<
+    DevServerGroupState,
+    unknown,
+    DevServerTaskScope,
+    DevServerMutationContext
+  >(
     createScopedMutationOptions(
       async (scope): Promise<DevServerGroupState> =>
         hostClient.devServerStart(scope.repoPath, scope.taskId),
@@ -325,14 +380,24 @@ export function useAgentStudioDevServerPanel({
     ),
   );
 
-  const stopMutation = useMutation<DevServerGroupState, unknown, DevServerTaskScope>(
+  const stopMutation = useMutation<
+    DevServerGroupState,
+    unknown,
+    DevServerTaskScope,
+    DevServerMutationContext
+  >(
     createScopedMutationOptions(
       async (scope): Promise<DevServerGroupState> =>
         hostClient.devServerStop(scope.repoPath, scope.taskId),
     ),
   );
 
-  const restartMutation = useMutation<DevServerGroupState, unknown, DevServerTaskScope>(
+  const restartMutation = useMutation<
+    DevServerGroupState,
+    unknown,
+    DevServerTaskScope,
+    DevServerMutationContext
+  >(
     createScopedMutationOptions(
       async (scope): Promise<DevServerGroupState> =>
         hostClient.devServerRestart(scope.repoPath, scope.taskId),
@@ -349,6 +414,16 @@ export function useAgentStudioDevServerPanel({
 
     void subscribeDevServerEvents((payload) => {
       if (isDevServerSubscriptionControlEvent(payload)) {
+        if (payload.kind === BROWSER_LIVE_RECONNECTED_EVENT_KIND) {
+          const nextTransportGeneration = transportGenerationRef.current + 1;
+          transportGenerationRef.current = nextTransportGeneration;
+          clearTerminalBuffers();
+          dispatchLocalState({
+            type: "transportReconnected",
+            generation: nextTransportGeneration,
+          });
+          return;
+        }
         requestTerminalRehydrate();
         return;
       }
@@ -403,14 +478,29 @@ export function useAgentStudioDevServerPanel({
       cancelled = true;
       unsubscribe?.();
     };
-  }, [queryEnabled, repoPath, requestTerminalRehydrate, syncStateFromEvent, taskId]);
+  }, [
+    clearTerminalBuffers,
+    queryEnabled,
+    repoPath,
+    requestTerminalRehydrate,
+    syncStateFromEvent,
+    taskId,
+  ]);
 
   const selectedScript =
     effectiveState?.scripts.find((script) => script.scriptId === effectiveSelectedScriptId) ?? null;
-  const isStartPending = startMutation.isPending && isActiveMutationScope(startMutation.variables);
-  const isStopPending = stopMutation.isPending && isActiveMutationScope(stopMutation.variables);
+  const isStartPending =
+    startMutation.isPending &&
+    startMutation.context?.transportGeneration === transportGeneration &&
+    isActiveMutationScope(startMutation.variables);
+  const isStopPending =
+    stopMutation.isPending &&
+    stopMutation.context?.transportGeneration === transportGeneration &&
+    isActiveMutationScope(stopMutation.variables);
   const isRestartPending =
-    restartMutation.isPending && isActiveMutationScope(restartMutation.variables);
+    restartMutation.isPending &&
+    restartMutation.context?.transportGeneration === transportGeneration &&
+    isActiveMutationScope(restartMutation.variables);
   const isExpanded = isDevServerPanelExpanded(
     effectiveState?.scripts ?? [],
     isStartPending || isRestartPending,
@@ -470,12 +560,6 @@ export function useAgentStudioDevServerPanel({
         return;
       }
 
-      dispatchLocalState({ type: "actionStarted" });
-      if (effectiveState) {
-        const optimisticState = buildOptimisticStartingState(effectiveState);
-        replaceTerminalBuffersFromState(optimisticState, selectedScriptIdRef.current);
-        dispatchLocalState({ type: "liveStateChanged", state: optimisticState });
-      }
       startMutation.mutate(activeTaskScope);
     },
     onStop: () => {

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-state-query.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-state-query.ts
@@ -7,6 +7,7 @@ type UseAgentStudioDevServerStateQueryArgs = {
   taskId: string | null;
   queryEnabled: boolean;
   liveState: DevServerGroupState | null;
+  transportGeneration: number;
 };
 
 export function useAgentStudioDevServerStateQuery({
@@ -14,11 +15,12 @@ export function useAgentStudioDevServerStateQuery({
   taskId,
   queryEnabled,
   liveState,
+  transportGeneration,
 }: UseAgentStudioDevServerStateQueryArgs) {
   const queryOptions =
     repoPath && taskId
-      ? devServerGroupStateQueryOptions(repoPath, taskId)
-      : devServerGroupStateQueryOptions("__disabled__", "__disabled__");
+      ? devServerGroupStateQueryOptions(repoPath, taskId, transportGeneration)
+      : devServerGroupStateQueryOptions("__disabled__", "__disabled__", transportGeneration);
   const stateQuery = useQuery({
     ...queryOptions,
     enabled: queryEnabled,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-state-query.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-state-query.ts
@@ -7,7 +7,7 @@ type UseAgentStudioDevServerStateQueryArgs = {
   taskId: string | null;
   queryEnabled: boolean;
   liveState: DevServerGroupState | null;
-  transportGeneration: number;
+  transportEpoch: string | null;
 };
 
 export function useAgentStudioDevServerStateQuery({
@@ -15,12 +15,12 @@ export function useAgentStudioDevServerStateQuery({
   taskId,
   queryEnabled,
   liveState,
-  transportGeneration,
+  transportEpoch,
 }: UseAgentStudioDevServerStateQueryArgs) {
   const queryOptions =
-    repoPath && taskId
-      ? devServerGroupStateQueryOptions(repoPath, taskId, transportGeneration)
-      : devServerGroupStateQueryOptions("__disabled__", "__disabled__", transportGeneration);
+    repoPath && taskId && transportEpoch
+      ? devServerGroupStateQueryOptions(repoPath, taskId, transportEpoch)
+      : devServerGroupStateQueryOptions("__disabled__", "__disabled__", "disabled");
   const stateQuery = useQuery({
     ...queryOptions,
     enabled: queryEnabled,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
+import { Suspense, startTransition, useState } from "react";
 import { buildScript, buildState } from "./use-agent-studio-dev-server-panel-test-fixtures";
 import { renderDevServerPanelHook } from "./use-agent-studio-dev-server-panel-test-harness";
 import { useAgentStudioDevServerTerminalBuffers } from "./use-agent-studio-dev-server-terminal-buffers";
@@ -86,6 +87,100 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
       ).toEqual(["task seven output\r\n"]);
     } finally {
       harness.unmount();
+    }
+  });
+
+  test("keeps committed task buffers when a different task render suspends", () => {
+    type Scope = Parameters<typeof useAgentStudioDevServerTerminalBuffers>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerTerminalBuffers>;
+    const suspendedTask = new Promise<void>(() => {});
+    let latest: HookResult | null = null;
+    let setScope: ((scope: Scope) => void) | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+
+      return latest;
+    };
+
+    function HookHarness() {
+      const [scope, setCurrentScope] = useState<Scope>({
+        repoPath: "/repo",
+        taskId: "task-7",
+      });
+      setScope = setCurrentScope;
+      const result = useAgentStudioDevServerTerminalBuffers(scope);
+      if (scope?.taskId === "task-8") {
+        throw suspendedTask;
+      }
+      latest = result;
+      return null;
+    }
+
+    const view = render(
+      <Suspense fallback={null}>
+        <HookHarness />
+      </Suspense>,
+    );
+
+    try {
+      act(() => {
+        getLatest().replaceTerminalBuffersFromState(
+          buildState({
+            taskId: "task-7",
+            scripts: [
+              buildScript({
+                status: "running",
+                bufferedTerminalChunks: [
+                  {
+                    scriptId: "frontend",
+                    sequence: 0,
+                    data: "task seven output\r\n",
+                    timestamp: "2026-03-25T10:00:00.000Z",
+                  },
+                ],
+              }),
+            ],
+          }),
+          "frontend",
+        );
+      });
+
+      expect(getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data)).toEqual([
+        "task seven output\r\n",
+      ]);
+      const committedTaskSevenBuffers = getLatest();
+
+      act(() => {
+        startTransition(() => {
+          setScope?.({ repoPath: "/repo", taskId: "task-8" });
+        });
+      });
+
+      act(() => {
+        committedTaskSevenBuffers.applyTerminalBuffersFromEvent(
+          {
+            type: "terminal_chunk",
+            repoPath: "/repo",
+            taskId: "task-7",
+            terminalChunk: {
+              scriptId: "frontend",
+              sequence: 1,
+              data: "task seven still live\r\n",
+              timestamp: "2026-03-25T10:00:01.000Z",
+            },
+          },
+          "frontend",
+        );
+      });
+
+      expect(getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data)).toEqual([
+        "task seven output\r\n",
+        "task seven still live\r\n",
+      ]);
+    } finally {
+      view.unmount();
     }
   });
 });

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
@@ -30,6 +30,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                   {
                     scriptId: "frontend",
                     runId: "frontend:1",
+                    runOrder: { hostInstanceId: "host-1", generation: 1 },
                     sequence: 0,
                     data: "task seven output\r\n",
                     timestamp: "2026-03-25T10:00:00.000Z",
@@ -58,6 +59,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                   {
                     scriptId: "frontend",
                     runId: "frontend:1",
+                    runOrder: { hostInstanceId: "host-1", generation: 1 },
                     sequence: 0,
                     data: "task eight state\r\n",
                     timestamp: "2026-03-25T10:00:01.000Z",
@@ -76,6 +78,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
             terminalChunk: {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "task eight event\r\n",
               timestamp: "2026-03-25T10:00:02.000Z",
@@ -139,6 +142,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                   {
                     scriptId: "frontend",
                     runId: "frontend:1",
+                    runOrder: { hostInstanceId: "host-1", generation: 1 },
                     sequence: 0,
                     data: "task seven output\r\n",
                     timestamp: "2026-03-25T10:00:00.000Z",
@@ -171,6 +175,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
             terminalChunk: {
               scriptId: "frontend",
               runId: "frontend:1",
+              runOrder: { hostInstanceId: "host-1", generation: 1 },
               sequence: 1,
               data: "task seven still live\r\n",
               timestamp: "2026-03-25T10:00:01.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
@@ -29,8 +29,10 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                 bufferedTerminalChunks: [
                   {
                     scriptId: "frontend",
-                    runId: "frontend:1",
-                    runOrder: { hostInstanceId: "host-1", generation: 1 },
+                    runIdentity: {
+                      runId: "frontend:1",
+                      runOrder: { hostInstanceId: "host-1", generation: 1 },
+                    },
                     sequence: 0,
                     data: "task seven output\r\n",
                     timestamp: "2026-03-25T10:00:00.000Z",
@@ -58,8 +60,10 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                 bufferedTerminalChunks: [
                   {
                     scriptId: "frontend",
-                    runId: "frontend:1",
-                    runOrder: { hostInstanceId: "host-1", generation: 1 },
+                    runIdentity: {
+                      runId: "frontend:1",
+                      runOrder: { hostInstanceId: "host-1", generation: 1 },
+                    },
                     sequence: 0,
                     data: "task eight state\r\n",
                     timestamp: "2026-03-25T10:00:01.000Z",
@@ -77,8 +81,10 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
             taskId: "task-8",
             terminalChunk: {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "task eight event\r\n",
               timestamp: "2026-03-25T10:00:02.000Z",
@@ -141,8 +147,10 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                 bufferedTerminalChunks: [
                   {
                     scriptId: "frontend",
-                    runId: "frontend:1",
-                    runOrder: { hostInstanceId: "host-1", generation: 1 },
+                    runIdentity: {
+                      runId: "frontend:1",
+                      runOrder: { hostInstanceId: "host-1", generation: 1 },
+                    },
                     sequence: 0,
                     data: "task seven output\r\n",
                     timestamp: "2026-03-25T10:00:00.000Z",
@@ -174,8 +182,10 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
             taskId: "task-7",
             terminalChunk: {
               scriptId: "frontend",
-              runId: "frontend:1",
-              runOrder: { hostInstanceId: "host-1", generation: 1 },
+              runIdentity: {
+                runId: "frontend:1",
+                runOrder: { hostInstanceId: "host-1", generation: 1 },
+              },
               sequence: 1,
               data: "task seven still live\r\n",
               timestamp: "2026-03-25T10:00:01.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "@testing-library/react";
+import { buildScript, buildState } from "./use-agent-studio-dev-server-panel-test-fixtures";
+import { renderDevServerPanelHook } from "./use-agent-studio-dev-server-panel-test-harness";
+import { useAgentStudioDevServerTerminalBuffers } from "./use-agent-studio-dev-server-terminal-buffers";
+
+if (typeof document === "undefined") {
+  GlobalRegistrator.register();
+}
+
+describe("useAgentStudioDevServerTerminalBuffers", () => {
+  test("ignores state and events outside the active task scope", () => {
+    const harness = renderDevServerPanelHook(useAgentStudioDevServerTerminalBuffers, {
+      repoPath: "/repo",
+      taskId: "task-7",
+    });
+
+    try {
+      act(() => {
+        harness.getLatest().replaceTerminalBuffersFromState(
+          buildState({
+            repoPath: "/repo",
+            taskId: "task-7",
+            scripts: [
+              buildScript({
+                status: "running",
+                bufferedTerminalChunks: [
+                  {
+                    scriptId: "frontend",
+                    sequence: 0,
+                    data: "task seven output\r\n",
+                    timestamp: "2026-03-25T10:00:00.000Z",
+                  },
+                ],
+              }),
+            ],
+          }),
+          "frontend",
+        );
+      });
+
+      expect(
+        harness.getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
+      ).toEqual(["task seven output\r\n"]);
+
+      act(() => {
+        harness.getLatest().replaceTerminalBuffersFromState(
+          buildState({
+            repoPath: "/repo",
+            taskId: "task-8",
+            scripts: [
+              buildScript({
+                status: "running",
+                bufferedTerminalChunks: [
+                  {
+                    scriptId: "frontend",
+                    sequence: 0,
+                    data: "task eight state\r\n",
+                    timestamp: "2026-03-25T10:00:01.000Z",
+                  },
+                ],
+              }),
+            ],
+          }),
+          "frontend",
+        );
+        harness.getLatest().applyTerminalBuffersFromEvent(
+          {
+            type: "terminal_chunk",
+            repoPath: "/repo",
+            taskId: "task-8",
+            terminalChunk: {
+              scriptId: "frontend",
+              sequence: 1,
+              data: "task eight event\r\n",
+              timestamp: "2026-03-25T10:00:02.000Z",
+            },
+          },
+          "frontend",
+        );
+      });
+
+      expect(
+        harness.getLatest().selectedScriptTerminalBuffer?.entries.map((entry) => entry.data),
+      ).toEqual(["task seven output\r\n"]);
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.test.tsx
@@ -29,6 +29,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                 bufferedTerminalChunks: [
                   {
                     scriptId: "frontend",
+                    runId: "frontend:1",
                     sequence: 0,
                     data: "task seven output\r\n",
                     timestamp: "2026-03-25T10:00:00.000Z",
@@ -56,6 +57,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                 bufferedTerminalChunks: [
                   {
                     scriptId: "frontend",
+                    runId: "frontend:1",
                     sequence: 0,
                     data: "task eight state\r\n",
                     timestamp: "2026-03-25T10:00:01.000Z",
@@ -73,6 +75,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
             taskId: "task-8",
             terminalChunk: {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "task eight event\r\n",
               timestamp: "2026-03-25T10:00:02.000Z",
@@ -135,6 +138,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
                 bufferedTerminalChunks: [
                   {
                     scriptId: "frontend",
+                    runId: "frontend:1",
                     sequence: 0,
                     data: "task seven output\r\n",
                     timestamp: "2026-03-25T10:00:00.000Z",
@@ -166,6 +170,7 @@ describe("useAgentStudioDevServerTerminalBuffers", () => {
             taskId: "task-7",
             terminalChunk: {
               scriptId: "frontend",
+              runId: "frontend:1",
               sequence: 1,
               data: "task seven still live\r\n",
               timestamp: "2026-03-25T10:00:01.000Z",

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -25,6 +25,11 @@ type SelectedScriptTerminalBufferState = {
   scopeKey: string;
 };
 
+type DevServerTerminalBufferScope = {
+  repoPath: string;
+  taskId: string;
+};
+
 type UseAgentStudioDevServerTerminalBuffersResult = {
   applyTerminalBuffersFromEvent: (event: DevServerEvent, selectedScriptId: string | null) => void;
   beginMutationReplaySync: (state: DevServerGroupState | null) => void;
@@ -47,9 +52,36 @@ type UseAgentStudioDevServerTerminalBuffersResult = {
   ) => void;
 };
 
+const isDevServerStateInScope = (
+  state: DevServerGroupState,
+  scope: DevServerTerminalBufferScope | null,
+): boolean => {
+  if (!scope) {
+    return false;
+  }
+
+  return state.repoPath === scope.repoPath && state.taskId === scope.taskId;
+};
+
+const isDevServerEventInScope = (
+  event: DevServerEvent,
+  scope: DevServerTerminalBufferScope | null,
+): boolean => {
+  if (!scope) {
+    return false;
+  }
+
+  if (event.type === "snapshot") {
+    return isDevServerStateInScope(event.state, scope);
+  }
+
+  return event.repoPath === scope.repoPath && event.taskId === scope.taskId;
+};
+
 export const useAgentStudioDevServerTerminalBuffers = (
-  scopeKey: string | null,
+  scope: DevServerTerminalBufferScope | null,
 ): UseAgentStudioDevServerTerminalBuffersResult => {
+  const scopeKey = scope ? `${scope.repoPath}::${scope.taskId}` : null;
   const activeScopeKey = scopeKey ?? "__no-dev-server-task__";
   const terminalBuffersRef = useRef<DevServerTerminalBufferStore | null>(null);
   const terminalBuffersScopeRef = useRef<string | null>(null);
@@ -76,15 +108,23 @@ export const useAgentStudioDevServerTerminalBuffers = (
 
   const replaceTerminalBuffersFromState = useCallback(
     (state: DevServerGroupState | null, selectedScriptId: string | null): void => {
+      if (state !== null && !isDevServerStateInScope(state, scope)) {
+        return;
+      }
+
       syncDevServerTerminalBufferStore(terminalBuffers, state);
       syncSelectedScriptTerminalBuffer(selectedScriptId);
     },
-    [syncSelectedScriptTerminalBuffer, terminalBuffers],
+    [scope, syncSelectedScriptTerminalBuffer, terminalBuffers],
   );
 
   const hydrateTerminalBuffersFromState = useCallback(
     (state: DevServerGroupState | null, selectedScriptId: string | null): void => {
       if (state === null) {
+        return;
+      }
+
+      if (!isDevServerStateInScope(state, scope)) {
         return;
       }
 
@@ -97,11 +137,15 @@ export const useAgentStudioDevServerTerminalBuffers = (
         syncSelectedScriptTerminalBuffer(selectedScriptId);
       }
     },
-    [replaceTerminalBuffersFromState, syncSelectedScriptTerminalBuffer, terminalBuffers],
+    [replaceTerminalBuffersFromState, scope, syncSelectedScriptTerminalBuffer, terminalBuffers],
   );
 
   const beginMutationReplaySync = useCallback(
     (state: DevServerGroupState | null): void => {
+      if (state !== null && !isDevServerStateInScope(state, scope)) {
+        return;
+      }
+
       const baselineByScriptId = new Map<string, number | null>();
 
       for (const script of state?.scripts ?? []) {
@@ -117,11 +161,15 @@ export const useAgentStudioDevServerTerminalBuffers = (
         scopeKey: activeScopeKey,
       };
     },
-    [activeScopeKey, terminalBuffers],
+    [activeScopeKey, scope, terminalBuffers],
   );
 
   const syncTerminalBuffersFromMutationState = useCallback(
     (state: DevServerGroupState, selectedScriptId: string | null): void => {
+      if (!isDevServerStateInScope(state, scope)) {
+        return;
+      }
+
       const pendingReplaySync = pendingMutationReplaySyncRef.current;
       if (!pendingReplaySync) {
         hydrateTerminalBuffersFromState(state, selectedScriptId);
@@ -178,6 +226,7 @@ export const useAgentStudioDevServerTerminalBuffers = (
     [
       activeScopeKey,
       hydrateTerminalBuffersFromState,
+      scope,
       syncSelectedScriptTerminalBuffer,
       terminalBuffers,
     ],
@@ -185,6 +234,10 @@ export const useAgentStudioDevServerTerminalBuffers = (
 
   const markMutationReplayObserved = useCallback(
     (event: DevServerEvent): void => {
+      if (!isDevServerEventInScope(event, scope)) {
+        return;
+      }
+
       const pendingReplaySync = pendingMutationReplaySyncRef.current;
       if (!pendingReplaySync) {
         return;
@@ -209,11 +262,15 @@ export const useAgentStudioDevServerTerminalBuffers = (
 
       pendingReplaySync.observedScriptIds.add(event.terminalChunk.scriptId);
     },
-    [activeScopeKey],
+    [activeScopeKey, scope],
   );
 
   const applyTerminalBuffersFromEvent = useCallback(
     (event: DevServerEvent, selectedScriptId: string | null): void => {
+      if (!isDevServerEventInScope(event, scope)) {
+        return;
+      }
+
       if (event.type === "snapshot") {
         hydrateTerminalBuffersFromState(event.state, selectedScriptId);
         return;
@@ -246,7 +303,7 @@ export const useAgentStudioDevServerTerminalBuffers = (
         syncSelectedScriptTerminalBuffer(selectedScriptId);
       }
     },
-    [hydrateTerminalBuffersFromState, syncSelectedScriptTerminalBuffer, terminalBuffers],
+    [hydrateTerminalBuffersFromState, scope, syncSelectedScriptTerminalBuffer, terminalBuffers],
   );
 
   const cancelMutationReplaySync = useCallback((): void => {

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -4,8 +4,6 @@ import {
   type AgentStudioDevServerTerminalBuffer,
   appendDevServerTerminalChunk,
   applyDevServerTerminalBufferReplacement,
-  canApplyDevServerGroupState,
-  canApplyDevServerScriptStateToStore,
   createDevServerTerminalBufferStore,
   type DevServerTerminalBufferStore,
   getDevServerTerminalBuffer,
@@ -15,6 +13,10 @@ import {
   shouldReplaceDevServerTerminalBufferFromScript,
   syncDevServerTerminalBufferStore,
 } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
+import {
+  canApplyDevServerGroupState,
+  canApplyDevServerScriptStateToStore,
+} from "@/features/agent-studio-build-tools/dev-server-run-ownership";
 import {
   type DevServerTaskScope,
   formatDevServerTaskScopeKey,

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -51,19 +51,18 @@ export const useAgentStudioDevServerTerminalBuffers = (
   scopeKey: string | null,
 ): UseAgentStudioDevServerTerminalBuffersResult => {
   const activeScopeKey = scopeKey ?? "__no-dev-server-task__";
-  const terminalBuffersByScopeRef = useRef<Map<string, DevServerTerminalBufferStore> | null>(null);
-  if (terminalBuffersByScopeRef.current === null) {
-    terminalBuffersByScopeRef.current = new Map();
-  }
-  const terminalBuffersByScope = terminalBuffersByScopeRef.current;
-  let terminalBuffers = terminalBuffersByScope.get(activeScopeKey);
-  if (!terminalBuffers) {
-    terminalBuffers = createDevServerTerminalBufferStore();
-    terminalBuffersByScope.set(activeScopeKey, terminalBuffers);
-  }
+  const terminalBuffersRef = useRef<DevServerTerminalBufferStore | null>(null);
+  const terminalBuffersScopeRef = useRef<string | null>(null);
   const pendingMutationReplaySyncRef = useRef<PendingMutationReplaySync | null>(null);
   const [selectedScriptTerminalBufferState, setSelectedScriptTerminalBufferState] =
     useState<SelectedScriptTerminalBufferState | null>(null);
+
+  if (terminalBuffersRef.current === null || terminalBuffersScopeRef.current !== activeScopeKey) {
+    terminalBuffersRef.current = createDevServerTerminalBufferStore();
+    terminalBuffersScopeRef.current = activeScopeKey;
+    pendingMutationReplaySyncRef.current = null;
+  }
+  const terminalBuffers = terminalBuffersRef.current;
 
   const syncSelectedScriptTerminalBuffer = useCallback(
     (scriptId: string | null): void => {

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -4,6 +4,8 @@ import {
   type AgentStudioDevServerTerminalBuffer,
   appendDevServerTerminalChunk,
   applyDevServerTerminalBufferReplacement,
+  canApplyDevServerGroupState,
+  canApplyDevServerScriptStateToStore,
   createDevServerTerminalBufferStore,
   type DevServerTerminalBufferStore,
   getDevServerTerminalBuffer,
@@ -36,25 +38,28 @@ type DevServerTerminalBufferOwner = {
 };
 
 type UseAgentStudioDevServerTerminalBuffersResult = {
-  applyTerminalBuffersFromEvent: (event: DevServerEvent, selectedScriptId: string | null) => void;
+  applyTerminalBuffersFromEvent: (
+    event: DevServerEvent,
+    selectedScriptId: string | null,
+  ) => boolean;
   beginMutationReplaySync: (state: DevServerGroupState | null) => void;
   cancelMutationReplaySync: () => void;
   clearTerminalBuffers: () => void;
   hydrateTerminalBuffersFromState: (
     state: DevServerGroupState | null,
     selectedScriptId: string | null,
-  ) => void;
+  ) => boolean;
   markMutationReplayObserved: (event: DevServerEvent) => void;
   replaceTerminalBuffersFromState: (
     state: DevServerGroupState | null,
     selectedScriptId: string | null,
-  ) => void;
+  ) => boolean;
   selectedScriptTerminalBuffer: AgentStudioDevServerTerminalBuffer | null;
   syncSelectedScriptTerminalBuffer: (scriptId: string | null) => void;
   syncTerminalBuffersFromMutationState: (
     state: DevServerGroupState,
     selectedScriptId: string | null,
-  ) => void;
+  ) => boolean;
 };
 
 const isDevServerStateInScope = (
@@ -111,35 +116,42 @@ export const useAgentStudioDevServerTerminalBuffers = (
   );
 
   const replaceTerminalBuffersFromState = useCallback(
-    (state: DevServerGroupState | null, selectedScriptId: string | null): void => {
+    (state: DevServerGroupState | null, selectedScriptId: string | null): boolean => {
       if (state !== null && !isDevServerStateInScope(state, scope)) {
-        return;
+        return false;
+      }
+      if (state !== null && !canApplyDevServerGroupState(terminalBuffers, state)) {
+        return false;
       }
 
       syncDevServerTerminalBufferStore(terminalBuffers, state);
       syncSelectedScriptTerminalBuffer(selectedScriptId);
+      return true;
     },
     [scope, syncSelectedScriptTerminalBuffer, terminalBuffers],
   );
 
   const hydrateTerminalBuffersFromState = useCallback(
-    (state: DevServerGroupState | null, selectedScriptId: string | null): void => {
+    (state: DevServerGroupState | null, selectedScriptId: string | null): boolean => {
       if (state === null) {
-        return;
+        return false;
       }
 
       if (!isDevServerStateInScope(state, scope)) {
-        return;
+        return false;
+      }
+      if (!canApplyDevServerGroupState(terminalBuffers, state)) {
+        return false;
       }
 
       if (terminalBuffers.size === 0) {
-        replaceTerminalBuffersFromState(state, selectedScriptId);
-        return;
+        return replaceTerminalBuffersFromState(state, selectedScriptId);
       }
 
       if (reconcileDevServerTerminalBufferStore(terminalBuffers, state)) {
         syncSelectedScriptTerminalBuffer(selectedScriptId);
       }
+      return true;
     },
     [replaceTerminalBuffersFromState, scope, syncSelectedScriptTerminalBuffer, terminalBuffers],
   );
@@ -169,21 +181,22 @@ export const useAgentStudioDevServerTerminalBuffers = (
   );
 
   const syncTerminalBuffersFromMutationState = useCallback(
-    (state: DevServerGroupState, selectedScriptId: string | null): void => {
+    (state: DevServerGroupState, selectedScriptId: string | null): boolean => {
       if (!isDevServerStateInScope(state, scope)) {
-        return;
+        return false;
+      }
+      if (!canApplyDevServerGroupState(terminalBuffers, state)) {
+        return false;
       }
 
       const pendingReplaySync = terminalBufferOwner.pendingMutationReplaySync;
       if (!pendingReplaySync) {
-        hydrateTerminalBuffersFromState(state, selectedScriptId);
-        return;
+        return hydrateTerminalBuffersFromState(state, selectedScriptId);
       }
 
       if (pendingReplaySync.scopeKey !== activeScopeKey) {
         terminalBufferOwner.pendingMutationReplaySync = null;
-        hydrateTerminalBuffersFromState(state, selectedScriptId);
-        return;
+        return hydrateTerminalBuffersFromState(state, selectedScriptId);
       }
 
       const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
@@ -226,6 +239,7 @@ export const useAgentStudioDevServerTerminalBuffers = (
 
       terminalBufferOwner.pendingMutationReplaySync = null;
       syncSelectedScriptTerminalBuffer(selectedScriptId);
+      return true;
     },
     [
       activeScopeKey,
@@ -271,33 +285,33 @@ export const useAgentStudioDevServerTerminalBuffers = (
   );
 
   const applyTerminalBuffersFromEvent = useCallback(
-    (event: DevServerEvent, selectedScriptId: string | null): void => {
+    (event: DevServerEvent, selectedScriptId: string | null): boolean => {
       if (!isDevServerEventInScope(event, scope)) {
-        return;
+        return false;
       }
 
       if (event.type === "snapshot") {
-        hydrateTerminalBuffersFromState(event.state, selectedScriptId);
-        return;
+        return hydrateTerminalBuffersFromState(event.state, selectedScriptId);
       }
 
       if (event.type === "script_status_changed") {
-        const replacementContext =
-          event.script.status === "starting"
-            ? null
-            : getDevServerTerminalBufferReplacementContext(terminalBuffers, event.script.scriptId);
-        const replacement = getDevServerTerminalBufferReplacement(replacementContext, event.script);
-        if (replacement === null) {
-          return;
-        }
-
-        applyDevServerTerminalBufferReplacement(
+        const replacementContext = getDevServerTerminalBufferReplacementContext(
           terminalBuffers,
           event.script.scriptId,
-          replacement,
         );
-      } else {
-        appendDevServerTerminalChunk(terminalBuffers, event.terminalChunk);
+        if (!canApplyDevServerScriptStateToStore(terminalBuffers, event.script)) {
+          return false;
+        }
+        const replacement = getDevServerTerminalBufferReplacement(replacementContext, event.script);
+        if (replacement !== null) {
+          applyDevServerTerminalBufferReplacement(
+            terminalBuffers,
+            event.script.scriptId,
+            replacement,
+          );
+        }
+      } else if (!appendDevServerTerminalChunk(terminalBuffers, event.terminalChunk)) {
+        return false;
       }
 
       const touchedScriptId =
@@ -307,6 +321,7 @@ export const useAgentStudioDevServerTerminalBuffers = (
       if (selectedScriptId && touchedScriptId === selectedScriptId) {
         syncSelectedScriptTerminalBuffer(selectedScriptId);
       }
+      return true;
     },
     [hydrateTerminalBuffersFromState, scope, syncSelectedScriptTerminalBuffer, terminalBuffers],
   );

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -17,6 +17,12 @@ import {
 type PendingMutationReplaySync = {
   baselineByScriptId: Map<string, number | null>;
   observedScriptIds: Set<string>;
+  scopeKey: string;
+};
+
+type SelectedScriptTerminalBufferState = {
+  buffer: AgentStudioDevServerTerminalBuffer | null;
+  scopeKey: string;
 };
 
 type UseAgentStudioDevServerTerminalBuffersResult = {
@@ -41,124 +47,152 @@ type UseAgentStudioDevServerTerminalBuffersResult = {
   ) => void;
 };
 
-export const useAgentStudioDevServerTerminalBuffers =
-  (): UseAgentStudioDevServerTerminalBuffersResult => {
-    const terminalBuffersRef = useRef<DevServerTerminalBufferStore | null>(null);
-    if (terminalBuffersRef.current === null) {
-      terminalBuffersRef.current = createDevServerTerminalBufferStore();
-    }
-    const terminalBuffers = terminalBuffersRef.current;
-    const pendingMutationReplaySyncRef = useRef<PendingMutationReplaySync | null>(null);
-    const [selectedScriptTerminalBuffer, setSelectedScriptTerminalBuffer] =
-      useState<AgentStudioDevServerTerminalBuffer | null>(null);
+export const useAgentStudioDevServerTerminalBuffers = (
+  scopeKey: string | null,
+): UseAgentStudioDevServerTerminalBuffersResult => {
+  const activeScopeKey = scopeKey ?? "__no-dev-server-task__";
+  const terminalBuffersByScopeRef = useRef<Map<string, DevServerTerminalBufferStore> | null>(null);
+  if (terminalBuffersByScopeRef.current === null) {
+    terminalBuffersByScopeRef.current = new Map();
+  }
+  const terminalBuffersByScope = terminalBuffersByScopeRef.current;
+  let terminalBuffers = terminalBuffersByScope.get(activeScopeKey);
+  if (!terminalBuffers) {
+    terminalBuffers = createDevServerTerminalBufferStore();
+    terminalBuffersByScope.set(activeScopeKey, terminalBuffers);
+  }
+  const pendingMutationReplaySyncRef = useRef<PendingMutationReplaySync | null>(null);
+  const [selectedScriptTerminalBufferState, setSelectedScriptTerminalBufferState] =
+    useState<SelectedScriptTerminalBufferState | null>(null);
 
-    const syncSelectedScriptTerminalBuffer = useCallback(
-      (scriptId: string | null): void => {
-        setSelectedScriptTerminalBuffer(getDevServerTerminalBuffer(terminalBuffers, scriptId));
-      },
-      [terminalBuffers],
-    );
+  const syncSelectedScriptTerminalBuffer = useCallback(
+    (scriptId: string | null): void => {
+      setSelectedScriptTerminalBufferState({
+        buffer: getDevServerTerminalBuffer(terminalBuffers, scriptId),
+        scopeKey: activeScopeKey,
+      });
+    },
+    [activeScopeKey, terminalBuffers],
+  );
 
-    const replaceTerminalBuffersFromState = useCallback(
-      (state: DevServerGroupState | null, selectedScriptId: string | null): void => {
-        syncDevServerTerminalBufferStore(terminalBuffers, state);
+  const replaceTerminalBuffersFromState = useCallback(
+    (state: DevServerGroupState | null, selectedScriptId: string | null): void => {
+      syncDevServerTerminalBufferStore(terminalBuffers, state);
+      syncSelectedScriptTerminalBuffer(selectedScriptId);
+    },
+    [syncSelectedScriptTerminalBuffer, terminalBuffers],
+  );
+
+  const hydrateTerminalBuffersFromState = useCallback(
+    (state: DevServerGroupState | null, selectedScriptId: string | null): void => {
+      if (state === null) {
+        return;
+      }
+
+      if (terminalBuffers.size === 0) {
+        replaceTerminalBuffersFromState(state, selectedScriptId);
+        return;
+      }
+
+      if (reconcileDevServerTerminalBufferStore(terminalBuffers, state)) {
         syncSelectedScriptTerminalBuffer(selectedScriptId);
-      },
-      [syncSelectedScriptTerminalBuffer, terminalBuffers],
-    );
+      }
+    },
+    [replaceTerminalBuffersFromState, syncSelectedScriptTerminalBuffer, terminalBuffers],
+  );
 
-    const hydrateTerminalBuffersFromState = useCallback(
-      (state: DevServerGroupState | null, selectedScriptId: string | null): void => {
-        if (state === null) {
-          return;
-        }
+  const beginMutationReplaySync = useCallback(
+    (state: DevServerGroupState | null): void => {
+      const baselineByScriptId = new Map<string, number | null>();
 
-        if (terminalBuffers.size === 0) {
-          replaceTerminalBuffersFromState(state, selectedScriptId);
-          return;
-        }
+      for (const script of state?.scripts ?? []) {
+        baselineByScriptId.set(
+          script.scriptId,
+          getDevServerTerminalBuffer(terminalBuffers, script.scriptId)?.lastSequence ?? null,
+        );
+      }
 
-        if (reconcileDevServerTerminalBufferStore(terminalBuffers, state)) {
-          syncSelectedScriptTerminalBuffer(selectedScriptId);
-        }
-      },
-      [replaceTerminalBuffersFromState, syncSelectedScriptTerminalBuffer, terminalBuffers],
-    );
+      pendingMutationReplaySyncRef.current = {
+        baselineByScriptId,
+        observedScriptIds: new Set(),
+        scopeKey: activeScopeKey,
+      };
+    },
+    [activeScopeKey, terminalBuffers],
+  );
 
-    const beginMutationReplaySync = useCallback(
-      (state: DevServerGroupState | null): void => {
-        const baselineByScriptId = new Map<string, number | null>();
-
-        for (const script of state?.scripts ?? []) {
-          baselineByScriptId.set(
-            script.scriptId,
-            getDevServerTerminalBuffer(terminalBuffers, script.scriptId)?.lastSequence ?? null,
-          );
-        }
-
-        pendingMutationReplaySyncRef.current = {
-          baselineByScriptId,
-          observedScriptIds: new Set(),
-        };
-      },
-      [terminalBuffers],
-    );
-
-    const syncTerminalBuffersFromMutationState = useCallback(
-      (state: DevServerGroupState, selectedScriptId: string | null): void => {
-        const pendingReplaySync = pendingMutationReplaySyncRef.current;
-        if (!pendingReplaySync) {
-          hydrateTerminalBuffersFromState(state, selectedScriptId);
-          return;
-        }
-
-        const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
-        for (const scriptId of terminalBuffers.keys()) {
-          if (!nextScriptIds.has(scriptId)) {
-            terminalBuffers.delete(scriptId);
-          }
-        }
-
-        for (const script of state.scripts) {
-          const currentBuffer = getDevServerTerminalBuffer(terminalBuffers, script.scriptId);
-          const currentLastSequence = currentBuffer?.lastSequence ?? null;
-          const baselineLastSequence =
-            pendingReplaySync.baselineByScriptId.get(script.scriptId) ?? null;
-          const currentContext = getDevServerTerminalBufferReplacementContext(
-            terminalBuffers,
-            script.scriptId,
-          );
-          // Replace if no live replay was observed, if we only re-observed the baseline,
-          // or if the authoritative replay window proves the local buffer is stale.
-          const shouldReplaceReplay =
-            !pendingReplaySync.observedScriptIds.has(script.scriptId) ||
-            currentLastSequence === baselineLastSequence ||
-            shouldReplaceDevServerTerminalBufferFromScript(currentContext, script);
-
-          if (shouldReplaceReplay) {
-            const replacement =
-              !pendingReplaySync.observedScriptIds.has(script.scriptId) ||
-              currentLastSequence === baselineLastSequence
-                ? getDevServerTerminalBufferReplacement(null, script)
-                : getDevServerTerminalBufferReplacement(currentContext, script);
-            if (replacement === null) {
-              continue;
-            }
-
-            // Mutation success replaces the replay baseline when no new live output arrived yet.
-            applyDevServerTerminalBufferReplacement(terminalBuffers, script.scriptId, replacement);
-          }
-        }
-
-        pendingMutationReplaySyncRef.current = null;
-        syncSelectedScriptTerminalBuffer(selectedScriptId);
-      },
-      [hydrateTerminalBuffersFromState, syncSelectedScriptTerminalBuffer, terminalBuffers],
-    );
-
-    const markMutationReplayObserved = useCallback((event: DevServerEvent): void => {
+  const syncTerminalBuffersFromMutationState = useCallback(
+    (state: DevServerGroupState, selectedScriptId: string | null): void => {
       const pendingReplaySync = pendingMutationReplaySyncRef.current;
       if (!pendingReplaySync) {
+        hydrateTerminalBuffersFromState(state, selectedScriptId);
+        return;
+      }
+
+      if (pendingReplaySync.scopeKey !== activeScopeKey) {
+        pendingMutationReplaySyncRef.current = null;
+        hydrateTerminalBuffersFromState(state, selectedScriptId);
+        return;
+      }
+
+      const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
+      for (const scriptId of terminalBuffers.keys()) {
+        if (!nextScriptIds.has(scriptId)) {
+          terminalBuffers.delete(scriptId);
+        }
+      }
+
+      for (const script of state.scripts) {
+        const currentBuffer = getDevServerTerminalBuffer(terminalBuffers, script.scriptId);
+        const currentLastSequence = currentBuffer?.lastSequence ?? null;
+        const baselineLastSequence =
+          pendingReplaySync.baselineByScriptId.get(script.scriptId) ?? null;
+        const currentContext = getDevServerTerminalBufferReplacementContext(
+          terminalBuffers,
+          script.scriptId,
+        );
+        // Replace if no live replay was observed, if we only re-observed the baseline,
+        // or if the authoritative replay window proves the local buffer is stale.
+        const shouldReplaceReplay =
+          !pendingReplaySync.observedScriptIds.has(script.scriptId) ||
+          currentLastSequence === baselineLastSequence ||
+          shouldReplaceDevServerTerminalBufferFromScript(currentContext, script);
+
+        if (shouldReplaceReplay) {
+          const replacement =
+            !pendingReplaySync.observedScriptIds.has(script.scriptId) ||
+            currentLastSequence === baselineLastSequence
+              ? getDevServerTerminalBufferReplacement(null, script)
+              : getDevServerTerminalBufferReplacement(currentContext, script);
+          if (replacement === null) {
+            continue;
+          }
+
+          // Mutation success replaces the replay baseline when no new live output arrived yet.
+          applyDevServerTerminalBufferReplacement(terminalBuffers, script.scriptId, replacement);
+        }
+      }
+
+      pendingMutationReplaySyncRef.current = null;
+      syncSelectedScriptTerminalBuffer(selectedScriptId);
+    },
+    [
+      activeScopeKey,
+      hydrateTerminalBuffersFromState,
+      syncSelectedScriptTerminalBuffer,
+      terminalBuffers,
+    ],
+  );
+
+  const markMutationReplayObserved = useCallback(
+    (event: DevServerEvent): void => {
+      const pendingReplaySync = pendingMutationReplaySyncRef.current;
+      if (!pendingReplaySync) {
+        return;
+      }
+
+      if (pendingReplaySync.scopeKey !== activeScopeKey) {
+        pendingMutationReplaySyncRef.current = null;
         return;
       }
 
@@ -175,71 +209,71 @@ export const useAgentStudioDevServerTerminalBuffers =
       }
 
       pendingReplaySync.observedScriptIds.add(event.terminalChunk.scriptId);
-    }, []);
+    },
+    [activeScopeKey],
+  );
 
-    const applyTerminalBuffersFromEvent = useCallback(
-      (event: DevServerEvent, selectedScriptId: string | null): void => {
-        if (event.type === "snapshot") {
-          hydrateTerminalBuffersFromState(event.state, selectedScriptId);
+  const applyTerminalBuffersFromEvent = useCallback(
+    (event: DevServerEvent, selectedScriptId: string | null): void => {
+      if (event.type === "snapshot") {
+        hydrateTerminalBuffersFromState(event.state, selectedScriptId);
+        return;
+      }
+
+      if (event.type === "script_status_changed") {
+        const replacementContext =
+          event.script.status === "starting"
+            ? null
+            : getDevServerTerminalBufferReplacementContext(terminalBuffers, event.script.scriptId);
+        const replacement = getDevServerTerminalBufferReplacement(replacementContext, event.script);
+        if (replacement === null) {
           return;
         }
 
-        if (event.type === "script_status_changed") {
-          const replacementContext =
-            event.script.status === "starting"
-              ? null
-              : getDevServerTerminalBufferReplacementContext(
-                  terminalBuffers,
-                  event.script.scriptId,
-                );
-          const replacement = getDevServerTerminalBufferReplacement(
-            replacementContext,
-            event.script,
-          );
-          if (replacement === null) {
-            return;
-          }
+        applyDevServerTerminalBufferReplacement(
+          terminalBuffers,
+          event.script.scriptId,
+          replacement,
+        );
+      } else {
+        appendDevServerTerminalChunk(terminalBuffers, event.terminalChunk);
+      }
 
-          applyDevServerTerminalBufferReplacement(
-            terminalBuffers,
-            event.script.scriptId,
-            replacement,
-          );
-        } else {
-          appendDevServerTerminalChunk(terminalBuffers, event.terminalChunk);
-        }
+      const touchedScriptId =
+        event.type === "script_status_changed"
+          ? event.script.scriptId
+          : event.terminalChunk.scriptId;
+      if (selectedScriptId && touchedScriptId === selectedScriptId) {
+        syncSelectedScriptTerminalBuffer(selectedScriptId);
+      }
+    },
+    [hydrateTerminalBuffersFromState, syncSelectedScriptTerminalBuffer, terminalBuffers],
+  );
 
-        const touchedScriptId =
-          event.type === "script_status_changed"
-            ? event.script.scriptId
-            : event.terminalChunk.scriptId;
-        if (selectedScriptId && touchedScriptId === selectedScriptId) {
-          syncSelectedScriptTerminalBuffer(selectedScriptId);
-        }
-      },
-      [hydrateTerminalBuffersFromState, syncSelectedScriptTerminalBuffer, terminalBuffers],
-    );
+  const cancelMutationReplaySync = useCallback((): void => {
+    pendingMutationReplaySyncRef.current = null;
+  }, []);
 
-    const cancelMutationReplaySync = useCallback((): void => {
-      pendingMutationReplaySyncRef.current = null;
-    }, []);
+  const clearTerminalBuffers = useCallback((): void => {
+    terminalBuffers.clear();
+    pendingMutationReplaySyncRef.current = null;
+    setSelectedScriptTerminalBufferState({ buffer: null, scopeKey: activeScopeKey });
+  }, [activeScopeKey, terminalBuffers]);
+  const selectedScriptTerminalBuffer =
+    selectedScriptTerminalBufferState?.scopeKey === activeScopeKey
+      ? selectedScriptTerminalBufferState.buffer
+      : null;
 
-    const clearTerminalBuffers = useCallback((): void => {
-      terminalBuffers.clear();
-      pendingMutationReplaySyncRef.current = null;
-      setSelectedScriptTerminalBuffer(null);
-    }, [terminalBuffers]);
-
-    return {
-      applyTerminalBuffersFromEvent,
-      beginMutationReplaySync,
-      cancelMutationReplaySync,
-      clearTerminalBuffers,
-      hydrateTerminalBuffersFromState,
-      markMutationReplayObserved,
-      replaceTerminalBuffersFromState,
-      selectedScriptTerminalBuffer,
-      syncSelectedScriptTerminalBuffer,
-      syncTerminalBuffersFromMutationState,
-    };
+  return {
+    applyTerminalBuffersFromEvent,
+    beginMutationReplaySync,
+    cancelMutationReplaySync,
+    clearTerminalBuffers,
+    hydrateTerminalBuffersFromState,
+    markMutationReplayObserved,
+    replaceTerminalBuffersFromState,
+    selectedScriptTerminalBuffer,
+    syncSelectedScriptTerminalBuffer,
+    syncTerminalBuffersFromMutationState,
   };
+};

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -1,5 +1,5 @@
 import type { DevServerEvent, DevServerGroupState } from "@openducktor/contracts";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   type AgentStudioDevServerTerminalBuffer,
   appendDevServerTerminalChunk,
@@ -38,6 +38,12 @@ type DevServerTerminalBufferOwner = {
   scopeKey: string;
   terminalBuffers: DevServerTerminalBufferStore;
 };
+
+const createDevServerTerminalBufferOwner = (scopeKey: string): DevServerTerminalBufferOwner => ({
+  pendingMutationReplaySync: null,
+  scopeKey,
+  terminalBuffers: createDevServerTerminalBufferStore(),
+});
 
 type UseAgentStudioDevServerTerminalBuffersResult = {
   applyTerminalBuffersFromEvent: (
@@ -94,14 +100,12 @@ export const useAgentStudioDevServerTerminalBuffers = (
   scope: DevServerTaskScope | null,
 ): UseAgentStudioDevServerTerminalBuffersResult => {
   const requestedScopeKey = formatDevServerTaskScopeKey(scope);
-  const terminalBufferOwner = useMemo<DevServerTerminalBufferOwner>(
-    () => ({
-      pendingMutationReplaySync: null,
-      scopeKey: requestedScopeKey,
-      terminalBuffers: createDevServerTerminalBufferStore(),
-    }),
-    [requestedScopeKey],
+  const [terminalBufferOwner, setTerminalBufferOwner] = useState<DevServerTerminalBufferOwner>(() =>
+    createDevServerTerminalBufferOwner(requestedScopeKey),
   );
+  if (terminalBufferOwner.scopeKey !== requestedScopeKey) {
+    setTerminalBufferOwner(createDevServerTerminalBufferOwner(requestedScopeKey));
+  }
   const [selectedScriptTerminalBufferState, setSelectedScriptTerminalBufferState] =
     useState<SelectedScriptTerminalBufferState | null>(null);
   const activeScopeKey = terminalBufferOwner.scopeKey;

--- a/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
+++ b/packages/frontend/src/pages/agents/right-panel/use-agent-studio-dev-server-terminal-buffers.ts
@@ -1,5 +1,5 @@
 import type { DevServerEvent, DevServerGroupState } from "@openducktor/contracts";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   type AgentStudioDevServerTerminalBuffer,
   appendDevServerTerminalChunk,
@@ -13,6 +13,10 @@ import {
   shouldReplaceDevServerTerminalBufferFromScript,
   syncDevServerTerminalBufferStore,
 } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
+import {
+  type DevServerTaskScope,
+  formatDevServerTaskScopeKey,
+} from "@/types/dev-server-task-scope";
 
 type PendingMutationReplaySync = {
   baselineByScriptId: Map<string, number | null>;
@@ -25,9 +29,10 @@ type SelectedScriptTerminalBufferState = {
   scopeKey: string;
 };
 
-type DevServerTerminalBufferScope = {
-  repoPath: string;
-  taskId: string;
+type DevServerTerminalBufferOwner = {
+  pendingMutationReplaySync: PendingMutationReplaySync | null;
+  scopeKey: string;
+  terminalBuffers: DevServerTerminalBufferStore;
 };
 
 type UseAgentStudioDevServerTerminalBuffersResult = {
@@ -54,7 +59,7 @@ type UseAgentStudioDevServerTerminalBuffersResult = {
 
 const isDevServerStateInScope = (
   state: DevServerGroupState,
-  scope: DevServerTerminalBufferScope | null,
+  scope: DevServerTaskScope | null,
 ): boolean => {
   if (!scope) {
     return false;
@@ -65,7 +70,7 @@ const isDevServerStateInScope = (
 
 const isDevServerEventInScope = (
   event: DevServerEvent,
-  scope: DevServerTerminalBufferScope | null,
+  scope: DevServerTaskScope | null,
 ): boolean => {
   if (!scope) {
     return false;
@@ -79,22 +84,21 @@ const isDevServerEventInScope = (
 };
 
 export const useAgentStudioDevServerTerminalBuffers = (
-  scope: DevServerTerminalBufferScope | null,
+  scope: DevServerTaskScope | null,
 ): UseAgentStudioDevServerTerminalBuffersResult => {
-  const scopeKey = scope ? `${scope.repoPath}::${scope.taskId}` : null;
-  const activeScopeKey = scopeKey ?? "__no-dev-server-task__";
-  const terminalBuffersRef = useRef<DevServerTerminalBufferStore | null>(null);
-  const terminalBuffersScopeRef = useRef<string | null>(null);
-  const pendingMutationReplaySyncRef = useRef<PendingMutationReplaySync | null>(null);
+  const requestedScopeKey = formatDevServerTaskScopeKey(scope);
+  const terminalBufferOwner = useMemo<DevServerTerminalBufferOwner>(
+    () => ({
+      pendingMutationReplaySync: null,
+      scopeKey: requestedScopeKey,
+      terminalBuffers: createDevServerTerminalBufferStore(),
+    }),
+    [requestedScopeKey],
+  );
   const [selectedScriptTerminalBufferState, setSelectedScriptTerminalBufferState] =
     useState<SelectedScriptTerminalBufferState | null>(null);
-
-  if (terminalBuffersRef.current === null || terminalBuffersScopeRef.current !== activeScopeKey) {
-    terminalBuffersRef.current = createDevServerTerminalBufferStore();
-    terminalBuffersScopeRef.current = activeScopeKey;
-    pendingMutationReplaySyncRef.current = null;
-  }
-  const terminalBuffers = terminalBuffersRef.current;
+  const activeScopeKey = terminalBufferOwner.scopeKey;
+  const terminalBuffers = terminalBufferOwner.terminalBuffers;
 
   const syncSelectedScriptTerminalBuffer = useCallback(
     (scriptId: string | null): void => {
@@ -155,13 +159,13 @@ export const useAgentStudioDevServerTerminalBuffers = (
         );
       }
 
-      pendingMutationReplaySyncRef.current = {
+      terminalBufferOwner.pendingMutationReplaySync = {
         baselineByScriptId,
         observedScriptIds: new Set(),
         scopeKey: activeScopeKey,
       };
     },
-    [activeScopeKey, scope, terminalBuffers],
+    [activeScopeKey, scope, terminalBufferOwner, terminalBuffers],
   );
 
   const syncTerminalBuffersFromMutationState = useCallback(
@@ -170,14 +174,14 @@ export const useAgentStudioDevServerTerminalBuffers = (
         return;
       }
 
-      const pendingReplaySync = pendingMutationReplaySyncRef.current;
+      const pendingReplaySync = terminalBufferOwner.pendingMutationReplaySync;
       if (!pendingReplaySync) {
         hydrateTerminalBuffersFromState(state, selectedScriptId);
         return;
       }
 
       if (pendingReplaySync.scopeKey !== activeScopeKey) {
-        pendingMutationReplaySyncRef.current = null;
+        terminalBufferOwner.pendingMutationReplaySync = null;
         hydrateTerminalBuffersFromState(state, selectedScriptId);
         return;
       }
@@ -220,7 +224,7 @@ export const useAgentStudioDevServerTerminalBuffers = (
         }
       }
 
-      pendingMutationReplaySyncRef.current = null;
+      terminalBufferOwner.pendingMutationReplaySync = null;
       syncSelectedScriptTerminalBuffer(selectedScriptId);
     },
     [
@@ -228,6 +232,7 @@ export const useAgentStudioDevServerTerminalBuffers = (
       hydrateTerminalBuffersFromState,
       scope,
       syncSelectedScriptTerminalBuffer,
+      terminalBufferOwner,
       terminalBuffers,
     ],
   );
@@ -238,13 +243,13 @@ export const useAgentStudioDevServerTerminalBuffers = (
         return;
       }
 
-      const pendingReplaySync = pendingMutationReplaySyncRef.current;
+      const pendingReplaySync = terminalBufferOwner.pendingMutationReplaySync;
       if (!pendingReplaySync) {
         return;
       }
 
       if (pendingReplaySync.scopeKey !== activeScopeKey) {
-        pendingMutationReplaySyncRef.current = null;
+        terminalBufferOwner.pendingMutationReplaySync = null;
         return;
       }
 
@@ -262,7 +267,7 @@ export const useAgentStudioDevServerTerminalBuffers = (
 
       pendingReplaySync.observedScriptIds.add(event.terminalChunk.scriptId);
     },
-    [activeScopeKey, scope],
+    [activeScopeKey, scope, terminalBufferOwner],
   );
 
   const applyTerminalBuffersFromEvent = useCallback(
@@ -307,14 +312,14 @@ export const useAgentStudioDevServerTerminalBuffers = (
   );
 
   const cancelMutationReplaySync = useCallback((): void => {
-    pendingMutationReplaySyncRef.current = null;
-  }, []);
+    terminalBufferOwner.pendingMutationReplaySync = null;
+  }, [terminalBufferOwner]);
 
   const clearTerminalBuffers = useCallback((): void => {
     terminalBuffers.clear();
-    pendingMutationReplaySyncRef.current = null;
+    terminalBufferOwner.pendingMutationReplaySync = null;
     setSelectedScriptTerminalBufferState({ buffer: null, scopeKey: activeScopeKey });
-  }, [activeScopeKey, terminalBuffers]);
+  }, [activeScopeKey, terminalBufferOwner, terminalBuffers]);
   const selectedScriptTerminalBuffer =
     selectedScriptTerminalBufferState?.scopeKey === activeScopeKey
       ? selectedScriptTerminalBufferState.buffer

--- a/packages/frontend/src/shell-bootstrap.test.tsx
+++ b/packages/frontend/src/shell-bootstrap.test.tsx
@@ -25,7 +25,10 @@ const createTestShellBridge = (): ShellBridge =>
   ({
     client: {},
     subscribeRunEvents: async () => () => {},
-    subscribeDevServerEvents: async () => () => {},
+    subscribeDevServerEvents: async () => ({
+      transportEpoch: "test:0",
+      unsubscribe: () => {},
+    }),
     subscribeTaskEvents: async () => () => {},
     capabilities: {
       canOpenExternalUrls: true,

--- a/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/packages/frontend/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -597,6 +597,7 @@ describe("useAppLifecycle", () => {
         subscribedTaskListener?.({
           __openducktorBrowserLive: true,
           kind: "reconnected",
+          transportEpoch: "task-events:1",
         });
         await Promise.resolve();
       });

--- a/packages/frontend/src/state/queries/dev-servers.ts
+++ b/packages/frontend/src/state/queries/dev-servers.ts
@@ -6,13 +6,17 @@ const DEV_SERVER_STATE_STALE_TIME_MS = 5_000;
 
 export const devServerQueryKeys = {
   all: ["dev-servers"] as const,
-  state: (repoPath: string, taskId: string) =>
-    [...devServerQueryKeys.all, "state", repoPath, taskId] as const,
+  state: (repoPath: string, taskId: string, transportGeneration = 0) =>
+    [...devServerQueryKeys.all, "state", repoPath, taskId, transportGeneration] as const,
 };
 
-export const devServerGroupStateQueryOptions = (repoPath: string, taskId: string) =>
+export const devServerGroupStateQueryOptions = (
+  repoPath: string,
+  taskId: string,
+  transportGeneration = 0,
+) =>
   queryOptions({
-    queryKey: devServerQueryKeys.state(repoPath, taskId),
+    queryKey: devServerQueryKeys.state(repoPath, taskId, transportGeneration),
     queryFn: (): Promise<DevServerGroupState> => host.devServerGetState(repoPath, taskId),
     staleTime: DEV_SERVER_STATE_STALE_TIME_MS,
   });

--- a/packages/frontend/src/state/queries/dev-servers.ts
+++ b/packages/frontend/src/state/queries/dev-servers.ts
@@ -6,17 +6,17 @@ const DEV_SERVER_STATE_STALE_TIME_MS = 5_000;
 
 export const devServerQueryKeys = {
   all: ["dev-servers"] as const,
-  state: (repoPath: string, taskId: string, transportGeneration = 0) =>
-    [...devServerQueryKeys.all, "state", repoPath, taskId, transportGeneration] as const,
+  state: (repoPath: string, taskId: string, transportEpoch: string) =>
+    [...devServerQueryKeys.all, "state", repoPath, taskId, transportEpoch] as const,
 };
 
 export const devServerGroupStateQueryOptions = (
   repoPath: string,
   taskId: string,
-  transportGeneration = 0,
+  transportEpoch: string,
 ) =>
   queryOptions({
-    queryKey: devServerQueryKeys.state(repoPath, taskId, transportGeneration),
+    queryKey: devServerQueryKeys.state(repoPath, taskId, transportEpoch),
     queryFn: (): Promise<DevServerGroupState> => host.devServerGetState(repoPath, taskId),
     staleTime: DEV_SERVER_STATE_STALE_TIME_MS,
   });

--- a/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.test.ts
+++ b/packages/frontend/src/state/runtime-adapters/codex-app-server-runtime-adapter.test.ts
@@ -58,7 +58,10 @@ const configureCodexTestShellBridge = (
   configureShellBridge({
     client: {} as HostClient,
     subscribeRunEvents: async () => () => {},
-    subscribeDevServerEvents: async () => () => {},
+    subscribeDevServerEvents: async () => ({
+      transportEpoch: "test:0",
+      unsubscribe: () => {},
+    }),
     subscribeTaskEvents: async () => () => {},
     subscribeCodexAppServerEvents: async () => () => {},
     capabilities: {

--- a/packages/frontend/src/types/browser-live.ts
+++ b/packages/frontend/src/types/browser-live.ts
@@ -7,8 +7,14 @@ export type BrowserLiveControlEventKind =
   | typeof BROWSER_LIVE_RECONNECTED_EVENT_KIND
   | typeof BROWSER_LIVE_STREAM_WARNING_EVENT_KIND;
 
-export type BrowserLiveControlEvent = {
-  __openducktorBrowserLive: true;
-  kind: BrowserLiveControlEventKind;
-  message?: string;
-};
+export type BrowserLiveControlEvent =
+  | {
+      __openducktorBrowserLive: true;
+      kind: typeof BROWSER_LIVE_RECONNECTED_EVENT_KIND;
+      transportEpoch: string;
+    }
+  | {
+      __openducktorBrowserLive: true;
+      kind: typeof BROWSER_LIVE_STREAM_WARNING_EVENT_KIND;
+      message?: string;
+    };

--- a/packages/frontend/src/types/dev-server-task-scope.test.ts
+++ b/packages/frontend/src/types/dev-server-task-scope.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createDevServerTaskScope,
+  formatDevServerTaskScopeKey,
+  formatDevServerTerminalIdentityKey,
+} from "./dev-server-task-scope";
+
+describe("dev-server-task-scope", () => {
+  test("formats task scope keys without delimiter collisions", () => {
+    const left = formatDevServerTaskScopeKey(createDevServerTaskScope("/repo::task-b", "task-c"));
+    const right = formatDevServerTaskScopeKey(createDevServerTaskScope("/repo", "task-b::task-c"));
+
+    expect(left).not.toBe(right);
+  });
+
+  test("formats terminal identity keys without delimiter collisions", () => {
+    const left = formatDevServerTerminalIdentityKey(
+      formatDevServerTaskScopeKey(createDevServerTaskScope("/repo::task-b", "task-c")),
+      "web",
+    );
+    const right = formatDevServerTerminalIdentityKey(
+      formatDevServerTaskScopeKey(createDevServerTaskScope("/repo", "task-b::task-c")),
+      "web",
+    );
+
+    expect(left).not.toBe(right);
+  });
+});

--- a/packages/frontend/src/types/dev-server-task-scope.ts
+++ b/packages/frontend/src/types/dev-server-task-scope.ts
@@ -7,7 +7,6 @@ export const MISSING_DEV_SERVER_TASK_SCOPE_MESSAGE =
   "Builder dev servers require an active repository and task.";
 
 const EMPTY_DEV_SERVER_TASK_SCOPE_KEY = "__no-dev-server-task__";
-const DEV_SERVER_TASK_SCOPE_KEY_SEPARATOR = "::";
 
 export const createDevServerTaskScope = (
   repoPath: string | null,
@@ -25,11 +24,11 @@ export const formatDevServerTaskScopeKey = (scope: DevServerTaskScope | null): s
     return EMPTY_DEV_SERVER_TASK_SCOPE_KEY;
   }
 
-  return `${scope.repoPath}${DEV_SERVER_TASK_SCOPE_KEY_SEPARATOR}${scope.taskId}`;
+  return JSON.stringify([scope.repoPath, scope.taskId]);
 };
 
 export const formatDevServerTerminalIdentityKey = (scopeKey: string, scriptId: string): string =>
-  `${scopeKey}${DEV_SERVER_TASK_SCOPE_KEY_SEPARATOR}${scriptId}`;
+  JSON.stringify([scopeKey, scriptId]);
 
 export const isSameDevServerTaskScope = (
   left: DevServerTaskScope | null,

--- a/packages/frontend/src/types/dev-server-task-scope.ts
+++ b/packages/frontend/src/types/dev-server-task-scope.ts
@@ -1,0 +1,44 @@
+export type DevServerTaskScope = {
+  repoPath: string;
+  taskId: string;
+};
+
+export const MISSING_DEV_SERVER_TASK_SCOPE_MESSAGE =
+  "Builder dev servers require an active repository and task.";
+
+const EMPTY_DEV_SERVER_TASK_SCOPE_KEY = "__no-dev-server-task__";
+const DEV_SERVER_TASK_SCOPE_KEY_SEPARATOR = "::";
+
+export const createDevServerTaskScope = (
+  repoPath: string | null,
+  taskId: string | null,
+): DevServerTaskScope | null => {
+  if (!repoPath || !taskId) {
+    return null;
+  }
+
+  return { repoPath, taskId };
+};
+
+export const formatDevServerTaskScopeKey = (scope: DevServerTaskScope | null): string => {
+  if (!scope) {
+    return EMPTY_DEV_SERVER_TASK_SCOPE_KEY;
+  }
+
+  return `${scope.repoPath}${DEV_SERVER_TASK_SCOPE_KEY_SEPARATOR}${scope.taskId}`;
+};
+
+export const formatDevServerTerminalIdentityKey = (scopeKey: string, scriptId: string): string =>
+  `${scopeKey}${DEV_SERVER_TASK_SCOPE_KEY_SEPARATOR}${scriptId}`;
+
+export const isSameDevServerTaskScope = (
+  left: DevServerTaskScope | null,
+  right: DevServerTaskScope | null,
+): boolean => {
+  return (
+    left !== null &&
+    right !== null &&
+    left.repoPath === right.repoPath &&
+    left.taskId === right.taskId
+  );
+};

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -1,2 +1,3 @@
 export { AGENT_ROLE_LABELS } from "./agent-role-labels";
 export type { BrowserLiveControlEvent, BrowserLiveControlEventKind } from "./browser-live";
+export type { DevServerTaskScope } from "./dev-server-task-scope";

--- a/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
@@ -28,6 +28,7 @@ const createRuntime = (): DevServerGroupRuntime => ({
   state: buildGroupState(repoConfig, "task-1", "/worktrees/task-1", "2026-05-24T00:00:00.000Z"),
   terminalBufferedBytesByScriptId: new Map(),
   terminalNextSequenceByScriptId: new Map(),
+  terminalRunGenerationByScriptId: new Map(),
 });
 
 const updateScriptState: UpdateScriptState = (runtime, scriptId, update) => {

--- a/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-runtime-scripts.test.ts
@@ -28,7 +28,7 @@ const createRuntime = (): DevServerGroupRuntime => ({
   state: buildGroupState(repoConfig, "task-1", "/worktrees/task-1", "2026-05-24T00:00:00.000Z"),
   terminalBufferedBytesByScriptId: new Map(),
   terminalNextSequenceByScriptId: new Map(),
-  terminalRunGenerationByScriptId: new Map(),
+  terminalRunGeneration: 0,
 });
 
 const updateScriptState: UpdateScriptState = (runtime, scriptId, update) => {

--- a/packages/host/src/application/dev-servers/dev-server-service-types.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service-types.ts
@@ -54,6 +54,13 @@ export type StoppedDevServerScript = {
   taskId: string;
 };
 
+export type FailedDevServerScriptStart = {
+  command: string;
+  message: string;
+  name: string;
+  scriptId: string;
+};
+
 export type DevServerStopAllResult = {
   stoppedScripts: StoppedDevServerScript[];
 };

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -613,6 +613,69 @@ describe("createDevServerService", () => {
     ]);
     expect(state.scripts[0]).toMatchObject({ status: "stopped", pid: null });
   });
+  test("discards output from a stopped process after its replacement run starts", async () => {
+    const starts: DevServerProcessStartInput[] = [];
+    const processPort: DevServerProcessPort = {
+      start(input) {
+        starts.push(input);
+        const pid = 700;
+        return Effect.succeed({
+          pid,
+          stop: () =>
+            Effect.sync(() => {
+              input.onExit({ pid, exitCode: 0, signal: null, error: null });
+            }),
+        });
+      },
+    };
+    const { eventBus, events } = createEventBus();
+    const service = createDevServerService({
+      eventBus,
+      processPort,
+      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+      workspaceSettingsService: createWorkspaceSettingsService(repoConfig()),
+    });
+
+    await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    await Effect.runPromise(service.stop({ repoPath: "/repo", taskId: "task-1" }));
+    await Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    starts[0]?.onOutput({ data: "LATE-OLD\n" });
+    starts[0]?.onExit({ pid: 700, exitCode: 9, signal: null, error: null });
+
+    const state = await Effect.runPromise(
+      service.getState({ repoPath: "/repo", taskId: "task-1" }),
+    );
+    expect(
+      state.scripts[0]?.bufferedTerminalChunks.some((chunk) => chunk.data.includes("LATE-OLD")),
+    ).toBe(false);
+    expect(
+      events.some((event) =>
+        JSON.stringify((event as { payload?: unknown }).payload).includes("LATE-OLD"),
+      ),
+    ).toBe(false);
+    expect(state.scripts[0]).toMatchObject({ status: "running", pid: 700 });
+  });
+  test("uses a distinct run epoch after the host service is replaced", async () => {
+    const createStartedService = async () => {
+      const { processPort } = createProcessPort();
+      const service = createDevServerService({
+        processPort,
+        taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task-1" }),
+        workspaceSettingsService: createWorkspaceSettingsService(repoConfig()),
+      });
+      return Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-1" }));
+    };
+
+    const firstState = await createStartedService();
+    const replacementState = await createStartedService();
+    const firstRun = firstState.scripts[0];
+    const replacementRun = replacementState.scripts[0];
+
+    expect(firstRun?.runOrder?.generation).toBe(1);
+    expect(replacementRun?.runOrder?.generation).toBe(1);
+    expect(replacementRun?.runOrder?.hostInstanceId).not.toBe(firstRun?.runOrder?.hostInstanceId);
+    expect(replacementRun?.runId).not.toBe(firstRun?.runId);
+  });
   test("keeps runtime ownership isolated for delimiter-colliding repo and task strings", async () => {
     const { processPort, starts } = createProcessPort();
     const service = createDevServerService({

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -51,6 +51,24 @@ const createWorkspaceSettingsService = (config: RepoConfig): WorkspaceSettingsSe
       });
     },
   }) as unknown as WorkspaceSettingsService;
+const createWorkspaceSettingsServiceByRepoPath = (
+  configs: Record<string, RepoConfig>,
+): WorkspaceSettingsService =>
+  ({
+    getRepoConfigByRepoPath(repoPath: unknown) {
+      return Effect.try({
+        try: () => {
+          const config = configs[String(repoPath)];
+          if (!config) {
+            throw new Error(`Workspace is not configured for repository: ${String(repoPath)}`);
+          }
+          return config;
+        },
+        catch: (cause) =>
+          toHostOperationError(cause, "test.workspaceSettings.getRepoConfigByRepoPath"),
+      });
+    },
+  }) as unknown as WorkspaceSettingsService;
 const createTaskWorktreeService = (worktree: TaskWorktreeSummary | null): TaskWorktreeService => ({
   getTaskWorktree() {
     return Effect.succeed(worktree);
@@ -594,6 +612,53 @@ describe("createDevServerService", () => {
       "closing dev server\r\n",
     ]);
     expect(state.scripts[0]).toMatchObject({ status: "stopped", pid: null });
+  });
+  test("keeps runtime ownership isolated for delimiter-colliding repo and task strings", async () => {
+    const { processPort, starts } = createProcessPort();
+    const service = createDevServerService({
+      processPort,
+      taskWorktreeService: createTaskWorktreeService({ workingDirectory: "/worktrees/task" }),
+      workspaceSettingsService: createWorkspaceSettingsServiceByRepoPath({
+        "/repo": repoConfig({
+          repoPath: "/repo",
+          devServers: [{ id: "web", name: "Web", command: "right-command" }],
+        }),
+        "/repo::task-b": repoConfig({
+          repoPath: "/repo::task-b",
+          devServers: [{ id: "web", name: "Web", command: "left-command" }],
+        }),
+      }),
+    });
+
+    await expect(
+      Effect.runPromise(service.start({ repoPath: "/repo::task-b", taskId: "task-c" })),
+    ).resolves.toMatchObject({
+      repoPath: "/repo::task-b",
+      taskId: "task-c",
+      scripts: [{ scriptId: "web", pid: 400, command: "left-command" }],
+    });
+    await expect(
+      Effect.runPromise(service.start({ repoPath: "/repo", taskId: "task-b::task-c" })),
+    ).resolves.toMatchObject({
+      repoPath: "/repo",
+      taskId: "task-b::task-c",
+      scripts: [{ scriptId: "web", pid: 401, command: "right-command" }],
+    });
+    await expect(
+      Effect.runPromise(service.getState({ repoPath: "/repo::task-b", taskId: "task-c" })),
+    ).resolves.toMatchObject({
+      repoPath: "/repo::task-b",
+      taskId: "task-c",
+      scripts: [{ scriptId: "web", pid: 400, command: "left-command" }],
+    });
+    await expect(
+      Effect.runPromise(service.getState({ repoPath: "/repo", taskId: "task-b::task-c" })),
+    ).resolves.toMatchObject({
+      repoPath: "/repo",
+      taskId: "task-b::task-c",
+      scripts: [{ scriptId: "web", pid: 401, command: "right-command" }],
+    });
+    expect(starts.map((start) => start.command)).toEqual(["left-command", "right-command"]);
   });
   test("stops all running task dev server groups during host shutdown", async () => {
     const { processPort, stoppedPids } = createProcessPort();

--- a/packages/host/src/application/dev-servers/dev-server-service.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.test.ts
@@ -671,10 +671,12 @@ describe("createDevServerService", () => {
     const firstRun = firstState.scripts[0];
     const replacementRun = replacementState.scripts[0];
 
-    expect(firstRun?.runOrder?.generation).toBe(1);
-    expect(replacementRun?.runOrder?.generation).toBe(1);
-    expect(replacementRun?.runOrder?.hostInstanceId).not.toBe(firstRun?.runOrder?.hostInstanceId);
-    expect(replacementRun?.runId).not.toBe(firstRun?.runId);
+    expect(firstRun?.runIdentity?.runOrder.generation).toBe(1);
+    expect(replacementRun?.runIdentity?.runOrder.generation).toBe(1);
+    expect(replacementRun?.runIdentity?.runOrder.hostInstanceId).not.toBe(
+      firstRun?.runIdentity?.runOrder.hostInstanceId,
+    );
+    expect(replacementRun?.runIdentity?.runId).not.toBe(firstRun?.runIdentity?.runId);
   });
   test("keeps runtime ownership isolated for delimiter-colliding repo and task strings", async () => {
     const { processPort, starts } = createProcessPort();

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -155,7 +155,7 @@ export const createDevServerService = ({
     const isStartingWithoutRecordedPid = script?.pid === null && script.status === "starting";
     if (
       !script ||
-      script.runId !== expectedRunId ||
+      script.runIdentity?.runId !== expectedRunId ||
       (script.pid !== pid && !isStartingWithoutRecordedPid)
     ) {
       return;
@@ -204,7 +204,7 @@ export const createDevServerService = ({
       });
       const expectedRunId = runtime.state.scripts.find(
         (candidate) => candidate.scriptId === scriptConfig.id,
-      )?.runId;
+      )?.runIdentity?.runId;
       if (!expectedRunId) {
         return yield* Effect.fail(
           new HostInvariantError({

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -59,7 +59,6 @@ export type {
 } from "./dev-server-service-types";
 
 const nowIso = (): string => new Date().toISOString();
-const groupKey = (repoPath: string, taskId: string): string => `${repoPath}::${taskId}`;
 type FailedDevServerScriptStart = {
   command: string;
   message: string;
@@ -72,7 +71,7 @@ export const createDevServerService = ({
   taskWorktreeService,
   workspaceSettingsService,
 }: CreateDevServerServiceInput): DisposableDevServerService => {
-  const groups = new Map<string, DevServerGroupRuntime>();
+  const groups = new Map<string, Map<string, DevServerGroupRuntime>>();
   const publish = (event: DevServerEvent): void => {
     eventBus?.publish(DEV_SERVER_EVENT_CHANNEL, devServerEventSchema.parse(event));
   };
@@ -88,8 +87,9 @@ export const createDevServerService = ({
     });
   const getRuntime = (taskId: string, repoConfig: RepoConfig, worktreePath: string | null) =>
     Effect.sync(() => {
-      const key = groupKey(repoConfig.repoPath, taskId);
-      const existing = groups.get(key);
+      const repoGroups =
+        groups.get(repoConfig.repoPath) ?? new Map<string, DevServerGroupRuntime>();
+      const existing = repoGroups.get(taskId);
       if (existing) {
         syncGroupState(existing.state, repoConfig, taskId, worktreePath);
         syncRuntimeTerminalBufferByteCounts(existing);
@@ -101,7 +101,8 @@ export const createDevServerService = ({
         terminalBufferedBytesByScriptId: new Map<string, number>(),
         terminalNextSequenceByScriptId: new Map<string, number>(),
       };
-      groups.set(key, runtime);
+      repoGroups.set(taskId, runtime);
+      groups.set(repoConfig.repoPath, repoGroups);
       return runtime;
     });
   const resolveRuntime = (repoPath: string, taskId: string) =>
@@ -475,10 +476,12 @@ export const createDevServerService = ({
       return Effect.gen(function* () {
         const errors: string[] = [];
         const stoppedScripts: StoppedDevServerScript[] = [];
-        for (const runtime of groups.values()) {
-          stoppedScripts.push(...listRunningScripts(runtime));
-          errors.push(...(yield* stopRuntime(runtime)));
-          emitSnapshot(runtime);
+        for (const repoGroups of groups.values()) {
+          for (const runtime of repoGroups.values()) {
+            stoppedScripts.push(...listRunningScripts(runtime));
+            errors.push(...(yield* stopRuntime(runtime)));
+            emitSnapshot(runtime);
+          }
         }
         if (errors.length > 0) {
           return yield* Effect.fail(

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -28,7 +28,7 @@ import type {
   CreateDevServerServiceInput,
   DevServerService,
   DisposableDevServerService,
-  StoppedDevServerScript,
+  FailedDevServerScriptStart,
 } from "./dev-server-service-types";
 import {
   appendTerminalChunk,
@@ -42,8 +42,8 @@ import {
   formatTerminalProcessOutput,
   formatTerminalSystemMessage,
   nextTerminalSequence,
-  resetTerminalChunks,
   scriptHasLiveProcess,
+  startTerminalRun,
   syncGroupState,
   syncRuntimeTerminalBufferByteCounts,
 } from "./dev-server-state";
@@ -59,12 +59,6 @@ export type {
 } from "./dev-server-service-types";
 
 const nowIso = (): string => new Date().toISOString();
-type FailedDevServerScriptStart = {
-  command: string;
-  message: string;
-  name: string;
-  scriptId: string;
-};
 export const createDevServerService = ({
   eventBus,
   processPort,
@@ -72,12 +66,10 @@ export const createDevServerService = ({
   workspaceSettingsService,
 }: CreateDevServerServiceInput): DisposableDevServerService => {
   const groups = new Map<string, Map<string, DevServerGroupRuntime>>();
-  const publish = (event: DevServerEvent): void => {
+  const publish = (event: DevServerEvent): void =>
     eventBus?.publish(DEV_SERVER_EVENT_CHANNEL, devServerEventSchema.parse(event));
-  };
-  const emitSnapshot = (runtime: DevServerGroupRuntime): void => {
+  const emitSnapshot = (runtime: DevServerGroupRuntime): void =>
     publish({ type: "snapshot", state: runtime.state });
-  };
   const getWorktreePath = (repoPath: string, taskId: string) =>
     Effect.gen(function* () {
       const worktree = taskWorktreeService
@@ -100,6 +92,7 @@ export const createDevServerService = ({
         state: buildGroupState(repoConfig, taskId, worktreePath, nowIso()),
         terminalBufferedBytesByScriptId: new Map<string, number>(),
         terminalNextSequenceByScriptId: new Map<string, number>(),
+        terminalRunGenerationByScriptId: new Map<string, number>(),
       };
       repoGroups.set(taskId, runtime);
       groups.set(repoConfig.repoPath, repoGroups);
@@ -147,9 +140,16 @@ export const createDevServerService = ({
     if (!script) {
       return;
     }
+    if (!script.runId) {
+      throw new HostInvariantError({
+        invariant: "dev_server_script_run_known",
+        message: `Dev server script has no active run id: ${scriptId}`,
+      });
+    }
     const timestamp = nowIso();
     const terminalChunk = {
       scriptId,
+      runId: script.runId,
       sequence: nextTerminalSequence(runtime, script),
       data,
       timestamp,
@@ -234,11 +234,11 @@ export const createDevServerService = ({
       }
       updateScriptState(runtime, scriptConfig.id, (script) => {
         script.status = "starting";
+        startTerminalRun(runtime, script);
         script.pid = null;
         script.startedAt = null;
         script.exitCode = null;
         script.lastError = null;
-        resetTerminalChunks(runtime, script);
       });
       appendTerminalSystemMessage(runtime, scriptConfig.id, `Starting \`${scriptConfig.command}\``);
       const handle = yield* processPort
@@ -475,14 +475,13 @@ export const createDevServerService = ({
     stopAll() {
       return Effect.gen(function* () {
         const errors: string[] = [];
-        const stoppedScripts: StoppedDevServerScript[] = [];
-        for (const repoGroups of groups.values()) {
+        const stoppedScripts: ReturnType<typeof listRunningScripts> = [];
+        for (const repoGroups of groups.values())
           for (const runtime of repoGroups.values()) {
             stoppedScripts.push(...listRunningScripts(runtime));
             errors.push(...(yield* stopRuntime(runtime)));
             emitSnapshot(runtime);
           }
-        }
         if (errors.length > 0) {
           return yield* Effect.fail(
             new HostOperationError({

--- a/packages/host/src/application/dev-servers/dev-server-service.ts
+++ b/packages/host/src/application/dev-servers/dev-server-service.ts
@@ -31,7 +31,6 @@ import type {
   FailedDevServerScriptStart,
 } from "./dev-server-service-types";
 import {
-  appendTerminalChunk,
   buildGroupState,
   DEV_SERVER_CLICOLOR_FORCE,
   DEV_SERVER_COLORTERM,
@@ -39,14 +38,12 @@ import {
   DEV_SERVER_FORCE_COLOR,
   DEV_SERVER_TERM,
   type DevServerGroupRuntime,
-  formatTerminalProcessOutput,
-  formatTerminalSystemMessage,
-  nextTerminalSequence,
   scriptHasLiveProcess,
   startTerminalRun,
   syncGroupState,
   syncRuntimeTerminalBufferByteCounts,
 } from "./dev-server-state";
+import { createDevServerTerminalWriter } from "./dev-server-terminal-writer";
 
 export type {
   CreateDevServerServiceInput,
@@ -65,9 +62,11 @@ export const createDevServerService = ({
   taskWorktreeService,
   workspaceSettingsService,
 }: CreateDevServerServiceInput): DisposableDevServerService => {
+  const hostInstanceId = globalThis.crypto.randomUUID();
   const groups = new Map<string, Map<string, DevServerGroupRuntime>>();
   const publish = (event: DevServerEvent): void =>
     eventBus?.publish(DEV_SERVER_EVENT_CHANNEL, devServerEventSchema.parse(event));
+  const terminalWriter = createDevServerTerminalWriter(publish);
   const emitSnapshot = (runtime: DevServerGroupRuntime): void =>
     publish({ type: "snapshot", state: runtime.state });
   const getWorktreePath = (repoPath: string, taskId: string) =>
@@ -92,7 +91,7 @@ export const createDevServerService = ({
         state: buildGroupState(repoConfig, taskId, worktreePath, nowIso()),
         terminalBufferedBytesByScriptId: new Map<string, number>(),
         terminalNextSequenceByScriptId: new Map<string, number>(),
-        terminalRunGenerationByScriptId: new Map<string, number>(),
+        terminalRunGeneration: 0,
       };
       repoGroups.set(taskId, runtime);
       groups.set(repoConfig.repoPath, repoGroups);
@@ -128,48 +127,6 @@ export const createDevServerService = ({
       updatedAt: runtime.state.updatedAt,
     });
   };
-  const pushTerminalChunk = (
-    runtime: DevServerGroupRuntime,
-    scriptId: string,
-    data: string,
-  ): void => {
-    if (data.length === 0) {
-      return;
-    }
-    const script = runtime.state.scripts.find((candidate) => candidate.scriptId === scriptId);
-    if (!script) {
-      return;
-    }
-    if (!script.runId) {
-      throw new HostInvariantError({
-        invariant: "dev_server_script_run_known",
-        message: `Dev server script has no active run id: ${scriptId}`,
-      });
-    }
-    const timestamp = nowIso();
-    const terminalChunk = {
-      scriptId,
-      runId: script.runId,
-      sequence: nextTerminalSequence(runtime, script),
-      data,
-      timestamp,
-    };
-    appendTerminalChunk(runtime, script, terminalChunk);
-    runtime.state.updatedAt = timestamp;
-    publish({
-      type: "terminal_chunk",
-      repoPath: runtime.state.repoPath,
-      taskId: runtime.state.taskId,
-      terminalChunk,
-    });
-  };
-  const appendTerminalSystemMessage = (
-    runtime: DevServerGroupRuntime,
-    scriptId: string,
-    message: string,
-  ): void => {
-    pushTerminalChunk(runtime, scriptId, formatTerminalSystemMessage(message));
-  };
   const markStartFailed = (
     runtime: DevServerGroupRuntime,
     scriptId: string,
@@ -183,11 +140,12 @@ export const createDevServerService = ({
       script.exitCode = exitCode;
       script.lastError = message;
     });
-    appendTerminalSystemMessage(runtime, scriptId, message);
+    terminalWriter.appendSystemMessage(runtime, scriptId, message);
   };
   const handleProcessExit = (
     runtime: DevServerGroupRuntime,
     scriptId: string,
+    expectedRunId: string,
     pid: number,
     exitCode: number | null,
     signal: string | null,
@@ -195,14 +153,18 @@ export const createDevServerService = ({
   ): void => {
     const script = runtime.state.scripts.find((candidate) => candidate.scriptId === scriptId);
     const isStartingWithoutRecordedPid = script?.pid === null && script.status === "starting";
-    if (!script || (script.pid !== pid && !isStartingWithoutRecordedPid)) {
+    if (
+      !script ||
+      script.runId !== expectedRunId ||
+      (script.pid !== pid && !isStartingWithoutRecordedPid)
+    ) {
       return;
     }
     runtime.processes.delete(scriptId);
     const expectedStop = script.status === "stopping";
     const message = error ?? devServerExitMessage(exitCode, signal);
     if (!expectedStop) {
-      appendTerminalSystemMessage(runtime, scriptId, message);
+      terminalWriter.appendSystemMessage(runtime, scriptId, message);
     }
     updateScriptState(runtime, scriptId, (state) => {
       state.pid = null;
@@ -234,13 +196,28 @@ export const createDevServerService = ({
       }
       updateScriptState(runtime, scriptConfig.id, (script) => {
         script.status = "starting";
-        startTerminalRun(runtime, script);
+        startTerminalRun(runtime, script, hostInstanceId);
         script.pid = null;
         script.startedAt = null;
         script.exitCode = null;
         script.lastError = null;
       });
-      appendTerminalSystemMessage(runtime, scriptConfig.id, `Starting \`${scriptConfig.command}\``);
+      const expectedRunId = runtime.state.scripts.find(
+        (candidate) => candidate.scriptId === scriptConfig.id,
+      )?.runId;
+      if (!expectedRunId) {
+        return yield* Effect.fail(
+          new HostInvariantError({
+            invariant: "dev_server_script_run_known",
+            message: `Dev server script has no active run id: ${scriptConfig.id}`,
+          }),
+        );
+      }
+      terminalWriter.appendSystemMessage(
+        runtime,
+        scriptConfig.id,
+        `Starting \`${scriptConfig.command}\``,
+      );
       const handle = yield* processPort
         .start({
           command: scriptConfig.command,
@@ -252,9 +229,17 @@ export const createDevServerService = ({
             TERM: DEV_SERVER_TERM,
           },
           onExit: ({ pid, exitCode, signal, error }) =>
-            handleProcessExit(runtime, scriptConfig.id, pid, exitCode, signal, error),
+            handleProcessExit(
+              runtime,
+              scriptConfig.id,
+              expectedRunId,
+              pid,
+              exitCode,
+              signal,
+              error,
+            ),
           onOutput: ({ data }) =>
-            pushTerminalChunk(runtime, scriptConfig.id, formatTerminalProcessOutput(data)),
+            terminalWriter.pushProcessOutput(runtime, scriptConfig.id, expectedRunId, data),
         })
         .pipe(
           Effect.catchAll((error) =>

--- a/packages/host/src/application/dev-servers/dev-server-state.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.test.ts
@@ -2,6 +2,8 @@ import type { RepoConfig } from "@openducktor/contracts";
 import {
   buildGroupState,
   type DevServerGroupRuntime,
+  startTerminalRun,
+  syncGroupState,
   syncRuntimeTerminalBufferByteCounts,
 } from "./dev-server-state";
 
@@ -28,7 +30,7 @@ const createRuntime = (): DevServerGroupRuntime => ({
   state: buildGroupState(repoConfig, "task-1", "/worktrees/task-1", "2026-05-24T00:00:00.000Z"),
   terminalBufferedBytesByScriptId: new Map(),
   terminalNextSequenceByScriptId: new Map(),
-  terminalRunGenerationByScriptId: new Map(),
+  terminalRunGeneration: 0,
 });
 
 describe("dev-server state helpers", () => {
@@ -40,17 +42,36 @@ describe("dev-server state helpers", () => {
     runtime.terminalNextSequenceByScriptId.set("web", 3);
     runtime.terminalNextSequenceByScriptId.set("api", 9);
     runtime.terminalNextSequenceByScriptId.set("removed-sequence-only", 17);
-    runtime.terminalRunGenerationByScriptId.set("web", 1);
-    runtime.terminalRunGenerationByScriptId.set("api", 2);
+    runtime.terminalRunGeneration = 2;
 
     syncRuntimeTerminalBufferByteCounts(runtime);
 
     expect(runtime.terminalBufferedBytesByScriptId.has("api")).toBe(false);
     expect(runtime.terminalNextSequenceByScriptId.has("api")).toBe(false);
-    expect(runtime.terminalRunGenerationByScriptId.has("api")).toBe(false);
     expect(runtime.terminalNextSequenceByScriptId.has("removed-sequence-only")).toBe(false);
     expect(runtime.terminalBufferedBytesByScriptId.get("web")).toBe(12);
     expect(runtime.terminalNextSequenceByScriptId.get("web")).toBe(3);
-    expect(runtime.terminalRunGenerationByScriptId.get("web")).toBe(1);
+    expect(runtime.terminalRunGeneration).toBe(2);
+  });
+
+  test("does not reuse a run identity after a script is removed and re-added", () => {
+    const runtime = createRuntime();
+    const firstScript = runtime.state.scripts[0];
+    if (!firstScript) {
+      throw new Error("Expected configured web script.");
+    }
+    startTerminalRun(runtime, firstScript, "host-1");
+    const firstRunId = firstScript.runId;
+
+    syncGroupState(runtime.state, { ...repoConfig, devServers: [] }, "task-1", "/worktrees/task-1");
+    syncRuntimeTerminalBufferByteCounts(runtime);
+    syncGroupState(runtime.state, repoConfig, "task-1", "/worktrees/task-1");
+    const readdedScript = runtime.state.scripts[0];
+    if (!readdedScript) {
+      throw new Error("Expected re-added web script.");
+    }
+    startTerminalRun(runtime, readdedScript, "host-1");
+
+    expect(readdedScript.runId).not.toBe(firstRunId);
   });
 });

--- a/packages/host/src/application/dev-servers/dev-server-state.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.test.ts
@@ -28,6 +28,7 @@ const createRuntime = (): DevServerGroupRuntime => ({
   state: buildGroupState(repoConfig, "task-1", "/worktrees/task-1", "2026-05-24T00:00:00.000Z"),
   terminalBufferedBytesByScriptId: new Map(),
   terminalNextSequenceByScriptId: new Map(),
+  terminalRunGenerationByScriptId: new Map(),
 });
 
 describe("dev-server state helpers", () => {
@@ -39,13 +40,17 @@ describe("dev-server state helpers", () => {
     runtime.terminalNextSequenceByScriptId.set("web", 3);
     runtime.terminalNextSequenceByScriptId.set("api", 9);
     runtime.terminalNextSequenceByScriptId.set("removed-sequence-only", 17);
+    runtime.terminalRunGenerationByScriptId.set("web", 1);
+    runtime.terminalRunGenerationByScriptId.set("api", 2);
 
     syncRuntimeTerminalBufferByteCounts(runtime);
 
     expect(runtime.terminalBufferedBytesByScriptId.has("api")).toBe(false);
     expect(runtime.terminalNextSequenceByScriptId.has("api")).toBe(false);
+    expect(runtime.terminalRunGenerationByScriptId.has("api")).toBe(false);
     expect(runtime.terminalNextSequenceByScriptId.has("removed-sequence-only")).toBe(false);
     expect(runtime.terminalBufferedBytesByScriptId.get("web")).toBe(12);
     expect(runtime.terminalNextSequenceByScriptId.get("web")).toBe(3);
+    expect(runtime.terminalRunGenerationByScriptId.get("web")).toBe(1);
   });
 });

--- a/packages/host/src/application/dev-servers/dev-server-state.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.test.ts
@@ -61,7 +61,7 @@ describe("dev-server state helpers", () => {
       throw new Error("Expected configured web script.");
     }
     startTerminalRun(runtime, firstScript, "host-1");
-    const firstRunId = firstScript.runId;
+    const firstRunId = firstScript.runIdentity?.runId;
 
     syncGroupState(runtime.state, { ...repoConfig, devServers: [] }, "task-1", "/worktrees/task-1");
     syncRuntimeTerminalBufferByteCounts(runtime);
@@ -72,6 +72,6 @@ describe("dev-server state helpers", () => {
     }
     startTerminalRun(runtime, readdedScript, "host-1");
 
-    expect(readdedScript.runId).not.toBe(firstRunId);
+    expect(readdedScript.runIdentity?.runId).not.toBe(firstRunId);
   });
 });

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -12,7 +12,7 @@ export type DevServerGroupRuntime = {
   state: DevServerGroupState;
   terminalBufferedBytesByScriptId: Map<string, number>;
   terminalNextSequenceByScriptId: Map<string, number>;
-  terminalRunGenerationByScriptId: Map<string, number>;
+  terminalRunGeneration: number;
 };
 
 export const DEV_SERVER_EVENT_CHANNEL = "openducktor://dev-server-event";
@@ -32,6 +32,7 @@ const scriptStateFromConfig = (script: RepoConfig["devServers"][number]): DevSer
   command: script.command,
   status: "stopped",
   runId: null,
+  runOrder: null,
   pid: null,
   startedAt: null,
   exitCode: null,
@@ -96,12 +97,6 @@ export const syncRuntimeTerminalBufferByteCounts = (runtime: DevServerGroupRunti
       runtime.terminalNextSequenceByScriptId.delete(scriptId);
     }
   }
-  for (const scriptId of runtime.terminalRunGenerationByScriptId.keys()) {
-    if (!activeScriptIds.has(scriptId)) {
-      runtime.terminalRunGenerationByScriptId.delete(scriptId);
-    }
-  }
-
   for (const script of runtime.state.scripts) {
     if (!runtime.terminalBufferedBytesByScriptId.has(script.scriptId)) {
       runtime.terminalBufferedBytesByScriptId.set(
@@ -181,10 +176,20 @@ export const appendTerminalChunk = (
 export const startTerminalRun = (
   runtime: DevServerGroupRuntime,
   script: DevServerScriptState,
+  hostInstanceId: string,
 ): void => {
-  const nextGeneration = (runtime.terminalRunGenerationByScriptId.get(script.scriptId) ?? 0) + 1;
-  runtime.terminalRunGenerationByScriptId.set(script.scriptId, nextGeneration);
-  script.runId = `${script.scriptId}:${nextGeneration}`;
+  runtime.terminalRunGeneration += 1;
+  script.runId = JSON.stringify([
+    hostInstanceId,
+    runtime.state.repoPath,
+    runtime.state.taskId,
+    script.scriptId,
+    runtime.terminalRunGeneration,
+  ]);
+  script.runOrder = {
+    hostInstanceId,
+    generation: runtime.terminalRunGeneration,
+  };
   resetTerminalChunks(runtime, script);
 };
 

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -194,7 +194,7 @@ export const startTerminalRun = (
   resetTerminalChunks(runtime, script);
 };
 
-export const resetTerminalChunks = (
+const resetTerminalChunks = (
   runtime: DevServerGroupRuntime,
   script: DevServerScriptState,
 ): void => {

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -12,6 +12,7 @@ export type DevServerGroupRuntime = {
   state: DevServerGroupState;
   terminalBufferedBytesByScriptId: Map<string, number>;
   terminalNextSequenceByScriptId: Map<string, number>;
+  terminalRunGenerationByScriptId: Map<string, number>;
 };
 
 export const DEV_SERVER_EVENT_CHANNEL = "openducktor://dev-server-event";
@@ -30,6 +31,7 @@ const scriptStateFromConfig = (script: RepoConfig["devServers"][number]): DevSer
   name: script.name,
   command: script.command,
   status: "stopped",
+  runId: null,
   pid: null,
   startedAt: null,
   exitCode: null,
@@ -92,6 +94,11 @@ export const syncRuntimeTerminalBufferByteCounts = (runtime: DevServerGroupRunti
   for (const scriptId of runtime.terminalNextSequenceByScriptId.keys()) {
     if (!activeScriptIds.has(scriptId)) {
       runtime.terminalNextSequenceByScriptId.delete(scriptId);
+    }
+  }
+  for (const scriptId of runtime.terminalRunGenerationByScriptId.keys()) {
+    if (!activeScriptIds.has(scriptId)) {
+      runtime.terminalRunGenerationByScriptId.delete(scriptId);
     }
   }
 
@@ -169,6 +176,16 @@ export const appendTerminalChunk = (
     script.scriptId,
     trimTerminalChunksWithByteCount(chunks, totalBytes),
   );
+};
+
+export const startTerminalRun = (
+  runtime: DevServerGroupRuntime,
+  script: DevServerScriptState,
+): void => {
+  const nextGeneration = (runtime.terminalRunGenerationByScriptId.get(script.scriptId) ?? 0) + 1;
+  runtime.terminalRunGenerationByScriptId.set(script.scriptId, nextGeneration);
+  script.runId = `${script.scriptId}:${nextGeneration}`;
+  resetTerminalChunks(runtime, script);
 };
 
 export const resetTerminalChunks = (

--- a/packages/host/src/application/dev-servers/dev-server-state.ts
+++ b/packages/host/src/application/dev-servers/dev-server-state.ts
@@ -31,8 +31,7 @@ const scriptStateFromConfig = (script: RepoConfig["devServers"][number]): DevSer
   name: script.name,
   command: script.command,
   status: "stopped",
-  runId: null,
-  runOrder: null,
+  runIdentity: null,
   pid: null,
   startedAt: null,
   exitCode: null,
@@ -179,16 +178,18 @@ export const startTerminalRun = (
   hostInstanceId: string,
 ): void => {
   runtime.terminalRunGeneration += 1;
-  script.runId = JSON.stringify([
-    hostInstanceId,
-    runtime.state.repoPath,
-    runtime.state.taskId,
-    script.scriptId,
-    runtime.terminalRunGeneration,
-  ]);
-  script.runOrder = {
-    hostInstanceId,
-    generation: runtime.terminalRunGeneration,
+  script.runIdentity = {
+    runId: JSON.stringify([
+      hostInstanceId,
+      runtime.state.repoPath,
+      runtime.state.taskId,
+      script.scriptId,
+      runtime.terminalRunGeneration,
+    ]),
+    runOrder: {
+      hostInstanceId,
+      generation: runtime.terminalRunGeneration,
+    },
   };
   resetTerminalChunks(runtime, script);
 };

--- a/packages/host/src/application/dev-servers/dev-server-terminal-writer.test.ts
+++ b/packages/host/src/application/dev-servers/dev-server-terminal-writer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import type { DevServerEvent, DevServerRunIdentity } from "@openducktor/contracts";
+import type { DevServerGroupRuntime } from "./dev-server-state";
+import { createDevServerTerminalWriter } from "./dev-server-terminal-writer";
+
+const activeRunIdentity: DevServerRunIdentity = {
+  runId: "web:1",
+  runOrder: { hostInstanceId: "host-1", generation: 1 },
+};
+
+const createRuntime = (runIdentity: DevServerRunIdentity | null): DevServerGroupRuntime => ({
+  processes: new Map(),
+  state: {
+    repoPath: "/repo",
+    taskId: "task-1",
+    worktreePath: "/worktrees/task-1",
+    scripts: [
+      {
+        scriptId: "web",
+        name: "Web",
+        command: "bun run dev",
+        status: runIdentity === null ? "stopped" : "running",
+        runIdentity,
+        pid: runIdentity === null ? null : 4242,
+        startedAt: runIdentity === null ? null : "2026-07-10T10:00:00.000Z",
+        exitCode: null,
+        lastError: null,
+        bufferedTerminalChunks: [],
+      },
+    ],
+    updatedAt: "2026-07-10T10:00:00.000Z",
+  },
+  terminalBufferedBytesByScriptId: new Map(),
+  terminalNextSequenceByScriptId: new Map(),
+  terminalRunGeneration: 1,
+});
+
+describe("createDevServerTerminalWriter", () => {
+  test("publishes process output only for the active run", () => {
+    const published: DevServerEvent[] = [];
+    const runtime = createRuntime(activeRunIdentity);
+    const writer = createDevServerTerminalWriter((event) => published.push(event));
+
+    writer.pushProcessOutput(runtime, "web", activeRunIdentity.runId, "ready\n");
+    writer.pushProcessOutput(runtime, "web", "web:stale", "stale\n");
+
+    expect(runtime.state.scripts[0]?.bufferedTerminalChunks).toHaveLength(1);
+    expect(runtime.state.scripts[0]?.bufferedTerminalChunks[0]).toMatchObject({
+      scriptId: "web",
+      runIdentity: activeRunIdentity,
+      sequence: 0,
+      data: "ready\r\n",
+    });
+    expect(published).toHaveLength(1);
+    expect(published[0]).toMatchObject({
+      type: "terminal_chunk",
+      repoPath: "/repo",
+      taskId: "task-1",
+      terminalChunk: {
+        scriptId: "web",
+        runIdentity: activeRunIdentity,
+        sequence: 0,
+        data: "ready\r\n",
+      },
+    });
+  });
+
+  test("rejects system messages when the script has no active run", () => {
+    const runtime = createRuntime(null);
+    const writer = createDevServerTerminalWriter(() => {});
+
+    expect(() => writer.appendSystemMessage(runtime, "web", "Process exited")).toThrow(
+      "Dev server script has no active run identity: web",
+    );
+    expect(runtime.state.scripts[0]?.bufferedTerminalChunks).toEqual([]);
+  });
+});

--- a/packages/host/src/application/dev-servers/dev-server-terminal-writer.ts
+++ b/packages/host/src/application/dev-servers/dev-server-terminal-writer.ts
@@ -1,0 +1,79 @@
+import type { DevServerEvent } from "@openducktor/contracts";
+import { HostInvariantError } from "../../effect/host-errors";
+import {
+  appendTerminalChunk,
+  type DevServerGroupRuntime,
+  formatTerminalProcessOutput,
+  formatTerminalSystemMessage,
+  nextTerminalSequence,
+} from "./dev-server-state";
+
+type PublishDevServerEvent = (event: DevServerEvent) => void;
+
+export type DevServerTerminalWriter = {
+  appendSystemMessage(runtime: DevServerGroupRuntime, scriptId: string, message: string): void;
+  pushProcessOutput(
+    runtime: DevServerGroupRuntime,
+    scriptId: string,
+    expectedRunId: string,
+    data: string,
+  ): void;
+};
+
+export const createDevServerTerminalWriter = (
+  publish: PublishDevServerEvent,
+): DevServerTerminalWriter => {
+  const pushTerminalChunk = (
+    runtime: DevServerGroupRuntime,
+    scriptId: string,
+    expectedRunId: string,
+    data: string,
+  ): void => {
+    if (data.length === 0) {
+      return;
+    }
+    const script = runtime.state.scripts.find((candidate) => candidate.scriptId === scriptId);
+    if (!script || script.runId !== expectedRunId) {
+      return;
+    }
+    if (!script.runOrder) {
+      throw new HostInvariantError({
+        invariant: "dev_server_script_run_known",
+        message: `Dev server script has no active run order: ${scriptId}`,
+      });
+    }
+    const timestamp = new Date().toISOString();
+    const terminalChunk = {
+      scriptId,
+      runId: expectedRunId,
+      runOrder: script.runOrder,
+      sequence: nextTerminalSequence(runtime, script),
+      data,
+      timestamp,
+    };
+    appendTerminalChunk(runtime, script, terminalChunk);
+    runtime.state.updatedAt = timestamp;
+    publish({
+      type: "terminal_chunk",
+      repoPath: runtime.state.repoPath,
+      taskId: runtime.state.taskId,
+      terminalChunk,
+    });
+  };
+
+  return {
+    appendSystemMessage(runtime, scriptId, message) {
+      const script = runtime.state.scripts.find((candidate) => candidate.scriptId === scriptId);
+      if (!script?.runId) {
+        throw new HostInvariantError({
+          invariant: "dev_server_script_run_known",
+          message: `Dev server script has no active run id: ${scriptId}`,
+        });
+      }
+      pushTerminalChunk(runtime, scriptId, script.runId, formatTerminalSystemMessage(message));
+    },
+    pushProcessOutput(runtime, scriptId, expectedRunId, data) {
+      pushTerminalChunk(runtime, scriptId, expectedRunId, formatTerminalProcessOutput(data));
+    },
+  };
+};

--- a/packages/host/src/application/dev-servers/dev-server-terminal-writer.ts
+++ b/packages/host/src/application/dev-servers/dev-server-terminal-writer.ts
@@ -33,20 +33,13 @@ export const createDevServerTerminalWriter = (
       return;
     }
     const script = runtime.state.scripts.find((candidate) => candidate.scriptId === scriptId);
-    if (!script || script.runId !== expectedRunId) {
+    if (!script || script.runIdentity?.runId !== expectedRunId) {
       return;
-    }
-    if (!script.runOrder) {
-      throw new HostInvariantError({
-        invariant: "dev_server_script_run_known",
-        message: `Dev server script has no active run order: ${scriptId}`,
-      });
     }
     const timestamp = new Date().toISOString();
     const terminalChunk = {
       scriptId,
-      runId: expectedRunId,
-      runOrder: script.runOrder,
+      runIdentity: script.runIdentity,
       sequence: nextTerminalSequence(runtime, script),
       data,
       timestamp,
@@ -64,13 +57,18 @@ export const createDevServerTerminalWriter = (
   return {
     appendSystemMessage(runtime, scriptId, message) {
       const script = runtime.state.scripts.find((candidate) => candidate.scriptId === scriptId);
-      if (!script?.runId) {
+      if (!script?.runIdentity) {
         throw new HostInvariantError({
           invariant: "dev_server_script_run_known",
-          message: `Dev server script has no active run id: ${scriptId}`,
+          message: `Dev server script has no active run identity: ${scriptId}`,
         });
       }
-      pushTerminalChunk(runtime, scriptId, script.runId, formatTerminalSystemMessage(message));
+      pushTerminalChunk(
+        runtime,
+        scriptId,
+        script.runIdentity.runId,
+        formatTerminalSystemMessage(message),
+      );
     },
     pushProcessOutput(runtime, scriptId, expectedRunId, data) {
       pushTerminalChunk(runtime, scriptId, expectedRunId, formatTerminalProcessOutput(data));

--- a/packages/openducktor-web/src/local-host-transport.test.ts
+++ b/packages/openducktor-web/src/local-host-transport.test.ts
@@ -279,6 +279,7 @@ describe("local host SSE subscriptions", () => {
     expect(listener).toHaveBeenNthCalledWith(1, {
       __openducktorBrowserLive: true,
       kind: "reconnected",
+      transportEpoch: "task-events:1",
     });
     expect(listener).toHaveBeenNthCalledWith(2, {
       __openducktorBrowserLive: true,
@@ -307,13 +308,15 @@ describe("local host SSE subscriptions", () => {
     expect(didResolve).toBe(false);
 
     eventSource.emit("open", "");
-    const unsubscribe = await subscription;
+    const { transportEpoch, unsubscribe } = await subscription;
+    expect(transportEpoch).toBe("dev-server-events:0");
     expect(listener).not.toHaveBeenCalled();
 
     eventSource.emit("open", "");
     expect(listener).toHaveBeenNthCalledWith(1, {
       __openducktorBrowserLive: true,
       kind: "reconnected",
+      transportEpoch: "dev-server-events:1",
     });
 
     unsubscribe();
@@ -340,8 +343,8 @@ describe("local host SSE subscriptions", () => {
     const retrySubscription = subscribeLocalHostDevServerEvents(mock(() => {}));
     const retryEventSource = await waitForEventSourceInstance(1);
     retryEventSource.emit("open", "");
-    const unsubscribe = await retrySubscription;
-    expect(typeof unsubscribe).toBe("function");
+    const { transportEpoch, unsubscribe } = await retrySubscription;
+    expect(transportEpoch).toBe("dev-server-events:0");
     unsubscribe();
     expect(retryEventSource.closed).toBe(true);
   });
@@ -356,7 +359,7 @@ describe("local host SSE subscriptions", () => {
     const subscription = subscribeLocalHostDevServerEvents(listener);
     const eventSource = await waitForEventSourceInstance();
     eventSource.emit("open", "");
-    const unsubscribe = await subscription;
+    const { unsubscribe } = await subscription;
 
     eventSource.emit("error", "lost connection");
 
@@ -373,6 +376,7 @@ describe("local host SSE subscriptions", () => {
     expect(listener).toHaveBeenNthCalledWith(2, {
       __openducktorBrowserLive: true,
       kind: "reconnected",
+      transportEpoch: "dev-server-events:1",
     });
 
     eventSource.emit("error", "lost again");
@@ -398,8 +402,8 @@ describe("local host SSE subscriptions", () => {
     const throwingSubscription = subscribeLocalHostDevServerEvents(throwingListener);
     const eventSource = await waitForEventSourceInstance();
     eventSource.emit("open", "");
-    const unsubscribeThrowing = await throwingSubscription;
-    const unsubscribe = await subscribeLocalHostDevServerEvents(listener);
+    const { unsubscribe: unsubscribeThrowing } = await throwingSubscription;
+    const { unsubscribe } = await subscribeLocalHostDevServerEvents(listener);
 
     expect(() => eventSource.emit("error", "lost connection")).toThrow("listener failed");
     expect(listener).toHaveBeenNthCalledWith(1, {
@@ -428,8 +432,8 @@ describe("local host SSE subscriptions", () => {
     const throwingSubscription = subscribeLocalHostDevServerEvents(throwingListener);
     const eventSource = await waitForEventSourceInstance();
     eventSource.emit("open", "");
-    const unsubscribeThrowing = await throwingSubscription;
-    const unsubscribe = await subscribeLocalHostDevServerEvents(listener);
+    const { unsubscribe: unsubscribeThrowing } = await throwingSubscription;
+    const { unsubscribe } = await subscribeLocalHostDevServerEvents(listener);
 
     expect(() =>
       eventSource.emit(

--- a/packages/openducktor-web/src/local-host-transport.test.ts
+++ b/packages/openducktor-web/src/local-host-transport.test.ts
@@ -415,6 +415,38 @@ describe("local host SSE subscriptions", () => {
     unsubscribe();
   });
 
+  test("isolates named dev-server stream-warning listener failures", async () => {
+    const { subscribeLocalHostDevServerEvents } = await loadLocalHostTransport();
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+    const throwingListener = mock(() => {
+      throw new Error("listener failed");
+    });
+    const listener = mock(() => {});
+
+    const throwingSubscription = subscribeLocalHostDevServerEvents(throwingListener);
+    const eventSource = await waitForEventSourceInstance();
+    eventSource.emit("open", "");
+    const unsubscribeThrowing = await throwingSubscription;
+    const unsubscribe = await subscribeLocalHostDevServerEvents(listener);
+
+    expect(() =>
+      eventSource.emit(
+        "stream-warning",
+        "Dev server stream skipped 2 events; reconnect will replay buffered events.",
+      ),
+    ).toThrow("listener failed");
+    expect(listener).toHaveBeenNthCalledWith(1, {
+      __openducktorBrowserLive: true,
+      kind: "stream-warning",
+      message: "Dev server stream skipped 2 events; reconnect will replay buffered events.",
+    });
+
+    unsubscribeThrowing();
+    unsubscribe();
+  });
+
   test("buildLocalAttachmentPreviewUrl normalizes the backend base URL", async () => {
     const { buildLocalAttachmentPreviewUrl } = await loadLocalHostTransport();
 

--- a/packages/openducktor-web/src/local-host-transport.ts
+++ b/packages/openducktor-web/src/local-host-transport.ts
@@ -1,3 +1,4 @@
+import type { DevServerEventSubscription } from "@openducktor/frontend";
 import {
   BROWSER_LIVE_RECONNECTED_EVENT_KIND,
   BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
@@ -28,6 +29,7 @@ type BrowserSseChannel = {
   eventSource: EventSource;
   listeners: Map<number, BrowserSseListener>;
   ready: Promise<void>;
+  readTransportEpoch: () => string | null;
   handleMessage: (event: MessageEvent<string>) => void;
   handleOpen: () => void;
   handleError: (event: Event) => void;
@@ -35,12 +37,13 @@ type BrowserSseChannel = {
 };
 
 type BrowserSseSubscription = {
-  ready: Promise<void>;
+  ready: Promise<string>;
   unsubscribe: () => void;
 };
 
 const sseChannels = new Map<string, BrowserSseChannel>();
 let nextSseListenerId = 0;
+let nextSseTransportEpoch = 0;
 let sessionPromise: Promise<void> | null = null;
 
 const readFailureKind = (payload: unknown): string | undefined => {
@@ -242,6 +245,7 @@ const subscribeSseChannelEffect = (
       const shouldEmitControlEvents = CONTROL_EVENT_SSE_PATHS.has(path);
       let hasOpened = false;
       let hasReportedPostOpenError = false;
+      let transportEpoch: string | null = null;
       let resolveReady: () => void = () => {};
       let rejectReady: (error: unknown) => void = () => {};
       const ready = new Promise<void>((resolve, reject) => {
@@ -256,6 +260,8 @@ const subscribeSseChannelEffect = (
         }
       };
       const handleOpen = (): void => {
+        transportEpoch = `${path}:${nextSseTransportEpoch}`;
+        nextSseTransportEpoch += 1;
         if (!hasOpened) {
           hasOpened = true;
           hasReportedPostOpenError = false;
@@ -267,7 +273,9 @@ const subscribeSseChannelEffect = (
           return;
         }
         for (const currentListener of listeners.values()) {
-          currentListener(browserLiveControlEvent(BROWSER_LIVE_RECONNECTED_EVENT_KIND));
+          currentListener(
+            browserLiveControlEvent(BROWSER_LIVE_RECONNECTED_EVENT_KIND, transportEpoch),
+          );
         }
       };
       const handleError = (event: Event): void => {
@@ -315,6 +323,7 @@ const subscribeSseChannelEffect = (
         eventSource,
         listeners,
         ready,
+        readTransportEpoch: () => transportEpoch,
         handleMessage,
         handleOpen,
         handleError,
@@ -326,9 +335,23 @@ const subscribeSseChannelEffect = (
     const listenerId = nextSseListenerId;
     nextSseListenerId += 1;
     channel.listeners.set(listenerId, listener);
+    const activeChannel = channel;
+    const subscriptionReady = activeChannel.ready.then(() => {
+      const transportEpoch = activeChannel.readTransportEpoch();
+      if (transportEpoch === null) {
+        throw new WebDependencyError({
+          dependency: "event-source",
+          operation: "read-transport-epoch",
+          message: `EventSource ${path} opened without a transport epoch.`,
+          details: { path },
+        });
+      }
+      return transportEpoch;
+    });
+    void subscriptionReady.catch(() => {});
 
     return {
-      ready: channel.ready,
+      ready: subscriptionReady,
       unsubscribe: () => {
         const currentChannel = sseChannels.get(path);
         if (!currentChannel) {
@@ -353,7 +376,7 @@ export const subscribeLocalHostRunEvents = async (
 
 export const subscribeLocalHostDevServerEvents = async (
   listener: (payload: unknown) => void,
-): Promise<() => void> => {
+): Promise<DevServerEventSubscription> => {
   return runWebBoundary(
     Effect.gen(function* () {
       yield* ensureLocalHostSessionDedupedEffect();
@@ -403,7 +426,10 @@ export const subscribeLocalHostDevServerEvents = async (
         subscription.unsubscribe();
         return yield* causeToWebBoundaryError(readyExit.cause);
       }
-      return subscription.unsubscribe;
+      return {
+        transportEpoch: readyExit.value,
+        unsubscribe: subscription.unsubscribe,
+      };
     }),
   );
 };

--- a/packages/openducktor-web/src/local-host-transport.ts
+++ b/packages/openducktor-web/src/local-host-transport.ts
@@ -288,10 +288,24 @@ const subscribeSseChannelEffect = (
         if (!shouldEmitControlEvents) {
           return;
         }
+        let hasListenerError = false;
+        let listenerError: unknown;
+        const warningPayload = browserLiveControlEvent(
+          BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+          event.data,
+        );
         for (const currentListener of listeners.values()) {
-          currentListener(
-            browserLiveControlEvent(BROWSER_LIVE_STREAM_WARNING_EVENT_KIND, event.data),
-          );
+          try {
+            currentListener(warningPayload);
+          } catch (error) {
+            if (!hasListenerError) {
+              listenerError = error;
+            }
+            hasListenerError = true;
+          }
+        }
+        if (hasListenerError) {
+          throw listenerError;
         }
       };
 

--- a/packages/openducktor-web/src/local-host-transport.ts
+++ b/packages/openducktor-web/src/local-host-transport.ts
@@ -180,6 +180,29 @@ const parseSsePayload = (raw: string): unknown => {
   }
 };
 
+const dispatchBrowserSseWarning = (
+  listeners: Iterable<BrowserSseListener>,
+  warningPayload: unknown,
+): void => {
+  let didListenerThrow = false;
+  let firstListenerError: unknown;
+
+  for (const currentListener of listeners) {
+    try {
+      currentListener(warningPayload);
+    } catch (error) {
+      if (!didListenerThrow) {
+        firstListenerError = error;
+      }
+      didListenerThrow = true;
+    }
+  }
+
+  if (didListenerThrow) {
+    throw firstListenerError;
+  }
+};
+
 const closeSseChannelIfUnused = (path: string, channel: BrowserSseChannel): void => {
   if (channel.listeners.size > 0) {
     return;
@@ -256,21 +279,10 @@ const subscribeSseChannelEffect = (
             BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
             `EventSource ${path} reported an error after opening.`,
           );
-          let hasListenerError = false;
-          let listenerError: unknown;
-          for (const currentListener of listeners.values()) {
-            try {
-              currentListener(warningPayload);
-            } catch (error) {
-              if (!hasListenerError) {
-                listenerError = error;
-              }
-              hasListenerError = true;
-            }
-          }
-          hasReportedPostOpenError = true;
-          if (hasListenerError) {
-            throw listenerError;
+          try {
+            dispatchBrowserSseWarning(listeners.values(), warningPayload);
+          } finally {
+            hasReportedPostOpenError = true;
           }
           return;
         }
@@ -288,25 +300,11 @@ const subscribeSseChannelEffect = (
         if (!shouldEmitControlEvents) {
           return;
         }
-        let hasListenerError = false;
-        let listenerError: unknown;
         const warningPayload = browserLiveControlEvent(
           BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
           event.data,
         );
-        for (const currentListener of listeners.values()) {
-          try {
-            currentListener(warningPayload);
-          } catch (error) {
-            if (!hasListenerError) {
-              listenerError = error;
-            }
-            hasListenerError = true;
-          }
-        }
-        if (hasListenerError) {
-          throw listenerError;
-        }
+        dispatchBrowserSseWarning(listeners.values(), warningPayload);
       };
 
       eventSource.addEventListener("message", handleMessage as EventListener);

--- a/packages/openducktor-web/src/typescript-host-backend-support.ts
+++ b/packages/openducktor-web/src/typescript-host-backend-support.ts
@@ -19,6 +19,10 @@ export type BufferedHostEvent = {
   id: number;
   payload: string;
 };
+export type BufferedHostEventReplay = {
+  events: BufferedHostEvent[];
+  skippedEventCount: number;
+};
 type JsonRpcRequestId = string | number;
 type StopTypescriptHostBackendServicesInput = {
   disposeHost: () => Effect.Effect<void, unknown>;
@@ -120,6 +124,26 @@ export class BufferedHostEventStream {
       return options.includeRecentWhenNoLastEventId ? [...this.recent] : [];
     }
     return this.recent.filter((event) => event.id > lastSeenId);
+  }
+
+  replayAfterWithDiagnostics(
+    lastSeenId: number | null,
+    options: { includeRecentWhenNoLastEventId?: boolean } = {},
+  ): BufferedHostEventReplay {
+    const events = this.replayAfter(lastSeenId, options);
+    if (lastSeenId === null) {
+      return { events, skippedEventCount: 0 };
+    }
+
+    const firstAvailableEventId = this.recent[0]?.id ?? null;
+    if (firstAvailableEventId === null || lastSeenId >= firstAvailableEventId - 1) {
+      return { events, skippedEventCount: 0 };
+    }
+
+    return {
+      events,
+      skippedEventCount: firstAvailableEventId - lastSeenId - 1,
+    };
   }
 
   subscribe(listener: (event: BufferedHostEvent) => void): HostEventUnsubscribe {

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -262,6 +262,58 @@ describe("TypeScript web host backend", () => {
     }
   });
 
+  test("emits a stream warning when dev-server SSE replay cannot cover the reconnect gap", async () => {
+    const eventBus = new BufferedHostEventBus();
+    for (let index = 0; index < 258; index += 1) {
+      eventBus.publish("openducktor://dev-server-event", {
+        type: "terminal_chunk",
+        repoPath: "/repo",
+        taskId: "task-1",
+        terminalChunk: {
+          scriptId: "web",
+          sequence: index,
+          data: `line-${index}\r\n`,
+          timestamp: "2026-03-19T15:30:00.000Z",
+        },
+      });
+    }
+
+    const response = await handleTestRequest(
+      new Request("http://127.0.0.1/dev-server-events", {
+        method: "GET",
+        headers: {
+          "last-event-id": "1",
+          "x-openducktor-app-token": APP_TOKEN,
+        },
+      }),
+      { eventBus },
+    );
+
+    expect(response.status).toBe(200);
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Expected SSE response body.");
+    }
+    try {
+      const readyChunk = await readImmediateStreamChunk(reader);
+      expect(readyChunk.done).toBe(false);
+      expect(new TextDecoder().decode(readyChunk.value)).toBe(": openducktor-ready\n\n");
+
+      const warningChunk = await readImmediateStreamChunk(reader);
+      expect(warningChunk.done).toBe(false);
+      expect(new TextDecoder().decode(warningChunk.value)).toBe(
+        "event: stream-warning\n" +
+          "data: Dev server stream skipped 1 event; reconnect will replay buffered events.\n\n",
+      );
+
+      const replayChunk = await readImmediateStreamChunk(reader);
+      expect(replayChunk.done).toBe(false);
+      expect(new TextDecoder().decode(replayChunk.value)).toContain('"data":"line-2\\r\\n"');
+    } finally {
+      await reader.cancel();
+    }
+  });
+
   test("does not replay Codex app-server requests after resolved notifications", () => {
     const eventBus = new BufferedHostEventBus();
     eventBus.publish("openducktor://codex-app-server-event", {

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -266,10 +266,31 @@ const writeSseEvent = (event: BufferedHostEvent): string =>
   [`id: ${event.id}`, ...event.payload.split(/\r?\n/).map((line) => `data: ${line}`), "", ""].join(
     "\n",
   );
+const writeSseNamedEvent = (eventName: string, data: string): string =>
+  [`event: ${eventName}`, ...data.split(/\r?\n/).map((line) => `data: ${line}`), "", ""].join("\n");
 const SSE_READY_COMMENT = ": openducktor-ready\n\n";
+
+const streamWarningSubject = (streamPath: string): string => {
+  if (streamPath === "dev-server-events") {
+    return "Dev server stream";
+  }
+  if (streamPath === "task-events") {
+    return "Task stream";
+  }
+  if (streamPath === "codex-app-server-events") {
+    return "Codex app-server stream";
+  }
+  return "Event stream";
+};
+
+const skippedReplayWarningMessage = (streamPath: string, skippedEventCount: number): string => {
+  const eventLabel = skippedEventCount === 1 ? "event" : "events";
+  return `${streamWarningSubject(streamPath)} skipped ${skippedEventCount} ${eventLabel}; reconnect will replay buffered events.`;
+};
 
 const createSseResponse = (
   stream: BufferedHostEventStream,
+  streamPath: string,
   lastEventId: number | null,
   corsHeaders: HeadersInit,
   options: { includeRecentWhenNoLastEventId?: boolean } = {},
@@ -279,7 +300,18 @@ const createSseResponse = (
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       controller.enqueue(encoder.encode(SSE_READY_COMMENT));
-      for (const event of stream.replayAfter(lastEventId, options)) {
+      const replay = stream.replayAfterWithDiagnostics(lastEventId, options);
+      if (replay.skippedEventCount > 0) {
+        controller.enqueue(
+          encoder.encode(
+            writeSseNamedEvent(
+              "stream-warning",
+              skippedReplayWarningMessage(streamPath, replay.skippedEventCount),
+            ),
+          ),
+        );
+      }
+      for (const event of replay.events) {
         controller.enqueue(encoder.encode(writeSseEvent(event)));
       }
       unsubscribe = stream.subscribe((event) => {
@@ -509,6 +541,7 @@ const routeCorsRequest = ({
       requestTimeouts?.timeout(request, 0);
       return createSseResponse(
         eventBus.streamFor(streamChannel),
+        streamPath,
         yield* parseLastEventId(request),
         corsHeaders,
         { includeRecentWhenNoLastEventId: INITIAL_REPLAY_STREAM_PATHS.has(streamPath) },


### PR DESCRIPTION
## Summary

- Make dev-server log streams and replay explicitly scoped to repository and task identity.
- Prevent stale runs, retired hosts, old subscriptions, and late async work from replacing current terminal output.
- Centralize run ownership in a shared contract and focused frontend ownership module.

## Goal

Dev-server output could stop updating until the user switched tabs, and logs from one task could appear after stopping the server and starting it in another task. This was an architecture problem rather than a rendering-only issue: task identity, live host ownership, run ordering, replay state, and subscription lifetime were not enforced consistently across the host, transport, query, and terminal-buffer layers.

This pull request makes cross-task log leakage impossible by design and keeps terminal streaming live without relying on tab remounts, polling, fallback routes, or durable runtime metadata.

## Technical approach

- Scope host dev-server groups and commands by repository path and task id.
- Carry a single runIdentity value through script state and terminal chunks so run id and ordering metadata cannot diverge.
- Assign host instance and generation ownership to each run, rejecting stale generations and foreign hosts before they can mutate the terminal store.
- Bind browser and Electron subscriptions to transport epochs and include the epoch in frontend query and mutation ownership.
- Reconcile bounded replay with live chunks while preserving newer output, clearing obsolete windows, and rejecting late process callbacks.
- Extract pure run comparison and cross-script host ownership policy from the circular log buffer into a focused module.
- Add regression coverage for task switches, host rollover, reconnects, start-after-stop, replay gaps, capped replay, stale mutations, retired listeners, and delayed old process output.

## Verification

- Cargo checks: not applicable; the repository contains no Cargo workspace or manifest.
- Bun lint: passed, including frontend boundary and host architecture guards.
- Bun typecheck: passed for every workspace.
- Bun tests: passed for every workspace, including 3,315 frontend tests and release script tests.
- Bun build: passed for every workspace, including Electron and browser production builds.

Task: openduckto-8b7n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dev-server terminal replay across reconnects, task switches, and restarts.
  * Added clearer stream warnings when buffered events are missed during reconnection.
  * Terminal subscriptions now provide connection status details and a dedicated unsubscribe action.

* **Bug Fixes**
  * Prevented stale or foreign terminal output from appearing in the active task.
  * Improved handling of late process events and out-of-order terminal updates.
  * Strengthened validation to keep terminal history associated with the correct script run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->