### PR TITLE
fix(host): propagate mdfind discovery failures

### DIFF
--- a/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.test.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.test.ts
@@ -115,9 +115,6 @@ describe("createOpenInToolsAdapter", () => {
         if (command === "mdfind") {
           return Effect.succeed({ ok: false, stdout: "", stderr: "Spotlight unavailable" });
         }
-        if (command === "mdls") {
-          return Effect.succeed({ ok: true, stdout: "MissingIcon\n", stderr: "" });
-        }
         return Effect.succeed({ ok: true, stdout: "", stderr: "" });
       },
     });
@@ -142,6 +139,34 @@ describe("createOpenInToolsAdapter", () => {
       program: "mdfind",
       stderr: "Spotlight unavailable",
     });
+  });
+  test("checks every direct application alias before requiring Spotlight", async () => {
+    const { launches, systemCommands } = createSystemCommands({
+      resolvedCommands: {},
+      runCommand: ({ command }) =>
+        Effect.succeed({
+          ok: command !== "mdfind",
+          stdout: "",
+          stderr: command === "mdfind" ? "Spotlight unavailable" : "",
+        }),
+    });
+    const port = createOpenInToolsAdapter({
+      platform: "darwin",
+      systemCommands,
+      homeDirectory: () => "/Users/dev",
+      pathExists: (inputPath) => Effect.succeed(inputPath === "/Applications/PyCharm CE.app"),
+      pathIsDirectory: () => Effect.succeed(true),
+      realpathFn: (inputPath) => Effect.succeed(inputPath),
+    });
+
+    await Effect.runPromise(port.openDirectoryInTool("/repo", "pycharm"));
+
+    expect(launches).toEqual([
+      {
+        command: "open",
+        args: ["-na", "/Applications/PyCharm CE.app", "--args", "/repo"],
+      },
+    ]);
   });
   test("treats successful empty Spotlight output as an application-not-found result", async () => {
     const { launches, systemCommands } = createSystemCommands({ resolvedCommands: {} });

--- a/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.test.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect } from "effect";
-import { HostValidationError } from "../../effect/host-errors";
+import { HostOperationError, HostValidationError } from "../../effect/host-errors";
 import type {
   SystemCommandPort,
   SystemCommandRunOptions,
@@ -108,7 +108,7 @@ describe("createOpenInToolsAdapter", () => {
     ]);
     expect(launches.some((launch) => launch.command === "sips")).toBe(false);
   });
-  test("keeps catalog discovery available when Spotlight lookup fails", async () => {
+  test("propagates Spotlight lookup failures", async () => {
     const { systemCommands } = createSystemCommands({
       resolvedCommands: {},
       runCommand: ({ command }) => {
@@ -128,9 +128,33 @@ describe("createOpenInToolsAdapter", () => {
       pathExists: (inputPath) => Effect.succeed(inputPath === "/Applications/Finder.app"),
       pathIsDirectory: (inputPath) => Effect.succeed(inputPath.endsWith(".app")),
     });
-    await expect(Effect.runPromise(port.discoverOpenInTools())).resolves.toEqual([
-      { toolId: "finder", iconDataUrl: null },
-    ]);
+    const result = await Effect.runPromise(Effect.either(port.discoverOpenInTools()));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag !== "Left") {
+      return;
+    }
+    expect(result.left).toBeInstanceOf(HostOperationError);
+    expect(result.left).toHaveProperty("operation", "openInTools.runCommand");
+    expect(result.left.message).toContain("Command mdfind exited unsuccessfully");
+    expect(result.left.details).toMatchObject({
+      args: ["-name", expect.stringMatching(/\.app$/)],
+      program: "mdfind",
+      stderr: "Spotlight unavailable",
+    });
+  });
+  test("treats successful empty Spotlight output as an application-not-found result", async () => {
+    const { launches, systemCommands } = createSystemCommands({ resolvedCommands: {} });
+    const port = createOpenInToolsAdapter({
+      platform: "darwin",
+      systemCommands,
+      homeDirectory: () => "/Users/dev",
+      pathExists: () => Effect.succeed(false),
+      pathIsDirectory: () => Effect.succeed(false),
+    });
+
+    await expect(Effect.runPromise(port.discoverOpenInTools())).resolves.toEqual([]);
+    expect(launches.some((launch) => launch.command === "mdfind")).toBe(true);
   });
   test("launches a directory with the selected app", async () => {
     const { launches, systemCommands } = createSystemCommands({

--- a/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.ts
@@ -219,9 +219,9 @@ export const createOpenInToolsAdapter = ({
         );
       }
     });
-  const resolveApplicationPathByName = (
+  const resolveDirectApplicationPathByName = (
     appName: string,
-  ): Effect.Effect<string | null, HostOperationError | HostPathAccessError> =>
+  ): Effect.Effect<string | null, HostPathAccessError> =>
     Effect.gen(function* () {
       for (const candidate of candidateApplicationPaths(appName, homeDirectory)) {
         if (yield* pathExists(candidate)) {
@@ -229,6 +229,12 @@ export const createOpenInToolsAdapter = ({
         }
       }
 
+      return null;
+    });
+  const resolveApplicationPathWithSpotlight = (
+    appName: string,
+  ): Effect.Effect<string | null, HostOperationError | HostPathAccessError> =>
+    Effect.gen(function* () {
       const bundleName = bundleNameForApp(appName);
       const output = yield* runRequiredOpenInCommand("mdfind", ["-name", bundleName]);
 
@@ -251,7 +257,14 @@ export const createOpenInToolsAdapter = ({
   ): Effect.Effect<string | null, HostOperationError | HostPathAccessError> =>
     Effect.gen(function* () {
       for (const appName of metadata.appNames) {
-        const appPath = yield* resolveApplicationPathByName(appName);
+        const appPath = yield* resolveDirectApplicationPathByName(appName);
+        if (appPath) {
+          return appPath;
+        }
+      }
+
+      for (const appName of metadata.appNames) {
+        const appPath = yield* resolveApplicationPathWithSpotlight(appName);
         if (appPath) {
           return appPath;
         }

--- a/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.ts
+++ b/packages/host/src/adapters/open-in-tools/open-in-tools-adapter.ts
@@ -230,12 +230,7 @@ export const createOpenInToolsAdapter = ({
       }
 
       const bundleName = bundleNameForApp(appName);
-      const output = yield* runRequiredOpenInCommand("mdfind", ["-name", bundleName]).pipe(
-        Effect.catchAll(() => Effect.succeed(null)),
-      );
-      if (!output) {
-        return null;
-      }
+      const output = yield* runRequiredOpenInCommand("mdfind", ["-name", bundleName]);
 
       for (const line of output.stdout.split(/\r?\n/)) {
         const candidate = line.trim();


### PR DESCRIPTION
## Summary

Propagate macOS Spotlight lookup failures during Open In tool discovery instead of silently treating infrastructure errors as missing applications.

## Goal

The macOS adapter runs mdfind when direct application bundle candidates are absent. A broad Effect failure recovery converted command execution failures and unsuccessful exits into null, which is also the legitimate application-not-found result. This hid actionable Spotlight, permission, and process errors and conflicted with the host fail-fast policy.

## Implementation

- Removed the broad catchAll around the required mdfind command so its typed HostOperationError remains in the Effect error channel.
- Kept successful empty stdout on the existing scan path, which naturally returns null when no valid application bundle is found.
- Preserved direct candidate-path discovery before Spotlight lookup.
- Replaced the failure-swallowing regression test with assertions for the propagated error operation, command arguments, and stderr.
- Added explicit coverage for successful empty Spotlight output returning no discovered tools.

## Verification

- bun run lint
- bun run test
- bun run typecheck
- bun run build

All commands passed with a 10-minute timeout. Cargo checks are not applicable because this repository has no Cargo.toml.