### PR TITLE
fix(frontend): use blue for pending CI checks

### DIFF
--- a/packages/frontend/src/components/features/agents/task-execution-ci-check-card.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-check-card.tsx
@@ -14,16 +14,16 @@ import { TaskExecutionCiTimestampLine } from "./task-execution-ci-timestamp-line
 
 const CHECK_ICON_BY_VARIANT = {
   danger: CircleX,
+  info: Clock,
   secondary: CircleDashed,
   success: CircleCheck,
-  warning: Clock,
 } as const;
 
 const CHECK_TEXT_CLASS_BY_VARIANT = {
   danger: "text-destructive-muted",
+  info: "text-info-muted",
   secondary: "text-muted-foreground",
   success: "text-success-muted",
-  warning: "text-warning-muted",
 } as const;
 
 export function TaskExecutionCiCheckCard({

--- a/packages/frontend/src/components/features/agents/task-execution-ci-checks-list.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-checks-list.tsx
@@ -12,28 +12,34 @@ import { aggregateLabel } from "./task-execution-ci-presentation";
 const AGGREGATE_STATUS_PRESENTATION = {
   failure: {
     badgeVariant: "danger",
+    badgeClassName: "",
     textClassName: "text-destructive-muted",
   },
   neutral: {
     badgeVariant: "secondary",
+    badgeClassName: "",
     textClassName: "text-muted-foreground",
   },
   pending: {
-    badgeVariant: "warning",
-    textClassName: "text-warning-muted",
+    badgeVariant: "secondary",
+    badgeClassName: "bg-info-surface text-info-surface-foreground",
+    textClassName: "text-info-muted",
   },
   success: {
     badgeVariant: "success",
+    badgeClassName: "",
     textClassName: "text-success-muted",
   },
   unknown: {
     badgeVariant: "secondary",
+    badgeClassName: "",
     textClassName: "text-muted-foreground",
   },
 } as const satisfies Record<
   PullRequestReviewAggregateStatus,
   {
-    badgeVariant: "danger" | "secondary" | "success" | "warning";
+    badgeVariant: "danger" | "secondary" | "success";
+    badgeClassName: string;
     textClassName: string;
   }
 >;
@@ -60,7 +66,10 @@ export function TaskExecutionCiChecksList({
             {summaryLabel}
           </span>
         </div>
-        <Badge variant={statusPresentation.badgeVariant} className="shrink-0">
+        <Badge
+          variant={statusPresentation.badgeVariant}
+          className={cn("shrink-0", statusPresentation.badgeClassName)}
+        >
           {aggregateLabel(aggregateStatus)}
         </Badge>
       </summary>

--- a/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/components/layout/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { createQueryClient } from "@/lib/query-client";
 import { pullRequestReviewQueryKeys } from "@/state/queries/pull-request-review";
+import { TaskExecutionCiCheckCard } from "./task-execution-ci-check-card";
 import { TaskExecutionCiChecksPanel } from "./task-execution-ci-checks-panel";
 import { TaskExecutionCiPanelState } from "./task-execution-ci-panel-state";
 import { isBotCommentAuthor } from "./task-execution-ci-presentation";
@@ -122,6 +123,22 @@ const renderPendingPanel = (): string => {
   return renderPanel(queryClient);
 };
 
+const renderCheckCard = (status: "queued" | "in_progress" | "unknown"): string =>
+  renderToStaticMarkup(
+    <TaskExecutionCiCheckCard
+      check={{
+        name: `${status} check`,
+        workflow: "CI",
+        status,
+        conclusion: null,
+        url: null,
+        details: null,
+        startedAt: null,
+        completedAt: null,
+      }}
+    />,
+  );
+
 describe("TaskExecutionCiChecksPanel", () => {
   test("renders a useful loading state while review data is pending", () => {
     const html = renderPanel();
@@ -232,6 +249,21 @@ describe("TaskExecutionCiChecksPanel", () => {
     expect(html).toContain("bg-info-surface");
     expect(html).toContain("text-info-surface-foreground");
     expect(html).toContain("text-info-muted");
+  });
+
+  test("colors only queued and in-progress check rows as informational blue", () => {
+    for (const status of ["queued", "in_progress"] as const) {
+      const html = renderCheckCard(status);
+
+      expect(html).toContain("lucide-clock");
+      expect(html.match(/text-info-muted/g)?.length).toBe(2);
+    }
+
+    const unknownHtml = renderCheckCard("unknown");
+
+    expect(unknownHtml).toContain("lucide-circle-dashed");
+    expect(unknownHtml).toContain("text-muted-foreground");
+    expect(unknownHtml).not.toContain("text-info-muted");
   });
 
   test("classifies common automation authors as bots", () => {

--- a/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
@@ -96,6 +96,32 @@ const renderLoadedPanel = (): string => {
   return renderPanel(queryClient);
 };
 
+const renderPendingPanel = (): string => {
+  const queryClient = createQueryClient();
+  queryClient.setQueryData(pullRequestReviewQueryKeys.context(queryInput), {
+    ...loadedContext,
+    aggregateStatus: "pending",
+    comments: [],
+    checks: [
+      {
+        name: "Unit tests",
+        workflow: "CI",
+        status: "in_progress",
+        conclusion: null,
+        url: "https://github.com/openai/openducktor/actions/runs/1",
+        details: null,
+        startedAt: "2026-07-08T10:00:00Z",
+        completedAt: null,
+      },
+    ],
+    reviewThreads: {
+      openCount: 0,
+    },
+  } satisfies PullRequestReviewContext);
+
+  return renderPanel(queryClient);
+};
+
 describe("TaskExecutionCiChecksPanel", () => {
   test("renders a useful loading state while review data is pending", () => {
     const html = renderPanel();
@@ -196,6 +222,16 @@ describe("TaskExecutionCiChecksPanel", () => {
     expect(html).not.toContain("PR #42");
     expect(html).not.toContain(">GitHub<");
     expect(html).not.toContain("Open pull request #42");
+  });
+
+  test("renders pending check icons and labels as informational blue", () => {
+    const html = renderPendingPanel();
+
+    expect(html).toContain("1 pending");
+    expect(html).toContain("in progress");
+    expect(html).toContain("bg-info-surface");
+    expect(html).toContain("text-info-surface-foreground");
+    expect(html).toContain("text-info-muted");
   });
 
   test("classifies common automation authors as bots", () => {

--- a/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
@@ -123,14 +123,17 @@ const renderPendingPanel = (): string => {
   return renderPanel(queryClient);
 };
 
-const renderCheckCard = (status: "queued" | "in_progress" | "unknown"): string =>
+const renderCheckCard = (
+  status: "queued" | "in_progress" | "unknown",
+  conclusion: "failure" | "success" | null = null,
+): string =>
   renderToStaticMarkup(
     <TaskExecutionCiCheckCard
       check={{
         name: `${status} check`,
         workflow: "CI",
         status,
-        conclusion: null,
+        conclusion,
         url: null,
         details: null,
         startedAt: null,
@@ -259,11 +262,15 @@ describe("TaskExecutionCiChecksPanel", () => {
       expect(html.match(/text-info-muted/g)?.length).toBe(2);
     }
 
-    const unknownHtml = renderCheckCard("unknown");
+    for (const conclusion of [null, "success", "failure"] as const) {
+      const unknownHtml = renderCheckCard("unknown", conclusion);
 
-    expect(unknownHtml).toContain("lucide-circle-dashed");
-    expect(unknownHtml).toContain("text-muted-foreground");
-    expect(unknownHtml).not.toContain("text-info-muted");
+      expect(unknownHtml).toContain("lucide-circle-dashed");
+      expect(unknownHtml).toContain("text-muted-foreground");
+      expect(unknownHtml).not.toContain("text-info-muted");
+      expect(unknownHtml).not.toContain("text-success-muted");
+      expect(unknownHtml).not.toContain("text-destructive-muted");
+    }
   });
 
   test("classifies common automation authors as bots", () => {

--- a/packages/frontend/src/components/features/agents/task-execution-ci-presentation.ts
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-presentation.ts
@@ -26,15 +26,10 @@ export const checkBadgeVariant = (
   if (isPendingCheck(check)) {
     return "info";
   }
-  if (check.conclusion === "success" || check.conclusion === "skipped") {
+  if (isPassingCheck(check)) {
     return "success";
   }
-  if (
-    check.conclusion === "failure" ||
-    check.conclusion === "cancelled" ||
-    check.conclusion === "timed_out" ||
-    check.conclusion === "action_required"
-  ) {
+  if (isFailingCheck(check)) {
     return "danger";
   }
   return "secondary";

--- a/packages/frontend/src/components/features/agents/task-execution-ci-presentation.ts
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-presentation.ts
@@ -22,9 +22,9 @@ export const aggregateLabel = (status: PullRequestReviewAggregateStatus): string
 
 export const checkBadgeVariant = (
   check: PullRequestReviewCheck,
-): "success" | "danger" | "warning" | "secondary" => {
+): "success" | "danger" | "info" | "secondary" => {
   if (check.status !== "completed") {
-    return "warning";
+    return "info";
   }
   if (check.conclusion === "success" || check.conclusion === "skipped") {
     return "success";

--- a/packages/frontend/src/components/features/agents/task-execution-ci-presentation.ts
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-presentation.ts
@@ -23,7 +23,7 @@ export const aggregateLabel = (status: PullRequestReviewAggregateStatus): string
 export const checkBadgeVariant = (
   check: PullRequestReviewCheck,
 ): "success" | "danger" | "info" | "secondary" => {
-  if (check.status !== "completed") {
+  if (isPendingCheck(check)) {
     return "info";
   }
   if (check.conclusion === "success" || check.conclusion === "skipped") {

--- a/packages/frontend/src/components/features/agents/task-execution-ci-tab-indicator.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-tab-indicator.tsx
@@ -16,7 +16,7 @@ const inactiveCiReviewQueryInput = { repoPath: "__inactive_ci_header__" };
 
 const ciCheckStatusDotClassName = {
   failure: "bg-rose-500",
-  pending: "bg-amber-500",
+  pending: "bg-sky-500",
   success: "bg-emerald-500",
 } satisfies Record<CiChecksIndicatorStatus, string>;
 

--- a/packages/frontend/src/components/features/agents/task-execution-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-panel.test.tsx
@@ -466,7 +466,7 @@ describe("TaskExecutionPanel", () => {
         }),
       },
       {
-        expectedClassName: "bg-amber-500",
+        expectedClassName: "bg-sky-500",
         context: createLoadedCiContext({
           checks: [
             {


### PR DESCRIPTION
## Summary

Updates Agent Studio CI check presentation so queued and in-progress checks use blue informational styling instead of warning orange, including the CI status dot in the task execution panel header.

## Goal

Pending CI work previously appeared orange, which suggested a warning or failure even though the checks were simply running. This PR makes active CI states visually informational while preserving success, failure, and unknown semantics.

## Implementation

- Maps queued and in-progress check icons and labels to the existing theme-aware info tokens.
- Uses a sky-blue status dot for pending checks in the task execution panel header.
- Uses shared pending, passing, and failing predicates for individual check presentation so row, aggregate, and header classifications remain consistent.
- Keeps unknown checks neutral for every schema-valid conclusion combination.
- Adds focused rendered-markup coverage for queued, in-progress, and unknown check rows, plus aggregate and header-dot coverage.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Cargo checks: not applicable because this repository contains no `Cargo.toml`.