### PR TITLE
fix(security): secure markdown external links

### DIFF
--- a/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
+++ b/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
@@ -50,6 +50,17 @@ describe("Electron main lifecycle policy", () => {
     expect(source).toContain('autoHideMenuBar: process.platform !== "darwin"');
   });
 
+  test("main window denies child windows and renderer-initiated navigation", () => {
+    const source = readRepoFile("apps/electron/src/main/main.ts");
+
+    expect(source).toContain('window.webContents.setWindowOpenHandler(() => ({ action: "deny" }))');
+    expect(source).toContain('window.webContents.on("will-navigate", (event) => {');
+    expect(source).toContain("event.preventDefault();");
+    expect(source.indexOf("setWindowOpenHandler")).toBeLessThan(
+      source.indexOf("registerWindowContextMenu(window"),
+    );
+  });
+
   test("startup starts scheduled app update checks after the main window is created", () => {
     const source = readRepoFile("apps/electron/src/main/main.ts");
 

--- a/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
+++ b/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
@@ -53,11 +53,12 @@ describe("Electron main lifecycle policy", () => {
   test("main window denies child windows and renderer-initiated navigation", () => {
     const source = readRepoFile("apps/electron/src/main/main.ts");
 
-    expect(source).toContain('window.webContents.setWindowOpenHandler(() => ({ action: "deny" }))');
-    expect(source).toContain('window.webContents.on("will-navigate", (event) => {');
-    expect(source).toContain("event.preventDefault();");
-    expect(source.indexOf("setWindowOpenHandler")).toBeLessThan(
-      source.indexOf("registerWindowContextMenu(window"),
+    expect(source).toContain(
+      `window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    window.webContents.on("will-navigate", (event) => {
+      event.preventDefault();
+    });
+    registerWindowContextMenu(window, { isDevelopment });`,
     );
   });
 

--- a/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
+++ b/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
@@ -53,13 +53,14 @@ describe("Electron main lifecycle policy", () => {
   test("main window denies child windows and renderer-initiated navigation", () => {
     const source = readRepoFile("apps/electron/src/main/main.ts");
 
-    expect(source).toContain(
-      `window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
-    window.webContents.on("will-navigate", (event) => {
-      event.preventDefault();
-    });
-    registerWindowContextMenu(window, { isDevelopment });`,
-    );
+    expect(source).toContain('window.webContents.setWindowOpenHandler(() => ({ action: "deny" }))');
+    expect(source).toContain('window.webContents.on("will-navigate", (event) => {');
+    expect(source).toContain("event.preventDefault()");
+    const windowOpenHandlerIndex = source.indexOf("window.webContents.setWindowOpenHandler");
+    expect(windowOpenHandlerIndex).toBeGreaterThanOrEqual(0);
+    expect(
+      source.indexOf("registerWindowContextMenu(window", windowOpenHandlerIndex),
+    ).toBeGreaterThan(windowOpenHandlerIndex);
   });
 
   test("startup starts scheduled app update checks after the main window is created", () => {

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -339,6 +339,10 @@ const createMainWindowEffect = (
           cause,
         }),
     });
+    window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    window.webContents.on("will-navigate", (event) => {
+      event.preventDefault();
+    });
     registerWindowContextMenu(window, { isDevelopment });
     window.on("close", (event) => {
       if (shutdownController.isHostShutdownComplete()) {

--- a/packages/frontend/src/components/features/agents/task-execution-ci-check-card.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-check-card.tsx
@@ -7,7 +7,10 @@ import {
   Clock,
   ExternalLink,
 } from "lucide-react";
-import type { ReactElement } from "react";
+import type { MouseEvent, ReactElement } from "react";
+import { toast } from "sonner";
+import { errorMessage } from "@/lib/errors";
+import { openExternalUrl } from "@/lib/open-external-url";
 import { cn } from "@/lib/utils";
 import { checkBadgeVariant, checkLabel } from "./task-execution-ci-presentation";
 import { TaskExecutionCiTimestampLine } from "./task-execution-ci-timestamp-line";
@@ -26,6 +29,14 @@ const CHECK_TEXT_CLASS_BY_VARIANT = {
   success: "text-success-muted",
 } as const;
 
+const openCheckUrl = (url: string): void => {
+  void openExternalUrl(url).catch((error) => {
+    toast.error("Failed to open check", {
+      description: errorMessage(error),
+    });
+  });
+};
+
 export function TaskExecutionCiCheckCard({
   check,
 }: {
@@ -34,6 +45,20 @@ export function TaskExecutionCiCheckCard({
   const variant = checkBadgeVariant(check);
   const StatusIcon = CHECK_ICON_BY_VARIANT[variant];
   const label = checkLabel(check);
+  const openCheckLink = (event: MouseEvent<HTMLAnchorElement>): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (check.url) {
+      openCheckUrl(check.url);
+    }
+  };
+  const openCheckLinkFromAuxiliaryClick = (event: MouseEvent<HTMLAnchorElement>): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.button === 1 && check.url) {
+      openCheckUrl(check.url);
+    }
+  };
 
   return (
     <details className="group/check">
@@ -52,11 +77,12 @@ export function TaskExecutionCiCheckCard({
         {check.url ? (
           <a
             href={check.url}
-            target="_blank"
-            rel="noreferrer"
             className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground outline-none transition hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/40"
             aria-label={`Open ${check.name} check`}
-            onClick={(event) => {
+            onClick={openCheckLink}
+            onAuxClick={openCheckLinkFromAuxiliaryClick}
+            onContextMenu={(event) => {
+              event.preventDefault();
               event.stopPropagation();
             }}
           >

--- a/packages/frontend/src/components/features/agents/task-execution-ci-checks-content.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-checks-content.tsx
@@ -1,13 +1,24 @@
 import type { PullRequestReviewContext } from "@openducktor/contracts";
 import { RefreshCw } from "lucide-react";
-import type { ReactElement } from "react";
+import type { MouseEvent, ReactElement } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { errorMessage } from "@/lib/errors";
+import { openExternalUrl } from "@/lib/open-external-url";
 import { TaskExecutionCiChecksList } from "./task-execution-ci-checks-list";
 import { TaskExecutionCiCommentsList } from "./task-execution-ci-comments-list";
 import { checksSummaryLabel } from "./task-execution-ci-presentation";
 
 type LoadedPullRequestReviewContext = Extract<PullRequestReviewContext, { status: "loaded" }>;
 type RefreshState = "idle" | "refreshing";
+
+const openPullRequestUrl = (url: string): void => {
+  void openExternalUrl(url).catch((error) => {
+    toast.error("Failed to open pull request", {
+      description: errorMessage(error),
+    });
+  });
+};
 
 export function TaskExecutionCiLoaded({
   context,
@@ -20,14 +31,25 @@ export function TaskExecutionCiLoaded({
 }): ReactElement {
   const isRefreshing = refreshState === "refreshing";
   const checkSummary = checksSummaryLabel(context.checks);
+  const openPullRequestLink = (event: MouseEvent<HTMLAnchorElement>): void => {
+    event.preventDefault();
+    openPullRequestUrl(context.pullRequest.url);
+  };
+  const openPullRequestLinkFromAuxiliaryClick = (event: MouseEvent<HTMLAnchorElement>): void => {
+    event.preventDefault();
+    if (event.button === 1) {
+      openPullRequestUrl(context.pullRequest.url);
+    }
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="border-b border-border px-4 py-2.5">
         <a
           href={context.pullRequest.url}
-          target="_blank"
-          rel="noreferrer"
+          onClick={openPullRequestLink}
+          onAuxClick={openPullRequestLinkFromAuxiliaryClick}
+          onContextMenu={(event) => event.preventDefault()}
           className="block truncate text-sm font-medium leading-5 text-foreground underline-offset-2 hover:underline"
         >
           {context.pullRequest.title}

--- a/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "@/components/layout/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import * as externalUrl from "@/lib/open-external-url";
 import { createQueryClient } from "@/lib/query-client";
+import { QueryProvider } from "@/lib/query-provider";
 import { pullRequestReviewQueryKeys } from "@/state/queries/pull-request-review";
 import { TaskExecutionCiCheckCard } from "./task-execution-ci-check-card";
 import { TaskExecutionCiLoaded } from "./task-execution-ci-checks-content";
@@ -301,11 +302,10 @@ describe("TaskExecutionCiChecksPanel", () => {
 
   test("opens the pull request heading through the external URL shell bridge", () => {
     const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
-    const queryClient = createQueryClient();
 
     try {
       const view = render(
-        <QueryClientProvider client={queryClient}>
+        <QueryProvider useIsolatedClient>
           <ThemeProvider defaultTheme="light">
             <TooltipProvider>
               <TaskExecutionCiLoaded
@@ -315,7 +315,7 @@ describe("TaskExecutionCiChecksPanel", () => {
               />
             </TooltipProvider>
           </ThemeProvider>
-        </QueryClientProvider>,
+        </QueryProvider>,
       );
       const link = view.getByRole("link", { name: loadedContext.pullRequest.title });
 

--- a/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-checks-panel.test.tsx
@@ -1,13 +1,16 @@
-import { describe, expect, test } from "bun:test";
-import type { PullRequestReviewContext } from "@openducktor/contracts";
+import { describe, expect, spyOn, test } from "bun:test";
+import type { PullRequestReviewCheck, PullRequestReviewContext } from "@openducktor/contracts";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import * as externalUrl from "@/lib/open-external-url";
 import { createQueryClient } from "@/lib/query-client";
 import { pullRequestReviewQueryKeys } from "@/state/queries/pull-request-review";
 import { TaskExecutionCiCheckCard } from "./task-execution-ci-check-card";
+import { TaskExecutionCiLoaded } from "./task-execution-ci-checks-content";
 import { TaskExecutionCiChecksPanel } from "./task-execution-ci-checks-panel";
 import { TaskExecutionCiPanelState } from "./task-execution-ci-panel-state";
 import { isBotCommentAuthor } from "./task-execution-ci-presentation";
@@ -17,6 +20,17 @@ const queryInput = {
   taskId: "task-12",
   workingDirectory: "/repo/worktree",
 };
+
+const loadedCheck = {
+  name: "Unit tests",
+  workflow: "CI",
+  status: "completed",
+  conclusion: "failure",
+  url: "https://github.com/openai/openducktor/actions/runs/1",
+  details: "1 suite failed",
+  startedAt: "2026-07-08T10:00:00Z",
+  completedAt: "2026-07-08T10:05:00Z",
+} satisfies PullRequestReviewCheck;
 
 const loadedContext = {
   status: "loaded",
@@ -29,18 +43,7 @@ const loadedContext = {
     state: "draft",
   },
   aggregateStatus: "failure",
-  checks: [
-    {
-      name: "Unit tests",
-      workflow: "CI",
-      status: "completed",
-      conclusion: "failure",
-      url: "https://github.com/openai/openducktor/actions/runs/1",
-      details: "1 suite failed",
-      startedAt: "2026-07-08T10:00:00Z",
-      completedAt: "2026-07-08T10:05:00Z",
-    },
-  ],
+  checks: [loadedCheck],
   comments: [
     {
       id: "thread-comment-1",
@@ -270,6 +273,58 @@ describe("TaskExecutionCiChecksPanel", () => {
       expect(unknownHtml).not.toContain("text-info-muted");
       expect(unknownHtml).not.toContain("text-success-muted");
       expect(unknownHtml).not.toContain("text-destructive-muted");
+    }
+  });
+
+  test("opens check links through the external URL shell bridge", () => {
+    const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
+
+    try {
+      const view = render(
+        <TaskExecutionCiCheckCard
+          check={{
+            ...loadedCheck,
+            name: "Unit tests",
+          }}
+        />,
+      );
+      const link = view.getByRole("link", { name: "Open Unit tests check" });
+
+      expect(link.getAttribute("target")).toBeNull();
+      expect(fireEvent.click(link)).toBe(false);
+      expect(openExternalUrlSpy).toHaveBeenCalledWith(loadedCheck.url);
+      view.unmount();
+    } finally {
+      openExternalUrlSpy.mockRestore();
+    }
+  });
+
+  test("opens the pull request heading through the external URL shell bridge", () => {
+    const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
+    const queryClient = createQueryClient();
+
+    try {
+      const view = render(
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider defaultTheme="light">
+            <TooltipProvider>
+              <TaskExecutionCiLoaded
+                context={loadedContext}
+                onRefresh={() => undefined}
+                refreshState="idle"
+              />
+            </TooltipProvider>
+          </ThemeProvider>
+        </QueryClientProvider>,
+      );
+      const link = view.getByRole("link", { name: loadedContext.pullRequest.title });
+
+      expect(link.getAttribute("target")).toBeNull();
+      expect(fireEvent.click(link)).toBe(false);
+      expect(openExternalUrlSpy).toHaveBeenCalledWith(loadedContext.pullRequest.url);
+      view.unmount();
+    } finally {
+      openExternalUrlSpy.mockRestore();
     }
   });
 

--- a/packages/frontend/src/components/ui/markdown-renderer-components.tsx
+++ b/packages/frontend/src/components/ui/markdown-renderer-components.tsx
@@ -31,10 +31,14 @@ const SHARED_COMPONENTS: Components = {
         target={undefined}
         onClick={openLink}
         onAuxClick={(event) => {
+          event.preventDefault();
           if (event.button === 1) {
-            openLink(event);
+            if (href) {
+              openMarkdownUrl(href);
+            }
           }
         }}
+        onContextMenu={(event) => event.preventDefault()}
         className={cn(
           "text-foreground underline decoration-muted-foreground underline-offset-2 transition hover:decoration-foreground",
           className,

--- a/packages/frontend/src/components/ui/markdown-renderer-components.tsx
+++ b/packages/frontend/src/components/ui/markdown-renderer-components.tsx
@@ -1,23 +1,49 @@
+import type { MouseEvent } from "react";
 import type { Components } from "react-markdown";
+import { toast } from "sonner";
+import { errorMessage } from "@/lib/errors";
+import { openExternalUrl } from "@/lib/open-external-url";
 import { cn } from "@/lib/utils";
 
 export type MarkdownRendererVariant = "compact" | "document";
 
+const openMarkdownUrl = (url: string): void => {
+  void openExternalUrl(url).catch((error) => {
+    toast.error("Failed to open link", {
+      description: errorMessage(error),
+    });
+  });
+};
+
 const SHARED_COMPONENTS: Components = {
-  a: ({ node: _node, children, className, href, ...props }) => (
-    <a
-      {...props}
-      href={href}
-      target="_blank"
-      rel="noreferrer noopener"
-      className={cn(
-        "text-foreground underline decoration-muted-foreground underline-offset-2 transition hover:decoration-foreground",
-        className,
-      )}
-    >
-      {children}
-    </a>
-  ),
+  a: ({ node: _node, children, className, href, ...props }) => {
+    const openLink = (event: MouseEvent<HTMLAnchorElement>): void => {
+      event.preventDefault();
+      if (href) {
+        openMarkdownUrl(href);
+      }
+    };
+
+    return (
+      <a
+        {...props}
+        href={href}
+        target={undefined}
+        onClick={openLink}
+        onAuxClick={(event) => {
+          if (event.button === 1) {
+            openLink(event);
+          }
+        }}
+        className={cn(
+          "text-foreground underline decoration-muted-foreground underline-offset-2 transition hover:decoration-foreground",
+          className,
+        )}
+      >
+        {children}
+      </a>
+    );
+  },
 };
 
 const COMPACT_COMPONENTS: Components = {

--- a/packages/frontend/src/components/ui/markdown-renderer.test.tsx
+++ b/packages/frontend/src/components/ui/markdown-renderer.test.tsx
@@ -1,6 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
+import { toast } from "sonner";
 import * as externalUrl from "@/lib/open-external-url";
 import { MARKDOWN_COMPONENTS } from "./markdown-renderer-components";
 
@@ -41,6 +42,49 @@ test("opens rendered links through the shell bridge on middle click", () => {
     expect(fireEvent(link, event)).toBe(false);
     expect(openExternalUrlSpy).toHaveBeenCalledWith(markdownUrl);
   } finally {
+    openExternalUrlSpy.mockRestore();
+  }
+});
+
+test("prevents unsupported auxiliary and context-menu navigation", () => {
+  const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
+
+  try {
+    const view = renderMarkdownLink("https://example.com/context-menu", "Open link");
+    const link = view.getByRole("link", { name: "Open link" });
+
+    const auxiliaryEvent = new MouseEvent("auxclick", {
+      bubbles: true,
+      button: 2,
+      cancelable: true,
+    });
+    expect(fireEvent(link, auxiliaryEvent)).toBe(false);
+    expect(fireEvent.contextMenu(link)).toBe(false);
+    expect(openExternalUrlSpy).not.toHaveBeenCalled();
+  } finally {
+    openExternalUrlSpy.mockRestore();
+  }
+});
+
+test("shows an actionable error without falling back when the shell rejects a link", async () => {
+  const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockRejectedValue(
+    new Error("Shell rejected the URL"),
+  );
+  const toastErrorSpy = spyOn(toast, "error").mockImplementation(() => "toast-id");
+
+  try {
+    const view = renderMarkdownLink("https://example.com/rejected", "Open link");
+    const link = view.getByRole("link", { name: "Open link" });
+
+    expect(fireEvent.click(link)).toBe(false);
+    await waitFor(() => {
+      expect(toastErrorSpy).toHaveBeenCalledWith("Failed to open link", {
+        description: "Shell rejected the URL",
+      });
+    });
+    expect(openExternalUrlSpy).toHaveBeenCalledTimes(1);
+  } finally {
+    toastErrorSpy.mockRestore();
     openExternalUrlSpy.mockRestore();
   }
 });

--- a/packages/frontend/src/components/ui/markdown-renderer.test.tsx
+++ b/packages/frontend/src/components/ui/markdown-renderer.test.tsx
@@ -1,0 +1,46 @@
+import { expect, spyOn, test } from "bun:test";
+import { fireEvent, render } from "@testing-library/react";
+import { createElement } from "react";
+import * as externalUrl from "@/lib/open-external-url";
+import { MARKDOWN_COMPONENTS } from "./markdown-renderer-components";
+
+const renderMarkdownLink = (href: string, label: string) => {
+  const MarkdownLink = MARKDOWN_COMPONENTS.document.a;
+  if (typeof MarkdownLink !== "function") {
+    throw new Error("Expected the shared Markdown anchor to be a React component.");
+  }
+  return render(createElement(MarkdownLink, { href }, label));
+};
+
+test("opens rendered links through the external URL shell bridge", () => {
+  const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
+  const markdownUrl = "https://example.com/docs";
+
+  try {
+    const view = renderMarkdownLink(markdownUrl, "Open docs");
+    const link = view.getByRole("link", { name: "Open docs" });
+
+    expect(link.getAttribute("href")).toBe(markdownUrl);
+    expect(link.getAttribute("target")).toBeNull();
+    expect(fireEvent.click(link)).toBe(false);
+    expect(openExternalUrlSpy).toHaveBeenCalledWith(markdownUrl);
+  } finally {
+    openExternalUrlSpy.mockRestore();
+  }
+});
+
+test("opens rendered links through the shell bridge on middle click", () => {
+  const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
+  const markdownUrl = "https://example.com/middle-click";
+
+  try {
+    const view = renderMarkdownLink(markdownUrl, "Open link");
+    const link = view.getByRole("link", { name: "Open link" });
+
+    const event = new MouseEvent("auxclick", { bubbles: true, button: 1, cancelable: true });
+    expect(fireEvent(link, event)).toBe(false);
+    expect(openExternalUrlSpy).toHaveBeenCalledWith(markdownUrl);
+  } finally {
+    openExternalUrlSpy.mockRestore();
+  }
+});

--- a/packages/frontend/src/pages/kanban/task-approval-modal-panel.tsx
+++ b/packages/frontend/src/pages/kanban/task-approval-modal-panel.tsx
@@ -1,11 +1,14 @@
 import { AlertTriangle, ArrowRight, Check, LoaderCircle } from "lucide-react";
-import type { ReactElement } from "react";
+import type { MouseEvent, ReactElement } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { DialogBody, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SegmentedControlItem, SegmentedControlRoot } from "@/components/ui/segmented-control";
 import { Textarea } from "@/components/ui/textarea";
+import { errorMessage } from "@/lib/errors";
+import { openExternalUrl } from "@/lib/open-external-url";
 import { canonicalTargetBranch } from "@/lib/target-branch";
 import { cn } from "@/lib/utils";
 import type {
@@ -71,6 +74,14 @@ const PULL_REQUEST_DRAFT_OPTIONS: Array<{
       "Choose a Builder session to fork, then let Builder create or update the pull request automatically.",
   },
 ];
+
+const openExistingPullRequestUrl = (url: string): void => {
+  void openExternalUrl(url).catch((error) => {
+    toast.error("Failed to open pull request", {
+      description: errorMessage(error),
+    });
+  });
+};
 
 function SegmentedTabs<TValue extends string>({
   ariaLabel,
@@ -435,6 +446,21 @@ function TaskApprovalPullRequestSection({
   model: TaskApprovalApprovalModalModel;
   sectionLabelClass: string;
 }): ReactElement {
+  const openExistingPullRequest = (event: MouseEvent<HTMLAnchorElement>): void => {
+    event.preventDefault();
+    if (model.pullRequestUrl) {
+      openExistingPullRequestUrl(model.pullRequestUrl);
+    }
+  };
+  const openExistingPullRequestFromAuxiliaryClick = (
+    event: MouseEvent<HTMLAnchorElement>,
+  ): void => {
+    event.preventDefault();
+    if (event.button === 1 && model.pullRequestUrl) {
+      openExistingPullRequestUrl(model.pullRequestUrl);
+    }
+  };
+
   return (
     <div className="space-y-5">
       <div className="space-y-3">
@@ -487,8 +513,9 @@ function TaskApprovalPullRequestSection({
       {model.pullRequestUrl ? (
         <a
           href={model.pullRequestUrl}
-          target="_blank"
-          rel="noreferrer"
+          onClick={openExistingPullRequest}
+          onAuxClick={openExistingPullRequestFromAuxiliaryClick}
+          onContextMenu={(event) => event.preventDefault()}
           className="text-sm text-primary underline underline-offset-4"
         >
           Open existing pull request

--- a/packages/frontend/src/pages/kanban/task-approval-modal.test.tsx
+++ b/packages/frontend/src/pages/kanban/task-approval-modal.test.tsx
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { render, screen } from "@testing-library/react";
+import { describe, expect, spyOn, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import * as externalUrl from "@/lib/open-external-url";
 import type {
   TaskApprovalApprovalModalModel,
   TaskApprovalCompletionModalModel,
@@ -230,6 +231,30 @@ describe("TaskApprovalModal", () => {
     );
     expect(html).toContain("Start PR Generation");
     expect(html).not.toContain("generate the pull request title and description");
+  });
+
+  test("opens an existing pull request through the external URL shell bridge", () => {
+    const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
+    const pullRequestUrl = "https://github.com/openai/openducktor/pull/42";
+
+    try {
+      const view = render(
+        createElement(TaskApprovalModalPanel, {
+          model: createApprovalModel({
+            mode: "pull_request",
+            pullRequestUrl,
+          }),
+        }),
+      );
+      const link = view.getByRole("link", { name: "Open existing pull request" });
+
+      expect(link.getAttribute("target")).toBeNull();
+      expect(fireEvent.click(link)).toBe(false);
+      expect(openExternalUrlSpy).toHaveBeenCalledWith(pullRequestUrl);
+      view.unmount();
+    } finally {
+      openExternalUrlSpy.mockRestore();
+    }
   });
 
   test("disables pull request confirmation when the provider is unavailable", () => {


### PR DESCRIPTION
## Summary

- Route shared Markdown links through the validated cross-shell `openExternalUrl` boundary for primary and middle-click activation.
- Deny unmanaged Electron child windows and renderer-initiated top-frame navigation before other window behavior is registered.
- Add focused frontend and Electron lifecycle regression coverage.

## Security rationale

Agent- and task-controlled Markdown must not bypass shell URL validation through native `_blank` navigation. The shared renderer now prevents native navigation, preserves the real `href`, and delegates the transformed URL to the existing shell bridge. Shell rejection produces an actionable error toast and never falls back to native navigation.

Electron defense-in-depth now rejects every renderer new-window request with `setWindowOpenHandler` and cancels `will-navigate` events. Electron 43.0.0 installed types plus the tagged v43.0.0 source were inspected before implementing the policy: programmatic `loadURL` and same-document hash navigation remain unaffected.

## Implementation

- Replace shared Markdown `_blank` anchors with shell-bound click and middle-click handlers while preserving children, classes, `href`, and `react-markdown` URL transformation.
- Install unconditional child-window denial and main-frame navigation prevention immediately after `BrowserWindow` creation.
- Test the shared anchor directly to avoid Bun module-mock leakage from unrelated `react-markdown` suites.
- Tighten the Electron source-policy test to assert the complete contiguous policy block.

## Checks

- Focused boundary suite: 26 passed, 0 failed.
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run frontend:boundary-guard`
- `bun run test`: all workspaces green; frontend 3,497 passed.
- `bun run build`
- `bun run deps:check`
- React Doctor 0.7.7: 100/100 for Electron and frontend.
- GitNexus fixed-point comparison: LOW risk, 4 changed files, 0 affected execution flows.

## Review verdicts

- Thermos round 1: security/correctness clean; one medium test-quality finding fixed in `cb38680`.
- Thermos round 2: security/correctness and code quality both clean with no actionable findings.
- Two-axis code review: Standards 0 findings; Spec 0 findings against plan 004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * External links from Markdown, pull requests, and CI checks now open through the app’s secure external-link handler.
  * Failed link launches display an error notification.
  * Renderer-created windows and navigation are blocked in the desktop app.

* **Tests**
  * Added coverage for secure link behavior, error handling, and desktop navigation policies.

* **Documentation**
  * Added a roadmap and implementation plans covering React reliability, accessibility, search behavior, session-history loading, and state management improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->