### PR TITLE
fix(codex): handle optional context usage replay

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
@@ -1,25 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
   codexSessionRef,
-  codexSessionRuntimeRef,
   codexStartSessionInput,
   createDeferred,
   createHarness,
   createRuntimeStreamSubscription,
   flushCodexAdapterWork,
-  makeRuntimeSummary,
-  RecordingTransport,
 } from "./codex-app-server-adapter.test-harness";
-import { CodexContextUsageTracker } from "./codex-context-usage-tracker";
-import type { CodexPendingInputState } from "./codex-pending-input-state";
-import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
-import type { CodexSessionContextUsage } from "./types";
 
-const tokenUsageNotification = (
-  totalTokens: number,
-  contextWindow = 200_000,
-  threadId = "thread/start-runtime-live",
-) => ({
+const tokenUsageNotification = (totalTokens: number, threadId = "thread/start-runtime-live") => ({
   method: "thread/tokenUsage/updated",
   params: {
     threadId,
@@ -27,46 +16,13 @@ const tokenUsageNotification = (
     tokenUsage: {
       total: { totalTokens },
       last: { totalTokens },
-      modelContextWindow: contextWindow,
+      modelContextWindow: 200_000,
     },
   },
 });
 
-const expectNoContextReadOrResume = (transport?: RecordingTransport): void => {
-  expect(
-    transport?.calls.filter(
-      (call) => call.method === "thread/read" || call.method === "thread/resume",
-    ) ?? [],
-  ).toEqual([]);
-};
-
-describe("CodexContextUsageTracker", () => {
-  test("shares a synchronously reentrant load", async () => {
-    const tracker = new CodexContextUsageTracker();
-    const callbackRan = createDeferred<void>();
-    let nestedLoad: Promise<CodexSessionContextUsage | null> | null = null;
-    let resumeAttempts = 0;
-
-    const outerLoad = tracker.load("runtime-live", "thread-idle", async () => {
-      resumeAttempts += 1;
-      nestedLoad = tracker.load("runtime-live", "thread-idle", async () => {
-        resumeAttempts += 1;
-      });
-      callbackRan.resolve(undefined);
-    });
-
-    await callbackRan.promise;
-    if (!nestedLoad) {
-      throw new Error("Expected reentrant context load.");
-    }
-    expect(resumeAttempts).toBe(1);
-    await expect(Promise.all([outerLoad, nestedLoad])).resolves.toEqual([null, null]);
-    expect(resumeAttempts).toBe(1);
-  });
-});
-
 describe("CodexAppServerAdapter context loading", () => {
-  test("returns retained context without a Codex read or resume", async () => {
+  test("returns retained context without a Codex resume", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({
       subscribeEvents: runtimeStream.subscribeEvents,
@@ -75,72 +31,31 @@ describe("CodexAppServerAdapter context loading", () => {
     runtimeStream.emitNotification(tokenUsageNotification(1_000));
     await flushCodexAdapterWork();
 
-    const usage = await adapter.loadLiveSessionContextUsage({
-      runtimeId: "runtime-live",
-      externalSessionId: "thread/start-runtime-live",
-    });
-
-    expect(usage).toEqual({ totalTokens: 1_000, contextWindow: 200_000 });
-    expect(
-      transports
-        .get("runtime-live")
-        ?.calls.filter((call) => call.method === "thread/read" || call.method === "thread/resume"),
-    ).toEqual([]);
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([
-      expect.objectContaining({
-        ref: {
-          repoPath: "/repo",
-          runtimeKind: "codex",
-          workingDirectory: "/repo",
-          externalSessionId: "thread/start-runtime-live",
-        },
-        contextUsage: { totalTokens: 1_000, contextWindow: 200_000 },
-        pendingApprovals: [],
-        pendingQuestions: [],
-      }),
-    ]);
-  });
-
-  test("updates retained context to zero when cumulative usage remains positive", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter } = createHarness({ subscribeEvents: runtimeStream.subscribeEvents });
-    await adapter.startSession(codexStartSessionInput());
-    runtimeStream.emitNotification(tokenUsageNotification(42_000));
-    await flushCodexAdapterWork();
-    runtimeStream.emitNotification({
-      method: "thread/tokenUsage/updated",
-      params: {
-        threadId: "thread/start-runtime-live",
-        turnId: "turn-2",
-        tokenUsage: {
-          total: { totalTokens: 42_000 },
-          last: { totalTokens: 0 },
-          modelContextWindow: 200_000,
-        },
-      },
-    });
-    await flushCodexAdapterWork();
-
-    expect(adapter.listLiveSessionSnapshots("runtime-live")[0]?.contextUsage).toEqual({
-      totalTokens: 0,
+    await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toEqual({
+      totalTokens: 1_000,
       contextWindow: 200_000,
     });
-  });
-
-  test("returns null immediately after a successful resume without usage", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-
-    await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toBeNull();
     expect(
       transports.get("runtime-live")?.calls.filter((call) => call.method === "thread/resume"),
-    ).toHaveLength(1);
+    ).toEqual([]);
   });
 
-  test("shares concurrent missing-context loads and returns null to both callers", async () => {
+  test("retains a recovered cold session even when its context usage is null", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter } = createHarness({ subscribeEvents: runtimeStream.subscribeEvents });
+
+    await expect(
+      adapter.loadSessionContextUsage(codexSessionRef("thread-idle")),
+    ).resolves.toBeNull();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
+        contextUsage: null,
+      }),
+    );
+  });
+
+  test("uses stream usage that arrives while resume is outstanding", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({
       subscribeEvents: runtimeStream.subscribeEvents,
@@ -150,38 +65,6 @@ describe("CodexAppServerAdapter context loading", () => {
     const request = transport?.request.bind(transport);
     const resumeStarted = createDeferred<void>();
     const resume = createDeferred<void>();
-    let resumeAttempts = 0;
-    if (transport && request) {
-      transport.request = async <Response>(input): Promise<Response> => {
-        if (input.method === "thread/resume") {
-          resumeAttempts += 1;
-          resumeStarted.resolve(undefined);
-          await resume.promise;
-        }
-        return request<Response>(input);
-      };
-    }
-
-    const firstLoad = adapter.loadSessionContextUsage(codexSessionRef());
-    await resumeStarted.promise;
-    const secondLoad = adapter.loadSessionContextUsage(codexSessionRef());
-
-    expect(resumeAttempts).toBe(1);
-    resume.resolve(undefined);
-    await expect(Promise.all([firstLoad, secondLoad])).resolves.toEqual([null, null]);
-    expect(resumeAttempts).toBe(1);
-  });
-
-  test("returns usage observed while resume is outstanding", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    const transport = transports.get("runtime-live");
-    const request = transport?.request.bind(transport);
     if (transport && request) {
       transport.request = async <Response>(input): Promise<Response> => {
         if (input.method === "thread/resume") {
@@ -201,7 +84,7 @@ describe("CodexAppServerAdapter context loading", () => {
     await expect(loading).resolves.toEqual({ totalTokens: 2_000, contextWindow: 200_000 });
   });
 
-  test("propagates usage arriving after a null result through the live snapshot", async () => {
+  test("projects usage that arrives after a successful null resume", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter } = createHarness({ subscribeEvents: runtimeStream.subscribeEvents });
     await adapter.startSession(codexStartSessionInput());
@@ -216,677 +99,18 @@ describe("CodexAppServerAdapter context loading", () => {
     });
   });
 
-  test("retains an unloaded session after a successful null resume", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter } = createHarness({ subscribeEvents: runtimeStream.subscribeEvents });
-
-    await expect(
-      adapter.loadSessionContextUsage(codexSessionRef("thread-idle")),
-    ).resolves.toBeNull();
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
-      expect.objectContaining({
-        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
-        contextUsage: null,
-      }),
-    );
-  });
-
-  test("keeps the runtime stream for a bound cold load after another session is released", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const transport = transports.get("runtime-live");
-    const request = transport?.request.bind(transport);
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    if (transport && request) {
-      transport.request = async <Response>(input): Promise<Response> => {
-        if (input.method === "thread/resume") {
-          resumeStarted.resolve(undefined);
-          await resume.promise;
-        }
-        return request<Response>(input);
-      };
-    }
-
-    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
-    await resumeStarted.promise;
-    await adapter.releaseSession(codexSessionRef());
-
-    expect(runtimeStream.unsubscribedRuntimeIds).toEqual([]);
-    runtimeStream.emitNotification(tokenUsageNotification(3_000, 200_000, "thread-idle"));
-    await flushCodexAdapterWork();
-    resume.resolve(undefined);
-
-    await expect(loading).resolves.toEqual({ totalTokens: 3_000, contextWindow: 200_000 });
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([
-      expect.objectContaining({
-        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
-        contextUsage: { totalTokens: 3_000, contextWindow: 200_000 },
-      }),
-    ]);
-    expect(runtimeStream.unsubscribedRuntimeIds).toEqual([]);
-  });
-
-  test("stops the runtime stream after a bound cold load fails following another session release", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const transport = transports.get("runtime-live");
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    if (transport) {
-      transport.request = async (input) => {
-        if (input.method === "thread/resume") {
-          resumeStarted.resolve(undefined);
-          await resume.promise;
-          throw new Error("resume unavailable");
-        }
-        throw new Error(`Unexpected Codex request '${input.method}'.`);
-      };
-    }
-
-    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
-    await resumeStarted.promise;
-    await adapter.releaseSession(codexSessionRef());
-
-    expect(runtimeStream.unsubscribedRuntimeIds).toEqual([]);
-    resume.resolve(undefined);
-    await expect(loading).rejects.toThrow("resume unavailable");
-    await flushCodexAdapterWork();
-
-    expect(runtimeStream.unsubscribedRuntimeIds).toEqual(["runtime-live"]);
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("fails actionably and permits a later explicit resume retry", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const transport = transports.get("runtime-live");
-    const request = transport?.request.bind(transport);
-    let resumeAttempts = 0;
-    if (transport && request) {
-      transport.request = async <Response>(input): Promise<Response> => {
-        if (input.method === "thread/resume") {
-          resumeAttempts += 1;
-          if (resumeAttempts === 1) {
-            throw new Error("resume unavailable");
-          }
-        }
-        return request<Response>(input);
-      };
-    }
-
-    await expect(adapter.loadSessionContextUsage(codexSessionRef())).rejects.toThrow(
-      "resume unavailable",
-    );
-    await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toBeNull();
-    expect(resumeAttempts).toBe(2);
-  });
-  test("rejects a cold load promptly when its session is released without resurrecting state", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const transport = new RecordingTransport("runtime-live", false);
+  test("keeps the stream through session release and stops it on runtime release", async () => {
+    const unsubscribedRuntimeIds: string[] = [];
     const { adapter } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-      transportFactory: () => transport,
-    });
-    const request = transport.request.bind(transport);
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    const resumeCompleted = createDeferred<void>();
-    transport.request = async <Response>(input): Promise<Response> => {
-      if (input.method === "thread/resume") {
-        resumeStarted.resolve(undefined);
-        await resume.promise;
-        const response = await request<Response>(input);
-        resumeCompleted.resolve(undefined);
-        return response;
-      }
-      return request<Response>(input);
-    };
-
-    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
-    await resumeStarted.promise;
-    await adapter.releaseSession(codexSessionRef("thread-idle"));
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).not.toContainEqual(
-      expect.objectContaining({
-        ref: expect.objectContaining({
-          externalSessionId: "thread-idle",
-          repoPath: "/repo",
-          workingDirectory: "/repo",
-        }),
-      }),
-    );
-    resume.resolve(undefined);
-    await resumeCompleted.promise;
-    await flushCodexAdapterWork();
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("rejects a cold load promptly when its runtime is released without resurrecting state", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const transport = new RecordingTransport("runtime-live", false);
-    const { adapter } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-      transportFactory: () => transport,
-    });
-    const request = transport.request.bind(transport);
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    const resumeCompleted = createDeferred<void>();
-    transport.request = async <Response>(input): Promise<Response> => {
-      if (input.method === "thread/resume") {
-        resumeStarted.resolve(undefined);
-        await resume.promise;
-        const response = await request<Response>(input);
-        resumeCompleted.resolve(undefined);
-        return response;
-      }
-      return request<Response>(input);
-    };
-
-    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
-    await resumeStarted.promise;
-    adapter.releaseRuntime("runtime-live");
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).not.toContainEqual(
-      expect.objectContaining({
-        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
-      }),
-    );
-    resume.resolve(undefined);
-    await resumeCompleted.promise;
-    await flushCodexAdapterWork();
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("rejects a retained live load promptly when its session is released", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
+      subscribeEvents: (runtimeId) => () => {
+        unsubscribedRuntimeIds.push(runtimeId);
+      },
     });
     await adapter.startSession(codexStartSessionInput());
-    const transport = transports.get("runtime-live");
-    const request = transport?.request.bind(transport);
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    const resumeCompleted = createDeferred<void>();
-    if (transport && request) {
-      transport.request = async <Response>(input): Promise<Response> => {
-        if (input.method === "thread/resume") {
-          resumeStarted.resolve(undefined);
-          await resume.promise;
-          const response = await request<Response>(input);
-          resumeCompleted.resolve(undefined);
-          return response;
-        }
-        return request<Response>(input);
-      };
-    }
 
-    const loading = adapter.loadLiveSessionContextUsage({
-      runtimeId: "runtime-live",
-      externalSessionId: "thread/start-runtime-live",
-    });
-    await resumeStarted.promise;
     await adapter.releaseSession(codexSessionRef());
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    resume.resolve(undefined);
-    await resumeCompleted.promise;
-    await flushCodexAdapterWork();
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("cancels a retained live context load when its session is stopped", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const transport = transports.get("runtime-live");
-    const request = transport?.request.bind(transport);
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    const resumeCompleted = createDeferred<void>();
-    if (transport && request) {
-      transport.request = async <Response>(input): Promise<Response> => {
-        if (input.method === "thread/resume") {
-          resumeStarted.resolve(undefined);
-          await resume.promise;
-          const response = await request<Response>(input);
-          resumeCompleted.resolve(undefined);
-          return response;
-        }
-        return request<Response>(input);
-      };
-    }
-
-    const loading = adapter.loadLiveSessionContextUsage({
-      runtimeId: "runtime-live",
-      externalSessionId: "thread/start-runtime-live",
-    });
-    await resumeStarted.promise;
-    await adapter.stopSession(codexSessionRef());
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    expect(runtimeStream.unsubscribedRuntimeIds).toEqual(["runtime-live"]);
-    resume.resolve(undefined);
-    await resumeCompleted.promise;
-    await flushCodexAdapterWork();
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-    expect(runtimeStream.unsubscribedRuntimeIds).toEqual(["runtime-live"]);
-  });
-
-  test("rejects a retained live load promptly when its runtime is released", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const transport = transports.get("runtime-live");
-    const request = transport?.request.bind(transport);
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    const resumeCompleted = createDeferred<void>();
-    if (transport && request) {
-      transport.request = async <Response>(input): Promise<Response> => {
-        if (input.method === "thread/resume") {
-          resumeStarted.resolve(undefined);
-          await resume.promise;
-          const response = await request<Response>(input);
-          resumeCompleted.resolve(undefined);
-          return response;
-        }
-        return request<Response>(input);
-      };
-    }
-
-    const loading = adapter.loadLiveSessionContextUsage({
-      runtimeId: "runtime-live",
-      externalSessionId: "thread/start-runtime-live",
-    });
-    await resumeStarted.promise;
+    expect(unsubscribedRuntimeIds).toEqual([]);
     adapter.releaseRuntime("runtime-live");
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    resume.resolve(undefined);
-    await resumeCompleted.promise;
-    await flushCodexAdapterWork();
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("rejects a session release during runtime resolution without resuming or retaining", async () => {
-    const ref = codexSessionRef("thread-idle");
-    const runtime = createDeferred<ReturnType<typeof makeRuntimeSummary>>();
-    const { adapter, transports } = createHarness({
-      repoRuntimeResolver: { requireRepoRuntime: () => runtime.promise },
-    });
-
-    const loading = adapter.loadSessionContextUsage(ref);
-    await adapter.releaseSession(ref);
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    runtime.resolve(makeRuntimeSummary("runtime-live"));
-    expectNoContextReadOrResume(transports.get("runtime-live"));
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("rejects a runtime release during runtime resolution without resuming or retaining", async () => {
-    const runtime = createDeferred<ReturnType<typeof makeRuntimeSummary>>();
-    const { adapter, transports } = createHarness({
-      repoRuntimeResolver: { requireRepoRuntime: () => runtime.promise },
-    });
-
-    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
-    adapter.releaseRuntime("runtime-live");
-    runtime.resolve(makeRuntimeSummary("runtime-live"));
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    expectNoContextReadOrResume(transports.get("runtime-live"));
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("rejects a session release during runtime preparation without resuming or retaining", async () => {
-    const ref = codexSessionRef("thread-idle");
-    const preparationStarted = createDeferred<void>();
-    const preparation = createDeferred<() => void>();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: () => {
-        preparationStarted.resolve(undefined);
-        return preparation.promise;
-      },
-    });
-
-    const loading = adapter.loadSessionContextUsage(ref);
-    await preparationStarted.promise;
-    await adapter.releaseSession(ref);
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    preparation.resolve(() => {});
-    expectNoContextReadOrResume(transports.get("runtime-live"));
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("rejects a runtime release during runtime preparation without resuming or retaining", async () => {
-    const preparationStarted = createDeferred<void>();
-    const preparation = createDeferred<() => void>();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: () => {
-        preparationStarted.resolve(undefined);
-        return preparation.promise;
-      },
-    });
-
-    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
-    await preparationStarted.promise;
-    adapter.releaseRuntime("runtime-live");
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    preparation.resolve(() => {});
-    expectNoContextReadOrResume(transports.get("runtime-live"));
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
-  });
-
-  test("does not cancel a context load when a mismatched retained-session release is rejected", async () => {
-    const ref = codexSessionRef("thread-idle");
-    const transport = new RecordingTransport("runtime-live", false);
-    const originalRequest = transport.request.bind(transport);
-    const firstResumeStarted = createDeferred<void>();
-    const unblockFirstResume = createDeferred<void>();
-    let resumeCount = 0;
-    transport.request = async <Response>(input): Promise<Response> => {
-      const response = await originalRequest<Response>(input);
-      if (input.method === "thread/resume") {
-        resumeCount += 1;
-        if (resumeCount === 1) {
-          firstResumeStarted.resolve(undefined);
-          await unblockFirstResume.promise;
-        }
-      }
-      return response;
-    };
-    const { adapter } = createHarness({ transportFactory: () => transport });
-
-    const loading = adapter.loadSessionContextUsage(ref);
-    await firstResumeStarted.promise;
-    await adapter.resumeSession(codexSessionRuntimeRef("thread-idle"));
-    await expect(adapter.releaseSession({ ...ref, repoPath: "/other-repo" })).rejects.toThrow(
-      "Cannot release Codex session",
-    );
-    unblockFirstResume.resolve(undefined);
-
-    await expect(loading).resolves.toBeNull();
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
-      expect.objectContaining({
-        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
-      }),
-    );
-  });
-  test("cancels a matching blocked load before failing session cleanup", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const transport = new RecordingTransport("runtime-live", false);
-    const { adapter } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-      transportFactory: () => transport,
-    });
-    const request = transport.request.bind(transport);
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    transport.request = async <Response>(input): Promise<Response> => {
-      if (input.method === "thread/resume") {
-        resumeStarted.resolve(undefined);
-        await resume.promise;
-      }
-      return request<Response>(input);
-    };
-    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
-    await resumeStarted.promise;
-    await adapter.startSession(codexStartSessionInput());
-    const localSessions = adapter as unknown as {
-      localSessions: {
-        get(id: string): { summary: { externalSessionId: string }; threadId: string } | undefined;
-        remember(session: unknown): void;
-        release(id: string): void;
-      };
-    };
-    const retained = localSessions.localSessions.get("thread/start-runtime-live");
-    if (!retained) {
-      throw new Error("Expected retained session.");
-    }
-    localSessions.localSessions.remember({
-      ...retained,
-      threadId: "thread-idle",
-      summary: { ...retained.summary, externalSessionId: "thread-idle" },
-    });
-    const release = localSessions.localSessions.release.bind(localSessions.localSessions);
-    localSessions.localSessions.release = (id) => {
-      release(id);
-      throw new Error("cleanup failed");
-    };
-
-    await expect(adapter.releaseSession(codexSessionRef("thread-idle"))).rejects.toThrow(
-      "cleanup failed",
-    );
-    resume.resolve(undefined);
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).not.toContainEqual(
-      expect.objectContaining({
-        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
-      }),
-    );
-  });
-});
-
-describe("CodexAppServerAdapter live child projection", () => {
-  test("rejects a blocked routed-child context load when the child is released", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const adapterState = adapter as unknown as { subagents: CodexSubagentLinkState };
-    adapterState.subagents.upsertLink({
-      runtimeId: "runtime-live",
-      parentThreadId: "thread/start-runtime-live",
-      childThreadId: "child-thread",
-      itemId: "child-thread",
-      status: "running",
-    });
-    const transport = transports.get("runtime-live");
-    const request = transport?.request.bind(transport);
-    const resume = createDeferred<void>();
-    const resumeStarted = createDeferred<void>();
-    const resumeCompleted = createDeferred<void>();
-    if (transport && request) {
-      transport.request = async <Response>(input): Promise<Response> => {
-        if (input.method === "thread/resume") {
-          resumeStarted.resolve(undefined);
-          await resume.promise;
-          const response = await request<Response>(input);
-          resumeCompleted.resolve(undefined);
-          return response;
-        }
-        return request<Response>(input);
-      };
-    }
-    const childRef = { ...codexSessionRef(), externalSessionId: "child-thread" };
-
-    const loading = adapter.loadLiveSessionContextUsage({
-      runtimeId: "runtime-live",
-      externalSessionId: childRef.externalSessionId,
-    });
-    await resumeStarted.promise;
-    await adapter.releaseSession(childRef);
-
-    await expect(loading).rejects.toThrow("was released while loading context usage");
-    resume.resolve(undefined);
-    await resumeCompleted.promise;
-    await flushCodexAdapterWork();
-    expect(
-      adapter
-        .listLiveSessionSnapshots("runtime-live")
-        .find((snapshot) => snapshot.ref.externalSessionId === childRef.externalSessionId),
-    ).toEqual(
-      expect.objectContaining({
-        ref: expect.objectContaining({
-          repoPath: "/repo",
-          runtimeKind: "codex",
-          workingDirectory: "/repo",
-          externalSessionId: childRef.externalSessionId,
-        }),
-        parentExternalSessionId: "thread/start-runtime-live",
-        contextUsage: null,
-      }),
-    );
-  });
-
-  test("projects and routes pending input for an unloaded child session", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, respondServerRequest, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const adapterState = adapter as unknown as {
-      pendingInput: CodexPendingInputState;
-      subagents: CodexSubagentLinkState;
-    };
-    const route = {
-      runtimeId: "runtime-live",
-      parentExternalSessionId: "thread/start-runtime-live",
-      childExternalSessionId: "child-thread",
-      subagentCorrelationKey: "codex-subagent:thread/start-runtime-live:child-thread",
-    };
-    adapterState.subagents.upsertLink({
-      runtimeId: "runtime-live",
-      parentThreadId: route.parentExternalSessionId,
-      childThreadId: route.childExternalSessionId,
-      itemId: route.childExternalSessionId,
-      status: "running",
-    });
-    const approval = adapterState.pendingInput.addApproval({
-      runtimeId: "runtime-live",
-      threadId: route.childExternalSessionId,
-      nativeRequest: {
-        id: 7,
-        method: "item/commandExecution/requestApproval",
-        params: { threadId: route.childExternalSessionId },
-      },
-      request: {
-        requestType: "permission_grant",
-        title: "Approve child command",
-      },
-      route,
-    });
-    const question = adapterState.pendingInput.addQuestion({
-      runtimeId: "runtime-live",
-      threadId: route.childExternalSessionId,
-      nativeRequest: {
-        id: 7,
-        method: "item/tool/requestUserInput",
-        params: { threadId: route.childExternalSessionId },
-      },
-      request: {
-        questions: [{ header: "Confirm", question: "Proceed?", options: [] }],
-      },
-      questionIds: ["question-1"],
-      input: { questions: [{ header: "Confirm", question: "Proceed?", options: [] }] },
-      route,
-    });
-
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
-      expect.objectContaining({
-        ref: expect.objectContaining({ externalSessionId: "child-thread" }),
-        parentExternalSessionId: "thread/start-runtime-live",
-        activity: "waiting_for_question",
-        pendingApprovals: [
-          expect.objectContaining({ requestId: approval.entry.request.requestId }),
-        ],
-        pendingQuestions: [
-          expect.objectContaining({ requestId: question.entry.request.requestId }),
-        ],
-      }),
-    );
-
-    const transport = transports.get("runtime-live");
-    expect(transport).toBeDefined();
-    const originalRequest = transport?.request.bind(transport);
-    const resumeResponseDelivered = createDeferred<void>();
-    if (transport && originalRequest) {
-      transport.request = async <Response>(request): Promise<Response> => {
-        const response = await originalRequest<Response>(request);
-        if (request.method === "thread/resume") {
-          resumeResponseDelivered.resolve(undefined);
-        }
-        return response;
-      };
-    }
-    const contextLoading = adapter.loadLiveSessionContextUsage({
-      runtimeId: "runtime-live",
-      externalSessionId: route.childExternalSessionId,
-    });
-    await resumeResponseDelivered.promise;
-    await expect(contextLoading).resolves.toBeNull();
-    runtimeStream.emitNotification(
-      tokenUsageNotification(4_200, 200_000, route.childExternalSessionId),
-    );
-    await flushCodexAdapterWork();
-    expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
-      expect.objectContaining({
-        ref: expect.objectContaining({ externalSessionId: route.childExternalSessionId }),
-        contextUsage: { totalTokens: 4_200, contextWindow: 200_000 },
-      }),
-    );
-    expect(transport?.calls.filter((call) => call.method === "thread/resume")).toEqual([
-      expect.objectContaining({
-        params: expect.objectContaining({
-          threadId: route.childExternalSessionId,
-          excludeTurns: false,
-        }),
-      }),
-    ]);
-
-    await adapter.replyLiveApproval({
-      runtimeId: "runtime-live",
-      externalSessionId: "child-thread",
-      requestId: approval.entry.request.requestId,
-      outcome: "approve_once",
-    });
-    await adapter.replyLiveQuestion({
-      runtimeId: "runtime-live",
-      externalSessionId: "child-thread",
-      requestId: question.entry.request.requestId,
-      answers: [["Yes"]],
-    });
-
-    expect(respondServerRequest).toHaveBeenNthCalledWith(
-      1,
-      "runtime-live",
-      7,
-      { decision: "accept" },
-      undefined,
-    );
-    expect(respondServerRequest).toHaveBeenNthCalledWith(
-      2,
-      "runtime-live",
-      7,
-      { answers: { "question-1": { answers: ["Yes"] } } },
-      undefined,
-    );
-    expect(
-      adapter
-        .listLiveSessionSnapshots("runtime-live")
-        .find((snapshot) => snapshot.ref.externalSessionId === "child-thread"),
-    ).toMatchObject({ pendingApprovals: [], pendingQuestions: [], activity: "running" });
+    expect(unsubscribedRuntimeIds).toEqual(["runtime-live"]);
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
@@ -10,8 +10,10 @@ import {
   makeRuntimeSummary,
   RecordingTransport,
 } from "./codex-app-server-adapter.test-harness";
+import { CodexContextUsageTracker } from "./codex-context-usage-tracker";
 import type { CodexPendingInputState } from "./codex-pending-input-state";
 import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
+import type { CodexSessionContextUsage } from "./types";
 
 const tokenUsageNotification = (
   totalTokens: number,
@@ -37,6 +39,31 @@ const expectNoContextReadOrResume = (transport?: RecordingTransport): void => {
     ) ?? [],
   ).toEqual([]);
 };
+
+describe("CodexContextUsageTracker", () => {
+  test("shares a synchronously reentrant load", async () => {
+    const tracker = new CodexContextUsageTracker();
+    const callbackRan = createDeferred<void>();
+    let nestedLoad: Promise<CodexSessionContextUsage | null> | null = null;
+    let resumeAttempts = 0;
+
+    const outerLoad = tracker.load("runtime-live", "thread-idle", async () => {
+      resumeAttempts += 1;
+      nestedLoad = tracker.load("runtime-live", "thread-idle", async () => {
+        resumeAttempts += 1;
+      });
+      callbackRan.resolve(undefined);
+    });
+
+    await callbackRan.promise;
+    if (!nestedLoad) {
+      throw new Error("Expected reentrant context load.");
+    }
+    expect(resumeAttempts).toBe(1);
+    await expect(Promise.all([outerLoad, nestedLoad])).resolves.toEqual([null, null]);
+    expect(resumeAttempts).toBe(1);
+  });
+});
 
 describe("CodexAppServerAdapter context loading", () => {
   test("returns retained context without a Codex read or resume", async () => {
@@ -87,6 +114,38 @@ describe("CodexAppServerAdapter context loading", () => {
     ).toHaveLength(1);
   });
 
+  test("shares concurrent missing-context loads and returns null to both callers", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    const transport = transports.get("runtime-live");
+    const request = transport?.request.bind(transport);
+    const resumeStarted = createDeferred<void>();
+    const resume = createDeferred<void>();
+    let resumeAttempts = 0;
+    if (transport && request) {
+      transport.request = async <Response>(input): Promise<Response> => {
+        if (input.method === "thread/resume") {
+          resumeAttempts += 1;
+          resumeStarted.resolve(undefined);
+          await resume.promise;
+        }
+        return request<Response>(input);
+      };
+    }
+
+    const firstLoad = adapter.loadSessionContextUsage(codexSessionRef());
+    await resumeStarted.promise;
+    const secondLoad = adapter.loadSessionContextUsage(codexSessionRef());
+
+    expect(resumeAttempts).toBe(1);
+    resume.resolve(undefined);
+    await expect(Promise.all([firstLoad, secondLoad])).resolves.toEqual([null, null]);
+    expect(resumeAttempts).toBe(1);
+  });
+
   test("returns usage observed while resume is outstanding", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({
@@ -94,22 +153,21 @@ describe("CodexAppServerAdapter context loading", () => {
     });
     await adapter.startSession(codexStartSessionInput());
     const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
     const transport = transports.get("runtime-live");
     const request = transport?.request.bind(transport);
     if (transport && request) {
       transport.request = async <Response>(input): Promise<Response> => {
-        const response = await request<Response>(input);
         if (input.method === "thread/resume") {
+          resumeStarted.resolve(undefined);
           await resume.promise;
         }
-        return response;
+        return request<Response>(input);
       };
     }
 
     const loading = adapter.loadSessionContextUsage(codexSessionRef());
-    while (!transport?.calls.some((call) => call.method === "thread/resume")) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await resumeStarted.promise;
     runtimeStream.emitNotification(tokenUsageNotification(2_000));
     await flushCodexAdapterWork();
     resume.resolve(undefined);
@@ -174,7 +232,7 @@ describe("CodexAppServerAdapter context loading", () => {
     await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toBeNull();
     expect(resumeAttempts).toBe(2);
   });
-  test("does not retain an unloaded session resumed after its release", async () => {
+  test("rejects a cold load promptly when its session is released without resurrecting state", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const transport = new RecordingTransport("runtime-live", false);
     const { adapter } = createHarness({
@@ -184,14 +242,14 @@ describe("CodexAppServerAdapter context loading", () => {
     const request = transport.request.bind(transport);
     const resume = createDeferred<void>();
     const resumeStarted = createDeferred<void>();
-    let resumeAttempts = 0;
+    const resumeCompleted = createDeferred<void>();
     transport.request = async <Response>(input): Promise<Response> => {
       if (input.method === "thread/resume") {
-        resumeAttempts += 1;
-        if (resumeAttempts === 1) {
-          resumeStarted.resolve(undefined);
-          await resume.promise;
-        }
+        resumeStarted.resolve(undefined);
+        await resume.promise;
+        const response = await request<Response>(input);
+        resumeCompleted.resolve(undefined);
+        return response;
       }
       return request<Response>(input);
     };
@@ -199,7 +257,6 @@ describe("CodexAppServerAdapter context loading", () => {
     const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
     await resumeStarted.promise;
     await adapter.releaseSession(codexSessionRef("thread-idle"));
-    resume.resolve(undefined);
 
     await expect(loading).rejects.toThrow("was released while loading context usage");
     expect(adapter.listLiveSessionSnapshots("runtime-live")).not.toContainEqual(
@@ -211,12 +268,13 @@ describe("CodexAppServerAdapter context loading", () => {
         }),
       }),
     );
-    await expect(
-      adapter.loadSessionContextUsage(codexSessionRef("thread-idle")),
-    ).resolves.toBeNull();
+    resume.resolve(undefined);
+    await resumeCompleted.promise;
+    await flushCodexAdapterWork();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
   });
 
-  test("does not retain an unloaded session resumed after its runtime release", async () => {
+  test("rejects a cold load promptly when its runtime is released without resurrecting state", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const transport = new RecordingTransport("runtime-live", false);
     const { adapter } = createHarness({
@@ -226,10 +284,14 @@ describe("CodexAppServerAdapter context loading", () => {
     const request = transport.request.bind(transport);
     const resume = createDeferred<void>();
     const resumeStarted = createDeferred<void>();
+    const resumeCompleted = createDeferred<void>();
     transport.request = async <Response>(input): Promise<Response> => {
       if (input.method === "thread/resume") {
         resumeStarted.resolve(undefined);
         await resume.promise;
+        const response = await request<Response>(input);
+        resumeCompleted.resolve(undefined);
+        return response;
       }
       return request<Response>(input);
     };
@@ -237,7 +299,6 @@ describe("CodexAppServerAdapter context loading", () => {
     const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
     await resumeStarted.promise;
     adapter.releaseRuntime("runtime-live");
-    resume.resolve(undefined);
 
     await expect(loading).rejects.toThrow("was released while loading context usage");
     expect(adapter.listLiveSessionSnapshots("runtime-live")).not.toContainEqual(
@@ -245,6 +306,86 @@ describe("CodexAppServerAdapter context loading", () => {
         ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
       }),
     );
+    resume.resolve(undefined);
+    await resumeCompleted.promise;
+    await flushCodexAdapterWork();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+  });
+
+  test("rejects a retained live load promptly when its session is released", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    const transport = transports.get("runtime-live");
+    const request = transport?.request.bind(transport);
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    const resumeCompleted = createDeferred<void>();
+    if (transport && request) {
+      transport.request = async <Response>(input): Promise<Response> => {
+        if (input.method === "thread/resume") {
+          resumeStarted.resolve(undefined);
+          await resume.promise;
+          const response = await request<Response>(input);
+          resumeCompleted.resolve(undefined);
+          return response;
+        }
+        return request<Response>(input);
+      };
+    }
+
+    const loading = adapter.loadLiveSessionContextUsage({
+      runtimeId: "runtime-live",
+      externalSessionId: "thread/start-runtime-live",
+    });
+    await resumeStarted.promise;
+    await adapter.releaseSession(codexSessionRef());
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    resume.resolve(undefined);
+    await resumeCompleted.promise;
+    await flushCodexAdapterWork();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+  });
+
+  test("rejects a retained live load promptly when its runtime is released", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    const transport = transports.get("runtime-live");
+    const request = transport?.request.bind(transport);
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    const resumeCompleted = createDeferred<void>();
+    if (transport && request) {
+      transport.request = async <Response>(input): Promise<Response> => {
+        if (input.method === "thread/resume") {
+          resumeStarted.resolve(undefined);
+          await resume.promise;
+          const response = await request<Response>(input);
+          resumeCompleted.resolve(undefined);
+          return response;
+        }
+        return request<Response>(input);
+      };
+    }
+
+    const loading = adapter.loadLiveSessionContextUsage({
+      runtimeId: "runtime-live",
+      externalSessionId: "thread/start-runtime-live",
+    });
+    await resumeStarted.promise;
+    adapter.releaseRuntime("runtime-live");
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    resume.resolve(undefined);
+    await resumeCompleted.promise;
+    await flushCodexAdapterWork();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
   });
 
   test("rejects a session release during runtime resolution without resuming or retaining", async () => {
@@ -256,9 +397,9 @@ describe("CodexAppServerAdapter context loading", () => {
 
     const loading = adapter.loadSessionContextUsage(ref);
     await adapter.releaseSession(ref);
-    runtime.resolve(makeRuntimeSummary("runtime-live"));
 
     await expect(loading).rejects.toThrow("was released while loading context usage");
+    runtime.resolve(makeRuntimeSummary("runtime-live"));
     expectNoContextReadOrResume(transports.get("runtime-live"));
     expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
   });
@@ -292,9 +433,9 @@ describe("CodexAppServerAdapter context loading", () => {
     const loading = adapter.loadSessionContextUsage(ref);
     await preparationStarted.promise;
     await adapter.releaseSession(ref);
-    preparation.resolve(() => {});
 
     await expect(loading).rejects.toThrow("was released while loading context usage");
+    preparation.resolve(() => {});
     expectNoContextReadOrResume(transports.get("runtime-live"));
     expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
   });
@@ -312,9 +453,9 @@ describe("CodexAppServerAdapter context loading", () => {
     const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
     await preparationStarted.promise;
     adapter.releaseRuntime("runtime-live");
-    preparation.resolve(() => {});
 
     await expect(loading).rejects.toThrow("was released while loading context usage");
+    preparation.resolve(() => {});
     expectNoContextReadOrResume(transports.get("runtime-live"));
     expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
   });
@@ -410,6 +551,68 @@ describe("CodexAppServerAdapter context loading", () => {
 });
 
 describe("CodexAppServerAdapter live child projection", () => {
+  test("rejects a blocked routed-child context load when the child is released", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    const adapterState = adapter as unknown as { subagents: CodexSubagentLinkState };
+    adapterState.subagents.upsertLink({
+      runtimeId: "runtime-live",
+      parentThreadId: "thread/start-runtime-live",
+      childThreadId: "child-thread",
+      itemId: "child-thread",
+      status: "running",
+    });
+    const transport = transports.get("runtime-live");
+    const request = transport?.request.bind(transport);
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    const resumeCompleted = createDeferred<void>();
+    if (transport && request) {
+      transport.request = async <Response>(input): Promise<Response> => {
+        if (input.method === "thread/resume") {
+          resumeStarted.resolve(undefined);
+          await resume.promise;
+          const response = await request<Response>(input);
+          resumeCompleted.resolve(undefined);
+          return response;
+        }
+        return request<Response>(input);
+      };
+    }
+    const childRef = { ...codexSessionRef(), externalSessionId: "child-thread" };
+
+    const loading = adapter.loadLiveSessionContextUsage({
+      runtimeId: "runtime-live",
+      externalSessionId: childRef.externalSessionId,
+    });
+    await resumeStarted.promise;
+    await adapter.releaseSession(childRef);
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    resume.resolve(undefined);
+    await resumeCompleted.promise;
+    await flushCodexAdapterWork();
+    expect(
+      adapter
+        .listLiveSessionSnapshots("runtime-live")
+        .find((snapshot) => snapshot.ref.externalSessionId === childRef.externalSessionId),
+    ).toEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({
+          repoPath: "/repo",
+          runtimeKind: "codex",
+          workingDirectory: "/repo",
+          externalSessionId: childRef.externalSessionId,
+        }),
+        parentExternalSessionId: "thread/start-runtime-live",
+        contextUsage: null,
+      }),
+    );
+  });
+
   test("projects and routes pending input for an unloaded child session", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, respondServerRequest, transports } = createHarness({

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import {
   codexSessionRef,
+  codexSessionRuntimeRef,
   codexStartSessionInput,
   createDeferred,
   createHarness,
   createRuntimeStreamSubscription,
   flushCodexAdapterWork,
+  makeRuntimeSummary,
   RecordingTransport,
 } from "./codex-app-server-adapter.test-harness";
-import { CodexContextUsageTracker } from "./codex-context-usage-tracker";
 import type { CodexPendingInputState } from "./codex-pending-input-state";
 import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
 
@@ -29,24 +30,15 @@ const tokenUsageNotification = (
   },
 });
 
+const expectNoContextReadOrResume = (transport?: RecordingTransport): void => {
+  expect(
+    transport?.calls.filter(
+      (call) => call.method === "thread/read" || call.method === "thread/resume",
+    ) ?? [],
+  ).toEqual([]);
+};
+
 describe("CodexAppServerAdapter context loading", () => {
-  test("shares the initialized recovery with a synchronous reentrant load", async () => {
-    const tracker = new CodexContextUsageTracker(async () => undefined);
-    let reentrant: Promise<unknown> | null = null;
-    const loading = tracker.load("runtime-live", "thread-live", async () => {
-      reentrant = tracker.load("runtime-live", "thread-live", async () => {
-        throw new Error("unexpected duplicate recovery");
-      });
-    });
-    const outcome = loading.catch((error: unknown) => error);
-
-    await Promise.resolve();
-
-    expect(reentrant).toBe(loading);
-    tracker.releaseRuntime("runtime-live", new Error("runtime released"));
-    await expect(outcome).resolves.toBeInstanceOf(Error);
-  });
-
   test("returns retained context without a Codex read or resume", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({
@@ -82,262 +74,337 @@ describe("CodexAppServerAdapter context loading", () => {
     ]);
   });
 
-  test("shares one include-turns resume for concurrent missing-context loads", async () => {
+  test("returns null immediately after a successful resume without usage", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({
       subscribeEvents: runtimeStream.subscribeEvents,
     });
     await adapter.startSession(codexStartSessionInput());
-    const resumeResponseDelivered = createDeferred<void>();
-    const transport = transports.get("runtime-live");
-    expect(transport).toBeDefined();
-    const originalRequest = transport?.request.bind(transport);
-    if (transport && originalRequest) {
-      transport.request = async <Response>(request): Promise<Response> => {
-        const response = await originalRequest<Response>(request);
-        if (request.method === "thread/resume") {
-          resumeResponseDelivered.resolve(undefined);
-        }
-        return response;
-      };
-    }
 
-    const first = adapter.loadSessionContextUsage(codexSessionRef());
-    const second = adapter.loadSessionContextUsage(codexSessionRef());
-    await resumeResponseDelivered.promise;
-    await flushCodexAdapterWork();
-    runtimeStream.emitNotification(tokenUsageNotification(2_000));
-
-    await expect(Promise.all([first, second])).resolves.toEqual([
-      { totalTokens: 2_000, contextWindow: 200_000 },
-      { totalTokens: 2_000, contextWindow: 200_000 },
-    ]);
-    expect(transport?.calls.filter((call) => call.method === "thread/resume")).toEqual([
-      expect.objectContaining({
-        params: expect.objectContaining({
-          threadId: "thread/start-runtime-live",
-          excludeTurns: false,
-        }),
-      }),
-    ]);
+    await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toBeNull();
+    expect(
+      transports.get("runtime-live")?.calls.filter((call) => call.method === "thread/resume"),
+    ).toHaveLength(1);
   });
 
-  test("waits for matching context usage emitted after the resume response", async () => {
+  test("returns usage observed while resume is outstanding", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({
       subscribeEvents: runtimeStream.subscribeEvents,
     });
     await adapter.startSession(codexStartSessionInput());
-    const resumeResponseDelivered = createDeferred<void>();
+    const resume = createDeferred<void>();
     const transport = transports.get("runtime-live");
-    expect(transport).toBeDefined();
-    const originalRequest = transport?.request.bind(transport);
-    if (transport && originalRequest) {
-      transport.request = async <Response>(request): Promise<Response> => {
-        const response = await originalRequest<Response>(request);
-        if (request.method === "thread/resume") {
-          resumeResponseDelivered.resolve(undefined);
+    const request = transport?.request.bind(transport);
+    if (transport && request) {
+      transport.request = async <Response>(input): Promise<Response> => {
+        const response = await request<Response>(input);
+        if (input.method === "thread/resume") {
+          await resume.promise;
         }
         return response;
       };
     }
 
     const loading = adapter.loadSessionContextUsage(codexSessionRef());
-    const outcome = loading.then(
-      (usage) => ({ status: "resolved" as const, usage }),
-      (error: unknown) => ({ status: "rejected" as const, error }),
-    );
-    await resumeResponseDelivered.promise;
+    while (!transport?.calls.some((call) => call.method === "thread/resume")) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    runtimeStream.emitNotification(tokenUsageNotification(2_000));
     await flushCodexAdapterWork();
-    runtimeStream.emitNotification(tokenUsageNotification(2_100));
+    resume.resolve(undefined);
 
-    await expect(outcome).resolves.toEqual({
-      status: "resolved",
-      usage: { totalTokens: 2_100, contextWindow: 200_000 },
+    await expect(loading).resolves.toEqual({ totalTokens: 2_000, contextWindow: 200_000 });
+  });
+
+  test("propagates usage arriving after a null result through the live snapshot", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter } = createHarness({ subscribeEvents: runtimeStream.subscribeEvents });
+    await adapter.startSession(codexStartSessionInput());
+
+    await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toBeNull();
+    runtimeStream.emitNotification(tokenUsageNotification(2_100));
+    await flushCodexAdapterWork();
+
+    expect(adapter.listLiveSessionSnapshots("runtime-live")[0]?.contextUsage).toEqual({
+      totalTokens: 2_100,
+      contextWindow: 200_000,
     });
   });
 
-  test("retains a previously unloaded session after successful include-turns recovery", async () => {
+  test("retains an unloaded session after a successful null resume", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
-    const transport = new RecordingTransport("runtime-live", false);
-    const resumeResponseDelivered = createDeferred<void>();
-    const originalRequest = transport.request.bind(transport);
-    transport.request = async <Response>(request): Promise<Response> => {
-      const response = await originalRequest<Response>(request);
-      if (request.method === "thread/resume") {
-        resumeResponseDelivered.resolve(undefined);
-      }
-      return response;
-    };
-    const { adapter } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-      transportFactory: () => transport,
-    });
+    const { adapter } = createHarness({ subscribeEvents: runtimeStream.subscribeEvents });
 
-    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
-    await resumeResponseDelivered.promise;
-    await flushCodexAdapterWork();
-    runtimeStream.emitNotification(tokenUsageNotification(2_250, 200_000, "thread-idle"));
-
-    await expect(loading).resolves.toEqual({
-      totalTokens: 2_250,
-      contextWindow: 200_000,
-    });
+    await expect(
+      adapter.loadSessionContextUsage(codexSessionRef("thread-idle")),
+    ).resolves.toBeNull();
     expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
       expect.objectContaining({
         ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
-        contextUsage: { totalTokens: 2_250, contextWindow: 200_000 },
+        contextUsage: null,
       }),
     );
-    expect(
-      transport.calls.filter((call) =>
-        ["thread/resume", "thread/read", "turn/start"].includes(call.method),
-      ),
-    ).toEqual([
-      expect.objectContaining({
-        method: "thread/resume",
-        params: expect.objectContaining({ threadId: "thread-idle", excludeTurns: false }),
-      }),
-    ]);
   });
 
-  test("preserves the latest live usage when updates arrive before the persisted replay", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const resumeResponse = createDeferred<void>();
-    const transport = transports.get("runtime-live");
-    expect(transport).toBeDefined();
-    const originalRequest = transport?.request.bind(transport);
-    if (transport && originalRequest) {
-      transport.request = async <Response>(request): Promise<Response> => {
-        const response = await originalRequest<Response>(request);
-        if (request.method === "thread/resume") {
-          await resumeResponse.promise;
-        }
-        return response;
-      };
-    }
-
-    const loading = adapter.loadSessionContextUsage(codexSessionRef());
-    while (!transport?.calls.some((call) => call.method === "thread/resume")) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-    runtimeStream.emitNotification(tokenUsageNotification(2_000));
-    runtimeStream.emitNotification(tokenUsageNotification(2_500));
-    await flushCodexAdapterWork();
-    resumeResponse.resolve(undefined);
-    await flushCodexAdapterWork();
-    runtimeStream.emitNotification(tokenUsageNotification(1_000));
-
-    await expect(loading).resolves.toEqual({ totalTokens: 2_500, contextWindow: 200_000 });
-  });
-
-  test("does not let a later persisted replay overwrite a live update during recovery", async () => {
-    const runtimeStream = createRuntimeStreamSubscription();
-    const resumeResponse = createDeferred<void>();
-    const { adapter, transports } = createHarness({
-      subscribeEvents: runtimeStream.subscribeEvents,
-    });
-    await adapter.startSession(codexStartSessionInput());
-    const transport = transports.get("runtime-live");
-    expect(transport).toBeDefined();
-    const originalRequest = transport?.request.bind(transport);
-    if (transport && originalRequest) {
-      transport.request = async <Response>(request): Promise<Response> => {
-        const response = await originalRequest<Response>(request);
-        if (request.method === "thread/resume") {
-          await resumeResponse.promise;
-        }
-        return response;
-      };
-    }
-
-    const loading = adapter.loadSessionContextUsage(codexSessionRef());
-    while (!transport?.calls.some((call) => call.method === "thread/resume")) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-    runtimeStream.emitNotification(tokenUsageNotification(3_000));
-    await flushCodexAdapterWork();
-    resumeResponse.resolve(undefined);
-    await flushCodexAdapterWork();
-    runtimeStream.emitNotification(tokenUsageNotification(1_000));
-    await flushCodexAdapterWork();
-
-    await expect(loading).resolves.toEqual({ totalTokens: 3_000, contextWindow: 200_000 });
-    expect(adapter.listLiveSessionSnapshots("runtime-live")[0]?.contextUsage).toEqual({
-      totalTokens: 3_000,
-      contextWindow: 200_000,
-    });
-  });
-
-  test("fails actionably and allows retry after a failed resume", async () => {
+  test("fails actionably and permits a later explicit resume retry", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({
       subscribeEvents: runtimeStream.subscribeEvents,
     });
     await adapter.startSession(codexStartSessionInput());
     const transport = transports.get("runtime-live");
-    expect(transport).toBeDefined();
-    const originalRequest = transport?.request.bind(transport);
-    const retryResumeResponseDelivered = createDeferred<void>();
+    const request = transport?.request.bind(transport);
     let resumeAttempts = 0;
-    if (transport && originalRequest) {
-      transport.request = async <Response>(request): Promise<Response> => {
-        if (request.method === "thread/resume") {
+    if (transport && request) {
+      transport.request = async <Response>(input): Promise<Response> => {
+        if (input.method === "thread/resume") {
           resumeAttempts += 1;
           if (resumeAttempts === 1) {
             throw new Error("resume unavailable");
           }
         }
-        const response = await originalRequest<Response>(request);
-        if (request.method === "thread/resume") {
-          retryResumeResponseDelivered.resolve(undefined);
-        }
-        return response;
+        return request<Response>(input);
       };
     }
 
     await expect(adapter.loadSessionContextUsage(codexSessionRef())).rejects.toThrow(
-      "Failed to load Codex context usage for runtime 'runtime-live' session 'thread/start-runtime-live': resume unavailable",
+      "resume unavailable",
     );
-
-    const retry = adapter.loadSessionContextUsage(codexSessionRef());
-    await retryResumeResponseDelivered.promise;
-    await flushCodexAdapterWork();
-    runtimeStream.emitNotification(tokenUsageNotification(3_000));
-    await expect(retry).resolves.toEqual({ totalTokens: 3_000, contextWindow: 200_000 });
+    await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toBeNull();
     expect(resumeAttempts).toBe(2);
   });
-
-  test("fails a post-resume context wait when its session is released", async () => {
+  test("does not retain an unloaded session resumed after its release", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
-    const { adapter, transports } = createHarness({
+    const transport = new RecordingTransport("runtime-live", false);
+    const { adapter } = createHarness({
       subscribeEvents: runtimeStream.subscribeEvents,
+      transportFactory: () => transport,
     });
-    await adapter.startSession(codexStartSessionInput());
-    const resumeResponseDelivered = createDeferred<void>();
-    const transport = transports.get("runtime-live");
-    expect(transport).toBeDefined();
-    const originalRequest = transport?.request.bind(transport);
-    if (transport && originalRequest) {
-      transport.request = async <Response>(request): Promise<Response> => {
-        const response = await originalRequest<Response>(request);
-        if (request.method === "thread/resume") {
-          resumeResponseDelivered.resolve(undefined);
+    const request = transport.request.bind(transport);
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    let resumeAttempts = 0;
+    transport.request = async <Response>(input): Promise<Response> => {
+      if (input.method === "thread/resume") {
+        resumeAttempts += 1;
+        if (resumeAttempts === 1) {
+          resumeStarted.resolve(undefined);
+          await resume.promise;
         }
-        return response;
+      }
+      return request<Response>(input);
+    };
+
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    await resumeStarted.promise;
+    await adapter.releaseSession(codexSessionRef("thread-idle"));
+    resume.resolve(undefined);
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).not.toContainEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({
+          externalSessionId: "thread-idle",
+          repoPath: "/repo",
+          workingDirectory: "/repo",
+        }),
+      }),
+    );
+    await expect(
+      adapter.loadSessionContextUsage(codexSessionRef("thread-idle")),
+    ).resolves.toBeNull();
+  });
+
+  test("does not retain an unloaded session resumed after its runtime release", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const transport = new RecordingTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+      transportFactory: () => transport,
+    });
+    const request = transport.request.bind(transport);
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    transport.request = async <Response>(input): Promise<Response> => {
+      if (input.method === "thread/resume") {
+        resumeStarted.resolve(undefined);
+        await resume.promise;
+      }
+      return request<Response>(input);
+    };
+
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    await resumeStarted.promise;
+    adapter.releaseRuntime("runtime-live");
+    resume.resolve(undefined);
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).not.toContainEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
+      }),
+    );
+  });
+
+  test("rejects a session release during runtime resolution without resuming or retaining", async () => {
+    const ref = codexSessionRef("thread-idle");
+    const runtime = createDeferred<ReturnType<typeof makeRuntimeSummary>>();
+    const { adapter, transports } = createHarness({
+      repoRuntimeResolver: { requireRepoRuntime: () => runtime.promise },
+    });
+
+    const loading = adapter.loadSessionContextUsage(ref);
+    await adapter.releaseSession(ref);
+    runtime.resolve(makeRuntimeSummary("runtime-live"));
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expectNoContextReadOrResume(transports.get("runtime-live"));
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+  });
+
+  test("rejects a runtime release during runtime resolution without resuming or retaining", async () => {
+    const runtime = createDeferred<ReturnType<typeof makeRuntimeSummary>>();
+    const { adapter, transports } = createHarness({
+      repoRuntimeResolver: { requireRepoRuntime: () => runtime.promise },
+    });
+
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    adapter.releaseRuntime("runtime-live");
+    runtime.resolve(makeRuntimeSummary("runtime-live"));
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expectNoContextReadOrResume(transports.get("runtime-live"));
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+  });
+
+  test("rejects a session release during runtime preparation without resuming or retaining", async () => {
+    const ref = codexSessionRef("thread-idle");
+    const preparationStarted = createDeferred<void>();
+    const preparation = createDeferred<() => void>();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: () => {
+        preparationStarted.resolve(undefined);
+        return preparation.promise;
+      },
+    });
+
+    const loading = adapter.loadSessionContextUsage(ref);
+    await preparationStarted.promise;
+    await adapter.releaseSession(ref);
+    preparation.resolve(() => {});
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expectNoContextReadOrResume(transports.get("runtime-live"));
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+  });
+
+  test("rejects a runtime release during runtime preparation without resuming or retaining", async () => {
+    const preparationStarted = createDeferred<void>();
+    const preparation = createDeferred<() => void>();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: () => {
+        preparationStarted.resolve(undefined);
+        return preparation.promise;
+      },
+    });
+
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    await preparationStarted.promise;
+    adapter.releaseRuntime("runtime-live");
+    preparation.resolve(() => {});
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expectNoContextReadOrResume(transports.get("runtime-live"));
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+  });
+
+  test("does not cancel a context load when a mismatched retained-session release is rejected", async () => {
+    const ref = codexSessionRef("thread-idle");
+    const transport = new RecordingTransport("runtime-live", false);
+    const originalRequest = transport.request.bind(transport);
+    const firstResumeStarted = createDeferred<void>();
+    const unblockFirstResume = createDeferred<void>();
+    let resumeCount = 0;
+    transport.request = async <Response>(input): Promise<Response> => {
+      const response = await originalRequest<Response>(input);
+      if (input.method === "thread/resume") {
+        resumeCount += 1;
+        if (resumeCount === 1) {
+          firstResumeStarted.resolve(undefined);
+          await unblockFirstResume.promise;
+        }
+      }
+      return response;
+    };
+    const { adapter } = createHarness({ transportFactory: () => transport });
+
+    const loading = adapter.loadSessionContextUsage(ref);
+    await firstResumeStarted.promise;
+    await adapter.resumeSession(codexSessionRuntimeRef("thread-idle"));
+    await expect(adapter.releaseSession({ ...ref, repoPath: "/other-repo" })).rejects.toThrow(
+      "Cannot release Codex session",
+    );
+    unblockFirstResume.resolve(undefined);
+
+    await expect(loading).resolves.toBeNull();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
+      }),
+    );
+  });
+  test("cancels a matching blocked load before failing session cleanup", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const transport = new RecordingTransport("runtime-live", false);
+    const { adapter } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+      transportFactory: () => transport,
+    });
+    const request = transport.request.bind(transport);
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    transport.request = async <Response>(input): Promise<Response> => {
+      if (input.method === "thread/resume") {
+        resumeStarted.resolve(undefined);
+        await resume.promise;
+      }
+      return request<Response>(input);
+    };
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    await resumeStarted.promise;
+    await adapter.startSession(codexStartSessionInput());
+    const localSessions = adapter as unknown as {
+      localSessions: {
+        get(id: string): { summary: { externalSessionId: string }; threadId: string } | undefined;
+        remember(session: unknown): void;
+        release(id: string): void;
       };
+    };
+    const retained = localSessions.localSessions.get("thread/start-runtime-live");
+    if (!retained) {
+      throw new Error("Expected retained session.");
     }
+    localSessions.localSessions.remember({
+      ...retained,
+      threadId: "thread-idle",
+      summary: { ...retained.summary, externalSessionId: "thread-idle" },
+    });
+    const release = localSessions.localSessions.release.bind(localSessions.localSessions);
+    localSessions.localSessions.release = (id) => {
+      release(id);
+      throw new Error("cleanup failed");
+    };
 
-    const loading = adapter.loadSessionContextUsage(codexSessionRef());
-    await resumeResponseDelivered.promise;
-    await adapter.releaseSession(codexSessionRef());
-
-    await expect(loading).rejects.toThrow(
-      "Codex session 'thread/start-runtime-live' was released while context usage was loading",
+    await expect(adapter.releaseSession(codexSessionRef("thread-idle"))).rejects.toThrow(
+      "cleanup failed",
+    );
+    resume.resolve(undefined);
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).not.toContainEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
+      }),
     );
   });
 });
@@ -428,14 +495,17 @@ describe("CodexAppServerAdapter live child projection", () => {
       externalSessionId: route.childExternalSessionId,
     });
     await resumeResponseDelivered.promise;
-    await flushCodexAdapterWork();
+    await expect(contextLoading).resolves.toBeNull();
     runtimeStream.emitNotification(
       tokenUsageNotification(4_200, 200_000, route.childExternalSessionId),
     );
-    await expect(contextLoading).resolves.toEqual({
-      totalTokens: 4_200,
-      contextWindow: 200_000,
-    });
+    await flushCodexAdapterWork();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({ externalSessionId: route.childExternalSessionId }),
+        contextUsage: { totalTokens: 4_200, contextWindow: 200_000 },
+      }),
+    );
     expect(transport?.calls.filter((call) => call.method === "thread/resume")).toEqual([
       expect.objectContaining({
         params: expect.objectContaining({

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
@@ -55,6 +55,31 @@ describe("CodexAppServerAdapter context loading", () => {
     );
   });
 
+  test("rehydrates a cold session when delayed usage is cached", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    await adapter.releaseSession(codexSessionRef());
+    runtimeStream.emitNotification(tokenUsageNotification(3_000));
+    await flushCodexAdapterWork();
+
+    await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toEqual({
+      totalTokens: 3_000,
+      contextWindow: 200_000,
+    });
+    expect(
+      transports.get("runtime-live")?.calls.filter((call) => call.method === "thread/resume"),
+    ).toHaveLength(1);
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
+      expect.objectContaining({
+        ref: expect.objectContaining({ externalSessionId: "thread/start-runtime-live" }),
+        contextUsage: { totalTokens: 3_000, contextWindow: 200_000 },
+      }),
+    );
+  });
+
   test("uses stream usage that arrives while resume is outstanding", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
@@ -101,6 +101,32 @@ describe("CodexAppServerAdapter context loading", () => {
     ]);
   });
 
+  test("updates retained context to zero when cumulative usage remains positive", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter } = createHarness({ subscribeEvents: runtimeStream.subscribeEvents });
+    await adapter.startSession(codexStartSessionInput());
+    runtimeStream.emitNotification(tokenUsageNotification(42_000));
+    await flushCodexAdapterWork();
+    runtimeStream.emitNotification({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread/start-runtime-live",
+        turnId: "turn-2",
+        tokenUsage: {
+          total: { totalTokens: 42_000 },
+          last: { totalTokens: 0 },
+          modelContextWindow: 200_000,
+        },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    expect(adapter.listLiveSessionSnapshots("runtime-live")[0]?.contextUsage).toEqual({
+      totalTokens: 0,
+      contextWindow: 200_000,
+    });
+  });
+
   test("returns null immediately after a successful resume without usage", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter, transports } = createHarness({
@@ -203,6 +229,78 @@ describe("CodexAppServerAdapter context loading", () => {
         contextUsage: null,
       }),
     );
+  });
+
+  test("keeps the runtime stream for a bound cold load after another session is released", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    const transport = transports.get("runtime-live");
+    const request = transport?.request.bind(transport);
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    if (transport && request) {
+      transport.request = async <Response>(input): Promise<Response> => {
+        if (input.method === "thread/resume") {
+          resumeStarted.resolve(undefined);
+          await resume.promise;
+        }
+        return request<Response>(input);
+      };
+    }
+
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    await resumeStarted.promise;
+    await adapter.releaseSession(codexSessionRef());
+
+    expect(runtimeStream.unsubscribedRuntimeIds).toEqual([]);
+    runtimeStream.emitNotification(tokenUsageNotification(3_000, 200_000, "thread-idle"));
+    await flushCodexAdapterWork();
+    resume.resolve(undefined);
+
+    await expect(loading).resolves.toEqual({ totalTokens: 3_000, contextWindow: 200_000 });
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([
+      expect.objectContaining({
+        ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
+        contextUsage: { totalTokens: 3_000, contextWindow: 200_000 },
+      }),
+    ]);
+    expect(runtimeStream.unsubscribedRuntimeIds).toEqual([]);
+  });
+
+  test("stops the runtime stream after a bound cold load fails following another session release", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    const transport = transports.get("runtime-live");
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    if (transport) {
+      transport.request = async (input) => {
+        if (input.method === "thread/resume") {
+          resumeStarted.resolve(undefined);
+          await resume.promise;
+          throw new Error("resume unavailable");
+        }
+        throw new Error(`Unexpected Codex request '${input.method}'.`);
+      };
+    }
+
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    await resumeStarted.promise;
+    await adapter.releaseSession(codexSessionRef());
+
+    expect(runtimeStream.unsubscribedRuntimeIds).toEqual([]);
+    resume.resolve(undefined);
+    await expect(loading).rejects.toThrow("resume unavailable");
+    await flushCodexAdapterWork();
+
+    expect(runtimeStream.unsubscribedRuntimeIds).toEqual(["runtime-live"]);
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
   });
 
   test("fails actionably and permits a later explicit resume retry", async () => {
@@ -348,6 +446,46 @@ describe("CodexAppServerAdapter context loading", () => {
     await resumeCompleted.promise;
     await flushCodexAdapterWork();
     expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+  });
+
+  test("cancels a retained live context load when its session is stopped", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    const transport = transports.get("runtime-live");
+    const request = transport?.request.bind(transport);
+    const resume = createDeferred<void>();
+    const resumeStarted = createDeferred<void>();
+    const resumeCompleted = createDeferred<void>();
+    if (transport && request) {
+      transport.request = async <Response>(input): Promise<Response> => {
+        if (input.method === "thread/resume") {
+          resumeStarted.resolve(undefined);
+          await resume.promise;
+          const response = await request<Response>(input);
+          resumeCompleted.resolve(undefined);
+          return response;
+        }
+        return request<Response>(input);
+      };
+    }
+
+    const loading = adapter.loadLiveSessionContextUsage({
+      runtimeId: "runtime-live",
+      externalSessionId: "thread/start-runtime-live",
+    });
+    await resumeStarted.promise;
+    await adapter.stopSession(codexSessionRef());
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expect(runtimeStream.unsubscribedRuntimeIds).toEqual(["runtime-live"]);
+    resume.resolve(undefined);
+    await resumeCompleted.promise;
+    await flushCodexAdapterWork();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+    expect(runtimeStream.unsubscribedRuntimeIds).toEqual(["runtime-live"]);
   });
 
   test("rejects a retained live load promptly when its runtime is released", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
@@ -243,7 +243,7 @@ class RestoredUsageStreamTransport extends StoredIdleHistoryTransport {
             turnId: "turn-1",
             tokenUsage: {
               total: { totalTokens: 42_000 },
-              last: { totalTokens: 1_000 },
+              last: { totalTokens: 42_000 },
               modelContextWindow: 200_000,
             },
           },
@@ -425,13 +425,9 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
     );
   });
 
-  test("retains explicit Codex context recovery as an idle live session", async () => {
-    const transport = new RestoredUsageStreamTransport("runtime-live", false);
-    const subscribeEvents = mock((runtimeId: string, listener) => {
-      transport.emitRestoredUsage = (message) =>
-        listener(withRuntimeReceivedAt({ runtimeId, kind: "notification", message }));
-      return () => undefined;
-    });
+  test("retains an idle live session after a successful null context resume", async () => {
+    const transport = new StoredIdleHistoryTransport("runtime-live", false);
+    const subscribeEvents = mock((_runtimeId: string, _listener) => () => undefined);
     const { adapter } = createHarness({
       subscribeEvents,
       transportFactory: mock(() => transport),
@@ -447,7 +443,7 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
         sessionScope: { kind: "workflow", taskId: "task-1", role: "build" },
         runtimePolicy: { kind: "codex", policy: defaultCodexEffectivePolicy() },
       }),
-    ).resolves.toEqual({ totalTokens: 1_000, contextWindow: 200_000 });
+    ).resolves.toBeNull();
     expect(transport.calls).toContainEqual(
       expect.objectContaining({
         method: "thread/resume",
@@ -532,7 +528,7 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
     });
   });
 
-  test("retains restored context usage emitted before the session is observed", async () => {
+  test("applies delayed live context usage to the retained session", async () => {
     const transport = new RestoredUsageStreamTransport("runtime-live", false);
     const subscribeEvents = mock((runtimeId: string, listener) => {
       transport.emitRestoredUsage = (message) =>
@@ -554,23 +550,14 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
         sessionScope: { kind: "workflow", taskId: "task-1", role: "build" },
         runtimePolicy: { kind: "codex", policy: defaultCodexEffectivePolicy() },
       }),
-    ).resolves.toEqual({ totalTokens: 1_000, contextWindow: 200_000 });
+    ).resolves.toBeNull();
     expect(localSessions(adapter).has("thread-idle")).toBe(true);
 
-    await adapter.resumeSession({
-      repoPath: "/repo",
-      runtimeKind: "codex",
-      workingDirectory: "/repo",
-      sessionScope: { kind: "workflow", taskId: "task-1", role: "build" },
-      runtimePolicy: { kind: "codex", policy: defaultCodexEffectivePolicy() },
-      systemPrompt: "Use the repo rules.",
-      externalSessionId: "thread-idle",
-      model: { providerId: "openai", modelId: "gpt-5", variant: "medium" },
-    });
+    await flushCodexAdapterWork();
     expect(adapter.listLiveSessionSnapshots("runtime-live")).toContainEqual(
       expect.objectContaining({
         ref: expect.objectContaining({ externalSessionId: "thread-idle" }),
-        contextUsage: { totalTokens: 1_000, contextWindow: 200_000 },
+        contextUsage: { totalTokens: 42_000, contextWindow: 200_000 },
       }),
     );
   });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -90,9 +90,16 @@ type TestRuntimeStreamListener = (event: {
 
 export const createRuntimeStreamSubscription = () => {
   const streamListeners: TestRuntimeStreamListener[] = [];
+  const unsubscribedRuntimeIds: string[] = [];
   const subscribeEvents = mock((_runtimeId: string, listener: TestRuntimeStreamListener) => {
     streamListeners.push(listener);
-    return () => {};
+    return () => {
+      unsubscribedRuntimeIds.push(_runtimeId);
+      const index = streamListeners.indexOf(listener);
+      if (index >= 0) {
+        streamListeners.splice(index, 1);
+      }
+    };
   });
   const emitEvent = (
     kind: "notification" | "server_request",
@@ -112,7 +119,7 @@ export const createRuntimeStreamSubscription = () => {
     emitEvent("notification", message, receivedAt);
   const emitServerRequest = (message: unknown, receivedAt?: string) =>
     emitEvent("server_request", message, receivedAt);
-  return { subscribeEvents, emitNotification, emitServerRequest };
+  return { subscribeEvents, emitNotification, emitServerRequest, unsubscribedRuntimeIds };
 };
 
 export const createDeferred = <T>() => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -90,16 +90,9 @@ type TestRuntimeStreamListener = (event: {
 
 export const createRuntimeStreamSubscription = () => {
   const streamListeners: TestRuntimeStreamListener[] = [];
-  const unsubscribedRuntimeIds: string[] = [];
   const subscribeEvents = mock((_runtimeId: string, listener: TestRuntimeStreamListener) => {
     streamListeners.push(listener);
-    return () => {
-      unsubscribedRuntimeIds.push(_runtimeId);
-      const index = streamListeners.indexOf(listener);
-      if (index >= 0) {
-        streamListeners.splice(index, 1);
-      }
-    };
+    return () => {};
   });
   const emitEvent = (
     kind: "notification" | "server_request",
@@ -119,7 +112,7 @@ export const createRuntimeStreamSubscription = () => {
     emitEvent("notification", message, receivedAt);
   const emitServerRequest = (message: unknown, receivedAt?: string) =>
     emitEvent("server_request", message, receivedAt);
-  return { subscribeEvents, emitNotification, emitServerRequest, unsubscribedRuntimeIds };
+  return { subscribeEvents, emitNotification, emitServerRequest };
 };
 
 export const createDeferred = <T>() => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -180,10 +180,12 @@ const toLivePendingQuestion = (
 });
 
 type ContextUsageLoadGuard = {
-  ref: PolicyBoundSessionRef;
+  ref: SessionRef;
   runtimeId: string | null;
   releasedRuntimeIds: Set<string>;
   error: Error | null;
+  cancellation: Promise<never>;
+  cancel: (error: Error) => void;
 };
 
 export class CodexAppServerAdapter
@@ -540,40 +542,49 @@ export class CodexAppServerAdapter
     }
     const guard = this.beginContextLoad(input);
     try {
-      const runtime = await this.runtimeClients.resolve(input, "load Codex session context usage");
+      const runtime = await this.awaitContextLoad(
+        guard,
+        this.runtimeClients.resolve(input, "load Codex session context usage"),
+      );
       this.bindContextLoadRuntime(guard, runtime.runtimeId);
       this.assertContextLoadActive(guard);
-      await this.prepareRuntime(runtime.runtimeId);
+      await this.awaitContextLoad(guard, this.prepareRuntime(runtime.runtimeId));
       this.assertContextLoadActive(guard);
       const policy = requireCodexRuntimePolicy(
         input.runtimePolicy,
         "load Codex session context usage",
       );
-      return await this.runtimeEvents.loadSessionContextUsage(
-        runtime.runtimeId,
-        input.externalSessionId,
-        async () => {
-          const response = await runtime.client.threadResume({
-            ...codexTransportPolicy(policy),
-            threadId: input.externalSessionId,
-            cwd: input.workingDirectory,
-            excludeTurns: false,
-          });
-          this.assertContextLoadActive(guard);
-          const recoveredSession = sessionStateFromExistingThread(
-            input,
-            runtime.runtimeId,
-            input.model,
-            response,
-          );
-          this.localSessions.remember(
-            preserveRuntimeContextForExistingThread(
-              recoveredSession,
-              this.localSessions.get(input.externalSessionId),
-            ),
-          );
-          this.clearThreadInventory(runtime.runtimeId);
-        },
+      return await this.awaitContextLoad(
+        guard,
+        this.runtimeEvents.loadSessionContextUsage(
+          runtime.runtimeId,
+          input.externalSessionId,
+          async () => {
+            const response = await this.awaitContextLoad(
+              guard,
+              runtime.client.threadResume({
+                ...codexTransportPolicy(policy),
+                threadId: input.externalSessionId,
+                cwd: input.workingDirectory,
+                excludeTurns: false,
+              }),
+            );
+            this.assertContextLoadActive(guard);
+            const recoveredSession = sessionStateFromExistingThread(
+              input,
+              runtime.runtimeId,
+              input.model,
+              response,
+            );
+            this.localSessions.remember(
+              preserveRuntimeContextForExistingThread(
+                recoveredSession,
+                this.localSessions.get(input.externalSessionId),
+              ),
+            );
+            this.clearThreadInventory(runtime.runtimeId);
+          },
+        ),
       );
     } finally {
       this.inFlightContextLoads.delete(guard);
@@ -600,24 +611,41 @@ export class CodexAppServerAdapter
         `Cannot load Codex session context usage because session '${input.externalSessionId}' is not retained by runtime '${input.runtimeId}'.`,
       );
     }
-    await this.prepareRuntime(input.runtimeId);
-    const policy = requireCodexRuntimePolicy(
-      session.runtimePolicy,
-      "load Codex session context usage",
-    );
-    return this.runtimeEvents.loadSessionContextUsage(
-      input.runtimeId,
-      input.externalSessionId,
-      async () => {
-        await this.runtimeClients.clientForRuntime(input.runtimeId).threadResume({
-          ...codexTransportPolicy(policy),
-          threadId: input.externalSessionId,
-          cwd: session.workingDirectory,
-          excludeTurns: false,
-        });
-        this.clearThreadInventory(input.runtimeId);
-      },
-    );
+    const guard = this.beginContextLoad({
+      ...codexSessionRef(session),
+      externalSessionId: input.externalSessionId,
+    });
+    this.bindContextLoadRuntime(guard, input.runtimeId);
+    try {
+      await this.awaitContextLoad(guard, this.prepareRuntime(input.runtimeId));
+      this.assertContextLoadActive(guard);
+      const policy = requireCodexRuntimePolicy(
+        session.runtimePolicy,
+        "load Codex session context usage",
+      );
+      return await this.awaitContextLoad(
+        guard,
+        this.runtimeEvents.loadSessionContextUsage(
+          input.runtimeId,
+          input.externalSessionId,
+          async () => {
+            await this.awaitContextLoad(
+              guard,
+              this.runtimeClients.clientForRuntime(input.runtimeId).threadResume({
+                ...codexTransportPolicy(policy),
+                threadId: input.externalSessionId,
+                cwd: session.workingDirectory,
+                excludeTurns: false,
+              }),
+            );
+            this.assertContextLoadActive(guard);
+            this.clearThreadInventory(input.runtimeId);
+          },
+        ),
+      );
+    } finally {
+      this.inFlightContextLoads.delete(guard);
+    }
   }
 
   listLiveSessionSnapshots(runtimeId: string): AgentSessionLiveSnapshot[] {
@@ -728,12 +756,17 @@ export class CodexAppServerAdapter
     }
   }
 
-  private beginContextLoad(input: PolicyBoundSessionRef): ContextUsageLoadGuard {
+  private beginContextLoad(input: SessionRef): ContextUsageLoadGuard {
+    let cancel: (error: Error) => void = () => {};
     const guard = {
       ref: input,
       runtimeId: null,
       releasedRuntimeIds: new Set<string>(),
       error: null,
+      cancellation: new Promise<never>((_, reject) => {
+        cancel = reject;
+      }),
+      cancel,
     };
     this.inFlightContextLoads.add(guard);
     return guard;
@@ -742,8 +775,9 @@ export class CodexAppServerAdapter
   private bindContextLoadRuntime(guard: ContextUsageLoadGuard, runtimeId: string): void {
     guard.runtimeId = runtimeId;
     if (guard.releasedRuntimeIds.has(runtimeId)) {
-      guard.error = new Error(
-        `Codex runtime '${runtimeId}' was released while loading context usage.`,
+      this.cancelContextLoad(
+        guard,
+        new Error(`Codex runtime '${runtimeId}' was released while loading context usage.`),
       );
     }
   }
@@ -751,8 +785,11 @@ export class CodexAppServerAdapter
   private cancelSessionContextLoads(input: SessionRef): void {
     for (const guard of this.inFlightContextLoads) {
       if (agentSessionRefsEqual(guard.ref, input)) {
-        guard.error = new Error(
-          `Codex session '${input.externalSessionId}' was released while loading context usage.`,
+        this.cancelContextLoad(
+          guard,
+          new Error(
+            `Codex session '${input.externalSessionId}' was released while loading context usage.`,
+          ),
         );
       }
     }
@@ -762,8 +799,9 @@ export class CodexAppServerAdapter
     for (const guard of this.inFlightContextLoads) {
       guard.releasedRuntimeIds.add(runtimeId);
       if (guard.runtimeId === runtimeId) {
-        guard.error = new Error(
-          `Codex runtime '${runtimeId}' was released while loading context usage.`,
+        this.cancelContextLoad(
+          guard,
+          new Error(`Codex runtime '${runtimeId}' was released while loading context usage.`),
         );
       }
     }
@@ -773,6 +811,21 @@ export class CodexAppServerAdapter
     if (guard.error) {
       throw guard.error;
     }
+  }
+
+  private awaitContextLoad<Value>(
+    guard: ContextUsageLoadGuard,
+    operation: Promise<Value>,
+  ): Promise<Value> {
+    return Promise.race([operation, guard.cancellation]);
+  }
+
+  private cancelContextLoad(guard: ContextUsageLoadGuard, error: Error): void {
+    if (guard.error) {
+      return;
+    }
+    guard.error = error;
+    guard.cancel(error);
   }
 
   async listSessionRuntimeSnapshots(

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -59,6 +59,7 @@ import { type ActiveCodexTurn, unsupported } from "./codex-app-server-shared";
 import { createCodexAcceptedUserMessage } from "./codex-app-server-streaming";
 import type { CodexThreadInventory } from "./codex-app-server-threads";
 import { codexTodosFromThreadRead } from "./codex-app-server-transcript";
+import { CodexContextUsageLoader } from "./codex-context-usage-loader";
 import { toFileDiffs } from "./codex-file-diffs";
 import { CodexLocalSessionState } from "./codex-local-session-state";
 import { CodexPendingInputState } from "./codex-pending-input-state";
@@ -179,15 +180,6 @@ const toLivePendingQuestion = (
   })),
 });
 
-type ContextUsageLoadGuard = {
-  ref: SessionRef;
-  runtimeId: string | null;
-  releasedRuntimeIds: Set<string>;
-  error: Error | null;
-  cancellation: Promise<never>;
-  cancel: (error: Error) => void;
-};
-
 export class CodexAppServerAdapter
   implements AgentCatalogPort, AgentSessionPort, AgentWorkspaceInspectionPort
 {
@@ -196,11 +188,11 @@ export class CodexAppServerAdapter
   private readonly pendingInput = new CodexPendingInputState();
   private readonly activeTurnsBySessionId = new Map<string, ActiveCodexTurn>();
   private readonly localSessions: CodexLocalSessionState;
+  private readonly contextUsageLoader: CodexContextUsageLoader;
   private readonly runtimeEvents: CodexRuntimeSessionEvents;
   private readonly models = new CodexModels();
   private readonly threadInventory = new CodexThreadInventoryReader();
   private readonly subagents = new CodexSubagentLinkState();
-  private readonly inFlightContextLoads = new Set<ContextUsageLoadGuard>();
 
   constructor(private readonly options: CodexAppServerAdapterOptions) {
     this.runtimeClients = new CodexRuntimeClientResolver(options);
@@ -241,9 +233,15 @@ export class CodexAppServerAdapter
       sessionEvents: {
         clear: (session) => this.sessionEvents.clear(codexSessionRef(session)),
       },
-      onLastRuntimeSessionReleased: (runtimeId) =>
-        this.stopRuntimeEventSubscriptionIfUnused(runtimeId),
       runtimeEvents: this.runtimeEvents,
+    });
+    this.contextUsageLoader = new CodexContextUsageLoader({
+      runtimeClients: this.runtimeClients,
+      runtimeEvents: this.runtimeEvents,
+      localSessions: this.localSessions,
+      subagents: this.subagents,
+      prepareRuntime: (runtimeId) => this.prepareRuntime(runtimeId),
+      clearThreadInventory: (runtimeId) => this.clearThreadInventory(runtimeId),
     });
   }
 
@@ -266,7 +264,7 @@ export class CodexAppServerAdapter
   }
 
   releaseRuntime(runtimeId: string): void {
-    this.cancelRuntimeContextLoads(runtimeId);
+    this.contextUsageLoader.cancelRuntime(runtimeId);
     const failures: Array<{ label: string; cause: unknown }> = [];
     const cleanup = (label: string, operation: () => void): void => {
       try {
@@ -276,10 +274,7 @@ export class CodexAppServerAdapter
       }
     };
 
-    cleanup("sessions", () => {
-      this.localSessions.releaseRuntime(runtimeId);
-      this.runtimeEvents.stopRuntimeEventSubscription(runtimeId);
-    });
+    cleanup("sessions", () => this.localSessions.releaseRuntime(runtimeId));
     cleanup("pending input", () => this.pendingInput.clearRuntime(runtimeId));
     cleanup("subagents", () => this.subagents.clearRuntime(runtimeId));
     cleanup("runtime events", () => this.runtimeEvents.clearRuntime(runtimeId));
@@ -538,121 +533,13 @@ export class CodexAppServerAdapter
     input: PolicyBoundSessionRef,
   ): Promise<CodexSessionContextUsage | null> {
     assertCodexRuntimePolicyBinding(input, "load Codex session context usage");
-    const session = this.localSessions.get(input.externalSessionId);
-    if (session) {
-      return this.loadLiveSessionContextUsage({
-        runtimeId: session.runtimeId,
-        externalSessionId: session.threadId,
-      });
-    }
-    const guard = this.beginContextLoad(input);
-    try {
-      const runtime = await this.awaitContextLoad(
-        guard,
-        this.runtimeClients.resolve(input, "load Codex session context usage"),
-      );
-      this.bindContextLoadRuntime(guard, runtime.runtimeId);
-      this.assertContextLoadActive(guard);
-      await this.awaitContextLoad(guard, this.prepareRuntime(runtime.runtimeId));
-      this.assertContextLoadActive(guard);
-      const policy = requireCodexRuntimePolicy(
-        input.runtimePolicy,
-        "load Codex session context usage",
-      );
-      return await this.awaitContextLoad(
-        guard,
-        this.runtimeEvents.loadSessionContextUsage(
-          runtime.runtimeId,
-          input.externalSessionId,
-          async () => {
-            const response = await this.awaitContextLoad(
-              guard,
-              runtime.client.threadResume({
-                ...codexTransportPolicy(policy),
-                threadId: input.externalSessionId,
-                cwd: input.workingDirectory,
-                excludeTurns: false,
-              }),
-            );
-            this.assertContextLoadActive(guard);
-            const recoveredSession = sessionStateFromExistingThread(
-              input,
-              runtime.runtimeId,
-              input.model,
-              response,
-            );
-            this.localSessions.remember(
-              preserveRuntimeContextForExistingThread(
-                recoveredSession,
-                this.localSessions.get(input.externalSessionId),
-              ),
-            );
-            this.clearThreadInventory(runtime.runtimeId);
-          },
-        ),
-      );
-    } finally {
-      this.inFlightContextLoads.delete(guard);
-      this.stopRuntimeEventSubscriptionIfUnused(guard.runtimeId);
-    }
+    return this.contextUsageLoader.loadSession(input);
   }
 
   async loadLiveSessionContextUsage(
     input: CodexLiveSessionLocator,
   ): Promise<CodexSessionContextUsage | null> {
-    const retained = this.runtimeEvents.latestContextUsage(
-      input.runtimeId,
-      input.externalSessionId,
-    );
-    if (retained) {
-      return retained;
-    }
-    const localSession = this.localSessions.get(input.externalSessionId);
-    const route = localSession
-      ? null
-      : this.subagents.routeForChild(input.externalSessionId, input.runtimeId);
-    const session = localSession ?? this.localSessions.get(route?.parentExternalSessionId ?? "");
-    if (!session || session.runtimeId !== input.runtimeId) {
-      throw new Error(
-        `Cannot load Codex session context usage because session '${input.externalSessionId}' is not retained by runtime '${input.runtimeId}'.`,
-      );
-    }
-    const guard = this.beginContextLoad({
-      ...codexSessionRef(session),
-      externalSessionId: input.externalSessionId,
-    });
-    this.bindContextLoadRuntime(guard, input.runtimeId);
-    try {
-      await this.awaitContextLoad(guard, this.prepareRuntime(input.runtimeId));
-      this.assertContextLoadActive(guard);
-      const policy = requireCodexRuntimePolicy(
-        session.runtimePolicy,
-        "load Codex session context usage",
-      );
-      return await this.awaitContextLoad(
-        guard,
-        this.runtimeEvents.loadSessionContextUsage(
-          input.runtimeId,
-          input.externalSessionId,
-          async () => {
-            await this.awaitContextLoad(
-              guard,
-              this.runtimeClients.clientForRuntime(input.runtimeId).threadResume({
-                ...codexTransportPolicy(policy),
-                threadId: input.externalSessionId,
-                cwd: session.workingDirectory,
-                excludeTurns: false,
-              }),
-            );
-            this.assertContextLoadActive(guard);
-            this.clearThreadInventory(input.runtimeId);
-          },
-        ),
-      );
-    } finally {
-      this.inFlightContextLoads.delete(guard);
-      this.stopRuntimeEventSubscriptionIfUnused(guard.runtimeId);
-    }
+    return this.contextUsageLoader.loadLive(input);
   }
 
   listLiveSessionSnapshots(runtimeId: string): AgentSessionLiveSnapshot[] {
@@ -757,102 +644,10 @@ export class CodexAppServerAdapter
         );
       }
     }
-    this.cancelSessionContextLoads(input);
+    this.contextUsageLoader.cancelSession(input);
     if (session) {
       this.localSessions.release(input.externalSessionId);
     }
-  }
-
-  private beginContextLoad(input: SessionRef): ContextUsageLoadGuard {
-    let cancel: (error: Error) => void = () => {};
-    const guard = {
-      ref: input,
-      runtimeId: null,
-      releasedRuntimeIds: new Set<string>(),
-      error: null,
-      cancellation: new Promise<never>((_, reject) => {
-        cancel = reject;
-      }),
-      cancel,
-    };
-    this.inFlightContextLoads.add(guard);
-    return guard;
-  }
-
-  private bindContextLoadRuntime(guard: ContextUsageLoadGuard, runtimeId: string): void {
-    guard.runtimeId = runtimeId;
-    if (guard.releasedRuntimeIds.has(runtimeId)) {
-      this.cancelContextLoad(
-        guard,
-        new Error(`Codex runtime '${runtimeId}' was released while loading context usage.`),
-      );
-    }
-  }
-
-  private cancelSessionContextLoads(input: SessionRef): void {
-    for (const guard of this.inFlightContextLoads) {
-      if (agentSessionRefsEqual(guard.ref, input)) {
-        this.cancelContextLoad(
-          guard,
-          new Error(
-            `Codex session '${input.externalSessionId}' was released while loading context usage.`,
-          ),
-        );
-      }
-    }
-  }
-
-  private cancelRuntimeContextLoads(runtimeId: string): void {
-    for (const guard of this.inFlightContextLoads) {
-      guard.releasedRuntimeIds.add(runtimeId);
-      if (guard.runtimeId === runtimeId) {
-        this.cancelContextLoad(
-          guard,
-          new Error(`Codex runtime '${runtimeId}' was released while loading context usage.`),
-        );
-      }
-    }
-  }
-
-  private assertContextLoadActive(guard: ContextUsageLoadGuard): void {
-    if (guard.error) {
-      throw guard.error;
-    }
-  }
-
-  private awaitContextLoad<Value>(
-    guard: ContextUsageLoadGuard,
-    operation: Promise<Value>,
-  ): Promise<Value> {
-    return Promise.race([operation, guard.cancellation]);
-  }
-
-  private cancelContextLoad(guard: ContextUsageLoadGuard, error: Error): void {
-    if (guard.error) {
-      return;
-    }
-    guard.error = error;
-    guard.cancel(error);
-  }
-
-  private stopRuntimeEventSubscriptionIfUnused(runtimeId: string | null): void {
-    if (
-      !runtimeId ||
-      this.localSessions.hasRuntimeSession(runtimeId) ||
-      this.hasRuntimeBoundContextLoad(runtimeId)
-    ) {
-      return;
-    }
-    this.runtimeEvents.stopRuntimeEventSubscription(runtimeId);
-  }
-
-  private hasRuntimeBoundContextLoad(runtimeId: string): boolean {
-    for (const guard of this.inFlightContextLoads) {
-      if (guard.runtimeId === runtimeId) {
-        return true;
-      }
-    }
-    return false;
   }
 
   async listSessionRuntimeSnapshots(
@@ -1191,7 +986,7 @@ export class CodexAppServerAdapter
       );
     }
 
-    this.cancelSessionContextLoads(input);
+    this.contextUsageLoader.cancelSession(input);
     this.localSessions.release(input.externalSessionId);
   }
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -241,6 +241,8 @@ export class CodexAppServerAdapter
       sessionEvents: {
         clear: (session) => this.sessionEvents.clear(codexSessionRef(session)),
       },
+      onLastRuntimeSessionReleased: (runtimeId) =>
+        this.stopRuntimeEventSubscriptionIfUnused(runtimeId),
       runtimeEvents: this.runtimeEvents,
     });
   }
@@ -274,7 +276,10 @@ export class CodexAppServerAdapter
       }
     };
 
-    cleanup("sessions", () => this.localSessions.releaseRuntime(runtimeId));
+    cleanup("sessions", () => {
+      this.localSessions.releaseRuntime(runtimeId);
+      this.runtimeEvents.stopRuntimeEventSubscription(runtimeId);
+    });
     cleanup("pending input", () => this.pendingInput.clearRuntime(runtimeId));
     cleanup("subagents", () => this.subagents.clearRuntime(runtimeId));
     cleanup("runtime events", () => this.runtimeEvents.clearRuntime(runtimeId));
@@ -588,6 +593,7 @@ export class CodexAppServerAdapter
       );
     } finally {
       this.inFlightContextLoads.delete(guard);
+      this.stopRuntimeEventSubscriptionIfUnused(guard.runtimeId);
     }
   }
 
@@ -645,6 +651,7 @@ export class CodexAppServerAdapter
       );
     } finally {
       this.inFlightContextLoads.delete(guard);
+      this.stopRuntimeEventSubscriptionIfUnused(guard.runtimeId);
     }
   }
 
@@ -826,6 +833,26 @@ export class CodexAppServerAdapter
     }
     guard.error = error;
     guard.cancel(error);
+  }
+
+  private stopRuntimeEventSubscriptionIfUnused(runtimeId: string | null): void {
+    if (
+      !runtimeId ||
+      this.localSessions.hasRuntimeSession(runtimeId) ||
+      this.hasRuntimeBoundContextLoad(runtimeId)
+    ) {
+      return;
+    }
+    this.runtimeEvents.stopRuntimeEventSubscription(runtimeId);
+  }
+
+  private hasRuntimeBoundContextLoad(runtimeId: string): boolean {
+    for (const guard of this.inFlightContextLoads) {
+      if (guard.runtimeId === runtimeId) {
+        return true;
+      }
+    }
+    return false;
   }
 
   async listSessionRuntimeSnapshots(
@@ -1164,6 +1191,7 @@ export class CodexAppServerAdapter
       );
     }
 
+    this.cancelSessionContextLoads(input);
     this.localSessions.release(input.externalSessionId);
   }
 

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -179,6 +179,13 @@ const toLivePendingQuestion = (
   })),
 });
 
+type ContextUsageLoadGuard = {
+  ref: PolicyBoundSessionRef;
+  runtimeId: string | null;
+  releasedRuntimeIds: Set<string>;
+  error: Error | null;
+};
+
 export class CodexAppServerAdapter
   implements AgentCatalogPort, AgentSessionPort, AgentWorkspaceInspectionPort
 {
@@ -191,6 +198,7 @@ export class CodexAppServerAdapter
   private readonly models = new CodexModels();
   private readonly threadInventory = new CodexThreadInventoryReader();
   private readonly subagents = new CodexSubagentLinkState();
+  private readonly inFlightContextLoads = new Set<ContextUsageLoadGuard>();
 
   constructor(private readonly options: CodexAppServerAdapterOptions) {
     this.runtimeClients = new CodexRuntimeClientResolver(options);
@@ -254,6 +262,7 @@ export class CodexAppServerAdapter
   }
 
   releaseRuntime(runtimeId: string): void {
+    this.cancelRuntimeContextLoads(runtimeId);
     const failures: Array<{ label: string; cause: unknown }> = [];
     const cleanup = (label: string, operation: () => void): void => {
       try {
@@ -518,7 +527,9 @@ export class CodexAppServerAdapter
     });
   }
 
-  async loadSessionContextUsage(input: PolicyBoundSessionRef): Promise<CodexSessionContextUsage> {
+  async loadSessionContextUsage(
+    input: PolicyBoundSessionRef,
+  ): Promise<CodexSessionContextUsage | null> {
     assertCodexRuntimePolicyBinding(input, "load Codex session context usage");
     const session = this.localSessions.get(input.externalSessionId);
     if (session) {
@@ -527,42 +538,51 @@ export class CodexAppServerAdapter
         externalSessionId: session.threadId,
       });
     }
-    const runtime = await this.runtimeClients.resolve(input, "load Codex session context usage");
-    await this.prepareRuntime(runtime.runtimeId);
-    const policy = requireCodexRuntimePolicy(
-      input.runtimePolicy,
-      "load Codex session context usage",
-    );
-    return this.runtimeEvents.loadSessionContextUsage(
-      runtime.runtimeId,
-      input.externalSessionId,
-      async () => {
-        const response = await runtime.client.threadResume({
-          ...codexTransportPolicy(policy),
-          threadId: input.externalSessionId,
-          cwd: input.workingDirectory,
-          excludeTurns: false,
-        });
-        const recoveredSession = sessionStateFromExistingThread(
-          input,
-          runtime.runtimeId,
-          input.model,
-          response,
-        );
-        this.localSessions.remember(
-          preserveRuntimeContextForExistingThread(
-            recoveredSession,
-            this.localSessions.get(input.externalSessionId),
-          ),
-        );
-        this.clearThreadInventory(runtime.runtimeId);
-      },
-    );
+    const guard = this.beginContextLoad(input);
+    try {
+      const runtime = await this.runtimeClients.resolve(input, "load Codex session context usage");
+      this.bindContextLoadRuntime(guard, runtime.runtimeId);
+      this.assertContextLoadActive(guard);
+      await this.prepareRuntime(runtime.runtimeId);
+      this.assertContextLoadActive(guard);
+      const policy = requireCodexRuntimePolicy(
+        input.runtimePolicy,
+        "load Codex session context usage",
+      );
+      return await this.runtimeEvents.loadSessionContextUsage(
+        runtime.runtimeId,
+        input.externalSessionId,
+        async () => {
+          const response = await runtime.client.threadResume({
+            ...codexTransportPolicy(policy),
+            threadId: input.externalSessionId,
+            cwd: input.workingDirectory,
+            excludeTurns: false,
+          });
+          this.assertContextLoadActive(guard);
+          const recoveredSession = sessionStateFromExistingThread(
+            input,
+            runtime.runtimeId,
+            input.model,
+            response,
+          );
+          this.localSessions.remember(
+            preserveRuntimeContextForExistingThread(
+              recoveredSession,
+              this.localSessions.get(input.externalSessionId),
+            ),
+          );
+          this.clearThreadInventory(runtime.runtimeId);
+        },
+      );
+    } finally {
+      this.inFlightContextLoads.delete(guard);
+    }
   }
 
   async loadLiveSessionContextUsage(
     input: CodexLiveSessionLocator,
-  ): Promise<CodexSessionContextUsage> {
+  ): Promise<CodexSessionContextUsage | null> {
     const retained = this.runtimeEvents.latestContextUsage(
       input.runtimeId,
       input.externalSessionId,
@@ -694,17 +714,65 @@ export class CodexAppServerAdapter
 
   async releaseSession(input: SessionRef): Promise<void> {
     const session = this.localSessions.get(input.externalSessionId);
-    if (!session) {
-      return;
+    if (session) {
+      const sessionRef = codexSessionRef(session);
+      if (!agentSessionRefsEqual(sessionRef, input)) {
+        throw new Error(
+          `Cannot release Codex session '${input.externalSessionId}' from repo '${input.repoPath}' and working directory '${input.workingDirectory}' because the registered session belongs to repo '${sessionRef.repoPath}' and working directory '${sessionRef.workingDirectory}'.`,
+        );
+      }
     }
-    const sessionRef = codexSessionRef(session);
-    if (!agentSessionRefsEqual(sessionRef, input)) {
-      throw new Error(
-        `Cannot release Codex session '${input.externalSessionId}' from repo '${input.repoPath}' and working directory '${input.workingDirectory}' because the registered session belongs to repo '${sessionRef.repoPath}' and working directory '${sessionRef.workingDirectory}'.`,
+    this.cancelSessionContextLoads(input);
+    if (session) {
+      this.localSessions.release(input.externalSessionId);
+    }
+  }
+
+  private beginContextLoad(input: PolicyBoundSessionRef): ContextUsageLoadGuard {
+    const guard = {
+      ref: input,
+      runtimeId: null,
+      releasedRuntimeIds: new Set<string>(),
+      error: null,
+    };
+    this.inFlightContextLoads.add(guard);
+    return guard;
+  }
+
+  private bindContextLoadRuntime(guard: ContextUsageLoadGuard, runtimeId: string): void {
+    guard.runtimeId = runtimeId;
+    if (guard.releasedRuntimeIds.has(runtimeId)) {
+      guard.error = new Error(
+        `Codex runtime '${runtimeId}' was released while loading context usage.`,
       );
     }
+  }
 
-    this.localSessions.release(input.externalSessionId);
+  private cancelSessionContextLoads(input: SessionRef): void {
+    for (const guard of this.inFlightContextLoads) {
+      if (agentSessionRefsEqual(guard.ref, input)) {
+        guard.error = new Error(
+          `Codex session '${input.externalSessionId}' was released while loading context usage.`,
+        );
+      }
+    }
+  }
+
+  private cancelRuntimeContextLoads(runtimeId: string): void {
+    for (const guard of this.inFlightContextLoads) {
+      guard.releasedRuntimeIds.add(runtimeId);
+      if (guard.runtimeId === runtimeId) {
+        guard.error = new Error(
+          `Codex runtime '${runtimeId}' was released while loading context usage.`,
+        );
+      }
+    }
+  }
+
+  private assertContextLoadActive(guard: ContextUsageLoadGuard): void {
+    if (guard.error) {
+      throw guard.error;
+    }
   }
 
   async listSessionRuntimeSnapshots(

--- a/packages/adapters-codex-app-server/src/codex-context-usage-loader.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-loader.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import {
+  codexSessionRef,
+  codexStartSessionInput,
+  createDeferred,
+  createHarness,
+  createRuntimeStreamSubscription,
+  flushCodexAdapterWork,
+  makeRuntimeSummary,
+  RecordingTransport,
+} from "./codex-app-server-adapter.test-harness";
+import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
+
+const blockResume = (transport: RecordingTransport) => {
+  const request = transport.request.bind(transport);
+  const started = createDeferred<void>();
+  const resume = createDeferred<void>();
+  const completed = createDeferred<void>();
+  transport.request = async <Response>(input): Promise<Response> => {
+    if (input.method === "thread/resume") {
+      started.resolve(undefined);
+      await resume.promise;
+      const response = await request<Response>(input);
+      completed.resolve(undefined);
+      return response;
+    }
+    return request<Response>(input);
+  };
+  return { started, resume, completed };
+};
+
+describe("CodexContextUsageLoader", () => {
+  test("cancels cold loads for released sessions and runtimes without late retention", async () => {
+    for (const release of ["session", "runtime"] as const) {
+      const runtimeStream = createRuntimeStreamSubscription();
+      const transport = new RecordingTransport("runtime-live", false);
+      const { adapter } = createHarness({
+        subscribeEvents: runtimeStream.subscribeEvents,
+        transportFactory: () => transport,
+      });
+      const blocked = blockResume(transport);
+      const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+      await blocked.started.promise;
+      if (release === "session") {
+        await adapter.releaseSession(codexSessionRef("thread-idle"));
+      } else {
+        adapter.releaseRuntime("runtime-live");
+      }
+
+      await expect(loading).rejects.toThrow("was released while loading context usage");
+      blocked.resume.resolve(undefined);
+      await blocked.completed.promise;
+      await flushCodexAdapterWork();
+      expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+    }
+  });
+
+  test("rejects before runtime binding and during preparation", async () => {
+    const runtime = createDeferred<ReturnType<typeof makeRuntimeSummary>>();
+    const { adapter, transports } = createHarness({
+      repoRuntimeResolver: { requireRepoRuntime: () => runtime.promise },
+    });
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    await adapter.releaseSession(codexSessionRef("thread-idle"));
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    runtime.resolve(makeRuntimeSummary("runtime-live"));
+    expect(transports.get("runtime-live")?.calls ?? []).toEqual([]);
+
+    const preparationStarted = createDeferred<void>();
+    const preparation = createDeferred<() => void>();
+    const prepared = createHarness({
+      subscribeEvents: () => {
+        preparationStarted.resolve(undefined);
+        return preparation.promise;
+      },
+    });
+    const preparationLoad = prepared.adapter.loadSessionContextUsage(
+      codexSessionRef("thread-idle"),
+    );
+    await preparationStarted.promise;
+    prepared.adapter.releaseRuntime("runtime-live");
+    await expect(preparationLoad).rejects.toThrow("was released while loading context usage");
+    preparation.resolve(() => {});
+    expect(prepared.transports.get("runtime-live")?.calls ?? []).toEqual([]);
+  });
+
+  test("treats runtime release before binding as terminal", async () => {
+    const runtime = createDeferred<ReturnType<typeof makeRuntimeSummary>>();
+    const { adapter, transports } = createHarness({
+      repoRuntimeResolver: { requireRepoRuntime: () => runtime.promise },
+    });
+    const loading = adapter.loadSessionContextUsage(codexSessionRef("thread-idle"));
+    adapter.releaseRuntime("runtime-live");
+    runtime.resolve(makeRuntimeSummary("runtime-live"));
+
+    await expect(loading).rejects.toThrow("was released while loading context usage");
+    expect(transports.get("runtime-live")?.calls ?? []).toEqual([]);
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+  });
+
+  test("cancels retained and routed-child live loads on stop or release", async () => {
+    const runtimeStream = createRuntimeStreamSubscription();
+    const { adapter, transports } = createHarness({
+      subscribeEvents: runtimeStream.subscribeEvents,
+    });
+    await adapter.startSession(codexStartSessionInput());
+    const transport = transports.get("runtime-live");
+    if (!transport) {
+      throw new Error("Expected Codex transport.");
+    }
+    const stopped = blockResume(transport);
+    const liveLoading = adapter.loadLiveSessionContextUsage({
+      runtimeId: "runtime-live",
+      externalSessionId: "thread/start-runtime-live",
+    });
+    await stopped.started.promise;
+    await adapter.stopSession(codexSessionRef());
+    await expect(liveLoading).rejects.toThrow("was released while loading context usage");
+    stopped.resume.resolve(undefined);
+    await stopped.completed.promise;
+    await flushCodexAdapterWork();
+    expect(adapter.listLiveSessionSnapshots("runtime-live")).toEqual([]);
+
+    await adapter.startSession(codexStartSessionInput());
+    const state = adapter as unknown as { subagents: CodexSubagentLinkState };
+    state.subagents.upsertLink({
+      runtimeId: "runtime-live",
+      parentThreadId: "thread/start-runtime-live",
+      childThreadId: "child-thread",
+      itemId: "child-thread",
+      status: "running",
+    });
+    const child = blockResume(transport);
+    const childLoading = adapter.loadLiveSessionContextUsage({
+      runtimeId: "runtime-live",
+      externalSessionId: "child-thread",
+    });
+    await child.started.promise;
+    await adapter.releaseSession({ ...codexSessionRef(), externalSessionId: "child-thread" });
+    await expect(childLoading).rejects.toThrow("was released while loading context usage");
+    child.resume.resolve(undefined);
+    await child.completed.promise;
+    await flushCodexAdapterWork();
+    expect(
+      adapter
+        .listLiveSessionSnapshots("runtime-live")
+        .find((snapshot) => snapshot.ref.externalSessionId === "child-thread")?.contextUsage,
+    ).toBeNull();
+  });
+});

--- a/packages/adapters-codex-app-server/src/codex-context-usage-loader.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-loader.test.ts
@@ -147,4 +147,47 @@ describe("CodexContextUsageLoader", () => {
         .find((snapshot) => snapshot.ref.externalSessionId === "child-thread")?.contextUsage,
     ).toBeNull();
   });
+
+  test("cancels routed-child loads when the parent is released or stopped", async () => {
+    for (const action of ["release", "stop"] as const) {
+      const runtimeStream = createRuntimeStreamSubscription();
+      const { adapter, transports } = createHarness({
+        subscribeEvents: runtimeStream.subscribeEvents,
+      });
+      await adapter.startSession(codexStartSessionInput());
+      const transport = transports.get("runtime-live");
+      if (!transport) {
+        throw new Error("Expected Codex transport.");
+      }
+      const state = adapter as unknown as { subagents: CodexSubagentLinkState };
+      state.subagents.upsertLink({
+        runtimeId: "runtime-live",
+        parentThreadId: "thread/start-runtime-live",
+        childThreadId: "child-thread",
+        itemId: "child-thread",
+        status: "running",
+      });
+      const child = blockResume(transport);
+      const loading = adapter.loadLiveSessionContextUsage({
+        runtimeId: "runtime-live",
+        externalSessionId: "child-thread",
+      });
+      await child.started.promise;
+      if (action === "release") {
+        await adapter.releaseSession(codexSessionRef());
+      } else {
+        await adapter.stopSession(codexSessionRef());
+      }
+
+      await expect(loading).rejects.toThrow("was released while loading context usage");
+      child.resume.resolve(undefined);
+      await child.completed.promise;
+      await flushCodexAdapterWork();
+      expect(
+        adapter
+          .listLiveSessionSnapshots("runtime-live")
+          .find((snapshot) => snapshot.ref.externalSessionId === "child-thread"),
+      ).toBeUndefined();
+    }
+  });
 });

--- a/packages/adapters-codex-app-server/src/codex-context-usage-loader.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-loader.ts
@@ -1,0 +1,218 @@
+import type { PolicyBoundSessionRef, SessionRef } from "@openducktor/core";
+import { agentSessionRefsEqual } from "@openducktor/core";
+import type { CodexLocalSessionState } from "./codex-local-session-state";
+import type { CodexRuntimeClientResolver } from "./codex-runtime-client-resolver";
+import type { CodexRuntimeSessionEvents } from "./codex-runtime-session-events";
+import {
+  preserveRuntimeContextForExistingThread,
+  sessionStateFromExistingThread,
+} from "./codex-session-lifecycle";
+import { codexTransportPolicy, requireCodexRuntimePolicy } from "./codex-session-policy";
+import { codexSessionRef } from "./codex-session-ref";
+import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
+import type { CodexLiveSessionLocator, CodexSessionContextUsage } from "./types";
+
+type ContextUsageLoadGuard = {
+  ref: SessionRef;
+  runtimeId: string | null;
+  releasedRuntimeIds: Set<string>;
+  error: Error | null;
+  cancellation: Promise<never>;
+  cancel: (error: Error) => void;
+};
+
+type CodexContextUsageLoaderDeps = {
+  runtimeClients: CodexRuntimeClientResolver;
+  runtimeEvents: CodexRuntimeSessionEvents;
+  localSessions: CodexLocalSessionState;
+  subagents: CodexSubagentLinkState;
+  prepareRuntime(runtimeId: string): Promise<void>;
+  clearThreadInventory(runtimeId: string): void;
+};
+
+export class CodexContextUsageLoader {
+  private readonly inFlightLoads = new Set<ContextUsageLoadGuard>();
+
+  constructor(private readonly deps: CodexContextUsageLoaderDeps) {}
+
+  async loadSession(input: PolicyBoundSessionRef): Promise<CodexSessionContextUsage | null> {
+    const session = this.deps.localSessions.get(input.externalSessionId);
+    if (session) {
+      return this.loadLive({ runtimeId: session.runtimeId, externalSessionId: session.threadId });
+    }
+    const guard = this.begin(input);
+    try {
+      const runtime = await this.wait(
+        guard,
+        this.deps.runtimeClients.resolve(input, "load Codex session context usage"),
+      );
+      this.bindRuntime(guard, runtime.runtimeId);
+      this.assertActive(guard);
+      await this.wait(guard, this.deps.prepareRuntime(runtime.runtimeId));
+      this.assertActive(guard);
+      const policy = requireCodexRuntimePolicy(
+        input.runtimePolicy,
+        "load Codex session context usage",
+      );
+      return await this.wait(
+        guard,
+        this.deps.runtimeEvents.loadSessionContextUsage(
+          runtime.runtimeId,
+          input.externalSessionId,
+          async () => {
+            const response = await this.wait(
+              guard,
+              runtime.client.threadResume({
+                ...codexTransportPolicy(policy),
+                threadId: input.externalSessionId,
+                cwd: input.workingDirectory,
+                excludeTurns: false,
+              }),
+            );
+            this.assertActive(guard);
+            const recoveredSession = sessionStateFromExistingThread(
+              input,
+              runtime.runtimeId,
+              input.model,
+              response,
+            );
+            this.deps.localSessions.remember(
+              preserveRuntimeContextForExistingThread(
+                recoveredSession,
+                this.deps.localSessions.get(input.externalSessionId),
+              ),
+            );
+            this.deps.clearThreadInventory(runtime.runtimeId);
+          },
+        ),
+      );
+    } finally {
+      this.inFlightLoads.delete(guard);
+    }
+  }
+
+  async loadLive(input: CodexLiveSessionLocator): Promise<CodexSessionContextUsage | null> {
+    const retained = this.deps.runtimeEvents.latestContextUsage(
+      input.runtimeId,
+      input.externalSessionId,
+    );
+    if (retained) {
+      return retained;
+    }
+    const localSession = this.deps.localSessions.get(input.externalSessionId);
+    const route = localSession
+      ? null
+      : this.deps.subagents.routeForChild(input.externalSessionId, input.runtimeId);
+    const session =
+      localSession ?? this.deps.localSessions.get(route?.parentExternalSessionId ?? "");
+    if (!session || session.runtimeId !== input.runtimeId) {
+      throw new Error(
+        `Cannot load Codex session context usage because session '${input.externalSessionId}' is not retained by runtime '${input.runtimeId}'.`,
+      );
+    }
+    const guard = this.begin({
+      ...codexSessionRef(session),
+      externalSessionId: input.externalSessionId,
+    });
+    this.bindRuntime(guard, input.runtimeId);
+    try {
+      await this.wait(guard, this.deps.prepareRuntime(input.runtimeId));
+      this.assertActive(guard);
+      const policy = requireCodexRuntimePolicy(
+        session.runtimePolicy,
+        "load Codex session context usage",
+      );
+      return await this.wait(
+        guard,
+        this.deps.runtimeEvents.loadSessionContextUsage(
+          input.runtimeId,
+          input.externalSessionId,
+          async () => {
+            await this.wait(
+              guard,
+              this.deps.runtimeClients.clientForRuntime(input.runtimeId).threadResume({
+                ...codexTransportPolicy(policy),
+                threadId: input.externalSessionId,
+                cwd: session.workingDirectory,
+                excludeTurns: false,
+              }),
+            );
+            this.assertActive(guard);
+            this.deps.clearThreadInventory(input.runtimeId);
+          },
+        ),
+      );
+    } finally {
+      this.inFlightLoads.delete(guard);
+    }
+  }
+
+  cancelSession(input: SessionRef): void {
+    for (const guard of this.inFlightLoads) {
+      if (agentSessionRefsEqual(guard.ref, input)) {
+        this.cancel(
+          guard,
+          new Error(
+            `Codex session '${input.externalSessionId}' was released while loading context usage.`,
+          ),
+        );
+      }
+    }
+  }
+
+  cancelRuntime(runtimeId: string): void {
+    for (const guard of this.inFlightLoads) {
+      guard.releasedRuntimeIds.add(runtimeId);
+      if (guard.runtimeId === runtimeId) {
+        this.cancel(
+          guard,
+          new Error(`Codex runtime '${runtimeId}' was released while loading context usage.`),
+        );
+      }
+    }
+  }
+
+  private begin(ref: SessionRef): ContextUsageLoadGuard {
+    let cancel: (error: Error) => void = () => {};
+    const guard = {
+      ref,
+      runtimeId: null,
+      releasedRuntimeIds: new Set<string>(),
+      error: null,
+      cancellation: new Promise<never>((_, reject) => {
+        cancel = reject;
+      }),
+      cancel,
+    };
+    this.inFlightLoads.add(guard);
+    return guard;
+  }
+
+  private bindRuntime(guard: ContextUsageLoadGuard, runtimeId: string): void {
+    guard.runtimeId = runtimeId;
+    if (guard.releasedRuntimeIds.has(runtimeId)) {
+      this.cancel(
+        guard,
+        new Error(`Codex runtime '${runtimeId}' was released while loading context usage.`),
+      );
+    }
+  }
+
+  private wait<Value>(guard: ContextUsageLoadGuard, operation: Promise<Value>): Promise<Value> {
+    return Promise.race([operation, guard.cancellation]);
+  }
+
+  private assertActive(guard: ContextUsageLoadGuard): void {
+    if (guard.error) {
+      throw guard.error;
+    }
+  }
+
+  private cancel(guard: ContextUsageLoadGuard, error: Error): void {
+    if (guard.error) {
+      return;
+    }
+    guard.error = error;
+    guard.cancel(error);
+  }
+}

--- a/packages/adapters-codex-app-server/src/codex-context-usage-loader.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-loader.ts
@@ -13,7 +13,7 @@ import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
 import type { CodexLiveSessionLocator, CodexSessionContextUsage } from "./types";
 
 type ContextUsageLoadGuard = {
-  ref: SessionRef;
+  refs: readonly SessionRef[];
   runtimeId: string | null;
   releasedRuntimeIds: Set<string>;
   error: Error | null;
@@ -40,7 +40,7 @@ export class CodexContextUsageLoader {
     if (session) {
       return this.loadLive({ runtimeId: session.runtimeId, externalSessionId: session.threadId });
     }
-    const guard = this.begin(input);
+    const guard = this.begin([input]);
     try {
       const runtime = await this.wait(
         guard,
@@ -110,10 +110,11 @@ export class CodexContextUsageLoader {
         `Cannot load Codex session context usage because session '${input.externalSessionId}' is not retained by runtime '${input.runtimeId}'.`,
       );
     }
-    const guard = this.begin({
+    const targetRef = {
       ...codexSessionRef(session),
       externalSessionId: input.externalSessionId,
-    });
+    };
+    const guard = this.begin(localSession ? [targetRef] : [targetRef, codexSessionRef(session)]);
     this.bindRuntime(guard, input.runtimeId);
     try {
       await this.wait(guard, this.deps.prepareRuntime(input.runtimeId));
@@ -149,7 +150,7 @@ export class CodexContextUsageLoader {
 
   cancelSession(input: SessionRef): void {
     for (const guard of this.inFlightLoads) {
-      if (agentSessionRefsEqual(guard.ref, input)) {
+      if (guard.refs.some((ref) => agentSessionRefsEqual(ref, input))) {
         this.cancel(
           guard,
           new Error(
@@ -172,10 +173,10 @@ export class CodexContextUsageLoader {
     }
   }
 
-  private begin(ref: SessionRef): ContextUsageLoadGuard {
+  private begin(refs: readonly SessionRef[]): ContextUsageLoadGuard {
     let cancel: (error: Error) => void = () => {};
     const guard = {
-      ref,
+      refs,
       runtimeId: null,
       releasedRuntimeIds: new Set<string>(),
       error: null,

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.test.ts
@@ -26,6 +26,23 @@ describe("CodexContextUsageTracker", () => {
     });
   });
 
+  test("accepts zero usage without a model context window", () => {
+    const tracker = new CodexContextUsageTracker();
+    tracker.observeNotification("runtime-live", {
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-idle",
+        tokenUsage: {
+          last: { totalTokens: 0 },
+          total: { totalTokens: 0 },
+        },
+      },
+      receivedAt: "2026-07-06T12:00:00.000Z",
+    });
+
+    expect(tracker.latest("runtime-live", "thread-idle")).toEqual({ totalTokens: 0 });
+  });
+
   test("shares concurrent and synchronously reentrant loads", async () => {
     const tracker = new CodexContextUsageTracker();
     let nestedLoad: Promise<unknown> | null = null;

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { CodexContextUsageTracker } from "./codex-context-usage-tracker";
+
+const usageNotification = (lastTotalTokens: number, totalTokens = lastTotalTokens) => ({
+  method: "thread/tokenUsage/updated",
+  params: {
+    threadId: "thread-idle",
+    tokenUsage: {
+      last: { totalTokens: lastTotalTokens },
+      total: { totalTokens },
+      modelContextWindow: 200_000,
+    },
+  },
+  receivedAt: "2026-07-06T12:00:00.000Z",
+});
+
+describe("CodexContextUsageTracker", () => {
+  test("accepts zero current usage with a positive cumulative total", () => {
+    const tracker = new CodexContextUsageTracker();
+    tracker.observeNotification("runtime-live", usageNotification(42_000));
+    tracker.observeNotification("runtime-live", usageNotification(0, 42_000));
+
+    expect(tracker.latest("runtime-live", "thread-idle")).toEqual({
+      totalTokens: 0,
+      contextWindow: 200_000,
+    });
+  });
+
+  test("shares concurrent and synchronously reentrant loads", async () => {
+    const tracker = new CodexContextUsageTracker();
+    let nestedLoad: Promise<unknown> | null = null;
+    let resumeAttempts = 0;
+    const firstLoad = tracker.load("runtime-live", "thread-idle", async () => {
+      resumeAttempts += 1;
+      nestedLoad = tracker.load("runtime-live", "thread-idle", async () => {
+        resumeAttempts += 1;
+      });
+    });
+    const secondLoad = tracker.load("runtime-live", "thread-idle", async () => {
+      resumeAttempts += 1;
+    });
+
+    await expect(Promise.all([firstLoad, secondLoad])).resolves.toEqual([null, null]);
+    await expect(nestedLoad).resolves.toBeNull();
+    expect(resumeAttempts).toBe(1);
+  });
+
+  test("clears a failed load so an explicit later load retries", async () => {
+    const tracker = new CodexContextUsageTracker();
+    let resumeAttempts = 0;
+
+    await expect(
+      tracker.load("runtime-live", "thread-idle", async () => {
+        resumeAttempts += 1;
+        throw new Error("resume unavailable");
+      }),
+    ).rejects.toThrow("resume unavailable");
+    await expect(
+      tracker.load("runtime-live", "thread-idle", async () => {
+        resumeAttempts += 1;
+      }),
+    ).resolves.toBeNull();
+
+    expect(resumeAttempts).toBe(2);
+  });
+});

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
@@ -25,7 +25,11 @@ const canonicalZeroUsage = (params: unknown): CodexSessionContextUsage | null =>
     return null;
   }
   const contextWindow = usage.modelContextWindow;
-  if (contextWindow !== null && (typeof contextWindow !== "number" || contextWindow <= 0)) {
+  if (
+    contextWindow !== null &&
+    contextWindow !== undefined &&
+    (typeof contextWindow !== "number" || contextWindow <= 0)
+  ) {
     return null;
   }
   return {

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
@@ -47,10 +47,6 @@ export class CodexContextUsageTracker {
     threadId: string,
     resumeWithTurns: () => Promise<void>,
   ): Promise<CodexSessionContextUsage | null> {
-    const retained = this.latest(runtimeId, threadId);
-    if (retained) {
-      return retained;
-    }
     const key = contextUsageKey(runtimeId, threadId);
     const inFlight = this.inFlightLoadsByKey.get(key);
     if (inFlight) {

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
@@ -1,180 +1,84 @@
 import { extractThreadIdFromParams } from "./codex-app-server-requests";
 import { isPlainObject } from "./codex-app-server-shared";
 import { extractCodexTokenUsageTotals } from "./codex-app-server-transcript";
-import type { CodexRuntimeStreamEvent } from "./codex-runtime-events";
 import type { CodexNotificationRecord, CodexSessionContextUsage } from "./types";
-
-export type CodexContextUsageReplayScheduler = {
-  clearTimeout(handle: unknown): void;
-  setTimeout(callback: () => void, timeoutMs: number): unknown;
-};
-
-export type CodexContextUsageObservation = {
-  key: string;
-  generation: number;
-};
-
-type RetainedContextUsage = {
-  usage: CodexSessionContextUsage;
-  observationGeneration: number;
-};
-
-type ContextUsageRecovery = {
-  runtimeId: string;
-  threadId: string;
-  released: Promise<never>;
-  rejectReleased(error: Error): void;
-  replayObserved: Promise<void>;
-  resolveReplayObserved(): void;
-  observationGenerationAtStart: number;
-  resumeCompletedObservationGeneration: number | null;
-  promise?: Promise<CodexSessionContextUsage>;
-};
 
 const contextUsageKey = (runtimeId: string, threadId: string): string =>
   JSON.stringify([runtimeId, threadId]);
 
 const parseContextUsageKey = (key: string): [string, string] => JSON.parse(key) as [string, string];
 
-const CODEX_CONTEXT_USAGE_REPLAY_TIMEOUT_MS = 10_000;
-
-const defaultContextUsageReplayScheduler: CodexContextUsageReplayScheduler = {
-  clearTimeout: (handle) => {
-    clearTimeout(handle as ReturnType<typeof setTimeout>);
-  },
-  setTimeout: (callback, timeoutMs) => setTimeout(callback, timeoutMs),
+const canonicalZeroUsage = (params: unknown): CodexSessionContextUsage | null => {
+  if (!isPlainObject(params) || !isPlainObject(params.tokenUsage)) {
+    return null;
+  }
+  const usage = params.tokenUsage;
+  if (!isPlainObject(usage.last) || !isPlainObject(usage.total)) {
+    return null;
+  }
+  if (usage.last.totalTokens !== 0 || usage.total.totalTokens !== 0) {
+    return null;
+  }
+  const contextWindow = usage.modelContextWindow;
+  if (contextWindow !== null && (typeof contextWindow !== "number" || contextWindow <= 0)) {
+    return null;
+  }
+  return {
+    totalTokens: 0,
+    ...(typeof contextWindow === "number" ? { contextWindow } : {}),
+  };
 };
 
 export class CodexContextUsageTracker {
-  private readonly latestByKey = new Map<string, RetainedContextUsage>();
-  private readonly observationGenerationByKey = new Map<string, number>();
-  private readonly recoveriesByKey = new Map<string, ContextUsageRecovery>();
-
-  constructor(
-    private readonly waitForRuntimeEventBarrier: (runtimeId: string) => Promise<void>,
-    private readonly replayScheduler: CodexContextUsageReplayScheduler = defaultContextUsageReplayScheduler,
-  ) {}
+  private readonly latestByKey = new Map<string, CodexSessionContextUsage>();
 
   latest(runtimeId: string, threadId: string): CodexSessionContextUsage | null {
-    return this.latestByKey.get(contextUsageKey(runtimeId, threadId))?.usage ?? null;
+    return this.latestByKey.get(contextUsageKey(runtimeId, threadId)) ?? null;
   }
 
-  load(
+  async load(
     runtimeId: string,
     threadId: string,
     resumeWithTurns: () => Promise<void>,
-  ): Promise<CodexSessionContextUsage> {
+  ): Promise<CodexSessionContextUsage | null> {
     const retained = this.latest(runtimeId, threadId);
     if (retained) {
-      return Promise.resolve(retained);
+      return retained;
     }
-
-    const key = contextUsageKey(runtimeId, threadId);
-    const existing = this.recoveriesByKey.get(key);
-    if (existing) {
-      if (!existing.promise) {
-        throw new Error(
-          `Codex context usage recovery for runtime '${runtimeId}' session '${threadId}' was not initialized.`,
-        );
-      }
-      return existing.promise;
+    try {
+      await resumeWithTurns();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to load Codex context usage for runtime '${runtimeId}' session '${threadId}': ${message}`,
+        { cause: error },
+      );
     }
-
-    let rejectReleased: ((error: Error) => void) | undefined;
-    const released = new Promise<never>((_resolve, reject) => {
-      rejectReleased = reject;
-    });
-    let resolveReplayObserved!: () => void;
-    const replayObserved = new Promise<void>((resolve) => {
-      resolveReplayObserved = resolve;
-    });
-    const recovery: ContextUsageRecovery = {
-      runtimeId,
-      threadId,
-      released,
-      rejectReleased: (error) => rejectReleased?.(error),
-      replayObserved,
-      resolveReplayObserved,
-      observationGenerationAtStart: this.observationGenerationByKey.get(key) ?? 0,
-      resumeCompletedObservationGeneration: null,
-    };
-    this.recoveriesByKey.set(key, recovery);
-    const promise = this.performRecovery(recovery, resumeWithTurns);
-    recovery.promise = promise;
-    return promise;
+    return this.latest(runtimeId, threadId);
   }
 
-  reserveObservation(
-    event: Pick<CodexRuntimeStreamEvent, "runtimeId" | "kind" | "message">,
-  ): CodexContextUsageObservation | null {
-    if (
-      event.kind !== "notification" ||
-      !isPlainObject(event.message) ||
-      event.message.method !== "thread/tokenUsage/updated"
-    ) {
-      return null;
-    }
-    const threadId = extractThreadIdFromParams(event.message.params);
-    if (!threadId) {
-      return null;
-    }
-    return this.nextObservation(contextUsageKey(event.runtimeId, threadId));
-  }
-
-  observeNotification(
-    runtimeId: string,
-    notification: CodexNotificationRecord,
-    reservedObservation?: CodexContextUsageObservation | null,
-  ): void {
+  observeNotification(runtimeId: string, notification: CodexNotificationRecord): void {
     if (notification.method !== "thread/tokenUsage/updated") {
       return;
     }
     const threadId = extractThreadIdFromParams(notification.params);
-    const usage = extractCodexTokenUsageTotals(notification.params);
-    if (!threadId || !usage) {
-      return;
+    if (!threadId) {
+      throw new Error("Codex context usage notification is missing threadId.");
     }
-    const key = contextUsageKey(runtimeId, threadId);
-    const observation =
-      reservedObservation?.key === key ? reservedObservation : this.nextObservation(key);
-    const retained = this.latestByKey.get(key);
-    const recovery = this.recoveriesByKey.get(key);
-    const isPostResponseReplay =
-      recovery?.resumeCompletedObservationGeneration !== null &&
-      recovery?.resumeCompletedObservationGeneration !== undefined &&
-      observation.generation > recovery.resumeCompletedObservationGeneration;
-    const alreadyObservedSinceRecoveryStarted = recovery
-      ? (retained?.observationGeneration ?? 0) > recovery.observationGenerationAtStart
-      : false;
-    if (isPostResponseReplay) {
-      recovery.resolveReplayObserved();
+    const usage =
+      extractCodexTokenUsageTotals(notification.params) ?? canonicalZeroUsage(notification.params);
+    if (!usage) {
+      throw new Error(
+        `Codex context usage notification for thread '${threadId}' has invalid token usage.`,
+      );
     }
-    if (
-      (retained && retained.observationGeneration > observation.generation) ||
-      (isPostResponseReplay && alreadyObservedSinceRecoveryStarted)
-    ) {
-      return;
-    }
-    this.latestByKey.set(key, {
-      usage,
-      observationGeneration: observation.generation,
-    });
+    this.latestByKey.set(contextUsageKey(runtimeId, threadId), usage);
   }
 
-  releaseRuntime(runtimeId: string, error: Error): void {
+  clearRuntime(runtimeId: string): void {
     for (const [key] of this.latestByKey) {
       if (parseContextUsageKey(key)[0] === runtimeId) {
         this.latestByKey.delete(key);
-      }
-    }
-    for (const key of this.observationGenerationByKey.keys()) {
-      if (parseContextUsageKey(key)[0] === runtimeId) {
-        this.observationGenerationByKey.delete(key);
-      }
-    }
-    for (const recovery of this.recoveriesByKey.values()) {
-      if (recovery.runtimeId === runtimeId) {
-        recovery.rejectReleased(error);
       }
     }
   }
@@ -186,75 +90,5 @@ export class CodexContextUsageTracker {
         this.latestByKey.delete(key);
       }
     }
-    for (const key of this.observationGenerationByKey.keys()) {
-      const [retainedRuntimeId, retainedThreadId] = parseContextUsageKey(key);
-      if (retainedThreadId === threadId && (!runtimeId || retainedRuntimeId === runtimeId)) {
-        this.observationGenerationByKey.delete(key);
-      }
-    }
-    for (const recovery of this.recoveriesByKey.values()) {
-      if (recovery.threadId === threadId && (!runtimeId || recovery.runtimeId === runtimeId)) {
-        recovery.rejectReleased(
-          new Error(`Codex session '${threadId}' was released while context usage was loading.`),
-        );
-      }
-    }
-  }
-
-  private async performRecovery(
-    recovery: ContextUsageRecovery,
-    resumeWithTurns: () => Promise<void>,
-  ): Promise<CodexSessionContextUsage> {
-    const key = contextUsageKey(recovery.runtimeId, recovery.threadId);
-    try {
-      await Promise.resolve();
-      await Promise.race([resumeWithTurns(), recovery.released]);
-      recovery.resumeCompletedObservationGeneration =
-        this.observationGenerationByKey.get(key) ?? recovery.observationGenerationAtStart;
-      await this.waitForReplay(recovery);
-      await Promise.race([this.waitForRuntimeEventBarrier(recovery.runtimeId), recovery.released]);
-      const retained = this.latest(recovery.runtimeId, recovery.threadId);
-      if (!retained) {
-        throw new Error("Codex context usage was observed without retained context state.");
-      }
-      return retained;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(
-        `Failed to load Codex context usage for runtime '${recovery.runtimeId}' session '${recovery.threadId}': ${message}`,
-        { cause: error },
-      );
-    } finally {
-      if (this.recoveriesByKey.get(key) === recovery) {
-        this.recoveriesByKey.delete(key);
-      }
-    }
-  }
-
-  private async waitForReplay(recovery: ContextUsageRecovery): Promise<void> {
-    let timeoutHandle: unknown | null = null;
-    const timedOut = new Promise<never>((_resolve, reject) => {
-      timeoutHandle = this.replayScheduler.setTimeout(() => {
-        reject(
-          new Error(
-            `Timed out waiting for Codex context usage replay for runtime '${recovery.runtimeId}' session '${recovery.threadId}' after ${CODEX_CONTEXT_USAGE_REPLAY_TIMEOUT_MS}ms: thread/resume completed but no matching thread/tokenUsage/updated notification arrived.`,
-          ),
-        );
-      }, CODEX_CONTEXT_USAGE_REPLAY_TIMEOUT_MS);
-    });
-
-    try {
-      await Promise.race([recovery.replayObserved, recovery.released, timedOut]);
-    } finally {
-      if (timeoutHandle !== null) {
-        this.replayScheduler.clearTimeout(timeoutHandle);
-      }
-    }
-  }
-
-  private nextObservation(key: string): CodexContextUsageObservation {
-    const generation = (this.observationGenerationByKey.get(key) ?? 0) + 1;
-    this.observationGenerationByKey.set(key, generation);
-    return { key, generation };
   }
 }

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
@@ -31,6 +31,7 @@ const canonicalZeroUsage = (params: unknown): CodexSessionContextUsage | null =>
 
 export class CodexContextUsageTracker {
   private readonly latestByKey = new Map<string, CodexSessionContextUsage>();
+  private readonly inFlightLoadsByKey = new Map<string, Promise<CodexSessionContextUsage | null>>();
 
   latest(runtimeId: string, threadId: string): CodexSessionContextUsage | null {
     return this.latestByKey.get(contextUsageKey(runtimeId, threadId)) ?? null;
@@ -45,16 +46,31 @@ export class CodexContextUsageTracker {
     if (retained) {
       return retained;
     }
-    try {
-      await resumeWithTurns();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(
-        `Failed to load Codex context usage for runtime '${runtimeId}' session '${threadId}': ${message}`,
-        { cause: error },
-      );
+    const key = contextUsageKey(runtimeId, threadId);
+    const inFlight = this.inFlightLoadsByKey.get(key);
+    if (inFlight) {
+      return inFlight;
     }
-    return this.latest(runtimeId, threadId);
+    const load = Promise.resolve().then(async () => {
+      try {
+        await resumeWithTurns();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Failed to load Codex context usage for runtime '${runtimeId}' session '${threadId}': ${message}`,
+          { cause: error },
+        );
+      }
+      return this.latest(runtimeId, threadId);
+    });
+    this.inFlightLoadsByKey.set(key, load);
+    try {
+      return await load;
+    } finally {
+      if (this.inFlightLoadsByKey.get(key) === load) {
+        this.inFlightLoadsByKey.delete(key);
+      }
+    }
   }
 
   observeNotification(runtimeId: string, notification: CodexNotificationRecord): void {

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
@@ -16,7 +16,12 @@ const canonicalZeroUsage = (params: unknown): CodexSessionContextUsage | null =>
   if (!isPlainObject(usage.last) || !isPlainObject(usage.total)) {
     return null;
   }
-  if (usage.last.totalTokens !== 0 || usage.total.totalTokens !== 0) {
+  if (
+    usage.last.totalTokens !== 0 ||
+    typeof usage.total.totalTokens !== "number" ||
+    !Number.isFinite(usage.total.totalTokens) ||
+    usage.total.totalTokens < 0
+  ) {
     return null;
   }
   const contextWindow = usage.modelContextWindow;

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
@@ -26,7 +26,6 @@ const createStore = () => {
   const clearedRuntimeEvents: Array<{ externalSessionId: string; runtimeId?: string }> = [];
   const clearedSubagents: Array<{ externalSessionId: string; runtimeId?: string }> = [];
   const clearedThreadStatusOverrides: Array<{ runtimeId: string; threadId: string }> = [];
-  const stoppedRuntimeSubscriptions: string[] = [];
   const activeTurnsBySessionId = new Map<string, unknown>();
   const store = new CodexLocalSessionState({
     sessionEvents: {
@@ -47,7 +46,6 @@ const createStore = () => {
       clearSession: (externalSessionId, runtimeId) =>
         clearedRuntimeEvents.push({ externalSessionId, runtimeId }),
     },
-    onLastRuntimeSessionReleased: (runtimeId) => stoppedRuntimeSubscriptions.push(runtimeId),
   });
   return {
     store,
@@ -57,7 +55,6 @@ const createStore = () => {
     clearedRuntimeEvents,
     clearedSubagents,
     clearedThreadStatusOverrides,
-    stoppedRuntimeSubscriptions,
   };
 };
 
@@ -82,7 +79,6 @@ describe("CodexLocalSessionState", () => {
       clearedRuntimeEvents,
       clearedSubagents,
       clearedThreadStatusOverrides,
-      stoppedRuntimeSubscriptions,
     } = createStore();
     store.remember(session("thread-1"));
     store.remember(session("thread-2"));
@@ -105,27 +101,21 @@ describe("CodexLocalSessionState", () => {
     expect(clearedThreadStatusOverrides).toEqual([
       { runtimeId: "runtime-1", threadId: "thread-1" },
     ]);
-    expect(stoppedRuntimeSubscriptions).toEqual([]);
   });
 
-  test("stops runtime subscription when the last local session for a runtime is released", () => {
-    const { store, stoppedRuntimeSubscriptions } = createStore();
+  test("releases the last local session without runtime coordination", () => {
+    const { store } = createStore();
     store.remember(session("thread-1", "runtime-1"));
     store.remember(session("thread-2", "runtime-2"));
 
     store.release("thread-1");
 
-    expect(stoppedRuntimeSubscriptions).toEqual(["runtime-1"]);
+    expect(store.has("thread-1")).toBe(false);
   });
 
   test("releases every local session for one stopped runtime without affecting another", () => {
-    const {
-      store,
-      activeTurnsBySessionId,
-      clearedSessionEvents,
-      clearedRuntimeEvents,
-      stoppedRuntimeSubscriptions,
-    } = createStore();
+    const { store, activeTurnsBySessionId, clearedSessionEvents, clearedRuntimeEvents } =
+      createStore();
     store.remember(session("thread-1", "runtime-1"));
     store.remember(session("thread-2", "runtime-1"));
     store.remember(session("thread-3", "runtime-2"));
@@ -147,16 +137,10 @@ describe("CodexLocalSessionState", () => {
       { externalSessionId: "thread-1", runtimeId: "runtime-1" },
       { externalSessionId: "thread-2", runtimeId: "runtime-1" },
     ]);
-    expect(stoppedRuntimeSubscriptions).toEqual([]);
   });
 
   test("clears missing local sessions without throwing", () => {
-    const {
-      store,
-      activeTurnsBySessionId,
-      clearedThreadStatusOverrides,
-      stoppedRuntimeSubscriptions,
-    } = createStore();
+    const { store, activeTurnsBySessionId, clearedThreadStatusOverrides } = createStore();
     store.remember(session("thread-2"));
     activeTurnsBySessionId.set("thread-2", {});
 
@@ -165,6 +149,5 @@ describe("CodexLocalSessionState", () => {
     expect(store.has("thread-2")).toBe(true);
     expect(activeTurnsBySessionId.has("thread-2")).toBe(true);
     expect(clearedThreadStatusOverrides).toEqual([]);
-    expect(stoppedRuntimeSubscriptions).toEqual([]);
   });
 });

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
@@ -46,8 +46,8 @@ const createStore = () => {
     runtimeEvents: {
       clearSession: (externalSessionId, runtimeId) =>
         clearedRuntimeEvents.push({ externalSessionId, runtimeId }),
-      stopRuntimeEventSubscription: (runtimeId) => stoppedRuntimeSubscriptions.push(runtimeId),
     },
+    onLastRuntimeSessionReleased: (runtimeId) => stoppedRuntimeSubscriptions.push(runtimeId),
   });
   return {
     store,
@@ -147,7 +147,7 @@ describe("CodexLocalSessionState", () => {
       { externalSessionId: "thread-1", runtimeId: "runtime-1" },
       { externalSessionId: "thread-2", runtimeId: "runtime-1" },
     ]);
-    expect(stoppedRuntimeSubscriptions).toEqual(["runtime-1"]);
+    expect(stoppedRuntimeSubscriptions).toEqual([]);
   });
 
   test("clears missing local sessions without throwing", () => {

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.ts
@@ -11,7 +11,6 @@ type CodexLocalSessionStateDeps = {
   pendingInput: { clearSession(externalSessionId: string, runtimeId?: string): void };
   subagents: { clearSession(externalSessionId: string, runtimeId?: string): void };
   threadStatusOverrides: { clear(runtimeId: string, threadId: string): void };
-  onLastRuntimeSessionReleased(runtimeId: string): void;
   runtimeEvents: {
     clearSession(externalSessionId: string, runtimeId?: string): void;
   };
@@ -39,11 +38,7 @@ export class CodexLocalSessionState implements CodexSessionLookup {
   }
 
   release(externalSessionId: string): CodexSessionState | undefined {
-    const session = this.clearSessionState(externalSessionId);
-    if (session && !this.hasRuntimeSession(session.runtimeId)) {
-      this.deps.onLastRuntimeSessionReleased(session.runtimeId);
-    }
-    return session;
+    return this.clearSessionState(externalSessionId);
   }
 
   releaseRuntime(runtimeId: string): CodexSessionState[] {
@@ -72,14 +67,5 @@ export class CodexLocalSessionState implements CodexSessionLookup {
     this.deps.subagents.clearSession(externalSessionId, session?.runtimeId);
     this.deps.runtimeEvents.clearSession(externalSessionId, session?.runtimeId);
     return session;
-  }
-
-  hasRuntimeSession(runtimeId: string): boolean {
-    for (const session of this.sessions.values()) {
-      if (session.runtimeId === runtimeId) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.ts
@@ -11,9 +11,9 @@ type CodexLocalSessionStateDeps = {
   pendingInput: { clearSession(externalSessionId: string, runtimeId?: string): void };
   subagents: { clearSession(externalSessionId: string, runtimeId?: string): void };
   threadStatusOverrides: { clear(runtimeId: string, threadId: string): void };
+  onLastRuntimeSessionReleased(runtimeId: string): void;
   runtimeEvents: {
     clearSession(externalSessionId: string, runtimeId?: string): void;
-    stopRuntimeEventSubscription(runtimeId: string): void;
   };
 };
 
@@ -41,7 +41,7 @@ export class CodexLocalSessionState implements CodexSessionLookup {
   release(externalSessionId: string): CodexSessionState | undefined {
     const session = this.clearSessionState(externalSessionId);
     if (session && !this.hasRuntimeSession(session.runtimeId)) {
-      this.deps.runtimeEvents.stopRuntimeEventSubscription(session.runtimeId);
+      this.deps.onLastRuntimeSessionReleased(session.runtimeId);
     }
     return session;
   }
@@ -57,7 +57,6 @@ export class CodexLocalSessionState implements CodexSessionLookup {
         released.push(cleared);
       }
     }
-    this.deps.runtimeEvents.stopRuntimeEventSubscription(runtimeId);
     return released;
   }
 
@@ -75,7 +74,7 @@ export class CodexLocalSessionState implements CodexSessionLookup {
     return session;
   }
 
-  private hasRuntimeSession(runtimeId: string): boolean {
+  hasRuntimeSession(runtimeId: string): boolean {
     for (const session of this.sessions.values()) {
       if (session.runtimeId === runtimeId) {
         return true;

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { CODEX_APP_SERVER_SERVER_REQUEST_METHOD } from "@openducktor/contracts";
 import type { AgentModelSelection } from "@openducktor/core";
-import { createDeferred } from "./codex-app-server-adapter.test-harness";
 import type { ActiveCodexTurn } from "./codex-app-server-shared";
 import { CodexPendingInputState } from "./codex-pending-input-state";
 import { CodexRuntimeSessionEvents } from "./codex-runtime-session-events";
@@ -18,7 +17,6 @@ const flushRuntimeEvents = async (): Promise<void> => {
 };
 
 const runtimeEventReceivedAt = "2026-07-06T12:00:00.000Z";
-const expectedContextUsageReplayTimeoutMs = 10_000;
 
 type RuntimeEventInput = {
   runtimeId: string;
@@ -48,54 +46,6 @@ const createRuntimeEvents = (
     flushQueuedUserMessagesLater: () => undefined,
     ...overrides,
   });
-
-type FakeScheduledTimeout = {
-  callback: () => void;
-  cleared: boolean;
-  timeoutMs: number;
-};
-
-const createFakeTimeoutScheduler = () => {
-  const clearedTimeouts: FakeScheduledTimeout[] = [];
-  const timeouts: FakeScheduledTimeout[] = [];
-  const scheduledWaiters = new Map<number, ReturnType<typeof createDeferred<void>>>();
-  const scheduler = {
-    clearTimeout(handle: unknown): void {
-      const timeout = handle as FakeScheduledTimeout;
-      timeout.cleared = true;
-      clearedTimeouts.push(timeout);
-    },
-    setTimeout(callback: () => void, timeoutMs: number): FakeScheduledTimeout {
-      const timeout = { callback, cleared: false, timeoutMs };
-      timeouts.push(timeout);
-      scheduledWaiters.get(timeouts.length)?.resolve(undefined);
-      return timeout;
-    },
-  };
-  const waitForScheduledCount = (count: number): Promise<void> => {
-    if (timeouts.length >= count) {
-      return Promise.resolve();
-    }
-    const waiter = createDeferred<void>();
-    scheduledWaiters.set(count, waiter);
-    return waiter.promise;
-  };
-
-  return {
-    runTimeout(index: number): void {
-      const timeout = timeouts[index];
-      if (!timeout || timeout.cleared) {
-        throw new Error(`Context usage replay timeout ${index} is unavailable.`);
-      }
-      timeout.cleared = true;
-      timeout.callback();
-    },
-    clearedTimeouts,
-    scheduler,
-    timeouts,
-    waitForScheduledCount,
-  };
-};
 
 const model = { providerId: "openai", modelId: "gpt-5", variant: "medium" } as const;
 
@@ -560,129 +510,59 @@ describe("CodexRuntimeSessionEvents", () => {
     });
   });
 
-  test("waits only for context usage from the matching runtime and thread", async () => {
-    const listeners = new Map<string, RuntimeListener>();
-    let processedMutation = createDeferred<void>();
-    const runtimeEvents = createRuntimeEvents({
-      subscribeEvents: (runtimeId, next) => {
-        listeners.set(runtimeId, (event) => next(withRuntimeReceivedAt(event)));
-        return () => undefined;
-      },
-      onLiveSessionMutation: () => {
-        processedMutation.resolve(undefined);
-      },
-    });
-    const emitUsageAndWait = async (
-      runtimeId: string,
-      threadId: string,
-      totalTokens: number,
-    ): Promise<void> => {
-      const currentMutation = processedMutation;
-      listeners.get(runtimeId)?.({
-        runtimeId,
-        kind: "notification",
-        message: {
-          method: "thread/tokenUsage/updated",
-          params: {
-            threadId,
-            turnId: `${threadId}-turn`,
-            tokenUsage: {
-              total: { totalTokens },
-              last: { totalTokens },
-              modelContextWindow: 200_000,
-            },
-          },
-        },
-      });
-      await currentMutation.promise;
-      processedMutation = createDeferred<void>();
-    };
+  test("returns null after a successful resume with no retained usage", async () => {
+    const runtimeEvents = createRuntimeEvents();
 
-    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
-    await runtimeEvents.ensureRuntimeEventSubscription("runtime-2");
-    const loading = runtimeEvents.loadSessionContextUsage(
-      "runtime-1",
-      "thread-target",
-      async () => undefined,
-    );
-    const outcome = loading.then(
-      (usage) => ({ status: "resolved" as const, usage }),
-      (error: unknown) => ({ status: "rejected" as const, error }),
-    );
-
-    await emitUsageAndWait("runtime-1", "thread-other", 100);
-    await emitUsageAndWait("runtime-2", "thread-target", 200);
-    expect(runtimeEvents.latestContextUsage("runtime-1", "thread-target")).toBeNull();
-
-    await emitUsageAndWait("runtime-1", "thread-target", 300);
-    await expect(outcome).resolves.toEqual({
-      status: "resolved",
-      usage: { totalTokens: 300, contextWindow: 200_000 },
-    });
+    await expect(
+      runtimeEvents.loadSessionContextUsage("runtime-1", "thread-target", async () => undefined),
+    ).resolves.toBeNull();
   });
 
-  test("fails a successful resume with no usage replay and allows an explicit retry", async () => {
+  test("records a malformed token notification as a stream fault without changing usage", async () => {
     let listener: RuntimeListener | null = null;
-    const replayScheduler = createFakeTimeoutScheduler();
+    const mutations: Array<{ fault?: string }> = [];
     const runtimeEvents = createRuntimeEvents({
       subscribeEvents: (_runtimeId, next) => {
         listener = (event) => next(withRuntimeReceivedAt(event));
         return () => undefined;
       },
-      contextUsageReplayScheduler: replayScheduler.scheduler,
+      onLiveSessionMutation: (mutation) => mutations.push(mutation),
     });
-    let resumeAttempts = 0;
-    const resumeWithTurns = async (): Promise<void> => {
-      resumeAttempts += 1;
-    };
 
     await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
-    const firstAttempt = runtimeEvents.loadSessionContextUsage(
-      "runtime-1",
-      "thread-target",
-      resumeWithTurns,
-    );
-    const concurrentAttempt = runtimeEvents.loadSessionContextUsage(
-      "runtime-1",
-      "thread-target",
-      resumeWithTurns,
-    );
-    expect(concurrentAttempt).toBe(firstAttempt);
-    const firstAttemptOutcomes = Promise.all(
-      [firstAttempt, concurrentAttempt].map((attempt) =>
-        attempt.then(
-          (usage) => ({ status: "resolved" as const, usage }),
-          (error: unknown) => ({ status: "rejected" as const, error }),
-        ),
-      ),
-    );
-    await replayScheduler.waitForScheduledCount(1);
-    expect(resumeAttempts).toBe(1);
-    expect(replayScheduler.timeouts[0]?.timeoutMs).toBe(expectedContextUsageReplayTimeoutMs);
-    replayScheduler.runTimeout(0);
+    listener?.({
+      runtimeId: "runtime-1",
+      kind: "notification",
+      message: {
+        method: "thread/tokenUsage/updated",
+        params: {
+          turnId: "thread-target-turn",
+          tokenUsage: {
+            total: { totalTokens: 300 },
+            last: { totalTokens: 300 },
+            modelContextWindow: 200_000,
+          },
+        },
+      },
+    });
+    await flushRuntimeEvents();
 
-    const outcomes = await firstAttemptOutcomes;
-    expect(outcomes).toHaveLength(2);
-    for (const outcome of outcomes) {
-      expect(outcome.status).toBe("rejected");
-      if (outcome.status === "rejected") {
-        expect(outcome.error).toBeInstanceOf(Error);
-        expect((outcome.error as Error).message).toContain(
-          `Timed out waiting for Codex context usage replay for runtime 'runtime-1' session 'thread-target' after ${expectedContextUsageReplayTimeoutMs}ms: thread/resume completed but no matching thread/tokenUsage/updated notification arrived.`,
-        );
-      }
-    }
-    expect(replayScheduler.timeouts[0]?.cleared).toBe(true);
-    expect(replayScheduler.clearedTimeouts).toEqual([replayScheduler.timeouts[0]]);
+    expect(runtimeEvents.latestContextUsage("runtime-1", "thread-target")).toBeNull();
+    expect(mutations.at(-1)?.fault).toContain("missing threadId");
+  });
 
-    const retry = runtimeEvents.loadSessionContextUsage(
-      "runtime-1",
-      "thread-target",
-      resumeWithTurns,
-    );
-    expect(resumeAttempts).toBe(1);
-    await replayScheduler.waitForScheduledCount(2);
-    expect(resumeAttempts).toBe(2);
+  test("retains canonical zero token usage without a stream fault", async () => {
+    let listener: RuntimeListener | null = null;
+    const mutations: Array<{ fault?: string }> = [];
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (_runtimeId, next) => {
+        listener = (event) => next(withRuntimeReceivedAt(event));
+        return () => undefined;
+      },
+      onLiveSessionMutation: (mutation) => mutations.push(mutation),
+    });
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
     listener?.({
       runtimeId: "runtime-1",
       kind: "notification",
@@ -692,17 +572,71 @@ describe("CodexRuntimeSessionEvents", () => {
           threadId: "thread-target",
           turnId: "thread-target-turn",
           tokenUsage: {
-            total: { totalTokens: 400 },
-            last: { totalTokens: 400 },
+            total: { totalTokens: 0 },
+            last: { totalTokens: 0 },
             modelContextWindow: 200_000,
           },
         },
       },
     });
+    await flushRuntimeEvents();
 
-    await expect(retry).resolves.toEqual({ totalTokens: 400, contextWindow: 200_000 });
-    expect(replayScheduler.timeouts[1]?.cleared).toBe(true);
-    expect(resumeAttempts).toBe(2);
+    expect(mutations.at(-1)?.fault).toBeUndefined();
+    expect(runtimeEvents.latestContextUsage("runtime-1", "thread-target")).toEqual({
+      totalTokens: 0,
+      contextWindow: 200_000,
+    });
+  });
+
+  test("clears context usage for only the requested runtime", async () => {
+    const listeners = new Map<string, RuntimeListener>();
+    const runtimeEvents = createRuntimeEvents({
+      subscribeEvents: (runtimeId, next) => {
+        listeners.set(runtimeId, (event) => next(withRuntimeReceivedAt(event)));
+        return () => undefined;
+      },
+    });
+    const emitUsage = (runtimeId: string, totalTokens: number): void => {
+      listeners.get(runtimeId)?.({
+        runtimeId,
+        kind: "notification",
+        message: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "shared-thread",
+            turnId: `${runtimeId}-turn`,
+            tokenUsage: {
+              total: { totalTokens },
+              last: { totalTokens },
+              modelContextWindow: 200_000,
+            },
+          },
+        },
+      });
+    };
+
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-1");
+    await runtimeEvents.ensureRuntimeEventSubscription("runtime-2");
+    emitUsage("runtime-1", 100);
+    emitUsage("runtime-2", 200);
+    await flushRuntimeEvents();
+
+    expect(runtimeEvents.latestContextUsage("runtime-1", "shared-thread")).toEqual({
+      totalTokens: 100,
+      contextWindow: 200_000,
+    });
+    expect(runtimeEvents.latestContextUsage("runtime-2", "shared-thread")).toEqual({
+      totalTokens: 200,
+      contextWindow: 200_000,
+    });
+
+    runtimeEvents.clearRuntime("runtime-1");
+
+    expect(runtimeEvents.latestContextUsage("runtime-1", "shared-thread")).toBeNull();
+    expect(runtimeEvents.latestContextUsage("runtime-2", "shared-thread")).toEqual({
+      totalTokens: 200,
+      contextWindow: 200_000,
+    });
   });
 
   test("routes buffered child server requests through a loaded linked parent", async () => {

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -31,11 +31,7 @@ import {
 } from "./codex-app-server-streaming";
 import type { CodexThreadStatusSnapshot } from "./codex-app-server-threads";
 import type { CodexTokenUsageTotals } from "./codex-app-server-transcript";
-import {
-  type CodexContextUsageObservation,
-  type CodexContextUsageReplayScheduler,
-  CodexContextUsageTracker,
-} from "./codex-context-usage-tracker";
+import { CodexContextUsageTracker } from "./codex-context-usage-tracker";
 
 import { createCodexEventMapperPipeline } from "./codex-event-mapper-pipeline";
 import type { CodexSessionLookup } from "./codex-local-session-state";
@@ -65,7 +61,6 @@ import type {
 type CodexRuntimeSessionEventsDeps = {
   subscribeEvents: CodexAppServerAdapterOptions["subscribeEvents"];
   respondServerRequest: CodexAppServerAdapterOptions["respondServerRequest"];
-  contextUsageReplayScheduler?: CodexContextUsageReplayScheduler;
   onLiveSessionMutation?: (mutation: CodexRuntimeLiveSessionMutation) => void | Promise<void>;
   onCatalogInvalidated?: CodexAppServerAdapterOptions["onCatalogInvalidated"];
   sessions: CodexSessionLookup;
@@ -142,10 +137,7 @@ export class CodexRuntimeSessionEvents {
       createCodexEventMappers(deps.subagents),
     );
     this.runtimeEventSubscriptions = new CodexRuntimeEventSubscriptions(deps.subscribeEvents);
-    this.contextUsage = new CodexContextUsageTracker(
-      (runtimeId) => this.waitForRuntimeEventBarrier(runtimeId),
-      deps.contextUsageReplayScheduler,
-    );
+    this.contextUsage = new CodexContextUsageTracker();
     this.subagentLifecycle = new CodexSubagentLifecycleProjector({
       sessions: deps.sessions,
       subagents: deps.subagents,
@@ -167,10 +159,7 @@ export class CodexRuntimeSessionEvents {
     try {
       this.runtimeEventSubscriptions.stop(runtimeId);
     } finally {
-      this.contextUsage.releaseRuntime(
-        runtimeId,
-        new Error(`Codex runtime '${runtimeId}' stopped while context usage was loading.`),
-      );
+      this.contextUsage.clearRuntime(runtimeId);
     }
   }
 
@@ -208,16 +197,15 @@ export class CodexRuntimeSessionEvents {
     runtimeId: string,
     threadId: string,
     resumeWithTurns: () => Promise<void>,
-  ): Promise<CodexSessionContextUsage> {
+  ): Promise<CodexSessionContextUsage | null> {
     return this.contextUsage.load(runtimeId, threadId, resumeWithTurns);
   }
 
   private enqueueRuntimeStreamEvent(event: CodexRuntimeStreamEvent): void {
-    const contextUsageObservation = this.contextUsage.reserveObservation(event);
     const previous =
       this.runtimeEventProcessingByRuntimeId.get(event.runtimeId) ?? Promise.resolve();
     const processing = previous
-      .then(() => this.processRuntimeStreamEventMutation(event, contextUsageObservation))
+      .then(() => this.processRuntimeStreamEventMutation(event))
       .catch((error) => this.emitRuntimeStreamEventError(event, error));
     this.runtimeEventProcessingByRuntimeId.set(event.runtimeId, processing);
     void processing.finally(() => {
@@ -227,10 +215,7 @@ export class CodexRuntimeSessionEvents {
     });
   }
 
-  private async processRuntimeStreamEventMutation(
-    event: CodexRuntimeStreamEvent,
-    contextUsageObservation: CodexContextUsageObservation | null,
-  ): Promise<void> {
+  private async processRuntimeStreamEventMutation(event: CodexRuntimeStreamEvent): Promise<void> {
     const mutation: CodexRuntimeLiveSessionMutation = {
       runtimeId: event.runtimeId,
       transcriptEvents: [],
@@ -239,7 +224,7 @@ export class CodexRuntimeSessionEvents {
     this.activeMutationByRuntimeId.set(event.runtimeId, mutation);
     try {
       try {
-        await this.handleRuntimeStreamEvent(event, contextUsageObservation);
+        await this.handleRuntimeStreamEvent(event);
       } catch (error) {
         mutation.fault = this.errorMessage(error);
         this.emitRuntimeStreamEventError(event, error);
@@ -253,10 +238,6 @@ export class CodexRuntimeSessionEvents {
         this.activeMutationByRuntimeId.delete(event.runtimeId);
       }
     }
-  }
-
-  private waitForRuntimeEventBarrier(runtimeId: string): Promise<void> {
-    return this.runtimeEventProcessingByRuntimeId.get(runtimeId) ?? Promise.resolve();
   }
 
   latestTodos(externalSessionId: string): AgentSessionTodoItem[] | undefined {
@@ -399,13 +380,17 @@ export class CodexRuntimeSessionEvents {
     this.emitSessionError(externalSessionId, error);
   }
 
-  private async handleRuntimeStreamEvent(
-    event: CodexRuntimeStreamEvent,
-    contextUsageObservation: CodexContextUsageObservation | null,
-  ): Promise<void> {
+  private async handleRuntimeStreamEvent(event: CodexRuntimeStreamEvent): Promise<void> {
     this.assertRuntimeStreamEventReceivedAt(event);
     if (event.kind === "notification") {
       this.observeCatalogInvalidation(event.runtimeId, event.message);
+    }
+    const notification =
+      event.kind === "notification"
+        ? parseNotificationRecord(event.message, event.receivedAt)
+        : null;
+    if (notification?.method === "thread/tokenUsage/updated") {
+      this.contextUsage.observeNotification(event.runtimeId, notification);
     }
     const threadId = threadIdFromRuntimeStreamEvent(event);
     if (!threadId) {
@@ -414,13 +399,9 @@ export class CodexRuntimeSessionEvents {
       }
       return;
     }
-    if (event.kind === "notification") {
-      const notification = parseNotificationRecord(event.message, event.receivedAt);
-      this.contextUsage.observeNotification(event.runtimeId, notification, contextUsageObservation);
-      if (notification.method === "serverRequest/resolved") {
-        this.handleServerRequestResolvedNotification(event.runtimeId, notification);
-        return;
-      }
+    if (notification?.method === "serverRequest/resolved") {
+      this.handleServerRequestResolvedNotification(event.runtimeId, notification);
+      return;
     }
     const session = this.deps.sessions.get(threadId);
     if (!session) {
@@ -447,10 +428,9 @@ export class CodexRuntimeSessionEvents {
           `Cannot route Codex server request for thread '${threadId}' because no retained session or subagent route exists.`,
         );
       }
-      this.subagentLifecycle.projectNotification(
-        event.runtimeId,
-        parseNotificationRecord(event.message, event.receivedAt),
-      );
+      if (notification) {
+        this.subagentLifecycle.projectNotification(event.runtimeId, notification);
+      }
       if (route && parentSession) {
         if (parentSession.runtimeId !== event.runtimeId) {
           throw new Error(
@@ -472,11 +452,8 @@ export class CodexRuntimeSessionEvents {
       }
       return;
     }
-    if (event.kind === "notification") {
-      this.subagentLifecycle.projectNotification(
-        event.runtimeId,
-        parseNotificationRecord(event.message, event.receivedAt),
-      );
+    if (notification) {
+      this.subagentLifecycle.projectNotification(event.runtimeId, notification);
     }
     await this.processRuntimeStreamEventForSession(session, event);
   }

--- a/packages/host/src/adapters/agent-sessions/codex-live-session-adapter.test.ts
+++ b/packages/host/src/adapters/agent-sessions/codex-live-session-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type {
   CodexAppServerAdapter,
   CodexAppServerAdapterOptions,
+  CodexSessionContextUsage,
 } from "@openducktor/adapters-codex-app-server";
 import {
   type AgentSessionLiveSnapshot,
@@ -94,10 +95,19 @@ const createLifecycle = (changes: AgentSessionLiveAdapterChange[]) =>
       ),
   }) satisfies RuntimeLiveSessionLifecyclePort;
 
-const createControllerHarness = (
-  initialSnapshots: AgentSessionLiveSnapshot[] = [liveSnapshot()],
-  releaseRuntime: () => void = () => undefined,
-) => {
+type ControllerHarnessOptions = {
+  initialSnapshots?: AgentSessionLiveSnapshot[];
+  releaseRuntime?: () => void;
+  liveContextUsage?: CodexSessionContextUsage | null;
+  persistedContextUsage?: CodexSessionContextUsage | null;
+};
+
+const createControllerHarness = ({
+  initialSnapshots = [liveSnapshot()],
+  releaseRuntime = () => undefined,
+  liveContextUsage = { totalTokens: 123, contextWindow: 1_000 },
+  persistedContextUsage = { totalTokens: 456, contextWindow: 2_000 },
+}: ControllerHarnessOptions = {}) => {
   let options: CodexAppServerAdapterOptions | null = null;
   let snapshots = initialSnapshots;
   const rawEvents: unknown[] = [];
@@ -128,7 +138,7 @@ const createControllerHarness = (
         listLiveSessionSnapshots: () => snapshots,
         loadLiveSessionContextUsage: async (input: unknown) => {
           liveContextLoads.push(input);
-          const usage = { totalTokens: 123, contextWindow: 1_000 };
+          const usage = liveContextUsage;
           const snapshot = snapshots[0];
           if (!snapshot) {
             throw new Error("Expected a retained Codex snapshot before loading context.");
@@ -140,7 +150,7 @@ const createControllerHarness = (
           input: Parameters<CodexAppServerAdapter["loadSessionContextUsage"]>[0],
         ) => {
           policyBoundContextLoads.push(input);
-          const usage = { totalTokens: 456, contextWindow: 2_000 };
+          const usage = persistedContextUsage;
           snapshots = [
             {
               ...liveSnapshot(),
@@ -423,8 +433,11 @@ describe("createCodexLiveSessionAdapterPreparer", () => {
 
   test("clears the retained projection when controller cleanup fails", async () => {
     const changes: AgentSessionLiveAdapterChange[] = [];
-    const harness = createControllerHarness([liveSnapshot()], () => {
-      throw new Error("controller cleanup failed");
+    const harness = createControllerHarness({
+      initialSnapshots: [liveSnapshot()],
+      releaseRuntime: () => {
+        throw new Error("controller cleanup failed");
+      },
     });
     const prepared = await Effect.runPromise(
       createCodexLiveSessionAdapterPreparer({
@@ -472,7 +485,7 @@ describe("createCodexLiveSessionAdapterPreparer", () => {
       adapterRegistry: createLiveSessionAdapterRegistry(),
       publish: (event) => events.push(event),
     });
-    const harness = createControllerHarness(snapshots);
+    const harness = createControllerHarness({ initialSnapshots: snapshots });
     const prepared = await Effect.runPromise(
       createCodexLiveSessionAdapterPreparer({
         liveSessionLifecycle: service,
@@ -684,9 +697,33 @@ describe("createCodexLiveSessionAdapterPreparer", () => {
     ).resolves.toEqual([]);
   });
 
+  test("returns nullable Codex context usage through the public host adapter", async () => {
+    const harness = createControllerHarness({
+      initialSnapshots: [liveSnapshot()],
+      liveContextUsage: null,
+    });
+    const prepared = await Effect.runPromise(
+      createCodexLiveSessionAdapterPreparer({
+        liveSessionLifecycle: createLifecycle([]),
+        codexAppServer,
+        resolveRuntimePolicy,
+        createController: harness.createController,
+      })(runtime),
+    );
+    await Effect.runPromise(prepared.startForwarding());
+    await harness.getOptions().onLiveSessionMutation?.({
+      runtimeId: "runtime-1",
+      snapshots: [liveSnapshot()],
+      transcriptEvents: [],
+      catalogInvalidated: false,
+    });
+    await expect(Effect.runPromise(prepared.adapter.loadContext({ ...ref }))).resolves.toBeNull();
+    expect(harness.liveContextLoads).toHaveLength(1);
+  });
+
   test("loads an unmatched persisted session with host-resolved workflow policy", async () => {
     const changes: AgentSessionLiveAdapterChange[] = [];
-    const harness = createControllerHarness([]);
+    const harness = createControllerHarness({ initialSnapshots: [] });
     const policyScopes: AgentSessionWorkflowScope[] = [];
     const qaPolicy: CodexEffectivePolicy = {
       ...codexPolicy,
@@ -733,8 +770,45 @@ describe("createCodexLiveSessionAdapterPreparer", () => {
     });
   });
 
+  test("returns nullable context for an unmatched persisted session", async () => {
+    const changes: AgentSessionLiveAdapterChange[] = [];
+    const harness = createControllerHarness({
+      initialSnapshots: [],
+      persistedContextUsage: null,
+    });
+    const prepared = await Effect.runPromise(
+      createCodexLiveSessionAdapterPreparer({
+        liveSessionLifecycle: createLifecycle(changes),
+        codexAppServer,
+        resolveRuntimePolicy,
+        createController: harness.createController,
+      })(runtime),
+    );
+    await Effect.runPromise(prepared.startForwarding());
+    const persistedRef = {
+      ...ref,
+      externalSessionId: "persisted-thread",
+      sessionScope: { kind: "workflow", taskId: "task-1", role: "build" } as const,
+    };
+    await expect(Effect.runPromise(prepared.adapter.loadContext(persistedRef))).resolves.toBeNull();
+    expect(harness.liveContextLoads).toEqual([]);
+    expect(harness.policyBoundContextLoads).toEqual([
+      expect.objectContaining({
+        ...persistedRef,
+        runtimePolicy: { kind: "codex", policy: codexPolicy },
+      }),
+    ]);
+    expect(changes.at(-1)).toMatchObject({
+      type: "session_upsert",
+      snapshot: {
+        ref: expect.objectContaining({ externalSessionId: "persisted-thread" }),
+        contextUsage: null,
+      },
+    });
+  });
+
   test("rejects an unmatched context load without workflow scope", async () => {
-    const harness = createControllerHarness([]);
+    const harness = createControllerHarness({ initialSnapshots: [] });
     const prepared = await Effect.runPromise(
       createCodexLiveSessionAdapterPreparer({
         liveSessionLifecycle: createLifecycle([]),

--- a/packages/host/src/adapters/agent-sessions/codex-live-session-adapter.ts
+++ b/packages/host/src/adapters/agent-sessions/codex-live-session-adapter.ts
@@ -5,13 +5,12 @@ import {
   type CodexLiveSessionMutation,
 } from "@openducktor/adapters-codex-app-server";
 import {
-  type AgentSessionContextUsage,
   type AgentSessionControlSummary,
   type AgentSessionLiveRef,
   type AgentSessionWorkflowScope,
   acceptedAgentUserMessageSchema,
-  agentSessionContextUsageSchema,
   agentSessionControlSummarySchema,
+  agentSessionLiveLoadContextResultSchema,
   type CodexEffectivePolicy,
   type RuntimeInstanceSummary,
 } from "@openducktor/contracts";
@@ -352,8 +351,8 @@ export const createCodexLiveSessionAdapterPreparer =
                     ),
                   });
                 });
-            const normalized = yield* parseOutput<AgentSessionContextUsage>(
-              agentSessionContextUsageSchema,
+            const normalized = yield* parseOutput(
+              agentSessionLiveLoadContextResultSchema,
               usage,
               "codex-live-session.normalize-context",
             );


### PR DESCRIPTION
## Summary
- stop treating context-usage replay as a required `thread/resume` dependency and return retained usage or `null` immediately
- propagate delayed usage through the live session stream, preserve protocol-valid zero usage, and surface malformed usage notifications as faults
- prevent released sessions from being resurrected across resolve, prepare, and resume boundaries with bounded in-flight guards
- carry nullable context usage through the host adapter and expand regression coverage for release races and runtime isolation

## Goal
Allow Codex sessions to resume when the app server does not immediately replay context usage, while retaining eventual live usage updates and fail-fast protocol validation.

## Technical choices
- model replayed context usage as optional runtime state rather than introducing retries, polling, or fallback paths
- keep delayed updates on the existing live event stream
- remove in-flight guards before fallible cleanup so release remains terminal
- retain zero-token snapshots because they are valid protocol data

## Verification
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`

No Cargo workspace is present, so Cargo checks are not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session context-usage loading: missing or idle usage now resolves cleanly to `null`/empty instead of failing.
  * Prevented duplicate concurrent (and reentrant) context-usage load requests, with successful retries after prior failures.
  * Updated live session snapshots so token-usage totals are applied correctly when usage events arrive during or after a resume.
  * Safely cancels in-progress context-usage loads when sessions/runtimes are released or stopped, including in-flight cancellation when nothing is yet retained.
  * Added strict handling for token-usage updates: canonical zero usage is accepted, while malformed updates trigger a stream fault without updating stored usage.
  * Runtime stream subscriptions now remain active through session release and are only stopped when the runtime is released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->