### PR TITLE
refactor(frontend): break app state import cycle

### DIFF
--- a/packages/frontend/src/state/app-state-contexts.ts
+++ b/packages/frontend/src/state/app-state-contexts.ts
@@ -199,6 +199,9 @@ export const useAgentSessionHistoryLoadContext = (): AgentSessionHistoryLoadCont
 export const useAgentSessionReadModelStateContext = (): AgentSessionReadModelStateContextValue =>
   useRequiredContext(AgentSessionReadModelStateContext, "useAgentSessionReadModelState");
 
+export const useWorkspaceStateContext = (): WorkspaceStateContextValue =>
+  useRequiredContext(WorkspaceStateContext, "useWorkspaceState");
+
 export const useWorkspaceBranchStateContext = (): WorkspaceBranchStateContextValue =>
   useRequiredContext(WorkspaceBranchStateContext, "useWorkspaceBranchState");
 

--- a/packages/frontend/src/state/app-state-provider.test.tsx
+++ b/packages/frontend/src/state/app-state-provider.test.tsx
@@ -6,8 +6,8 @@ import {
   useDelegationState,
   useSpecState,
   useTasksState,
-  useWorkspaceState,
 } from "./app-state-provider";
+import { useWorkspaceState } from "./index";
 
 const HookProbe = ({ hook }: { hook: () => unknown }): ReactElement => {
   hook();

--- a/packages/frontend/src/state/app-state-provider.tsx
+++ b/packages/frontend/src/state/app-state-provider.tsx
@@ -34,7 +34,7 @@ import {
   useRequiredContext,
   useWorkspaceBranchStateContext,
   useWorkspacePresenceContext,
-  WorkspaceStateContext,
+  useWorkspaceStateContext,
 } from "./app-state-contexts";
 import { AgentStudioStateProvider } from "./providers/agent-studio-state-provider";
 import { AppLifecycleStateProvider } from "./providers/app-lifecycle-state-provider";
@@ -87,8 +87,7 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
   );
 }
 
-export const useWorkspaceState = (): WorkspaceStateContextValue =>
-  useRequiredContext(WorkspaceStateContext, "useWorkspaceState");
+export const useWorkspaceState = (): WorkspaceStateContextValue => useWorkspaceStateContext();
 
 export const useWorkspaceBranchState = (): WorkspaceBranchStateContextValue =>
   useWorkspaceBranchStateContext();

--- a/packages/frontend/src/state/providers/autopilot-provider.tsx
+++ b/packages/frontend/src/state/providers/autopilot-provider.tsx
@@ -14,11 +14,11 @@ import {
 } from "@/features/autopilot/autopilot-events";
 import { useSessionStartWorkflowRunner } from "@/features/session-start";
 import { errorMessage } from "@/lib/errors";
-import { useWorkspaceState } from "@/state";
 import {
   useAgentOperationsContext,
   useRuntimeDefinitionsContext,
   useTaskSnapshotContext,
+  useWorkspaceStateContext,
 } from "../app-state-contexts";
 import { loadTaskWorktree } from "../operations/agent-orchestrator/runtime/runtime";
 import { loadAgentSessionListFromQuery } from "../queries/agent-sessions";
@@ -26,7 +26,7 @@ import { settingsSnapshotQueryOptions } from "../queries/workspace";
 
 export function AutopilotProvider({ children }: PropsWithChildren): ReactElement {
   const queryClient = useQueryClient();
-  const { activeWorkspace } = useWorkspaceState();
+  const { activeWorkspace } = useWorkspaceStateContext();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
   const { tasks } = useTaskSnapshotContext();
   const { loadRepoRuntimeCatalog } = useRuntimeDefinitionsContext();


### PR DESCRIPTION
## Summary

- Break the app-state provider import cycle by adding a focused internal `useWorkspaceStateContext` hook.
- Keep the public `useWorkspaceState` barrel API and exact outside-provider error contract unchanged.
- Preserve provider order and all Autopilot event, baseline, settings, and session-start behavior.

## Boundary and import cycle

The previous provider-internal path closed a cycle through `@/state`:

`state/index.ts -> app-state-provider.tsx -> autopilot-provider.tsx -> state/index.ts`

Autopilot now depends inward on `app-state-contexts.ts`, while `App.tsx` and `state/index.ts` remain unchanged:

`state/index.ts -> app-state-provider.tsx -> autopilot-provider.tsx -> app-state-contexts.ts`

GitNexus no longer reports the targeted app-state cycle. Its remaining reported cycles are unrelated pre-existing paths.

## Verification

- `bun test packages/frontend/src/state/app-state-provider.test.tsx --max-concurrency=1`
- `bun run frontend:boundary-guard`
- `bun run --filter @openducktor/frontend typecheck`
- `bun run --filter @openducktor/frontend lint`
- `npx -y react-doctor@latest . --diff main --yes` — 100/100
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- GitNexus `detect_changes` — four changed files, three expected context-read flows

## Review verdicts

- Thermos correctness/security: CLEAN
- Thermos code quality: CLEAN
- Code review Standards axis: CLEAN
- Code review Spec axis against plan 010: CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal access to workspace state across the application.
  * Standardized workspace state usage for automation features without changing user-facing behavior.

* **Tests**
  * Updated state provider tests to use the centralized workspace state access path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->