### PR TITLE
refactor(frontend): use external IDs in Agent Studio routes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -821,7 +821,7 @@
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
@@ -1205,7 +1205,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -1661,7 +1661,7 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
-    "tar": ["tar@7.5.15", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ=="],
+    "tar": ["tar@7.5.20", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ=="],
 
     "temp": ["temp@0.9.4", "", { "dependencies": { "mkdirp": "^0.5.1", "rimraf": "~2.6.2" } }, "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA=="],
 
@@ -1945,9 +1945,9 @@
 
     "@develar/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
-    "@electron/asar/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+    "@electron/asar/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
 
-    "@electron/universal/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+    "@electron/universal/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -2045,7 +2045,7 @@
 
     "cmdk/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+    "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
 
     "dmg-license/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -2079,11 +2079,11 @@
 
     "electron/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+    "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
 
     "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 

--- a/packages/frontend/src/components/layout/sidebar/agent-activity-card.test.tsx
+++ b/packages/frontend/src/components/layout/sidebar/agent-activity-card.test.tsx
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { AgentActivityCard } from "./agent-activity-card";
 
 const activeSession = {
@@ -30,7 +29,7 @@ const waitingSession = {
 const expectedSessionHref = (session: typeof activeSession | typeof waitingSession): string => {
   const params = new URLSearchParams({
     task: session.taskId,
-    session: agentSessionIdentityKey(session),
+    session: session.externalSessionId,
     agent: session.role,
   });
   return `/agents?${params.toString()}`.replaceAll("&", "&amp;");

--- a/packages/frontend/src/components/layout/sidebar/agent-activity-card.tsx
+++ b/packages/frontend/src/components/layout/sidebar/agent-activity-card.tsx
@@ -15,7 +15,7 @@ type AgentActivityCardProps = {
 const toSessionHref = (session: AgentActivitySessionItem): string => {
   const params = new URLSearchParams({
     task: session.taskId,
-    session: agentSessionIdentityKey(session),
+    session: session.externalSessionId,
     agent: session.role,
   });
   return `/agents?${params.toString()}`;

--- a/packages/frontend/src/components/layout/sidebar/agent-activity-card.tsx
+++ b/packages/frontend/src/components/layout/sidebar/agent-activity-card.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from "react";
 import { Link } from "react-router-dom";
 import { formatAgentSessionActivityStateLabel } from "@/lib/agent-session-activity-state";
 import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
+import { buildAgentStudioHref } from "@/pages/agents/query-sync/agent-studio-navigation";
 import type { AgentActivitySessionItem } from "@/state/read-models/agent-activity-read-model";
 
 type AgentActivityCardProps = {
@@ -10,15 +11,6 @@ type AgentActivityCardProps = {
   waitingForInputCount: number;
   activeSessions: AgentActivitySessionItem[];
   waitingForInputSessions: AgentActivitySessionItem[];
-};
-
-const toSessionHref = (session: AgentActivitySessionItem): string => {
-  const params = new URLSearchParams({
-    task: session.taskId,
-    session: session.externalSessionId,
-    agent: session.role,
-  });
-  return `/agents?${params.toString()}`;
 };
 
 function SessionList({
@@ -33,7 +25,11 @@ function SessionList({
       {sessions.map((session) => (
         <li key={agentSessionIdentityKey(session)}>
           <Link
-            to={toSessionHref(session)}
+            to={buildAgentStudioHref({
+              taskId: session.taskId,
+              sessionExternalId: session.externalSessionId,
+              role: session.role,
+            })}
             className="block rounded-md border border-border bg-card px-2 py-1.5 hover:border-input hover:bg-accent"
           >
             <p className="truncate text-xs font-medium text-foreground">{session.taskTitle}</p>

--- a/packages/frontend/src/pages/agents/agent-studio-navigation-state.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-navigation-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import {
+  failedAgentSessionReadModelLoadState,
   loadingAgentSessionReadModelLoadState,
   readyAgentSessionReadModelLoadState,
 } from "@/types/agent-session-read-model";
@@ -8,6 +8,7 @@ import { resolveAgentStudioNavigationState } from "./agent-studio-navigation-sta
 import { createAgentSessionSummaryFixture, createTaskCardFixture } from "./agent-studio-test-utils";
 import {
   createAgentStudioRouteSelectionState,
+  toAgentStudioSessionSelection,
   toAgentStudioTaskSelection,
 } from "./shell/agent-studio-selection-state";
 
@@ -19,8 +20,9 @@ const createSession = (taskId: string, externalSessionId: string) =>
     taskId,
   });
 
-const sessionKeyParam = (session: ReturnType<typeof createAgentSessionSummaryFixture>): string =>
-  agentSessionIdentityKey(session);
+const sessionExternalIdParam = (
+  session: ReturnType<typeof createAgentSessionSummaryFixture>,
+): string => session.externalSessionId;
 
 const createNavigationState = (
   overrides: Partial<Parameters<typeof resolveAgentStudioNavigationState>[0]> = {},
@@ -32,7 +34,7 @@ const createNavigationState = (
     tasks: [createTask("task-1")],
     sessions: [],
     taskIdParam: "task-1",
-    sessionKeyParam: null,
+    sessionExternalIdParam: null,
     hasExplicitRoleParam: false,
     roleFromQuery: "spec" as const,
     activeTaskTabId: "",
@@ -45,7 +47,7 @@ const createNavigationState = (
       createAgentStudioRouteSelectionState({
         isRepoNavigationBoundaryPending: base.isRepoNavigationBoundaryPending,
         taskIdParam: base.taskIdParam,
-        sessionKeyParam: base.sessionKeyParam,
+        sessionExternalIdParam: base.sessionExternalIdParam,
         hasExplicitRoleParam: base.hasExplicitRoleParam,
         roleFromQuery: base.roleFromQuery,
       }),
@@ -66,54 +68,82 @@ describe("resolveAgentStudioNavigationState", () => {
     });
   });
 
-  test("backfills missing task param from selected session", () => {
+  test("does not resolve an external session id without its task id", () => {
     const selectedSession = createSession("task-2", "session-2");
 
-    expect(
-      createNavigationState({
-        tasks: [createTask("task-1"), createTask("task-2")],
-        sessions: [selectedSession],
-        taskIdParam: "",
-        sessionKeyParam: sessionKeyParam(selectedSession),
-      }).queryUpdate,
-    ).toEqual({ task: "task-2" });
+    const state = createNavigationState({
+      tasks: [createTask("task-1"), createTask("task-2")],
+      sessions: [selectedSession],
+      taskIdParam: "",
+      sessionExternalIdParam: sessionExternalIdParam(selectedSession),
+    });
+
+    expect(state.routeSessionResolution).toEqual({
+      kind: "missing",
+      sessionExternalId: selectedSession.externalSessionId,
+    });
+    expect(state.queryUpdate).toBeNull();
   });
 
   test("does not clear a session deep link before the session catalog can resolve it", () => {
-    expect(
-      createNavigationState({
-        tasks: [createTask("task-1")],
-        taskIdParam: "missing-task",
-        sessionKeyParam: "session-2",
-        sessionReadModelLoadState: loadingAgentSessionReadModelLoadState("/repo"),
-      }).queryUpdate,
-    ).toBeNull();
+    const state = createNavigationState({
+      tasks: [createTask("task-1")],
+      taskIdParam: "missing-task",
+      sessionExternalIdParam: "session-2",
+      sessionReadModelLoadState: loadingAgentSessionReadModelLoadState("/repo"),
+    });
+    expect(state.routeSessionResolution).toEqual({
+      kind: "pending",
+      sessionExternalId: "session-2",
+    });
+    expect(state.queryUpdate).toBeNull();
   });
 
-  test("clears stale session selection for an existing reset task", () => {
-    expect(
-      createNavigationState({
-        tasks: [createTask("task-1")],
-        taskIdParam: "task-1",
-        sessionKeyParam: "removed-session",
-      }).queryUpdate,
-    ).toEqual({ session: undefined });
+  test("keeps a matching session pending until task session metadata is ready", () => {
+    const session = createSession("task-1", "session-1");
+    const state = createNavigationState({
+      sessions: [session],
+      sessionExternalIdParam: session.externalSessionId,
+      sessionReadModelLoadState: loadingAgentSessionReadModelLoadState("/repo"),
+    });
+
+    expect(state.routeSessionResolution).toEqual({
+      kind: "pending",
+      sessionExternalId: session.externalSessionId,
+    });
+    expect(state.view.sessionIdentity).toBeNull();
   });
 
-  test("corrects the task when a resolved session belongs to another task", () => {
+  test("keeps a missing explicit session selected without default fallback", () => {
+    const state = createNavigationState({
+      tasks: [createTask("task-1")],
+      taskIdParam: "task-1",
+      sessionExternalIdParam: "removed-session",
+    });
+
+    expect(state.routeSessionResolution).toEqual({
+      kind: "missing",
+      sessionExternalId: "removed-session",
+    });
+    expect(state.view.sessionIdentity).toBeNull();
+    expect(state.queryUpdate).toBeNull();
+  });
+
+  test("does not resolve an external session id against another task", () => {
     const selectedSession = createSession("task-2", "session-2");
 
-    expect(
-      createNavigationState({
-        tasks: [createTask("task-1"), createTask("task-2")],
-        sessions: [selectedSession],
-        taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(selectedSession),
-      }).queryUpdate,
-    ).toEqual({ task: "task-2" });
+    const state = createNavigationState({
+      tasks: [createTask("task-1"), createTask("task-2")],
+      sessions: [selectedSession],
+      taskIdParam: "task-1",
+      sessionExternalIdParam: sessionExternalIdParam(selectedSession),
+    });
+
+    expect(state.routeSessionResolution.kind).toBe("missing");
+    expect(state.queryUpdate).toBeNull();
   });
 
-  test("aligns missing task and stale role in one query update", () => {
+  test("aligns a stale role with the resolved task session", () => {
     const resolvedSession = createAgentSessionSummaryFixture({
       runtimeKind: "opencode",
       externalSessionId: "ext-session-1",
@@ -123,15 +153,63 @@ describe("resolveAgentStudioNavigationState", () => {
 
     expect(
       createNavigationState({
-        taskIdParam: "",
-        sessionKeyParam: sessionKeyParam(resolvedSession),
+        taskIdParam: "task-1",
+        sessionExternalIdParam: sessionExternalIdParam(resolvedSession),
         sessions: [resolvedSession],
         roleFromQuery: "spec",
       }).queryUpdate,
     ).toEqual({
-      task: "task-1",
       agent: "planner",
     });
+  });
+
+  test("derives full runtime identity from the matching task session summary", () => {
+    const resolvedSession = createAgentSessionSummaryFixture({
+      runtimeKind: "codex",
+      externalSessionId: "session-1",
+      taskId: "task-1",
+      role: "build",
+      workingDirectory: "/repo/worktrees/authoritative",
+    });
+    const state = createNavigationState({
+      sessions: [resolvedSession],
+      taskIdParam: "task-1",
+      sessionExternalIdParam: "session-1",
+      hasExplicitRoleParam: true,
+      roleFromQuery: "build",
+      selectionState: toAgentStudioSessionSelection({
+        externalSessionId: "session-1",
+        runtimeKind: "opencode",
+        workingDirectory: "/repo/worktrees/stale",
+        taskId: "task-1",
+        role: "build",
+      }),
+    });
+
+    expect(state.view.sessionIdentity).toEqual({
+      externalSessionId: "session-1",
+      runtimeKind: "codex",
+      workingDirectory: "/repo/worktrees/authoritative",
+    });
+  });
+
+  test("surfaces session read-model failure for an explicit session", () => {
+    const state = createNavigationState({
+      taskIdParam: "task-1",
+      sessionExternalIdParam: "session-1",
+      sessionReadModelLoadState: failedAgentSessionReadModelLoadState(
+        "/repo",
+        "Failed to load task session metadata",
+      ),
+    });
+
+    expect(state.routeSessionResolution).toEqual({
+      kind: "failed",
+      sessionExternalId: "session-1",
+      message: "Failed to load task session metadata",
+    });
+    expect(state.view.sessionIdentity).toBeNull();
+    expect(state.queryUpdate).toBeNull();
   });
 
   test("does not repair the URL while local tab selection is ahead of route persistence", () => {
@@ -142,7 +220,7 @@ describe("resolveAgentStudioNavigationState", () => {
         tasks: [createTask("task-1"), createTask("task-2")],
         sessions: [routeSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(routeSession),
+        sessionExternalIdParam: sessionExternalIdParam(routeSession),
         hasExplicitRoleParam: true,
         roleFromQuery: "spec",
         selectionState: toAgentStudioTaskSelection("task-2"),

--- a/packages/frontend/src/pages/agents/agent-studio-navigation-state.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-navigation-state.ts
@@ -1,16 +1,14 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
+import { agentSessionIdentityKey, toAgentSessionIdentity } from "@/lib/agent-session-identity";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import type { AgentSessionReadModelLoadState } from "@/types/agent-session-read-model";
 import {
   type AgentStudioRouteSessionResolution,
-  findAgentStudioSessionSummaryByKey,
   groupSessionsByTaskId,
   resolveAgentStudioRouteSession,
   resolveAgentStudioSessionSelection,
-  resolveAgentStudioTaskId,
 } from "./agents-page-selection";
 import {
   AGENT_STUDIO_QUERY_KEYS,
@@ -19,7 +17,7 @@ import {
 import {
   type AgentStudioSelectionState,
   agentStudioSelectionQueryKey,
-  agentStudioSelectionSessionKey,
+  agentStudioSelectionSessionExternalId,
   createAgentStudioRouteSelectionState,
 } from "./shell/agent-studio-selection-state";
 
@@ -27,7 +25,7 @@ export type AgentStudioNavigationViewSelection = {
   taskId: string;
   selectedTask: TaskCard | null;
   sessionsForTask: AgentSessionSummary[];
-  sessionKey: string | null;
+  sessionExternalId: string | null;
   sessionIdentity: AgentSessionIdentity | null;
   role: AgentRole;
   hasExplicitRoleSelection: boolean;
@@ -53,7 +51,7 @@ export type ResolveAgentStudioNavigationStateArgs = {
   tasks: TaskCard[];
   sessions: AgentSessionSummary[];
   taskIdParam: string;
-  sessionKeyParam: string | null;
+  sessionExternalIdParam: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
   selectionState: AgentStudioSelectionState;
@@ -67,7 +65,7 @@ export const resolveAgentStudioNavigationState = ({
   tasks,
   sessions,
   taskIdParam,
-  sessionKeyParam,
+  sessionExternalIdParam,
   hasExplicitRoleParam,
   roleFromQuery,
   selectionState,
@@ -80,30 +78,29 @@ export const resolveAgentStudioNavigationState = ({
     isLoadingTasks,
     sessionReadModelLoadState,
     sessions,
-    sessionKey: sessionKeyParam,
+    taskId: taskIdParam,
+    sessionExternalId: sessionExternalIdParam,
   });
   const selectedSessionFromRoute =
     routeSessionResolution.kind === "found" ? routeSessionResolution.session : null;
-  const selectedSessionFromSelection = findAgentStudioSessionSummaryByKey(
-    sessions,
-    agentStudioSelectionSessionKey(selectionState),
-  );
-  const taskId = resolveAgentStudioTaskId({
-    taskIdParam: selectionState.taskId,
-    selectedSessionFromRoute: selectedSessionFromSelection,
-  });
+  const selectionIdentity = selectionState.sessionIdentity;
+  const selectedSessionFromSelection = selectionIdentity
+    ? (sessions.find(
+        (session) =>
+          agentSessionIdentityKey(session) === agentSessionIdentityKey(selectionIdentity),
+      ) ?? null)
+    : null;
+  const taskId = selectionState.taskId;
   const selectedTask = taskId ? (tasksById.get(taskId) ?? null) : null;
   const sessionsForTask = taskId ? (sessionsByTaskId.get(taskId) ?? []) : [];
-  const routeTaskId = resolveAgentStudioTaskId({
-    taskIdParam,
-    selectedSessionFromRoute,
-  });
+  const routeTaskId = taskIdParam;
   const resolvedRouteSession = resolveRouteSession({
     isRepoNavigationBoundaryPending,
     tasksById,
     sessionsByTaskId,
     routeTaskId,
-    sessionKeyParam,
+    sessionExternalIdParam,
+    routeSessionResolution,
     hasExplicitRoleParam,
     roleFromQuery,
   });
@@ -125,9 +122,8 @@ export const resolveAgentStudioNavigationState = ({
     isLoadingTasks,
     tasks,
     taskIdParam,
-    sessionKeyParam,
+    sessionExternalIdParam,
     routeSessionResolution,
-    routeTaskId,
     resolvedSession: resolvedRouteSession,
     roleFromQuery,
     selectionState,
@@ -152,7 +148,8 @@ const resolveRouteSession = ({
   tasksById,
   sessionsByTaskId,
   routeTaskId,
-  sessionKeyParam,
+  sessionExternalIdParam,
+  routeSessionResolution,
   hasExplicitRoleParam,
   roleFromQuery,
 }: {
@@ -160,7 +157,8 @@ const resolveRouteSession = ({
   tasksById: Map<string, TaskCard>;
   sessionsByTaskId: Map<string, AgentSessionSummary[]>;
   routeTaskId: string;
-  sessionKeyParam: string | null;
+  sessionExternalIdParam: string | null;
+  routeSessionResolution: AgentStudioRouteSessionResolution;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
 }): AgentSessionSummary | null => {
@@ -168,11 +166,15 @@ const resolveRouteSession = ({
     return null;
   }
 
+  if (sessionExternalIdParam) {
+    return routeSessionResolution.kind === "found" ? routeSessionResolution.session : null;
+  }
+
   const routeSelectedTask = routeTaskId ? (tasksById.get(routeTaskId) ?? null) : null;
   const routeSessionsForTask = routeTaskId ? (sessionsByTaskId.get(routeTaskId) ?? []) : [];
   return resolveAgentStudioSessionSelection({
     sessionsForTask: routeSessionsForTask,
-    sessionKey: sessionKeyParam,
+    sessionExternalId: null,
     hasExplicitRoleParam,
     roleFromQuery,
     selectedTask: routeSelectedTask,
@@ -195,19 +197,20 @@ const resolveNavigationViewSelection = ({
   selectedViewTask: TaskCard | null;
   selectedViewSessions: AgentSessionSummary[];
 }): AgentStudioNavigationViewSelection => {
-  const selectionSessionKey = agentStudioSelectionSessionKey(selectionState);
+  const selectionSessionExternalId = agentStudioSelectionSessionExternalId(selectionState);
   const isDetachedFromSelectedTask = Boolean(
     selectedViewTaskId && selectedTaskId && selectedViewTaskId !== selectedTaskId,
   );
-  const hasMissingRouteSessionSelection =
-    routeSessionResolution.kind === "missing" &&
-    selectionSessionKey === routeSessionResolution.sessionKey;
-  const sessionKey =
-    isDetachedFromSelectedTask || hasMissingRouteSessionSelection ? null : selectionSessionKey;
-  const sessionIdentity =
-    isDetachedFromSelectedTask || hasMissingRouteSessionSelection
-      ? null
-      : selectionState.sessionIdentity;
+  const sessionExternalId = isDetachedFromSelectedTask ? null : selectionSessionExternalId;
+  const resolvedRouteSessionIdentity =
+    routeSessionResolution.kind === "found" &&
+    routeSessionResolution.session.taskId === selectionState.taskId &&
+    routeSessionResolution.session.externalSessionId === selectionSessionExternalId
+      ? toAgentSessionIdentity(routeSessionResolution.session)
+      : null;
+  const sessionIdentity = isDetachedFromSelectedTask
+    ? null
+    : (resolvedRouteSessionIdentity ?? selectionState.sessionIdentity);
   const role = isDetachedFromSelectedTask ? "spec" : selectionState.role;
   const hasExplicitRoleSelection =
     !isDetachedFromSelectedTask && selectionState.hasExplicitRoleSelection;
@@ -216,12 +219,12 @@ const resolveNavigationViewSelection = ({
     taskId: selectedViewTaskId,
     selectedTask: selectedViewTask,
     sessionsForTask: selectedViewSessions,
-    sessionKey,
+    sessionExternalId,
     sessionIdentity,
     role,
     hasExplicitRoleSelection,
     keepExplicitRoleSessionless:
-      !isDetachedFromSelectedTask && selectionState.keepSessionless && sessionKey === null,
+      !isDetachedFromSelectedTask && selectionState.keepSessionless && sessionExternalId === null,
   };
 };
 
@@ -230,9 +233,8 @@ const resolveNavigationQueryUpdate = ({
   isLoadingTasks,
   tasks,
   taskIdParam,
-  sessionKeyParam,
+  sessionExternalIdParam,
   routeSessionResolution,
-  routeTaskId,
   resolvedSession,
   roleFromQuery,
   selectionState,
@@ -242,9 +244,8 @@ const resolveNavigationQueryUpdate = ({
   isLoadingTasks: boolean;
   tasks: TaskCard[];
   taskIdParam: string;
-  sessionKeyParam: string | null;
+  sessionExternalIdParam: string | null;
   routeSessionResolution: AgentStudioRouteSessionResolution;
-  routeTaskId: string;
   resolvedSession: AgentSessionSummary | null;
   roleFromQuery: AgentRole;
   selectionState: AgentStudioSelectionState;
@@ -255,7 +256,7 @@ const resolveNavigationQueryUpdate = ({
     hasLocalSelectionAheadOfRoute({
       isRepoNavigationBoundaryPending,
       taskIdParam,
-      sessionKeyParam,
+      sessionExternalIdParam,
       hasExplicitRoleParam,
       roleFromQuery,
       selectionState,
@@ -266,12 +267,11 @@ const resolveNavigationQueryUpdate = ({
 
   const sessionFromQuery =
     routeSessionResolution.kind === "found" ? routeSessionResolution.session : null;
-  const isMissingRouteSession = routeSessionResolution.kind === "missing";
 
   if (
     !isLoadingTasks &&
     taskIdParam &&
-    !sessionKeyParam &&
+    !sessionExternalIdParam &&
     !sessionFromQuery &&
     !tasks.some((entry) => entry.id === taskIdParam)
   ) {
@@ -280,32 +280,7 @@ const resolveNavigationQueryUpdate = ({
 
   const updates: AgentStudioQueryUpdate = {};
 
-  if (sessionFromQuery && !taskIdParam) {
-    updates[AGENT_STUDIO_QUERY_KEYS.task] = sessionFromQuery.taskId;
-  }
-
-  const routeTaskExists = routeTaskId.length > 0 && tasks.some((entry) => entry.id === routeTaskId);
-  if (sessionKeyParam && isMissingRouteSession && taskIdParam && !routeTaskExists) {
-    return clearAgentStudioRouteSelection();
-  }
-  const shouldClearSessionKey = Boolean(sessionKeyParam) && isMissingRouteSession;
-
-  if (sessionKeyParam) {
-    if (sessionFromQuery && routeTaskId && sessionFromQuery.taskId !== routeTaskId) {
-      updates[AGENT_STUDIO_QUERY_KEYS.task] = sessionFromQuery.taskId;
-    } else if (shouldClearSessionKey) {
-      updates[AGENT_STUDIO_QUERY_KEYS.session] = undefined;
-    }
-  }
-
-  if (sessionKeyParam && !shouldClearSessionKey && resolvedSession) {
-    if (taskIdParam !== resolvedSession.taskId) {
-      updates[AGENT_STUDIO_QUERY_KEYS.task] = resolvedSession.taskId;
-    }
-    const resolvedSessionKey = agentSessionIdentityKey(resolvedSession);
-    if (sessionKeyParam !== resolvedSessionKey) {
-      updates[AGENT_STUDIO_QUERY_KEYS.session] = resolvedSessionKey;
-    }
+  if (sessionExternalIdParam && sessionFromQuery && resolvedSession) {
     if (roleFromQuery !== resolvedSession.role) {
       updates[AGENT_STUDIO_QUERY_KEYS.agent] = resolvedSession.role;
     }
@@ -317,14 +292,14 @@ const resolveNavigationQueryUpdate = ({
 const hasLocalSelectionAheadOfRoute = ({
   isRepoNavigationBoundaryPending,
   taskIdParam,
-  sessionKeyParam,
+  sessionExternalIdParam,
   hasExplicitRoleParam,
   roleFromQuery,
   selectionState,
 }: {
   isRepoNavigationBoundaryPending: boolean;
   taskIdParam: string;
-  sessionKeyParam: string | null;
+  sessionExternalIdParam: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
   selectionState: AgentStudioSelectionState;
@@ -332,7 +307,7 @@ const hasLocalSelectionAheadOfRoute = ({
   const routeSelection = createAgentStudioRouteSelectionState({
     isRepoNavigationBoundaryPending,
     taskIdParam,
-    sessionKeyParam,
+    sessionExternalIdParam,
     hasExplicitRoleParam,
     roleFromQuery,
   });

--- a/packages/frontend/src/pages/agents/agent-studio-navigation-state.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-navigation-state.ts
@@ -1,6 +1,6 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
-import { agentSessionIdentityKey, toAgentSessionIdentity } from "@/lib/agent-session-identity";
+import { toAgentSessionIdentity } from "@/lib/agent-session-identity";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import type { AgentSessionReadModelLoadState } from "@/types/agent-session-read-model";
@@ -35,7 +35,6 @@ export type AgentStudioNavigationViewSelection = {
 export type AgentStudioNavigationState = {
   routeSessionResolution: AgentStudioRouteSessionResolution;
   selectedSessionFromRoute: AgentSessionSummary | null;
-  selectedSessionFromSelection: AgentSessionSummary | null;
   taskId: string;
   selectedTask: TaskCard | null;
   sessionsForTask: AgentSessionSummary[];
@@ -83,13 +82,6 @@ export const resolveAgentStudioNavigationState = ({
   });
   const selectedSessionFromRoute =
     routeSessionResolution.kind === "found" ? routeSessionResolution.session : null;
-  const selectionIdentity = selectionState.sessionIdentity;
-  const selectedSessionFromSelection = selectionIdentity
-    ? (sessions.find(
-        (session) =>
-          agentSessionIdentityKey(session) === agentSessionIdentityKey(selectionIdentity),
-      ) ?? null)
-    : null;
   const taskId = selectionState.taskId;
   const selectedTask = taskId ? (tasksById.get(taskId) ?? null) : null;
   const sessionsForTask = taskId ? (sessionsByTaskId.get(taskId) ?? []) : [];
@@ -133,7 +125,6 @@ export const resolveAgentStudioNavigationState = ({
   return {
     routeSessionResolution,
     selectedSessionFromRoute,
-    selectedSessionFromSelection,
     taskId,
     selectedTask,
     sessionsForTask,

--- a/packages/frontend/src/pages/agents/agent-studio-navigation.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createAgentSessionFixture } from "./agent-studio-test-utils";
 import {
+  buildAgentStudioHref,
   buildAgentStudioSelectionQueryUpdate,
   buildSearchParamsFromNavigationState,
   parseNavigationStateFromSearchParams,
@@ -20,7 +21,7 @@ describe("agent-studio-navigation", () => {
     expect(
       buildAgentStudioSelectionQueryUpdate({
         taskId: "task-1",
-        session,
+        sessionExternalId: session.externalSessionId,
         role: "spec",
       }),
     ).toEqual({
@@ -28,6 +29,29 @@ describe("agent-studio-navigation", () => {
       session: "session-1",
       agent: "spec",
     });
+  });
+
+  test("buildAgentStudioHref builds session and sessionless destinations", () => {
+    const session = createAgentSessionFixture({
+      externalSessionId: "session-1",
+      runtimeKind: "opencode",
+      workingDirectory: "/repo/worktrees/session-1",
+    });
+
+    expect(
+      buildAgentStudioHref({
+        taskId: "task-1",
+        sessionExternalId: session.externalSessionId,
+        role: "build",
+      }),
+    ).toBe("/agents?task=task-1&session=session-1&agent=build");
+    expect(
+      buildAgentStudioHref({
+        taskId: "task-1",
+        sessionExternalId: null,
+        role: "qa",
+      }),
+    ).toBe("/agents?task=task-1&agent=qa");
   });
 
   test("round trips a plain external session id through the Agent Studio URL", () => {

--- a/packages/frontend/src/pages/agents/agent-studio-navigation.test.ts
+++ b/packages/frontend/src/pages/agents/agent-studio-navigation.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { createAgentSessionFixture } from "./agent-studio-test-utils";
 import {
   buildAgentStudioSelectionQueryUpdate,
+  buildSearchParamsFromNavigationState,
+  parseNavigationStateFromSearchParams,
+  parsePersistedContext,
   restoreNavigationFromPersistedContext,
+  serializePersistedContext,
 } from "./query-sync/agent-studio-navigation";
 
 describe("agent-studio-navigation", () => {
@@ -22,9 +25,52 @@ describe("agent-studio-navigation", () => {
       }),
     ).toEqual({
       task: "task-1",
-      session: agentSessionIdentityKey(session),
+      session: "session-1",
       agent: "spec",
     });
+  });
+
+  test("round trips a plain external session id through the Agent Studio URL", () => {
+    const navigation = parseNavigationStateFromSearchParams(
+      new URLSearchParams("task=task-1&session=session-1&agent=build"),
+    );
+
+    expect(navigation).toEqual({
+      taskId: "task-1",
+      sessionExternalId: "session-1",
+      role: "build",
+    });
+    expect(buildSearchParamsFromNavigationState(new URLSearchParams(), navigation).toString()).toBe(
+      "task=task-1&session=session-1&agent=build",
+    );
+  });
+
+  test("persists only the external session id for workspace navigation", () => {
+    const serialized = serializePersistedContext({
+      taskId: "task-1",
+      sessionExternalId: "session-1",
+      role: "build",
+    });
+
+    expect(JSON.parse(serialized)).toEqual({
+      taskId: "task-1",
+      sessionExternalId: "session-1",
+      role: "build",
+    });
+    expect(serialized).not.toContain("opencode");
+    expect(serialized).not.toContain("/repo/worktrees/session-1");
+  });
+
+  test("discards legacy composite session navigation state", () => {
+    expect(
+      parsePersistedContext(
+        JSON.stringify({
+          taskId: "task-1",
+          role: "build",
+          sessionKey: "session-1|opencode|%2Frepo%2Fworktrees%2Fsession-1",
+        }),
+      ),
+    ).toEqual({ taskId: "task-1", role: "build" });
   });
 
   test("does not restore a stale persisted session over an explicit task", () => {
@@ -32,18 +78,18 @@ describe("agent-studio-navigation", () => {
       restoreNavigationFromPersistedContext(
         {
           taskId: "task-current",
-          sessionKey: null,
+          sessionExternalId: null,
           role: null,
         },
         {
           taskId: "task-persisted",
-          sessionKey: "session-persisted",
+          sessionExternalId: "session-persisted",
           role: "planner",
         },
       ),
     ).toEqual({
       taskId: "task-current",
-      sessionKey: null,
+      sessionExternalId: null,
       role: "planner",
     });
   });
@@ -53,18 +99,18 @@ describe("agent-studio-navigation", () => {
       restoreNavigationFromPersistedContext(
         {
           taskId: "task-current",
-          sessionKey: null,
+          sessionExternalId: null,
           role: null,
         },
         {
           taskId: "task-current",
-          sessionKey: "session-persisted",
+          sessionExternalId: "session-persisted",
           role: "planner",
         },
       ),
     ).toEqual({
       taskId: "task-current",
-      sessionKey: "session-persisted",
+      sessionExternalId: "session-persisted",
       role: "planner",
     });
   });

--- a/packages/frontend/src/pages/agents/agents-page-selection.test.ts
+++ b/packages/frontend/src/pages/agents/agents-page-selection.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { createAgentSessionSummaryFixture, createTaskCardFixture } from "./agent-studio-test-utils";
 import {
   coerceVisibleSelectionToCatalog,
@@ -20,7 +19,7 @@ import {
 
 const resolveAgentStudioSelectedSessionSummary = (args: {
   sessionsForTask: Parameters<typeof resolveAgentStudioSessionSelection>[0]["sessionsForTask"];
-  sessionKey: Parameters<typeof resolveAgentStudioSessionSelection>[0]["sessionKey"];
+  sessionExternalId: Parameters<typeof resolveAgentStudioSessionSelection>[0]["sessionExternalId"];
   hasExplicitRoleParam: boolean;
   roleFromQuery: Parameters<typeof resolveAgentStudioSessionSelection>[0]["roleFromQuery"];
   selectedTask: Parameters<typeof resolveAgentStudioSessionSelection>[0]["selectedTask"];
@@ -216,7 +215,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [plannerSession, buildSession],
-      sessionKey: "session-from-other-task",
+      sessionExternalId: "session-from-other-task",
       hasExplicitRoleParam: true,
       roleFromQuery: "planner",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
@@ -241,7 +240,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [plannerSession, buildSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: true,
       roleFromQuery: "planner",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
@@ -260,7 +259,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSessionSelection({
       sessionsForTask: [buildSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: true,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
@@ -291,7 +290,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [olderBuildSession, runningSpecSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
@@ -332,7 +331,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [olderBuildSession, waitingSpecSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
@@ -361,7 +360,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [olderRunningSession, newerStartingSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "human_review" }),
@@ -388,7 +387,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [buildSession, specSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "spec",
       selectedTask: createTaskCardFixture({
@@ -416,7 +415,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [buildSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({
@@ -452,7 +451,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [olderSpecSession, latestSpecSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "planner",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "spec_ready" }),
@@ -479,7 +478,7 @@ describe("agents-page-selection", () => {
 
     const resolvedWithPlanner = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [latestSpecSession, latestPlannerSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "ready_for_dev" }),
@@ -487,7 +486,7 @@ describe("agents-page-selection", () => {
 
     const resolvedWithFallback = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [latestSpecSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "ready_for_dev" }),
@@ -522,7 +521,7 @@ describe("agents-page-selection", () => {
     for (const status of statuses) {
       const resolved = resolveAgentStudioSelectedSessionSummary({
         sessionsForTask: [olderBuildSession, latestBuildSession],
-        sessionKey: null,
+        sessionExternalId: null,
         hasExplicitRoleParam: false,
         roleFromQuery: "spec",
         selectedTask: createTaskCardFixture({ id: "task-1", status }),
@@ -553,7 +552,7 @@ describe("agents-page-selection", () => {
     for (const status of statuses) {
       const resolvedWithBuild = resolveAgentStudioSelectedSessionSummary({
         sessionsForTask: [latestSpecSession, latestBuildSession],
-        sessionKey: null,
+        sessionExternalId: null,
         hasExplicitRoleParam: false,
         roleFromQuery: "qa",
         selectedTask: createTaskCardFixture({ id: "task-1", status }),
@@ -561,7 +560,7 @@ describe("agents-page-selection", () => {
 
       const resolvedFallback = resolveAgentStudioSelectedSessionSummary({
         sessionsForTask: [latestSpecSession],
-        sessionKey: null,
+        sessionExternalId: null,
         hasExplicitRoleParam: false,
         roleFromQuery: "qa",
         selectedTask: createTaskCardFixture({ id: "task-1", status }),
@@ -582,7 +581,7 @@ describe("agents-page-selection", () => {
 
     const resolved = resolveAgentStudioSelectedSessionSummary({
       sessionsForTask: [buildSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "build",
       selectedTask: null,
@@ -594,7 +593,7 @@ describe("agents-page-selection", () => {
   test("resolves role from workflow default even when no session exists", () => {
     const selection = resolveAgentStudioSessionSelection({
       sessionsForTask: [],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "spec",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "human_review" }),
@@ -616,7 +615,7 @@ describe("agents-page-selection", () => {
 
     const selection = resolveAgentStudioSessionSelection({
       sessionsForTask: [qaSession],
-      sessionKey: agentSessionIdentityKey(qaSession),
+      sessionExternalId: qaSession.externalSessionId,
       hasExplicitRoleParam: false,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "human_review" }),
@@ -638,7 +637,7 @@ describe("agents-page-selection", () => {
 
     const selection = resolveAgentStudioSessionSelection({
       sessionsForTask: [buildSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: true,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
@@ -667,7 +666,7 @@ describe("agents-page-selection", () => {
 
     const selection = resolveAgentStudioSessionSelection({
       sessionsForTask: [olderSpecSession, newerQaSession],
-      sessionKey: null,
+      sessionExternalId: null,
       hasExplicitRoleParam: false,
       roleFromQuery: "spec",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "blocked" }),
@@ -729,12 +728,6 @@ describe("agents-page-selection", () => {
       taskId: "task-1",
       role: "build",
     });
-    const duplicateBuildSession = createAgentSessionSummaryFixture({
-      runtimeKind: "opencode",
-      externalSessionId: "build-active",
-      taskId: "task-1",
-      role: "build",
-    });
     const secondaryBuildSession = createAgentSessionSummaryFixture({
       runtimeKind: "opencode",
       externalSessionId: "build-secondary",
@@ -747,7 +740,7 @@ describe("agents-page-selection", () => {
       candidateSessions: [
         activeBuildSession,
         null,
-        duplicateBuildSession,
+        activeBuildSession,
         secondaryBuildSession,
         activeBuildSession,
         secondaryBuildSession,
@@ -757,47 +750,6 @@ describe("agents-page-selection", () => {
     expect(sessions.map((session) => session.externalSessionId)).toEqual([
       "build-active",
       "build-secondary",
-    ]);
-  });
-
-  test("keeps build sessions distinct when only external id matches", () => {
-    const liveBuildSession = createAgentSessionSummaryFixture({
-      runtimeKind: "opencode",
-      externalSessionId: "build-shared",
-      taskId: "task-1",
-      role: "build",
-      workingDirectory: "/repo/live",
-    });
-    const persistedBuildSession = createAgentSessionSummaryFixture({
-      runtimeKind: "codex",
-      externalSessionId: "build-shared",
-      taskId: "task-1",
-      role: "build",
-      workingDirectory: "/repo/persisted",
-    });
-
-    const sessions = resolveAgentStudioBuilderSessionsForTask({
-      taskId: "task-1",
-      candidateSessions: [liveBuildSession, null, persistedBuildSession],
-    });
-
-    expect(
-      sessions.map((session) => ({
-        externalSessionId: session.externalSessionId,
-        runtimeKind: session.runtimeKind,
-        workingDirectory: session.workingDirectory,
-      })),
-    ).toEqual([
-      {
-        externalSessionId: "build-shared",
-        runtimeKind: "opencode",
-        workingDirectory: "/repo/live",
-      },
-      {
-        externalSessionId: "build-shared",
-        runtimeKind: "codex",
-        workingDirectory: "/repo/persisted",
-      },
     ]);
   });
 });

--- a/packages/frontend/src/pages/agents/agents-page-selection.test.ts
+++ b/packages/frontend/src/pages/agents/agents-page-selection.test.ts
@@ -11,7 +11,6 @@ import {
   resolveAgentStudioBuilderSessionsForTask,
   resolveAgentStudioDefaultRoleForTask,
   resolveAgentStudioSessionSelection,
-  resolveAgentStudioTaskId,
   toContextStorageKey,
   toRightPanelStorageKey,
   toTabsStorageKey,
@@ -161,27 +160,6 @@ describe("agents-page-selection", () => {
         { providerId: "openai", modelId: "gpt-5", variant: "fast" },
       ),
     ).toBe(false);
-  });
-
-  test("prefers explicit task id over session-derived task id", () => {
-    const session = createAgentSessionSummaryFixture({
-      runtimeKind: "opencode",
-      externalSessionId: "session-1",
-      taskId: "task-from-session",
-    });
-
-    expect(
-      resolveAgentStudioTaskId({
-        taskIdParam: "task-from-url",
-        selectedSessionFromRoute: session,
-      }),
-    ).toBe("task-from-url");
-    expect(
-      resolveAgentStudioTaskId({
-        taskIdParam: "",
-        selectedSessionFromRoute: session,
-      }),
-    ).toBe("task-from-session");
   });
 
   test("resolves default role for open tasks from first required available workflow", () => {

--- a/packages/frontend/src/pages/agents/agents-page-selection.ts
+++ b/packages/frontend/src/pages/agents/agents-page-selection.ts
@@ -63,16 +63,6 @@ export const emptyDraftSelections = (): Record<AgentRole, AgentModelSelection | 
   qa: null,
 });
 
-export const resolveAgentStudioTaskId = ({
-  taskIdParam,
-  selectedSessionFromRoute,
-}: {
-  taskIdParam: string;
-  selectedSessionFromRoute: AgentSessionSummary | null;
-}): string => {
-  return taskIdParam || selectedSessionFromRoute?.taskId || "";
-};
-
 export const resolveAgentStudioDefaultRoleForTask = (task: TaskCard | null): AgentRole | null => {
   if (!task) {
     return null;

--- a/packages/frontend/src/pages/agents/agents-page-selection.ts
+++ b/packages/frontend/src/pages/agents/agents-page-selection.ts
@@ -112,7 +112,7 @@ export const resolveAgentStudioDefaultRoleForTask = (task: TaskCard | null): Age
 
 type AgentStudioSessionSelectionInput = {
   sessionsForTask: AgentSessionSummary[];
-  sessionKey: string | null;
+  sessionExternalId: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
   selectedTask: TaskCard | null;
@@ -125,7 +125,7 @@ const isActiveSessionSelectionCandidate = (session: AgentSessionSummary): boolea
 
 export const resolveAgentStudioSessionSelection = ({
   sessionsForTask,
-  sessionKey,
+  sessionExternalId,
   hasExplicitRoleParam,
   roleFromQuery,
   selectedTask,
@@ -165,8 +165,9 @@ export const resolveAgentStudioSessionSelection = ({
     };
   };
 
-  if (sessionKey) {
-    const explicitSession = findAgentStudioSessionSummaryByKey(sessionsForTask, sessionKey);
+  if (sessionExternalId) {
+    const explicitSession =
+      sessionsForTask.find((session) => session.externalSessionId === sessionExternalId) ?? null;
     if (explicitSession) {
       return toSelection(explicitSession.role, explicitSession);
     }
@@ -222,50 +223,62 @@ export const resolveAgentStudioSessionSelection = ({
   }
 };
 
-export const findAgentStudioSessionSummaryByKey = (
+export const findAgentStudioTaskSessionSummary = (
   sessions: AgentSessionSummary[],
-  sessionKey: string | null,
+  taskId: string,
+  sessionExternalId: string | null,
 ): AgentSessionSummary | null => {
-  if (!sessionKey) {
+  if (!taskId || !sessionExternalId) {
     return null;
   }
 
-  return sessions.find((entry) => agentSessionIdentityKey(entry) === sessionKey) ?? null;
+  return (
+    sessions.find(
+      (entry) => entry.taskId === taskId && entry.externalSessionId === sessionExternalId,
+    ) ?? null
+  );
 };
 
 export type AgentStudioRouteSessionResolution =
   | { kind: "none" }
-  | { kind: "pending"; sessionKey: string }
+  | { kind: "pending"; sessionExternalId: string }
   | { kind: "found"; session: AgentSessionSummary }
-  | { kind: "missing"; sessionKey: string };
+  | { kind: "missing"; sessionExternalId: string }
+  | { kind: "failed"; sessionExternalId: string; message: string };
 
 export const resolveAgentStudioRouteSession = ({
   isRepoNavigationBoundaryPending,
   isLoadingTasks,
   sessionReadModelLoadState,
   sessions,
-  sessionKey,
+  taskId,
+  sessionExternalId,
 }: {
   isRepoNavigationBoundaryPending: boolean;
   isLoadingTasks: boolean;
   sessionReadModelLoadState: AgentSessionReadModelLoadState;
   sessions: AgentSessionSummary[];
-  sessionKey: string | null;
+  taskId: string;
+  sessionExternalId: string | null;
 }): AgentStudioRouteSessionResolution => {
-  if (isRepoNavigationBoundaryPending || !sessionKey) {
+  if (isRepoNavigationBoundaryPending || !sessionExternalId) {
     return { kind: "none" };
   }
 
-  const session = findAgentStudioSessionSummaryByKey(sessions, sessionKey);
-  if (session) {
-    return { kind: "found", session };
+  if (sessionReadModelLoadState.kind === "failed") {
+    return {
+      kind: "failed",
+      sessionExternalId,
+      message: sessionReadModelLoadState.message,
+    };
   }
 
-  if (!isLoadingTasks && sessionReadModelLoadState.kind === "ready") {
-    return { kind: "missing", sessionKey };
+  if (isLoadingTasks || sessionReadModelLoadState.kind !== "ready") {
+    return { kind: "pending", sessionExternalId };
   }
 
-  return { kind: "pending", sessionKey };
+  const session = findAgentStudioTaskSessionSummary(sessions, taskId, sessionExternalId);
+  return session ? { kind: "found", session } : { kind: "missing", sessionExternalId };
 };
 
 export const groupSessionsByTaskId = (
@@ -297,23 +310,25 @@ const findViewSessionCandidateByIdentity = (
   );
 };
 
-const resolveViewSessionKey = ({
-  sessionKey,
+const resolveViewSessionExternalId = ({
+  sessionExternalId,
   candidates,
 }: {
-  sessionKey: string | null;
+  sessionExternalId: string | null;
   candidates: AgentSessionSummary[];
 }): string | null => {
-  if (!sessionKey) {
+  if (!sessionExternalId) {
     return null;
   }
-  const belongsToVisibleSession = findAgentStudioSessionSummaryByKey(candidates, sessionKey);
-  return belongsToVisibleSession ? sessionKey : null;
+  const belongsToVisibleSession = candidates.some(
+    (candidate) => candidate.externalSessionId === sessionExternalId,
+  );
+  return belongsToVisibleSession ? sessionExternalId : null;
 };
 
 export const resolveAgentStudioViewSessionSelection = ({
   sessionSummaries,
-  sessionKey,
+  sessionExternalId,
   sessionIdentity,
   hasExplicitRoleParam,
   roleFromQuery,
@@ -322,7 +337,7 @@ export const resolveAgentStudioViewSessionSelection = ({
   keepExplicitRoleSessionless = false,
 }: {
   sessionSummaries: AgentSessionSummary[];
-  sessionKey: string | null;
+  sessionExternalId: string | null;
   sessionIdentity: AgentSessionIdentity | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
@@ -343,18 +358,25 @@ export const resolveAgentStudioViewSessionSelection = ({
     };
   }
 
-  const resolvedSessionKey = resolveViewSessionKey({
-    sessionKey,
+  const resolvedSessionExternalId = resolveViewSessionExternalId({
+    sessionExternalId,
     candidates: sessionSummaries,
   });
+  if (sessionExternalId && !resolvedSessionExternalId) {
+    return {
+      role: roleFromQuery,
+      sessionIdentity: null,
+      sessionSummary: null,
+    };
+  }
   const selection = resolveAgentStudioSessionSelection({
     sessionsForTask: sessionSummaries,
-    sessionKey: resolvedSessionKey,
+    sessionExternalId: resolvedSessionExternalId,
     hasExplicitRoleParam,
     roleFromQuery,
     selectedTask,
     sessionlessRole,
-    keepExplicitRoleSessionless: keepExplicitRoleSessionless && resolvedSessionKey === null,
+    keepExplicitRoleSessionless: keepExplicitRoleSessionless && resolvedSessionExternalId === null,
   });
   return {
     role: selection.role,

--- a/packages/frontend/src/pages/agents/agents-page-view-session-selection.test.ts
+++ b/packages/frontend/src/pages/agents/agents-page-view-session-selection.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-  agentSessionIdentityKey,
-  parseAgentSessionIdentityKey,
-} from "@/lib/agent-session-identity";
+import { toAgentSessionIdentity } from "@/lib/agent-session-identity";
 import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import { createAgentSessionFixture, createTaskCardFixture } from "./agent-studio-test-utils";
 import {
@@ -66,7 +63,7 @@ describe("Agent Studio view session selection", () => {
     ]);
   });
 
-  test("uses the selected route identity before the read model materializes a summary", () => {
+  test("derives the selected route identity only after the read model materializes a summary", () => {
     const sessionSummary = toAgentSessionSummary(
       createAgentSessionFixture({
         runtimeKind: "opencode",
@@ -79,12 +76,11 @@ describe("Agent Studio view session selection", () => {
       }),
     );
 
-    const sessionKey = agentSessionIdentityKey(sessionSummary);
-    const routeIdentity = parseAgentSessionIdentityKey(sessionKey);
+    const sessionExternalId = sessionSummary.externalSessionId;
     const loadingSelection = resolveAgentStudioViewSessionSelection({
       sessionSummaries: [],
-      sessionKey,
-      sessionIdentity: routeIdentity,
+      sessionExternalId,
+      sessionIdentity: null,
       hasExplicitRoleParam: true,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
@@ -94,13 +90,13 @@ describe("Agent Studio view session selection", () => {
     expect(loadingSelection).toEqual({
       role: "build",
       sessionSummary: null,
-      sessionIdentity: routeIdentity,
+      sessionIdentity: null,
     });
 
     const materializedSelection = resolveAgentStudioViewSessionSelection({
       sessionSummaries: [sessionSummary],
-      sessionKey,
-      sessionIdentity: routeIdentity,
+      sessionExternalId,
+      sessionIdentity: null,
       hasExplicitRoleParam: true,
       roleFromQuery: "build",
       selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
@@ -123,7 +119,7 @@ describe("Agent Studio view session selection", () => {
     };
     const selection = resolveAgentStudioViewSessionSelection({
       sessionSummaries: [],
-      sessionKey: "session-started",
+      sessionExternalId: "session-started",
       sessionIdentity,
       hasExplicitRoleParam: true,
       roleFromQuery: "build",
@@ -136,49 +132,6 @@ describe("Agent Studio view session selection", () => {
       sessionSummary: null,
       sessionIdentity,
     });
-  });
-
-  test("resolves duplicated external ids by full session identity", () => {
-    const liveBuildSummary = toAgentSessionSummary(
-      createAgentSessionFixture({
-        runtimeKind: "opencode",
-        externalSessionId: "shared-session-id",
-        taskId: "task-1",
-        role: "build",
-        status: "idle",
-        startedAt: "2026-02-22T12:00:00.000Z",
-        workingDirectory: "/repo/live",
-      }),
-    );
-    const livePlannerSummary = toAgentSessionSummary(
-      createAgentSessionFixture({
-        runtimeKind: "codex",
-        externalSessionId: "shared-session-id",
-        taskId: "task-1",
-        role: "planner",
-        status: "idle",
-        startedAt: "2026-02-22T11:00:00.000Z",
-        workingDirectory: "/repo/other",
-      }),
-    );
-
-    const selection = resolveAgentStudioViewSessionSelection({
-      sessionSummaries: [liveBuildSummary, livePlannerSummary],
-      sessionKey: agentSessionIdentityKey(liveBuildSummary),
-      sessionIdentity: parseAgentSessionIdentityKey(agentSessionIdentityKey(liveBuildSummary)),
-      hasExplicitRoleParam: true,
-      roleFromQuery: "qa",
-      selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
-      sessionlessRole: "qa",
-    });
-
-    expect(selection.sessionSummary).toBe(liveBuildSummary);
-    expect(selection.sessionIdentity).toEqual({
-      externalSessionId: "shared-session-id",
-      runtimeKind: "opencode",
-      workingDirectory: "/repo/live",
-    });
-    expect(selection.role).toBe("build");
   });
 
   test("sanitizes the selected session identity before resolving view selection", () => {
@@ -196,8 +149,8 @@ describe("Agent Studio view session selection", () => {
 
     expect(
       resolveAgentStudioViewSessionSelection({
-        sessionKey: agentSessionIdentityKey(sessionSummary),
-        sessionIdentity: parseAgentSessionIdentityKey(agentSessionIdentityKey(sessionSummary)),
+        sessionExternalId: sessionSummary.externalSessionId,
+        sessionIdentity: toAgentSessionIdentity(sessionSummary),
         sessionSummaries: [sessionSummary],
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
@@ -207,7 +160,7 @@ describe("Agent Studio view session selection", () => {
     ).toBe("session-summary");
     expect(
       resolveAgentStudioViewSessionSelection({
-        sessionKey: "session-unknown",
+        sessionExternalId: "session-unknown",
         sessionIdentity: null,
         sessionSummaries: [sessionSummary],
         hasExplicitRoleParam: true,
@@ -218,7 +171,7 @@ describe("Agent Studio view session selection", () => {
     ).toBeUndefined();
     expect(
       resolveAgentStudioViewSessionSelection({
-        sessionKey: "session-other-task",
+        sessionExternalId: "session-other-task",
         sessionIdentity: null,
         sessionSummaries: [sessionSummary],
         hasExplicitRoleParam: false,
@@ -226,6 +179,6 @@ describe("Agent Studio view session selection", () => {
         selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
         sessionlessRole: "build",
       }).sessionIdentity?.externalSessionId,
-    ).toBe("session-summary");
+    ).toBeUndefined();
   });
 });

--- a/packages/frontend/src/pages/agents/query-sync/agent-studio-navigation.ts
+++ b/packages/frontend/src/pages/agents/query-sync/agent-studio-navigation.ts
@@ -1,7 +1,6 @@
 import { agentRoleValues } from "@openducktor/contracts";
 import { type AgentRole, isRecord } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
-import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 
 const AGENT_STUDIO_CONTEXT_STORAGE_PREFIX = "openducktor:agent-studio:context";
 const AGENT_STUDIO_TABS_STORAGE_PREFIX = "openducktor:agent-studio:tabs";
@@ -46,7 +45,7 @@ export type AgentStudioNavigationState = {
 
 type AgentStudioSessionSelectionQueryParams = {
   taskId: string;
-  session: AgentSessionIdentity | null;
+  sessionExternalId: string | null;
   role: AgentRole;
 };
 
@@ -144,9 +143,18 @@ export const buildAgentStudioSelectionQueryUpdate = (
   params: AgentStudioSessionSelectionQueryParams,
 ): AgentStudioQueryUpdate => ({
   [AGENT_STUDIO_QUERY_KEYS.task]: params.taskId,
-  [AGENT_STUDIO_QUERY_KEYS.session]: params.session?.externalSessionId,
+  [AGENT_STUDIO_QUERY_KEYS.session]: params.sessionExternalId ?? undefined,
   [AGENT_STUDIO_QUERY_KEYS.agent]: params.role,
 });
+
+export const buildAgentStudioHref = (params: AgentStudioSessionSelectionQueryParams): string => {
+  const searchParams = buildSearchParamsFromNavigationState(new URLSearchParams(), {
+    taskId: params.taskId,
+    sessionExternalId: params.sessionExternalId,
+    role: params.role,
+  });
+  return `/agents?${searchParams.toString()}`;
+};
 
 export const isSameNavigationState = (
   left: AgentStudioNavigationState,

--- a/packages/frontend/src/pages/agents/query-sync/agent-studio-navigation.ts
+++ b/packages/frontend/src/pages/agents/query-sync/agent-studio-navigation.ts
@@ -1,6 +1,5 @@
 import { agentRoleValues } from "@openducktor/contracts";
 import { type AgentRole, isRecord } from "@openducktor/core";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { errorMessage } from "@/lib/errors";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 
@@ -31,7 +30,7 @@ const AGENT_STUDIO_MANAGED_URL_QUERY_KEYS = [
 const AGENT_STUDIO_PERSISTED_CONTEXT_KEYS = {
   taskId: "taskId",
   role: "role",
-  sessionKey: "sessionKey",
+  sessionExternalId: "sessionExternalId",
 } as const;
 
 export type AgentStudioQueryKey =
@@ -41,7 +40,7 @@ export type AgentStudioQueryUpdate = Partial<Record<AgentStudioQueryKey, string 
 
 export type AgentStudioNavigationState = {
   taskId: string;
-  sessionKey: string | null;
+  sessionExternalId: string | null;
   role: AgentRole | null;
 };
 
@@ -54,7 +53,7 @@ type AgentStudioSessionSelectionQueryParams = {
 export type PersistedAgentStudioContext = {
   taskId?: string;
   role?: AgentRole;
-  sessionKey?: string;
+  sessionExternalId?: string;
 };
 
 const AGENT_ROLE_SET = new Set<string>(agentRoleValues);
@@ -77,7 +76,8 @@ export const parseNavigationStateFromSearchParams = (
 
   return {
     taskId: readOptionalString(searchParams.get(AGENT_STUDIO_QUERY_KEYS.task)) ?? "",
-    sessionKey: readOptionalString(searchParams.get(AGENT_STUDIO_QUERY_KEYS.session)) ?? null,
+    sessionExternalId:
+      readOptionalString(searchParams.get(AGENT_STUDIO_QUERY_KEYS.session)) ?? null,
     role: isRole(roleValue) ? roleValue : null,
   };
 };
@@ -95,8 +95,8 @@ export const buildSearchParamsFromNavigationState = (
   if (navigation.taskId) {
     next.set(AGENT_STUDIO_QUERY_KEYS.task, navigation.taskId);
   }
-  if (navigation.sessionKey) {
-    next.set(AGENT_STUDIO_QUERY_KEYS.session, navigation.sessionKey);
+  if (navigation.sessionExternalId) {
+    next.set(AGENT_STUDIO_QUERY_KEYS.session, navigation.sessionExternalId);
   }
   if (navigation.role) {
     next.set(AGENT_STUDIO_QUERY_KEYS.agent, navigation.role);
@@ -121,9 +121,9 @@ export const applyQueryUpdateToNavigationState = (
   }
 
   if (AGENT_STUDIO_QUERY_KEYS.session in updates) {
-    const sessionKey = readOptionalString(updates.session) ?? null;
-    if (sessionKey !== next.sessionKey) {
-      next.sessionKey = sessionKey;
+    const sessionExternalId = readOptionalString(updates.session) ?? null;
+    if (sessionExternalId !== next.sessionExternalId) {
+      next.sessionExternalId = sessionExternalId;
       hasChanged = true;
     }
   }
@@ -144,9 +144,7 @@ export const buildAgentStudioSelectionQueryUpdate = (
   params: AgentStudioSessionSelectionQueryParams,
 ): AgentStudioQueryUpdate => ({
   [AGENT_STUDIO_QUERY_KEYS.task]: params.taskId,
-  [AGENT_STUDIO_QUERY_KEYS.session]: params.session
-    ? agentSessionIdentityKey(params.session)
-    : undefined,
+  [AGENT_STUDIO_QUERY_KEYS.session]: params.session?.externalSessionId,
   [AGENT_STUDIO_QUERY_KEYS.agent]: params.role,
 });
 
@@ -155,7 +153,9 @@ export const isSameNavigationState = (
   right: AgentStudioNavigationState,
 ): boolean => {
   return (
-    left.taskId === right.taskId && left.sessionKey === right.sessionKey && left.role === right.role
+    left.taskId === right.taskId &&
+    left.sessionExternalId === right.sessionExternalId &&
+    left.role === right.role
   );
 };
 
@@ -165,7 +165,7 @@ export const clearAgentStudioNavigationState = (
   return {
     ...current,
     taskId: "",
-    sessionKey: null,
+    sessionExternalId: null,
     role: null,
   };
 };
@@ -173,7 +173,7 @@ export const clearAgentStudioNavigationState = (
 export const hasAgentStudioNavigationSelection = (
   navigation: AgentStudioNavigationState,
 ): boolean => {
-  return Boolean(navigation.taskId || navigation.sessionKey || navigation.role);
+  return Boolean(navigation.taskId || navigation.sessionExternalId || navigation.role);
 };
 
 export const parsePersistedContext = (raw: string): PersistedAgentStudioContext => {
@@ -202,14 +202,14 @@ export const parsePersistedContext = (raw: string): PersistedAgentStudioContext 
         return roleValue;
       })()
     : undefined;
-  const sessionKey = parsePersistedContextString(
+  const sessionExternalId = parsePersistedContextString(
     parsed,
-    AGENT_STUDIO_PERSISTED_CONTEXT_KEYS.sessionKey,
+    AGENT_STUDIO_PERSISTED_CONTEXT_KEYS.sessionExternalId,
   );
   return {
     ...(taskId ? { taskId } : {}),
     ...(role ? { role } : {}),
-    ...(sessionKey ? { sessionKey } : {}),
+    ...(sessionExternalId ? { sessionExternalId } : {}),
   };
 };
 
@@ -219,16 +219,16 @@ export const restoreNavigationFromPersistedContext = (
 ): AgentStudioNavigationState => {
   const role = current.role ?? persisted.role ?? null;
   const taskId = current.taskId || persisted.taskId || "";
-  const sessionKey =
-    current.sessionKey ??
+  const sessionExternalId =
+    current.sessionExternalId ??
     (!current.taskId || persisted.taskId === current.taskId
-      ? (persisted.sessionKey ?? null)
+      ? (persisted.sessionExternalId ?? null)
       : null);
 
   return {
     ...current,
     taskId,
-    sessionKey,
+    sessionExternalId,
     role,
   };
 };
@@ -237,7 +237,8 @@ export const serializePersistedContext = (navigation: AgentStudioNavigationState
   const payload = {
     [AGENT_STUDIO_PERSISTED_CONTEXT_KEYS.taskId]: navigation.taskId || undefined,
     [AGENT_STUDIO_PERSISTED_CONTEXT_KEYS.role]: navigation.role ?? undefined,
-    [AGENT_STUDIO_PERSISTED_CONTEXT_KEYS.sessionKey]: navigation.sessionKey || undefined,
+    [AGENT_STUDIO_PERSISTED_CONTEXT_KEYS.sessionExternalId]:
+      navigation.sessionExternalId || undefined,
   };
 
   return JSON.stringify(payload);

--- a/packages/frontend/src/pages/agents/query-sync/use-agent-studio-query-sync.ts
+++ b/packages/frontend/src/pages/agents/query-sync/use-agent-studio-query-sync.ts
@@ -18,7 +18,7 @@ export function useAgentStudioQuerySync({
   setSearchParams,
 }: UseAgentStudioQuerySyncArgs): {
   taskIdParam: string;
-  sessionKeyParam: string | null;
+  sessionExternalIdParam: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
   isRepoNavigationBoundaryPending: boolean;
@@ -44,7 +44,7 @@ export function useAgentStudioQuerySync({
 
   return {
     taskIdParam: navigation.taskId,
-    sessionKeyParam: navigation.sessionKey,
+    sessionExternalIdParam: navigation.sessionExternalId,
     hasExplicitRoleParam,
     roleFromQuery,
     isRepoNavigationBoundaryPending,

--- a/packages/frontend/src/pages/agents/selected-session/use-agent-studio-selected-session-view.ts
+++ b/packages/frontend/src/pages/agents/selected-session/use-agent-studio-selected-session-view.ts
@@ -6,6 +6,7 @@ import {
   resolveBuildContinuationLaunchAction,
   type SessionLaunchActionId,
 } from "@/features/session-start";
+import { inactiveRepoRuntimeReadinessTarget } from "@/lib/repo-runtime-readiness";
 import { useRepoRuntimeReadiness } from "@/lib/use-repo-runtime-readiness";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import { useRuntimeAvailabilityContext } from "@/state/app-state-contexts";
@@ -17,7 +18,10 @@ import {
 import { useSessionRuntimeData } from "@/state/operations/agent-orchestrator/hooks/use-session-runtime-data";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
-import { resolveAgentStudioViewSessionSelection } from "../agents-page-selection";
+import {
+  type AgentStudioRouteSessionResolution,
+  resolveAgentStudioViewSessionSelection,
+} from "../agents-page-selection";
 import type { AgentStudioSelectedSessionState } from "./selected-session-state";
 import {
   deriveSelectedSessionRuntimeTarget,
@@ -28,7 +32,8 @@ type UseAgentStudioSelectedSessionViewArgs = {
   workspaceRepoPath: string | null;
   selectedTask: TaskCard | null;
   sessionSummaries: AgentSessionSummary[];
-  sessionKey: string | null;
+  sessionExternalId: string | null;
+  routeSessionResolution: AgentStudioRouteSessionResolution;
   hasExplicitRoleSelection: boolean;
   roleSelection: AgentRole;
   sessionlessRole: AgentRole;
@@ -48,7 +53,8 @@ export function useAgentStudioSelectedSessionView({
   workspaceRepoPath,
   selectedTask,
   sessionSummaries,
-  sessionKey,
+  sessionExternalId,
+  routeSessionResolution,
   hasExplicitRoleSelection,
   roleSelection,
   sessionlessRole,
@@ -63,7 +69,7 @@ export function useAgentStudioSelectedSessionView({
   const selection = useMemo(() => {
     return resolveAgentStudioViewSessionSelection({
       sessionSummaries,
-      sessionKey,
+      sessionExternalId,
       sessionIdentity: sessionIdentityFromRoute,
       hasExplicitRoleParam: hasExplicitRoleSelection,
       roleFromQuery: roleSelection,
@@ -72,7 +78,7 @@ export function useAgentStudioSelectedSessionView({
       keepExplicitRoleSessionless,
     });
   }, [
-    sessionKey,
+    sessionExternalId,
     hasExplicitRoleSelection,
     keepExplicitRoleSessionless,
     roleSelection,
@@ -82,44 +88,92 @@ export function useAgentStudioSelectedSessionView({
     sessionSummaries,
   ]);
 
-  const selectedSessionIdentity = selection.sessionIdentity;
+  const unresolvedRouteSessionExternalId =
+    routeSessionResolution.kind === "pending" ||
+    routeSessionResolution.kind === "missing" ||
+    routeSessionResolution.kind === "failed"
+      ? routeSessionResolution.sessionExternalId
+      : null;
+  const isUnresolvedExplicitRouteSession =
+    sessionExternalId !== null && sessionExternalId === unresolvedRouteSessionExternalId;
+  const selectedSessionIdentity = isUnresolvedExplicitRouteSession
+    ? null
+    : selection.sessionIdentity;
   const session = useAgentSession(selectedSessionIdentity);
   const { sessionReadModelLoadState } = useAgentSessionReadModelState();
   const runtimeTarget = useMemo(
     () =>
-      deriveSelectedSessionRuntimeTarget({
-        selectedSessionIdentity,
-        selectedTask,
-        role: selection.role,
-        repoSettings,
-        isLoadingRepoSettings,
-      }),
-    [isLoadingRepoSettings, repoSettings, selectedSessionIdentity, selectedTask, selection.role],
+      isUnresolvedExplicitRouteSession
+        ? inactiveRepoRuntimeReadinessTarget
+        : deriveSelectedSessionRuntimeTarget({
+            selectedSessionIdentity,
+            selectedTask,
+            role: selection.role,
+            repoSettings,
+            isLoadingRepoSettings,
+          }),
+    [
+      isLoadingRepoSettings,
+      isUnresolvedExplicitRouteSession,
+      repoSettings,
+      selectedSessionIdentity,
+      selectedTask,
+      selection.role,
+    ],
   );
   const runtimeReadiness = useRepoRuntimeReadiness({
     hasWorkspace: workspaceRepoPath !== null,
     runtimeTarget,
   });
   const repoReadinessState = runtimeReadiness.state;
-  const selectedSessionViewProjection = useMemo(
-    () =>
-      deriveSelectedSessionViewProjection({
-        selectedSessionIdentity,
-        session,
-        sessionSummary: selection.sessionSummary,
-        selectedTask,
-        readModelLoadState: sessionReadModelLoadState,
-        repoReadinessState,
-      }),
-    [
-      repoReadinessState,
+  const selectedSessionViewProjection = useMemo(() => {
+    if (isUnresolvedExplicitRouteSession && routeSessionResolution.kind === "pending") {
+      return {
+        activityState: null,
+        selectedModel: null,
+        transcriptState: { kind: "session_loading", reason: "preparing" } as const,
+      };
+    }
+    if (isUnresolvedExplicitRouteSession && routeSessionResolution.kind === "missing") {
+      const missingSessionTask = selectedTask ? `task "${selectedTask.id}"` : "the selected task";
+      return {
+        activityState: null,
+        selectedModel: null,
+        transcriptState: {
+          kind: "failed",
+          message: `Agent session "${routeSessionResolution.sessionExternalId}" was not found for ${missingSessionTask}.`,
+        } as const,
+      };
+    }
+    if (isUnresolvedExplicitRouteSession && routeSessionResolution.kind === "failed") {
+      return {
+        activityState: null,
+        selectedModel: null,
+        transcriptState: {
+          kind: "failed",
+          message: routeSessionResolution.message,
+        } as const,
+      };
+    }
+
+    return deriveSelectedSessionViewProjection({
       selectedSessionIdentity,
-      selectedTask,
       session,
-      selection.sessionSummary,
-      sessionReadModelLoadState,
-    ],
-  );
+      sessionSummary: selection.sessionSummary,
+      selectedTask,
+      readModelLoadState: sessionReadModelLoadState,
+      repoReadinessState,
+    });
+  }, [
+    repoReadinessState,
+    isUnresolvedExplicitRouteSession,
+    routeSessionResolution,
+    selectedSessionIdentity,
+    selectedTask,
+    session,
+    selection.sessionSummary,
+    sessionReadModelLoadState,
+  ]);
   const selectedSessionActivityState = selectedSessionViewProjection.activityState;
   const selectedSessionModel = selectedSessionViewProjection.selectedModel;
   const transcriptState = selectedSessionViewProjection.transcriptState;

--- a/packages/frontend/src/pages/agents/session-actions/use-agent-studio-selection-actions.ts
+++ b/packages/frontend/src/pages/agents/session-actions/use-agent-studio-selection-actions.ts
@@ -1,7 +1,7 @@
 import type { AgentRole } from "@openducktor/core";
 import { useCallback } from "react";
+import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
-import { findAgentStudioSessionSummaryByKey } from "../agents-page-selection";
 import type { SessionCreateOption } from "../agents-page-session-tabs";
 import {
   type SelectAgentStudioSelection,
@@ -30,7 +30,7 @@ export function useAgentStudioSelectionActions({
 } {
   const findSessionByValue = useCallback(
     (sessionValue: string): AgentSessionSummary | null =>
-      findAgentStudioSessionSummaryByKey(sessionsForTask, sessionValue),
+      sessionsForTask.find((session) => agentSessionIdentityKey(session) === sessionValue) ?? null,
     [sessionsForTask],
   );
 

--- a/packages/frontend/src/pages/agents/session-start/use-agent-studio-session-start-flow.ts
+++ b/packages/frontend/src/pages/agents/session-start/use-agent-studio-session-start-flow.ts
@@ -195,7 +195,7 @@ export function useAgentStudioSessionStartFlow({
           scheduleQueryUpdate(
             buildAgentStudioSelectionQueryUpdate({
               taskId: request.taskId,
-              session: workflow,
+              sessionExternalId: workflow.externalSessionId,
               role: request.role,
             }),
           );

--- a/packages/frontend/src/pages/agents/shell/agent-studio-selection-state.ts
+++ b/packages/frontend/src/pages/agents/shell/agent-studio-selection-state.ts
@@ -1,9 +1,5 @@
 import type { AgentRole } from "@openducktor/core";
-import {
-  agentSessionIdentityKey,
-  parseAgentSessionIdentityKey,
-  toAgentSessionIdentity,
-} from "@/lib/agent-session-identity";
+import { toAgentSessionIdentity } from "@/lib/agent-session-identity";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import {
   AGENT_STUDIO_QUERY_KEYS,
@@ -12,6 +8,7 @@ import {
 
 export type AgentStudioSelectionState = {
   taskId: string;
+  sessionExternalId: string | null;
   sessionIdentity: AgentSessionIdentity | null;
   role: AgentRole;
   hasExplicitRoleSelection: boolean;
@@ -22,21 +19,21 @@ export type SelectAgentStudioSelection = (selection: AgentStudioSelectionState) 
 
 export const emptyAgentStudioSelectionState = (): AgentStudioSelectionState => ({
   taskId: "",
+  sessionExternalId: null,
   sessionIdentity: null,
   role: "spec",
   hasExplicitRoleSelection: false,
   keepSessionless: false,
 });
 
-export const agentStudioSelectionSessionKey = (
+export const agentStudioSelectionSessionExternalId = (
   selection: AgentStudioSelectionState,
-): string | null =>
-  selection.sessionIdentity ? agentSessionIdentityKey(selection.sessionIdentity) : null;
+): string | null => selection.sessionIdentity?.externalSessionId ?? selection.sessionExternalId;
 
 export const agentStudioSelectionQueryKey = (selection: AgentStudioSelectionState): string =>
   [
     selection.taskId,
-    agentStudioSelectionSessionKey(selection) ?? "",
+    agentStudioSelectionSessionExternalId(selection) ?? "",
     selection.hasExplicitRoleSelection ? selection.role : "",
     selection.hasExplicitRoleSelection ? "role:explicit" : "role:derived",
   ].join("\u001f");
@@ -44,13 +41,13 @@ export const agentStudioSelectionQueryKey = (selection: AgentStudioSelectionStat
 export const createAgentStudioRouteSelectionState = ({
   isRepoNavigationBoundaryPending,
   taskIdParam,
-  sessionKeyParam,
+  sessionExternalIdParam,
   hasExplicitRoleParam,
   roleFromQuery,
 }: {
   isRepoNavigationBoundaryPending: boolean;
   taskIdParam: string;
-  sessionKeyParam: string | null;
+  sessionExternalIdParam: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
 }): AgentStudioSelectionState => {
@@ -60,7 +57,8 @@ export const createAgentStudioRouteSelectionState = ({
 
   return {
     taskId: taskIdParam,
-    sessionIdentity: parseAgentSessionIdentityKey(sessionKeyParam),
+    sessionExternalId: sessionExternalIdParam,
+    sessionIdentity: null,
     role: roleFromQuery,
     hasExplicitRoleSelection: hasExplicitRoleParam,
     keepSessionless: false,
@@ -69,6 +67,7 @@ export const createAgentStudioRouteSelectionState = ({
 
 export const toAgentStudioTaskSelection = (taskId: string): AgentStudioSelectionState => ({
   taskId,
+  sessionExternalId: null,
   sessionIdentity: null,
   role: "spec",
   hasExplicitRoleSelection: false,
@@ -79,6 +78,7 @@ export const toAgentStudioSessionSelection = (
   session: AgentSessionIdentity & { taskId: string; role: AgentRole },
 ): AgentStudioSelectionState => ({
   taskId: session.taskId,
+  sessionExternalId: session.externalSessionId,
   sessionIdentity: toAgentSessionIdentity(session),
   role: session.role,
   hasExplicitRoleSelection: true,
@@ -93,6 +93,7 @@ export const toAgentStudioSessionlessRoleSelection = ({
   role: AgentRole;
 }): AgentStudioSelectionState => ({
   taskId,
+  sessionExternalId: null,
   sessionIdentity: null,
   role,
   hasExplicitRoleSelection: true,
@@ -103,6 +104,6 @@ export const buildAgentStudioSelectionQueryUpdateFromState = (
   selection: AgentStudioSelectionState,
 ): AgentStudioQueryUpdate => ({
   [AGENT_STUDIO_QUERY_KEYS.task]: selection.taskId || undefined,
-  [AGENT_STUDIO_QUERY_KEYS.session]: agentStudioSelectionSessionKey(selection) ?? undefined,
+  [AGENT_STUDIO_QUERY_KEYS.session]: agentStudioSelectionSessionExternalId(selection) ?? undefined,
   [AGENT_STUDIO_QUERY_KEYS.agent]: selection.hasExplicitRoleSelection ? selection.role : undefined,
 });

--- a/packages/frontend/src/pages/agents/shell/use-agent-studio-selection-state.test.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agent-studio-selection-state.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, mock, test } from "bun:test";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
@@ -26,7 +25,7 @@ const session = {
 const baseProps = (overrides: Partial<HookProps> = {}): HookProps => ({
   isRepoNavigationBoundaryPending: false,
   taskIdParam: "task-1",
-  sessionKeyParam: null,
+  sessionExternalIdParam: null,
   hasExplicitRoleParam: false,
   roleFromQuery: "spec",
   scheduleQueryUpdate: () => {},
@@ -49,7 +48,7 @@ describe("useAgentStudioSelectionState", () => {
     expect(harness.getLatest().selection).toEqual(toAgentStudioSessionSelection(session));
     expect(scheduleQueryUpdate).toHaveBeenCalledWith({
       task: "task-1",
-      session: agentSessionIdentityKey(session),
+      session: "session-1",
       agent: "build",
     });
 
@@ -95,6 +94,7 @@ describe("useAgentStudioSelectionState", () => {
 
     expect(harness.getLatest().selection).toEqual({
       taskId: "task-3",
+      sessionExternalId: null,
       sessionIdentity: null,
       role: "qa",
       hasExplicitRoleSelection: true,

--- a/packages/frontend/src/pages/agents/shell/use-agent-studio-selection-state.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agent-studio-selection-state.ts
@@ -12,7 +12,7 @@ import {
 type UseAgentStudioSelectionStateArgs = {
   isRepoNavigationBoundaryPending: boolean;
   taskIdParam: string;
-  sessionKeyParam: string | null;
+  sessionExternalIdParam: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
   scheduleQueryUpdate: (updates: AgentStudioQueryUpdate) => void;
@@ -31,7 +31,7 @@ export type AgentStudioSelectionStateModel = {
 export function useAgentStudioSelectionState({
   isRepoNavigationBoundaryPending,
   taskIdParam,
-  sessionKeyParam,
+  sessionExternalIdParam,
   hasExplicitRoleParam,
   roleFromQuery,
   scheduleQueryUpdate,
@@ -41,7 +41,7 @@ export function useAgentStudioSelectionState({
       createAgentStudioRouteSelectionState({
         isRepoNavigationBoundaryPending,
         taskIdParam,
-        sessionKeyParam,
+        sessionExternalIdParam,
         hasExplicitRoleParam,
         roleFromQuery,
       }),
@@ -49,7 +49,7 @@ export function useAgentStudioSelectionState({
       hasExplicitRoleParam,
       isRepoNavigationBoundaryPending,
       roleFromQuery,
-      sessionKeyParam,
+      sessionExternalIdParam,
       taskIdParam,
     ],
   );

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-route-session-model.ts
@@ -40,7 +40,7 @@ export function useAgentsPageRouteSessionModel({
 
   const {
     taskIdParam,
-    sessionKeyParam,
+    sessionExternalIdParam,
     hasExplicitRoleParam,
     roleFromQuery,
     isRepoNavigationBoundaryPending,
@@ -67,7 +67,7 @@ export function useAgentsPageRouteSessionModel({
   const { selection: selectionState, selectAgentStudioSelection } = useAgentStudioSelectionState({
     isRepoNavigationBoundaryPending,
     taskIdParam,
-    sessionKeyParam,
+    sessionExternalIdParam,
     hasExplicitRoleParam,
     roleFromQuery,
     scheduleQueryUpdate,
@@ -81,7 +81,7 @@ export function useAgentsPageRouteSessionModel({
     isLoadingTasks: isForegroundLoadingTasks,
     sessions,
     taskIdParam,
-    sessionKeyParam,
+    sessionExternalIdParam,
     hasExplicitRoleParam,
     roleFromQuery,
     selectionState,

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -54,7 +54,7 @@ const handleResolveRebaseConflict = mock(async () => true);
 
 type QuerySyncState = {
   taskIdParam: string;
-  sessionKeyParam: string;
+  sessionExternalIdParam: string;
   hasExplicitRoleParam: boolean;
   roleFromQuery: "planner";
   launchActionId: "planner_initial";
@@ -223,7 +223,7 @@ let agentOperations: AgentOperationsContextValue = {
 };
 let querySyncState: QuerySyncState = {
   taskIdParam: "task-1",
-  sessionKeyParam: selectedSessionKey(),
+  sessionExternalIdParam: selectedSessionKey(),
   hasExplicitRoleParam: false,
   roleFromQuery: "planner" as const,
   launchActionId: "planner_initial" as const,
@@ -559,7 +559,7 @@ beforeEach(async () => {
   };
   querySyncState = {
     taskIdParam: "task-1",
-    sessionKeyParam: selectedSessionKey(),
+    sessionExternalIdParam: selectedSessionKey(),
     hasExplicitRoleParam: false,
     roleFromQuery: "planner",
     launchActionId: "planner_initial",

--- a/packages/frontend/src/pages/agents/use-agent-studio-query-sync.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-query-sync.test.tsx
@@ -18,7 +18,7 @@ enableReactActEnvironment();
 type HookArgs = Parameters<typeof useAgentStudioQuerySync>[0];
 type SearchParamsCall = Parameters<SetURLSearchParams>;
 
-const sessionKeyParam = (sessionKey: string) => sessionKey;
+const sessionExternalIdParam = (sessionExternalId: string) => sessionExternalId;
 
 type StatefulQuerySyncArgs = {
   activeWorkspaceId: string | null;
@@ -152,7 +152,7 @@ describe("useAgentStudioQuerySync", () => {
 
     const latest = harness.getLatest();
     expect(latest.taskIdParam).toBe("task-2");
-    expect(latest.sessionKeyParam).toEqual(sessionKeyParam("session-2"));
+    expect(latest.sessionExternalIdParam).toEqual(sessionExternalIdParam("session-2"));
     expect(latest.roleFromQuery).toBe("planner");
 
     expect(calls).toHaveLength(0);
@@ -179,7 +179,7 @@ describe("useAgentStudioQuerySync", () => {
         JSON.stringify({
           taskId: "task-from-context",
           role: "planner",
-          sessionKey: "session-from-context",
+          sessionExternalId: "session-from-context",
         }),
       );
 
@@ -197,7 +197,7 @@ describe("useAgentStudioQuerySync", () => {
 
       const latest = harness.getLatest();
       expect(latest.taskIdParam).toBe("task-from-context");
-      expect(latest.sessionKeyParam).toEqual(sessionKeyParam("session-from-context"));
+      expect(latest.sessionExternalIdParam).toEqual(sessionExternalIdParam("session-from-context"));
       expect(latest.roleFromQuery).toBe("planner");
 
       await harness.unmount();
@@ -244,7 +244,7 @@ describe("useAgentStudioQuerySync", () => {
         JSON.stringify({
           taskId: "task-from-context",
           role: "planner",
-          sessionKey: "session-from-context",
+          sessionExternalId: "session-from-context",
         }),
       );
 
@@ -277,7 +277,7 @@ describe("useAgentStudioQuerySync", () => {
         JSON.stringify({
           taskId: "task-from-context",
           role: "build",
-          sessionKey: "session-from-context",
+          sessionExternalId: "session-from-context",
         }),
       );
 
@@ -295,7 +295,7 @@ describe("useAgentStudioQuerySync", () => {
       await harness.mount();
       const latest = harness.getLatest();
       expect(latest.taskIdParam).toBe("task-from-url");
-      expect(latest.sessionKeyParam).toEqual(sessionKeyParam("session-from-url"));
+      expect(latest.sessionExternalIdParam).toEqual(sessionExternalIdParam("session-from-url"));
       expect(latest.roleFromQuery).toBe("spec");
       expect(latest.hasExplicitRoleParam).toBe(true);
       await harness.unmount();
@@ -315,7 +315,7 @@ describe("useAgentStudioQuerySync", () => {
         JSON.stringify({
           taskId: "task-from-repo-b",
           role: "planner",
-          sessionKey: "session-from-repo-b",
+          sessionExternalId: "session-from-repo-b",
         }),
       );
 
@@ -336,7 +336,7 @@ describe("useAgentStudioQuerySync", () => {
       const latest = harness.getLatest();
       expect(latest.isRepoNavigationBoundaryPending).toBeFalse();
       expect(latest.taskIdParam).toBe("task-from-repo-b");
-      expect(latest.sessionKeyParam).toEqual(sessionKeyParam("session-from-repo-b"));
+      expect(latest.sessionExternalIdParam).toEqual(sessionExternalIdParam("session-from-repo-b"));
       expect(latest.roleFromQuery).toBe("planner");
 
       await harness.unmount();
@@ -347,8 +347,8 @@ describe("useAgentStudioQuerySync", () => {
     const memoryStorage = createMemoryStorage();
     await withMockedLocalStorage(memoryStorage, async () => {
       seedWorkspaceNavigationContexts(memoryStorage, {
-        "workspace-repo-a": { taskId: "task-a", role: "spec", sessionKey: "session-a" },
-        "workspace-repo-b": { taskId: "task-b", role: "planner", sessionKey: "session-b" },
+        "workspace-repo-a": { taskId: "task-a", role: "spec", sessionExternalId: "session-a" },
+        "workspace-repo-b": { taskId: "task-b", role: "planner", sessionExternalId: "session-b" },
       });
 
       const harness = createStatefulQuerySyncHarness({
@@ -373,7 +373,7 @@ describe("useAgentStudioQuerySync", () => {
 
       const latest = harness.getLatest();
       expect(latest.taskIdParam).toBe("task-a");
-      expect(latest.sessionKeyParam).toEqual(sessionKeyParam("session-a"));
+      expect(latest.sessionExternalIdParam).toEqual(sessionExternalIdParam("session-a"));
       expect(latest.roleFromQuery).toBe("spec");
 
       await harness.unmount();
@@ -384,8 +384,8 @@ describe("useAgentStudioQuerySync", () => {
     const memoryStorage = createMemoryStorage();
     await withMockedLocalStorage(memoryStorage, async () => {
       seedWorkspaceNavigationContexts(memoryStorage, {
-        "workspace-repo-a": { taskId: "task-a", role: "spec", sessionKey: "session-a" },
-        "workspace-repo-b": { taskId: "task-b", role: "planner", sessionKey: "session-b" },
+        "workspace-repo-a": { taskId: "task-a", role: "spec", sessionExternalId: "session-a" },
+        "workspace-repo-b": { taskId: "task-b", role: "planner", sessionExternalId: "session-b" },
       });
 
       const harness = createStatefulQuerySyncHarness({
@@ -408,7 +408,7 @@ describe("useAgentStudioQuerySync", () => {
 
       const latest = harness.getLatest();
       expect(latest.taskIdParam).toBe("task-a");
-      expect(latest.sessionKeyParam).toEqual(sessionKeyParam("session-a"));
+      expect(latest.sessionExternalIdParam).toEqual(sessionExternalIdParam("session-a"));
       expect(latest.roleFromQuery).toBe("spec");
 
       await harness.unmount();
@@ -447,12 +447,12 @@ describe("useAgentStudioQuerySync", () => {
 
       const parsed = JSON.parse(stored) as {
         taskId?: string;
-        sessionKey?: string;
+        sessionExternalId?: string;
         role?: string;
       };
 
       expect(parsed.taskId).toBe("task-from-cleanup");
-      expect(parsed.sessionKey).toBe("session-from-cleanup");
+      expect(parsed.sessionExternalId).toBe("session-from-cleanup");
       expect(parsed.role).toBe("spec");
     } finally {
       Object.defineProperty(globalThis, "localStorage", {

--- a/packages/frontend/src/pages/agents/use-agent-studio-rebase-conflict-resolution.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-rebase-conflict-resolution.test.tsx
@@ -135,7 +135,7 @@ describe("useAgentStudioRebaseConflictResolution", () => {
       );
       expect(args.scheduleQueryUpdate).toHaveBeenCalledWith({
         task: "task-1",
-        session: agentSessionIdentityKey(sessionWorkflowResult("build-1")),
+        session: "build-1",
         agent: "build",
       });
     } finally {
@@ -233,7 +233,7 @@ describe("useAgentStudioRebaseConflictResolution", () => {
       );
       expect(args.scheduleQueryUpdate).toHaveBeenCalledWith({
         task: "task-1",
-        session: agentSessionIdentityKey(sessionWorkflowResult("build-new-9")),
+        session: "build-new-9",
         agent: "build",
       });
     } finally {
@@ -269,7 +269,7 @@ describe("useAgentStudioRebaseConflictResolution", () => {
       );
       expect(args.scheduleQueryUpdate).toHaveBeenCalledWith({
         task: "task-1",
-        session: agentSessionIdentityKey(sessionWorkflowResult("build-new-9")),
+        session: "build-new-9",
         agent: "build",
       });
     } finally {

--- a/packages/frontend/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
@@ -14,7 +14,10 @@ import { matchesAgentSessionIdentity } from "@/lib/agent-session-identity";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import { loadEffectivePromptOverrides } from "../../state/operations/prompt-overrides";
 import { resolveAgentStudioBuilderSessionsForTask } from "./agents-page-selection";
-import type { AgentStudioQueryUpdate } from "./query-sync/agent-studio-navigation";
+import {
+  type AgentStudioQueryUpdate,
+  buildAgentStudioSelectionQueryUpdate,
+} from "./query-sync/agent-studio-navigation";
 import type { AgentStudioSelectionControllerResult } from "./use-agent-studio-selection-controller";
 
 type AgentStudioRebaseConflictResolutionSelectionContext = {
@@ -100,11 +103,13 @@ export function useAgentStudioRebaseConflictResolution({
         onOpenSession: (session) => {
           const builderSession =
             builderSessions.find((entry) => matchesAgentSessionIdentity(entry, session)) ?? null;
-          scheduleQueryUpdate({
-            task: view.taskId,
-            session: session.externalSessionId,
-            agent: builderSession?.role ?? defaultBuilderSession?.role ?? "build",
-          });
+          scheduleQueryUpdate(
+            buildAgentStudioSelectionQueryUpdate({
+              taskId: view.taskId,
+              sessionExternalId: session.externalSessionId,
+              role: builderSession?.role ?? defaultBuilderSession?.role ?? "build",
+            }),
+          );
         },
       });
     },

--- a/packages/frontend/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
@@ -10,7 +10,7 @@ import type {
   SessionStartLaunchRequest,
   SessionStartWorkflowResult,
 } from "@/features/session-start";
-import { agentSessionIdentityKey, matchesAgentSessionIdentity } from "@/lib/agent-session-identity";
+import { matchesAgentSessionIdentity } from "@/lib/agent-session-identity";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import { loadEffectivePromptOverrides } from "../../state/operations/prompt-overrides";
 import { resolveAgentStudioBuilderSessionsForTask } from "./agents-page-selection";
@@ -102,7 +102,7 @@ export function useAgentStudioRebaseConflictResolution({
             builderSessions.find((entry) => matchesAgentSessionIdentity(entry, session)) ?? null;
           scheduleQueryUpdate({
             task: view.taskId,
-            session: agentSessionIdentityKey(session),
+            session: session.externalSessionId,
             agent: builderSession?.role ?? defaultBuilderSession?.role ?? "build",
           });
         },

--- a/packages/frontend/src/pages/agents/use-agent-studio-selection-controller.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-selection-controller.test.tsx
@@ -127,7 +127,7 @@ const createSession = (
   return toAgentSessionSummary(session);
 };
 
-const sessionKeyParam = (session: AgentSessionIdentity): string => agentSessionIdentityKey(session);
+const sessionExternalIdParam = (session: AgentSessionIdentity): string => session.externalSessionId;
 
 const syncSessionLookup = (sessions: HookArgs["sessions"]): void => {
   sessionStore.setSessionCollection(() =>
@@ -250,7 +250,7 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => {
     isLoadingTasks: false,
     sessions: [],
     taskIdParam: "task-1",
-    sessionKeyParam: null,
+    sessionExternalIdParam: null,
     hasExplicitRoleParam: false,
     roleFromQuery: "spec",
     repoSettings,
@@ -265,7 +265,7 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => {
       createAgentStudioRouteSelectionState({
         isRepoNavigationBoundaryPending: baseArgs.isRepoNavigationBoundaryPending,
         taskIdParam: baseArgs.taskIdParam,
-        sessionKeyParam: baseArgs.sessionKeyParam,
+        sessionExternalIdParam: baseArgs.sessionExternalIdParam,
         hasExplicitRoleParam: baseArgs.hasExplicitRoleParam,
         roleFromQuery: baseArgs.roleFromQuery,
       }),
@@ -283,13 +283,13 @@ describe("useAgentStudioSelectionController", () => {
     sessionStore = createAgentSessionsStore(workspaceRepoPath);
   });
 
-  test("resolves task context from selected session when task param is missing", async () => {
+  test("does not resolve a session without its task route context", async () => {
     const session = createSession("task-2", "session-2");
     const harness = createHookHarness(
       createBaseArgs({
         sessions: [session],
         taskIdParam: "",
-        sessionKeyParam: sessionKeyParam(session),
+        sessionExternalIdParam: sessionExternalIdParam(session),
       }),
     );
 
@@ -297,11 +297,14 @@ describe("useAgentStudioSelectionController", () => {
       await harness.mount();
 
       const latest = harness.getLatest();
-      expect(latest.taskId).toBe("task-2");
-      expect(latest.selectedTask?.id).toBe("task-2");
-      expect(latest.resolvedRouteSession?.externalSessionId).toBe("session-2");
-      expect(latest.view.taskId).toBe("task-2");
-      expect(latest.view.selectedSession.loadedSession?.externalSessionId).toBe("session-2");
+      expect(latest.routeSessionResolution).toEqual({
+        kind: "pending",
+        sessionExternalId: "session-2",
+      });
+      expect(latest.taskId).toBe("");
+      expect(latest.selectedTask).toBeNull();
+      expect(latest.resolvedRouteSession).toBeNull();
+      expect(latest.view.selectedSession.loadedSession).toBeNull();
     } finally {
       await harness.unmount();
     }
@@ -324,7 +327,7 @@ describe("useAgentStudioSelectionController", () => {
         workspaceRepoPath,
         sessions: [selectedSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(selectedSession),
+        sessionExternalIdParam: sessionExternalIdParam(selectedSession),
       }),
       {
         loadAgentSessionContext: async () => {
@@ -411,7 +414,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [createTask("task-1")],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: false,
       }),
       {
@@ -433,7 +436,7 @@ describe("useAgentStudioSelectionController", () => {
     }
   });
 
-  test("keeps the selected task in runtime waiting while runtime readiness is checking", async () => {
+  test("does not probe runtime readiness while explicit session metadata is pending", async () => {
     const task = createTaskCardFixture({
       id: "task-1",
       title: "task-1",
@@ -446,7 +449,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: "session-reloaded",
+        sessionExternalIdParam: "session-reloaded",
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -468,7 +471,8 @@ describe("useAgentStudioSelectionController", () => {
 
       const latest = harness.getLatest();
       expect(latest.view.selectedSession.transcriptState).toEqual({
-        kind: "runtime_waiting",
+        kind: "session_loading",
+        reason: "preparing",
       });
       expect(latest.view.selectedSession.loadedSession).toBeNull();
     } finally {
@@ -495,7 +499,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [codexSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(codexSession),
+        sessionExternalIdParam: sessionExternalIdParam(codexSession),
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -549,7 +553,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [codexSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(codexSession),
+        sessionExternalIdParam: sessionExternalIdParam(codexSession),
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -597,7 +601,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -644,7 +648,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -702,7 +706,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -745,7 +749,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -789,7 +793,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: "session-reloaded",
+        sessionExternalIdParam: "session-reloaded",
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -805,6 +809,11 @@ describe("useAgentStudioSelectionController", () => {
       await harness.mount();
 
       const latest = harness.getLatest();
+      expect(latest.routeSessionResolution).toEqual({
+        kind: "failed",
+        sessionExternalId: "session-reloaded",
+        message: "Failed to load agent session read model",
+      });
       expect(latest.view.selectedSession.transcriptState).toEqual({
         kind: "failed",
         message: "Failed to load agent session read model",
@@ -826,7 +835,7 @@ describe("useAgentStudioSelectionController", () => {
         workspaceRepoPath,
         sessions: [session],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(session),
+        sessionExternalIdParam: sessionExternalIdParam(session),
       }),
       { loadSelectedSessionBaselineHistory: loadSessionHistory },
     );
@@ -863,7 +872,7 @@ describe("useAgentStudioSelectionController", () => {
         workspaceRepoPath,
         sessions: [session],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(session),
+        sessionExternalIdParam: sessionExternalIdParam(session),
       }),
       { loadSelectedSessionBaselineHistory: loadSessionHistory },
     );
@@ -902,7 +911,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [task],
         sessions: [session],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(session),
+        sessionExternalIdParam: sessionExternalIdParam(session),
       }),
       {
         loadSelectedSessionBaselineHistory: loadSessionHistory,
@@ -943,7 +952,7 @@ describe("useAgentStudioSelectionController", () => {
       createBaseArgs({
         sessions: [specSession, plannerSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(specSession),
+        sessionExternalIdParam: sessionExternalIdParam(specSession),
         hasExplicitRoleParam: true,
         roleFromQuery: "spec",
         selectionState: toAgentStudioSessionSelection(plannerSession),
@@ -957,7 +966,11 @@ describe("useAgentStudioSelectionController", () => {
       expect(latest.view.role).toBe("planner");
       expect(latest.view.launchActionId).toBe("planner_initial");
       expect(latest.view.selectedSession.loadedSession?.externalSessionId).toBe("session-planner");
-      expect(latest.resolvedRouteSession?.externalSessionId).toBe("session-spec");
+      expect(latest.routeSessionResolution).toEqual({
+        kind: "pending",
+        sessionExternalId: "session-spec",
+      });
+      expect(latest.resolvedRouteSession).toBeNull();
     } finally {
       await harness.unmount();
     }
@@ -973,7 +986,7 @@ describe("useAgentStudioSelectionController", () => {
       createBaseArgs({
         sessions: [buildSession],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: false,
         roleFromQuery: "spec",
         selectionState: toAgentStudioSessionlessRoleSelection({
@@ -1008,7 +1021,7 @@ describe("useAgentStudioSelectionController", () => {
         workspaceRepoPath,
         sessions: [buildSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(buildSession),
+        sessionExternalIdParam: sessionExternalIdParam(buildSession),
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -1027,12 +1040,16 @@ describe("useAgentStudioSelectionController", () => {
     }
   });
 
-  test("keeps full route session identity pending while the session read model loads", async () => {
+  test("keeps an external route session id pending without starting runtime operations", async () => {
     const staleSessionIdentity: AgentSessionIdentity = {
       externalSessionId: "deleted-session",
       runtimeKind: "opencode",
       workingDirectory: "/repo/worktrees/deleted-session",
     };
+    const loadSessionHistory = mock(async () => null);
+    const readSessionTodos = mock(async () => []);
+    const loadAgentSessionContext = mock(async () => undefined);
+    const loadRepoRuntimeCatalog = mock(async () => emptyCatalog);
     const harness = createHookHarness(
       createBaseArgs({
         activeWorkspaceId,
@@ -1040,12 +1057,16 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [createTask("task-1")],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(staleSessionIdentity),
+        sessionExternalIdParam: sessionExternalIdParam(staleSessionIdentity),
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
       {
         sessionReadModelLoadState: loadingAgentSessionReadModelLoadState(workspaceRepoPath),
+        loadSelectedSessionBaselineHistory: loadSessionHistory,
+        readSessionTodos,
+        loadAgentSessionContext,
+        runtimeDefinitionsContext: { loadRepoRuntimeCatalog },
       },
     );
 
@@ -1055,19 +1076,23 @@ describe("useAgentStudioSelectionController", () => {
       const latest = harness.getLatest();
       expect(latest.routeSessionResolution).toEqual({
         kind: "pending",
-        sessionKey: sessionKeyParam(staleSessionIdentity),
+        sessionExternalId: sessionExternalIdParam(staleSessionIdentity),
       });
-      expect(latest.view.selectedSession.identity).toEqual(staleSessionIdentity);
+      expect(latest.view.selectedSession.identity).toBeNull();
       expect(latest.view.selectedSession.transcriptState).toEqual({
         kind: "session_loading",
         reason: "preparing",
       });
+      expect(loadSessionHistory).not.toHaveBeenCalled();
+      expect(readSessionTodos).not.toHaveBeenCalled();
+      expect(loadAgentSessionContext).not.toHaveBeenCalled();
+      expect(loadRepoRuntimeCatalog).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
     }
   });
 
-  test("drops stale full route session identity after the session read model resolves", async () => {
+  test("surfaces a missing external route session without default fallback", async () => {
     const staleSessionIdentity: AgentSessionIdentity = {
       externalSessionId: "deleted-session",
       runtimeKind: "opencode",
@@ -1080,7 +1105,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [createTask("task-1")],
         sessions: [],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(staleSessionIdentity),
+        sessionExternalIdParam: sessionExternalIdParam(staleSessionIdentity),
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -1092,15 +1117,15 @@ describe("useAgentStudioSelectionController", () => {
       const latest = harness.getLatest();
       expect(latest.routeSessionResolution).toEqual({
         kind: "missing",
-        sessionKey: sessionKeyParam(staleSessionIdentity),
+        sessionExternalId: sessionExternalIdParam(staleSessionIdentity),
       });
       expect(latest.taskId).toBe("task-1");
       expect(latest.selectedTask?.id).toBe("task-1");
       expect(latest.view.selectedSession.identity).toBeNull();
       expect(latest.view.selectedSession.loadedSession).toBeNull();
       expect(latest.view.selectedSession.transcriptState).toEqual({
-        kind: "empty",
-        reason: "sessionless",
+        kind: "failed",
+        message: 'Agent session "deleted-session" was not found for task "task-1".',
       });
     } finally {
       await harness.unmount();
@@ -1128,7 +1153,7 @@ describe("useAgentStudioSelectionController", () => {
         workspaceRepoPath,
         sessions: [buildSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(buildSession),
+        sessionExternalIdParam: sessionExternalIdParam(buildSession),
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -1140,6 +1165,13 @@ describe("useAgentStudioSelectionController", () => {
       await harness.waitFor((latest) => latest.view.selectedSession.runtimeData.todos.length === 1);
 
       expect(readSessionTodos).toHaveBeenCalledTimes(1);
+      expect(readSessionTodos).toHaveBeenCalledWith(
+        expect.objectContaining({
+          externalSessionId: "session-build",
+          runtimeKind: "opencode",
+          workingDirectory: "/repo",
+        }),
+      );
       expect(harness.getLatest().view.selectedSession.runtimeData.todos[0]?.id).toBe("todo-1");
     } finally {
       await harness.unmount();
@@ -1173,7 +1205,7 @@ describe("useAgentStudioSelectionController", () => {
         workspaceRepoPath,
         sessions: [activeSession, viewSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(activeSession),
+        sessionExternalIdParam: sessionExternalIdParam(activeSession),
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -1204,7 +1236,7 @@ describe("useAgentStudioSelectionController", () => {
           workspaceRepoPath,
           sessions: [activeSession, viewSession],
           taskIdParam: "task-1",
-          sessionKeyParam: sessionKeyParam(activeSession),
+          sessionExternalIdParam: sessionExternalIdParam(activeSession),
           hasExplicitRoleParam: true,
           roleFromQuery: "build",
           selectionState: toAgentStudioTaskSelection("task-2"),
@@ -1242,7 +1274,7 @@ describe("useAgentStudioSelectionController", () => {
         isRepoNavigationBoundaryPending: true,
         sessions: [staleSession],
         taskIdParam: "task-1",
-        sessionKeyParam: sessionKeyParam(staleSession),
+        sessionExternalIdParam: sessionExternalIdParam(staleSession),
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
       }),
@@ -1520,7 +1552,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [humanReviewTask, createTask("task-2")],
         sessions: [initialBuildSession],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: false,
       }),
     );
@@ -1538,7 +1570,7 @@ describe("useAgentStudioSelectionController", () => {
           tasks: [humanReviewTask, createTask("task-2")],
           sessions: [newerQaSession, initialBuildSession],
           taskIdParam: "task-1",
-          sessionKeyParam: null,
+          sessionExternalIdParam: null,
           hasExplicitRoleParam: false,
         }),
       );
@@ -1575,7 +1607,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [humanReviewTask, createTask("task-2")],
         sessions: [qaSession, buildSession],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: false,
         roleFromQuery: "build",
       }),
@@ -1593,7 +1625,7 @@ describe("useAgentStudioSelectionController", () => {
           tasks: [humanReviewTask, createTask("task-2")],
           sessions: [qaSession, buildSession],
           taskIdParam: "task-1",
-          sessionKeyParam: null,
+          sessionExternalIdParam: null,
           hasExplicitRoleParam: false,
           roleFromQuery: "qa",
         }),
@@ -1633,7 +1665,7 @@ describe("useAgentStudioSelectionController", () => {
         tasks: [taskOne, humanReviewTask],
         sessions: [buildSession, qaSession],
         taskIdParam: "task-1",
-        sessionKeyParam: null,
+        sessionExternalIdParam: null,
         hasExplicitRoleParam: false,
         roleFromQuery: "qa",
         selectAgentStudioSelection,
@@ -1653,7 +1685,7 @@ describe("useAgentStudioSelectionController", () => {
           tasks: [taskOne, humanReviewTask],
           sessions: [buildSession, qaSession],
           taskIdParam: "task-1",
-          sessionKeyParam: null,
+          sessionExternalIdParam: null,
           hasExplicitRoleParam: false,
           roleFromQuery: "qa",
           selectionState: toAgentStudioTaskSelection("task-2"),
@@ -1672,7 +1704,7 @@ describe("useAgentStudioSelectionController", () => {
           tasks: [taskOne, humanReviewTask],
           sessions: [buildSession, qaSession],
           taskIdParam: "task-2",
-          sessionKeyParam: null,
+          sessionExternalIdParam: null,
           hasExplicitRoleParam: false,
           roleFromQuery: "qa",
           selectAgentStudioSelection,

--- a/packages/frontend/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -30,7 +30,7 @@ type UseAgentStudioSelectionControllerArgs = {
   isLoadingTasks: boolean;
   sessions: AgentSessionSummary[];
   taskIdParam: string;
-  sessionKeyParam: string | null;
+  sessionExternalIdParam: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
   selectionState: AgentStudioSelectionState;
@@ -78,7 +78,7 @@ export function useAgentStudioSelectionController({
   isLoadingTasks,
   sessions,
   taskIdParam,
-  sessionKeyParam,
+  sessionExternalIdParam,
   hasExplicitRoleParam,
   roleFromQuery,
   selectionState,
@@ -99,7 +99,7 @@ export function useAgentStudioSelectionController({
         tasks,
         sessions,
         taskIdParam,
-        sessionKeyParam,
+        sessionExternalIdParam,
         hasExplicitRoleParam,
         roleFromQuery,
         selectionState,
@@ -111,7 +111,7 @@ export function useAgentStudioSelectionController({
       isRepoNavigationBoundaryPending,
       roleFromQuery,
       selectionState,
-      sessionKeyParam,
+      sessionExternalIdParam,
       sessionReadModelLoadState,
       sessions,
       taskIdParam,
@@ -178,7 +178,7 @@ export function useAgentStudioSelectionController({
       tasks,
       sessions,
       taskIdParam,
-      sessionKeyParam,
+      sessionExternalIdParam,
       hasExplicitRoleParam,
       roleFromQuery,
       selectionState,
@@ -192,7 +192,7 @@ export function useAgentStudioSelectionController({
     navigationBase,
     roleFromQuery,
     selectionState,
-    sessionKeyParam,
+    sessionExternalIdParam,
     sessionReadModelLoadState,
     sessions,
     taskIdParam,
@@ -203,7 +203,8 @@ export function useAgentStudioSelectionController({
     workspaceRepoPath,
     selectedTask: navigationState.view.selectedTask,
     sessionSummaries: navigationState.view.sessionsForTask,
-    sessionKey: navigationState.view.sessionKey,
+    sessionExternalId: navigationState.view.sessionExternalId,
+    routeSessionResolution: navigationState.routeSessionResolution,
     hasExplicitRoleSelection: navigationState.view.hasExplicitRoleSelection,
     roleSelection: navigationState.view.role,
     sessionlessRole: navigationState.view.role,

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -416,6 +416,7 @@ describe("useAgentStudioSessionActions", () => {
     expect(scheduleQueryUpdate).not.toHaveBeenCalled();
     expect(selectAgentStudioSelection).toHaveBeenCalledWith({
       taskId: "task-1",
+      sessionExternalId: null,
       sessionIdentity: null,
       role: "build",
       hasExplicitRoleSelection: true,
@@ -652,11 +653,7 @@ describe("useAgentStudioSessionActions", () => {
     expect(sendAgentMessage).toHaveBeenCalledWith(sessionIdentity("session-new"), [
       { kind: "text", text: "  hello world  " },
     ]);
-    expect(
-      updateCalls.some(
-        (entry) => entry.session === agentSessionIdentityKey(sessionIdentity("session-new")),
-      ),
-    ).toBe(true);
+    expect(updateCalls.some((entry) => entry.session === "session-new")).toBe(true);
 
     await harness.unmount();
   });
@@ -1664,6 +1661,7 @@ describe("useAgentStudioSessionActions", () => {
 
     expect(selectAgentStudioSelection).toHaveBeenCalledWith({
       taskId: "task-2",
+      sessionExternalId: "session-2",
       sessionIdentity: toAgentSessionIdentity(sessionTwo),
       role: "spec",
       hasExplicitRoleSelection: true,
@@ -1690,6 +1688,7 @@ describe("useAgentStudioSessionActions", () => {
 
     expect(selectAgentStudioSelection).toHaveBeenCalledWith({
       taskId: "task-1",
+      sessionExternalId: null,
       sessionIdentity: null,
       role: "planner",
       hasExplicitRoleSelection: true,
@@ -1878,6 +1877,7 @@ describe("useAgentStudioSessionActions", () => {
 
     expect(selectAgentStudioSelection).toHaveBeenCalledWith({
       taskId: "task-1",
+      sessionExternalId: "session-1",
       sessionIdentity: toAgentSessionIdentity(session),
       role: "spec",
       hasExplicitRoleSelection: true,
@@ -1906,6 +1906,7 @@ describe("useAgentStudioSessionActions", () => {
     expect(selections).toEqual([
       {
         taskId: "task-1",
+        sessionExternalId: "session-1",
         sessionIdentity: toAgentSessionIdentity(session),
         role: "spec",
         hasExplicitRoleSelection: true,
@@ -1920,6 +1921,7 @@ describe("useAgentStudioSessionActions", () => {
     expect(selections).toEqual([
       {
         taskId: "task-1",
+        sessionExternalId: null,
         sessionIdentity: null,
         role: "planner",
         hasExplicitRoleSelection: true,

--- a/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -8,7 +8,6 @@ import {
   createSessionStartWorkflowRunner,
   type SessionStartWorkflowResult,
 } from "@/features/session-start";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { QueryProvider } from "@/lib/query-provider";
 import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import {
@@ -417,7 +416,7 @@ describe("useAgentStudioSessionStartFlow", () => {
 
     expect(updateCalls).toContainEqual({
       task: "task-1",
-      session: agentSessionIdentityKey(sessionIdentity("session-new")),
+      session: "session-new",
       agent: "spec",
     });
 
@@ -511,7 +510,7 @@ describe("useAgentStudioSessionStartFlow", () => {
     });
     expect(updateCalls).toContainEqual({
       task: "task-1",
-      session: agentSessionIdentityKey(sessionIdentity("session-new")),
+      session: "session-new",
       agent: "planner",
     });
     expect(harness.getLatest().isStarting).toBe(false);
@@ -617,7 +616,7 @@ describe("useAgentStudioSessionStartFlow", () => {
     });
     expect(updateCalls).toContainEqual({
       task: "task-1",
-      session: agentSessionIdentityKey(sessionIdentity("session-plan")),
+      session: "session-plan",
       agent: "planner",
     });
 
@@ -828,7 +827,7 @@ describe("useAgentStudioSessionStartFlow", () => {
     });
     expect(updateCalls).toContainEqual({
       task: "task-1",
-      session: agentSessionIdentityKey(sessionIdentity("session-build-rework")),
+      session: "session-build-rework",
       agent: "build",
     });
 
@@ -920,7 +919,7 @@ describe("useAgentStudioSessionStartFlow", () => {
     );
     expect(updateCalls).toContainEqual({
       task: "task-1",
-      session: agentSessionIdentityKey(sessionIdentity("session-existing")),
+      session: "session-existing",
       agent: "build",
     });
     await harness.waitFor(() => sendAgentMessage.mock.calls.length > 0);

--- a/packages/frontend/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -63,6 +63,7 @@ const createSession = (taskId: string, externalSessionId: string) =>
 
 const taskSelection = (taskId: string): AgentStudioSelectionState => ({
   taskId,
+  sessionExternalId: null,
   sessionIdentity: null,
   role: "spec",
   hasExplicitRoleSelection: false,

--- a/packages/frontend/src/pages/agents/use-navigation-url-sync.test.tsx
+++ b/packages/frontend/src/pages/agents/use-navigation-url-sync.test.tsx
@@ -34,7 +34,7 @@ describe("useNavigationUrlSync", () => {
       await harness.mount();
       expect(harness.getLatest().navigation).toMatchObject({
         taskId: "task-1",
-        sessionKey: null,
+        sessionExternalId: null,
         role: "build",
       });
       calls.length = 0;
@@ -82,7 +82,7 @@ describe("useNavigationUrlSync", () => {
     await harness.mount();
     expect(harness.getLatest().navigation).toMatchObject({
       taskId: "task-1",
-      sessionKey: null,
+      sessionExternalId: null,
       role: "spec",
     });
     expect(calls).toHaveLength(0);
@@ -95,7 +95,7 @@ describe("useNavigationUrlSync", () => {
 
     expect(harness.getLatest().navigation).toMatchObject({
       taskId: "task-2",
-      sessionKey: "session-2",
+      sessionExternalId: "session-2",
       role: "planner",
     });
     expect(calls).toHaveLength(0);
@@ -144,7 +144,7 @@ describe("useNavigationUrlSync", () => {
 
     expect(harness.getLatest().navigation).toMatchObject({
       taskId: "task-1",
-      sessionKey: "session-1",
+      sessionExternalId: "session-1",
       role: "build",
     });
     expect(calls).toHaveLength(2);
@@ -157,7 +157,7 @@ describe("useNavigationUrlSync", () => {
 
     expect(harness.getLatest().navigation).toMatchObject({
       taskId: "task-1",
-      sessionKey: "session-1",
+      sessionExternalId: "session-1",
       role: "build",
     });
     expect(calls).toHaveLength(2);
@@ -200,7 +200,7 @@ describe("useNavigationUrlSync", () => {
 
     expect(harness.getLatest().navigation).toMatchObject({
       taskId: "task-1",
-      sessionKey: null,
+      sessionExternalId: null,
       role: "build",
     });
     expect(calls).toHaveLength(2);

--- a/packages/frontend/src/pages/agents/use-repo-navigation-persistence.test.tsx
+++ b/packages/frontend/src/pages/agents/use-repo-navigation-persistence.test.tsx
@@ -26,7 +26,7 @@ type HookArgs = {
   initialNavigation?: AgentStudioNavigationState;
 };
 
-const sessionKeyParam = (sessionKey: string) => sessionKey;
+const sessionExternalIdParam = (sessionExternalId: string) => sessionExternalId;
 
 const createRecordingStorage = () => {
   const store = new Map<string, string>();
@@ -90,7 +90,7 @@ const useHookHarness = ({ activeWorkspaceId, initialNavigation }: HookArgs) => {
   const [navigation, setNavigation] = useState<AgentStudioNavigationState>(
     initialNavigation ?? {
       taskId: "",
-      sessionKey: null,
+      sessionExternalId: null,
       role: null,
     },
   );
@@ -146,7 +146,7 @@ describe("useRepoNavigationPersistence", () => {
         JSON.stringify({
           taskId: "task-from-context",
           role: "planner",
-          sessionKey: "session-from-context",
+          sessionExternalId: "session-from-context",
         }),
       );
 
@@ -159,7 +159,7 @@ describe("useRepoNavigationPersistence", () => {
 
       expect(harness.getLatest().navigation).toMatchObject({
         taskId: "task-from-context",
-        sessionKey: sessionKeyParam("session-from-context"),
+        sessionExternalId: sessionExternalIdParam("session-from-context"),
         role: "planner",
       });
 
@@ -179,7 +179,7 @@ describe("useRepoNavigationPersistence", () => {
         "workspace-repo": {
           taskId: "task-from-context",
           role: "qa",
-          sessionKey: "session-from-context",
+          sessionExternalId: "session-from-context",
         },
       });
 
@@ -187,7 +187,7 @@ describe("useRepoNavigationPersistence", () => {
         activeWorkspaceId: "workspace-repo",
         initialNavigation: {
           taskId: "",
-          sessionKey: null,
+          sessionExternalId: null,
           role: "planner",
         },
       });
@@ -196,7 +196,7 @@ describe("useRepoNavigationPersistence", () => {
 
       expect(harness.getLatest().navigation).toEqual({
         taskId: "",
-        sessionKey: null,
+        sessionExternalId: null,
         role: "planner",
       });
 
@@ -221,7 +221,7 @@ describe("useRepoNavigationPersistence", () => {
       await harness.run((latest) => {
         latest.setNavigation({
           taskId: "task-from-cleanup",
-          sessionKey: sessionKeyParam("session-from-cleanup"),
+          sessionExternalId: sessionExternalIdParam("session-from-cleanup"),
           role: "spec",
         });
       });
@@ -236,7 +236,7 @@ describe("useRepoNavigationPersistence", () => {
       expect(JSON.parse(stored)).toEqual({
         taskId: "task-from-cleanup",
         role: "spec",
-        sessionKey: "session-from-cleanup",
+        sessionExternalId: "session-from-cleanup",
       });
     } finally {
       Object.defineProperty(globalThis, "localStorage", {
@@ -263,7 +263,7 @@ describe("useRepoNavigationPersistence", () => {
       await harness.run((latest) => {
         latest.setNavigation({
           taskId: "task-without-role",
-          sessionKey: sessionKeyParam("session-without-role"),
+          sessionExternalId: sessionExternalIdParam("session-without-role"),
           role: null,
         });
       });
@@ -277,7 +277,7 @@ describe("useRepoNavigationPersistence", () => {
 
       expect(JSON.parse(stored)).toEqual({
         taskId: "task-without-role",
-        sessionKey: "session-without-role",
+        sessionExternalId: "session-without-role",
       });
     } finally {
       Object.defineProperty(globalThis, "localStorage", {
@@ -312,7 +312,7 @@ describe("useRepoNavigationPersistence", () => {
 
       expect(harness.getLatest().navigation).toEqual({
         taskId: "",
-        sessionKey: null,
+        sessionExternalId: null,
         role: null,
       });
 
@@ -321,7 +321,7 @@ describe("useRepoNavigationPersistence", () => {
         JSON.stringify({
           taskId: "task-from-context",
           role: "planner",
-          sessionKey: "session-from-context",
+          sessionExternalId: "session-from-context",
         }),
       );
 
@@ -389,7 +389,7 @@ describe("useRepoNavigationPersistence", () => {
         JSON.stringify({
           taskId: "task-from-repo-b",
           role: "planner",
-          sessionKey: "session-from-repo-b",
+          sessionExternalId: "session-from-repo-b",
         }),
       );
 
@@ -428,7 +428,7 @@ describe("useRepoNavigationPersistence", () => {
         JSON.stringify({
           taskId: "task-b",
           role: "planner",
-          sessionKey: "session-b",
+          sessionExternalId: "session-b",
         }),
       );
 
@@ -436,7 +436,7 @@ describe("useRepoNavigationPersistence", () => {
         activeWorkspaceId: "workspace-repo-a",
         initialNavigation: {
           taskId: "task-a",
-          sessionKey: sessionKeyParam("session-a"),
+          sessionExternalId: sessionExternalIdParam("session-a"),
           role: "build",
         },
       });
@@ -452,7 +452,7 @@ describe("useRepoNavigationPersistence", () => {
       expect(harness.getLatest().isRepoNavigationBoundaryPending).toBeFalse();
       expect(harness.getLatest().navigation).toEqual({
         taskId: "task-b",
-        sessionKey: sessionKeyParam("session-b"),
+        sessionExternalId: sessionExternalIdParam("session-b"),
         role: "planner",
       });
 
@@ -470,8 +470,8 @@ describe("useRepoNavigationPersistence", () => {
     const memoryStorage = createMemoryStorage();
     await withMockedLocalStorage(memoryStorage, async () => {
       seedWorkspaceNavigationContexts(memoryStorage, {
-        "workspace-repo-a": { taskId: "task-a", role: "spec", sessionKey: "session-a" },
-        "workspace-repo-b": { taskId: "task-b", role: "planner", sessionKey: "session-b" },
+        "workspace-repo-a": { taskId: "task-a", role: "spec", sessionExternalId: "session-a" },
+        "workspace-repo-b": { taskId: "task-b", role: "planner", sessionExternalId: "session-b" },
       });
 
       const harness = createHookHarness({
@@ -493,7 +493,7 @@ describe("useRepoNavigationPersistence", () => {
 
       expect(harness.getLatest().navigation).toEqual({
         taskId: "task-a",
-        sessionKey: sessionKeyParam("session-a"),
+        sessionExternalId: sessionExternalIdParam("session-a"),
         role: "spec",
       });
 
@@ -505,8 +505,8 @@ describe("useRepoNavigationPersistence", () => {
     const memoryStorage = createMemoryStorage();
     await withMockedLocalStorage(memoryStorage, async () => {
       seedWorkspaceNavigationContexts(memoryStorage, {
-        "workspace-repo-a": { taskId: "task-a", role: "spec", sessionKey: "session-a" },
-        "workspace-repo-b": { taskId: "task-b", role: "planner", sessionKey: "session-b" },
+        "workspace-repo-a": { taskId: "task-a", role: "spec", sessionExternalId: "session-a" },
+        "workspace-repo-b": { taskId: "task-b", role: "planner", sessionExternalId: "session-b" },
       });
 
       const harness = createHookHarness({
@@ -526,7 +526,7 @@ describe("useRepoNavigationPersistence", () => {
 
       expect(harness.getLatest().navigation).toEqual({
         taskId: "task-a",
-        sessionKey: sessionKeyParam("session-a"),
+        sessionExternalId: sessionExternalIdParam("session-a"),
         role: "spec",
       });
 
@@ -576,7 +576,7 @@ describe("useRepoNavigationPersistence", () => {
       await harness.run((latest) => {
         latest.setNavigation({
           taskId: "task-from-cleanup",
-          sessionKey: sessionKeyParam("session-from-cleanup"),
+          sessionExternalId: sessionExternalIdParam("session-from-cleanup"),
           role: "spec",
         });
       });
@@ -639,7 +639,7 @@ describe("useRepoNavigationPersistence", () => {
       expect(JSON.parse(stored)).toEqual({
         taskId: "task-from-cleanup",
         role: "spec",
-        sessionKey: "session-from-cleanup",
+        sessionExternalId: "session-from-cleanup",
       });
       expect(harness.getLatest().persistenceError).toBeNull();
 

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -588,6 +588,16 @@ const renderPage = async (
   });
 };
 
+const unmountPageIfRendered = async (renderer: KanbanPageHarness | null): Promise<void> => {
+  if (!renderer) {
+    return;
+  }
+
+  await act(async () => {
+    renderer.unmount();
+  });
+};
+
 const waitForMockCall = async (
   fn: { mock: { calls: unknown[][] } },
   minCalls = 1,
@@ -834,12 +844,7 @@ describe("KanbanPage session start modal flow", () => {
         });
       } finally {
         hostClient.workspaceGetSettingsSnapshot = originalLoadSettingsSnapshot;
-        if (renderer) {
-          const mountedRenderer = renderer;
-          await act(async () => {
-            mountedRenderer.unmount();
-          });
-        }
+        await unmountPageIfRendered(renderer);
       }
     },
   );
@@ -884,12 +889,7 @@ describe("KanbanPage session start modal flow", () => {
       expect(systemGetPlatform).toHaveBeenCalledTimes(0);
     } finally {
       hostClient.systemGetPlatform = originalSystemGetPlatform;
-      if (renderer) {
-        const mountedRenderer = renderer;
-        await act(async () => {
-          mountedRenderer.unmount();
-        });
-      }
+      await unmountPageIfRendered(renderer);
     }
   });
 
@@ -916,12 +916,7 @@ describe("KanbanPage session start modal flow", () => {
       expect(renderer.getShowHorizontalScrollbars()).toBeNull();
     } finally {
       hostClient.systemGetPlatform = originalSystemGetPlatform;
-      if (renderer) {
-        const mountedRenderer = renderer;
-        await act(async () => {
-          mountedRenderer.unmount();
-        });
-      }
+      await unmountPageIfRendered(renderer);
     }
   });
 
@@ -1763,12 +1758,7 @@ describe("KanbanPage session start modal flow", () => {
         hostClient.taskDirectMerge = originalTaskDirectMerge;
         hostClient.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
         hostClient.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
-        if (renderer) {
-          const mountedRenderer = renderer;
-          await act(async () => {
-            mountedRenderer.unmount();
-          });
-        }
+        await unmountPageIfRendered(renderer);
       }
     },
   );

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -808,7 +808,7 @@ describe("KanbanPage session start modal flow", () => {
         }),
       );
       expect(updateAgentSessionModelMock).not.toHaveBeenCalled();
-      expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
+      expect(renderer.getLocation()).toBe("/agents?task=TASK-123&session=session-1&agent=build");
 
       await act(async () => {
         renderer.unmount();
@@ -820,13 +820,13 @@ describe("KanbanPage session start modal flow", () => {
     "settings load failure reports an error without issuing a task-list request",
     async () => {
       const originalLoadSettingsSnapshot = hostClient.workspaceGetSettingsSnapshot;
-      hostClient.workspaceGetSettingsSnapshot = async () => {
-        throw new Error("settings unavailable");
-      };
-
-      const renderer = await renderPage({ seedSettingsSnapshot: false });
+      let renderer: KanbanPageHarness | null = null;
 
       try {
+        hostClient.workspaceGetSettingsSnapshot = async () => {
+          throw new Error("settings unavailable");
+        };
+        renderer = await renderPage({ seedSettingsSnapshot: false });
         await waitForMockCall(toastErrorMock);
 
         expect(toastErrorMock).toHaveBeenCalledWith("Failed to load Kanban settings", {
@@ -834,9 +834,12 @@ describe("KanbanPage session start modal flow", () => {
         });
       } finally {
         hostClient.workspaceGetSettingsSnapshot = originalLoadSettingsSnapshot;
-        await act(async () => {
-          renderer.unmount();
-        });
+        if (renderer) {
+          const mountedRenderer = renderer;
+          await act(async () => {
+            mountedRenderer.unmount();
+          });
+        }
       }
     },
   );
@@ -869,36 +872,39 @@ describe("KanbanPage session start modal flow", () => {
     const systemGetPlatform = mock(async () => {
       throw new Error("platform should not be requested for explicit Appearance modes");
     });
-    hostClient.systemGetPlatform = systemGetPlatform;
     currentSettingsSnapshotFixture = createSettingsSnapshotFixture({
       appearance: { horizontalScrollbarVisibility: "show" },
     });
-
-    const renderer = await renderPage();
+    let renderer: KanbanPageHarness | null = null;
 
     try {
+      hostClient.systemGetPlatform = systemGetPlatform;
+      renderer = await renderPage();
       expect(renderer.getKanbanColumnProps()).toBeTruthy();
       expect(systemGetPlatform).toHaveBeenCalledTimes(0);
     } finally {
       hostClient.systemGetPlatform = originalSystemGetPlatform;
-      await act(async () => {
-        renderer.unmount();
-      });
+      if (renderer) {
+        const mountedRenderer = renderer;
+        await act(async () => {
+          mountedRenderer.unmount();
+        });
+      }
     }
   });
 
   kanbanTest("reports System platform resolution failures once", async () => {
     const originalSystemGetPlatform = hostClient.systemGetPlatform;
-    hostClient.systemGetPlatform = async () => {
-      throw new Error("unsupported platform");
-    };
     currentSettingsSnapshotFixture = createSettingsSnapshotFixture({
       appearance: { horizontalScrollbarVisibility: "system" },
     });
-
-    const renderer = await renderPage({ platform: null });
+    let renderer: KanbanPageHarness | null = null;
 
     try {
+      hostClient.systemGetPlatform = async () => {
+        throw new Error("unsupported platform");
+      };
+      renderer = await renderPage({ platform: null });
       await waitForMockCall(toastErrorMock);
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to resolve horizontal scrollbar default",
@@ -910,9 +916,12 @@ describe("KanbanPage session start modal flow", () => {
       expect(renderer.getShowHorizontalScrollbars()).toBeNull();
     } finally {
       hostClient.systemGetPlatform = originalSystemGetPlatform;
-      await act(async () => {
-        renderer.unmount();
-      });
+      if (renderer) {
+        const mountedRenderer = renderer;
+        await act(async () => {
+          mountedRenderer.unmount();
+        });
+      }
     }
   });
 
@@ -960,9 +969,7 @@ describe("KanbanPage session start modal flow", () => {
         actionButton.click();
         await Promise.resolve();
       });
-      expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
-      expect(renderer.getLocation()).toContain("session=session-1");
-      expect(renderer.getLocation()).toContain("agent=build");
+      expect(renderer.getLocation()).toBe("/agents?task=TASK-123&session=session-1&agent=build");
 
       toastDescriptionRender.unmount();
 
@@ -1058,7 +1065,7 @@ describe("KanbanPage session start modal flow", () => {
 
     expect(startAgentSessionMock).toHaveBeenCalledTimes(1);
     expect(sendAgentMessageMock).toHaveBeenCalledTimes(1);
-    expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
+    expect(renderer.getLocation()).toBe("/agents?task=TASK-123&session=session-1&agent=build");
     await waitForMockCall(toastErrorMock);
     expect(toastErrorMock).toHaveBeenCalledWith(
       "Session started, but the kickoff prompt failed to send.",
@@ -1193,8 +1200,7 @@ describe("KanbanPage session start modal flow", () => {
 
       expect(renderer.getSessionStartModalModel()).toBeNull();
       expect(startAgentSessionMock).not.toHaveBeenCalled();
-      expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
-      expect(renderer.getLocation()).toContain("session=session-spec");
+      expect(renderer.getLocation()).toBe("/agents?task=TASK-123&session=session-spec&agent=spec");
 
       await act(async () => {
         renderer.unmount();
@@ -1659,9 +1665,9 @@ describe("KanbanPage session start modal flow", () => {
 
     expect(renderer.getSessionStartModalModel()).toBeNull();
     expect(startAgentSessionMock).not.toHaveBeenCalled();
-    expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
-    expect(renderer.getLocation()).toContain("agent=build");
-    expect(renderer.getLocation()).toContain("session=session-build-older");
+    expect(renderer.getLocation()).toBe(
+      "/agents?task=TASK-123&session=session-build-older&agent=build",
+    );
 
     await act(async () => {
       renderer.unmount();
@@ -1688,36 +1694,38 @@ describe("KanbanPage session start modal flow", () => {
         uncommittedFileCount: 0,
         providers: [],
       };
-      hostClient.taskApprovalContextGet = async () => ({
-        outcome: "ready",
-        approvalContext,
-      });
-      hostClient.taskDirectMerge = async () => ({
-        outcome: "conflicts",
-        conflict: {
-          operation: "direct_merge_merge_commit",
-          currentBranch: "odt/TASK-123",
-          targetBranch: "main",
-          conflictedFiles: ["src/app.ts"],
-          output: "conflict output",
-          workingDir: "/repo/worktrees/conflict",
-        },
-      });
-      hostClient.workspaceGetRepoConfig = async () => currentRepoConfigFixture;
-      hostClient.workspaceGetSettingsSnapshot = async () => currentSettingsSnapshotFixture;
-
-      const renderer = await renderPage();
+      let renderer: KanbanPageHarness | null = null;
 
       try {
+        hostClient.taskApprovalContextGet = async () => ({
+          outcome: "ready",
+          approvalContext,
+        });
+        hostClient.taskDirectMerge = async () => ({
+          outcome: "conflicts",
+          conflict: {
+            operation: "direct_merge_merge_commit",
+            currentBranch: "odt/TASK-123",
+            targetBranch: "main",
+            conflictedFiles: ["src/app.ts"],
+            output: "conflict output",
+            workingDir: "/repo/worktrees/conflict",
+          },
+        });
+        hostClient.workspaceGetRepoConfig = async () => currentRepoConfigFixture;
+        hostClient.workspaceGetSettingsSnapshot = async () => currentSettingsSnapshotFixture;
+
+        const page = await renderPage();
+        renderer = page;
         await act(async () => {
-          (renderer.getKanbanColumnProps().onHumanApprove as (taskId: string) => void)("TASK-123");
+          (page.getKanbanColumnProps().onHumanApprove as (taskId: string) => void)("TASK-123");
           await Promise.resolve();
         });
         await waitFor(() => {
-          expect(renderer.getTaskApprovalModalModel()?.stage).toBe("approval");
+          expect(page.getTaskApprovalModalModel()?.stage).toBe("approval");
         });
 
-        const approvalModal = renderer.getTaskApprovalModalModel();
+        const approvalModal = page.getTaskApprovalModalModel();
         if (approvalModal?.stage !== "approval") {
           throw new Error("Expected the task approval modal.");
         }
@@ -1726,26 +1734,24 @@ describe("KanbanPage session start modal flow", () => {
           await Promise.resolve();
         });
         await waitFor(() => {
-          expect(renderer.getTaskGitConflictDialogModel()?.open).toBe(true);
+          expect(page.getTaskGitConflictDialogModel()?.open).toBe(true);
         });
 
         await act(async () => {
-          renderer.getTaskGitConflictDialogModel()?.onAskBuilder();
+          page.getTaskGitConflictDialogModel()?.onAskBuilder();
           await Promise.resolve();
         });
-        await confirmSessionStartModal(renderer, {
+        await confirmSessionStartModal(page, {
           modelId: "openai/gpt-5",
           profileId: "build-agent",
           startMode: "fresh",
           variant: "default",
         });
         await waitFor(() => {
-          expect(renderer.getLocation()).toBe(
-            "/agents?task=TASK-123&session=session-1&agent=build",
-          );
+          expect(page.getLocation()).toBe("/agents?task=TASK-123&session=session-1&agent=build");
         });
         const sessionExternalId = new URL(
-          renderer.getLocation(),
+          page.getLocation(),
           "https://openducktor.local",
         ).searchParams.get("session");
         expect(sessionExternalId).toBe("session-1");
@@ -1757,9 +1763,12 @@ describe("KanbanPage session start modal flow", () => {
         hostClient.taskDirectMerge = originalTaskDirectMerge;
         hostClient.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
         hostClient.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
-        await act(async () => {
-          renderer.unmount();
-        });
+        if (renderer) {
+          const mountedRenderer = renderer;
+          await act(async () => {
+            mountedRenderer.unmount();
+          });
+        }
       }
     },
   );
@@ -1781,9 +1790,9 @@ describe("KanbanPage session start modal flow", () => {
 
       expect(renderer.getSessionStartModalModel()).toBeNull();
       expect(startAgentSessionMock).not.toHaveBeenCalled();
-      expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
-      expect(renderer.getLocation()).toContain("agent=build");
-      expect(renderer.getLocation()).toContain("session=session-build-older");
+      expect(renderer.getLocation()).toBe(
+        "/agents?task=TASK-123&session=session-build-older&agent=build",
+      );
 
       await act(async () => {
         renderer.unmount();
@@ -1803,9 +1812,9 @@ describe("KanbanPage session start modal flow", () => {
 
       expect(renderer.getSessionStartModalModel()).toBeNull();
       expect(startAgentSessionMock).not.toHaveBeenCalled();
-      expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
-      expect(renderer.getLocation()).toContain("agent=build");
-      expect(renderer.getLocation()).toContain("session=session-build-older");
+      expect(renderer.getLocation()).toBe(
+        "/agents?task=TASK-123&session=session-build-older&agent=build",
+      );
 
       await act(async () => {
         renderer.unmount();
@@ -1822,8 +1831,7 @@ describe("KanbanPage session start modal flow", () => {
     });
 
     expect(renderer.getSessionStartModalModel()).toBeNull();
-    expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
-    expect(renderer.getLocation()).toContain("agent=qa");
+    expect(renderer.getLocation()).toBe("/agents?task=TASK-123&agent=qa");
 
     await act(async () => {
       renderer.unmount();
@@ -1900,9 +1908,9 @@ describe("KanbanPage session start modal flow", () => {
 
       expect(renderer.getSessionStartModalModel()).toBeNull();
       expect(startAgentSessionMock).not.toHaveBeenCalled();
-      expect(renderer.getLocation()).toContain("/agents?task=TASK-123");
-      expect(renderer.getLocation()).toContain("agent=build");
-      expect(renderer.getLocation()).toContain("session=session-build-older");
+      expect(renderer.getLocation()).toBe(
+        "/agents?task=TASK-123&session=session-build-older&agent=build",
+      );
 
       await act(async () => {
         renderer.unmount();

--- a/packages/frontend/src/pages/kanban/kanban-page.test.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page.test.tsx
@@ -6,6 +6,7 @@ import {
   type RepoConfig,
   type RepoPromptOverrides,
   type SettingsSnapshot,
+  type TaskApprovalContext,
   type TaskCard,
   type WorkspaceRecord,
 } from "@openducktor/contracts";
@@ -136,6 +137,8 @@ type LatestKanbanPageModels = {
   isLoadingTasks: boolean | null;
   showHorizontalScrollbars: boolean | null;
   humanReviewFeedbackModalModel: Record<string, unknown> | null;
+  taskApprovalModalModel: KanbanPageModels["taskApprovalModal"];
+  taskGitConflictDialogModel: KanbanPageModels["taskGitConflictDialog"];
   sessionStartModalModel: Record<string, unknown> | null;
   resetImplementationModalModel: Record<string, unknown> | null;
   mergedPullRequestModalProps: Record<string, unknown> | null;
@@ -156,6 +159,8 @@ type KanbanPageHarness = RenderResult & {
   getIsLoadingTasks: () => boolean | null;
   getShowHorizontalScrollbars: () => boolean | null;
   getHumanReviewFeedbackModalModel: () => Record<string, unknown> | null;
+  getTaskApprovalModalModel: () => KanbanPageModels["taskApprovalModal"];
+  getTaskGitConflictDialogModel: () => KanbanPageModels["taskGitConflictDialog"];
   getSessionStartModalModel: () => Record<string, unknown> | null;
   getResetImplementationModalModel: () => Record<string, unknown> | null;
   getMergedPullRequestModalProps: () => Record<string, unknown> | null;
@@ -417,6 +422,8 @@ const publishKanbanPageModels = (
   latest.isLoadingTasks = models.content.isLoadingTasks;
   latest.showHorizontalScrollbars = models.content.showHorizontalScrollbars;
   latest.humanReviewFeedbackModalModel = models.humanReviewFeedbackModal;
+  latest.taskApprovalModalModel = models.taskApprovalModal;
+  latest.taskGitConflictDialogModel = models.taskGitConflictDialog;
   latest.sessionStartModalModel = models.sessionStartModal;
   latest.resetImplementationModalModel = models.resetImplementationModal;
   latest.mergedPullRequestModalProps = models.mergedPullRequestModal;
@@ -450,6 +457,8 @@ const renderPage = async (
     isLoadingTasks: null,
     showHorizontalScrollbars: null,
     humanReviewFeedbackModalModel: null,
+    taskApprovalModalModel: null,
+    taskGitConflictDialogModel: null,
     sessionStartModalModel: null,
     resetImplementationModalModel: null,
     mergedPullRequestModalProps: null,
@@ -570,6 +579,8 @@ const renderPage = async (
     getIsLoadingTasks: () => latest.isLoadingTasks,
     getShowHorizontalScrollbars: () => latest.showHorizontalScrollbars,
     getHumanReviewFeedbackModalModel: () => latest.humanReviewFeedbackModalModel,
+    getTaskApprovalModalModel: () => latest.taskApprovalModalModel,
+    getTaskGitConflictDialogModel: () => latest.taskGitConflictDialogModel,
     getSessionStartModalModel: () => latest.sessionStartModalModel,
     getResetImplementationModalModel: () => latest.resetImplementationModalModel,
     getMergedPullRequestModalProps: () => latest.mergedPullRequestModalProps,
@@ -1656,6 +1667,102 @@ describe("KanbanPage session start modal flow", () => {
       renderer.unmount();
     });
   });
+
+  kanbanTest(
+    "git conflict resolution opens the exact external-session Agent Studio route",
+    async () => {
+      currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "human_review" });
+      const originalTaskApprovalContextGet = hostClient.taskApprovalContextGet;
+      const originalTaskDirectMerge = hostClient.taskDirectMerge;
+      const originalWorkspaceGetRepoConfig = hostClient.workspaceGetRepoConfig;
+      const originalWorkspaceGetSettingsSnapshot = hostClient.workspaceGetSettingsSnapshot;
+      const approvalContext: TaskApprovalContext = {
+        taskId: "TASK-123",
+        taskStatus: "human_review",
+        workingDirectory: "/repo/worktrees/conflict",
+        sourceBranch: "odt/TASK-123",
+        targetBranch: { remote: "origin", branch: "main" },
+        publishTarget: { remote: "origin", branch: "main" },
+        defaultMergeMethod: "merge_commit",
+        hasUncommittedChanges: false,
+        uncommittedFileCount: 0,
+        providers: [],
+      };
+      hostClient.taskApprovalContextGet = async () => ({
+        outcome: "ready",
+        approvalContext,
+      });
+      hostClient.taskDirectMerge = async () => ({
+        outcome: "conflicts",
+        conflict: {
+          operation: "direct_merge_merge_commit",
+          currentBranch: "odt/TASK-123",
+          targetBranch: "main",
+          conflictedFiles: ["src/app.ts"],
+          output: "conflict output",
+          workingDir: "/repo/worktrees/conflict",
+        },
+      });
+      hostClient.workspaceGetRepoConfig = async () => currentRepoConfigFixture;
+      hostClient.workspaceGetSettingsSnapshot = async () => currentSettingsSnapshotFixture;
+
+      const renderer = await renderPage();
+
+      try {
+        await act(async () => {
+          (renderer.getKanbanColumnProps().onHumanApprove as (taskId: string) => void)("TASK-123");
+          await Promise.resolve();
+        });
+        await waitFor(() => {
+          expect(renderer.getTaskApprovalModalModel()?.stage).toBe("approval");
+        });
+
+        const approvalModal = renderer.getTaskApprovalModalModel();
+        if (approvalModal?.stage !== "approval") {
+          throw new Error("Expected the task approval modal.");
+        }
+        await act(async () => {
+          approvalModal.onConfirm();
+          await Promise.resolve();
+        });
+        await waitFor(() => {
+          expect(renderer.getTaskGitConflictDialogModel()?.open).toBe(true);
+        });
+
+        await act(async () => {
+          renderer.getTaskGitConflictDialogModel()?.onAskBuilder();
+          await Promise.resolve();
+        });
+        await confirmSessionStartModal(renderer, {
+          modelId: "openai/gpt-5",
+          profileId: "build-agent",
+          startMode: "fresh",
+          variant: "default",
+        });
+        await waitFor(() => {
+          expect(renderer.getLocation()).toBe(
+            "/agents?task=TASK-123&session=session-1&agent=build",
+          );
+        });
+        const sessionExternalId = new URL(
+          renderer.getLocation(),
+          "https://openducktor.local",
+        ).searchParams.get("session");
+        expect(sessionExternalId).toBe("session-1");
+        expect(sessionExternalId).not.toContain("opencode");
+        expect(sessionExternalId).not.toContain("%2Frepo");
+        expect(sessionExternalId).not.toContain("|");
+      } finally {
+        hostClient.taskApprovalContextGet = originalTaskApprovalContextGet;
+        hostClient.taskDirectMerge = originalTaskDirectMerge;
+        hostClient.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
+        hostClient.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+        await act(async () => {
+          renderer.unmount();
+        });
+      }
+    },
+  );
 
   kanbanTest(
     "build action for a QA-rejected task navigates to the QA follow-up builder launch action",

--- a/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
+++ b/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
@@ -6,7 +6,6 @@ import { toast } from "sonner";
 import type { GitConflict } from "@/features/agent-studio-git";
 import { useGitConflictResolution } from "@/features/git-conflict-resolution";
 import { useSessionStartWorkflowRunner } from "@/features/session-start";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { errorMessage } from "@/lib/errors";
 import {
   useAgentOperations,
@@ -264,7 +263,7 @@ export function useKanbanPageModels({
         onOpenSession: (session) => {
           const search = new URLSearchParams({
             task: taskId,
-            session: agentSessionIdentityKey(session),
+            session: session.externalSessionId,
             agent: "build",
           });
           navigate(`/agents?${search.toString()}`);

--- a/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
+++ b/packages/frontend/src/pages/kanban/use-kanban-page-models.ts
@@ -16,6 +16,7 @@ import {
 import { useAgentSessionLists } from "@/state/queries/use-agent-session-lists";
 import { useHorizontalScrollbarVisibility } from "@/state/queries/use-horizontal-scrollbar-visibility";
 import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
+import { buildAgentStudioHref } from "../agents/query-sync/agent-studio-navigation";
 import { useAgentStudioRepoSettings } from "../agents/use-agent-studio-repo-settings";
 import type { KanbanPageModels } from "./kanban-page-model-types";
 import { useKanbanBoardModel } from "./use-kanban-board-model";
@@ -261,12 +262,13 @@ export function useKanbanPageModels({
         builderSessions,
         currentViewSession: null,
         onOpenSession: (session) => {
-          const search = new URLSearchParams({
-            task: taskId,
-            session: session.externalSessionId,
-            agent: "build",
-          });
-          navigate(`/agents?${search.toString()}`);
+          navigate(
+            buildAgentStudioHref({
+              taskId,
+              sessionExternalId: session.externalSessionId,
+              role: "build",
+            }),
+          );
         },
       });
     },

--- a/packages/frontend/src/pages/kanban/use-kanban-session-start-flow.test.tsx
+++ b/packages/frontend/src/pages/kanban/use-kanban-session-start-flow.test.tsx
@@ -12,7 +12,6 @@ import {
   createSessionStartWorkflowRunner,
   resolveBuildContinuationLaunchAction,
 } from "@/features/session-start";
-import { agentSessionIdentityKey } from "@/lib/agent-session-identity";
 import { QueryProvider } from "@/lib/query-provider";
 import {
   ChecksOperationsContext,
@@ -61,11 +60,11 @@ const createRunSessionStartWorkflow = (
 const agentStudioSessionUrl = (
   taskId: string,
   role: string,
-  session: Parameters<typeof agentSessionIdentityKey>[0],
+  session: { externalSessionId: string },
 ): string => {
   const search = new URLSearchParams({
     task: taskId,
-    session: agentSessionIdentityKey(session),
+    session: session.externalSessionId,
     agent: role,
   });
   return `/agents?${search.toString()}`;

--- a/packages/frontend/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/packages/frontend/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -30,6 +30,7 @@ import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
+import { buildAgentStudioHref } from "../agents/query-sync/agent-studio-navigation";
 import type { KanbanSessionStartIntent } from "./kanban-page-model-types";
 import { startKanbanSessionFlow } from "./kanban-session-start-actions";
 
@@ -154,23 +155,20 @@ export function useKanbanSessionStartFlow({
 
   const openAgents = useCallback(
     (taskId: string, role: AgentRole): void => {
-      const params = new URLSearchParams({
-        task: taskId,
-        agent: role,
-      });
-      navigate(`/agents?${params.toString()}`);
+      navigate(buildAgentStudioHref({ taskId, sessionExternalId: null, role }));
     },
     [navigate],
   );
 
   const openSessionInAgentStudio = useCallback(
     (intent: KanbanSessionStartIntent, session: AgentSessionIdentity): void => {
-      const params = new URLSearchParams({
-        task: intent.taskId,
-        session: session.externalSessionId,
-        agent: intent.role,
-      });
-      navigate(`/agents?${params.toString()}`);
+      navigate(
+        buildAgentStudioHref({
+          taskId: intent.taskId,
+          sessionExternalId: session.externalSessionId,
+          role: intent.role,
+        }),
+      );
     },
     [navigate],
   );

--- a/packages/frontend/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/packages/frontend/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -25,11 +25,7 @@ import {
   resolveBuildContinuationLaunchAction,
   useSessionStartModalRunner,
 } from "@/features/session-start";
-import {
-  agentSessionIdentityKey,
-  matchesAgentSessionIdentity,
-  toAgentSessionIdentity,
-} from "@/lib/agent-session-identity";
+import { matchesAgentSessionIdentity, toAgentSessionIdentity } from "@/lib/agent-session-identity";
 import type { AgentSessionSummary } from "@/state/agent-sessions-store";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
@@ -171,7 +167,7 @@ export function useKanbanSessionStartFlow({
     (intent: KanbanSessionStartIntent, session: AgentSessionIdentity): void => {
       const params = new URLSearchParams({
         task: intent.taskId,
-        session: agentSessionIdentityKey(session),
+        session: session.externalSessionId,
         agent: intent.role,
       });
       navigate(`/agents?${params.toString()}`);


### PR DESCRIPTION
## Summary

- Store only externalSessionId in Agent Studio URLs and workspace navigation state.
- Resolve full runtime identity from task-scoped session metadata.
- Route every Agent Studio deep-link producer through the same external-ID-only contract.

## Goal

Agent Studio navigation previously serialized runtime kind and working directory with the session ID. This exposed internal routing details in links and local navigation state. The new route uses task ID plus the globally unique external session ID while keeping full runtime identity inside the application.

## Implementation

- Replaced navigation-only composite session keys with sessionExternalId values.
- Added explicit pending, found, missing, and failed route-resolution states.
- Prevented default session or runtime work while an explicit session is unresolved.
- Derived runtime kind and working directory from the matching task session summary.
- Updated session start, Kanban, conflict resolution, and sidebar links together.
- Centralized Agent Studio destination construction while leaving internal SessionRef and AgentSessionIdentity routing unchanged.

## Verification

- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
- bun run build

Cargo checks are not applicable because this repository has no Cargo manifest.

Task: openduckto-xsv7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent Studio session links now use external session IDs for more reliable navigation.
  * Added improved handling for loading, missing, or failed sessions, preserving deep links while data loads.
  * Git conflict resolution now opens the correct Agent Studio session.

* **Bug Fixes**
  * Prevented stale or cross-task sessions from being selected or restored.
  * Improved navigation persistence and URL synchronization for selected sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->