### PR TITLE
fix(frontend): name compact workflow menu

### DIFF
--- a/packages/frontend/src/components/features/kanban/task-workflow-action-group.test.tsx
+++ b/packages/frontend/src/components/features/kanban/task-workflow-action-group.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import {
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "@/pages/agents/agent-studio-test-utils";
+import { TaskWorkflowActionGroup } from "./task-workflow-action-group";
+
+enableReactActEnvironment();
+
+function renderWorkflowActionGroup(compactMenuTrigger = false) {
+  return render(
+    <TaskWorkflowActionGroup
+      task={createTaskCardFixture({
+        status: "in_progress",
+        issueType: "task",
+        availableActions: ["open_builder", "open_qa", "build_start"],
+        documentSummary: {
+          spec: { has: false, updatedAt: undefined },
+          plan: { has: false, updatedAt: undefined },
+          qaReport: { has: true, updatedAt: "2026-03-09T10:00:00.000Z", verdict: "rejected" },
+        },
+      })}
+      onAction={() => {}}
+      compactMenuTrigger={compactMenuTrigger}
+    />,
+  );
+}
+
+describe("TaskWorkflowActionGroup", () => {
+  test("names the compact workflow menu trigger", () => {
+    const { unmount } = renderWorkflowActionGroup(true);
+
+    expect(screen.getByRole("button", { name: "Open workflow actions menu" })).toBeDefined();
+
+    unmount();
+  });
+
+  test("keeps the noncompact workflow menu trigger named More", () => {
+    const { unmount } = renderWorkflowActionGroup();
+
+    expect(screen.getByRole("button", { name: "More" })).toBeDefined();
+
+    unmount();
+  });
+});

--- a/packages/frontend/src/components/features/kanban/task-workflow-action-group.test.tsx
+++ b/packages/frontend/src/components/features/kanban/task-workflow-action-group.test.tsx
@@ -1,15 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { describe, test } from "bun:test";
 import { render, screen } from "@testing-library/react";
-import {
-  createTaskCardFixture,
-  enableReactActEnvironment,
-} from "@/pages/agents/agent-studio-test-utils";
+import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
 import { TaskWorkflowActionGroup } from "./task-workflow-action-group";
 
-enableReactActEnvironment();
-
 function renderWorkflowActionGroup(compactMenuTrigger = false) {
-  return render(
+  render(
     <TaskWorkflowActionGroup
       task={createTaskCardFixture({
         status: "in_progress",
@@ -29,18 +24,14 @@ function renderWorkflowActionGroup(compactMenuTrigger = false) {
 
 describe("TaskWorkflowActionGroup", () => {
   test("names the compact workflow menu trigger", () => {
-    const { unmount } = renderWorkflowActionGroup(true);
+    renderWorkflowActionGroup(true);
 
-    expect(screen.getByRole("button", { name: "Open workflow actions menu" })).toBeDefined();
-
-    unmount();
+    screen.getByRole("button", { name: "Open workflow actions menu" });
   });
 
   test("keeps the noncompact workflow menu trigger named More", () => {
-    const { unmount } = renderWorkflowActionGroup();
+    renderWorkflowActionGroup();
 
-    expect(screen.getByRole("button", { name: "More" })).toBeDefined();
-
-    unmount();
+    screen.getByRole("button", { name: "More" });
   });
 });

--- a/packages/frontend/src/components/features/kanban/task-workflow-action-group.tsx
+++ b/packages/frontend/src/components/features/kanban/task-workflow-action-group.tsx
@@ -120,6 +120,7 @@ export function TaskWorkflowActionGroup({
           <PopoverTrigger asChild>
             <Button
               type="button"
+              aria-label={compactMenuTrigger ? "Open workflow actions menu" : undefined}
               size={size}
               variant="outline"
               className={cn(


### PR DESCRIPTION
## Summary

Name the compact Kanban workflow action trigger for screen readers while preserving the existing noncompact More label.

## Goal

The compact workflow trigger rendered only a decorative chevron, leaving the recurring Kanban action menu without an accessible name. This change implements plan 006 by giving only the compact variant the action-oriented accessible name Open workflow actions menu.

## Implementation

- Add a conditional aria-label at the TaskWorkflowActionGroup button ownership boundary.
- Preserve the existing Shadcn Button and Radix PopoverTrigger composition, styling, ordering, and activation behavior.
- Add focused Testing Library role/name coverage for compact and noncompact modes using the deterministic multi-action task fixture.

## Tests

- bun test packages/frontend/src/components/features/kanban/task-workflow-action-group.test.tsx --max-concurrency=1
- npx -y react-doctor@latest . --diff main --yes — 100/100
- bun run typecheck
- bun run lint
- bun run test — all workspaces green
- bun run build

## Review verdicts

- Thermos correctness/security: CLEAN
- Thermos maintainability/code quality: CLEAN
- Code review Standards axis: PASS — 0 violations, 0 smells
- Code review Spec axis: CLEAN — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)