### PR TITLE
fix(frontend): make workspace branch identity commit-safe

### DIFF
--- a/packages/frontend/src/state/operations/workspace/use-workspace-branch-operations.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-branch-operations.test.tsx
@@ -23,7 +23,7 @@ const createBranchHarness = (initialArgs: BranchHarnessArgs) => {
     latest = useWorkspaceBranchOperations({
       activeRepo: args.activeRepo,
       hostClient: workspaceHost,
-      clearBranchSyncDegraded: () => {},
+      updateBranchSyncDegradedForRepo: () => {},
     });
     return null;
   };

--- a/packages/frontend/src/state/operations/workspace/use-workspace-branch-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-branch-operations.ts
@@ -53,22 +53,12 @@ export function useWorkspaceBranchOperations({
   }, [activeRepo]);
 
   const applyBranchState = useCallback(
-    (repoPath: string, current: GitCurrentBranch, allBranches: GitBranch[]): void => {
+    (repoPath: string, current: GitCurrentBranch, allBranches?: GitBranch[]): void => {
       setBranchDataRepoPath(repoPath);
       setActiveBranch(current);
-      setBranches(allBranches);
-      lastKnownBranchNameRef.current = current.name ?? null;
-      lastKnownDetachedRef.current = current.detached;
-      lastKnownRevisionRef.current = current.revision ?? null;
-      updateBranchSyncDegradedForRepo(repoPath, false);
-    },
-    [updateBranchSyncDegradedForRepo],
-  );
-
-  const applyCurrentBranchSnapshot = useCallback(
-    (repoPath: string, current: GitCurrentBranch): void => {
-      setBranchDataRepoPath(repoPath);
-      setActiveBranch(current);
+      if (allBranches) {
+        setBranches(allBranches);
+      }
       lastKnownBranchNameRef.current = current.name ?? null;
       lastKnownDetachedRef.current = current.detached;
       lastKnownRevisionRef.current = current.revision ?? null;
@@ -200,7 +190,7 @@ export function useWorkspaceBranchOperations({
           currentWorkspaceRepoPathRef.current === repoPath
         ) {
           queryClient.setQueryData(gitQueryKeys.currentBranch(repoPath), current);
-          applyCurrentBranchSnapshot(repoPath, current);
+          applyBranchState(repoPath, current);
 
           try {
             await queryClient.invalidateQueries({
@@ -238,7 +228,7 @@ export function useWorkspaceBranchOperations({
         }
       }
     },
-    [activeBranchForCurrentRepo, activeRepo, applyCurrentBranchSnapshot, hostClient, queryClient],
+    [activeBranchForCurrentRepo, activeRepo, applyBranchState, hostClient, queryClient],
   );
 
   const branchProbeController = useMemo<WorkspaceBranchProbeController>(

--- a/packages/frontend/src/state/operations/workspace/use-workspace-branch-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-branch-operations.ts
@@ -17,7 +17,7 @@ import type {
 type UseWorkspaceBranchOperationsArgs = {
   activeRepo: string | null;
   hostClient: WorkspaceBranchOperationsHostClient;
-  clearBranchSyncDegraded: (repoPath: string | null) => void;
+  updateBranchSyncDegradedForRepo: (repoPath: string | null, value: boolean) => void;
 };
 
 type UseWorkspaceBranchOperationsResult = {
@@ -34,7 +34,7 @@ type UseWorkspaceBranchOperationsResult = {
 export function useWorkspaceBranchOperations({
   activeRepo,
   hostClient,
-  clearBranchSyncDegraded,
+  updateBranchSyncDegradedForRepo,
 }: UseWorkspaceBranchOperationsArgs): UseWorkspaceBranchOperationsResult {
   const queryClient = useQueryClient();
   const [branchDataRepoPath, setBranchDataRepoPath] = useState<string | null>(activeRepo);
@@ -60,9 +60,9 @@ export function useWorkspaceBranchOperations({
       lastKnownBranchNameRef.current = current.name ?? null;
       lastKnownDetachedRef.current = current.detached;
       lastKnownRevisionRef.current = current.revision ?? null;
-      clearBranchSyncDegraded(repoPath);
+      updateBranchSyncDegradedForRepo(repoPath, false);
     },
-    [clearBranchSyncDegraded],
+    [updateBranchSyncDegradedForRepo],
   );
 
   const applyCurrentBranchSnapshot = useCallback(
@@ -72,9 +72,9 @@ export function useWorkspaceBranchOperations({
       lastKnownBranchNameRef.current = current.name ?? null;
       lastKnownDetachedRef.current = current.detached;
       lastKnownRevisionRef.current = current.revision ?? null;
-      clearBranchSyncDegraded(repoPath);
+      updateBranchSyncDegradedForRepo(repoPath, false);
     },
-    [clearBranchSyncDegraded],
+    [updateBranchSyncDegradedForRepo],
   );
 
   const clearBranchData = useCallback(
@@ -88,9 +88,9 @@ export function useWorkspaceBranchOperations({
       setActiveBranch(null);
       setIsLoadingBranches(false);
       setIsSwitchingBranch(false);
-      clearBranchSyncDegraded(repoPath);
+      updateBranchSyncDegradedForRepo(repoPath, false);
     },
-    [clearBranchSyncDegraded],
+    [updateBranchSyncDegradedForRepo],
   );
 
   const refreshBranchesForRepo = useCallback(

--- a/packages/frontend/src/state/operations/workspace/use-workspace-branch-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-branch-operations.ts
@@ -1,9 +1,8 @@
 import type { GitBranch, GitCurrentBranch } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import type { ActiveWorkspace } from "@/types/state-slices";
 import {
   gitQueryKeys,
   loadCurrentBranchFromQuery,
@@ -18,7 +17,7 @@ import type {
 type UseWorkspaceBranchOperationsArgs = {
   activeRepo: string | null;
   hostClient: WorkspaceBranchOperationsHostClient;
-  clearBranchSyncDegraded: () => void;
+  clearBranchSyncDegraded: (repoPath: string | null) => void;
 };
 
 type UseWorkspaceBranchOperationsResult = {
@@ -48,25 +47,10 @@ export function useWorkspaceBranchOperations({
   const lastKnownDetachedRef = useRef<boolean | null>(null);
   const lastKnownRevisionRef = useRef<string | null>(null);
   const currentWorkspaceRepoPathRef = useRef(activeRepo);
-  const activeWorkspaceRef = useRef<ActiveWorkspace | null>(
-    activeRepo
-      ? {
-          workspaceId: "",
-          workspaceName: "",
-          repoPath: activeRepo,
-        }
-      : null,
-  );
 
-  currentWorkspaceRepoPathRef.current = activeRepo;
-  activeWorkspaceRef.current =
-    activeRepo === null
-      ? null
-      : {
-          workspaceId: "",
-          workspaceName: "",
-          repoPath: activeRepo,
-        };
+  useLayoutEffect(() => {
+    currentWorkspaceRepoPathRef.current = activeRepo;
+  }, [activeRepo]);
 
   const applyBranchState = useCallback(
     (repoPath: string, current: GitCurrentBranch, allBranches: GitBranch[]): void => {
@@ -76,19 +60,19 @@ export function useWorkspaceBranchOperations({
       lastKnownBranchNameRef.current = current.name ?? null;
       lastKnownDetachedRef.current = current.detached;
       lastKnownRevisionRef.current = current.revision ?? null;
-      clearBranchSyncDegraded();
+      clearBranchSyncDegraded(repoPath);
     },
     [clearBranchSyncDegraded],
   );
 
   const applyCurrentBranchSnapshot = useCallback(
-    (current: GitCurrentBranch): void => {
-      setBranchDataRepoPath(currentWorkspaceRepoPathRef.current);
+    (repoPath: string, current: GitCurrentBranch): void => {
+      setBranchDataRepoPath(repoPath);
       setActiveBranch(current);
       lastKnownBranchNameRef.current = current.name ?? null;
       lastKnownDetachedRef.current = current.detached;
       lastKnownRevisionRef.current = current.revision ?? null;
-      clearBranchSyncDegraded();
+      clearBranchSyncDegraded(repoPath);
     },
     [clearBranchSyncDegraded],
   );
@@ -104,7 +88,7 @@ export function useWorkspaceBranchOperations({
       setActiveBranch(null);
       setIsLoadingBranches(false);
       setIsSwitchingBranch(false);
-      clearBranchSyncDegraded();
+      clearBranchSyncDegraded(repoPath);
     },
     [clearBranchSyncDegraded],
   );
@@ -112,7 +96,7 @@ export function useWorkspaceBranchOperations({
   const refreshBranchesForRepo = useCallback(
     async (repoPath: string): Promise<void> => {
       const requestVersion = ++branchRequestVersionRef.current;
-      setBranchDataRepoPath(repoPath);
+      setBranchDataRepoPath(() => repoPath);
       setBranches([]);
       setActiveBranch(null);
       setIsLoadingBranches(true);
@@ -216,7 +200,7 @@ export function useWorkspaceBranchOperations({
           currentWorkspaceRepoPathRef.current === repoPath
         ) {
           queryClient.setQueryData(gitQueryKeys.currentBranch(repoPath), current);
-          applyCurrentBranchSnapshot(current);
+          applyCurrentBranchSnapshot(repoPath, current);
 
           try {
             await queryClient.invalidateQueries({
@@ -260,7 +244,6 @@ export function useWorkspaceBranchOperations({
   const branchProbeController = useMemo<WorkspaceBranchProbeController>(
     () => ({
       currentWorkspaceRepoPathRef,
-      activeWorkspaceRef,
       lastKnownBranchNameRef,
       lastKnownDetachedRef,
       lastKnownRevisionRef,

--- a/packages/frontend/src/state/operations/workspace/use-workspace-branch-probe.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-branch-probe.test.tsx
@@ -163,81 +163,6 @@ describe("use-workspace-branch-probe", () => {
     }
   });
 
-  test("keeps the new repo probe gate active when a stale repo probe finishes", async () => {
-    const { triggerFocus, restoreBrowserGlobals } = createBrowserListenerHarness();
-    const repoAProbe = createDeferred<{ name: string | undefined; detached: boolean }>();
-    const repoBProbe = createDeferred<{ name: string | undefined; detached: boolean }>();
-    const setBranchSyncDegraded = mock((_repoPath: string, _value: boolean) => {});
-    const gitGetCurrentBranch = mock(async () => {
-      const callIndex = gitGetCurrentBranch.mock.calls.length;
-
-      if (callIndex === 1) {
-        return repoAProbe.promise;
-      }
-
-      if (callIndex === 2) {
-        return repoBProbe.promise;
-      }
-
-      return {
-        name: "main",
-        detached: false,
-      };
-    });
-
-    workspaceHost.gitGetCurrentBranch = gitGetCurrentBranch;
-
-    const rendered = render(
-      <ProbeHarness
-        activeRepoPath="/repo-a"
-        isSwitchingWorkspace={false}
-        isLoadingBranches={false}
-        isSwitchingBranch={false}
-        setBranchSyncDegraded={setBranchSyncDegraded}
-      />,
-      { wrapper: IsolatedQueryWrapper },
-    );
-
-    try {
-      await triggerFocus();
-      expect(gitGetCurrentBranch).toHaveBeenCalledTimes(1);
-
-      rendered.rerender(
-        <ProbeHarness
-          activeRepoPath="/repo-b"
-          isSwitchingWorkspace={false}
-          isLoadingBranches={false}
-          isSwitchingBranch={false}
-          setBranchSyncDegraded={setBranchSyncDegraded}
-        />,
-      );
-
-      await triggerFocus();
-      expect(gitGetCurrentBranch).toHaveBeenCalledTimes(2);
-
-      repoAProbe.resolve({
-        name: "main",
-        detached: false,
-      });
-      await flush();
-
-      await triggerFocus();
-      expect(gitGetCurrentBranch).toHaveBeenCalledTimes(2);
-
-      repoBProbe.resolve({
-        name: "main",
-        detached: false,
-      });
-      await flush();
-
-      await triggerFocus();
-      expect(gitGetCurrentBranch).toHaveBeenCalledTimes(3);
-    } finally {
-      rendered.unmount();
-      restoreBrowserGlobals();
-    }
-  });
-
   test("uses the committed repository without letting a stale probe release its gate", async () => {
     const { triggerFocus, restoreBrowserGlobals } = createBrowserListenerHarness();
     const repoAProbe = createDeferred<{ name: string | undefined; detached: boolean }>();
@@ -266,6 +191,7 @@ describe("use-workspace-branch-probe", () => {
 
     try {
       await triggerFocus();
+      expect(gitGetCurrentBranch).toHaveBeenCalledTimes(1);
       expect(gitGetCurrentBranch).toHaveBeenNthCalledWith(1, "/repo-a");
 
       rendered.rerender(
@@ -277,7 +203,9 @@ describe("use-workspace-branch-probe", () => {
           setBranchSyncDegraded={setBranchSyncDegraded}
         />,
       );
+
       await triggerFocus();
+      expect(gitGetCurrentBranch).toHaveBeenCalledTimes(2);
       expect(gitGetCurrentBranch).toHaveBeenNthCalledWith(2, "/repo-b");
 
       repoAProbe.resolve({
@@ -289,9 +217,16 @@ describe("use-workspace-branch-probe", () => {
       expect(setBranchSyncDegraded).not.toHaveBeenCalled();
       await triggerFocus();
       expect(gitGetCurrentBranch).toHaveBeenCalledTimes(2);
+
+      repoBProbe.resolve({
+        name: "main",
+        detached: false,
+      });
+      await flush();
+
+      await triggerFocus();
+      expect(gitGetCurrentBranch).toHaveBeenCalledTimes(3);
     } finally {
-      repoAProbe.resolve({ name: "main", detached: false });
-      repoBProbe.resolve({ name: "main", detached: false });
       rendered.unmount();
       restoreBrowserGlobals();
     }

--- a/packages/frontend/src/state/operations/workspace/use-workspace-branch-probe.test.tsx
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-branch-probe.test.tsx
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { render } from "@testing-library/react";
-import { useMemo, useRef } from "react";
-import type { ActiveWorkspace } from "@/types/state-slices";
+import { useLayoutEffect, useMemo, useRef } from "react";
 import { useWorkspaceBranchProbe } from "./use-workspace-branch-probe";
 import { createBrowserListenerHarness } from "./workspace-browser-test-utils";
 import { createDeferred, createWorkspaceHostClient, flush } from "./workspace-hook-test-fixtures";
@@ -15,28 +14,30 @@ beforeEach(() => {
 });
 
 type ProbeHarnessArgs = {
-  activeWorkspace: ActiveWorkspace | null;
+  activeRepoPath: string | null;
   isSwitchingWorkspace: boolean;
   isLoadingBranches: boolean;
   isSwitchingBranch: boolean;
-  setBranchSyncDegraded: (value: boolean) => void;
+  setBranchSyncDegraded: (repoPath: string, value: boolean) => void;
   refreshBranchesForRepo?: (repoPath: string) => Promise<void>;
 };
 
 const ProbeHarness = ({
-  activeWorkspace,
+  activeRepoPath,
   isSwitchingWorkspace,
   isLoadingBranches,
   isSwitchingBranch,
   setBranchSyncDegraded,
   refreshBranchesForRepo = noopRefreshBranchesForRepo,
 }: ProbeHarnessArgs) => {
-  const currentWorkspaceRepoPathRef = useRef<string | null>(activeWorkspace?.repoPath ?? null);
+  const currentWorkspaceRepoPathRef = useRef<string | null>(activeRepoPath);
   const lastKnownBranchNameRef = useRef<string | null>(null);
   const lastKnownDetachedRef = useRef<boolean | null>(null);
   const lastKnownRevisionRef = useRef<string | null>(null);
 
-  currentWorkspaceRepoPathRef.current = activeWorkspace?.repoPath ?? null;
+  useLayoutEffect(() => {
+    currentWorkspaceRepoPathRef.current = activeRepoPath;
+  }, [activeRepoPath]);
 
   const branchProbeController = useMemo(
     () => ({
@@ -50,7 +51,7 @@ const ProbeHarness = ({
   );
 
   useWorkspaceBranchProbe({
-    activeWorkspace,
+    activeRepoPath,
     isSwitchingWorkspace,
     isLoadingBranches,
     isSwitchingBranch,
@@ -61,12 +62,6 @@ const ProbeHarness = ({
 
   return null;
 };
-
-const createActiveWorkspace = (repoPath: string): ActiveWorkspace => ({
-  workspaceId: repoPath.replace(/^\//, "").replaceAll("/", "-"),
-  workspaceName: repoPath.split("/").filter(Boolean).at(-1) ?? "repo",
-  repoPath,
-});
 
 describe("use-workspace-branch-probe", () => {
   test("keeps listeners mounted while transient branch flags change", async () => {
@@ -81,11 +76,11 @@ describe("use-workspace-branch-probe", () => {
       name: "main",
       detached: false,
     }));
-    const setBranchSyncDegraded = mock((_value: boolean) => {});
+    const setBranchSyncDegraded = mock((_repoPath: string, _value: boolean) => {});
 
     const rendered = render(
       <ProbeHarness
-        activeWorkspace={createActiveWorkspace("/repo-a")}
+        activeRepoPath="/repo-a"
         isSwitchingWorkspace={false}
         isLoadingBranches={false}
         isSwitchingBranch={false}
@@ -97,7 +92,7 @@ describe("use-workspace-branch-probe", () => {
     try {
       rendered.rerender(
         <ProbeHarness
-          activeWorkspace={createActiveWorkspace("/repo-a")}
+          activeRepoPath="/repo-a"
           isSwitchingWorkspace={false}
           isLoadingBranches
           isSwitchingBranch={false}
@@ -106,7 +101,7 @@ describe("use-workspace-branch-probe", () => {
       );
       rendered.rerender(
         <ProbeHarness
-          activeWorkspace={createActiveWorkspace("/repo-a")}
+          activeRepoPath="/repo-a"
           isSwitchingWorkspace={false}
           isLoadingBranches={false}
           isSwitchingBranch
@@ -131,13 +126,13 @@ describe("use-workspace-branch-probe", () => {
   test("suppresses stale degraded updates after the active repository changes", async () => {
     const { triggerFocus, restoreBrowserGlobals } = createBrowserListenerHarness();
     const branchProbeDeferred = createDeferred<{ name: string | undefined; detached: boolean }>();
-    const setBranchSyncDegraded = mock((_value: boolean) => {});
+    const setBranchSyncDegraded = mock((_repoPath: string, _value: boolean) => {});
 
     workspaceHost.gitGetCurrentBranch = mock(async () => branchProbeDeferred.promise);
 
     const rendered = render(
       <ProbeHarness
-        activeWorkspace={createActiveWorkspace("/repo-a")}
+        activeRepoPath="/repo-a"
         isSwitchingWorkspace={false}
         isLoadingBranches={false}
         isSwitchingBranch={false}
@@ -150,7 +145,7 @@ describe("use-workspace-branch-probe", () => {
       await triggerFocus();
       rendered.rerender(
         <ProbeHarness
-          activeWorkspace={createActiveWorkspace("/repo-b")}
+          activeRepoPath="/repo-b"
           isSwitchingWorkspace={false}
           isLoadingBranches={false}
           isSwitchingBranch={false}
@@ -161,7 +156,7 @@ describe("use-workspace-branch-probe", () => {
       branchProbeDeferred.reject(new Error("permission denied while reading branch"));
       await flush();
 
-      expect(setBranchSyncDegraded).not.toHaveBeenCalledWith(true);
+      expect(setBranchSyncDegraded).not.toHaveBeenCalledWith("/repo-b", true);
     } finally {
       rendered.unmount();
       restoreBrowserGlobals();
@@ -172,7 +167,7 @@ describe("use-workspace-branch-probe", () => {
     const { triggerFocus, restoreBrowserGlobals } = createBrowserListenerHarness();
     const repoAProbe = createDeferred<{ name: string | undefined; detached: boolean }>();
     const repoBProbe = createDeferred<{ name: string | undefined; detached: boolean }>();
-    const setBranchSyncDegraded = mock((_value: boolean) => {});
+    const setBranchSyncDegraded = mock((_repoPath: string, _value: boolean) => {});
     const gitGetCurrentBranch = mock(async () => {
       const callIndex = gitGetCurrentBranch.mock.calls.length;
 
@@ -194,7 +189,7 @@ describe("use-workspace-branch-probe", () => {
 
     const rendered = render(
       <ProbeHarness
-        activeWorkspace={createActiveWorkspace("/repo-a")}
+        activeRepoPath="/repo-a"
         isSwitchingWorkspace={false}
         isLoadingBranches={false}
         isSwitchingBranch={false}
@@ -209,7 +204,7 @@ describe("use-workspace-branch-probe", () => {
 
       rendered.rerender(
         <ProbeHarness
-          activeWorkspace={createActiveWorkspace("/repo-b")}
+          activeRepoPath="/repo-b"
           isSwitchingWorkspace={false}
           isLoadingBranches={false}
           isSwitchingBranch={false}
@@ -243,10 +238,69 @@ describe("use-workspace-branch-probe", () => {
     }
   });
 
+  test("uses the committed repository without letting a stale probe release its gate", async () => {
+    const { triggerFocus, restoreBrowserGlobals } = createBrowserListenerHarness();
+    const repoAProbe = createDeferred<{ name: string | undefined; detached: boolean }>();
+    const repoBProbe = createDeferred<{ name: string | undefined; detached: boolean }>();
+    const setBranchSyncDegraded = mock((_repoPath: string, _value: boolean) => {});
+    const gitGetCurrentBranch = mock(async (repoPath: string) => {
+      if (repoPath === "/repo-a") {
+        return repoAProbe.promise;
+      }
+
+      return repoBProbe.promise;
+    });
+
+    workspaceHost.gitGetCurrentBranch = gitGetCurrentBranch;
+
+    const rendered = render(
+      <ProbeHarness
+        activeRepoPath="/repo-a"
+        isSwitchingWorkspace={false}
+        isLoadingBranches={false}
+        isSwitchingBranch={false}
+        setBranchSyncDegraded={setBranchSyncDegraded}
+      />,
+      { wrapper: IsolatedQueryWrapper },
+    );
+
+    try {
+      await triggerFocus();
+      expect(gitGetCurrentBranch).toHaveBeenNthCalledWith(1, "/repo-a");
+
+      rendered.rerender(
+        <ProbeHarness
+          activeRepoPath="/repo-b"
+          isSwitchingWorkspace={false}
+          isLoadingBranches={false}
+          isSwitchingBranch={false}
+          setBranchSyncDegraded={setBranchSyncDegraded}
+        />,
+      );
+      await triggerFocus();
+      expect(gitGetCurrentBranch).toHaveBeenNthCalledWith(2, "/repo-b");
+
+      repoAProbe.resolve({
+        name: "main",
+        detached: false,
+      });
+      await flush();
+
+      expect(setBranchSyncDegraded).not.toHaveBeenCalled();
+      await triggerFocus();
+      expect(gitGetCurrentBranch).toHaveBeenCalledTimes(2);
+    } finally {
+      repoAProbe.resolve({ name: "main", detached: false });
+      repoBProbe.resolve({ name: "main", detached: false });
+      rendered.unmount();
+      restoreBrowserGlobals();
+    }
+  });
+
   test("ignores stale synced outcomes after the repo changes during branch refresh", async () => {
     const { triggerFocus, restoreBrowserGlobals } = createBrowserListenerHarness();
     const refreshDeferred = createDeferred<void>();
-    const setBranchSyncDegraded = mock((_value: boolean) => {});
+    const setBranchSyncDegraded = mock((_repoPath: string, _value: boolean) => {});
 
     workspaceHost.gitGetCurrentBranch = mock(async () => ({
       name: "main",
@@ -255,7 +309,7 @@ describe("use-workspace-branch-probe", () => {
 
     const rendered = render(
       <ProbeHarness
-        activeWorkspace={createActiveWorkspace("/repo-a")}
+        activeRepoPath="/repo-a"
         isSwitchingWorkspace={false}
         isLoadingBranches={false}
         isSwitchingBranch={false}
@@ -269,7 +323,7 @@ describe("use-workspace-branch-probe", () => {
       await triggerFocus();
       rendered.rerender(
         <ProbeHarness
-          activeWorkspace={createActiveWorkspace("/repo-b")}
+          activeRepoPath="/repo-b"
           isSwitchingWorkspace={false}
           isLoadingBranches={false}
           isSwitchingBranch={false}
@@ -291,7 +345,7 @@ describe("use-workspace-branch-probe", () => {
   test("ignores stale refresh failures after the repo changes during branch refresh", async () => {
     const { triggerFocus, restoreBrowserGlobals } = createBrowserListenerHarness();
     const refreshDeferred = createDeferred<void>();
-    const setBranchSyncDegraded = mock((_value: boolean) => {});
+    const setBranchSyncDegraded = mock((_repoPath: string, _value: boolean) => {});
 
     workspaceHost.gitGetCurrentBranch = mock(async () => ({
       name: "main",
@@ -300,7 +354,7 @@ describe("use-workspace-branch-probe", () => {
 
     const rendered = render(
       <ProbeHarness
-        activeWorkspace={createActiveWorkspace("/repo-a")}
+        activeRepoPath="/repo-a"
         isSwitchingWorkspace={false}
         isLoadingBranches={false}
         isSwitchingBranch={false}
@@ -314,7 +368,7 @@ describe("use-workspace-branch-probe", () => {
       await triggerFocus();
       rendered.rerender(
         <ProbeHarness
-          activeWorkspace={createActiveWorkspace("/repo-b")}
+          activeRepoPath="/repo-b"
           isSwitchingWorkspace={false}
           isLoadingBranches={false}
           isSwitchingBranch={false}

--- a/packages/frontend/src/state/operations/workspace/use-workspace-branch-probe.ts
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-branch-probe.ts
@@ -1,7 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import type { ActiveWorkspace } from "@/types/state-slices";
 import { gitQueryKeys, loadCurrentBranchFromQuery } from "../../queries/git";
 import { createProbeGateController } from "./workspace-branch-probe-gate";
 import {
@@ -20,13 +19,13 @@ import type {
 } from "./workspace-operations-types";
 
 type UseWorkspaceBranchProbeArgs = {
-  activeWorkspace: ActiveWorkspace | null;
+  activeRepoPath: string | null;
   isSwitchingWorkspace: boolean;
   isLoadingBranches: boolean;
   isSwitchingBranch: boolean;
   hostClient: WorkspaceBranchProbeHostClient;
   branchProbeController: WorkspaceBranchProbeController;
-  setBranchSyncDegraded: (value: boolean) => void;
+  setBranchSyncDegraded: (repoPath: string, value: boolean) => void;
 };
 
 type ProbeGates = {
@@ -36,7 +35,7 @@ type ProbeGates = {
 };
 
 export function useWorkspaceBranchProbe({
-  activeWorkspace,
+  activeRepoPath,
   isSwitchingWorkspace,
   isLoadingBranches,
   isSwitchingBranch,
@@ -44,14 +43,8 @@ export function useWorkspaceBranchProbe({
   branchProbeController,
   setBranchSyncDegraded,
 }: UseWorkspaceBranchProbeArgs): void {
-  const activeRepoPath =
-    activeWorkspace?.repoPath ?? branchProbeController.currentWorkspaceRepoPathRef.current;
   const queryClient = useQueryClient();
-  const probeGateRef = useRef<ReturnType<typeof createProbeGateController> | null>(null);
-  if (probeGateRef.current === null) {
-    probeGateRef.current = createProbeGateController();
-  }
-  const probeGate = probeGateRef.current;
+  const [probeGate] = useState(createProbeGateController);
   const lastProbeErrorToastAtRef = useRef<number | null>(null);
   const lastProbeErrorSignatureRef = useRef<string | null>(null);
   const previousWorkspaceRepoPathRef = useRef(activeRepoPath);
@@ -61,11 +54,15 @@ export function useWorkspaceBranchProbe({
     isSwitchingBranch,
   });
 
-  probeGatesRef.current.isSwitchingWorkspace = isSwitchingWorkspace;
-  probeGatesRef.current.isLoadingBranches = isLoadingBranches;
-  probeGatesRef.current.isSwitchingBranch = isSwitchingBranch;
+  useLayoutEffect(() => {
+    probeGatesRef.current = {
+      isSwitchingWorkspace,
+      isLoadingBranches,
+      isSwitchingBranch,
+    };
+  }, [isLoadingBranches, isSwitchingBranch, isSwitchingWorkspace]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (previousWorkspaceRepoPathRef.current === activeRepoPath) {
       return;
     }
@@ -195,18 +192,28 @@ export function useWorkspaceBranchProbe({
   }, [branchProbeController, hostClient, probeGate, queryClient]);
 
   const syncExternalBranchChange = useCallback(async (): Promise<void> => {
+    const repoPath = branchProbeController.currentWorkspaceRepoPathRef.current;
+    if (!repoPath) {
+      return;
+    }
+
     const outcome = await probeExternalBranchChange();
 
     if (outcome.status === "degraded") {
-      setBranchSyncDegraded(true);
+      setBranchSyncDegraded(repoPath, true);
       reportBranchProbeError(outcome.error);
       return;
     }
 
     if (outcome.status === "synced" || outcome.status === "unchanged") {
-      setBranchSyncDegraded(false);
+      setBranchSyncDegraded(repoPath, false);
     }
-  }, [probeExternalBranchChange, reportBranchProbeError, setBranchSyncDegraded]);
+  }, [
+    branchProbeController,
+    probeExternalBranchChange,
+    reportBranchProbeError,
+    setBranchSyncDegraded,
+  ]);
 
   useEffect(() => {
     if (!activeRepoPath || typeof window === "undefined" || typeof document === "undefined") {

--- a/packages/frontend/src/state/operations/workspace/use-workspace-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-operations.ts
@@ -32,21 +32,17 @@ export function useWorkspaceOperations({
     repoPath: activeRepo,
     value: false,
   });
-  const setBranchSyncDegraded = useCallback((repoPath: string, value: boolean): void => {
+  const setBranchSyncDegraded = useCallback((repoPath: string | null, value: boolean): void => {
     setBranchSyncDegradedState((current) =>
       current.repoPath === repoPath && current.value === value ? current : { repoPath, value },
     );
   }, []);
-  const clearBranchSyncDegraded = useCallback((repoPath: string | null): void => {
-    setBranchSyncDegradedState((current) =>
-      current.repoPath === repoPath && !current.value
-        ? current
-        : {
-            repoPath,
-            value: false,
-          },
-    );
-  }, []);
+  const clearBranchSyncDegraded = useCallback(
+    (repoPath: string | null): void => {
+      setBranchSyncDegraded(repoPath, false);
+    },
+    [setBranchSyncDegraded],
+  );
 
   const {
     branches,

--- a/packages/frontend/src/state/operations/workspace/use-workspace-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-operations.ts
@@ -1,5 +1,4 @@
-import type { WorkspaceRecord } from "@openducktor/contracts";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import type { ActiveWorkspace } from "@/types/state-slices";
 import { host } from "../shared/host";
 import { useWorkspaceBranchOperations } from "./use-workspace-branch-operations";
@@ -26,7 +25,6 @@ export function useWorkspaceOperations({
   hostClient = host,
 }: UseWorkspaceOperationsArgs): UseWorkspaceOperationsResult {
   const activeRepo = activeWorkspace?.repoPath ?? null;
-  const activeRepoRef = useRef(activeRepo);
   const [branchSyncDegradedState, setBranchSyncDegradedState] = useState<{
     repoPath: string | null;
     value: boolean;
@@ -34,17 +32,21 @@ export function useWorkspaceOperations({
     repoPath: activeRepo,
     value: false,
   });
-  activeRepoRef.current = activeRepo;
-
-  const setBranchSyncDegraded = useCallback((value: boolean): void => {
-    const repoPath = activeRepoRef.current;
+  const setBranchSyncDegraded = useCallback((repoPath: string, value: boolean): void => {
     setBranchSyncDegradedState((current) =>
       current.repoPath === repoPath && current.value === value ? current : { repoPath, value },
     );
   }, []);
-  const clearBranchSyncDegraded = useCallback((): void => {
-    setBranchSyncDegraded(false);
-  }, [setBranchSyncDegraded]);
+  const clearBranchSyncDegraded = useCallback((repoPath: string | null): void => {
+    setBranchSyncDegradedState((current) =>
+      current.repoPath === repoPath && !current.value
+        ? current
+        : {
+            repoPath,
+            value: false,
+          },
+    );
+  }, []);
 
   const {
     branches,
@@ -79,16 +81,11 @@ export function useWorkspaceOperations({
     hostClient,
   });
 
-  const resolvedActiveWorkspace = useMemo<WorkspaceRecord | null>(
-    () => workspaces.find((workspace) => workspace.repoPath === activeRepo) ?? null,
-    [activeRepo, workspaces],
-  );
-
   const branchSyncDegraded =
     branchSyncDegradedState.repoPath === activeRepo ? branchSyncDegradedState.value : false;
 
   useWorkspaceBranchProbe({
-    activeWorkspace: resolvedActiveWorkspace,
+    activeRepoPath: activeRepo,
     isSwitchingWorkspace,
     isLoadingBranches,
     isSwitchingBranch,

--- a/packages/frontend/src/state/operations/workspace/use-workspace-operations.ts
+++ b/packages/frontend/src/state/operations/workspace/use-workspace-operations.ts
@@ -32,16 +32,13 @@ export function useWorkspaceOperations({
     repoPath: activeRepo,
     value: false,
   });
-  const setBranchSyncDegraded = useCallback((repoPath: string | null, value: boolean): void => {
-    setBranchSyncDegradedState((current) =>
-      current.repoPath === repoPath && current.value === value ? current : { repoPath, value },
-    );
-  }, []);
-  const clearBranchSyncDegraded = useCallback(
-    (repoPath: string | null): void => {
-      setBranchSyncDegraded(repoPath, false);
+  const updateBranchSyncDegradedForRepo = useCallback(
+    (repoPath: string | null, value: boolean): void => {
+      setBranchSyncDegradedState((current) =>
+        current.repoPath === repoPath && current.value === value ? current : { repoPath, value },
+      );
     },
-    [setBranchSyncDegraded],
+    [],
   );
 
   const {
@@ -56,7 +53,7 @@ export function useWorkspaceOperations({
   } = useWorkspaceBranchOperations({
     activeRepo,
     hostClient,
-    clearBranchSyncDegraded,
+    updateBranchSyncDegradedForRepo,
   });
 
   const {
@@ -87,7 +84,7 @@ export function useWorkspaceOperations({
     isSwitchingBranch,
     hostClient,
     branchProbeController,
-    setBranchSyncDegraded,
+    setBranchSyncDegraded: updateBranchSyncDegradedForRepo,
   });
 
   return {

--- a/packages/frontend/src/state/operations/workspace/workspace-operations-types.ts
+++ b/packages/frontend/src/state/operations/workspace/workspace-operations-types.ts
@@ -1,6 +1,6 @@
 import type { GitBranch, GitCurrentBranch, WorkspaceRecord } from "@openducktor/contracts";
 import type { MutableRefObject } from "react";
-import type { ActiveWorkspace, WorkspaceSelectionOperationsInput } from "@/types/state-slices";
+import type { WorkspaceSelectionOperationsInput } from "@/types/state-slices";
 import type { host } from "../shared/host";
 
 export type WorkspaceBranchOperationsHostClient = Pick<
@@ -39,7 +39,6 @@ export type UseWorkspaceOperationsResult = {
 
 export type WorkspaceBranchProbeController = {
   currentWorkspaceRepoPathRef: MutableRefObject<string | null>;
-  activeWorkspaceRef?: MutableRefObject<ActiveWorkspace | null>;
   lastKnownBranchNameRef: MutableRefObject<string | null>;
   lastKnownDetachedRef: MutableRefObject<boolean | null>;
   lastKnownRevisionRef: MutableRefObject<string | null>;

--- a/packages/frontend/src/state/operations/workspace/workspace-operations-types.ts
+++ b/packages/frontend/src/state/operations/workspace/workspace-operations-types.ts
@@ -32,7 +32,7 @@ export type UseWorkspaceOperationsResult = {
   reorderWorkspaces: (workspaceIds: string[]) => Promise<void>;
   refreshBranches: (force?: boolean) => Promise<void>;
   switchBranch: (branchName: string) => Promise<void>;
-  clearBranchData: () => void;
+  clearBranchData: (repoPath?: string | null) => void;
   applyWorkspaceRecords: (records: WorkspaceRecord[]) => void;
   applyWorkspaceRecord: (record: WorkspaceRecord) => void;
 };


### PR DESCRIPTION
## Summary

- Make workspace repository identity commit-safe by synchronizing async guard refs after commit.
- Pass the active repository directly into the branch probe and keep focus/visibility listeners stable across transient flags.
- Keep degraded-state updates tagged to the repository that produced them while preserving TanStack Query branch loaders and stale-result guards.

## Goal

Plan 009 fixes render-phase ref writes that could let replayed or abandoned renders invalidate live branch refreshes, skip loading cleanup, or let stale probe completions affect the newly active repository.

## Implementation

- Move repository and probe-gate snapshots into layout effects.
- Replace render-time gate initialization with lazy state.
- Remove the unused synthetic active workspace ref and pass activeRepoPath directly.
- Use one repository-explicit degraded-state updater across refresh, switch, and probe paths.
- Consolidate current/full branch snapshot application without weakening request-version or repository checks.
- Add a focused repo A to repo B race covering committed routing, stale degraded isolation, and probe-gate ownership.

## Validation

- Focused plan suites: 26 passed, 0 failed, 97 assertions.
- Race result: the post-commit focus probe uses repo B; resolving repo A neither updates repo B degraded state nor releases the repo B gate.
- React Doctor: 83/100, no changed-file diagnostics.
- bun run typecheck: passed.
- bun run lint: passed.
- bun run test: passed, including 3,495 frontend tests.
- bun run build: passed.
- GitNexus final comparison: LOW risk, six expected files, no affected execution flows.

## Reviews

- Thermos correctness/security: FINAL CLEAN.
- Thermos code quality: FINAL CLEAN.
- Two-axis code review Standards: CLEAN.
- Two-axis code review Spec: CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)