### PR TITLE
fix(frontend): purify live transcript overlay updates

### DIFF
--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -7,6 +7,7 @@ import type {
   RepoConfig,
 } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
 import { createAgentSessionsStore } from "@/state/agent-sessions-store";
 import { type AgentSessionReadPort, agentSessionQueryKeys } from "@/state/queries/agent-sessions";
 import { workspaceQueryKeys } from "@/state/queries/workspace";
@@ -73,6 +74,7 @@ const createState = (
   const sessionStore = createAgentSessionsStore("/repo");
   let listener: ((payload: AgentSessionLiveEnvelope) => void) | null = null;
   const callOrder: string[] = [];
+  const unsubscribe = mock(() => undefined);
   const observeAgentSessionLive = mock(
     async (
       _input: { repoPath: string },
@@ -81,7 +83,7 @@ const createState = (
       callOrder.push("observe");
       listener = nextListener;
       duringObservation(nextListener, observeAgentSessionLive.mock.calls.length);
-      return mock(() => undefined);
+      return unsubscribe;
     },
   );
   const agentSessionLiveReplyApproval = mock(
@@ -123,6 +125,7 @@ const createState = (
     harness: createHookHarness(useRepoSessionReadModel, props),
     props,
     observeAgentSessionLive,
+    unsubscribe,
     agentSessionLiveReplyApproval,
     recoverTranscriptGap,
     transcriptEvents,
@@ -214,7 +217,7 @@ describe("useRepoSessionReadModel", () => {
     }
   });
 
-  test("uses refreshed stream callbacks without restarting repository observation", async () => {
+  test("keeps the active observation stable when stream callbacks refresh", async () => {
     const state = createState((emit) => {
       emit({ type: "snapshot", repoPath: "/repo", sessions: [snapshot()] });
     });
@@ -271,11 +274,53 @@ describe("useRepoSessionReadModel", () => {
     expect(refreshedTranscriptEvents.close).toHaveBeenCalledTimes(1);
   });
 
+  test("uses the latest observe callback when stream identity changes", async () => {
+    const state = createState((emit) => {
+      emit({ type: "snapshot", repoPath: "/repo", sessions: [snapshot()] });
+    });
+    const secondUnsubscribe = mock(() => undefined);
+    const secondObserveAgentSessionLive = mock(
+      async (
+        _input: { repoPath: string },
+        listener: (payload: AgentSessionLiveEnvelope) => void,
+      ) => {
+        listener({ type: "snapshot", repoPath: "/repo", sessions: [snapshot()] });
+        return secondUnsubscribe;
+      },
+    );
+    const refreshedProps = {
+      ...state.props,
+      liveSessionPort: {
+        ...state.props.liveSessionPort,
+        observeAgentSessionLive: secondObserveAgentSessionLive,
+      },
+    };
+
+    try {
+      await state.harness.mount();
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "ready");
+
+      await state.harness.update(refreshedProps);
+      expect(state.observeAgentSessionLive).toHaveBeenCalledTimes(1);
+      expect(secondObserveAgentSessionLive).not.toHaveBeenCalled();
+      expect(state.unsubscribe).not.toHaveBeenCalled();
+
+      await state.harness.update({ ...refreshedProps, workspaceRepoPath: null });
+      expect(state.unsubscribe).toHaveBeenCalledTimes(1);
+
+      await state.harness.update(refreshedProps);
+      await state.harness.waitFor(() => secondObserveAgentSessionLive.mock.calls.length === 1);
+    } finally {
+      await state.harness.unmount();
+    }
+
+    expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   test("unsubscribes exactly once when repository observation resolves after unmount", async () => {
     const state = createState(() => undefined);
     const deferredObservation = createDeferred<() => void>();
-    const unsubscribed = createDeferred<void>();
-    const unsubscribe = mock(() => unsubscribed.resolve(undefined));
+    const unsubscribe = mock(() => undefined);
     const observeAgentSessionLive = mock(async () => deferredObservation.promise);
     state.props.liveSessionPort.observeAgentSessionLive = observeAgentSessionLive;
 
@@ -285,9 +330,7 @@ describe("useRepoSessionReadModel", () => {
 
     expect(unsubscribe).not.toHaveBeenCalled();
     deferredObservation.resolve(unsubscribe);
-    await unsubscribed.promise;
-
-    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(unsubscribe).toHaveBeenCalledTimes(1), { timeout: 1_000 });
   });
 
   test("derives the waiting counter from the same initial snapshot collection commit", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -27,7 +27,7 @@ const record: AgentSessionRecord = {
   selectedModel: null,
 };
 
-const readOnlyRepoConfig: RepoConfig = {
+const createReadOnlyRepoConfig = (): RepoConfig => ({
   workspaceId: "/repo",
   workspaceName: "Repo",
   repoPath: "/repo",
@@ -46,7 +46,7 @@ const readOnlyRepoConfig: RepoConfig = {
   },
   worktreeCopyPaths: [],
   agentDefaults: {},
-};
+});
 
 const createDeferred = <T,>() => {
   let resolve!: (value: T) => void;
@@ -260,7 +260,7 @@ describe("useRepoSessionReadModel", () => {
       });
 
       expect(state.observeAgentSessionLive).toHaveBeenCalledTimes(1);
-      expect(state.transcriptEvents.close).not.toHaveBeenCalled();
+      expect(state.transcriptEvents.close).toHaveBeenCalledTimes(1);
 
       await state.harness.run(async () => {
         state.emit({
@@ -291,7 +291,7 @@ describe("useRepoSessionReadModel", () => {
       await state.harness.unmount();
     }
 
-    expect(state.transcriptEvents.close).not.toHaveBeenCalled();
+    expect(state.transcriptEvents.close).toHaveBeenCalledTimes(1);
     expect(refreshedTranscriptEvents.close).toHaveBeenCalledTimes(1);
   });
 
@@ -361,7 +361,10 @@ describe("useRepoSessionReadModel", () => {
         agentSessionLiveReplyApproval: refreshedReplyApproval,
       },
     };
-    state.queryClient.setQueryData(workspaceQueryKeys.repoConfig("/repo"), readOnlyRepoConfig);
+    state.queryClient.setQueryData(
+      workspaceQueryKeys.repoConfig("/repo"),
+      createReadOnlyRepoConfig(),
+    );
     state.queryClient.setQueryData(
       workspaceQueryKeys.settingsSnapshot(),
       createSettingsSnapshotFixture(),
@@ -381,7 +384,7 @@ describe("useRepoSessionReadModel", () => {
         });
       });
       await waitFor(() => expect(refreshedReplyApproval).toHaveBeenCalledTimes(1), {
-        timeout: 1_000,
+        timeout: 750,
       });
 
       expect(state.agentSessionLiveReplyApproval).not.toHaveBeenCalled();
@@ -416,7 +419,7 @@ describe("useRepoSessionReadModel", () => {
       expect(unsubscribe).not.toHaveBeenCalled();
       deferredObservation.resolve(unsubscribe);
       observationResolved = true;
-      await waitFor(() => expect(unsubscribe).toHaveBeenCalledTimes(1), { timeout: 1_000 });
+      await waitFor(() => expect(unsubscribe).toHaveBeenCalledTimes(1), { timeout: 750 });
     } finally {
       try {
         if (!harnessUnmounted) {
@@ -777,7 +780,10 @@ describe("useRepoSessionReadModel", () => {
       },
       { ...record, role: "spec" },
     );
-    state.queryClient.setQueryData(workspaceQueryKeys.repoConfig("/repo"), readOnlyRepoConfig);
+    state.queryClient.setQueryData(
+      workspaceQueryKeys.repoConfig("/repo"),
+      createReadOnlyRepoConfig(),
+    );
     state.queryClient.setQueryData(
       workspaceQueryKeys.settingsSnapshot(),
       createSettingsSnapshotFixture(),

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -214,6 +214,82 @@ describe("useRepoSessionReadModel", () => {
     }
   });
 
+  test("uses refreshed stream callbacks without restarting repository observation", async () => {
+    const state = createState((emit) => {
+      emit({ type: "snapshot", repoPath: "/repo", sessions: [snapshot()] });
+    });
+    const refreshedTranscriptEvents: AgentSessionTranscriptEventConsumer = {
+      handle: mock(() => undefined),
+      close: mock(() => undefined),
+    };
+    const refreshedRecoverTranscriptGap = mock(async (_message: string) => undefined);
+
+    try {
+      await state.harness.mount();
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "ready");
+
+      await state.harness.update({
+        ...state.props,
+        liveSessionPort: { ...state.props.liveSessionPort },
+        transcriptEvents: refreshedTranscriptEvents,
+        recoverTranscriptGap: refreshedRecoverTranscriptGap,
+      });
+
+      expect(state.observeAgentSessionLive).toHaveBeenCalledTimes(1);
+      expect(state.transcriptEvents.close).not.toHaveBeenCalled();
+
+      await state.harness.run(async () => {
+        state.emit({
+          type: "transcript_event",
+          event: {
+            type: "assistant_message",
+            externalSessionId: record.externalSessionId,
+            messageId: "message-after-callback-refresh",
+            message: "Still streaming",
+            timestamp: "2026-07-17T14:00:00.000Z",
+            sessionRef: snapshot().ref,
+          },
+        });
+        state.emit({
+          type: "transcript_gap",
+          repoPath: "/repo",
+          message: "Refresh history with the latest callback.",
+        });
+      });
+
+      expect(state.transcriptEvents.handle).not.toHaveBeenCalled();
+      expect(refreshedTranscriptEvents.handle).toHaveBeenCalledTimes(1);
+      expect(state.recoverTranscriptGap).not.toHaveBeenCalled();
+      expect(refreshedRecoverTranscriptGap).toHaveBeenCalledWith(
+        "Refresh history with the latest callback.",
+      );
+    } finally {
+      await state.harness.unmount();
+    }
+
+    expect(state.transcriptEvents.close).not.toHaveBeenCalled();
+    expect(refreshedTranscriptEvents.close).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribes exactly once when repository observation resolves after unmount", async () => {
+    const state = createState(() => undefined);
+    const deferredObservation = createDeferred<() => void>();
+    const unsubscribed = createDeferred<void>();
+    const unsubscribe = mock(() => unsubscribed.resolve(undefined));
+    const observeAgentSessionLive = mock(async () => deferredObservation.promise);
+    state.props.liveSessionPort.observeAgentSessionLive = observeAgentSessionLive;
+
+    await state.harness.mount();
+    await state.harness.waitFor(() => observeAgentSessionLive.mock.calls.length === 1);
+    await state.harness.unmount();
+
+    expect(unsubscribe).not.toHaveBeenCalled();
+    deferredObservation.resolve(unsubscribe);
+    await unsubscribed.promise;
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   test("derives the waiting counter from the same initial snapshot collection commit", async () => {
     const records = [
       record,

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -27,6 +27,27 @@ const record: AgentSessionRecord = {
   selectedModel: null,
 };
 
+const readOnlyRepoConfig: RepoConfig = {
+  workspaceId: "/repo",
+  workspaceName: "Repo",
+  repoPath: "/repo",
+  defaultRuntimeKind: "codex",
+  branchPrefix: "odt/",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  git: { providers: {} },
+  hooks: { preStart: [], postComplete: [] },
+  devServers: [],
+  promptOverrides: {
+    "permission.read_only.reject": {
+      template: "Custom read-only rejection for {{role}}.",
+      baseVersion: 1,
+      enabled: true,
+    },
+  },
+  worktreeCopyPaths: [],
+  agentDefaults: {},
+};
+
 const createDeferred = <T,>() => {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -315,6 +336,66 @@ describe("useRepoSessionReadModel", () => {
     }
 
     expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses the latest approval reply callback without restarting observation", async () => {
+    const mutatingApproval = {
+      requestId: "latest-mutating",
+      requestType: "file_change" as const,
+      title: "Edit file",
+      mutation: "mutating" as const,
+    };
+    const state = createState(
+      (emit) => {
+        emit({ type: "snapshot", repoPath: "/repo", sessions: [snapshot()] });
+      },
+      { ...record, role: "spec" },
+    );
+    const refreshedReplyApproval = mock(
+      async (_input: AgentSessionLiveReplyApprovalInput) => undefined,
+    );
+    const refreshedProps = {
+      ...state.props,
+      liveSessionPort: {
+        ...state.props.liveSessionPort,
+        agentSessionLiveReplyApproval: refreshedReplyApproval,
+      },
+    };
+    state.queryClient.setQueryData(workspaceQueryKeys.repoConfig("/repo"), readOnlyRepoConfig);
+    state.queryClient.setQueryData(
+      workspaceQueryKeys.settingsSnapshot(),
+      createSettingsSnapshotFixture(),
+    );
+
+    try {
+      await state.harness.mount();
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "ready");
+
+      await state.harness.update(refreshedProps);
+      expect(state.observeAgentSessionLive).toHaveBeenCalledTimes(1);
+
+      await state.harness.run(async () => {
+        state.emit({
+          type: "session_upsert",
+          session: snapshot({ pendingApprovals: [mutatingApproval] }),
+        });
+      });
+      await waitFor(() => expect(refreshedReplyApproval).toHaveBeenCalledTimes(1), {
+        timeout: 1_000,
+      });
+
+      expect(state.agentSessionLiveReplyApproval).not.toHaveBeenCalled();
+      expect(refreshedReplyApproval).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: "latest-mutating",
+          outcome: "reject",
+          message: "Custom read-only rejection for spec.",
+        }),
+      );
+      expect(state.observeAgentSessionLive).toHaveBeenCalledTimes(1);
+    } finally {
+      await state.harness.unmount();
+    }
   });
 
   test("unsubscribes exactly once when repository observation resolves after unmount", async () => {
@@ -680,27 +761,7 @@ describe("useRepoSessionReadModel", () => {
       },
       { ...record, role: "spec" },
     );
-    const repoConfig: RepoConfig = {
-      workspaceId: "/repo",
-      workspaceName: "Repo",
-      repoPath: "/repo",
-      defaultRuntimeKind: "codex",
-      branchPrefix: "odt/",
-      defaultTargetBranch: { remote: "origin", branch: "main" },
-      git: { providers: {} },
-      hooks: { preStart: [], postComplete: [] },
-      devServers: [],
-      promptOverrides: {
-        "permission.read_only.reject": {
-          template: "Custom read-only rejection for {{role}}.",
-          baseVersion: 1,
-          enabled: true,
-        },
-      },
-      worktreeCopyPaths: [],
-      agentDefaults: {},
-    };
-    state.queryClient.setQueryData(workspaceQueryKeys.repoConfig("/repo"), repoConfig);
+    state.queryClient.setQueryData(workspaceQueryKeys.repoConfig("/repo"), readOnlyRepoConfig);
     state.queryClient.setQueryData(
       workspaceQueryKeys.settingsSnapshot(),
       createSettingsSnapshotFixture(),

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -404,14 +404,30 @@ describe("useRepoSessionReadModel", () => {
     const unsubscribe = mock(() => undefined);
     const observeAgentSessionLive = mock(async () => deferredObservation.promise);
     state.props.liveSessionPort.observeAgentSessionLive = observeAgentSessionLive;
+    let observationResolved = false;
+    let harnessUnmounted = false;
 
-    await state.harness.mount();
-    await state.harness.waitFor(() => observeAgentSessionLive.mock.calls.length === 1);
-    await state.harness.unmount();
+    try {
+      await state.harness.mount();
+      await state.harness.waitFor(() => observeAgentSessionLive.mock.calls.length === 1);
+      await state.harness.unmount();
+      harnessUnmounted = true;
 
-    expect(unsubscribe).not.toHaveBeenCalled();
-    deferredObservation.resolve(unsubscribe);
-    await waitFor(() => expect(unsubscribe).toHaveBeenCalledTimes(1), { timeout: 1_000 });
+      expect(unsubscribe).not.toHaveBeenCalled();
+      deferredObservation.resolve(unsubscribe);
+      observationResolved = true;
+      await waitFor(() => expect(unsubscribe).toHaveBeenCalledTimes(1), { timeout: 1_000 });
+    } finally {
+      try {
+        if (!harnessUnmounted) {
+          await state.harness.unmount();
+        }
+      } finally {
+        if (!observationResolved) {
+          deferredObservation.resolve(unsubscribe);
+        }
+      }
+    }
   });
 
   test("derives the waiting counter from the same initial snapshot collection commit", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -119,7 +119,7 @@ const createState = (
     close: mock(() => undefined),
   };
   const recoverTranscriptGap = mock(async (_message: string) => undefined);
-  const props = {
+  const props: Parameters<typeof useRepoSessionReadModel>[0] = {
     workspaceRepoPath: "/repo",
     taskIds: ["task-1"],
     isLoadingTasks: false,

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
@@ -3,7 +3,7 @@ import { buildReadOnlyPermissionRejectionMessage } from "@openducktor/core";
 import type { HostClient } from "@openducktor/host-client";
 import type { QueryClient } from "@tanstack/react-query";
 import type { MutableRefObject } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { errorMessage } from "@/lib/errors";
 import type { AgentSessionsStore } from "@/state/agent-sessions-store";
 import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
@@ -75,9 +75,26 @@ export const useRepoSessionReadModel = ({
   const [sessionReadModelLoadState, setSessionReadModelLoadState] =
     useState<AgentSessionReadModelLoadState>(unavailableAgentSessionReadModelLoadState);
   const [reloadGeneration, setReloadGeneration] = useState(0);
-  const latestReloadGenerationRef = useRef(reloadGeneration);
   const retryAttemptRef = useRef(0);
-  latestReloadGenerationRef.current = reloadGeneration;
+  const readReloadGeneration = useEffectEvent(() => reloadGeneration);
+  const observeLiveSessions = useEffectEvent(
+    (
+      input: Parameters<AgentSessionLiveFrontendPort["observeAgentSessionLive"]>[0],
+      listener: Parameters<AgentSessionLiveFrontendPort["observeAgentSessionLive"]>[1],
+    ) => liveSessionPort.observeAgentSessionLive(input, listener),
+  );
+  const replyLiveApproval = useEffectEvent(
+    (input: Parameters<AgentSessionLiveFrontendPort["agentSessionLiveReplyApproval"]>[0]) =>
+      liveSessionPort.agentSessionLiveReplyApproval(input),
+  );
+  const handleTranscriptEvent = useEffectEvent(
+    (event: Parameters<AgentSessionTranscriptEventConsumer["handle"]>[0]) =>
+      transcriptEvents.handle(event),
+  );
+  const closeTranscriptEvents = useEffectEvent(() => transcriptEvents.close());
+  const recoverTranscriptHistory = useEffectEvent((message: string) =>
+    recoverTranscriptGap(message),
+  );
   const reloadSessionReadModel = useCallback(() => {
     const retryAttempt = retryAttemptRef.current + 1;
     retryAttemptRef.current = retryAttempt;
@@ -207,7 +224,7 @@ export const useRepoSessionReadModel = ({
       return current.records;
     };
     const isStaleRepoOperation = (): boolean =>
-      cancelled || isRepoStale() || latestReloadGenerationRef.current !== effectReloadGeneration;
+      cancelled || isRepoStale() || readReloadGeneration() !== effectReloadGeneration;
     const failObservation = (message: string): void => {
       if (!isStaleRepoOperation()) {
         setSessionReadModelLoadState(failedAgentSessionReadModelLoadState(repoPath, message));
@@ -222,7 +239,7 @@ export const useRepoSessionReadModel = ({
         runOrchestratorSideEffect(
           "agent-session-live-auto-reject-mutating-approval",
           promptOverrides.then((overrides) =>
-            liveSessionPort.agentSessionLiveReplyApproval({
+            replyLiveApproval({
               ...action.input,
               message: buildReadOnlyPermissionRejectionMessage({
                 role: action.role,
@@ -299,11 +316,11 @@ export const useRepoSessionReadModel = ({
         return;
       }
       if (envelope.type === "transcript_event") {
-        transcriptEvents.handle(envelope.event);
+        handleTranscriptEvent(envelope.event);
         return;
       }
       if (envelope.type === "transcript_gap") {
-        void recoverTranscriptGap(envelope.message).catch((error: unknown) => {
+        void recoverTranscriptHistory(envelope.message).catch((error: unknown) => {
           failObservation(
             `Failed to recover transcript history after a live-stream gap: ${errorMessage(error)}`,
           );
@@ -346,13 +363,12 @@ export const useRepoSessionReadModel = ({
     observedRepoPathRef.current = repoPath;
     // react-doctor-disable-next-line react-doctor/no-adjust-state-on-prop-change, react-doctor/no-derived-state
     setSessionReadModelLoadState(loadingAgentSessionReadModelLoadState(repoPath));
-    void liveSessionPort
-      .observeAgentSessionLive({ repoPath }, (envelope) => {
-        if (isStaleRepoOperation()) {
-          return;
-        }
-        applyEnvelope(envelope);
-      })
+    void observeLiveSessions({ repoPath }, (envelope) => {
+      if (isStaleRepoOperation()) {
+        return;
+      }
+      applyEnvelope(envelope);
+    })
       .then((stopObserving) => {
         if (isStaleRepoOperation()) {
           stopObserving();
@@ -372,18 +388,15 @@ export const useRepoSessionReadModel = ({
         observedRepoPathRef.current = null;
       }
       unsubscribe?.();
-      transcriptEvents.close();
+      closeTranscriptEvents();
     };
   }, [
     canObserveRepo,
     commitSessionCollection,
     currentWorkspaceRepoPathRef,
-    liveSessionPort,
     queryClient,
-    recoverTranscriptGap,
     reloadGeneration,
     repoEpochRef,
-    transcriptEvents,
     workspaceRepoPath,
   ]);
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
@@ -91,7 +91,6 @@ export const useRepoSessionReadModel = ({
     (event: Parameters<AgentSessionTranscriptEventConsumer["handle"]>[0]) =>
       transcriptEvents.handle(event),
   );
-  const closeTranscriptEvents = useEffectEvent(() => transcriptEvents.close());
   const recoverTranscriptHistory = useEffectEvent((message: string) =>
     recoverTranscriptGap(message),
   );
@@ -198,6 +197,23 @@ export const useRepoSessionReadModel = ({
       result: undefined,
     }));
   }, [commitSessionCollection, taskSessionRecordsState, workspaceRepoPath]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Consumer cleanup must match every live-stream restart as well as consumer replacement.
+  useEffect(() => {
+    if (!workspaceRepoPath || !canObserveRepo) {
+      return;
+    }
+    return () => transcriptEvents.close();
+  }, [
+    canObserveRepo,
+    commitSessionCollection,
+    currentWorkspaceRepoPathRef,
+    queryClient,
+    reloadGeneration,
+    repoEpochRef,
+    transcriptEvents,
+    workspaceRepoPath,
+  ]);
 
   // Owns the async stream lifecycle; its loading state is not render-derived.
   // react-doctor-disable-next-line react-doctor/no-derived-state-effect
@@ -388,7 +404,6 @@ export const useRepoSessionReadModel = ({
         observedRepoPathRef.current = null;
       }
       unsubscribe?.();
-      closeTranscriptEvents();
     };
   }, [
     canObserveRepo,


### PR DESCRIPTION
## Summary

- Keep live transcript event-stream state local while making state and ref commits atomic and value-based.
- Use React Effect Events for callback freshness without restarting the active runtime subscription.
- Add focused coverage for projected refreshes, back-to-back live/history updates, callback churn, refreshed reply callbacks, and late unsubscribe cleanup.

## Goal

Implement plan 002 by removing render-phase ref writes and callback-driven observer churn from the live transcript overlay without introducing retries, fallbacks, persistence changes, or a competing server-state cache.

## Validation

- bun run format:check
- bun run typecheck
- bun run lint
- focused transcript overlay/session-history tests: 22 passed
- bun run --filter @openducktor/frontend test: 3501 passed
- bun run test: passed across all workspaces
- bun run build
- React Doctor: 84/100, no diagnostics for the changed files
- GitNexus detect_changes: low risk, 2 files, 32 symbols, 0 affected processes
- Thermos correctness and maintainability reviews: clean
- Code review Standards and Spec axes: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)