### PR TITLE
fix(frontend): restore live transcript syntax highlighting

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -161,6 +161,7 @@ describe("AgentChatFileEditCard", () => {
 
     expect(preloadedViewerMock).toHaveBeenCalledTimes(1);
     expect(viewerMock).not.toHaveBeenCalled();
+    expect(fileViewerMock).not.toHaveBeenCalled();
   });
 
   test("does not mount the hidden diff preloader while collapsed", () => {
@@ -254,6 +255,8 @@ describe("AgentChatFileEditCard", () => {
 
     expect(screen.getByTestId("pierre-file-viewer").getAttribute("data-content")).toBe("");
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
+    expect(preloadedViewerMock).not.toHaveBeenCalled();
+    expect(viewerMock).not.toHaveBeenCalled();
   });
 
   test("uses full-file content change type for the status badge", () => {
@@ -343,5 +346,6 @@ describe("AgentChatFileEditCard", () => {
     expect(preloaderMock).not.toHaveBeenCalled();
     expect(preloadedViewerMock).not.toHaveBeenCalled();
     expect(viewerMock).not.toHaveBeenCalled();
+    expect(fileViewerMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -13,38 +13,41 @@ const preloaderMock = mock(({ filePath }: { patch: string; filePath: string }) =
   <div data-testid="pierre-diff-preloader">{filePath}</div>
 ));
 
-const viewerMock = mock(
-  ({
-    diffIndicators,
-    diffStyle,
-    filePath,
-    heightMode,
-    hunkSeparators,
-    lineOverflow,
-    patch,
-  }: {
-    patch: string;
-    filePath: string;
-    diffStyle?: string;
-    diffIndicators?: string;
-    heightMode?: string;
-    lineOverflow?: string;
-    hunkSeparators?: string;
-  }) => (
-    <div
-      data-testid="pierre-diff-viewer"
-      data-diff-indicators={diffIndicators ?? ""}
-      data-diff-style={diffStyle ?? ""}
-      data-file-path={filePath}
-      data-height-mode={heightMode ?? ""}
-      data-hunk-separators={hunkSeparators ?? ""}
-      data-line-overflow={lineOverflow ?? ""}
-      data-patch={patch}
-    >
-      {filePath}
-    </div>
-  ),
+type DiffViewerMockProps = {
+  patch: string;
+  filePath: string;
+  diffStyle?: string;
+  diffIndicators?: string;
+  heightMode?: string;
+  lineOverflow?: string;
+  hunkSeparators?: string;
+};
+
+const DiffViewerMock = ({
+  diffIndicators,
+  diffStyle,
+  filePath,
+  heightMode,
+  hunkSeparators,
+  lineOverflow,
+  patch,
+}: DiffViewerMockProps) => (
+  <div
+    data-testid="pierre-diff-viewer"
+    data-diff-indicators={diffIndicators ?? ""}
+    data-diff-style={diffStyle ?? ""}
+    data-file-path={filePath}
+    data-height-mode={heightMode ?? ""}
+    data-hunk-separators={hunkSeparators ?? ""}
+    data-line-overflow={lineOverflow ?? ""}
+    data-patch={patch}
+  >
+    {filePath}
+  </div>
 );
+
+const viewerMock = mock(DiffViewerMock);
+const preloadedViewerMock = mock(DiffViewerMock);
 
 const fileViewerMock = mock(
   ({ content, filePath }: { content: string; filePath: string; className?: string }) => (
@@ -118,6 +121,7 @@ beforeEach(async () => {
 
   mock.module("@/components/features/agents/pierre-diff-viewer", () => ({
     PierreDiffPreloader: preloaderMock,
+    PierrePreloadedDiffViewer: preloadedViewerMock,
     PierreDiffViewer: viewerMock,
     PierreFileViewer: fileViewerMock,
   }));
@@ -129,6 +133,7 @@ beforeEach(async () => {
 afterEach(() => {
   cleanup();
   preloaderMock.mockClear();
+  preloadedViewerMock.mockClear();
   viewerMock.mockClear();
   fileViewerMock.mockClear();
 });
@@ -151,12 +156,20 @@ afterEach(async () => {
 });
 
 describe("AgentChatFileEditCard", () => {
+  test("uses the cache-aware viewer for a newly displayed transcript diff", () => {
+    renderFileEditCard(buildFileEditData(), true);
+
+    expect(preloadedViewerMock).toHaveBeenCalledTimes(1);
+    expect(viewerMock).not.toHaveBeenCalled();
+  });
+
   test("does not mount the hidden diff preloader while collapsed", () => {
     renderFileEditCard(buildFileEditData(), false);
 
     expect(screen.queryByTestId("pierre-diff-preloader")).toBeNull();
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
     expect(preloaderMock).not.toHaveBeenCalled();
+    expect(preloadedViewerMock).not.toHaveBeenCalled();
     expect(viewerMock).not.toHaveBeenCalled();
   });
 
@@ -173,7 +186,8 @@ describe("AgentChatFileEditCard", () => {
     expect(viewer.getAttribute("data-hunk-separators")).toBe("line-info");
     expect(viewer.parentElement).toBe(screen.getByTestId("agent-chat-file-edit-card"));
     expect(preloaderMock).not.toHaveBeenCalled();
-    expect(viewerMock).toHaveBeenCalledTimes(1);
+    expect(preloadedViewerMock).toHaveBeenCalledTimes(1);
+    expect(viewerMock).not.toHaveBeenCalled();
   });
 
   test("renders the visible diff viewer after expansion with default chat diff settings", () => {
@@ -190,7 +204,8 @@ describe("AgentChatFileEditCard", () => {
     expect(viewer.getAttribute("data-line-overflow")).toBe("wrap");
     expect(viewer.getAttribute("data-hunk-separators")).toBe("line-info");
     expect(preloaderMock).not.toHaveBeenCalled();
-    expect(viewerMock).toHaveBeenCalledTimes(1);
+    expect(preloadedViewerMock).toHaveBeenCalledTimes(1);
+    expect(viewerMock).not.toHaveBeenCalled();
   });
 
   test("passes explicit chat diff display settings to expanded transcript diffs", () => {
@@ -224,6 +239,7 @@ describe("AgentChatFileEditCard", () => {
       "src/AuthContext.test.tsx",
     );
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
+    expect(preloadedViewerMock).not.toHaveBeenCalled();
     expect(viewerMock).not.toHaveBeenCalled();
     expect(fileViewerMock).toHaveBeenCalledTimes(1);
   });
@@ -325,6 +341,7 @@ describe("AgentChatFileEditCard", () => {
     expect(screen.queryByTestId("pierre-diff-preloader")).toBeNull();
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
     expect(preloaderMock).not.toHaveBeenCalled();
+    expect(preloadedViewerMock).not.toHaveBeenCalled();
     expect(viewerMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -1,8 +1,8 @@
 import { ChevronDown, ChevronRight, FilePlus, FileText, FileX } from "lucide-react";
 import { memo, type ReactElement, useEffect, useRef, useState } from "react";
 import {
-  PierreDiffViewer,
   PierreFileViewer,
+  PierrePreloadedDiffViewer,
 } from "@/components/features/agents/pierre-diff-viewer";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -112,7 +112,7 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
       </button>
 
       {isExpanded && data.kind === "diff" ? (
-        <PierreDiffViewer
+        <PierrePreloadedDiffViewer
           patch={data.diff}
           filePath={data.filePath}
           diffStyle={chatSettings.diffStyle}

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -10,8 +10,11 @@ import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 let pierreViewerModule: typeof import("./pierre-diff-viewer");
 let pierreViewerModelModule: typeof import("./pierre-diff-viewer-model");
 let workerPoolMock: {
+  cleanUpTasks?: ReturnType<typeof mock>;
   getDiffResultCache: ReturnType<typeof mock>;
   getFileResultCache?: ReturnType<typeof mock>;
+  highlightDiffAST?: ReturnType<typeof mock>;
+  highlightFileAST?: ReturnType<typeof mock>;
   isWorkingPool?: ReturnType<typeof mock>;
   primeDiffHighlightCache: ReturnType<typeof mock>;
   primeFileHighlightCache?: ReturnType<typeof mock>;
@@ -55,6 +58,7 @@ beforeEach(async () => {
               disableFileHeader?: boolean;
               overflow?: string;
               themeType?: string;
+              tokenizeMaxLength?: number;
             };
           }) => {
             const [mountId] = useState(() => {
@@ -71,6 +75,7 @@ beforeEach(async () => {
                 data-mount-id={String(mountId)}
                 data-overflow={String(props.options?.overflow ?? "")}
                 data-theme-type={String(props.options?.themeType ?? "")}
+                data-tokenize-max-length={String(props.options?.tokenizeMaxLength ?? "")}
               />
             );
           },
@@ -84,6 +89,7 @@ beforeEach(async () => {
               onLineSelectionChange?: (range: unknown) => void;
               onLineSelectionStart?: (range: unknown) => void;
               overflow?: string;
+              tokenizeMaxLength?: number;
             };
             selectedLines?: unknown;
           }) => {
@@ -104,6 +110,7 @@ beforeEach(async () => {
                 data-hunk-separators={String(options?.hunkSeparators ?? "")}
                 data-line-diff-type={String(options?.lineDiffType ?? "")}
                 data-overflow={String(options?.overflow ?? "")}
+                data-tokenize-max-length={String(options?.tokenizeMaxLength ?? "")}
               >
                 <output data-testid="pierre-selected-lines">{selectedLinesText}</output>
                 <button
@@ -190,13 +197,17 @@ describe("PierreDiffViewer", () => {
     let notifyStatsChanged: (() => void) | undefined;
     const getDiffResultCache = mock(() => cachedHighlight);
     const primeDiffHighlightCache = mock();
+    const highlightDiffAST = mock();
+    const cleanUpTasks = mock();
     const unsubscribeFromStats = mock();
     const subscribeToStatChanges = mock((callback: () => void) => {
       notifyStatsChanged = callback;
       return unsubscribeFromStats;
     });
     workerPoolMock = {
+      cleanUpTasks,
       getDiffResultCache,
+      highlightDiffAST,
       isWorkingPool: mock(() => true),
       primeDiffHighlightCache,
       subscribeToStatChanges,
@@ -204,24 +215,54 @@ describe("PierreDiffViewer", () => {
 
     render(<PierrePreloadedDiffViewer patch={selectionPatch} filePath="src/app.ts" />);
 
-    expect(screen.getByTestId("pierre-file-diff").getAttribute("data-mount-id")).toBe("1");
-    expect(screen.getByTestId("pierre-file-diff").closest(".invisible")).not.toBeNull();
+    expect(screen.queryByTestId("pierre-file-diff")).toBeNull();
     expect(screen.getByTestId("pierre-diff-highlight-skeleton")).not.toBeNull();
+    expect(highlightDiffAST).toHaveBeenCalledTimes(1);
     expect(primeDiffHighlightCache).not.toHaveBeenCalled();
 
     cachedHighlight = {};
+    const [observer] = highlightDiffAST.mock.calls[0] ?? [];
+    observer?.onHighlightSuccess();
     act(() => notifyStatsChanged?.());
 
     await waitFor(
       () => {
-        expect(screen.getByTestId("pierre-file-diff").getAttribute("data-mount-id")).toBe("2");
+        expect(screen.getByTestId("pierre-file-diff").getAttribute("data-mount-id")).toBe("1");
         expect(screen.queryByTestId("pierre-diff-highlight-skeleton")).toBeNull();
       },
       { timeout: 1000 },
     );
-    expect(screen.getByTestId("pierre-file-diff").closest(".invisible")).toBeNull();
+    expect(cleanUpTasks).toHaveBeenCalledWith(observer);
     expect(unsubscribeFromStats).toHaveBeenCalledTimes(1);
     expect(getDiffResultCache.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  test("shows an actionable error when diff highlighting fails", async () => {
+    const { PierrePreloadedDiffViewer } = pierreViewerModule;
+    const highlightDiffAST = mock();
+    const cleanUpTasks = mock();
+    workerPoolMock = {
+      cleanUpTasks,
+      getDiffResultCache: mock(() => undefined),
+      highlightDiffAST,
+      isWorkingPool: mock(() => true),
+      primeDiffHighlightCache: mock(),
+      subscribeToStatChanges: mock(() => () => undefined),
+    };
+
+    render(<PierrePreloadedDiffViewer patch={selectionPatch} filePath="src/app.ts" />);
+
+    const [observer] = highlightDiffAST.mock.calls[0] ?? [];
+    act(() => observer?.onHighlightError(new Error("worker failed")));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain(
+        "Syntax highlighting failed for src/app.ts",
+      );
+    });
+    expect(screen.queryByTestId("pierre-diff-highlight-skeleton")).toBeNull();
+    expect(screen.queryByTestId("pierre-file-diff")).toBeNull();
+    expect(cleanUpTasks).toHaveBeenCalledWith(observer);
   });
 
   test("renders a warm cached diff immediately without subscribing", () => {
@@ -315,6 +356,7 @@ describe("PierreDiffViewer", () => {
     const primeDiffHighlightCache = mock();
     workerPoolMock = {
       getDiffResultCache: mock(() => null),
+      isWorkingPool: mock(() => true),
       primeDiffHighlightCache,
     };
 
@@ -339,6 +381,7 @@ describe("PierreDiffViewer", () => {
     const primeDiffHighlightCache = mock();
     workerPoolMock = {
       getDiffResultCache,
+      isWorkingPool: mock(() => true),
       primeDiffHighlightCache,
     };
 
@@ -350,6 +393,25 @@ describe("PierreDiffViewer", () => {
       },
       { timeout: 1000 },
     );
+    expect(primeDiffHighlightCache).not.toHaveBeenCalled();
+  });
+
+  test("skips preloading when the worker pool is unavailable", async () => {
+    const { PierreDiffPreloader } = pierreViewerModule;
+    const getDiffResultCache = mock(() => null);
+    const primeDiffHighlightCache = mock();
+    workerPoolMock = {
+      getDiffResultCache,
+      isWorkingPool: mock(() => false),
+      primeDiffHighlightCache,
+    };
+
+    render(<PierreDiffPreloader patch={selectionPatch} filePath="src/app.ts" />);
+
+    await waitFor(() => {
+      expect(workerPoolMock?.isWorkingPool).toHaveBeenCalledTimes(1);
+    });
+    expect(getDiffResultCache).not.toHaveBeenCalled();
     expect(primeDiffHighlightCache).not.toHaveBeenCalled();
   });
 
@@ -460,6 +522,7 @@ describe("PierreDiffViewer", () => {
     expect(diff.getAttribute("data-hunk-separators")).toBe("line-info");
     expect(diff.getAttribute("data-line-diff-type")).toBe("word-alt");
     expect(diff.getAttribute("data-overflow")).toBe("wrap");
+    expect(diff.getAttribute("data-tokenize-max-length")).toBe("1000");
     expect(diff.parentElement?.className).toContain("max-h-[min(50vh,32rem)]");
     expect(diff.parentElement?.className).toContain("overflow-auto");
   });
@@ -512,6 +575,7 @@ describe("PierreDiffViewer", () => {
     expect(file.getAttribute("data-disable-file-header")).toBe("true");
     expect(file.getAttribute("data-overflow")).toBe("wrap");
     expect(file.getAttribute("data-theme-type")).toBe("light");
+    expect(file.getAttribute("data-tokenize-max-length")).toBe("1000");
     expect(screen.queryByTestId("pierre-file-highlight-skeleton")).toBeNull();
     expect(subscribeToStatChanges).not.toHaveBeenCalled();
     expect(primeFileHighlightCache).not.toHaveBeenCalled();
@@ -535,14 +599,18 @@ describe("PierreDiffViewer", () => {
     let notifyStatsChanged: (() => void) | undefined;
     const getFileResultCache = mock(() => cachedHighlight);
     const primeFileHighlightCache = mock();
+    const highlightFileAST = mock();
+    const cleanUpTasks = mock();
     const unsubscribeFromStats = mock();
     const subscribeToStatChanges = mock((callback: () => void) => {
       notifyStatsChanged = callback;
       return unsubscribeFromStats;
     });
     workerPoolMock = {
+      cleanUpTasks,
       getDiffResultCache: mock(() => null),
       getFileResultCache,
+      highlightFileAST,
       isWorkingPool: mock(() => true),
       primeDiffHighlightCache: mock(),
       primeFileHighlightCache,
@@ -553,24 +621,57 @@ describe("PierreDiffViewer", () => {
       <PierreFileViewer filePath="src/AuthContext.test.tsx" content="export const value = 1;" />,
     );
 
-    expect(screen.getByTestId("pierre-file").getAttribute("data-mount-id")).toBe("1");
-    expect(screen.getByTestId("pierre-file").parentElement?.className).toContain("invisible");
+    expect(screen.queryByTestId("pierre-file")).toBeNull();
     expect(screen.getByTestId("pierre-file-highlight-skeleton")).not.toBeNull();
+    expect(highlightFileAST).toHaveBeenCalledTimes(1);
     expect(primeFileHighlightCache).not.toHaveBeenCalled();
 
     cachedHighlight = {};
+    const [observer] = highlightFileAST.mock.calls[0] ?? [];
+    observer?.onHighlightSuccess();
     act(() => notifyStatsChanged?.());
 
     await waitFor(
       () => {
-        expect(screen.getByTestId("pierre-file").getAttribute("data-mount-id")).toBe("2");
+        expect(screen.getByTestId("pierre-file").getAttribute("data-mount-id")).toBe("1");
         expect(screen.queryByTestId("pierre-file-highlight-skeleton")).toBeNull();
       },
       { timeout: 1000 },
     );
-    expect(screen.getByTestId("pierre-file").parentElement?.className).not.toContain("invisible");
+    expect(cleanUpTasks).toHaveBeenCalledWith(observer);
     expect(unsubscribeFromStats).toHaveBeenCalledTimes(1);
     expect(getFileResultCache.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  test("shows an actionable error when file highlighting fails", async () => {
+    const { PierreFileViewer } = pierreViewerModule;
+    const highlightFileAST = mock();
+    const cleanUpTasks = mock();
+    workerPoolMock = {
+      cleanUpTasks,
+      getDiffResultCache: mock(() => null),
+      getFileResultCache: mock(() => undefined),
+      highlightFileAST,
+      isWorkingPool: mock(() => true),
+      primeDiffHighlightCache: mock(),
+      subscribeToStatChanges: mock(() => () => undefined),
+    };
+
+    render(
+      <PierreFileViewer filePath="src/AuthContext.test.tsx" content="export const value = 1;" />,
+    );
+
+    const [observer] = highlightFileAST.mock.calls[0] ?? [];
+    act(() => observer?.onHighlightError(new Error("worker failed")));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain(
+        "Syntax highlighting failed for src/AuthContext.test.tsx",
+      );
+    });
+    expect(screen.queryByTestId("pierre-file-highlight-skeleton")).toBeNull();
+    expect(screen.queryByTestId("pierre-file")).toBeNull();
+    expect(cleanUpTasks).toHaveBeenCalledWith(observer);
   });
 
   test("renders oversized code as terminal plain content without entering loading", () => {

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import {
   withCapturedConsoleMethods,
   withCapturedOutputStreams,
@@ -10,9 +11,12 @@ let pierreViewerModule: typeof import("./pierre-diff-viewer");
 let pierreViewerModelModule: typeof import("./pierre-diff-viewer-model");
 let workerPoolMock: {
   getDiffResultCache: ReturnType<typeof mock>;
+  getFileResultCache?: ReturnType<typeof mock>;
   primeDiffHighlightCache: ReturnType<typeof mock>;
+  primeFileHighlightCache?: ReturnType<typeof mock>;
   subscribeToStatChanges?: ReturnType<typeof mock>;
 } | null = null;
+let pierreFileMountCount = 0;
 
 const OMITTED_SELECTED_LINES_LABEL = "__omitted__";
 const mockedGutterSelection = {
@@ -36,6 +40,7 @@ const selectionPatch = [
 ].join("\n");
 
 beforeEach(async () => {
+  pierreFileMountCount = 0;
   await withCapturedOutputStreams(["stdout", "stderr"], async (chunksByStream) => {
     await withCapturedConsoleMethods(
       ["debug", "error", "info", "log", "warn"],
@@ -48,17 +53,24 @@ beforeEach(async () => {
               overflow?: string;
               themeType?: string;
             };
-          }) => (
-            <div
-              data-testid="pierre-file"
-              data-cache-key={props.file.cacheKey ?? ""}
-              data-disable-file-header={String(props.options?.disableFileHeader ?? "")}
-              data-file-contents={props.file.contents}
-              data-file-name={props.file.name}
-              data-overflow={String(props.options?.overflow ?? "")}
-              data-theme-type={String(props.options?.themeType ?? "")}
-            />
-          ),
+          }) => {
+            const [mountId] = useState(() => {
+              pierreFileMountCount += 1;
+              return pierreFileMountCount;
+            });
+            return (
+              <div
+                data-testid="pierre-file"
+                data-cache-key={props.file.cacheKey ?? ""}
+                data-disable-file-header={String(props.options?.disableFileHeader ?? "")}
+                data-file-contents={props.file.contents}
+                data-file-name={props.file.name}
+                data-mount-id={String(mountId)}
+                data-overflow={String(props.options?.overflow ?? "")}
+                data-theme-type={String(props.options?.themeType ?? "")}
+              />
+            );
+          },
           FileDiff: (props: {
             options?: {
               diffIndicators?: string;
@@ -420,6 +432,48 @@ describe("PierreDiffViewer", () => {
     expect(screen.getByTestId("pierre-file").getAttribute("data-cache-key")).not.toBe(
       firstCacheKey,
     );
+  });
+
+  test("remounts plain file content when the worker finishes highlighting it", async () => {
+    const { PierreFileViewer } = pierreViewerModule;
+    let cachedHighlight: object | undefined;
+    let notifyStatsChanged: (() => void) | undefined;
+    const getFileResultCache = mock(() => cachedHighlight);
+    const primeFileHighlightCache = mock();
+    const subscribeToStatChanges = mock((callback: () => void) => {
+      notifyStatsChanged = callback;
+      return () => undefined;
+    });
+    workerPoolMock = {
+      getDiffResultCache: mock(() => null),
+      getFileResultCache,
+      primeDiffHighlightCache: mock(),
+      primeFileHighlightCache,
+      subscribeToStatChanges,
+    };
+
+    render(
+      <PierreFileViewer filePath="src/AuthContext.test.tsx" content="export const value = 1;" />,
+    );
+
+    expect(screen.getByTestId("pierre-file").getAttribute("data-mount-id")).toBe("1");
+    await waitFor(
+      () => {
+        expect(primeFileHighlightCache).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 1000 },
+    );
+
+    cachedHighlight = {};
+    act(() => notifyStatsChanged?.());
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("pierre-file").getAttribute("data-mount-id")).toBe("2");
+      },
+      { timeout: 1000 },
+    );
+    expect(getFileResultCache.mock.calls.length).toBeGreaterThan(1);
   });
 
   test("keeps raw fallback diffs inside the Pierre scroll container", async () => {

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -12,11 +12,13 @@ let pierreViewerModelModule: typeof import("./pierre-diff-viewer-model");
 let workerPoolMock: {
   getDiffResultCache: ReturnType<typeof mock>;
   getFileResultCache?: ReturnType<typeof mock>;
+  isWorkingPool?: ReturnType<typeof mock>;
   primeDiffHighlightCache: ReturnType<typeof mock>;
   primeFileHighlightCache?: ReturnType<typeof mock>;
   subscribeToStatChanges?: ReturnType<typeof mock>;
 } | null = null;
 let pierreFileMountCount = 0;
+let pierreFileDiffMountCount = 0;
 
 const OMITTED_SELECTED_LINES_LABEL = "__omitted__";
 const mockedGutterSelection = {
@@ -41,6 +43,7 @@ const selectionPatch = [
 
 beforeEach(async () => {
   pierreFileMountCount = 0;
+  pierreFileDiffMountCount = 0;
   await withCapturedOutputStreams(["stdout", "stderr"], async (chunksByStream) => {
     await withCapturedConsoleMethods(
       ["debug", "error", "info", "log", "warn"],
@@ -85,12 +88,17 @@ beforeEach(async () => {
             selectedLines?: unknown;
           }) => {
             const { options } = props;
+            const [mountId] = useState(() => {
+              pierreFileDiffMountCount += 1;
+              return pierreFileDiffMountCount;
+            });
             const selectedLinesText = Object.hasOwn(props, "selectedLines")
               ? JSON.stringify(props.selectedLines)
               : OMITTED_SELECTED_LINES_LABEL;
             return (
               <div
                 data-testid="pierre-file-diff"
+                data-mount-id={String(mountId)}
                 data-diff-indicators={String(options?.diffIndicators ?? "")}
                 data-diff-style={String(options?.diffStyle ?? "")}
                 data-hunk-separators={String(options?.hunkSeparators ?? "")}
@@ -176,58 +184,130 @@ afterEach(async () => {
 });
 
 describe("PierreDiffViewer", () => {
-  test("preloads a diff rendered immediately without a separate preload queue", async () => {
-    const { PierrePreloadedDiffViewer } = pierreViewerModule;
-    const primeDiffHighlightCache = mock();
-    workerPoolMock = {
-      getDiffResultCache: mock(() => null),
-      primeDiffHighlightCache,
-      subscribeToStatChanges: mock(() => () => undefined),
-    };
-
-    render(<PierrePreloadedDiffViewer patch={selectionPatch} filePath="src/app.ts" />);
-
-    expect(screen.getByTestId("pierre-file-diff")).not.toBeNull();
-    await waitFor(
-      () => {
-        expect(primeDiffHighlightCache).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 1000 },
-    );
-  });
-
-  test("observes the worker cache until an immediately rendered diff is highlighted", async () => {
+  test("keeps a cold diff hidden behind a skeleton until highlighting finishes", async () => {
     const { PierrePreloadedDiffViewer } = pierreViewerModule;
     let cachedHighlight: object | undefined;
     let notifyStatsChanged: (() => void) | undefined;
     const getDiffResultCache = mock(() => cachedHighlight);
+    const primeDiffHighlightCache = mock();
+    const unsubscribeFromStats = mock();
     const subscribeToStatChanges = mock((callback: () => void) => {
       notifyStatsChanged = callback;
-      return () => undefined;
+      return unsubscribeFromStats;
     });
     workerPoolMock = {
       getDiffResultCache,
+      isWorkingPool: mock(() => true),
+      primeDiffHighlightCache,
+      subscribeToStatChanges,
+    };
+
+    render(<PierrePreloadedDiffViewer patch={selectionPatch} filePath="src/app.ts" />);
+
+    expect(screen.getByTestId("pierre-file-diff").getAttribute("data-mount-id")).toBe("1");
+    expect(screen.getByTestId("pierre-file-diff").closest(".invisible")).not.toBeNull();
+    expect(screen.getByTestId("pierre-diff-highlight-skeleton")).not.toBeNull();
+    expect(primeDiffHighlightCache).not.toHaveBeenCalled();
+
+    cachedHighlight = {};
+    act(() => notifyStatsChanged?.());
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("pierre-file-diff").getAttribute("data-mount-id")).toBe("2");
+        expect(screen.queryByTestId("pierre-diff-highlight-skeleton")).toBeNull();
+      },
+      { timeout: 1000 },
+    );
+    expect(screen.getByTestId("pierre-file-diff").closest(".invisible")).toBeNull();
+    expect(unsubscribeFromStats).toHaveBeenCalledTimes(1);
+    expect(getDiffResultCache.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  test("renders a warm cached diff immediately without subscribing", () => {
+    const { PierrePreloadedDiffViewer } = pierreViewerModule;
+    const subscribeToStatChanges = mock(() => () => undefined);
+    const primeDiffHighlightCache = mock();
+    workerPoolMock = {
+      getDiffResultCache: mock(() => ({})),
+      isWorkingPool: mock(() => true),
+      primeDiffHighlightCache,
+      subscribeToStatChanges,
+    };
+
+    render(
+      <PierrePreloadedDiffViewer
+        patch={selectionPatch}
+        filePath="src/app.ts"
+        className="rounded-md"
+      />,
+    );
+
+    expect(screen.getByTestId("pierre-file-diff").closest(".invisible")).toBeNull();
+    expect(screen.getByTestId("pierre-file-diff").closest(".grid")?.className).toContain(
+      "rounded-md",
+    );
+    expect(screen.queryByTestId("pierre-diff-highlight-skeleton")).toBeNull();
+    expect(subscribeToStatChanges).not.toHaveBeenCalled();
+    expect(primeDiffHighlightCache).not.toHaveBeenCalled();
+  });
+
+  test("renders oversized diffs as terminal plain content without entering loading", () => {
+    const { PierrePreloadedDiffViewer } = pierreViewerModule;
+    const subscribeToStatChanges = mock(() => () => undefined);
+    const primeDiffHighlightCache = mock();
+    workerPoolMock = {
+      getDiffResultCache: mock(() => undefined),
+      isWorkingPool: mock(() => true),
+      primeDiffHighlightCache,
+      subscribeToStatChanges,
+    };
+    const addedLines = Array.from({ length: 1001 }, (_, index) => `+value ${index}`);
+    const oversizedPatch = [
+      "diff --git a/src/generated.ts b/src/generated.ts",
+      "--- /dev/null",
+      "+++ b/src/generated.ts",
+      "@@ -0,0 +1,1001 @@",
+      ...addedLines,
+      "",
+    ].join("\n");
+
+    render(<PierrePreloadedDiffViewer patch={oversizedPatch} filePath="src/generated.ts" />);
+
+    expect(screen.queryByTestId("pierre-diff-highlight-skeleton")).toBeNull();
+    expect(screen.getByTestId("pierre-file-diff").closest(".invisible")).toBeNull();
+    expect(subscribeToStatChanges).not.toHaveBeenCalled();
+    expect(primeDiffHighlightCache).not.toHaveBeenCalled();
+  });
+
+  test("renders plain-text diffs immediately without a worker pool", () => {
+    const { PierrePreloadedDiffViewer } = pierreViewerModule;
+
+    render(<PierrePreloadedDiffViewer patch={selectionPatch} filePath="notes.txt" />);
+
+    expect(screen.getByTestId("pierre-file-diff").closest(".invisible")).toBeNull();
+    expect(screen.queryByTestId("pierre-diff-highlight-skeleton")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  test("shows an actionable error when diff highlighting is unavailable", () => {
+    const { PierrePreloadedDiffViewer } = pierreViewerModule;
+    const subscribeToStatChanges = mock(() => () => undefined);
+    workerPoolMock = {
+      getDiffResultCache: mock(() => undefined),
+      isWorkingPool: mock(() => false),
       primeDiffHighlightCache: mock(),
       subscribeToStatChanges,
     };
 
     render(<PierrePreloadedDiffViewer patch={selectionPatch} filePath="src/app.ts" />);
 
-    await waitFor(
-      () => {
-        expect(subscribeToStatChanges).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 1000 },
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Syntax highlighting is unavailable for src/app.ts",
     );
-    cachedHighlight = {};
-    act(() => notifyStatsChanged?.());
-
-    await waitFor(
-      () => {
-        expect(getDiffResultCache.mock.calls.length).toBeGreaterThan(1);
-      },
-      { timeout: 1000 },
-    );
+    expect(screen.queryByTestId("pierre-diff-highlight-skeleton")).toBeNull();
+    expect(screen.queryByTestId("pierre-file-diff")).toBeNull();
+    expect(subscribeToStatChanges).not.toHaveBeenCalled();
   });
 
   test("preloads parsed diffs by priming the worker cache", async () => {
@@ -409,8 +489,18 @@ describe("PierreDiffViewer", () => {
     expect(diff.parentElement?.className).not.toContain("overflow-auto");
   });
 
-  test("renders plain file content through Pierre File with a worker cache key", () => {
+  test("renders cached file content immediately with a worker cache key", () => {
     const { PierreFileViewer } = pierreViewerModule;
+    const subscribeToStatChanges = mock(() => () => undefined);
+    const primeFileHighlightCache = mock();
+    workerPoolMock = {
+      getDiffResultCache: mock(() => null),
+      getFileResultCache: mock(() => ({})),
+      isWorkingPool: mock(() => true),
+      primeDiffHighlightCache: mock(),
+      primeFileHighlightCache,
+      subscribeToStatChanges,
+    };
     const { rerender } = render(
       <PierreFileViewer filePath="src/AuthContext.test.tsx" content="export const value = 1;" />,
     );
@@ -422,7 +512,12 @@ describe("PierreDiffViewer", () => {
     expect(file.getAttribute("data-disable-file-header")).toBe("true");
     expect(file.getAttribute("data-overflow")).toBe("wrap");
     expect(file.getAttribute("data-theme-type")).toBe("light");
-    expect(file.parentElement?.className).toContain("max-h-[min(50vh,32rem)]");
+    expect(screen.queryByTestId("pierre-file-highlight-skeleton")).toBeNull();
+    expect(subscribeToStatChanges).not.toHaveBeenCalled();
+    expect(primeFileHighlightCache).not.toHaveBeenCalled();
+    expect(file.parentElement?.parentElement?.parentElement?.className).toContain(
+      "max-h-[min(50vh,32rem)]",
+    );
 
     const firstCacheKey = file.getAttribute("data-cache-key");
     rerender(
@@ -434,19 +529,21 @@ describe("PierreDiffViewer", () => {
     );
   });
 
-  test("remounts plain file content when the worker finishes highlighting it", async () => {
+  test("keeps cold file content hidden behind a skeleton until highlighting finishes", async () => {
     const { PierreFileViewer } = pierreViewerModule;
     let cachedHighlight: object | undefined;
     let notifyStatsChanged: (() => void) | undefined;
     const getFileResultCache = mock(() => cachedHighlight);
     const primeFileHighlightCache = mock();
+    const unsubscribeFromStats = mock();
     const subscribeToStatChanges = mock((callback: () => void) => {
       notifyStatsChanged = callback;
-      return () => undefined;
+      return unsubscribeFromStats;
     });
     workerPoolMock = {
       getDiffResultCache: mock(() => null),
       getFileResultCache,
+      isWorkingPool: mock(() => true),
       primeDiffHighlightCache: mock(),
       primeFileHighlightCache,
       subscribeToStatChanges,
@@ -457,12 +554,9 @@ describe("PierreDiffViewer", () => {
     );
 
     expect(screen.getByTestId("pierre-file").getAttribute("data-mount-id")).toBe("1");
-    await waitFor(
-      () => {
-        expect(primeFileHighlightCache).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 1000 },
-    );
+    expect(screen.getByTestId("pierre-file").parentElement?.className).toContain("invisible");
+    expect(screen.getByTestId("pierre-file-highlight-skeleton")).not.toBeNull();
+    expect(primeFileHighlightCache).not.toHaveBeenCalled();
 
     cachedHighlight = {};
     act(() => notifyStatsChanged?.());
@@ -470,10 +564,71 @@ describe("PierreDiffViewer", () => {
     await waitFor(
       () => {
         expect(screen.getByTestId("pierre-file").getAttribute("data-mount-id")).toBe("2");
+        expect(screen.queryByTestId("pierre-file-highlight-skeleton")).toBeNull();
       },
       { timeout: 1000 },
     );
+    expect(screen.getByTestId("pierre-file").parentElement?.className).not.toContain("invisible");
+    expect(unsubscribeFromStats).toHaveBeenCalledTimes(1);
     expect(getFileResultCache.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  test("renders oversized code as terminal plain content without entering loading", () => {
+    const { PierreFileViewer } = pierreViewerModule;
+    const subscribeToStatChanges = mock(() => () => undefined);
+    const primeFileHighlightCache = mock();
+    workerPoolMock = {
+      getDiffResultCache: mock(() => null),
+      getFileResultCache: mock(() => undefined),
+      isWorkingPool: mock(() => true),
+      primeDiffHighlightCache: mock(),
+      primeFileHighlightCache,
+      subscribeToStatChanges,
+    };
+    const oversizedContent = Array.from(
+      { length: 1001 },
+      (_, index) => `export const value${index} = ${index};`,
+    ).join("\n");
+
+    render(<PierreFileViewer filePath="src/generated.ts" content={oversizedContent} />);
+
+    expect(screen.queryByTestId("pierre-file-highlight-skeleton")).toBeNull();
+    expect(screen.getByTestId("pierre-file").parentElement?.className).not.toContain("invisible");
+    expect(subscribeToStatChanges).not.toHaveBeenCalled();
+    expect(primeFileHighlightCache).not.toHaveBeenCalled();
+  });
+
+  test("renders plain-text files immediately without a worker pool", () => {
+    const { PierreFileViewer } = pierreViewerModule;
+
+    render(<PierreFileViewer filePath="notes.txt" content="No syntax highlighting required." />);
+
+    expect(screen.getByTestId("pierre-file").parentElement?.className).not.toContain("invisible");
+    expect(screen.queryByTestId("pierre-file-highlight-skeleton")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  test("shows an actionable error when the highlight worker pool is unavailable", () => {
+    const { PierreFileViewer } = pierreViewerModule;
+    const subscribeToStatChanges = mock(() => () => undefined);
+    workerPoolMock = {
+      getDiffResultCache: mock(() => null),
+      getFileResultCache: mock(() => undefined),
+      isWorkingPool: mock(() => false),
+      primeDiffHighlightCache: mock(),
+      subscribeToStatChanges,
+    };
+
+    render(
+      <PierreFileViewer filePath="src/AuthContext.test.tsx" content="export const value = 1;" />,
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Syntax highlighting is unavailable for src/AuthContext.test.tsx",
+    );
+    expect(screen.queryByTestId("pierre-file-highlight-skeleton")).toBeNull();
+    expect(screen.queryByTestId("pierre-file")).toBeNull();
+    expect(subscribeToStatChanges).not.toHaveBeenCalled();
   });
 
   test("keeps raw fallback diffs inside the Pierre scroll container", async () => {

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -2,6 +2,7 @@ import {
   type BaseDiffOptions,
   type DiffLineAnnotation,
   type FileContents,
+  type FileDiffMetadata,
   getFiletypeFromFileName,
   type SelectedLineRange,
 } from "@pierre/diffs";
@@ -23,6 +24,8 @@ import {
 } from "react";
 import { useTheme } from "@/components/layout/theme-provider";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PIERRE_HIGHLIGHT_LINE_LIMIT } from "@/lib/diff/pierre-config";
 import { cn } from "@/lib/utils";
 import type { HunkResetAnnotationMetadata, PierreDiffSelection } from "./pierre-diff-viewer-model";
 import {
@@ -78,6 +81,8 @@ type PierreFileViewerProps = {
   className?: string;
 };
 
+type PierreHighlightState = "ready" | "pending" | "unavailable";
+
 const DIFF_THEME = { dark: "pierre-dark", light: "pierre-light" } as const;
 const DIFF_WRAPPER_STYLE = {
   "--diffs-font-size": "12px",
@@ -92,6 +97,14 @@ const HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE = "data-hunk-reset-annotation";
 const HUNK_RESET_BUTTON_CLASS_NAME =
   "pointer-events-auto absolute right-3 top-1 h-7 gap-1.5 px-2.5 text-[11px] shadow-sm";
 const PIERRE_VIEWER_SCROLL_CONTAINER_CLASS_NAME = "max-h-[min(50vh,32rem)] overflow-auto";
+const PIERRE_HIGHLIGHT_SKELETON_WIDTHS = [
+  "w-3/5",
+  "w-4/5",
+  "w-2/3",
+  "w-5/6",
+  "w-1/2",
+  "w-3/4",
+] as const;
 const HUNK_RESET_FLOATING_CSS = `
 [data-line-annotation]:has([${HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE}]),
 [data-gutter-buffer='annotation']:has([${HUNK_RESET_ANNOTATION_MARKER_ATTRIBUTE}]) {
@@ -121,13 +134,65 @@ const getRawDiffFallbackClassName = (lineOverflow: PierreLineOverflow): string =
     lineOverflow === "wrap" ? "whitespace-pre-wrap break-words" : "overflow-x-auto whitespace-pre",
   );
 
-const contentHash = (value: string): string => {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
+const getPierreFileHighlightState = (
+  workerPool: ReturnType<typeof useWorkerPool>,
+  file: FileContents,
+  requiresHighlight: boolean,
+): PierreHighlightState => {
+  if (!requiresHighlight) {
+    return "ready";
   }
-  return (hash >>> 0).toString(36);
+  if (workerPool == null || !workerPool.isWorkingPool()) {
+    return "unavailable";
+  }
+  return workerPool.getFileResultCache(file) == null ? "pending" : "ready";
+};
+
+const getPierreDiffHighlightState = (
+  workerPool: ReturnType<typeof useWorkerPool>,
+  fileDiff: FileDiffMetadata | null,
+  requiresHighlight: boolean,
+): PierreHighlightState => {
+  if (!requiresHighlight) {
+    return "ready";
+  }
+  if (workerPool == null || !workerPool.isWorkingPool()) {
+    return "unavailable";
+  }
+  return fileDiff != null && workerPool.getDiffResultCache(fileDiff) != null ? "ready" : "pending";
+};
+
+const PierreHighlightSkeleton = ({
+  filePath,
+  testId,
+}: {
+  filePath: string;
+  testId: string;
+}): ReactElement => (
+  <div
+    className="col-start-1 row-start-1 space-y-2 overflow-hidden bg-background px-3 py-3"
+    data-testid={testId}
+    role="status"
+    aria-label={`Highlighting ${filePath}`}
+  >
+    {PIERRE_HIGHLIGHT_SKELETON_WIDTHS.map((widthClassName) => (
+      <Skeleton key={widthClassName} className={cn("h-3 rounded-sm", widthClassName)} />
+    ))}
+  </div>
+);
+
+const getContentMetrics = (value: string): { hash: string; lineCount: number } => {
+  let hash = 0x811c9dc5;
+  let lineCount = 1;
+  for (let index = 0; index < value.length; index += 1) {
+    const charCode = value.charCodeAt(index);
+    hash ^= charCode;
+    hash = Math.imul(hash, 0x01000193);
+    if (charCode === 10) {
+      lineCount += 1;
+    }
+  }
+  return { hash: (hash >>> 0).toString(36), lineCount };
 };
 
 export const PierreDiffPreloader = memo(function PierreDiffPreloader({
@@ -158,42 +223,44 @@ export const PierreFileViewer = memo(function PierreFileViewer({
 }: PierreFileViewerProps): ReactElement {
   const { theme } = useTheme();
   const workerPool = useWorkerPool();
-  const file = useMemo<FileContents>(
-    () => ({
-      name: filePath,
-      contents: content,
-      lang: getFiletypeFromFileName(filePath),
-      cacheKey: `${filePath}:${content.length}:${contentHash(content)}`,
-    }),
-    [content, filePath],
+  const { file, lineCount } = useMemo<{ file: FileContents; lineCount: number }>(() => {
+    const metrics = getContentMetrics(content);
+    return {
+      file: {
+        name: filePath,
+        contents: content,
+        lang: getFiletypeFromFileName(filePath),
+        cacheKey: `${filePath}:${content.length}:${metrics.hash}`,
+      },
+      lineCount: metrics.lineCount,
+    };
+  }, [content, filePath]);
+  const requiresHighlight =
+    content.length > 0 && file.lang !== "text" && lineCount <= PIERRE_HIGHLIGHT_LINE_LIMIT;
+  const highlightStateBeforeSubscription = getPierreFileHighlightState(
+    workerPool,
+    file,
+    requiresHighlight,
   );
-  const requiresHighlight = file.lang !== "text";
+  const shouldSubscribeToHighlightCache = highlightStateBeforeSubscription === "pending";
   const subscribeToHighlightCache = useCallback(
     (onStoreChange: () => void) => {
-      if (workerPool == null || !requiresHighlight) {
+      if (!shouldSubscribeToHighlightCache || workerPool == null) {
         return () => undefined;
       }
       return workerPool.subscribeToStatChanges(onStoreChange);
     },
-    [requiresHighlight, workerPool],
+    [shouldSubscribeToHighlightCache, workerPool],
   );
   const getHighlightCacheSnapshot = useCallback(
-    () => workerPool == null || !requiresHighlight || workerPool.getFileResultCache(file) != null,
+    () => getPierreFileHighlightState(workerPool, file, requiresHighlight),
     [file, requiresHighlight, workerPool],
   );
-  const isHighlightReady = useSyncExternalStore(
+  const highlightState = useSyncExternalStore(
     subscribeToHighlightCache,
     getHighlightCacheSnapshot,
-    () => false,
+    () => (requiresHighlight ? "pending" : "ready"),
   );
-
-  useEffect(() => {
-    if (workerPool == null || !requiresHighlight || isHighlightReady) {
-      return;
-    }
-    workerPool.primeFileHighlightCache(file);
-  }, [file, isHighlightReady, requiresHighlight, workerPool]);
-
   const options = useMemo(
     () => ({
       theme: DIFF_THEME,
@@ -203,12 +270,38 @@ export const PierreFileViewer = memo(function PierreFileViewer({
     }),
     [theme],
   );
+  const isHighlightReady = highlightState === "ready";
   const renderPhase = isHighlightReady ? "highlighted" : "pending";
+
+  if (highlightState === "unavailable") {
+    return (
+      <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
+        <div
+          className="px-3 py-4 text-sm text-destructive"
+          role="alert"
+        >{`Syntax highlighting is unavailable for ${filePath}.`}</div>
+      </div>
+    );
+  }
 
   return (
     <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
       <div className={PIERRE_VIEWER_SCROLL_CONTAINER_CLASS_NAME}>
-        <PierreReactFile key={`${file.cacheKey}:${renderPhase}`} file={file} options={options} />
+        <div className="grid min-w-0">
+          <div
+            className={cn("col-start-1 row-start-1 min-w-0", !isHighlightReady && "invisible")}
+            aria-hidden={!isHighlightReady || undefined}
+          >
+            <PierreReactFile
+              key={`${file.cacheKey}:${renderPhase}`}
+              file={file}
+              options={options}
+            />
+          </div>
+          {!isHighlightReady ? (
+            <PierreHighlightSkeleton filePath={filePath} testId="pierre-file-highlight-skeleton" />
+          ) : null}
+        </div>
       </div>
     </div>
   );
@@ -388,39 +481,72 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
 export const PierrePreloadedDiffViewer = memo(function PierrePreloadedDiffViewer(
   props: PierreDiffViewerProps,
 ): ReactElement {
+  const { className, ...viewerProps } = props;
   const workerPool = useWorkerPool();
   const { fileDiff } = useMemo(
     () => getRenderableFileDiff(props.patch, props.filePath),
     [props.filePath, props.patch],
   );
   const fileDiffCacheKey = fileDiff?.cacheKey ?? null;
+  const diffLineCount =
+    fileDiff == null ? 0 : Math.max(fileDiff.additionLines.length, fileDiff.deletionLines.length);
+  const requiresHighlight =
+    fileDiff != null &&
+    diffLineCount > 0 &&
+    fileDiff.lang !== "text" &&
+    diffLineCount <= PIERRE_HIGHLIGHT_LINE_LIMIT;
+  const highlightStateBeforeSubscription = getPierreDiffHighlightState(
+    workerPool,
+    fileDiff,
+    requiresHighlight,
+  );
+  const shouldSubscribeToHighlightCache = highlightStateBeforeSubscription === "pending";
   const subscribeToHighlightCache = useCallback(
     (onStoreChange: () => void) => {
-      if (workerPool == null || fileDiff == null) {
+      if (!shouldSubscribeToHighlightCache || workerPool == null) {
         return () => undefined;
       }
       return workerPool.subscribeToStatChanges(onStoreChange);
     },
-    [fileDiff, workerPool],
+    [shouldSubscribeToHighlightCache, workerPool],
   );
   const getHighlightCacheSnapshot = useCallback(
-    () => workerPool != null && fileDiff != null && workerPool.getDiffResultCache(fileDiff) != null,
-    [fileDiff, workerPool],
+    () => getPierreDiffHighlightState(workerPool, fileDiff, requiresHighlight),
+    [fileDiff, requiresHighlight, workerPool],
   );
-  const isHighlightCached = useSyncExternalStore(
+  const highlightState = useSyncExternalStore(
     subscribeToHighlightCache,
     getHighlightCacheSnapshot,
-    () => false,
+    () => (requiresHighlight ? "pending" : "ready"),
   );
+  const isHighlightReady = highlightState === "ready";
+  const renderPhase = isHighlightReady ? "highlighted" : "pending";
 
-  useEffect(() => {
-    if (workerPool == null || fileDiff == null || isHighlightCached) {
-      return;
-    }
-    workerPool.primeDiffHighlightCache(fileDiff);
-  }, [fileDiff, isHighlightCached, workerPool]);
+  if (highlightState === "unavailable") {
+    return (
+      <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
+        <div
+          className="px-3 py-4 text-sm text-destructive"
+          role="alert"
+        >{`Syntax highlighting is unavailable for ${props.filePath}.`}</div>
+      </div>
+    );
+  }
 
-  const renderPhase = isHighlightCached ? "highlighted" : "pending";
-
-  return <PierreDiffViewer key={`${fileDiffCacheKey}:${renderPhase}`} {...props} />;
+  return (
+    <div className={cn("grid min-w-0", className)}>
+      <div
+        className={cn("col-start-1 row-start-1 min-w-0", !isHighlightReady && "invisible")}
+        aria-hidden={!isHighlightReady || undefined}
+      >
+        <PierreDiffViewer key={`${fileDiffCacheKey}:${renderPhase}`} {...viewerProps} />
+      </div>
+      {!isHighlightReady ? (
+        <PierreHighlightSkeleton
+          filePath={props.filePath}
+          testId="pierre-diff-highlight-skeleton"
+        />
+      ) : null}
+    </div>
+  );
 });

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -18,6 +18,7 @@ import {
   type ReactElement,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useState,
   useSyncExternalStore,
@@ -82,6 +83,12 @@ type PierreFileViewerProps = {
 };
 
 type PierreHighlightState = "ready" | "pending" | "unavailable";
+type PierreWorkerPool = NonNullable<ReturnType<typeof useWorkerPool>>;
+type PierreFileHighlightObserver = Parameters<PierreWorkerPool["highlightFileAST"]>[0];
+type PierreDiffHighlightObserver = Parameters<PierreWorkerPool["highlightDiffAST"]>[0];
+type PierreHighlightTarget =
+  | { kind: "file"; file: FileContents; taskKey: string }
+  | { kind: "diff"; fileDiff: FileDiffMetadata; taskKey: string };
 
 const DIFF_THEME = { dark: "pierre-dark", light: "pierre-light" } as const;
 const DIFF_WRAPPER_STYLE = {
@@ -138,6 +145,7 @@ const getPierreFileHighlightState = (
   workerPool: ReturnType<typeof useWorkerPool>,
   file: FileContents,
   requiresHighlight: boolean,
+  didHighlightFail: boolean,
 ): PierreHighlightState => {
   if (!requiresHighlight) {
     return "ready";
@@ -145,13 +153,17 @@ const getPierreFileHighlightState = (
   if (workerPool == null || !workerPool.isWorkingPool()) {
     return "unavailable";
   }
-  return workerPool.getFileResultCache(file) == null ? "pending" : "ready";
+  if (workerPool.getFileResultCache(file) != null) {
+    return "ready";
+  }
+  return didHighlightFail ? "unavailable" : "pending";
 };
 
 const getPierreDiffHighlightState = (
   workerPool: ReturnType<typeof useWorkerPool>,
   fileDiff: FileDiffMetadata | null,
   requiresHighlight: boolean,
+  didHighlightFail: boolean,
 ): PierreHighlightState => {
   if (!requiresHighlight) {
     return "ready";
@@ -159,7 +171,52 @@ const getPierreDiffHighlightState = (
   if (workerPool == null || !workerPool.isWorkingPool()) {
     return "unavailable";
   }
-  return fileDiff != null && workerPool.getDiffResultCache(fileDiff) != null ? "ready" : "pending";
+  if (fileDiff != null && workerPool.getDiffResultCache(fileDiff) != null) {
+    return "ready";
+  }
+  return didHighlightFail ? "unavailable" : "pending";
+};
+
+const usePierreHighlightTaskFailure = ({
+  target,
+  workerPool,
+  shouldStart,
+}: {
+  target: PierreHighlightTarget | null;
+  workerPool: ReturnType<typeof useWorkerPool>;
+  shouldStart: boolean;
+}): boolean => {
+  const reactId = useId();
+  const [failedTaskKey, setFailedTaskKey] = useState<string | null>(null);
+  const didHighlightFail = target != null && failedTaskKey === target.taskKey;
+
+  useEffect(() => {
+    if (!shouldStart || workerPool == null || target == null || didHighlightFail) {
+      return;
+    }
+
+    const instanceId = `openducktor-highlight:${reactId}:${target.taskKey}`;
+    const onHighlightError = () => setFailedTaskKey(target.taskKey);
+    if (target.kind === "file") {
+      const observer: PierreFileHighlightObserver = {
+        __id: instanceId,
+        onHighlightSuccess: () => undefined,
+        onHighlightError,
+      };
+      workerPool.highlightFileAST(observer, target.file);
+      return () => workerPool.cleanUpTasks(observer);
+    }
+
+    const observer: PierreDiffHighlightObserver = {
+      __id: instanceId,
+      onHighlightSuccess: () => undefined,
+      onHighlightError,
+    };
+    workerPool.highlightDiffAST(observer, target.fileDiff);
+    return () => workerPool.cleanUpTasks(observer);
+  }, [didHighlightFail, reactId, shouldStart, target, workerPool]);
+
+  return didHighlightFail;
 };
 
 const PierreHighlightSkeleton = ({
@@ -203,7 +260,7 @@ export const PierreDiffPreloader = memo(function PierreDiffPreloader({
   const { fileDiff } = useMemo(() => getRenderableFileDiff(patch, filePath), [filePath, patch]);
 
   useEffect(() => {
-    if (workerPool == null || fileDiff == null) {
+    if (workerPool == null || !workerPool.isWorkingPool() || fileDiff == null) {
       return;
     }
     if (workerPool.getDiffResultCache(fileDiff) != null) {
@@ -223,15 +280,21 @@ export const PierreFileViewer = memo(function PierreFileViewer({
 }: PierreFileViewerProps): ReactElement {
   const { theme } = useTheme();
   const workerPool = useWorkerPool();
-  const { file, lineCount } = useMemo<{ file: FileContents; lineCount: number }>(() => {
+  const { file, fileCacheKey, lineCount } = useMemo<{
+    file: FileContents;
+    fileCacheKey: string;
+    lineCount: number;
+  }>(() => {
     const metrics = getContentMetrics(content);
+    const fileCacheKey = `${filePath}:${content.length}:${metrics.hash}`;
     return {
       file: {
         name: filePath,
         contents: content,
         lang: getFiletypeFromFileName(filePath),
-        cacheKey: `${filePath}:${content.length}:${metrics.hash}`,
+        cacheKey: fileCacheKey,
       },
+      fileCacheKey,
       lineCount: metrics.lineCount,
     };
   }, [content, filePath]);
@@ -241,8 +304,19 @@ export const PierreFileViewer = memo(function PierreFileViewer({
     workerPool,
     file,
     requiresHighlight,
+    false,
   );
-  const shouldSubscribeToHighlightCache = highlightStateBeforeSubscription === "pending";
+  const highlightTarget = useMemo<PierreHighlightTarget>(
+    () => ({ kind: "file", file, taskKey: fileCacheKey }),
+    [file, fileCacheKey],
+  );
+  const didHighlightFail = usePierreHighlightTaskFailure({
+    target: highlightTarget,
+    workerPool,
+    shouldStart: highlightStateBeforeSubscription === "pending",
+  });
+  const shouldSubscribeToHighlightCache =
+    highlightStateBeforeSubscription === "pending" && !didHighlightFail;
   const subscribeToHighlightCache = useCallback(
     (onStoreChange: () => void) => {
       if (!shouldSubscribeToHighlightCache || workerPool == null) {
@@ -253,8 +327,8 @@ export const PierreFileViewer = memo(function PierreFileViewer({
     [shouldSubscribeToHighlightCache, workerPool],
   );
   const getHighlightCacheSnapshot = useCallback(
-    () => getPierreFileHighlightState(workerPool, file, requiresHighlight),
-    [file, requiresHighlight, workerPool],
+    () => getPierreFileHighlightState(workerPool, file, requiresHighlight, didHighlightFail),
+    [didHighlightFail, file, requiresHighlight, workerPool],
   );
   const highlightState = useSyncExternalStore(
     subscribeToHighlightCache,
@@ -267,11 +341,11 @@ export const PierreFileViewer = memo(function PierreFileViewer({
       themeType: theme,
       overflow: "wrap" as const,
       disableFileHeader: true,
+      tokenizeMaxLength: PIERRE_HIGHLIGHT_LINE_LIMIT,
     }),
     [theme],
   );
   const isHighlightReady = highlightState === "ready";
-  const renderPhase = isHighlightReady ? "highlighted" : "pending";
 
   if (highlightState === "unavailable") {
     return (
@@ -279,7 +353,7 @@ export const PierreFileViewer = memo(function PierreFileViewer({
         <div
           className="px-3 py-4 text-sm text-destructive"
           role="alert"
-        >{`Syntax highlighting is unavailable for ${filePath}.`}</div>
+        >{`Syntax highlighting ${didHighlightFail ? "failed" : "is unavailable"} for ${filePath}. Reload the session to try again.`}</div>
       </div>
     );
   }
@@ -288,19 +362,13 @@ export const PierreFileViewer = memo(function PierreFileViewer({
     <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
       <div className={PIERRE_VIEWER_SCROLL_CONTAINER_CLASS_NAME}>
         <div className="grid min-w-0">
-          <div
-            className={cn("col-start-1 row-start-1 min-w-0", !isHighlightReady && "invisible")}
-            aria-hidden={!isHighlightReady || undefined}
-          >
-            <PierreReactFile
-              key={`${file.cacheKey}:${renderPhase}`}
-              file={file}
-              options={options}
-            />
-          </div>
-          {!isHighlightReady ? (
+          {isHighlightReady ? (
+            <div className="col-start-1 row-start-1 min-w-0">
+              <PierreReactFile key={fileCacheKey} file={file} options={options} />
+            </div>
+          ) : (
             <PierreHighlightSkeleton filePath={filePath} testId="pierre-file-highlight-skeleton" />
-          ) : null}
+          )}
         </div>
       </div>
     </div>
@@ -387,6 +455,7 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
       lineDiffType,
       overflow: lineOverflow,
       disableFileHeader: true,
+      tokenizeMaxLength: PIERRE_HIGHLIGHT_LINE_LIMIT,
       enableLineSelection,
       enableGutterUtility: handleGutterUtilityClick != null,
       ...(handleLineSelectionChange
@@ -499,8 +568,22 @@ export const PierrePreloadedDiffViewer = memo(function PierrePreloadedDiffViewer
     workerPool,
     fileDiff,
     requiresHighlight,
+    false,
   );
-  const shouldSubscribeToHighlightCache = highlightStateBeforeSubscription === "pending";
+  const highlightTarget = useMemo<PierreHighlightTarget | null>(
+    () =>
+      fileDiff == null || fileDiffCacheKey == null
+        ? null
+        : { kind: "diff", fileDiff, taskKey: fileDiffCacheKey },
+    [fileDiff, fileDiffCacheKey],
+  );
+  const didHighlightFail = usePierreHighlightTaskFailure({
+    target: highlightTarget,
+    workerPool,
+    shouldStart: highlightStateBeforeSubscription === "pending",
+  });
+  const shouldSubscribeToHighlightCache =
+    highlightStateBeforeSubscription === "pending" && !didHighlightFail;
   const subscribeToHighlightCache = useCallback(
     (onStoreChange: () => void) => {
       if (!shouldSubscribeToHighlightCache || workerPool == null) {
@@ -511,8 +594,8 @@ export const PierrePreloadedDiffViewer = memo(function PierrePreloadedDiffViewer
     [shouldSubscribeToHighlightCache, workerPool],
   );
   const getHighlightCacheSnapshot = useCallback(
-    () => getPierreDiffHighlightState(workerPool, fileDiff, requiresHighlight),
-    [fileDiff, requiresHighlight, workerPool],
+    () => getPierreDiffHighlightState(workerPool, fileDiff, requiresHighlight, didHighlightFail),
+    [didHighlightFail, fileDiff, requiresHighlight, workerPool],
   );
   const highlightState = useSyncExternalStore(
     subscribeToHighlightCache,
@@ -520,7 +603,6 @@ export const PierrePreloadedDiffViewer = memo(function PierrePreloadedDiffViewer
     () => (requiresHighlight ? "pending" : "ready"),
   );
   const isHighlightReady = highlightState === "ready";
-  const renderPhase = isHighlightReady ? "highlighted" : "pending";
 
   if (highlightState === "unavailable") {
     return (
@@ -528,25 +610,23 @@ export const PierrePreloadedDiffViewer = memo(function PierrePreloadedDiffViewer
         <div
           className="px-3 py-4 text-sm text-destructive"
           role="alert"
-        >{`Syntax highlighting is unavailable for ${props.filePath}.`}</div>
+        >{`Syntax highlighting ${didHighlightFail ? "failed" : "is unavailable"} for ${props.filePath}. Reload the session to try again.`}</div>
       </div>
     );
   }
 
   return (
     <div className={cn("grid min-w-0", className)}>
-      <div
-        className={cn("col-start-1 row-start-1 min-w-0", !isHighlightReady && "invisible")}
-        aria-hidden={!isHighlightReady || undefined}
-      >
-        <PierreDiffViewer key={`${fileDiffCacheKey}:${renderPhase}`} {...viewerProps} />
-      </div>
-      {!isHighlightReady ? (
+      {isHighlightReady ? (
+        <div className="col-start-1 row-start-1 min-w-0">
+          <PierreDiffViewer key={fileDiffCacheKey} {...viewerProps} />
+        </div>
+      ) : (
         <PierreHighlightSkeleton
           filePath={props.filePath}
           testId="pierre-diff-highlight-skeleton"
         />
-      ) : null}
+      )}
     </div>
   );
 });

--- a/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/packages/frontend/src/components/features/agents/pierre-diff-viewer.tsx
@@ -1,8 +1,9 @@
-import type {
-  BaseDiffOptions,
-  DiffLineAnnotation,
-  FileContents,
-  SelectedLineRange,
+import {
+  type BaseDiffOptions,
+  type DiffLineAnnotation,
+  type FileContents,
+  getFiletypeFromFileName,
+  type SelectedLineRange,
 } from "@pierre/diffs";
 import {
   File as PierreReactFile,
@@ -156,14 +157,43 @@ export const PierreFileViewer = memo(function PierreFileViewer({
   className,
 }: PierreFileViewerProps): ReactElement {
   const { theme } = useTheme();
+  const workerPool = useWorkerPool();
   const file = useMemo<FileContents>(
     () => ({
       name: filePath,
       contents: content,
+      lang: getFiletypeFromFileName(filePath),
       cacheKey: `${filePath}:${content.length}:${contentHash(content)}`,
     }),
     [content, filePath],
   );
+  const requiresHighlight = file.lang !== "text";
+  const subscribeToHighlightCache = useCallback(
+    (onStoreChange: () => void) => {
+      if (workerPool == null || !requiresHighlight) {
+        return () => undefined;
+      }
+      return workerPool.subscribeToStatChanges(onStoreChange);
+    },
+    [requiresHighlight, workerPool],
+  );
+  const getHighlightCacheSnapshot = useCallback(
+    () => workerPool == null || !requiresHighlight || workerPool.getFileResultCache(file) != null,
+    [file, requiresHighlight, workerPool],
+  );
+  const isHighlightReady = useSyncExternalStore(
+    subscribeToHighlightCache,
+    getHighlightCacheSnapshot,
+    () => false,
+  );
+
+  useEffect(() => {
+    if (workerPool == null || !requiresHighlight || isHighlightReady) {
+      return;
+    }
+    workerPool.primeFileHighlightCache(file);
+  }, [file, isHighlightReady, requiresHighlight, workerPool]);
+
   const options = useMemo(
     () => ({
       theme: DIFF_THEME,
@@ -173,11 +203,12 @@ export const PierreFileViewer = memo(function PierreFileViewer({
     }),
     [theme],
   );
+  const renderPhase = isHighlightReady ? "highlighted" : "pending";
 
   return (
     <div className={cn("min-w-0", className)} style={DIFF_WRAPPER_STYLE}>
       <div className={PIERRE_VIEWER_SCROLL_CONTAINER_CLASS_NAME}>
-        <PierreReactFile file={file} options={options} />
+        <PierreReactFile key={`${file.cacheKey}:${renderPhase}`} file={file} options={options} />
       </div>
     </div>
   );

--- a/packages/frontend/src/contexts/DiffWorkerProvider.tsx
+++ b/packages/frontend/src/contexts/DiffWorkerProvider.tsx
@@ -1,6 +1,7 @@
 import { preloadHighlighter, type SupportedLanguages } from "@pierre/diffs";
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import { type ReactElement, type ReactNode, useEffect, useMemo } from "react";
+import { PIERRE_HIGHLIGHT_LINE_LIMIT } from "@/lib/diff/pierre-config";
 import { workerFactory } from "@/lib/diff/workerFactory";
 
 // ─── Pre-warm config ───────────────────────────────────────────────────────────
@@ -52,6 +53,7 @@ export function DiffWorkerProvider({ children }: { children: ReactNode }): React
         theme: { light: "pierre-light", dark: "pierre-dark" },
         langs: PRELOAD_LANGS,
         lineDiffType: "word-alt",
+        tokenizeMaxLineLength: PIERRE_HIGHLIGHT_LINE_LIMIT,
       }}
     >
       {children}

--- a/packages/frontend/src/contexts/DiffWorkerProvider.tsx
+++ b/packages/frontend/src/contexts/DiffWorkerProvider.tsx
@@ -1,7 +1,6 @@
 import { preloadHighlighter, type SupportedLanguages } from "@pierre/diffs";
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import { type ReactElement, type ReactNode, useEffect, useMemo } from "react";
-import { PIERRE_HIGHLIGHT_LINE_LIMIT } from "@/lib/diff/pierre-config";
 import { workerFactory } from "@/lib/diff/workerFactory";
 
 // ─── Pre-warm config ───────────────────────────────────────────────────────────
@@ -53,7 +52,6 @@ export function DiffWorkerProvider({ children }: { children: ReactNode }): React
         theme: { light: "pierre-light", dark: "pierre-dark" },
         langs: PRELOAD_LANGS,
         lineDiffType: "word-alt",
-        tokenizeMaxLineLength: PIERRE_HIGHLIGHT_LINE_LIMIT,
       }}
     >
       {children}

--- a/packages/frontend/src/lib/diff/pierre-config.ts
+++ b/packages/frontend/src/lib/diff/pierre-config.ts
@@ -1,5 +1,5 @@
 /**
- * Pierre 1.2.12 renders larger files and diffs as terminal plain text instead of
- * scheduling syntax highlighting. Keep the visible loading gate aligned with that policy.
+ * App-level line limit passed to Pierre's `tokenizeMaxLength` option. Larger files and
+ * diffs render as terminal plain text instead of entering the highlighting loading state.
  */
 export const PIERRE_HIGHLIGHT_LINE_LIMIT = 1000;

--- a/packages/frontend/src/lib/diff/pierre-config.ts
+++ b/packages/frontend/src/lib/diff/pierre-config.ts
@@ -1,0 +1,5 @@
+/**
+ * Pierre 1.2.12 renders larger files and diffs as terminal plain text instead of
+ * scheduling syntax highlighting. Keep the visible loading gate aligned with that policy.
+ */
+export const PIERRE_HIGHLIGHT_LINE_LIMIT = 1000;


### PR DESCRIPTION
Summary: Restores syntax highlighting for file edits as they appear in live agent transcripts, while preventing a visible plain-text-to-highlighted flicker.

## Goal

Live OpenCode write-tool output could render without syntax highlighting until the user navigated away and returned. The live transcript path was displaying Pierre content before worker-backed highlighting had reached the cache, while hydrated history benefited from the completed cache state.

This pull request makes live and hydrated transcript rendering consistent and keeps the loading transition visually stable.

## Implementation

- Routes both parsed diffs and full-file write output through cache-aware Pierre viewers with stable cache keys.
- Uses the shared Pierre worker pool and Pierre automatic highlighting rather than manually priming the visible render path.
- Keeps cold content invisible behind a mandatory semantic skeleton, then remounts it atomically once the highlighted cache entry is available.
- Renders warm cache hits immediately and unsubscribes from worker statistics after completion.
- Keeps plain-text, raw or empty diffs, and content above the Pierre 1,000-line highlighting threshold on their terminal plain rendering path without a loading state.
- Aligns the application loading threshold with the worker pool highlighter configuration.
- Surfaces an actionable alert if the worker pool becomes unavailable instead of silently falling back.

## Verification

- bun run lint
- bun run test
- bun run typecheck
- bun run build
- React Doctor: no diagnostics
- GitNexus staged impact: low risk, no affected execution flows

Cargo checks are not applicable because this repository contains no Cargo.toml.