### PR TITLE
perf(web): cache static shell asset resolution

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -365,8 +365,8 @@ function AgentChatComposerFormView({
       <div
         className={
           isWaitingInput
-            ? "odt-waiting-input-card relative border border-warning-border bg-card shadow-md transition-[border-color,box-shadow,background-color] focus-within:shadow-xl"
-            : "relative border border-input border-l-0 bg-card shadow-md transition-[border-color,box-shadow,background-color] focus-within:shadow-xl"
+            ? "odt-waiting-input-card relative border border-warning-border bg-card shadow-md focus-within:shadow-xl"
+            : "relative border border-input border-l-0 bg-card shadow-md focus-within:shadow-xl"
         }
       >
         {isSessionWorking && !isWaitingInput ? (

--- a/packages/frontend/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -199,7 +199,7 @@ function AgentStudioTaskTabShell({
         className={cn(
           "mr-1 rounded-md p-1 text-muted-foreground transition-opacity hover:bg-secondary hover:text-foreground",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-          "opacity-60 group-hover:opacity-100 data-[active=true]:opacity-100",
+          "opacity-60 group-hover:opacity-100 data-[active=true]:opacity-100 transition-none",
           onCloseTab ? "cursor-pointer" : "pointer-events-none",
         )}
         data-active={tab.isActive ? "true" : "false"}

--- a/packages/frontend/src/components/ui/resizable-handle.tsx
+++ b/packages/frontend/src/components/ui/resizable-handle.tsx
@@ -20,11 +20,11 @@ export function ResizableHandle({
       {...props}
     >
       <span
-        className="pointer-events-none absolute left-1/2 top-0 h-full w-px -translate-x-1/2 bg-input transition-colors duration-200 group-hover:bg-selected-accent group-aria-[orientation=horizontal]:left-0 group-aria-[orientation=horizontal]:top-1/2 group-aria-[orientation=horizontal]:h-px group-aria-[orientation=horizontal]:w-full group-aria-[orientation=horizontal]:-translate-y-1/2 group-aria-[orientation=horizontal]:translate-x-0"
+        className="pointer-events-none absolute left-1/2 top-0 h-full w-px -translate-x-1/2 bg-input group-hover:bg-selected-accent group-aria-[orientation=horizontal]:left-0 group-aria-[orientation=horizontal]:top-1/2 group-aria-[orientation=horizontal]:h-px group-aria-[orientation=horizontal]:w-full group-aria-[orientation=horizontal]:-translate-y-1/2 group-aria-[orientation=horizontal]:translate-x-0"
         aria-hidden="true"
       />
       {withHandle ? (
-        <div className="relative z-10 flex h-8 w-4 items-center justify-center rounded-md border border-border bg-card text-muted-foreground shadow-sm transition-all duration-150 group-hover:border-selected-accent group-hover:bg-accent group-hover:text-selected-accent group-aria-[orientation=horizontal]:h-4 group-aria-[orientation=horizontal]:w-8">
+        <div className="relative z-10 flex h-8 w-4 items-center justify-center rounded-md border border-border bg-card text-muted-foreground shadow-sm group-hover:border-selected-accent group-hover:bg-accent group-hover:text-selected-accent group-aria-[orientation=horizontal]:h-4 group-aria-[orientation=horizontal]:w-8">
           <EllipsisVertical className="size-3.5 shrink-0 group-aria-[orientation=horizontal]:rotate-90" />
         </div>
       ) : null}

--- a/packages/frontend/src/components/ui/tabs.tsx
+++ b/packages/frontend/src/components/ui/tabs.tsx
@@ -31,7 +31,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-xs font-medium text-muted-foreground transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-border data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        "inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-xs font-medium text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-border data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-sm",
         className,
       )}
       {...props}

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -274,7 +274,7 @@ export const resolveStaticAssetPath = (staticRoot: string, requestPath: string):
   }
   const relativePath = decodedPath === "/" ? "index.html" : decodedPath.replace(/^\/+/, "");
   const normalized = path.normalize(relativePath);
-  if (normalized.startsWith("..") || path.isAbsolute(normalized)) {
+  if (normalized === "." || normalized.startsWith("..") || path.isAbsolute(normalized)) {
     return null;
   }
 

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -263,6 +263,15 @@ export const resolveStaticAssetPath = (staticRoot: string, requestPath: string):
   } catch {
     return null;
   }
+  for (const character of decodedPath) {
+    const codePoint = character.codePointAt(0);
+    if (
+      codePoint !== undefined &&
+      (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
+    ) {
+      return null;
+    }
+  }
   const relativePath = decodedPath === "/" ? "index.html" : decodedPath.replace(/^\/+/, "");
   const normalized = path.normalize(relativePath);
   if (normalized.startsWith("..") || path.isAbsolute(normalized)) {

--- a/packages/openducktor-web/src/launcher-support.ts
+++ b/packages/openducktor-web/src/launcher-support.ts
@@ -1,3 +1,4 @@
+import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { Effect } from "effect";
 import {
@@ -256,7 +257,12 @@ export const buildBrowserRuntimeConfigJson = (backendUrl: string, appToken: stri
   `${JSON.stringify({ backendUrl, appToken })}\n`;
 
 export const resolveStaticAssetPath = (staticRoot: string, requestPath: string): string | null => {
-  const decodedPath = decodeURIComponent(requestPath);
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(requestPath);
+  } catch {
+    return null;
+  }
   const relativePath = decodedPath === "/" ? "index.html" : decodedPath.replace(/^\/+/, "");
   const normalized = path.normalize(relativePath);
   if (normalized.startsWith("..") || path.isAbsolute(normalized)) {
@@ -264,6 +270,43 @@ export const resolveStaticAssetPath = (staticRoot: string, requestPath: string):
   }
 
   return path.join(staticRoot, normalized);
+};
+
+export const indexStaticAssetPaths = async (staticRoot: string): Promise<Set<string>> => {
+  const assetPaths = new Set<string>();
+
+  const visitDirectory = async (directoryPath: string): Promise<void> => {
+    const entries = await readdir(directoryPath, { withFileTypes: true });
+    await Promise.all(
+      entries.map(async (entry) => {
+        const entryPath = path.join(directoryPath, entry.name);
+        if (entry.isDirectory()) {
+          await visitDirectory(entryPath);
+        } else if (entry.isFile()) {
+          assetPaths.add(entryPath);
+        }
+      }),
+    );
+  };
+
+  await visitDirectory(staticRoot);
+  return assetPaths;
+};
+
+export const resolveIndexedStaticAssetPath = (
+  staticRoot: string,
+  indexPath: string,
+  assetPaths: ReadonlySet<string>,
+  requestPath: string,
+): string | null => {
+  const assetPath = resolveStaticAssetPath(staticRoot, requestPath);
+  if (!assetPath) {
+    return null;
+  }
+  if (assetPaths.has(assetPath)) {
+    return assetPath;
+  }
+  return path.extname(assetPath) ? null : indexPath;
 };
 
 const launcherShutdownFailure = (failures: unknown[]): WebOperationError | null => {

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -308,10 +308,12 @@ describe("launcher internals", () => {
       path.join("/web-shell", "assets/app.js"),
     );
     expect(resolveStaticAssetPath("/web-shell", "/../secret.txt")).toBeNull();
-    expect(resolveStaticAssetPath("/web-shell", "/%E0%A4%A")).toBeNull();
+    expect(resolveStaticAssetPath("/web-shell", "/foo/..")).toBeNull();
+    expect(resolveStaticAssetPath("/web-shell", "/foo%2F..")).toBeNull();
   });
 
-  test("rejects decoded control characters in static request paths", () => {
+  test("rejects malformed and decoded control characters in static request paths", () => {
+    expect(resolveStaticAssetPath("/web-shell", "/%E0%A4%A")).toBeNull();
     expect(resolveStaticAssetPath("/web-shell", "/%00")).toBeNull();
     expect(resolveStaticAssetPath("/web-shell", "/%0A")).toBeNull();
     expect(resolveStaticAssetPath("/web-shell", "/%C2%80")).toBeNull();
@@ -323,6 +325,7 @@ describe("launcher internals", () => {
     const appPath = path.join(staticRoot, "assets/app.js");
     const assetPaths = new Set([indexPath, appPath]);
 
+    expect(resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/")).toBe(indexPath);
     expect(resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/assets/app.js")).toBe(
       appPath,
     );
@@ -349,11 +352,12 @@ describe("launcher internals", () => {
   test("indexes nested web shell assets during startup", async () => {
     const staticRoot = await mkdtemp(path.join(os.tmpdir(), "openducktor-web-shell-"));
     const assetDirectory = path.join(staticRoot, "assets");
+    const chunksDirectory = path.join(assetDirectory, "chunks");
     const indexPath = path.join(staticRoot, "index.html");
-    const appPath = path.join(assetDirectory, "app.js");
+    const appPath = path.join(chunksDirectory, "app.js");
 
     try {
-      await mkdir(assetDirectory);
+      await mkdir(chunksDirectory, { recursive: true });
       await Promise.all([writeFile(indexPath, "shell"), writeFile(appPath, "app")]);
 
       expect(await indexStaticAssetPaths(staticRoot)).toEqual(new Set([appPath, indexPath]));

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
   buildBrowserRuntimeConfigJson,
   buildFrontendDisplayUrls,
   closeFrontendServer,
+  indexStaticAssetPaths,
   keepProcessAliveDuring,
+  resolveIndexedStaticAssetPath,
   resolveStaticAssetPath,
   stopLauncherServices,
   waitForBackend,
@@ -304,5 +308,50 @@ describe("launcher internals", () => {
       path.join("/web-shell", "assets/app.js"),
     );
     expect(resolveStaticAssetPath("/web-shell", "/../secret.txt")).toBeNull();
+    expect(resolveStaticAssetPath("/web-shell", "/%E0%A4%A")).toBeNull();
+  });
+
+  test("resolves static requests against the startup asset index", () => {
+    const staticRoot = path.resolve("/web-shell");
+    const indexPath = path.join(staticRoot, "index.html");
+    const appPath = path.join(staticRoot, "assets/app.js");
+    const assetPaths = new Set([indexPath, appPath]);
+
+    expect(resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/assets/app.js")).toBe(
+      appPath,
+    );
+    expect(
+      resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/missing.js"),
+    ).toBeNull();
+    expect(
+      resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/missing%2Ejs"),
+    ).toBeNull();
+    expect(resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/tasks/example")).toBe(
+      indexPath,
+    );
+    expect(
+      resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/%2e%2e/secret.txt"),
+    ).toBeNull();
+
+    const traversalUrl = new URL("http://127.0.0.1/%2e%2e%2fsecret.txt");
+    expect(
+      resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, traversalUrl.pathname),
+    ).toBeNull();
+  });
+
+  test("indexes nested web shell assets during startup", async () => {
+    const staticRoot = await mkdtemp(path.join(os.tmpdir(), "openducktor-web-shell-"));
+    const assetDirectory = path.join(staticRoot, "assets");
+    const indexPath = path.join(staticRoot, "index.html");
+    const appPath = path.join(assetDirectory, "app.js");
+
+    try {
+      await mkdir(assetDirectory);
+      await Promise.all([writeFile(indexPath, "shell"), writeFile(appPath, "app")]);
+
+      expect(await indexStaticAssetPaths(staticRoot)).toEqual(new Set([appPath, indexPath]));
+    } finally {
+      await rm(staticRoot, { force: true, recursive: true });
+    }
   });
 });

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -311,6 +311,12 @@ describe("launcher internals", () => {
     expect(resolveStaticAssetPath("/web-shell", "/%E0%A4%A")).toBeNull();
   });
 
+  test("rejects decoded control characters in static request paths", () => {
+    expect(resolveStaticAssetPath("/web-shell", "/%00")).toBeNull();
+    expect(resolveStaticAssetPath("/web-shell", "/%0A")).toBeNull();
+    expect(resolveStaticAssetPath("/web-shell", "/%C2%80")).toBeNull();
+  });
+
   test("resolves static requests against the startup asset index", () => {
     const staticRoot = path.resolve("/web-shell");
     const indexPath = path.join(staticRoot, "index.html");
@@ -326,6 +332,7 @@ describe("launcher internals", () => {
     expect(
       resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/missing%2Ejs"),
     ).toBeNull();
+    expect(resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/%00")).toBeNull();
     expect(resolveIndexedStaticAssetPath(staticRoot, indexPath, assetPaths, "/tasks/example")).toBe(
       indexPath,
     );

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { Deferred, Effect } from "effect";
 import type { ViteDevServer } from "vite";
@@ -18,9 +17,10 @@ import {
   buildFrontendUrl,
   closeFrontendServerEffect,
   type FrontendServer,
+  indexStaticAssetPaths,
   keepProcessAliveDuringEffect,
   LOCALHOST,
-  resolveStaticAssetPath,
+  resolveIndexedStaticAssetPath,
   stopLauncherServicesEffect,
   waitForBackendEffect,
 } from "./launcher-support";
@@ -170,18 +170,18 @@ const startStaticFrontendServerEffect = (
   Effect.gen(function* () {
     const staticRoot = path.join(options.packageRoot, "dist/web-shell");
     const indexPath = path.join(staticRoot, "index.html");
-    const indexFileExists = yield* Effect.try({
-      try: () => existsSync(indexPath) && statSync(indexPath).isFile(),
+    const assetPaths = yield* Effect.tryPromise({
+      try: () => indexStaticAssetPaths(staticRoot),
       catch: (cause) =>
         new WebResourceError({
           resource: "web-shell-assets",
-          operation: "stat",
+          operation: "index",
           message: errorMessage(cause),
           cause,
           details: { indexPath, staticRoot },
         }),
     });
-    if (!indexFileExists) {
+    if (!assetPaths.has(indexPath)) {
       return yield* new WebResourceError({
         resource: "web-shell-assets",
         operation: "resolve",
@@ -208,17 +208,16 @@ const startStaticFrontendServerEffect = (
                 });
               }
 
-              const assetPath = resolveStaticAssetPath(staticRoot, requestUrl.pathname);
-              if (!assetPath) {
+              const responsePath = resolveIndexedStaticAssetPath(
+                staticRoot,
+                indexPath,
+                assetPaths,
+                requestUrl.pathname,
+              );
+              if (!responsePath) {
                 return new Response("Not found", { status: 404 });
               }
 
-              const assetExists = existsSync(assetPath) && statSync(assetPath).isFile();
-              if (!assetExists && path.extname(requestUrl.pathname)) {
-                return new Response("Not found", { status: 404 });
-              }
-
-              const responsePath = assetExists ? assetPath : indexPath;
               return new Response(Bun.file(responsePath), {
                 headers: {
                   "content-type": contentTypeForPath(responsePath),


### PR DESCRIPTION
## Summary

Caches the static browser shell asset inventory at server startup and resolves requests from memory.

## Goal

The production web launcher previously called synchronous filesystem metadata APIs for every static asset request. Asset-heavy startup and reloads could therefore block the event loop. This PR moves filesystem discovery out of the request hot path while preserving existing asset, SPA, configuration, and invalid-path routing semantics.\n\n## Implementation

- Recursively indexes regular web-shell files once before starting the Bun frontend server.
- Replaces request-time existsSync and statSync probes with Set membership.
- Keeps missing explicit assets as 404 responses and extensionless routes as index.html SPA fallbacks.
- Preserves the generated /openducktor-config.json response.
- Rejects malformed encodings, traversal attempts, and decoded control characters before asset resolution.
- Adds regression coverage for nested indexing, existing and missing assets, encoded extensions, SPA fallback, traversal, malformed paths, and control bytes.