### PR TITLE
perf(kanban): batch session history reads

### DIFF
--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -155,6 +155,7 @@ import type {
   SystemOpenInToolId,
   SystemOpenInToolInfo,
   TaskAction,
+  TaskAgentSessions,
   TaskCard,
   TaskCreateInput,
   TaskDirectMergeInput,
@@ -212,6 +213,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "agentSessionStartModeValues",
   "agentSessionStatusSchema",
   "agentSessionStopTargetSchema",
+  "taskAgentSessionsSchema",
   "APP_PLATFORM_VALUES",
   "appUpdateCheckInputSchema",
   "appUpdateCheckInitiatorSchema",
@@ -576,6 +578,7 @@ type ExportedTypeContract = {
   AgentSessionRole: AgentSessionRole;
   AgentSessionStatus: AgentSessionStatus;
   AgentSessionStopTarget: AgentSessionStopTarget;
+  TaskAgentSessions: TaskAgentSessions;
   AgentToolName: AgentToolName;
   AgentWorkflowState: AgentWorkflowState;
   AgentWorkflows: AgentWorkflows;

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -39,6 +39,7 @@ import {
   runtimeInstanceSummarySchema,
   runtimeTransportSchema,
   slashCommandCatalogSchema,
+  taskAgentSessionsSchema,
   taskCardSchema,
   taskWorktreeSummarySchema,
   toOpencodeExposedOdtToolIds,
@@ -1606,6 +1607,43 @@ describe("runtime schemas", () => {
     expect(parsed.externalSessionId).toBe("session-opencode-1");
     expect(parsed.runtimeKind).toBe("opencode");
     expect(parsed.selectedModel?.modelId).toBe("gpt-5");
+  });
+
+  test("task agent sessions parses a batch session response", () => {
+    const parsed = taskAgentSessionsSchema.parse({
+      taskId: "task-1",
+      agentSessions: [
+        {
+          externalSessionId: "session-opencode-1",
+          role: "spec",
+          startedAt: "2026-02-18T17:11:00.000Z",
+          runtimeKind: "opencode",
+          workingDirectory: "/repo",
+          selectedModel: null,
+        },
+      ],
+    });
+
+    expect(parsed.taskId).toBe("task-1");
+    expect(parsed.agentSessions).toHaveLength(1);
+  });
+
+  test("task agent sessions rejects invalid nested session records", () => {
+    expect(() =>
+      taskAgentSessionsSchema.parse({
+        taskId: "task-1",
+        agentSessions: [
+          {
+            externalSessionId: "session-opencode-1",
+            role: "invalid-role",
+            startedAt: "2026-02-18T17:11:00.000Z",
+            runtimeKind: "opencode",
+            workingDirectory: "/repo",
+            selectedModel: null,
+          },
+        ],
+      }),
+    ).toThrow();
   });
 
   test("agent session record parses compact persisted payload with explicit runtime kind", () => {

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -115,6 +115,12 @@ export type AgentSessionIdentity = Pick<
   "externalSessionId" | "runtimeKind" | "workingDirectory"
 >;
 
+export const taskAgentSessionsSchema = z.object({
+  taskId: z.string(),
+  agentSessions: z.array(agentSessionRecordSchema),
+});
+export type TaskAgentSessions = z.infer<typeof taskAgentSessionsSchema>;
+
 export const agentSessionStopTargetSchema = z.object({
   repoPath: nonEmptyStringSchema,
   taskId: nonEmptyStringSchema,

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -6,6 +6,7 @@ import {
   type RepoConfig,
   type RepoPromptOverrides,
   type SettingsSnapshot,
+  type TaskAgentSessions,
   type TaskCard,
   type WorkspaceRecord,
 } from "@openducktor/contracts";
@@ -75,7 +76,9 @@ const sessionIdentity = (externalSessionId: string) => ({
 const startAgentSessionMock = mock(async () => sessionIdentity("session-1"));
 const sendAgentMessageMock = mock(async () => {});
 const updateAgentSessionModelMock = mock(() => {});
-const agentSessionsListMock = mock(async (_repoPath: string, _taskId: string) => []);
+const agentSessionsListForTasksMock = mock(
+  async (_repoPath: string, _taskIds: string[]): Promise<TaskAgentSessions[]> => [],
+);
 const humanApproveTaskMock = mock(async () => {});
 const humanRequestChangesTaskMock = mock(async () => {});
 const deleteTaskMock = mock(async () => {});
@@ -144,7 +147,7 @@ type LatestKanbanPageModels = {
 };
 
 type KanbanPageRenderState = {
-  task: TaskCard;
+  tasks: TaskCard[];
   repoConfig: RepoConfig;
   settingsSnapshot: SettingsSnapshot;
   sessions: AgentSessionState[];
@@ -292,12 +295,12 @@ const createAgentOperationsValue = (): AgentOperationsContextValue => ({
 const createTasksStateValue = (
   renderState: Pick<
     KanbanPageRenderState,
-    "task" | "pendingMergedPullRequest" | "linkingMergedPullRequestTaskId"
+    "tasks" | "pendingMergedPullRequest" | "linkingMergedPullRequestTaskId"
   >,
 ): TasksStateContextValue => ({
   isForegroundLoadingTasks: false,
   isRefreshingTasksInBackground: false,
-  tasks: [renderState.task],
+  tasks: renderState.tasks,
   isLoadingTasks: false,
   createTask: async () => {},
   updateTask: async () => {},
@@ -431,10 +434,15 @@ const getKanbanColumnProps = (latest: LatestKanbanPageModels): Record<string, un
 };
 
 const renderPage = async (
-  options: { seedSettingsSnapshot?: boolean; platform?: AppPlatform | null } = {},
+  options: {
+    seedSettingsSnapshot?: boolean;
+    seedAgentSessionBatch?: boolean;
+    platform?: AppPlatform | null;
+    tasks?: TaskCard[];
+  } = {},
 ): Promise<KanbanPageHarness> => {
   const renderState: KanbanPageRenderState = {
-    task: currentTaskFixture,
+    tasks: options.tasks ?? [currentTaskFixture],
     repoConfig: currentRepoConfigFixture,
     settingsSnapshot: currentSettingsSnapshotFixture,
     sessions: currentSessionsFixture,
@@ -463,7 +471,13 @@ const renderPage = async (
   if (options.platform !== null) {
     queryClient.setQueryData(systemQueryKeys.platform(), options.platform ?? "darwin");
   }
-  queryClient.setQueryData(agentSessionQueryKeys.list("/repo", renderState.task.id), []);
+  if (options.seedAgentSessionBatch !== false) {
+    const taskIds = renderState.tasks.map((task) => task.id);
+    queryClient.setQueryData(
+      agentSessionQueryKeys.listForTasks("/repo", taskIds),
+      Object.fromEntries(taskIds.map((taskId) => [taskId, []])),
+    );
+  }
   const LocationProbe = (): ReactElement | null => {
     const location = useLocation();
     latest.location = `${location.pathname}${location.search}`;
@@ -735,7 +749,7 @@ describe("KanbanPage session start modal flow", () => {
     startAgentSessionMock.mockClear();
     sendAgentMessageMock.mockClear();
     updateAgentSessionModelMock.mockClear();
-    agentSessionsListMock.mockClear();
+    agentSessionsListForTasksMock.mockClear();
     humanApproveTaskMock.mockClear();
     humanRequestChangesTaskMock.mockClear();
     deleteTaskMock.mockClear();
@@ -752,6 +766,54 @@ describe("KanbanPage session start modal flow", () => {
 
   afterAll(async () => {
     console.error = originalConsoleError;
+  });
+
+  kanbanTest("loads histories for multiple tasks with one batch call", async () => {
+    const secondTask = createTaskCardFixture({ id: "TASK-456", status: "open" });
+    const firstSession = {
+      externalSessionId: "session-task-123",
+      role: "spec" as const,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      runtimeKind: "opencode" as const,
+      workingDirectory: "/repo/worktrees/TASK-123",
+      selectedModel: null,
+    };
+    const secondSession = {
+      externalSessionId: "session-task-456",
+      role: "build" as const,
+      startedAt: "2026-01-02T00:00:00.000Z",
+      runtimeKind: "opencode" as const,
+      workingDirectory: "/repo/worktrees/TASK-456",
+      selectedModel: null,
+    };
+    const originalAgentSessionsListForTasks = hostClient.agentSessionsListForTasks;
+    agentSessionsListForTasksMock.mockImplementation(async () => [
+      { taskId: "TASK-123", agentSessions: [firstSession] },
+      { taskId: "TASK-456", agentSessions: [secondSession] },
+    ]);
+    hostClient.agentSessionsListForTasks = agentSessionsListForTasksMock;
+
+    const renderer = await renderPage({
+      seedAgentSessionBatch: false,
+      tasks: [currentTaskFixture, secondTask],
+    });
+
+    try {
+      await waitForMockCall(agentSessionsListForTasksMock);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["TASK-123", "TASK-456"]);
+      expect(renderer.getKanbanColumnProps().historicalSessionsByTaskId).toEqual(
+        new Map([
+          ["TASK-123", [firstSession]],
+          ["TASK-456", [secondSession]],
+        ]),
+      );
+    } finally {
+      hostClient.agentSessionsListForTasks = originalAgentSessionsListForTasks;
+      await act(async () => {
+        renderer.unmount();
+      });
+    }
   });
 
   kanbanTest(

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -6,7 +6,6 @@ import {
   type RepoConfig,
   type RepoPromptOverrides,
   type SettingsSnapshot,
-  type TaskAgentSessions,
   type TaskCard,
   type WorkspaceRecord,
 } from "@openducktor/contracts";
@@ -76,9 +75,6 @@ const sessionIdentity = (externalSessionId: string) => ({
 const startAgentSessionMock = mock(async () => sessionIdentity("session-1"));
 const sendAgentMessageMock = mock(async () => {});
 const updateAgentSessionModelMock = mock(() => {});
-const agentSessionsListForTasksMock = mock(
-  async (_repoPath: string, _taskIds: string[]): Promise<TaskAgentSessions[]> => [],
-);
 const humanApproveTaskMock = mock(async () => {});
 const humanRequestChangesTaskMock = mock(async () => {});
 const deleteTaskMock = mock(async () => {});
@@ -749,7 +745,6 @@ describe("KanbanPage session start modal flow", () => {
     startAgentSessionMock.mockClear();
     sendAgentMessageMock.mockClear();
     updateAgentSessionModelMock.mockClear();
-    agentSessionsListForTasksMock.mockClear();
     humanApproveTaskMock.mockClear();
     humanRequestChangesTaskMock.mockClear();
     deleteTaskMock.mockClear();
@@ -786,11 +781,11 @@ describe("KanbanPage session start modal flow", () => {
       workingDirectory: "/repo/worktrees/TASK-456",
       selectedModel: null,
     };
-    const originalAgentSessionsListForTasks = hostClient.agentSessionsListForTasks;
-    agentSessionsListForTasksMock.mockImplementation(async () => [
+    const agentSessionsListForTasksMock = mock(async () => [
       { taskId: "TASK-123", agentSessions: [firstSession] },
       { taskId: "TASK-456", agentSessions: [secondSession] },
     ]);
+    const originalAgentSessionsListForTasks = hostClient.agentSessionsListForTasks;
     hostClient.agentSessionsListForTasks = agentSessionsListForTasksMock;
 
     const renderer = await renderPage({

--- a/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
+++ b/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_KANBAN_SETTINGS, type TaskCard } from "@openducktor/contracts";
-import { useQueries, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
@@ -14,7 +14,7 @@ import {
   useTasksState,
   useWorkspaceState,
 } from "@/state";
-import { agentSessionListQueryOptions } from "@/state/queries/agent-sessions";
+import { agentSessionListsQueryOptions } from "@/state/queries/agent-sessions";
 import { useHorizontalScrollbarVisibility } from "@/state/queries/use-horizontal-scrollbar-visibility";
 import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
 import { useAgentStudioRepoSettings } from "../agents/use-agent-studio-repo-settings";
@@ -142,20 +142,20 @@ export function useKanbanPageModels({
     workspaceRepoPath && !settingsSnapshotQuery.isError ? tasks : EMPTY_KANBAN_TASKS;
   const kanbanTaskIds = useMemo(() => kanbanTasks.map((task) => task.id), [kanbanTasks]);
   const shouldLoadHistoricalSessions = workspaceRepoPath !== null && kanbanTaskIds.length > 0;
-  const historicalSessionQueries = useQueries({
-    queries:
-      shouldLoadHistoricalSessions && workspaceRepoPath
-        ? kanbanTaskIds.map((taskId) => agentSessionListQueryOptions(workspaceRepoPath, taskId))
-        : [],
+  const historicalSessionsQuery = useQuery({
+    ...agentSessionListsQueryOptions(workspaceRepoPath ?? "", kanbanTaskIds),
+    enabled: shouldLoadHistoricalSessions,
   });
   const historicalSessionsByTaskId = useMemo(
     () =>
       new Map(
-        kanbanTaskIds.map((taskId, index) => [taskId, historicalSessionQueries[index]?.data ?? []]),
+        kanbanTaskIds.map((taskId) => [taskId, historicalSessionsQuery.data?.[taskId] ?? []]),
       ),
-    [historicalSessionQueries, kanbanTaskIds],
+    [historicalSessionsQuery.data, kanbanTaskIds],
   );
-  const historicalSessionsError = historicalSessionQueries.find((query) => query.isError)?.error;
+  const historicalSessionsError = historicalSessionsQuery.isError
+    ? historicalSessionsQuery.error
+    : undefined;
   const reportedHistoricalSessionsErrorRef = useRef<string | null>(null);
   useEffect(() => {
     if (!historicalSessionsError) {

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -7,6 +7,7 @@ import {
   agentSessionQueryKeys,
   invalidateAgentSessionListQuery,
   loadAgentSessionListsFromQuery,
+  removeAgentSessionRecordFromQuery,
   upsertAgentSessionRecordInQuery,
 } from "./agent-sessions";
 
@@ -180,6 +181,28 @@ describe("agent session query cache helpers", () => {
         agentSessionQueryKeys.listForTasks("/other", ["task-1"]),
       ),
     ).toEqual({ "task-1": [] });
+  });
+
+  test("removeAgentSessionRecordFromQuery updates repository batch caches containing the task", () => {
+    const queryClient = new QueryClient();
+    const batchKey = agentSessionQueryKeys.listForTasks("/repo", ["task-1", "task-2"]);
+    const otherBatchKey = agentSessionQueryKeys.listForTasks("/other", ["task-1"]);
+    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
+    queryClient.setQueryData(batchKey, { "task-1": [sessionFixture], "task-2": [] });
+    queryClient.setQueryData(otherBatchKey, { "task-1": [sessionFixture] });
+
+    removeAgentSessionRecordFromQuery(queryClient, "/repo", "task-1", sessionFixture);
+
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
+    ).toEqual([]);
+    expect(queryClient.getQueryData<Record<string, AgentSessionRecord[]>>(batchKey)).toEqual({
+      "task-1": [],
+      "task-2": [],
+    });
+    expect(queryClient.getQueryData<Record<string, AgentSessionRecord[]>>(otherBatchKey)).toEqual({
+      "task-1": [sessionFixture],
+    });
   });
 
   test("invalidateAgentSessionListQuery invalidates per-task and repository batch caches", async () => {

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -3,7 +3,9 @@ import type { AgentSessionRecord } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { host } from "../operations/host";
 import {
+  agentSessionListsQueryOptions,
   agentSessionQueryKeys,
+  invalidateAgentSessionListQuery,
   loadAgentSessionListsFromQuery,
   upsertAgentSessionRecordInQuery,
 } from "./agent-sessions";
@@ -25,6 +27,36 @@ describe("agent session query cache helpers", () => {
     variant: "latest",
     profileId: "work",
   };
+
+  test("batch query keys normalize task ordering, whitespace, duplicates, and empty IDs", () => {
+    expect(
+      agentSessionQueryKeys.listForTasks("/repo", [" task-2 ", "", "task-1", "task-2"]),
+    ).toEqual(["agent-sessions", "list-for-tasks", "/repo", ["task-1", "task-2"]]);
+  });
+
+  test("agentSessionListsQueryOptions makes one normalized host call and defaults missing tasks", async () => {
+    const queryClient = new QueryClient();
+    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
+    const calls: unknown[] = [];
+    host.agentSessionsListForTasks = async (repoPath, taskIds) => {
+      calls.push({ repoPath, taskIds });
+      return [{ taskId: "task-1", agentSessions: [sessionFixture] }];
+    };
+
+    try {
+      const result = await queryClient.fetchQuery(
+        agentSessionListsQueryOptions("/repo", [" task-2 ", "task-1", "task-2"]),
+      );
+
+      expect(result).toEqual({
+        "task-1": [sessionFixture],
+        "task-2": [],
+      });
+      expect(calls).toEqual([{ repoPath: "/repo", taskIds: ["task-1", "task-2"] }]);
+    } finally {
+      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
+    }
+  });
 
   test("upsertAgentSessionRecordInQuery inserts a missing session record", () => {
     const queryClient = new QueryClient();
@@ -127,6 +159,43 @@ describe("agent session query cache helpers", () => {
     );
 
     expect(sessions).toEqual([sessionFixture, otherRuntimeSession]);
+  });
+
+  test("upsertAgentSessionRecordInQuery updates repository batch caches containing the task", () => {
+    const queryClient = new QueryClient();
+    const batchKey = agentSessionQueryKeys.listForTasks("/repo", ["task-1", "task-2"]);
+    queryClient.setQueryData(batchKey, { "task-1": [], "task-2": [] });
+    queryClient.setQueryData(agentSessionQueryKeys.listForTasks("/other", ["task-1"]), {
+      "task-1": [],
+    });
+
+    upsertAgentSessionRecordInQuery(queryClient, "/repo", "task-1", sessionFixture);
+
+    expect(queryClient.getQueryData<Record<string, AgentSessionRecord[]>>(batchKey)).toEqual({
+      "task-1": [sessionFixture],
+      "task-2": [],
+    });
+    expect(
+      queryClient.getQueryData<Record<string, AgentSessionRecord[]>>(
+        agentSessionQueryKeys.listForTasks("/other", ["task-1"]),
+      ),
+    ).toEqual({ "task-1": [] });
+  });
+
+  test("invalidateAgentSessionListQuery invalidates per-task and repository batch caches", async () => {
+    const queryClient = new QueryClient();
+    const listKey = agentSessionQueryKeys.list("/repo", "task-1");
+    const batchKey = agentSessionQueryKeys.listForTasks("/repo", ["task-1", "task-2"]);
+    const otherBatchKey = agentSessionQueryKeys.listForTasks("/other", ["task-1"]);
+    queryClient.setQueryData(listKey, []);
+    queryClient.setQueryData(batchKey, { "task-1": [], "task-2": [] });
+    queryClient.setQueryData(otherBatchKey, { "task-1": [] });
+
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
+
+    expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(batchKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(otherBatchKey)?.isInvalidated).toBe(false);
   });
 
   test("loadAgentSessionListsFromQuery reads the per-task session cache", async () => {

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { host } from "../operations/host";
@@ -36,12 +36,11 @@ describe("agent session query cache helpers", () => {
 
   test("agentSessionListsQueryOptions makes one normalized host call and defaults missing tasks", async () => {
     const queryClient = new QueryClient();
+    const agentSessionsListForTasksMock = mock(async () => [
+      { taskId: "task-1", agentSessions: [sessionFixture] },
+    ]);
     const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
-    const calls: unknown[] = [];
-    host.agentSessionsListForTasks = async (repoPath, taskIds) => {
-      calls.push({ repoPath, taskIds });
-      return [{ taskId: "task-1", agentSessions: [sessionFixture] }];
-    };
+    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
 
     try {
       const result = await queryClient.fetchQuery(
@@ -52,7 +51,8 @@ describe("agent session query cache helpers", () => {
         "task-1": [sessionFixture],
         "task-2": [],
       });
-      expect(calls).toEqual([{ repoPath: "/repo", taskIds: ["task-1", "task-2"] }]);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
     } finally {
       host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     }

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -6,7 +6,14 @@ import { host } from "../operations/host";
 const AGENT_SESSION_LIST_STALE_TIME_MS = 30_000;
 
 const normalizeTaskIds = (taskIds: string[]): string[] =>
-  Array.from(new Set(taskIds.map((taskId) => taskId.trim()).filter(Boolean))).sort();
+  Array.from(
+    new Set(
+      taskIds.flatMap((taskId) => {
+        const normalizedTaskId = taskId.trim();
+        return normalizedTaskId ? [normalizedTaskId] : [];
+      }),
+    ),
+  ).sort();
 
 export const agentSessionQueryKeys = {
   all: ["agent-sessions"] as const,
@@ -26,9 +33,10 @@ export const agentSessionListQueryOptions = (repoPath: string, taskId: string) =
   });
 
 export const agentSessionListsQueryOptions = (repoPath: string, taskIds: string[]) => {
-  const normalizedTaskIds = normalizeTaskIds(taskIds);
+  const queryKey = agentSessionQueryKeys.listForTasks(repoPath, taskIds);
+  const normalizedTaskIds = queryKey[3];
   return queryOptions({
-    queryKey: agentSessionQueryKeys.listForTasks(repoPath, normalizedTaskIds),
+    queryKey,
     queryFn: async (): Promise<Record<string, AgentSessionRecord[]>> => {
       const sessionsByTaskId = Object.fromEntries(
         normalizedTaskIds.map((taskId) => [taskId, [] as AgentSessionRecord[]]),

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -192,8 +192,31 @@ export const removeAgentSessionRecordFromQuery = (
   identity: AgentSessionIdentity,
 ): void => {
   const identityKey = agentSessionIdentityKey(identity);
+  const removeSession = (
+    current: AgentSessionRecord[] | undefined,
+  ): AgentSessionRecord[] | undefined => {
+    if (!current) {
+      return current;
+    }
+    const nextSessions = current.filter((entry) => agentSessionIdentityKey(entry) !== identityKey);
+    return nextSessions.length === current.length ? current : nextSessions;
+  };
   queryClient.setQueryData<AgentSessionRecord[] | undefined>(
     agentSessionQueryKeys.list(repoPath, taskId),
-    (current) => current?.filter((entry) => agentSessionIdentityKey(entry) !== identityKey),
+    removeSession,
+  );
+  queryClient.setQueriesData<Record<string, AgentSessionRecord[]> | undefined>(
+    { queryKey: agentSessionQueryKeys.batches(repoPath) },
+    (current) => {
+      if (!current || !(taskId in current)) {
+        return current;
+      }
+      const currentSessions = current[taskId];
+      const nextSessions = removeSession(currentSessions);
+      if (nextSessions === currentSessions || !nextSessions) {
+        return current;
+      }
+      return { ...current, [taskId]: nextSessions };
+    },
   );
 };

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -5,10 +5,17 @@ import { host } from "../operations/host";
 
 const AGENT_SESSION_LIST_STALE_TIME_MS = 30_000;
 
+const normalizeTaskIds = (taskIds: string[]): string[] =>
+  Array.from(new Set(taskIds.map((taskId) => taskId.trim()).filter(Boolean))).sort();
+
 export const agentSessionQueryKeys = {
   all: ["agent-sessions"] as const,
   list: (repoPath: string, taskId: string) =>
     [...agentSessionQueryKeys.all, "list", repoPath, taskId] as const,
+  batches: (repoPath: string) =>
+    [...agentSessionQueryKeys.all, "list-for-tasks", repoPath] as const,
+  listForTasks: (repoPath: string, taskIds: string[]) =>
+    [...agentSessionQueryKeys.batches(repoPath), normalizeTaskIds(taskIds)] as const,
 };
 
 export const agentSessionListQueryOptions = (repoPath: string, taskId: string) =>
@@ -17,6 +24,24 @@ export const agentSessionListQueryOptions = (repoPath: string, taskId: string) =
     queryFn: (): Promise<AgentSessionRecord[]> => host.agentSessionsList(repoPath, taskId),
     staleTime: AGENT_SESSION_LIST_STALE_TIME_MS,
   });
+
+export const agentSessionListsQueryOptions = (repoPath: string, taskIds: string[]) => {
+  const normalizedTaskIds = normalizeTaskIds(taskIds);
+  return queryOptions({
+    queryKey: agentSessionQueryKeys.listForTasks(repoPath, normalizedTaskIds),
+    queryFn: async (): Promise<Record<string, AgentSessionRecord[]>> => {
+      const sessionsByTaskId = Object.fromEntries(
+        normalizedTaskIds.map((taskId) => [taskId, [] as AgentSessionRecord[]]),
+      );
+      const taskSessions = await host.agentSessionsListForTasks(repoPath, normalizedTaskIds);
+      for (const taskSession of taskSessions) {
+        sessionsByTaskId[taskSession.taskId] = taskSession.agentSessions;
+      }
+      return sessionsByTaskId;
+    },
+    staleTime: AGENT_SESSION_LIST_STALE_TIME_MS,
+  });
+};
 
 export const loadAgentSessionListFromQuery = (
   queryClient: QueryClient,
@@ -58,11 +83,17 @@ export const invalidateAgentSessionListQuery = (
     refetchActive?: boolean;
   },
 ): Promise<void> =>
-  queryClient.invalidateQueries({
-    queryKey: agentSessionQueryKeys.list(repoPath, taskId),
-    exact: true,
-    refetchType: options?.refetchActive === true ? "active" : "none",
-  });
+  Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: agentSessionQueryKeys.list(repoPath, taskId),
+      exact: true,
+      refetchType: options?.refetchActive === true ? "active" : "none",
+    }),
+    queryClient.invalidateQueries({
+      queryKey: agentSessionQueryKeys.batches(repoPath),
+      refetchType: options?.refetchActive === true ? "active" : "none",
+    }),
+  ]).then(() => undefined);
 
 const areSelectedModelsEquivalent = (
   left: AgentSessionRecord["selectedModel"],
@@ -94,6 +125,32 @@ const areAgentSessionRecordsEquivalent = (
   left.workingDirectory === right.workingDirectory &&
   areSelectedModelsEquivalent(left.selectedModel, right.selectedModel);
 
+const upsertAgentSessionRecord = (
+  current: AgentSessionRecord[] | undefined,
+  session: AgentSessionRecord,
+): AgentSessionRecord[] | undefined => {
+  if (!current) {
+    return current;
+  }
+
+  const sessionKey = agentSessionIdentityKey(session);
+  const existingIndex = current.findIndex((entry) => agentSessionIdentityKey(entry) === sessionKey);
+  if (existingIndex === -1) {
+    return [...current, session];
+  }
+
+  const existingSession = current[existingIndex];
+  if (!existingSession || existingSession === session) {
+    return current;
+  }
+
+  if (areAgentSessionRecordsEquivalent(existingSession, session)) {
+    return current;
+  }
+
+  return current.map((entry, index) => (index === existingIndex ? session : entry));
+};
+
 export const upsertAgentSessionRecordInQuery = (
   queryClient: QueryClient,
   repoPath: string,
@@ -102,29 +159,20 @@ export const upsertAgentSessionRecordInQuery = (
 ): void => {
   queryClient.setQueryData<AgentSessionRecord[] | undefined>(
     agentSessionQueryKeys.list(repoPath, taskId),
-    (current): AgentSessionRecord[] | undefined => {
-      if (!current) {
+    (current) => upsertAgentSessionRecord(current, session),
+  );
+  queryClient.setQueriesData<Record<string, AgentSessionRecord[]> | undefined>(
+    { queryKey: agentSessionQueryKeys.batches(repoPath) },
+    (current) => {
+      if (!current || !(taskId in current)) {
         return current;
       }
-
-      const sessionKey = agentSessionIdentityKey(session);
-      const existingIndex = current.findIndex(
-        (entry) => agentSessionIdentityKey(entry) === sessionKey,
-      );
-      if (existingIndex === -1) {
-        return [...current, session];
-      }
-
-      const existingSession = current[existingIndex];
-      if (!existingSession || existingSession === session) {
+      const currentSessions = current[taskId];
+      const nextSessions = upsertAgentSessionRecord(currentSessions, session);
+      if (nextSessions === currentSessions || !nextSessions) {
         return current;
       }
-
-      if (areAgentSessionRecordsEquivalent(existingSession, session)) {
-        return current;
-      }
-
-      return current.map((entry, index) => (index === existingIndex ? session : entry));
+      return { ...current, [taskId]: nextSessions };
     },
   );
 };

--- a/packages/host-client/src/index.test.ts
+++ b/packages/host-client/src/index.test.ts
@@ -1874,6 +1874,64 @@ describe("HostClient", () => {
     });
   });
 
+  test("agentSessionsListForTasks uses one command and parses the batch response", async () => {
+    const { client, calls } = createClient((command) => {
+      if (command === "agent_sessions_list_for_tasks") {
+        return [
+          {
+            taskId: "task-1",
+            agentSessions: [
+              {
+                externalSessionId: "session-opencode-1",
+                role: "spec",
+                startedAt: "2026-02-18T17:20:00Z",
+                runtimeKind: "opencode",
+                workingDirectory: "/repo",
+                selectedModel: null,
+              },
+            ],
+          },
+        ];
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const sessions = await client.agentSessionsListForTasks("/repo", ["task-2", "task-1"]);
+
+    expect(sessions).toHaveLength(1);
+    expect(calls).toEqual([
+      {
+        command: "agent_sessions_list_for_tasks",
+        args: { repoPath: "/repo", taskIds: ["task-2", "task-1"] },
+      },
+    ]);
+  });
+
+  test("agentSessionsListForTasks rejects invalid nested session entries", async () => {
+    const { client } = createClient((command) => {
+      if (command === "agent_sessions_list_for_tasks") {
+        return [
+          {
+            taskId: "task-1",
+            agentSessions: [
+              {
+                externalSessionId: "session-opencode-1",
+                role: "invalid-role",
+                startedAt: "2026-02-18T17:20:00Z",
+                runtimeKind: "opencode",
+                workingDirectory: "/repo",
+                selectedModel: null,
+              },
+            ],
+          },
+        ];
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(client.agentSessionsListForTasks("/repo", ["task-1"])).rejects.toThrow("role");
+  });
+
   test("agentSessionsList rejects invalid persisted agent session entries", async () => {
     const { client } = createClient((command) => {
       if (command === "task_metadata_get") {

--- a/packages/host-client/src/index.ts
+++ b/packages/host-client/src/index.ts
@@ -72,6 +72,7 @@ const TASK_METHODS = [
   "qaApproved",
   "qaRejected",
   "agentSessionsList",
+  "agentSessionsListForTasks",
   "agentSessionDelete",
   "agentSessionUpsert",
 ] as const satisfies readonly MethodName<HostTaskClient>[];

--- a/packages/host-client/src/task-client.ts
+++ b/packages/host-client/src/task-client.ts
@@ -2,10 +2,12 @@ import {
   type AgentSessionIdentity,
   type AgentSessionRecord,
   type PlanSubtaskInput,
+  type TaskAgentSessions,
   type TaskCard,
   type TaskCreateInput,
   type TaskStatus,
   type TaskUpdatePatch,
+  taskAgentSessionsSchema,
   taskCardSchema,
   taskCreateInputSchema,
   taskStatusSchema,
@@ -301,6 +303,14 @@ export class HostTaskClient {
   async agentSessionsList(repoPath: string, taskId: string): Promise<AgentSessionRecord[]> {
     const payload = await this.readTaskMetadata(repoPath, taskId);
     return payload.agentSessions;
+  }
+
+  async agentSessionsListForTasks(
+    repoPath: string,
+    taskIds: string[],
+  ): Promise<TaskAgentSessions[]> {
+    const payload = await this.invokeFn("agent_sessions_list_for_tasks", { repoPath, taskIds });
+    return parseArray(taskAgentSessionsSchema, payload, "agent_sessions_list_for_tasks");
   }
 
   async agentSessionUpsert(

--- a/packages/host/src/adapters/sqlite/sqlite-json-codecs.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-json-codecs.ts
@@ -90,7 +90,7 @@ export const labelsFromRow = (row: TaskRow): Effect.Effect<string[], SqliteTaskS
   );
 
 export const agentSessionsFromRow = (
-  row: TaskRow,
+  row: Pick<TaskRow, "agentSessionsJson" | "id">,
 ): Effect.Effect<AgentSessionRecord[], SqliteTaskStoreDataError> =>
   parseJsonColumn(
     row.agentSessionsJson,

--- a/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
@@ -32,21 +32,16 @@ const compactAgentSessionForStorage = (
 export const listAgentSessionsForTasks = (
   session: TaskStoreSession,
   input: Parameters<TaskStorePort["listAgentSessionsForTasks"]>[0],
-): Effect.Effect<TaskAgentSessions[], SqliteTaskStoreReadError> => {
-  const taskIds = Array.from(new Set(input.taskIds.map((taskId) => taskId.trim()).filter(Boolean)));
-  if (taskIds.length === 0) {
-    return Effect.succeed([]);
-  }
-
-  return Effect.gen(function* () {
+): Effect.Effect<TaskAgentSessions[], SqliteTaskStoreReadError> =>
+  Effect.gen(function* () {
     const rows = yield* session.execute(
-      (database) => database.select().from(tasks).where(inArray(tasks.id, taskIds)),
+      (database) => database.select().from(tasks).where(inArray(tasks.id, input.taskIds)),
       "sqliteTaskRepository.listAgentSessionsForTasks.selectTasks",
-      { taskIds },
+      { taskIds: input.taskIds },
     );
     const rowsByTaskId = new Map(rows.map((row) => [row.id, row]));
     const results: TaskAgentSessions[] = [];
-    for (const taskId of taskIds) {
+    for (const taskId of input.taskIds) {
       const row = rowsByTaskId.get(taskId);
       if (!row) {
         continue;
@@ -58,7 +53,6 @@ export const listAgentSessionsForTasks = (
     }
     return results;
   });
-};
 
 export const clearAgentSessionsByRoles = (
   session: TaskStoreSession,

--- a/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
@@ -35,7 +35,14 @@ export const listAgentSessionsForTasks = (
 ): Effect.Effect<TaskAgentSessions[], SqliteTaskStoreReadError> =>
   Effect.gen(function* () {
     const rows = yield* session.execute(
-      (database) => database.select().from(tasks).where(inArray(tasks.id, input.taskIds)),
+      (database) =>
+        database
+          .select({
+            id: tasks.id,
+            agentSessionsJson: tasks.agentSessionsJson,
+          })
+          .from(tasks)
+          .where(inArray(tasks.id, input.taskIds)),
       "sqliteTaskRepository.listAgentSessionsForTasks.selectTasks",
       { taskIds: input.taskIds },
     );

--- a/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
@@ -1,5 +1,5 @@
-import type { AgentSessionRecord } from "@openducktor/contracts";
-import { eq } from "drizzle-orm";
+import type { AgentSessionRecord, TaskAgentSessions } from "@openducktor/contracts";
+import { eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 import { hasSameAgentSessionIdentity } from "../../domain/agent-session-identity";
 import { compactAgentSessionRecord } from "../../domain/agent-session-records";
@@ -8,6 +8,7 @@ import { agentSessionsFromRow, encodeJson } from "./sqlite-json-codecs";
 import { requireTaskRow } from "./sqlite-task-queries";
 import {
   SqliteTaskStoreDataError,
+  type SqliteTaskStoreReadError,
   type SqliteTaskStoreWriteError,
 } from "./sqlite-task-store-errors";
 import { type TaskStoreSession, tasks } from "./sqlite-task-store-schema";
@@ -26,6 +27,37 @@ const compactAgentSessionForStorage = (
       field: compacted.error.field === "agentSession" ? "agentSessionsJson" : compacted.error.field,
     }),
   );
+};
+
+export const listAgentSessionsForTasks = (
+  session: TaskStoreSession,
+  input: Parameters<TaskStorePort["listAgentSessionsForTasks"]>[0],
+): Effect.Effect<TaskAgentSessions[], SqliteTaskStoreReadError> => {
+  const taskIds = Array.from(new Set(input.taskIds.map((taskId) => taskId.trim()).filter(Boolean)));
+  if (taskIds.length === 0) {
+    return Effect.succeed([]);
+  }
+
+  return Effect.gen(function* () {
+    const rows = yield* session.execute(
+      (database) => database.select().from(tasks).where(inArray(tasks.id, taskIds)),
+      "sqliteTaskRepository.listAgentSessionsForTasks.selectTasks",
+      { taskIds },
+    );
+    const rowsByTaskId = new Map(rows.map((row) => [row.id, row]));
+    const results: TaskAgentSessions[] = [];
+    for (const taskId of taskIds) {
+      const row = rowsByTaskId.get(taskId);
+      if (!row) {
+        continue;
+      }
+      results.push({
+        taskId,
+        agentSessions: yield* agentSessionsFromRow(row),
+      });
+    }
+    return results;
+  });
 };
 
 export const clearAgentSessionsByRoles = (

--- a/packages/host/src/adapters/sqlite/sqlite-task-repository.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-repository.ts
@@ -6,6 +6,7 @@ import { encodeJson, normalizeLabels } from "./sqlite-json-codecs";
 import {
   clearAgentSessionsByRoles,
   deleteAgentSession,
+  listAgentSessionsForTasks,
   upsertAgentSession,
 } from "./sqlite-task-agent-sessions";
 import { getTaskCard, listTasksInDatabase } from "./sqlite-task-card-read-model";
@@ -206,6 +207,16 @@ export const createSqliteTaskRepository = ({
         input.repoPath,
         "sqliteTaskRepository.listPullRequestSyncCandidates",
         ({ session }) => listPullRequestSyncCandidatesInDatabase(session),
+      );
+    },
+    listAgentSessionsForTasks(input) {
+      if (input.taskIds.length === 0) {
+        return Effect.succeed([]);
+      }
+      return withDatabase(
+        input.repoPath,
+        "sqliteTaskRepository.listAgentSessionsForTasks",
+        ({ session }) => listAgentSessionsForTasks(session, input),
       );
     },
     listTasks(input) {

--- a/packages/host/src/adapters/sqlite/sqlite-task-repository.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-repository.ts
@@ -210,13 +210,16 @@ export const createSqliteTaskRepository = ({
       );
     },
     listAgentSessionsForTasks(input) {
-      if (input.taskIds.length === 0) {
+      const taskIds = Array.from(
+        new Set(input.taskIds.map((taskId) => taskId.trim()).filter(Boolean)),
+      );
+      if (taskIds.length === 0) {
         return Effect.succeed([]);
       }
       return withDatabase(
         input.repoPath,
         "sqliteTaskRepository.listAgentSessionsForTasks",
-        ({ session }) => listAgentSessionsForTasks(session, input),
+        ({ session }) => listAgentSessionsForTasks(session, { ...input, taskIds }),
       );
     },
     listTasks(input) {

--- a/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
@@ -4,11 +4,28 @@ import {
   createAgentSessionRecord,
   describeTaskStorePortContract,
 } from "../../ports/task-store-port-contract.test-support";
+import { createSqliteTaskRepository } from "./sqlite-task-repository";
 import { createSqliteTaskStoreHarness } from "./sqlite-task-store-test-support";
 
 describeTaskStorePortContract("SQLite TaskStorePort contract", createSqliteTaskStoreHarness);
 
 describe("SQLite task agent session batches", () => {
+  test("returns an empty normalized ID list without resolving storage", async () => {
+    let resolverCalls = 0;
+    const store = createSqliteTaskRepository({
+      resolveWorkspaceIdForRepoPath: () =>
+        Effect.sync(() => {
+          resolverCalls += 1;
+          return "workspace";
+        }),
+    });
+
+    await expect(
+      Effect.runPromise(store.listAgentSessionsForTasks({ repoPath: "/repo", taskIds: [" ", ""] })),
+    ).resolves.toEqual([]);
+    expect(resolverCalls).toBe(0);
+  });
+
   test("lists multiple tasks, ignores duplicates and missing tasks, and handles empty IDs", async () => {
     const { cleanup, repoPath, store } = await createSqliteTaskStoreHarness();
     try {

--- a/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
@@ -1,4 +1,70 @@
-import { describeTaskStorePortContract } from "../../ports/task-store-port-contract.test-support";
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import {
+  createAgentSessionRecord,
+  describeTaskStorePortContract,
+} from "../../ports/task-store-port-contract.test-support";
 import { createSqliteTaskStoreHarness } from "./sqlite-task-store-test-support";
 
 describeTaskStorePortContract("SQLite TaskStorePort contract", createSqliteTaskStoreHarness);
+
+describe("SQLite task agent session batches", () => {
+  test("lists multiple tasks, ignores duplicates and missing tasks, and handles empty IDs", async () => {
+    const { cleanup, repoPath, store } = await createSqliteTaskStoreHarness();
+    try {
+      const firstTask = await Effect.runPromise(
+        store.createTask({
+          repoPath,
+          task: {
+            title: "First sessions",
+            issueType: "task",
+            priority: 2,
+            aiReviewEnabled: true,
+          },
+        }),
+      );
+      const secondTask = await Effect.runPromise(
+        store.createTask({
+          repoPath,
+          task: {
+            title: "Second sessions",
+            issueType: "task",
+            priority: 2,
+            aiReviewEnabled: true,
+          },
+        }),
+      );
+      const olderSession = createAgentSessionRecord({
+        externalSessionId: "older-session",
+        startedAt: "2026-06-10T10:00:00.000Z",
+      });
+      const newerSession = createAgentSessionRecord({
+        externalSessionId: "newer-session",
+        startedAt: "2026-06-10T11:00:00.000Z",
+      });
+      await Effect.runPromise(
+        store.upsertAgentSession({ repoPath, taskId: firstTask.id, session: olderSession }),
+      );
+      await Effect.runPromise(
+        store.upsertAgentSession({ repoPath, taskId: firstTask.id, session: newerSession }),
+      );
+
+      await expect(
+        Effect.runPromise(
+          store.listAgentSessionsForTasks({
+            repoPath,
+            taskIds: [secondTask.id, firstTask.id, firstTask.id, "missing-task"],
+          }),
+        ),
+      ).resolves.toEqual([
+        { taskId: secondTask.id, agentSessions: [] },
+        { taskId: firstTask.id, agentSessions: [newerSession, olderSession] },
+      ]);
+      await expect(
+        Effect.runPromise(store.listAgentSessionsForTasks({ repoPath, taskIds: [] })),
+      ).resolves.toEqual([]);
+    } finally {
+      await cleanup?.();
+    }
+  });
+});

--- a/packages/host/src/application/tasks/support/builder-worktree-cleanup.test.ts
+++ b/packages/host/src/application/tasks/support/builder-worktree-cleanup.test.ts
@@ -54,6 +54,7 @@ const taskStoreWithTasks = (
       }),
     listPullRequestSyncCandidates: () =>
       Effect.dieMessage("unexpected listPullRequestSyncCandidates"),
+    listAgentSessionsForTasks: () => Effect.dieMessage("unexpected listAgentSessionsForTasks"),
     listTasks: () => Effect.succeed(tasks),
     recordQaOutcome: () => Effect.dieMessage("unexpected recordQaOutcome"),
     setDirectMerge: () => Effect.dieMessage("unexpected setDirectMerge"),

--- a/packages/host/src/application/tasks/task-inputs.ts
+++ b/packages/host/src/application/tasks/task-inputs.ts
@@ -22,6 +22,10 @@ export type ListTasksInput = RepoPathInput & {
   doneVisibleDays?: number;
 };
 
+export type ListAgentSessionsForTasksInput = RepoPathInput & {
+  taskIds: string[];
+};
+
 export type AgentSessionUpsertInput = TaskIdInput & {
   session: AgentSessionRecord;
 };

--- a/packages/host/src/application/tasks/task-service-list-and-sessions.test.ts
+++ b/packages/host/src/application/tasks/task-service-list-and-sessions.test.ts
@@ -12,6 +12,26 @@ import {
 } from "./test-support/task-workflow-harness";
 
 describe("createTaskService list and session reads", () => {
+  test("loads agent sessions for task IDs with one task-store call", async () => {
+    const session = createAgentSessionRecord();
+    const calls: unknown[] = [];
+    const service = createTaskService({
+      taskStore: {
+        listAgentSessionsForTasks(input) {
+          calls.push(input);
+          return Effect.succeed([{ taskId: "task-1", agentSessions: [session] }]);
+        },
+      },
+    });
+
+    await expect(
+      Effect.runPromise(
+        service.agentSessionsListForTasks({ repoPath: "/repo", taskIds: ["task-1", "task-2"] }),
+      ),
+    ).resolves.toEqual([{ taskId: "task-1", agentSessions: [session] }]);
+    expect(calls).toEqual([{ repoPath: "/repo", taskIds: ["task-1", "task-2"] }]);
+  });
+
   test("loads tasks and enriches available actions and workflow state", async () => {
     const calls: unknown[] = [];
     const taskStore: TaskStorePort = {

--- a/packages/host/src/application/tasks/task-service.ts
+++ b/packages/host/src/application/tasks/task-service.ts
@@ -3,6 +3,7 @@ import {
   type BuildSessionBootstrap,
   buildSessionBootstrapSchema,
   type PullRequest,
+  type TaskAgentSessions,
   type TaskApprovalContextLoadResult,
   type TaskCard,
   type TaskDirectMergeResult,
@@ -49,6 +50,7 @@ import type {
   CreateTaskUseCaseInput,
   DeleteTaskInput,
   DirectMergeInput,
+  ListAgentSessionsForTasksInput,
   ListTasksInput,
   MarkdownDocumentInput,
   OptionalNoteInput,
@@ -109,6 +111,9 @@ export type TaskService = {
   listTasks(input: ListTasksInput): Effect.Effect<TaskCard[], TaskServiceError>;
   getTaskMetadata(input: TaskIdInput): Effect.Effect<TaskMetadataPayload, TaskServiceError>;
   agentSessionsList(input: TaskIdInput): Effect.Effect<AgentSessionRecord[], TaskServiceError>;
+  agentSessionsListForTasks(
+    input: ListAgentSessionsForTasksInput,
+  ): Effect.Effect<TaskAgentSessions[], TaskServiceError>;
   agentSessionUpsert(input: AgentSessionUpsertInput): Effect.Effect<boolean, TaskServiceError>;
   agentSessionDelete(input: AgentSessionDeleteInput): Effect.Effect<boolean, TaskServiceError>;
   getApprovalContext(
@@ -285,6 +290,8 @@ export const createTaskService = (input: CreateTaskServiceInput): TaskService =>
   return {
     agentSessionDelete: (input) => mapTaskServiceErrors(service.agentSessionDelete(input)),
     agentSessionsList: (input) => mapTaskServiceErrors(service.agentSessionsList(input)),
+    agentSessionsListForTasks: (input) =>
+      mapTaskServiceErrors(service.agentSessionsListForTasks(input)),
     agentSessionUpsert: (input) => mapTaskServiceErrors(service.agentSessionUpsert(input)),
     buildBlocked: (input) => mapTaskServiceErrors(service.buildBlocked(input)),
     buildCompleted: (input) => mapTaskServiceErrors(service.buildCompleted(input)),

--- a/packages/host/src/application/tasks/test-support/task-workflow-harness.ts
+++ b/packages/host/src/application/tasks/test-support/task-workflow-harness.ts
@@ -189,6 +189,7 @@ const createTaskStorePort = (overrides: TaskStorePort): RealTaskStorePort =>
     getTask: unexpectedTaskStoreCall("getTask"),
     getTaskMetadata: unexpectedTaskStoreCall("getTaskMetadata"),
     listPullRequestSyncCandidates: unexpectedTaskStoreCall("listPullRequestSyncCandidates"),
+    listAgentSessionsForTasks: unexpectedTaskStoreCall("listAgentSessionsForTasks"),
     listTasks: unexpectedTaskStoreCall("listTasks"),
     recordQaOutcome: unexpectedTaskStoreCall("recordQaOutcome"),
     setDirectMerge: unexpectedTaskStoreCall("setDirectMerge"),

--- a/packages/host/src/application/tasks/use-cases/query-tasks.ts
+++ b/packages/host/src/application/tasks/use-cases/query-tasks.ts
@@ -15,6 +15,7 @@ export const createTaskQueryUseCases = ({
   | "listTasks"
   | "getTaskMetadata"
   | "agentSessionsList"
+  | "agentSessionsListForTasks"
   | "agentSessionUpsert"
   | "agentSessionDelete"
 > => ({
@@ -36,6 +37,10 @@ export const createTaskQueryUseCases = ({
 
       return metadata.agentSessions;
     });
+  },
+
+  agentSessionsListForTasks(input) {
+    return taskStore.listAgentSessionsForTasks(input);
   },
 
   agentSessionUpsert(input) {

--- a/packages/host/src/interface/commands/host-command-registry.ts
+++ b/packages/host/src/interface/commands/host-command-registry.ts
@@ -5,6 +5,7 @@ export const HOST_COMMAND_NAMES = [
   "agent_session_stop",
   "agent_session_upsert",
   "agent_sessions_list",
+  "agent_sessions_list_for_tasks",
   "build_blocked",
   "build_completed",
   "build_resumed",

--- a/packages/host/src/interface/commands/task-command-handlers.test.ts
+++ b/packages/host/src/interface/commands/task-command-handlers.test.ts
@@ -48,6 +48,20 @@ describe("createTaskCommandHandlers", () => {
             }),
         });
       },
+      agentSessionsListForTasks(input: unknown) {
+        return Effect.tryPromise({
+          try: async () => {
+            calls.push({ command: "agent_sessions_list_for_tasks", input });
+            return [];
+          },
+          catch: (cause) =>
+            new HostOperationError({
+              operation: "test.effect",
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause: cause,
+            }),
+        });
+      },
       getApprovalContext(input: unknown) {
         return Effect.tryPromise({
           try: async () => {
@@ -668,6 +682,17 @@ describe("createTaskCommandHandlers", () => {
     ).resolves.toEqual([]);
     await expect(
       runHandler(
+        handlers.agent_sessions_list_for_tasks?.(
+          { repoPath: "/repo", taskIds: [" task-2 ", "", "task-1", "task-2"] },
+          {
+            command: "agent_sessions_list_for_tasks",
+            args: { repoPath: "/repo", taskIds: [" task-2 ", "", "task-1", "task-2"] },
+          },
+        ),
+      ),
+    ).resolves.toEqual([]);
+    await expect(
+      runHandler(
         handlers.task_approval_context_get?.(
           { repoPath: "/repo", taskId: "task-1" },
           {
@@ -1022,6 +1047,10 @@ describe("createTaskCommandHandlers", () => {
       {
         command: "agent_sessions_list",
         input: { repoPath: "/repo", taskId: "task-1" },
+      },
+      {
+        command: "agent_sessions_list_for_tasks",
+        input: { repoPath: "/repo", taskIds: ["task-2", "task-1"] },
       },
       {
         command: "task_approval_context_get",

--- a/packages/host/src/interface/commands/task-command-handlers.ts
+++ b/packages/host/src/interface/commands/task-command-handlers.ts
@@ -9,6 +9,7 @@ import {
   parseCreateTaskInput,
   parseDeleteTaskInput,
   parseDirectMergeInput,
+  parseListAgentSessionsForTasksInput,
   parseListTasksInput,
   parseMarkdownDocumentInput,
   parseOptionalNoteInput,
@@ -33,6 +34,8 @@ export const createTaskCommandHandlers = (taskService: TaskService): HostCommand
     taskService.agentSessionUpsert(parseAgentSessionUpsertInput(args)),
   agent_sessions_list: (args) =>
     taskService.agentSessionsList(parseTaskIdInput(args, "agent_sessions_list input")),
+  agent_sessions_list_for_tasks: (args) =>
+    taskService.agentSessionsListForTasks(parseListAgentSessionsForTasksInput(args)),
   build_blocked: (args) => taskService.buildBlocked(parseBuildBlockedInput(args)),
   build_completed: (args) => taskService.buildCompleted(parseBuildCompletedInput(args)),
   build_resumed: (args) => taskService.buildResumed(parseTaskIdInput(args, "build_resumed input")),

--- a/packages/host/src/interface/commands/task-command-inputs.ts
+++ b/packages/host/src/interface/commands/task-command-inputs.ts
@@ -8,6 +8,7 @@ import type {
   CreateTaskUseCaseInput,
   DeleteTaskInput,
   DirectMergeInput,
+  ListAgentSessionsForTasksInput,
   ListTasksInput,
   MarkdownDocumentInput,
   OptionalNoteInput,
@@ -61,6 +62,27 @@ export const parseListTasksInput = (input: unknown): ListTasksInput => {
   const repoPath = requireString(record.repoPath, "repoPath");
   const doneVisibleDays = optionalNonNegativeInteger(record.doneVisibleDays, "doneVisibleDays");
   return doneVisibleDays === undefined ? { repoPath } : { repoPath, doneVisibleDays };
+};
+
+export const parseListAgentSessionsForTasksInput = (
+  input: unknown,
+): ListAgentSessionsForTasksInput => {
+  const record = requireRecord(input, "agent_sessions_list_for_tasks input");
+  if (
+    !Array.isArray(record.taskIds) ||
+    record.taskIds.some((taskId) => typeof taskId !== "string")
+  ) {
+    throw new HostValidationError({
+      message: "taskIds must be an array of strings.",
+      field: "taskIds",
+      details: { value: record.taskIds },
+    });
+  }
+
+  return {
+    repoPath: requireString(record.repoPath, "repoPath"),
+    taskIds: Array.from(new Set(record.taskIds.map((taskId) => taskId.trim()).filter(Boolean))),
+  };
 };
 
 export const parseAgentSessionUpsertInput = (input: unknown): AgentSessionUpsertInput => {

--- a/packages/host/src/ports/task-repository-ports.ts
+++ b/packages/host/src/ports/task-repository-ports.ts
@@ -5,6 +5,7 @@ import type {
   PullRequest,
   QaReportVerdict,
   RepoStoreHealth,
+  TaskAgentSessions,
   TaskCard,
   TaskCreateInput,
   TaskMetadataDocument,
@@ -98,6 +99,10 @@ export type WorkflowDocumentRepository = {
   }): Effect.Effect<TaskMetadataDocument, TaskStoreError>;
 };
 export type AgentSessionRepository = {
+  listAgentSessionsForTasks(input: {
+    repoPath: string;
+    taskIds: string[];
+  }): Effect.Effect<TaskAgentSessions[], TaskStoreError>;
   clearAgentSessionsByRoles(input: {
     repoPath: string;
     taskId: string;


### PR DESCRIPTION
## Summary

- add a non-durable batch session-history contract and wire it through the Effect-native host, command, and host-client layers
- read all requested task session histories with one SQLite `WHERE id IN (...)` query against existing task rows
- replace Kanban per-task observers with one normalized TanStack Query while preserving per-task APIs and cache coherence
- cover normalization, missing tasks, invalid records, ordering, one-command behavior, upsert, and invalidation

## Goal

Prevent a Kanban board with N tasks from producing N IPC commands and N SQLite task reads while preserving existing card history, role, resume, and open-session behavior.

## Technical choices

- normalize and deduplicate task IDs before storage resolution, including a no-storage fast path for normalized-empty input
- pre-seed every requested task ID with an empty session list in the frontend batch result
- keep existing per-task host methods and query keys unchanged for Agent Studio, task details, and orchestration
- propagate typed Effect errors and decode existing persisted session JSON through the current codec

## Verification

- all plan-focused contract, host, host-client, frontend, and Kanban tests pass sequentially
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- React Doctor: 98/100, unchanged
- Thermos correctness/security and maintainability reruns: clean
- fixed-point Standards and Spec code-review axes: clean

## Schema impact

No durable schema changed. There is no migration, Drizzle schema/table/column change, persisted record shape change, or durable data transformation; the implementation reads the existing task ID and session JSON columns.

## Runtime evidence

The focused Kanban test proves that two tasks produce one `agent_sessions_list_for_tasks` call with the normalized ID set and retain correctly keyed histories. No per-task metadata path is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading agent-session histories for multiple tasks in a single request.
  * Kanban views now load and display historical sessions across multiple tasks more efficiently.
  * Added validation for batched task-session responses, including invalid session roles and task IDs.

* **Bug Fixes**
  * Improved session cache updates and invalidation for both individual and batched task queries.
  * Normalized task IDs by trimming whitespace, removing duplicates, and ignoring empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->