### PR TITLE
perf(frontend): debounce composer file search

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -1067,6 +1067,9 @@ describe("AgentChatComposerEditor", () => {
     expect(screen.getByRole("option", { name: /alpha.ts/i })).toBeDefined();
     expect(screen.queryByText("Searching files...")).toBeNull();
 
+    await waitFor(() => {
+      expect(resolveSecondSearch).not.toBeNull();
+    });
     if (!resolveSecondSearch) {
       throw new Error("Expected second file search to be pending");
     }
@@ -1144,8 +1147,8 @@ describe("AgentChatComposerEditor", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("option", { name: /@reviewer/i })).toBeDefined();
+      expect(screen.getByRole("option", { name: /main.ts/i })).toBeDefined();
     });
-    expect(screen.getByRole("option", { name: /main.ts/i })).toBeDefined();
     expect(
       screen.getByRole("option", { name: /@reviewer/i }).querySelector(".lucide-bot"),
     ).toBeDefined();
@@ -1178,7 +1181,7 @@ describe("AgentChatComposerEditor", () => {
     });
     expect(screen.getByTestId("draft-state").textContent).toContain('"kind":"subagent_reference"');
     expect(onSend).not.toHaveBeenCalled();
-    expect(searchFiles).toHaveBeenCalledWith("rev");
+    expect(searchFiles).not.toHaveBeenCalled();
   });
 
   test("shows subagents without searching files when only subagent references are supported", async () => {

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.test.tsx
@@ -486,6 +486,45 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
     await harness.unmount();
   });
 
+  test("does not start a scheduled file search after the search implementation changes", async () => {
+    const firstSearchFiles = mock(async () => [buildFileSearchResult()]);
+    const secondSearchFiles = mock(async () => [buildFileSearchResult()]);
+    const harness = createHarness(firstSearchFiles);
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.syncMenusForSelectionTarget(buildDraft("@a"), {
+        segmentId: "segment-1",
+        offset: 2,
+      });
+    });
+
+    await harness.update(createAutocompleteProps(secondSearchFiles));
+
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+    });
+
+    expect(firstSearchFiles).not.toHaveBeenCalled();
+    expect(secondSearchFiles).not.toHaveBeenCalled();
+    expect(harness.getLatest().referenceMenuState).toBeNull();
+
+    await harness.run((state) => {
+      state.syncMenusForSelectionTarget(buildDraft("@a"), {
+        segmentId: "segment-1",
+        offset: 2,
+      });
+    });
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+    });
+
+    expect(secondSearchFiles).toHaveBeenCalledTimes(1);
+    expect(secondSearchFiles).toHaveBeenCalledWith("a");
+
+    await harness.unmount();
+  });
+
   test("debounces rapid file search queries to the latest trigger", async () => {
     const searchFiles = mock(async () => [buildFileSearchResult()]);
     const harness = createHarness(searchFiles);

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.test.tsx
@@ -121,6 +121,8 @@ const wait = (ms: number): Promise<void> => {
   });
 };
 
+const FILE_SEARCH_DEBOUNCE_WAIT_MS = 200;
+
 describe("useAgentChatComposerEditorAutocomplete", () => {
   test("filters slash commands from the current selection target", async () => {
     const searchFiles = mock(async () => []);
@@ -284,13 +286,21 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
     expect(harness.getLatest().isFileSearchLoading).toBe(false);
 
     await harness.run(async () => {
-      await wait(650);
+      await wait(450);
+    });
+
+    expect(harness.getLatest().isFileSearchLoading).toBe(false);
+
+    await harness.run(async () => {
+      await wait(100);
     });
 
     expect(harness.getLatest().isFileSearchLoading).toBe(true);
 
     slowSearch.resolve([buildFileSearchResult({ path: "src/slow.ts", name: "slow.ts" })]);
-    await harness.waitFor((state) => state.isFileSearchLoading === false);
+    await harness.waitFor((state) => {
+      return state.fileSearchResults.some((result) => result.path === "src/slow.ts");
+    });
 
     expect(harness.getLatest().fileSearchResults.map((result) => result.path)).toEqual([
       "src/slow.ts",
@@ -314,7 +324,7 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
       });
     });
 
-    await harness.waitFor((state) => state.isFileSearchLoading === false);
+    await harness.waitFor((state) => state.referenceMenuItems.some((item) => item.kind === "file"));
 
     expect(harness.getLatest().showReferenceMenu).toBe(true);
     expect(harness.getLatest().filteredSubagents.map((subagent) => subagent.name)).toEqual([
@@ -372,12 +382,22 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
       });
     });
 
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+    });
+
     await harness.run((state) => {
       state.syncMenusForSelectionTarget(buildDraft("@ab"), {
         segmentId: "segment-1",
         offset: 3,
       });
     });
+
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+    });
+
+    expect(searchFiles).toHaveBeenCalledTimes(2);
 
     secondSearch.resolve([buildFileSearchResult({ path: "src/ab.ts", name: "ab.ts" })]);
     await harness.waitFor((state) => {
@@ -410,6 +430,12 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
     expect(harness.getLatest().showReferenceMenu).toBe(true);
     expect(harness.getLatest().isFileSearchLoading).toBe(false);
 
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+    });
+
+    expect(searchFiles).toHaveBeenCalledTimes(1);
+
     await harness.update(
       createAutocompleteProps(searchFiles, {
         supportsFileSearch: false,
@@ -433,6 +459,109 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
     await harness.unmount();
   });
 
+  test("does not start a scheduled file search after file search support is disabled", async () => {
+    const searchFiles = mock(async () => [buildFileSearchResult()]);
+    const harness = createHarness(searchFiles);
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.syncMenusForSelectionTarget(buildDraft("@a"), {
+        segmentId: "segment-1",
+        offset: 2,
+      });
+    });
+
+    await harness.update(
+      createAutocompleteProps(searchFiles, {
+        supportsFileSearch: false,
+      }),
+    );
+
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+    });
+
+    expect(searchFiles).not.toHaveBeenCalled();
+
+    await harness.unmount();
+  });
+
+  test("debounces rapid file search queries to the latest trigger", async () => {
+    const searchFiles = mock(async () => [buildFileSearchResult()]);
+    const harness = createHarness(searchFiles);
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.syncMenusForSelectionTarget(buildDraft("@a"), {
+        segmentId: "segment-1",
+        offset: 2,
+      });
+    });
+    await harness.run((state) => {
+      state.syncMenusForSelectionTarget(buildDraft("@ab"), {
+        segmentId: "segment-1",
+        offset: 3,
+      });
+    });
+    await harness.run((state) => {
+      state.syncMenusForSelectionTarget(buildDraft("@abc"), {
+        segmentId: "segment-1",
+        offset: 4,
+      });
+    });
+
+    expect(searchFiles).not.toHaveBeenCalled();
+
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+    });
+
+    expect(searchFiles).toHaveBeenCalledTimes(1);
+    expect(searchFiles).toHaveBeenCalledWith("abc");
+
+    await harness.unmount();
+  });
+
+  test("does not start a scheduled file search after the reference menu closes", async () => {
+    const searchFiles = mock(async () => [buildFileSearchResult()]);
+    const harness = createHarness(searchFiles);
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.syncMenusForSelectionTarget(buildDraft("@a"), {
+        segmentId: "segment-1",
+        offset: 2,
+      });
+      state.closeReferenceMenu();
+    });
+
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+    });
+
+    expect(searchFiles).not.toHaveBeenCalled();
+
+    await harness.unmount();
+  });
+
+  test("does not start a scheduled file search after unmount", async () => {
+    const searchFiles = mock(async () => [buildFileSearchResult()]);
+    const harness = createHarness(searchFiles);
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.syncMenusForSelectionTarget(buildDraft("@a"), {
+        segmentId: "segment-1",
+        offset: 2,
+      });
+    });
+
+    await harness.unmount();
+    await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
+
+    expect(searchFiles).not.toHaveBeenCalled();
+  });
+
   test("does not repeat the same file search request for an unchanged trigger", async () => {
     const firstSearch = createDeferred<ReturnType<typeof buildFileSearchResult>[]>();
     const searchFiles = mock(() => firstSearch.promise);
@@ -447,7 +576,7 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
       });
     });
 
-    expect(searchFiles).toHaveBeenCalledTimes(1);
+    expect(searchFiles).not.toHaveBeenCalled();
     expect(harness.getLatest().isFileSearchLoading).toBe(false);
 
     await harness.run((state) => {
@@ -455,6 +584,12 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
         segmentId: "segment-1",
         offset: 3,
       });
+    });
+
+    expect(searchFiles).not.toHaveBeenCalled();
+
+    await harness.run(async () => {
+      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
     });
 
     expect(searchFiles).toHaveBeenCalledTimes(1);

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.test.tsx
@@ -486,9 +486,11 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
     await harness.unmount();
   });
 
-  test("does not start a scheduled file search after the search implementation changes", async () => {
+  test("keeps a scheduled file search when the search callback identity changes", async () => {
     const firstSearchFiles = mock(async () => [buildFileSearchResult()]);
-    const secondSearchFiles = mock(async () => [buildFileSearchResult()]);
+    const secondSearchFiles = mock(async () => [
+      buildFileSearchResult({ path: "src/latest.ts", name: "latest.ts" }),
+    ]);
     const harness = createHarness(firstSearchFiles);
     await harness.mount();
 
@@ -501,26 +503,21 @@ describe("useAgentChatComposerEditorAutocomplete", () => {
 
     await harness.update(createAutocompleteProps(secondSearchFiles));
 
+    expect(harness.getLatest().showReferenceMenu).toBe(true);
+    expect(harness.getLatest().referenceMenuState).not.toBeNull();
+
     await harness.run(async () => {
       await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
     });
 
     expect(firstSearchFiles).not.toHaveBeenCalled();
-    expect(secondSearchFiles).not.toHaveBeenCalled();
-    expect(harness.getLatest().referenceMenuState).toBeNull();
-
-    await harness.run((state) => {
-      state.syncMenusForSelectionTarget(buildDraft("@a"), {
-        segmentId: "segment-1",
-        offset: 2,
-      });
-    });
-    await harness.run(async () => {
-      await wait(FILE_SEARCH_DEBOUNCE_WAIT_MS);
-    });
-
     expect(secondSearchFiles).toHaveBeenCalledTimes(1);
     expect(secondSearchFiles).toHaveBeenCalledWith("a");
+    await harness.waitFor((state) => {
+      return state.fileSearchResults.some((result) => result.path === "src/latest.ts");
+    });
+
+    expect(harness.getLatest().showReferenceMenu).toBe(true);
 
     await harness.unmount();
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.ts
@@ -89,7 +89,7 @@ export const AUTOCOMPLETE_NAVIGATION_KEYS = new Set([
 ]);
 
 const FILE_SEARCH_FAILED_MESSAGE = "Failed to search files.";
-const FILE_SEARCH_DEBOUNCE_MS = 150;
+const FILE_SEARCH_DEBOUNCE_MS = 100;
 const FILE_SEARCH_LOADING_INDICATOR_DELAY_MS = 500;
 
 const isSameTextMenuRequest = (

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.ts
@@ -73,6 +73,7 @@ type InternalSlashMenuState = SlashMenuState & {
 type InternalReferenceMenuState = ReferenceMenuState & {
   availabilityContext: AutocompleteAvailabilityContext;
   requestId: number;
+  searchFiles: (query: string) => Promise<AgentFileSearchResult[]>;
   showLoadingIndicator: boolean;
 };
 
@@ -284,7 +285,8 @@ export const useAgentChatComposerEditorAutocomplete = ({
   const effectiveReferenceMenuState =
     disabled ||
     (!supportsFileSearch && !supportsSubagentReferences) ||
-    referenceMenuState?.availabilityContext !== availabilityContext
+    referenceMenuState?.availabilityContext !== availabilityContext ||
+    referenceMenuState?.searchFiles !== searchFiles
       ? null
       : referenceMenuState;
   const effectiveSkillMenuState =
@@ -350,23 +352,17 @@ export const useAgentChatComposerEditorAutocomplete = ({
     clearFileSearchLoadingTimer();
   }, [clearFileSearchDebounceTimer, clearFileSearchLoadingTimer]);
 
-  useEffect(() => {
-    return () => {
-      invalidateFileSearchRequest();
-    };
-  }, [invalidateFileSearchRequest]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Context changes must run cleanup to invalidate queued work.
+  useEffect(
+    () => invalidateFileSearchRequest,
+    [availabilityContext, invalidateFileSearchRequest, searchFiles],
+  );
 
   const closeReferenceMenu = useCallback(() => {
     invalidateFileSearchRequest();
     setActiveReferenceIndex(0);
     setReferenceMenuState(null);
   }, [invalidateFileSearchRequest]);
-
-  useEffect(() => {
-    if (referenceMenuState && referenceMenuState.availabilityContext !== availabilityContext) {
-      invalidateFileSearchRequest();
-    }
-  }, [availabilityContext, invalidateFileSearchRequest, referenceMenuState]);
 
   const closeSkillMenu = useCallback(() => {
     setActiveSkillIndex(0);
@@ -432,6 +428,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
       }
 
       const requestAvailabilityContext = availabilityContext;
+      const requestSearchFiles = searchFiles;
       invalidateFileSearchRequest();
       const requestId = fileSearchRequestIdRef.current;
       setActiveReferenceIndex(0);
@@ -443,7 +440,8 @@ export const useAgentChatComposerEditorAutocomplete = ({
         results:
           previousState &&
           previousState.textSegmentId === segmentId &&
-          previousState.availabilityContext === requestAvailabilityContext
+          previousState.availabilityContext === requestAvailabilityContext &&
+          previousState.searchFiles === requestSearchFiles
             ? previousState.results
             : [],
         isLoading: true,
@@ -451,6 +449,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
         error: null,
         availabilityContext: requestAvailabilityContext,
         requestId,
+        searchFiles: requestSearchFiles,
       }));
 
       if (!supportsFileSearch) {
@@ -465,6 +464,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
           error: null,
           availabilityContext: requestAvailabilityContext,
           requestId,
+          searchFiles: requestSearchFiles,
         });
         return;
       }
@@ -492,7 +492,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
           return;
         }
 
-        void searchFiles(match.query)
+        void requestSearchFiles(match.query)
           .then((results) => {
             if (fileSearchRequestIdRef.current !== requestId) {
               return;
@@ -509,6 +509,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
               error: null,
               availabilityContext: requestAvailabilityContext,
               requestId,
+              searchFiles: requestSearchFiles,
             });
           })
           .catch((error) => {
@@ -527,6 +528,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
               error: error instanceof Error ? error.message : FILE_SEARCH_FAILED_MESSAGE,
               availabilityContext: requestAvailabilityContext,
               requestId,
+              searchFiles: requestSearchFiles,
             }));
           });
       }, FILE_SEARCH_DEBOUNCE_MS);

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.ts
@@ -89,6 +89,7 @@ export const AUTOCOMPLETE_NAVIGATION_KEYS = new Set([
 ]);
 
 const FILE_SEARCH_FAILED_MESSAGE = "Failed to search files.";
+const FILE_SEARCH_DEBOUNCE_MS = 150;
 const FILE_SEARCH_LOADING_INDICATOR_DELAY_MS = 500;
 
 const isSameTextMenuRequest = (
@@ -255,6 +256,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
   );
   const [activeReferenceIndex, setActiveReferenceIndex] = useState(0);
   const fileSearchRequestIdRef = useRef(0);
+  const fileSearchDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileSearchLoadingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const availabilityContext = useMemo<AutocompleteAvailabilityContext>(
     () => ({
@@ -324,7 +326,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
 
   const clearFileSearchLoadingTimer = useCallback(() => {
     const timer = fileSearchLoadingTimerRef.current;
-    if (!timer) {
+    if (timer === null) {
       return;
     }
 
@@ -332,18 +334,39 @@ export const useAgentChatComposerEditorAutocomplete = ({
     fileSearchLoadingTimerRef.current = null;
   }, []);
 
+  const clearFileSearchDebounceTimer = useCallback(() => {
+    const timer = fileSearchDebounceTimerRef.current;
+    if (timer === null) {
+      return;
+    }
+
+    clearTimeout(timer);
+    fileSearchDebounceTimerRef.current = null;
+  }, []);
+
+  const invalidateFileSearchRequest = useCallback(() => {
+    fileSearchRequestIdRef.current += 1;
+    clearFileSearchDebounceTimer();
+    clearFileSearchLoadingTimer();
+  }, [clearFileSearchDebounceTimer, clearFileSearchLoadingTimer]);
+
   useEffect(() => {
     return () => {
-      clearFileSearchLoadingTimer();
+      invalidateFileSearchRequest();
     };
-  }, [clearFileSearchLoadingTimer]);
+  }, [invalidateFileSearchRequest]);
 
   const closeReferenceMenu = useCallback(() => {
-    clearFileSearchLoadingTimer();
-    fileSearchRequestIdRef.current += 1;
+    invalidateFileSearchRequest();
     setActiveReferenceIndex(0);
     setReferenceMenuState(null);
-  }, [clearFileSearchLoadingTimer]);
+  }, [invalidateFileSearchRequest]);
+
+  useEffect(() => {
+    if (referenceMenuState && referenceMenuState.availabilityContext !== availabilityContext) {
+      invalidateFileSearchRequest();
+    }
+  }, [availabilityContext, invalidateFileSearchRequest, referenceMenuState]);
 
   const closeSkillMenu = useCallback(() => {
     setActiveSkillIndex(0);
@@ -408,10 +431,9 @@ export const useAgentChatComposerEditorAutocomplete = ({
         return;
       }
 
-      const requestId = fileSearchRequestIdRef.current + 1;
       const requestAvailabilityContext = availabilityContext;
-      clearFileSearchLoadingTimer();
-      fileSearchRequestIdRef.current = requestId;
+      invalidateFileSearchRequest();
+      const requestId = fileSearchRequestIdRef.current;
       setActiveReferenceIndex(0);
       setReferenceMenuState((previousState) => ({
         textSegmentId: segmentId,
@@ -419,7 +441,11 @@ export const useAgentChatComposerEditorAutocomplete = ({
         rangeStart: match.rangeStart,
         rangeEnd: match.rangeEnd,
         results:
-          previousState && previousState.textSegmentId === segmentId ? previousState.results : [],
+          previousState &&
+          previousState.textSegmentId === segmentId &&
+          previousState.availabilityContext === requestAvailabilityContext
+            ? previousState.results
+            : [],
         isLoading: true,
         showLoadingIndicator: false,
         error: null,
@@ -460,43 +486,50 @@ export const useAgentChatComposerEditorAutocomplete = ({
         });
       }, FILE_SEARCH_LOADING_INDICATOR_DELAY_MS);
 
-      void searchFiles(match.query)
-        .then((results) => {
-          if (fileSearchRequestIdRef.current !== requestId) {
-            return;
-          }
-          clearFileSearchLoadingTimer();
-          setReferenceMenuState({
-            textSegmentId: segmentId,
-            query: match.query,
-            rangeStart: match.rangeStart,
-            rangeEnd: match.rangeEnd,
-            results,
-            isLoading: false,
-            showLoadingIndicator: false,
-            error: null,
-            availabilityContext: requestAvailabilityContext,
-            requestId,
+      fileSearchDebounceTimerRef.current = setTimeout(() => {
+        fileSearchDebounceTimerRef.current = null;
+        if (fileSearchRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        void searchFiles(match.query)
+          .then((results) => {
+            if (fileSearchRequestIdRef.current !== requestId) {
+              return;
+            }
+            clearFileSearchLoadingTimer();
+            setReferenceMenuState({
+              textSegmentId: segmentId,
+              query: match.query,
+              rangeStart: match.rangeStart,
+              rangeEnd: match.rangeEnd,
+              results,
+              isLoading: false,
+              showLoadingIndicator: false,
+              error: null,
+              availabilityContext: requestAvailabilityContext,
+              requestId,
+            });
+          })
+          .catch((error) => {
+            if (fileSearchRequestIdRef.current !== requestId) {
+              return;
+            }
+            clearFileSearchLoadingTimer();
+            setReferenceMenuState((previousState) => ({
+              textSegmentId: segmentId,
+              query: match.query,
+              rangeStart: match.rangeStart,
+              rangeEnd: match.rangeEnd,
+              results: previousState?.results ?? [],
+              isLoading: false,
+              showLoadingIndicator: false,
+              error: error instanceof Error ? error.message : FILE_SEARCH_FAILED_MESSAGE,
+              availabilityContext: requestAvailabilityContext,
+              requestId,
+            }));
           });
-        })
-        .catch((error) => {
-          if (fileSearchRequestIdRef.current !== requestId) {
-            return;
-          }
-          clearFileSearchLoadingTimer();
-          setReferenceMenuState((previousState) => ({
-            textSegmentId: segmentId,
-            query: match.query,
-            rangeStart: match.rangeStart,
-            rangeEnd: match.rangeEnd,
-            results: previousState?.results ?? [],
-            isLoading: false,
-            showLoadingIndicator: false,
-            error: error instanceof Error ? error.message : FILE_SEARCH_FAILED_MESSAGE,
-            availabilityContext: requestAvailabilityContext,
-            requestId,
-          }));
-        });
+      }, FILE_SEARCH_DEBOUNCE_MS);
     },
     [
       availabilityContext,
@@ -504,6 +537,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
       closeReferenceMenu,
       disabled,
       effectiveReferenceMenuState,
+      invalidateFileSearchRequest,
       searchFiles,
       supportsFileSearch,
       supportsSubagentReferences,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.ts
@@ -73,7 +73,6 @@ type InternalSlashMenuState = SlashMenuState & {
 type InternalReferenceMenuState = ReferenceMenuState & {
   availabilityContext: AutocompleteAvailabilityContext;
   requestId: number;
-  searchFiles: (query: string) => Promise<AgentFileSearchResult[]>;
   showLoadingIndicator: boolean;
 };
 
@@ -259,6 +258,10 @@ export const useAgentChatComposerEditorAutocomplete = ({
   const fileSearchRequestIdRef = useRef(0);
   const fileSearchDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileSearchLoadingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchFilesRef = useRef(searchFiles);
+  useEffect(() => {
+    searchFilesRef.current = searchFiles;
+  }, [searchFiles]);
   const availabilityContext = useMemo<AutocompleteAvailabilityContext>(
     () => ({
       disabled,
@@ -285,8 +288,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
   const effectiveReferenceMenuState =
     disabled ||
     (!supportsFileSearch && !supportsSubagentReferences) ||
-    referenceMenuState?.availabilityContext !== availabilityContext ||
-    referenceMenuState?.searchFiles !== searchFiles
+    referenceMenuState?.availabilityContext !== availabilityContext
       ? null
       : referenceMenuState;
   const effectiveSkillMenuState =
@@ -352,11 +354,8 @@ export const useAgentChatComposerEditorAutocomplete = ({
     clearFileSearchLoadingTimer();
   }, [clearFileSearchDebounceTimer, clearFileSearchLoadingTimer]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Context changes must run cleanup to invalidate queued work.
-  useEffect(
-    () => invalidateFileSearchRequest,
-    [availabilityContext, invalidateFileSearchRequest, searchFiles],
-  );
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Availability changes must invalidate queued work.
+  useEffect(() => invalidateFileSearchRequest, [availabilityContext, invalidateFileSearchRequest]);
 
   const closeReferenceMenu = useCallback(() => {
     invalidateFileSearchRequest();
@@ -428,7 +427,6 @@ export const useAgentChatComposerEditorAutocomplete = ({
       }
 
       const requestAvailabilityContext = availabilityContext;
-      const requestSearchFiles = searchFiles;
       invalidateFileSearchRequest();
       const requestId = fileSearchRequestIdRef.current;
       setActiveReferenceIndex(0);
@@ -440,8 +438,7 @@ export const useAgentChatComposerEditorAutocomplete = ({
         results:
           previousState &&
           previousState.textSegmentId === segmentId &&
-          previousState.availabilityContext === requestAvailabilityContext &&
-          previousState.searchFiles === requestSearchFiles
+          previousState.availabilityContext === requestAvailabilityContext
             ? previousState.results
             : [],
         isLoading: true,
@@ -449,7 +446,6 @@ export const useAgentChatComposerEditorAutocomplete = ({
         error: null,
         availabilityContext: requestAvailabilityContext,
         requestId,
-        searchFiles: requestSearchFiles,
       }));
 
       if (!supportsFileSearch) {
@@ -464,7 +460,6 @@ export const useAgentChatComposerEditorAutocomplete = ({
           error: null,
           availabilityContext: requestAvailabilityContext,
           requestId,
-          searchFiles: requestSearchFiles,
         });
         return;
       }
@@ -492,7 +487,8 @@ export const useAgentChatComposerEditorAutocomplete = ({
           return;
         }
 
-        void requestSearchFiles(match.query)
+        void searchFilesRef
+          .current(match.query)
           .then((results) => {
             if (fileSearchRequestIdRef.current !== requestId) {
               return;
@@ -509,7 +505,6 @@ export const useAgentChatComposerEditorAutocomplete = ({
               error: null,
               availabilityContext: requestAvailabilityContext,
               requestId,
-              searchFiles: requestSearchFiles,
             });
           })
           .catch((error) => {
@@ -528,7 +523,6 @@ export const useAgentChatComposerEditorAutocomplete = ({
               error: error instanceof Error ? error.message : FILE_SEARCH_FAILED_MESSAGE,
               availabilityContext: requestAvailabilityContext,
               requestId,
-              searchFiles: requestSearchFiles,
             }));
           });
       }, FILE_SEARCH_DEBOUNCE_MS);
@@ -540,7 +534,6 @@ export const useAgentChatComposerEditorAutocomplete = ({
       disabled,
       effectiveReferenceMenuState,
       invalidateFileSearchRequest,
-      searchFiles,
       supportsFileSearch,
       supportsSubagentReferences,
     ],


### PR DESCRIPTION
## Summary

- Debounce composer file-reference searches by 100 ms so rapid incremental <code>@</code> queries start only the latest runtime request.
- Keep reference-menu feedback immediate and preserve the existing 500 ms loading-indicator timing.
- Retain request-ID stale-response protection while keeping the menu stable across equivalent search callback rerenders.

## Why

Typing incremental file queries previously started host/runtime work for every distinct query. This change prevents superseded searches before they start without adding cancellation for already-started work, fallback behavior, polling, retries, or a second cache.

## Implementation

- Added a dedicated debounce timer separate from the loading-indicator timer.
- Centralized request invalidation so close, trigger loss, support or availability changes, disabled state, and unmount clear both timers and advance the request ID.
- Use the latest committed <code>searchFiles</code> callback through a ref without treating callback identity as menu validity.
- Kept TanStack Query ownership, runtime query keys, stale time, filtering, ranking, trigger syntax, and error semantics unchanged.
- Added focused coverage for rapid typing, close, unmount, stale started requests, support changes, callback replacement, unchanged triggers, and loading timing.

## Verification

- <code>bun test packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-editor-autocomplete.test.tsx --max-concurrency=1</code> — 15 passed
- <code>bun run format:check</code> — passed
- <code>bun run lint</code> — passed
- <code>bun run typecheck</code> — passed
- <code>bun run --filter @openducktor/frontend test</code> — 3500 passed
- <code>bun run test</code> — passed across all workspaces and release-script tests
- <code>bun run build</code> — passed
- React Doctor — no findings in changed files
- GitNexus change detection — LOW risk with no affected execution flows

## Reviews

- Thermos correctness/security — clean after the callback lifecycle fixes
- Thermos code quality — clean
- Standards review — clean with no violations or smells
- Spec review — clean with no missing, partial, scope-creep, or incorrect requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)