### PR TITLE
perf(sessions): batch hydrate per-task query caches

### DIFF
--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -191,6 +191,7 @@ import type {
   SystemOpenInToolId,
   SystemOpenInToolInfo,
   TaskAction,
+  TaskAgentSessions,
   TaskCard,
   TaskCreateInput,
   TaskDirectMergeInput,
@@ -278,6 +279,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "agentSessionTranscriptEventSchema",
   "agentSessionUserMessagePartSchema",
   "agentSessionWorkflowScopeSchema",
+  "taskAgentSessionsSchema",
   "APP_PLATFORM_VALUES",
   "appUpdateCheckInputSchema",
   "appUpdateCheckInitiatorSchema",
@@ -680,6 +682,7 @@ type ExportedTypeContract = {
   AgentSessionRole: AgentSessionRole;
   AgentSessionStatus: AgentSessionStatus;
   AgentSessionStopTarget: AgentSessionStopTarget;
+  TaskAgentSessions: TaskAgentSessions;
   AgentToolName: AgentToolName;
   AgentWorkflowState: AgentWorkflowState;
   AgentWorkflows: AgentWorkflows;

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -1646,6 +1646,15 @@ describe("runtime schemas", () => {
     ).toThrow();
   });
 
+  test("task agent sessions rejects blank task IDs", () => {
+    expect(() =>
+      taskAgentSessionsSchema.parse({
+        taskId: " ",
+        agentSessions: [],
+      }),
+    ).toThrow();
+  });
+
   test("agent session record parses compact persisted payload with explicit runtime kind", () => {
     const parsed = agentSessionRecordSchema.parse({
       externalSessionId: "obp-session-2",

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -39,6 +39,7 @@ import {
   runtimeInstanceSummarySchema,
   runtimeTransportSchema,
   slashCommandCatalogSchema,
+  taskAgentSessionsSchema,
   taskCardSchema,
   taskWorktreeSummarySchema,
   toOpencodeExposedOdtToolIds,
@@ -1606,6 +1607,43 @@ describe("runtime schemas", () => {
     expect(parsed.externalSessionId).toBe("session-opencode-1");
     expect(parsed.runtimeKind).toBe("opencode");
     expect(parsed.selectedModel?.modelId).toBe("gpt-5");
+  });
+
+  test("task agent sessions parses a batch session response", () => {
+    const parsed = taskAgentSessionsSchema.parse({
+      taskId: "task-1",
+      agentSessions: [
+        {
+          externalSessionId: "session-opencode-1",
+          role: "spec",
+          startedAt: "2026-02-18T17:11:00.000Z",
+          runtimeKind: "opencode",
+          workingDirectory: "/repo",
+          selectedModel: null,
+        },
+      ],
+    });
+
+    expect(parsed.taskId).toBe("task-1");
+    expect(parsed.agentSessions).toHaveLength(1);
+  });
+
+  test("task agent sessions rejects invalid nested session records", () => {
+    expect(() =>
+      taskAgentSessionsSchema.parse({
+        taskId: "task-1",
+        agentSessions: [
+          {
+            externalSessionId: "session-opencode-1",
+            role: "invalid-role",
+            startedAt: "2026-02-18T17:11:00.000Z",
+            runtimeKind: "opencode",
+            workingDirectory: "/repo",
+            selectedModel: null,
+          },
+        ],
+      }),
+    ).toThrow();
   });
 
   test("agent session record parses compact persisted payload with explicit runtime kind", () => {

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -115,6 +115,12 @@ export type AgentSessionIdentity = Pick<
   "externalSessionId" | "runtimeKind" | "workingDirectory"
 >;
 
+export const taskAgentSessionsSchema = z.object({
+  taskId: z.string(),
+  agentSessions: z.array(agentSessionRecordSchema),
+});
+export type TaskAgentSessions = z.infer<typeof taskAgentSessionsSchema>;
+
 export const agentSessionStopTargetSchema = z.object({
   repoPath: nonEmptyStringSchema,
   taskId: nonEmptyStringSchema,

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -116,7 +116,7 @@ export type AgentSessionIdentity = Pick<
 >;
 
 export const taskAgentSessionsSchema = z.object({
-  taskId: z.string(),
+  taskId: nonEmptyStringSchema,
   agentSessions: z.array(agentSessionRecordSchema),
 });
 export type TaskAgentSessions = z.infer<typeof taskAgentSessionsSchema>;

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -75,7 +75,6 @@ const sessionIdentity = (externalSessionId: string) => ({
 const startAgentSessionMock = mock(async () => sessionIdentity("session-1"));
 const sendAgentMessageMock = mock(async () => {});
 const updateAgentSessionModelMock = mock(() => {});
-const agentSessionsListMock = mock(async (_repoPath: string, _taskId: string) => []);
 const humanApproveTaskMock = mock(async () => {});
 const humanRequestChangesTaskMock = mock(async () => {});
 const deleteTaskMock = mock(async () => {});
@@ -144,7 +143,7 @@ type LatestKanbanPageModels = {
 };
 
 type KanbanPageRenderState = {
-  task: TaskCard;
+  tasks: TaskCard[];
   repoConfig: RepoConfig;
   settingsSnapshot: SettingsSnapshot;
   sessions: AgentSessionState[];
@@ -292,12 +291,12 @@ const createAgentOperationsValue = (): AgentOperationsContextValue => ({
 const createTasksStateValue = (
   renderState: Pick<
     KanbanPageRenderState,
-    "task" | "pendingMergedPullRequest" | "linkingMergedPullRequestTaskId"
+    "tasks" | "pendingMergedPullRequest" | "linkingMergedPullRequestTaskId"
   >,
 ): TasksStateContextValue => ({
   isForegroundLoadingTasks: false,
   isRefreshingTasksInBackground: false,
-  tasks: [renderState.task],
+  tasks: renderState.tasks,
   isLoadingTasks: false,
   createTask: async () => {},
   updateTask: async () => {},
@@ -431,10 +430,15 @@ const getKanbanColumnProps = (latest: LatestKanbanPageModels): Record<string, un
 };
 
 const renderPage = async (
-  options: { seedSettingsSnapshot?: boolean; platform?: AppPlatform | null } = {},
+  options: {
+    seedSettingsSnapshot?: boolean;
+    seedAgentSessionLists?: boolean;
+    platform?: AppPlatform | null;
+    tasks?: TaskCard[];
+  } = {},
 ): Promise<KanbanPageHarness> => {
   const renderState: KanbanPageRenderState = {
-    task: currentTaskFixture,
+    tasks: options.tasks ?? [currentTaskFixture],
     repoConfig: currentRepoConfigFixture,
     settingsSnapshot: currentSettingsSnapshotFixture,
     sessions: currentSessionsFixture,
@@ -463,7 +467,18 @@ const renderPage = async (
   if (options.platform !== null) {
     queryClient.setQueryData(systemQueryKeys.platform(), options.platform ?? "darwin");
   }
-  queryClient.setQueryData(agentSessionQueryKeys.list("/repo", renderState.task.id), []);
+  if (options.seedAgentSessionLists !== false) {
+    for (const task of renderState.tasks) {
+      queryClient.setQueryData(agentSessionQueryKeys.list("/repo", task.id), []);
+    }
+    queryClient.setQueryData(
+      agentSessionQueryKeys.hydration(
+        "/repo",
+        renderState.tasks.map((task) => task.id),
+      ),
+      true,
+    );
+  }
   const LocationProbe = (): ReactElement | null => {
     const location = useLocation();
     latest.location = `${location.pathname}${location.search}`;
@@ -735,7 +750,6 @@ describe("KanbanPage session start modal flow", () => {
     startAgentSessionMock.mockClear();
     sendAgentMessageMock.mockClear();
     updateAgentSessionModelMock.mockClear();
-    agentSessionsListMock.mockClear();
     humanApproveTaskMock.mockClear();
     humanRequestChangesTaskMock.mockClear();
     deleteTaskMock.mockClear();
@@ -752,6 +766,54 @@ describe("KanbanPage session start modal flow", () => {
 
   afterAll(async () => {
     console.error = originalConsoleError;
+  });
+
+  kanbanTest("loads histories for multiple tasks with one batch call", async () => {
+    const secondTask = createTaskCardFixture({ id: "TASK-456", status: "open" });
+    const firstSession = {
+      externalSessionId: "session-task-123",
+      role: "spec" as const,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      runtimeKind: "opencode" as const,
+      workingDirectory: "/repo/worktrees/TASK-123",
+      selectedModel: null,
+    };
+    const secondSession = {
+      externalSessionId: "session-task-456",
+      role: "build" as const,
+      startedAt: "2026-01-02T00:00:00.000Z",
+      runtimeKind: "opencode" as const,
+      workingDirectory: "/repo/worktrees/TASK-456",
+      selectedModel: null,
+    };
+    const agentSessionsListForTasksMock = mock(async () => [
+      { taskId: "TASK-123", agentSessions: [firstSession] },
+      { taskId: "TASK-456", agentSessions: [secondSession] },
+    ]);
+    const originalAgentSessionsListForTasks = hostClient.agentSessionsListForTasks;
+    hostClient.agentSessionsListForTasks = agentSessionsListForTasksMock;
+
+    const renderer = await renderPage({
+      seedAgentSessionLists: false,
+      tasks: [currentTaskFixture, secondTask],
+    });
+
+    try {
+      await waitForMockCall(agentSessionsListForTasksMock);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["TASK-123", "TASK-456"]);
+      expect(renderer.getKanbanColumnProps().historicalSessionsByTaskId).toEqual(
+        new Map([
+          ["TASK-123", [firstSession]],
+          ["TASK-456", [secondSession]],
+        ]),
+      );
+    } finally {
+      hostClient.agentSessionsListForTasks = originalAgentSessionsListForTasks;
+      await act(async () => {
+        renderer.unmount();
+      });
+    }
   });
 
   kanbanTest(

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -768,54 +768,6 @@ describe("KanbanPage session start modal flow", () => {
     console.error = originalConsoleError;
   });
 
-  kanbanTest("loads histories for multiple tasks with one batch call", async () => {
-    const secondTask = createTaskCardFixture({ id: "TASK-456", status: "open" });
-    const firstSession = {
-      externalSessionId: "session-task-123",
-      role: "spec" as const,
-      startedAt: "2026-01-01T00:00:00.000Z",
-      runtimeKind: "opencode" as const,
-      workingDirectory: "/repo/worktrees/TASK-123",
-      selectedModel: null,
-    };
-    const secondSession = {
-      externalSessionId: "session-task-456",
-      role: "build" as const,
-      startedAt: "2026-01-02T00:00:00.000Z",
-      runtimeKind: "opencode" as const,
-      workingDirectory: "/repo/worktrees/TASK-456",
-      selectedModel: null,
-    };
-    const agentSessionsListForTasksMock = mock(async () => [
-      { taskId: "TASK-123", agentSessions: [firstSession] },
-      { taskId: "TASK-456", agentSessions: [secondSession] },
-    ]);
-    const originalAgentSessionsListForTasks = hostClient.agentSessionsListForTasks;
-    hostClient.agentSessionsListForTasks = agentSessionsListForTasksMock;
-
-    const renderer = await renderPage({
-      seedAgentSessionLists: false,
-      tasks: [currentTaskFixture, secondTask],
-    });
-
-    try {
-      await waitForMockCall(agentSessionsListForTasksMock);
-      expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
-      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["TASK-123", "TASK-456"]);
-      expect(renderer.getKanbanColumnProps().historicalSessionsByTaskId).toEqual(
-        new Map([
-          ["TASK-123", [firstSession]],
-          ["TASK-456", [secondSession]],
-        ]),
-      );
-    } finally {
-      hostClient.agentSessionsListForTasks = originalAgentSessionsListForTasks;
-      await act(async () => {
-        renderer.unmount();
-      });
-    }
-  });
-
   kanbanTest(
     "delegate action opens modal and foreground confirm navigates to Agent Studio",
     async () => {

--- a/packages/frontend/src/pages/kanban/task-approval-flow-direct-merge.ts
+++ b/packages/frontend/src/pages/kanban/task-approval-flow-direct-merge.ts
@@ -65,6 +65,7 @@ export async function submitDirectMergeApproval({
 }: SubmitDirectMergeApprovalArgs): Promise<SubmitDirectMergeApprovalResult> {
   const approvalContext = approval.approvalContext;
   const directMergeResult = await runTaskMutationWithChatDraftCleanup({
+    agentSessionReadPort: host,
     queryClient,
     repoPath,
     workspaceId,
@@ -134,6 +135,7 @@ export async function completeDirectMergeApproval({
   const publishTarget = approvalContext.publishTarget;
 
   await runTaskMutationWithChatDraftCleanup({
+    agentSessionReadPort: host,
     queryClient,
     repoPath,
     workspaceId,

--- a/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
+++ b/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_KANBAN_SETTINGS, type TaskCard } from "@openducktor/contracts";
-import { useQueries, useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
@@ -14,7 +14,7 @@ import {
   useTasksState,
   useWorkspaceState,
 } from "@/state";
-import { agentSessionListQueryOptions } from "@/state/queries/agent-sessions";
+import { useAgentSessionLists } from "@/state/queries/use-agent-session-lists";
 import { useHorizontalScrollbarVisibility } from "@/state/queries/use-horizontal-scrollbar-visibility";
 import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
 import { useAgentStudioRepoSettings } from "../agents/use-agent-studio-repo-settings";
@@ -87,6 +87,7 @@ export function useKanbanPageModels({
   } = useTasksState();
   const reportedSettingsErrorRef = useRef<string | null>(null);
   const reportedPlatformErrorRef = useRef<string | null>(null);
+  const queryClient = useQueryClient();
   const settingsSnapshotQuery = useQuery(settingsSnapshotQueryOptions());
   const doneVisibleDays = settingsSnapshotQuery.data?.kanban.doneVisibleDays;
   const horizontalScrollbarVisibility =
@@ -142,20 +143,18 @@ export function useKanbanPageModels({
     workspaceRepoPath && !settingsSnapshotQuery.isError ? tasks : EMPTY_KANBAN_TASKS;
   const kanbanTaskIds = useMemo(() => kanbanTasks.map((task) => task.id), [kanbanTasks]);
   const shouldLoadHistoricalSessions = workspaceRepoPath !== null && kanbanTaskIds.length > 0;
-  const historicalSessionQueries = useQueries({
-    queries:
-      shouldLoadHistoricalSessions && workspaceRepoPath
-        ? kanbanTaskIds.map((taskId) => agentSessionListQueryOptions(workspaceRepoPath, taskId))
-        : [],
+  const historicalSessionLists = useAgentSessionLists({
+    repoPath: workspaceRepoPath,
+    taskIds: kanbanTaskIds,
+    enabled: shouldLoadHistoricalSessions,
+    queryClient,
   });
   const historicalSessionsByTaskId = useMemo(
     () =>
-      new Map(
-        kanbanTaskIds.map((taskId, index) => [taskId, historicalSessionQueries[index]?.data ?? []]),
-      ),
-    [historicalSessionQueries, kanbanTaskIds],
+      new Map(kanbanTaskIds.map((taskId) => [taskId, historicalSessionLists.data[taskId] ?? []])),
+    [historicalSessionLists.data, kanbanTaskIds],
   );
-  const historicalSessionsError = historicalSessionQueries.find((query) => query.isError)?.error;
+  const historicalSessionsError = historicalSessionLists.error ?? undefined;
   const reportedHistoricalSessionsErrorRef = useRef<string | null>(null);
   useEffect(() => {
     if (!historicalSessionsError) {

--- a/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -61,7 +61,7 @@ const defaultGitPushBranch = async () => ({
 const defaultGitAbortConflict = async () => {};
 const defaultHumanApproveTask = async () => {};
 const defaultOpenResetImplementation = (_taskId: string) => true;
-const defaultAgentSessionsList = async () => [
+const defaultAgentSessionsList = async (_repoPath: string, _taskId: string) => [
   {
     ...createAgentSessionFixture({
       externalSessionId: "builder-session-old",
@@ -152,6 +152,13 @@ const buildMockedHost = () => ({
   gitPushBranch: gitPushBranchMock,
   gitAbortConflict: gitAbortConflictMock,
   agentSessionsList: agentSessionsListMock,
+  agentSessionsListForTasks: async (repoPath: string, taskIds: string[]) =>
+    Promise.all(
+      taskIds.map(async (taskId) => ({
+        taskId,
+        agentSessions: await agentSessionsListMock(repoPath, taskId),
+      })),
+    ),
   specGet: async () => ({ markdown: "", updatedAt: null }),
   planGet: async () => ({ markdown: "", updatedAt: null }),
   qaGetReport: async () => ({ markdown: "", updatedAt: null }),
@@ -167,6 +174,7 @@ const HOST_METHOD_NAMES = [
   "gitPushBranch",
   "gitAbortConflict",
   "agentSessionsList",
+  "agentSessionsListForTasks",
   "specGet",
   "planGet",
   "qaGetReport",

--- a/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -61,7 +61,7 @@ const defaultGitPushBranch = async () => ({
 const defaultGitAbortConflict = async () => {};
 const defaultHumanApproveTask = async () => {};
 const defaultOpenResetImplementation = (_taskId: string) => true;
-const defaultAgentSessionsList = async (_repoPath: string, _taskId: string) => [
+const defaultAgentSessions = [
   {
     ...createAgentSessionFixture({
       externalSessionId: "builder-session-old",
@@ -81,6 +81,10 @@ const defaultAgentSessionsList = async (_repoPath: string, _taskId: string) => [
     }),
   },
 ];
+const defaultAgentSessionsList = async () => defaultAgentSessions;
+const defaultAgentSessionsListForTasks = async () => [
+  { taskId: "TASK-1", agentSessions: defaultAgentSessions },
+];
 
 const taskApprovalContextGetMock = mock(defaultTaskApprovalContextGet);
 const taskDirectMergeMock = mock(defaultTaskDirectMerge);
@@ -91,6 +95,7 @@ const gitAbortConflictMock = mock(defaultGitAbortConflict);
 const humanApproveTaskMock = mock(defaultHumanApproveTask);
 const openResetImplementationMock = mock(defaultOpenResetImplementation);
 const agentSessionsListMock = mock(defaultAgentSessionsList);
+const agentSessionsListForTasksMock = mock(defaultAgentSessionsListForTasks);
 const toastLoadingMock = mock(() => "toast-id");
 const toastSuccessMock = mock(() => {});
 const toastErrorMock = mock(() => {});
@@ -152,13 +157,7 @@ const buildMockedHost = () => ({
   gitPushBranch: gitPushBranchMock,
   gitAbortConflict: gitAbortConflictMock,
   agentSessionsList: agentSessionsListMock,
-  agentSessionsListForTasks: async (repoPath: string, taskIds: string[]) =>
-    Promise.all(
-      taskIds.map(async (taskId) => ({
-        taskId,
-        agentSessions: await agentSessionsListMock(repoPath, taskId),
-      })),
-    ),
+  agentSessionsListForTasks: agentSessionsListForTasksMock,
   specGet: async () => ({ markdown: "", updatedAt: null }),
   planGet: async () => ({ markdown: "", updatedAt: null }),
   qaGetReport: async () => ({ markdown: "", updatedAt: null }),
@@ -381,6 +380,8 @@ describe("useTaskApprovalFlow", () => {
     openResetImplementationMock.mockImplementation(defaultOpenResetImplementation);
     agentSessionsListMock.mockClear();
     agentSessionsListMock.mockImplementation(defaultAgentSessionsList);
+    agentSessionsListForTasksMock.mockClear();
+    agentSessionsListForTasksMock.mockImplementation(defaultAgentSessionsListForTasks);
   });
 
   afterAll(async () => {
@@ -1169,7 +1170,7 @@ describe("useTaskApprovalFlow", () => {
   });
 
   test("reports cleanup target lookup failure after direct merge succeeds", async () => {
-    agentSessionsListMock.mockImplementationOnce(async () => {
+    agentSessionsListForTasksMock.mockImplementationOnce(async () => {
       throw new Error("session lookup failed");
     });
     taskApprovalContextGetMock.mockResolvedValueOnce(
@@ -1205,7 +1206,7 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(agentSessionsListMock).toHaveBeenCalledWith("/repo", "TASK-1");
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["TASK-1"]);
     expect(taskDirectMergeMock).toHaveBeenCalledWith("/repo", "TASK-1", {
       mergeMethod: "merge_commit",
       squashCommitMessage: undefined,
@@ -1221,7 +1222,7 @@ describe("useTaskApprovalFlow", () => {
   });
 
   test("reports cleanup target lookup failure after direct merge completion succeeds", async () => {
-    agentSessionsListMock.mockImplementationOnce(async () => {
+    agentSessionsListForTasksMock.mockImplementationOnce(async () => {
       throw new Error("session lookup failed");
     });
     taskApprovalContextGetMock.mockResolvedValueOnce(
@@ -1266,7 +1267,7 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(agentSessionsListMock).toHaveBeenCalledWith("/repo", "TASK-1");
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["TASK-1"]);
     expect(gitPushBranchMock).toHaveBeenCalledWith("/repo", "main", {
       remote: "origin",
     });

--- a/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -61,7 +61,7 @@ const defaultGitPushBranch = async () => ({
 const defaultGitAbortConflict = async () => {};
 const defaultHumanApproveTask = async () => {};
 const defaultOpenResetImplementation = (_taskId: string) => true;
-const defaultAgentSessions = [
+const createDefaultAgentSessions = () => [
   {
     ...createAgentSessionFixture({
       externalSessionId: "builder-session-old",
@@ -81,9 +81,9 @@ const defaultAgentSessions = [
     }),
   },
 ];
-const defaultAgentSessionsList = async () => defaultAgentSessions;
+const defaultAgentSessionsList = async () => createDefaultAgentSessions();
 const defaultAgentSessionsListForTasks = async () => [
-  { taskId: "TASK-1", agentSessions: defaultAgentSessions },
+  { taskId: "TASK-1", agentSessions: createDefaultAgentSessions() },
 ];
 
 const taskApprovalContextGetMock = mock(defaultTaskApprovalContextGet);

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -8,7 +8,7 @@ import type {
 } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { createAgentSessionsStore } from "@/state/agent-sessions-store";
-import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
+import { type AgentSessionReadPort, agentSessionQueryKeys } from "@/state/queries/agent-sessions";
 import { workspaceQueryKeys } from "@/state/queries/workspace";
 import { summarizeAgentActivity } from "@/state/read-models/agent-activity-read-model";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
@@ -48,6 +48,14 @@ const createState = (
     observeIndex: number,
   ) => void,
   taskRecords: AgentSessionRecord | AgentSessionRecord[] = record,
+  sessionReadPort: AgentSessionReadPort = {
+    agentSessionsList: async () => {
+      throw new Error("Per-task session cache should already be hydrated.");
+    },
+    agentSessionsListForTasks: async () => {
+      throw new Error("Per-task session cache should already be hydrated.");
+    },
+  },
 ) => {
   const queryClient = new QueryClient();
   const records = Array.isArray(taskRecords) ? taskRecords : [taskRecords];
@@ -89,14 +97,7 @@ const createState = (
     transcriptEvents,
     recoverTranscriptGap,
     queryClient,
-    sessionReadPort: {
-      agentSessionsList: async () => {
-        throw new Error("Per-task session cache should already be hydrated.");
-      },
-      agentSessionsListForTasks: async () => {
-        throw new Error("Per-task session cache should already be hydrated.");
-      },
-    },
+    sessionReadPort,
   };
 
   return {
@@ -366,6 +367,54 @@ describe("useRepoSessionReadModel", () => {
         message:
           "Failed to recover transcript history after a live-stream gap: history reload failed",
       });
+    } finally {
+      await state.harness.unmount();
+    }
+  });
+
+  test("explicit retry recovers a failed task session query without reloading healthy caches", async () => {
+    const recoveredRecord = { ...record, externalSessionId: "thread-recovered" };
+    const batchList = mock(async () => [{ taskId: "task-1", agentSessions: [recoveredRecord] }]);
+    const state = createState(
+      (emit) => {
+        emit({ type: "snapshot", repoPath: "/repo", sessions: [snapshot()] });
+      },
+      record,
+      {
+        agentSessionsList: async () => {
+          throw new Error("Exact reads are not used by explicit batch retry.");
+        },
+        agentSessionsListForTasks: batchList,
+      },
+    );
+
+    try {
+      await state.harness.mount();
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "ready");
+      await expect(
+        state.queryClient.fetchQuery({
+          queryKey: agentSessionQueryKeys.list("/repo", "task-1"),
+          queryFn: async () => {
+            throw new Error("temporary exact refresh failure");
+          },
+          staleTime: 0,
+          retry: false,
+        }),
+      ).rejects.toThrow("temporary exact refresh failure");
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "failed");
+
+      await state.harness.run(() => {
+        state.harness.getLatest().reloadSessionReadModel();
+      });
+
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "ready");
+      expect(batchList).toHaveBeenCalledTimes(1);
+      expect(batchList).toHaveBeenCalledWith("/repo", ["task-1"]);
+      expect(
+        state.queryClient.getQueryData<AgentSessionRecord[]>(
+          agentSessionQueryKeys.list("/repo", "task-1"),
+        ),
+      ).toEqual([recoveredRecord]);
     } finally {
       await state.harness.unmount();
     }

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -26,6 +26,16 @@ const record: AgentSessionRecord = {
   selectedModel: null,
 };
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
+
 const snapshot = (overrides: Partial<AgentSessionLiveSnapshot> = {}): AgentSessionLiveSnapshot => ({
   ref: {
     repoPath: "/repo",
@@ -415,6 +425,112 @@ describe("useRepoSessionReadModel", () => {
           agentSessionQueryKeys.list("/repo", "task-1"),
         ),
       ).toEqual([recoveredRecord]);
+    } finally {
+      await state.harness.unmount();
+    }
+  });
+
+  test("an older failed retry cannot overwrite a newer successful retry", async () => {
+    const firstRetry =
+      createDeferred<Array<{ taskId: string; agentSessions: AgentSessionRecord[] }>>();
+    const secondRetry =
+      createDeferred<Array<{ taskId: string; agentSessions: AgentSessionRecord[] }>>();
+    const batchList = mock(() =>
+      batchList.mock.calls.length === 1 ? firstRetry.promise : secondRetry.promise,
+    );
+    const state = createState(
+      (emit) => {
+        emit({ type: "snapshot", repoPath: "/repo", sessions: [snapshot()] });
+      },
+      record,
+      {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks: batchList,
+      },
+    );
+
+    try {
+      await state.harness.mount();
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "ready");
+      await expect(
+        state.queryClient.fetchQuery({
+          queryKey: agentSessionQueryKeys.list("/repo", "task-1"),
+          queryFn: async () => {
+            throw new Error("initial refresh failed");
+          },
+          staleTime: 0,
+          retry: false,
+        }),
+      ).rejects.toThrow("initial refresh failed");
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "failed");
+
+      await state.harness.run(() => state.harness.getLatest().reloadSessionReadModel());
+      await state.harness.run(() => state.harness.getLatest().reloadSessionReadModel());
+      expect(batchList).toHaveBeenCalledTimes(2);
+
+      secondRetry.resolve([{ taskId: "task-1", agentSessions: [record] }]);
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "ready");
+      firstRetry.reject(new Error("older retry failed"));
+      await state.harness.run(async () => {
+        await Promise.resolve();
+      });
+
+      expect(state.harness.getLatest().sessionReadModelLoadState.kind).toBe("ready");
+    } finally {
+      await state.harness.unmount();
+    }
+  });
+
+  test("an older successful retry cannot overwrite a newer failed retry", async () => {
+    const firstRetry =
+      createDeferred<Array<{ taskId: string; agentSessions: AgentSessionRecord[] }>>();
+    const secondRetry =
+      createDeferred<Array<{ taskId: string; agentSessions: AgentSessionRecord[] }>>();
+    const batchList = mock(() =>
+      batchList.mock.calls.length === 1 ? firstRetry.promise : secondRetry.promise,
+    );
+    const state = createState(
+      (emit) => {
+        emit({ type: "snapshot", repoPath: "/repo", sessions: [snapshot()] });
+      },
+      record,
+      {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks: batchList,
+      },
+    );
+
+    try {
+      await state.harness.mount();
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "ready");
+      await expect(
+        state.queryClient.fetchQuery({
+          queryKey: agentSessionQueryKeys.list("/repo", "task-1"),
+          queryFn: async () => {
+            throw new Error("initial refresh failed");
+          },
+          staleTime: 0,
+          retry: false,
+        }),
+      ).rejects.toThrow("initial refresh failed");
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "failed");
+
+      await state.harness.run(() => state.harness.getLatest().reloadSessionReadModel());
+      await state.harness.run(() => state.harness.getLatest().reloadSessionReadModel());
+      expect(batchList).toHaveBeenCalledTimes(2);
+
+      secondRetry.reject(new Error("newer retry failed"));
+      await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "failed");
+      firstRetry.resolve([{ taskId: "task-1", agentSessions: [record] }]);
+      await state.harness.run(async () => {
+        await Promise.resolve();
+      });
+
+      expect(state.harness.getLatest().sessionReadModelLoadState).toEqual({
+        kind: "failed",
+        workspaceRepoPath: "/repo",
+        message: "Failed to retry task session records for repo '/repo': newer retry failed",
+      });
     } finally {
       await state.harness.unmount();
     }

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -52,6 +52,7 @@ const createState = (
   const queryClient = new QueryClient();
   const records = Array.isArray(taskRecords) ? taskRecords : [taskRecords];
   queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), records);
+  queryClient.setQueryData(agentSessionQueryKeys.hydration("/repo", ["task-1"]), true);
   const sessionStore = createAgentSessionsStore("/repo");
   let listener: ((payload: AgentSessionLiveEnvelope) => void) | null = null;
   const callOrder: string[] = [];

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -52,7 +52,6 @@ const createState = (
   const queryClient = new QueryClient();
   const records = Array.isArray(taskRecords) ? taskRecords : [taskRecords];
   queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), records);
-  queryClient.setQueryData(agentSessionQueryKeys.hydration("/repo", ["task-1"]), true);
   const sessionStore = createAgentSessionsStore("/repo");
   let listener: ((payload: AgentSessionLiveEnvelope) => void) | null = null;
   const callOrder: string[] = [];

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -482,6 +482,7 @@ describe("useRepoSessionReadModel", () => {
   });
 
   test("an older successful retry cannot overwrite a newer failed retry", async () => {
+    const staleRecord = { ...record, externalSessionId: "external-stale" };
     const firstRetry =
       createDeferred<Array<{ taskId: string; agentSessions: AgentSessionRecord[] }>>();
     const secondRetry =
@@ -521,7 +522,7 @@ describe("useRepoSessionReadModel", () => {
 
       secondRetry.reject(new Error("newer retry failed"));
       await state.harness.waitFor((value) => value.sessionReadModelLoadState.kind === "failed");
-      firstRetry.resolve([{ taskId: "task-1", agentSessions: [record] }]);
+      firstRetry.resolve([{ taskId: "task-1", agentSessions: [staleRecord] }]);
       await state.harness.run(async () => {
         await Promise.resolve();
       });
@@ -531,6 +532,9 @@ describe("useRepoSessionReadModel", () => {
         workspaceRepoPath: "/repo",
         message: "Failed to retry task session records for repo '/repo': newer retry failed",
       });
+      const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+      expect(state.queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([record]);
+      expect(state.queryClient.getQueryState(queryKey)?.status).toBe("error");
     } finally {
       await state.harness.unmount();
     }

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.test.tsx
@@ -89,6 +89,14 @@ const createState = (
     transcriptEvents,
     recoverTranscriptGap,
     queryClient,
+    sessionReadPort: {
+      agentSessionsList: async () => {
+        throw new Error("Per-task session cache should already be hydrated.");
+      },
+      agentSessionsListForTasks: async () => {
+        throw new Error("Per-task session cache should already be hydrated.");
+      },
+    },
   };
 
   return {

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
@@ -76,8 +76,11 @@ export const useRepoSessionReadModel = ({
     useState<AgentSessionReadModelLoadState>(unavailableAgentSessionReadModelLoadState);
   const [reloadGeneration, setReloadGeneration] = useState(0);
   const latestReloadGenerationRef = useRef(reloadGeneration);
+  const retryAttemptRef = useRef(0);
   latestReloadGenerationRef.current = reloadGeneration;
   const reloadSessionReadModel = useCallback(() => {
+    const retryAttempt = retryAttemptRef.current + 1;
+    retryAttemptRef.current = retryAttempt;
     if (!workspaceRepoPath) {
       setReloadGeneration((current) => current + 1);
       return;
@@ -88,6 +91,7 @@ export const useRepoSessionReadModel = ({
     void retryAgentSessionListQueries(queryClient, repoPath, taskIds, sessionReadPort).then(
       () => {
         if (
+          retryAttemptRef.current === retryAttempt &&
           currentWorkspaceRepoPathRef.current === repoPath &&
           repoEpochRef.current === repoEpoch
         ) {
@@ -96,6 +100,7 @@ export const useRepoSessionReadModel = ({
       },
       (error: unknown) => {
         if (
+          retryAttemptRef.current === retryAttempt &&
           currentWorkspaceRepoPathRef.current === repoPath &&
           repoEpochRef.current === repoEpoch
         ) {

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
@@ -6,6 +6,7 @@ import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { errorMessage } from "@/lib/errors";
 import type { AgentSessionsStore } from "@/state/agent-sessions-store";
+import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
 import { runtimeCatalogQueryKeys } from "@/state/queries/runtime-catalog";
 import {
   type AgentSessionReadModelLoadState,
@@ -49,6 +50,7 @@ type UseRepoSessionReadModelArgs = {
   transcriptEvents: AgentSessionTranscriptEventConsumer;
   recoverTranscriptGap: (message: string) => Promise<void>;
   queryClient: QueryClient;
+  sessionReadPort: AgentSessionReadPort;
 };
 
 export type RepoSessionReadModelState = {
@@ -67,6 +69,7 @@ export const useRepoSessionReadModel = ({
   transcriptEvents,
   recoverTranscriptGap,
   queryClient,
+  sessionReadPort,
 }: UseRepoSessionReadModelArgs): RepoSessionReadModelState => {
   const [sessionReadModelLoadState, setSessionReadModelLoadState] =
     useState<AgentSessionReadModelLoadState>(unavailableAgentSessionReadModelLoadState);
@@ -89,6 +92,7 @@ export const useRepoSessionReadModel = ({
     taskIds,
     enabled: !isLoadingTasks,
     queryClient,
+    readPort: sessionReadPort,
   });
   const taskSessionRecordsRef = useRef<{
     repoPath: string;

--- a/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/hooks/use-repo-session-read-model.ts
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { errorMessage } from "@/lib/errors";
 import type { AgentSessionsStore } from "@/state/agent-sessions-store";
 import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
+import { retryAgentSessionListQueries } from "@/state/queries/agent-sessions";
 import { runtimeCatalogQueryKeys } from "@/state/queries/runtime-catalog";
 import {
   type AgentSessionReadModelLoadState,
@@ -77,8 +78,44 @@ export const useRepoSessionReadModel = ({
   const latestReloadGenerationRef = useRef(reloadGeneration);
   latestReloadGenerationRef.current = reloadGeneration;
   const reloadSessionReadModel = useCallback(() => {
-    setReloadGeneration((current) => current + 1);
-  }, []);
+    if (!workspaceRepoPath) {
+      setReloadGeneration((current) => current + 1);
+      return;
+    }
+    const repoPath = workspaceRepoPath;
+    const repoEpoch = repoEpochRef.current;
+    setSessionReadModelLoadState(loadingAgentSessionReadModelLoadState(repoPath));
+    void retryAgentSessionListQueries(queryClient, repoPath, taskIds, sessionReadPort).then(
+      () => {
+        if (
+          currentWorkspaceRepoPathRef.current === repoPath &&
+          repoEpochRef.current === repoEpoch
+        ) {
+          setReloadGeneration((current) => current + 1);
+        }
+      },
+      (error: unknown) => {
+        if (
+          currentWorkspaceRepoPathRef.current === repoPath &&
+          repoEpochRef.current === repoEpoch
+        ) {
+          setSessionReadModelLoadState(
+            failedAgentSessionReadModelLoadState(
+              repoPath,
+              `Failed to retry task session records for repo '${repoPath}': ${errorMessage(error)}`,
+            ),
+          );
+        }
+      },
+    );
+  }, [
+    currentWorkspaceRepoPathRef,
+    queryClient,
+    repoEpochRef,
+    sessionReadPort,
+    taskIds,
+    workspaceRepoPath,
+  ]);
   const currentSessionReadModelLoadState = useMemo(
     () =>
       currentAgentSessionReadModelLoadState({

--- a/packages/frontend/src/state/operations/agent-orchestrator/session-read-model/use-task-session-records.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/session-read-model/use-task-session-records.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
+import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
 import { useAgentSessionLists } from "@/state/queries/use-agent-session-lists";
 import { type TaskSessionRecords, toTaskSessionRecords } from "./task-session-records";
 
@@ -13,6 +14,7 @@ type UseTaskSessionRecordsArgs = {
   taskIds: string[];
   enabled: boolean;
   queryClient: QueryClient;
+  readPort: AgentSessionReadPort;
 };
 
 export const useTaskSessionRecords = ({
@@ -20,8 +22,15 @@ export const useTaskSessionRecords = ({
   taskIds,
   enabled,
   queryClient,
+  readPort,
 }: UseTaskSessionRecordsArgs): TaskSessionRecordsState => {
-  const sessionLists = useAgentSessionLists({ repoPath, taskIds, enabled, queryClient });
+  const sessionLists = useAgentSessionLists({
+    repoPath,
+    taskIds,
+    enabled,
+    queryClient,
+    readPort,
+  });
   return useMemo((): TaskSessionRecordsState => {
     if (sessionLists.isPending) {
       return { kind: "loading" };

--- a/packages/frontend/src/state/operations/agent-orchestrator/session-read-model/use-task-session-records.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/session-read-model/use-task-session-records.ts
@@ -1,11 +1,7 @@
-import type { AgentSessionRecord } from "@openducktor/contracts";
-import type { QueryClient, UseQueryResult } from "@tanstack/react-query";
-import { useQueries } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { agentSessionListQueryOptions } from "@/state/queries/agent-sessions";
+import { useAgentSessionLists } from "@/state/queries/use-agent-session-lists";
 import { type TaskSessionRecords, toTaskSessionRecords } from "./task-session-records";
-
-type AgentSessionListQueryResult = UseQueryResult<AgentSessionRecord[], Error>;
 
 export type TaskSessionRecordsState =
   | { kind: "loading" }
@@ -19,55 +15,24 @@ type UseTaskSessionRecordsArgs = {
   queryClient: QueryClient;
 };
 
-const TASK_ID_SEPARATOR = "\u001f";
-
-const toTaskIdSetKey = (taskIds: string[]): string =>
-  [...new Set(taskIds)].toSorted().join(TASK_ID_SEPARATOR);
-
-const toTaskSessionTargets = (taskIdsKey: string): { id: string }[] => {
-  if (!taskIdsKey) {
-    return [];
-  }
-  return taskIdsKey.split(TASK_ID_SEPARATOR).map((id) => ({ id }));
-};
-
 export const useTaskSessionRecords = ({
   repoPath,
   taskIds,
   enabled,
   queryClient,
 }: UseTaskSessionRecordsArgs): TaskSessionRecordsState => {
-  const taskIdsKey = toTaskIdSetKey(taskIds);
-  const taskSessionTargets = useMemo(() => toTaskSessionTargets(taskIdsKey), [taskIdsKey]);
-  const shouldReadRecords = enabled && repoPath !== null;
-
-  return useQueries(
-    {
-      queries: shouldReadRecords
-        ? taskSessionTargets.map((task) => agentSessionListQueryOptions(repoPath, task.id))
-        : [],
-      combine: (queries: AgentSessionListQueryResult[]): TaskSessionRecordsState => {
-        if (!shouldReadRecords) {
-          return { kind: "loading" };
-        }
-        if (queries.some((query) => query.isPending)) {
-          return { kind: "loading" };
-        }
-        const failedQuery = queries.find((query) => query.isError);
-        if (failedQuery) {
-          return { kind: "failed", error: failedQuery.error };
-        }
-        return {
-          kind: "ready",
-          records: toTaskSessionRecords(
-            taskSessionTargets,
-            Object.fromEntries(
-              taskSessionTargets.map((task, index) => [task.id, queries[index]?.data ?? []]),
-            ),
-          ),
-        };
-      },
-    },
-    queryClient,
-  );
+  const sessionLists = useAgentSessionLists({ repoPath, taskIds, enabled, queryClient });
+  return useMemo((): TaskSessionRecordsState => {
+    if (sessionLists.isPending) {
+      return { kind: "loading" };
+    }
+    if (sessionLists.error) {
+      return { kind: "failed", error: sessionLists.error };
+    }
+    const taskSessionTargets = Object.keys(sessionLists.data).map((id) => ({ id }));
+    return {
+      kind: "ready",
+      records: toTaskSessionRecords(taskSessionTargets, sessionLists.data),
+    };
+  }, [sessionLists.data, sessionLists.error, sessionLists.isPending]);
 };

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-dependency-defaults.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-dependency-defaults.ts
@@ -8,6 +8,9 @@ export const createDefaultAgentOrchestratorDependencies = (): AgentOrchestratorD
   hostPort: {
     agentSessionDelete: (repoPath, taskId, identity) =>
       host.agentSessionDelete(repoPath, taskId, identity),
+    agentSessionsList: (repoPath, taskId) => host.agentSessionsList(repoPath, taskId),
+    agentSessionsListForTasks: (repoPath, taskIds) =>
+      host.agentSessionsListForTasks(repoPath, taskIds),
     agentSessionUpsert: (repoPath, taskId, record) =>
       host.agentSessionUpsert(repoPath, taskId, record),
     taskWorktreeGet: (repoPath, taskId) => host.taskWorktreeGet(repoPath, taskId),

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-dependency-defaults.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-dependency-defaults.ts
@@ -8,7 +8,6 @@ export const createDefaultAgentOrchestratorDependencies = (): AgentOrchestratorD
   hostPort: {
     agentSessionDelete: (repoPath, taskId, identity) =>
       host.agentSessionDelete(repoPath, taskId, identity),
-    agentSessionsList: (repoPath, taskId) => host.agentSessionsList(repoPath, taskId),
     agentSessionUpsert: (repoPath, taskId, record) =>
       host.agentSessionUpsert(repoPath, taskId, record),
     taskWorktreeGet: (repoPath, taskId) => host.taskWorktreeGet(repoPath, taskId),

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-dependency-defaults.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-dependency-defaults.ts
@@ -8,6 +8,7 @@ export const createDefaultAgentOrchestratorDependencies = (): AgentOrchestratorD
   hostPort: {
     agentSessionDelete: (repoPath, taskId, identity) =>
       host.agentSessionDelete(repoPath, taskId, identity),
+    agentSessionsList: (repoPath, taskId) => host.agentSessionsList(repoPath, taskId),
     agentSessionUpsert: (repoPath, taskId, record) =>
       host.agentSessionUpsert(repoPath, taskId, record),
     taskWorktreeGet: (repoPath, taskId) => host.taskWorktreeGet(repoPath, taskId),

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-ports.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-ports.ts
@@ -13,6 +13,7 @@ export type AgentOrchestratorHostPort = {
     taskId: string,
     identity: AgentSessionIdentity,
   ) => Promise<void>;
+  agentSessionsList: (repoPath: string, taskId: string) => Promise<AgentSessionRecord[]>;
   agentSessionUpsert: (
     repoPath: string,
     taskId: string,

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-ports.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-ports.ts
@@ -13,7 +13,6 @@ export type AgentOrchestratorHostPort = {
     taskId: string,
     identity: AgentSessionIdentity,
   ) => Promise<void>;
-  agentSessionsList: (repoPath: string, taskId: string) => Promise<AgentSessionRecord[]>;
   agentSessionUpsert: (
     repoPath: string,
     taskId: string,

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-ports.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/orchestrator-ports.ts
@@ -5,9 +5,10 @@ import type {
   TaskWorktreeSummary,
 } from "@openducktor/contracts";
 import type { QueryClient } from "@tanstack/react-query";
+import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
 import type { host } from "../../shared/host";
 
-export type AgentOrchestratorHostPort = {
+export type AgentOrchestratorHostPort = AgentSessionReadPort & {
   agentSessionDelete: (
     repoPath: string,
     taskId: string,

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
@@ -151,7 +151,7 @@ describe("createSessionCacheEffects", () => {
     ).toBeUndefined();
   });
 
-  test("invalidates stop-related queries on the injected query client", async () => {
+  test("invalidates stop-related task queries without superseding session refreshes", async () => {
     const queryClient = createQueryClient();
     const invalidatedKeys: unknown[] = [];
     const originalInvalidateQueries = queryClient.invalidateQueries.bind(queryClient);
@@ -175,7 +175,7 @@ describe("createSessionCacheEffects", () => {
     });
 
     expect(invalidatedKeys).toContainEqual(taskQueryKeys.repoDataPrefix("/repo"));
-    expect(invalidatedKeys).toContainEqual(agentSessionQueryKeys.list("/repo", "task-1"));
+    expect(invalidatedKeys).not.toContainEqual(agentSessionQueryKeys.list("/repo", "task-1"));
   });
 
   test("deletes through the injected host port and authoritatively refetches the task query", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
@@ -3,7 +3,10 @@ import type { AgentSessionRecord } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
 import { taskQueryKeys } from "@/state/queries/tasks";
-import { createSessionCacheEffects } from "./session-cache-effects";
+import {
+  createSessionCacheEffects,
+  sessionCacheRefreshFailureDescription,
+} from "./session-cache-effects";
 
 const sessionRecord: AgentSessionRecord = {
   runtimeKind: "opencode",
@@ -23,6 +26,16 @@ const createQueryClient = (): QueryClient =>
   });
 
 describe("createSessionCacheEffects", () => {
+  test("formats the default cache refresh report with repository, task, and error", () => {
+    expect(
+      sessionCacheRefreshFailureDescription({
+        repoPath: "/repo",
+        taskId: "task-1",
+        error: new Error("refresh failed"),
+      }),
+    ).toBe("/repo · task-1: refresh failed");
+  });
+
   test("persists and authoritatively refetches the canonical task query", async () => {
     const queryClient = createQueryClient();
     let persistedSessions: AgentSessionRecord[] = [];

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
@@ -80,7 +80,7 @@ describe("createSessionCacheEffects", () => {
     const effects = createSessionCacheEffects({
       workspaceRepoPath: "/repo",
       queryClient,
-      hostPort: { agentSessionUpsert: upsert },
+      hostPort: { agentSessionDelete: async () => undefined, agentSessionUpsert: upsert },
       reportCacheRefreshFailure,
     });
     failRefresh = true;
@@ -107,6 +107,7 @@ describe("createSessionCacheEffects", () => {
       workspaceRepoPath: "/repo",
       queryClient,
       hostPort: {
+        agentSessionDelete: async () => undefined,
         agentSessionUpsert: async () => {
           throw persistenceError;
         },
@@ -167,14 +168,16 @@ describe("createSessionCacheEffects", () => {
     expect(invalidatedKeys).toContainEqual(agentSessionQueryKeys.list("/repo", "task-1"));
   });
 
-  test("deletes through the injected host port and removes only the matching cache record", async () => {
+  test("deletes through the injected host port and authoritatively refetches the task query", async () => {
     const queryClient = createQueryClient();
-    const deleteSession = mock(async () => undefined);
     const otherSession = { ...sessionRecord, externalSessionId: "session-2" };
-    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [
-      sessionRecord,
-      otherSession,
-    ]);
+    let persistedSessions = [sessionRecord, otherSession];
+    const list = mock(async () => persistedSessions);
+    const deleteSession = mock(async () => {
+      persistedSessions = [otherSession];
+    });
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    await queryClient.fetchQuery({ queryKey, queryFn: list });
     const effects = createSessionCacheEffects({
       workspaceRepoPath: "/repo",
       queryClient,
@@ -187,8 +190,8 @@ describe("createSessionCacheEffects", () => {
     await effects.deleteSessionRecord("task-1", sessionRecord);
 
     expect(deleteSession).toHaveBeenCalledWith("/repo", "task-1", sessionRecord);
-    expect(
-      queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
-    ).toEqual([otherSession]);
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([otherSession]);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
   });
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
@@ -63,10 +63,12 @@ describe("createSessionCacheEffects", () => {
       },
     });
     const upsert = mock(async () => undefined);
+    const reportCacheRefreshFailure = mock(() => undefined);
     const effects = createSessionCacheEffects({
       workspaceRepoPath: "/repo",
       queryClient,
       hostPort: { agentSessionUpsert: upsert },
+      reportCacheRefreshFailure,
     });
     failRefresh = true;
 
@@ -77,6 +79,32 @@ describe("createSessionCacheEffects", () => {
     expect(queryClient.getQueryState(queryKey)?.error).toEqual(
       new Error("Session cache refresh failed."),
     );
+    expect(reportCacheRefreshFailure).toHaveBeenCalledWith({
+      repoPath: "/repo",
+      taskId: "task-1",
+      error: new Error("Session cache refresh failed."),
+    });
+  });
+
+  test("propagates persistence failures without reporting a cache refresh failure", async () => {
+    const queryClient = createQueryClient();
+    const persistenceError = new Error("Session persistence failed.");
+    const reportCacheRefreshFailure = mock(() => undefined);
+    const effects = createSessionCacheEffects({
+      workspaceRepoPath: "/repo",
+      queryClient,
+      hostPort: {
+        agentSessionUpsert: async () => {
+          throw persistenceError;
+        },
+      },
+      reportCacheRefreshFailure,
+    });
+
+    await expect(effects.persistSessionRecord("task-1", sessionRecord)).rejects.toBe(
+      persistenceError,
+    );
+    expect(reportCacheRefreshFailure).not.toHaveBeenCalled();
   });
 
   test("fails instead of silently dropping a session record without an active workspace", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
@@ -23,25 +23,34 @@ const createQueryClient = (): QueryClient =>
   });
 
 describe("createSessionCacheEffects", () => {
-  test("persists through the injected host port and invalidates the canonical task query", async () => {
+  test("persists and authoritatively refetches the canonical task query", async () => {
     const queryClient = createQueryClient();
-    const upsert = mock(async () => undefined);
+    let persistedSessions: AgentSessionRecord[] = [];
+    const upsert = mock(async (_repoPath: string, _taskId: string, record: AgentSessionRecord) => {
+      persistedSessions = [record];
+    });
+    const list = mock(async () => persistedSessions);
     queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), []);
     const effects = createSessionCacheEffects({
       workspaceRepoPath: "/repo",
       queryClient,
-      hostPort: { agentSessionDelete: async () => undefined, agentSessionUpsert: upsert },
+      hostPort: {
+        agentSessionDelete: async () => undefined,
+        agentSessionsList: list,
+        agentSessionUpsert: upsert,
+      },
     });
 
     await effects.persistSessionRecord("task-1", sessionRecord);
 
     expect(upsert).toHaveBeenCalledWith("/repo", "task-1", sessionRecord);
+    expect(list).toHaveBeenCalledWith("/repo", "task-1");
     expect(
       queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
-    ).toEqual([]);
+    ).toEqual([sessionRecord]);
     expect(
       queryClient.getQueryState(agentSessionQueryKeys.list("/repo", "task-1"))?.isInvalidated,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("fails instead of silently dropping a session record without an active workspace", async () => {
@@ -50,7 +59,11 @@ describe("createSessionCacheEffects", () => {
     const effects = createSessionCacheEffects({
       workspaceRepoPath: null,
       queryClient,
-      hostPort: { agentSessionDelete: async () => undefined, agentSessionUpsert: upsert },
+      hostPort: {
+        agentSessionDelete: async () => undefined,
+        agentSessionsList: async () => [],
+        agentSessionUpsert: upsert,
+      },
     });
 
     await expect(effects.persistSessionRecord("task-1", sessionRecord)).rejects.toThrow(
@@ -75,6 +88,7 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: async () => undefined,
+        agentSessionsList: async () => [],
         agentSessionUpsert: async () => undefined,
       },
     });
@@ -99,7 +113,11 @@ describe("createSessionCacheEffects", () => {
     const effects = createSessionCacheEffects({
       workspaceRepoPath: "/repo",
       queryClient,
-      hostPort: { agentSessionDelete: deleteSession, agentSessionUpsert: async () => undefined },
+      hostPort: {
+        agentSessionDelete: deleteSession,
+        agentSessionsList: async () => [otherSession],
+        agentSessionUpsert: async () => undefined,
+      },
     });
 
     await effects.deleteSessionRecord("task-1", sessionRecord);

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
@@ -30,13 +30,13 @@ describe("createSessionCacheEffects", () => {
       persistedSessions = [record];
     });
     const list = mock(async () => persistedSessions);
-    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), []);
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    await queryClient.fetchQuery({ queryKey, queryFn: list });
     const effects = createSessionCacheEffects({
       workspaceRepoPath: "/repo",
       queryClient,
       hostPort: {
         agentSessionDelete: async () => undefined,
-        agentSessionsList: list,
         agentSessionUpsert: upsert,
       },
     });
@@ -44,13 +44,39 @@ describe("createSessionCacheEffects", () => {
     await effects.persistSessionRecord("task-1", sessionRecord);
 
     expect(upsert).toHaveBeenCalledWith("/repo", "task-1", sessionRecord);
-    expect(list).toHaveBeenCalledWith("/repo", "task-1");
-    expect(
-      queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
-    ).toEqual([sessionRecord]);
-    expect(
-      queryClient.getQueryState(agentSessionQueryKeys.list("/repo", "task-1"))?.isInvalidated,
-    ).toBe(false);
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([sessionRecord]);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
+  });
+
+  test("keeps a successful durable write successful when the query refresh fails", async () => {
+    const queryClient = createQueryClient();
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    let failRefresh = false;
+    await queryClient.fetchQuery({
+      queryKey,
+      queryFn: async () => {
+        if (failRefresh) {
+          throw new Error("Session cache refresh failed.");
+        }
+        return [];
+      },
+    });
+    const upsert = mock(async () => undefined);
+    const effects = createSessionCacheEffects({
+      workspaceRepoPath: "/repo",
+      queryClient,
+      hostPort: { agentSessionUpsert: upsert },
+    });
+    failRefresh = true;
+
+    await expect(effects.persistSessionRecord("task-1", sessionRecord)).resolves.toBeUndefined();
+
+    expect(upsert).toHaveBeenCalledWith("/repo", "task-1", sessionRecord);
+    expect(queryClient.getQueryState(queryKey)?.status).toBe("error");
+    expect(queryClient.getQueryState(queryKey)?.error).toEqual(
+      new Error("Session cache refresh failed."),
+    );
   });
 
   test("fails instead of silently dropping a session record without an active workspace", async () => {
@@ -61,7 +87,6 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: async () => undefined,
-        agentSessionsList: async () => [],
         agentSessionUpsert: upsert,
       },
     });
@@ -88,7 +113,6 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: async () => undefined,
-        agentSessionsList: async () => [],
         agentSessionUpsert: async () => undefined,
       },
     });
@@ -115,7 +139,6 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: deleteSession,
-        agentSessionsList: async () => [otherSession],
         agentSessionUpsert: async () => undefined,
       },
     });

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
@@ -50,6 +50,7 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: async () => undefined,
+        agentSessionsList: list,
         agentSessionUpsert: upsert,
       },
     });
@@ -66,21 +67,26 @@ describe("createSessionCacheEffects", () => {
     const queryClient = createQueryClient();
     const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
     let failRefresh = false;
+    const list = async () => {
+      if (failRefresh) {
+        throw new Error("Session cache refresh failed.");
+      }
+      return [];
+    };
     await queryClient.fetchQuery({
       queryKey,
-      queryFn: async () => {
-        if (failRefresh) {
-          throw new Error("Session cache refresh failed.");
-        }
-        return [];
-      },
+      queryFn: list,
     });
     const upsert = mock(async () => undefined);
     const reportCacheRefreshFailure = mock(() => undefined);
     const effects = createSessionCacheEffects({
       workspaceRepoPath: "/repo",
       queryClient,
-      hostPort: { agentSessionDelete: async () => undefined, agentSessionUpsert: upsert },
+      hostPort: {
+        agentSessionDelete: async () => undefined,
+        agentSessionsList: list,
+        agentSessionUpsert: upsert,
+      },
       reportCacheRefreshFailure,
     });
     failRefresh = true;
@@ -93,6 +99,7 @@ describe("createSessionCacheEffects", () => {
       new Error("Session cache refresh failed."),
     );
     expect(reportCacheRefreshFailure).toHaveBeenCalledWith({
+      operation: "save",
       repoPath: "/repo",
       taskId: "task-1",
       error: new Error("Session cache refresh failed."),
@@ -108,6 +115,7 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: async () => undefined,
+        agentSessionsList: async () => [],
         agentSessionUpsert: async () => {
           throw persistenceError;
         },
@@ -129,6 +137,7 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: async () => undefined,
+        agentSessionsList: async () => [],
         agentSessionUpsert: upsert,
       },
     });
@@ -155,6 +164,7 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: async () => undefined,
+        agentSessionsList: async () => [],
         agentSessionUpsert: async () => undefined,
       },
     });
@@ -183,6 +193,7 @@ describe("createSessionCacheEffects", () => {
       queryClient,
       hostPort: {
         agentSessionDelete: deleteSession,
+        agentSessionsList: list,
         agentSessionUpsert: async () => undefined,
       },
     });
@@ -193,5 +204,48 @@ describe("createSessionCacheEffects", () => {
     expect(list).toHaveBeenCalledTimes(2);
     expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([otherSession]);
     expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
+  });
+
+  test("keeps a successful durable deletion successful when the query refresh fails", async () => {
+    const queryClient = createQueryClient();
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    let failRefresh = false;
+    const list = async () => {
+      if (failRefresh) {
+        throw new Error("Session cache refresh failed.");
+      }
+      return [sessionRecord];
+    };
+    await queryClient.fetchQuery({
+      queryKey,
+      queryFn: list,
+    });
+    const deleteSession = mock(async () => undefined);
+    const reportCacheRefreshFailure = mock(() => undefined);
+    const effects = createSessionCacheEffects({
+      workspaceRepoPath: "/repo",
+      queryClient,
+      hostPort: {
+        agentSessionDelete: deleteSession,
+        agentSessionsList: list,
+        agentSessionUpsert: async () => undefined,
+      },
+      reportCacheRefreshFailure,
+    });
+    failRefresh = true;
+
+    await expect(effects.deleteSessionRecord("task-1", sessionRecord)).resolves.toBeUndefined();
+
+    expect(deleteSession).toHaveBeenCalledWith("/repo", "task-1", sessionRecord);
+    expect(queryClient.getQueryState(queryKey)?.status).toBe("error");
+    expect(queryClient.getQueryState(queryKey)?.error).toEqual(
+      new Error("Session cache refresh failed."),
+    );
+    expect(reportCacheRefreshFailure).toHaveBeenCalledWith({
+      operation: "delete",
+      repoPath: "/repo",
+      taskId: "task-1",
+      error: new Error("Session cache refresh failed."),
+    });
   });
 });

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.test.ts
@@ -23,7 +23,7 @@ const createQueryClient = (): QueryClient =>
   });
 
 describe("createSessionCacheEffects", () => {
-  test("persists through the injected host port and updates the injected query client", async () => {
+  test("persists through the injected host port and invalidates the canonical task query", async () => {
     const queryClient = createQueryClient();
     const upsert = mock(async () => undefined);
     queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), []);
@@ -38,7 +38,10 @@ describe("createSessionCacheEffects", () => {
     expect(upsert).toHaveBeenCalledWith("/repo", "task-1", sessionRecord);
     expect(
       queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
-    ).toEqual([sessionRecord]);
+    ).toEqual([]);
+    expect(
+      queryClient.getQueryState(agentSessionQueryKeys.list("/repo", "task-1"))?.isInvalidated,
+    ).toBe(true);
   });
 
   test("fails instead of silently dropping a session record without an active workspace", async () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -2,7 +2,10 @@ import type { AgentSessionIdentity, AgentSessionRecord } from "@openducktor/cont
 import type { QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import { invalidateAgentSessionListQuery } from "@/state/queries/agent-sessions";
+import {
+  invalidateAgentSessionListQuery,
+  refreshAgentSessionListQuery,
+} from "@/state/queries/agent-sessions";
 import { invalidateRepoTaskQueries } from "@/state/queries/tasks";
 import type { AgentOrchestratorHostPort } from "./orchestrator-ports";
 import { requireWorkspaceRepoPath } from "./session-invariants";
@@ -58,10 +61,7 @@ export const createSessionCacheEffects = ({
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionUpsert(repoPath, taskId, record);
     try {
-      await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
-        readPort: hostPort,
-        refetchType: "all",
-      });
+      await refreshAgentSessionListQuery(queryClient, repoPath, taskId, hostPort);
     } catch (error) {
       reportCacheRefreshFailure({ operation: "save", repoPath, taskId, error });
     }
@@ -74,10 +74,7 @@ export const createSessionCacheEffects = ({
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionDelete(repoPath, taskId, identity);
     try {
-      await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
-        readPort: hostPort,
-        refetchType: "all",
-      });
+      await refreshAgentSessionListQuery(queryClient, repoPath, taskId, hostPort);
     } catch (error) {
       reportCacheRefreshFailure({ operation: "delete", repoPath, taskId, error });
     }

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -1,10 +1,6 @@
 import type { AgentSessionIdentity, AgentSessionRecord } from "@openducktor/contracts";
 import type { QueryClient } from "@tanstack/react-query";
-import {
-  invalidateAgentSessionListQuery,
-  removeAgentSessionRecordFromQuery,
-  upsertAgentSessionRecordInQuery,
-} from "@/state/queries/agent-sessions";
+import { invalidateAgentSessionListQuery } from "@/state/queries/agent-sessions";
 import { invalidateRepoTaskQueries } from "@/state/queries/tasks";
 import type { AgentOrchestratorHostPort } from "./orchestrator-ports";
 import { requireWorkspaceRepoPath } from "./session-invariants";
@@ -26,7 +22,9 @@ export const createSessionCacheEffects = ({
   ): Promise<void> => {
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionUpsert(repoPath, taskId, record);
-    upsertAgentSessionRecordInQuery(queryClient, repoPath, taskId, record);
+    await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
+      refetchActive: true,
+    });
   };
 
   const deleteSessionRecord = async (
@@ -35,7 +33,9 @@ export const createSessionCacheEffects = ({
   ): Promise<void> => {
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionDelete(repoPath, taskId, identity);
-    removeAgentSessionRecordFromQuery(queryClient, repoPath, taskId, identity);
+    await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
+      refetchActive: true,
+    });
   };
 
   const invalidateSessionStopQueries = async ({

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -21,16 +21,23 @@ type CreateSessionCacheEffectsArgs = {
   }) => void;
 };
 
-const reportDefaultCacheRefreshFailure = ({
+export const sessionCacheRefreshFailureDescription = ({
+  repoPath,
   taskId,
   error,
 }: {
   repoPath: string;
   taskId: string;
   error: unknown;
+}): string => `${repoPath} · ${taskId}: ${errorMessage(error)}`;
+
+const reportDefaultCacheRefreshFailure = (failure: {
+  repoPath: string;
+  taskId: string;
+  error: unknown;
 }): void => {
   toast.error("Session saved, but metadata refresh failed", {
-    description: `${taskId}: ${errorMessage(error)}`,
+    description: sessionCacheRefreshFailureDescription(failure),
   });
 };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -10,10 +10,7 @@ import { requireWorkspaceRepoPath } from "./session-invariants";
 type CreateSessionCacheEffectsArgs = {
   workspaceRepoPath: string | null;
   queryClient: QueryClient;
-  hostPort: Pick<
-    AgentOrchestratorHostPort,
-    "agentSessionDelete" | "agentSessionUpsert"
-  >;
+  hostPort: Pick<AgentOrchestratorHostPort, "agentSessionDelete" | "agentSessionUpsert">;
   reportCacheRefreshFailure?: (failure: {
     repoPath: string;
     taskId: string;

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -1,5 +1,7 @@
 import type { AgentSessionIdentity, AgentSessionRecord } from "@openducktor/contracts";
 import type { QueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { errorMessage } from "@/lib/errors";
 import { invalidateAgentSessionListQuery } from "@/state/queries/agent-sessions";
 import { invalidateRepoTaskQueries } from "@/state/queries/tasks";
 import type { AgentOrchestratorHostPort } from "./orchestrator-ports";
@@ -12,12 +14,31 @@ type CreateSessionCacheEffectsArgs = {
     AgentOrchestratorHostPort,
     "agentSessionDelete" | "agentSessionUpsert"
   >;
+  reportCacheRefreshFailure?: (failure: {
+    repoPath: string;
+    taskId: string;
+    error: unknown;
+  }) => void;
+};
+
+const reportDefaultCacheRefreshFailure = ({
+  taskId,
+  error,
+}: {
+  repoPath: string;
+  taskId: string;
+  error: unknown;
+}): void => {
+  toast.error("Session saved, but metadata refresh failed", {
+    description: `${taskId}: ${errorMessage(error)}`,
+  });
 };
 
 export const createSessionCacheEffects = ({
   workspaceRepoPath,
   queryClient,
   hostPort,
+  reportCacheRefreshFailure = reportDefaultCacheRefreshFailure,
 }: CreateSessionCacheEffectsArgs) => {
   const persistSessionRecord = async (
     taskId: string,
@@ -25,9 +46,13 @@ export const createSessionCacheEffects = ({
   ): Promise<void> => {
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionUpsert(repoPath, taskId, record);
-    await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
-      refetchType: "all",
-    });
+    try {
+      await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
+        refetchType: "all",
+      });
+    } catch (error) {
+      reportCacheRefreshFailure({ repoPath, taskId, error });
+    }
   };
 
   const deleteSessionRecord = async (
@@ -37,7 +62,7 @@ export const createSessionCacheEffects = ({
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionDelete(repoPath, taskId, identity);
     await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
-      refetchActive: true,
+      refetchType: "all",
     });
   };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -7,15 +7,21 @@ import { invalidateRepoTaskQueries } from "@/state/queries/tasks";
 import type { AgentOrchestratorHostPort } from "./orchestrator-ports";
 import { requireWorkspaceRepoPath } from "./session-invariants";
 
+type SessionCacheRefreshFailure = {
+  operation: "delete" | "save";
+  repoPath: string;
+  taskId: string;
+  error: unknown;
+};
+
 type CreateSessionCacheEffectsArgs = {
   workspaceRepoPath: string | null;
   queryClient: QueryClient;
-  hostPort: Pick<AgentOrchestratorHostPort, "agentSessionDelete" | "agentSessionUpsert">;
-  reportCacheRefreshFailure?: (failure: {
-    repoPath: string;
-    taskId: string;
-    error: unknown;
-  }) => void;
+  hostPort: Pick<
+    AgentOrchestratorHostPort,
+    "agentSessionDelete" | "agentSessionsList" | "agentSessionUpsert"
+  >;
+  reportCacheRefreshFailure?: (failure: SessionCacheRefreshFailure) => void;
 };
 
 export const sessionCacheRefreshFailureDescription = ({
@@ -28,12 +34,13 @@ export const sessionCacheRefreshFailureDescription = ({
   error: unknown;
 }): string => `${repoPath} · ${taskId}: ${errorMessage(error)}`;
 
-const reportDefaultCacheRefreshFailure = (failure: {
-  repoPath: string;
-  taskId: string;
-  error: unknown;
-}): void => {
-  toast.error("Session saved, but metadata refresh failed", {
+const cacheRefreshFailureTitles: Record<SessionCacheRefreshFailure["operation"], string> = {
+  delete: "Session deleted, but metadata refresh failed",
+  save: "Session saved, but metadata refresh failed",
+};
+
+const reportDefaultCacheRefreshFailure = (failure: SessionCacheRefreshFailure): void => {
+  toast.error(cacheRefreshFailureTitles[failure.operation], {
     description: sessionCacheRefreshFailureDescription(failure),
   });
 };
@@ -52,10 +59,11 @@ export const createSessionCacheEffects = ({
     await hostPort.agentSessionUpsert(repoPath, taskId, record);
     try {
       await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
+        readPort: hostPort,
         refetchType: "all",
       });
     } catch (error) {
-      reportCacheRefreshFailure({ repoPath, taskId, error });
+      reportCacheRefreshFailure({ operation: "save", repoPath, taskId, error });
     }
   };
 
@@ -65,9 +73,14 @@ export const createSessionCacheEffects = ({
   ): Promise<void> => {
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionDelete(repoPath, taskId, identity);
-    await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
-      refetchType: "all",
-    });
+    try {
+      await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
+        readPort: hostPort,
+        refetchType: "all",
+      });
+    } catch (error) {
+      reportCacheRefreshFailure({ operation: "delete", repoPath, taskId, error });
+    }
   };
 
   const invalidateSessionStopQueries = async ({

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -2,10 +2,7 @@ import type { AgentSessionIdentity, AgentSessionRecord } from "@openducktor/cont
 import type { QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import {
-  invalidateAgentSessionListQuery,
-  refreshAgentSessionListQuery,
-} from "@/state/queries/agent-sessions";
+import { refreshAgentSessionListQuery } from "@/state/queries/agent-sessions";
 import { invalidateRepoTaskQueries } from "@/state/queries/tasks";
 import type { AgentOrchestratorHostPort } from "./orchestrator-ports";
 import { requireWorkspaceRepoPath } from "./session-invariants";
@@ -82,15 +79,11 @@ export const createSessionCacheEffects = ({
 
   const invalidateSessionStopQueries = async ({
     repoPath,
-    taskId,
   }: {
     repoPath: string;
     taskId: string;
   }): Promise<void> => {
-    await Promise.all([
-      invalidateRepoTaskQueries(queryClient, repoPath),
-      invalidateAgentSessionListQuery(queryClient, repoPath, taskId),
-    ]);
+    await invalidateRepoTaskQueries(queryClient, repoPath);
   };
 
   return { deleteSessionRecord, persistSessionRecord, invalidateSessionStopQueries };

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -1,6 +1,9 @@
 import type { AgentSessionIdentity, AgentSessionRecord } from "@openducktor/contracts";
 import type { QueryClient } from "@tanstack/react-query";
-import { invalidateAgentSessionListQuery } from "@/state/queries/agent-sessions";
+import {
+  agentSessionListQueryOptions,
+  invalidateAgentSessionListQuery,
+} from "@/state/queries/agent-sessions";
 import { invalidateRepoTaskQueries } from "@/state/queries/tasks";
 import type { AgentOrchestratorHostPort } from "./orchestrator-ports";
 import { requireWorkspaceRepoPath } from "./session-invariants";
@@ -8,7 +11,10 @@ import { requireWorkspaceRepoPath } from "./session-invariants";
 type CreateSessionCacheEffectsArgs = {
   workspaceRepoPath: string | null;
   queryClient: QueryClient;
-  hostPort: Pick<AgentOrchestratorHostPort, "agentSessionDelete" | "agentSessionUpsert">;
+  hostPort: Pick<
+    AgentOrchestratorHostPort,
+    "agentSessionDelete" | "agentSessionsList" | "agentSessionUpsert"
+  >;
 };
 
 export const createSessionCacheEffects = ({
@@ -22,8 +28,11 @@ export const createSessionCacheEffects = ({
   ): Promise<void> => {
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionUpsert(repoPath, taskId, record);
-    await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
-      refetchActive: true,
+    await invalidateAgentSessionListQuery(queryClient, repoPath, taskId);
+    await queryClient.fetchQuery({
+      ...agentSessionListQueryOptions(repoPath, taskId),
+      queryFn: () => hostPort.agentSessionsList(repoPath, taskId),
+      staleTime: 0,
     });
   };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-cache-effects.ts
@@ -1,9 +1,6 @@
 import type { AgentSessionIdentity, AgentSessionRecord } from "@openducktor/contracts";
 import type { QueryClient } from "@tanstack/react-query";
-import {
-  agentSessionListQueryOptions,
-  invalidateAgentSessionListQuery,
-} from "@/state/queries/agent-sessions";
+import { invalidateAgentSessionListQuery } from "@/state/queries/agent-sessions";
 import { invalidateRepoTaskQueries } from "@/state/queries/tasks";
 import type { AgentOrchestratorHostPort } from "./orchestrator-ports";
 import { requireWorkspaceRepoPath } from "./session-invariants";
@@ -13,7 +10,7 @@ type CreateSessionCacheEffectsArgs = {
   queryClient: QueryClient;
   hostPort: Pick<
     AgentOrchestratorHostPort,
-    "agentSessionDelete" | "agentSessionsList" | "agentSessionUpsert"
+    "agentSessionDelete" | "agentSessionUpsert"
   >;
 };
 
@@ -28,11 +25,8 @@ export const createSessionCacheEffects = ({
   ): Promise<void> => {
     const repoPath = requireWorkspaceRepoPath(workspaceRepoPath);
     await hostPort.agentSessionUpsert(repoPath, taskId, record);
-    await invalidateAgentSessionListQuery(queryClient, repoPath, taskId);
-    await queryClient.fetchQuery({
-      ...agentSessionListQueryOptions(repoPath, taskId),
-      queryFn: () => hostPort.agentSessionsList(repoPath, taskId),
-      staleTime: 0,
+    await invalidateAgentSessionListQuery(queryClient, repoPath, taskId, {
+      refetchType: "all",
     });
   };
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
@@ -41,6 +41,9 @@ describe("use-agent-orchestrator-operations session state", () => {
     host.agentSessionsList = async () => {
       throw new Error("session store unavailable");
     };
+    host.agentSessionsListForTasks = async () => {
+      throw new Error("session store unavailable");
+    };
 
     const harness = createHookHarness({
       activeRepo: "/tmp/repo",
@@ -70,9 +73,9 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalAgentSessionsList = host.agentSessionsList;
     let sessionListCalls = 0;
 
-    host.agentSessionsList = async () => {
+    host.agentSessionsListForTasks = async (_repoPath, taskIds) => {
       sessionListCalls += 1;
-      return [];
+      return taskIds.map((taskId) => ({ taskId, agentSessions: [] }));
     };
 
     const harness = createHookHarness({
@@ -128,6 +131,9 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -259,7 +265,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalSpecGet = host.specGet;
     const originalPlanGet = host.planGet;
     const originalQaGetReport = host.qaGetReport;
-    const originalTaskSessionBootstrapPrepare = host.taskSessionBootstrapPrepare;
     const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
 
     const originalStartSession = OpencodeSdkAdapter.prototype.startSession;
@@ -271,7 +276,12 @@ describe("use-agent-orchestrator-operations session state", () => {
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
-    host.taskSessionBootstrapPrepare = async (_repoPath, _taskId, role, runtimeKind) => {
+    const taskSessionBootstrapPrepare = async (
+      _repoPath: string,
+      _taskId: string,
+      role: "spec" | "planner" | "build" | "qa",
+      runtimeKind: "opencode" | "codex",
+    ) => {
       buildStartCalls += 1;
       return { ...buildBootstrapFixture, bootstrapId: "bootstrap-latest", role, runtimeKind };
     };
@@ -317,6 +327,13 @@ describe("use-agent-orchestrator-operations session state", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
+      dependencies: createTestDependencies(
+        {
+          agentSessionsList: async () => [],
+          agentSessionUpsert: async () => undefined,
+        },
+        { taskSessionBootstrapPrepare },
+      ),
     });
 
     try {
@@ -341,7 +358,6 @@ describe("use-agent-orchestrator-operations session state", () => {
       host.specGet = originalSpecGet;
       host.planGet = originalPlanGet;
       host.qaGetReport = originalQaGetReport;
-      host.taskSessionBootstrapPrepare = originalTaskSessionBootstrapPrepare;
       host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
 
       OpencodeSdkAdapter.prototype.startSession = originalStartSession;
@@ -364,6 +380,9 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -435,6 +454,9 @@ describe("use-agent-orchestrator-operations session state", () => {
 
     const upsertedRecords: unknown[] = [];
     host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+    ];
     host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
       upsertedRecords.push(record);
     };
@@ -522,6 +544,18 @@ describe("use-agent-orchestrator-operations session state", () => {
         ...persistedSessionFixture,
         role: "build",
         workingDirectory: "/tmp/repo/worktree",
+      },
+    ];
+    host.agentSessionsListForTasks = async () => [
+      {
+        taskId: "task-1",
+        agentSessions: [
+          {
+            ...persistedSessionFixture,
+            role: "build",
+            workingDirectory: "/tmp/repo/worktree",
+          },
+        ],
       },
     ];
     host.agentSessionUpsert = async () => {};
@@ -654,9 +688,9 @@ describe("use-agent-orchestrator-operations session state", () => {
   test("revisit to the same repo refreshes task sessions again", async () => {
     const originalAgentSessionsList = host.agentSessionsList;
     let persistedListCalls = 0;
-    host.agentSessionsList = async () => {
+    host.agentSessionsListForTasks = async () => {
       persistedListCalls += 1;
-      return [persistedSessionFixture];
+      return [{ taskId: "task-1", agentSessions: [persistedSessionFixture] }];
     };
 
     const harness = createHookHarness({
@@ -695,6 +729,9 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -763,6 +800,9 @@ describe("use-agent-orchestrator-operations session state", () => {
     } = { current: null };
 
     host.agentSessionsList = async () => [codexRecord];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [codexRecord] },
+    ];
     CodexAppServerAdapter.prototype.loadSessionHistory = async (input) => {
       receivedHistoryInputRef.current = input;
       return [
@@ -854,6 +894,9 @@ describe("use-agent-orchestrator-operations session state", () => {
     let resumeCalls = 0;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
@@ -36,19 +36,18 @@ describe("use-agent-orchestrator-operations session state", () => {
   });
 
   test("exposes startup read-model failures as one load state", async () => {
-    const originalAgentSessionsList = host.agentSessionsList;
-
-    host.agentSessionsList = async () => {
-      throw new Error("session store unavailable");
-    };
-    host.agentSessionsListForTasks = async () => {
-      throw new Error("session store unavailable");
-    };
-
     const harness = createHookHarness({
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
+      dependencies: createTestDependencies({
+        agentSessionsList: async () => {
+          throw new Error("session store unavailable");
+        },
+        agentSessionsListForTasks: async () => {
+          throw new Error("session store unavailable");
+        },
+      }),
     });
 
     try {
@@ -65,24 +64,23 @@ describe("use-agent-orchestrator-operations session state", () => {
       expect(readModelLoadState.message).toContain("session store unavailable");
     } finally {
       await harness.unmount();
-      host.agentSessionsList = originalAgentSessionsList;
     }
   });
 
   test("keeps the repo session read model loading until task data is ready", async () => {
-    const originalAgentSessionsList = host.agentSessionsList;
     let sessionListCalls = 0;
-
-    host.agentSessionsListForTasks = async (_repoPath, taskIds) => {
-      sessionListCalls += 1;
-      return taskIds.map((taskId) => ({ taskId, agentSessions: [] }));
-    };
 
     const harness = createHookHarness({
       activeRepo: "/tmp/repo",
       tasks: [],
       isLoadingTasks: true,
       refreshTaskData: async () => {},
+      dependencies: createTestDependencies({
+        agentSessionsListForTasks: async (_repoPath, taskIds) => {
+          sessionListCalls += 1;
+          return taskIds.map((taskId) => ({ taskId, agentSessions: [] }));
+        },
+      }),
     });
 
     try {
@@ -109,7 +107,6 @@ describe("use-agent-orchestrator-operations session state", () => {
       expect(sessionListCalls).toBe(1);
     } finally {
       await harness.unmount();
-      host.agentSessionsList = originalAgentSessionsList;
     }
   });
 
@@ -374,8 +371,6 @@ describe("use-agent-orchestrator-operations session state", () => {
   test("uses latest tasks after args update when validating send permissions", async () => {
     let sendCalls = 0;
 
-    const originalAgentSessionsList = host.agentSessionsList;
-    const originalAgentSessionUpsert = host.agentSessionUpsert;
     const originalSpecGet = host.specGet;
     const originalPlanGet = host.planGet;
     const originalQaGetReport = host.qaGetReport;
@@ -384,11 +379,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
-    host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
-    ];
-    host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
@@ -408,6 +398,13 @@ describe("use-agent-orchestrator-operations session state", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
+      dependencies: createTestDependencies({
+        agentSessionsList: async () => [persistedSessionFixture],
+        agentSessionsListForTasks: async () => [
+          { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+        ],
+        agentSessionUpsert: async () => {},
+      }),
     });
 
     const unavailableTask = createUnavailableBuildTaskFixture();
@@ -434,8 +431,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     } finally {
       await harness.unmount();
 
-      host.agentSessionsList = originalAgentSessionsList;
-      host.agentSessionUpsert = originalAgentSessionUpsert;
       host.specGet = originalSpecGet;
       host.planGet = originalPlanGet;
       host.qaGetReport = originalQaGetReport;
@@ -537,8 +532,6 @@ describe("use-agent-orchestrator-operations session state", () => {
   test("reuses freshly loaded sessions without starting a new session", async () => {
     let startCalls = 0;
 
-    const originalAgentSessionsList = host.agentSessionsList;
-    const originalAgentSessionUpsert = host.agentSessionUpsert;
     const originalSpecGet = host.specGet;
     const originalPlanGet = host.planGet;
     const originalQaGetReport = host.qaGetReport;
@@ -549,26 +542,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
     const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
 
-    host.agentSessionsList = async () => [
-      {
-        ...persistedSessionFixture,
-        role: "build",
-        workingDirectory: "/tmp/repo/worktree",
-      },
-    ];
-    host.agentSessionsListForTasks = async () => [
-      {
-        taskId: "task-1",
-        agentSessions: [
-          {
-            ...persistedSessionFixture,
-            role: "build",
-            workingDirectory: "/tmp/repo/worktree",
-          },
-        ],
-      },
-    ];
-    host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
@@ -600,6 +573,28 @@ describe("use-agent-orchestrator-operations session state", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
+      dependencies: createTestDependencies({
+        agentSessionsList: async () => [
+          {
+            ...persistedSessionFixture,
+            role: "build",
+            workingDirectory: "/tmp/repo/worktree",
+          },
+        ],
+        agentSessionsListForTasks: async () => [
+          {
+            taskId: "task-1",
+            agentSessions: [
+              {
+                ...persistedSessionFixture,
+                role: "build",
+                workingDirectory: "/tmp/repo/worktree",
+              },
+            ],
+          },
+        ],
+        agentSessionUpsert: async () => {},
+      }),
     });
 
     try {
@@ -629,8 +624,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     } finally {
       await harness.unmount();
 
-      host.agentSessionsList = originalAgentSessionsList;
-      host.agentSessionUpsert = originalAgentSessionUpsert;
       host.specGet = originalSpecGet;
       host.planGet = originalPlanGet;
       host.qaGetReport = originalQaGetReport;
@@ -696,17 +689,18 @@ describe("use-agent-orchestrator-operations session state", () => {
   });
 
   test("revisit to the same repo refreshes task sessions again", async () => {
-    const originalAgentSessionsList = host.agentSessionsList;
     let persistedListCalls = 0;
-    host.agentSessionsListForTasks = async () => {
-      persistedListCalls += 1;
-      return [{ taskId: "task-1", agentSessions: [persistedSessionFixture] }];
-    };
 
     const harness = createHookHarness({
       activeRepo: "/tmp/repo-a",
       tasks: [taskFixtureWithPersistedBuildSession],
       refreshTaskData: async () => {},
+      dependencies: createTestDependencies({
+        agentSessionsListForTasks: async () => {
+          persistedListCalls += 1;
+          return [{ taskId: "task-1", agentSessions: [persistedSessionFixture] }];
+        },
+      }),
     });
 
     try {
@@ -724,7 +718,6 @@ describe("use-agent-orchestrator-operations session state", () => {
       expect(persistedListCalls).toBe(1);
     } finally {
       await harness.unmount();
-      host.agentSessionsList = originalAgentSessionsList;
     }
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
@@ -609,6 +609,10 @@ describe("use-agent-orchestrator-operations session state", () => {
         role: "spec",
       },
     ]);
+    dependencies.queryClient.setQueryData(
+      agentSessionQueryKeys.hydration("/tmp/repo", ["task-1"]),
+      true,
+    );
     const harness = createHookHarness({
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
@@ -131,9 +131,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
-    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -200,7 +197,15 @@ describe("use-agent-orchestrator-operations session state", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {
@@ -454,9 +459,6 @@ describe("use-agent-orchestrator-operations session state", () => {
 
     const upsertedRecords: unknown[] = [];
     host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
-    ];
     host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
       upsertedRecords.push(record);
     };
@@ -478,7 +480,15 @@ describe("use-agent-orchestrator-operations session state", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixtureWithPersistedBuildSession],
       refreshTaskData: async () => {},
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {
@@ -729,9 +739,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
-    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -758,7 +765,15 @@ describe("use-agent-orchestrator-operations session state", () => {
       },
       refreshTaskData: async () => {},
       agentEngine: createAgentRuntimeServices().agentEngine,
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {
@@ -800,9 +815,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     } = { current: null };
 
     host.agentSessionsList = async () => [codexRecord];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [codexRecord] },
-    ];
     CodexAppServerAdapter.prototype.loadSessionHistory = async (input) => {
       receivedHistoryInputRef.current = input;
       return [
@@ -835,7 +847,15 @@ describe("use-agent-orchestrator-operations session state", () => {
       },
       refreshTaskData: async () => {},
       agentEngine: createAgentRuntimeServices().agentEngine,
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            { taskId: "task-1", agentSessions: [codexRecord] },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {
@@ -894,9 +914,6 @@ describe("use-agent-orchestrator-operations session state", () => {
     let resumeCalls = 0;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
-    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -926,7 +943,15 @@ describe("use-agent-orchestrator-operations session state", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixtureWithPersistedBuildSession],
       refreshTaskData: async () => {},
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {
@@ -963,7 +988,11 @@ describe("use-agent-orchestrator-operations session state", () => {
     host.agentSessionsList = async () => [persistedSessionFixture];
     const liveStream = createLiveSessionStreamFixture();
     const dependencies = createTestDependencies(
-      {},
+      {
+        agentSessionsListForTasks: async () => [
+          { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+        ],
+      },
       {},
       {
         ...liveStream.portOverrides,

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.session-state.test.tsx
@@ -501,9 +501,14 @@ describe("use-agent-orchestrator-operations session state", () => {
       await harness.run(() => {
         harness.getLatest().operations.updateAgentSessionModel(session, BUILD_SELECTION);
       });
-      await Promise.resolve();
-
-      const updatedSession = listHarnessSessions(harness.getLatest()).find(
+      const updated = await harness.waitFor((state) =>
+        listHarnessSessions(state).some(
+          (entry) =>
+            entry.externalSessionId === "external-1" &&
+            entry.selectedModel?.modelId === BUILD_SELECTION.modelId,
+        ),
+      );
+      const updatedSession = listHarnessSessions(updated).find(
         (entry) => entry.externalSessionId === "external-1",
       );
       expect(updatedSession?.selectedModel).toEqual(BUILD_SELECTION);

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
@@ -290,8 +290,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
     let persistedListCalls = 0;
     let persistedSessions = [] as (typeof persistedSessionFixture)[];
 
-    const originalAgentSessionsList = host.agentSessionsList;
-    const originalAgentSessionUpsert = host.agentSessionUpsert;
     const originalSpecGet = host.specGet;
     const originalPlanGet = host.planGet;
     const originalQaGetReport = host.qaGetReport;
@@ -303,17 +301,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
     const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
 
-    host.agentSessionsList = async () => {
-      persistedListCalls += 1;
-      return persistedSessions;
-    };
-    host.agentSessionsListForTasks = async () => {
-      persistedListCalls += 1;
-      return [{ taskId: "task-1", agentSessions: persistedSessions }];
-    };
-    host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
-      persistedSessions = [record];
-    };
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
@@ -363,6 +350,19 @@ describe("use-agent-orchestrator-operations start and send", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
+      dependencies: createTestDependencies({
+        agentSessionsList: async () => {
+          persistedListCalls += 1;
+          return persistedSessions;
+        },
+        agentSessionsListForTasks: async () => {
+          persistedListCalls += 1;
+          return [{ taskId: "task-1", agentSessions: persistedSessions }];
+        },
+        agentSessionUpsert: async (_repoPath, _taskId, record) => {
+          persistedSessions = [record];
+        },
+      }),
     });
 
     try {
@@ -401,8 +401,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
     } finally {
       await harness.unmount();
 
-      host.agentSessionsList = originalAgentSessionsList;
-      host.agentSessionUpsert = originalAgentSessionUpsert;
       host.specGet = originalSpecGet;
       host.planGet = originalPlanGet;
       host.qaGetReport = originalQaGetReport;
@@ -429,8 +427,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
       status: "idle";
     }>();
 
-    const originalAgentSessionsList = host.agentSessionsList;
-    const originalAgentSessionUpsert = host.agentSessionUpsert;
     const originalSpecGet = host.specGet;
     const originalPlanGet = host.planGet;
     const originalQaGetReport = host.qaGetReport;
@@ -442,17 +438,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
     const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
 
-    host.agentSessionsList = async () => {
-      persistedListCalls += 1;
-      return persistedSessions;
-    };
-    host.agentSessionsListForTasks = async () => {
-      persistedListCalls += 1;
-      return [{ taskId: "task-1", agentSessions: persistedSessions }];
-    };
-    host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
-      persistedSessions = [record];
-    };
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
@@ -496,6 +481,19 @@ describe("use-agent-orchestrator-operations start and send", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
+      dependencies: createTestDependencies({
+        agentSessionsList: async () => {
+          persistedListCalls += 1;
+          return persistedSessions;
+        },
+        agentSessionsListForTasks: async () => {
+          persistedListCalls += 1;
+          return [{ taskId: "task-1", agentSessions: persistedSessions }];
+        },
+        agentSessionUpsert: async (_repoPath, _taskId, record) => {
+          persistedSessions = [record];
+        },
+      }),
     });
 
     try {
@@ -539,8 +537,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
     } finally {
       await harness.unmount();
 
-      host.agentSessionsList = originalAgentSessionsList;
-      host.agentSessionUpsert = originalAgentSessionUpsert;
       host.specGet = originalSpecGet;
       host.planGet = originalPlanGet;
       host.qaGetReport = originalQaGetReport;

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
@@ -65,7 +65,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
-    host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsList = async () => [{ ...persistedSessionFixture }];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -95,7 +95,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
       dependencies: createTestDependencies(
         {
           agentSessionsListForTasks: async () => [
-            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+            { taskId: "task-1", agentSessions: [{ ...persistedSessionFixture }] },
           ],
         },
         {},
@@ -145,7 +145,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
     const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
 
-    host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsList = async () => [{ ...persistedSessionFixture }];
     host.agentSessionUpsert = async () => {};
     OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
     OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
@@ -168,7 +168,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
       dependencies: createTestDependencies(
         {
           agentSessionsListForTasks: async () => [
-            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+            { taskId: "task-1", agentSessions: [{ ...persistedSessionFixture }] },
           ],
         },
         {},
@@ -208,7 +208,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     toast.error = toastError;
-    host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsList = async () => [{ ...persistedSessionFixture }];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -239,7 +239,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
       dependencies: createTestDependencies(
         {
           agentSessionsListForTasks: async () => [
-            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+            { taskId: "task-1", agentSessions: [{ ...persistedSessionFixture }] },
           ],
         },
         {},
@@ -416,7 +416,8 @@ describe("use-agent-orchestrator-operations start and send", () => {
 
   test("dedupes concurrent starts for the same repo and task", async () => {
     let startCalls = 0;
-    let persistedListCalls = 0;
+    let persistedBatchListCalls = 0;
+    let persistedSingleListCalls = 0;
     let persistedSessions = [] as (typeof persistedSessionFixture)[];
     const startDeferred = createDeferred<{
       runtimeKind: "opencode";
@@ -483,11 +484,11 @@ describe("use-agent-orchestrator-operations start and send", () => {
       refreshTaskData: async () => {},
       dependencies: createTestDependencies({
         agentSessionsList: async () => {
-          persistedListCalls += 1;
+          persistedSingleListCalls += 1;
           return persistedSessions;
         },
         agentSessionsListForTasks: async () => {
-          persistedListCalls += 1;
+          persistedBatchListCalls += 1;
           return [{ taskId: "task-1", agentSessions: persistedSessions }];
         },
         agentSessionUpsert: async (_repoPath, _taskId, record) => {
@@ -533,7 +534,8 @@ describe("use-agent-orchestrator-operations start and send", () => {
       expect(firstSessionId).toBe("external-concurrent");
       expect(secondSessionId).toBe("external-concurrent");
       expect(startCalls).toBe(1);
-      expect(persistedListCalls).toBeGreaterThanOrEqual(1);
+      expect(persistedBatchListCalls).toBe(1);
+      expect(persistedSingleListCalls).toBe(1);
     } finally {
       await harness.unmount();
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
@@ -66,9 +66,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
-    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -95,7 +92,15 @@ describe("use-agent-orchestrator-operations start and send", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {
@@ -141,9 +146,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
-    ];
     host.agentSessionUpsert = async () => {};
     OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
     OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
@@ -163,7 +165,15 @@ describe("use-agent-orchestrator-operations start and send", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {
@@ -199,9 +209,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
 
     toast.error = toastError;
     host.agentSessionsList = async () => [persistedSessionFixture];
-    host.agentSessionsListForTasks = async () => [
-      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
-    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -229,7 +236,15 @@ describe("use-agent-orchestrator-operations start and send", () => {
       activeRepo: "/tmp/repo",
       tasks: [unavailableTask],
       refreshTaskData: async () => {},
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {
@@ -561,18 +576,6 @@ describe("use-agent-orchestrator-operations start and send", () => {
         role: "build",
       },
     ];
-    host.agentSessionsListForTasks = async () => [
-      {
-        taskId: "task-1",
-        agentSessions: [
-          {
-            ...persistedSessionFixture,
-            role: "build",
-            workingDirectory: "/tmp/repo/worktree",
-          },
-        ],
-      },
-    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -621,7 +624,24 @@ describe("use-agent-orchestrator-operations start and send", () => {
       activeRepo: "/tmp/repo",
       tasks: [taskFixture],
       refreshTaskData: async () => {},
-      dependencies: createTestDependencies({}, {}, liveStream.portOverrides),
+      dependencies: createTestDependencies(
+        {
+          agentSessionsListForTasks: async () => [
+            {
+              taskId: "task-1",
+              agentSessions: [
+                {
+                  ...persistedSessionFixture,
+                  role: "build",
+                  workingDirectory: "/tmp/repo/worktree",
+                },
+              ],
+            },
+          ],
+        },
+        {},
+        liveStream.portOverrides,
+      ),
     });
 
     try {

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
@@ -66,6 +66,9 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -138,6 +141,9 @@ describe("use-agent-orchestrator-operations start and send", () => {
     const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
 
     host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+    ];
     host.agentSessionUpsert = async () => {};
     OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
     OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
@@ -193,6 +199,9 @@ describe("use-agent-orchestrator-operations start and send", () => {
 
     toast.error = toastError;
     host.agentSessionsList = async () => [persistedSessionFixture];
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [persistedSessionFixture] },
+    ];
     host.agentSessionUpsert = async () => {};
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
@@ -282,6 +291,10 @@ describe("use-agent-orchestrator-operations start and send", () => {
     host.agentSessionsList = async () => {
       persistedListCalls += 1;
       return persistedSessions;
+    };
+    host.agentSessionsListForTasks = async () => {
+      persistedListCalls += 1;
+      return [{ taskId: "task-1", agentSessions: persistedSessions }];
     };
     host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
       persistedSessions = [record];
@@ -418,6 +431,10 @@ describe("use-agent-orchestrator-operations start and send", () => {
       persistedListCalls += 1;
       return persistedSessions;
     };
+    host.agentSessionsListForTasks = async () => {
+      persistedListCalls += 1;
+      return [{ taskId: "task-1", agentSessions: persistedSessions }];
+    };
     host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
       persistedSessions = [record];
     };
@@ -542,6 +559,18 @@ describe("use-agent-orchestrator-operations start and send", () => {
       {
         ...persistedSessionFixture,
         role: "build",
+      },
+    ];
+    host.agentSessionsListForTasks = async () => [
+      {
+        taskId: "task-1",
+        agentSessions: [
+          {
+            ...persistedSessionFixture,
+            role: "build",
+            workingDirectory: "/tmp/repo/worktree",
+          },
+        ],
       },
     ];
     host.agentSessionUpsert = async () => {};

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.start.test.tsx
@@ -264,6 +264,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
   test("reuses an in-memory session after it has been started", async () => {
     let startCalls = 0;
     let persistedListCalls = 0;
+    let persistedSessions = [] as (typeof persistedSessionFixture)[];
 
     const originalAgentSessionsList = host.agentSessionsList;
     const originalAgentSessionUpsert = host.agentSessionUpsert;
@@ -280,9 +281,11 @@ describe("use-agent-orchestrator-operations start and send", () => {
 
     host.agentSessionsList = async () => {
       persistedListCalls += 1;
-      return [];
+      return persistedSessions;
     };
-    host.agentSessionUpsert = async () => {};
+    host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
+      persistedSessions = [record];
+    };
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
@@ -366,7 +369,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
       expect(firstSessionId).toBe("external-in-memory");
       expect(secondSessionId).toBe("external-in-memory");
       expect(startCalls).toBe(1);
-      expect(persistedListCalls).toBe(1);
+      expect(persistedListCalls).toBe(2);
     } finally {
       await harness.unmount();
 
@@ -388,6 +391,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
   test("dedupes concurrent starts for the same repo and task", async () => {
     let startCalls = 0;
     let persistedListCalls = 0;
+    let persistedSessions = [] as (typeof persistedSessionFixture)[];
     const startDeferred = createDeferred<{
       runtimeKind: "opencode";
       workingDirectory: string;
@@ -412,9 +416,11 @@ describe("use-agent-orchestrator-operations start and send", () => {
 
     host.agentSessionsList = async () => {
       persistedListCalls += 1;
-      return [];
+      return persistedSessions;
     };
-    host.agentSessionUpsert = async () => {};
+    host.agentSessionUpsert = async (_repoPath, _taskId, record) => {
+      persistedSessions = [record];
+    };
     host.specGet = async () => ({ markdown: "", updatedAt: null });
     host.planGet = async () => ({ markdown: "", updatedAt: null });
     host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
@@ -497,7 +503,7 @@ describe("use-agent-orchestrator-operations start and send", () => {
       expect(firstSessionId).toBe("external-concurrent");
       expect(secondSessionId).toBe("external-concurrent");
       expect(startCalls).toBe(1);
-      expect(persistedListCalls).toBe(1);
+      expect(persistedListCalls).toBeGreaterThanOrEqual(1);
     } finally {
       await harness.unmount();
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-environment.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-environment.ts
@@ -8,6 +8,7 @@ import { createWorktreeRuntimeFixture } from "./use-agent-orchestrator-operation
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 export const setupOrchestratorOperationsTestEnvironment = async () => {
+  const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
   const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
   const originalBuildContinuationTargetGet = host.taskWorktreeGet;
   const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
@@ -21,6 +22,8 @@ export const setupOrchestratorOperationsTestEnvironment = async () => {
   const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
 
   await clearAppQueryClient();
+  host.agentSessionsListForTasks = async (_repoPath, taskIds) =>
+    taskIds.map((taskId) => ({ taskId, agentSessions: [] }));
   host.taskWorktreeGet = async () => ({
     workingDirectory: "/tmp/repo/worktree",
   });
@@ -71,6 +74,7 @@ export const setupOrchestratorOperationsTestEnvironment = async () => {
   OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
 
   return () => {
+    host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
     host.taskWorktreeGet = originalBuildContinuationTargetGet;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-environment.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-environment.ts
@@ -8,7 +8,6 @@ import { createWorktreeRuntimeFixture } from "./use-agent-orchestrator-operation
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 export const setupOrchestratorOperationsTestEnvironment = async () => {
-  const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
   const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
   const originalBuildContinuationTargetGet = host.taskWorktreeGet;
   const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
@@ -22,8 +21,6 @@ export const setupOrchestratorOperationsTestEnvironment = async () => {
   const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
 
   await clearAppQueryClient();
-  host.agentSessionsListForTasks = async (_repoPath, taskIds) =>
-    taskIds.map((taskId) => ({ taskId, agentSessions: [] }));
   host.taskWorktreeGet = async () => ({
     workingDirectory: "/tmp/repo/worktree",
   });
@@ -74,7 +71,6 @@ export const setupOrchestratorOperationsTestEnvironment = async () => {
   OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
 
   return () => {
-    host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
     host.taskWorktreeGet = originalBuildContinuationTargetGet;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-environment.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-environment.ts
@@ -8,6 +8,7 @@ import { createWorktreeRuntimeFixture } from "./use-agent-orchestrator-operation
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 export const setupOrchestratorOperationsTestEnvironment = async () => {
+  const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
   const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
   const originalBuildContinuationTargetGet = host.taskWorktreeGet;
   const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
@@ -21,6 +22,13 @@ export const setupOrchestratorOperationsTestEnvironment = async () => {
   const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
 
   await clearAppQueryClient();
+  host.agentSessionsListForTasks = async (repoPath, taskIds) =>
+    Promise.all(
+      taskIds.map(async (taskId) => ({
+        taskId,
+        agentSessions: await host.agentSessionsList(repoPath, taskId),
+      })),
+    );
   host.taskWorktreeGet = async () => ({
     workingDirectory: "/tmp/repo/worktree",
   });
@@ -71,6 +79,7 @@ export const setupOrchestratorOperationsTestEnvironment = async () => {
   OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
 
   return () => {
+    host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
     host.taskWorktreeGet = originalBuildContinuationTargetGet;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-environment.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-environment.ts
@@ -8,7 +8,6 @@ import { createWorktreeRuntimeFixture } from "./use-agent-orchestrator-operation
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 export const setupOrchestratorOperationsTestEnvironment = async () => {
-  const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
   const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
   const originalBuildContinuationTargetGet = host.taskWorktreeGet;
   const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
@@ -22,13 +21,6 @@ export const setupOrchestratorOperationsTestEnvironment = async () => {
   const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
 
   await clearAppQueryClient();
-  host.agentSessionsListForTasks = async (repoPath, taskIds) =>
-    Promise.all(
-      taskIds.map(async (taskId) => ({
-        taskId,
-        agentSessions: await host.agentSessionsList(repoPath, taskId),
-      })),
-    );
   host.taskWorktreeGet = async () => ({
     workingDirectory: "/tmp/repo/worktree",
   });
@@ -79,7 +71,6 @@ export const setupOrchestratorOperationsTestEnvironment = async () => {
   OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
 
   return () => {
-    host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
     host.taskWorktreeGet = originalBuildContinuationTargetGet;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
@@ -111,7 +111,8 @@ export const createTestDependencies = (
     hostPort: {
       agentSessionDelete: async () => undefined,
       agentSessionsList: async () => [],
-      agentSessionsListForTasks: async () => [],
+      agentSessionsListForTasks: async (_repoPath, taskIds) =>
+        taskIds.map((taskId) => ({ taskId, agentSessions: [] })),
       agentSessionUpsert: (...args) => host.agentSessionUpsert(...args),
       taskWorktreeGet: (...args) => host.taskWorktreeGet(...args),
       ...hostOverrides,

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
@@ -101,6 +101,16 @@ export const createTestDependencies = (
   runtimeHostOverrides: Partial<OrchestratorDependencies["runtimeHostPort"]> = {},
   liveSessionHostOverrides: Partial<OrchestratorDependencies["liveSessionHostPort"]> = {},
 ): OrchestratorDependencies => {
+  const agentSessionsList = hostOverrides.agentSessionsList ?? (async () => []);
+  const agentSessionsListForTasks =
+    hostOverrides.agentSessionsListForTasks ??
+    (async (repoPath, taskIds) =>
+      Promise.all(
+        taskIds.map(async (taskId) => ({
+          taskId,
+          agentSessions: await agentSessionsList(repoPath, taskId),
+        })),
+      ));
   return {
     queryClient: new QueryClient({
       defaultOptions: {
@@ -110,6 +120,8 @@ export const createTestDependencies = (
     }),
     hostPort: {
       agentSessionDelete: async () => undefined,
+      agentSessionsList,
+      agentSessionsListForTasks,
       agentSessionUpsert: (...args) => host.agentSessionUpsert(...args),
       taskWorktreeGet: (...args) => host.taskWorktreeGet(...args),
       ...hostOverrides,
@@ -227,6 +239,19 @@ export const createHookHarness = (args: {
   dependencies?: OrchestratorDependencies;
 }) => {
   let latest: OrchestratorHookState | null = null;
+  const dependencies =
+    args.dependencies ??
+    createTestDependencies(
+      {
+        agentSessionsList: (repoPath, taskId) => host.agentSessionsList(repoPath, taskId),
+        agentSessionUpsert: (repoPath, taskId, record) =>
+          host.agentSessionUpsert(repoPath, taskId, record),
+        taskWorktreeGet: (repoPath, taskId) => host.taskWorktreeGet(repoPath, taskId),
+      },
+      {
+        runtimeEnsure: (...runtimeEnsureArgs) => host.runtimeEnsure(...runtimeEnsureArgs),
+      },
+    );
   let currentArgs = {
     ...args,
     activeWorkspace: args.activeWorkspace ?? createDefaultActiveWorkspace(args.activeRepo),
@@ -235,7 +260,7 @@ export const createHookHarness = (args: {
       opencode: createRepoRuntimeHealthFixture(),
     },
     agentEngine: args.agentEngine ?? (new OpencodeSdkAdapter() as AgentEnginePort),
-    dependencies: args.dependencies ?? createTestDependencies(),
+    dependencies,
   };
 
   const Harness = () => {

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
@@ -110,6 +110,7 @@ export const createTestDependencies = (
     }),
     hostPort: {
       agentSessionDelete: async () => undefined,
+      agentSessionsList: async () => [],
       agentSessionUpsert: (...args) => host.agentSessionUpsert(...args),
       taskWorktreeGet: (...args) => host.taskWorktreeGet(...args),
       ...hostOverrides,

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
@@ -101,16 +101,6 @@ export const createTestDependencies = (
   runtimeHostOverrides: Partial<OrchestratorDependencies["runtimeHostPort"]> = {},
   liveSessionHostOverrides: Partial<OrchestratorDependencies["liveSessionHostPort"]> = {},
 ): OrchestratorDependencies => {
-  const agentSessionsList = hostOverrides.agentSessionsList ?? (async () => []);
-  const agentSessionsListForTasks =
-    hostOverrides.agentSessionsListForTasks ??
-    (async (repoPath, taskIds) =>
-      Promise.all(
-        taskIds.map(async (taskId) => ({
-          taskId,
-          agentSessions: await agentSessionsList(repoPath, taskId),
-        })),
-      ));
   return {
     queryClient: new QueryClient({
       defaultOptions: {
@@ -120,8 +110,8 @@ export const createTestDependencies = (
     }),
     hostPort: {
       agentSessionDelete: async () => undefined,
-      agentSessionsList,
-      agentSessionsListForTasks,
+      agentSessionsList: async () => [],
+      agentSessionsListForTasks: async () => [],
       agentSessionUpsert: (...args) => host.agentSessionUpsert(...args),
       taskWorktreeGet: (...args) => host.taskWorktreeGet(...args),
       ...hostOverrides,
@@ -244,6 +234,8 @@ export const createHookHarness = (args: {
     createTestDependencies(
       {
         agentSessionsList: (repoPath, taskId) => host.agentSessionsList(repoPath, taskId),
+        agentSessionsListForTasks: (repoPath, taskIds) =>
+          host.agentSessionsListForTasks(repoPath, taskIds),
         agentSessionUpsert: (repoPath, taskId, record) =>
           host.agentSessionUpsert(repoPath, taskId, record),
         taskWorktreeGet: (repoPath, taskId) => host.taskWorktreeGet(repoPath, taskId),

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test-harness.tsx
@@ -110,7 +110,6 @@ export const createTestDependencies = (
     }),
     hostPort: {
       agentSessionDelete: async () => undefined,
-      agentSessionsList: async () => [],
       agentSessionUpsert: (...args) => host.agentSessionUpsert(...args),
       taskWorktreeGet: (...args) => host.taskWorktreeGet(...args),
       ...hostOverrides,

--- a/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -230,6 +230,7 @@ export function useAgentOrchestratorOperations({
     transcriptEvents,
     recoverTranscriptGap,
     queryClient,
+    sessionReadPort: hostPort,
   });
   const ensureRuntime = useMemo(
     () =>

--- a/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
+++ b/packages/frontend/src/state/operations/tasks/task-chat-draft-cleanup.ts
@@ -6,7 +6,10 @@ import {
   clearAgentChatDraftsForTargets,
 } from "@/components/features/agents/agent-chat/agent-chat-draft-store";
 import { errorMessage } from "@/lib/errors";
-import { loadAgentSessionListsFromQuery } from "../../queries/agent-sessions";
+import {
+  type AgentSessionReadPort,
+  loadAgentSessionListsFromQuery,
+} from "../../queries/agent-sessions";
 
 export type TaskChatDraftCleanupPlan = {
   targets: AgentChatDraftCleanupTarget[];
@@ -17,6 +20,7 @@ type TaskChatDraftCleanupInput = {
   repoPath: string;
   workspaceId: string | null;
   taskIds: string[];
+  agentSessionReadPort: AgentSessionReadPort;
 };
 
 type RunTaskMutationWithChatDraftCleanupInput<TResult> = TaskChatDraftCleanupInput & {
@@ -35,6 +39,7 @@ export const prepareTaskChatDraftCleanupTargets = async ({
   repoPath,
   workspaceId,
   taskIds,
+  agentSessionReadPort,
 }: TaskChatDraftCleanupInput): Promise<TaskChatDraftCleanupPlan> => {
   if (!workspaceId) {
     throw new Error("Cannot clean chat drafts without an active workspace id.");
@@ -46,6 +51,7 @@ export const prepareTaskChatDraftCleanupTargets = async ({
     taskIds,
     {
       forceFresh: true,
+      readPort: agentSessionReadPort,
     },
   );
   const targets = new Map<string, AgentChatDraftCleanupTarget>();
@@ -86,6 +92,7 @@ export const runTaskMutationWithChatDraftCleanup = async <TResult>({
   repoPath,
   workspaceId,
   taskIds,
+  agentSessionReadPort,
   mutation,
   shouldCleanup = () => true,
 }: RunTaskMutationWithChatDraftCleanupInput<TResult>): Promise<TResult> => {
@@ -97,6 +104,7 @@ export const runTaskMutationWithChatDraftCleanup = async <TResult>({
       repoPath,
       workspaceId,
       taskIds,
+      agentSessionReadPort,
     });
   } catch (error) {
     cleanupTargetLookupError = error;

--- a/packages/frontend/src/state/operations/tasks/task-operations-types.ts
+++ b/packages/frontend/src/state/operations/tasks/task-operations-types.ts
@@ -7,10 +7,12 @@ import type {
   TaskUpdatePatch,
 } from "@openducktor/contracts";
 import type { TaskDataRefreshOptions, TaskRefreshOptions } from "@/state/app-state-contexts";
+import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
 import type { ActiveWorkspace } from "@/types/state-slices";
 
 export type UseTaskOperationsArgs = {
   activeWorkspace: ActiveWorkspace | null;
+  agentSessionReadPort?: AgentSessionReadPort;
 };
 
 export type UseTaskOperationsResult = {

--- a/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
@@ -8,6 +8,7 @@ import type {
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { taskWorktreeQueryKeys } from "@/state/queries/build-runtime";
+import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
 import { host } from "../shared/host";
 import { runTaskMutationWithChatDraftCleanup } from "./task-chat-draft-cleanup";
 import { collectTaskDeletionIds } from "./task-deletion-ids";
@@ -23,6 +24,7 @@ type UseTaskMutationCommandsArgs = {
   activeWorkspaceId: string | null;
   tasks: TaskCard[];
   runTaskMutation: TaskMutationRunner["runTaskMutation"];
+  agentSessionReadPort: AgentSessionReadPort;
 };
 
 export type TaskMutationCommands = {
@@ -41,6 +43,7 @@ export function useTaskMutationCommands({
   activeWorkspaceId,
   tasks,
   runTaskMutation,
+  agentSessionReadPort,
 }: UseTaskMutationCommandsArgs): TaskMutationCommands {
   const queryClient = useQueryClient();
 
@@ -106,6 +109,7 @@ export function useTaskMutationCommands({
             repoPath,
             workspaceId: activeWorkspaceId,
             taskIds: taskIdsToRemove,
+            agentSessionReadPort,
             mutation: async () => {
               await host.taskDelete(repoPath, taskId, deleteSubtasks);
               await Promise.all(
@@ -126,7 +130,7 @@ export function useTaskMutationCommands({
         failureTitle: "Failed to delete task",
       });
     },
-    [activeWorkspaceId, queryClient, runTaskMutation, tasks],
+    [activeWorkspaceId, agentSessionReadPort, queryClient, runTaskMutation, tasks],
   );
 
   const closeTask = useCallback(
@@ -139,6 +143,7 @@ export function useTaskMutationCommands({
             repoPath,
             workspaceId: activeWorkspaceId,
             taskIds: [taskId],
+            agentSessionReadPort,
             mutation: async () => {
               await host.taskClose(repoPath, taskId);
               await queryClient.invalidateQueries({
@@ -152,7 +157,7 @@ export function useTaskMutationCommands({
         failureTitle: "Failed to close task",
       });
     },
-    [activeWorkspaceId, queryClient, runTaskMutation],
+    [activeWorkspaceId, agentSessionReadPort, queryClient, runTaskMutation],
   );
 
   const transitionTask = useCallback(
@@ -170,6 +175,7 @@ export function useTaskMutationCommands({
             repoPath,
             workspaceId: activeWorkspaceId,
             taskIds: [taskId],
+            agentSessionReadPort,
             mutation: async () => {
               await host.taskTransition(repoPath, taskId, status, reason);
             },
@@ -179,7 +185,7 @@ export function useTaskMutationCommands({
         failureTitle: "Failed to transition task",
       });
     },
-    [activeWorkspaceId, queryClient, runTaskMutation],
+    [activeWorkspaceId, agentSessionReadPort, queryClient, runTaskMutation],
   );
 
   const humanApproveTask = useCallback(
@@ -192,6 +198,7 @@ export function useTaskMutationCommands({
             repoPath,
             workspaceId: activeWorkspaceId,
             taskIds: [taskId],
+            agentSessionReadPort,
             mutation: async () => {
               await host.humanApprove(repoPath, taskId);
             },
@@ -202,7 +209,7 @@ export function useTaskMutationCommands({
         failureTitle: "Failed to approve task",
       });
     },
-    [activeWorkspaceId, queryClient, runTaskMutation],
+    [activeWorkspaceId, agentSessionReadPort, queryClient, runTaskMutation],
   );
 
   const humanRequestChangesTask = useCallback(

--- a/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
@@ -115,26 +115,27 @@ export function useTaskMutationCommands({
             agentSessionReadPort,
             mutation: async () => {
               await host.taskDelete(repoPath, taskId, deleteSubtasks);
-              await Promise.all(
-                taskIdsToRemove.map((deletedTaskId) =>
-                  queryClient.invalidateQueries({
-                    queryKey: taskWorktreeQueryKeys.taskWorktree({
-                      repoPath,
-                      taskId: deletedTaskId,
-                    }),
-                  }),
-                ),
-              );
             },
           });
-          await removeAgentSessionListQueries(queryClient, repoPath, taskIdsToRemove);
         },
         successTitle: "Task deleted",
         successDescription: taskId,
         failureTitle: "Failed to delete task",
       });
+      const repoPath = requireActiveRepo(activeRepoPath);
+      await Promise.all([
+        removeAgentSessionListQueries(queryClient, repoPath, taskIdsToRemove),
+        ...taskIdsToRemove.map((deletedTaskId) =>
+          queryClient.invalidateQueries({
+            queryKey: taskWorktreeQueryKeys.taskWorktree({
+              repoPath,
+              taskId: deletedTaskId,
+            }),
+          }),
+        ),
+      ]);
     },
-    [activeWorkspaceId, agentSessionReadPort, queryClient, runTaskMutation, tasks],
+    [activeRepoPath, activeWorkspaceId, agentSessionReadPort, queryClient, runTaskMutation, tasks],
   );
 
   const closeTask = useCallback(

--- a/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
@@ -7,7 +7,10 @@ import type {
 } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
+import {
+  type AgentSessionReadPort,
+  removeAgentSessionListQueries,
+} from "@/state/queries/agent-sessions";
 import { taskWorktreeQueryKeys } from "@/state/queries/build-runtime";
 import { host } from "../shared/host";
 import { runTaskMutationWithChatDraftCleanup } from "./task-chat-draft-cleanup";
@@ -124,6 +127,7 @@ export function useTaskMutationCommands({
               );
             },
           });
+          await removeAgentSessionListQueries(queryClient, repoPath, taskIdsToRemove);
         },
         successTitle: "Task deleted",
         successDescription: taskId,

--- a/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-mutation-commands.ts
@@ -7,8 +7,8 @@ import type {
 } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { taskWorktreeQueryKeys } from "@/state/queries/build-runtime";
 import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
+import { taskWorktreeQueryKeys } from "@/state/queries/build-runtime";
 import { host } from "../shared/host";
 import { runTaskMutationWithChatDraftCleanup } from "./task-chat-draft-cleanup";
 import { collectTaskDeletionIds } from "./task-deletion-ids";

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -1833,8 +1833,12 @@ describe("use-task-operations", () => {
 
   test("deleteTask removes cached task documents for deleted tasks and subtasks", async () => {
     let isDeleted = false;
+    let deletePromise: Promise<void> | null = null;
+    const taskDeleted = createDeferred<void>();
+    const deletedTasksList = createDeferred<TaskCard[]>();
     const taskDelete = mock(async () => {
       isDeleted = true;
+      taskDeleted.resolve();
       return { ok: true };
     });
     const agentSessionsListForTasks = mock(async () => [
@@ -1857,9 +1861,12 @@ describe("use-task-operations", () => {
         ],
       },
     ]);
-    const tasksList = mock(async () =>
-      isDeleted ? [] : [{ ...makeTask("A", "open"), subtaskIds: ["B"] }, makeTask("B", "open")],
-    );
+    const tasksList = mock(async () => {
+      if (isDeleted) {
+        return deletedTasksList.promise;
+      }
+      return [{ ...makeTask("A", "open"), subtaskIds: ["B"] }, makeTask("B", "open")];
+    });
     const runsList = mock(async (): Promise<RunSummary[]> => []);
 
     const original = {
@@ -1925,13 +1932,32 @@ describe("use-task-operations", () => {
 
       await harness.mount();
       await harness.waitFor(() => latest?.tasks.length === 2);
-      await harness.run(async () => {
-        if (!latest) {
-          throw new Error("Hook not mounted");
-        }
+      const operations = latest as ReturnType<typeof useTaskOperations> | null;
+      if (!operations) {
+        throw new Error("Hook not mounted");
+      }
+      deletePromise = operations.deleteTask("A", true);
+      await taskDeleted.promise;
 
-        await latest.deleteTask("A", true);
-      });
+      expect(
+        queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "A")),
+      ).toEqual([
+        buildAgentSessionRecord({
+          externalSessionId: "session-shared",
+          workingDirectory: "/repo/parent",
+        }),
+      ]);
+      expect(
+        queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "B")),
+      ).toEqual([
+        buildAgentSessionRecord({
+          externalSessionId: "session-b",
+          workingDirectory: "/repo/child",
+        }),
+      ]);
+
+      deletedTasksList.resolve([]);
+      await deletePromise;
 
       await harness.waitFor(
         () =>
@@ -1951,6 +1977,8 @@ describe("use-task-operations", () => {
       expect(queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "A"))).toBeUndefined();
       expect(queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "B"))).toBeUndefined();
     } finally {
+      deletedTasksList.resolve([]);
+      await deletePromise?.catch(() => undefined);
       await harness.unmount();
       host.taskDelete = original.taskDelete;
       host.tasksList = original.tasksList;

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -751,9 +751,16 @@ describe("use-task-operations", () => {
   });
 
   test("reset operations report refresh failures without rejecting successful mutations", async () => {
-    const taskResetImplementation = mock(async () => makeTask("A", "ready_for_dev"));
-    const taskReset = mock(async () => makeTask("A", "open"));
-    const tasksList = mock(async () => [makeTask("A", "in_progress")]);
+    let currentStatus: TaskCard["status"] = "in_progress";
+    const taskResetImplementation = mock(async () => {
+      currentStatus = "ready_for_dev";
+      return makeTask("A", currentStatus);
+    });
+    const taskReset = mock(async () => {
+      currentStatus = "open";
+      return makeTask("A", currentStatus);
+    });
+    const tasksList = mock(async () => [makeTask("A", currentStatus)]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
     const toastError = mock(() => {});
     const original = {
@@ -807,7 +814,9 @@ describe("use-task-operations", () => {
       await expect(
         harness.run(() => getLatest().resetTaskImplementation("A")),
       ).resolves.toBeUndefined();
+      await harness.waitFor(() => getLatest().tasks[0]?.status === "ready_for_dev");
       await expect(harness.run(() => getLatest().resetTask("A"))).resolves.toBeUndefined();
+      await harness.waitFor(() => getLatest().tasks[0]?.status === "open");
 
       expect(toastError).toHaveBeenCalledWith("Implementation reset, but metadata refresh failed", {
         description: "/repo · A: metadata unavailable",
@@ -815,6 +824,7 @@ describe("use-task-operations", () => {
       expect(toastError).toHaveBeenCalledWith("Task reset, but metadata refresh failed", {
         description: "/repo · A: metadata unavailable",
       });
+      expect(getLatest().tasks[0]?.status).toBe("open");
     } finally {
       await harness.unmount();
       queryClient.clear();

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/test-utils/shared-test-fixtures";
 import type { AgentSessionIdentity, AgentSessionState } from "@/types/agent-orchestrator";
 import type { ActiveWorkspace } from "@/types/state-slices";
-import { agentSessionQueryKeys } from "../../queries/agent-sessions";
+import { type AgentSessionReadPort, agentSessionQueryKeys } from "../../queries/agent-sessions";
 import { documentQueryKeys } from "../../queries/documents";
 import { repoTaskDataQueryOptions, taskQueryKeys } from "../../queries/tasks";
 import { workspaceQueryKeys } from "../../queries/workspace";
@@ -214,10 +214,10 @@ const createActiveWorkspace = (repoPath: string): ActiveWorkspace => ({
   repoPath,
 });
 
-const testAgentSessionReadPort = {
-  agentSessionsList: (repoPath: string, taskId: string) => host.agentSessionsList(repoPath, taskId),
-  agentSessionsListForTasks: (repoPath: string, taskIds: string[]) =>
-    host.agentSessionsListForTasks(repoPath, taskIds),
+const testAgentSessionReadPort: AgentSessionReadPort = {
+  agentSessionsList: async () => [],
+  agentSessionsListForTasks: async (_repoPath, taskIds) =>
+    taskIds.map((taskId) => ({ taskId, agentSessions: [] })),
 };
 
 const normalizeHookArgs = ({
@@ -757,14 +757,12 @@ describe("use-task-operations", () => {
 
     const original = {
       taskReset: host.taskReset,
-      agentSessionsList: host.agentSessionsList,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       taskDocumentGet: host.taskDocumentGet,
       taskDocumentGetFresh: host.taskDocumentGetFresh,
     };
     host.taskReset = taskReset;
-    host.agentSessionsList = agentSessionsList;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     host.taskDocumentGet = (async () => ({
@@ -806,6 +804,11 @@ describe("use-task-operations", () => {
       {
         args: {
           activeWorkspace: createActiveWorkspace("/repo"),
+          agentSessionReadPort: {
+            agentSessionsList,
+            agentSessionsListForTasks: async (_repoPath, taskIds) =>
+              taskIds.map((taskId) => ({ taskId, agentSessions: [] })),
+          },
           refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
         },
       },
@@ -864,7 +867,6 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskReset = original.taskReset;
-      host.agentSessionsList = original.agentSessionsList;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       host.taskDocumentGet = original.taskDocumentGet;
@@ -1862,12 +1864,10 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskDelete = taskDelete;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -1888,6 +1888,12 @@ describe("use-task-operations", () => {
       {
         args: {
           activeWorkspace: createActiveWorkspace("/repo"),
+          agentSessionReadPort: {
+            agentSessionsList: async () => {
+              throw new Error("Exact session reads are not expected during deletion cleanup.");
+            },
+            agentSessionsListForTasks,
+          },
           refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
         },
       },
@@ -1942,10 +1948,11 @@ describe("use-task-operations", () => {
       expect(storage.getItem(toAgentChatDraftStorageKey(unrelatedDraftIdentity))).not.toBeNull();
       expect(queryClient.getQueryData(documentQueryKeys.spec("/repo", "A"))).toBeUndefined();
       expect(queryClient.getQueryData(documentQueryKeys.plan("/repo", "B"))).toBeUndefined();
+      expect(queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "A"))).toBeUndefined();
+      expect(queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "B"))).toBeUndefined();
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
     }
@@ -1967,13 +1974,11 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
     };
     host.taskDelete = taskDelete;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
@@ -1985,6 +1990,10 @@ describe("use-task-operations", () => {
 
     const harness = createHookHarness({
       activeRepo: "/repo",
+      agentSessionReadPort: {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks,
+      },
       refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
     });
 
@@ -2003,7 +2012,6 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2028,13 +2036,11 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
     };
     host.taskDelete = taskDelete;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
@@ -2050,6 +2056,10 @@ describe("use-task-operations", () => {
 
     const harness = createHookHarness({
       activeRepo: "/repo",
+      agentSessionReadPort: {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks,
+      },
       refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
     });
 
@@ -2069,7 +2079,6 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2089,19 +2098,21 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
     };
     host.taskDelete = taskDelete;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
 
     const harness = createHookHarness({
       activeRepo: "/repo",
+      agentSessionReadPort: {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks,
+      },
       refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
     });
 
@@ -2121,7 +2132,6 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2143,7 +2153,6 @@ describe("use-task-operations", () => {
       taskClose: host.taskClose,
       humanApprove: host.humanApprove,
       taskTransition: host.taskTransition,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
@@ -2151,13 +2160,16 @@ describe("use-task-operations", () => {
     host.taskClose = taskClose;
     host.humanApprove = humanApprove;
     host.taskTransition = taskTransition;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
 
     const harness = createHookHarness({
       activeRepo: "/repo",
+      agentSessionReadPort: {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks,
+      },
       refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
     });
 
@@ -2188,7 +2200,6 @@ describe("use-task-operations", () => {
       host.taskClose = original.taskClose;
       host.humanApprove = original.humanApprove;
       host.taskTransition = original.taskTransition;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2212,12 +2223,10 @@ describe("use-task-operations", () => {
 
     const original = {
       taskClose: host.taskClose,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskClose = taskClose;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -2238,6 +2247,10 @@ describe("use-task-operations", () => {
       {
         args: {
           activeWorkspace: createActiveWorkspace("/repo"),
+          agentSessionReadPort: {
+            agentSessionsList: async () => [],
+            agentSessionsListForTasks,
+          },
           refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
         },
       },
@@ -2274,7 +2287,6 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskClose = original.taskClose;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
     }
@@ -2740,13 +2752,11 @@ describe("use-task-operations", () => {
     const original = {
       taskPullRequestDetect: host.taskPullRequestDetect,
       taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -2757,6 +2767,10 @@ describe("use-task-operations", () => {
 
     const harness = createHookHarness({
       activeRepo: "/repo",
+      agentSessionReadPort: {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks,
+      },
       refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
     });
 
@@ -2800,7 +2814,6 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.success = originalToastSuccess;
@@ -2834,20 +2847,22 @@ describe("use-task-operations", () => {
     const original = {
       taskPullRequestDetect: host.taskPullRequestDetect,
       taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
     };
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
 
     const harness = createHookHarness({
       activeRepo: "/repo",
+      agentSessionReadPort: {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks,
+      },
       refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
     });
 
@@ -2871,7 +2886,6 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2906,18 +2920,20 @@ describe("use-task-operations", () => {
     const original = {
       taskPullRequestDetect: host.taskPullRequestDetect,
       taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
-      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
-    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
     const harness = createTaskAndKanbanHarness({
       activeRepo: "/repo",
+      agentSessionReadPort: {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks,
+      },
       refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
     });
 
@@ -2971,7 +2987,6 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
-      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
     }

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -216,13 +216,8 @@ const createActiveWorkspace = (repoPath: string): ActiveWorkspace => ({
 
 const testAgentSessionReadPort = {
   agentSessionsList: (repoPath: string, taskId: string) => host.agentSessionsList(repoPath, taskId),
-  agentSessionsListForTasks: async (repoPath: string, taskIds: string[]) =>
-    Promise.all(
-      taskIds.map(async (taskId) => ({
-        taskId,
-        agentSessions: await host.agentSessionsList(repoPath, taskId),
-      })),
-    ),
+  agentSessionsListForTasks: (repoPath: string, taskIds: string[]) =>
+    host.agentSessionsListForTasks(repoPath, taskIds),
 };
 
 const normalizeHookArgs = ({
@@ -750,104 +745,6 @@ describe("use-task-operations", () => {
     }
   });
 
-  test("reset operations report refresh failures without rejecting successful mutations", async () => {
-    let currentStatus: TaskCard["status"] = "in_progress";
-    let failTaskRefresh = false;
-    const taskResetImplementation = mock(async () => {
-      currentStatus = "ready_for_dev";
-      return makeTask("A", currentStatus);
-    });
-    const taskReset = mock(async () => {
-      currentStatus = "open";
-      return makeTask("A", currentStatus);
-    });
-    const tasksList = mock(async () => {
-      if (failTaskRefresh) {
-        throw new Error("task state unavailable");
-      }
-      return [makeTask("A", currentStatus)];
-    });
-    const runsList = mock(async (): Promise<RunSummary[]> => []);
-    const toastError = mock(() => {});
-    const original = {
-      taskResetImplementation: host.taskResetImplementation,
-      taskReset: host.taskReset,
-      tasksList: host.tasksList,
-      runsList: legacyHost.runsList,
-      toastError: toast.error,
-    };
-    host.taskResetImplementation = taskResetImplementation;
-    host.taskReset = taskReset;
-    host.tasksList = tasksList;
-    legacyHost.runsList = runsList;
-    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
-    const queryClient = createQueryClient();
-    const originalInvalidateQueries = queryClient.invalidateQueries.bind(queryClient);
-    queryClient.invalidateQueries = mock(async (filters, options) => {
-      if (
-        JSON.stringify(filters.queryKey) ===
-        JSON.stringify(agentSessionQueryKeys.list("/repo", "A"))
-      ) {
-        throw new Error("metadata unavailable");
-      }
-      return originalInvalidateQueries(filters, options);
-    }) as typeof queryClient.invalidateQueries;
-    let latest: ReturnType<typeof useTaskOperations> | null = null;
-    const Harness = () => {
-      latest = useTaskOperations(
-        normalizeHookArgs({
-          activeRepo: "/repo",
-          refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
-        }),
-      );
-      return null;
-    };
-    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
-    const harness = createSharedHookHarness(Harness, undefined, { wrapper });
-    const getLatest = () => {
-      if (!latest) {
-        throw new Error("Hook not mounted");
-      }
-      return latest;
-    };
-
-    try {
-      await harness.mount();
-      await harness.waitFor(() => getLatest().tasks[0]?.status === "in_progress");
-
-      await expect(
-        harness.run(() => getLatest().resetTaskImplementation("A")),
-      ).resolves.toBeUndefined();
-      await harness.waitFor(() => getLatest().tasks[0]?.status === "ready_for_dev");
-      await expect(harness.run(() => getLatest().resetTask("A"))).resolves.toBeUndefined();
-      await harness.waitFor(() => getLatest().tasks[0]?.status === "open");
-      failTaskRefresh = true;
-      await expect(harness.run(() => getLatest().resetTask("A"))).resolves.toBeUndefined();
-
-      expect(toastError).toHaveBeenCalledWith("Implementation reset, but metadata refresh failed", {
-        description: "/repo · A: metadata unavailable",
-      });
-      expect(toastError).toHaveBeenCalledWith("Task reset, but metadata refresh failed", {
-        description: "/repo · A: metadata unavailable",
-      });
-      expect(toastError).toHaveBeenCalledWith("Task reset, but metadata refresh failed", {
-        description:
-          "/repo · A: Post-reset metadata refreshes failed: metadata unavailable; task state unavailable",
-      });
-      expect(getLatest().tasks[0]?.status).toBe("open");
-    } finally {
-      await harness.unmount();
-      queryClient.clear();
-      host.taskResetImplementation = original.taskResetImplementation;
-      host.taskReset = original.taskReset;
-      host.tasksList = original.tasksList;
-      legacyHost.runsList = original.runsList;
-      toast.error = original.toastError;
-    }
-  });
-
   test("resetTask refreshes task data after host reset completes", async () => {
     let currentStatus: TaskCard["status"] = "human_review";
     const taskReset = mock(async () => {
@@ -856,15 +753,18 @@ describe("use-task-operations", () => {
     });
     const tasksList = mock(async () => [makeTask("A", currentStatus)]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const agentSessionsList = mock(async () => []);
 
     const original = {
       taskReset: host.taskReset,
+      agentSessionsList: host.agentSessionsList,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       taskDocumentGet: host.taskDocumentGet,
       taskDocumentGetFresh: host.taskDocumentGetFresh,
     };
     host.taskReset = taskReset;
+    host.agentSessionsList = agentSessionsList;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     host.taskDocumentGet = (async () => ({
@@ -937,14 +837,15 @@ describe("use-task-operations", () => {
 
       expect(taskReset).toHaveBeenCalledWith("/repo", "A");
       expect(getLatest().tasks[0]?.status).toBe("open");
-      expect(invalidateQueriesMock).toHaveBeenCalledWith(
-        {
-          queryKey: agentSessionQueryKeys.list("/repo", "A"),
-          exact: true,
-          refetchType: "all",
-        },
-        { throwOnError: true },
-      );
+      expect(invalidateQueriesMock).toHaveBeenCalledWith({
+        queryKey: agentSessionQueryKeys.list("/repo", "A"),
+        exact: true,
+        refetchType: "none",
+      });
+      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(
+        queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "A")),
+      ).toEqual([]);
       expect(invalidateQueriesMock).toHaveBeenCalledWith({
         queryKey: documentQueryKeys.qaReport("/repo", "A"),
         exact: true,
@@ -963,6 +864,7 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskReset = original.taskReset;
+      host.agentSessionsList = original.agentSessionsList;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       host.taskDocumentGet = original.taskDocumentGet;
@@ -1933,25 +1835,26 @@ describe("use-task-operations", () => {
       isDeleted = true;
       return { ok: true };
     });
-    const agentSessionsList = mock(async (_repoPath: string, taskId: string) => {
-      if (taskId === "A") {
-        return [
+    const agentSessionsListForTasks = mock(async () => [
+      {
+        taskId: "A",
+        agentSessions: [
           buildAgentSessionRecord({
             externalSessionId: "session-shared",
             workingDirectory: "/repo/parent",
           }),
-        ];
-      }
-      if (taskId === "B") {
-        return [
+        ],
+      },
+      {
+        taskId: "B",
+        agentSessions: [
           buildAgentSessionRecord({
             externalSessionId: "session-b",
             workingDirectory: "/repo/child",
           }),
-        ];
-      }
-      return [];
-    });
+        ],
+      },
+    ]);
     const tasksList = mock(async () =>
       isDeleted ? [] : [{ ...makeTask("A", "open"), subtaskIds: ["B"] }, makeTask("B", "open")],
     );
@@ -1959,12 +1862,12 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskDelete = taskDelete;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -2033,8 +1936,7 @@ describe("use-task-operations", () => {
       );
 
       expect(taskDelete).toHaveBeenCalledWith("/repo", "A", true);
-      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
-      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "B");
+      expect(agentSessionsListForTasks).toHaveBeenCalledWith("/repo", ["A", "B"]);
       expect(storage.getItem(toAgentChatDraftStorageKey(parentDraftIdentity))).toBeNull();
       expect(storage.getItem(toAgentChatDraftStorageKey(childDraftIdentity))).toBeNull();
       expect(storage.getItem(toAgentChatDraftStorageKey(unrelatedDraftIdentity))).not.toBeNull();
@@ -2043,7 +1945,7 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
     }
@@ -2053,8 +1955,11 @@ describe("use-task-operations", () => {
     const taskDelete = mock(async () => {
       throw new Error("delete failed");
     });
-    const agentSessionsList = mock(async () => [
-      buildAgentSessionRecord({ externalSessionId: "session-a" }),
+    const agentSessionsListForTasks = mock(async () => [
+      {
+        taskId: "A",
+        agentSessions: [buildAgentSessionRecord({ externalSessionId: "session-a" })],
+      },
     ]);
     const tasksList = mock(async () => [makeTask("A", "open")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
@@ -2062,13 +1967,13 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
     };
     host.taskDelete = taskDelete;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
@@ -2093,12 +1998,12 @@ describe("use-task-operations", () => {
         }),
       ).rejects.toThrow("delete failed");
 
-      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(agentSessionsListForTasks).toHaveBeenCalledWith("/repo", ["A"]);
       expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).not.toBeNull();
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2111,8 +2016,11 @@ describe("use-task-operations", () => {
       isDeleted = true;
       return { ok: true };
     });
-    const agentSessionsList = mock(async () => [
-      buildAgentSessionRecord({ externalSessionId: "session-a" }),
+    const agentSessionsListForTasks = mock(async () => [
+      {
+        taskId: "A",
+        agentSessions: [buildAgentSessionRecord({ externalSessionId: "session-a" })],
+      },
     ]);
     const tasksList = mock(async () => (isDeleted ? [] : [makeTask("A", "open")]));
     const runsList = mock(async (): Promise<RunSummary[]> => []);
@@ -2120,13 +2028,13 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
     };
     host.taskDelete = taskDelete;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
@@ -2153,7 +2061,7 @@ describe("use-task-operations", () => {
         await value.deleteTask("A");
       });
 
-      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(agentSessionsListForTasks).toHaveBeenCalledWith("/repo", ["A"]);
       expect(taskDelete).toHaveBeenCalledWith("/repo", "A", false);
       expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
         description: "Failed to clean 1 chat draft storage key(s).",
@@ -2161,7 +2069,7 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2172,7 +2080,7 @@ describe("use-task-operations", () => {
     const taskDelete = mock(async () => {
       return { ok: true };
     });
-    const agentSessionsList = mock(async () => {
+    const agentSessionsListForTasks = mock(async () => {
       throw new Error("session lookup failed");
     });
     const tasksList = mock(async () => [makeTask("A", "open")]);
@@ -2181,13 +2089,13 @@ describe("use-task-operations", () => {
 
     const original = {
       taskDelete: host.taskDelete,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
     };
     host.taskDelete = taskDelete;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
@@ -2205,7 +2113,7 @@ describe("use-task-operations", () => {
         await value.deleteTask("A");
       });
 
-      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(agentSessionsListForTasks).toHaveBeenCalledWith("/repo", ["A"]);
       expect(taskDelete).toHaveBeenCalledWith("/repo", "A", false);
       expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
         description: "session lookup failed",
@@ -2213,7 +2121,7 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.taskDelete = original.taskDelete;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2224,7 +2132,7 @@ describe("use-task-operations", () => {
     const taskClose = mock(async () => makeTask("A", "closed"));
     const humanApprove = mock(async () => makeTask("A", "closed"));
     const taskTransition = mock(async () => makeTask("A", "closed"));
-    const agentSessionsList = mock(async () => {
+    const agentSessionsListForTasks = mock(async () => {
       throw new Error("session lookup failed");
     });
     const tasksList = mock(async () => [makeTask("A", "human_review")]);
@@ -2235,7 +2143,7 @@ describe("use-task-operations", () => {
       taskClose: host.taskClose,
       humanApprove: host.humanApprove,
       taskTransition: host.taskTransition,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
@@ -2243,7 +2151,7 @@ describe("use-task-operations", () => {
     host.taskClose = taskClose;
     host.humanApprove = humanApprove;
     host.taskTransition = taskTransition;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
@@ -2267,7 +2175,7 @@ describe("use-task-operations", () => {
         await value.transitionTask("A", "closed");
       });
 
-      expect(agentSessionsList).toHaveBeenCalledTimes(3);
+      expect(agentSessionsListForTasks).toHaveBeenCalledTimes(3);
       expect(taskClose).toHaveBeenCalledWith("/repo", "A");
       expect(humanApprove).toHaveBeenCalledWith("/repo", "A");
       expect(taskTransition).toHaveBeenCalledWith("/repo", "A", "closed", undefined);
@@ -2280,7 +2188,7 @@ describe("use-task-operations", () => {
       host.taskClose = original.taskClose;
       host.humanApprove = original.humanApprove;
       host.taskTransition = original.taskTransition;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2293,20 +2201,23 @@ describe("use-task-operations", () => {
       isClosed = true;
       return makeTask("A", "closed");
     });
-    const agentSessionsList = mock(async () => [
-      buildAgentSessionRecord({ externalSessionId: "session-a" }),
+    const agentSessionsListForTasks = mock(async () => [
+      {
+        taskId: "A",
+        agentSessions: [buildAgentSessionRecord({ externalSessionId: "session-a" })],
+      },
     ]);
     const tasksList = mock(async () => [makeTask("A", isClosed ? "closed" : "in_progress")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
 
     const original = {
       taskClose: host.taskClose,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskClose = taskClose;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -2358,12 +2269,12 @@ describe("use-task-operations", () => {
       );
 
       expect(taskClose).toHaveBeenCalledWith("/repo", "A");
-      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(agentSessionsListForTasks).toHaveBeenCalledWith("/repo", ["A"]);
       expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).toBeNull();
     } finally {
       await harness.unmount();
       host.taskClose = original.taskClose;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
     }
@@ -2817,8 +2728,11 @@ describe("use-task-operations", () => {
       },
     }));
     const taskPullRequestLinkMerged = mock(async () => makeTask("A", "closed"));
-    const agentSessionsList = mock(async () => [
-      buildAgentSessionRecord({ externalSessionId: "session-a" }),
+    const agentSessionsListForTasks = mock(async () => [
+      {
+        taskId: "A",
+        agentSessions: [buildAgentSessionRecord({ externalSessionId: "session-a" })],
+      },
     ]);
     const tasksList = mock(async () => [makeTask("A", "closed")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
@@ -2826,13 +2740,13 @@ describe("use-task-operations", () => {
     const original = {
       taskPullRequestDetect: host.taskPullRequestDetect,
       taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -2875,7 +2789,7 @@ describe("use-task-operations", () => {
         closedAt: "2026-02-20T10:00:00Z",
       });
       expect(tasksList).toHaveBeenCalledWith("/repo", 1);
-      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(agentSessionsListForTasks).toHaveBeenCalledWith("/repo", ["A"]);
       expect(storage.getItem(toAgentChatDraftStorageKey(draftIdentity))).toBeNull();
       expect(harness.getLatest().pendingMergedPullRequest).toBeNull();
       expect(harness.getLatest().linkingMergedPullRequestTaskId).toBeNull();
@@ -2886,7 +2800,7 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.success = originalToastSuccess;
@@ -2910,7 +2824,7 @@ describe("use-task-operations", () => {
       pullRequest: mergedPullRequest,
     }));
     const taskPullRequestLinkMerged = mock(async () => makeTask("A", "closed"));
-    const agentSessionsList = mock(async () => {
+    const agentSessionsListForTasks = mock(async () => {
       throw new Error("session lookup failed");
     });
     const tasksList = mock(async () => [makeTask("A", "human_review")]);
@@ -2920,14 +2834,14 @@ describe("use-task-operations", () => {
     const original = {
       taskPullRequestDetect: host.taskPullRequestDetect,
       taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
       toastError: toast.error,
     };
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
@@ -2947,7 +2861,7 @@ describe("use-task-operations", () => {
         await value.linkMergedPullRequest();
       });
 
-      expect(agentSessionsList).toHaveBeenCalledWith("/repo", "A");
+      expect(agentSessionsListForTasks).toHaveBeenCalledWith("/repo", ["A"]);
       expect(taskPullRequestLinkMerged).toHaveBeenCalledWith("/repo", "A", mergedPullRequest);
       expect(toastError).toHaveBeenCalledWith("Task updated, but chat draft cleanup failed", {
         description: "session lookup failed",
@@ -2957,7 +2871,7 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
       toast.error = original.toastError;
@@ -2985,20 +2899,20 @@ describe("use-task-operations", () => {
       currentStatus = "closed";
       return makeTask("A", currentStatus);
     });
-    const agentSessionsList = mock(async () => []);
+    const agentSessionsListForTasks = mock(async () => [{ taskId: "A", agentSessions: [] }]);
     const tasksList = mock(async () => [makeTask("A", currentStatus)]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
 
     const original = {
       taskPullRequestDetect: host.taskPullRequestDetect,
       taskPullRequestLinkMerged: host.taskPullRequestLinkMerged,
-      agentSessionsList: host.agentSessionsList,
+      agentSessionsListForTasks: host.agentSessionsListForTasks,
       tasksList: host.tasksList,
       runsList: legacyHost.runsList,
     };
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.taskPullRequestLinkMerged = taskPullRequestLinkMerged;
-    host.agentSessionsList = agentSessionsList;
+    host.agentSessionsListForTasks = agentSessionsListForTasks;
     host.tasksList = tasksList;
     legacyHost.runsList = runsList;
 
@@ -3057,7 +2971,7 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.taskPullRequestLinkMerged = original.taskPullRequestLinkMerged;
-      host.agentSessionsList = original.agentSessionsList;
+      host.agentSessionsListForTasks = original.agentSessionsListForTasks;
       host.tasksList = original.tasksList;
       legacyHost.runsList = original.runsList;
     }

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -82,7 +82,6 @@ const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 const originalToastSuccess = toast.success;
 const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
-const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
 
 const createSettingsSnapshotFixture = () => createSharedSettingsSnapshotFixture();
 
@@ -215,6 +214,17 @@ const createActiveWorkspace = (repoPath: string): ActiveWorkspace => ({
   repoPath,
 });
 
+const testAgentSessionReadPort = {
+  agentSessionsList: (repoPath: string, taskId: string) => host.agentSessionsList(repoPath, taskId),
+  agentSessionsListForTasks: async (repoPath: string, taskIds: string[]) =>
+    Promise.all(
+      taskIds.map(async (taskId) => ({
+        taskId,
+        agentSessions: await host.agentSessionsList(repoPath, taskId),
+      })),
+    ),
+};
+
 const normalizeHookArgs = ({
   activeWorkspace,
   activeRepo,
@@ -223,6 +233,7 @@ const normalizeHookArgs = ({
 }: LegacyHookArgs): HookArgs => ({
   ...rest,
   activeWorkspace: activeWorkspace ?? (activeRepo ? createActiveWorkspace(activeRepo) : null),
+  agentSessionReadPort: rest.agentSessionReadPort ?? testAgentSessionReadPort,
 });
 
 const createHookHarness = (initialArgs: LegacyHookArgs) => {
@@ -230,7 +241,7 @@ const createHookHarness = (initialArgs: LegacyHookArgs) => {
   let currentArgs = normalizeHookArgs(initialArgs);
 
   const Harness = ({ args }: { args: HookArgs }) => {
-    latest = useTaskOperations(args);
+    latest = useTaskOperations(normalizeHookArgs(args));
     return null;
   };
 
@@ -291,7 +302,7 @@ const createTaskAndKanbanHarness = (initialArgs: LegacyHookArgs, doneVisibleDays
   const currentArgs = normalizeHookArgs(initialArgs);
 
   const Harness = ({ args }: { args: HookArgs }) => {
-    const operations = useTaskOperations(args);
+    const operations = useTaskOperations(normalizeHookArgs(args));
     const activeRepoPath = args.activeWorkspace?.repoPath ?? null;
     const kanbanTaskListQuery = useQuery({
       ...repoTaskDataQueryOptions(activeRepoPath ?? "__disabled__", doneVisibleDays),
@@ -462,13 +473,6 @@ describe("use-task-operations", () => {
       (_message: string, _options?: { description?: string }) => "",
     ) as unknown as typeof toast.success;
     host.workspaceGetSettingsSnapshot = mock(async () => createSettingsSnapshotFixture()) as never;
-    host.agentSessionsListForTasks = async (repoPath, taskIds) =>
-      Promise.all(
-        taskIds.map(async (taskId) => ({
-          taskId,
-          agentSessions: await host.agentSessionsList(repoPath, taskId),
-        })),
-      );
   });
 
   afterEach(() => {
@@ -476,7 +480,6 @@ describe("use-task-operations", () => {
     console.warn = originalConsoleWarn;
     toast.success = originalToastSuccess;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
-    host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     resetAgentChatDraftStoreForTests();
   });
 
@@ -635,7 +638,7 @@ describe("use-task-operations", () => {
       refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
     });
     const Harness = () => {
-      latest = useTaskOperations(args);
+      latest = useTaskOperations(normalizeHookArgs(args));
       return null;
     };
     const getLatest = (): ReturnType<typeof useTaskOperations> => {
@@ -792,7 +795,7 @@ describe("use-task-operations", () => {
     };
 
     const Harness = ({ args }: { args: HookArgs }) => {
-      latest = useTaskOperations(args);
+      latest = useTaskOperations(normalizeHookArgs(args));
       return null;
     };
 
@@ -1577,7 +1580,7 @@ describe("use-task-operations", () => {
     let latest: ReturnType<typeof useTaskOperations> | null = null;
 
     const Harness = ({ args }: { args: HookArgs }) => {
-      latest = useTaskOperations(args);
+      latest = useTaskOperations(normalizeHookArgs(args));
       return null;
     };
 
@@ -1682,7 +1685,7 @@ describe("use-task-operations", () => {
     };
 
     const Harness = ({ args }: { args: HookArgs }) => {
-      const operations = useTaskOperations(args);
+      const operations = useTaskOperations(normalizeHookArgs(args));
       const { planDoc } = useTaskDocuments("A", true, args.activeWorkspace?.repoPath ?? "");
       latest = {
         operations,
@@ -1781,7 +1784,7 @@ describe("use-task-operations", () => {
     };
 
     const Harness = ({ args }: { args: HookArgs }) => {
-      latest = useTaskOperations(args);
+      latest = useTaskOperations(normalizeHookArgs(args));
       return null;
     };
 
@@ -1868,7 +1871,7 @@ describe("use-task-operations", () => {
     let latest: ReturnType<typeof useTaskOperations> | null = null;
 
     const Harness = ({ args }: { args: HookArgs }) => {
-      latest = useTaskOperations(args);
+      latest = useTaskOperations(normalizeHookArgs(args));
       return null;
     };
 
@@ -2210,7 +2213,7 @@ describe("use-task-operations", () => {
     let latest: ReturnType<typeof useTaskOperations> | null = null;
 
     const Harness = ({ args }: { args: HookArgs }) => {
-      latest = useTaskOperations(args);
+      latest = useTaskOperations(normalizeHookArgs(args));
       return null;
     };
 

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -752,6 +752,7 @@ describe("use-task-operations", () => {
 
   test("reset operations report refresh failures without rejecting successful mutations", async () => {
     let currentStatus: TaskCard["status"] = "in_progress";
+    let failTaskRefresh = false;
     const taskResetImplementation = mock(async () => {
       currentStatus = "ready_for_dev";
       return makeTask("A", currentStatus);
@@ -760,7 +761,12 @@ describe("use-task-operations", () => {
       currentStatus = "open";
       return makeTask("A", currentStatus);
     });
-    const tasksList = mock(async () => [makeTask("A", currentStatus)]);
+    const tasksList = mock(async () => {
+      if (failTaskRefresh) {
+        throw new Error("task state unavailable");
+      }
+      return [makeTask("A", currentStatus)];
+    });
     const runsList = mock(async (): Promise<RunSummary[]> => []);
     const toastError = mock(() => {});
     const original = {
@@ -817,12 +823,18 @@ describe("use-task-operations", () => {
       await harness.waitFor(() => getLatest().tasks[0]?.status === "ready_for_dev");
       await expect(harness.run(() => getLatest().resetTask("A"))).resolves.toBeUndefined();
       await harness.waitFor(() => getLatest().tasks[0]?.status === "open");
+      failTaskRefresh = true;
+      await expect(harness.run(() => getLatest().resetTask("A"))).resolves.toBeUndefined();
 
       expect(toastError).toHaveBeenCalledWith("Implementation reset, but metadata refresh failed", {
         description: "/repo · A: metadata unavailable",
       });
       expect(toastError).toHaveBeenCalledWith("Task reset, but metadata refresh failed", {
         description: "/repo · A: metadata unavailable",
+      });
+      expect(toastError).toHaveBeenCalledWith("Task reset, but metadata refresh failed", {
+        description:
+          "/repo · A: Post-reset metadata refreshes failed: metadata unavailable; task state unavailable",
       });
       expect(getLatest().tasks[0]?.status).toBe("open");
     } finally {

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -82,6 +82,7 @@ const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 const originalToastSuccess = toast.success;
 const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
+const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
 
 const createSettingsSnapshotFixture = () => createSharedSettingsSnapshotFixture();
 
@@ -461,6 +462,13 @@ describe("use-task-operations", () => {
       (_message: string, _options?: { description?: string }) => "",
     ) as unknown as typeof toast.success;
     host.workspaceGetSettingsSnapshot = mock(async () => createSettingsSnapshotFixture()) as never;
+    host.agentSessionsListForTasks = async (repoPath, taskIds) =>
+      Promise.all(
+        taskIds.map(async (taskId) => ({
+          taskId,
+          agentSessions: await host.agentSessionsList(repoPath, taskId),
+        })),
+      );
   });
 
   afterEach(() => {
@@ -468,6 +476,7 @@ describe("use-task-operations", () => {
     console.warn = originalConsoleWarn;
     toast.success = originalToastSuccess;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+    host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     resetAgentChatDraftStoreForTests();
   });
 

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -839,11 +839,14 @@ describe("use-task-operations", () => {
 
       expect(taskReset).toHaveBeenCalledWith("/repo", "A");
       expect(getLatest().tasks[0]?.status).toBe("open");
-      expect(invalidateQueriesMock).toHaveBeenCalledWith({
-        queryKey: agentSessionQueryKeys.list("/repo", "A"),
-        exact: true,
-        refetchType: "all",
-      });
+      expect(invalidateQueriesMock).toHaveBeenCalledWith(
+        {
+          queryKey: agentSessionQueryKeys.list("/repo", "A"),
+          exact: true,
+          refetchType: "all",
+        },
+        { throwOnError: true },
+      );
       expect(invalidateQueriesMock).toHaveBeenCalledWith({
         queryKey: documentQueryKeys.qaReport("/repo", "A"),
         exact: true,

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -750,6 +750,82 @@ describe("use-task-operations", () => {
     }
   });
 
+  test("reset operations report refresh failures without rejecting successful mutations", async () => {
+    const taskResetImplementation = mock(async () => makeTask("A", "ready_for_dev"));
+    const taskReset = mock(async () => makeTask("A", "open"));
+    const tasksList = mock(async () => [makeTask("A", "in_progress")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock(() => {});
+    const original = {
+      taskResetImplementation: host.taskResetImplementation,
+      taskReset: host.taskReset,
+      tasksList: host.tasksList,
+      runsList: legacyHost.runsList,
+      toastError: toast.error,
+    };
+    host.taskResetImplementation = taskResetImplementation;
+    host.taskReset = taskReset;
+    host.tasksList = tasksList;
+    legacyHost.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+    const queryClient = createQueryClient();
+    const originalInvalidateQueries = queryClient.invalidateQueries.bind(queryClient);
+    queryClient.invalidateQueries = mock(async (filters, options) => {
+      if (
+        JSON.stringify(filters.queryKey) ===
+        JSON.stringify(agentSessionQueryKeys.list("/repo", "A"))
+      ) {
+        throw new Error("metadata unavailable");
+      }
+      return originalInvalidateQueries(filters, options);
+    }) as typeof queryClient.invalidateQueries;
+    let latest: ReturnType<typeof useTaskOperations> | null = null;
+    const Harness = () => {
+      latest = useTaskOperations(
+        normalizeHookArgs({
+          activeRepo: "/repo",
+          refreshTaskStoreCheckForRepo: async (): Promise<TaskStoreCheck> => makeTaskStoreCheck(),
+        }),
+      );
+      return null;
+    };
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const harness = createSharedHookHarness(Harness, undefined, { wrapper });
+    const getLatest = () => {
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+      return latest;
+    };
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => getLatest().tasks[0]?.status === "in_progress");
+
+      await expect(
+        harness.run(() => getLatest().resetTaskImplementation("A")),
+      ).resolves.toBeUndefined();
+      await expect(harness.run(() => getLatest().resetTask("A"))).resolves.toBeUndefined();
+
+      expect(toastError).toHaveBeenCalledWith("Implementation reset, but metadata refresh failed", {
+        description: "/repo · A: metadata unavailable",
+      });
+      expect(toastError).toHaveBeenCalledWith("Task reset, but metadata refresh failed", {
+        description: "/repo · A: metadata unavailable",
+      });
+    } finally {
+      await harness.unmount();
+      queryClient.clear();
+      host.taskResetImplementation = original.taskResetImplementation;
+      host.taskReset = original.taskReset;
+      host.tasksList = original.tasksList;
+      legacyHost.runsList = original.runsList;
+      toast.error = original.toastError;
+    }
+  });
+
   test("resetTask refreshes task data after host reset completes", async () => {
     let currentStatus: TaskCard["status"] = "human_review";
     const taskReset = mock(async () => {

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.test.tsx
@@ -842,7 +842,7 @@ describe("use-task-operations", () => {
       expect(invalidateQueriesMock).toHaveBeenCalledWith({
         queryKey: agentSessionQueryKeys.list("/repo", "A"),
         exact: true,
-        refetchType: "active",
+        refetchType: "all",
       });
       expect(invalidateQueriesMock).toHaveBeenCalledWith({
         queryKey: documentQueryKeys.qaReport("/repo", "A"),

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { host } from "../shared/host";
 import { useTaskMutationRunner } from "./task-mutation-runner";
 import type { UseTaskOperationsArgs, UseTaskOperationsResult } from "./task-operations-types";
 import { useTaskMutationCommands } from "./use-task-mutation-commands";
@@ -8,6 +9,7 @@ import { useTaskResetOperations } from "./use-task-reset-operations";
 
 export function useTaskOperations({
   activeWorkspace,
+  agentSessionReadPort = host,
 }: UseTaskOperationsArgs): UseTaskOperationsResult {
   const activeRepoPath = activeWorkspace?.repoPath ?? null;
   const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
@@ -18,6 +20,7 @@ export function useTaskOperations({
     activeWorkspaceId,
     tasks: taskReadFlow.tasks,
     runTaskMutation: mutationRunner.runTaskMutation,
+    agentSessionReadPort,
   });
   const resetOperations = useTaskResetOperations({
     activeRepoPath,
@@ -28,6 +31,7 @@ export function useTaskOperations({
     activeWorkspaceId,
     refreshTaskData: taskReadFlow.refreshTaskData,
     runTaskMutation: mutationRunner.runTaskMutation,
+    agentSessionReadPort,
   });
 
   const clearTaskData = useCallback(() => {

--- a/packages/frontend/src/state/operations/tasks/use-task-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-operations.ts
@@ -24,6 +24,7 @@ export function useTaskOperations({
   });
   const resetOperations = useTaskResetOperations({
     activeRepoPath,
+    agentSessionReadPort,
     refreshTaskData: taskReadFlow.refreshTaskData,
   });
   const pullRequestOperations = useTaskPullRequestOperations({

--- a/packages/frontend/src/state/operations/tasks/use-task-pull-request-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-pull-request-operations.test.tsx
@@ -52,6 +52,11 @@ const createOperationsHarness = () => {
     const operations = useTaskPullRequestOperations({
       activeRepoPath,
       activeWorkspaceId: null,
+      agentSessionReadPort: {
+        agentSessionsList: async () => [],
+        agentSessionsListForTasks: async (_repoPath, taskIds) =>
+          taskIds.map((taskId) => ({ taskId, agentSessions: [] })),
+      },
       refreshTaskData,
       runTaskMutation,
     });

--- a/packages/frontend/src/state/operations/tasks/use-task-pull-request-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-pull-request-operations.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
+import type { AgentSessionReadPort } from "@/state/queries/agent-sessions";
 import { invalidatePullRequestReviewContextQueries } from "@/state/queries/pull-request-review";
 import { host } from "../shared/host";
 import { runTaskMutationWithChatDraftCleanup } from "./task-chat-draft-cleanup";
@@ -15,6 +16,7 @@ type UseTaskPullRequestOperationsArgs = {
   activeWorkspaceId: string | null;
   refreshTaskData: UseTaskOperationsResult["refreshTaskData"];
   runTaskMutation: TaskMutationRunner["runTaskMutation"];
+  agentSessionReadPort: AgentSessionReadPort;
 };
 
 type PendingMergedPullRequestState = {
@@ -45,6 +47,7 @@ export function useTaskPullRequestOperations({
   activeWorkspaceId,
   refreshTaskData,
   runTaskMutation,
+  agentSessionReadPort,
 }: UseTaskPullRequestOperationsArgs): TaskPullRequestOperations {
   const queryClient = useQueryClient();
   const [detectingPullRequestState, setDetectingPullRequestState] = useState<TaskRepoState | null>(
@@ -150,6 +153,7 @@ export function useTaskPullRequestOperations({
         repoPath,
         workspaceId: activeWorkspaceId,
         taskIds: [taskId],
+        agentSessionReadPort,
         mutation: async () => {
           await host.taskPullRequestLinkMerged(repoPath, taskId, pullRequest);
         },
@@ -172,7 +176,13 @@ export function useTaskPullRequestOperations({
         currentTaskId === taskId ? null : currentTaskId,
       );
     }
-  }, [activeWorkspaceId, pendingMergedPullRequestState, queryClient, refreshTaskData]);
+  }, [
+    activeWorkspaceId,
+    agentSessionReadPort,
+    pendingMergedPullRequestState,
+    queryClient,
+    refreshTaskData,
+  ]);
 
   const unlinkPullRequest = useCallback(
     async (taskId: string): Promise<void> => {

--- a/packages/frontend/src/state/operations/tasks/use-task-reset-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-reset-operations.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren, ReactElement } from "react";
+import { createHookHarness } from "@/test-utils/react-hook-harness";
+import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
+import type { AgentSessionReadPort } from "../../queries/agent-sessions";
+import type { UseTaskOperationsResult } from "./task-operations-types";
+import { useTaskResetOperations } from "./use-task-reset-operations";
+
+const createHarness = ({
+  agentSessionsList,
+  refreshTaskData,
+}: {
+  agentSessionsList: AgentSessionReadPort["agentSessionsList"];
+  refreshTaskData: UseTaskOperationsResult["refreshTaskData"];
+}) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const taskReset = mock(async () => createTaskCardFixture({ id: "A", status: "open" }));
+  const taskResetImplementation = mock(async () =>
+    createTaskCardFixture({ id: "A", status: "ready_for_dev" }),
+  );
+  const error = mock(() => "error-toast");
+  const success = mock(() => "success-toast");
+  const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const harness = createHookHarness(
+    () =>
+      useTaskResetOperations({
+        activeRepoPath: "/repo",
+        agentSessionReadPort: { agentSessionsList },
+        refreshTaskData,
+        hostPort: { taskReset, taskResetImplementation },
+        notificationPort: { error, success },
+      }),
+    undefined,
+    { wrapper },
+  );
+
+  return {
+    error,
+    harness,
+    queryClient,
+    taskReset,
+    taskResetImplementation,
+  };
+};
+
+describe("useTaskResetOperations", () => {
+  test("reports a session refresh failure without rejecting a successful reset", async () => {
+    const metadataError = new Error("metadata unavailable");
+    const setup = createHarness({
+      agentSessionsList: async () => {
+        throw metadataError;
+      },
+      refreshTaskData: async () => undefined,
+    });
+
+    try {
+      await setup.harness.mount();
+      await expect(
+        setup.harness.run((operations) => operations.resetTaskImplementation("A")),
+      ).resolves.toBeUndefined();
+
+      expect(setup.taskResetImplementation).toHaveBeenCalledWith("/repo", "A");
+      expect(setup.error).toHaveBeenCalledWith(
+        "Implementation reset, but metadata refresh failed",
+        { description: "/repo · A: metadata unavailable" },
+      );
+    } finally {
+      await setup.harness.unmount();
+      setup.queryClient.clear();
+    }
+  });
+
+  test("reports both refresh failures without rejecting a successful task reset", async () => {
+    const setup = createHarness({
+      agentSessionsList: async () => {
+        throw new Error("metadata unavailable");
+      },
+      refreshTaskData: async () => {
+        throw new Error("task state unavailable");
+      },
+    });
+
+    try {
+      await setup.harness.mount();
+      await expect(
+        setup.harness.run((operations) => operations.resetTask("A")),
+      ).resolves.toBeUndefined();
+
+      expect(setup.taskReset).toHaveBeenCalledWith("/repo", "A");
+      expect(setup.error).toHaveBeenCalledWith("Task reset, but metadata refresh failed", {
+        description:
+          "/repo · A: Post-reset metadata refreshes failed: metadata unavailable; task state unavailable",
+      });
+    } finally {
+      await setup.harness.unmount();
+      setup.queryClient.clear();
+    }
+  });
+});

--- a/packages/frontend/src/state/operations/tasks/use-task-reset-operations.test.tsx
+++ b/packages/frontend/src/state/operations/tasks/use-task-reset-operations.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { PropsWithChildren, ReactElement } from "react";
+import { IsolatedQueryWrapper } from "@/test-utils/isolated-query-wrapper";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
 import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
 import type { AgentSessionReadPort } from "../../queries/agent-sessions";
@@ -14,16 +13,12 @@ const createHarness = ({
   agentSessionsList: AgentSessionReadPort["agentSessionsList"];
   refreshTaskData: UseTaskOperationsResult["refreshTaskData"];
 }) => {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const taskReset = mock(async () => createTaskCardFixture({ id: "A", status: "open" }));
   const taskResetImplementation = mock(async () =>
     createTaskCardFixture({ id: "A", status: "ready_for_dev" }),
   );
   const error = mock(() => "error-toast");
   const success = mock(() => "success-toast");
-  const wrapper = ({ children }: PropsWithChildren): ReactElement => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
   const harness = createHookHarness(
     () =>
       useTaskResetOperations({
@@ -34,13 +29,12 @@ const createHarness = ({
         notificationPort: { error, success },
       }),
     undefined,
-    { wrapper },
+    { wrapper: IsolatedQueryWrapper },
   );
 
   return {
     error,
     harness,
-    queryClient,
     taskReset,
     taskResetImplementation,
   };
@@ -69,7 +63,6 @@ describe("useTaskResetOperations", () => {
       );
     } finally {
       await setup.harness.unmount();
-      setup.queryClient.clear();
     }
   });
 
@@ -96,7 +89,6 @@ describe("useTaskResetOperations", () => {
       });
     } finally {
       await setup.harness.unmount();
-      setup.queryClient.clear();
     }
   });
 });

--- a/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
@@ -5,14 +5,20 @@ import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { taskWorktreeQueryKeys } from "@/state/queries/build-runtime";
 import { documentQueryKeys } from "@/state/queries/documents";
-import { invalidateAgentSessionListQuery } from "../../queries/agent-sessions";
+import {
+  type AgentSessionReadPort,
+  refreshAgentSessionListQuery,
+} from "../../queries/agent-sessions";
 import { host } from "../shared/host";
 import { requireActiveRepo } from "./task-operations-model";
 import type { UseTaskOperationsResult } from "./task-operations-types";
 
 type UseTaskResetOperationsArgs = {
   activeRepoPath: string | null;
+  agentSessionReadPort: Pick<AgentSessionReadPort, "agentSessionsList">;
   refreshTaskData: UseTaskOperationsResult["refreshTaskData"];
+  hostPort?: Pick<typeof host, "taskReset" | "taskResetImplementation">;
+  notificationPort?: Pick<typeof toast, "error" | "success">;
 };
 
 export type TaskResetOperations = {
@@ -22,7 +28,10 @@ export type TaskResetOperations = {
 
 export function useTaskResetOperations({
   activeRepoPath,
+  agentSessionReadPort,
   refreshTaskData,
+  hostPort = host,
+  notificationPort = toast,
 }: UseTaskResetOperationsArgs): TaskResetOperations {
   const queryClient = useQueryClient();
 
@@ -30,44 +39,72 @@ export function useTaskResetOperations({
     async (taskId: string): Promise<void> => {
       const repoPath = requireActiveRepo(activeRepoPath);
       try {
-        await host.taskResetImplementation(repoPath, taskId);
+        await hostPort.taskResetImplementation(repoPath, taskId);
       } catch (error) {
-        toast.error("Failed to reset implementation", { description: errorMessage(error) });
+        notificationPort.error("Failed to reset implementation", {
+          description: errorMessage(error),
+        });
         throw error;
       }
       try {
-        await refreshTaskAfterReset(queryClient, repoPath, taskId, refreshTaskData);
+        await refreshTaskAfterReset(
+          queryClient,
+          repoPath,
+          taskId,
+          refreshTaskData,
+          agentSessionReadPort,
+        );
       } catch (error) {
-        toast.error("Implementation reset, but metadata refresh failed", {
+        notificationPort.error("Implementation reset, but metadata refresh failed", {
           description: `${repoPath} · ${taskId}: ${errorMessage(error)}`,
         });
         return;
       }
-      toast.success("Implementation reset", { description: taskId });
+      notificationPort.success("Implementation reset", { description: taskId });
     },
-    [activeRepoPath, queryClient, refreshTaskData],
+    [
+      activeRepoPath,
+      agentSessionReadPort,
+      hostPort,
+      notificationPort,
+      queryClient,
+      refreshTaskData,
+    ],
   );
 
   const resetTask = useCallback(
     async (taskId: string): Promise<void> => {
       const repoPath = requireActiveRepo(activeRepoPath);
       try {
-        await host.taskReset(repoPath, taskId);
+        await hostPort.taskReset(repoPath, taskId);
       } catch (error) {
-        toast.error("Failed to reset task", { description: errorMessage(error) });
+        notificationPort.error("Failed to reset task", { description: errorMessage(error) });
         throw error;
       }
       try {
-        await refreshTaskAfterReset(queryClient, repoPath, taskId, refreshTaskData);
+        await refreshTaskAfterReset(
+          queryClient,
+          repoPath,
+          taskId,
+          refreshTaskData,
+          agentSessionReadPort,
+        );
       } catch (error) {
-        toast.error("Task reset, but metadata refresh failed", {
+        notificationPort.error("Task reset, but metadata refresh failed", {
           description: `${repoPath} · ${taskId}: ${errorMessage(error)}`,
         });
         return;
       }
-      toast.success("Task reset", { description: taskId });
+      notificationPort.success("Task reset", { description: taskId });
     },
-    [activeRepoPath, queryClient, refreshTaskData],
+    [
+      activeRepoPath,
+      agentSessionReadPort,
+      hostPort,
+      notificationPort,
+      queryClient,
+      refreshTaskData,
+    ],
   );
 
   return { resetTaskImplementation, resetTask };
@@ -78,9 +115,10 @@ const refreshTaskAfterReset = async (
   repoPath: string,
   taskId: string,
   refreshTaskData: UseTaskOperationsResult["refreshTaskData"],
+  agentSessionReadPort: Pick<AgentSessionReadPort, "agentSessionsList">,
 ): Promise<void> => {
   const results = await Promise.allSettled([
-    invalidateTaskWorkflowQueries(queryClient, repoPath, taskId),
+    invalidateTaskWorkflowQueries(queryClient, repoPath, taskId, agentSessionReadPort),
     refreshTaskData(repoPath, taskId),
   ]);
   const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
@@ -97,6 +135,7 @@ const invalidateTaskWorkflowQueries = async (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
+  agentSessionReadPort: Pick<AgentSessionReadPort, "agentSessionsList">,
 ): Promise<void> => {
   await Promise.all([
     queryClient.invalidateQueries({
@@ -104,7 +143,7 @@ const invalidateTaskWorkflowQueries = async (
       exact: true,
       refetchType: "none",
     }),
-    invalidateAgentSessionListQuery(queryClient, repoPath, taskId, { refetchType: "all" }),
+    refreshAgentSessionListQuery(queryClient, repoPath, taskId, agentSessionReadPort),
     queryClient.invalidateQueries({
       queryKey: documentQueryKeys.spec(repoPath, taskId),
       exact: true,

--- a/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
@@ -76,7 +76,7 @@ const invalidateTaskWorkflowQueries = async (
       exact: true,
       refetchType: "none",
     }),
-    invalidateAgentSessionListQuery(queryClient, repoPath, taskId, { refetchType: "active" }),
+    invalidateAgentSessionListQuery(queryClient, repoPath, taskId, { refetchType: "all" }),
     queryClient.invalidateQueries({
       queryKey: documentQueryKeys.spec(repoPath, taskId),
       exact: true,

--- a/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
@@ -76,7 +76,7 @@ const invalidateTaskWorkflowQueries = async (
       exact: true,
       refetchType: "none",
     }),
-    invalidateAgentSessionListQuery(queryClient, repoPath, taskId, { refetchActive: true }),
+    invalidateAgentSessionListQuery(queryClient, repoPath, taskId, { refetchType: "active" }),
     queryClient.invalidateQueries({
       queryKey: documentQueryKeys.spec(repoPath, taskId),
       exact: true,

--- a/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
@@ -88,7 +88,8 @@ const refreshTaskAfterReset = async (
     throw errors[0];
   }
   if (errors.length > 1) {
-    throw new AggregateError(errors, "Multiple post-reset metadata refreshes failed.");
+    const details = errors.map(errorMessage).join("; ");
+    throw new AggregateError(errors, `Post-reset metadata refreshes failed: ${details}`);
   }
 };
 

--- a/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
@@ -31,15 +31,20 @@ export function useTaskResetOperations({
       const repoPath = requireActiveRepo(activeRepoPath);
       try {
         await host.taskResetImplementation(repoPath, taskId);
-        await Promise.all([
-          invalidateTaskWorkflowQueries(queryClient, repoPath, taskId),
-          refreshTaskData(repoPath, taskId),
-        ]);
-        toast.success("Implementation reset", { description: taskId });
       } catch (error) {
         toast.error("Failed to reset implementation", { description: errorMessage(error) });
         throw error;
       }
+      try {
+        await invalidateTaskWorkflowQueries(queryClient, repoPath, taskId);
+        await refreshTaskData(repoPath, taskId);
+      } catch (error) {
+        toast.error("Implementation reset, but metadata refresh failed", {
+          description: `${repoPath} · ${taskId}: ${errorMessage(error)}`,
+        });
+        return;
+      }
+      toast.success("Implementation reset", { description: taskId });
     },
     [activeRepoPath, queryClient, refreshTaskData],
   );
@@ -49,15 +54,20 @@ export function useTaskResetOperations({
       const repoPath = requireActiveRepo(activeRepoPath);
       try {
         await host.taskReset(repoPath, taskId);
-        await Promise.all([
-          invalidateTaskWorkflowQueries(queryClient, repoPath, taskId),
-          refreshTaskData(repoPath, taskId),
-        ]);
-        toast.success("Task reset", { description: taskId });
       } catch (error) {
         toast.error("Failed to reset task", { description: errorMessage(error) });
         throw error;
       }
+      try {
+        await invalidateTaskWorkflowQueries(queryClient, repoPath, taskId);
+        await refreshTaskData(repoPath, taskId);
+      } catch (error) {
+        toast.error("Task reset, but metadata refresh failed", {
+          description: `${repoPath} · ${taskId}: ${errorMessage(error)}`,
+        });
+        return;
+      }
+      toast.success("Task reset", { description: taskId });
     },
     [activeRepoPath, queryClient, refreshTaskData],
   );

--- a/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
+++ b/packages/frontend/src/state/operations/tasks/use-task-reset-operations.ts
@@ -36,8 +36,7 @@ export function useTaskResetOperations({
         throw error;
       }
       try {
-        await invalidateTaskWorkflowQueries(queryClient, repoPath, taskId);
-        await refreshTaskData(repoPath, taskId);
+        await refreshTaskAfterReset(queryClient, repoPath, taskId, refreshTaskData);
       } catch (error) {
         toast.error("Implementation reset, but metadata refresh failed", {
           description: `${repoPath} · ${taskId}: ${errorMessage(error)}`,
@@ -59,8 +58,7 @@ export function useTaskResetOperations({
         throw error;
       }
       try {
-        await invalidateTaskWorkflowQueries(queryClient, repoPath, taskId);
-        await refreshTaskData(repoPath, taskId);
+        await refreshTaskAfterReset(queryClient, repoPath, taskId, refreshTaskData);
       } catch (error) {
         toast.error("Task reset, but metadata refresh failed", {
           description: `${repoPath} · ${taskId}: ${errorMessage(error)}`,
@@ -74,6 +72,25 @@ export function useTaskResetOperations({
 
   return { resetTaskImplementation, resetTask };
 }
+
+const refreshTaskAfterReset = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+  refreshTaskData: UseTaskOperationsResult["refreshTaskData"],
+): Promise<void> => {
+  const results = await Promise.allSettled([
+    invalidateTaskWorkflowQueries(queryClient, repoPath, taskId),
+    refreshTaskData(repoPath, taskId),
+  ]);
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Multiple post-reset metadata refreshes failed.");
+  }
+};
 
 const invalidateTaskWorkflowQueries = async (
   queryClient: QueryClient,

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
-import { host } from "../operations/host";
 import {
+  type AgentSessionReadPort,
   agentSessionListHydrationQueryOptions,
   agentSessionQueryKeys,
   hydrateAgentSessionListQueries,
@@ -18,6 +18,15 @@ const sessionFixture: AgentSessionRecord = {
   startedAt: "2026-03-22T12:00:00.000Z",
   selectedModel: null,
 };
+
+const createReadPort = (
+  agentSessionsListForTasks: AgentSessionReadPort["agentSessionsListForTasks"],
+): AgentSessionReadPort => ({
+  agentSessionsList: async () => {
+    throw new Error("The per-task read was not expected.");
+  },
+  agentSessionsListForTasks,
+});
 
 describe("agent session query cache helpers", () => {
   test("hydration query keys normalize task ordering, whitespace, duplicates, and empty IDs", () => {
@@ -35,70 +44,49 @@ describe("agent session query cache helpers", () => {
       { taskId: "task-1", agentSessions: [sessionFixture] },
       { taskId: "task-2", agentSessions: [] },
     ]);
-    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
-    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
+    const result = await queryClient.fetchQuery(
+      agentSessionListHydrationQueryOptions(
+        queryClient,
+        "/repo",
+        [" task-2 ", "task-1", "task-2"],
+        createReadPort(agentSessionsListForTasksMock),
+      ),
+    );
 
-    try {
-      const result = await queryClient.fetchQuery(
-        agentSessionListHydrationQueryOptions(queryClient, "/repo", [
-          " task-2 ",
-          "task-1",
-          "task-2",
-        ]),
-      );
-
-      expect(result).toBe(true);
-      expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
-      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
-      expect(
-        queryClient.getQueryData<AgentSessionRecord[]>(
-          agentSessionQueryKeys.list("/repo", "task-1"),
-        ),
-      ).toEqual([sessionFixture]);
-      expect(
-        queryClient.getQueryData<AgentSessionRecord[]>(
-          agentSessionQueryKeys.list("/repo", "task-2"),
-        ),
-      ).toEqual([]);
-    } finally {
-      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
-    }
+    expect(result).toBe(true);
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
+    ).toEqual([sessionFixture]);
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-2")),
+    ).toEqual([]);
   });
 
   test("empty hydration does not call the host", async () => {
     const queryClient = new QueryClient();
     const agentSessionsListForTasksMock = mock(async () => []);
-    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
-    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
-
-    try {
-      await hydrateAgentSessionListQueries(queryClient, "/repo", ["", " "]);
-      expect(agentSessionsListForTasksMock).not.toHaveBeenCalled();
-    } finally {
-      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
-    }
+    await hydrateAgentSessionListQueries(
+      queryClient,
+      "/repo",
+      ["", " "],
+      createReadPort(agentSessionsListForTasksMock),
+    );
+    expect(agentSessionsListForTasksMock).not.toHaveBeenCalled();
   });
 
   test("batch hydration fails when the host omits a requested task", async () => {
     const queryClient = new QueryClient();
-    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
-    host.agentSessionsListForTasks = async () => [
+    const readPort = createReadPort(async () => [
       { taskId: "task-1", agentSessions: [sessionFixture] },
-    ];
+    ]);
 
-    try {
-      await expect(
-        hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1", "task-2"]),
-      ).rejects.toThrow('Batch session response omitted task "task-2".');
-      expect(
-        queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "task-1")),
-      ).toBeUndefined();
-      expect(
-        queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "task-2")),
-      ).toBeUndefined();
-    } finally {
-      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
-    }
+    await expect(
+      hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1", "task-2"], readPort),
+    ).rejects.toThrow('Batch session response omitted task "task-2".');
+    expect(queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "task-1"))).toBeUndefined();
+    expect(queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "task-2"))).toBeUndefined();
   });
 
   test("batch hydration does not overwrite a task cache updated while the batch is in flight", async () => {
@@ -109,22 +97,19 @@ describe("agent session query cache helpers", () => {
       () => {
         throw new Error("Batch resolver was not initialized.");
       };
-    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
-    host.agentSessionsListForTasks = () =>
-      new Promise((resolve) => {
-        resolveBatch = resolve;
-      });
+    const readPort = createReadPort(
+      () =>
+        new Promise((resolve) => {
+          resolveBatch = resolve;
+        }),
+    );
 
-    try {
-      const hydration = hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1"]);
-      queryClient.setQueryData(queryKey, [newerSession]);
-      resolveBatch([{ taskId: "task-1", agentSessions: [sessionFixture] }]);
-      await hydration;
+    const hydration = hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1"], readPort);
+    queryClient.setQueryData(queryKey, [newerSession]);
+    resolveBatch([{ taskId: "task-1", agentSessions: [sessionFixture] }]);
+    await hydration;
 
-      expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([newerSession]);
-    } finally {
-      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
-    }
+    expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([newerSession]);
   });
 
   test("invalidation targets only the canonical per-task cache", async () => {
@@ -145,84 +130,90 @@ describe("agent session query cache helpers", () => {
 
   test("loadAgentSessionListsFromQuery batch-hydrates the per-task session cache", async () => {
     const queryClient = new QueryClient();
-    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
     const agentSessionsListForTasksMock = mock(async () => [
       { taskId: "task-1", agentSessions: [sessionFixture] },
       { taskId: "task-2", agentSessions: [] },
     ]);
-    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
+    const sessionsByTaskId = await loadAgentSessionListsFromQuery(
+      queryClient,
+      "/repo",
+      ["task-1", "task-2"],
+      { readPort: createReadPort(agentSessionsListForTasksMock) },
+    );
 
-    try {
-      const sessionsByTaskId = await loadAgentSessionListsFromQuery(queryClient, "/repo", [
-        "task-1",
-        "task-2",
-      ]);
-
-      expect(sessionsByTaskId).toEqual({
-        "task-1": [sessionFixture],
-        "task-2": [],
-      });
-      expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
-      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
-      expect(
-        queryClient.getQueryData<AgentSessionRecord[]>(
-          agentSessionQueryKeys.list("/repo", "task-1"),
-        ),
-      ).toEqual([sessionFixture]);
-      expect(
-        queryClient.getQueryData<AgentSessionRecord[]>(
-          agentSessionQueryKeys.list("/repo", "task-2"),
-        ),
-      ).toEqual([]);
-    } finally {
-      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
-    }
+    expect(sessionsByTaskId).toEqual({
+      "task-1": [sessionFixture],
+      "task-2": [],
+    });
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
+    ).toEqual([sessionFixture]);
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-2")),
+    ).toEqual([]);
   });
 
   test("loadAgentSessionListsFromQuery batch-hydrates only missing per-task caches", async () => {
     const queryClient = new QueryClient();
     queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
-    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
     const agentSessionsListForTasksMock = mock(async () => [
       { taskId: "task-2", agentSessions: [] },
     ]);
-    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
+    const sessionsByTaskId = await loadAgentSessionListsFromQuery(
+      queryClient,
+      "/repo",
+      ["task-1", "task-2"],
+      { readPort: createReadPort(agentSessionsListForTasksMock) },
+    );
 
-    try {
-      const sessionsByTaskId = await loadAgentSessionListsFromQuery(queryClient, "/repo", [
-        "task-1",
-        "task-2",
-      ]);
-
-      expect(sessionsByTaskId).toEqual({
-        "task-1": [sessionFixture],
-        "task-2": [],
-      });
-      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-2"]);
-    } finally {
-      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
-    }
+    expect(sessionsByTaskId).toEqual({
+      "task-1": [sessionFixture],
+      "task-2": [],
+    });
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-2"]);
   });
 
   test("loadAgentSessionListsFromQuery reuses hydrated per-task cache entries", async () => {
     const queryClient = new QueryClient();
     queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
 
-    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
-    host.agentSessionsListForTasks = async () => {
+    const readPort = createReadPort(async () => {
       throw new Error("The cached per-task session list should be authoritative.");
-    };
+    });
 
-    try {
-      const sessionsByTaskId = await loadAgentSessionListsFromQuery(queryClient, "/repo", [
-        "task-1",
-      ]);
+    const sessionsByTaskId = await loadAgentSessionListsFromQuery(
+      queryClient,
+      "/repo",
+      ["task-1"],
+      { readPort },
+    );
 
-      expect(sessionsByTaskId).toEqual({
-        "task-1": [sessionFixture],
-      });
-    } finally {
-      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
-    }
+    expect(sessionsByTaskId).toEqual({
+      "task-1": [sessionFixture],
+    });
+  });
+
+  test("loadAgentSessionListsFromQuery refreshes invalidated per-task cache entries", async () => {
+    const queryClient = new QueryClient();
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    const refreshedSession = { ...sessionFixture, externalSessionId: "external-2" };
+    const agentSessionsListForTasksMock = mock(async () => [
+      { taskId: "task-1", agentSessions: [refreshedSession] },
+    ]);
+    queryClient.setQueryData(queryKey, [sessionFixture]);
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
+
+    const sessionsByTaskId = await loadAgentSessionListsFromQuery(
+      queryClient,
+      "/repo",
+      ["task-1"],
+      { readPort: createReadPort(agentSessionsListForTasksMock) },
+    );
+
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+    expect(sessionsByTaskId).toEqual({ "task-1": [refreshedSession] });
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
   });
 });

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -90,6 +90,19 @@ describe("agent session query cache helpers", () => {
     expect(queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "task-2"))).toBeUndefined();
   });
 
+  test("batch hydration fails when the host returns a task more than once", async () => {
+    const queryClient = new QueryClient();
+    const readPort = createReadPort(async () => [
+      { taskId: "task-1", agentSessions: [sessionFixture] },
+      { taskId: "task-1", agentSessions: [] },
+    ]);
+
+    await expect(
+      hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1"], readPort),
+    ).rejects.toThrow('Batch session response included task "task-1" more than once.');
+    expect(queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "task-1"))).toBeUndefined();
+  });
+
   test("batch hydration does not overwrite a task cache updated while the batch is in flight", async () => {
     const queryClient = new QueryClient();
     const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
@@ -194,6 +207,18 @@ describe("agent session query cache helpers", () => {
     expect(
       queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-2")),
     ).toEqual([]);
+  });
+
+  test("loadAgentSessionListsFromQuery returns an empty result for empty normalized task IDs", async () => {
+    const queryClient = new QueryClient();
+    const agentSessionsListForTasksMock = mock(async () => []);
+
+    await expect(
+      loadAgentSessionListsFromQuery(queryClient, "/repo", ["", " "], {
+        readPort: createReadPort(agentSessionsListForTasksMock),
+      }),
+    ).resolves.toEqual({});
+    expect(agentSessionsListForTasksMock).not.toHaveBeenCalled();
   });
 
   test("loadAgentSessionListsFromQuery batch-hydrates only missing per-task caches", async () => {

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -256,4 +256,49 @@ describe("agent session query cache helpers", () => {
     expect(sessionsByTaskId).toEqual({ "task-1": [refreshedSession] });
     expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
   });
+
+  test("force-fresh batch loads return the exact task refetch when superseded", async () => {
+    const queryClient = new QueryClient();
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    const refreshedSession = { ...sessionFixture, externalSessionId: "external-2" };
+    let resolveBatch: (value: { taskId: string; agentSessions: AgentSessionRecord[] }[]) => void =
+      () => {
+        throw new Error("Batch resolver was not initialized.");
+      };
+    const batchList = mock(
+      () =>
+        new Promise<{ taskId: string; agentSessions: AgentSessionRecord[] }[]>((resolve) => {
+          resolveBatch = resolve;
+        }),
+    );
+    const singleList = mock(async (_repoPath: string, _taskId: string) => [refreshedSession]);
+    const readPort = {
+      agentSessionsList: singleList,
+      agentSessionsListForTasks: batchList,
+    };
+    queryClient.setQueryDefaults(queryKey, {
+      queryFn: () => singleList("/repo", "task-1"),
+    });
+    queryClient.setQueryData(queryKey, [sessionFixture]);
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
+
+    const load = loadAgentSessionListsFromQuery(queryClient, "/repo", ["task-1"], {
+      forceFresh: true,
+      readPort,
+    });
+    await Promise.resolve();
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+      refetchType: "all",
+    });
+    resolveBatch([
+      {
+        taskId: "task-1",
+        agentSessions: [{ ...sessionFixture, externalSessionId: "stale-session" }],
+      },
+    ]);
+
+    await expect(load).resolves.toEqual({ "task-1": [refreshedSession] });
+    expect(batchList).toHaveBeenCalledTimes(1);
+    expect(singleList).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -112,6 +112,48 @@ describe("agent session query cache helpers", () => {
     expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([newerSession]);
   });
 
+  test("batch hydration does not overwrite an invalidation repeated while already invalidated", async () => {
+    const queryClient = new QueryClient();
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    let resolveBatch: (value: { taskId: string; agentSessions: AgentSessionRecord[] }[]) => void =
+      () => {
+        throw new Error("Batch resolver was not initialized.");
+      };
+    const agentSessionsListForTasksMock = mock(
+      () =>
+        new Promise<{ taskId: string; agentSessions: AgentSessionRecord[] }[]>((resolve) => {
+          resolveBatch = resolve;
+        }),
+    );
+    queryClient.setQueryData(queryKey, [sessionFixture]);
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
+
+    const hydration = queryClient
+      .fetchQuery(
+        agentSessionListHydrationQueryOptions(
+          queryClient,
+          "/repo",
+          ["task-1"],
+          createReadPort(agentSessionsListForTasksMock),
+        ),
+      )
+      .catch(() => undefined);
+    await Promise.resolve();
+    expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
+    resolveBatch([
+      {
+        taskId: "task-1",
+        agentSessions: [{ ...sessionFixture, externalSessionId: "stale-session" }],
+      },
+    ]);
+    await hydration;
+
+    expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([sessionFixture]);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+  });
+
   test("invalidation targets only the canonical per-task cache", async () => {
     const queryClient = new QueryClient();
     const firstListKey = agentSessionQueryKeys.list("/repo", "task-1");

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -23,7 +23,7 @@ describe("agent session query cache helpers", () => {
   test("hydration query keys normalize task ordering, whitespace, duplicates, and empty IDs", () => {
     expect(agentSessionQueryKeys.hydration("/repo", [" task-2 ", "", "task-1", "task-2"])).toEqual([
       "agent-sessions",
-      "hydrate-lists",
+      "hydrate-missing-lists",
       "/repo",
       ["task-1", "task-2"],
     ]);
@@ -33,7 +33,7 @@ describe("agent session query cache helpers", () => {
     const queryClient = new QueryClient();
     const agentSessionsListForTasksMock = mock(async () => [
       { taskId: "task-1", agentSessions: [sessionFixture] },
-      { taskId: "unrequested-task", agentSessions: [sessionFixture] },
+      { taskId: "task-2", agentSessions: [] },
     ]);
     const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
     host.agentSessionsListForTasks = agentSessionsListForTasksMock;
@@ -60,9 +60,6 @@ describe("agent session query cache helpers", () => {
           agentSessionQueryKeys.list("/repo", "task-2"),
         ),
       ).toEqual([]);
-      expect(
-        queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "unrequested-task")),
-      ).toBeUndefined();
     } finally {
       host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     }
@@ -77,6 +74,54 @@ describe("agent session query cache helpers", () => {
     try {
       await hydrateAgentSessionListQueries(queryClient, "/repo", ["", " "]);
       expect(agentSessionsListForTasksMock).not.toHaveBeenCalled();
+    } finally {
+      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
+    }
+  });
+
+  test("batch hydration fails when the host omits a requested task", async () => {
+    const queryClient = new QueryClient();
+    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
+    host.agentSessionsListForTasks = async () => [
+      { taskId: "task-1", agentSessions: [sessionFixture] },
+    ];
+
+    try {
+      await expect(
+        hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1", "task-2"]),
+      ).rejects.toThrow('Batch session response omitted task "task-2".');
+      expect(
+        queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "task-1")),
+      ).toBeUndefined();
+      expect(
+        queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "task-2")),
+      ).toBeUndefined();
+    } finally {
+      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
+    }
+  });
+
+  test("batch hydration does not overwrite a task cache updated while the batch is in flight", async () => {
+    const queryClient = new QueryClient();
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    const newerSession = { ...sessionFixture, externalSessionId: "external-2" };
+    let resolveBatch: (value: { taskId: string; agentSessions: AgentSessionRecord[] }[]) => void =
+      () => {
+        throw new Error("Batch resolver was not initialized.");
+      };
+    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
+    host.agentSessionsListForTasks = () =>
+      new Promise((resolve) => {
+        resolveBatch = resolve;
+      });
+
+    try {
+      const hydration = hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1"]);
+      queryClient.setQueryData(queryKey, [newerSession]);
+      resolveBatch([{ taskId: "task-1", agentSessions: [sessionFixture] }]);
+      await hydration;
+
+      expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([newerSession]);
     } finally {
       host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     }
@@ -134,10 +179,34 @@ describe("agent session query cache helpers", () => {
     }
   });
 
+  test("loadAgentSessionListsFromQuery batch-hydrates only missing per-task caches", async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
+    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
+    const agentSessionsListForTasksMock = mock(async () => [
+      { taskId: "task-2", agentSessions: [] },
+    ]);
+    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
+
+    try {
+      const sessionsByTaskId = await loadAgentSessionListsFromQuery(queryClient, "/repo", [
+        "task-1",
+        "task-2",
+      ]);
+
+      expect(sessionsByTaskId).toEqual({
+        "task-1": [sessionFixture],
+        "task-2": [],
+      });
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-2"]);
+    } finally {
+      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
+    }
+  });
+
   test("loadAgentSessionListsFromQuery reuses hydrated per-task cache entries", async () => {
     const queryClient = new QueryClient();
     queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
-    queryClient.setQueryData(agentSessionQueryKeys.hydration("/repo", ["task-1"]), true);
 
     const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
     host.agentSessionsListForTasks = async () => {

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -412,4 +412,38 @@ describe("agent session query cache helpers", () => {
     expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([afterSecondMutation]);
     expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
   });
+
+  test("plain invalidation cancels an older exact refresh and remains invalidated", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    let releaseRead: () => void = () => {
+      throw new Error("Read was not started.");
+    };
+    let markReadStarted: () => void = () => {
+      throw new Error("Read-start signal was not initialized.");
+    };
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    const readRelease = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const singleList = mock(async () => {
+      markReadStarted();
+      await readRelease;
+      return [{ ...sessionFixture, externalSessionId: "stale-session" }];
+    });
+    queryClient.setQueryData(queryKey, [sessionFixture]);
+
+    const refresh = refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+      agentSessionsList: singleList,
+    });
+    await readStarted;
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
+    releaseRead();
+    await refresh;
+
+    expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([sessionFixture]);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+  });
 });

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -128,16 +128,14 @@ describe("agent session query cache helpers", () => {
     queryClient.setQueryData(queryKey, [sessionFixture]);
     await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
 
-    const hydration = queryClient
-      .fetchQuery(
-        agentSessionListHydrationQueryOptions(
-          queryClient,
-          "/repo",
-          ["task-1"],
-          createReadPort(agentSessionsListForTasksMock),
-        ),
-      )
-      .catch(() => undefined);
+    const hydration = queryClient.fetchQuery(
+      agentSessionListHydrationQueryOptions(
+        queryClient,
+        "/repo",
+        ["task-1"],
+        createReadPort(agentSessionsListForTasksMock),
+      ),
+    );
     await Promise.resolve();
     expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
 

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -288,6 +288,7 @@ describe("agent session query cache helpers", () => {
     });
     await Promise.resolve();
     await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+      readPort,
       refetchType: "all",
     });
     resolveBatch([
@@ -306,19 +307,21 @@ describe("agent session query cache helpers", () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
     let failRefresh = false;
+    const singleList = async () => {
+      if (failRefresh) {
+        throw new Error("ordinary refresh failed");
+      }
+      return [sessionFixture];
+    };
     await queryClient.fetchQuery({
       queryKey,
-      queryFn: async () => {
-        if (failRefresh) {
-          throw new Error("ordinary refresh failed");
-        }
-        return [sessionFixture];
-      },
+      queryFn: singleList,
     });
     failRefresh = true;
 
     await expect(
       invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+        readPort: { agentSessionsList: singleList },
         refetchType: "all",
       }),
     ).rejects.toThrow("ordinary refresh failed");
@@ -329,23 +332,48 @@ describe("agent session query cache helpers", () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
     let failRefresh = false;
+    const singleList = async () => {
+      if (failRefresh) {
+        throw new Error("static refresh failed");
+      }
+      return [sessionFixture];
+    };
     await queryClient.fetchQuery({
       queryKey,
-      queryFn: async () => {
-        if (failRefresh) {
-          throw new Error("static refresh failed");
-        }
-        return [sessionFixture];
-      },
+      queryFn: singleList,
       staleTime: "static",
     });
     failRefresh = true;
 
     await expect(
       invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+        readPort: { agentSessionsList: singleList },
         refetchType: "all",
       }),
     ).rejects.toThrow("static refresh failed");
     expect(queryClient.getQueryState(queryKey)?.status).toBe("error");
+  });
+
+  test("exact invalidation refetches a batch-seeded inactive task with canonical options", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const refreshedSession = { ...sessionFixture, externalSessionId: "session-refreshed" };
+    const singleList = mock(async () => [refreshedSession]);
+    const readPort = {
+      agentSessionsList: singleList,
+      agentSessionsListForTasks: mock(async () => [
+        { taskId: "task-1", agentSessions: [sessionFixture] },
+      ]),
+    };
+
+    await hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1"], readPort);
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+      readPort,
+      refetchType: "all",
+    });
+
+    expect(singleList).toHaveBeenCalledTimes(1);
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
+    ).toEqual([refreshedSession]);
   });
 });

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -8,6 +8,7 @@ import {
   hydrateAgentSessionListQueries,
   invalidateAgentSessionListQuery,
   loadAgentSessionListsFromQuery,
+  refreshAgentSessionListQuery,
 } from "./agent-sessions";
 
 const sessionFixture: AgentSessionRecord = {
@@ -287,10 +288,7 @@ describe("agent session query cache helpers", () => {
       readPort,
     });
     await Promise.resolve();
-    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
-      readPort,
-      refetchType: "all",
-    });
+    await refreshAgentSessionListQuery(queryClient, "/repo", "task-1", readPort);
     resolveBatch([
       {
         taskId: "task-1",
@@ -320,9 +318,8 @@ describe("agent session query cache helpers", () => {
     failRefresh = true;
 
     await expect(
-      invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
-        readPort: { agentSessionsList: singleList },
-        refetchType: "all",
+      refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+        agentSessionsList: singleList,
       }),
     ).rejects.toThrow("ordinary refresh failed");
     expect(queryClient.getQueryState(queryKey)?.status).toBe("error");
@@ -346,9 +343,8 @@ describe("agent session query cache helpers", () => {
     failRefresh = true;
 
     await expect(
-      invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
-        readPort: { agentSessionsList: singleList },
-        refetchType: "all",
+      refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+        agentSessionsList: singleList,
       }),
     ).rejects.toThrow("static refresh failed");
     expect(queryClient.getQueryState(queryKey)?.status).toBe("error");
@@ -366,14 +362,54 @@ describe("agent session query cache helpers", () => {
     };
 
     await hydrateAgentSessionListQueries(queryClient, "/repo", ["task-1"], readPort);
-    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
-      readPort,
-      refetchType: "all",
-    });
+    await refreshAgentSessionListQuery(queryClient, "/repo", "task-1", readPort);
 
     expect(singleList).toHaveBeenCalledTimes(1);
     expect(
       queryClient.getQueryData<AgentSessionRecord[]>(agentSessionQueryKeys.list("/repo", "task-1")),
     ).toEqual([refreshedSession]);
+  });
+
+  test("a newer exact invalidation starts a fresh read instead of sharing an older snapshot", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    const afterFirstMutation = { ...sessionFixture, externalSessionId: "after-first" };
+    const afterSecondMutation = { ...sessionFixture, externalSessionId: "after-second" };
+    let durableSessions = [afterFirstMutation];
+    let releaseFirstRead: () => void = () => {
+      throw new Error("First read was not started.");
+    };
+    let markFirstReadStarted: () => void = () => {
+      throw new Error("First-read signal was not initialized.");
+    };
+    const firstReadStarted = new Promise<void>((resolve) => {
+      markFirstReadStarted = resolve;
+    });
+    const firstReadRelease = new Promise<void>((resolve) => {
+      releaseFirstRead = resolve;
+    });
+    const singleList = mock(async () => {
+      const snapshot = durableSessions;
+      if (singleList.mock.calls.length === 1) {
+        markFirstReadStarted();
+        await firstReadRelease;
+      }
+      return snapshot;
+    });
+    const readPort = { agentSessionsList: singleList };
+    queryClient.setQueryData(queryKey, [sessionFixture]);
+
+    const firstRefresh = refreshAgentSessionListQuery(queryClient, "/repo", "task-1", readPort);
+    await firstReadStarted;
+    durableSessions = [afterSecondMutation];
+    const secondRefresh = refreshAgentSessionListQuery(queryClient, "/repo", "task-1", readPort);
+
+    await secondRefresh;
+    releaseFirstRead();
+    await firstRefresh;
+
+    expect(singleList).toHaveBeenCalledTimes(2);
+    expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([afterSecondMutation]);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
   });
 });

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -4,6 +4,7 @@ import { QueryClient } from "@tanstack/react-query";
 import {
   type AgentSessionReadPort,
   agentSessionListHydrationQueryOptions,
+  agentSessionListQueryOptions,
   agentSessionQueryKeys,
   hydrateAgentSessionListQueries,
   invalidateAgentSessionListQuery,
@@ -283,7 +284,7 @@ describe("agent session query cache helpers", () => {
     expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
   });
 
-  test("force-fresh batch loads return the exact task refetch when superseded", async () => {
+  test("force-fresh batch loads await an exact task refetch that is still in flight", async () => {
     const queryClient = new QueryClient();
     const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
     const refreshedSession = { ...sessionFixture, externalSessionId: "external-2" };
@@ -297,7 +298,23 @@ describe("agent session query cache helpers", () => {
           resolveBatch = resolve;
         }),
     );
-    const singleList = mock(async (_repoPath: string, _taskId: string) => [refreshedSession]);
+    let releaseSingleRead: () => void = () => {
+      throw new Error("Single-read release was not initialized.");
+    };
+    let markSingleReadStarted: () => void = () => {
+      throw new Error("Single-read start signal was not initialized.");
+    };
+    const singleReadStarted = new Promise<void>((resolve) => {
+      markSingleReadStarted = resolve;
+    });
+    const singleReadRelease = new Promise<void>((resolve) => {
+      releaseSingleRead = resolve;
+    });
+    const singleList = mock(async (_repoPath: string, _taskId: string) => {
+      markSingleReadStarted();
+      await singleReadRelease;
+      return [refreshedSession];
+    });
     const readPort = {
       agentSessionsList: singleList,
       agentSessionsListForTasks: batchList,
@@ -313,16 +330,88 @@ describe("agent session query cache helpers", () => {
       readPort,
     });
     await Promise.resolve();
-    await refreshAgentSessionListQuery(queryClient, "/repo", "task-1", readPort);
+    const refresh = refreshAgentSessionListQuery(queryClient, "/repo", "task-1", readPort);
+    await singleReadStarted;
     resolveBatch([
       {
         taskId: "task-1",
         agentSessions: [{ ...sessionFixture, externalSessionId: "stale-session" }],
       },
     ]);
+    let loadOutcome: "pending" | "resolved" | "rejected" = "pending";
+    const observedLoad = load.then(
+      (value) => {
+        loadOutcome = "resolved";
+        return { status: "resolved" as const, value };
+      },
+      (error: unknown) => {
+        loadOutcome = "rejected";
+        return { status: "rejected" as const, error };
+      },
+    );
+    const hydrationKey = agentSessionQueryKeys.hydration("/repo", ["task-1"]);
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (queryClient.getQueryState(hydrationKey)?.status === "success") {
+        break;
+      }
+      await Promise.resolve();
+    }
+    await Promise.resolve();
 
-    await expect(load).resolves.toEqual({ "task-1": [refreshedSession] });
+    expect(queryClient.getQueryState(hydrationKey)?.status).toBe("success");
+    expect(loadOutcome).toBe("pending");
+    releaseSingleRead();
+    await expect(observedLoad).resolves.toEqual({
+      status: "resolved",
+      value: { "task-1": [refreshedSession] },
+    });
+    await refresh;
     expect(batchList).toHaveBeenCalledTimes(1);
+    expect(singleList).toHaveBeenCalledTimes(1);
+  });
+
+  test("batch hydration defers to a canonical per-task read already in flight", async () => {
+    const queryClient = new QueryClient();
+    const firstQueryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    const secondQueryKey = agentSessionQueryKeys.list("/repo", "task-2");
+    const canonicalSession = { ...sessionFixture, externalSessionId: "canonical-session" };
+    let releaseCanonicalRead: () => void = () => {
+      throw new Error("Canonical read release was not initialized.");
+    };
+    const canonicalReadRelease = new Promise<void>((resolve) => {
+      releaseCanonicalRead = resolve;
+    });
+    const singleList = mock(async () => {
+      await canonicalReadRelease;
+      return [canonicalSession];
+    });
+    const batchList = mock(async (_repoPath: string, taskIds: string[]) => {
+      expect(taskIds).toEqual(["task-2"]);
+      return [{ taskId: "task-2", agentSessions: [] }];
+    });
+    const readPort = {
+      agentSessionsList: singleList,
+      agentSessionsListForTasks: batchList,
+    };
+
+    const canonicalRead = queryClient.fetchQuery(
+      agentSessionListQueryOptions("/repo", "task-1", readPort),
+    );
+    const hydration = hydrateAgentSessionListQueries(
+      queryClient,
+      "/repo",
+      ["task-1", "task-2"],
+      readPort,
+    );
+    await Promise.resolve();
+
+    expect(batchList).toHaveBeenCalledTimes(1);
+    releaseCanonicalRead();
+    await Promise.all([canonicalRead, hydration]);
+    expect(queryClient.getQueryData<AgentSessionRecord[]>(firstQueryKey)).toEqual([
+      canonicalSession,
+    ]);
+    expect(queryClient.getQueryData<AgentSessionRecord[]>(secondQueryKey)).toEqual([]);
     expect(singleList).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { host } from "../operations/host";
 import {
+  agentSessionListHydrationQueryOptions,
   agentSessionQueryKeys,
+  hydrateAgentSessionListQueries,
+  invalidateAgentSessionListQuery,
   loadAgentSessionListsFromQuery,
-  upsertAgentSessionRecordInQuery,
 } from "./agent-sessions";
 
 const sessionFixture: AgentSessionRecord = {
@@ -18,125 +20,92 @@ const sessionFixture: AgentSessionRecord = {
 };
 
 describe("agent session query cache helpers", () => {
-  const selectedModelFixture: NonNullable<AgentSessionRecord["selectedModel"]> = {
-    runtimeKind: "opencode",
-    providerId: "anthropic",
-    modelId: "claude-sonnet",
-    variant: "latest",
-    profileId: "work",
-  };
-
-  test("upsertAgentSessionRecordInQuery inserts a missing session record", () => {
-    const queryClient = new QueryClient();
-    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), []);
-
-    upsertAgentSessionRecordInQuery(queryClient, "/repo", "task-1", sessionFixture);
-
-    const sessions = queryClient.getQueryData<AgentSessionRecord[]>(
-      agentSessionQueryKeys.list("/repo", "task-1"),
-    );
-
-    expect(sessions).toEqual([sessionFixture]);
+  test("hydration query keys normalize task ordering, whitespace, duplicates, and empty IDs", () => {
+    expect(agentSessionQueryKeys.hydration("/repo", [" task-2 ", "", "task-1", "task-2"])).toEqual([
+      "agent-sessions",
+      "hydrate-lists",
+      "/repo",
+      ["task-1", "task-2"],
+    ]);
   });
 
-  test("upsertAgentSessionRecordInQuery replaces an existing session record with the same identity", () => {
+  test("batch hydration makes one normalized host call and seeds canonical per-task caches", async () => {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
+    const agentSessionsListForTasksMock = mock(async () => [
+      { taskId: "task-1", agentSessions: [sessionFixture] },
+      { taskId: "unrequested-task", agentSessions: [sessionFixture] },
+    ]);
+    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
+    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
 
-    const updatedSession: AgentSessionRecord = {
-      ...sessionFixture,
-      startedAt: "2026-03-22T12:30:00.000Z",
-    };
+    try {
+      const result = await queryClient.fetchQuery(
+        agentSessionListHydrationQueryOptions(queryClient, "/repo", [
+          " task-2 ",
+          "task-1",
+          "task-2",
+        ]),
+      );
 
-    upsertAgentSessionRecordInQuery(queryClient, "/repo", "task-1", updatedSession);
-
-    const sessions = queryClient.getQueryData<AgentSessionRecord[]>(
-      agentSessionQueryKeys.list("/repo", "task-1"),
-    );
-
-    expect(sessions).toEqual([updatedSession]);
+      expect(result).toBe(true);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
+      expect(
+        queryClient.getQueryData<AgentSessionRecord[]>(
+          agentSessionQueryKeys.list("/repo", "task-1"),
+        ),
+      ).toEqual([sessionFixture]);
+      expect(
+        queryClient.getQueryData<AgentSessionRecord[]>(
+          agentSessionQueryKeys.list("/repo", "task-2"),
+        ),
+      ).toEqual([]);
+      expect(
+        queryClient.getQueryData(agentSessionQueryKeys.list("/repo", "unrequested-task")),
+      ).toBeUndefined();
+    } finally {
+      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
+    }
   });
 
-  test("upsertAgentSessionRecordInQuery keeps equivalent session records stable", () => {
+  test("empty hydration does not call the host", async () => {
     const queryClient = new QueryClient();
-    const sessionWithModel: AgentSessionRecord = {
-      ...sessionFixture,
-      selectedModel: selectedModelFixture,
-    };
-    const cachedSessions = [sessionWithModel];
-    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), cachedSessions);
+    const agentSessionsListForTasksMock = mock(async () => []);
+    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
+    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
 
-    upsertAgentSessionRecordInQuery(queryClient, "/repo", "task-1", {
-      ...sessionWithModel,
-      selectedModel: {
-        ...selectedModelFixture,
-      },
-    });
-
-    const sessions = queryClient.getQueryData<AgentSessionRecord[]>(
-      agentSessionQueryKeys.list("/repo", "task-1"),
-    );
-
-    expect(sessions).toBe(cachedSessions);
-    expect(sessions?.[0]).toBe(sessionWithModel);
+    try {
+      await hydrateAgentSessionListQueries(queryClient, "/repo", ["", " "]);
+      expect(agentSessionsListForTasksMock).not.toHaveBeenCalled();
+    } finally {
+      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
+    }
   });
 
-  test("upsertAgentSessionRecordInQuery replaces records when selected model changes", () => {
+  test("invalidation targets only the canonical per-task cache", async () => {
     const queryClient = new QueryClient();
-    const originalSession: AgentSessionRecord = {
-      ...sessionFixture,
-      selectedModel: {
-        runtimeKind: "opencode",
-        providerId: "anthropic",
-        modelId: "claude-sonnet",
-      },
-    };
-    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [originalSession]);
+    const firstListKey = agentSessionQueryKeys.list("/repo", "task-1");
+    const secondListKey = agentSessionQueryKeys.list("/repo", "task-2");
+    const hydrationKey = agentSessionQueryKeys.hydration("/repo", ["task-1", "task-2"]);
+    queryClient.setQueryData(firstListKey, []);
+    queryClient.setQueryData(secondListKey, []);
+    queryClient.setQueryData(hydrationKey, true);
 
-    const updatedSession: AgentSessionRecord = {
-      ...originalSession,
-      selectedModel: {
-        runtimeKind: "opencode",
-        providerId: "anthropic",
-        modelId: "claude-opus",
-      },
-    };
-    upsertAgentSessionRecordInQuery(queryClient, "/repo", "task-1", updatedSession);
+    await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
 
-    const sessions = queryClient.getQueryData<AgentSessionRecord[]>(
-      agentSessionQueryKeys.list("/repo", "task-1"),
-    );
-
-    expect(sessions).toEqual([updatedSession]);
+    expect(queryClient.getQueryState(firstListKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(secondListKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(hydrationKey)?.isInvalidated).toBe(false);
   });
 
-  test("upsertAgentSessionRecordInQuery keeps records distinct when only external id matches", () => {
+  test("loadAgentSessionListsFromQuery batch-hydrates the per-task session cache", async () => {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
-
-    const otherRuntimeSession: AgentSessionRecord = {
-      ...sessionFixture,
-      runtimeKind: "codex",
-      workingDirectory: "/tmp/repo/codex-worktree",
-    };
-
-    upsertAgentSessionRecordInQuery(queryClient, "/repo", "task-1", otherRuntimeSession);
-
-    const sessions = queryClient.getQueryData<AgentSessionRecord[]>(
-      agentSessionQueryKeys.list("/repo", "task-1"),
-    );
-
-    expect(sessions).toEqual([sessionFixture, otherRuntimeSession]);
-  });
-
-  test("loadAgentSessionListsFromQuery reads the per-task session cache", async () => {
-    const queryClient = new QueryClient();
-    const originalAgentSessionsList = host.agentSessionsList;
-    const hostCalls: string[] = [];
-    host.agentSessionsList = async (_repoPath, taskId) => {
-      hostCalls.push(taskId);
-      return taskId === "task-2" ? [] : [sessionFixture];
-    };
+    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
+    const agentSessionsListForTasksMock = mock(async () => [
+      { taskId: "task-1", agentSessions: [sessionFixture] },
+      { taskId: "task-2", agentSessions: [] },
+    ]);
+    host.agentSessionsListForTasks = agentSessionsListForTasksMock;
 
     try {
       const sessionsByTaskId = await loadAgentSessionListsFromQuery(queryClient, "/repo", [
@@ -148,7 +117,8 @@ describe("agent session query cache helpers", () => {
         "task-1": [sessionFixture],
         "task-2": [],
       });
-      expect(hostCalls).toEqual(["task-1", "task-2"]);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledTimes(1);
+      expect(agentSessionsListForTasksMock).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
       expect(
         queryClient.getQueryData<AgentSessionRecord[]>(
           agentSessionQueryKeys.list("/repo", "task-1"),
@@ -160,17 +130,17 @@ describe("agent session query cache helpers", () => {
         ),
       ).toEqual([]);
     } finally {
-      host.agentSessionsList = originalAgentSessionsList;
+      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     }
   });
 
-  test("loadAgentSessionListsFromQuery uses the same list cache updated by session upserts", async () => {
+  test("loadAgentSessionListsFromQuery reuses hydrated per-task cache entries", async () => {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), []);
-    upsertAgentSessionRecordInQuery(queryClient, "/repo", "task-1", sessionFixture);
+    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
+    queryClient.setQueryData(agentSessionQueryKeys.hydration("/repo", ["task-1"]), true);
 
-    const originalAgentSessionsList = host.agentSessionsList;
-    host.agentSessionsList = async () => {
+    const originalAgentSessionsListForTasks = host.agentSessionsListForTasks;
+    host.agentSessionsListForTasks = async () => {
       throw new Error("The cached per-task session list should be authoritative.");
     };
 
@@ -183,7 +153,7 @@ describe("agent session query cache helpers", () => {
         "task-1": [sessionFixture],
       });
     } finally {
-      host.agentSessionsList = originalAgentSessionsList;
+      host.agentSessionsListForTasks = originalAgentSessionsListForTasks;
     }
   });
 });

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -10,6 +10,8 @@ import {
   invalidateAgentSessionListQuery,
   loadAgentSessionListsFromQuery,
   refreshAgentSessionListQuery,
+  removeAgentSessionListQueries,
+  retryAgentSessionListQueries,
 } from "./agent-sessions";
 
 const sessionFixture: AgentSessionRecord = {
@@ -165,6 +167,41 @@ describe("agent session query cache helpers", () => {
 
     expect(queryClient.getQueryData<AgentSessionRecord[]>(queryKey)).toEqual([sessionFixture]);
     expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+  });
+
+  test("removing a task cache prevents an older batch from restoring it", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    queryClient.setQueryData(queryKey, [sessionFixture]);
+    let releaseBatch: () => void = () => {
+      throw new Error("Batch read was not started.");
+    };
+    let markBatchStarted: () => void = () => {
+      throw new Error("Batch-start signal was not initialized.");
+    };
+    const batchStarted = new Promise<void>((resolve) => {
+      markBatchStarted = resolve;
+    });
+    const batchRelease = new Promise<void>((resolve) => {
+      releaseBatch = resolve;
+    });
+    const hydration = hydrateAgentSessionListQueries(
+      queryClient,
+      "/repo",
+      ["task-1"],
+      createReadPort(async () => {
+        markBatchStarted();
+        await batchRelease;
+        return [{ taskId: "task-1", agentSessions: [sessionFixture] }];
+      }),
+    );
+    await batchStarted;
+
+    await removeAgentSessionListQueries(queryClient, "/repo", ["task-1"]);
+    releaseBatch();
+    await hydration;
+
+    expect(queryClient.getQueryData(queryKey)).toBeUndefined();
   });
 
   test("invalidation targets only the canonical per-task cache", async () => {
@@ -437,6 +474,51 @@ describe("agent session query cache helpers", () => {
       }),
     ).rejects.toThrow("ordinary refresh failed");
     expect(queryClient.getQueryState(queryKey)?.status).toBe("error");
+  });
+
+  test("explicit retry batch-loads only failed and missing task session queries", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const healthySession = { ...sessionFixture, externalSessionId: "healthy" };
+    const recoveredSession = { ...sessionFixture, externalSessionId: "recovered" };
+    const missingSession = { ...sessionFixture, externalSessionId: "missing" };
+    queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-healthy"), [healthySession]);
+    await expect(
+      queryClient.fetchQuery({
+        queryKey: agentSessionQueryKeys.list("/repo", "task-failed"),
+        queryFn: async () => {
+          throw new Error("temporary failure");
+        },
+      }),
+    ).rejects.toThrow("temporary failure");
+    const batchList = mock(async () => [
+      { taskId: "task-failed", agentSessions: [recoveredSession] },
+      { taskId: "task-missing", agentSessions: [missingSession] },
+    ]);
+
+    await retryAgentSessionListQueries(
+      queryClient,
+      "/repo",
+      ["task-healthy", "task-failed", "task-missing"],
+      createReadPort(batchList),
+    );
+
+    expect(batchList).toHaveBeenCalledTimes(1);
+    expect(batchList).toHaveBeenCalledWith("/repo", ["task-failed", "task-missing"]);
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(
+        agentSessionQueryKeys.list("/repo", "task-healthy"),
+      ),
+    ).toEqual([healthySession]);
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(
+        agentSessionQueryKeys.list("/repo", "task-failed"),
+      ),
+    ).toEqual([recoveredSession]);
+    expect(
+      queryClient.getQueryData<AgentSessionRecord[]>(
+        agentSessionQueryKeys.list("/repo", "task-missing"),
+      ),
+    ).toEqual([missingSession]);
   });
 
   test("exact invalidation propagates a disabled static-query refresh failure", async () => {

--- a/packages/frontend/src/state/queries/agent-sessions.test.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.test.ts
@@ -301,4 +301,51 @@ describe("agent session query cache helpers", () => {
     expect(batchList).toHaveBeenCalledTimes(1);
     expect(singleList).toHaveBeenCalledTimes(1);
   });
+
+  test("exact invalidation propagates an ordinary refetch failure", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    let failRefresh = false;
+    await queryClient.fetchQuery({
+      queryKey,
+      queryFn: async () => {
+        if (failRefresh) {
+          throw new Error("ordinary refresh failed");
+        }
+        return [sessionFixture];
+      },
+    });
+    failRefresh = true;
+
+    await expect(
+      invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+        refetchType: "all",
+      }),
+    ).rejects.toThrow("ordinary refresh failed");
+    expect(queryClient.getQueryState(queryKey)?.status).toBe("error");
+  });
+
+  test("exact invalidation propagates a disabled static-query refresh failure", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const queryKey = agentSessionQueryKeys.list("/repo", "task-1");
+    let failRefresh = false;
+    await queryClient.fetchQuery({
+      queryKey,
+      queryFn: async () => {
+        if (failRefresh) {
+          throw new Error("static refresh failed");
+        }
+        return [sessionFixture];
+      },
+      staleTime: "static",
+    });
+    failRefresh = true;
+
+    await expect(
+      invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+        refetchType: "all",
+      }),
+    ).rejects.toThrow("static refresh failed");
+    expect(queryClient.getQueryState(queryKey)?.status).toBe("error");
+  });
 });

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -64,6 +64,7 @@ export const agentSessionListQueryOptions = (
   queryOptions({
     queryKey: agentSessionQueryKeys.list(repoPath, taskId),
     queryFn: (): Promise<AgentSessionRecord[]> => readPort.agentSessionsList(repoPath, taskId),
+    retryOnMount: false,
     staleTime: AGENT_SESSION_LIST_STALE_TIME,
   });
 

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -281,6 +281,9 @@ export const retryAgentSessionListQueries = async (
       queryClient.getQueryData(queryKey) === undefined
     );
   });
+  for (const taskId of taskIdsToRetry) {
+    incrementAgentSessionInvalidationVersion(queryClient, repoPath, taskId);
+  }
   await hydrateAgentSessionListQueries(queryClient, repoPath, taskIdsToRetry, readPort);
 };
 

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -285,7 +285,7 @@ export const refreshAgentSessionListQuery = async (
     queryClient,
     repoPath,
     taskId,
-    async ({ invalidationVersion, queryKey }) => {
+    async ({ invalidationVersion }) => {
       try {
         await queryClient.fetchQuery({
           ...agentSessionListQueryOptions(repoPath, taskId, readPort),

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -1,5 +1,5 @@
 import type { AgentSessionRecord } from "@openducktor/contracts";
-import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { isCancelledError, type QueryClient, queryOptions } from "@tanstack/react-query";
 import { host } from "../operations/host";
 
 const AGENT_SESSION_LIST_STALE_TIME = Number.POSITIVE_INFINITY;
@@ -26,11 +26,13 @@ const incrementAgentSessionInvalidationVersion = (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
-): void => {
+): number => {
   const versions = invalidationVersionsByQueryClient.get(queryClient) ?? new Map<string, number>();
   const versionKey = agentSessionInvalidationVersionKey(repoPath, taskId);
-  versions.set(versionKey, (versions.get(versionKey) ?? 0) + 1);
+  const version = (versions.get(versionKey) ?? 0) + 1;
+  versions.set(versionKey, version);
   invalidationVersionsByQueryClient.set(queryClient, versions);
+  return version;
 };
 
 export const normalizeAgentSessionTaskIds = (taskIds: string[]): string[] =>
@@ -216,33 +218,59 @@ export const loadAgentSessionListsFromQuery = async (
   return Object.fromEntries(entries);
 };
 
+const beginAgentSessionListInvalidation = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): Promise<number> => {
+  const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+  const invalidationVersion = incrementAgentSessionInvalidationVersion(
+    queryClient,
+    repoPath,
+    taskId,
+  );
+  await queryClient.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
+  return invalidationVersion;
+};
+
 export const invalidateAgentSessionListQuery = async (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
-  options?: {
-    readPort?: Pick<AgentSessionReadPort, "agentSessionsList">;
-    refetchType?: "active" | "all";
-  },
+): Promise<void> => {
+  await beginAgentSessionListInvalidation(queryClient, repoPath, taskId);
+};
+
+export const refreshAgentSessionListQuery = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+  readPort: Pick<AgentSessionReadPort, "agentSessionsList"> = host,
 ): Promise<void> => {
   const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
-  incrementAgentSessionInvalidationVersion(queryClient, repoPath, taskId);
-
-  if (options?.refetchType === "all") {
-    await queryClient.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
-    await queryClient.fetchQuery({
-      ...agentSessionListQueryOptions(repoPath, taskId, options.readPort),
-      staleTime: 0,
-    });
+  const invalidationVersion = await beginAgentSessionListInvalidation(
+    queryClient,
+    repoPath,
+    taskId,
+  );
+  if (getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion) {
     return;
   }
-
-  await queryClient.invalidateQueries(
-    {
-      queryKey,
-      exact: true,
-      refetchType: options?.refetchType ?? "none",
-    },
-    { throwOnError: true },
-  );
+  await queryClient.cancelQueries({ queryKey, exact: true });
+  if (getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion) {
+    return;
+  }
+  try {
+    await queryClient.fetchQuery({
+      ...agentSessionListQueryOptions(repoPath, taskId, readPort),
+      staleTime: 0,
+    });
+  } catch (error) {
+    const superseded =
+      getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion;
+    if (superseded && isCancelledError(error)) {
+      return;
+    }
+    throw error;
+  }
 };

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -70,6 +70,17 @@ export const agentSessionListQueryOptions = (
     staleTime: AGENT_SESSION_LIST_STALE_TIME,
   });
 
+const joinInFlightAgentSessionListQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+  readPort: Pick<AgentSessionReadPort, "agentSessionsList">,
+): Promise<AgentSessionRecord[]> =>
+  queryClient.fetchQuery({
+    ...agentSessionListQueryOptions(repoPath, taskId, readPort),
+    staleTime: 0,
+  });
+
 export const hydrateAgentSessionListQueries = async (
   queryClient: QueryClient,
   repoPath: string,
@@ -81,20 +92,36 @@ export const hydrateAgentSessionListQueries = async (
     return;
   }
 
-  const requestedTaskIds = new Set(normalizedTaskIds);
   const initialQueryStates = new Map(
     normalizedTaskIds.map((taskId) => [
       taskId,
       queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId)),
     ]),
   );
+  const taskIdsWithInFlightQueries = normalizedTaskIds.filter(
+    (taskId) => initialQueryStates.get(taskId)?.fetchStatus === "fetching",
+  );
+  const taskIdsToHydrate = normalizedTaskIds.filter(
+    (taskId) => initialQueryStates.get(taskId)?.fetchStatus !== "fetching",
+  );
+  const inFlightQueries = taskIdsWithInFlightQueries.map((taskId) =>
+    joinInFlightAgentSessionListQuery(queryClient, repoPath, taskId, readPort),
+  );
+  if (taskIdsToHydrate.length === 0) {
+    await Promise.all(inFlightQueries);
+    return;
+  }
   const initialInvalidationVersions = new Map(
-    normalizedTaskIds.map((taskId) => [
+    taskIdsToHydrate.map((taskId) => [
       taskId,
       getAgentSessionInvalidationVersion(queryClient, repoPath, taskId),
     ]),
   );
-  const taskSessions = await readPort.agentSessionsListForTasks(repoPath, normalizedTaskIds);
+  const [taskSessions] = await Promise.all([
+    readPort.agentSessionsListForTasks(repoPath, taskIdsToHydrate),
+    Promise.all(inFlightQueries),
+  ]);
+  const requestedTaskIds = new Set(taskIdsToHydrate);
   const sessionsByTaskId = new Map<string, AgentSessionRecord[]>();
   for (const taskSession of taskSessions) {
     if (!requestedTaskIds.has(taskSession.taskId)) {
@@ -108,11 +135,11 @@ export const hydrateAgentSessionListQueries = async (
     sessionsByTaskId.set(taskSession.taskId, taskSession.agentSessions);
   }
 
-  const missingTaskId = normalizedTaskIds.find((taskId) => !sessionsByTaskId.has(taskId));
+  const missingTaskId = taskIdsToHydrate.find((taskId) => !sessionsByTaskId.has(taskId));
   if (missingTaskId) {
     throw new Error(`Batch session response omitted task "${missingTaskId}".`);
   }
-  for (const taskId of normalizedTaskIds) {
+  for (const taskId of taskIdsToHydrate) {
     const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
     const initialState = initialQueryStates.get(taskId);
     const currentState = queryClient.getQueryState(queryKey);
@@ -203,15 +230,34 @@ export const loadAgentSessionListsFromQuery = async (
       ),
       ...(options?.forceFresh || refreshesInvalidatedData ? { staleTime: 0 } : {}),
     });
+    await Promise.all(
+      taskIdsToHydrate.flatMap((taskId) => {
+        const queryState = queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId));
+        return queryState?.fetchStatus === "fetching"
+          ? [
+              joinInFlightAgentSessionListQuery(
+                queryClient,
+                repoPath,
+                taskId,
+                options?.readPort ?? host,
+              ),
+            ]
+          : [];
+      }),
+    );
   }
 
   const entries = normalizedTaskIds.map((taskId) => {
     const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+    const queryState = queryClient.getQueryState(queryKey);
+    if (queryState?.status === "error") {
+      throw queryState.error;
+    }
     const records = queryClient.getQueryData<AgentSessionRecord[]>(queryKey);
     if (!records) {
       throw new Error(`Batch session hydration did not populate task "${taskId}".`);
     }
-    if (queryClient.getQueryState(queryKey)?.isInvalidated === true) {
+    if (queryState?.isInvalidated === true) {
       throw new Error(`Batch session hydration for task "${taskId}" was superseded.`);
     }
     return [taskId, records] as const;

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -3,11 +3,35 @@ import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { host } from "../operations/host";
 
 const AGENT_SESSION_LIST_STALE_TIME = Number.POSITIVE_INFINITY;
+const invalidationVersionsByQueryClient = new WeakMap<QueryClient, Map<string, number>>();
 
 export type AgentSessionReadPort = Pick<
   typeof host,
   "agentSessionsList" | "agentSessionsListForTasks"
 >;
+
+const agentSessionInvalidationVersionKey = (repoPath: string, taskId: string): string =>
+  JSON.stringify([repoPath, taskId]);
+
+const getAgentSessionInvalidationVersion = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): number =>
+  invalidationVersionsByQueryClient
+    .get(queryClient)
+    ?.get(agentSessionInvalidationVersionKey(repoPath, taskId)) ?? 0;
+
+const incrementAgentSessionInvalidationVersion = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): void => {
+  const versions = invalidationVersionsByQueryClient.get(queryClient) ?? new Map<string, number>();
+  const versionKey = agentSessionInvalidationVersionKey(repoPath, taskId);
+  versions.set(versionKey, (versions.get(versionKey) ?? 0) + 1);
+  invalidationVersionsByQueryClient.set(queryClient, versions);
+};
 
 export const normalizeAgentSessionTaskIds = (taskIds: string[]): string[] =>
   Array.from(
@@ -48,7 +72,6 @@ export const hydrateAgentSessionListQueries = async (
   repoPath: string,
   taskIds: string[],
   readPort: AgentSessionReadPort = host,
-  signal?: AbortSignal,
 ): Promise<void> => {
   const normalizedTaskIds = normalizeAgentSessionTaskIds(taskIds);
   if (normalizedTaskIds.length === 0) {
@@ -60,6 +83,12 @@ export const hydrateAgentSessionListQueries = async (
     normalizedTaskIds.map((taskId) => [
       taskId,
       queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId)),
+    ]),
+  );
+  const initialInvalidationVersions = new Map(
+    normalizedTaskIds.map((taskId) => [
+      taskId,
+      getAgentSessionInvalidationVersion(queryClient, repoPath, taskId),
     ]),
   );
   const taskSessions = await readPort.agentSessionsListForTasks(repoPath, normalizedTaskIds);
@@ -80,8 +109,6 @@ export const hydrateAgentSessionListQueries = async (
   if (missingTaskId) {
     throw new Error(`Batch session response omitted task "${missingTaskId}".`);
   }
-  signal?.throwIfAborted();
-
   for (const taskId of normalizedTaskIds) {
     const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
     const initialState = initialQueryStates.get(taskId);
@@ -91,7 +118,10 @@ export const hydrateAgentSessionListQueries = async (
       (currentState?.errorUpdateCount ?? 0) !== (initialState?.errorUpdateCount ?? 0);
     const invalidatedAfterBatchStarted =
       initialState?.isInvalidated !== true && currentState?.isInvalidated === true;
-    if (generationChanged || invalidatedAfterBatchStarted) {
+    const invalidationVersionChanged =
+      getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !==
+      initialInvalidationVersions.get(taskId);
+    if (generationChanged || invalidatedAfterBatchStarted || invalidationVersionChanged) {
       continue;
     }
     queryClient.setQueryData(queryKey, sessionsByTaskId.get(taskId));
@@ -108,14 +138,8 @@ export const agentSessionListHydrationQueryOptions = (
   const normalizedTaskIds = queryKey[3];
   return queryOptions({
     queryKey,
-    queryFn: async ({ signal }): Promise<true> => {
-      await hydrateAgentSessionListQueries(
-        queryClient,
-        repoPath,
-        normalizedTaskIds,
-        readPort,
-        signal,
-      );
+    queryFn: async (): Promise<true> => {
+      await hydrateAgentSessionListQueries(queryClient, repoPath, normalizedTaskIds, readPort);
       return true;
     },
     staleTime: AGENT_SESSION_LIST_STALE_TIME,
@@ -197,18 +221,7 @@ export const invalidateAgentSessionListQuery = async (
     refetchType?: "active" | "all";
   },
 ): Promise<void> => {
-  await queryClient.cancelQueries({
-    predicate: (query) => {
-      const [root, kind, queryRepoPath, queryTaskIds] = query.queryKey;
-      return (
-        root === agentSessionQueryKeys.all[0] &&
-        kind === "hydrate-missing-lists" &&
-        queryRepoPath === repoPath &&
-        Array.isArray(queryTaskIds) &&
-        queryTaskIds.includes(taskId)
-      );
-    },
-  });
+  incrementAgentSessionInvalidationVersion(queryClient, repoPath, taskId);
   await queryClient.invalidateQueries({
     queryKey: agentSessionQueryKeys.list(repoPath, taskId),
     exact: true,

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -201,11 +201,13 @@ export const loadAgentSessionListsFromQuery = async (
   }
 
   const entries = normalizedTaskIds.map((taskId) => {
-    const records = queryClient.getQueryData<AgentSessionRecord[]>(
-      agentSessionQueryKeys.list(repoPath, taskId),
-    );
+    const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+    const records = queryClient.getQueryData<AgentSessionRecord[]>(queryKey);
     if (!records) {
       throw new Error(`Batch session hydration did not populate task "${taskId}".`);
+    }
+    if (queryClient.getQueryState(queryKey)?.isInvalidated === true) {
+      throw new Error(`Batch session hydration for task "${taskId}" was superseded.`);
     }
     return [taskId, records] as const;
   });
@@ -221,10 +223,24 @@ export const invalidateAgentSessionListQuery = async (
     refetchType?: "active" | "all";
   },
 ): Promise<void> => {
+  const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+  const initialState = queryClient.getQueryState(queryKey);
   incrementAgentSessionInvalidationVersion(queryClient, repoPath, taskId);
   await queryClient.invalidateQueries({
-    queryKey: agentSessionQueryKeys.list(repoPath, taskId),
+    queryKey,
     exact: true,
     refetchType: options?.refetchType ?? "none",
   });
+  const currentState = queryClient.getQueryState(queryKey);
+  const refetchCompleted =
+    (currentState?.dataUpdateCount ?? 0) !== (initialState?.dataUpdateCount ?? 0) ||
+    (currentState?.errorUpdateCount ?? 0) !== (initialState?.errorUpdateCount ?? 0);
+  const disabledRefetchWasSkipped =
+    options?.refetchType === "all" &&
+    initialState !== undefined &&
+    currentState?.isInvalidated === true &&
+    !refetchCompleted;
+  if (disabledRefetchWasSkipped) {
+    await queryClient.prefetchQuery({ queryKey, staleTime: 0 });
+  }
 };

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -1,14 +1,30 @@
-import type { AgentSessionIdentity, AgentSessionRecord } from "@openducktor/contracts";
+import type { AgentSessionRecord } from "@openducktor/contracts";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { host } from "../operations/host";
 
 const AGENT_SESSION_LIST_STALE_TIME_MS = 30_000;
+
+export const normalizeAgentSessionTaskIds = (taskIds: string[]): string[] =>
+  Array.from(
+    new Set(
+      taskIds.flatMap((taskId) => {
+        const normalizedTaskId = taskId.trim();
+        return normalizedTaskId ? [normalizedTaskId] : [];
+      }),
+    ),
+  ).sort();
 
 export const agentSessionQueryKeys = {
   all: ["agent-sessions"] as const,
   list: (repoPath: string, taskId: string) =>
     [...agentSessionQueryKeys.all, "list", repoPath, taskId] as const,
+  hydration: (repoPath: string, taskIds: string[]) =>
+    [
+      ...agentSessionQueryKeys.all,
+      "hydrate-lists",
+      repoPath,
+      normalizeAgentSessionTaskIds(taskIds),
+    ] as const,
 };
 
 export const agentSessionListQueryOptions = (repoPath: string, taskId: string) =>
@@ -17,6 +33,49 @@ export const agentSessionListQueryOptions = (repoPath: string, taskId: string) =
     queryFn: (): Promise<AgentSessionRecord[]> => host.agentSessionsList(repoPath, taskId),
     staleTime: AGENT_SESSION_LIST_STALE_TIME_MS,
   });
+
+export const hydrateAgentSessionListQueries = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskIds: string[],
+): Promise<void> => {
+  const normalizedTaskIds = normalizeAgentSessionTaskIds(taskIds);
+  if (normalizedTaskIds.length === 0) {
+    return;
+  }
+
+  const sessionsByTaskId = new Map<string, AgentSessionRecord[]>(
+    normalizedTaskIds.map((taskId) => [taskId, []]),
+  );
+  const taskSessions = await host.agentSessionsListForTasks(repoPath, normalizedTaskIds);
+  for (const taskSession of taskSessions) {
+    if (sessionsByTaskId.has(taskSession.taskId)) {
+      sessionsByTaskId.set(taskSession.taskId, taskSession.agentSessions);
+    }
+  }
+
+  const updatedAt = Date.now();
+  for (const [taskId, sessions] of sessionsByTaskId) {
+    queryClient.setQueryData(agentSessionQueryKeys.list(repoPath, taskId), sessions, { updatedAt });
+  }
+};
+
+export const agentSessionListHydrationQueryOptions = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskIds: string[],
+) => {
+  const queryKey = agentSessionQueryKeys.hydration(repoPath, taskIds);
+  const normalizedTaskIds = queryKey[3];
+  return queryOptions({
+    queryKey,
+    queryFn: async (): Promise<true> => {
+      await hydrateAgentSessionListQueries(queryClient, repoPath, normalizedTaskIds);
+      return true;
+    },
+    staleTime: AGENT_SESSION_LIST_STALE_TIME_MS,
+  });
+};
 
 export const loadAgentSessionListFromQuery = (
   queryClient: QueryClient,
@@ -39,13 +98,29 @@ export const loadAgentSessionListsFromQuery = async (
     forceFresh?: boolean;
   },
 ): Promise<Record<string, AgentSessionRecord[]>> => {
-  const uniqueTaskIds = Array.from(new Set(taskIds));
-  const entries = await Promise.all(
-    uniqueTaskIds.map(async (taskId) => {
-      const records = await loadAgentSessionListFromQuery(queryClient, repoPath, taskId, options);
-      return [taskId, records] as const;
-    }),
+  const normalizedTaskIds = normalizeAgentSessionTaskIds(taskIds);
+  if (normalizedTaskIds.length === 0) {
+    return {};
+  }
+
+  const hasMissingList = normalizedTaskIds.some(
+    (taskId) =>
+      queryClient.getQueryData(agentSessionQueryKeys.list(repoPath, taskId)) === undefined,
   );
+  await queryClient.fetchQuery({
+    ...agentSessionListHydrationQueryOptions(queryClient, repoPath, normalizedTaskIds),
+    ...(options?.forceFresh || hasMissingList ? { staleTime: 0 } : {}),
+  });
+
+  const entries = normalizedTaskIds.map((taskId) => {
+    const records = queryClient.getQueryData<AgentSessionRecord[]>(
+      agentSessionQueryKeys.list(repoPath, taskId),
+    );
+    if (!records) {
+      throw new Error(`Batch session hydration did not populate task "${taskId}".`);
+    }
+    return [taskId, records] as const;
+  });
 
   return Object.fromEntries(entries);
 };
@@ -63,81 +138,3 @@ export const invalidateAgentSessionListQuery = (
     exact: true,
     refetchType: options?.refetchActive === true ? "active" : "none",
   });
-
-const areSelectedModelsEquivalent = (
-  left: AgentSessionRecord["selectedModel"],
-  right: AgentSessionRecord["selectedModel"],
-): boolean => {
-  if (left === right) {
-    return true;
-  }
-  if (left === null || right === null) {
-    return false;
-  }
-  return (
-    left.runtimeKind === right.runtimeKind &&
-    left.providerId === right.providerId &&
-    left.modelId === right.modelId &&
-    left.variant === right.variant &&
-    left.profileId === right.profileId
-  );
-};
-
-const areAgentSessionRecordsEquivalent = (
-  left: AgentSessionRecord,
-  right: AgentSessionRecord,
-): boolean =>
-  left.externalSessionId === right.externalSessionId &&
-  left.role === right.role &&
-  left.startedAt === right.startedAt &&
-  left.runtimeKind === right.runtimeKind &&
-  left.workingDirectory === right.workingDirectory &&
-  areSelectedModelsEquivalent(left.selectedModel, right.selectedModel);
-
-export const upsertAgentSessionRecordInQuery = (
-  queryClient: QueryClient,
-  repoPath: string,
-  taskId: string,
-  session: AgentSessionRecord,
-): void => {
-  queryClient.setQueryData<AgentSessionRecord[] | undefined>(
-    agentSessionQueryKeys.list(repoPath, taskId),
-    (current): AgentSessionRecord[] | undefined => {
-      if (!current) {
-        return current;
-      }
-
-      const sessionKey = agentSessionIdentityKey(session);
-      const existingIndex = current.findIndex(
-        (entry) => agentSessionIdentityKey(entry) === sessionKey,
-      );
-      if (existingIndex === -1) {
-        return [...current, session];
-      }
-
-      const existingSession = current[existingIndex];
-      if (!existingSession || existingSession === session) {
-        return current;
-      }
-
-      if (areAgentSessionRecordsEquivalent(existingSession, session)) {
-        return current;
-      }
-
-      return current.map((entry, index) => (index === existingIndex ? session : entry));
-    },
-  );
-};
-
-export const removeAgentSessionRecordFromQuery = (
-  queryClient: QueryClient,
-  repoPath: string,
-  taskId: string,
-  identity: AgentSessionIdentity,
-): void => {
-  const identityKey = agentSessionIdentityKey(identity);
-  queryClient.setQueryData<AgentSessionRecord[] | undefined>(
-    agentSessionQueryKeys.list(repoPath, taskId),
-    (current) => current?.filter((entry) => agentSessionIdentityKey(entry) !== identityKey),
-  );
-};

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -48,6 +48,7 @@ export const hydrateAgentSessionListQueries = async (
   repoPath: string,
   taskIds: string[],
   readPort: AgentSessionReadPort = host,
+  signal?: AbortSignal,
 ): Promise<void> => {
   const normalizedTaskIds = normalizeAgentSessionTaskIds(taskIds);
   if (normalizedTaskIds.length === 0) {
@@ -79,6 +80,7 @@ export const hydrateAgentSessionListQueries = async (
   if (missingTaskId) {
     throw new Error(`Batch session response omitted task "${missingTaskId}".`);
   }
+  signal?.throwIfAborted();
 
   for (const taskId of normalizedTaskIds) {
     const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
@@ -106,8 +108,14 @@ export const agentSessionListHydrationQueryOptions = (
   const normalizedTaskIds = queryKey[3];
   return queryOptions({
     queryKey,
-    queryFn: async (): Promise<true> => {
-      await hydrateAgentSessionListQueries(queryClient, repoPath, normalizedTaskIds, readPort);
+    queryFn: async ({ signal }): Promise<true> => {
+      await hydrateAgentSessionListQueries(
+        queryClient,
+        repoPath,
+        normalizedTaskIds,
+        readPort,
+        signal,
+      );
       return true;
     },
     staleTime: AGENT_SESSION_LIST_STALE_TIME,
@@ -181,16 +189,29 @@ export const loadAgentSessionListsFromQuery = async (
   return Object.fromEntries(entries);
 };
 
-export const invalidateAgentSessionListQuery = (
+export const invalidateAgentSessionListQuery = async (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
   options?: {
     refetchType?: "active" | "all";
   },
-): Promise<void> =>
-  queryClient.invalidateQueries({
+): Promise<void> => {
+  await queryClient.cancelQueries({
+    predicate: (query) => {
+      const [root, kind, queryRepoPath, queryTaskIds] = query.queryKey;
+      return (
+        root === agentSessionQueryKeys.all[0] &&
+        kind === "hydrate-missing-lists" &&
+        queryRepoPath === repoPath &&
+        Array.isArray(queryTaskIds) &&
+        queryTaskIds.includes(taskId)
+      );
+    },
+  });
+  await queryClient.invalidateQueries({
     queryKey: agentSessionQueryKeys.list(repoPath, taskId),
     exact: true,
     refetchType: options?.refetchType ?? "none",
   });
+};

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -178,20 +178,22 @@ export const loadAgentSessionListsFromQuery = async (
     return {};
   }
 
-  const taskIdsToHydrate = normalizedTaskIds.filter((taskId) => {
+  const taskIdsToHydrate: string[] = [];
+  let refreshesInvalidatedData = false;
+  for (const taskId of normalizedTaskIds) {
     const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
-    return (
+    const queryState = queryClient.getQueryState(queryKey);
+    const shouldHydrate =
       options?.forceFresh === true ||
       queryClient.getQueryData(queryKey) === undefined ||
-      queryClient.getQueryState(queryKey)?.isInvalidated === true
-    );
-  });
+      queryState?.isInvalidated === true;
+    if (!shouldHydrate) {
+      continue;
+    }
+    taskIdsToHydrate.push(taskId);
+    refreshesInvalidatedData ||= queryState?.isInvalidated === true;
+  }
   if (taskIdsToHydrate.length > 0) {
-    const refreshesInvalidatedData = taskIdsToHydrate.some(
-      (taskId) =>
-        queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId))?.isInvalidated ===
-        true,
-    );
     await queryClient.fetchQuery({
       ...agentSessionListHydrationQueryOptions(
         queryClient,

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -4,6 +4,11 @@ import { host } from "../operations/host";
 
 const AGENT_SESSION_LIST_STALE_TIME = Number.POSITIVE_INFINITY;
 
+export type AgentSessionReadPort = Pick<
+  typeof host,
+  "agentSessionsList" | "agentSessionsListForTasks"
+>;
+
 export const normalizeAgentSessionTaskIds = (taskIds: string[]): string[] =>
   Array.from(
     new Set(
@@ -27,10 +32,14 @@ export const agentSessionQueryKeys = {
     ] as const,
 };
 
-export const agentSessionListQueryOptions = (repoPath: string, taskId: string) =>
+export const agentSessionListQueryOptions = (
+  repoPath: string,
+  taskId: string,
+  readPort: AgentSessionReadPort = host,
+) =>
   queryOptions({
     queryKey: agentSessionQueryKeys.list(repoPath, taskId),
-    queryFn: (): Promise<AgentSessionRecord[]> => host.agentSessionsList(repoPath, taskId),
+    queryFn: (): Promise<AgentSessionRecord[]> => readPort.agentSessionsList(repoPath, taskId),
     staleTime: AGENT_SESSION_LIST_STALE_TIME,
   });
 
@@ -38,6 +47,7 @@ export const hydrateAgentSessionListQueries = async (
   queryClient: QueryClient,
   repoPath: string,
   taskIds: string[],
+  readPort: AgentSessionReadPort = host,
 ): Promise<void> => {
   const normalizedTaskIds = normalizeAgentSessionTaskIds(taskIds);
   if (normalizedTaskIds.length === 0) {
@@ -45,13 +55,13 @@ export const hydrateAgentSessionListQueries = async (
   }
 
   const requestedTaskIds = new Set(normalizedTaskIds);
-  const initialUpdateCounts = new Map(
+  const initialQueryStates = new Map(
     normalizedTaskIds.map((taskId) => [
       taskId,
-      queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId))?.dataUpdateCount ?? 0,
+      queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId)),
     ]),
   );
-  const taskSessions = await host.agentSessionsListForTasks(repoPath, normalizedTaskIds);
+  const taskSessions = await readPort.agentSessionsListForTasks(repoPath, normalizedTaskIds);
   const sessionsByTaskId = new Map<string, AgentSessionRecord[]>();
   for (const taskSession of taskSessions) {
     if (!requestedTaskIds.has(taskSession.taskId)) {
@@ -72,10 +82,14 @@ export const hydrateAgentSessionListQueries = async (
 
   for (const taskId of normalizedTaskIds) {
     const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+    const initialState = initialQueryStates.get(taskId);
     const currentState = queryClient.getQueryState(queryKey);
-    const updateCountChanged =
-      (currentState?.dataUpdateCount ?? 0) !== initialUpdateCounts.get(taskId);
-    if (updateCountChanged || currentState?.isInvalidated) {
+    const generationChanged =
+      (currentState?.dataUpdateCount ?? 0) !== (initialState?.dataUpdateCount ?? 0) ||
+      (currentState?.errorUpdateCount ?? 0) !== (initialState?.errorUpdateCount ?? 0);
+    const invalidatedAfterBatchStarted =
+      initialState?.isInvalidated !== true && currentState?.isInvalidated === true;
+    if (generationChanged || invalidatedAfterBatchStarted) {
       continue;
     }
     queryClient.setQueryData(queryKey, sessionsByTaskId.get(taskId));
@@ -86,13 +100,14 @@ export const agentSessionListHydrationQueryOptions = (
   queryClient: QueryClient,
   repoPath: string,
   taskIds: string[],
+  readPort: AgentSessionReadPort = host,
 ) => {
   const queryKey = agentSessionQueryKeys.hydration(repoPath, taskIds);
   const normalizedTaskIds = queryKey[3];
   return queryOptions({
     queryKey,
     queryFn: async (): Promise<true> => {
-      await hydrateAgentSessionListQueries(queryClient, repoPath, normalizedTaskIds);
+      await hydrateAgentSessionListQueries(queryClient, repoPath, normalizedTaskIds, readPort);
       return true;
     },
     staleTime: AGENT_SESSION_LIST_STALE_TIME,
@@ -106,10 +121,11 @@ export const loadAgentSessionListFromQuery = (
   taskId: string,
   options?: {
     forceFresh?: boolean;
+    readPort?: AgentSessionReadPort;
   },
 ): Promise<AgentSessionRecord[]> =>
   queryClient.fetchQuery({
-    ...agentSessionListQueryOptions(repoPath, taskId),
+    ...agentSessionListQueryOptions(repoPath, taskId, options?.readPort),
     ...(options?.forceFresh ? { staleTime: 0 } : {}),
   });
 
@@ -119,6 +135,7 @@ export const loadAgentSessionListsFromQuery = async (
   taskIds: string[],
   options?: {
     forceFresh?: boolean;
+    readPort?: AgentSessionReadPort;
   },
 ): Promise<Record<string, AgentSessionRecord[]>> => {
   const normalizedTaskIds = normalizeAgentSessionTaskIds(taskIds);
@@ -126,16 +143,28 @@ export const loadAgentSessionListsFromQuery = async (
     return {};
   }
 
-  const taskIdsToHydrate = options?.forceFresh
-    ? normalizedTaskIds
-    : normalizedTaskIds.filter(
-        (taskId) =>
-          queryClient.getQueryData(agentSessionQueryKeys.list(repoPath, taskId)) === undefined,
-      );
+  const taskIdsToHydrate = normalizedTaskIds.filter((taskId) => {
+    const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+    return (
+      options?.forceFresh === true ||
+      queryClient.getQueryData(queryKey) === undefined ||
+      queryClient.getQueryState(queryKey)?.isInvalidated === true
+    );
+  });
   if (taskIdsToHydrate.length > 0) {
+    const refreshesInvalidatedData = taskIdsToHydrate.some(
+      (taskId) =>
+        queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId))?.isInvalidated ===
+        true,
+    );
     await queryClient.fetchQuery({
-      ...agentSessionListHydrationQueryOptions(queryClient, repoPath, taskIdsToHydrate),
-      ...(options?.forceFresh ? { staleTime: 0 } : {}),
+      ...agentSessionListHydrationQueryOptions(
+        queryClient,
+        repoPath,
+        taskIdsToHydrate,
+        options?.readPort,
+      ),
+      ...(options?.forceFresh || refreshesInvalidatedData ? { staleTime: 0 } : {}),
     });
   }
 

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -59,7 +59,7 @@ export const agentSessionQueryKeys = {
 export const agentSessionListQueryOptions = (
   repoPath: string,
   taskId: string,
-  readPort: AgentSessionReadPort = host,
+  readPort: Pick<AgentSessionReadPort, "agentSessionsList"> = host,
 ) =>
   queryOptions({
     queryKey: agentSessionQueryKeys.list(repoPath, taskId),
@@ -221,12 +221,22 @@ export const invalidateAgentSessionListQuery = async (
   repoPath: string,
   taskId: string,
   options?: {
+    readPort?: Pick<AgentSessionReadPort, "agentSessionsList">;
     refetchType?: "active" | "all";
   },
 ): Promise<void> => {
   const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
-  const initialState = queryClient.getQueryState(queryKey);
   incrementAgentSessionInvalidationVersion(queryClient, repoPath, taskId);
+
+  if (options?.refetchType === "all") {
+    await queryClient.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
+    await queryClient.fetchQuery({
+      ...agentSessionListQueryOptions(repoPath, taskId, options.readPort),
+      staleTime: 0,
+    });
+    return;
+  }
+
   await queryClient.invalidateQueries(
     {
       queryKey,
@@ -235,16 +245,4 @@ export const invalidateAgentSessionListQuery = async (
     },
     { throwOnError: true },
   );
-  const currentState = queryClient.getQueryState(queryKey);
-  const refetchCompleted =
-    (currentState?.dataUpdateCount ?? 0) !== (initialState?.dataUpdateCount ?? 0) ||
-    (currentState?.errorUpdateCount ?? 0) !== (initialState?.errorUpdateCount ?? 0);
-  const disabledRefetchWasSkipped =
-    options?.refetchType === "all" &&
-    initialState !== undefined &&
-    currentState?.isInvalidated === true &&
-    !refetchCompleted;
-  if (disabledRefetchWasSkipped) {
-    await queryClient.fetchQuery({ queryKey, staleTime: 0 });
-  }
 };

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -157,11 +157,11 @@ export const invalidateAgentSessionListQuery = (
   repoPath: string,
   taskId: string,
   options?: {
-    refetchActive?: boolean;
+    refetchType?: "active" | "all";
   },
 ): Promise<void> =>
   queryClient.invalidateQueries({
     queryKey: agentSessionQueryKeys.list(repoPath, taskId),
     exact: true,
-    refetchType: options?.refetchActive === true ? "active" : "none",
+    refetchType: options?.refetchType ?? "none",
   });

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -2,7 +2,7 @@ import type { AgentSessionRecord } from "@openducktor/contracts";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { host } from "../operations/host";
 
-const AGENT_SESSION_LIST_STALE_TIME_MS = 30_000;
+const AGENT_SESSION_LIST_STALE_TIME = Number.POSITIVE_INFINITY;
 
 export const normalizeAgentSessionTaskIds = (taskIds: string[]): string[] =>
   Array.from(
@@ -21,7 +21,7 @@ export const agentSessionQueryKeys = {
   hydration: (repoPath: string, taskIds: string[]) =>
     [
       ...agentSessionQueryKeys.all,
-      "hydrate-lists",
+      "hydrate-missing-lists",
       repoPath,
       normalizeAgentSessionTaskIds(taskIds),
     ] as const,
@@ -31,7 +31,7 @@ export const agentSessionListQueryOptions = (repoPath: string, taskId: string) =
   queryOptions({
     queryKey: agentSessionQueryKeys.list(repoPath, taskId),
     queryFn: (): Promise<AgentSessionRecord[]> => host.agentSessionsList(repoPath, taskId),
-    staleTime: AGENT_SESSION_LIST_STALE_TIME_MS,
+    staleTime: AGENT_SESSION_LIST_STALE_TIME,
   });
 
 export const hydrateAgentSessionListQueries = async (
@@ -44,19 +44,41 @@ export const hydrateAgentSessionListQueries = async (
     return;
   }
 
-  const sessionsByTaskId = new Map<string, AgentSessionRecord[]>(
-    normalizedTaskIds.map((taskId) => [taskId, []]),
+  const requestedTaskIds = new Set(normalizedTaskIds);
+  const initialUpdateCounts = new Map(
+    normalizedTaskIds.map((taskId) => [
+      taskId,
+      queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId))?.dataUpdateCount ?? 0,
+    ]),
   );
   const taskSessions = await host.agentSessionsListForTasks(repoPath, normalizedTaskIds);
+  const sessionsByTaskId = new Map<string, AgentSessionRecord[]>();
   for (const taskSession of taskSessions) {
-    if (sessionsByTaskId.has(taskSession.taskId)) {
-      sessionsByTaskId.set(taskSession.taskId, taskSession.agentSessions);
+    if (!requestedTaskIds.has(taskSession.taskId)) {
+      throw new Error(`Batch session response included unexpected task "${taskSession.taskId}".`);
     }
+    if (sessionsByTaskId.has(taskSession.taskId)) {
+      throw new Error(
+        `Batch session response included task "${taskSession.taskId}" more than once.`,
+      );
+    }
+    sessionsByTaskId.set(taskSession.taskId, taskSession.agentSessions);
   }
 
-  const updatedAt = Date.now();
-  for (const [taskId, sessions] of sessionsByTaskId) {
-    queryClient.setQueryData(agentSessionQueryKeys.list(repoPath, taskId), sessions, { updatedAt });
+  const missingTaskId = normalizedTaskIds.find((taskId) => !sessionsByTaskId.has(taskId));
+  if (missingTaskId) {
+    throw new Error(`Batch session response omitted task "${missingTaskId}".`);
+  }
+
+  for (const taskId of normalizedTaskIds) {
+    const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+    const currentState = queryClient.getQueryState(queryKey);
+    const updateCountChanged =
+      (currentState?.dataUpdateCount ?? 0) !== initialUpdateCounts.get(taskId);
+    if (updateCountChanged || currentState?.isInvalidated) {
+      continue;
+    }
+    queryClient.setQueryData(queryKey, sessionsByTaskId.get(taskId));
   }
 };
 
@@ -73,7 +95,8 @@ export const agentSessionListHydrationQueryOptions = (
       await hydrateAgentSessionListQueries(queryClient, repoPath, normalizedTaskIds);
       return true;
     },
-    staleTime: AGENT_SESSION_LIST_STALE_TIME_MS,
+    staleTime: AGENT_SESSION_LIST_STALE_TIME,
+    gcTime: 0,
   });
 };
 
@@ -103,14 +126,18 @@ export const loadAgentSessionListsFromQuery = async (
     return {};
   }
 
-  const hasMissingList = normalizedTaskIds.some(
-    (taskId) =>
-      queryClient.getQueryData(agentSessionQueryKeys.list(repoPath, taskId)) === undefined,
-  );
-  await queryClient.fetchQuery({
-    ...agentSessionListHydrationQueryOptions(queryClient, repoPath, normalizedTaskIds),
-    ...(options?.forceFresh || hasMissingList ? { staleTime: 0 } : {}),
-  });
+  const taskIdsToHydrate = options?.forceFresh
+    ? normalizedTaskIds
+    : normalizedTaskIds.filter(
+        (taskId) =>
+          queryClient.getQueryData(agentSessionQueryKeys.list(repoPath, taskId)) === undefined,
+      );
+  if (taskIdsToHydrate.length > 0) {
+    await queryClient.fetchQuery({
+      ...agentSessionListHydrationQueryOptions(queryClient, repoPath, taskIdsToHydrate),
+      ...(options?.forceFresh ? { staleTime: 0 } : {}),
+    });
+  }
 
   const entries = normalizedTaskIds.map((taskId) => {
     const records = queryClient.getQueryData<AgentSessionRecord[]>(

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -233,10 +233,16 @@ const beginAgentSessionListInvalidation = async (
   return invalidationVersion;
 };
 
-export const invalidateAgentSessionListQuery = async (
+type AuthoritativeAgentSessionListInvalidation = {
+  queryKey: ReturnType<typeof agentSessionQueryKeys.list>;
+  invalidationVersion: number;
+};
+
+const runAuthoritativeAgentSessionListInvalidation = async (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
+  complete: (invalidation: AuthoritativeAgentSessionListInvalidation) => Promise<void>,
 ): Promise<void> => {
   const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
   const invalidationVersion = await beginAgentSessionListInvalidation(
@@ -251,7 +257,22 @@ export const invalidateAgentSessionListQuery = async (
   if (getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion) {
     return;
   }
-  await queryClient.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
+  await complete({ queryKey, invalidationVersion });
+};
+
+export const invalidateAgentSessionListQuery = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): Promise<void> => {
+  await runAuthoritativeAgentSessionListInvalidation(
+    queryClient,
+    repoPath,
+    taskId,
+    async ({ queryKey }) => {
+      await queryClient.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
+    },
+  );
 };
 
 export const refreshAgentSessionListQuery = async (
@@ -260,30 +281,24 @@ export const refreshAgentSessionListQuery = async (
   taskId: string,
   readPort: Pick<AgentSessionReadPort, "agentSessionsList"> = host,
 ): Promise<void> => {
-  const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
-  const invalidationVersion = await beginAgentSessionListInvalidation(
+  await runAuthoritativeAgentSessionListInvalidation(
     queryClient,
     repoPath,
     taskId,
+    async ({ invalidationVersion, queryKey }) => {
+      try {
+        await queryClient.fetchQuery({
+          ...agentSessionListQueryOptions(repoPath, taskId, readPort),
+          staleTime: 0,
+        });
+      } catch (error) {
+        const superseded =
+          getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion;
+        if (superseded && isCancelledError(error)) {
+          return;
+        }
+        throw error;
+      }
+    },
   );
-  if (getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion) {
-    return;
-  }
-  await queryClient.cancelQueries({ queryKey, exact: true });
-  if (getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion) {
-    return;
-  }
-  try {
-    await queryClient.fetchQuery({
-      ...agentSessionListQueryOptions(repoPath, taskId, readPort),
-      staleTime: 0,
-    });
-  } catch (error) {
-    const superseded =
-      getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion;
-    if (superseded && isCancelledError(error)) {
-      return;
-    }
-    throw error;
-  }
 };

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -226,11 +226,14 @@ export const invalidateAgentSessionListQuery = async (
   const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
   const initialState = queryClient.getQueryState(queryKey);
   incrementAgentSessionInvalidationVersion(queryClient, repoPath, taskId);
-  await queryClient.invalidateQueries({
-    queryKey,
-    exact: true,
-    refetchType: options?.refetchType ?? "none",
-  });
+  await queryClient.invalidateQueries(
+    {
+      queryKey,
+      exact: true,
+      refetchType: options?.refetchType ?? "none",
+    },
+    { throwOnError: true },
+  );
   const currentState = queryClient.getQueryState(queryKey);
   const refetchCompleted =
     (currentState?.dataUpdateCount ?? 0) !== (initialState?.dataUpdateCount ?? 0) ||
@@ -241,6 +244,6 @@ export const invalidateAgentSessionListQuery = async (
     currentState?.isInvalidated === true &&
     !refetchCompleted;
   if (disabledRefetchWasSkipped) {
-    await queryClient.prefetchQuery({ queryKey, staleTime: 0 });
+    await queryClient.fetchQuery({ queryKey, staleTime: 0 });
   }
 };

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -238,7 +238,20 @@ export const invalidateAgentSessionListQuery = async (
   repoPath: string,
   taskId: string,
 ): Promise<void> => {
-  await beginAgentSessionListInvalidation(queryClient, repoPath, taskId);
+  const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+  const invalidationVersion = await beginAgentSessionListInvalidation(
+    queryClient,
+    repoPath,
+    taskId,
+  );
+  if (getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion) {
+    return;
+  }
+  await queryClient.cancelQueries({ queryKey, exact: true });
+  if (getAgentSessionInvalidationVersion(queryClient, repoPath, taskId) !== invalidationVersion) {
+    return;
+  }
+  await queryClient.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
 };
 
 export const refreshAgentSessionListQuery = async (

--- a/packages/frontend/src/state/queries/agent-sessions.ts
+++ b/packages/frontend/src/state/queries/agent-sessions.ts
@@ -266,6 +266,41 @@ export const loadAgentSessionListsFromQuery = async (
   return Object.fromEntries(entries);
 };
 
+export const retryAgentSessionListQueries = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskIds: string[],
+  readPort: AgentSessionReadPort = host,
+): Promise<void> => {
+  const taskIdsToRetry = normalizeAgentSessionTaskIds(taskIds).filter((taskId) => {
+    const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+    const queryState = queryClient.getQueryState(queryKey);
+    return (
+      queryState?.status === "error" ||
+      queryState?.isInvalidated === true ||
+      queryClient.getQueryData(queryKey) === undefined
+    );
+  });
+  await hydrateAgentSessionListQueries(queryClient, repoPath, taskIdsToRetry, readPort);
+};
+
+export const removeAgentSessionListQueries = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskIds: string[],
+): Promise<void> => {
+  const queryKeys = normalizeAgentSessionTaskIds(taskIds).map((taskId) => {
+    incrementAgentSessionInvalidationVersion(queryClient, repoPath, taskId);
+    return agentSessionQueryKeys.list(repoPath, taskId);
+  });
+  await Promise.all(
+    queryKeys.map((queryKey) => queryClient.cancelQueries({ queryKey, exact: true })),
+  );
+  for (const queryKey of queryKeys) {
+    queryClient.removeQueries({ queryKey, exact: true });
+  }
+};
+
 const beginAgentSessionListInvalidation = async (
   queryClient: QueryClient,
   repoPath: string,

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -24,7 +24,7 @@ describe("useAgentSessionLists", () => {
       { taskId: "task-1", agentSessions: [sessionFixture] },
       { taskId: "task-2", agentSessions: [] },
     ]);
-    const singleList = mock(async () => [refreshedSession]);
+    const singleList = mock(async (_repoPath: string, _taskId: string) => [refreshedSession]);
     const harness = createHookHarness(
       () =>
         useAgentSessionLists({
@@ -76,7 +76,7 @@ describe("useAgentSessionLists", () => {
     }
   });
 
-  test("replaces only a task invalidated during initial batch hydration", async () => {
+  test("refetches only a task invalidated during initial batch hydration", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -86,14 +86,13 @@ describe("useAgentSessionLists", () => {
     ) => void = () => {
       throw new Error("Initial batch resolver was not initialized.");
     };
-    const batchList = mock(async (_repoPath: string, taskIds: string[]) => {
-      if (taskIds.length === 2) {
-        return new Promise<{ taskId: string; agentSessions: AgentSessionRecord[] }[]>((resolve) => {
+    const batchList = mock(
+      async (_repoPath: string, _taskIds: string[]) =>
+        new Promise<{ taskId: string; agentSessions: AgentSessionRecord[] }[]>((resolve) => {
           resolveInitialBatch = resolve;
-        });
-      }
-      return [{ taskId: "task-1", agentSessions: [refreshedSession] }];
-    });
+        }),
+    );
+    const singleList = mock(async (_repoPath: string, _taskId: string) => [refreshedSession]);
     const harness = createHookHarness(
       () =>
         useAgentSessionLists({
@@ -102,9 +101,7 @@ describe("useAgentSessionLists", () => {
           enabled: true,
           queryClient,
           readPort: {
-            agentSessionsList: async () => {
-              throw new Error("Per-task fan-out was not expected.");
-            },
+            agentSessionsList: singleList,
             agentSessionsListForTasks: batchList,
           },
         }),
@@ -115,7 +112,9 @@ describe("useAgentSessionLists", () => {
       await harness.mount();
       await harness.waitFor(() => batchList.mock.calls.length === 1);
       await harness.run(async () => {
-        await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
+        await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+          refetchType: "all",
+        });
         resolveInitialBatch([
           { taskId: "task-1", agentSessions: [sessionFixture] },
           { taskId: "task-2", agentSessions: [] },
@@ -127,9 +126,10 @@ describe("useAgentSessionLists", () => {
       );
       const state = harness.getLatest();
 
-      expect(batchList).toHaveBeenCalledTimes(2);
+      expect(batchList).toHaveBeenCalledTimes(1);
+      expect(singleList).toHaveBeenCalledTimes(1);
+      expect(singleList).toHaveBeenCalledWith("/repo", "task-1");
       expect(batchList.mock.calls[0]).toEqual(["/repo", ["task-1", "task-2"]]);
-      expect(batchList.mock.calls[1]).toEqual(["/repo", ["task-1"]]);
       expect(state.data).toEqual({
         "task-1": [refreshedSession],
         "task-2": [],

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
-import { QueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
+import { IsolatedQueryWrapper } from "@/test-utils/isolated-query-wrapper";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
 import { agentSessionQueryKeys, refreshAgentSessionListQuery } from "./agent-sessions";
 import { useAgentSessionLists } from "./use-agent-session-lists";
@@ -14,25 +15,43 @@ const sessionFixture: AgentSessionRecord = {
   selectedModel: null,
 };
 
+type HarnessProps = Omit<Parameters<typeof useAgentSessionLists>[0], "queryClient">;
+
+const createHarness = (initialProps: HarnessProps) => {
+  let queryClient: QueryClient | null = null;
+  const harness = createHookHarness(
+    (props: HarnessProps) => {
+      queryClient = useQueryClient();
+      return useAgentSessionLists({ ...props, queryClient });
+    },
+    initialProps,
+    { wrapper: IsolatedQueryWrapper },
+  );
+
+  return {
+    ...harness,
+    getQueryClient: (): QueryClient => {
+      if (!queryClient) {
+        throw new Error("Query client unavailable before harness mount");
+      }
+      return queryClient;
+    },
+  };
+};
+
 describe("useAgentSessionLists", () => {
   test("stays pending without reading when disabled", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const batchList = mock(async () => []);
     const singleList = mock(async () => []);
-    const harness = createHookHarness(
-      () =>
-        useAgentSessionLists({
-          repoPath: "/repo",
-          taskIds: ["task-1"],
-          enabled: false,
-          queryClient,
-          readPort: {
-            agentSessionsList: singleList,
-            agentSessionsListForTasks: batchList,
-          },
-        }),
-      undefined,
-    );
+    const harness = createHarness({
+      repoPath: "/repo",
+      taskIds: ["task-1"],
+      enabled: false,
+      readPort: {
+        agentSessionsList: singleList,
+        agentSessionsListForTasks: batchList,
+      },
+    });
 
     try {
       await harness.mount();
@@ -45,28 +64,21 @@ describe("useAgentSessionLists", () => {
       expect(singleList).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
-      queryClient.clear();
     }
   });
 
   test("stays pending without reading when no repository is selected", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const batchList = mock(async () => []);
     const singleList = mock(async () => []);
-    const harness = createHookHarness(
-      () =>
-        useAgentSessionLists({
-          repoPath: null,
-          taskIds: ["task-1"],
-          enabled: true,
-          queryClient,
-          readPort: {
-            agentSessionsList: singleList,
-            agentSessionsListForTasks: batchList,
-          },
-        }),
-      undefined,
-    );
+    const harness = createHarness({
+      repoPath: null,
+      taskIds: ["task-1"],
+      enabled: true,
+      readPort: {
+        agentSessionsList: singleList,
+        agentSessionsListForTasks: batchList,
+      },
+    });
 
     try {
       await harness.mount();
@@ -79,48 +91,41 @@ describe("useAgentSessionLists", () => {
       expect(singleList).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
-      queryClient.clear();
     }
   });
 
   test("batches initial missing tasks once and leaves exact invalidation to the per-task query", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
     const refreshedSession = { ...sessionFixture, externalSessionId: "external-2" };
     const batchList = mock(async () => [
       { taskId: "task-1", agentSessions: [sessionFixture] },
       { taskId: "task-2", agentSessions: [] },
     ]);
     const singleList = mock(async (_repoPath: string, _taskId: string) => [refreshedSession]);
-    const harness = createHookHarness(
-      () =>
-        useAgentSessionLists({
-          repoPath: "/repo",
-          taskIds: ["task-1", "task-2"],
-          enabled: true,
-          queryClient,
-          readPort: {
-            agentSessionsList: singleList,
-            agentSessionsListForTasks: batchList,
-          },
-        }),
-      undefined,
-    );
+    const props: HarnessProps = {
+      repoPath: "/repo",
+      taskIds: ["task-1", "task-2"],
+      enabled: true,
+      readPort: {
+        agentSessionsList: singleList,
+        agentSessionsListForTasks: batchList,
+      },
+    };
+    const harness = createHarness(props);
 
     try {
       await harness.mount();
+      const queryClient = harness.getQueryClient();
       await harness.waitFor((state) => !state.isPending);
       expect(batchList).toHaveBeenCalledTimes(1);
       expect(singleList).not.toHaveBeenCalled();
 
-      await harness.unmount();
+      await harness.update({ ...props, taskIds: [] });
       for (const taskId of ["task-1", "task-2"]) {
         const queryKey = agentSessionQueryKeys.list("/repo", taskId);
         queryClient.setQueryData(queryKey, queryClient.getQueryData(queryKey), { updatedAt: 1 });
       }
 
-      await harness.mount();
+      await harness.update(props);
       await harness.waitFor((state) => !state.isPending);
       expect(batchList).toHaveBeenCalledTimes(1);
       expect(singleList).not.toHaveBeenCalled();
@@ -140,14 +145,10 @@ describe("useAgentSessionLists", () => {
       expect(batchList).toHaveBeenCalledTimes(1);
     } finally {
       await harness.unmount();
-      queryClient.clear();
     }
   });
 
   test("refetches only a task invalidated during initial batch hydration", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
     const refreshedSession = { ...sessionFixture, externalSessionId: "external-2" };
     let resolveInitialBatch: (
       value: { taskId: string; agentSessions: AgentSessionRecord[] }[],
@@ -161,23 +162,19 @@ describe("useAgentSessionLists", () => {
         }),
     );
     const singleList = mock(async (_repoPath: string, _taskId: string) => [refreshedSession]);
-    const harness = createHookHarness(
-      () =>
-        useAgentSessionLists({
-          repoPath: "/repo",
-          taskIds: ["task-1", "task-2"],
-          enabled: true,
-          queryClient,
-          readPort: {
-            agentSessionsList: singleList,
-            agentSessionsListForTasks: batchList,
-          },
-        }),
-      undefined,
-    );
+    const harness = createHarness({
+      repoPath: "/repo",
+      taskIds: ["task-1", "task-2"],
+      enabled: true,
+      readPort: {
+        agentSessionsList: singleList,
+        agentSessionsListForTasks: batchList,
+      },
+    });
 
     try {
       await harness.mount();
+      const queryClient = harness.getQueryClient();
       await harness.waitFor(() => batchList.mock.calls.length === 1);
       await harness.run(async () => {
         await refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
@@ -204,14 +201,10 @@ describe("useAgentSessionLists", () => {
       });
     } finally {
       await harness.unmount();
-      queryClient.clear();
     }
   });
 
   test("does not retry a failed exact refetch when startup hydration enables the task query", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
     let resolveInitialBatch: (
       value: { taskId: string; agentSessions: AgentSessionRecord[] }[],
     ) => void = () => {
@@ -226,23 +219,19 @@ describe("useAgentSessionLists", () => {
     const singleList = mock(async (_repoPath: string, _taskId: string) => {
       throw new Error("exact refresh failed");
     });
-    const harness = createHookHarness(
-      () =>
-        useAgentSessionLists({
-          repoPath: "/repo",
-          taskIds: ["task-1"],
-          enabled: true,
-          queryClient,
-          readPort: {
-            agentSessionsList: singleList,
-            agentSessionsListForTasks: batchList,
-          },
-        }),
-      undefined,
-    );
+    const harness = createHarness({
+      repoPath: "/repo",
+      taskIds: ["task-1"],
+      enabled: true,
+      readPort: {
+        agentSessionsList: singleList,
+        agentSessionsListForTasks: batchList,
+      },
+    });
 
     try {
       await harness.mount();
+      const queryClient = harness.getQueryClient();
       await harness.waitFor(() => batchList.mock.calls.length === 1);
       await harness.run(async () => {
         await expect(
@@ -262,40 +251,36 @@ describe("useAgentSessionLists", () => {
       expect(harness.getLatest().isPending).toBe(false);
     } finally {
       await harness.unmount();
-      queryClient.clear();
     }
   });
 
   test("surfaces an exact refresh error without batch-hydrating the failed query", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
     const batchList = mock(async () => [{ taskId: "task-1", agentSessions: [sessionFixture] }]);
     const singleList = mock(async () => {
       throw new Error("exact refresh failed before mount");
     });
-    await expect(
-      refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+    const props: HarnessProps = {
+      repoPath: "/repo",
+      taskIds: ["task-1"],
+      enabled: false,
+      readPort: {
         agentSessionsList: singleList,
-      }),
-    ).rejects.toThrow("exact refresh failed before mount");
-    const harness = createHookHarness(
-      () =>
-        useAgentSessionLists({
-          repoPath: "/repo",
-          taskIds: ["task-1"],
-          enabled: true,
-          queryClient,
-          readPort: {
-            agentSessionsList: singleList,
-            agentSessionsListForTasks: batchList,
-          },
-        }),
-      undefined,
-    );
+        agentSessionsListForTasks: batchList,
+      },
+    };
+    const harness = createHarness(props);
 
     try {
       await harness.mount();
+      const queryClient = harness.getQueryClient();
+      await harness.run(async () => {
+        await expect(
+          refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+            agentSessionsList: singleList,
+          }),
+        ).rejects.toThrow("exact refresh failed before mount");
+      });
+      await harness.update({ ...props, enabled: true });
       await harness.waitFor(
         (current) =>
           current.error instanceof Error &&
@@ -307,7 +292,6 @@ describe("useAgentSessionLists", () => {
       expect(harness.getLatest().isPending).toBe(false);
     } finally {
       await harness.unmount();
-      queryClient.clear();
     }
   });
 });

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -139,4 +139,62 @@ describe("useAgentSessionLists", () => {
       queryClient.clear();
     }
   });
+
+  test("does not retry a failed exact refetch when startup hydration enables the task query", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    let resolveInitialBatch: (
+      value: { taskId: string; agentSessions: AgentSessionRecord[] }[],
+    ) => void = () => {
+      throw new Error("Initial batch resolver was not initialized.");
+    };
+    const batchList = mock(
+      async (_repoPath: string, _taskIds: string[]) =>
+        new Promise<{ taskId: string; agentSessions: AgentSessionRecord[] }[]>((resolve) => {
+          resolveInitialBatch = resolve;
+        }),
+    );
+    const singleList = mock(async (_repoPath: string, _taskId: string) => {
+      throw new Error("exact refresh failed");
+    });
+    const harness = createHookHarness(
+      () =>
+        useAgentSessionLists({
+          repoPath: "/repo",
+          taskIds: ["task-1"],
+          enabled: true,
+          queryClient,
+          readPort: {
+            agentSessionsList: singleList,
+            agentSessionsListForTasks: batchList,
+          },
+        }),
+      undefined,
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => batchList.mock.calls.length === 1);
+      await harness.run(async () => {
+        await expect(
+          invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+            refetchType: "all",
+          }),
+        ).rejects.toThrow("exact refresh failed");
+        resolveInitialBatch([{ taskId: "task-1", agentSessions: [sessionFixture] }]);
+      });
+      await harness.waitFor(
+        (current) =>
+          current.error instanceof Error && current.error.message === "exact refresh failed",
+      );
+
+      expect(batchList).toHaveBeenCalledTimes(1);
+      expect(singleList).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().isPending).toBe(false);
+    } finally {
+      await harness.unmount();
+      queryClient.clear();
+    }
+  });
 });

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -59,6 +59,7 @@ describe("useAgentSessionLists", () => {
 
       await harness.run(async () => {
         await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+          readPort: { agentSessionsList: singleList },
           refetchType: "active",
         });
       });
@@ -113,6 +114,7 @@ describe("useAgentSessionLists", () => {
       await harness.waitFor(() => batchList.mock.calls.length === 1);
       await harness.run(async () => {
         await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+          readPort: { agentSessionsList: singleList },
           refetchType: "all",
         });
         resolveInitialBatch([
@@ -179,6 +181,7 @@ describe("useAgentSessionLists", () => {
       await harness.run(async () => {
         await expect(
           invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+            readPort: { agentSessionsList: singleList },
             refetchType: "all",
           }),
         ).rejects.toThrow("exact refresh failed");

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -265,4 +265,49 @@ describe("useAgentSessionLists", () => {
       queryClient.clear();
     }
   });
+
+  test("surfaces an exact refresh error without batch-hydrating the failed query", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const batchList = mock(async () => [{ taskId: "task-1", agentSessions: [sessionFixture] }]);
+    const singleList = mock(async () => {
+      throw new Error("exact refresh failed before mount");
+    });
+    await expect(
+      refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+        agentSessionsList: singleList,
+      }),
+    ).rejects.toThrow("exact refresh failed before mount");
+    const harness = createHookHarness(
+      () =>
+        useAgentSessionLists({
+          repoPath: "/repo",
+          taskIds: ["task-1"],
+          enabled: true,
+          queryClient,
+          readPort: {
+            agentSessionsList: singleList,
+            agentSessionsListForTasks: batchList,
+          },
+        }),
+      undefined,
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (current) =>
+          current.error instanceof Error &&
+          current.error.message === "exact refresh failed before mount",
+      );
+
+      expect(batchList).not.toHaveBeenCalled();
+      expect(singleList).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().isPending).toBe(false);
+    } finally {
+      await harness.unmount();
+      queryClient.clear();
+    }
+  });
 });

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import { QueryClient } from "@tanstack/react-query";
+import { createHookHarness } from "@/test-utils/react-hook-harness";
+import { host } from "../operations/host";
+import { agentSessionQueryKeys, invalidateAgentSessionListQuery } from "./agent-sessions";
+import { useAgentSessionLists } from "./use-agent-session-lists";
+
+const sessionFixture: AgentSessionRecord = {
+  externalSessionId: "external-1",
+  role: "build",
+  runtimeKind: "opencode",
+  workingDirectory: "/tmp/repo/worktree",
+  startedAt: "2026-03-22T12:00:00.000Z",
+  selectedModel: null,
+};
+
+describe("useAgentSessionLists", () => {
+  test("batches initial missing tasks once and leaves exact invalidation to the per-task query", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const refreshedSession = { ...sessionFixture, externalSessionId: "external-2" };
+    const batchList = mock(async () => [
+      { taskId: "task-1", agentSessions: [sessionFixture] },
+      { taskId: "task-2", agentSessions: [] },
+    ]);
+    const singleList = mock(async () => [refreshedSession]);
+    const originalBatchList = host.agentSessionsListForTasks;
+    const originalSingleList = host.agentSessionsList;
+    host.agentSessionsListForTasks = batchList;
+    host.agentSessionsList = singleList;
+    const harness = createHookHarness(
+      () =>
+        useAgentSessionLists({
+          repoPath: "/repo",
+          taskIds: ["task-1", "task-2"],
+          enabled: true,
+          queryClient,
+        }),
+      undefined,
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => !state.isPending);
+      expect(batchList).toHaveBeenCalledTimes(1);
+      expect(singleList).not.toHaveBeenCalled();
+
+      await harness.unmount();
+      for (const taskId of ["task-1", "task-2"]) {
+        const queryKey = agentSessionQueryKeys.list("/repo", taskId);
+        queryClient.setQueryData(queryKey, queryClient.getQueryData(queryKey), { updatedAt: 1 });
+      }
+
+      await harness.mount();
+      await harness.waitFor((state) => !state.isPending);
+      expect(batchList).toHaveBeenCalledTimes(1);
+      expect(singleList).not.toHaveBeenCalled();
+
+      await harness.run(async () => {
+        await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
+          refetchActive: true,
+        });
+      });
+      expect(singleList).toHaveBeenCalledTimes(1);
+      expect(singleList).toHaveBeenCalledWith("/repo", "task-1");
+      expect(
+        queryClient.getQueryData<AgentSessionRecord[]>(
+          agentSessionQueryKeys.list("/repo", "task-1"),
+        ),
+      ).toEqual([refreshedSession]);
+      expect(batchList).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
+      host.agentSessionsListForTasks = originalBatchList;
+      host.agentSessionsList = originalSingleList;
+      queryClient.clear();
+    }
+  });
+});

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
-import { agentSessionQueryKeys, invalidateAgentSessionListQuery } from "./agent-sessions";
+import { agentSessionQueryKeys, refreshAgentSessionListQuery } from "./agent-sessions";
 import { useAgentSessionLists } from "./use-agent-session-lists";
 
 const sessionFixture: AgentSessionRecord = {
@@ -58,9 +58,8 @@ describe("useAgentSessionLists", () => {
       expect(singleList).not.toHaveBeenCalled();
 
       await harness.run(async () => {
-        await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
-          readPort: { agentSessionsList: singleList },
-          refetchType: "active",
+        await refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+          agentSessionsList: singleList,
         });
       });
       expect(singleList).toHaveBeenCalledTimes(1);
@@ -113,9 +112,8 @@ describe("useAgentSessionLists", () => {
       await harness.mount();
       await harness.waitFor(() => batchList.mock.calls.length === 1);
       await harness.run(async () => {
-        await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
-          readPort: { agentSessionsList: singleList },
-          refetchType: "all",
+        await refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+          agentSessionsList: singleList,
         });
         resolveInitialBatch([
           { taskId: "task-1", agentSessions: [sessionFixture] },
@@ -180,9 +178,8 @@ describe("useAgentSessionLists", () => {
       await harness.waitFor(() => batchList.mock.calls.length === 1);
       await harness.run(async () => {
         await expect(
-          invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
-            readPort: { agentSessionsList: singleList },
-            refetchType: "all",
+          refreshAgentSessionListQuery(queryClient, "/repo", "task-1", {
+            agentSessionsList: singleList,
           }),
         ).rejects.toThrow("exact refresh failed");
         resolveInitialBatch([{ taskId: "task-1", agentSessions: [sessionFixture] }]);

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -2,7 +2,6 @@ import { describe, expect, mock, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
-import { host } from "../operations/host";
 import { agentSessionQueryKeys, invalidateAgentSessionListQuery } from "./agent-sessions";
 import { useAgentSessionLists } from "./use-agent-session-lists";
 
@@ -26,10 +25,6 @@ describe("useAgentSessionLists", () => {
       { taskId: "task-2", agentSessions: [] },
     ]);
     const singleList = mock(async () => [refreshedSession]);
-    const originalBatchList = host.agentSessionsListForTasks;
-    const originalSingleList = host.agentSessionsList;
-    host.agentSessionsListForTasks = batchList;
-    host.agentSessionsList = singleList;
     const harness = createHookHarness(
       () =>
         useAgentSessionLists({
@@ -37,6 +32,10 @@ describe("useAgentSessionLists", () => {
           taskIds: ["task-1", "task-2"],
           enabled: true,
           queryClient,
+          readPort: {
+            agentSessionsList: singleList,
+            agentSessionsListForTasks: batchList,
+          },
         }),
       undefined,
     );
@@ -73,8 +72,6 @@ describe("useAgentSessionLists", () => {
       expect(batchList).toHaveBeenCalledTimes(1);
     } finally {
       await harness.unmount();
-      host.agentSessionsListForTasks = originalBatchList;
-      host.agentSessionsList = originalSingleList;
       queryClient.clear();
     }
   });

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -75,4 +75,68 @@ describe("useAgentSessionLists", () => {
       queryClient.clear();
     }
   });
+
+  test("replaces only a task invalidated during initial batch hydration", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const refreshedSession = { ...sessionFixture, externalSessionId: "external-2" };
+    let resolveInitialBatch: (
+      value: { taskId: string; agentSessions: AgentSessionRecord[] }[],
+    ) => void = () => {
+      throw new Error("Initial batch resolver was not initialized.");
+    };
+    const batchList = mock(async (_repoPath: string, taskIds: string[]) => {
+      if (taskIds.length === 2) {
+        return new Promise<{ taskId: string; agentSessions: AgentSessionRecord[] }[]>((resolve) => {
+          resolveInitialBatch = resolve;
+        });
+      }
+      return [{ taskId: "task-1", agentSessions: [refreshedSession] }];
+    });
+    const harness = createHookHarness(
+      () =>
+        useAgentSessionLists({
+          repoPath: "/repo",
+          taskIds: ["task-1", "task-2"],
+          enabled: true,
+          queryClient,
+          readPort: {
+            agentSessionsList: async () => {
+              throw new Error("Per-task fan-out was not expected.");
+            },
+            agentSessionsListForTasks: batchList,
+          },
+        }),
+      undefined,
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => batchList.mock.calls.length === 1);
+      await harness.run(async () => {
+        await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1");
+        resolveInitialBatch([
+          { taskId: "task-1", agentSessions: [sessionFixture] },
+          { taskId: "task-2", agentSessions: [] },
+        ]);
+      });
+      await harness.waitFor(
+        (current) =>
+          !current.isPending && current.data["task-1"]?.[0]?.externalSessionId === "external-2",
+      );
+      const state = harness.getLatest();
+
+      expect(batchList).toHaveBeenCalledTimes(2);
+      expect(batchList.mock.calls[0]).toEqual(["/repo", ["task-1", "task-2"]]);
+      expect(batchList.mock.calls[1]).toEqual(["/repo", ["task-1"]]);
+      expect(state.data).toEqual({
+        "task-1": [refreshedSession],
+        "task-2": [],
+      });
+    } finally {
+      await harness.unmount();
+      queryClient.clear();
+    }
+  });
 });

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -60,7 +60,7 @@ describe("useAgentSessionLists", () => {
 
       await harness.run(async () => {
         await invalidateAgentSessionListQuery(queryClient, "/repo", "task-1", {
-          refetchActive: true,
+          refetchType: "active",
         });
       });
       expect(singleList).toHaveBeenCalledTimes(1);

--- a/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.test.tsx
@@ -15,6 +15,74 @@ const sessionFixture: AgentSessionRecord = {
 };
 
 describe("useAgentSessionLists", () => {
+  test("stays pending without reading when disabled", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const batchList = mock(async () => []);
+    const singleList = mock(async () => []);
+    const harness = createHookHarness(
+      () =>
+        useAgentSessionLists({
+          repoPath: "/repo",
+          taskIds: ["task-1"],
+          enabled: false,
+          queryClient,
+          readPort: {
+            agentSessionsList: singleList,
+            agentSessionsListForTasks: batchList,
+          },
+        }),
+      undefined,
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest()).toEqual({
+        data: { "task-1": [] },
+        error: null,
+        isPending: true,
+      });
+      expect(batchList).not.toHaveBeenCalled();
+      expect(singleList).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+      queryClient.clear();
+    }
+  });
+
+  test("stays pending without reading when no repository is selected", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const batchList = mock(async () => []);
+    const singleList = mock(async () => []);
+    const harness = createHookHarness(
+      () =>
+        useAgentSessionLists({
+          repoPath: null,
+          taskIds: ["task-1"],
+          enabled: true,
+          queryClient,
+          readPort: {
+            agentSessionsList: singleList,
+            agentSessionsListForTasks: batchList,
+          },
+        }),
+      undefined,
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest()).toEqual({
+        data: { "task-1": [] },
+        error: null,
+        isPending: true,
+      });
+      expect(batchList).not.toHaveBeenCalled();
+      expect(singleList).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+      queryClient.clear();
+    }
+  });
+
   test("batches initial missing tasks once and leaves exact invalidation to the per-task query", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },

--- a/packages/frontend/src/state/queries/use-agent-session-lists.ts
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.ts
@@ -45,10 +45,10 @@ export const useAgentSessionLists = ({
   const normalizedTaskIds = useMemo(() => toTaskIds(taskIdsKey), [taskIdsKey]);
   const shouldReadLists = enabled && repoPath !== null;
   const missingTaskIds = shouldReadLists
-    ? normalizedTaskIds.filter(
-        (taskId) =>
-          queryClient.getQueryData(agentSessionQueryKeys.list(repoPath, taskId)) === undefined,
-      )
+    ? normalizedTaskIds.filter((taskId) => {
+        const queryState = queryClient.getQueryState(agentSessionQueryKeys.list(repoPath, taskId));
+        return queryState?.status !== "error" && queryState?.data === undefined;
+      })
     : [];
   const shouldHydrateLists = missingTaskIds.length > 0;
   const hydrationQuery = useQuery(

--- a/packages/frontend/src/state/queries/use-agent-session-lists.ts
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.ts
@@ -100,10 +100,14 @@ export const useAgentSessionLists = ({
   return useQueries(
     {
       queries: shouldReadLists
-        ? normalizedTaskIds.map((taskId) => ({
-            ...agentSessionListQueryOptions(repoPath, taskId, readPort),
-            enabled: hydrationReady,
-          }))
+        ? normalizedTaskIds.map((taskId) => {
+            const queryKey = agentSessionQueryKeys.list(repoPath, taskId);
+            const exactRefreshFailed = queryClient.getQueryState(queryKey)?.status === "error";
+            return {
+              ...agentSessionListQueryOptions(repoPath, taskId, readPort),
+              enabled: hydrationReady && !exactRefreshFailed,
+            };
+          })
         : [],
       combine: combineAgentSessionListQueries,
     },

--- a/packages/frontend/src/state/queries/use-agent-session-lists.ts
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.ts
@@ -1,0 +1,97 @@
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import type { QueryClient, UseQueryResult } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+import {
+  agentSessionListHydrationQueryOptions,
+  agentSessionListQueryOptions,
+  normalizeAgentSessionTaskIds,
+} from "./agent-sessions";
+
+type AgentSessionListQueryResult = UseQueryResult<AgentSessionRecord[], Error>;
+
+export type AgentSessionListsState = {
+  data: Record<string, AgentSessionRecord[]>;
+  error: unknown | null;
+  isPending: boolean;
+};
+
+type UseAgentSessionListsArgs = {
+  repoPath: string | null;
+  taskIds: string[];
+  enabled: boolean;
+  queryClient: QueryClient;
+};
+
+const TASK_ID_SEPARATOR = "\u001f";
+
+const toTaskIdSetKey = (taskIds: string[]): string =>
+  normalizeAgentSessionTaskIds(taskIds).join(TASK_ID_SEPARATOR);
+
+const toTaskIds = (taskIdsKey: string): string[] =>
+  taskIdsKey ? taskIdsKey.split(TASK_ID_SEPARATOR) : [];
+
+export const useAgentSessionLists = ({
+  repoPath,
+  taskIds,
+  enabled,
+  queryClient,
+}: UseAgentSessionListsArgs): AgentSessionListsState => {
+  const taskIdsKey = toTaskIdSetKey(taskIds);
+  const normalizedTaskIds = useMemo(() => toTaskIds(taskIdsKey), [taskIdsKey]);
+  const shouldReadLists = enabled && repoPath !== null;
+  const shouldHydrateLists = shouldReadLists && normalizedTaskIds.length > 0;
+  const hydrationQuery = useQuery(
+    {
+      ...agentSessionListHydrationQueryOptions(queryClient, repoPath ?? "", normalizedTaskIds),
+      enabled: shouldHydrateLists,
+    },
+    queryClient,
+  );
+  const hydrationReady = normalizedTaskIds.length === 0 || hydrationQuery.isSuccess;
+  const combineAgentSessionListQueries = useCallback(
+    (queries: AgentSessionListQueryResult[]): AgentSessionListsState => {
+      const data = Object.fromEntries(
+        normalizedTaskIds.map((taskId, index) => [taskId, queries[index]?.data ?? []]),
+      );
+      if (!shouldReadLists) {
+        return { data, error: null, isPending: true };
+      }
+      if (hydrationQuery.isError) {
+        return { data, error: hydrationQuery.error, isPending: false };
+      }
+      const failedQuery = queries.find((query) => query.isError);
+      if (failedQuery) {
+        return { data, error: failedQuery.error, isPending: false };
+      }
+      return {
+        data,
+        error: null,
+        isPending:
+          (shouldHydrateLists && hydrationQuery.isPending) ||
+          queries.some((query) => query.isPending),
+      };
+    },
+    [
+      hydrationQuery.error,
+      hydrationQuery.isError,
+      hydrationQuery.isPending,
+      normalizedTaskIds,
+      shouldHydrateLists,
+      shouldReadLists,
+    ],
+  );
+
+  return useQueries(
+    {
+      queries: shouldReadLists
+        ? normalizedTaskIds.map((taskId) => ({
+            ...agentSessionListQueryOptions(repoPath, taskId),
+            enabled: hydrationReady,
+          }))
+        : [],
+      combine: combineAgentSessionListQueries,
+    },
+    queryClient,
+  );
+};

--- a/packages/frontend/src/state/queries/use-agent-session-lists.ts
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.ts
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from "react";
 import {
   agentSessionListHydrationQueryOptions,
   agentSessionListQueryOptions,
+  agentSessionQueryKeys,
   normalizeAgentSessionTaskIds,
 } from "./agent-sessions";
 
@@ -40,15 +41,21 @@ export const useAgentSessionLists = ({
   const taskIdsKey = toTaskIdSetKey(taskIds);
   const normalizedTaskIds = useMemo(() => toTaskIds(taskIdsKey), [taskIdsKey]);
   const shouldReadLists = enabled && repoPath !== null;
-  const shouldHydrateLists = shouldReadLists && normalizedTaskIds.length > 0;
+  const missingTaskIds = shouldReadLists
+    ? normalizedTaskIds.filter(
+        (taskId) =>
+          queryClient.getQueryData(agentSessionQueryKeys.list(repoPath, taskId)) === undefined,
+      )
+    : [];
+  const shouldHydrateLists = missingTaskIds.length > 0;
   const hydrationQuery = useQuery(
     {
-      ...agentSessionListHydrationQueryOptions(queryClient, repoPath ?? "", normalizedTaskIds),
+      ...agentSessionListHydrationQueryOptions(queryClient, repoPath ?? "", missingTaskIds),
       enabled: shouldHydrateLists,
     },
     queryClient,
   );
-  const hydrationReady = normalizedTaskIds.length === 0 || hydrationQuery.isSuccess;
+  const hydrationReady = !shouldHydrateLists || hydrationQuery.isSuccess;
   const combineAgentSessionListQueries = useCallback(
     (queries: AgentSessionListQueryResult[]): AgentSessionListsState => {
       const data = Object.fromEntries(

--- a/packages/frontend/src/state/queries/use-agent-session-lists.ts
+++ b/packages/frontend/src/state/queries/use-agent-session-lists.ts
@@ -3,6 +3,7 @@ import type { QueryClient, UseQueryResult } from "@tanstack/react-query";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import {
+  type AgentSessionReadPort,
   agentSessionListHydrationQueryOptions,
   agentSessionListQueryOptions,
   agentSessionQueryKeys,
@@ -22,6 +23,7 @@ type UseAgentSessionListsArgs = {
   taskIds: string[];
   enabled: boolean;
   queryClient: QueryClient;
+  readPort?: AgentSessionReadPort;
 };
 
 const TASK_ID_SEPARATOR = "\u001f";
@@ -37,6 +39,7 @@ export const useAgentSessionLists = ({
   taskIds,
   enabled,
   queryClient,
+  readPort,
 }: UseAgentSessionListsArgs): AgentSessionListsState => {
   const taskIdsKey = toTaskIdSetKey(taskIds);
   const normalizedTaskIds = useMemo(() => toTaskIds(taskIdsKey), [taskIdsKey]);
@@ -50,7 +53,12 @@ export const useAgentSessionLists = ({
   const shouldHydrateLists = missingTaskIds.length > 0;
   const hydrationQuery = useQuery(
     {
-      ...agentSessionListHydrationQueryOptions(queryClient, repoPath ?? "", missingTaskIds),
+      ...agentSessionListHydrationQueryOptions(
+        queryClient,
+        repoPath ?? "",
+        missingTaskIds,
+        readPort,
+      ),
       enabled: shouldHydrateLists,
     },
     queryClient,
@@ -93,7 +101,7 @@ export const useAgentSessionLists = ({
     {
       queries: shouldReadLists
         ? normalizedTaskIds.map((taskId) => ({
-            ...agentSessionListQueryOptions(repoPath, taskId),
+            ...agentSessionListQueryOptions(repoPath, taskId, readPort),
             enabled: hydrationReady,
           }))
         : [],

--- a/packages/host-client/src/index.test.ts
+++ b/packages/host-client/src/index.test.ts
@@ -1901,6 +1901,64 @@ describe("HostClient", () => {
     });
   });
 
+  test("agentSessionsListForTasks uses one command and parses the batch response", async () => {
+    const { client, calls } = createClient((command) => {
+      if (command === "agent_sessions_list_for_tasks") {
+        return [
+          {
+            taskId: "task-1",
+            agentSessions: [
+              {
+                externalSessionId: "session-opencode-1",
+                role: "spec",
+                startedAt: "2026-02-18T17:20:00Z",
+                runtimeKind: "opencode",
+                workingDirectory: "/repo",
+                selectedModel: null,
+              },
+            ],
+          },
+        ];
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const sessions = await client.agentSessionsListForTasks("/repo", ["task-2", "task-1"]);
+
+    expect(sessions).toHaveLength(1);
+    expect(calls).toEqual([
+      {
+        command: "agent_sessions_list_for_tasks",
+        args: { repoPath: "/repo", taskIds: ["task-2", "task-1"] },
+      },
+    ]);
+  });
+
+  test("agentSessionsListForTasks rejects invalid nested session entries", async () => {
+    const { client } = createClient((command) => {
+      if (command === "agent_sessions_list_for_tasks") {
+        return [
+          {
+            taskId: "task-1",
+            agentSessions: [
+              {
+                externalSessionId: "session-opencode-1",
+                role: "invalid-role",
+                startedAt: "2026-02-18T17:20:00Z",
+                runtimeKind: "opencode",
+                workingDirectory: "/repo",
+                selectedModel: null,
+              },
+            ],
+          },
+        ];
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(client.agentSessionsListForTasks("/repo", ["task-1"])).rejects.toThrow("role");
+  });
+
   test("agentSessionsList rejects invalid persisted agent session entries", async () => {
     const { client } = createClient((command) => {
       if (command === "task_metadata_get") {

--- a/packages/host-client/src/index.test.ts
+++ b/packages/host-client/src/index.test.ts
@@ -1858,22 +1858,8 @@ describe("HostClient", () => {
 
   test("agent session history commands use expected IPC routes", async () => {
     const { client, calls } = createClient((command) => {
-      if (command === "task_metadata_get") {
-        return {
-          spec: { markdown: "", updatedAt: null },
-          plan: { markdown: "", updatedAt: null },
-          qaReport: null,
-          agentSessions: [
-            {
-              externalSessionId: "session-opencode-1",
-              role: "spec",
-              startedAt: "2026-02-18T17:20:00Z",
-              runtimeKind: "opencode",
-              workingDirectory: "/repo",
-              selectedModel: null,
-            },
-          ],
-        };
+      if (command === "agent_sessions_list") {
+        return makeTaskMetadataPayload().agentSessions;
       }
       if (command === "agent_session_upsert" || command === "agent_session_delete") {
         return { ok: true };
@@ -1891,7 +1877,7 @@ describe("HostClient", () => {
 
     expect(history).toHaveLength(1);
     expect(calls.map((entry) => entry.command)).toEqual([
-      "task_metadata_get",
+      "agent_sessions_list",
       "agent_session_upsert",
       "agent_session_delete",
     ]);
@@ -1934,6 +1920,40 @@ describe("HostClient", () => {
     ]);
   });
 
+  test("agentSessionsList stays authoritative after a newer batch read", async () => {
+    const newerSession = {
+      externalSessionId: "session-opencode-2",
+      role: "build",
+      startedAt: "2026-02-19T17:20:00Z",
+      runtimeKind: "opencode",
+      workingDirectory: "/repo",
+      selectedModel: null,
+    };
+    const { client, calls } = createClient((command) => {
+      if (command === "task_metadata_get") {
+        return makeTaskMetadataPayload();
+      }
+      if (command === "agent_sessions_list_for_tasks") {
+        return [{ taskId: "task-1", agentSessions: [newerSession] }];
+      }
+      if (command === "agent_sessions_list") {
+        return [newerSession];
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await client.specGet("/repo", "task-1");
+    await client.agentSessionsListForTasks("/repo", ["task-1"]);
+    const sessions = await client.agentSessionsList("/repo", "task-1");
+
+    expect(sessions.map((session) => session.externalSessionId)).toEqual(["session-opencode-2"]);
+    expect(calls.map((call) => call.command)).toEqual([
+      "task_metadata_get",
+      "agent_sessions_list_for_tasks",
+      "agent_sessions_list",
+    ]);
+  });
+
   test("agentSessionsListForTasks rejects invalid nested session entries", async () => {
     const { client } = createClient((command) => {
       if (command === "agent_sessions_list_for_tasks") {
@@ -1961,22 +1981,17 @@ describe("HostClient", () => {
 
   test("agentSessionsList rejects invalid persisted agent session entries", async () => {
     const { client } = createClient((command) => {
-      if (command === "task_metadata_get") {
-        return {
-          spec: { markdown: "", updatedAt: null },
-          plan: { markdown: "", updatedAt: null },
-          qaReport: null,
-          agentSessions: [
-            {
-              externalSessionId: "ext-1",
-              role: "invalid-role",
-              startedAt: "2026-02-18T17:20:00Z",
-              runtimeKind: "opencode",
-              workingDirectory: "/repo",
-              selectedModel: null,
-            },
-          ],
-        };
+      if (command === "agent_sessions_list") {
+        return [
+          {
+            externalSessionId: "ext-1",
+            role: "invalid-role",
+            startedAt: "2026-02-18T17:20:00Z",
+            runtimeKind: "opencode",
+            workingDirectory: "/repo",
+            selectedModel: null,
+          },
+        ];
       }
       throw new Error(`Unexpected command: ${command}`);
     });
@@ -1984,10 +1999,13 @@ describe("HostClient", () => {
     await expect(client.agentSessionsList("/repo", "task-1")).rejects.toThrow("role");
   });
 
-  test("spec, plan, qa, and session reads share one metadata IPC call per task", async () => {
+  test("document reads share metadata while session reads stay independently authoritative", async () => {
     const { client, calls } = createClient((command) => {
       if (command === "task_metadata_get") {
         return makeTaskMetadataPayload();
+      }
+      if (command === "agent_sessions_list") {
+        return makeTaskMetadataPayload().agentSessions;
       }
       throw new Error(`Unexpected command: ${command}`);
     });
@@ -2011,13 +2029,23 @@ describe("HostClient", () => {
           taskId: "task-1",
         },
       },
+      {
+        command: "agent_sessions_list",
+        args: {
+          repoPath: "/repo",
+          taskId: "task-1",
+        },
+      },
     ]);
   });
 
-  test("sequential metadata reads reuse cache for the same task", async () => {
+  test("sequential document reads reuse metadata while session reads remain independent", async () => {
     const { client, calls } = createClient((command) => {
       if (command === "task_metadata_get") {
         return makeTaskMetadataPayload();
+      }
+      if (command === "agent_sessions_list") {
+        return makeTaskMetadataPayload().agentSessions;
       }
       throw new Error(`Unexpected command: ${command}`);
     });
@@ -2034,6 +2062,13 @@ describe("HostClient", () => {
     expect(calls).toEqual([
       {
         command: "task_metadata_get",
+        args: {
+          repoPath: "/repo",
+          taskId: "task-1",
+        },
+      },
+      {
+        command: "agent_sessions_list",
         args: {
           repoPath: "/repo",
           taskId: "task-1",

--- a/packages/host-client/src/index.ts
+++ b/packages/host-client/src/index.ts
@@ -77,6 +77,7 @@ const TASK_METHODS = [
   "qaRejected",
   "agentSessionsList",
   "agentSessionDelete",
+  "agentSessionsListForTasks",
   "agentSessionUpsert",
 ] as const satisfies readonly MethodName<HostTaskClient>[];
 

--- a/packages/host-client/src/task-client.ts
+++ b/packages/host-client/src/task-client.ts
@@ -1,6 +1,7 @@
 import {
   type AgentSessionIdentity,
   type AgentSessionRecord,
+  agentSessionRecordSchema,
   type PlanSubtaskInput,
   type TaskAgentSessions,
   type TaskCard,
@@ -301,8 +302,8 @@ export class HostTaskClient {
   }
 
   async agentSessionsList(repoPath: string, taskId: string): Promise<AgentSessionRecord[]> {
-    const payload = await this.readTaskMetadata(repoPath, taskId);
-    return payload.agentSessions;
+    const payload = await this.invokeFn("agent_sessions_list", { repoPath, taskId });
+    return parseArray(agentSessionRecordSchema, payload, "agent_sessions_list");
   }
 
   async agentSessionsListForTasks(

--- a/packages/host-client/src/task-client.ts
+++ b/packages/host-client/src/task-client.ts
@@ -2,10 +2,12 @@ import {
   type AgentSessionIdentity,
   type AgentSessionRecord,
   type PlanSubtaskInput,
+  type TaskAgentSessions,
   type TaskCard,
   type TaskCreateInput,
   type TaskStatus,
   type TaskUpdatePatch,
+  taskAgentSessionsSchema,
   taskCardSchema,
   taskCreateInputSchema,
   taskStatusSchema,
@@ -301,6 +303,14 @@ export class HostTaskClient {
   async agentSessionsList(repoPath: string, taskId: string): Promise<AgentSessionRecord[]> {
     const payload = await this.readTaskMetadata(repoPath, taskId);
     return payload.agentSessions;
+  }
+
+  async agentSessionsListForTasks(
+    repoPath: string,
+    taskIds: string[],
+  ): Promise<TaskAgentSessions[]> {
+    const payload = await this.invokeFn("agent_sessions_list_for_tasks", { repoPath, taskIds });
+    return parseArray(taskAgentSessionsSchema, payload, "agent_sessions_list_for_tasks");
   }
 
   async agentSessionUpsert(

--- a/packages/host/src/adapters/sqlite/sqlite-json-codecs.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-json-codecs.ts
@@ -90,7 +90,7 @@ export const labelsFromRow = (row: TaskRow): Effect.Effect<string[], SqliteTaskS
   );
 
 export const agentSessionsFromRow = (
-  row: TaskRow,
+  row: Pick<TaskRow, "agentSessionsJson" | "id">,
 ): Effect.Effect<AgentSessionRecord[], SqliteTaskStoreDataError> =>
   parseJsonColumn(
     row.agentSessionsJson,

--- a/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
@@ -1,5 +1,5 @@
-import type { AgentSessionRecord } from "@openducktor/contracts";
-import { eq } from "drizzle-orm";
+import type { AgentSessionRecord, TaskAgentSessions } from "@openducktor/contracts";
+import { eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 import { hasSameAgentSessionIdentity } from "../../domain/agent-session-identity";
 import { compactAgentSessionRecord } from "../../domain/agent-session-records";
@@ -8,6 +8,7 @@ import { agentSessionsFromRow, encodeJson } from "./sqlite-json-codecs";
 import { requireTaskRow } from "./sqlite-task-queries";
 import {
   SqliteTaskStoreDataError,
+  type SqliteTaskStoreReadError,
   type SqliteTaskStoreWriteError,
 } from "./sqlite-task-store-errors";
 import { type TaskStoreSession, tasks } from "./sqlite-task-store-schema";
@@ -27,6 +28,38 @@ const compactAgentSessionForStorage = (
     }),
   );
 };
+
+export const listAgentSessionsForTasks = (
+  session: TaskStoreSession,
+  input: Parameters<TaskStorePort["listAgentSessionsForTasks"]>[0],
+): Effect.Effect<TaskAgentSessions[], SqliteTaskStoreReadError> =>
+  Effect.gen(function* () {
+    const rows = yield* session.execute(
+      (database) =>
+        database
+          .select({
+            id: tasks.id,
+            agentSessionsJson: tasks.agentSessionsJson,
+          })
+          .from(tasks)
+          .where(inArray(tasks.id, input.taskIds)),
+      "sqliteTaskRepository.listAgentSessionsForTasks.selectTasks",
+      { taskIds: input.taskIds },
+    );
+    const rowsByTaskId = new Map(rows.map((row) => [row.id, row]));
+    const results: TaskAgentSessions[] = [];
+    for (const taskId of input.taskIds) {
+      const row = rowsByTaskId.get(taskId);
+      if (!row) {
+        continue;
+      }
+      results.push({
+        taskId,
+        agentSessions: yield* agentSessionsFromRow(row),
+      });
+    }
+    return results;
+  });
 
 export const clearAgentSessionsByRoles = (
   session: TaskStoreSession,

--- a/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-agent-sessions.ts
@@ -3,6 +3,7 @@ import { eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 import { hasSameAgentSessionIdentity } from "../../domain/agent-session-identity";
 import { compactAgentSessionRecord } from "../../domain/agent-session-records";
+import { HostResourceError } from "../../effect/host-errors";
 import type { TaskStorePort } from "../../ports/task-repository-ports";
 import { agentSessionsFromRow, encodeJson } from "./sqlite-json-codecs";
 import { requireTaskRow } from "./sqlite-task-queries";
@@ -51,7 +52,12 @@ export const listAgentSessionsForTasks = (
     for (const taskId of input.taskIds) {
       const row = rowsByTaskId.get(taskId);
       if (!row) {
-        continue;
+        return yield* new HostResourceError({
+          resource: "task",
+          operation: "sqliteTaskRepository.listAgentSessionsForTasks",
+          message: `Task not found: ${taskId}`,
+          details: { repoPath: input.repoPath, taskId },
+        });
       }
       results.push({
         taskId,

--- a/packages/host/src/adapters/sqlite/sqlite-task-repository.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-repository.ts
@@ -6,6 +6,7 @@ import { encodeJson, normalizeLabels } from "./sqlite-json-codecs";
 import {
   clearAgentSessionsByRoles,
   deleteAgentSession,
+  listAgentSessionsForTasks,
   upsertAgentSession,
 } from "./sqlite-task-agent-sessions";
 import { getTaskCard, listTasksInDatabase } from "./sqlite-task-card-read-model";
@@ -206,6 +207,19 @@ export const createSqliteTaskRepository = ({
         input.repoPath,
         "sqliteTaskRepository.listPullRequestSyncCandidates",
         ({ session }) => listPullRequestSyncCandidatesInDatabase(session),
+      );
+    },
+    listAgentSessionsForTasks(input) {
+      const taskIds = Array.from(
+        new Set(input.taskIds.map((taskId) => taskId.trim()).filter(Boolean)),
+      );
+      if (taskIds.length === 0) {
+        return Effect.succeed([]);
+      }
+      return withDatabase(
+        input.repoPath,
+        "sqliteTaskRepository.listAgentSessionsForTasks",
+        ({ session }) => listAgentSessionsForTasks(session, { ...input, taskIds }),
       );
     },
     listTasks(input) {

--- a/packages/host/src/adapters/sqlite/sqlite-task-repository.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-repository.ts
@@ -210,16 +210,13 @@ export const createSqliteTaskRepository = ({
       );
     },
     listAgentSessionsForTasks(input) {
-      const taskIds = Array.from(
-        new Set(input.taskIds.map((taskId) => taskId.trim()).filter(Boolean)),
-      );
-      if (taskIds.length === 0) {
+      if (input.taskIds.length === 0) {
         return Effect.succeed([]);
       }
       return withDatabase(
         input.repoPath,
         "sqliteTaskRepository.listAgentSessionsForTasks",
-        ({ session }) => listAgentSessionsForTasks(session, { ...input, taskIds }),
+        ({ session }) => listAgentSessionsForTasks(session, input),
       );
     },
     listTasks(input) {

--- a/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
@@ -26,7 +26,7 @@ describe("SQLite task agent session batches", () => {
     expect(resolverCalls).toBe(0);
   });
 
-  test("lists multiple tasks, ignores duplicates and missing tasks, and handles empty IDs", async () => {
+  test("lists multiple tasks, ignores duplicate IDs, and rejects missing tasks", async () => {
     const { cleanup, repoPath, store } = await createSqliteTaskStoreHarness();
     try {
       const firstTask = await Effect.runPromise(
@@ -70,13 +70,21 @@ describe("SQLite task agent session batches", () => {
         Effect.runPromise(
           store.listAgentSessionsForTasks({
             repoPath,
-            taskIds: [secondTask.id, firstTask.id, firstTask.id, "missing-task"],
+            taskIds: [secondTask.id, firstTask.id, firstTask.id],
           }),
         ),
       ).resolves.toEqual([
         { taskId: secondTask.id, agentSessions: [] },
         { taskId: firstTask.id, agentSessions: [newerSession, olderSession] },
       ]);
+      await expect(
+        Effect.runPromise(
+          store.listAgentSessionsForTasks({
+            repoPath,
+            taskIds: [firstTask.id, "missing-task"],
+          }),
+        ),
+      ).rejects.toThrow("Task not found: missing-task");
       await expect(
         Effect.runPromise(store.listAgentSessionsForTasks({ repoPath, taskIds: [] })),
       ).resolves.toEqual([]);

--- a/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
@@ -1,4 +1,87 @@
-import { describeTaskStorePortContract } from "../../ports/task-store-port-contract.test-support";
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import {
+  createAgentSessionRecord,
+  describeTaskStorePortContract,
+} from "../../ports/task-store-port-contract.test-support";
+import { createSqliteTaskRepository } from "./sqlite-task-repository";
 import { createSqliteTaskStoreHarness } from "./sqlite-task-store-test-support";
 
 describeTaskStorePortContract("SQLite TaskStorePort contract", createSqliteTaskStoreHarness);
+
+describe("SQLite task agent session batches", () => {
+  test("returns an empty normalized ID list without resolving storage", async () => {
+    let resolverCalls = 0;
+    const store = createSqliteTaskRepository({
+      resolveWorkspaceIdForRepoPath: () =>
+        Effect.sync(() => {
+          resolverCalls += 1;
+          return "workspace";
+        }),
+    });
+
+    await expect(
+      Effect.runPromise(store.listAgentSessionsForTasks({ repoPath: "/repo", taskIds: [" ", ""] })),
+    ).resolves.toEqual([]);
+    expect(resolverCalls).toBe(0);
+  });
+
+  test("lists multiple tasks, ignores duplicates and missing tasks, and handles empty IDs", async () => {
+    const { cleanup, repoPath, store } = await createSqliteTaskStoreHarness();
+    try {
+      const firstTask = await Effect.runPromise(
+        store.createTask({
+          repoPath,
+          task: {
+            title: "First sessions",
+            issueType: "task",
+            priority: 2,
+            aiReviewEnabled: true,
+          },
+        }),
+      );
+      const secondTask = await Effect.runPromise(
+        store.createTask({
+          repoPath,
+          task: {
+            title: "Second sessions",
+            issueType: "task",
+            priority: 2,
+            aiReviewEnabled: true,
+          },
+        }),
+      );
+      const olderSession = createAgentSessionRecord({
+        externalSessionId: "older-session",
+        startedAt: "2026-06-10T10:00:00.000Z",
+      });
+      const newerSession = createAgentSessionRecord({
+        externalSessionId: "newer-session",
+        startedAt: "2026-06-10T11:00:00.000Z",
+      });
+      await Effect.runPromise(
+        store.upsertAgentSession({ repoPath, taskId: firstTask.id, session: olderSession }),
+      );
+      await Effect.runPromise(
+        store.upsertAgentSession({ repoPath, taskId: firstTask.id, session: newerSession }),
+      );
+
+      await expect(
+        Effect.runPromise(
+          store.listAgentSessionsForTasks({
+            repoPath,
+            taskIds: [secondTask.id, firstTask.id, firstTask.id, "missing-task"],
+          }),
+        ),
+      ).resolves.toEqual([
+        { taskId: secondTask.id, agentSessions: [] },
+        { taskId: firstTask.id, agentSessions: [newerSession, olderSession] },
+      ]);
+      await expect(
+        Effect.runPromise(store.listAgentSessionsForTasks({ repoPath, taskIds: [] })),
+      ).resolves.toEqual([]);
+    } finally {
+      await cleanup?.();
+    }
+  });
+});

--- a/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
+++ b/packages/host/src/adapters/sqlite/sqlite-task-store-port-contract.test.ts
@@ -10,7 +10,7 @@ import { createSqliteTaskStoreHarness } from "./sqlite-task-store-test-support";
 describeTaskStorePortContract("SQLite TaskStorePort contract", createSqliteTaskStoreHarness);
 
 describe("SQLite task agent session batches", () => {
-  test("returns an empty normalized ID list without resolving storage", async () => {
+  test("returns an empty ID list without resolving storage", async () => {
     let resolverCalls = 0;
     const store = createSqliteTaskRepository({
       resolveWorkspaceIdForRepoPath: () =>
@@ -21,12 +21,12 @@ describe("SQLite task agent session batches", () => {
     });
 
     await expect(
-      Effect.runPromise(store.listAgentSessionsForTasks({ repoPath: "/repo", taskIds: [" ", ""] })),
+      Effect.runPromise(store.listAgentSessionsForTasks({ repoPath: "/repo", taskIds: [] })),
     ).resolves.toEqual([]);
     expect(resolverCalls).toBe(0);
   });
 
-  test("lists multiple tasks, ignores duplicate IDs, and rejects missing tasks", async () => {
+  test("lists multiple tasks and rejects missing tasks", async () => {
     const { cleanup, repoPath, store } = await createSqliteTaskStoreHarness();
     try {
       const firstTask = await Effect.runPromise(
@@ -70,7 +70,7 @@ describe("SQLite task agent session batches", () => {
         Effect.runPromise(
           store.listAgentSessionsForTasks({
             repoPath,
-            taskIds: [secondTask.id, firstTask.id, firstTask.id],
+            taskIds: [secondTask.id, firstTask.id],
           }),
         ),
       ).resolves.toEqual([

--- a/packages/host/src/application/tasks/support/builder-worktree-cleanup.test.ts
+++ b/packages/host/src/application/tasks/support/builder-worktree-cleanup.test.ts
@@ -54,6 +54,7 @@ const taskStoreWithTasks = (
       }),
     listPullRequestSyncCandidates: () =>
       Effect.dieMessage("unexpected listPullRequestSyncCandidates"),
+    listAgentSessionsForTasks: () => Effect.dieMessage("unexpected listAgentSessionsForTasks"),
     listTasks: () => Effect.succeed(tasks),
     recordQaOutcome: () => Effect.dieMessage("unexpected recordQaOutcome"),
     setDirectMerge: () => Effect.dieMessage("unexpected setDirectMerge"),

--- a/packages/host/src/application/tasks/task-inputs.ts
+++ b/packages/host/src/application/tasks/task-inputs.ts
@@ -22,6 +22,10 @@ export type ListTasksInput = RepoPathInput & {
   doneVisibleDays?: number;
 };
 
+export type ListAgentSessionsForTasksInput = RepoPathInput & {
+  taskIds: string[];
+};
+
 export type AgentSessionUpsertInput = TaskIdInput & {
   session: AgentSessionRecord;
 };

--- a/packages/host/src/application/tasks/task-service-list-and-sessions.test.ts
+++ b/packages/host/src/application/tasks/task-service-list-and-sessions.test.ts
@@ -12,6 +12,26 @@ import {
 } from "./test-support/task-workflow-harness";
 
 describe("createTaskService list and session reads", () => {
+  test("loads agent sessions for task IDs with one task-store call", async () => {
+    const session = createAgentSessionRecord();
+    const calls: unknown[] = [];
+    const service = createTaskService({
+      taskStore: {
+        listAgentSessionsForTasks(input) {
+          calls.push(input);
+          return Effect.succeed([{ taskId: "task-1", agentSessions: [session] }]);
+        },
+      },
+    });
+
+    await expect(
+      Effect.runPromise(
+        service.agentSessionsListForTasks({ repoPath: "/repo", taskIds: ["task-1", "task-2"] }),
+      ),
+    ).resolves.toEqual([{ taskId: "task-1", agentSessions: [session] }]);
+    expect(calls).toEqual([{ repoPath: "/repo", taskIds: ["task-1", "task-2"] }]);
+  });
+
   test("loads tasks and enriches available actions and workflow state", async () => {
     const calls: unknown[] = [];
     const taskStore: TaskStorePort = {

--- a/packages/host/src/application/tasks/task-service.ts
+++ b/packages/host/src/application/tasks/task-service.ts
@@ -3,6 +3,7 @@ import {
   type BuildSessionBootstrap,
   buildSessionBootstrapSchema,
   type PullRequest,
+  type TaskAgentSessions,
   type TaskApprovalContextLoadResult,
   type TaskCard,
   type TaskDirectMergeResult,
@@ -49,6 +50,7 @@ import type {
   CreateTaskUseCaseInput,
   DeleteTaskInput,
   DirectMergeInput,
+  ListAgentSessionsForTasksInput,
   ListTasksInput,
   MarkdownDocumentInput,
   OptionalNoteInput,
@@ -109,6 +111,9 @@ export type TaskService = {
   listTasks(input: ListTasksInput): Effect.Effect<TaskCard[], TaskServiceError>;
   getTaskMetadata(input: TaskIdInput): Effect.Effect<TaskMetadataPayload, TaskServiceError>;
   agentSessionsList(input: TaskIdInput): Effect.Effect<AgentSessionRecord[], TaskServiceError>;
+  agentSessionsListForTasks(
+    input: ListAgentSessionsForTasksInput,
+  ): Effect.Effect<TaskAgentSessions[], TaskServiceError>;
   agentSessionUpsert(input: AgentSessionUpsertInput): Effect.Effect<boolean, TaskServiceError>;
   agentSessionDelete(input: AgentSessionDeleteInput): Effect.Effect<boolean, TaskServiceError>;
   getApprovalContext(
@@ -285,6 +290,8 @@ export const createTaskService = (input: CreateTaskServiceInput): TaskService =>
   return {
     agentSessionDelete: (input) => mapTaskServiceErrors(service.agentSessionDelete(input)),
     agentSessionsList: (input) => mapTaskServiceErrors(service.agentSessionsList(input)),
+    agentSessionsListForTasks: (input) =>
+      mapTaskServiceErrors(service.agentSessionsListForTasks(input)),
     agentSessionUpsert: (input) => mapTaskServiceErrors(service.agentSessionUpsert(input)),
     buildBlocked: (input) => mapTaskServiceErrors(service.buildBlocked(input)),
     buildCompleted: (input) => mapTaskServiceErrors(service.buildCompleted(input)),

--- a/packages/host/src/application/tasks/test-support/task-workflow-harness.ts
+++ b/packages/host/src/application/tasks/test-support/task-workflow-harness.ts
@@ -189,6 +189,7 @@ const createTaskStorePort = (overrides: TaskStorePort): RealTaskStorePort =>
     getTask: unexpectedTaskStoreCall("getTask"),
     getTaskMetadata: unexpectedTaskStoreCall("getTaskMetadata"),
     listPullRequestSyncCandidates: unexpectedTaskStoreCall("listPullRequestSyncCandidates"),
+    listAgentSessionsForTasks: unexpectedTaskStoreCall("listAgentSessionsForTasks"),
     listTasks: unexpectedTaskStoreCall("listTasks"),
     recordQaOutcome: unexpectedTaskStoreCall("recordQaOutcome"),
     setDirectMerge: unexpectedTaskStoreCall("setDirectMerge"),

--- a/packages/host/src/application/tasks/use-cases/query-tasks.ts
+++ b/packages/host/src/application/tasks/use-cases/query-tasks.ts
@@ -15,8 +15,9 @@ export const createTaskQueryUseCases = ({
   | "listTasks"
   | "getTaskMetadata"
   | "agentSessionsList"
-  | "agentSessionUpsert"
   | "agentSessionDelete"
+  | "agentSessionsListForTasks"
+  | "agentSessionUpsert"
 > => ({
   listTasks(input) {
     return Effect.gen(function* () {
@@ -36,6 +37,10 @@ export const createTaskQueryUseCases = ({
 
       return metadata.agentSessions;
     });
+  },
+
+  agentSessionsListForTasks(input) {
+    return taskStore.listAgentSessionsForTasks(input);
   },
 
   agentSessionUpsert(input) {

--- a/packages/host/src/interface/commands/host-command-registry.ts
+++ b/packages/host/src/interface/commands/host-command-registry.ts
@@ -18,6 +18,7 @@ export const HOST_COMMAND_NAMES = [
   "agent_session_stop",
   "agent_session_upsert",
   "agent_sessions_list",
+  "agent_sessions_list_for_tasks",
   "build_blocked",
   "build_completed",
   "build_resumed",

--- a/packages/host/src/interface/commands/task-command-handlers.test.ts
+++ b/packages/host/src/interface/commands/task-command-handlers.test.ts
@@ -49,17 +49,9 @@ describe("createTaskCommandHandlers", () => {
         });
       },
       agentSessionsListForTasks(input: unknown) {
-        return Effect.tryPromise({
-          try: async () => {
-            calls.push({ command: "agent_sessions_list_for_tasks", input });
-            return [];
-          },
-          catch: (cause) =>
-            new HostOperationError({
-              operation: "test.effect",
-              message: cause instanceof Error ? cause.message : String(cause),
-              cause: cause,
-            }),
+        return Effect.sync(() => {
+          calls.push({ command: "agent_sessions_list_for_tasks", input });
+          return [];
         });
       },
       getApprovalContext(input: unknown) {

--- a/packages/host/src/interface/commands/task-command-handlers.test.ts
+++ b/packages/host/src/interface/commands/task-command-handlers.test.ts
@@ -683,10 +683,10 @@ describe("createTaskCommandHandlers", () => {
     await expect(
       runHandler(
         handlers.agent_sessions_list_for_tasks?.(
-          { repoPath: "/repo", taskIds: [" task-2 ", "", "task-1", "task-2"] },
+          { repoPath: "/repo", taskIds: ["task-2", "task-1", "task-2"] },
           {
             command: "agent_sessions_list_for_tasks",
-            args: { repoPath: "/repo", taskIds: [" task-2 ", "", "task-1", "task-2"] },
+            args: { repoPath: "/repo", taskIds: ["task-2", "task-1", "task-2"] },
           },
         ),
       ),

--- a/packages/host/src/interface/commands/task-command-handlers.test.ts
+++ b/packages/host/src/interface/commands/task-command-handlers.test.ts
@@ -48,6 +48,20 @@ describe("createTaskCommandHandlers", () => {
             }),
         });
       },
+      agentSessionsListForTasks(input: unknown) {
+        return Effect.tryPromise({
+          try: async () => {
+            calls.push({ command: "agent_sessions_list_for_tasks", input });
+            return [];
+          },
+          catch: (cause) =>
+            new HostOperationError({
+              operation: "test.effect",
+              message: cause instanceof Error ? cause.message : String(cause),
+              cause: cause,
+            }),
+        });
+      },
       getApprovalContext(input: unknown) {
         return Effect.tryPromise({
           try: async () => {
@@ -668,6 +682,17 @@ describe("createTaskCommandHandlers", () => {
     ).resolves.toEqual([]);
     await expect(
       runHandler(
+        handlers.agent_sessions_list_for_tasks?.(
+          { repoPath: "/repo", taskIds: [" task-2 ", "", "task-1", "task-2"] },
+          {
+            command: "agent_sessions_list_for_tasks",
+            args: { repoPath: "/repo", taskIds: [" task-2 ", "", "task-1", "task-2"] },
+          },
+        ),
+      ),
+    ).resolves.toEqual([]);
+    await expect(
+      runHandler(
         handlers.task_approval_context_get?.(
           { repoPath: "/repo", taskId: "task-1" },
           {
@@ -1022,6 +1047,10 @@ describe("createTaskCommandHandlers", () => {
       {
         command: "agent_sessions_list",
         input: { repoPath: "/repo", taskId: "task-1" },
+      },
+      {
+        command: "agent_sessions_list_for_tasks",
+        input: { repoPath: "/repo", taskIds: ["task-2", "task-1"] },
       },
       {
         command: "task_approval_context_get",

--- a/packages/host/src/interface/commands/task-command-handlers.ts
+++ b/packages/host/src/interface/commands/task-command-handlers.ts
@@ -9,6 +9,7 @@ import {
   parseCreateTaskInput,
   parseDeleteTaskInput,
   parseDirectMergeInput,
+  parseListAgentSessionsForTasksInput,
   parseListTasksInput,
   parseMarkdownDocumentInput,
   parseOptionalNoteInput,
@@ -33,6 +34,8 @@ export const createTaskCommandHandlers = (taskService: TaskService): HostCommand
     taskService.agentSessionUpsert(parseAgentSessionUpsertInput(args)),
   agent_sessions_list: (args) =>
     taskService.agentSessionsList(parseTaskIdInput(args, "agent_sessions_list input")),
+  agent_sessions_list_for_tasks: (args) =>
+    taskService.agentSessionsListForTasks(parseListAgentSessionsForTasksInput(args)),
   build_blocked: (args) => taskService.buildBlocked(parseBuildBlockedInput(args)),
   build_completed: (args) => taskService.buildCompleted(parseBuildCompletedInput(args)),
   build_resumed: (args) => taskService.buildResumed(parseTaskIdInput(args, "build_resumed input")),

--- a/packages/host/src/interface/commands/task-command-inputs.test.ts
+++ b/packages/host/src/interface/commands/task-command-inputs.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { HostValidationError } from "../../effect/host-errors";
+import { parseListAgentSessionsForTasksInput } from "./task-command-inputs";
+
+describe("parseListAgentSessionsForTasksInput", () => {
+  test("rejects blank task IDs with a typed validation error", () => {
+    expect(() =>
+      parseListAgentSessionsForTasksInput({
+        repoPath: "/repo",
+        taskIds: ["task-1", " "],
+      }),
+    ).toThrow(HostValidationError);
+    expect(() =>
+      parseListAgentSessionsForTasksInput({
+        repoPath: "/repo",
+        taskIds: ["task-1", " "],
+      }),
+    ).toThrow("taskIds[1] is required.");
+  });
+
+  test("trims and deduplicates valid task IDs at the command boundary", () => {
+    expect(
+      parseListAgentSessionsForTasksInput({
+        repoPath: "/repo",
+        taskIds: [" task-2 ", "task-1", "task-2"],
+      }),
+    ).toEqual({ repoPath: "/repo", taskIds: ["task-2", "task-1"] });
+  });
+});

--- a/packages/host/src/interface/commands/task-command-inputs.test.ts
+++ b/packages/host/src/interface/commands/task-command-inputs.test.ts
@@ -3,6 +3,32 @@ import { HostValidationError } from "../../effect/host-errors";
 import { parseListAgentSessionsForTasksInput } from "./task-command-inputs";
 
 describe("parseListAgentSessionsForTasksInput", () => {
+  test("rejects a missing repo path", () => {
+    expect(() =>
+      parseListAgentSessionsForTasksInput({
+        taskIds: ["task-1"],
+      }),
+    ).toThrow("repoPath is required.");
+  });
+
+  test("rejects non-array task IDs", () => {
+    expect(() =>
+      parseListAgentSessionsForTasksInput({
+        repoPath: "/repo",
+        taskIds: "task-1",
+      }),
+    ).toThrow("taskIds must be an array of strings.");
+  });
+
+  test("rejects non-string task IDs with an accurate field error", () => {
+    expect(() =>
+      parseListAgentSessionsForTasksInput({
+        repoPath: "/repo",
+        taskIds: ["task-1", 2],
+      }),
+    ).toThrow("taskIds[1] must be a string.");
+  });
+
   test("rejects blank task IDs with a typed validation error", () => {
     expect(() =>
       parseListAgentSessionsForTasksInput({
@@ -25,5 +51,14 @@ describe("parseListAgentSessionsForTasksInput", () => {
         taskIds: [" task-2 ", "task-1", "task-2"],
       }),
     ).toEqual({ repoPath: "/repo", taskIds: ["task-2", "task-1"] });
+  });
+
+  test("accepts an empty task ID list", () => {
+    expect(
+      parseListAgentSessionsForTasksInput({
+        repoPath: "/repo",
+        taskIds: [],
+      }),
+    ).toEqual({ repoPath: "/repo", taskIds: [] });
   });
 });

--- a/packages/host/src/interface/commands/task-command-inputs.ts
+++ b/packages/host/src/interface/commands/task-command-inputs.ts
@@ -75,7 +75,17 @@ export const parseListAgentSessionsForTasksInput = (
       details: { value: record.taskIds },
     });
   }
-  const taskIds = record.taskIds.map((taskId, index) => requireString(taskId, `taskIds[${index}]`));
+  const taskIds = record.taskIds.map((taskId, index) => {
+    const field = `taskIds[${index}]`;
+    if (typeof taskId !== "string") {
+      throw new HostValidationError({
+        message: `${field} must be a string.`,
+        field,
+        details: { value: taskId },
+      });
+    }
+    return requireString(taskId, field);
+  });
 
   return {
     repoPath: requireString(record.repoPath, "repoPath"),

--- a/packages/host/src/interface/commands/task-command-inputs.ts
+++ b/packages/host/src/interface/commands/task-command-inputs.ts
@@ -68,20 +68,18 @@ export const parseListAgentSessionsForTasksInput = (
   input: unknown,
 ): ListAgentSessionsForTasksInput => {
   const record = requireRecord(input, "agent_sessions_list_for_tasks input");
-  if (
-    !Array.isArray(record.taskIds) ||
-    record.taskIds.some((taskId) => typeof taskId !== "string")
-  ) {
+  if (!Array.isArray(record.taskIds)) {
     throw new HostValidationError({
       message: "taskIds must be an array of strings.",
       field: "taskIds",
       details: { value: record.taskIds },
     });
   }
+  const taskIds = record.taskIds.map((taskId, index) => requireString(taskId, `taskIds[${index}]`));
 
   return {
     repoPath: requireString(record.repoPath, "repoPath"),
-    taskIds: Array.from(new Set(record.taskIds.map((taskId) => taskId.trim()).filter(Boolean))),
+    taskIds: Array.from(new Set(taskIds)),
   };
 };
 

--- a/packages/host/src/interface/commands/task-command-inputs.ts
+++ b/packages/host/src/interface/commands/task-command-inputs.ts
@@ -8,6 +8,7 @@ import type {
   CreateTaskUseCaseInput,
   DeleteTaskInput,
   DirectMergeInput,
+  ListAgentSessionsForTasksInput,
   ListTasksInput,
   MarkdownDocumentInput,
   OptionalNoteInput,
@@ -61,6 +62,27 @@ export const parseListTasksInput = (input: unknown): ListTasksInput => {
   const repoPath = requireString(record.repoPath, "repoPath");
   const doneVisibleDays = optionalNonNegativeInteger(record.doneVisibleDays, "doneVisibleDays");
   return doneVisibleDays === undefined ? { repoPath } : { repoPath, doneVisibleDays };
+};
+
+export const parseListAgentSessionsForTasksInput = (
+  input: unknown,
+): ListAgentSessionsForTasksInput => {
+  const record = requireRecord(input, "agent_sessions_list_for_tasks input");
+  if (
+    !Array.isArray(record.taskIds) ||
+    record.taskIds.some((taskId) => typeof taskId !== "string")
+  ) {
+    throw new HostValidationError({
+      message: "taskIds must be an array of strings.",
+      field: "taskIds",
+      details: { value: record.taskIds },
+    });
+  }
+
+  return {
+    repoPath: requireString(record.repoPath, "repoPath"),
+    taskIds: Array.from(new Set(record.taskIds.map((taskId) => taskId.trim()).filter(Boolean))),
+  };
 };
 
 export const parseAgentSessionUpsertInput = (input: unknown): AgentSessionUpsertInput => {

--- a/packages/host/src/ports/task-repository-ports.ts
+++ b/packages/host/src/ports/task-repository-ports.ts
@@ -5,6 +5,7 @@ import type {
   PullRequest,
   QaReportVerdict,
   RepoStoreHealth,
+  TaskAgentSessions,
   TaskCard,
   TaskCreateInput,
   TaskMetadataDocument,
@@ -98,6 +99,10 @@ export type WorkflowDocumentRepository = {
   }): Effect.Effect<TaskMetadataDocument, TaskStoreError>;
 };
 export type AgentSessionRepository = {
+  listAgentSessionsForTasks(input: {
+    repoPath: string;
+    taskIds: string[];
+  }): Effect.Effect<TaskAgentSessions[], TaskStoreError>;
   clearAgentSessionsByRoles(input: {
     repoPath: string;
     taskId: string;


### PR DESCRIPTION
## Summary

Batch-load task session metadata once at startup while keeping TanStack Query ownership canonical and isolated per task.

## Why

The Kanban and session read models need metadata for many tasks at startup. Fetching it task-by-task creates avoidable host and SQLite work, while owning one global metadata query makes every task mutation invalidate unrelated task data and encourages fragile cache patching.

## Implementation

- Adds one typed host command that reads all requested tasks with a single SQLite `IN` query and returns task-scoped session groups.
- Uses the startup batch only as a hydration coordinator; each task's session list remains owned by its canonical TanStack Query key.
- Exact-invalidates and refetches only the affected task after session mutations, resets, and approval flows.
- Guards startup hydration against stale writes when a task changes during the batch request.
- Surfaces exact refresh failures without retry, fallback data, hidden observer refetches, mutation cache patching, or production per-task fan-out.
- Keeps host failures Effect-native and schema-validates the command boundary.

No database migration, table, column, durable schema, or persisted task/session record shape changed. The existing `agentSessionsJson` data is read in one batch; only the request/response API was added.

## Verification

- Frontend: 3608 passed
- Contracts: 200 passed
- Host: 679 passed, 1 intentional platform skip
- Host client: 63 passed
- Release scripts: 11 passed
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- React Doctor changed-scope scan: 0 diagnostics
- Thermos correctness and maintainability: clean
- Code review Standards and Spec axes: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving agent session history across multiple tasks in a single operation.
  * Improved session loading and caching for Kanban views, including task-scoped hydration and refresh handling.
* **Bug Fixes**
  * Improved reliability when saving, deleting, resetting, or approving tasks if session metadata refreshes fail.
  * Added clearer notifications for partial refresh failures while preserving successful task operations.
* **Validation**
  * Added validation for task-scoped session responses, including invalid task IDs, duplicate IDs, missing tasks, and invalid session roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->