### PR TITLE
fix(frontend): name the message composer

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -426,6 +426,14 @@ const createClipboardFileItem = (file: File) => ({
 });
 
 describe("AgentChatComposerEditor", () => {
+  test("names the message composer", () => {
+    const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
+
+    expect(screen.getByRole("textbox", { name: "Message composer" })).toBe(
+      getEditorRoot(rendered.container),
+    );
+  });
+
   test("shows the slash-command error state after typing a slash trigger", async () => {
     const rendered = render(
       <EditorHarness slashCommands={COMMANDS} slashCommandsError="Slash commands unavailable." />,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
@@ -506,6 +506,7 @@ export function AgentChatComposerEditor({
       <div
         ref={editorRef}
         role="textbox"
+        aria-label="Message composer"
         aria-multiline="true"
         tabIndex={disabled ? -1 : 0}
         contentEditable={!disabled}


### PR DESCRIPTION
## Summary

- Give the primary rich-text Chat Composer a stable accessible name.
- Add a focused role-and-name regression test that resolves the actual editor root.

## Goal

Screen readers currently encounter the primary contenteditable textbox without an accessible name. This change exposes the exact stable name "Message composer" without coupling it to placeholder, runtime, selected agent, or disabled state.

## Implementation

- Add `aria-label="Message composer"` beside the existing textbox role.
- Preserve the contenteditable root, semantic-element suppression, placeholder, styling, handlers, and interaction behavior.
- Verify the computed accessible role and name through Testing Library and assert the result is the existing editor-root helper result.

## Validation

- React Doctor: 98/100, selected control-label diagnostic absent.
- Focused composer editor suite: 71 passed.
- Format check: passed.
- Typecheck: passed.
- Lint: passed.
- Full workspace tests: passed.
- Full workspace build: passed.
- GitNexus detect_changes: low risk, one changed symbol, zero affected execution flows.

## Review verdicts

- Thermos correctness/security: PASS, no actionable findings.
- Thermos maintainability/code quality: PASS, no actionable findings.
- Code review Standards axis: PASS, 0 findings.
- Code review Spec axis: PASS, 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
