### PR TITLE
fix(codex): always approve OpenDucktor MCP tools

### DIFF
--- a/packages/host/src/adapters/codex/codex-workspace-runtime-config.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-config.ts
@@ -20,7 +20,7 @@ export const buildCodexMcpConfigArgs = (mcpCommand: string[]): string[] => {
     `mcp_servers.openducktor.command=${tomlString(mcpBinary)}`,
     `mcp_servers.openducktor.args=${tomlStringArray(mcpArgs)}`,
     `mcp_servers.openducktor.env_vars=${tomlStringArray(OPENDUCKTOR_MCP_ENV_VAR_NAMES)}`,
-    `mcp_servers.openducktor.default_tools_approval_mode=${tomlString("prompt")}`,
+    `mcp_servers.openducktor.default_tools_approval_mode=${tomlString("approve")}`,
     "mcp_servers.openducktor.enabled=true",
   ].flatMap((config) => ["--config", config]);
 };

--- a/packages/host/src/adapters/codex/codex-workspace-runtime-starter.test.ts
+++ b/packages/host/src/adapters/codex/codex-workspace-runtime-starter.test.ts
@@ -390,7 +390,7 @@ describe("createCodexWorkspaceRuntimeStarter", () => {
           "--config",
           "mcp_servers.openducktor.env_vars=['ODT_WORKSPACE_ID', 'ODT_HOST_URL', 'ODT_HOST_TOKEN', 'ODT_FORBID_WORKSPACE_ID_INPUT', 'ODT_ALLOWED_TOOLS']",
           "--config",
-          "mcp_servers.openducktor.default_tools_approval_mode='prompt'",
+          "mcp_servers.openducktor.default_tools_approval_mode='approve'",
           "--config",
           "mcp_servers.openducktor.enabled=true",
         ]),


### PR DESCRIPTION
## Summary

Configure the OpenDucktor MCP server injected into Codex app-server runtimes to run its workflow tools without prompting for per-call approval.

## Goal

Codex workspace-write sessions currently prompt before every OpenDucktor workflow tool call, including task reads. These tools are part of the trusted workflow bridge that OpenDucktor starts for the active workspace, so repeated approval requests interrupt normal planning, build, and QA flows.

## Implementation

- Change the injected openducktor MCP server policy from default_tools_approval_mode=prompt to default_tools_approval_mode=approve.
- Keep the override scoped to the openducktor server so shell commands, other MCP servers, sandbox restrictions, and the configured global approval policy are unchanged.
- Update the runtime starter regression test to assert the exact app-server CLI configuration.

This uses the native Codex server-scoped MCP approval setting instead of weakening the thread approval policy or adding approval fallback logic in OpenDucktor.

## Verification

- bun run lint
- bun run test
- bun run typecheck
- bun run build
- Real Codex config parse smoke confirmed default_tools_approval_mode: approve
- GitNexus change analysis: low risk, no affected indexed execution flows

Cargo checks are not applicable because this repository has no Cargo.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex workspace runtimes now automatically approve default MCP tool actions instead of prompting for approval.
* **Bug Fixes**
  * Updated startup validation to reflect the new default approval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->