### PR TITLE
refactor(opencode): consolidate tool strategies

### DIFF
--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -78,6 +78,21 @@ const createSyntheticTextPart = ({
   }) as unknown as Part;
 
 describe("stream-part-mapper", () => {
+  test("uses normalized task strategies for subagent mapping", () => {
+    for (const tool of ["task", "delegate", "functions.task", " Functions.Delegate "]) {
+      const mapped = mapPartToAgentStreamPart(
+        createToolPart({
+          id: `tool-subagent-${tool}`,
+          tool,
+          status: "running",
+          input: { agent: "build", prompt: "Inspect the adapter" },
+        }),
+      );
+
+      expect(mapped?.kind, tool).toBe("subagent");
+    }
+  });
+
   test("maps raw subtask parts to canonical subagent parts", () => {
     const part = {
       id: "subtask-1",

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -15,6 +15,7 @@ import {
 } from "./guards";
 import { toTokenTotal } from "./message-normalizers";
 import { deriveToolPreview, deriveToolType } from "./tool-preview";
+import { resolveOpencodeToolStrategy } from "./tool-strategy-catalog";
 
 const toDisplayText = (value: unknown): string | undefined => {
   if (typeof value === "string") {
@@ -421,13 +422,6 @@ type ToolStreamPart = Extract<AgentStreamPart, { kind: "tool" }>;
 type SubagentStreamPart = Extract<AgentStreamPart, { kind: "subagent" }>;
 type ToolStatus = ToolStreamPart["status"];
 
-const SUBAGENT_TOOL_NAMES = new Set(["task", "delegate"]);
-
-const normalizeToolName = (value: string): string => {
-  const trimmed = value.trim().toLowerCase();
-  return trimmed.startsWith("functions.") ? trimmed.slice("functions.".length) : trimmed;
-};
-
 const readTrimmedString = (source: unknown, keys: string[]): string | undefined => {
   const value = readStringProp(source, keys);
   if (!value) {
@@ -814,7 +808,7 @@ export const mapPartToAgentStreamPart = (part: Part): AgentStreamPart | null => 
       const toolState = asUnknownRecord(part.state) ?? {};
       const timing = extractPartTiming(part);
       const metadata = normalizeMetadata(readUnknownProp(toolState, "metadata"));
-      if (SUBAGENT_TOOL_NAMES.has(normalizeToolName(part.tool))) {
+      if (resolveOpencodeToolStrategy(part.tool).streamPartKind === "subagent") {
         const rawOutput = readUnknownProp(toolState, "output");
         const structuredError =
           readStructuredToolError(rawOutput) ?? readStructuredToolError(metadata);

--- a/packages/adapters-opencode-sdk/src/tool-preview.test.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, test } from "bun:test";
 import { deriveToolPreview } from "./tool-preview";
 
 describe("deriveToolPreview", () => {
+  test("uses generic input when a specialized preview has no matching field", () => {
+    const cases = [
+      { tool: "bash", rawInput: { description: "shell fallback" } },
+      { tool: "question", rawInput: { name: "question fallback" } },
+      { tool: "odt_set_spec", rawInput: { description: "workflow fallback" } },
+      { tool: "webfetch", rawInput: { description: "web fallback" } },
+      { tool: "session_read", rawInput: { description: "session fallback" } },
+    ] as const;
+
+    for (const testCase of cases) {
+      expect(
+        deriveToolPreview({
+          tool: testCase.tool,
+          rawInput: testCase.rawInput,
+          rawOutput: undefined,
+        }),
+      ).toBe(testCase.rawInput.description ?? testCase.rawInput.name);
+    }
+  });
+
   test("derives previews for namespaced ODT tool ids", () => {
     expect(
       deriveToolPreview({

--- a/packages/adapters-opencode-sdk/src/tool-preview.test.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.test.ts
@@ -4,11 +4,31 @@ import { deriveToolPreview } from "./tool-preview";
 describe("deriveToolPreview", () => {
   test("uses generic input when a specialized preview has no matching field", () => {
     const cases = [
-      { tool: "bash", rawInput: { description: "shell fallback" } },
-      { tool: "question", rawInput: { name: "question fallback" } },
-      { tool: "odt_set_spec", rawInput: { description: "workflow fallback" } },
-      { tool: "webfetch", rawInput: { description: "web fallback" } },
-      { tool: "session_read", rawInput: { description: "session fallback" } },
+      {
+        tool: "bash",
+        rawInput: { description: "shell fallback" },
+        expectedPreview: "shell fallback",
+      },
+      {
+        tool: "question",
+        rawInput: { name: "question fallback" },
+        expectedPreview: "question fallback",
+      },
+      {
+        tool: "odt_set_spec",
+        rawInput: { description: "workflow fallback" },
+        expectedPreview: "workflow fallback",
+      },
+      {
+        tool: "webfetch",
+        rawInput: { description: "web fallback" },
+        expectedPreview: "web fallback",
+      },
+      {
+        tool: "session_read",
+        rawInput: { description: "session fallback" },
+        expectedPreview: "session fallback",
+      },
     ] as const;
 
     for (const testCase of cases) {
@@ -18,7 +38,7 @@ describe("deriveToolPreview", () => {
           rawInput: testCase.rawInput,
           rawOutput: undefined,
         }),
-      ).toBe(testCase.rawInput.description ?? testCase.rawInput.name);
+      ).toBe(testCase.expectedPreview);
     }
   });
 

--- a/packages/adapters-opencode-sdk/src/tool-preview.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.ts
@@ -329,8 +329,9 @@ export const deriveToolPreview = (input: {
       break;
   }
 
-  if (!preview) {
+  const resolvedPreview = preview ?? summarizeGenericInput(rawInput);
+  if (!resolvedPreview) {
     return undefined;
   }
-  return compactText(preview, tool === "bash" ? 120 : 160);
+  return compactText(resolvedPreview, tool === "bash" ? 120 : 160);
 };

--- a/packages/adapters-opencode-sdk/src/tool-preview.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.ts
@@ -325,7 +325,7 @@ export const deriveToolPreview = (input: {
       preview = summarizeSessionTool(rawInput);
       break;
     case "generic":
-      preview = summarizeGenericInput(rawInput);
+      preview = null;
       break;
   }
 

--- a/packages/adapters-opencode-sdk/src/tool-preview.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.ts
@@ -1,65 +1,10 @@
 import type { AgentToolType } from "@openducktor/core";
 import { basenameForPath } from "@openducktor/path-support";
 import { asUnknownRecord } from "./guards";
-
-const SHELL_TOOL_NAMES = new Set(["bash", "shell", "exec", "command"]);
-const READ_TOOL_NAMES = new Set(["read", "cat", "view"]);
-const LIST_TOOL_NAMES = new Set(["list", "ls"]);
-const SEARCH_TOOL_NAMES = new Set(["glob", "grep", "find", "search", "ast_grep_search"]);
-const TODO_TOOL_NAMES = new Set(["todowrite", "todoread"]);
-const TASK_TOOL_NAMES = new Set(["task", "delegate"]);
-const SESSION_TOOL_NAMES = new Set([
-  "session_info",
-  "session_list",
-  "session_read",
-  "session_search",
-]);
-const LSP_TOOL_NAMES = new Set([
-  "lsp_diagnostic",
-  "lsp_diagnostics",
-  "lsp_find_references",
-  "lsp_goto_definition",
-  "lsp_prepare_rename",
-  "lsp_symbols",
-]);
-const FILE_EDIT_TOOL_NAMES = new Set([
-  "edit",
-  "multiedit",
-  "write",
-  "create",
-  "file_write",
-  "apply_patch",
-  "str_replace",
-  "str_replace_based_edit_tool",
-  "patch",
-  "insert",
-  "replace",
-]);
-
-const normalizeToolName = (value: string): string => {
-  const trimmed = value.trim().toLowerCase();
-  const withoutFunctionsNamespace = trimmed.startsWith("functions.")
-    ? trimmed.slice("functions.".length)
-    : trimmed;
-  return withoutFunctionsNamespace.startsWith("openducktor_odt_")
-    ? withoutFunctionsNamespace.slice("openducktor_".length)
-    : withoutFunctionsNamespace;
-};
+import { resolveOpencodeToolStrategy } from "./tool-strategy-catalog";
 
 export const deriveToolType = (toolName: string): AgentToolType => {
-  const tool = normalizeToolName(toolName);
-  if (SHELL_TOOL_NAMES.has(tool)) return "bash";
-  if (READ_TOOL_NAMES.has(tool)) return "read";
-  if (LIST_TOOL_NAMES.has(tool)) return "list";
-  if (SEARCH_TOOL_NAMES.has(tool)) return "search";
-  if (TODO_TOOL_NAMES.has(tool) || tool.endsWith("_todowrite") || tool.endsWith("_todoread")) {
-    return "todo";
-  }
-  if (FILE_EDIT_TOOL_NAMES.has(tool)) return "file_edit";
-  if (tool === "question" || tool.endsWith("_question")) return "question";
-  if (tool.startsWith("odt_")) return "workflow";
-  if (tool.startsWith("webfetch") || tool.startsWith("websearch")) return "web";
-  return "generic";
+  return resolveOpencodeToolStrategy(toolName).toolType;
 };
 
 const compactText = (value: string, maxLength = 160): string => {
@@ -328,36 +273,61 @@ export const deriveToolPreview = (input: {
   rawOutput: unknown;
   metadata?: Record<string, unknown>;
 }): string | undefined => {
-  const tool = normalizeToolName(input.tool);
+  const strategy = resolveOpencodeToolStrategy(input.tool);
+  const tool = strategy.canonicalName;
   const rawInput = asUnknownRecord(input.rawInput);
 
-  const preview =
-    (SHELL_TOOL_NAMES.has(tool) ? readTrimmedString(rawInput, ["command"]) : null) ??
-    (READ_TOOL_NAMES.has(tool) ? extractPathFromInput(rawInput) : null) ??
-    (LIST_TOOL_NAMES.has(tool)
-      ? (readTrimmedString(rawInput, ["path", "cwd", "directory"]) ?? null)
-      : null) ??
-    (SEARCH_TOOL_NAMES.has(tool) ? summarizeSearchInput(tool, rawInput) : null) ??
-    ((tool === "skill" && summarizeSkillTool(rawInput)) || null) ??
-    (TODO_TOOL_NAMES.has(tool) || tool.endsWith("_todowrite") || tool.endsWith("_todoread")
-      ? summarizeTodoTool(rawInput, input.rawOutput)
-      : null) ??
-    (tool === "question" || tool.endsWith("_question")
-      ? summarizeQuestionTool(rawInput, input.metadata, input.rawOutput)
-      : null) ??
-    (TASK_TOOL_NAMES.has(tool)
-      ? summarizeTaskTool(rawInput, input.metadata, input.rawOutput)
-      : null) ??
-    (tool === "odt_read_task" ? summarizeOdtReadTask(rawInput, input.rawOutput) : null) ??
-    (tool.startsWith("odt_") ? summarizeOdtMutation(tool, rawInput) : null) ??
-    (tool === "webfetch" || tool.startsWith("websearch")
-      ? summarizeWebTool(tool, rawInput)
-      : null) ??
-    (tool.startsWith("context7_") ? summarizeContextTool(tool, rawInput) : null) ??
-    (tool === "grep_app_searchgithub" ? summarizeGithubSearchTool(rawInput) : null) ??
-    (LSP_TOOL_NAMES.has(tool) ? summarizeLspTool(rawInput) : null) ??
-    (SESSION_TOOL_NAMES.has(tool) ? summarizeSessionTool(rawInput) : null) ??
-    summarizeGenericInput(rawInput);
+  let preview: string | null;
+  switch (strategy.previewStrategy) {
+    case "shell":
+      preview = readTrimmedString(rawInput, ["command"]);
+      break;
+    case "read":
+      preview = extractPathFromInput(rawInput);
+      break;
+    case "list":
+      preview = readTrimmedString(rawInput, ["path", "cwd", "directory"]);
+      break;
+    case "search":
+      preview = summarizeSearchInput(tool, rawInput);
+      break;
+    case "skill":
+      preview = summarizeSkillTool(rawInput);
+      break;
+    case "todo":
+      preview = summarizeTodoTool(rawInput, input.rawOutput);
+      break;
+    case "question":
+      preview = summarizeQuestionTool(rawInput, input.metadata, input.rawOutput);
+      break;
+    case "task":
+      preview = summarizeTaskTool(rawInput, input.metadata, input.rawOutput);
+      break;
+    case "workflow":
+      preview =
+        tool === "odt_read_task"
+          ? summarizeOdtReadTask(rawInput, input.rawOutput)
+          : summarizeOdtMutation(tool, rawInput);
+      break;
+    case "web":
+      preview = summarizeWebTool(tool, rawInput);
+      break;
+    case "context":
+      preview = summarizeContextTool(tool, rawInput);
+      break;
+    case "github_search":
+      preview = summarizeGithubSearchTool(rawInput);
+      break;
+    case "lsp":
+      preview = summarizeLspTool(rawInput);
+      break;
+    case "session":
+      preview = summarizeSessionTool(rawInput);
+      break;
+    case "generic":
+      preview = summarizeGenericInput(rawInput);
+      break;
+  }
 
   if (!preview) {
     return undefined;

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.test.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { ODT_WORKFLOW_AGENT_TOOL_NAMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { deriveToolPreview, deriveToolType } from "./tool-preview";
+import { resolveOpencodeToolStrategy } from "./tool-strategy-catalog";
+
+describe("OpenCode tool strategy catalog", () => {
+  test("classifies and previews each supported tool family from one strategy", () => {
+    const cases = [
+      {
+        label: "shell",
+        tool: "bash",
+        rawInput: { command: "bun run test" },
+        rawOutput: undefined,
+        expectedType: "bash",
+        expectedPreview: "bun run test",
+      },
+      {
+        label: "read",
+        tool: "read",
+        rawInput: { filePath: "/repo/src/index.ts" },
+        rawOutput: undefined,
+        expectedType: "read",
+        expectedPreview: "/repo/src/index.ts",
+      },
+      {
+        label: "list",
+        tool: "list",
+        rawInput: { path: "/repo/src" },
+        rawOutput: undefined,
+        expectedType: "list",
+        expectedPreview: "/repo/src",
+      },
+      {
+        label: "search",
+        tool: "grep",
+        rawInput: { pattern: "deriveToolType", path: "/repo/src" },
+        rawOutput: undefined,
+        expectedType: "search",
+        expectedPreview: "deriveToolType in /repo/src",
+      },
+      {
+        label: "todo",
+        tool: "todowrite",
+        rawInput: { todos: [{ content: "Add catalog" }, { content: "Run tests" }] },
+        rawOutput: undefined,
+        expectedType: "todo",
+        expectedPreview: "2 todos",
+      },
+      {
+        label: "file edit",
+        tool: "apply_patch",
+        rawInput: { filePath: "/repo/src/tool-preview.ts", patch: "@@" },
+        rawOutput: undefined,
+        expectedType: "file_edit",
+        expectedPreview: "/repo/src/tool-preview.ts",
+      },
+      {
+        label: "question",
+        tool: "question",
+        rawInput: { questions: [{ question: "Keep the current preview?" }] },
+        rawOutput: undefined,
+        expectedType: "question",
+        expectedPreview: "Keep the current preview?",
+      },
+      {
+        label: "subagent task",
+        tool: "task",
+        rawInput: { agent: "build", prompt: "Inspect the adapter" },
+        rawOutput: undefined,
+        expectedType: "generic",
+        expectedPreview: "build",
+      },
+      {
+        label: "web",
+        tool: "websearch",
+        rawInput: { query: "OpenCode SDK tools" },
+        rawOutput: undefined,
+        expectedType: "web",
+        expectedPreview: "OpenCode SDK tools",
+      },
+      {
+        label: "session",
+        tool: "session_read",
+        rawInput: { sessionId: "session-42" },
+        rawOutput: undefined,
+        expectedType: "generic",
+        expectedPreview: "session-42",
+      },
+      {
+        label: "generic fallback",
+        tool: "custom_runtime_tool",
+        rawInput: { description: "Inspect runtime state" },
+        rawOutput: undefined,
+        expectedType: "generic",
+        expectedPreview: "Inspect runtime state",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const strategy = resolveOpencodeToolStrategy(testCase.tool);
+      expect(strategy.toolType, testCase.label).toBe(testCase.expectedType);
+      expect(deriveToolType(testCase.tool), testCase.label).toBe(testCase.expectedType);
+      expect(
+        deriveToolPreview({
+          tool: testCase.tool,
+          rawInput: testCase.rawInput,
+          rawOutput: testCase.rawOutput,
+        }),
+        testCase.label,
+      ).toBe(testCase.expectedPreview);
+    }
+  });
+
+  test("uses the runtime descriptor aliases for workflow classification", () => {
+    for (const canonicalName of ODT_WORKFLOW_AGENT_TOOL_NAMES) {
+      const aliases = OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical[canonicalName];
+      expect(aliases).toHaveLength(2);
+
+      for (const toolName of [canonicalName, ...(aliases ?? [])]) {
+        expect(resolveOpencodeToolStrategy(toolName)).toMatchObject({
+          canonicalName,
+          toolType: "workflow",
+          previewStrategy: "workflow",
+        });
+        expect(deriveToolType(toolName)).toBe("workflow");
+      }
+    }
+  });
+
+  test("previews canonical and prefixed workflow aliases with canonical parsing", () => {
+    const cases = [
+      {
+        canonicalName: "odt_read_task_documents",
+        rawInput: { taskId: "task-42" },
+        expectedPreview: "task-42",
+      },
+      {
+        canonicalName: "odt_set_pull_request",
+        rawInput: { taskId: "task-42", providerId: "github", number: 17 },
+        expectedPreview: "task-42 · github · #17",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const aliases =
+        OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical[testCase.canonicalName] ?? [];
+      for (const toolName of [testCase.canonicalName, ...aliases]) {
+        expect(
+          deriveToolPreview({
+            tool: toolName,
+            rawInput: testCase.rawInput,
+            rawOutput: undefined,
+          }),
+        ).toBe(testCase.expectedPreview);
+      }
+    }
+  });
+});

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.test.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.test.ts
@@ -4,6 +4,14 @@ import { deriveToolPreview, deriveToolType } from "./tool-preview";
 import { resolveOpencodeToolStrategy } from "./tool-strategy-catalog";
 
 describe("OpenCode tool strategy catalog", () => {
+  test("marks normalized task tools as subagent stream parts", () => {
+    for (const toolName of ["task", "delegate", "functions.task", " Functions.Delegate "]) {
+      expect(resolveOpencodeToolStrategy(toolName).streamPartKind, toolName).toBe("subagent");
+    }
+
+    expect(resolveOpencodeToolStrategy("custom_runtime_tool").streamPartKind).toBe("tool");
+  });
+
   test("classifies and previews each supported tool family from one strategy", () => {
     const cases = [
       {

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.test.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.test.ts
@@ -121,6 +121,38 @@ describe("OpenCode tool strategy catalog", () => {
     }
   });
 
+  test("preserves the shorter preview limit only for the literal bash tool", () => {
+    const command = "x".repeat(200);
+
+    expect(deriveToolPreview({ tool: "bash", rawInput: { command }, rawOutput: undefined })).toBe(
+      `${"x".repeat(120)}...`,
+    );
+
+    for (const tool of ["shell", "exec", "command"]) {
+      expect(deriveToolPreview({ tool, rawInput: { command }, rawOutput: undefined }), tool).toBe(
+        `${"x".repeat(160)}...`,
+      );
+    }
+  });
+
+  test("keeps exact webfetch parsing separate from prefixed webfetch tools", () => {
+    expect(
+      deriveToolPreview({
+        tool: "webfetch",
+        rawInput: { href: "https://openducktor.dev/docs" },
+        rawOutput: undefined,
+      }),
+    ).toBe("https://openducktor.dev/docs");
+
+    expect(
+      deriveToolPreview({
+        tool: "webfetch_custom",
+        rawInput: { href: "https://openducktor.dev/docs" },
+        rawOutput: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
   test("uses the runtime descriptor aliases for workflow classification", () => {
     for (const canonicalName of ODT_WORKFLOW_AGENT_TOOL_NAMES) {
       const aliases = OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical[canonicalName];
@@ -140,14 +172,54 @@ describe("OpenCode tool strategy catalog", () => {
   test("previews canonical and prefixed workflow aliases with canonical parsing", () => {
     const cases = [
       {
+        canonicalName: "odt_read_task",
+        rawInput: { taskId: "task-42" },
+        expectedPreview: "task-42",
+      },
+      {
         canonicalName: "odt_read_task_documents",
         rawInput: { taskId: "task-42" },
         expectedPreview: "task-42",
       },
       {
+        canonicalName: "odt_set_spec",
+        rawInput: { taskId: "task-42" },
+        expectedPreview: "task-42",
+      },
+      {
+        canonicalName: "odt_set_plan",
+        rawInput: { taskId: "task-42", subtasks: [{ id: "1" }, { id: "2" }] },
+        expectedPreview: "task-42 · 2 subtasks",
+      },
+      {
+        canonicalName: "odt_build_blocked",
+        rawInput: { taskId: "task-42", reason: "Waiting for design input" },
+        expectedPreview: "Waiting for design input",
+      },
+      {
+        canonicalName: "odt_build_resumed",
+        rawInput: { taskId: "task-42" },
+        expectedPreview: "task-42",
+      },
+      {
+        canonicalName: "odt_build_completed",
+        rawInput: { taskId: "task-42", summary: "Catalog complete" },
+        expectedPreview: "Catalog complete",
+      },
+      {
         canonicalName: "odt_set_pull_request",
         rawInput: { taskId: "task-42", providerId: "github", number: 17 },
         expectedPreview: "task-42 · github · #17",
+      },
+      {
+        canonicalName: "odt_qa_approved",
+        rawInput: { taskId: "task-42" },
+        expectedPreview: "task-42",
+      },
+      {
+        canonicalName: "odt_qa_rejected",
+        rawInput: { taskId: "task-42" },
+        expectedPreview: "task-42",
       },
     ] as const;
 

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.test.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.test.ts
@@ -9,7 +9,9 @@ describe("OpenCode tool strategy catalog", () => {
       expect(resolveOpencodeToolStrategy(toolName).streamPartKind, toolName).toBe("subagent");
     }
 
-    expect(resolveOpencodeToolStrategy("custom_runtime_tool").streamPartKind).toBe("tool");
+    for (const toolName of ["bash", "custom_runtime_tool"]) {
+      expect(resolveOpencodeToolStrategy(toolName).streamPartKind, toolName).toBe("tool");
+    }
   });
 
   test("classifies and previews each supported tool family from one strategy", () => {

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
@@ -1,0 +1,207 @@
+import { ODT_WORKFLOW_AGENT_TOOL_NAMES, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import type { AgentToolType } from "@openducktor/core";
+
+export type OpenCodeToolPreviewStrategy =
+  | "shell"
+  | "read"
+  | "list"
+  | "search"
+  | "skill"
+  | "todo"
+  | "question"
+  | "task"
+  | "workflow"
+  | "web"
+  | "context"
+  | "github_search"
+  | "lsp"
+  | "session"
+  | "generic";
+
+type OpenCodeToolStrategyDefinition = {
+  toolType: AgentToolType;
+  previewStrategy: OpenCodeToolPreviewStrategy;
+  match: (normalizedName: string) => string | null;
+};
+
+export type ResolvedOpenCodeToolStrategy = {
+  normalizedName: string;
+  canonicalName: string;
+  toolType: AgentToolType;
+  previewStrategy: OpenCodeToolPreviewStrategy;
+};
+
+const SHELL_TOOL_NAMES = new Set(["bash", "shell", "exec", "command"]);
+const READ_TOOL_NAMES = new Set(["read", "cat", "view"]);
+const LIST_TOOL_NAMES = new Set(["list", "ls"]);
+const SEARCH_TOOL_NAMES = new Set(["glob", "grep", "find", "search", "ast_grep_search"]);
+const TODO_TOOL_NAMES = new Set(["todowrite", "todoread"]);
+const TASK_TOOL_NAMES = new Set(["task", "delegate"]);
+const SESSION_TOOL_NAMES = new Set([
+  "session_info",
+  "session_list",
+  "session_read",
+  "session_search",
+]);
+const LSP_TOOL_NAMES = new Set([
+  "lsp_diagnostic",
+  "lsp_diagnostics",
+  "lsp_find_references",
+  "lsp_goto_definition",
+  "lsp_prepare_rename",
+  "lsp_symbols",
+]);
+const FILE_EDIT_TOOL_NAMES = new Set([
+  "edit",
+  "multiedit",
+  "write",
+  "create",
+  "file_write",
+  "apply_patch",
+  "str_replace",
+  "str_replace_based_edit_tool",
+  "patch",
+  "insert",
+  "replace",
+]);
+
+const normalizeToolName = (value: string): string => {
+  const normalized = value.trim().toLowerCase();
+  return normalized.startsWith("functions.") ? normalized.slice("functions.".length) : normalized;
+};
+
+const createWorkflowCanonicalNameByAlias = (): ReadonlyMap<string, string> => {
+  const canonicalNameByAlias = new Map<string, string>();
+
+  for (const canonicalName of ODT_WORKFLOW_AGENT_TOOL_NAMES) {
+    canonicalNameByAlias.set(normalizeToolName(canonicalName), canonicalName);
+    const aliases = OPENCODE_RUNTIME_DESCRIPTOR.workflowToolAliasesByCanonical[canonicalName] ?? [];
+    for (const alias of aliases) {
+      canonicalNameByAlias.set(normalizeToolName(alias), canonicalName);
+    }
+  }
+
+  return canonicalNameByAlias;
+};
+
+const WORKFLOW_CANONICAL_NAME_BY_ALIAS = createWorkflowCanonicalNameByAlias();
+
+const matchExact =
+  (toolNames: ReadonlySet<string>) =>
+  (normalizedName: string): string | null =>
+    toolNames.has(normalizedName) ? normalizedName : null;
+
+export const OPENCODE_TOOL_STRATEGY_CATALOG = [
+  {
+    toolType: "bash",
+    previewStrategy: "shell",
+    match: matchExact(SHELL_TOOL_NAMES),
+  },
+  {
+    toolType: "read",
+    previewStrategy: "read",
+    match: matchExact(READ_TOOL_NAMES),
+  },
+  {
+    toolType: "list",
+    previewStrategy: "list",
+    match: matchExact(LIST_TOOL_NAMES),
+  },
+  {
+    toolType: "search",
+    previewStrategy: "search",
+    match: matchExact(SEARCH_TOOL_NAMES),
+  },
+  {
+    toolType: "generic",
+    previewStrategy: "skill",
+    match: (normalizedName) => (normalizedName === "skill" ? normalizedName : null),
+  },
+  {
+    toolType: "todo",
+    previewStrategy: "todo",
+    match: (normalizedName) =>
+      TODO_TOOL_NAMES.has(normalizedName) ||
+      normalizedName.endsWith("_todowrite") ||
+      normalizedName.endsWith("_todoread")
+        ? normalizedName
+        : null,
+  },
+  {
+    toolType: "file_edit",
+    previewStrategy: "generic",
+    match: matchExact(FILE_EDIT_TOOL_NAMES),
+  },
+  {
+    toolType: "question",
+    previewStrategy: "question",
+    match: (normalizedName) =>
+      normalizedName === "question" || normalizedName.endsWith("_question") ? normalizedName : null,
+  },
+  {
+    toolType: "generic",
+    previewStrategy: "task",
+    match: matchExact(TASK_TOOL_NAMES),
+  },
+  {
+    toolType: "workflow",
+    previewStrategy: "workflow",
+    match: (normalizedName) => WORKFLOW_CANONICAL_NAME_BY_ALIAS.get(normalizedName) ?? null,
+  },
+  {
+    toolType: "web",
+    previewStrategy: "web",
+    match: (normalizedName) =>
+      normalizedName === "webfetch" || normalizedName.startsWith("websearch")
+        ? normalizedName
+        : null,
+  },
+  {
+    toolType: "web",
+    previewStrategy: "generic",
+    match: (normalizedName) => (normalizedName.startsWith("webfetch") ? normalizedName : null),
+  },
+  {
+    toolType: "generic",
+    previewStrategy: "context",
+    match: (normalizedName) => (normalizedName.startsWith("context7_") ? normalizedName : null),
+  },
+  {
+    toolType: "generic",
+    previewStrategy: "github_search",
+    match: (normalizedName) => (normalizedName === "grep_app_searchgithub" ? normalizedName : null),
+  },
+  {
+    toolType: "generic",
+    previewStrategy: "lsp",
+    match: matchExact(LSP_TOOL_NAMES),
+  },
+  {
+    toolType: "generic",
+    previewStrategy: "session",
+    match: matchExact(SESSION_TOOL_NAMES),
+  },
+] as const satisfies readonly OpenCodeToolStrategyDefinition[];
+
+export const resolveOpencodeToolStrategy = (toolName: string): ResolvedOpenCodeToolStrategy => {
+  const normalizedName = normalizeToolName(toolName);
+
+  for (const strategy of OPENCODE_TOOL_STRATEGY_CATALOG) {
+    const canonicalName = strategy.match(normalizedName);
+    if (canonicalName) {
+      return {
+        normalizedName,
+        canonicalName,
+        toolType: strategy.toolType,
+        previewStrategy: strategy.previewStrategy,
+      };
+    }
+  }
+
+  return {
+    normalizedName,
+    canonicalName: normalizedName,
+    toolType: "generic",
+    previewStrategy: "generic",
+  };
+};

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
@@ -95,7 +95,7 @@ const matchExact =
   (normalizedName: string): string | null =>
     toolNames.has(normalizedName) ? normalizedName : null;
 
-export const OPENCODE_TOOL_STRATEGY_CATALOG: readonly OpenCodeToolStrategyDefinition[] = [
+const OPENCODE_TOOL_STRATEGY_CATALOG: readonly OpenCodeToolStrategyDefinition[] = [
   {
     toolType: "bash",
     previewStrategy: "shell",
@@ -166,7 +166,9 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG: readonly OpenCodeToolStrategyDefini
     toolType: "web",
     previewStrategy: "generic",
     resolveCanonicalName: (normalizedName) =>
-      normalizedName.startsWith("webfetch") ? normalizedName : null,
+      normalizedName !== "webfetch" && normalizedName.startsWith("webfetch")
+        ? normalizedName
+        : null,
   },
   {
     toolType: "generic",

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
@@ -18,12 +18,12 @@ export type OpenCodeToolPreviewStrategy =
   | "session"
   | "generic";
 
-export type OpenCodeToolStreamPartKind = "tool" | "subagent";
+type OpenCodeToolStreamPartKind = "tool" | "subagent";
 
 type OpenCodeToolStrategyDefinition = {
   toolType: AgentToolType;
   previewStrategy: OpenCodeToolPreviewStrategy;
-  streamPartKind: OpenCodeToolStreamPartKind;
+  streamPartKind?: OpenCodeToolStreamPartKind;
   resolveCanonicalName: (normalizedName: string) => string | null;
 };
 
@@ -95,41 +95,35 @@ const matchExact =
   (normalizedName: string): string | null =>
     toolNames.has(normalizedName) ? normalizedName : null;
 
-export const OPENCODE_TOOL_STRATEGY_CATALOG = [
+export const OPENCODE_TOOL_STRATEGY_CATALOG: readonly OpenCodeToolStrategyDefinition[] = [
   {
     toolType: "bash",
     previewStrategy: "shell",
-    streamPartKind: "tool",
     resolveCanonicalName: matchExact(SHELL_TOOL_NAMES),
   },
   {
     toolType: "read",
     previewStrategy: "read",
-    streamPartKind: "tool",
     resolveCanonicalName: matchExact(READ_TOOL_NAMES),
   },
   {
     toolType: "list",
     previewStrategy: "list",
-    streamPartKind: "tool",
     resolveCanonicalName: matchExact(LIST_TOOL_NAMES),
   },
   {
     toolType: "search",
     previewStrategy: "search",
-    streamPartKind: "tool",
     resolveCanonicalName: matchExact(SEARCH_TOOL_NAMES),
   },
   {
     toolType: "generic",
     previewStrategy: "skill",
-    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) => (normalizedName === "skill" ? normalizedName : null),
   },
   {
     toolType: "todo",
     previewStrategy: "todo",
-    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       TODO_TOOL_NAMES.has(normalizedName) ||
       normalizedName.endsWith("_todowrite") ||
@@ -140,13 +134,11 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "file_edit",
     previewStrategy: "generic",
-    streamPartKind: "tool",
     resolveCanonicalName: matchExact(FILE_EDIT_TOOL_NAMES),
   },
   {
     toolType: "question",
     previewStrategy: "question",
-    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName === "question" || normalizedName.endsWith("_question") ? normalizedName : null,
   },
@@ -159,14 +151,12 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "workflow",
     previewStrategy: "workflow",
-    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       WORKFLOW_CANONICAL_NAME_BY_ALIAS.get(normalizedName) ?? null,
   },
   {
     toolType: "web",
     previewStrategy: "web",
-    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName === "webfetch" || normalizedName.startsWith("websearch")
         ? normalizedName
@@ -175,37 +165,32 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "web",
     previewStrategy: "generic",
-    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName.startsWith("webfetch") ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "context",
-    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName.startsWith("context7_") ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "github_search",
-    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName === "grep_app_searchgithub" ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "lsp",
-    streamPartKind: "tool",
     resolveCanonicalName: matchExact(LSP_TOOL_NAMES),
   },
   {
     toolType: "generic",
     previewStrategy: "session",
-    streamPartKind: "tool",
     resolveCanonicalName: matchExact(SESSION_TOOL_NAMES),
   },
-] as const satisfies readonly OpenCodeToolStrategyDefinition[];
+];
 
 export const resolveOpencodeToolStrategy = (toolName: string): ResolvedOpenCodeToolStrategy => {
   const normalizedName = normalizeToolName(toolName);
@@ -218,7 +203,7 @@ export const resolveOpencodeToolStrategy = (toolName: string): ResolvedOpenCodeT
         canonicalName,
         toolType: strategy.toolType,
         previewStrategy: strategy.previewStrategy,
-        streamPartKind: strategy.streamPartKind,
+        streamPartKind: strategy.streamPartKind ?? "tool",
       };
     }
   }

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
@@ -21,7 +21,7 @@ export type OpenCodeToolPreviewStrategy =
 type OpenCodeToolStrategyDefinition = {
   toolType: AgentToolType;
   previewStrategy: OpenCodeToolPreviewStrategy;
-  match: (normalizedName: string) => string | null;
+  resolveCanonicalName: (normalizedName: string) => string | null;
 };
 
 export type ResolvedOpenCodeToolStrategy = {
@@ -95,32 +95,32 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "bash",
     previewStrategy: "shell",
-    match: matchExact(SHELL_TOOL_NAMES),
+    resolveCanonicalName: matchExact(SHELL_TOOL_NAMES),
   },
   {
     toolType: "read",
     previewStrategy: "read",
-    match: matchExact(READ_TOOL_NAMES),
+    resolveCanonicalName: matchExact(READ_TOOL_NAMES),
   },
   {
     toolType: "list",
     previewStrategy: "list",
-    match: matchExact(LIST_TOOL_NAMES),
+    resolveCanonicalName: matchExact(LIST_TOOL_NAMES),
   },
   {
     toolType: "search",
     previewStrategy: "search",
-    match: matchExact(SEARCH_TOOL_NAMES),
+    resolveCanonicalName: matchExact(SEARCH_TOOL_NAMES),
   },
   {
     toolType: "generic",
     previewStrategy: "skill",
-    match: (normalizedName) => (normalizedName === "skill" ? normalizedName : null),
+    resolveCanonicalName: (normalizedName) => (normalizedName === "skill" ? normalizedName : null),
   },
   {
     toolType: "todo",
     previewStrategy: "todo",
-    match: (normalizedName) =>
+    resolveCanonicalName: (normalizedName) =>
       TODO_TOOL_NAMES.has(normalizedName) ||
       normalizedName.endsWith("_todowrite") ||
       normalizedName.endsWith("_todoread")
@@ -130,28 +130,29 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "file_edit",
     previewStrategy: "generic",
-    match: matchExact(FILE_EDIT_TOOL_NAMES),
+    resolveCanonicalName: matchExact(FILE_EDIT_TOOL_NAMES),
   },
   {
     toolType: "question",
     previewStrategy: "question",
-    match: (normalizedName) =>
+    resolveCanonicalName: (normalizedName) =>
       normalizedName === "question" || normalizedName.endsWith("_question") ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "task",
-    match: matchExact(TASK_TOOL_NAMES),
+    resolveCanonicalName: matchExact(TASK_TOOL_NAMES),
   },
   {
     toolType: "workflow",
     previewStrategy: "workflow",
-    match: (normalizedName) => WORKFLOW_CANONICAL_NAME_BY_ALIAS.get(normalizedName) ?? null,
+    resolveCanonicalName: (normalizedName) =>
+      WORKFLOW_CANONICAL_NAME_BY_ALIAS.get(normalizedName) ?? null,
   },
   {
     toolType: "web",
     previewStrategy: "web",
-    match: (normalizedName) =>
+    resolveCanonicalName: (normalizedName) =>
       normalizedName === "webfetch" || normalizedName.startsWith("websearch")
         ? normalizedName
         : null,
@@ -159,27 +160,30 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "web",
     previewStrategy: "generic",
-    match: (normalizedName) => (normalizedName.startsWith("webfetch") ? normalizedName : null),
+    resolveCanonicalName: (normalizedName) =>
+      normalizedName.startsWith("webfetch") ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "context",
-    match: (normalizedName) => (normalizedName.startsWith("context7_") ? normalizedName : null),
+    resolveCanonicalName: (normalizedName) =>
+      normalizedName.startsWith("context7_") ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "github_search",
-    match: (normalizedName) => (normalizedName === "grep_app_searchgithub" ? normalizedName : null),
+    resolveCanonicalName: (normalizedName) =>
+      normalizedName === "grep_app_searchgithub" ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "lsp",
-    match: matchExact(LSP_TOOL_NAMES),
+    resolveCanonicalName: matchExact(LSP_TOOL_NAMES),
   },
   {
     toolType: "generic",
     previewStrategy: "session",
-    match: matchExact(SESSION_TOOL_NAMES),
+    resolveCanonicalName: matchExact(SESSION_TOOL_NAMES),
   },
 ] as const satisfies readonly OpenCodeToolStrategyDefinition[];
 
@@ -187,7 +191,7 @@ export const resolveOpencodeToolStrategy = (toolName: string): ResolvedOpenCodeT
   const normalizedName = normalizeToolName(toolName);
 
   for (const strategy of OPENCODE_TOOL_STRATEGY_CATALOG) {
-    const canonicalName = strategy.match(normalizedName);
+    const canonicalName = strategy.resolveCanonicalName(normalizedName);
     if (canonicalName) {
       return {
         normalizedName,

--- a/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
+++ b/packages/adapters-opencode-sdk/src/tool-strategy-catalog.ts
@@ -18,9 +18,12 @@ export type OpenCodeToolPreviewStrategy =
   | "session"
   | "generic";
 
+export type OpenCodeToolStreamPartKind = "tool" | "subagent";
+
 type OpenCodeToolStrategyDefinition = {
   toolType: AgentToolType;
   previewStrategy: OpenCodeToolPreviewStrategy;
+  streamPartKind: OpenCodeToolStreamPartKind;
   resolveCanonicalName: (normalizedName: string) => string | null;
 };
 
@@ -29,6 +32,7 @@ export type ResolvedOpenCodeToolStrategy = {
   canonicalName: string;
   toolType: AgentToolType;
   previewStrategy: OpenCodeToolPreviewStrategy;
+  streamPartKind: OpenCodeToolStreamPartKind;
 };
 
 const SHELL_TOOL_NAMES = new Set(["bash", "shell", "exec", "command"]);
@@ -95,31 +99,37 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "bash",
     previewStrategy: "shell",
+    streamPartKind: "tool",
     resolveCanonicalName: matchExact(SHELL_TOOL_NAMES),
   },
   {
     toolType: "read",
     previewStrategy: "read",
+    streamPartKind: "tool",
     resolveCanonicalName: matchExact(READ_TOOL_NAMES),
   },
   {
     toolType: "list",
     previewStrategy: "list",
+    streamPartKind: "tool",
     resolveCanonicalName: matchExact(LIST_TOOL_NAMES),
   },
   {
     toolType: "search",
     previewStrategy: "search",
+    streamPartKind: "tool",
     resolveCanonicalName: matchExact(SEARCH_TOOL_NAMES),
   },
   {
     toolType: "generic",
     previewStrategy: "skill",
+    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) => (normalizedName === "skill" ? normalizedName : null),
   },
   {
     toolType: "todo",
     previewStrategy: "todo",
+    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       TODO_TOOL_NAMES.has(normalizedName) ||
       normalizedName.endsWith("_todowrite") ||
@@ -130,28 +140,33 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "file_edit",
     previewStrategy: "generic",
+    streamPartKind: "tool",
     resolveCanonicalName: matchExact(FILE_EDIT_TOOL_NAMES),
   },
   {
     toolType: "question",
     previewStrategy: "question",
+    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName === "question" || normalizedName.endsWith("_question") ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "task",
+    streamPartKind: "subagent",
     resolveCanonicalName: matchExact(TASK_TOOL_NAMES),
   },
   {
     toolType: "workflow",
     previewStrategy: "workflow",
+    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       WORKFLOW_CANONICAL_NAME_BY_ALIAS.get(normalizedName) ?? null,
   },
   {
     toolType: "web",
     previewStrategy: "web",
+    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName === "webfetch" || normalizedName.startsWith("websearch")
         ? normalizedName
@@ -160,29 +175,34 @@ export const OPENCODE_TOOL_STRATEGY_CATALOG = [
   {
     toolType: "web",
     previewStrategy: "generic",
+    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName.startsWith("webfetch") ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "context",
+    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName.startsWith("context7_") ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "github_search",
+    streamPartKind: "tool",
     resolveCanonicalName: (normalizedName) =>
       normalizedName === "grep_app_searchgithub" ? normalizedName : null,
   },
   {
     toolType: "generic",
     previewStrategy: "lsp",
+    streamPartKind: "tool",
     resolveCanonicalName: matchExact(LSP_TOOL_NAMES),
   },
   {
     toolType: "generic",
     previewStrategy: "session",
+    streamPartKind: "tool",
     resolveCanonicalName: matchExact(SESSION_TOOL_NAMES),
   },
 ] as const satisfies readonly OpenCodeToolStrategyDefinition[];
@@ -198,6 +218,7 @@ export const resolveOpencodeToolStrategy = (toolName: string): ResolvedOpenCodeT
         canonicalName,
         toolType: strategy.toolType,
         previewStrategy: strategy.previewStrategy,
+        streamPartKind: strategy.streamPartKind,
       };
     }
   }
@@ -207,5 +228,6 @@ export const resolveOpencodeToolStrategy = (toolName: string): ResolvedOpenCodeT
     canonicalName: normalizedName,
     toolType: "generic",
     previewStrategy: "generic",
+    streamPartKind: "tool",
   };
 };


### PR DESCRIPTION
## Summary

- Consolidates OpenCode tool-name matching, semantic classification, preview selection, and task/subagent mapping in one adapter-local typed catalog.
- Preserves existing preview behavior and descriptor-owned workflow aliases.

## Goal

OpenCode classification and preview logic previously kept overlapping tool-name buckets. That made semantic type, preview parsing, and mapper behavior prone to drift as runtime tool names changed.

This change creates one typed strategy source for normalized matching while keeping OpenCode-specific presentation parsing inside the adapter and leaving Core authorization policy unchanged.

## Implementation

- Added a typed OpenCode strategy catalog for canonical name resolution, AgentToolType, preview strategy, and stream-part kind.
- Builds workflow mappings from the canonical workflow IDs and OPENCODE_RUNTIME_DESCRIPTOR aliases.
- Routes deriveToolType, deriveToolPreview, and task/subagent mapper decisions through the catalog.
- Preserves generic preview fallback when specialized parsing has no result.
- Adds focused catalog, preview, and mapper coverage for supported tool families, workflow aliases, fallback behavior, and normalized task forms.

## Verification

- bun run lint
- bun run typecheck
- All 11 workspace package test commands run sequentially, plus bun run test:scripts
- bun run build

The repository has no Cargo.toml, so Rust checks do not apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition of task and delegate tools, including supported aliases.
  * Added more consistent classification and previews for workflow, session, web, context, and custom tools.
  * Added generic previews when a specialized tool preview is unavailable.

* **Bug Fixes**
  * Corrected tool mapping and preview behavior across tool-name variants.
  * Improved handling of workflow aliases and streamed subagent tasks.

* **Tests**
  * Expanded coverage for tool aliases, classifications, workflow previews, and generic fallback previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->