### PR TITLE
fix(electron): gate host IPC during shutdown

### DIFF
--- a/apps/electron/src/main/electron-host-invoke-handler.test.ts
+++ b/apps/electron/src/main/electron-host-invoke-handler.test.ts
@@ -101,23 +101,26 @@ describe("Electron host invoke IPC handler", () => {
       "args",
       "Electron host invoke arguments must be an object when provided.",
     ],
-  ] as const)("rejects %s without invoking the router", async (_case, invalidRequest, field, message) => {
-    const invoke = mock(async () => ({ repoPath: "/workspace" }));
-    const registered = createRegisteredHandler();
+  ] as const)(
+    "rejects %s without invoking the router",
+    async (_case, invalidRequest, field, message) => {
+      const invoke = mock(async () => ({ repoPath: "/workspace" }));
+      const registered = createRegisteredHandler();
 
-    registerElectronHostInvokeHandler(registered.ipcMain, {
-      isHostShutdownStarted: () => false,
-      invoke,
-    });
+      registerElectronHostInvokeHandler(registered.ipcMain, {
+        isHostShutdownStarted: () => false,
+        invoke,
+      });
 
-    await expect(registered.handler({}, invalidRequest)).rejects.toMatchObject({
-      _tag: "ElectronValidationError",
-      operation: "electron.ipc.host-invoke.validate",
-      field,
-      message,
-    });
-    expect(invoke).not.toHaveBeenCalled();
-  });
+      await expect(registered.handler({}, invalidRequest)).rejects.toMatchObject({
+        _tag: "ElectronValidationError",
+        operation: "electron.ipc.host-invoke.validate",
+        field,
+        message,
+      });
+      expect(invoke).not.toHaveBeenCalled();
+    },
+  );
 
   test("preserves genuine host failures", async () => {
     const failure = new Error("host failure");

--- a/apps/electron/src/main/electron-host-invoke-handler.test.ts
+++ b/apps/electron/src/main/electron-host-invoke-handler.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ElectronHostInvokeRequest } from "../shared/electron-bridge-contract";
+import { registerElectronHostInvokeHandler } from "./electron-host-invoke-handler";
+
+const request: ElectronHostInvokeRequest = {
+  command: "workspace_get_context",
+};
+
+type ElectronHostInvokeHandler = (
+  event: unknown,
+  request: ElectronHostInvokeRequest,
+) => Promise<unknown>;
+
+const createRegisteredHandler = (): {
+  channel: string | undefined;
+  handler: ElectronHostInvokeHandler;
+  ipcMain: {
+    handle(channel: string, handler: ElectronHostInvokeHandler): void;
+  };
+} => {
+  let channel: string | undefined;
+  let handler: ElectronHostInvokeHandler | undefined;
+
+  return {
+    get channel() {
+      return channel;
+    },
+    get handler() {
+      if (!handler) {
+        throw new Error("Expected Electron host invoke handler to be registered.");
+      }
+      return handler;
+    },
+    ipcMain: {
+      handle(registeredChannel, registeredHandler) {
+        channel = registeredChannel;
+        handler = registeredHandler;
+      },
+    },
+  };
+};
+
+const createDeferred = <Value>(): {
+  promise: Promise<Value>;
+  reject(reason: unknown): void;
+  resolve(value: Value): void;
+} => {
+  let reject: (reason: unknown) => void = () => {};
+  let resolve: (value: Value) => void = () => {};
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+};
+
+describe("Electron host invoke IPC handler", () => {
+  test("registers the host channel and wraps a normal host result", async () => {
+    const result = { repoPath: "/workspace" };
+    const invoke = mock(async () => result);
+    const registered = createRegisteredHandler();
+
+    registerElectronHostInvokeHandler(registered.ipcMain, {
+      isHostShutdownStarted: () => false,
+      invoke,
+    });
+
+    expect(registered.channel).toBe("openducktor:host-invoke");
+    await expect(registered.handler({}, request)).resolves.toEqual({
+      status: "success",
+      payload: result,
+    });
+    expect(invoke).toHaveBeenCalledWith("workspace_get_context", undefined);
+  });
+
+  test("checks shutdown when a request arrives and does not invoke the router", async () => {
+    const invoke = mock(async () => ({ repoPath: "/workspace" }));
+    let shutdownStarted = false;
+    const registered = createRegisteredHandler();
+
+    registerElectronHostInvokeHandler(registered.ipcMain, {
+      isHostShutdownStarted: () => shutdownStarted,
+      invoke,
+    });
+    shutdownStarted = true;
+
+    await expect(registered.handler({}, request)).resolves.toEqual({ status: "shutdown" });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  test("preserves genuine host failures", async () => {
+    const failure = new Error("host failure");
+    const invoke = mock(async () => {
+      throw failure;
+    });
+    const registered = createRegisteredHandler();
+
+    registerElectronHostInvokeHandler(registered.ipcMain, {
+      isHostShutdownStarted: () => false,
+      invoke,
+    });
+
+    await expect(registered.handler({}, request)).rejects.toBe(failure);
+  });
+
+  test("keeps an admitted pending invocation's success outcome after shutdown starts", async () => {
+    const deferred = createDeferred<{ repoPath: string }>();
+    const invoke = mock(() => deferred.promise);
+    let shutdownStarted = false;
+    const registered = createRegisteredHandler();
+
+    registerElectronHostInvokeHandler(registered.ipcMain, {
+      isHostShutdownStarted: () => shutdownStarted,
+      invoke,
+    });
+
+    const response = registered.handler({}, request);
+    expect(invoke).toHaveBeenCalledWith("workspace_get_context", undefined);
+    shutdownStarted = true;
+    deferred.resolve({ repoPath: "/workspace" });
+
+    await expect(response).resolves.toEqual({
+      status: "success",
+      payload: { repoPath: "/workspace" },
+    });
+  });
+
+  test("keeps an admitted pending invocation's rejection after shutdown starts", async () => {
+    const deferred = createDeferred<never>();
+    const failure = new Error("host failure");
+    const invoke = mock(() => deferred.promise);
+    let shutdownStarted = false;
+    const registered = createRegisteredHandler();
+
+    registerElectronHostInvokeHandler(registered.ipcMain, {
+      isHostShutdownStarted: () => shutdownStarted,
+      invoke,
+    });
+
+    const response = registered.handler({}, request);
+    expect(invoke).toHaveBeenCalledWith("workspace_get_context", undefined);
+    shutdownStarted = true;
+    deferred.reject(failure);
+
+    await expect(response).rejects.toBe(failure);
+  });
+});

--- a/apps/electron/src/main/electron-host-invoke-handler.test.ts
+++ b/apps/electron/src/main/electron-host-invoke-handler.test.ts
@@ -1,15 +1,12 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { ElectronHostInvokeRequest } from "../shared/electron-bridge-contract";
 import { registerElectronHostInvokeHandler } from "./electron-host-invoke-handler";
 
-const request: ElectronHostInvokeRequest = {
+const request = {
   command: "workspace_get_context",
+  args: { repoPath: "/workspace" },
 };
 
-type ElectronHostInvokeHandler = (
-  event: unknown,
-  request: ElectronHostInvokeRequest,
-) => Promise<unknown>;
+type ElectronHostInvokeHandler = (event: unknown, request: unknown) => Promise<unknown>;
 
 const createRegisteredHandler = (): {
   channel: string | undefined;
@@ -71,7 +68,7 @@ describe("Electron host invoke IPC handler", () => {
       status: "success",
       payload: result,
     });
-    expect(invoke).toHaveBeenCalledWith("workspace_get_context", undefined);
+    expect(invoke).toHaveBeenCalledWith("workspace_get_context", request.args);
   });
 
   test("checks shutdown when a request arrives and does not invoke the router", async () => {
@@ -85,7 +82,40 @@ describe("Electron host invoke IPC handler", () => {
     });
     shutdownStarted = true;
 
-    await expect(registered.handler({}, request)).resolves.toEqual({ status: "shutdown" });
+    await expect(registered.handler({}, null)).resolves.toEqual({ status: "shutdown" });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["null", null, "request", "Electron host invoke request must be an object."],
+    ["undefined", undefined, "request", "Electron host invoke request must be an object."],
+    [
+      "a null command",
+      { command: null },
+      "command",
+      "Electron host invoke command must be a string.",
+    ],
+    [
+      "null arguments",
+      { command: "workspace_list", args: null },
+      "args",
+      "Electron host invoke arguments must be an object when provided.",
+    ],
+  ] as const)("rejects %s without invoking the router", async (_case, invalidRequest, field, message) => {
+    const invoke = mock(async () => ({ repoPath: "/workspace" }));
+    const registered = createRegisteredHandler();
+
+    registerElectronHostInvokeHandler(registered.ipcMain, {
+      isHostShutdownStarted: () => false,
+      invoke,
+    });
+
+    await expect(registered.handler({}, invalidRequest)).rejects.toMatchObject({
+      _tag: "ElectronValidationError",
+      operation: "electron.ipc.host-invoke.validate",
+      field,
+      message,
+    });
     expect(invoke).not.toHaveBeenCalled();
   });
 
@@ -116,7 +146,7 @@ describe("Electron host invoke IPC handler", () => {
     });
 
     const response = registered.handler({}, request);
-    expect(invoke).toHaveBeenCalledWith("workspace_get_context", undefined);
+    expect(invoke).toHaveBeenCalledWith("workspace_get_context", request.args);
     shutdownStarted = true;
     deferred.resolve({ repoPath: "/workspace" });
 
@@ -139,7 +169,7 @@ describe("Electron host invoke IPC handler", () => {
     });
 
     const response = registered.handler({}, request);
-    expect(invoke).toHaveBeenCalledWith("workspace_get_context", undefined);
+    expect(invoke).toHaveBeenCalledWith("workspace_get_context", request.args);
     shutdownStarted = true;
     deferred.reject(failure);
 

--- a/apps/electron/src/main/electron-host-invoke-handler.ts
+++ b/apps/electron/src/main/electron-host-invoke-handler.ts
@@ -1,23 +1,55 @@
-import type { HostCommandName } from "@openducktor/host";
+import { ElectronValidationError } from "../effect/electron-errors";
 import {
   ELECTRON_HOST_INVOKE_CHANNEL,
-  type ElectronHostInvokeRequest,
   type ElectronHostInvokeResponse,
 } from "../shared/electron-bridge-contract";
 
 type ElectronIpcMainLike = {
   handle(
     channel: string,
-    listener: (
-      event: unknown,
-      request: ElectronHostInvokeRequest,
-    ) => Promise<ElectronHostInvokeResponse>,
+    listener: (event: unknown, request: unknown) => Promise<ElectronHostInvokeResponse>,
   ): void;
 };
 
 type ElectronHostInvokeHandlerOptions = {
   isHostShutdownStarted(): boolean;
-  invoke(command: HostCommandName, args?: Record<string, unknown>): Promise<unknown>;
+  invoke(command: string, args?: Record<string, unknown>): Promise<unknown>;
+};
+
+type ValidatedElectronHostInvokeRequest = {
+  command: string;
+  args?: Record<string, unknown>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readElectronHostInvokeRequest = (request: unknown): ValidatedElectronHostInvokeRequest => {
+  if (!isRecord(request)) {
+    throw new ElectronValidationError({
+      operation: "electron.ipc.host-invoke.validate",
+      message: "Electron host invoke request must be an object.",
+      field: "request",
+    });
+  }
+  if (typeof request.command !== "string") {
+    throw new ElectronValidationError({
+      operation: "electron.ipc.host-invoke.validate",
+      message: "Electron host invoke command must be a string.",
+      field: "command",
+    });
+  }
+  if (request.args !== undefined && !isRecord(request.args)) {
+    throw new ElectronValidationError({
+      operation: "electron.ipc.host-invoke.validate",
+      message: "Electron host invoke arguments must be an object when provided.",
+      field: "args",
+    });
+  }
+
+  return request.args === undefined
+    ? { command: request.command }
+    : { command: request.command, args: request.args };
 };
 
 export const registerElectronHostInvokeHandler = (
@@ -29,7 +61,8 @@ export const registerElectronHostInvokeHandler = (
       return { status: "shutdown" };
     }
 
-    const invocation = options.invoke(request.command, request.args);
+    const parsedRequest = readElectronHostInvokeRequest(request);
+    const invocation = options.invoke(parsedRequest.command, parsedRequest.args);
     return { status: "success", payload: await invocation };
   });
 };

--- a/apps/electron/src/main/electron-host-invoke-handler.ts
+++ b/apps/electron/src/main/electron-host-invoke-handler.ts
@@ -1,0 +1,35 @@
+import type { HostCommandName } from "@openducktor/host";
+import {
+  ELECTRON_HOST_INVOKE_CHANNEL,
+  type ElectronHostInvokeRequest,
+  type ElectronHostInvokeResponse,
+} from "../shared/electron-bridge-contract";
+
+type ElectronIpcMainLike = {
+  handle(
+    channel: string,
+    listener: (
+      event: unknown,
+      request: ElectronHostInvokeRequest,
+    ) => Promise<ElectronHostInvokeResponse>,
+  ): void;
+};
+
+type ElectronHostInvokeHandlerOptions = {
+  isHostShutdownStarted(): boolean;
+  invoke(command: HostCommandName, args?: Record<string, unknown>): Promise<unknown>;
+};
+
+export const registerElectronHostInvokeHandler = (
+  ipcMain: ElectronIpcMainLike,
+  options: ElectronHostInvokeHandlerOptions,
+): void => {
+  ipcMain.handle(ELECTRON_HOST_INVOKE_CHANNEL, async (_event, request) => {
+    if (options.isHostShutdownStarted()) {
+      return { status: "shutdown" };
+    }
+
+    const invocation = options.invoke(request.command, request.args);
+    return { status: "success", payload: await invocation };
+  });
+};

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -36,12 +36,10 @@ import {
   ELECTRON_APP_UPDATE_INSTALL_CHANNEL,
   ELECTRON_APP_UPDATE_STATE_CHANGED_CHANNEL,
   ELECTRON_HOST_EVENT_CHANNEL,
-  ELECTRON_HOST_INVOKE_CHANNEL,
   ELECTRON_LOCAL_ATTACHMENT_PREVIEW_CHANNEL,
   ELECTRON_OPEN_EXTERNAL_URL_CHANNEL,
   type ElectronAppUpdateCheckInput,
   type ElectronHostEventEnvelope,
-  type ElectronHostInvokeRequest,
 } from "../shared/electron-bridge-contract";
 import {
   createElectronAppUpdateService,
@@ -51,6 +49,7 @@ import { createElectronUpdaterAdapter } from "./app-updates/electron-updater-ada
 import { createGitHubReleaseSource } from "./app-updates/github-release-source";
 import { configureElectronAppIdentity } from "./electron-app-identity";
 import { createElectronEffectHostCommandRouter } from "./electron-host";
+import { registerElectronHostInvokeHandler } from "./electron-host-invoke-handler";
 import {
   createElectronLocalAttachmentPreviewUrl,
   ELECTRON_LOCAL_ATTACHMENT_PREVIEW_PROTOCOL,
@@ -549,9 +548,10 @@ const registerIpcHandlers = (
   hostCommandRouter: EffectHostCommandRouter,
   appUpdateService: ElectronAppUpdateService,
 ): void => {
-  ipcMain.handle(ELECTRON_HOST_INVOKE_CHANNEL, async (_event, request: ElectronHostInvokeRequest) =>
-    runElectronEffect(hostCommandRouter.invoke(request.command, request.args)),
-  );
+  registerElectronHostInvokeHandler(ipcMain, {
+    isHostShutdownStarted: shutdownController.isHostShutdownStarted,
+    invoke: (command, args) => runElectronEffect(hostCommandRouter.invoke(command, args)),
+  });
 
   ipcMain.handle(ELECTRON_OPEN_EXTERNAL_URL_CHANNEL, async (_event, url: string) => {
     await runElectronEffect(openExternalUrlEffect(url));

--- a/apps/electron/src/preload/electron-host-invoke.test.ts
+++ b/apps/electron/src/preload/electron-host-invoke.test.ts
@@ -24,16 +24,16 @@ describe("Electron preload host invoke", () => {
     );
   });
 
-  test.each([
-    { status: "success" },
-    { status: "shutdown", payload: null },
-  ])("rejects malformed responses with an explicit protocol error", async (response) => {
-    const hostInvoke = createElectronHostInvoke({ invoke: async () => response });
+  test.each([{ status: "success" }, { status: "shutdown", payload: null }])(
+    "rejects malformed responses with an explicit protocol error",
+    async (response) => {
+      const hostInvoke = createElectronHostInvoke({ invoke: async () => response });
 
-    await expect(hostInvoke("workspace_get_context")).rejects.toThrow(
-      "Received an invalid host invoke response from the Electron main process.",
-    );
-  });
+      await expect(hostInvoke("workspace_get_context")).rejects.toThrow(
+        "Received an invalid host invoke response from the Electron main process.",
+      );
+    },
+  );
 
   test("preserves raw IPC invocation failures", async () => {
     const failure = new Error("IPC unavailable");

--- a/apps/electron/src/preload/electron-host-invoke.test.ts
+++ b/apps/electron/src/preload/electron-host-invoke.test.ts
@@ -24,10 +24,11 @@ describe("Electron preload host invoke", () => {
     );
   });
 
-  test("rejects malformed responses with an explicit protocol error", async () => {
-    const hostInvoke = createElectronHostInvoke({
-      invoke: async () => ({ status: "success" }),
-    });
+  test.each([
+    { status: "success" },
+    { status: "shutdown", payload: null },
+  ])("rejects malformed responses with an explicit protocol error", async (response) => {
+    const hostInvoke = createElectronHostInvoke({ invoke: async () => response });
 
     await expect(hostInvoke("workspace_get_context")).rejects.toThrow(
       "Received an invalid host invoke response from the Electron main process.",

--- a/apps/electron/src/preload/electron-host-invoke.test.ts
+++ b/apps/electron/src/preload/electron-host-invoke.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, mock, test } from "bun:test";
+import { ELECTRON_HOST_SHUTDOWN_MESSAGE } from "../shared/electron-bridge-contract";
+import { createElectronHostInvoke } from "./electron-host-invoke";
+
+describe("Electron preload host invoke", () => {
+  test("sends the exact host channel and request and returns a success payload", async () => {
+    const result = { repoPath: "/workspace" };
+    const invoke = mock(async () => ({ status: "success", payload: result }));
+    const hostInvoke = createElectronHostInvoke({ invoke });
+
+    await expect(hostInvoke("workspace_get_context")).resolves.toBe(result);
+    expect(invoke).toHaveBeenCalledWith("openducktor:host-invoke", {
+      command: "workspace_get_context",
+    });
+  });
+
+  test("rejects shutdown responses with the stable shutdown message", async () => {
+    const hostInvoke = createElectronHostInvoke({
+      invoke: async () => ({ status: "shutdown" }),
+    });
+
+    await expect(hostInvoke("workspace_get_context")).rejects.toThrow(
+      ELECTRON_HOST_SHUTDOWN_MESSAGE,
+    );
+  });
+
+  test("rejects malformed responses with an explicit protocol error", async () => {
+    const hostInvoke = createElectronHostInvoke({
+      invoke: async () => ({ status: "success" }),
+    });
+
+    await expect(hostInvoke("workspace_get_context")).rejects.toThrow(
+      "Received an invalid host invoke response from the Electron main process.",
+    );
+  });
+
+  test("preserves raw IPC invocation failures", async () => {
+    const failure = new Error("IPC unavailable");
+    const hostInvoke = createElectronHostInvoke({
+      invoke: async () => {
+        throw failure;
+      },
+    });
+
+    await expect(hostInvoke("workspace_get_context")).rejects.toBe(failure);
+  });
+});

--- a/apps/electron/src/preload/electron-host-invoke.ts
+++ b/apps/electron/src/preload/electron-host-invoke.ts
@@ -1,0 +1,39 @@
+import {
+  ELECTRON_HOST_INVOKE_CHANNEL,
+  ELECTRON_HOST_SHUTDOWN_MESSAGE,
+  type ElectronHostInvokeRequest,
+  type OpenDucktorElectronApi,
+} from "../shared/electron-bridge-contract";
+
+const ELECTRON_HOST_INVOKE_PROTOCOL_ERROR_MESSAGE =
+  "Received an invalid host invoke response from the Electron main process.";
+
+type ElectronIpcRendererLike = {
+  invoke(channel: string, request: ElectronHostInvokeRequest): Promise<unknown>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const unwrapResponse = (response: unknown): unknown => {
+  if (!isRecord(response) || !Object.hasOwn(response, "status")) {
+    throw new Error(ELECTRON_HOST_INVOKE_PROTOCOL_ERROR_MESSAGE);
+  }
+
+  if (response.status === "success" && Object.hasOwn(response, "payload")) {
+    return response.payload;
+  }
+
+  if (response.status === "shutdown" && !Object.hasOwn(response, "payload")) {
+    throw new Error(ELECTRON_HOST_SHUTDOWN_MESSAGE);
+  }
+
+  throw new Error(ELECTRON_HOST_INVOKE_PROTOCOL_ERROR_MESSAGE);
+};
+
+export const createElectronHostInvoke =
+  (ipcRenderer: ElectronIpcRendererLike): OpenDucktorElectronApi["invoke"] =>
+  async (command, args) => {
+    const request: ElectronHostInvokeRequest = args === undefined ? { command } : { command, args };
+    return unwrapResponse(await ipcRenderer.invoke(ELECTRON_HOST_INVOKE_CHANNEL, request));
+  };

--- a/apps/electron/src/preload/preload.ts
+++ b/apps/electron/src/preload/preload.ts
@@ -7,7 +7,6 @@ import {
   ELECTRON_APP_UPDATE_INSTALL_CHANNEL,
   ELECTRON_APP_UPDATE_STATE_CHANGED_CHANNEL,
   ELECTRON_HOST_EVENT_CHANNEL,
-  ELECTRON_HOST_INVOKE_CHANNEL,
   ELECTRON_LOCAL_ATTACHMENT_PREVIEW_CHANNEL,
   ELECTRON_OPEN_EXTERNAL_URL_CHANNEL,
   type ElectronAppUpdateCheckInput,
@@ -15,6 +14,7 @@ import {
   type OpenDucktorElectronApi,
   type OpenDucktorElectronAppUpdateApi,
 } from "../shared/electron-bridge-contract";
+import { createElectronHostInvoke } from "./electron-host-invoke";
 
 const { contextBridge, ipcRenderer } = electron;
 
@@ -60,12 +60,7 @@ const appUpdates: OpenDucktorElectronAppUpdateApi = {
 };
 
 const electronApi: OpenDucktorElectronApi = {
-  invoke(command, args) {
-    return ipcRenderer.invoke(ELECTRON_HOST_INVOKE_CHANNEL, {
-      command,
-      args,
-    });
-  },
+  invoke: createElectronHostInvoke(ipcRenderer),
   subscribe(channel, listener) {
     const handleEvent = (
       _event: Electron.IpcRendererEvent,

--- a/apps/electron/src/shared/electron-bridge-contract.ts
+++ b/apps/electron/src/shared/electron-bridge-contract.ts
@@ -14,11 +14,22 @@ export const ELECTRON_APP_UPDATE_CHECK_CHANNEL = "openducktor:app-update:check";
 export const ELECTRON_APP_UPDATE_DOWNLOAD_CHANNEL = "openducktor:app-update:download";
 export const ELECTRON_APP_UPDATE_INSTALL_CHANNEL = "openducktor:app-update:install";
 export const ELECTRON_APP_UPDATE_STATE_CHANGED_CHANNEL = "openducktor:app-update:state-changed";
+export const ELECTRON_HOST_SHUTDOWN_MESSAGE =
+  "OpenDucktor is shutting down. The requested command was not run.";
 
 export type ElectronHostInvokeRequest = {
   command: HostCommandName;
   args?: Record<string, unknown>;
 };
+
+export type ElectronHostInvokeResponse =
+  | {
+      status: "success";
+      payload: unknown;
+    }
+  | {
+      status: "shutdown";
+    };
 
 export type ElectronHostEventEnvelope = {
   channel: string;

--- a/apps/electron/src/shared/electron-bridge-contract.ts
+++ b/apps/electron/src/shared/electron-bridge-contract.ts
@@ -18,7 +18,7 @@ export const ELECTRON_HOST_SHUTDOWN_MESSAGE =
   "OpenDucktor is shutting down. The requested command was not run.";
 
 export type ElectronHostInvokeRequest = {
-  command: HostCommandName;
+  command: string;
   args?: Record<string, unknown>;
 };
 

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -44,6 +44,14 @@ type TestHostCommandInvoke = (
   args?: Record<string, unknown>,
 ) => Effect.Effect<unknown, unknown>;
 
+const createDeferred = <Value = void>() => {
+  let resolve: (value: Value | PromiseLike<Value>) => void = () => {};
+  const promise = new Promise<Value>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+};
+
 const PENDING_STREAM_READ = Symbol("pending-stream-read");
 type StreamReadResult = Awaited<ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]>>;
 
@@ -458,6 +466,176 @@ describe("TypeScript web host backend", () => {
     expect(response.status).toBe(202);
     expect(shutdownStarted).toBe(true);
     expect(stopCalls).toBe(0);
+  });
+
+  test("rejects invokes after the shutdown gate while host teardown remains pending", async () => {
+    const disposeStarted = createDeferred();
+    const disposeReleased = createDeferred();
+    let invokeCalls = 0;
+    const teardown = stopTypescriptHostBackendServices({
+      disposeHost: () =>
+        Effect.promise(async () => {
+          disposeStarted.resolve();
+          await disposeReleased.promise;
+        }),
+      resolveExited: () => {},
+      stopServer: () => {},
+    });
+
+    await disposeStarted.promise;
+    try {
+      const response = await handleTestRequest(
+        new Request("http://127.0.0.1/invoke/runtime_ensure", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-openducktor-app-token": APP_TOKEN,
+          },
+          body: JSON.stringify({}),
+        }),
+        {
+          hostCommandRouter: createTestHostCommandRouter(() => {
+            invokeCalls += 1;
+            return Effect.succeed(null);
+          }),
+          shutdownStarted: true,
+        },
+      );
+
+      expect(response.status).toBe(503);
+      expect(await response.json()).toEqual({
+        error: "Browser backend is shutting down and is no longer accepting new work.",
+        message: "Browser backend is shutting down and is no longer accepting new work.",
+      });
+      expect(invokeCalls).toBe(0);
+    } finally {
+      disposeReleased.resolve();
+      await teardown;
+    }
+  });
+
+  test("rejects new SSE streams after the shutdown gate without opening a subscription", async () => {
+    const eventBus = new BufferedHostEventBus();
+    const stream = eventBus.stream();
+    const originalStream = eventBus.stream.bind(eventBus);
+    const originalSubscribe = stream.subscribe.bind(stream);
+    let streamCalls = 0;
+    let subscribeCalls = 0;
+    eventBus.stream = () => {
+      streamCalls += 1;
+      return originalStream();
+    };
+    stream.subscribe = (listener) => {
+      subscribeCalls += 1;
+      return originalSubscribe(listener);
+    };
+
+    const response = await handleTestRequest(
+      new Request("http://127.0.0.1/events", {
+        method: "GET",
+        headers: { "x-openducktor-app-token": APP_TOKEN },
+      }),
+      { eventBus, shutdownStarted: true },
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Browser backend is shutting down and is no longer accepting new work.",
+      message: "Browser backend is shutting down and is no longer accepting new work.",
+    });
+    expect(streamCalls).toBe(0);
+    expect(subscribeCalls).toBe(0);
+  });
+
+  test("keeps active SSE streams open until forced server shutdown", async () => {
+    const eventBus = new BufferedHostEventBus();
+    const disposeStarted = createDeferred();
+    const disposeReleased = createDeferred();
+    let shutdownStarted = false;
+    let server!: ReturnType<typeof Bun.serve>;
+    let stopPromise: Promise<void> | null = null;
+    const stop = (): Promise<void> => {
+      if (stopPromise) {
+        return stopPromise;
+      }
+      shutdownStarted = true;
+      stopPromise = stopTypescriptHostBackendServices({
+        disposeHost: () =>
+          Effect.promise(async () => {
+            disposeStarted.resolve();
+            await disposeReleased.promise;
+          }),
+        resolveExited: () => {},
+        stopServer: () => server.stop(true),
+      });
+      return stopPromise;
+    };
+    server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request, requestServer) =>
+        Effect.runPromise(
+          handleTypescriptHostBackendRequest({
+            allowedOrigins: new Set(),
+            appToken: APP_TOKEN,
+            controlToken: CONTROL_TOKEN,
+            eventBus,
+            hostCommandRouter: createTestHostCommandRouter(),
+            localAttachments: createLocalAttachmentAdapter(),
+            request,
+            requestTimeouts: requestServer,
+            shutdownStarted,
+            beginShutdown: () => {
+              shutdownStarted = true;
+            },
+            stop,
+          }),
+        ),
+    });
+
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    try {
+      const response = await Bun.fetch(`http://127.0.0.1:${server.port}/events`, {
+        headers: { "x-openducktor-app-token": APP_TOKEN },
+      });
+      expect(response.status).toBe(200);
+      reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("Expected SSE response body.");
+      }
+      expect(new TextDecoder().decode((await readImmediateStreamChunk(reader)).value)).toBe(
+        ": openducktor-ready\n\n",
+      );
+
+      const shutdown = stop();
+      await disposeStarted.promise;
+      eventBus.publish("openducktor://run-event", { type: "run" });
+      expect(new TextDecoder().decode((await reader.read()).value)).toContain('"type":"run"');
+
+      disposeReleased.resolve();
+      await shutdown;
+      const terminalRead = await reader.read().then(
+        (result) => ({ result }),
+        (error: unknown) => ({ error }),
+      );
+      if ("error" in terminalRead) {
+        expect(terminalRead.error).toBeInstanceOf(Error);
+      } else {
+        expect(terminalRead.result.done).toBe(true);
+      }
+    } finally {
+      disposeReleased.resolve();
+      if (stopPromise) {
+        await stopPromise;
+      } else {
+        server.stop(true);
+      }
+      try {
+        await reader?.cancel();
+      } catch {
+        // Bun rejects an SSE reader after server.stop(true) force-closes its socket.
+      }
+    }
   });
 
   test("keeps the backend server alive until host disposal finishes", async () => {


### PR DESCRIPTION
## Summary

- stop admitting Electron host commands after host shutdown begins
- return a fulfilled shutdown envelope so expected close-time requests do not trigger Electron handler stack traces
- decode the private transport response in preload while preserving genuine host failures
- cover late admission and already-admitted command outcomes with focused IPC boundary tests

## Goal

Closing OpenDucktor while agent sessions are active can leave the hidden renderer issuing a late host request after live runtimes have already been removed. The host correctly fails that request, but Electron logs the rejected `ipcMain.handle` call as a full error stack even though application shutdown is normal user behavior.

This change makes the shutdown boundary explicit: requests arriving after shutdown starts are not routed into disposed host resources and are reported quietly to the renderer. Commands admitted before shutdown retain their original success or failure semantics.

## Implementation

- add an Electron-private success/shutdown response contract
- register the host invoke channel through a focused main-process adapter that checks `isHostShutdownStarted()` at request time
- return a shutdown response instead of rejecting the main-process handler, avoiding Electron automatic error logging
- add a focused preload adapter that strictly validates responses, unwraps successful payloads, and turns shutdown into a local error with a stable message
- keep genuine IPC and host failures unchanged rather than masking or reclassifying them
- avoid draining or cancelling already-admitted commands because the host does not yet provide uniform structured cancellation and waiting could deadlock shutdown

## Verification

- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- focused Electron IPC tests
- GitNexus staged change analysis: low risk, 0 affected execution processes

Cargo checks are not applicable because this repository contains no `Cargo.toml`, `Cargo.lock`, or Rust toolchain configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Electron host-command invocation through a consistent IPC bridge.
  - Added clear success and shutdown response handling.
  - Added validation for malformed command requests and responses.
  - Preserved in-progress invocation results during shutdown.

- **Bug Fixes**
  - Improved handling of host errors and IPC failures.
  - Prevented new host requests and subscriptions after shutdown begins while allowing active streams to finish.

- **Tests**
  - Added comprehensive coverage for IPC validation, shutdown behavior, error propagation, and stream lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->