### PR TITLE
fix(codex): scope live turn timing to completion

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -187,7 +187,13 @@ describe("CodexAppServerAdapter streaming", () => {
           method: "turn/completed",
           params: {
             threadId: "thread/start-runtime-live",
-            turn: { id: "turn-1", status: "completed", completedAt: 1_777_766_403 },
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              startedAt: 1_777_766_401.8,
+              completedAt: 1_777_766_403,
+              durationMs: 1_200,
+            },
           },
         },
       ]);
@@ -215,6 +221,13 @@ describe("CodexAppServerAdapter streaming", () => {
         messageId: "agent-1",
         delta: "Hi",
         timestamp: new Date(1_777_766_401_500).toISOString(),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "session_status",
+        timestamp: "2026-05-03T00:00:01.800Z",
+        status: { type: "busy", message: null },
       }),
     );
     expect(events).toContainEqual(
@@ -558,6 +571,7 @@ describe("CodexAppServerAdapter streaming", () => {
               id: "turn-notification-first",
               status: "completed",
               completedAt: 1_777_766_421,
+              durationMs: 1_000,
             },
           },
         },
@@ -584,6 +598,45 @@ describe("CodexAppServerAdapter streaming", () => {
       message: "Done with low reasoning.",
       model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
     });
+  });
+
+  test("rejects final live Codex turns without runtime duration", async () => {
+    const takeBufferedEvents = mock(async (_runtimeId: string) => []);
+    const { adapter, transports } = createHarness({ takeBufferedEvents }, { deferTurnStart: true });
+
+    await adapter.startSession(codexStartSessionInput());
+    await adapter.subscribeEvents(codexSessionRuntimeRef("thread/start-runtime-live"), () => {});
+    takeBufferedEvents.mockImplementationOnce(async () => {
+      transports.get("runtime-live")?.turnStartDeferred.resolve({ turn: { id: "turn-1" } });
+      return bufferedNotifications([
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread/start-runtime-live",
+            turnId: "turn-1",
+            completedAtMs: 1_777_766_403_000,
+            item: { type: "agentMessage", id: "agent-1", text: "Hi there" },
+          },
+        },
+        {
+          method: "turn/completed",
+          params: {
+            threadId: "thread/start-runtime-live",
+            turn: { id: "turn-1", status: "completed", completedAt: 1_777_766_403 },
+          },
+        },
+      ]);
+    });
+
+    await expect(
+      adapter.sendUserMessage(
+        codexUserMessageInput({
+          externalSessionId: "thread/start-runtime-live",
+          parts: [{ kind: "text", text: "Hello Codex" }],
+          model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
+        }),
+      ),
+    ).rejects.toThrow("Completed Codex turn with a final assistant message is missing durationMs.");
   });
 
   test("uses active turn model for completed user messages without turn id", async () => {
@@ -983,7 +1036,7 @@ describe("CodexAppServerAdapter streaming", () => {
     unsubscribe();
   });
 
-  test("flushes the buffered final assistant message before settling from idle status", async () => {
+  test("waits for turn completion timing before flushing a final assistant message", async () => {
     const { subscribeEvents, emitNotification } = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({ subscribeEvents }, { deferTurnStart: true });
 
@@ -1012,7 +1065,7 @@ describe("CodexAppServerAdapter streaming", () => {
       params: {
         threadId: "thread/start-runtime-live",
         turnId: "turn-live",
-        completedAtMs: 1_777_766_420_000,
+        completedAtMs: 1_777_766_419_650,
         item: {
           type: "agentMessage",
           id: "agent-idle-final",
@@ -1042,6 +1095,30 @@ describe("CodexAppServerAdapter streaming", () => {
     });
     await flushCodexAdapterWork();
 
+    expect(events.some((event) => event.type === "assistant_message")).toBe(false);
+    expect(events.some((event) => event.type === "session_idle")).toBe(false);
+
+    emitNotification({
+      method: "turn/completed",
+      params: {
+        threadId: "thread/start-runtime-live",
+        turn: {
+          id: "turn-live",
+          status: "completed",
+          completedAt: 1_777_766_420,
+          durationMs: 1_200,
+        },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "session_status",
+        timestamp: "2026-05-03T00:00:18.450Z",
+        status: { type: "busy", message: null },
+      }),
+    );
     expect(events).toContainEqual(
       expect.objectContaining({
         type: "assistant_message",
@@ -1050,7 +1127,7 @@ describe("CodexAppServerAdapter streaming", () => {
       }),
     );
     const assistantMessageIndex = events.findIndex((event) => event.type === "assistant_message");
-    const sessionIdleIndex = events.findIndex((event) => event.type === "session_idle");
+    const sessionIdleIndex = events.findLastIndex((event) => event.type === "session_idle");
     expect(assistantMessageIndex).toBeGreaterThanOrEqual(0);
     expect(sessionIdleIndex).toBeGreaterThan(assistantMessageIndex);
     unsubscribe();

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -600,7 +600,11 @@ describe("CodexAppServerAdapter streaming", () => {
     });
   });
 
-  test("rejects final live Codex turns without runtime duration", async () => {
+  test.each([
+    ["missing", undefined, "is missing durationMs."],
+    ["fractional", 1.5, "has invalid durationMs."],
+    ["out-of-range", Number.MAX_SAFE_INTEGER, "has invalid durationMs."],
+  ])("rejects %s final live Codex turn duration", async (_case, durationMs, expectedError) => {
     const takeBufferedEvents = mock(async (_runtimeId: string) => []);
     const { adapter, transports } = createHarness({ takeBufferedEvents }, { deferTurnStart: true });
 
@@ -622,7 +626,12 @@ describe("CodexAppServerAdapter streaming", () => {
           method: "turn/completed",
           params: {
             threadId: "thread/start-runtime-live",
-            turn: { id: "turn-1", status: "completed", completedAt: 1_777_766_403 },
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              completedAt: 1_777_766_403,
+              ...(durationMs === undefined ? {} : { durationMs }),
+            },
           },
         },
       ]);
@@ -636,7 +645,7 @@ describe("CodexAppServerAdapter streaming", () => {
           model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
         }),
       ),
-    ).rejects.toThrow("Completed Codex turn with a final assistant message is missing durationMs.");
+    ).rejects.toThrow(`Completed Codex turn with a final assistant message ${expectedError}`);
   });
 
   test("uses active turn model for completed user messages without turn id", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -13,6 +13,7 @@ import {
 } from "./codex-app-server-requests";
 import {
   type ActiveCodexTurn,
+  extractNumberField,
   extractStringField,
   isPlainObject,
   MAX_CODEX_EVENT_BACKLOG_PER_SESSION,
@@ -511,6 +512,31 @@ const flushBufferedFinalAgentMessage = (
   );
 };
 
+const emitCodexCompletedTurnTiming = (
+  context: CodexStreamingContext,
+  session: CodexSessionState,
+  completedAgentMessage: CompletedAgentMessage,
+  turn: Record<string, unknown>,
+): void => {
+  const durationMs = extractNumberField(turn, ["durationMs", "duration_ms"]);
+  if (durationMs === null || durationMs < 0) {
+    throw new Error("Completed Codex turn with a final assistant message is missing durationMs.");
+  }
+
+  const completedAtMs = Date.parse(completedAgentMessage.timestamp);
+  if (Number.isNaN(completedAtMs)) {
+    throw new Error("Completed Codex assistant message has an invalid timestamp.");
+  }
+
+  const activityStartedAt = new Date(completedAtMs - durationMs).toISOString();
+  emitCodexSessionEvent(context, session.threadId, {
+    type: "session_status",
+    externalSessionId: session.threadId,
+    timestamp: activityStartedAt,
+    status: { type: "busy", message: null },
+  });
+};
+
 export const handleCodexPendingNotifications = async (
   context: CodexStreamingContext,
   session: CodexSessionState,
@@ -582,15 +608,18 @@ export const handleCodexPendingNotifications = async (
         const liveStatus = codexThreadStatusSnapshot(notification.params.status);
         context.setSessionLiveStatus(session, liveStatus);
         if (activeTurn && isIdleStatus) {
-          if (activeTurn.turnId) {
-            flushBufferedFinalAgentMessage(context, session, activeTurn.turnId);
-            clearTurnScopedStreamingState(context, session.threadId, activeTurn.turnId);
+          const hasBufferedFinalAgentMessage =
+            activeTurn.turnId !== undefined &&
+            context.completedAgentMessagesByTurnKey.has(
+              codexTurnKey(session.threadId, activeTurn.turnId),
+            );
+          if (!hasBufferedFinalAgentMessage) {
+            emitCodexSessionEvent(context, session.threadId, {
+              type: "session_idle",
+              externalSessionId: session.threadId,
+              timestamp: notification.receivedAt,
+            });
           }
-          emitCodexSessionEvent(context, session.threadId, {
-            type: "session_idle",
-            externalSessionId: session.threadId,
-            timestamp: notification.receivedAt,
-          });
           activeTurn.markTurnSettled();
         }
       }
@@ -683,6 +712,12 @@ export const handleCodexPendingNotifications = async (
       const turn = isPlainObject(notification.params) ? notification.params.turn : null;
       const turnId = isPlainObject(turn) ? extractStringField(turn, ["id", "turnId"]) : null;
       if (turnId && isPlainObject(turn) && turn.status === "completed") {
+        const completedAgentMessage = context.completedAgentMessagesByTurnKey.get(
+          codexTurnKey(session.threadId, turnId),
+        );
+        if (completedAgentMessage) {
+          emitCodexCompletedTurnTiming(context, session, completedAgentMessage, turn);
+        }
         flushBufferedFinalAgentMessage(context, session, turnId);
         clearTurnScopedStreamingState(context, session.threadId, turnId);
       } else if (turnId) {

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -519,8 +519,11 @@ const emitCodexCompletedTurnTiming = (
   turn: Record<string, unknown>,
 ): void => {
   const durationMs = extractNumberField(turn, ["durationMs", "duration_ms"]);
-  if (durationMs === null || durationMs < 0) {
+  if (durationMs === null) {
     throw new Error("Completed Codex turn with a final assistant message is missing durationMs.");
+  }
+  if (!Number.isSafeInteger(durationMs) || durationMs < 0) {
+    throw new Error("Completed Codex turn with a final assistant message has invalid durationMs.");
   }
 
   const completedAtMs = Date.parse(completedAgentMessage.timestamp);
@@ -528,7 +531,11 @@ const emitCodexCompletedTurnTiming = (
     throw new Error("Completed Codex assistant message has an invalid timestamp.");
   }
 
-  const activityStartedAt = new Date(completedAtMs - durationMs).toISOString();
+  const activityStartedAtDate = new Date(completedAtMs - durationMs);
+  if (Number.isNaN(activityStartedAtDate.getTime())) {
+    throw new Error("Completed Codex turn with a final assistant message has invalid durationMs.");
+  }
+  const activityStartedAt = activityStartedAtDate.toISOString();
   emitCodexSessionEvent(context, session.threadId, {
     type: "session_status",
     externalSessionId: session.threadId,

--- a/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/events/session-transcript-events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createSessionTurnTiming } from "../support/session-turn-timing";
 import {
   buildSession,
   createRecordingSessionTodosUpdater,
@@ -138,6 +139,69 @@ describe("agent-orchestrator session transcript events", () => {
     });
 
     expect(getSession(sessionsRef).historyLoadState).toBe("loaded");
+  });
+
+  test("keeps consecutive live Codex turn durations scoped to their current turn", async () => {
+    const handlers: Array<(event: SessionEvent) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: async (_sessionRef, handler) => {
+        handlers.push(handler);
+        return () => {};
+      },
+      replyApproval: async () => {},
+    };
+    const sessionsRef = createSessionsRef([
+      buildSession({ runtimeKind: "codex", status: "running" }),
+    ]);
+    const turnTiming = createSessionTurnTiming();
+
+    await listenToAgentSessionEvents({
+      adapter,
+      repoPath: "/tmp/repo",
+      externalSessionId: "session-1",
+      sessionsRef,
+      updateSession: createSessionUpdater(sessionsRef),
+      recordTurnActivityTimestamp: turnTiming.recordTurnActivityTimestamp,
+      resolveTurnDurationMs: turnTiming.resolveTurnDurationMs,
+      clearTurnDuration: turnTiming.clearTurnDuration,
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+    handleEvent({
+      type: "session_status",
+      externalSessionId: "session-1",
+      timestamp: "2026-02-22T08:00:01.800Z",
+      status: { type: "busy", message: null },
+    });
+    handleEvent({
+      type: "assistant_message",
+      externalSessionId: "session-1",
+      messageId: "assistant-1",
+      timestamp: "2026-02-22T08:00:03.000Z",
+      message: "First answer",
+    });
+    handleEvent({
+      type: "session_status",
+      externalSessionId: "session-1",
+      timestamp: "2026-02-22T08:00:14.700Z",
+      status: { type: "busy", message: null },
+    });
+    handleEvent({
+      type: "assistant_message",
+      externalSessionId: "session-1",
+      messageId: "assistant-2",
+      timestamp: "2026-02-22T08:00:17.000Z",
+      message: "Second answer",
+    });
+
+    const durations = getSessionMessages(sessionsRef)
+      .filter((message) => message.meta?.kind === "assistant")
+      .map((message) => (message.meta?.kind === "assistant" ? message.meta.durationMs : undefined));
+    expect(durations).toEqual([1_200, 2_300]);
   });
 
   test("ignores observed session events after the mounted identity changes", async () => {


### PR DESCRIPTION
Summary

Fixes the live-only Codex turn-duration regression while keeping shared runtime contracts and common frontend production logic unchanged.

Goal

Live Codex sessions could display a duration anchored to the previous user message, while the same session showed the correct duration after hydration. The live adapter flushed the final assistant message when an early thread idle notification arrived, before turn completion supplied authoritative timing.

Implementation

- Keep final Codex assistant messages buffered until the matching successful turn/completed notification.
- Require the runtime-provided durationMs for completed turns with a final assistant message and fail clearly when it is absent.
- Derive the existing activity timing anchor from the buffered assistant completion timestamp minus durationMs, so live calculation exactly matches the authoritative duration used during hydration.
- Suppress a premature UI idle event when the final assistant message is already buffered, then emit timing anchor, final message, and canonical idle in order.
- Keep the implementation entirely within the Codex adapter; no shared event contract or common frontend production behavior changes.

Regression coverage

- Reproduces idle arriving before turn/completed.
- Uses deliberately different item and turn completion timestamps to prove the live duration does not depend on those timestamps being equal.
- Verifies consecutive live turns remain scoped to their own durations.

Verification

- bun run lint
- bun run test
- bun run typecheck
- bun run build
- Cargo checks: not applicable because this repository has no Cargo.toml.