### PR TITLE
fix: isolate development MCP discovery from production

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ Example commit messages:
 
 OpenDucktor resolves its base directory to `~/.openducktor` by default. You can override this with `OPENDUCKTOR_CONFIG_DIR`.
 
-You may use a separate config root such as `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` when you want all contributor settings, task-store databases, and runtime caches kept apart from your normal app data. This is optional and is not needed to keep development MCP discovery from overwriting production discovery.
+You may use a separate config root such as `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` when you want all contributor settings, task-store databases, and runtime caches kept apart from your normal app data. You can skip this setting because OpenDucktor already keeps development MCP discovery from overwriting production discovery.
 
 Important paths:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ Example commit messages:
 
 OpenDucktor resolves its base directory to `~/.openducktor` by default. You can override this with `OPENDUCKTOR_CONFIG_DIR`.
 
-You may use a separate config root such as `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` when you want all contributor settings, task-store databases, and runtime caches kept apart from your normal app data. You can skip this setting because OpenDucktor already keeps development MCP discovery from overwriting production discovery.
+You may use a separate config root such as `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` when you want to keep all contributor settings, task-store databases, and runtime caches apart from your normal app data. You can skip this setting because OpenDucktor already keeps development MCP discovery from overwriting production discovery.
 
 Important paths:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ Example commit messages:
 
 OpenDucktor resolves its base directory to `~/.openducktor` by default. You can override this with `OPENDUCKTOR_CONFIG_DIR`.
 
-You may use a separate config root such as `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` when you want to keep all contributor settings, task-store databases, and runtime caches apart from your normal app data. You can skip this setting because OpenDucktor already keeps development MCP discovery from overwriting production discovery.
+A separate config root such as `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` remains useful when you want to keep contributor settings, task-store databases, and runtime caches apart from your normal app data. It is not required solely to protect production MCP discovery because development hosts use `runtime/mcp-bridge-dev.json`.
 
 Important paths:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,7 @@ bun install
 
 That install also activates the repository's shared local Git hooks through the root `prepare` script.
 
-3. Use a dedicated development config directory so your local contributor data stays separate from your regular app data:
-
-```sh
-export OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"
-```
-
-4. Start the Electron desktop app:
+3. Start the Electron desktop app:
 
 ```sh
 bun run electron:dev
@@ -59,7 +53,7 @@ Notes:
 
 ## Main Development Commands
 
-Recommended for local development: keep contributor data isolated with `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` in your shell session.
+The development commands need no channel or config-directory environment variable. Electron and browser workspace development publish `runtime/mcp-bridge-dev.json`; packaged and installed production hosts publish `runtime/mcp-bridge.json`.
 
 Electron desktop:
 
@@ -74,6 +68,12 @@ bun run browser:dev
 ```
 
 The browser command starts the TypeScript host on `127.0.0.1`, serves the shared frontend with Vite, and requires the web shell to use the explicit local-host HTTP/SSE bridge. Shared frontend code must use the shell bridge instead of importing shell internals directly; run `bun run frontend:boundary-guard` after shell-boundary changes.
+
+To connect a standalone external MCP client to either development command, select the development descriptor:
+
+```sh
+OPENDUCKTOR_CHANNEL=dev bunx @openducktor/mcp@latest
+```
 
 ## Verification Commands
 
@@ -128,7 +128,7 @@ Example commit messages:
 
 OpenDucktor resolves its base directory to `~/.openducktor` by default. You can override this with `OPENDUCKTOR_CONFIG_DIR`.
 
-For local development, it is recommended to use a separate config root such as `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` so contributor state, task-store databases, and runtime caches stay isolated from your normal app usage.
+You may use a separate config root such as `OPENDUCKTOR_CONFIG_DIR="$HOME/.openducktor-dev"` when you want all contributor settings, task-store databases, and runtime caches kept apart from your normal app data. This is optional and is not needed to keep development MCP discovery from overwriting production discovery.
 
 Important paths:
 

--- a/apps/electron/src/main/electron-host-discovery.test.ts
+++ b/apps/electron/src/main/electron-host-discovery.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createArtifactRuntimeDistribution, Effect, type TerminalPtyPort } from "@openducktor/host";
+import {
+  createElectronHostCommandRouter,
+  resolveElectronMcpBridgeDiscoveryMode,
+} from "./electron-host";
+
+const testRuntimeDistribution = createArtifactRuntimeDistribution({
+  mcpLauncher: {
+    kind: "executable",
+    executablePath: process.execPath,
+  },
+});
+const testTerminalPty: TerminalPtyPort = {
+  start: () => Effect.die("Terminal PTY is not expected in this composition test."),
+};
+
+describe("Electron host MCP discovery composition", () => {
+  test("derives production discovery ownership from packaged launch context", () => {
+    expect(resolveElectronMcpBridgeDiscoveryMode(true)).toBe("production");
+  });
+
+  test("derives development discovery ownership from source launch context", () => {
+    expect(resolveElectronMcpBridgeDiscoveryMode(false)).toBe("development");
+  });
+
+  for (const scenario of [
+    {
+      descriptorName: "mcp-bridge.json",
+      isPackaged: true,
+      oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:1","hostToken":"dev","pid":1}\n',
+      oppositeDescriptorName: "mcp-bridge-dev.json",
+      title: "packaged Electron owns only production discovery",
+    },
+    {
+      descriptorName: "mcp-bridge-dev.json",
+      isPackaged: false,
+      oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:2","hostToken":"prod","pid":2}\n',
+      oppositeDescriptorName: "mcp-bridge.json",
+      title: "source Electron owns only development discovery",
+    },
+  ] as const) {
+    test(scenario.title, async () => {
+      const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-electron-discovery-"));
+      const runtimeDirectory = path.join(configDirectory, "runtime");
+      const descriptorPath = path.join(runtimeDirectory, scenario.descriptorName);
+      const oppositeDescriptorPath = path.join(runtimeDirectory, scenario.oppositeDescriptorName);
+      const router = createElectronHostCommandRouter({
+        isPackaged: scenario.isPackaged,
+        lifecycleLogger: {
+          error: () => Effect.void,
+          info: () => Effect.void,
+        },
+        onBackgroundFailure: () => Effect.void,
+        processEnv: {
+          OPENDUCKTOR_CONFIG_DIR: configDirectory,
+          PATH: "/usr/bin:/bin",
+        },
+        runtimeDistribution: testRuntimeDistribution,
+        terminalPty: testTerminalPty,
+      });
+      let disposed = false;
+
+      try {
+        await mkdir(runtimeDirectory, { recursive: true });
+        await writeFile(oppositeDescriptorPath, scenario.oppositeDescriptor, "utf8");
+
+        await router.initialize();
+
+        expect(JSON.parse(await readFile(descriptorPath, "utf8"))).toEqual({
+          hostToken: expect.any(String),
+          hostUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+          pid: process.pid,
+        });
+        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
+          scenario.oppositeDescriptor,
+        );
+
+        await router.dispose();
+        disposed = true;
+
+        await expect(readFile(descriptorPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
+          scenario.oppositeDescriptor,
+        );
+      } finally {
+        if (!disposed) {
+          await router.dispose().catch(() => {});
+        }
+        await rm(configDirectory, { force: true, recursive: true });
+      }
+    });
+  }
+});

--- a/apps/electron/src/main/electron-host.test.ts
+++ b/apps/electron/src/main/electron-host.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { GlobalConfig, RepoConfig, RuntimeInstanceSummary } from "@openducktor/contracts";
@@ -19,14 +19,12 @@ import {
   type SettingsConfigPort,
   type SystemCommandPort,
   type TaskStorePort,
-  type TerminalPtyPort,
   type WorktreeFilePort,
 } from "@openducktor/host";
 import { Deferred, TestClock, TestContext } from "effect";
 import {
   createElectronEffectHostCommandRouter,
   createElectronHostCommandRouter as createProductionElectronHostCommandRouter,
-  resolveElectronMcpBridgeDiscoveryMode,
 } from "./electron-host";
 import { createElectronMainLogger } from "./electron-main-logger";
 
@@ -41,10 +39,6 @@ const testRuntimeDistribution = createArtifactRuntimeDistribution({
     executablePath: process.execPath,
   },
 });
-
-const testTerminalPty: TerminalPtyPort = {
-  start: () => Effect.die("Terminal PTY is not expected in this composition test."),
-};
 
 const createElectronHostCommandRouter = (input: Partial<ElectronHostCommandRouterInput> = {}) =>
   createProductionElectronHostCommandRouter({
@@ -519,78 +513,6 @@ const createEventBus = () => {
 };
 
 describe("createElectronHostCommandRouter", () => {
-  test("derives production discovery ownership from packaged launch context", () => {
-    expect(resolveElectronMcpBridgeDiscoveryMode(true)).toBe("production");
-  });
-
-  test("derives development discovery ownership from source launch context", () => {
-    expect(resolveElectronMcpBridgeDiscoveryMode(false)).toBe("development");
-  });
-
-  for (const scenario of [
-    {
-      descriptorName: "mcp-bridge.json",
-      isPackaged: true,
-      oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:1","hostToken":"dev","pid":1}\n',
-      oppositeDescriptorName: "mcp-bridge-dev.json",
-      title: "packaged Electron owns only production discovery",
-    },
-    {
-      descriptorName: "mcp-bridge-dev.json",
-      isPackaged: false,
-      oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:2","hostToken":"prod","pid":2}\n',
-      oppositeDescriptorName: "mcp-bridge.json",
-      title: "source Electron owns only development discovery",
-    },
-  ] as const) {
-    test(scenario.title, async () => {
-      const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-electron-discovery-"));
-      const runtimeDirectory = path.join(configDirectory, "runtime");
-      const descriptorPath = path.join(runtimeDirectory, scenario.descriptorName);
-      const oppositeDescriptorPath = path.join(runtimeDirectory, scenario.oppositeDescriptorName);
-      const router = createElectronHostCommandRouter({
-        isPackaged: scenario.isPackaged,
-        lifecycleLogger: {
-          error: () => Effect.void,
-          info: () => Effect.void,
-        },
-        processEnv: {
-          OPENDUCKTOR_CONFIG_DIR: configDirectory,
-          PATH: "/usr/bin:/bin",
-        },
-        runtimeDistribution: testRuntimeDistribution,
-        taskStore: createTaskStore(),
-        terminalPty: testTerminalPty,
-      });
-
-      try {
-        await mkdir(runtimeDirectory, { recursive: true });
-        await writeFile(oppositeDescriptorPath, scenario.oppositeDescriptor, "utf8");
-
-        await router.initialize();
-
-        expect(JSON.parse(await readFile(descriptorPath, "utf8"))).toEqual({
-          hostToken: expect.any(String),
-          hostUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
-          pid: process.pid,
-        });
-        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
-          scenario.oppositeDescriptor,
-        );
-
-        await router.dispose();
-
-        await expect(readFile(descriptorPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
-        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
-          scenario.oppositeDescriptor,
-        );
-      } finally {
-        await router.dispose().catch(() => {});
-        await rm(configDirectory, { force: true, recursive: true });
-      }
-    });
-  }
-
   test("owns a scheduled task-sync disk-write failure through the Electron host lifecycle", async () => {
     const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-electron-task-sync-"));
     const recordedAt = new Date(2026, 4, 13, 23, 45, 12, 345);

--- a/apps/electron/src/main/electron-host.test.ts
+++ b/apps/electron/src/main/electron-host.test.ts
@@ -25,6 +25,7 @@ import { Deferred, TestClock, TestContext } from "effect";
 import {
   createElectronEffectHostCommandRouter,
   createElectronHostCommandRouter as createProductionElectronHostCommandRouter,
+  resolveElectronMcpBridgeDiscoveryMode,
 } from "./electron-host";
 import { createElectronMainLogger } from "./electron-main-logger";
 
@@ -42,6 +43,7 @@ const testRuntimeDistribution = createArtifactRuntimeDistribution({
 
 const createElectronHostCommandRouter = (input: Partial<ElectronHostCommandRouterInput> = {}) =>
   createProductionElectronHostCommandRouter({
+    isPackaged: false,
     onBackgroundFailure: () => Effect.void,
     processEnv: { PATH: "/usr/bin:/bin" },
     runtimeDistribution: testRuntimeDistribution,
@@ -512,6 +514,14 @@ const createEventBus = () => {
 };
 
 describe("createElectronHostCommandRouter", () => {
+  test("derives production discovery ownership from packaged launch context", () => {
+    expect(resolveElectronMcpBridgeDiscoveryMode(true)).toBe("production");
+  });
+
+  test("derives development discovery ownership from source launch context", () => {
+    expect(resolveElectronMcpBridgeDiscoveryMode(false)).toBe("development");
+  });
+
   test("owns a scheduled task-sync disk-write failure through the Electron host lifecycle", async () => {
     const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-electron-task-sync-"));
     const recordedAt = new Date(2026, 4, 13, 23, 45, 12, 345);
@@ -540,6 +550,7 @@ describe("createElectronHostCommandRouter", () => {
             filesystem: createFilesystem(),
             git: createGit(),
             lifecycleLogger: logger,
+            isPackaged: false,
             mcpHostBridge: {
               ensureConnection: () => Effect.succeed({ baseUrl: "http://127.0.0.1:5000" }),
               ensureExternalDiscoveryReady: () =>

--- a/apps/electron/src/main/electron-host.test.ts
+++ b/apps/electron/src/main/electron-host.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { GlobalConfig, RepoConfig, RuntimeInstanceSummary } from "@openducktor/contracts";
@@ -19,6 +19,7 @@ import {
   type SettingsConfigPort,
   type SystemCommandPort,
   type TaskStorePort,
+  type TerminalPtyPort,
   type WorktreeFilePort,
 } from "@openducktor/host";
 import { Deferred, TestClock, TestContext } from "effect";
@@ -40,6 +41,10 @@ const testRuntimeDistribution = createArtifactRuntimeDistribution({
     executablePath: process.execPath,
   },
 });
+
+const testTerminalPty: TerminalPtyPort = {
+  start: () => Effect.die("Terminal PTY is not expected in this composition test."),
+};
 
 const createElectronHostCommandRouter = (input: Partial<ElectronHostCommandRouterInput> = {}) =>
   createProductionElectronHostCommandRouter({
@@ -521,6 +526,70 @@ describe("createElectronHostCommandRouter", () => {
   test("derives development discovery ownership from source launch context", () => {
     expect(resolveElectronMcpBridgeDiscoveryMode(false)).toBe("development");
   });
+
+  for (const scenario of [
+    {
+      descriptorName: "mcp-bridge.json",
+      isPackaged: true,
+      oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:1","hostToken":"dev","pid":1}\n',
+      oppositeDescriptorName: "mcp-bridge-dev.json",
+      title: "packaged Electron owns only production discovery",
+    },
+    {
+      descriptorName: "mcp-bridge-dev.json",
+      isPackaged: false,
+      oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:2","hostToken":"prod","pid":2}\n',
+      oppositeDescriptorName: "mcp-bridge.json",
+      title: "source Electron owns only development discovery",
+    },
+  ] as const) {
+    test(scenario.title, async () => {
+      const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-electron-discovery-"));
+      const runtimeDirectory = path.join(configDirectory, "runtime");
+      const descriptorPath = path.join(runtimeDirectory, scenario.descriptorName);
+      const oppositeDescriptorPath = path.join(runtimeDirectory, scenario.oppositeDescriptorName);
+      const router = createElectronHostCommandRouter({
+        isPackaged: scenario.isPackaged,
+        lifecycleLogger: {
+          error: () => Effect.void,
+          info: () => Effect.void,
+        },
+        processEnv: {
+          OPENDUCKTOR_CONFIG_DIR: configDirectory,
+          PATH: "/usr/bin:/bin",
+        },
+        runtimeDistribution: testRuntimeDistribution,
+        taskStore: createTaskStore(),
+        terminalPty: testTerminalPty,
+      });
+
+      try {
+        await mkdir(runtimeDirectory, { recursive: true });
+        await writeFile(oppositeDescriptorPath, scenario.oppositeDescriptor, "utf8");
+
+        await router.initialize();
+
+        expect(JSON.parse(await readFile(descriptorPath, "utf8"))).toEqual({
+          hostToken: expect.any(String),
+          hostUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+          pid: process.pid,
+        });
+        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
+          scenario.oppositeDescriptor,
+        );
+
+        await router.dispose();
+
+        await expect(readFile(descriptorPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
+          scenario.oppositeDescriptor,
+        );
+      } finally {
+        await router.dispose().catch(() => {});
+        await rm(configDirectory, { force: true, recursive: true });
+      }
+    });
+  }
 
   test("owns a scheduled task-sync disk-write failure through the Electron host lifecycle", async () => {
     const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-electron-task-sync-"));

--- a/apps/electron/src/main/electron-host.ts
+++ b/apps/electron/src/main/electron-host.ts
@@ -1,5 +1,34 @@
-export {
-  type CreateNodeHostCommandRouterInput as CreateElectronHostCommandRouterInput,
-  createNodeEffectHostCommandRouter as createElectronEffectHostCommandRouter,
-  createNodeHostCommandRouter as createElectronHostCommandRouter,
+import {
+  type CreateNodeHostCommandRouterInput,
+  createNodeEffectHostCommandRouter,
+  createNodeHostCommandRouter,
+  type McpBridgeDiscoveryMode,
 } from "@openducktor/host";
+
+export type CreateElectronHostCommandRouterInput = Omit<
+  CreateNodeHostCommandRouterInput,
+  "mcpBridgeDiscoveryMode"
+> & {
+  isPackaged: boolean;
+};
+
+export const resolveElectronMcpBridgeDiscoveryMode = (
+  isPackaged: boolean,
+): McpBridgeDiscoveryMode => (isPackaged ? "production" : "development");
+
+const withElectronMcpBridgeDiscoveryMode = (
+  input: CreateElectronHostCommandRouterInput,
+): CreateNodeHostCommandRouterInput => {
+  const { isPackaged, ...hostInput } = input;
+  return {
+    ...hostInput,
+    mcpBridgeDiscoveryMode: resolveElectronMcpBridgeDiscoveryMode(isPackaged),
+  };
+};
+
+export const createElectronEffectHostCommandRouter = (
+  input: CreateElectronHostCommandRouterInput,
+) => createNodeEffectHostCommandRouter(withElectronMcpBridgeDiscoveryMode(input));
+
+export const createElectronHostCommandRouter = (input: CreateElectronHostCommandRouterInput) =>
+  createNodeHostCommandRouter(withElectronMcpBridgeDiscoveryMode(input));

--- a/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
+++ b/apps/electron/src/main/electron-main-lifecycle-policy.test.ts
@@ -94,6 +94,12 @@ describe("Electron main lifecycle policy", () => {
     expect(source).toContain("profileKind: resolveElectronProfileKind(app.isPackaged)");
   });
 
+  test("startup passes Electron packaging state to MCP discovery composition", () => {
+    const source = readRepoFile("apps/electron/src/main/main.ts");
+
+    expect(source).toContain("isPackaged: app.isPackaged");
+  });
+
   test("startup does not claim single-instance ownership of the selected profile", () => {
     const source = readRepoFile("apps/electron/src/main/main.ts");
 

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -205,6 +205,7 @@ const createElectronHostCommandRouter = (
   createElectronEffectHostCommandRouter({
     clientVersion: app.getVersion(),
     eventBus: hostEventBus,
+    isPackaged: app.isPackaged,
     lifecycleLogger: electronLifecycleLogger,
     onBackgroundFailure: (failure) =>
       Effect.sync(() => {

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -69,9 +69,9 @@ Automatic discovery:
 
 - With `OPENDUCKTOR_CHANNEL` unset, the MCP reads the production host bridge from `runtime/mcp-bridge.json`.
 - With `OPENDUCKTOR_CHANNEL=dev`, the MCP reads the development host bridge from `runtime/mcp-bridge-dev.json`.
-- When automatic discovery is used, empty or unknown channel values fail at startup. The MCP does not try the other channel's file.
+- The MCP rejects empty or unknown channel values during automatic discovery. It does not try the other channel's file.
 - The default config directory is `~/.openducktor`.
-- `OPENDUCKTOR_CONFIG_DIR`, when set, changes the config root for the selected discovery file.
+- Set `OPENDUCKTOR_CONFIG_DIR` to change the config root for the selected discovery file.
 
 To connect an external MCP client to `bun run electron:dev` or `bun run browser:dev`:
 

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -63,12 +63,21 @@ Equivalent environment variables:
 
 - `ODT_WORKSPACE_ID` optional default workspace
 - `ODT_HOST_URL` optional override
+- `OPENDUCKTOR_CHANNEL=dev` selects development host discovery; leave it unset for production
 
 Automatic discovery:
 
-- The MCP reads the current host bridge from `runtime/mcp-bridge.json` under the OpenDucktor config directory.
+- With `OPENDUCKTOR_CHANNEL` unset, the MCP reads the production host bridge from `runtime/mcp-bridge.json`.
+- With `OPENDUCKTOR_CHANNEL=dev`, the MCP reads the development host bridge from `runtime/mcp-bridge-dev.json`.
+- When automatic discovery is used, empty or unknown channel values fail at startup. The MCP does not try the other channel's file.
 - The default config directory is `~/.openducktor`.
-- If `OPENDUCKTOR_CONFIG_DIR` is set, discovery uses `<OPENDUCKTOR_CONFIG_DIR>/runtime/mcp-bridge.json` instead.
+- `OPENDUCKTOR_CONFIG_DIR`, when set, changes the config root for the selected discovery file.
+
+To connect an external MCP client to `bun run electron:dev` or `bun run browser:dev`:
+
+```sh
+OPENDUCKTOR_CHANNEL=dev bunx @openducktor/mcp@latest
+```
 
 Startup contract:
 
@@ -82,6 +91,8 @@ Startup contract:
 8. Do not implicitly choose a workspace. Workspace-scoped tool calls must resolve a workspace from tool input `workspaceId` first, then the startup default.
 
 Desktop-managed and standalone MCP clients intentionally use this same host-bridge path. The difference is only how the MCP learns the host URL: desktop mode injects it, while standalone mode usually discovers it. Workspace resolution is request-scoped for workspace-bound tools: tool-input `workspaceId` wins over any startup default, and missing both sources is an error.
+
+OpenDucktor-managed OpenCode and Codex sessions receive explicit `ODT_HOST_URL` and `ODT_HOST_TOKEN` values. They do not depend on discovery files or `OPENDUCKTOR_CHANNEL`.
 
 ## Public Tools
 

--- a/packages/host/src/adapters/mcp/mcp-bridge-discovery-file.test.ts
+++ b/packages/host/src/adapters/mcp/mcp-bridge-discovery-file.test.ts
@@ -26,21 +26,73 @@ const discovery = (input: Partial<McpBridgeDiscoveryFile> = {}): McpBridgeDiscov
 
 describe("MCP bridge discovery file", () => {
   test("defaults discovery to the home OpenDucktor config root", () => {
-    expect(resolveMcpBridgeDiscoveryPath({})).toBe(
+    expect(resolveMcpBridgeDiscoveryPath("production", {})).toBe(
       path.join(homedir(), ".openducktor", "runtime", "mcp-bridge.json"),
+    );
+  });
+
+  test("resolves development discovery under the same default config root", () => {
+    expect(resolveMcpBridgeDiscoveryPath("development", {})).toBe(
+      path.join(homedir(), ".openducktor", "runtime", "mcp-bridge-dev.json"),
     );
   });
 
   test("resolves discovery under the same configured OpenDucktor config root", () => {
     expect(
-      resolveMcpBridgeDiscoveryPath({ OPENDUCKTOR_CONFIG_DIR: ` "~/.openducktor-local" ` }),
+      resolveMcpBridgeDiscoveryPath("production", {
+        OPENDUCKTOR_CONFIG_DIR: ` "~/.openducktor-local" `,
+      }),
     ).toBe(path.join(homedir(), ".openducktor-local", "runtime", "mcp-bridge.json"));
   });
 
   test("resolves relative configured roots to absolute discovery paths", () => {
-    expect(resolveMcpBridgeDiscoveryPath({ OPENDUCKTOR_CONFIG_DIR: "./.openducktor-local" })).toBe(
-      path.resolve("./.openducktor-local", "runtime/mcp-bridge.json"),
-    );
+    expect(
+      resolveMcpBridgeDiscoveryPath("production", {
+        OPENDUCKTOR_CONFIG_DIR: "./.openducktor-local",
+      }),
+    ).toBe(path.resolve("./.openducktor-local", "runtime/mcp-bridge.json"));
+  });
+
+  test("publishing and removing development discovery preserves production discovery", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "openducktor-mcp-discovery-modes-"));
+    const env = { OPENDUCKTOR_CONFIG_DIR: tempDir };
+    const productionPath = resolveMcpBridgeDiscoveryPath("production", env);
+    const developmentPath = resolveMcpBridgeDiscoveryPath("development", env);
+    const production = discovery({ hostToken: "production-token", pid: 123 });
+    const development = discovery({ hostToken: "development-token", pid: 456 });
+    const productionPayload = `${JSON.stringify(production, null, 2)}\n`;
+
+    try {
+      await Effect.runPromise(writeMcpBridgeDiscoveryFile(productionPath, production));
+      await Effect.runPromise(writeMcpBridgeDiscoveryFile(developmentPath, development));
+      await expect(readFile(productionPath, "utf8")).resolves.toBe(productionPayload);
+
+      await Effect.runPromise(removeMcpBridgeDiscoveryFile(developmentPath, development));
+      await expect(readFile(productionPath, "utf8")).resolves.toBe(productionPayload);
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  test("publishing and removing production discovery preserves development discovery", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "openducktor-mcp-discovery-modes-"));
+    const env = { OPENDUCKTOR_CONFIG_DIR: tempDir };
+    const productionPath = resolveMcpBridgeDiscoveryPath("production", env);
+    const developmentPath = resolveMcpBridgeDiscoveryPath("development", env);
+    const production = discovery({ hostToken: "production-token", pid: 123 });
+    const development = discovery({ hostToken: "development-token", pid: 456 });
+    const developmentPayload = `${JSON.stringify(development, null, 2)}\n`;
+
+    try {
+      await Effect.runPromise(writeMcpBridgeDiscoveryFile(developmentPath, development));
+      await Effect.runPromise(writeMcpBridgeDiscoveryFile(productionPath, production));
+      await expect(readFile(developmentPath, "utf8")).resolves.toBe(developmentPayload);
+
+      await Effect.runPromise(removeMcpBridgeDiscoveryFile(productionPath, production));
+      await expect(readFile(developmentPath, "utf8")).resolves.toBe(developmentPayload);
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
   });
 
   test("removes the discovery file only when it still belongs to the current bridge", async () => {

--- a/packages/host/src/adapters/mcp/mcp-bridge-discovery-file.ts
+++ b/packages/host/src/adapters/mcp/mcp-bridge-discovery-file.ts
@@ -5,7 +5,12 @@ import { resolveOpenDucktorBaseDir } from "../../config/openducktor-config-dir";
 import { HostValidationError } from "../../effect/host-errors";
 import { parseJson } from "../../effect/json";
 
-const DISCOVERY_RELATIVE_PATH = "runtime/mcp-bridge.json";
+const DISCOVERY_RELATIVE_PATHS = {
+  development: "runtime/mcp-bridge-dev.json",
+  production: "runtime/mcp-bridge.json",
+} as const;
+
+export type McpBridgeDiscoveryMode = keyof typeof DISCOVERY_RELATIVE_PATHS;
 
 export type McpBridgeDiscoveryFile = {
   hostToken: string;
@@ -16,9 +21,10 @@ export type McpBridgeDiscoveryFile = {
 const isFsErrorCode = (error: unknown, code: string): boolean =>
   typeof error === "object" && error !== null && "code" in error && error.code === code;
 
-export const resolveMcpBridgeDiscoveryPath = (env: NodeJS.ProcessEnv = process.env): string => {
-  return path.resolve(resolveOpenDucktorBaseDir(env), DISCOVERY_RELATIVE_PATH);
-};
+export const resolveMcpBridgeDiscoveryPath = (
+  mode: McpBridgeDiscoveryMode,
+  env: NodeJS.ProcessEnv = process.env,
+): string => path.resolve(resolveOpenDucktorBaseDir(env), DISCOVERY_RELATIVE_PATHS[mode]);
 
 const parseDiscoveryFile = (payload: string, discoveryPath: string): McpBridgeDiscoveryFile => {
   const parsed = parseJson(payload);

--- a/packages/host/src/adapters/mcp/mcp-host-bridge-server.ts
+++ b/packages/host/src/adapters/mcp/mcp-host-bridge-server.ts
@@ -14,7 +14,6 @@ import type { OpenCodeMcpBridgeConnection } from "../opencode/opencode-workspace
 import {
   type McpBridgeDiscoveryFile,
   removeMcpBridgeDiscoveryFile,
-  resolveMcpBridgeDiscoveryPath,
   writeMcpBridgeDiscoveryFile,
 } from "./mcp-bridge-discovery-file";
 import { bridgeErrorPayload, bridgeMessagePayload } from "./mcp-host-bridge-errors";
@@ -40,7 +39,7 @@ export type McpHostBridgeCloseResult = {
 
 export type CreateMcpHostBridgeServerInput = {
   bridgeService: OdtMcpBridgeService;
-  discoveryPath?: string;
+  discoveryPath: string;
   workspaceSettingsService: WorkspaceSettingsService;
   token?: string;
 };
@@ -330,7 +329,7 @@ const createBridgeRequestHandler =
 
 export const createMcpHostBridgeServer = ({
   bridgeService,
-  discoveryPath = resolveMcpBridgeDiscoveryPath(),
+  discoveryPath,
   workspaceSettingsService,
   token = randomUUID(),
 }: CreateMcpHostBridgeServerInput): McpHostBridgeServer => {

--- a/packages/host/src/adapters/mcp/openducktor-mcp-environment.test.ts
+++ b/packages/host/src/adapters/mcp/openducktor-mcp-environment.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildOpenDucktorMcpBridgeEnvironment,
+  OPENDUCKTOR_MCP_ENV_VAR_NAMES,
+} from "./openducktor-mcp-environment";
+
+describe("OpenDucktor managed MCP environment", () => {
+  test("routes through the explicit bridge without injecting a discovery channel", () => {
+    const environment = buildOpenDucktorMcpBridgeEnvironment(
+      {
+        hostToken: "host-token",
+        hostUrl: "http://127.0.0.1:14327",
+        workspaceId: "workspace-1",
+      },
+      "Codex",
+    );
+
+    expect(environment.ODT_HOST_URL).toBe("http://127.0.0.1:14327");
+    expect(environment.ODT_HOST_TOKEN).toBe("host-token");
+    expect(environment).not.toHaveProperty("OPENDUCKTOR_CHANNEL");
+    expect(OPENDUCKTOR_MCP_ENV_VAR_NAMES).not.toContain("OPENDUCKTOR_CHANNEL");
+  });
+});

--- a/packages/host/src/composition/node/create-node-host-command-router.test.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { Cause, Effect } from "effect";
 import type { McpHostBridgeServer } from "../../adapters/mcp/mcp-host-bridge-server";
@@ -62,6 +64,7 @@ const createRouter = (input: {
   createNodeEffectHostCommandRouter({
     ...(input.eventBus ? { eventBus: input.eventBus } : {}),
     lifecycleLogger: input.logger,
+    mcpBridgeDiscoveryMode: "production",
     mcpHostBridge: createMcpHostBridge(),
     onBackgroundFailure: input.onBackgroundFailure ?? (() => Effect.void),
     runtimeDistribution,
@@ -71,6 +74,43 @@ const createRouter = (input: {
   });
 
 describe("createNodeEffectHostCommandRouter", () => {
+  test("publishes development discovery from composition mode despite ambient channel", async () => {
+    const configDir = await mkdtemp(path.join(tmpdir(), "openducktor-node-host-discovery-"));
+    const { logger } = createLogger();
+    const router = createNodeEffectHostCommandRouter({
+      lifecycleLogger: logger,
+      mcpBridgeDiscoveryMode: "development",
+      onBackgroundFailure: () => Effect.void,
+      processEnv: {
+        OPENDUCKTOR_CHANNEL: "production",
+        OPENDUCKTOR_CONFIG_DIR: configDir,
+      },
+      runtimeDistribution,
+      runtimeRegistry: createRuntimeRegistry(),
+      taskStore: {} as TaskStorePort,
+      terminalPty,
+    });
+
+    try {
+      await Effect.runPromise(router.initialize());
+
+      const payload = JSON.parse(
+        await readFile(path.join(configDir, "runtime", "mcp-bridge-dev.json"), "utf8"),
+      ) as Record<string, unknown>;
+      expect(payload).toEqual({
+        hostToken: expect.any(String),
+        hostUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+        pid: process.pid,
+      });
+      await expect(
+        readFile(path.join(configDir, "runtime", "mcp-bridge.json"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await Effect.runPromise(router.dispose());
+      await rm(configDir, { force: true, recursive: true });
+    }
+  });
+
   test("stops managed dev servers during normal host disposal", async () => {
     const { infos, logger } = createLogger();
 

--- a/packages/host/src/composition/node/create-node-host-command-router.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.ts
@@ -4,6 +4,7 @@ import { createCodexLiveSessionAdapterPreparer } from "../../adapters/agent-sess
 import { createLiveSessionAdapterRegistry } from "../../adapters/agent-sessions/live-session-adapter-registry";
 import { createOpenCodeLiveSessionAdapterPreparer } from "../../adapters/agent-sessions/opencode-live-session-adapter";
 import { createCodexWorkspaceRuntimeStarter } from "../../adapters/codex/codex-workspace-runtime-starter";
+import type { McpBridgeDiscoveryMode } from "../../adapters/mcp/mcp-bridge-discovery-file";
 import {
   createMcpHostBridgeServer,
   type McpHostBridgeServer,
@@ -94,6 +95,7 @@ export type CreateNodeHostCommandRouterInput = CreateNodeHostDefaultPortsInput &
   clientVersion?: string;
   eventBus?: HostEventBusPort;
   lifecycleLogger?: HostLifecycleLogger;
+  mcpBridgeDiscoveryMode: McpBridgeDiscoveryMode;
   mcpHostBridge?: McpHostBridgeServer;
   onBackgroundFailure(failure: HostOperationError): Effect.Effect<void, never>;
   runtimeRegistry?: RuntimeRegistryPort;
@@ -322,7 +324,7 @@ export const createNodeEffectHostCommandRouter = (
   });
   resolvedMcpHostBridge ??= createMcpHostBridgeServer({
     bridgeService: odtMcpBridgeService,
-    discoveryPath: resolveMcpBridgeDiscoveryPath(processEnv),
+    discoveryPath: resolveMcpBridgeDiscoveryPath(input.mcpBridgeDiscoveryMode, processEnv),
     workspaceSettingsService,
   });
   const runtimeOrchestratorWithEffectiveRegistry = createRuntimeOrchestratorService({

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -12,6 +12,7 @@ export {
   type OpenCodeLiveSessionAdapterPreparer,
 } from "./adapters/agent-sessions/opencode-live-session-adapter";
 export { createLocalAttachmentAdapter } from "./adapters/attachments/local-attachment-adapter";
+export type { McpBridgeDiscoveryMode } from "./adapters/mcp/mcp-bridge-discovery-file";
 export {
   type ArtifactMcpLauncher,
   type ArtifactRuntimeDistribution,

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -60,9 +60,9 @@ Automatic discovery:
 
 - With `OPENDUCKTOR_CHANNEL` unset, the MCP reads `runtime/mcp-bridge.json` for the production host.
 - With `OPENDUCKTOR_CHANNEL=dev`, the MCP reads `runtime/mcp-bridge-dev.json` for a development host.
-- When automatic discovery is used, empty or unknown channel values fail. The MCP never tries the other channel's descriptor.
+- The MCP rejects empty or unknown channel values during automatic discovery. It never tries the other channel's descriptor.
 - The default config directory is `~/.openducktor`.
-- `OPENDUCKTOR_CONFIG_DIR`, when set, changes the config root for the selected descriptor.
+- Set `OPENDUCKTOR_CONFIG_DIR` to change the config root for the selected descriptor.
 
 Connect to a source development host with:
 

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -54,12 +54,21 @@ Equivalent environment variables:
 
 - `ODT_WORKSPACE_ID` optional default workspace
 - `ODT_HOST_URL` optional override
+- `OPENDUCKTOR_CHANNEL=dev` selects development host discovery; leave it unset for production
 
 Automatic discovery:
 
-- The MCP reads the current host bridge from `runtime/mcp-bridge.json` under the OpenDucktor config directory.
+- With `OPENDUCKTOR_CHANNEL` unset, the MCP reads `runtime/mcp-bridge.json` for the production host.
+- With `OPENDUCKTOR_CHANNEL=dev`, the MCP reads `runtime/mcp-bridge-dev.json` for a development host.
+- When automatic discovery is used, empty or unknown channel values fail. The MCP never tries the other channel's descriptor.
 - The default config directory is `~/.openducktor`.
-- If `OPENDUCKTOR_CONFIG_DIR` is set, discovery uses `<OPENDUCKTOR_CONFIG_DIR>/runtime/mcp-bridge.json` instead.
+- `OPENDUCKTOR_CONFIG_DIR`, when set, changes the config root for the selected descriptor.
+
+Connect to a source development host with:
+
+```sh
+OPENDUCKTOR_CHANNEL=dev bunx @openducktor/mcp@latest
+```
 
 Startup behavior:
 
@@ -71,6 +80,8 @@ Startup behavior:
 - Startup no longer requires `--workspace-id` or `ODT_WORKSPACE_ID`.
 - When both a startup default and a tool-input `workspaceId` are present, the tool input wins.
 - Workspace-scoped tools fail fast with an explicit error when neither a startup default nor a tool-input `workspaceId` is available.
+
+OpenDucktor-managed OpenCode and Codex sessions receive explicit host URL and token values. Their routing does not use `OPENDUCKTOR_CHANNEL`.
 
 The OpenDucktor host owns SQLite task-store readiness, workflow transitions, and document persistence. This package owns MCP transport and schema validation only.
 

--- a/packages/openducktor-mcp/src/path-utils.test.ts
+++ b/packages/openducktor-mcp/src/path-utils.test.ts
@@ -4,20 +4,54 @@ import { join } from "node:path";
 import { resolveMcpBridgeDiscoveryPath } from "./path-utils";
 
 let previousConfigDir: string | undefined;
+let previousChannel: string | undefined;
 
 beforeEach(() => {
   previousConfigDir = process.env.OPENDUCKTOR_CONFIG_DIR;
+  previousChannel = process.env.OPENDUCKTOR_CHANNEL;
+  delete process.env.OPENDUCKTOR_CONFIG_DIR;
+  delete process.env.OPENDUCKTOR_CHANNEL;
 });
 
 afterEach(() => {
   if (previousConfigDir === undefined) {
     delete process.env.OPENDUCKTOR_CONFIG_DIR;
-    return;
+  } else {
+    process.env.OPENDUCKTOR_CONFIG_DIR = previousConfigDir;
   }
-  process.env.OPENDUCKTOR_CONFIG_DIR = previousConfigDir;
+  if (previousChannel === undefined) {
+    delete process.env.OPENDUCKTOR_CHANNEL;
+  } else {
+    process.env.OPENDUCKTOR_CHANNEL = previousChannel;
+  }
 });
 
 describe("MCP path utilities", () => {
+  test("defaults external discovery to the production descriptor", () => {
+    expect(resolveMcpBridgeDiscoveryPath()).toBe(
+      join(homedir(), ".openducktor", "runtime", "mcp-bridge.json"),
+    );
+  });
+
+  test("selects the development descriptor for the dev channel", () => {
+    process.env.OPENDUCKTOR_CHANNEL = "dev";
+
+    expect(resolveMcpBridgeDiscoveryPath()).toBe(
+      join(homedir(), ".openducktor", "runtime", "mcp-bridge-dev.json"),
+    );
+  });
+
+  test.each(["", "   ", "production", "preview"])(
+    "rejects unsupported external discovery channel %p",
+    (channel) => {
+      process.env.OPENDUCKTOR_CHANNEL = channel;
+
+      expect(() => resolveMcpBridgeDiscoveryPath()).toThrow(
+        "OPENDUCKTOR_CHANNEL must be unset for production discovery or set to dev",
+      );
+    },
+  );
+
   test("expands quoted home-relative config directories", () => {
     process.env.OPENDUCKTOR_CONFIG_DIR = ` "~/.openducktor-local" `;
 

--- a/packages/openducktor-mcp/src/path-utils.ts
+++ b/packages/openducktor-mcp/src/path-utils.ts
@@ -3,9 +3,11 @@ import { join, resolve } from "node:path";
 import { normalizeUserPathInput, resolveNormalizedUserPath } from "@openducktor/path-support";
 
 const EMPTY_ENV_SENTINELS = new Set(["undefined", "null"]);
+const OPENDUCKTOR_CHANNEL_ENV = "OPENDUCKTOR_CHANNEL";
 const OPENDUCKTOR_CONFIG_DIR_ENV = "OPENDUCKTOR_CONFIG_DIR";
 const DEFAULT_OPENDUCKTOR_CONFIG_DIR_NAME = ".openducktor";
-const MCP_BRIDGE_DISCOVERY_RELATIVE_PATH = "runtime/mcp-bridge.json";
+const DEVELOPMENT_MCP_BRIDGE_DISCOVERY_RELATIVE_PATH = "runtime/mcp-bridge-dev.json";
+const PRODUCTION_MCP_BRIDGE_DISCOVERY_RELATIVE_PATH = "runtime/mcp-bridge.json";
 
 export const normalizeOptionalInput = (value: string | undefined): string | undefined => {
   if (typeof value !== "string") {
@@ -52,8 +54,21 @@ const resolveOpenducktorBaseDir = (): string => {
   return join(resolveHomeDirectory(), DEFAULT_OPENDUCKTOR_CONFIG_DIR_NAME);
 };
 
+const resolveMcpBridgeDiscoveryRelativePath = (): string => {
+  if (!Object.hasOwn(process.env, OPENDUCKTOR_CHANNEL_ENV)) {
+    return PRODUCTION_MCP_BRIDGE_DISCOVERY_RELATIVE_PATH;
+  }
+  const channel = process.env[OPENDUCKTOR_CHANNEL_ENV];
+  if (channel === "dev") {
+    return DEVELOPMENT_MCP_BRIDGE_DISCOVERY_RELATIVE_PATH;
+  }
+  throw new Error(
+    `OPENDUCKTOR_CHANNEL must be unset for production discovery or set to dev. Received ${JSON.stringify(channel)}.`,
+  );
+};
+
 export const resolveMcpBridgeDiscoveryPath = (): string =>
-  join(resolveOpenducktorBaseDir(), MCP_BRIDGE_DISCOVERY_RELATIVE_PATH);
+  join(resolveOpenducktorBaseDir(), resolveMcpBridgeDiscoveryRelativePath());
 
 export const normalizeBaseUrl = (value: string): string =>
   value.endsWith("/") ? value.slice(0, -1) : value;

--- a/packages/openducktor-mcp/src/store-context.test.ts
+++ b/packages/openducktor-mcp/src/store-context.test.ts
@@ -47,6 +47,7 @@ const clearStoreContextEnv = (): void => {
   delete process.env.ODT_HOST_URL;
   delete process.env.ODT_HOST_TOKEN;
   delete process.env.ODT_FORBID_WORKSPACE_ID_INPUT;
+  delete process.env.OPENDUCKTOR_CHANNEL;
   delete process.env.OPENDUCKTOR_CONFIG_DIR;
 };
 
@@ -94,6 +95,7 @@ describe("resolveStoreContext", () => {
 
     process.env.ODT_WORKSPACE_ID = "repo";
     process.env.ODT_HOST_URL = "http://127.0.0.1:14327";
+    process.env.OPENDUCKTOR_CHANNEL = "preview";
 
     await expect(resolveStoreContext({})).resolves.toEqual({
       workspaceId: "repo",
@@ -273,6 +275,71 @@ describe("resolveStoreContext", () => {
       hostToken: "discovery-token",
     });
     expect(observedHostTokens).toEqual(["discovery-token", "discovery-token"]);
+  });
+
+  test("discovers the development host only from the dev channel descriptor", async () => {
+    const configDir = await createDiscoveryFile({
+      hostToken: "production-token",
+      hostUrl: "http://127.0.0.1:14327",
+    });
+    await writeFile(
+      join(configDir, "runtime", "mcp-bridge-dev.json"),
+      JSON.stringify(
+        {
+          hostToken: "development-token",
+          hostUrl: "http://127.0.0.1:24327",
+          pid: 23456,
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    process.env.OPENDUCKTOR_CONFIG_DIR = configDir;
+    process.env.OPENDUCKTOR_CHANNEL = "dev";
+
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      if (url === "http://127.0.0.1:24327/health") {
+        return jsonResponse({ ok: true });
+      }
+      if (url === "http://127.0.0.1:24327/invoke/odt_mcp_ready") {
+        return jsonResponse({
+          bridgeVersion: 1,
+          toolNames: Object.keys(ODT_TOOL_SCHEMAS),
+        });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as typeof fetch;
+
+    await expect(resolveStoreContext({})).resolves.toEqual({
+      hostToken: "development-token",
+      hostUrl: "http://127.0.0.1:24327",
+    });
+  });
+
+  test("does not fall back from development discovery to production", async () => {
+    const configDir = await createDiscoveryFile();
+    process.env.OPENDUCKTOR_CONFIG_DIR = configDir;
+    process.env.OPENDUCKTOR_CHANNEL = "dev";
+
+    await expect(resolveStoreContext({})).rejects.toThrow("mcp-bridge-dev.json");
+  });
+
+  test("does not fall back from production discovery to development", async () => {
+    const configDir = await createEmptyConfigDir();
+    await writeFile(
+      join(configDir, "runtime", "mcp-bridge-dev.json"),
+      JSON.stringify({
+        hostToken: "development-token",
+        hostUrl: "http://127.0.0.1:24327",
+        pid: 23456,
+      }),
+      "utf8",
+    );
+    process.env.OPENDUCKTOR_CONFIG_DIR = configDir;
+
+    await expect(resolveStoreContext({})).rejects.toThrow("mcp-bridge.json");
   });
 
   test("fails clearly when discovery cannot find any running host", async () => {

--- a/packages/openducktor-mcp/src/store-context.test.ts
+++ b/packages/openducktor-mcp/src/store-context.test.ts
@@ -7,6 +7,17 @@ import { resolveStoreContext } from "./store-context";
 
 const originalFetch = globalThis.fetch;
 const tempDirs: string[] = [];
+const STORE_CONTEXT_ENV_KEYS = [
+  "ODT_WORKSPACE_ID",
+  "ODT_HOST_URL",
+  "ODT_HOST_TOKEN",
+  "ODT_FORBID_WORKSPACE_ID_INPUT",
+  "OPENDUCKTOR_CHANNEL",
+  "OPENDUCKTOR_CONFIG_DIR",
+] as const;
+type StoreContextEnvKey = (typeof STORE_CONTEXT_ENV_KEYS)[number];
+type StoreContextEnvSnapshot = Record<StoreContextEnvKey, string | undefined>;
+let previousStoreContextEnv: StoreContextEnvSnapshot;
 
 const jsonResponse = (payload: unknown, init: ResponseInit = {}): Response =>
   new Response(JSON.stringify(payload), {
@@ -43,22 +54,39 @@ const createEmptyConfigDir = async (): Promise<string> => {
 };
 
 const clearStoreContextEnv = (): void => {
-  delete process.env.ODT_WORKSPACE_ID;
-  delete process.env.ODT_HOST_URL;
-  delete process.env.ODT_HOST_TOKEN;
-  delete process.env.ODT_FORBID_WORKSPACE_ID_INPUT;
-  delete process.env.OPENDUCKTOR_CHANNEL;
-  delete process.env.OPENDUCKTOR_CONFIG_DIR;
+  for (const key of STORE_CONTEXT_ENV_KEYS) {
+    delete process.env[key];
+  }
+};
+
+const snapshotStoreContextEnv = (): StoreContextEnvSnapshot =>
+  Object.fromEntries(
+    STORE_CONTEXT_ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as StoreContextEnvSnapshot;
+
+const restoreStoreContextEnv = (snapshot: StoreContextEnvSnapshot): void => {
+  for (const key of STORE_CONTEXT_ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
 };
 
 beforeEach(() => {
+  previousStoreContextEnv = snapshotStoreContextEnv();
   clearStoreContextEnv();
 });
 
 afterEach(async () => {
   globalThis.fetch = originalFetch;
-  clearStoreContextEnv();
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  try {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  } finally {
+    restoreStoreContextEnv(previousStoreContextEnv);
+  }
 });
 
 describe("resolveStoreContext", () => {

--- a/packages/openducktor-web/README.md
+++ b/packages/openducktor-web/README.md
@@ -18,6 +18,8 @@ bun run browser:dev
 
 That workspace mode runs the TypeScript host in-process and serves the frontend with Vite. Published installs use bundled static frontend assets plus the TypeScript host bundled into `dist/cli.js`.
 
+Workspace mode publishes external MCP discovery to `runtime/mcp-bridge-dev.json`. Published installs use the production `runtime/mcp-bridge.json` descriptor. External MCP clients must set `OPENDUCKTOR_CHANNEL=dev` to connect to workspace mode.
+
 ## Options
 
 ```sh

--- a/packages/openducktor-web/src/launcher-host-discovery-fixture.ts
+++ b/packages/openducktor-web/src/launcher-host-discovery-fixture.ts
@@ -21,11 +21,33 @@ const launchModes = {
 
 type LaunchMode = keyof typeof launchModes;
 
+type DiscoveryScenarioResult = {
+  descriptor: {
+    hostTokenPresent: boolean;
+    hostUrl: unknown;
+    pidMatchesProcess: boolean;
+  };
+  oppositeAfterStop: string;
+  oppositeDuringRun: string;
+  selectedMissingAfterStop: boolean;
+};
+
 const isLaunchMode = (value: string | undefined): value is LaunchMode =>
   value !== undefined && Object.hasOwn(launchModes, value);
 
 const isMissingFileError = (error: unknown): boolean =>
   typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+
+const isFileMissing = (filePath: string): Promise<boolean> =>
+  readFile(filePath, "utf8").then(
+    () => false,
+    (error: unknown) => {
+      if (isMissingFileError(error)) {
+        return true;
+      }
+      throw error;
+    },
+  );
 
 const sourceRuntimeDistribution = createSourceRuntimeDistribution(
   path.resolve(import.meta.dir, "../../.."),
@@ -36,7 +58,7 @@ const testLogger: WebLogger = {
   success: () => Effect.void,
 };
 
-const runDiscoveryScenario = async () => {
+const runDiscoveryScenario = async (): Promise<DiscoveryScenarioResult> => {
   const launchMode = process.argv[2];
   if (!isLaunchMode(launchMode)) {
     throw new Error(
@@ -57,7 +79,6 @@ const runDiscoveryScenario = async () => {
   const descriptorPath = path.join(runtimeDirectory, scenario.descriptorName);
   const oppositeDescriptorPath = path.join(runtimeDirectory, scenario.oppositeDescriptorName);
   let backend: TypescriptHostBackend | null = null;
-  let stopped = false;
 
   try {
     await mkdir(runtimeDirectory, { recursive: true });
@@ -83,17 +104,9 @@ const runDiscoveryScenario = async () => {
     const oppositeDuringRun = await readFile(oppositeDescriptorPath, "utf8");
 
     await backend.stop();
-    stopped = true;
+    backend = null;
 
-    const selectedMissingAfterStop = await readFile(descriptorPath, "utf8").then(
-      () => false,
-      (error: unknown) => {
-        if (isMissingFileError(error)) {
-          return true;
-        }
-        throw error;
-      },
-    );
+    const selectedMissingAfterStop = await isFileMissing(descriptorPath);
     const oppositeAfterStop = await readFile(oppositeDescriptorPath, "utf8");
 
     return {
@@ -108,9 +121,7 @@ const runDiscoveryScenario = async () => {
       selectedMissingAfterStop,
     };
   } finally {
-    if (!stopped) {
-      await backend?.stop().catch(() => {});
-    }
+    await backend?.stop().catch(() => {});
   }
 };
 

--- a/packages/openducktor-web/src/launcher-host-discovery-fixture.ts
+++ b/packages/openducktor-web/src/launcher-host-discovery-fixture.ts
@@ -21,10 +21,10 @@ const launchModes = {
 
 type LaunchMode = keyof typeof launchModes;
 
-type DiscoveryScenarioResult = {
+export type DiscoveryScenarioResult = {
   descriptor: {
     hostTokenPresent: boolean;
-    hostUrl: unknown;
+    hostUrl: string;
     pidMatchesProcess: boolean;
   };
   oppositeAfterStop: string;
@@ -49,9 +49,6 @@ const isFileMissing = (filePath: string): Promise<boolean> =>
     },
   );
 
-const sourceRuntimeDistribution = createSourceRuntimeDistribution(
-  path.resolve(import.meta.dir, "../../.."),
-);
 const testLogger: WebLogger = {
   error: () => Effect.void,
   info: () => Effect.void,
@@ -78,6 +75,9 @@ const runDiscoveryScenario = async (): Promise<DiscoveryScenarioResult> => {
   const runtimeDirectory = path.join(configDirectory, "runtime");
   const descriptorPath = path.join(runtimeDirectory, scenario.descriptorName);
   const oppositeDescriptorPath = path.join(runtimeDirectory, scenario.oppositeDescriptorName);
+  const runtimeDistribution = createSourceRuntimeDistribution(
+    path.resolve(import.meta.dir, "../../.."),
+  );
   let backend: TypescriptHostBackend | null = null;
 
   try {
@@ -91,7 +91,7 @@ const runDiscoveryScenario = async (): Promise<DiscoveryScenarioResult> => {
         logger: testLogger,
         onBackgroundFailure: () => {},
         port: 0,
-        runtimeDistribution: sourceRuntimeDistribution,
+        runtimeDistribution,
         workspaceMode: scenario.workspaceMode,
       }),
     );
@@ -101,6 +101,9 @@ const runDiscoveryScenario = async (): Promise<DiscoveryScenarioResult> => {
       hostUrl?: unknown;
       pid?: unknown;
     };
+    if (typeof descriptor.hostUrl !== "string") {
+      throw new Error("Expected launcher discovery descriptor hostUrl to be a string.");
+    }
     const oppositeDuringRun = await readFile(oppositeDescriptorPath, "utf8");
 
     await backend.stop();
@@ -125,4 +128,6 @@ const runDiscoveryScenario = async (): Promise<DiscoveryScenarioResult> => {
   }
 };
 
-process.stdout.write(JSON.stringify(await runDiscoveryScenario()));
+if (import.meta.main) {
+  process.stdout.write(JSON.stringify(await runDiscoveryScenario()));
+}

--- a/packages/openducktor-web/src/launcher-host-discovery-fixture.ts
+++ b/packages/openducktor-web/src/launcher-host-discovery-fixture.ts
@@ -1,0 +1,117 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createSourceRuntimeDistribution } from "@openducktor/host";
+import { Effect } from "effect";
+import { startWebLauncherHostBackendEffect } from "./launcher";
+import type { WebLogger } from "./logger";
+import type { TypescriptHostBackend } from "./typescript-host-backend";
+
+const launchModes = {
+  installed: {
+    descriptorName: "mcp-bridge.json",
+    oppositeDescriptorName: "mcp-bridge-dev.json",
+    workspaceMode: false,
+  },
+  workspace: {
+    descriptorName: "mcp-bridge-dev.json",
+    oppositeDescriptorName: "mcp-bridge.json",
+    workspaceMode: true,
+  },
+} as const;
+
+type LaunchMode = keyof typeof launchModes;
+
+const isLaunchMode = (value: string | undefined): value is LaunchMode =>
+  value !== undefined && Object.hasOwn(launchModes, value);
+
+const isMissingFileError = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+
+const sourceRuntimeDistribution = createSourceRuntimeDistribution(
+  path.resolve(import.meta.dir, "../../.."),
+);
+const testLogger: WebLogger = {
+  error: () => Effect.void,
+  info: () => Effect.void,
+  success: () => Effect.void,
+};
+
+const runDiscoveryScenario = async () => {
+  const launchMode = process.argv[2];
+  if (!isLaunchMode(launchMode)) {
+    throw new Error(
+      `Expected launcher discovery mode workspace or installed, received ${launchMode}.`,
+    );
+  }
+  const oppositeDescriptor = process.argv[3];
+  if (oppositeDescriptor === undefined) {
+    throw new Error("Expected the opposite launcher discovery descriptor fixture.");
+  }
+  const configDirectory = process.env.OPENDUCKTOR_CONFIG_DIR;
+  if (!configDirectory) {
+    throw new Error("Expected OPENDUCKTOR_CONFIG_DIR for launcher discovery fixture isolation.");
+  }
+
+  const scenario = launchModes[launchMode];
+  const runtimeDirectory = path.join(configDirectory, "runtime");
+  const descriptorPath = path.join(runtimeDirectory, scenario.descriptorName);
+  const oppositeDescriptorPath = path.join(runtimeDirectory, scenario.oppositeDescriptorName);
+  let backend: TypescriptHostBackend | null = null;
+  let stopped = false;
+
+  try {
+    await mkdir(runtimeDirectory, { recursive: true });
+    await writeFile(oppositeDescriptorPath, oppositeDescriptor, "utf8");
+    backend = await Effect.runPromise(
+      startWebLauncherHostBackendEffect({
+        appToken: "app-token",
+        controlToken: "control-token",
+        frontendOrigin: "http://127.0.0.1:1420",
+        logger: testLogger,
+        onBackgroundFailure: () => {},
+        port: 0,
+        runtimeDistribution: sourceRuntimeDistribution,
+        workspaceMode: scenario.workspaceMode,
+      }),
+    );
+
+    const descriptor = JSON.parse(await readFile(descriptorPath, "utf8")) as {
+      hostToken?: unknown;
+      hostUrl?: unknown;
+      pid?: unknown;
+    };
+    const oppositeDuringRun = await readFile(oppositeDescriptorPath, "utf8");
+
+    await backend.stop();
+    stopped = true;
+
+    const selectedMissingAfterStop = await readFile(descriptorPath, "utf8").then(
+      () => false,
+      (error: unknown) => {
+        if (isMissingFileError(error)) {
+          return true;
+        }
+        throw error;
+      },
+    );
+    const oppositeAfterStop = await readFile(oppositeDescriptorPath, "utf8");
+
+    return {
+      descriptor: {
+        hostTokenPresent:
+          typeof descriptor.hostToken === "string" && descriptor.hostToken.length > 0,
+        hostUrl: descriptor.hostUrl,
+        pidMatchesProcess: descriptor.pid === process.pid,
+      },
+      oppositeAfterStop,
+      oppositeDuringRun,
+      selectedMissingAfterStop,
+    };
+  } finally {
+    if (!stopped) {
+      await backend?.stop().catch(() => {});
+    }
+  }
+};
+
+process.stdout.write(JSON.stringify(await runDiscoveryScenario()));

--- a/packages/openducktor-web/src/launcher-host-discovery.test.ts
+++ b/packages/openducktor-web/src/launcher-host-discovery.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createSourceRuntimeDistribution } from "@openducktor/host";
+import { Effect } from "effect";
+import { startWebLauncherHostBackendEffect } from "./launcher";
+import type { WebLogger } from "./logger";
+import type { TypescriptHostBackend } from "./typescript-host-backend";
+
+const nativeResponse = await Bun.fetch("data:,");
+const nativeResponseConstructor = nativeResponse.constructor as typeof Response;
+
+const sourceRuntimeDistribution = createSourceRuntimeDistribution(
+  path.resolve(import.meta.dir, "../../.."),
+);
+const testLogger: WebLogger = {
+  error: () => Effect.void,
+  info: () => Effect.void,
+  success: () => Effect.void,
+};
+
+describe("web launcher MCP discovery composition", () => {
+  for (const scenario of [
+    {
+      descriptorName: "mcp-bridge-dev.json",
+      oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:1","hostToken":"prod","pid":1}\n',
+      oppositeDescriptorName: "mcp-bridge.json",
+      title: "workspace launches own only development discovery",
+      workspaceMode: true,
+    },
+    {
+      descriptorName: "mcp-bridge.json",
+      oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:2","hostToken":"dev","pid":2}\n',
+      oppositeDescriptorName: "mcp-bridge-dev.json",
+      title: "installed launches own only production discovery",
+      workspaceMode: false,
+    },
+  ] as const) {
+    test(scenario.title, async () => {
+      const previousResponse = globalThis.Response;
+      const previousConfigDirectory = process.env.OPENDUCKTOR_CONFIG_DIR;
+      const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-web-discovery-"));
+      const runtimeDirectory = path.join(configDirectory, "runtime");
+      const descriptorPath = path.join(runtimeDirectory, scenario.descriptorName);
+      const oppositeDescriptorPath = path.join(runtimeDirectory, scenario.oppositeDescriptorName);
+      let backend: TypescriptHostBackend | null = null;
+
+      try {
+        (globalThis as typeof globalThis & { Response: typeof Response }).Response =
+          nativeResponseConstructor;
+        process.env.OPENDUCKTOR_CONFIG_DIR = configDirectory;
+        await mkdir(runtimeDirectory, { recursive: true });
+        await writeFile(oppositeDescriptorPath, scenario.oppositeDescriptor, "utf8");
+
+        backend = await Effect.runPromise(
+          startWebLauncherHostBackendEffect({
+            appToken: "app-token",
+            controlToken: "control-token",
+            frontendOrigin: "http://127.0.0.1:1420",
+            logger: testLogger,
+            onBackgroundFailure: () => {},
+            port: 0,
+            runtimeDistribution: sourceRuntimeDistribution,
+            workspaceMode: scenario.workspaceMode,
+          }),
+        );
+
+        expect(JSON.parse(await readFile(descriptorPath, "utf8"))).toEqual({
+          hostToken: expect.any(String),
+          hostUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+          pid: process.pid,
+        });
+        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
+          scenario.oppositeDescriptor,
+        );
+
+        await backend.stop();
+
+        await expect(readFile(descriptorPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
+          scenario.oppositeDescriptor,
+        );
+      } finally {
+        await backend?.stop().catch(() => {});
+        (globalThis as typeof globalThis & { Response: typeof Response }).Response =
+          previousResponse;
+        if (previousConfigDirectory === undefined) {
+          delete process.env.OPENDUCKTOR_CONFIG_DIR;
+        } else {
+          process.env.OPENDUCKTOR_CONFIG_DIR = previousConfigDirectory;
+        }
+        await rm(configDirectory, { force: true, recursive: true });
+      }
+    }, 10_000);
+  }
+});

--- a/packages/openducktor-web/src/launcher-host-discovery.test.ts
+++ b/packages/openducktor-web/src/launcher-host-discovery.test.ts
@@ -1,95 +1,69 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { createSourceRuntimeDistribution } from "@openducktor/host";
-import { Effect } from "effect";
-import { startWebLauncherHostBackendEffect } from "./launcher";
-import type { WebLogger } from "./logger";
-import type { TypescriptHostBackend } from "./typescript-host-backend";
 
-const nativeResponse = await Bun.fetch("data:,");
-const nativeResponseConstructor = nativeResponse.constructor as typeof Response;
-
-const sourceRuntimeDistribution = createSourceRuntimeDistribution(
-  path.resolve(import.meta.dir, "../../.."),
-);
-const testLogger: WebLogger = {
-  error: () => Effect.void,
-  info: () => Effect.void,
-  success: () => Effect.void,
+type DiscoveryProcessResult = {
+  descriptor: {
+    hostTokenPresent: boolean;
+    hostUrl: string;
+    pidMatchesProcess: boolean;
+  };
+  oppositeAfterStop: string;
+  oppositeDuringRun: string;
+  selectedMissingAfterStop: boolean;
 };
+
+const fixturePath = path.join(import.meta.dir, "launcher-host-discovery-fixture.ts");
 
 describe("web launcher MCP discovery composition", () => {
   for (const scenario of [
     {
-      descriptorName: "mcp-bridge-dev.json",
+      launchMode: "workspace",
       oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:1","hostToken":"prod","pid":1}\n',
-      oppositeDescriptorName: "mcp-bridge.json",
       title: "workspace launches own only development discovery",
-      workspaceMode: true,
     },
     {
-      descriptorName: "mcp-bridge.json",
+      launchMode: "installed",
       oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:2","hostToken":"dev","pid":2}\n',
-      oppositeDescriptorName: "mcp-bridge-dev.json",
       title: "installed launches own only production discovery",
-      workspaceMode: false,
     },
   ] as const) {
     test(scenario.title, async () => {
-      const previousResponse = globalThis.Response;
-      const previousConfigDirectory = process.env.OPENDUCKTOR_CONFIG_DIR;
       const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-web-discovery-"));
-      const runtimeDirectory = path.join(configDirectory, "runtime");
-      const descriptorPath = path.join(runtimeDirectory, scenario.descriptorName);
-      const oppositeDescriptorPath = path.join(runtimeDirectory, scenario.oppositeDescriptorName);
-      let backend: TypescriptHostBackend | null = null;
 
       try {
-        (globalThis as typeof globalThis & { Response: typeof Response }).Response =
-          nativeResponseConstructor;
-        process.env.OPENDUCKTOR_CONFIG_DIR = configDirectory;
-        await mkdir(runtimeDirectory, { recursive: true });
-        await writeFile(oppositeDescriptorPath, scenario.oppositeDescriptor, "utf8");
-
-        backend = await Effect.runPromise(
-          startWebLauncherHostBackendEffect({
-            appToken: "app-token",
-            controlToken: "control-token",
-            frontendOrigin: "http://127.0.0.1:1420",
-            logger: testLogger,
-            onBackgroundFailure: () => {},
-            port: 0,
-            runtimeDistribution: sourceRuntimeDistribution,
-            workspaceMode: scenario.workspaceMode,
-          }),
+        const subprocess = Bun.spawn(
+          [process.execPath, fixturePath, scenario.launchMode, scenario.oppositeDescriptor],
+          {
+            env: {
+              ...process.env,
+              OPENDUCKTOR_CONFIG_DIR: configDirectory,
+            },
+            stderr: "pipe",
+            stdout: "pipe",
+          },
         );
+        const [exitCode, stdout, stderr] = await Promise.all([
+          subprocess.exited,
+          Bun.readableStreamToText(subprocess.stdout),
+          Bun.readableStreamToText(subprocess.stderr),
+        ]);
 
-        expect(JSON.parse(await readFile(descriptorPath, "utf8"))).toEqual({
-          hostToken: expect.any(String),
-          hostUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
-          pid: process.pid,
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+        const result = JSON.parse(stdout) as DiscoveryProcessResult;
+        expect(result).toEqual({
+          descriptor: {
+            hostTokenPresent: true,
+            hostUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+            pidMatchesProcess: true,
+          },
+          oppositeAfterStop: scenario.oppositeDescriptor,
+          oppositeDuringRun: scenario.oppositeDescriptor,
+          selectedMissingAfterStop: true,
         });
-        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
-          scenario.oppositeDescriptor,
-        );
-
-        await backend.stop();
-
-        await expect(readFile(descriptorPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
-        await expect(readFile(oppositeDescriptorPath, "utf8")).resolves.toBe(
-          scenario.oppositeDescriptor,
-        );
       } finally {
-        await backend?.stop().catch(() => {});
-        (globalThis as typeof globalThis & { Response: typeof Response }).Response =
-          previousResponse;
-        if (previousConfigDirectory === undefined) {
-          delete process.env.OPENDUCKTOR_CONFIG_DIR;
-        } else {
-          process.env.OPENDUCKTOR_CONFIG_DIR = previousConfigDirectory;
-        }
         await rm(configDirectory, { force: true, recursive: true });
       }
     }, 10_000);

--- a/packages/openducktor-web/src/launcher-host-discovery.test.ts
+++ b/packages/openducktor-web/src/launcher-host-discovery.test.ts
@@ -2,28 +2,20 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-
-type DiscoveryProcessResult = {
-  descriptor: {
-    hostTokenPresent: boolean;
-    hostUrl: string;
-    pidMatchesProcess: boolean;
-  };
-  oppositeAfterStop: string;
-  oppositeDuringRun: string;
-  selectedMissingAfterStop: boolean;
-};
+import type { DiscoveryScenarioResult } from "./launcher-host-discovery-fixture";
 
 const fixturePath = path.join(import.meta.dir, "launcher-host-discovery-fixture.ts");
 
 describe("web launcher MCP discovery composition", () => {
   for (const scenario of [
     {
+      ambientChannel: "production",
       launchMode: "workspace",
       oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:1","hostToken":"prod","pid":1}\n',
       title: "workspace launches own only development discovery",
     },
     {
+      ambientChannel: "dev",
       launchMode: "installed",
       oppositeDescriptor: '{"hostUrl":"http://127.0.0.1:2","hostToken":"dev","pid":2}\n',
       title: "installed launches own only production discovery",
@@ -38,6 +30,7 @@ describe("web launcher MCP discovery composition", () => {
           {
             env: {
               ...process.env,
+              OPENDUCKTOR_CHANNEL: scenario.ambientChannel,
               OPENDUCKTOR_CONFIG_DIR: configDirectory,
             },
             stderr: "pipe",
@@ -52,7 +45,7 @@ describe("web launcher MCP discovery composition", () => {
 
         expect(stderr).toBe("");
         expect(exitCode).toBe(0);
-        const result = JSON.parse(stdout) as DiscoveryProcessResult;
+        const result = JSON.parse(stdout) as DiscoveryScenarioResult;
         expect(result).toEqual({
           descriptor: {
             hostTokenPresent: true,

--- a/packages/openducktor-web/src/launcher.test.ts
+++ b/packages/openducktor-web/src/launcher.test.ts
@@ -7,6 +7,7 @@ import { WebOperationError } from "./effect/web-errors";
 import {
   logDuplicateWebTerminationNotice,
   preserveLauncherFailureAfterStop,
+  resolveWebMcpBridgeDiscoveryMode,
   runWebSignalShutdown,
 } from "./launcher";
 import {
@@ -33,6 +34,14 @@ const createHostProcess = (exited: Promise<number>): Bun.Subprocess => {
 };
 
 describe("launcher internals", () => {
+  test("uses development discovery for workspace source launches", () => {
+    expect(resolveWebMcpBridgeDiscoveryMode(true)).toBe("development");
+  });
+
+  test("uses production discovery for installed static launches", () => {
+    expect(resolveWebMcpBridgeDiscoveryMode(false)).toBe("production");
+  });
+
   test("waits for the fake host health and token-authenticated session endpoints", async () => {
     const requests: Array<{ url: string; method: string | undefined; token: string | null }> = [];
     let healthAttempts = 0;

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -29,7 +29,10 @@ import {
 } from "./launcher-support";
 import { type WebLogger, writeWebLogEffect } from "./logger";
 import { RUNTIME_CONFIG_PATH } from "./runtime-config";
-import { startTypescriptHostBackendEffect } from "./typescript-host-backend";
+import {
+  startTypescriptHostBackendEffect,
+  type TypescriptHostBackendOptions,
+} from "./typescript-host-backend";
 import { resolveWebRuntimeDistributionEffect } from "./web-runtime-distribution";
 import { resolveWebProvidedToolPathsEffect } from "./web-tool-discovery";
 
@@ -44,6 +47,22 @@ export type LauncherOptions = {
 
 export const resolveWebMcpBridgeDiscoveryMode = (workspaceMode: boolean): McpBridgeDiscoveryMode =>
   workspaceMode ? "development" : "production";
+
+export type WebLauncherHostBackendOptions = Omit<
+  TypescriptHostBackendOptions,
+  "mcpBridgeDiscoveryMode"
+> & {
+  workspaceMode: boolean;
+};
+
+export const startWebLauncherHostBackendEffect = ({
+  workspaceMode,
+  ...options
+}: WebLauncherHostBackendOptions) =>
+  startTypescriptHostBackendEffect({
+    ...options,
+    mcpBridgeDiscoveryMode: resolveWebMcpBridgeDiscoveryMode(workspaceMode),
+  });
 
 const logFrontendAvailability = (port: number, logger: WebLogger): Effect.Effect<void, WebError> =>
   Effect.gen(function* () {
@@ -431,7 +450,7 @@ export const runLauncherEffect = (
     let lifecycle: WebLauncherLifecycle | null = null;
 
     return yield* Effect.acquireUseRelease(
-      startTypescriptHostBackendEffect({
+      startWebLauncherHostBackendEffect({
         port: options.backendPort,
         frontendOrigin: frontendUrl,
         controlToken,
@@ -440,7 +459,7 @@ export const runLauncherEffect = (
         providedToolPaths,
         runtimeDistribution,
         logger,
-        mcpBridgeDiscoveryMode: resolveWebMcpBridgeDiscoveryMode(options.workspaceMode),
+        workspaceMode: options.workspaceMode,
       }),
       (hostBackend) =>
         Effect.gen(function* () {

--- a/packages/openducktor-web/src/launcher.ts
+++ b/packages/openducktor-web/src/launcher.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import type { McpBridgeDiscoveryMode } from "@openducktor/host";
 import { Effect } from "effect";
 import type { ViteDevServer } from "vite";
 import {
@@ -40,6 +41,9 @@ export type LauncherOptions = {
   backendPort: number;
   readinessTimeoutMs?: number;
 };
+
+export const resolveWebMcpBridgeDiscoveryMode = (workspaceMode: boolean): McpBridgeDiscoveryMode =>
+  workspaceMode ? "development" : "production";
 
 const logFrontendAvailability = (port: number, logger: WebLogger): Effect.Effect<void, WebError> =>
   Effect.gen(function* () {
@@ -436,6 +440,7 @@ export const runLauncherEffect = (
         providedToolPaths,
         runtimeDistribution,
         logger,
+        mcpBridgeDiscoveryMode: resolveWebMcpBridgeDiscoveryMode(options.workspaceMode),
       }),
       (hostBackend) =>
         Effect.gen(function* () {

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -131,9 +131,14 @@ describe("TypeScript web host backend", () => {
     const tempConfigDir = await mkdtemp(path.join(tmpdir(), "openducktor-web-host-"));
     let backend: Awaited<ReturnType<typeof startTypescriptHostBackend>> | undefined;
     const consoleLines: string[] = [];
+    const productionDiscoveryPath = path.join(tempConfigDir, "runtime", "mcp-bridge.json");
+    const developmentDiscoveryPath = path.join(tempConfigDir, "runtime", "mcp-bridge-dev.json");
+    const productionDiscovery = '{"hostUrl":"http://127.0.0.1:1","hostToken":"prod","pid":1}\n';
 
     try {
       process.env.OPENDUCKTOR_CONFIG_DIR = tempConfigDir;
+      await mkdir(path.dirname(productionDiscoveryPath), { recursive: true });
+      await writeFile(productionDiscoveryPath, productionDiscovery, "utf8");
       const logger = await Effect.runPromise(
         createWebLogger({
           console: {
@@ -150,10 +155,17 @@ describe("TypeScript web host backend", () => {
         controlToken: CONTROL_TOKEN,
         appToken: APP_TOKEN,
         logger,
+        mcpBridgeDiscoveryMode: "development",
         onBackgroundFailure: () => {},
         runtimeDistribution: SOURCE_RUNTIME_DISTRIBUTION,
       });
       const backendUrl = `http://127.0.0.1:${backend.port}`;
+      await expect(readFile(productionDiscoveryPath, "utf8")).resolves.toBe(productionDiscovery);
+      expect(JSON.parse(await readFile(developmentDiscoveryPath, "utf8"))).toEqual({
+        hostToken: expect.any(String),
+        hostUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+        pid: process.pid,
+      });
 
       const health = await Bun.fetch(`${backendUrl}/health`);
       expect(health.status).toBe(200);
@@ -325,6 +337,10 @@ describe("TypeScript web host backend", () => {
       });
       expect(shutdown.status).toBe(202);
       await expect(backend.exited).resolves.toBe(0);
+      await expect(readFile(productionDiscoveryPath, "utf8")).resolves.toBe(productionDiscovery);
+      await expect(readFile(developmentDiscoveryPath, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
       const persisted = await readFile(
         path.join(tempConfigDir, "logs", "openducktor-web-2026-05-13.log"),
         "utf8",
@@ -373,6 +389,7 @@ describe("TypeScript web host backend", () => {
             controlToken: CONTROL_TOKEN,
             appToken: APP_TOKEN,
             logger,
+            mcpBridgeDiscoveryMode: "development",
             onBackgroundFailure: (failure) => {
               Effect.runSync(Deferred.succeed(failureReported, failure));
             },

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -370,9 +370,9 @@ describe("TypeScript web host backend", () => {
     const configPath = path.join(tempConfigDir, "config.json");
     const logFilePath = path.join(tempConfigDir, "logs", "openducktor-web-2026-05-13.log");
     let backend: Awaited<ReturnType<typeof startTypescriptHostBackend>> | undefined;
-    process.env.OPENDUCKTOR_CONFIG_DIR = tempConfigDir;
 
     try {
+      process.env.OPENDUCKTOR_CONFIG_DIR = tempConfigDir;
       const logger = await Effect.runPromise(
         createWebLogger({
           console: { error: () => {}, log: () => {} },

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -13,6 +13,7 @@ import {
   type EffectHostCommandRouter,
   type EffectNodeHostCommandRouter,
   type HostRuntimeDistribution,
+  type McpBridgeDiscoveryMode,
   TerminalServiceError,
   type ToolDiscoveryId,
   terminalServiceErrorToFailure,
@@ -47,6 +48,7 @@ export type TypescriptHostBackendOptions = {
   controlToken: string;
   appToken: string;
   logger: WebLogger;
+  mcpBridgeDiscoveryMode: McpBridgeDiscoveryMode;
   onBackgroundFailure(failure: unknown): void;
   runtimeDistribution: HostRuntimeDistribution;
   providedToolPaths?: Partial<Record<ToolDiscoveryId, string>>;
@@ -723,6 +725,7 @@ export const startTypescriptHostBackendEffect = ({
   controlToken,
   appToken,
   logger,
+  mcpBridgeDiscoveryMode,
   onBackgroundFailure,
   providedToolPaths,
   runtimeDistribution,
@@ -753,6 +756,7 @@ export const startTypescriptHostBackendEffect = ({
         info: logger.info,
       },
       localAttachments,
+      mcpBridgeDiscoveryMode,
       onBackgroundFailure: (failure) =>
         Effect.sync(() => {
           rejectExited(failure);


### PR DESCRIPTION
## Summary

- Isolate production and development MCP bridge discovery descriptors under the existing OpenDucktor config directory.
- Select external MCP discovery with a strict `OPENDUCKTOR_CHANNEL` contract while keeping production as the default.
- Add launch-composition, ownership, cleanup, and channel-selection coverage, plus updated user and contributor docs.

## Goal

A source Electron or browser host could overwrite `runtime/mcp-bridge.json`, which packaged OpenDucktor and external agents treat as production discovery. When that development host stopped, external MCP clients could no longer connect until packaged OpenDucktor restarted and republished its descriptor.

This change makes discovery ownership follow immutable host launch context, so development commands cannot claim the production descriptor. It keeps the existing config directory, descriptor payload, explicit host URL behavior, and managed OpenCode/Codex routing unchanged.

## Implementation

- Map packaged Electron and installed browser launches to `runtime/mcp-bridge.json`.
- Map Electron development and browser workspace launches to `runtime/mcp-bridge-dev.json`.
- Pass the discovery mode from Electron `app.isPackaged` and browser workspace composition instead of reading ambient channel state on the host side.
- Parse `OPENDUCKTOR_CHANNEL` only in the external MCP: an absent value selects production, `dev` selects development, and empty or unknown values fail without probing another descriptor.
- Preserve ownership-safe cleanup within each channel so one host cannot remove another host replacement.
- Exercise real Electron and browser composition paths, including cross-channel descriptor preservation and cleanup, without process-global test state leaks.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Cargo checks: not applicable because this repository has no `Cargo.toml` or Rust workspace.
- Branch sync: 4 commits ahead of `origin/main`, 0 behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development/workspace and installed/production sessions now use separate MCP bridge discovery descriptors.
  * External MCP clients can connect to development hosts with `OPENDUCKTOR_CHANNEL=dev`.
  * Electron and web launcher hosting now publish the correct descriptor based on launch/packaging mode.
* **Bug Fixes**
  * Production discovery is preserved during development startup/shutdown, and development/production descriptors are cleaned up appropriately without cross-over.
* **Documentation**
  * Updated external MCP, web/Electron development, and local configuration guidance, including channel validation and `OPENDUCKTOR_CONFIG_DIR` usage.
* **Tests**
  * Added/expanded Bun test coverage for Electron and web MCP discovery composition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->