### PR TITLE
fix(frontend): wire composer autocomplete as a combobox

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -469,6 +469,13 @@ describe("AgentChatComposerEditor", () => {
       { timeout: COMPOSER_WAIT_TIMEOUT_MS },
     );
 
+    await waitFor(
+      () => {
+        expect(resolveSearch).not.toBeNull();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
+
     if (!resolveSearch) {
       throw new Error("Expected file search to be pending");
     }

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -426,12 +426,162 @@ const createClipboardFileItem = (file: File) => ({
 });
 
 describe("AgentChatComposerEditor", () => {
-  test("names the message composer", () => {
-    const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
+  test("exposes the rich editor as a collapsed named combobox", () => {
+    render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
 
-    expect(screen.getByRole("textbox", { name: "Message composer" })).toBe(
-      getEditorRoot(rendered.container),
+    const editor = screen.getByRole("combobox", { name: "Message composer" });
+
+    expect(editor.getAttribute("contenteditable")).toBe("true");
+    expect(editor.getAttribute("aria-expanded")).toBe("false");
+    expect(editor.getAttribute("aria-autocomplete")).toBe("list");
+    expect(editor.getAttribute("aria-controls")).toBeNull();
+    expect(editor.getAttribute("aria-activedescendant")).toBeNull();
+    expect(editor.getAttribute("aria-multiline")).toBeNull();
+  });
+
+  test("owns reference popup state while focus stays on the editor", async () => {
+    let resolveSearch: ((results: AgentFileSearchResult[]) => void) | null = null;
+    const searchFiles = mock(
+      () =>
+        new Promise<AgentFileSearchResult[]>((resolve) => {
+          resolveSearch = resolve;
+        }),
     );
+    const onSend = mock(() => {});
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        searchFiles={searchFiles}
+        onSend={onSend}
+      />,
+    );
+    const editor = screen.getByRole("combobox", { name: "Message composer" });
+    editor.focus();
+
+    typeIntoEditor(rendered.container, "@");
+
+    await waitFor(() => {
+      expect(editor.getAttribute("aria-expanded")).toBe("false");
+      expect(screen.queryByRole("listbox", { name: "References" })).toBeNull();
+    });
+
+    if (!resolveSearch) {
+      throw new Error("Expected file search to be pending");
+    }
+    const finishSearch = resolveSearch as (results: AgentFileSearchResult[]) => void;
+    finishSearch([
+      buildFileSearchResult({ id: "alpha", path: "src/alpha.ts", name: "alpha.ts" }),
+      buildFileSearchResult({ id: "beta", path: "src/beta.ts", name: "beta.ts" }),
+    ]);
+
+    const listbox = await screen.findByRole("listbox", { name: "References" });
+    const firstOption = screen.getByRole("option", { name: /alpha\.ts/i });
+    const secondOption = screen.getByRole("option", { name: /beta\.ts/i });
+    expect(editor.getAttribute("aria-expanded")).toBe("true");
+    expect(editor.getAttribute("aria-controls")).toBe(listbox.id);
+    expect(editor.getAttribute("aria-activedescendant")).toBe(firstOption.id);
+    expect(document.activeElement).toBe(editor);
+
+    fireEvent.keyDown(editor, { key: "ArrowDown" });
+
+    await waitFor(() => {
+      expect(editor.getAttribute("aria-activedescendant")).toBe(secondOption.id);
+      expect(secondOption.getAttribute("aria-selected")).toBe("true");
+    });
+    expect(document.activeElement).toBe(editor);
+
+    fireEvent.keyDown(editor, { key: "Tab" });
+
+    await waitFor(() => {
+      expect(
+        rendered.container.querySelector("[data-file-reference-path='src/beta.ts']"),
+      ).toBeTruthy();
+      expect(editor.getAttribute("aria-expanded")).toBe("false");
+      expect(editor.getAttribute("aria-controls")).toBeNull();
+      expect(editor.getAttribute("aria-activedescendant")).toBeNull();
+    });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(editor);
+  });
+
+  test("owns slash popup state through escape and enter selection", async () => {
+    const onSend = mock(() => {});
+    const rendered = render(
+      <EditorHarness slashCommands={COMMANDS} slashCommandsError={null} onSend={onSend} />,
+    );
+    const editor = screen.getByRole("combobox", { name: "Message composer" });
+    editor.focus();
+
+    typeIntoEditor(rendered.container, "/");
+
+    const initialListbox = await screen.findByRole("listbox", { name: "Slash commands" });
+    const initialOption = screen.getByRole("option", { name: /compact the current session/i });
+    expect(editor.getAttribute("aria-controls")).toBe(initialListbox.id);
+    expect(editor.getAttribute("aria-activedescendant")).toBe(initialOption.id);
+    expect(document.activeElement).toBe(editor);
+
+    fireEvent.keyDown(editor, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox", { name: "Slash commands" })).toBeNull();
+      expect(editor.getAttribute("aria-expanded")).toBe("false");
+      expect(editor.getAttribute("aria-controls")).toBeNull();
+      expect(editor.getAttribute("aria-activedescendant")).toBeNull();
+    });
+
+    typeIntoEditor(rendered.container, "/c");
+    await screen.findByRole("listbox", { name: "Slash commands" });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(rendered.container.querySelector("[data-chip-segment-id]")?.textContent).toContain(
+        "/compact",
+      );
+      expect(editor.getAttribute("aria-expanded")).toBe("false");
+    });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(editor);
+  });
+
+  test("owns skill popup selection through arrow navigation and tab acceptance", async () => {
+    const onSend = mock(() => {});
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        supportsSkillReferences={true}
+        skills={SKILLS}
+        onSend={onSend}
+      />,
+    );
+    const editor = screen.getByRole("combobox", { name: "Message composer" });
+    editor.focus();
+
+    typeIntoEditor(rendered.container, "$");
+
+    const listbox = await screen.findByRole("listbox", { name: "Skills" });
+    const firstOption = screen.getByRole("option", { name: /analyze/i });
+    const secondOption = screen.getByRole("option", { name: /review/i });
+    expect(editor.getAttribute("aria-controls")).toBe(listbox.id);
+    expect(editor.getAttribute("aria-activedescendant")).toBe(firstOption.id);
+
+    fireEvent.keyDown(editor, { key: "ArrowDown" });
+
+    await waitFor(() => {
+      expect(editor.getAttribute("aria-activedescendant")).toBe(secondOption.id);
+      expect(secondOption.getAttribute("aria-selected")).toBe("true");
+    });
+    fireEvent.keyDown(editor, { key: "Tab" });
+
+    await waitFor(() => {
+      expect(rendered.container.querySelector("[data-skill-reference-name='review']")).toBeTruthy();
+      expect(editor.getAttribute("aria-expanded")).toBe("false");
+      expect(editor.getAttribute("aria-controls")).toBeNull();
+      expect(editor.getAttribute("aria-activedescendant")).toBeNull();
+    });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(editor);
   });
 
   test("shows the slash-command error state after typing a slash trigger", async () => {
@@ -506,7 +656,7 @@ describe("AgentChatComposerEditor", () => {
       expect(screen.getByText("$analyze")).toBeDefined();
     });
     const skillButtons = screen
-      .getAllByRole("button")
+      .getAllByRole("option")
       .filter((button) => button.textContent?.startsWith("$"));
     expect(
       skillButtons.map((button) => button.querySelector(".text-foreground")?.textContent),
@@ -555,12 +705,12 @@ describe("AgentChatComposerEditor", () => {
 
     const editable = typeIntoEditor(rendered.container, "$");
 
-    await screen.findByRole("button", { name: /\$review/i });
+    await screen.findByRole("option", { name: /\$review/i });
 
     fireEvent.keyDown(editable, { key: "Enter", shiftKey: true });
 
     await waitFor(() => {
-      expect(screen.queryByRole("button", { name: /\$review/i })).toBeNull();
+      expect(screen.queryByRole("option", { name: /\$review/i })).toBeNull();
     });
   });
 
@@ -576,7 +726,7 @@ describe("AgentChatComposerEditor", () => {
 
     typeIntoEditor(rendered.container, "$");
 
-    await screen.findByRole("button", { name: /\$review/i });
+    await screen.findByRole("option", { name: /\$review/i });
 
     fireEvent.paste(getEditorRoot(rendered.container), {
       clipboardData: createClipboardData({
@@ -585,7 +735,7 @@ describe("AgentChatComposerEditor", () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByRole("button", { name: /\$review/i })).toBeNull();
+      expect(screen.queryByRole("option", { name: /\$review/i })).toBeNull();
     });
   });
 
@@ -597,7 +747,7 @@ describe("AgentChatComposerEditor", () => {
 
     typeIntoEditor(rendered.container, "/");
 
-    const commandButton = await screen.findByRole("button", {
+    const commandButton = await screen.findByRole("option", {
       name: /compact the current session/i,
     });
 
@@ -618,7 +768,7 @@ describe("AgentChatComposerEditor", () => {
     fireEvent.keyUp(editable, { key: "/" });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /compact the current session/i })).toBeDefined();
+      expect(screen.getByRole("option", { name: /compact the current session/i })).toBeDefined();
     });
   });
 
@@ -1072,7 +1222,7 @@ describe("AgentChatComposerEditor", () => {
     fireEvent.keyUp(editable, { key: "/" });
 
     await waitFor(() => {
-      expect(screen.queryByRole("button", { name: /compact the current session/i })).toBeNull();
+      expect(screen.queryByRole("option", { name: /compact the current session/i })).toBeNull();
     });
   });
 
@@ -1697,7 +1847,7 @@ describe("AgentChatComposerEditor", () => {
     fireEvent.keyUp(editable, { key: "/" });
     await waitFor(
       () => {
-        expect(screen.getByRole("button", { name: /compact the current session/i })).toBeDefined();
+        expect(screen.getByRole("option", { name: /compact the current session/i })).toBeDefined();
       },
       { timeout: COMPOSER_WAIT_TIMEOUT_MS },
     );
@@ -1723,7 +1873,7 @@ describe("AgentChatComposerEditor", () => {
     const editable = typeIntoEditor(rendered.container, "/");
     await waitFor(
       () => {
-        expect(screen.getByRole("button", { name: /compact the current session/i })).toBeDefined();
+        expect(screen.getByRole("option", { name: /compact the current session/i })).toBeDefined();
       },
       { timeout: COMPOSER_WAIT_TIMEOUT_MS },
     );
@@ -1773,7 +1923,7 @@ describe("AgentChatComposerEditor", () => {
     const editable = typeIntoEditor(rendered.container, "/");
     await waitFor(
       () => {
-        expect(screen.getByRole("button", { name: /compact the current session/i })).toBeDefined();
+        expect(screen.getByRole("option", { name: /compact the current session/i })).toBeDefined();
       },
       { timeout: COMPOSER_WAIT_TIMEOUT_MS },
     );
@@ -1817,7 +1967,7 @@ describe("AgentChatComposerEditor", () => {
     fireEvent.keyUp(editorRoot, { key: "a" });
 
     expect(setCaretOffsetWithinElementMock).not.toHaveBeenCalled();
-    expect(screen.queryByRole("button", { name: /compact the current session/i })).toBeNull();
+    expect(screen.queryByRole("option", { name: /compact the current session/i })).toBeNull();
   });
 
   test("renders empty trailing text segments as inline blocks for caret placement after file chips", async () => {
@@ -2366,7 +2516,7 @@ describe("AgentChatComposerEditor", () => {
 
     const editable = typeIntoEditor(rendered.container, "check $");
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /analyze/i })).toBeDefined();
+      expect(screen.getByRole("option", { name: /analyze/i })).toBeDefined();
     });
     fireEvent.keyDown(editable, { key: "Enter" });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -461,10 +461,13 @@ describe("AgentChatComposerEditor", () => {
 
     typeIntoEditor(rendered.container, "@");
 
-    await waitFor(() => {
-      expect(editor.getAttribute("aria-expanded")).toBe("false");
-      expect(screen.queryByRole("listbox", { name: "References" })).toBeNull();
-    });
+    await waitFor(
+      () => {
+        expect(editor.getAttribute("aria-expanded")).toBe("false");
+        expect(screen.queryByRole("listbox", { name: "References" })).toBeNull();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
 
     if (!resolveSearch) {
       throw new Error("Expected file search to be pending");
@@ -475,7 +478,13 @@ describe("AgentChatComposerEditor", () => {
       buildFileSearchResult({ id: "beta", path: "src/beta.ts", name: "beta.ts" }),
     ]);
 
-    const listbox = await screen.findByRole("listbox", { name: "References" });
+    await waitFor(
+      () => {
+        expect(screen.getByRole("listbox", { name: "References" })).toBeDefined();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
+    const listbox = screen.getByRole("listbox", { name: "References" });
     const firstOption = screen.getByRole("option", { name: /alpha\.ts/i });
     const secondOption = screen.getByRole("option", { name: /beta\.ts/i });
     expect(editor.getAttribute("aria-expanded")).toBe("true");
@@ -485,22 +494,28 @@ describe("AgentChatComposerEditor", () => {
 
     fireEvent.keyDown(editor, { key: "ArrowDown" });
 
-    await waitFor(() => {
-      expect(editor.getAttribute("aria-activedescendant")).toBe(secondOption.id);
-      expect(secondOption.getAttribute("aria-selected")).toBe("true");
-    });
+    await waitFor(
+      () => {
+        expect(editor.getAttribute("aria-activedescendant")).toBe(secondOption.id);
+        expect(secondOption.getAttribute("aria-selected")).toBe("true");
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
     expect(document.activeElement).toBe(editor);
 
     fireEvent.keyDown(editor, { key: "Tab" });
 
-    await waitFor(() => {
-      expect(
-        rendered.container.querySelector("[data-file-reference-path='src/beta.ts']"),
-      ).toBeTruthy();
-      expect(editor.getAttribute("aria-expanded")).toBe("false");
-      expect(editor.getAttribute("aria-controls")).toBeNull();
-      expect(editor.getAttribute("aria-activedescendant")).toBeNull();
-    });
+    await waitFor(
+      () => {
+        expect(
+          rendered.container.querySelector("[data-file-reference-path='src/beta.ts']"),
+        ).toBeTruthy();
+        expect(editor.getAttribute("aria-expanded")).toBe("false");
+        expect(editor.getAttribute("aria-controls")).toBeNull();
+        expect(editor.getAttribute("aria-activedescendant")).toBeNull();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
     expect(onSend).not.toHaveBeenCalled();
     expect(document.activeElement).toBe(editor);
   });
@@ -515,7 +530,13 @@ describe("AgentChatComposerEditor", () => {
 
     typeIntoEditor(rendered.container, "/");
 
-    const initialListbox = await screen.findByRole("listbox", { name: "Slash commands" });
+    await waitFor(
+      () => {
+        expect(screen.getByRole("listbox", { name: "Slash commands" })).toBeDefined();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
+    const initialListbox = screen.getByRole("listbox", { name: "Slash commands" });
     const initialOption = screen.getByRole("option", { name: /compact the current session/i });
     expect(editor.getAttribute("aria-controls")).toBe(initialListbox.id);
     expect(editor.getAttribute("aria-activedescendant")).toBe(initialOption.id);
@@ -523,23 +544,34 @@ describe("AgentChatComposerEditor", () => {
 
     fireEvent.keyDown(editor, { key: "Escape" });
 
-    await waitFor(() => {
-      expect(screen.queryByRole("listbox", { name: "Slash commands" })).toBeNull();
-      expect(editor.getAttribute("aria-expanded")).toBe("false");
-      expect(editor.getAttribute("aria-controls")).toBeNull();
-      expect(editor.getAttribute("aria-activedescendant")).toBeNull();
-    });
+    await waitFor(
+      () => {
+        expect(screen.queryByRole("listbox", { name: "Slash commands" })).toBeNull();
+        expect(editor.getAttribute("aria-expanded")).toBe("false");
+        expect(editor.getAttribute("aria-controls")).toBeNull();
+        expect(editor.getAttribute("aria-activedescendant")).toBeNull();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
 
     typeIntoEditor(rendered.container, "/c");
-    await screen.findByRole("listbox", { name: "Slash commands" });
+    await waitFor(
+      () => {
+        expect(screen.getByRole("listbox", { name: "Slash commands" })).toBeDefined();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
     fireEvent.keyDown(editor, { key: "Enter" });
 
-    await waitFor(() => {
-      expect(rendered.container.querySelector("[data-chip-segment-id]")?.textContent).toContain(
-        "/compact",
-      );
-      expect(editor.getAttribute("aria-expanded")).toBe("false");
-    });
+    await waitFor(
+      () => {
+        expect(rendered.container.querySelector("[data-chip-segment-id]")?.textContent).toContain(
+          "/compact",
+        );
+        expect(editor.getAttribute("aria-expanded")).toBe("false");
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
     expect(onSend).not.toHaveBeenCalled();
     expect(document.activeElement).toBe(editor);
   });
@@ -560,7 +592,13 @@ describe("AgentChatComposerEditor", () => {
 
     typeIntoEditor(rendered.container, "$");
 
-    const listbox = await screen.findByRole("listbox", { name: "Skills" });
+    await waitFor(
+      () => {
+        expect(screen.getByRole("listbox", { name: "Skills" })).toBeDefined();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
+    const listbox = screen.getByRole("listbox", { name: "Skills" });
     const firstOption = screen.getByRole("option", { name: /analyze/i });
     const secondOption = screen.getByRole("option", { name: /review/i });
     expect(editor.getAttribute("aria-controls")).toBe(listbox.id);
@@ -568,18 +606,26 @@ describe("AgentChatComposerEditor", () => {
 
     fireEvent.keyDown(editor, { key: "ArrowDown" });
 
-    await waitFor(() => {
-      expect(editor.getAttribute("aria-activedescendant")).toBe(secondOption.id);
-      expect(secondOption.getAttribute("aria-selected")).toBe("true");
-    });
+    await waitFor(
+      () => {
+        expect(editor.getAttribute("aria-activedescendant")).toBe(secondOption.id);
+        expect(secondOption.getAttribute("aria-selected")).toBe("true");
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
     fireEvent.keyDown(editor, { key: "Tab" });
 
-    await waitFor(() => {
-      expect(rendered.container.querySelector("[data-skill-reference-name='review']")).toBeTruthy();
-      expect(editor.getAttribute("aria-expanded")).toBe("false");
-      expect(editor.getAttribute("aria-controls")).toBeNull();
-      expect(editor.getAttribute("aria-activedescendant")).toBeNull();
-    });
+    await waitFor(
+      () => {
+        expect(
+          rendered.container.querySelector("[data-skill-reference-name='review']"),
+        ).toBeTruthy();
+        expect(editor.getAttribute("aria-expanded")).toBe("false");
+        expect(editor.getAttribute("aria-controls")).toBeNull();
+        expect(editor.getAttribute("aria-activedescendant")).toBeNull();
+      },
+      { timeout: COMPOSER_WAIT_TIMEOUT_MS },
+    );
     expect(onSend).not.toHaveBeenCalled();
     expect(document.activeElement).toBe(editor);
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
@@ -12,7 +12,10 @@ import {
   type AgentChatComposerDraft,
   draftHasMeaningfulContent,
 } from "./agent-chat-composer-draft";
-import { shouldRenderAgentChatComposerReferenceMenu } from "./agent-chat-composer-menu-state";
+import {
+  getComposerPopupOptionId,
+  shouldRenderAgentChatComposerReferenceMenu,
+} from "./agent-chat-composer-menu-state";
 import { AgentChatComposerReferenceMenu } from "./agent-chat-composer-reference-menu";
 import {
   readEditableTextContent,
@@ -112,7 +115,7 @@ const buildActiveComposerPopup = (
 
   return {
     listboxId,
-    activeOptionId: `${listboxId}-option-${activeIndex}`,
+    activeOptionId: getComposerPopupOptionId(listboxId, activeIndex),
   };
 };
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
@@ -4,7 +4,7 @@ import type {
   AgentSlashCommand,
   AgentSubagentReference,
 } from "@openducktor/core";
-import { type ReactElement, useLayoutEffect, useState } from "react";
+import { type ReactElement, useId, useLayoutEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { badgeVariants } from "@/components/ui/badge-variants";
 import { cn } from "@/lib/utils";
@@ -12,6 +12,7 @@ import {
   type AgentChatComposerDraft,
   draftHasMeaningfulContent,
 } from "./agent-chat-composer-draft";
+import { shouldRenderAgentChatComposerReferenceMenu } from "./agent-chat-composer-menu-state";
 import { AgentChatComposerReferenceMenu } from "./agent-chat-composer-reference-menu";
 import {
   readEditableTextContent,
@@ -95,6 +96,25 @@ type ComposerFileReferenceTooltipState = {
 type AgentChatComposerSegments = AgentChatComposerDraft["segments"];
 type AgentChatComposerSegment = AgentChatComposerSegments[number];
 type AgentChatComposerTextSegment = Extract<AgentChatComposerSegment, { kind: "text" }>;
+type ActiveComposerPopup = {
+  listboxId: string;
+  activeOptionId?: string;
+};
+
+const buildActiveComposerPopup = (
+  listboxId: string,
+  activeIndex: number,
+  itemCount: number,
+): ActiveComposerPopup => {
+  if (activeIndex < 0 || activeIndex >= itemCount) {
+    return { listboxId };
+  }
+
+  return {
+    listboxId,
+    activeOptionId: `${listboxId}-option-${activeIndex}`,
+  };
+};
 
 const readComposerFileReferenceChipElement = (target: EventTarget | null): HTMLElement | null => {
   if (!(target instanceof Element)) {
@@ -370,6 +390,9 @@ export function AgentChatComposerEditor({
   isSubagentsLoading,
   searchFiles,
 }: AgentChatComposerEditorProps): ReactElement {
+  const referenceListboxId = useId();
+  const slashListboxId = useId();
+  const skillListboxId = useId();
   const [composerFileReferenceTooltip, setComposerFileReferenceTooltip] =
     useState<ComposerFileReferenceTooltipState | null>(null);
   const {
@@ -415,6 +438,32 @@ export function AgentChatComposerEditor({
     searchFiles,
   });
   const draftSegments = draft.segments;
+  const isReferenceMenuVisible =
+    showReferenceMenu &&
+    shouldRenderAgentChatComposerReferenceMenu({
+      itemCount: referenceMenuItems.length,
+      fileSearchError,
+      isFileSearchPending,
+      isFileSearchLoading,
+      subagentsError,
+      isSubagentsLoading,
+    });
+  let activePopup: ActiveComposerPopup | null = null;
+  if (isReferenceMenuVisible) {
+    activePopup = buildActiveComposerPopup(
+      referenceListboxId,
+      activeReferenceIndex,
+      referenceMenuItems.length,
+    );
+  } else if (showSlashMenu) {
+    activePopup = buildActiveComposerPopup(
+      slashListboxId,
+      activeSlashIndex,
+      filteredSlashCommands.length,
+    );
+  } else if (showSkillMenu) {
+    activePopup = buildActiveComposerPopup(skillListboxId, activeSkillIndex, filteredSkills.length);
+  }
 
   useLayoutEffect(() => {
     const editor = editorRef.current?.querySelector<HTMLDivElement>("[data-composer-content-root]");
@@ -472,6 +521,7 @@ export function AgentChatComposerEditor({
         : null}
       {showReferenceMenu ? (
         <AgentChatComposerReferenceMenu
+          listboxId={referenceListboxId}
           items={referenceMenuItems}
           activeIndex={activeReferenceIndex}
           fileSearchError={fileSearchError}
@@ -486,6 +536,7 @@ export function AgentChatComposerEditor({
       ) : null}
       {showSlashMenu ? (
         <AgentChatComposerSlashMenu
+          listboxId={slashListboxId}
           commands={filteredSlashCommands}
           activeIndex={activeSlashIndex}
           slashCommandsError={slashCommandsError}
@@ -495,6 +546,7 @@ export function AgentChatComposerEditor({
       ) : null}
       {showSkillMenu ? (
         <AgentChatComposerSkillMenu
+          listboxId={skillListboxId}
           skills={filteredSkills}
           activeIndex={activeSkillIndex}
           skillsError={skillsError}
@@ -502,12 +554,14 @@ export function AgentChatComposerEditor({
           onSelectSkill={selectSkillReference}
         />
       ) : null}
-      {/* biome-ignore lint/a11y/useSemanticElements: the contenteditable root supports inline chips and file references. */}
       <div
         ref={editorRef}
-        role="textbox"
+        role="combobox"
         aria-label="Message composer"
-        aria-multiline="true"
+        aria-expanded={activePopup !== null}
+        aria-controls={activePopup?.listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={activePopup?.activeOptionId}
         tabIndex={disabled ? -1 : 0}
         contentEditable={!disabled}
         suppressContentEditableWarning

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
@@ -14,7 +14,7 @@ import {
 } from "./agent-chat-composer-draft";
 import {
   getComposerPopupOptionId,
-  shouldRenderAgentChatComposerReferenceMenu,
+  resolveAgentChatComposerReferenceMenuVisibility,
 } from "./agent-chat-composer-menu-state";
 import { AgentChatComposerReferenceMenu } from "./agent-chat-composer-reference-menu";
 import {
@@ -443,14 +443,14 @@ export function AgentChatComposerEditor({
   const draftSegments = draft.segments;
   const isReferenceMenuVisible =
     showReferenceMenu &&
-    shouldRenderAgentChatComposerReferenceMenu({
+    resolveAgentChatComposerReferenceMenuVisibility({
       itemCount: referenceMenuItems.length,
       fileSearchError,
       isFileSearchPending,
       isFileSearchLoading,
       subagentsError,
       isSubagentsLoading,
-    });
+    }).shouldRenderMenu;
   let activePopup: ActiveComposerPopup | null = null;
   if (isReferenceMenuVisible) {
     activePopup = buildActiveComposerPopup(

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-menu-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-menu-state.ts
@@ -4,6 +4,43 @@ type ComposerMenuClosers = {
   closeSkillMenu: () => void;
 };
 
+type ReferenceMenuVisibilityState = {
+  itemCount: number;
+  fileSearchError: string | null;
+  isFileSearchPending: boolean;
+  isFileSearchLoading: boolean;
+  subagentsError: string | null;
+  isSubagentsLoading: boolean;
+};
+
+export const shouldRenderAgentChatComposerReferenceMenu = ({
+  itemCount,
+  fileSearchError,
+  isFileSearchPending,
+  isFileSearchLoading,
+  subagentsError,
+  isSubagentsLoading,
+}: ReferenceMenuVisibilityState): boolean => {
+  const hasResults = itemCount > 0;
+  const showSubagentsLoading = isSubagentsLoading && !hasResults;
+  const showFileSearchLoading = isFileSearchLoading && !hasResults;
+  const showEmptyState =
+    !hasResults &&
+    !isFileSearchPending &&
+    !isSubagentsLoading &&
+    !fileSearchError &&
+    !subagentsError;
+
+  return (
+    hasResults ||
+    showFileSearchLoading ||
+    showSubagentsLoading ||
+    Boolean(fileSearchError) ||
+    Boolean(subagentsError) ||
+    showEmptyState
+  );
+};
+
 export function closeComposerAutocompleteMenus({
   closeSlashMenu,
   closeReferenceMenu,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-menu-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-menu-state.ts
@@ -13,6 +13,10 @@ type ReferenceMenuVisibilityState = {
   isSubagentsLoading: boolean;
 };
 
+export const getComposerPopupOptionId = (listboxId: string, index: number): string => {
+  return `${listboxId}-option-${index}`;
+};
+
 export const shouldRenderAgentChatComposerReferenceMenu = ({
   itemCount,
   fileSearchError,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-menu-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-menu-state.ts
@@ -13,18 +13,26 @@ type ReferenceMenuVisibilityState = {
   isSubagentsLoading: boolean;
 };
 
+type ReferenceMenuVisibility = {
+  hasResults: boolean;
+  showSubagentsLoading: boolean;
+  showFileSearchLoading: boolean;
+  showEmptyState: boolean;
+  shouldRenderMenu: boolean;
+};
+
 export const getComposerPopupOptionId = (listboxId: string, index: number): string => {
   return `${listboxId}-option-${index}`;
 };
 
-export const shouldRenderAgentChatComposerReferenceMenu = ({
+export const resolveAgentChatComposerReferenceMenuVisibility = ({
   itemCount,
   fileSearchError,
   isFileSearchPending,
   isFileSearchLoading,
   subagentsError,
   isSubagentsLoading,
-}: ReferenceMenuVisibilityState): boolean => {
+}: ReferenceMenuVisibilityState): ReferenceMenuVisibility => {
   const hasResults = itemCount > 0;
   const showSubagentsLoading = isSubagentsLoading && !hasResults;
   const showFileSearchLoading = isFileSearchLoading && !hasResults;
@@ -35,14 +43,21 @@ export const shouldRenderAgentChatComposerReferenceMenu = ({
     !fileSearchError &&
     !subagentsError;
 
-  return (
+  const shouldRenderMenu =
     hasResults ||
     showFileSearchLoading ||
     showSubagentsLoading ||
     Boolean(fileSearchError) ||
     Boolean(subagentsError) ||
-    showEmptyState
-  );
+    showEmptyState;
+
+  return {
+    hasResults,
+    showSubagentsLoading,
+    showFileSearchLoading,
+    showEmptyState,
+    shouldRenderMenu,
+  };
 };
 
 export function closeComposerAutocompleteMenus({

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { AgentFileSearchResult, AgentSubagentReference } from "@openducktor/core";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { AgentChatComposerReferenceMenu } from "./agent-chat-composer-reference-menu";
 import type { ReferenceMenuItem } from "./use-agent-chat-composer-editor-autocomplete";
 
@@ -149,15 +149,90 @@ describe("AgentChatComposerReferenceMenu", () => {
 
     const listbox = screen.getByRole("listbox", { name: "References" });
     const activeFile = screen.getByRole("option", { name: /styles\.css/i });
+    const inactiveFile = screen.getByRole("option", { name: /agent-chat-composer\.tsx/i });
 
     expect(activeFile.className).toContain("bg-selected-surface");
     expect(activeFile.className).not.toContain("bg-primary/20");
     expect(activeFile.id).toBe(`${LISTBOX_ID}-option-1`);
     expect(activeFile.getAttribute("aria-selected")).toBe("true");
     expect(activeFile.getAttribute("tabindex")).toBe("-1");
+    expect(inactiveFile.getAttribute("aria-selected")).toBe("false");
     expect(listbox.id).toBe(LISTBOX_ID);
     expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
     expect(listbox.getAttribute("tabindex")).toBeNull();
+  });
+
+  test("scrolls active subagent and file rows into view as selection changes", () => {
+    const scrollIntoView = mock(() => {});
+    const original = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollIntoView;
+    const items = [...subagentItems(SUBAGENTS), ...fileItems(RESULTS)];
+
+    try {
+      const rendered = render(
+        <AgentChatComposerReferenceMenu
+          listboxId={LISTBOX_ID}
+          items={items}
+          activeIndex={0}
+          fileSearchError={null}
+          isFileSearchPending={false}
+          isFileSearchLoading={false}
+          supportsSubagentReferences={true}
+          subagentsError={null}
+          isSubagentsLoading={false}
+          onSelectFile={() => {}}
+          onSelectSubagent={() => {}}
+        />,
+      );
+
+      rendered.rerender(
+        <AgentChatComposerReferenceMenu
+          listboxId={LISTBOX_ID}
+          items={items}
+          activeIndex={1}
+          fileSearchError={null}
+          isFileSearchPending={false}
+          isFileSearchLoading={false}
+          supportsSubagentReferences={true}
+          subagentsError={null}
+          isSubagentsLoading={false}
+          onSelectFile={() => {}}
+          onSelectSubagent={() => {}}
+        />,
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+      expect(scrollIntoView).toHaveBeenLastCalledWith({ block: "nearest", inline: "nearest" });
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
+  });
+
+  test("selects subagent and file rows on pointer down", () => {
+    const onSelectFile = mock(() => {});
+    const onSelectSubagent = mock(() => {});
+
+    render(
+      <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
+        items={[...subagentItems(SUBAGENTS), ...fileItems(RESULTS)]}
+        activeIndex={0}
+        fileSearchError={null}
+        isFileSearchPending={false}
+        isFileSearchLoading={false}
+        supportsSubagentReferences={true}
+        subagentsError={null}
+        isSubagentsLoading={false}
+        onSelectFile={onSelectFile}
+        onSelectSubagent={onSelectSubagent}
+      />,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("option", { name: /@reviewer/i }));
+    fireEvent.pointerDown(screen.getByRole("option", { name: /agent-chat-composer\.tsx/i }));
+
+    expect(onSelectSubagent).toHaveBeenCalledWith(SUBAGENTS[0]);
+    expect(onSelectFile).toHaveBeenCalledWith(RESULTS[0]);
   });
 
   test("uses the selected surface token for the active subagent row", () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
@@ -64,7 +64,7 @@ describe("AgentChatComposerReferenceMenu", () => {
     expect(rendered.container.firstChild).toBeNull();
   });
 
-  test("renders delayed file search loading inside the reference menu", () => {
+  test("announces reference loading while the controlled listbox is busy", () => {
     render(
       <AgentChatComposerReferenceMenu
         listboxId={LISTBOX_ID}
@@ -73,19 +73,23 @@ describe("AgentChatComposerReferenceMenu", () => {
         fileSearchError={null}
         isFileSearchPending={true}
         isFileSearchLoading={true}
-        supportsSubagentReferences={false}
+        supportsSubagentReferences={true}
         subagentsError={null}
-        isSubagentsLoading={false}
+        isSubagentsLoading={true}
         onSelectFile={() => {}}
         onSelectSubagent={() => {}}
       />,
     );
 
     const listbox = screen.getByRole("listbox", { name: "References" });
-
-    const loadingFeedback = screen.getByText("Searching files");
+    const loadingFeedback = screen.getAllByRole("status");
     expect(listbox.id).toBe(LISTBOX_ID);
-    expect(listbox.contains(loadingFeedback)).toBe(false);
+    expect(listbox.getAttribute("aria-busy")).toBe("true");
+    expect(loadingFeedback.map((element) => element.textContent)).toEqual([
+      "Loading subagents",
+      "Searching files",
+    ]);
+    expect(loadingFeedback.every((element) => !listbox.contains(element))).toBe(true);
   });
 
   test("does not render delayed file search loading when results are already visible", () => {
@@ -264,7 +268,7 @@ describe("AgentChatComposerReferenceMenu", () => {
     expect(listbox.getAttribute("tabindex")).toBeNull();
   });
 
-  test("mounts a controlled listbox for visible error feedback", () => {
+  test("announces visible reference errors outside the controlled listbox", () => {
     render(
       <AgentChatComposerReferenceMenu
         listboxId={LISTBOX_ID}
@@ -273,8 +277,8 @@ describe("AgentChatComposerReferenceMenu", () => {
         fileSearchError="File search unavailable."
         isFileSearchPending={false}
         isFileSearchLoading={false}
-        supportsSubagentReferences={false}
-        subagentsError={null}
+        supportsSubagentReferences={true}
+        subagentsError="Subagents unavailable."
         isSubagentsLoading={false}
         onSelectFile={() => {}}
         onSelectSubagent={() => {}}
@@ -282,9 +286,14 @@ describe("AgentChatComposerReferenceMenu", () => {
     );
 
     const listbox = screen.getByRole("listbox", { name: "References" });
-    const errorFeedback = screen.getByText("File search unavailable.");
+    const errorFeedback = screen.getAllByRole("alert");
     expect(listbox.id).toBe(LISTBOX_ID);
-    expect(listbox.contains(errorFeedback)).toBe(false);
+    expect(listbox.getAttribute("aria-busy")).toBeNull();
+    expect(errorFeedback.map((element) => element.textContent)).toEqual([
+      "Subagents unavailable.",
+      "File search unavailable.",
+    ]);
+    expect(errorFeedback.every((element) => !listbox.contains(element))).toBe(true);
   });
 
   test("mounts a controlled listbox for the visible empty state", () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
@@ -83,8 +83,9 @@ describe("AgentChatComposerReferenceMenu", () => {
 
     const listbox = screen.getByRole("listbox", { name: "References" });
 
+    const loadingFeedback = screen.getByText("Searching files");
     expect(listbox.id).toBe(LISTBOX_ID);
-    expect(screen.getByText("Searching files")).toBeDefined();
+    expect(listbox.contains(loadingFeedback)).toBe(false);
   });
 
   test("does not render delayed file search loading when results are already visible", () => {
@@ -205,8 +206,10 @@ describe("AgentChatComposerReferenceMenu", () => {
       />,
     );
 
-    expect(screen.getByRole("listbox", { name: "References" }).id).toBe(LISTBOX_ID);
-    expect(screen.getByText("File search unavailable.")).toBeDefined();
+    const listbox = screen.getByRole("listbox", { name: "References" });
+    const errorFeedback = screen.getByText("File search unavailable.");
+    expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.contains(errorFeedback)).toBe(false);
   });
 
   test("mounts a controlled listbox for the visible empty state", () => {
@@ -226,7 +229,9 @@ describe("AgentChatComposerReferenceMenu", () => {
       />,
     );
 
-    expect(screen.getByRole("listbox", { name: "References" }).id).toBe(LISTBOX_ID);
-    expect(screen.getByText("No files found.")).toBeDefined();
+    const listbox = screen.getByRole("listbox", { name: "References" });
+    const emptyFeedback = screen.getByText("No files found.");
+    expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.contains(emptyFeedback)).toBe(false);
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
@@ -27,6 +27,8 @@ const SUBAGENTS: AgentSubagentReference[] = [
   },
 ];
 
+const LISTBOX_ID = "reference-listbox";
+
 const fileItems = (results: AgentFileSearchResult[]): ReferenceMenuItem[] =>
   results.map((result) => ({
     kind: "file",
@@ -45,6 +47,7 @@ describe("AgentChatComposerReferenceMenu", () => {
   test("does not render an empty shell while file search is pending but hidden", () => {
     const rendered = render(
       <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
         items={[]}
         activeIndex={0}
         fileSearchError={null}
@@ -64,6 +67,7 @@ describe("AgentChatComposerReferenceMenu", () => {
   test("renders delayed file search loading inside the reference menu", () => {
     render(
       <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
         items={[]}
         activeIndex={0}
         fileSearchError={null}
@@ -77,12 +81,16 @@ describe("AgentChatComposerReferenceMenu", () => {
       />,
     );
 
+    const listbox = screen.getByRole("listbox", { name: "References" });
+
+    expect(listbox.id).toBe(LISTBOX_ID);
     expect(screen.getByText("Searching files")).toBeDefined();
   });
 
   test("does not render delayed file search loading when results are already visible", () => {
     render(
       <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
         items={fileItems(RESULTS)}
         activeIndex={0}
         fileSearchError={null}
@@ -103,6 +111,7 @@ describe("AgentChatComposerReferenceMenu", () => {
   test("does not render subagent loading when results are already visible", () => {
     render(
       <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
         items={fileItems(RESULTS)}
         activeIndex={0}
         fileSearchError={null}
@@ -123,6 +132,7 @@ describe("AgentChatComposerReferenceMenu", () => {
   test("uses the selected surface token for the active file row", () => {
     render(
       <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
         items={fileItems(RESULTS)}
         activeIndex={1}
         fileSearchError={null}
@@ -141,13 +151,18 @@ describe("AgentChatComposerReferenceMenu", () => {
 
     expect(activeFile.className).toContain("bg-selected-surface");
     expect(activeFile.className).not.toContain("bg-primary/20");
+    expect(activeFile.id).toBe(`${LISTBOX_ID}-option-1`);
     expect(activeFile.getAttribute("aria-selected")).toBe("true");
-    expect(listbox.getAttribute("aria-activedescendant")).toBe(activeFile.id);
+    expect(activeFile.getAttribute("tabindex")).toBe("-1");
+    expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
+    expect(listbox.getAttribute("tabindex")).toBeNull();
   });
 
   test("uses the selected surface token for the active subagent row", () => {
     render(
       <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
         items={[...subagentItems(SUBAGENTS), ...fileItems(RESULTS)]}
         activeIndex={0}
         fileSearchError={null}
@@ -166,7 +181,52 @@ describe("AgentChatComposerReferenceMenu", () => {
 
     expect(activeSubagent.className).toContain("bg-selected-surface");
     expect(activeSubagent.querySelector(".lucide-bot")).toBeDefined();
+    expect(activeSubagent.id).toBe(`${LISTBOX_ID}-option-0`);
     expect(activeSubagent.getAttribute("aria-selected")).toBe("true");
-    expect(listbox.getAttribute("aria-activedescendant")).toBe(activeSubagent.id);
+    expect(activeSubagent.getAttribute("tabindex")).toBe("-1");
+    expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
+    expect(listbox.getAttribute("tabindex")).toBeNull();
+  });
+
+  test("mounts a controlled listbox for visible error feedback", () => {
+    render(
+      <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
+        items={[]}
+        activeIndex={0}
+        fileSearchError="File search unavailable."
+        isFileSearchPending={false}
+        isFileSearchLoading={false}
+        supportsSubagentReferences={false}
+        subagentsError={null}
+        isSubagentsLoading={false}
+        onSelectFile={() => {}}
+        onSelectSubagent={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("listbox", { name: "References" }).id).toBe(LISTBOX_ID);
+    expect(screen.getByText("File search unavailable.")).toBeDefined();
+  });
+
+  test("mounts a controlled listbox for the visible empty state", () => {
+    render(
+      <AgentChatComposerReferenceMenu
+        listboxId={LISTBOX_ID}
+        items={[]}
+        activeIndex={0}
+        fileSearchError={null}
+        isFileSearchPending={false}
+        isFileSearchLoading={false}
+        supportsSubagentReferences={false}
+        subagentsError={null}
+        isSubagentsLoading={false}
+        onSelectFile={() => {}}
+        onSelectSubagent={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("listbox", { name: "References" }).id).toBe(LISTBOX_ID);
+    expect(screen.getByText("No files found.")).toBeDefined();
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.test.tsx
@@ -305,8 +305,9 @@ describe("AgentChatComposerReferenceMenu", () => {
     );
 
     const listbox = screen.getByRole("listbox", { name: "References" });
-    const emptyFeedback = screen.getByText("No files found.");
+    const emptyFeedback = screen.getByRole("status");
     expect(listbox.id).toBe(LISTBOX_ID);
     expect(listbox.contains(emptyFeedback)).toBe(false);
+    expect(emptyFeedback.textContent).toBe("No files found.");
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import {
   getComposerPopupOptionId,
-  shouldRenderAgentChatComposerReferenceMenu,
+  resolveAgentChatComposerReferenceMenuVisibility,
 } from "./agent-chat-composer-menu-state";
 import { AgentChatFileReferenceIcon } from "./agent-chat-file-reference-icon";
 import type { ReferenceMenuItem } from "./use-agent-chat-composer-editor-autocomplete";
@@ -36,16 +36,13 @@ export function AgentChatComposerReferenceMenu({
   onSelectFile,
   onSelectSubagent,
 }: AgentChatComposerReferenceMenuProps): ReactElement | null {
-  const hasResults = items.length > 0;
-  const showSubagentsLoading = isSubagentsLoading && !hasResults;
-  const showFileSearchLoading = isFileSearchLoading && !hasResults;
-  const showEmptyState =
-    !hasResults &&
-    !isFileSearchPending &&
-    !isSubagentsLoading &&
-    !fileSearchError &&
-    !subagentsError;
-  const shouldRenderMenu = shouldRenderAgentChatComposerReferenceMenu({
+  const {
+    hasResults,
+    showSubagentsLoading,
+    showFileSearchLoading,
+    showEmptyState,
+    shouldRenderMenu,
+  } = resolveAgentChatComposerReferenceMenuVisibility({
     itemCount: items.length,
     fileSearchError,
     isFileSearchPending,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
@@ -58,24 +58,30 @@ export function AgentChatComposerReferenceMenu({
   return (
     <div className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg">
       {showSubagentsLoading ? (
-        <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
+        <div
+          role="status"
+          className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground"
+        >
           <LoaderCircle className="size-4 animate-spin" />
           <span>Loading subagents</span>
         </div>
       ) : null}
       {subagentsError ? (
-        <div className="border-b border-border px-3 py-2 text-sm text-destructive">
+        <div role="alert" className="border-b border-border px-3 py-2 text-sm text-destructive">
           {subagentsError}
         </div>
       ) : null}
       {showFileSearchLoading ? (
-        <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
+        <div
+          role="status"
+          className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground"
+        >
           <LoaderCircle className="size-4 animate-spin" />
           <span>Searching files</span>
         </div>
       ) : null}
       {fileSearchError ? (
-        <div className="border-b border-border px-3 py-2 text-sm text-destructive">
+        <div role="alert" className="border-b border-border px-3 py-2 text-sm text-destructive">
           {fileSearchError}
         </div>
       ) : null}
@@ -88,6 +94,7 @@ export function AgentChatComposerReferenceMenu({
         id={listboxId}
         role="listbox"
         aria-label="References"
+        aria-busy={showSubagentsLoading || showFileSearchLoading || undefined}
         className="hide-scrollbar flex max-h-64 flex-col overflow-y-auto rounded-xl"
       >
         {hasResults

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
@@ -80,7 +80,7 @@ export function AgentChatComposerReferenceMenu({
         </div>
       ) : null}
       {showEmptyState ? (
-        <div className="px-3 py-2 text-sm text-muted-foreground">
+        <div role="status" className="px-3 py-2 text-sm text-muted-foreground">
           {supportsSubagentReferences ? "No references found." : "No files found."}
         </div>
       ) : null}

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
@@ -2,7 +2,10 @@ import type { AgentFileSearchResult, AgentSubagentReference } from "@openducktor
 import { Bot, ChevronRight, LoaderCircle } from "lucide-react";
 import { type ReactElement, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { shouldRenderAgentChatComposerReferenceMenu } from "./agent-chat-composer-menu-state";
+import {
+  getComposerPopupOptionId,
+  shouldRenderAgentChatComposerReferenceMenu,
+} from "./agent-chat-composer-menu-state";
 import { AgentChatFileReferenceIcon } from "./agent-chat-file-reference-icon";
 import type { ReferenceMenuItem } from "./use-agent-chat-composer-editor-autocomplete";
 
@@ -56,12 +59,7 @@ export function AgentChatComposerReferenceMenu({
   }
 
   return (
-    <div
-      id={listboxId}
-      role="listbox"
-      aria-label="References"
-      className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg"
-    >
+    <div className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg">
       {showSubagentsLoading ? (
         <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
           <LoaderCircle className="size-4 animate-spin" />
@@ -89,33 +87,38 @@ export function AgentChatComposerReferenceMenu({
           {supportsSubagentReferences ? "No references found." : "No files found."}
         </div>
       ) : null}
-      {hasResults ? (
-        <div className="hide-scrollbar flex max-h-64 flex-col overflow-y-auto rounded-xl">
-          {items.map((item, index) => {
-            const isActive = index === activeIndex;
-            if (item.kind === "subagent") {
+      <div
+        id={listboxId}
+        role="listbox"
+        aria-label="References"
+        className="hide-scrollbar flex max-h-64 flex-col overflow-y-auto rounded-xl"
+      >
+        {hasResults
+          ? items.map((item, index) => {
+              const isActive = index === activeIndex;
+              if (item.kind === "subagent") {
+                return (
+                  <SubagentReferenceMenuRow
+                    key={item.id}
+                    optionId={getComposerPopupOptionId(listboxId, index)}
+                    subagent={item.subagent}
+                    isActive={isActive}
+                    onSelect={onSelectSubagent}
+                  />
+                );
+              }
               return (
-                <SubagentReferenceMenuRow
+                <FileReferenceMenuRow
                   key={item.id}
-                  optionId={`${listboxId}-option-${index}`}
-                  subagent={item.subagent}
+                  optionId={getComposerPopupOptionId(listboxId, index)}
+                  result={item.result}
                   isActive={isActive}
-                  onSelect={onSelectSubagent}
+                  onSelect={onSelectFile}
                 />
               );
-            }
-            return (
-              <FileReferenceMenuRow
-                key={item.id}
-                optionId={`${listboxId}-option-${index}`}
-                result={item.result}
-                isActive={isActive}
-                onSelect={onSelectFile}
-              />
-            );
-          })}
-        </div>
-      ) : null}
+            })
+          : null}
+      </div>
     </div>
   );
 }

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-reference-menu.tsx
@@ -1,11 +1,13 @@
 import type { AgentFileSearchResult, AgentSubagentReference } from "@openducktor/core";
 import { Bot, ChevronRight, LoaderCircle } from "lucide-react";
-import { type ReactElement, useEffect, useId, useRef } from "react";
+import { type ReactElement, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { shouldRenderAgentChatComposerReferenceMenu } from "./agent-chat-composer-menu-state";
 import { AgentChatFileReferenceIcon } from "./agent-chat-file-reference-icon";
 import type { ReferenceMenuItem } from "./use-agent-chat-composer-editor-autocomplete";
 
 type AgentChatComposerReferenceMenuProps = {
+  listboxId: string;
   items: ReferenceMenuItem[];
   activeIndex: number;
   fileSearchError: string | null;
@@ -19,6 +21,7 @@ type AgentChatComposerReferenceMenuProps = {
 };
 
 export function AgentChatComposerReferenceMenu({
+  listboxId,
   items,
   activeIndex,
   fileSearchError,
@@ -31,11 +34,6 @@ export function AgentChatComposerReferenceMenu({
   onSelectSubagent,
 }: AgentChatComposerReferenceMenuProps): ReactElement | null {
   const hasResults = items.length > 0;
-  const listboxId = useId();
-  const activeOptionId =
-    activeIndex >= 0 && activeIndex < items.length
-      ? `${listboxId}-option-${activeIndex}`
-      : undefined;
   const showSubagentsLoading = isSubagentsLoading && !hasResults;
   const showFileSearchLoading = isFileSearchLoading && !hasResults;
   const showEmptyState =
@@ -44,20 +42,26 @@ export function AgentChatComposerReferenceMenu({
     !isSubagentsLoading &&
     !fileSearchError &&
     !subagentsError;
-  const shouldRenderMenu =
-    hasResults ||
-    showFileSearchLoading ||
-    showSubagentsLoading ||
-    Boolean(fileSearchError) ||
-    Boolean(subagentsError) ||
-    showEmptyState;
+  const shouldRenderMenu = shouldRenderAgentChatComposerReferenceMenu({
+    itemCount: items.length,
+    fileSearchError,
+    isFileSearchPending,
+    isFileSearchLoading,
+    subagentsError,
+    isSubagentsLoading,
+  });
 
   if (!shouldRenderMenu) {
     return null;
   }
 
   return (
-    <div className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg">
+    <div
+      id={listboxId}
+      role="listbox"
+      aria-label="References"
+      className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg"
+    >
       {showSubagentsLoading ? (
         <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
           <LoaderCircle className="size-4 animate-spin" />
@@ -86,14 +90,7 @@ export function AgentChatComposerReferenceMenu({
         </div>
       ) : null}
       {hasResults ? (
-        <div
-          id={listboxId}
-          role="listbox"
-          aria-label="References"
-          aria-activedescendant={activeOptionId}
-          tabIndex={0}
-          className="hide-scrollbar flex max-h-64 flex-col overflow-y-auto rounded-xl"
-        >
+        <div className="hide-scrollbar flex max-h-64 flex-col overflow-y-auto rounded-xl">
           {items.map((item, index) => {
             const isActive = index === activeIndex;
             if (item.kind === "subagent") {
@@ -155,6 +152,7 @@ function SubagentReferenceMenuRow({
       id={optionId}
       role="option"
       aria-selected={isActive}
+      tabIndex={-1}
       type="button"
       className={referenceMenuRowClassName(isActive)}
       onPointerDown={(event) => {
@@ -211,6 +209,7 @@ function FileReferenceMenuRow({
       id={optionId}
       role="option"
       aria-selected={isActive}
+      tabIndex={-1}
       type="button"
       className={referenceMenuRowClassName(isActive)}
       onPointerDown={(event) => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { AgentSkillReference } from "@openducktor/core";
 import { render, screen } from "@testing-library/react";
 import { AgentChatComposerSkillMenu } from "./agent-chat-composer-skill-menu";
@@ -43,5 +43,94 @@ describe("AgentChatComposerSkillMenu", () => {
     expect(activeSkill.id).toBe(`${LISTBOX_ID}-option-0`);
     expect(activeSkill.getAttribute("aria-selected")).toBe("true");
     expect(activeSkill.getAttribute("tabindex")).toBe("-1");
+  });
+
+  test("scrolls the active skill into view when keyboard navigation changes selection", () => {
+    const scrollIntoView = mock(() => {});
+    const original = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    try {
+      const rendered = render(
+        <AgentChatComposerSkillMenu
+          listboxId={LISTBOX_ID}
+          skills={SKILLS}
+          activeIndex={0}
+          skillsError={null}
+          isSkillsLoading={false}
+          onSelectSkill={() => {}}
+        />,
+      );
+
+      rendered.rerender(
+        <AgentChatComposerSkillMenu
+          listboxId={LISTBOX_ID}
+          skills={SKILLS}
+          activeIndex={1}
+          skillsError={null}
+          isSkillsLoading={false}
+          onSelectSkill={() => {}}
+        />,
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+      expect(scrollIntoView).toHaveBeenLastCalledWith({ block: "nearest", inline: "nearest" });
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
+  });
+
+  test("mounts the controlled listbox while skills are loading", () => {
+    render(
+      <AgentChatComposerSkillMenu
+        listboxId={LISTBOX_ID}
+        skills={[]}
+        activeIndex={0}
+        skillsError={null}
+        isSkillsLoading={true}
+        onSelectSkill={() => {}}
+      />,
+    );
+
+    const listbox = screen.getByRole("listbox", { name: "Skills" });
+    const loadingFeedback = screen.getByText("Loading skills");
+    expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.contains(loadingFeedback)).toBe(false);
+  });
+
+  test("mounts the controlled listbox for skill errors", () => {
+    render(
+      <AgentChatComposerSkillMenu
+        listboxId={LISTBOX_ID}
+        skills={[]}
+        activeIndex={0}
+        skillsError="Skills unavailable"
+        isSkillsLoading={false}
+        onSelectSkill={() => {}}
+      />,
+    );
+
+    const listbox = screen.getByRole("listbox", { name: "Skills" });
+    const errorFeedback = screen.getByText("Skills unavailable");
+    expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.contains(errorFeedback)).toBe(false);
+  });
+
+  test("mounts the controlled listbox for the empty skill state", () => {
+    render(
+      <AgentChatComposerSkillMenu
+        listboxId={LISTBOX_ID}
+        skills={[]}
+        activeIndex={0}
+        skillsError={null}
+        isSkillsLoading={false}
+        onSelectSkill={() => {}}
+      />,
+    );
+
+    const listbox = screen.getByRole("listbox", { name: "Skills" });
+    const emptyFeedback = screen.getByText("No skills found.");
+    expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.contains(emptyFeedback)).toBe(false);
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.test.tsx
@@ -129,8 +129,9 @@ describe("AgentChatComposerSkillMenu", () => {
     );
 
     const listbox = screen.getByRole("listbox", { name: "Skills" });
-    const emptyFeedback = screen.getByText("No skills found.");
+    const emptyFeedback = screen.getByRole("status");
     expect(listbox.id).toBe(LISTBOX_ID);
     expect(listbox.contains(emptyFeedback)).toBe(false);
+    expect(emptyFeedback.textContent).toBe("No skills found.");
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.test.tsx
@@ -93,9 +93,11 @@ describe("AgentChatComposerSkillMenu", () => {
     );
 
     const listbox = screen.getByRole("listbox", { name: "Skills" });
-    const loadingFeedback = screen.getByText("Loading skills");
+    const loadingFeedback = screen.getByRole("status");
     expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.getAttribute("aria-busy")).toBe("true");
     expect(listbox.contains(loadingFeedback)).toBe(false);
+    expect(loadingFeedback.textContent).toBe("Loading skills");
   });
 
   test("mounts the controlled listbox for skill errors", () => {
@@ -111,9 +113,11 @@ describe("AgentChatComposerSkillMenu", () => {
     );
 
     const listbox = screen.getByRole("listbox", { name: "Skills" });
-    const errorFeedback = screen.getByText("Skills unavailable");
+    const errorFeedback = screen.getByRole("alert");
     expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.getAttribute("aria-busy")).toBeNull();
     expect(listbox.contains(errorFeedback)).toBe(false);
+    expect(errorFeedback.textContent).toBe("Skills unavailable");
   });
 
   test("mounts the controlled listbox for the empty skill state", () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.test.tsx
@@ -19,10 +19,13 @@ const SKILLS: AgentSkillReference[] = [
   },
 ];
 
+const LISTBOX_ID = "skill-listbox";
+
 describe("AgentChatComposerSkillMenu", () => {
   test("uses the selected surface token for the active skill row", () => {
     render(
       <AgentChatComposerSkillMenu
+        listboxId={LISTBOX_ID}
         skills={SKILLS}
         activeIndex={0}
         skillsError={null}
@@ -31,9 +34,14 @@ describe("AgentChatComposerSkillMenu", () => {
       />,
     );
 
-    const activeSkill = screen.getByRole("button", { name: /review current changes/i });
+    const listbox = screen.getByRole("listbox", { name: "Skills" });
+    const activeSkill = screen.getByRole("option", { name: /review current changes/i });
 
+    expect(listbox.id).toBe(LISTBOX_ID);
     expect(activeSkill.className).toContain("bg-selected-surface");
     expect(activeSkill.className).not.toContain("bg-primary/20");
+    expect(activeSkill.id).toBe(`${LISTBOX_ID}-option-0`);
+    expect(activeSkill.getAttribute("aria-selected")).toBe("true");
+    expect(activeSkill.getAttribute("tabindex")).toBe("-1");
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.tsx
@@ -4,6 +4,7 @@ import { type ReactElement, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 type AgentChatComposerSkillMenuProps = {
+  listboxId: string;
   skills: AgentSkillReference[];
   activeIndex: number;
   skillsError: string | null;
@@ -16,6 +17,7 @@ const skillLabel = (skill: AgentSkillReference): string => {
 };
 
 export function AgentChatComposerSkillMenu({
+  listboxId,
   skills,
   activeIndex,
   skillsError,
@@ -37,7 +39,12 @@ export function AgentChatComposerSkillMenu({
   }, [activeIndex, skills]);
 
   return (
-    <div className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg">
+    <div
+      id={listboxId}
+      role="listbox"
+      aria-label="Skills"
+      className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg"
+    >
       {isSkillsLoading ? (
         <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
           <LoaderCircle className="size-4 animate-spin" />
@@ -59,9 +66,13 @@ export function AgentChatComposerSkillMenu({
             return (
               <button
                 key={skill.id}
+                id={`${listboxId}-option-${index}`}
                 ref={(element) => {
                   skillButtonRefs.current[skill.id] = element;
                 }}
+                role="option"
+                aria-selected={isActive}
+                tabIndex={-1}
                 type="button"
                 className={cn(
                   "flex w-full cursor-pointer gap-3 px-3 py-2 text-left transition-colors",

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.tsx
@@ -53,7 +53,9 @@ export function AgentChatComposerSkillMenu({
         </div>
       ) : null}
       {skills.length === 0 && !isSkillsLoading && !skillsError ? (
-        <div className="px-3 py-2 text-sm text-muted-foreground">No skills found.</div>
+        <div role="status" className="px-3 py-2 text-sm text-muted-foreground">
+          No skills found.
+        </div>
       ) : null}
       <div
         id={listboxId}

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.tsx
@@ -2,6 +2,7 @@ import type { AgentSkillReference } from "@openducktor/core";
 import { Blocks, ChevronRight, LoaderCircle } from "lucide-react";
 import { type ReactElement, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { getComposerPopupOptionId } from "./agent-chat-composer-menu-state";
 
 type AgentChatComposerSkillMenuProps = {
   listboxId: string;
@@ -39,12 +40,7 @@ export function AgentChatComposerSkillMenu({
   }, [activeIndex, skills]);
 
   return (
-    <div
-      id={listboxId}
-      role="listbox"
-      aria-label="Skills"
-      className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg"
-    >
+    <div className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg">
       {isSkillsLoading ? (
         <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
           <LoaderCircle className="size-4 animate-spin" />
@@ -59,52 +55,57 @@ export function AgentChatComposerSkillMenu({
       {skills.length === 0 && !isSkillsLoading && !skillsError ? (
         <div className="px-3 py-2 text-sm text-muted-foreground">No skills found.</div>
       ) : null}
-      {skills.length > 0 ? (
-        <div className="hide-scrollbar flex max-h-64 flex-col overflow-y-auto rounded-xl">
-          {skills.map((skill, index) => {
-            const isActive = index === activeIndex;
-            return (
-              <button
-                key={skill.id}
-                id={`${listboxId}-option-${index}`}
-                ref={(element) => {
-                  skillButtonRefs.current[skill.id] = element;
-                }}
-                role="option"
-                aria-selected={isActive}
-                tabIndex={-1}
-                type="button"
-                className={cn(
-                  "flex w-full cursor-pointer gap-3 px-3 py-2 text-left transition-colors",
-                  isActive ? "bg-selected-surface" : "hover:bg-muted/80",
-                )}
-                onPointerDown={(event) => {
-                  event.preventDefault();
-                  onSelectSkill(skill);
-                }}
-              >
-                <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-purple-100 text-purple-700 dark:bg-purple-950/50 dark:text-purple-200">
-                  <Blocks className="size-3.5" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium text-foreground">
-                    ${skill.name}
+      <div
+        id={listboxId}
+        role="listbox"
+        aria-label="Skills"
+        className="hide-scrollbar flex max-h-64 flex-col overflow-y-auto rounded-xl"
+      >
+        {skills.length > 0
+          ? skills.map((skill, index) => {
+              const isActive = index === activeIndex;
+              return (
+                <button
+                  key={skill.id}
+                  id={getComposerPopupOptionId(listboxId, index)}
+                  ref={(element) => {
+                    skillButtonRefs.current[skill.id] = element;
+                  }}
+                  role="option"
+                  aria-selected={isActive}
+                  tabIndex={-1}
+                  type="button"
+                  className={cn(
+                    "flex w-full cursor-pointer gap-3 px-3 py-2 text-left transition-colors",
+                    isActive ? "bg-selected-surface" : "hover:bg-muted/80",
+                  )}
+                  onPointerDown={(event) => {
+                    event.preventDefault();
+                    onSelectSkill(skill);
+                  }}
+                >
+                  <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-purple-100 text-purple-700 dark:bg-purple-950/50 dark:text-purple-200">
+                    <Blocks className="size-3.5" />
                   </span>
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {skillLabel(skill)}
-                  </span>
-                  {skill.description ? (
-                    <span className="line-clamp-2 text-xs text-muted-foreground">
-                      {skill.description}
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium text-foreground">
+                      ${skill.name}
                     </span>
-                  ) : null}
-                </span>
-                <ChevronRight className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {skillLabel(skill)}
+                    </span>
+                    {skill.description ? (
+                      <span className="line-clamp-2 text-xs text-muted-foreground">
+                        {skill.description}
+                      </span>
+                    ) : null}
+                  </span>
+                  <ChevronRight className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                </button>
+              );
+            })
+          : null}
+      </div>
     </div>
   );
 }

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-skill-menu.tsx
@@ -42,13 +42,16 @@ export function AgentChatComposerSkillMenu({
   return (
     <div className="absolute bottom-full z-20 mb-2 rounded-xl border border-border bg-popover shadow-lg">
       {isSkillsLoading ? (
-        <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
+        <div
+          role="status"
+          className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground"
+        >
           <LoaderCircle className="size-4 animate-spin" />
           <span>Loading skills</span>
         </div>
       ) : null}
       {skillsError ? (
-        <div className="border-b border-border px-3 py-2 text-sm text-destructive">
+        <div role="alert" className="border-b border-border px-3 py-2 text-sm text-destructive">
           {skillsError}
         </div>
       ) : null}
@@ -61,6 +64,7 @@ export function AgentChatComposerSkillMenu({
         id={listboxId}
         role="listbox"
         aria-label="Skills"
+        aria-busy={(isSkillsLoading && skills.length === 0) || undefined}
         className="hide-scrollbar flex max-h-64 flex-col overflow-y-auto rounded-xl"
       >
         {skills.length > 0

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.test.tsx
@@ -19,10 +19,13 @@ const COMMANDS = [
   },
 ];
 
+const LISTBOX_ID = "slash-listbox";
+
 describe("AgentChatComposerSlashMenu", () => {
   test("renders active command with selected-surface styling and pointer cursor", () => {
     render(
       <AgentChatComposerSlashMenu
+        listboxId={LISTBOX_ID}
         commands={COMMANDS}
         activeIndex={0}
         slashCommandsError={null}
@@ -31,11 +34,16 @@ describe("AgentChatComposerSlashMenu", () => {
       />,
     );
 
-    const activeCommand = screen.getByRole("button", { name: /first command/i });
+    const listbox = screen.getByRole("listbox", { name: "Slash commands" });
+    const activeCommand = screen.getByRole("option", { name: /first command/i });
 
+    expect(listbox.id).toBe(LISTBOX_ID);
     expect(activeCommand.className).toContain("cursor-pointer");
     expect(activeCommand.className).toContain("bg-selected-surface");
     expect(activeCommand.className).not.toContain("bg-primary/20");
+    expect(activeCommand.id).toBe(`${LISTBOX_ID}-option-0`);
+    expect(activeCommand.getAttribute("aria-selected")).toBe("true");
+    expect(activeCommand.getAttribute("tabindex")).toBe("-1");
   });
 
   test("scrolls the active command into view when keyboard navigation changes selection", () => {
@@ -46,6 +54,7 @@ describe("AgentChatComposerSlashMenu", () => {
     try {
       const rendered = render(
         <AgentChatComposerSlashMenu
+          listboxId={LISTBOX_ID}
           commands={COMMANDS}
           activeIndex={0}
           slashCommandsError={null}
@@ -56,6 +65,7 @@ describe("AgentChatComposerSlashMenu", () => {
 
       rendered.rerender(
         <AgentChatComposerSlashMenu
+          listboxId={LISTBOX_ID}
           commands={COMMANDS}
           activeIndex={1}
           slashCommandsError={null}
@@ -78,6 +88,7 @@ describe("AgentChatComposerSlashMenu", () => {
 
     render(
       <AgentChatComposerSlashMenu
+        listboxId={LISTBOX_ID}
         commands={[{ ...firstCommand, source: "custom" }]}
         activeIndex={0}
         slashCommandsError="Runtime commands failed"
@@ -87,7 +98,7 @@ describe("AgentChatComposerSlashMenu", () => {
     );
 
     expect(screen.getByText("Runtime commands failed")).toBeTruthy();
-    expect(screen.getByRole("button", { name: /first command/i })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /first command/i })).toBeTruthy();
     expect(screen.getByText("custom")).toBeTruthy();
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.test.tsx
@@ -99,10 +99,32 @@ describe("AgentChatComposerSlashMenu", () => {
     );
 
     const listbox = screen.getByRole("listbox", { name: "Slash commands" });
-    const errorFeedback = screen.getByText("Runtime commands failed");
+    const errorFeedback = screen.getByRole("alert");
     expect(listbox.contains(errorFeedback)).toBe(false);
+    expect(listbox.getAttribute("aria-busy")).toBeNull();
+    expect(errorFeedback.textContent).toBe("Runtime commands failed");
     expect(screen.getByRole("option", { name: /first command/i })).toBeTruthy();
     expect(screen.getByText("custom")).toBeTruthy();
+  });
+
+  test("announces loading while the empty controlled listbox is busy", () => {
+    render(
+      <AgentChatComposerSlashMenu
+        listboxId={LISTBOX_ID}
+        commands={[]}
+        activeIndex={0}
+        slashCommandsError={null}
+        isSlashCommandsLoading={true}
+        onSelectCommand={() => {}}
+      />,
+    );
+
+    const listbox = screen.getByRole("listbox", { name: "Slash commands" });
+    const loadingFeedback = screen.getByRole("status");
+
+    expect(listbox.getAttribute("aria-busy")).toBe("true");
+    expect(listbox.contains(loadingFeedback)).toBe(false);
+    expect(loadingFeedback.textContent).toBe("Loading slash commands…");
   });
 
   test("announces empty feedback outside the controlled listbox", () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.test.tsx
@@ -97,7 +97,9 @@ describe("AgentChatComposerSlashMenu", () => {
       />,
     );
 
-    expect(screen.getByText("Runtime commands failed")).toBeTruthy();
+    const listbox = screen.getByRole("listbox", { name: "Slash commands" });
+    const errorFeedback = screen.getByText("Runtime commands failed");
+    expect(listbox.contains(errorFeedback)).toBe(false);
     expect(screen.getByRole("option", { name: /first command/i })).toBeTruthy();
     expect(screen.getByText("custom")).toBeTruthy();
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.test.tsx
@@ -74,7 +74,8 @@ describe("AgentChatComposerSlashMenu", () => {
         />,
       );
 
-      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+      expect(scrollIntoView).toHaveBeenLastCalledWith({ block: "nearest", inline: "nearest" });
     } finally {
       Element.prototype.scrollIntoView = original;
     }
@@ -102,5 +103,26 @@ describe("AgentChatComposerSlashMenu", () => {
     expect(listbox.contains(errorFeedback)).toBe(false);
     expect(screen.getByRole("option", { name: /first command/i })).toBeTruthy();
     expect(screen.getByText("custom")).toBeTruthy();
+  });
+
+  test("announces empty feedback outside the controlled listbox", () => {
+    render(
+      <AgentChatComposerSlashMenu
+        listboxId={LISTBOX_ID}
+        commands={[]}
+        activeIndex={0}
+        slashCommandsError={null}
+        isSlashCommandsLoading={false}
+        onSelectCommand={() => {}}
+      />,
+    );
+
+    const listbox = screen.getByRole("listbox", { name: "Slash commands" });
+    const emptyFeedback = screen.getByRole("status");
+
+    expect(listbox.id).toBe(LISTBOX_ID);
+    expect(listbox.children).toHaveLength(0);
+    expect(listbox.contains(emptyFeedback)).toBe(false);
+    expect(emptyFeedback.textContent).toBe("No slash commands found.");
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.tsx
@@ -49,7 +49,9 @@ export function AgentChatComposerSlashMenu({
         </div>
       ) : null}
       {commands.length === 0 && !isSlashCommandsLoading && !slashCommandsError ? (
-        <div className="px-3 py-2 text-sm text-muted-foreground">No slash commands found.</div>
+        <div role="status" className="px-3 py-2 text-sm text-muted-foreground">
+          No slash commands found.
+        </div>
       ) : null}
       <div
         id={listboxId}

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.tsx
@@ -4,6 +4,7 @@ import { type ReactElement, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 type AgentChatComposerSlashMenuProps = {
+  listboxId: string;
   commands: AgentSlashCommand[];
   activeIndex: number;
   slashCommandsError: string | null;
@@ -12,6 +13,7 @@ type AgentChatComposerSlashMenuProps = {
 };
 
 export function AgentChatComposerSlashMenu({
+  listboxId,
   commands,
   activeIndex,
   slashCommandsError,
@@ -33,7 +35,12 @@ export function AgentChatComposerSlashMenu({
   }, [activeIndex, commands]);
 
   return (
-    <div className="absolute bottom-full rounded-xl z-20 mb-2 border border-border bg-popover shadow-lg">
+    <div
+      id={listboxId}
+      role="listbox"
+      aria-label="Slash commands"
+      className="absolute bottom-full rounded-xl z-20 mb-2 border border-border bg-popover shadow-lg"
+    >
       {isSlashCommandsLoading ? (
         <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
           <LoaderCircle className="size-4 animate-spin" />
@@ -55,9 +62,13 @@ export function AgentChatComposerSlashMenu({
             return (
               <button
                 key={command.id}
+                id={`${listboxId}-option-${index}`}
                 ref={(element) => {
                   commandButtonRefs.current[command.id] = element;
                 }}
+                role="option"
+                aria-selected={isActive}
+                tabIndex={-1}
                 type="button"
                 className={cn(
                   "flex w-full cursor-pointer gap-3 px-3 py-2 text-left transition-colors",

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.tsx
@@ -2,6 +2,7 @@ import type { AgentSlashCommand } from "@openducktor/core";
 import { ChevronRight, LoaderCircle, Terminal } from "lucide-react";
 import { type ReactElement, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { getComposerPopupOptionId } from "./agent-chat-composer-menu-state";
 
 type AgentChatComposerSlashMenuProps = {
   listboxId: string;
@@ -35,12 +36,7 @@ export function AgentChatComposerSlashMenu({
   }, [activeIndex, commands]);
 
   return (
-    <div
-      id={listboxId}
-      role="listbox"
-      aria-label="Slash commands"
-      className="absolute bottom-full rounded-xl z-20 mb-2 border border-border bg-popover shadow-lg"
-    >
+    <div className="absolute bottom-full rounded-xl z-20 mb-2 border border-border bg-popover shadow-lg">
       {isSlashCommandsLoading ? (
         <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
           <LoaderCircle className="size-4 animate-spin" />
@@ -55,54 +51,59 @@ export function AgentChatComposerSlashMenu({
       {commands.length === 0 && !isSlashCommandsLoading && !slashCommandsError ? (
         <div className="px-3 py-2 text-sm text-muted-foreground">No slash commands found.</div>
       ) : null}
-      {commands.length > 0 ? (
-        <div className="hide-scrollbar flex rounded-xl max-h-64 flex-col overflow-y-auto">
-          {commands.map((command, index) => {
-            const isActive = index === activeIndex;
-            return (
-              <button
-                key={command.id}
-                id={`${listboxId}-option-${index}`}
-                ref={(element) => {
-                  commandButtonRefs.current[command.id] = element;
-                }}
-                role="option"
-                aria-selected={isActive}
-                tabIndex={-1}
-                type="button"
-                className={cn(
-                  "flex w-full cursor-pointer gap-3 px-3 py-2 text-left transition-colors",
-                  isActive ? "bg-selected-surface" : "hover:bg-muted/80",
-                )}
-                onPointerDown={(event) => {
-                  event.preventDefault();
-                  onSelectCommand(command);
-                }}
-              >
-                <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                  <Terminal className="size-3.5" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="flex items-center gap-2 text-sm font-medium text-foreground">
-                    <span className="truncate">/{command.trigger}</span>
-                    {command.source ? (
-                      <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                        {command.source}
+      <div
+        id={listboxId}
+        role="listbox"
+        aria-label="Slash commands"
+        className="hide-scrollbar flex rounded-xl max-h-64 flex-col overflow-y-auto"
+      >
+        {commands.length > 0
+          ? commands.map((command, index) => {
+              const isActive = index === activeIndex;
+              return (
+                <button
+                  key={command.id}
+                  id={getComposerPopupOptionId(listboxId, index)}
+                  ref={(element) => {
+                    commandButtonRefs.current[command.id] = element;
+                  }}
+                  role="option"
+                  aria-selected={isActive}
+                  tabIndex={-1}
+                  type="button"
+                  className={cn(
+                    "flex w-full cursor-pointer gap-3 px-3 py-2 text-left transition-colors",
+                    isActive ? "bg-selected-surface" : "hover:bg-muted/80",
+                  )}
+                  onPointerDown={(event) => {
+                    event.preventDefault();
+                    onSelectCommand(command);
+                  }}
+                >
+                  <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                    <Terminal className="size-3.5" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+                      <span className="truncate">/{command.trigger}</span>
+                      {command.source ? (
+                        <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                          {command.source}
+                        </span>
+                      ) : null}
+                    </span>
+                    {command.description ? (
+                      <span className="line-clamp-2 text-xs text-muted-foreground">
+                        {command.description}
                       </span>
                     ) : null}
                   </span>
-                  {command.description ? (
-                    <span className="line-clamp-2 text-xs text-muted-foreground">
-                      {command.description}
-                    </span>
-                  ) : null}
-                </span>
-                <ChevronRight className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
+                  <ChevronRight className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                </button>
+              );
+            })
+          : null}
+      </div>
     </div>
   );
 }

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-slash-menu.tsx
@@ -38,13 +38,16 @@ export function AgentChatComposerSlashMenu({
   return (
     <div className="absolute bottom-full rounded-xl z-20 mb-2 border border-border bg-popover shadow-lg">
       {isSlashCommandsLoading ? (
-        <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground">
+        <div
+          role="status"
+          className="flex items-center gap-2 border-b border-border px-3 py-2 text-sm text-muted-foreground"
+        >
           <LoaderCircle className="size-4 animate-spin" />
           <span>Loading slash commands…</span>
         </div>
       ) : null}
       {slashCommandsError ? (
-        <div className="border-b border-border px-3 py-2 text-sm text-destructive">
+        <div role="alert" className="border-b border-border px-3 py-2 text-sm text-destructive">
           {slashCommandsError}
         </div>
       ) : null}
@@ -57,6 +60,7 @@ export function AgentChatComposerSlashMenu({
         id={listboxId}
         role="listbox"
         aria-label="Slash commands"
+        aria-busy={(isSlashCommandsLoading && commands.length === 0) || undefined}
         className="hide-scrollbar flex rounded-xl max-h-64 flex-col overflow-y-auto"
       >
         {commands.length > 0


### PR DESCRIPTION
## Summary

- wire the existing rich message composer to the reference, slash-command, and skill listboxes with editable-combobox ARIA relationships
- keep focus and keyboard selection in the existing editor state machine while removing popup options from the Tab order
- share the current reference-menu visibility and option-ID contracts so hidden pre-loading and active-descendant semantics stay aligned

## Goal

Make the composer suggestion popups behave as one accessible combobox without replacing the contenteditable editor, duplicating keyboard state, changing filtering/ranking, or copying plan 003's debounce implementation.

## Implementation

- preserve the exact `Message composer` accessible name and expose expanded, controls, autocomplete, and active-descendant state from the editor
- give each popup a stable listbox ID and each selectable row a deterministic option ID with `aria-selected` and `tabIndex={-1}`
- keep loading, error, and empty feedback outside option semantics while retaining an empty controlled listbox whenever a popup is visibly open
- centralize the existing reference-menu visibility derivation and composer option-ID construction
- cover reference, slash-command, and skill keyboard/focus cleanup paths plus listbox semantics in focused tests

## Dependencies and overlap

- **Plan 003 — Debounce composer file searches:** dependency declared by plan 008; no PR or remote plan-003 branch exists yet. This PR deliberately preserves the fixed-point visibility contract and does not copy plan 003's debounce work. When plan 003 lands, identical visibility-contract lines can drop during the base update.
- **Plan 005 / #751 — Name the message composer:** dependency declared by plan 008. This PR includes the exact `aria-label="Message composer"` self-contained from the common base. When #751 lands, that identical line can drop during the base update.
- Built from fixed point `7132fe4b2` against `fix/improve-react`; the target branch still points at that commit.

## Validation

- focused plan test command — 86 pass, 0 fail, 303 assertions
- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run --filter @openducktor/frontend test` — 3,501 pass, 0 fail, 10,325 assertions
- `bun run test` — pass across all workspaces and script tests
- `bun run build` — pass across all workspaces; existing Vite chunk-size warnings only
- React Doctor — 98/100 with no diagnostics and no score regression
- `git diff --check 7132fe4b2...HEAD` — pass
- GitNexus `detect_changes` — LOW risk, 9 files, 16 touched symbols, no affected execution flows
- Manual browser/screen-reader validation was not run because a live browser backend was not provided; the repository forbids starting it from this workflow

## Review verdicts

- Thermos correctness/security — **CLEAN / PASS** on the final `git diff 7132fe4b2...HEAD`
- Thermos maintainability — **CLEAN / PASS** after isolating listbox semantics and sharing option IDs
- Code review Standards — **CLEAN / PASS** after adding explicit async wait timeouts and centralizing visibility derivation
- Code review Spec — **CLEAN / PASS** against plan 008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved the message composer and autocomplete menus with clearer screen-reader semantics, keyboard navigation, active selection, and loading/error announcements.
  * Added more consistent support for slash commands, skills, files, and subagent references.

* **Bug Fixes**
  * Improved popup behavior while composing, including reliable selection and menu closing.
  * Fixed a macOS issue where Command+V could paste into the wrong target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->