### PR TITLE
fix(frontend): make composer refs commit-safe

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-autofocus.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-autofocus.test.ts
@@ -116,6 +116,32 @@ describe("resolveComposerAutofocus", () => {
     expect(result.nextState).toEqual(focusedResult.nextState);
   });
 
+  test("focuses each newly displayed session once", () => {
+    const firstSessionResult = resolveComposerAutofocus(createComposerAutofocusState(), {
+      displayedSessionKey: "session-1",
+      isComposerInteractive: true,
+      activeElement: document.body,
+      focusInsideComposer: false,
+    });
+    const secondSessionResult = resolveComposerAutofocus(firstSessionResult.nextState, {
+      displayedSessionKey: "session-2",
+      isComposerInteractive: true,
+      activeElement: document.body,
+      focusInsideComposer: false,
+    });
+    const secondSessionRerenderResult = resolveComposerAutofocus(secondSessionResult.nextState, {
+      displayedSessionKey: "session-2",
+      isComposerInteractive: true,
+      activeElement: document.createElement("button"),
+      focusInsideComposer: false,
+    });
+
+    expect(firstSessionResult.shouldFocus).toBe(true);
+    expect(secondSessionResult.shouldFocus).toBe(true);
+    expect(secondSessionRerenderResult.shouldFocus).toBe(false);
+    expect(secondSessionRerenderResult.nextState).toEqual(secondSessionResult.nextState);
+  });
+
   test("clears pending autofocus when no session is displayed", () => {
     const pendingResult = resolveComposerAutofocus(createComposerAutofocusState(), {
       displayedSessionKey: "session-1",

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -213,8 +213,13 @@ const EditorHarness = ({
     initialDraft,
   );
   const draft = controlledDraft ?? localDraft;
-  const handleDraftChange =
-    controlledDraft === undefined ? setDraft : (onDraftChange ?? (() => {}));
+  let handleDraftChange = setDraft;
+  if (controlledDraft !== undefined) {
+    if (!onDraftChange) {
+      throw new Error("Controlled EditorHarness requires onDraftChange.");
+    }
+    handleDraftChange = onDraftChange;
+  }
   const editorRef = useRef<HTMLDivElement>(null);
 
   return (

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -184,6 +184,8 @@ const EditorHarness = ({
   searchFiles = async () => [],
   onSend,
   initialDraft = createComposerDraft(""),
+  draft: controlledDraft,
+  onDraftChange,
   disabled = false,
   onAddFiles,
 }: {
@@ -201,20 +203,25 @@ const EditorHarness = ({
   searchFiles?: (query: string) => Promise<ReturnType<typeof buildFileSearchResult>[]>;
   onSend?: () => void;
   initialDraft?: AgentChatComposerDraft;
+  draft?: AgentChatComposerDraft;
+  onDraftChange?: (draft: AgentChatComposerDraft) => void;
   disabled?: boolean;
   onAddFiles?: (files: File[]) => void;
 }): ReactElement => {
-  const [draft, setDraft] = useReducer(
+  const [localDraft, setDraft] = useReducer(
     (_current: AgentChatComposerDraft, next: AgentChatComposerDraft) => next,
     initialDraft,
   );
+  const draft = controlledDraft ?? localDraft;
+  const handleDraftChange =
+    controlledDraft === undefined ? setDraft : (onDraftChange ?? (() => {}));
   const editorRef = useRef<HTMLDivElement>(null);
 
   return (
     <>
       <AgentChatComposerEditor
         draft={draft}
-        onDraftChange={setDraft}
+        onDraftChange={handleDraftChange}
         placeholder="Type a message"
         disabled={disabled}
         editorRef={editorRef}
@@ -613,6 +620,62 @@ describe("AgentChatComposerEditor", () => {
       const editable = rendered.container.querySelector("[data-text-segment-id]");
       expect(editable?.textContent).toBe("abc");
     });
+  });
+
+  test("edits the latest draft supplied by a parent rerender", async () => {
+    const onDraftChange = mock((_draft: AgentChatComposerDraft) => {});
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        draft={createComposerDraft("before")}
+        onDraftChange={onDraftChange}
+      />,
+    );
+
+    rendered.rerender(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        draft={createComposerDraft("after")}
+        onDraftChange={onDraftChange}
+      />,
+    );
+    await expectComposerText(rendered.container, "after");
+
+    const editable = getLastTextSegment(rendered.container);
+    selectTextSegmentRange(editable, 5, 5);
+    fireEvent.keyDown(editable, { key: "Enter", shiftKey: true });
+
+    expect(onDraftChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        segments: [expect.objectContaining({ text: "after\n" })],
+      }),
+    );
+  });
+
+  test("composes sequential local edits before the parent commits", async () => {
+    const onDraftChange = mock((_draft: AgentChatComposerDraft) => {});
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        draft={createComposerDraft("hello")}
+        onDraftChange={onDraftChange}
+      />,
+    );
+    await expectComposerText(rendered.container, "hello");
+
+    const editable = getLastTextSegment(rendered.container);
+    selectTextSegmentRange(editable, 5, 5);
+    fireEvent.keyDown(editable, { key: "Enter", shiftKey: true });
+    fireEvent.keyDown(editable, { key: "Enter", shiftKey: true });
+
+    expect(onDraftChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        segments: [expect.objectContaining({ text: "hello\n\n" })],
+      }),
+    );
   });
 
   test("does not rebuild composer markup for unchanged draft segments", async () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-selection.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-selection.test.ts
@@ -88,6 +88,37 @@ describe("agent-chat-composer-selection", () => {
     expect(range?.endOffset).toBe((textNode.textContent ?? "").length);
   });
 
+  test("keeps the caret attached when focusing triggers re-entrant selection repair", () => {
+    const element = createSelectionHost();
+    element.textContent = "hello";
+    const root = element.parentElement;
+    if (!root) {
+      throw new Error("Expected contenteditable root");
+    }
+
+    let isRepairingSelection = false;
+    root.focus = () => {
+      if (isRepairingSelection) {
+        return;
+      }
+      isRepairingSelection = true;
+      selectionModule.setCaretOffsetWithinElement(element, 0);
+    };
+
+    selectionModule.setCaretOffsetWithinElement(element, 5);
+
+    const selection = globalThis.getSelection?.();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    const currentTextNode = element.firstChild;
+    expect(currentTextNode).toBeInstanceOf(Text);
+    if (!(currentTextNode instanceof Text)) {
+      throw new Error("Expected composer text node");
+    }
+    expect(range?.endContainer).toBe(currentTextNode);
+    expect(element.contains(range?.endContainer ?? null)).toBe(true);
+    expect(range?.endOffset).toBe(5);
+  });
+
   test("places the caret on empty text segments next to chips without adding sentinel text", () => {
     const root = document.createElement("div");
     root.setAttribute("contenteditable", "true");

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-selection.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-selection.ts
@@ -98,6 +98,7 @@ export const setCaretOffsetWithinElement = (element: HTMLElement, logicalOffset:
     return;
   }
 
+  focusEditableTarget(element);
   const textNode = normalizeEditableTextNode(element);
 
   const textContent = textNode.textContent ?? "";
@@ -113,7 +114,6 @@ export const setCaretOffsetWithinElement = (element: HTMLElement, logicalOffset:
   } else if (shouldPlaceCaretAfterTrailingSentinel) {
     domOffset = textContent.length;
   }
-  focusEditableTarget(element);
   const range = ownerDocument.createRange();
   range.setStart(textNode, domOffset);
   range.collapse(true);

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -453,7 +453,6 @@ function useAgentChatComposerFocus({
   if (composerAutofocusStateRef.current === null) {
     composerAutofocusStateRef.current = createComposerAutofocusState();
   }
-  const composerAutofocusState = composerAutofocusStateRef.current;
 
   const focusComposerEditor = useCallback(() => {
     const editor = composerEditorRef.current;
@@ -498,6 +497,11 @@ function useAgentChatComposerFocus({
   );
 
   useLayoutEffect(() => {
+    const composerAutofocusState = composerAutofocusStateRef.current;
+    if (composerAutofocusState === null) {
+      throw new Error("Composer autofocus state was not initialized.");
+    }
+
     const isComposerInteractive = !isComposerInputDisabled && !isSubmitting;
     const activeElement = globalThis.document?.activeElement ?? null;
     const focusInsideComposer = isFocusInsideComposer(activeElement);
@@ -518,7 +522,6 @@ function useAgentChatComposerFocus({
     isFocusInsideComposer,
     isSubmitting,
     scheduleComposerFocus,
-    composerAutofocusState,
   ]);
 
   return scheduleComposerFocus;
@@ -677,9 +680,11 @@ export function AgentChatComposer({
     !hasComposerSendContent(draft, pendingInlineCommentCount) ||
     !isInteractionEnabled;
 
-  latestDraftRef.current = draft;
-  latestOnSendRef.current = onSend;
-  latestSendDisabledRef.current = sendDisabled;
+  useLayoutEffect(() => {
+    latestDraftRef.current = draft;
+    latestOnSendRef.current = onSend;
+    latestSendDisabledRef.current = sendDisabled;
+  }, [draft, onSend, sendDisabled]);
 
   useLayoutEffect(() => {
     if (previousAttachmentLayoutKeyRef.current === attachmentLayoutKey) {

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.test.ts
@@ -69,20 +69,23 @@ describe("useAgentChatComposerDraftState", () => {
     const storage = createMemoryStorage();
     setAgentChatDraftStorageForTests(storage);
     const harness = await mountHarness();
+    const stableCommitDraft = harness.getLatest().commitDraft;
 
-    await harness.run((value) => {
-      value.commitDraft(buildDraft("same session"));
-    });
     await harness.update({
       draftStateKey: "composer-key",
       persistenceIdentity: identity,
       taskId: "task-2",
     });
+    await harness.run(() => {
+      stableCommitDraft(buildDraft("rehydrated task"));
+    });
     await flushAgentChatDraft(identity);
 
     const raw = storage.getItem(toAgentChatDraftStorageKey(identity));
     expect(raw).not.toBeNull();
-    expect(JSON.parse(raw ?? "{}")).toEqual(expect.objectContaining({ taskId: "task-2" }));
+    expect(JSON.parse(raw ?? "{}")).toEqual(
+      expect.objectContaining({ taskId: "task-2", draft: buildDraft("rehydrated task") }),
+    );
     await harness.unmount();
   });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-draft-state.ts
@@ -85,7 +85,9 @@ export function useAgentChatComposerDraftState({
   const latestStateRef = useRef(state);
   const nextStateKey = toComposerDraftStateKey(draftStateKey, persistenceIdentity);
 
-  latestStateRef.current = state;
+  useLayoutEffect(() => {
+    latestStateRef.current = state;
+  }, [state]);
 
   useLayoutEffect(() => {
     const current = latestStateRef.current;

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -12,6 +12,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type RefObject,
   useCallback,
+  useLayoutEffect,
   useRef,
 } from "react";
 import {
@@ -96,7 +97,9 @@ export const useAgentChatComposerEditor = ({
 }: UseAgentChatComposerEditorArgs): UseAgentChatComposerEditorResult => {
   const latestDraftRef = useRef(draft);
 
-  latestDraftRef.current = draft;
+  useLayoutEffect(() => {
+    latestDraftRef.current = draft;
+  }, [draft]);
 
   const selection = useAgentChatComposerEditorSelection({ editorRef });
   const {

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
@@ -451,7 +451,7 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     const upsertedRecords: unknown[] = [];
-    let storedSession = persistedSessionFixture;
+    let storedSession = structuredClone(persistedSessionFixture);
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
@@ -442,8 +442,6 @@ describe("use-agent-orchestrator-operations session state", () => {
   });
 
   test("persists explicit session model updates through the orchestrator commit boundary", async () => {
-    const originalAgentSessionsList = host.agentSessionsList;
-    const originalAgentSessionUpsert = host.agentSessionUpsert;
     const originalSpecGet = host.specGet;
     const originalPlanGet = host.planGet;
     const originalQaGetReport = host.qaGetReport;
@@ -453,10 +451,7 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     const upsertedRecords: unknown[] = [];
-    host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
-      upsertedRecords.push(record);
-    };
+    let storedSession = persistedSessionFixture;
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
@@ -477,9 +472,14 @@ describe("use-agent-orchestrator-operations session state", () => {
       refreshTaskData: async () => {},
       dependencies: createTestDependencies(
         {
+          agentSessionsList: async () => [storedSession],
           agentSessionsListForTasks: async () => [
-            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+            { taskId: "task-1", agentSessions: [storedSession] },
           ],
+          agentSessionUpsert: async (_repoPath, _taskId, record) => {
+            upsertedRecords.push(record);
+            storedSession = record;
+          },
         },
         {},
         liveStream.portOverrides,
@@ -522,8 +522,6 @@ describe("use-agent-orchestrator-operations session state", () => {
       ]);
     } finally {
       await harness.unmount();
-      host.agentSessionsList = originalAgentSessionsList;
-      host.agentSessionUpsert = originalAgentSessionUpsert;
       host.specGet = originalSpecGet;
       host.planGet = originalPlanGet;
       host.qaGetReport = originalQaGetReport;


### PR DESCRIPTION
## Summary

Make Agent Studio composer ref synchronization commit-safe so stable handlers cannot observe values from abandoned React renders.

## Goal

The composer used render-phase ref writes for draft, submit, editor, draft persistence, and autofocus state. Under replayed or discarded renders, later event handlers could observe values that never committed.

## Technical choices

- Move render-derived latest-value synchronization into layout effects.
- Preserve immediate event-phase draft writes needed for sequential editor operations before the next parent commit.
- Read autofocus state only inside the autofocus layout effect while retaining supported lazy initialization.
- Add focused regression coverage for autofocus, task rehydration, rerendered drafts, and sequential editor edits.
- Make the controlled editor test harness fail with an actionable invariant rather than silently ignoring draft changes.

## Validation

- Focused composer tests: 82 passed
- Frontend suite: 3,498 passed
- Repository tests: passed
- Typecheck: passed
- Lint: passed
- Format check: passed
- Build: passed
- React Doctor: 100/100
- GitNexus: LOW risk, no affected execution flows
- Manual browser validation was not run because no user-started browser backend was available.

## Reviews

- Thermos correctness/security: CLEAN
- Thermos code quality: CLEAN
- Code review Standards: CLEAN after fixing one hard test-harness finding
- Code review Spec: CLEAN, zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent chat composer autofocus so each newly displayed session is focused once without repeated focus on rerenders.
  * Improved caret placement and selection stability when focusing the composer.
  * Ensured draft and session updates remain current during editing, sending, restoration, and persistence.

* **Tests**
  * Added coverage for autofocus, controlled drafts, caret selection, draft rehydration, and session persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->