### PR TITLE
feat(ci): show pull request review outcomes

### DIFF
--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -119,12 +119,13 @@ import type {
   PlanSubtaskInput,
   PlanSubtaskIssueType,
   PlanSubtaskPriority,
+  PullRequestReviewActivity,
   PullRequestReviewAggregateStatus,
   PullRequestReviewCheck,
   PullRequestReviewCheckConclusion,
   PullRequestReviewCheckStatus,
-  PullRequestReviewComment,
   PullRequestReviewContext,
+  PullRequestReviewOutcome,
   PullRequestReviewProviderId,
   PullRequestReviewPullRequest,
   PullRequestReviewState,
@@ -485,8 +486,9 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "pullRequestReviewCheckConclusionSchema",
   "pullRequestReviewCheckSchema",
   "pullRequestReviewCheckStatusSchema",
-  "pullRequestReviewCommentSchema",
+  "pullRequestReviewActivitySchema",
   "pullRequestReviewContextSchema",
+  "pullRequestReviewOutcomeSchema",
   "pullRequestReviewProviderIdSchema",
   "pullRequestReviewPullRequestSchema",
   "pullRequestReviewStateSchema",
@@ -801,8 +803,9 @@ type ExportedTypeContract = {
   PullRequestReviewCheck: PullRequestReviewCheck;
   PullRequestReviewCheckConclusion: PullRequestReviewCheckConclusion;
   PullRequestReviewCheckStatus: PullRequestReviewCheckStatus;
-  PullRequestReviewComment: PullRequestReviewComment;
+  PullRequestReviewActivity: PullRequestReviewActivity;
   PullRequestReviewContext: PullRequestReviewContext;
+  PullRequestReviewOutcome: PullRequestReviewOutcome;
   PullRequestReviewProviderId: PullRequestReviewProviderId;
   PullRequestReviewPullRequest: PullRequestReviewPullRequest;
   PullRequestReviewState: PullRequestReviewState;

--- a/packages/contracts/src/pull-request-review-schemas.test.ts
+++ b/packages/contracts/src/pull-request-review-schemas.test.ts
@@ -4,7 +4,7 @@ import {
   pullRequestReviewContextSchema,
 } from "./pull-request-review-schemas";
 
-const activityFields = {
+const createActivityFields = () => ({
   id: "activity-1",
   author: "reviewer",
   authorAvatarUrl: null,
@@ -18,7 +18,7 @@ const activityFields = {
   line: null,
   threadId: null,
   isResolved: null,
-};
+});
 
 describe("pullRequestReviewActivitySchema", () => {
   test.each(["approved", "changes_requested", "commented", "dismissed"] as const)(
@@ -26,12 +26,12 @@ describe("pullRequestReviewActivitySchema", () => {
     (reviewOutcome) => {
       expect(
         pullRequestReviewActivitySchema.parse({
-          ...activityFields,
+          ...createActivityFields(),
           source: "review",
           reviewOutcome,
         }),
       ).toEqual({
-        ...activityFields,
+        ...createActivityFields(),
         source: "review",
         reviewOutcome,
       });
@@ -41,8 +41,8 @@ describe("pullRequestReviewActivitySchema", () => {
   test.each(["comment", "review_thread"] as const)(
     "accepts a %s activity without a review outcome",
     (source) => {
-      expect(pullRequestReviewActivitySchema.parse({ ...activityFields, source })).toEqual({
-        ...activityFields,
+      expect(pullRequestReviewActivitySchema.parse({ ...createActivityFields(), source })).toEqual({
+        ...createActivityFields(),
         source,
       });
     },
@@ -50,7 +50,7 @@ describe("pullRequestReviewActivitySchema", () => {
 
   test("rejects a review without an outcome", () => {
     expect(() =>
-      pullRequestReviewActivitySchema.parse({ ...activityFields, source: "review" }),
+      pullRequestReviewActivitySchema.parse({ ...createActivityFields(), source: "review" }),
     ).toThrow();
   });
 
@@ -59,7 +59,7 @@ describe("pullRequestReviewActivitySchema", () => {
     (source) => {
       expect(() =>
         pullRequestReviewActivitySchema.parse({
-          ...activityFields,
+          ...createActivityFields(),
           source,
           reviewOutcome: "approved",
         }),
@@ -70,7 +70,7 @@ describe("pullRequestReviewActivitySchema", () => {
   test("rejects an unsupported review outcome", () => {
     expect(() =>
       pullRequestReviewActivitySchema.parse({
-        ...activityFields,
+        ...createActivityFields(),
         source: "review",
         reviewOutcome: "pending",
       }),

--- a/packages/contracts/src/pull-request-review-schemas.test.ts
+++ b/packages/contracts/src/pull-request-review-schemas.test.ts
@@ -1,5 +1,82 @@
 import { describe, expect, test } from "bun:test";
-import { pullRequestReviewContextSchema } from "./pull-request-review-schemas";
+import {
+  pullRequestReviewActivitySchema,
+  pullRequestReviewContextSchema,
+} from "./pull-request-review-schemas";
+
+const activityFields = {
+  id: "activity-1",
+  author: "reviewer",
+  authorAvatarUrl: null,
+  body: "",
+  patch: null,
+  suggestionPatches: [],
+  url: null,
+  createdAt: "2026-07-10T08:00:00Z",
+  updatedAt: null,
+  path: null,
+  line: null,
+  threadId: null,
+  isResolved: null,
+};
+
+describe("pullRequestReviewActivitySchema", () => {
+  test.each(["approved", "changes_requested", "commented", "dismissed"] as const)(
+    "accepts a bodyless review with the %s outcome",
+    (reviewOutcome) => {
+      expect(
+        pullRequestReviewActivitySchema.parse({
+          ...activityFields,
+          source: "review",
+          reviewOutcome,
+        }),
+      ).toEqual({
+        ...activityFields,
+        source: "review",
+        reviewOutcome,
+      });
+    },
+  );
+
+  test.each(["comment", "review_thread"] as const)(
+    "accepts a %s activity without a review outcome",
+    (source) => {
+      expect(pullRequestReviewActivitySchema.parse({ ...activityFields, source })).toEqual({
+        ...activityFields,
+        source,
+      });
+    },
+  );
+
+  test("rejects a review without an outcome", () => {
+    expect(() =>
+      pullRequestReviewActivitySchema.parse({ ...activityFields, source: "review" }),
+    ).toThrow();
+  });
+
+  test.each(["comment", "review_thread"] as const)(
+    "rejects reviewOutcome on a %s activity",
+    (source) => {
+      expect(() =>
+        pullRequestReviewActivitySchema.parse({
+          ...activityFields,
+          source,
+          reviewOutcome: "approved",
+        }),
+      ).toThrow();
+    },
+  );
+
+  test("rejects an unsupported review outcome", () => {
+    expect(() =>
+      pullRequestReviewActivitySchema.parse({
+        ...activityFields,
+        source: "review",
+        reviewOutcome: "pending",
+      }),
+    ).toThrow();
+  });
+});
 
 describe("pullRequestReviewContextSchema", () => {
   test("accepts provider-neutral pull request review contexts", () => {

--- a/packages/contracts/src/pull-request-review-schemas.ts
+++ b/packages/contracts/src/pull-request-review-schemas.ts
@@ -66,7 +66,7 @@ export const pullRequestReviewCheckSchema = z.object({
 });
 export type PullRequestReviewCheck = z.infer<typeof pullRequestReviewCheckSchema>;
 
-export const pullRequestReviewCommentSchema = z.object({
+const pullRequestReviewActivityFields = {
   id: z.string().min(1),
   author: z.string().nullable(),
   authorAvatarUrl: nullableUrlSchema,
@@ -80,9 +80,40 @@ export const pullRequestReviewCommentSchema = z.object({
   line: z.number().int().positive().nullable(),
   threadId: z.string().nullable(),
   isResolved: z.boolean().nullable(),
-  source: z.enum(["comment", "review", "review_thread"]),
+};
+
+export const pullRequestReviewOutcomeSchema = z.enum([
+  "approved",
+  "changes_requested",
+  "commented",
+  "dismissed",
+]);
+export type PullRequestReviewOutcome = z.infer<typeof pullRequestReviewOutcomeSchema>;
+
+const pullRequestReviewCommentActivitySchema = z.object({
+  ...pullRequestReviewActivityFields,
+  source: z.literal("comment"),
+  reviewOutcome: z.never().optional(),
 });
-export type PullRequestReviewComment = z.infer<typeof pullRequestReviewCommentSchema>;
+
+const pullRequestReviewSummaryActivitySchema = z.object({
+  ...pullRequestReviewActivityFields,
+  source: z.literal("review"),
+  reviewOutcome: pullRequestReviewOutcomeSchema,
+});
+
+const pullRequestReviewThreadActivitySchema = z.object({
+  ...pullRequestReviewActivityFields,
+  source: z.literal("review_thread"),
+  reviewOutcome: z.never().optional(),
+});
+
+export const pullRequestReviewActivitySchema = z.discriminatedUnion("source", [
+  pullRequestReviewCommentActivitySchema,
+  pullRequestReviewSummaryActivitySchema,
+  pullRequestReviewThreadActivitySchema,
+]);
+export type PullRequestReviewActivity = z.infer<typeof pullRequestReviewActivitySchema>;
 
 export const pullRequestReviewThreadsSummarySchema = z.object({
   openCount: z.number().int().nonnegative(),
@@ -111,7 +142,7 @@ export const pullRequestReviewContextSchema = z.discriminatedUnion("status", [
     pullRequest: pullRequestReviewPullRequestSchema,
     aggregateStatus: pullRequestReviewAggregateStatusSchema,
     checks: z.array(pullRequestReviewCheckSchema),
-    comments: z.array(pullRequestReviewCommentSchema),
+    comments: z.array(pullRequestReviewActivitySchema),
     reviewThreads: pullRequestReviewThreadsSummarySchema,
     refreshedAt: dateTimeSchema,
   }),

--- a/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.test.tsx
@@ -27,7 +27,10 @@ const createComment = (): PullRequestReviewActivity => ({
   source: "review_thread",
 });
 
-const review = (reviewOutcome: PullRequestReviewOutcome, body = ""): PullRequestReviewActivity => ({
+const createReview = (
+  reviewOutcome: PullRequestReviewOutcome,
+  body = "",
+): PullRequestReviewActivity => ({
   ...createComment(),
   id: `review-${reviewOutcome}`,
   body,
@@ -47,7 +50,7 @@ test.each([
 ] as const)("renders the %s review outcome without an empty-body placeholder", (outcome, label) => {
   const view = render(
     <TooltipProvider>
-      <TaskExecutionCiCommentCard comment={review(outcome)} isBot={false} />
+      <TaskExecutionCiCommentCard comment={createReview(outcome)} isBot={false} />
     </TooltipProvider>,
   );
 
@@ -56,7 +59,7 @@ test.each([
 });
 
 test("renders a review outcome before deferred body work and shows its body once ready", () => {
-  const reviewWithBody = review("approved", "This is ready to merge.");
+  const reviewWithBody = createReview("approved", "This is ready to merge.");
   const view = render(
     <TooltipProvider>
       <TaskExecutionCiCommentCard comment={reviewWithBody} isBot={false} isBodyReady={false} />
@@ -79,7 +82,7 @@ test("renders a review outcome before deferred body work and shows its body once
 test("uses review-specific accessible action names and external link text", () => {
   const view = render(
     <TooltipProvider>
-      <TaskExecutionCiCommentCard comment={review("commented")} isBot={false} />
+      <TaskExecutionCiCommentCard comment={createReview("commented")} isBot={false} />
     </TooltipProvider>,
   );
 
@@ -92,7 +95,7 @@ test.each(["light", "dark"] as const)("renders review outcome text in the %s the
     <QueryProvider useIsolatedClient>
       <ThemeProvider defaultTheme={theme}>
         <TooltipProvider>
-          <TaskExecutionCiCommentCard comment={review("dismissed")} isBot={false} />
+          <TaskExecutionCiCommentCard comment={createReview("dismissed")} isBot={false} />
         </TooltipProvider>
       </ThemeProvider>
     </QueryProvider>,

--- a/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.test.tsx
@@ -10,7 +10,7 @@ import {
   TaskExecutionCiMarkdownLink,
 } from "./task-execution-ci-comment-card";
 
-const comment: PullRequestReviewActivity = {
+const createComment = (): PullRequestReviewActivity => ({
   id: "comment-1",
   author: "reviewer",
   authorAvatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
@@ -25,10 +25,10 @@ const comment: PullRequestReviewActivity = {
   threadId: "thread-1",
   isResolved: false,
   source: "review_thread",
-};
+});
 
 const review = (reviewOutcome: PullRequestReviewOutcome, body = ""): PullRequestReviewActivity => ({
-  ...comment,
+  ...createComment(),
   id: `review-${reviewOutcome}`,
   body,
   path: null,
@@ -103,6 +103,7 @@ test.each(["light", "dark"] as const)("renders review outcome text in the %s the
 
 test("opens review comments through the external URL shell bridge", () => {
   const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
+  const comment = createComment();
 
   try {
     const view = render(
@@ -122,7 +123,7 @@ test("opens review comments through the external URL shell bridge", () => {
 test("skips unchanged card inputs and renders updated comments", () => {
   let bodyReadCount = 0;
   const trackedComment: PullRequestReviewActivity = {
-    ...comment,
+    ...createComment(),
     get body() {
       bodyReadCount += 1;
       return "Please update this.";
@@ -140,7 +141,7 @@ test("skips unchanged card inputs and renders updated comments", () => {
 
   expect(bodyReadCount).toBe(initialBodyReadCount);
 
-  view.rerender(card({ ...comment, body: "Updated review guidance." }));
+  view.rerender(card({ ...createComment(), body: "Updated review guidance." }));
 
   expect(view.getByText("Updated review guidance.")).toBeTruthy();
 });
@@ -171,7 +172,7 @@ test("labels suggested changes as a distinct review section", () => {
         <TooltipProvider>
           <TaskExecutionCiCommentCard
             comment={{
-              ...comment,
+              ...createComment(),
               body: "Use the shared loading state.",
               suggestionPatches: [
                 "@@ -8,1 +8,1 @@\n-disabled={isGoogleLoading}\n+disabled={isAnyLoading}",
@@ -190,7 +191,7 @@ test("labels suggested changes as a distinct review section", () => {
 
 test("collapses resolved comments by default and toggles comment bodies", () => {
   const resolvedComment = {
-    ...comment,
+    ...createComment(),
     body: "Resolved review guidance.",
     isResolved: true,
   };
@@ -211,16 +212,18 @@ test("collapses resolved comments by default and toggles comment bodies", () => 
   expect(resolvedView.queryByText(resolvedComment.body)).toBeNull();
   resolvedView.unmount();
 
+  const unresolvedComment = createComment();
   const unresolvedView = render(
     <TooltipProvider>
-      <TaskExecutionCiCommentCard comment={comment} isBot={false} />
+      <TaskExecutionCiCommentCard comment={unresolvedComment} isBot={false} />
     </TooltipProvider>,
   );
 
-  expect(unresolvedView.getByText(comment.body)).toBeTruthy();
+  expect(unresolvedView.getByText(unresolvedComment.body)).toBeTruthy();
 });
 
 test("resets the disclosure default when the thread resolution changes", () => {
+  const comment = createComment();
   const card = (isResolved: boolean) => (
     <TooltipProvider>
       <TaskExecutionCiCommentCard comment={{ ...comment, isResolved }} isBot={false} />
@@ -241,7 +244,7 @@ test("resets the disclosure default when the thread resolution changes", () => {
 
 test("renders a deferred body immediately when the user expands the comment", () => {
   const deferredComment = {
-    ...comment,
+    ...createComment(),
     body: "Deferred review guidance.",
   };
   const view = render(
@@ -260,6 +263,7 @@ test("renders a deferred body immediately when the user expands the comment", ()
 });
 
 test("shows the comment header as clickable and vertically centers its actions", () => {
+  const comment = createComment();
   const view = render(
     <TooltipProvider>
       <TaskExecutionCiCommentCard comment={comment} isBot={false} />
@@ -276,6 +280,7 @@ test("shows the comment header as clickable and vertically centers its actions",
 });
 
 test("shows either a lazy author avatar or its fallback", () => {
+  const comment = createComment();
   const view = render(
     <TooltipProvider>
       <TaskExecutionCiCommentCard comment={comment} isBot={false} />
@@ -310,7 +315,7 @@ test("keeps the filename visible when a comment path is truncated", () => {
   const view = render(
     <TooltipProvider>
       <TaskExecutionCiCommentCard
-        comment={{ ...comment, path: longPath, line: 16 }}
+        comment={{ ...createComment(), path: longPath, line: 16 }}
         isBot={false}
       />
     </TooltipProvider>,

--- a/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.test.tsx
@@ -1,5 +1,5 @@
 import { expect, spyOn, test } from "bun:test";
-import type { PullRequestReviewComment } from "@openducktor/contracts";
+import type { PullRequestReviewActivity, PullRequestReviewOutcome } from "@openducktor/contracts";
 import { fireEvent, render } from "@testing-library/react";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -10,7 +10,7 @@ import {
   TaskExecutionCiMarkdownLink,
 } from "./task-execution-ci-comment-card";
 
-const comment: PullRequestReviewComment = {
+const comment: PullRequestReviewActivity = {
   id: "comment-1",
   author: "reviewer",
   authorAvatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
@@ -26,6 +26,80 @@ const comment: PullRequestReviewComment = {
   isResolved: false,
   source: "review_thread",
 };
+
+const review = (reviewOutcome: PullRequestReviewOutcome, body = ""): PullRequestReviewActivity => ({
+  ...comment,
+  id: `review-${reviewOutcome}`,
+  body,
+  path: null,
+  line: null,
+  threadId: null,
+  isResolved: null,
+  source: "review",
+  reviewOutcome,
+});
+
+test.each([
+  ["approved", "Approved"],
+  ["changes_requested", "Changes requested"],
+  ["commented", "Commented"],
+  ["dismissed", "Review dismissed"],
+] as const)("renders the %s review outcome without an empty-body placeholder", (outcome, label) => {
+  const view = render(
+    <TooltipProvider>
+      <TaskExecutionCiCommentCard comment={review(outcome)} isBot={false} />
+    </TooltipProvider>,
+  );
+
+  expect(view.getByText(label)).toBeTruthy();
+  expect(view.queryByText("No comment body.")).toBeNull();
+});
+
+test("renders a review outcome before deferred body work and shows its body once ready", () => {
+  const reviewWithBody = review("approved", "This is ready to merge.");
+  const view = render(
+    <TooltipProvider>
+      <TaskExecutionCiCommentCard comment={reviewWithBody} isBot={false} isBodyReady={false} />
+    </TooltipProvider>,
+  );
+
+  expect(view.getByText("Approved")).toBeTruthy();
+  expect(view.queryByText(reviewWithBody.body)).toBeNull();
+
+  view.rerender(
+    <TooltipProvider>
+      <TaskExecutionCiCommentCard comment={reviewWithBody} isBot={false} isBodyReady />
+    </TooltipProvider>,
+  );
+
+  expect(view.getAllByText("Approved")).toHaveLength(1);
+  expect(view.getAllByText(reviewWithBody.body)).toHaveLength(1);
+});
+
+test("uses review-specific accessible action names and external link text", () => {
+  const view = render(
+    <TooltipProvider>
+      <TaskExecutionCiCommentCard comment={review("commented")} isBot={false} />
+    </TooltipProvider>,
+  );
+
+  expect(view.getByRole("button", { name: "Collapse review from reviewer" })).toBeTruthy();
+  expect(view.getByRole("button", { name: "Open review from reviewer" })).toBeTruthy();
+});
+
+test.each(["light", "dark"] as const)("renders review outcome text in the %s theme", (theme) => {
+  const view = render(
+    <QueryProvider useIsolatedClient>
+      <ThemeProvider defaultTheme={theme}>
+        <TooltipProvider>
+          <TaskExecutionCiCommentCard comment={review("dismissed")} isBot={false} />
+        </TooltipProvider>
+      </ThemeProvider>
+    </QueryProvider>,
+  );
+
+  expect(view.getByText("Review dismissed")).toBeTruthy();
+});
 
 test("opens review comments through the external URL shell bridge", () => {
   const openExternalUrlSpy = spyOn(externalUrl, "openExternalUrl").mockResolvedValue();
@@ -47,14 +121,14 @@ test("opens review comments through the external URL shell bridge", () => {
 
 test("skips unchanged card inputs and renders updated comments", () => {
   let bodyReadCount = 0;
-  const trackedComment: PullRequestReviewComment = {
+  const trackedComment: PullRequestReviewActivity = {
     ...comment,
     get body() {
       bodyReadCount += 1;
       return "Please update this.";
     },
   };
-  const card = (cardComment: PullRequestReviewComment) => (
+  const card = (cardComment: PullRequestReviewActivity) => (
     <TooltipProvider>
       <TaskExecutionCiCommentCard comment={cardComment} isBot={false} />
     </TooltipProvider>

--- a/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.tsx
@@ -1,4 +1,4 @@
-import type { PullRequestReviewComment } from "@openducktor/contracts";
+import type { PullRequestReviewActivity } from "@openducktor/contracts";
 import { ChevronRight, ExternalLink, Lightbulb, MessageSquare } from "lucide-react";
 import type { ComponentProps, MouseEvent, ReactElement } from "react";
 import { memo, useState } from "react";
@@ -11,7 +11,10 @@ import { errorMessage } from "@/lib/errors";
 import { openExternalUrl } from "@/lib/open-external-url";
 import { cn } from "@/lib/utils";
 import { PierrePreloadedDiffViewer } from "./pierre-diff-viewer";
-import { commentLocationLabel } from "./task-execution-ci-presentation";
+import {
+  commentLocationLabel,
+  REVIEW_OUTCOME_PRESENTATION,
+} from "./task-execution-ci-presentation";
 import { TaskExecutionCiRelativeTime } from "./task-execution-ci-relative-time";
 
 const openReviewUrl = (url: string, failureMessage: string): void => {
@@ -110,7 +113,7 @@ const TaskExecutionCiSuggestedChange = memo(function TaskExecutionCiSuggestedCha
 });
 
 type TaskExecutionCiCommentBodyProps = {
-  comment: PullRequestReviewComment;
+  comment: PullRequestReviewActivity;
 };
 
 const TaskExecutionCiCommentBody = memo(function TaskExecutionCiCommentBody({
@@ -159,7 +162,7 @@ const TaskExecutionCiCommentBody = memo(function TaskExecutionCiCommentBody({
             />
           ))
         : null}
-      {!hasBody && !hasPatch && !hasSuggestionPatches ? (
+      {!hasBody && !hasPatch && !hasSuggestionPatches && comment.source !== "review" ? (
         <p className="border-t border-border px-3 py-3 text-sm text-muted-foreground">
           No comment body.
         </p>
@@ -169,7 +172,7 @@ const TaskExecutionCiCommentBody = memo(function TaskExecutionCiCommentBody({
 });
 
 type TaskExecutionCiCommentCardProps = {
-  comment: PullRequestReviewComment;
+  comment: PullRequestReviewActivity;
   isBot: boolean;
   isBodyReady?: boolean;
 };
@@ -187,6 +190,9 @@ export const TaskExecutionCiCommentCard = memo(function TaskExecutionCiCommentCa
   isBodyReady = true,
 }: TaskExecutionCiCommentCardProps): ReactElement {
   const showThreadBadge = comment.isResolved !== null;
+  const reviewPresentation =
+    comment.source === "review" ? REVIEW_OUTCOME_PRESENTATION[comment.reviewOutcome] : null;
+  const activityName = reviewPresentation ? "review" : "comment";
   const location = commentLocationLabel(comment);
   const author = comment.author ?? "Unknown author";
   const activityTimestamp = comment.createdAt ?? comment.updatedAt;
@@ -210,7 +216,7 @@ export const TaskExecutionCiCommentCard = memo(function TaskExecutionCiCommentCa
     if (!comment.url) {
       return;
     }
-    openReviewUrl(comment.url, "Failed to open comment");
+    openReviewUrl(comment.url, `Failed to open ${activityName}`);
   };
 
   const toggleComment = (): void => {
@@ -229,7 +235,7 @@ export const TaskExecutionCiCommentCard = memo(function TaskExecutionCiCommentCa
           type="button"
           className="group/comment grid min-w-0 cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 px-3 py-2 text-left outline-none transition hover:bg-accent/40 focus-visible:bg-accent/50"
           aria-expanded={isOpen}
-          aria-label={`${isOpen ? "Collapse" : "Expand"} comment from ${author}`}
+          aria-label={`${isOpen ? "Collapse" : "Expand"} ${activityName} from ${author}`}
           data-state={isOpen ? "open" : "closed"}
           onClick={toggleComment}
         >
@@ -261,6 +267,14 @@ export const TaskExecutionCiCommentCard = memo(function TaskExecutionCiCommentCa
               {isBot ? (
                 <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
                   Bot
+                </Badge>
+              ) : null}
+              {reviewPresentation ? (
+                <Badge
+                  variant={reviewPresentation.variant}
+                  className="shrink-0 px-2 py-0 text-[10px]"
+                >
+                  {reviewPresentation.label}
                 </Badge>
               ) : null}
               {activityTimestamp ? (
@@ -301,12 +315,12 @@ export const TaskExecutionCiCommentCard = memo(function TaskExecutionCiCommentCa
                   type="button"
                   onClick={openComment}
                   className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground outline-none transition hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/40"
-                  aria-label={`Open comment from ${author}`}
+                  aria-label={`Open ${activityName} from ${author}`}
                 >
                   <ExternalLink className="size-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Open comment</TooltipContent>
+              <TooltipContent side="bottom">Open {activityName}</TooltipContent>
             </Tooltip>
           </div>
         ) : null}

--- a/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.tsx
@@ -190,9 +190,9 @@ export const TaskExecutionCiCommentCard = memo(function TaskExecutionCiCommentCa
   isBodyReady = true,
 }: TaskExecutionCiCommentCardProps): ReactElement {
   const showThreadBadge = comment.isResolved !== null;
-  const reviewPresentation =
-    comment.source === "review" ? REVIEW_OUTCOME_PRESENTATION[comment.reviewOutcome] : null;
-  const activityName = reviewPresentation ? "review" : "comment";
+  const isReview = comment.source === "review";
+  const reviewPresentation = isReview ? REVIEW_OUTCOME_PRESENTATION[comment.reviewOutcome] : null;
+  const activityName = isReview ? "review" : "comment";
   const location = commentLocationLabel(comment);
   const author = comment.author ?? "Unknown author";
   const activityTimestamp = comment.createdAt ?? comment.updatedAt;

--- a/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-comment-card.tsx
@@ -142,7 +142,7 @@ const TaskExecutionCiCommentBody = memo(function TaskExecutionCiCommentBody({
         </div>
       ) : null}
       {hasBody ? (
-        <div className="min-w-0 overflow-hidden border-t border-border px-3 py-1">
+        <div className="min-w-0 overflow-x-auto border-t border-border px-3 py-1">
           <MarkdownRenderer
             markdown={comment.body}
             variant="compact"

--- a/packages/frontend/src/components/features/agents/task-execution-ci-comments-list.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-comments-list.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { PullRequestReviewComment } from "@openducktor/contracts";
+import type { PullRequestReviewActivity } from "@openducktor/contracts";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { withAnimationFrameTestDriver } from "@/test-utils/animation-frame-test-driver";
@@ -9,7 +9,7 @@ import {
 } from "./task-execution-ci-comment-filters";
 import { TaskExecutionCiCommentsList } from "./task-execution-ci-comments-list";
 
-const comment = (id: string, author = "reviewer"): PullRequestReviewComment => ({
+const comment = (id: string, author = "reviewer"): PullRequestReviewActivity => ({
   id,
   author,
   authorAvatarUrl: null,
@@ -53,7 +53,7 @@ const withLocalStorage = async (storage: Storage, run: () => Promise<void>): Pro
   }
 };
 
-const commentsList = (comments: PullRequestReviewComment[]) => (
+const commentsList = (comments: PullRequestReviewActivity[]) => (
   <TooltipProvider>
     <TaskExecutionCiCommentsList comments={comments} />
   </TooltipProvider>
@@ -63,7 +63,7 @@ describe("TaskExecutionCiCommentsList", () => {
   test("skips stable comment inputs and renders changed comments", async () => {
     await withAnimationFrameTestDriver(async (frameDriver) => {
       let authorReadCount = 0;
-      const trackedComment: PullRequestReviewComment = {
+      const trackedComment: PullRequestReviewActivity = {
         ...comment("one"),
         get author() {
           authorReadCount += 1;

--- a/packages/frontend/src/components/features/agents/task-execution-ci-comments-list.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-comments-list.tsx
@@ -1,4 +1,4 @@
-import type { PullRequestReviewComment } from "@openducktor/contracts";
+import type { PullRequestReviewActivity } from "@openducktor/contracts";
 import { ChevronRight, ListFilter, MessageSquare } from "lucide-react";
 import type { ReactElement } from "react";
 import {
@@ -36,19 +36,19 @@ const COMMENT_FILTERS: Array<{ id: CommentFilter; label: string }> = [
 const COMMENT_BODY_BATCH_SIZE = 4;
 
 type TaskExecutionCiCommentsListProps = {
-  comments: PullRequestReviewComment[];
+  comments: PullRequestReviewActivity[];
 };
 
-const commentTimestamp = (comment: PullRequestReviewComment): number => {
+const commentTimestamp = (comment: PullRequestReviewActivity): number => {
   const timestamp = Date.parse(comment.createdAt ?? comment.updatedAt ?? "");
   return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
 };
 
 const filterComments = (
-  comments: readonly PullRequestReviewComment[],
+  comments: readonly PullRequestReviewActivity[],
   filter: CommentFilter,
   hideResolved: boolean,
-): PullRequestReviewComment[] => {
+): PullRequestReviewActivity[] => {
   const commentsByResolution = hideResolved
     ? comments.filter((comment) => comment.isResolved !== true)
     : comments;
@@ -68,7 +68,7 @@ const filterComments = (
 };
 
 const selectNextBodyBatchIds = (
-  comments: readonly PullRequestReviewComment[],
+  comments: readonly PullRequestReviewActivity[],
   readyBodyIds: ReadonlySet<string>,
 ): string[] => {
   const batchIds: string[] = [];

--- a/packages/frontend/src/components/features/agents/task-execution-ci-performance.test.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-performance.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { PullRequestReviewComment, PullRequestReviewContext } from "@openducktor/contracts";
+import type { PullRequestReviewActivity, PullRequestReviewContext } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { type PropsWithChildren, type ReactElement, useState } from "react";
@@ -19,7 +19,7 @@ const ciQueryInput = {
   taskId: "task-12",
 };
 
-const createPerformanceComment = (index: number): PullRequestReviewComment => ({
+const createPerformanceComment = (index: number): PullRequestReviewActivity => ({
   id: `performance-comment-${index}`,
   author: index % 2 === 0 ? "reviewer" : "review-bot[bot]",
   authorAvatarUrl: null,
@@ -46,7 +46,9 @@ const createPerformanceComment = (index: number): PullRequestReviewComment => ({
   source: "review_thread",
 });
 
-const createLoadedCiContext = (comments: PullRequestReviewComment[]): PullRequestReviewContext => ({
+const createLoadedCiContext = (
+  comments: PullRequestReviewActivity[],
+): PullRequestReviewContext => ({
   status: "loaded",
   providerId: "github",
   pullRequest: {
@@ -204,7 +206,7 @@ const renderCiPerformanceHarness = ({
   initiallyOpen,
   initialTabId,
 }: {
-  comments: PullRequestReviewComment[];
+  comments: PullRequestReviewActivity[];
   initiallyOpen: boolean;
   initialTabId: TaskExecutionPanelModel["activeTabId"];
 }) =>

--- a/packages/frontend/src/components/features/agents/task-execution-ci-presentation.ts
+++ b/packages/frontend/src/components/features/agents/task-execution-ci-presentation.ts
@@ -1,8 +1,24 @@
 import type {
+  PullRequestReviewActivity,
   PullRequestReviewAggregateStatus,
   PullRequestReviewCheck,
-  PullRequestReviewComment,
+  PullRequestReviewOutcome,
 } from "@openducktor/contracts";
+
+type ReviewOutcomePresentation = {
+  label: string;
+  variant: "success" | "danger" | "secondary" | "outline";
+};
+
+export const REVIEW_OUTCOME_PRESENTATION: Record<
+  PullRequestReviewOutcome,
+  ReviewOutcomePresentation
+> = {
+  approved: { label: "Approved", variant: "success" },
+  changes_requested: { label: "Changes requested", variant: "danger" },
+  commented: { label: "Commented", variant: "secondary" },
+  dismissed: { label: "Review dismissed", variant: "outline" },
+};
 
 export const aggregateLabel = (status: PullRequestReviewAggregateStatus): string => {
   if (status === "success") {
@@ -146,7 +162,7 @@ export const isBotCommentAuthor = (author: string | null): boolean => {
   return AUTOMATION_LOGIN_PATTERNS.some((pattern) => pattern.test(trimmedAuthor));
 };
 
-export const commentLocationLabel = (comment: PullRequestReviewComment): string | null => {
+export const commentLocationLabel = (comment: PullRequestReviewActivity): string | null => {
   if (!comment.path) {
     return null;
   }

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, mock, test } from "bun:test";
 import { type PullRequestReviewContext, repoConfigSchema } from "@openducktor/contracts";
 import { Effect } from "effect";
 import type { GithubCommandDependencies } from "../../../application/tasks/support/github-pull-requests";
+import { HostValidationError } from "../../../effect/host-errors";
 import type { SystemCommandPort } from "../../../ports/system-command-port";
+import type { ToolDiscoveryPort } from "../../../ports/tool-discovery-port";
 import { createGithubPullRequestReviewAdapter } from "./github-pull-request-review-adapter";
 import type { GithubPullRequestReviewReader } from "./github-pull-request-review-reader";
 
@@ -23,57 +25,74 @@ const loadedContext: PullRequestReviewContext = {
   refreshedAt: "2026-07-10T08:00:00.000Z",
 };
 
+const createRepoConfig = ({ githubEnabled = true }: { githubEnabled?: boolean } = {}) =>
+  repoConfigSchema.parse({
+    workspaceId: "repo",
+    workspaceName: "Repo",
+    repoPath: "/repo",
+    defaultRuntimeKind: "opencode",
+    git: {
+      providers: {
+        github: {
+          enabled: githubEnabled,
+          repository: { host: "github.com", owner: "openai", name: "openducktor" },
+        },
+      },
+    },
+  });
+
+const linkedPullRequest = (providerId = "github") => ({
+  providerId,
+  number: 42,
+  url: "https://github.com/openai/openducktor/pull/42",
+  state: "open" as const,
+  createdAt: "2026-07-10T08:00:00.000Z",
+  updatedAt: "2026-07-10T08:00:00.000Z",
+});
+
+const createGithubDependencies = () => {
+  const runCommandAllowFailure = mock((_command: string, args: string[]) => {
+    expect(args).toEqual(["auth", "status", "--hostname", "github.com"]);
+    return Effect.succeed({ ok: true, stdout: "", stderr: "" });
+  });
+  const systemCommands: Pick<SystemCommandPort, "runCommandAllowFailure"> = {
+    runCommandAllowFailure,
+  };
+  const toolDiscovery: ToolDiscoveryPort = {
+    resolveTool: () =>
+      Effect.succeed({
+        displayLabel: "GitHub CLI",
+        path: "gh",
+        sourceCategory: "system_path",
+      }),
+    resolveToolPath: () => Effect.succeed("gh"),
+  };
+  const dependencies: GithubCommandDependencies = {
+    resolveGithubCommand: () =>
+      Effect.succeed({
+        ghCommand: "gh",
+        systemCommands: systemCommands as SystemCommandPort,
+      }),
+    systemCommands: systemCommands as SystemCommandPort,
+    toolDiscovery,
+  };
+  return { dependencies, runCommandAllowFailure };
+};
+
 describe("createGithubPullRequestReviewAdapter", () => {
   test("uses the linked pull request without requiring a local Git remote", async () => {
-    const systemCommands: Pick<SystemCommandPort, "runCommandAllowFailure"> = {
-      runCommandAllowFailure: () =>
-        Effect.succeed({
-          ok: true,
-          stdout: "",
-          stderr: "",
-        }),
-    };
-    const githubDependencies: GithubCommandDependencies = {
-      resolveGithubCommand: () =>
-        Effect.succeed({
-          ghCommand: "gh",
-          systemCommands: systemCommands as SystemCommandPort,
-        }),
-      systemCommands: systemCommands as SystemCommandPort,
-      toolDiscovery: {} as GithubCommandDependencies["toolDiscovery"],
-    };
+    const { dependencies: githubDependencies, runCommandAllowFailure } = createGithubDependencies();
     const read = mock(() => Effect.succeed(loadedContext));
     const reviewReader: GithubPullRequestReviewReader = { read };
     const adapter = createGithubPullRequestReviewAdapter({
       githubDependencies,
       reviewReader,
     });
-    const repoConfig = repoConfigSchema.parse({
-      workspaceId: "repo",
-      workspaceName: "Repo",
-      repoPath: "/repo",
-      defaultRuntimeKind: "opencode",
-      git: {
-        providers: {
-          github: {
-            enabled: true,
-            repository: { host: "github.com", owner: "openai", name: "openducktor" },
-          },
-        },
-      },
-    });
 
     const context = await Effect.runPromise(
       adapter.readContext({
-        repoConfig,
-        linkedPullRequest: {
-          providerId: "github",
-          number: 42,
-          url: "https://github.com/openai/openducktor/pull/42",
-          state: "open",
-          createdAt: "2026-07-10T08:00:00.000Z",
-          updatedAt: "2026-07-10T08:00:00.000Z",
-        },
+        repoConfig: createRepoConfig(),
+        linkedPullRequest: linkedPullRequest(),
       }),
     );
 
@@ -84,5 +103,84 @@ describe("createGithubPullRequestReviewAdapter", () => {
       repository: { host: "github.com", owner: "openai", name: "openducktor" },
       pullRequestNumber: 42,
     });
+    expect(runCommandAllowFailure).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects a linked pull request from another provider", async () => {
+    const { dependencies: githubDependencies, runCommandAllowFailure } = createGithubDependencies();
+    const read = mock(() => Effect.succeed(loadedContext));
+    const adapter = createGithubPullRequestReviewAdapter({
+      githubDependencies,
+      reviewReader: { read },
+    });
+
+    const result = await Effect.runPromise(
+      adapter
+        .readContext({
+          repoConfig: createRepoConfig(),
+          linkedPullRequest: linkedPullRequest("gitlab"),
+        })
+        .pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(HostValidationError);
+      expect(result.left.field).toBe("pullRequest.providerId");
+    }
+    expect(read).not.toHaveBeenCalled();
+    expect(runCommandAllowFailure).not.toHaveBeenCalled();
+  });
+
+  test("returns unavailable when the configured GitHub repository cannot be read", async () => {
+    const { dependencies: githubDependencies, runCommandAllowFailure } = createGithubDependencies();
+    const read = mock(() => Effect.succeed(loadedContext));
+    const adapter = createGithubPullRequestReviewAdapter({
+      githubDependencies,
+      reviewReader: { read },
+    });
+
+    const context = await Effect.runPromise(
+      adapter.readContext({
+        repoConfig: createRepoConfig({ githubEnabled: false }),
+        linkedPullRequest: linkedPullRequest(),
+      }),
+    );
+
+    expect(context).toMatchObject({
+      status: "unavailable",
+      providerId: "github",
+      reason: expect.stringContaining("not enabled"),
+    });
+    expect(read).not.toHaveBeenCalled();
+    expect(runCommandAllowFailure).not.toHaveBeenCalled();
+  });
+
+  test("preserves typed reader failures", async () => {
+    const { dependencies: githubDependencies, runCommandAllowFailure } = createGithubDependencies();
+    const failure = new HostValidationError({
+      field: "github.review",
+      message: "GitHub review response is invalid.",
+    });
+    const read = mock(() => Effect.fail(failure));
+    const adapter = createGithubPullRequestReviewAdapter({
+      githubDependencies,
+      reviewReader: { read },
+    });
+
+    const result = await Effect.runPromise(
+      adapter
+        .readContext({
+          repoConfig: createRepoConfig(),
+          linkedPullRequest: linkedPullRequest(),
+        })
+        .pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBe(failure);
+    }
+    expect(runCommandAllowFailure).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.test.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import type { GithubCommandDependencies } from "../../../application/tasks/support/github-pull-requests";
 import type { SystemCommandPort } from "../../../ports/system-command-port";
 import { createGithubPullRequestReviewAdapter } from "./github-pull-request-review-adapter";
-import type { GithubPullRequestReviewProvider } from "./github-pull-request-review-provider";
+import type { GithubPullRequestReviewReader } from "./github-pull-request-review-reader";
 
 const loadedContext: PullRequestReviewContext = {
   status: "loaded",
@@ -43,10 +43,10 @@ describe("createGithubPullRequestReviewAdapter", () => {
       toolDiscovery: {} as GithubCommandDependencies["toolDiscovery"],
     };
     const read = mock(() => Effect.succeed(loadedContext));
-    const reviewProvider: GithubPullRequestReviewProvider = { read };
+    const reviewReader: GithubPullRequestReviewReader = { read };
     const adapter = createGithubPullRequestReviewAdapter({
       githubDependencies,
-      reviewProvider,
+      reviewReader,
     });
     const repoConfig = repoConfigSchema.parse({
       workspaceId: "repo",

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 import { type PullRequestReviewContext, repoConfigSchema } from "@openducktor/contracts";
 import { Effect } from "effect";
-import type { GithubPullRequestReviewProvider } from "../../application/pull-requests/github-pull-request-review-provider";
-import type { GithubCommandDependencies } from "../../application/tasks/support/github-pull-requests";
-import type { SystemCommandPort } from "../../ports/system-command-port";
+import type { GithubCommandDependencies } from "../../../application/tasks/support/github-pull-requests";
+import type { SystemCommandPort } from "../../../ports/system-command-port";
 import { createGithubPullRequestReviewAdapter } from "./github-pull-request-review-adapter";
+import type { GithubPullRequestReviewProvider } from "./github-pull-request-review-provider";
 
 const loadedContext: PullRequestReviewContext = {
   status: "loaded",

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.ts
@@ -1,16 +1,16 @@
 import { pullRequestReviewContextSchema } from "@openducktor/contracts";
 import { Effect } from "effect";
 import {
-  createGithubPullRequestReviewProvider,
-  type GithubPullRequestReviewProvider,
-} from "../../application/pull-requests/github-pull-request-review-provider";
-import {
   GITHUB_PROVIDER_ID,
   type GithubCommandDependencies,
   requireGithubPullRequestReadRepository,
-} from "../../application/tasks/support/github-pull-requests";
-import { errorMessage, HostValidationError } from "../../effect/host-errors";
-import type { PullRequestReviewProviderPort } from "../../ports/pull-request-review-provider-port";
+} from "../../../application/tasks/support/github-pull-requests";
+import { errorMessage, HostValidationError } from "../../../effect/host-errors";
+import type { PullRequestReviewProviderPort } from "../../../ports/pull-request-review-provider-port";
+import {
+  createGithubPullRequestReviewProvider,
+  type GithubPullRequestReviewProvider,
+} from "./github-pull-request-review-provider";
 
 const unavailable = (reason: string) =>
   pullRequestReviewContextSchema.parse({
@@ -28,7 +28,6 @@ export const createGithubPullRequestReviewAdapter = ({
 }): PullRequestReviewProviderPort => {
   return {
     providerId: GITHUB_PROVIDER_ID,
-    isEnabled: (repoConfig) => repoConfig.git.providers[GITHUB_PROVIDER_ID]?.enabled === true,
     readContext(input) {
       return Effect.gen(function* () {
         if (input.linkedPullRequest.providerId !== GITHUB_PROVIDER_ID) {

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-adapter.ts
@@ -8,9 +8,9 @@ import {
 import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 import type { PullRequestReviewProviderPort } from "../../../ports/pull-request-review-provider-port";
 import {
-  createGithubPullRequestReviewProvider,
-  type GithubPullRequestReviewProvider,
-} from "./github-pull-request-review-provider";
+  createGithubPullRequestReviewReader,
+  type GithubPullRequestReviewReader,
+} from "./github-pull-request-review-reader";
 
 const unavailable = (reason: string) =>
   pullRequestReviewContextSchema.parse({
@@ -21,10 +21,10 @@ const unavailable = (reason: string) =>
 
 export const createGithubPullRequestReviewAdapter = ({
   githubDependencies,
-  reviewProvider = createGithubPullRequestReviewProvider(),
+  reviewReader = createGithubPullRequestReviewReader(),
 }: {
   githubDependencies: GithubCommandDependencies;
-  reviewProvider?: GithubPullRequestReviewProvider;
+  reviewReader?: GithubPullRequestReviewReader;
 }): PullRequestReviewProviderPort => {
   return {
     providerId: GITHUB_PROVIDER_ID,
@@ -47,7 +47,7 @@ export const createGithubPullRequestReviewAdapter = ({
           return unavailable(errorMessage(repositoryResult.left));
         }
 
-        return yield* reviewProvider.read({
+        return yield* reviewReader.read({
           dependencies: githubDependencies,
           repoPath,
           repository: repositoryResult.right,

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.test.ts
@@ -402,6 +402,24 @@ describe("loadGithubPullRequestReviewOverview", () => {
     }
   });
 
+  test("rejects a malformed review node with its provider field path", async () => {
+    const result = await Effect.runPromise(
+      loadGithubPullRequestReviewOverview(
+        input(
+          createDependencies({
+            response: responsePage({ comments: [], reviews: [null] }),
+          }),
+        ),
+      ).pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("HostValidationError");
+      expect(result.left.field).toBe("pullRequest.reviews.nodes.0");
+    }
+  });
+
   test("rejects malformed GraphQL connections through the typed error channel", async () => {
     const malformed = {
       data: {

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.test.ts
@@ -160,9 +160,17 @@ describe("loadGithubPullRequestReviewOverview", () => {
       },
     ]);
     expect(commands).toHaveLength(1);
-    expect(commands[0]?.join(" ")).toContain("avatarUrl(size: 64)");
-    expect(commands[0]?.join(" ")).toContain("state");
     const command = commands[0] ?? [];
+    expect(command.join(" ")).toContain("avatarUrl(size: 64)");
+    const queryArgument = command.find((argument) => argument.startsWith("query="));
+    expect(queryArgument).toBeDefined();
+    const query = queryArgument?.slice("query=".length) ?? "";
+    const commentsStart = query.indexOf("comments(");
+    const reviewsStart = query.indexOf("reviews(");
+    expect(commentsStart).toBeGreaterThan(-1);
+    expect(reviewsStart).toBeGreaterThan(commentsStart);
+    expect(query.slice(commentsStart, reviewsStart)).not.toContain("\n          state\n");
+    expect(query.slice(reviewsStart)).toContain("\n          state\n");
     const flagFor = (argument: string): string | undefined => {
       const index = command.indexOf(argument);
       return index > 0 ? command[index - 1] : undefined;
@@ -367,6 +375,28 @@ describe("loadGithubPullRequestReviewOverview", () => {
       expect(result.left._tag).toBe("HostValidationError");
       expect(result.left.field).toBe("pullRequest.reviews.nodes.0.state");
       expect(result.left.message).toContain("review state");
+    }
+  });
+
+  test("rejects a non-string review body through the typed error channel", async () => {
+    const result = await Effect.runPromise(
+      loadGithubPullRequestReviewOverview(
+        input(
+          createDependencies({
+            response: responsePage({
+              comments: [],
+              reviews: [{ id: "review-invalid", body: { text: "Review" }, state: "APPROVED" }],
+            }),
+          }),
+        ),
+      ).pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("HostValidationError");
+      expect(result.left.field).toBe("pullRequest.reviews.nodes.0.body");
+      expect(result.left.message).toContain("review body");
     }
   });
 

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
-import { HostOperationError } from "../../effect/host-errors";
-import type { SystemCommandPort } from "../../ports/system-command-port";
-import type { GithubCommandDependencies } from "../tasks/support/github-pull-requests";
+import type { GithubCommandDependencies } from "../../../application/tasks/support/github-pull-requests";
+import { HostOperationError } from "../../../effect/host-errors";
+import type { SystemCommandPort } from "../../../ports/system-command-port";
 import { loadGithubPullRequestReviewOverview } from "./github-pull-request-review-overview";
 
 const createDependencies = ({
@@ -104,6 +104,7 @@ describe("loadGithubPullRequestReviewOverview", () => {
                   id: "review-1",
                   author: { login: "reviewer", avatarUrl: reviewerAvatarUrl },
                   body: "Changes requested.",
+                  state: "CHANGES_REQUESTED",
                   url: "https://github.com/openai/openducktor/pull/42#pullrequestreview-1",
                   createdAt: "2026-07-08T10:02:00Z",
                   submittedAt: "2026-07-08T10:03:00Z",
@@ -155,10 +156,12 @@ describe("loadGithubPullRequestReviewOverview", () => {
         threadId: null,
         isResolved: null,
         source: "review",
+        reviewOutcome: "changes_requested",
       },
     ]);
     expect(commands).toHaveLength(1);
     expect(commands[0]?.join(" ")).toContain("avatarUrl(size: 64)");
+    expect(commands[0]?.join(" ")).toContain("state");
     const command = commands[0] ?? [];
     const flagFor = (argument: string): string | undefined => {
       const index = command.indexOf(argument);
@@ -209,6 +212,7 @@ describe("loadGithubPullRequestReviewOverview", () => {
             id: "review-1",
             author: { login: "reviewer", avatarUrl: reviewerAvatarUrl },
             body: "Only review page.",
+            state: "APPROVED",
             url: "https://example.com/review-1",
             createdAt: "2026-07-08T10:02:00Z",
             submittedAt: null,
@@ -229,6 +233,141 @@ describe("loadGithubPullRequestReviewOverview", () => {
     ]);
     expect(overview.comments[1]).toMatchObject({ author: null, authorAvatarUrl: null });
     expect(commands).toHaveLength(2);
+  });
+
+  test("continues review history after comments finish and keeps repeated reviewers", async () => {
+    const commands: string[][] = [];
+    const response = (args: string[]): unknown => {
+      const command = args.join(" ");
+      if (command.includes("reviewsCursor=reviews-page-2")) {
+        expect(command).toContain("includeComments=false");
+        expect(command).toContain("includeReviews=true");
+        return responsePage({
+          comments: [],
+          reviews: [
+            {
+              id: "review-2",
+              author: { login: "same-reviewer" },
+              body: "Second review",
+              state: "COMMENTED",
+              url: "https://example.com/review-2",
+              submittedAt: "2026-07-08T10:04:00Z",
+            },
+          ],
+        });
+      }
+      return responsePage({
+        comments: [],
+        reviews: [
+          {
+            id: "review-1",
+            author: { login: "same-reviewer" },
+            body: "First review",
+            state: "APPROVED",
+            url: "https://example.com/review-1",
+            submittedAt: "2026-07-08T10:02:00Z",
+          },
+        ],
+        reviewsPageInfo: { hasNextPage: true, endCursor: "reviews-page-2" },
+      });
+    };
+
+    const overview = await Effect.runPromise(
+      loadGithubPullRequestReviewOverview(input(createDependencies({ commands, response }))),
+    );
+
+    expect(
+      overview.comments.map((comment) => [
+        comment.id,
+        comment.author,
+        comment.url,
+        comment.createdAt,
+      ]),
+    ).toEqual([
+      ["review-1", "same-reviewer", "https://example.com/review-1", "2026-07-08T10:02:00Z"],
+      ["review-2", "same-reviewer", "https://example.com/review-2", "2026-07-08T10:04:00Z"],
+    ]);
+    expect(commands).toHaveLength(2);
+  });
+
+  test("maps every submitted review outcome and keeps bodyless reviews", async () => {
+    const overview = await Effect.runPromise(
+      loadGithubPullRequestReviewOverview(
+        input(
+          createDependencies({
+            response: responsePage({
+              comments: [],
+              reviews: [
+                { id: "approved", body: "", state: "APPROVED" },
+                { id: "changes", body: "   ", state: "CHANGES_REQUESTED" },
+                { id: "commented", body: "", state: "COMMENTED" },
+                { id: "dismissed", body: "", state: "DISMISSED" },
+              ],
+            }),
+          }),
+        ),
+      ),
+    );
+
+    expect(
+      overview.comments.map(({ id, body, source, reviewOutcome }) => ({
+        id,
+        body,
+        source,
+        reviewOutcome,
+      })),
+    ).toEqual([
+      { id: "approved", body: "", source: "review", reviewOutcome: "approved" },
+      { id: "changes", body: "   ", source: "review", reviewOutcome: "changes_requested" },
+      { id: "commented", body: "", source: "review", reviewOutcome: "commented" },
+      { id: "dismissed", body: "", source: "review", reviewOutcome: "dismissed" },
+    ]);
+  });
+
+  test("omits pending reviews with and without a body", async () => {
+    const overview = await Effect.runPromise(
+      loadGithubPullRequestReviewOverview(
+        input(
+          createDependencies({
+            response: responsePage({
+              comments: [],
+              reviews: [
+                { id: "pending-empty", body: "", state: "PENDING" },
+                { id: "pending-draft", body: "Draft guidance", state: "PENDING" },
+              ],
+            }),
+          }),
+        ),
+      ),
+    );
+
+    expect(overview.comments).toEqual([]);
+  });
+
+  test.each([
+    ["missing", undefined],
+    ["non-string", 42],
+    ["unsupported", "STALE"],
+  ])("rejects a %s review state through the typed error channel", async (_label, state) => {
+    const result = await Effect.runPromise(
+      loadGithubPullRequestReviewOverview(
+        input(
+          createDependencies({
+            response: responsePage({
+              comments: [],
+              reviews: [{ id: "review-invalid", body: "Review", state }],
+            }),
+          }),
+        ),
+      ).pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("HostValidationError");
+      expect(result.left.field).toBe("pullRequest.reviews.nodes.0.state");
+      expect(result.left.message).toContain("review state");
+    }
   });
 
   test("rejects malformed GraphQL connections through the typed error channel", async () => {

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.test.ts
@@ -163,14 +163,16 @@ describe("loadGithubPullRequestReviewOverview", () => {
     const command = commands[0] ?? [];
     expect(command.join(" ")).toContain("avatarUrl(size: 64)");
     const queryArgument = command.find((argument) => argument.startsWith("query="));
-    expect(queryArgument).toBeDefined();
-    const query = queryArgument?.slice("query=".length) ?? "";
+    if (!queryArgument) {
+      throw new Error("Expected the GitHub GraphQL query argument.");
+    }
+    const query = queryArgument.slice("query=".length);
     const commentsStart = query.indexOf("comments(");
     const reviewsStart = query.indexOf("reviews(");
     expect(commentsStart).toBeGreaterThan(-1);
     expect(reviewsStart).toBeGreaterThan(commentsStart);
-    expect(query.slice(commentsStart, reviewsStart)).not.toContain("\n          state\n");
-    expect(query.slice(reviewsStart)).toContain("\n          state\n");
+    expect(query.slice(commentsStart, reviewsStart)).not.toMatch(/^\s*state\s*$/mu);
+    expect(query.slice(reviewsStart)).toMatch(/^\s*state\s*$/mu);
     const flagFor = (argument: string): string | undefined => {
       const index = command.indexOf(argument);
       return index > 0 ? command[index - 1] : undefined;

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.ts
@@ -11,50 +11,14 @@ import {
   runGithubCommand,
 } from "../../../application/tasks/support/github-pull-requests";
 import { errorMessage, HostValidationError } from "../../../effect/host-errors";
-
-type GithubGraphqlPageInfoPayload = {
-  hasNextPage?: unknown;
-  endCursor?: unknown;
-};
-
-type GithubAuthorPayload = {
-  avatarUrl?: unknown;
-  login?: unknown;
-};
-
-type GithubReviewItemPayload = {
-  author?: GithubAuthorPayload | null;
-  body?: unknown;
-  createdAt?: unknown;
-  id?: unknown;
-  submittedAt?: unknown;
-  state?: unknown;
-  updatedAt?: unknown;
-  url?: unknown;
-};
-
-type GithubReviewConnectionPayload = {
-  nodes?: unknown;
-  pageInfo?: GithubGraphqlPageInfoPayload | null;
-};
-
-type GithubPullRequestPayload = {
-  comments?: GithubReviewConnectionPayload | null;
-  isDraft?: unknown;
-  number?: unknown;
-  reviews?: GithubReviewConnectionPayload | null;
-  state?: unknown;
-  title?: unknown;
-  url?: unknown;
-};
-
-type GithubReviewOverviewPayload = {
-  data?: {
-    repository?: {
-      pullRequest?: GithubPullRequestPayload | null;
-    } | null;
-  } | null;
-};
+import {
+  parseGithubJsonObject,
+  requireGithubBoolean,
+  requireGithubObject,
+  requireGithubString,
+  toNullableGithubObject,
+  toNullableGithubString,
+} from "./github-pull-request-review-payload";
 
 type GithubPullRequestReviewOverviewReadInput = {
   dependencies: GithubCommandDependencies;
@@ -142,20 +106,6 @@ query PullRequestReviewOverview(
 }
 `;
 
-const toNullableString = (value: unknown): string | null =>
-  typeof value === "string" && value.trim().length > 0 ? value : null;
-
-const requireString = (value: unknown, field: string): string => {
-  const parsed = toNullableString(value);
-  if (parsed) {
-    return parsed;
-  }
-  throw new HostValidationError({
-    field,
-    message: `GitHub pull request review field '${field}' is missing or invalid.`,
-  });
-};
-
 const requirePositiveNumber = (value: unknown, field: string): number => {
   if (typeof value === "number" && Number.isInteger(value) && value > 0) {
     return value;
@@ -180,37 +130,30 @@ const normalizeReviewState = (state: unknown, isDraft: unknown): PullRequestRevi
   return "open";
 };
 
-const parseNextCursor = (
-  pageInfo: GithubGraphqlPageInfoPayload | null | undefined,
-  field: string,
-): string | null => {
-  if (!pageInfo || typeof pageInfo.hasNextPage !== "boolean") {
-    throw new HostValidationError({
-      field,
-      message: `GitHub pull request review field '${field}' is missing or invalid.`,
-    });
-  }
-  return pageInfo.hasNextPage ? requireString(pageInfo.endCursor, `${field}.endCursor`) : null;
+const parseNextCursor = (pageInfoValue: unknown, field: string): string | null => {
+  const pageInfo = requireGithubObject(pageInfoValue, field);
+  return requireGithubBoolean(pageInfo.hasNextPage, `${field}.hasNextPage`)
+    ? requireGithubString(pageInfo.endCursor, `${field}.endCursor`)
+    : null;
 };
 
-const parseComment = (
-  payload: GithubReviewItemPayload,
-  field: string,
-): PullRequestReviewActivity | null => {
+const parseComment = (payloadValue: unknown, field: string): PullRequestReviewActivity | null => {
+  const payload = requireGithubObject(payloadValue, field);
   const body = typeof payload.body === "string" ? payload.body : "";
   if (!body.trim()) {
     return null;
   }
+  const author = toNullableGithubObject(payload.author, `${field}.author`);
   return {
-    id: requireString(payload.id, `${field}.id`),
-    author: toNullableString(payload.author?.login),
-    authorAvatarUrl: toNullableString(payload.author?.avatarUrl),
+    id: requireGithubString(payload.id, `${field}.id`),
+    author: toNullableGithubString(author?.login),
+    authorAvatarUrl: toNullableGithubString(author?.avatarUrl),
     body,
     patch: null,
     suggestionPatches: [],
-    url: toNullableString(payload.url),
-    createdAt: toNullableString(payload.createdAt),
-    updatedAt: toNullableString(payload.updatedAt),
+    url: toNullableGithubString(payload.url),
+    createdAt: toNullableGithubString(payload.createdAt),
+    updatedAt: toNullableGithubString(payload.updatedAt),
     path: null,
     line: null,
     threadId: null,
@@ -247,10 +190,8 @@ const parseReviewOutcome = (state: unknown, field: string): PullRequestReviewOut
   }
 };
 
-const parseReview = (
-  payload: GithubReviewItemPayload,
-  field: string,
-): PullRequestReviewActivity | null => {
+const parseReview = (payloadValue: unknown, field: string): PullRequestReviewActivity | null => {
+  const payload = requireGithubObject(payloadValue, field);
   const reviewOutcome = parseReviewOutcome(payload.state, `${field}.state`);
   if (!reviewOutcome) {
     return null;
@@ -262,16 +203,18 @@ const parseReview = (
       details: { receivedType: typeof payload.body },
     });
   }
+  const author = toNullableGithubObject(payload.author, `${field}.author`);
   return {
-    id: requireString(payload.id, `${field}.id`),
-    author: toNullableString(payload.author?.login),
-    authorAvatarUrl: toNullableString(payload.author?.avatarUrl),
+    id: requireGithubString(payload.id, `${field}.id`),
+    author: toNullableGithubString(author?.login),
+    authorAvatarUrl: toNullableGithubString(author?.avatarUrl),
     body: payload.body,
     patch: null,
     suggestionPatches: [],
-    url: toNullableString(payload.url),
-    createdAt: toNullableString(payload.submittedAt) ?? toNullableString(payload.createdAt),
-    updatedAt: toNullableString(payload.updatedAt),
+    url: toNullableGithubString(payload.url),
+    createdAt:
+      toNullableGithubString(payload.submittedAt) ?? toNullableGithubString(payload.createdAt),
+    updatedAt: toNullableGithubString(payload.updatedAt),
     path: null,
     line: null,
     threadId: null,
@@ -282,15 +225,16 @@ const parseReview = (
 };
 
 const parseConnection = (
-  connection: GithubReviewConnectionPayload | null | undefined,
+  connectionValue: unknown,
   field: string,
-  parseItem: (payload: GithubReviewItemPayload, field: string) => PullRequestReviewActivity | null,
+  parseItem: (payload: unknown, field: string) => PullRequestReviewActivity | null,
   included: boolean,
 ): ParsedConnection => {
   if (!included) {
     return { items: [], nextCursor: null };
   }
-  if (!connection || !Array.isArray(connection.nodes)) {
+  const connection = requireGithubObject(connectionValue, field);
+  if (!Array.isArray(connection.nodes)) {
     throw new HostValidationError({
       field,
       message: `GitHub pull request review field '${field}.nodes' is missing or invalid.`,
@@ -298,7 +242,7 @@ const parseConnection = (
   }
   const items: PullRequestReviewActivity[] = [];
   for (const [index, entry] of connection.nodes.entries()) {
-    const item = parseItem(entry as GithubReviewItemPayload, `${field}.nodes.${index}`);
+    const item = parseItem(entry, `${field}.nodes.${index}`);
     if (item) {
       items.push(item);
     }
@@ -314,30 +258,16 @@ const parseOverviewPage = (
   includeComments: boolean,
   includeReviews: boolean,
 ): ParsedOverviewPage => {
-  let parsed: GithubReviewOverviewPayload;
-  try {
-    parsed = JSON.parse(payload) as GithubReviewOverviewPayload;
-  } catch (cause) {
-    throw new HostValidationError({
-      field: "payload",
-      message: `Failed to parse GitHub pull request review response: ${errorMessage(cause)}`,
-      cause,
-    });
-  }
-  const pullRequest = parsed.data?.repository?.pullRequest;
-  if (!pullRequest) {
-    throw new HostValidationError({
-      field: "pullRequest",
-      message:
-        "Failed to parse GitHub pull request review response: expected data.repository.pullRequest.",
-    });
-  }
+  const parsed = parseGithubJsonObject(payload, "pull request review");
+  const data = requireGithubObject(parsed.data, "data");
+  const repository = requireGithubObject(data.repository, "repository");
+  const pullRequest = requireGithubObject(repository.pullRequest, "pullRequest");
   return {
     pullRequest: {
       providerId: "github",
       number: requirePositiveNumber(pullRequest.number, "number"),
-      title: requireString(pullRequest.title, "title"),
-      url: requireString(pullRequest.url, "url"),
+      title: requireGithubString(pullRequest.title, "title"),
+      url: requireGithubString(pullRequest.url, "url"),
       state: normalizeReviewState(pullRequest.state, pullRequest.isDraft),
     },
     comments: parseConnection(

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.ts
@@ -1,15 +1,16 @@
 import type {
   GitProviderRepository,
-  PullRequestReviewComment,
+  PullRequestReviewActivity,
+  PullRequestReviewOutcome,
   PullRequestReviewPullRequest,
   PullRequestReviewState,
 } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { errorMessage, HostValidationError } from "../../effect/host-errors";
 import {
   type GithubCommandDependencies,
   runGithubCommand,
-} from "../tasks/support/github-pull-requests";
+} from "../../../application/tasks/support/github-pull-requests";
+import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 
 type GithubGraphqlPageInfoPayload = {
   hasNextPage?: unknown;
@@ -27,6 +28,7 @@ type GithubReviewItemPayload = {
   createdAt?: unknown;
   id?: unknown;
   submittedAt?: unknown;
+  state?: unknown;
   updatedAt?: unknown;
   url?: unknown;
 };
@@ -68,11 +70,11 @@ type GithubGraphqlVariable = {
 
 type GithubPullRequestReviewOverview = {
   pullRequest: PullRequestReviewPullRequest;
-  comments: PullRequestReviewComment[];
+  comments: PullRequestReviewActivity[];
 };
 
 type ParsedConnection = {
-  items: PullRequestReviewComment[];
+  items: PullRequestReviewActivity[];
   nextCursor: string | null;
 };
 
@@ -107,6 +109,7 @@ query PullRequestReviewOverview(
             avatarUrl(size: 64)
           }
           body
+          state
           url
           createdAt
           updatedAt
@@ -192,14 +195,12 @@ const parseNextCursor = (
 
 const parseComment = (
   payload: GithubReviewItemPayload,
-  source: "comment" | "review",
   field: string,
-): PullRequestReviewComment | null => {
+): PullRequestReviewActivity | null => {
   const body = typeof payload.body === "string" ? payload.body : "";
   if (!body.trim()) {
     return null;
   }
-  const submittedAt = source === "review" ? toNullableString(payload.submittedAt) : null;
   return {
     id: requireString(payload.id, `${field}.id`),
     author: toNullableString(payload.author?.login),
@@ -208,20 +209,75 @@ const parseComment = (
     patch: null,
     suggestionPatches: [],
     url: toNullableString(payload.url),
-    createdAt: submittedAt ?? toNullableString(payload.createdAt),
+    createdAt: toNullableString(payload.createdAt),
     updatedAt: toNullableString(payload.updatedAt),
     path: null,
     line: null,
     threadId: null,
     isResolved: null,
-    source,
+    source: "comment",
+  };
+};
+
+const parseReviewOutcome = (state: unknown, field: string): PullRequestReviewOutcome | null => {
+  if (typeof state !== "string") {
+    throw new HostValidationError({
+      field,
+      message: `GitHub pull request review state '${field}' is missing or invalid.`,
+      details: { receivedType: typeof state },
+    });
+  }
+  switch (state) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "changes_requested";
+    case "COMMENTED":
+      return "commented";
+    case "DISMISSED":
+      return "dismissed";
+    case "PENDING":
+      return null;
+    default:
+      throw new HostValidationError({
+        field,
+        message: `GitHub pull request review state '${field}' has unsupported value '${state}'.`,
+        details: { state },
+      });
+  }
+};
+
+const parseReview = (
+  payload: GithubReviewItemPayload,
+  field: string,
+): PullRequestReviewActivity | null => {
+  const reviewOutcome = parseReviewOutcome(payload.state, `${field}.state`);
+  if (!reviewOutcome) {
+    return null;
+  }
+  return {
+    id: requireString(payload.id, `${field}.id`),
+    author: toNullableString(payload.author?.login),
+    authorAvatarUrl: toNullableString(payload.author?.avatarUrl),
+    body: typeof payload.body === "string" ? payload.body : "",
+    patch: null,
+    suggestionPatches: [],
+    url: toNullableString(payload.url),
+    createdAt: toNullableString(payload.submittedAt) ?? toNullableString(payload.createdAt),
+    updatedAt: toNullableString(payload.updatedAt),
+    path: null,
+    line: null,
+    threadId: null,
+    isResolved: null,
+    source: "review",
+    reviewOutcome,
   };
 };
 
 const parseConnection = (
   connection: GithubReviewConnectionPayload | null | undefined,
   field: string,
-  source: "comment" | "review",
+  parseItem: (payload: GithubReviewItemPayload, field: string) => PullRequestReviewActivity | null,
   included: boolean,
 ): ParsedConnection => {
   if (!included) {
@@ -233,15 +289,11 @@ const parseConnection = (
       message: `GitHub pull request review field '${field}.nodes' is missing or invalid.`,
     });
   }
-  const items: PullRequestReviewComment[] = [];
+  const items: PullRequestReviewActivity[] = [];
   for (const [index, entry] of connection.nodes.entries()) {
-    const comment = parseComment(
-      entry as GithubReviewItemPayload,
-      source,
-      `${field}.nodes.${index}`,
-    );
-    if (comment) {
-      items.push(comment);
+    const item = parseItem(entry as GithubReviewItemPayload, `${field}.nodes.${index}`);
+    if (item) {
+      items.push(item);
     }
   }
   return {
@@ -284,10 +336,15 @@ const parseOverviewPage = (
     comments: parseConnection(
       pullRequest.comments,
       "pullRequest.comments",
-      "comment",
+      parseComment,
       includeComments,
     ),
-    reviews: parseConnection(pullRequest.reviews, "pullRequest.reviews", "review", includeReviews),
+    reviews: parseConnection(
+      pullRequest.reviews,
+      "pullRequest.reviews",
+      parseReview,
+      includeReviews,
+    ),
   };
 };
 
@@ -320,8 +377,8 @@ export const loadGithubPullRequestReviewOverview = (
   input: GithubPullRequestReviewOverviewReadInput,
 ): Effect.Effect<GithubPullRequestReviewOverview, HostValidationError> =>
   Effect.gen(function* () {
-    const comments: PullRequestReviewComment[] = [];
-    const reviews: PullRequestReviewComment[] = [];
+    const comments: PullRequestReviewActivity[] = [];
+    const reviews: PullRequestReviewActivity[] = [];
     let pullRequest: PullRequestReviewPullRequest | null = null;
     let commentsCursor: string | null = null;
     let reviewsCursor: string | null = null;

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.ts
@@ -109,7 +109,6 @@ query PullRequestReviewOverview(
             avatarUrl(size: 64)
           }
           body
-          state
           url
           createdAt
           updatedAt
@@ -127,6 +126,7 @@ query PullRequestReviewOverview(
             avatarUrl(size: 64)
           }
           body
+          state
           url
           createdAt
           submittedAt
@@ -255,11 +255,18 @@ const parseReview = (
   if (!reviewOutcome) {
     return null;
   }
+  if (typeof payload.body !== "string") {
+    throw new HostValidationError({
+      field: `${field}.body`,
+      message: `GitHub pull request review body '${field}.body' is missing or invalid.`,
+      details: { receivedType: typeof payload.body },
+    });
+  }
   return {
     id: requireString(payload.id, `${field}.id`),
     author: toNullableString(payload.author?.login),
     authorAvatarUrl: toNullableString(payload.author?.avatarUrl),
-    body: typeof payload.body === "string" ? payload.body : "",
+    body: payload.body,
     patch: null,
     suggestionPatches: [],
     url: toNullableString(payload.url),

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-overview.ts
@@ -13,7 +13,7 @@ import {
 import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 import {
   parseGithubJsonObject,
-  requireGithubBoolean,
+  parseGithubNextPageCursor,
   requireGithubObject,
   requireGithubString,
   toNullableGithubObject,
@@ -130,13 +130,6 @@ const normalizeReviewState = (state: unknown, isDraft: unknown): PullRequestRevi
   return "open";
 };
 
-const parseNextCursor = (pageInfoValue: unknown, field: string): string | null => {
-  const pageInfo = requireGithubObject(pageInfoValue, field);
-  return requireGithubBoolean(pageInfo.hasNextPage, `${field}.hasNextPage`)
-    ? requireGithubString(pageInfo.endCursor, `${field}.endCursor`)
-    : null;
-};
-
 const parseComment = (payloadValue: unknown, field: string): PullRequestReviewActivity | null => {
   const payload = requireGithubObject(payloadValue, field);
   const body = typeof payload.body === "string" ? payload.body : "";
@@ -249,7 +242,7 @@ const parseConnection = (
   }
   return {
     items,
-    nextCursor: parseNextCursor(connection.pageInfo, `${field}.pageInfo`),
+    nextCursor: parseGithubNextPageCursor(connection.pageInfo, `${field}.pageInfo`),
   };
 };
 

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-payload.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-payload.ts
@@ -76,3 +76,10 @@ export const requireGithubBoolean = (value: unknown, field: string): boolean => 
   }
   return value;
 };
+
+export const parseGithubNextPageCursor = (pageInfoValue: unknown, field: string): string | null => {
+  const pageInfo = requireGithubObject(pageInfoValue, field);
+  return requireGithubBoolean(pageInfo.hasNextPage, `${field}.hasNextPage`)
+    ? requireGithubString(pageInfo.endCursor, `${field}.endCursor`)
+    : null;
+};

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-payload.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-payload.ts
@@ -1,0 +1,78 @@
+import { errorMessage, HostValidationError } from "../../../effect/host-errors";
+
+export type GithubPayloadObject = Record<string, unknown>;
+
+const isGithubPayloadObject = (value: unknown): value is GithubPayloadObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const githubPayloadValueType = (value: unknown): string => {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  return typeof value;
+};
+
+export const parseGithubJson = (payload: string, responseLabel: string): unknown => {
+  try {
+    return JSON.parse(payload);
+  } catch (cause) {
+    throw new HostValidationError({
+      field: "payload",
+      message: `Failed to parse GitHub ${responseLabel} response: ${errorMessage(cause)}`,
+      cause,
+    });
+  }
+};
+
+export const requireGithubObject = (value: unknown, field: string): GithubPayloadObject => {
+  if (!isGithubPayloadObject(value)) {
+    throw new HostValidationError({
+      field,
+      message: `GitHub pull request review field '${field}' is missing or invalid.`,
+      details: { receivedType: githubPayloadValueType(value) },
+    });
+  }
+  return value;
+};
+
+export const parseGithubJsonObject = (
+  payload: string,
+  responseLabel: string,
+): GithubPayloadObject => requireGithubObject(parseGithubJson(payload, responseLabel), "payload");
+
+export const toNullableGithubObject = (
+  value: unknown,
+  field: string,
+): GithubPayloadObject | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return requireGithubObject(value, field);
+};
+
+export const toNullableGithubString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null;
+
+export const requireGithubString = (value: unknown, field: string): string => {
+  const parsed = toNullableGithubString(value);
+  if (!parsed) {
+    throw new HostValidationError({
+      field,
+      message: `GitHub pull request review field '${field}' is missing or invalid.`,
+    });
+  }
+  return parsed;
+};
+
+export const requireGithubBoolean = (value: unknown, field: string): boolean => {
+  if (typeof value !== "boolean") {
+    throw new HostValidationError({
+      field,
+      message: `GitHub pull request review field '${field}' is missing or invalid.`,
+    });
+  }
+  return value;
+};

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-provider.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-provider.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
-import { HostOperationError } from "../../effect/host-errors";
-import type { SystemCommandPort } from "../../ports/system-command-port";
-import type { GithubCommandDependencies } from "../tasks/support/github-pull-requests";
+import type { GithubCommandDependencies } from "../../../application/tasks/support/github-pull-requests";
+import { HostOperationError } from "../../../effect/host-errors";
+import type { SystemCommandPort } from "../../../ports/system-command-port";
 import { createGithubPullRequestReviewProvider } from "./github-pull-request-review-provider";
 
 const createDependencies = ({
@@ -486,8 +486,11 @@ describe("createGithubPullRequestReviewProvider", () => {
     expect(
       context.comments
         .filter((comment) => comment.source === "review")
-        .map((comment) => comment.body),
-    ).toEqual(["Changes requested.", "Follow-up review."]);
+        .map((comment) => [comment.body, comment.reviewOutcome]),
+    ).toEqual([
+      ["Changes requested.", "changes_requested"],
+      ["Follow-up review.", "commented"],
+    ]);
   });
 
   test("includes unresolved code review threads alongside review summaries", async () => {

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-provider.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-provider.ts
@@ -8,10 +8,10 @@ import {
   pullRequestReviewContextSchema,
 } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { errorMessage, HostValidationError } from "../../effect/host-errors";
-import { combinedCommandOutput } from "../tasks/support/github-pull-request-model";
-import type { GithubCommandDependencies } from "../tasks/support/github-pull-requests";
-import { runGithubRepositoryCommandAllowFailure } from "../tasks/support/github-repository-command";
+import { combinedCommandOutput } from "../../../application/tasks/support/github-pull-request-model";
+import type { GithubCommandDependencies } from "../../../application/tasks/support/github-pull-requests";
+import { runGithubRepositoryCommandAllowFailure } from "../../../application/tasks/support/github-repository-command";
+import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 import { loadGithubPullRequestReviewOverview } from "./github-pull-request-review-overview";
 import { loadGithubReviewThreads } from "./github-pull-request-review-threads";
 

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-reader.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-reader.test.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import type { GithubCommandDependencies } from "../../../application/tasks/support/github-pull-requests";
 import { HostOperationError } from "../../../effect/host-errors";
 import type { SystemCommandPort } from "../../../ports/system-command-port";
-import { createGithubPullRequestReviewProvider } from "./github-pull-request-review-provider";
+import { createGithubPullRequestReviewReader } from "./github-pull-request-review-reader";
 
 const createDependencies = ({
   commandActivity,
@@ -363,9 +363,9 @@ const fairnestPullRequestViewResponse = {
   ],
 };
 
-describe("createGithubPullRequestReviewProvider", () => {
+describe("createGithubPullRequestReviewReader", () => {
   test("loads checks and comments through the gh command boundary", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
     const commands: string[][] = [];
 
     const context = await Effect.runPromise(
@@ -431,7 +431,7 @@ describe("createGithubPullRequestReviewProvider", () => {
   });
 
   test("scopes pull request gh commands to the configured host and repository", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
     const commands: string[][] = [];
 
     await Effect.runPromise(
@@ -458,7 +458,7 @@ describe("createGithubPullRequestReviewProvider", () => {
   });
 
   test("uses the full review history", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
     const pullRequestViewResponse = defaultPullRequestViewResponse() as {
       reviews: unknown[];
     };
@@ -494,7 +494,7 @@ describe("createGithubPullRequestReviewProvider", () => {
   });
 
   test("includes unresolved code review threads alongside review summaries", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
     const commands: string[][] = [];
 
     const context = await Effect.runPromise(
@@ -577,7 +577,7 @@ describe("createGithubPullRequestReviewProvider", () => {
     const suggestionBody = ["```suggestion", "const enabled = isReady && isValid;", "```"].join(
       "\n",
     );
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
     const context = await Effect.runPromise(
       provider.read({
         dependencies: createDependencies({
@@ -626,7 +626,7 @@ describe("createGithubPullRequestReviewProvider", () => {
 
   test("preserves suggestion markdown when an outdated comment has no line metadata", async () => {
     const suggestionBody = ["```suggestion", "const enabled = true;", "```"].join("\n");
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
     const context = await Effect.runPromise(
       provider.read({
         dependencies: createDependencies({
@@ -674,7 +674,7 @@ describe("createGithubPullRequestReviewProvider", () => {
 
   test("loads every review thread and comment page", async () => {
     const commands: string[][] = [];
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
     const reviewThreadResponse = (args: string[]): unknown => {
       const command = args.join(" ");
       if (command.includes("PullRequestReviewThreadComments")) {
@@ -796,7 +796,7 @@ describe("createGithubPullRequestReviewProvider", () => {
 
   test("loads independent pull request resources concurrently", async () => {
     const commandActivity = { active: 0, maxActive: 0 };
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
 
     await Effect.runPromise(
       provider.read({
@@ -811,7 +811,7 @@ describe("createGithubPullRequestReviewProvider", () => {
   });
 
   test("loads pending checks from gh exit code 8", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
 
     const context = await Effect.runPromise(
       provider.read({
@@ -847,7 +847,7 @@ describe("createGithubPullRequestReviewProvider", () => {
   });
 
   test("loads an empty check list when gh reports no checks", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
 
     const context = await Effect.runPromise(
       provider.read({
@@ -875,7 +875,7 @@ describe("createGithubPullRequestReviewProvider", () => {
   });
 
   test("returns malformed review contexts through the typed error channel", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
     const malformedView = {
       ...(defaultPullRequestViewResponse() as Record<string, unknown>),
       url: "not-a-url",
@@ -899,8 +899,50 @@ describe("createGithubPullRequestReviewProvider", () => {
     }
   });
 
+  test("rejects a malformed review thread node with its provider field path", async () => {
+    const reader = createGithubPullRequestReviewReader();
+    const result = await Effect.runPromise(
+      reader
+        .read({
+          dependencies: createDependencies({ reviewThreadNodes: [null] }),
+          repoPath: "/repo",
+          repository: { host: "github.com", owner: "openai", name: "openducktor" },
+          pullRequestNumber: 42,
+        })
+        .pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("HostValidationError");
+      expect(result.left.field).toBe("reviewThreads.nodes.0");
+    }
+  });
+
+  test("rejects a malformed check node with its provider field path", async () => {
+    const reader = createGithubPullRequestReviewReader();
+    const result = await Effect.runPromise(
+      reader
+        .read({
+          dependencies: createDependencies({
+            checksResponse: { ok: true, stdout: [null] },
+          }),
+          repoPath: "/repo",
+          repository: { host: "github.com", owner: "openai", name: "openducktor" },
+          pullRequestNumber: 42,
+        })
+        .pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("HostValidationError");
+      expect(result.left.field).toBe("checks.0");
+    }
+  });
+
   test("maps the gh cancel bucket to a cancelled check", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
 
     const context = await Effect.runPromise(
       provider.read({
@@ -933,7 +975,7 @@ describe("createGithubPullRequestReviewProvider", () => {
   });
 
   test("rejects non-pending gh checks failures", async () => {
-    const provider = createGithubPullRequestReviewProvider();
+    const provider = createGithubPullRequestReviewReader();
 
     await expect(
       Effect.runPromise(

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-reader.test.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-reader.test.ts
@@ -493,6 +493,101 @@ describe("createGithubPullRequestReviewReader", () => {
     ]);
   });
 
+  test("omits a bodyless commented review when its inline comments are loaded separately", async () => {
+    const provider = createGithubPullRequestReviewReader();
+    const commands: string[][] = [];
+    const pullRequestViewResponse = defaultPullRequestViewResponse() as {
+      reviews: unknown[];
+    };
+    pullRequestViewResponse.reviews.push(
+      {
+        id: "review-inline-only",
+        author: { login: "reviewer" },
+        body: "",
+        state: "COMMENTED",
+        submittedAt: "2026-07-08T10:03:00Z",
+      },
+      {
+        id: "review-standalone",
+        author: { login: "reviewer" },
+        body: "",
+        state: "COMMENTED",
+        submittedAt: "2026-07-08T10:04:00Z",
+      },
+      {
+        id: "review-with-summary",
+        author: { login: "reviewer" },
+        body: "Review summary.",
+        state: "COMMENTED",
+        submittedAt: "2026-07-08T10:05:00Z",
+      },
+    );
+
+    const context = await Effect.runPromise(
+      provider.read({
+        dependencies: createDependencies({
+          commands,
+          pullRequestViewResponse,
+          reviewThreadNodes: [
+            {
+              id: "thread-inline-replies",
+              isResolved: true,
+              comments: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    id: "thread-comment-inline-only",
+                    author: { login: "reviewer" },
+                    body: "Test",
+                    pullRequestReview: { id: "review-inline-only" },
+                    url: "https://github.com/openai/openducktor/pull/42#discussion-inline",
+                    createdAt: "2026-07-08T10:03:00Z",
+                    updatedAt: "2026-07-08T10:03:00Z",
+                    path: "packages/host/src/provider.ts",
+                    line: 33,
+                  },
+                  {
+                    id: "thread-comment-with-summary",
+                    author: { login: "reviewer" },
+                    body: "Inline detail.",
+                    pullRequestReview: { id: "review-with-summary" },
+                    url: "https://github.com/openai/openducktor/pull/42#discussion-summary",
+                    createdAt: "2026-07-08T10:05:00Z",
+                    updatedAt: "2026-07-08T10:05:00Z",
+                    path: "packages/host/src/provider.ts",
+                    line: 34,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        repoPath: "/repo",
+        repository: { host: "github.com", owner: "openai", name: "openducktor" },
+        pullRequestNumber: 42,
+      }),
+    );
+
+    expect(context.status).toBe("loaded");
+    if (context.status !== "loaded") {
+      return;
+    }
+    expect(
+      context.comments
+        .filter((comment) => comment.source === "review")
+        .map((comment) => comment.id),
+    ).toEqual(["review-1", "review-standalone", "review-with-summary"]);
+    expect(
+      context.comments
+        .filter((comment) => comment.source === "review_thread")
+        .map((comment) => comment.body),
+    ).toEqual(["Test", "Inline detail."]);
+    const reviewThreadCommand = commands.find((args) =>
+      args.join(" ").includes("PullRequestReviewThreads"),
+    );
+    expect(reviewThreadCommand?.join(" ")).toContain("pullRequestReview {");
+  });
+
   test("includes unresolved code review threads alongside review summaries", async () => {
     const provider = createGithubPullRequestReviewReader();
     const commands: string[][] = [];

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-reader.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-reader.ts
@@ -13,19 +13,13 @@ import type { GithubCommandDependencies } from "../../../application/tasks/suppo
 import { runGithubRepositoryCommandAllowFailure } from "../../../application/tasks/support/github-repository-command";
 import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 import { loadGithubPullRequestReviewOverview } from "./github-pull-request-review-overview";
+import {
+  parseGithubJson,
+  requireGithubObject,
+  requireGithubString,
+  toNullableGithubString,
+} from "./github-pull-request-review-payload";
 import { loadGithubReviewThreads } from "./github-pull-request-review-threads";
-
-type GithubCheckPayload = {
-  bucket?: unknown;
-  completedAt?: unknown;
-  description?: unknown;
-  event?: unknown;
-  link?: unknown;
-  name?: unknown;
-  startedAt?: unknown;
-  state?: unknown;
-  workflow?: unknown;
-};
 
 type GithubPullRequestReviewReadInput = {
   dependencies: GithubCommandDependencies;
@@ -34,7 +28,7 @@ type GithubPullRequestReviewReadInput = {
   pullRequestNumber: number;
 };
 
-export type GithubPullRequestReviewProvider = {
+export type GithubPullRequestReviewReader = {
   read(
     input: GithubPullRequestReviewReadInput,
   ): Effect.Effect<PullRequestReviewContext, HostValidationError>;
@@ -48,32 +42,6 @@ const isNoChecksReported = (result: {
   result.exitCode === 1 &&
   result.stdout.trim().length === 0 &&
   result.stderr.toLowerCase().includes("no checks reported");
-
-const toNullableString = (value: unknown): string | null =>
-  typeof value === "string" && value.trim().length > 0 ? value : null;
-
-const requireString = (value: unknown, field: string): string => {
-  const parsed = toNullableString(value);
-  if (!parsed) {
-    throw new HostValidationError({
-      field,
-      message: `GitHub pull request review field '${field}' is missing or invalid.`,
-    });
-  }
-  return parsed;
-};
-
-const parseJson = (payload: string, label: string): unknown => {
-  try {
-    return JSON.parse(payload);
-  } catch (cause) {
-    throw new HostValidationError({
-      field: "payload",
-      message: `Failed to parse GitHub ${label} response: ${errorMessage(cause)}`,
-      cause,
-    });
-  }
-};
 
 const normalizeCheckStatus = (state: unknown): PullRequestReviewCheckStatus => {
   const normalized = typeof state === "string" ? state.trim().toLowerCase() : "";
@@ -131,24 +99,24 @@ const normalizeCheckConclusion = (
 };
 
 const parseChecks = (payload: string): PullRequestReviewCheck[] => {
-  const parsed = parseJson(payload, "pull request checks");
+  const parsed = parseGithubJson(payload, "pull request checks");
   if (!Array.isArray(parsed)) {
     throw new HostValidationError({
       field: "payload",
       message: "Failed to parse GitHub pull request checks response: expected an array.",
     });
   }
-  return parsed.map((entry) => {
-    const check = entry as GithubCheckPayload;
+  return parsed.map((entry, index) => {
+    const check = requireGithubObject(entry, `checks.${index}`);
     return {
-      name: requireString(check.name, "name"),
-      workflow: toNullableString(check.workflow),
+      name: requireGithubString(check.name, `checks.${index}.name`),
+      workflow: toNullableGithubString(check.workflow),
       status: normalizeCheckStatus(check.state),
       conclusion: normalizeCheckConclusion(check.bucket, check.state),
-      url: toNullableString(check.link),
-      details: toNullableString(check.description) ?? toNullableString(check.event),
-      startedAt: toNullableString(check.startedAt),
-      completedAt: toNullableString(check.completedAt),
+      url: toNullableGithubString(check.link),
+      details: toNullableGithubString(check.description) ?? toNullableGithubString(check.event),
+      startedAt: toNullableGithubString(check.startedAt),
+      completedAt: toNullableGithubString(check.completedAt),
     };
   });
 };
@@ -179,7 +147,7 @@ const aggregateChecks = (
   return "neutral";
 };
 
-export const createGithubPullRequestReviewProvider = (): GithubPullRequestReviewProvider => ({
+export const createGithubPullRequestReviewReader = (): GithubPullRequestReviewReader => ({
   read(input) {
     return Effect.gen(function* () {
       const [overview, checksPayload, reviewThreads] = yield* Effect.all(
@@ -230,12 +198,16 @@ export const createGithubPullRequestReviewProvider = (): GithubPullRequestReview
       );
       const checks = yield* Effect.try({
         try: () => parseChecks(checksPayload),
-        catch: (cause) =>
-          new HostValidationError({
+        catch: (cause) => {
+          if (cause instanceof HostValidationError) {
+            return cause;
+          }
+          return new HostValidationError({
             field: "github.checks",
             message: errorMessage(cause),
             cause,
-          }),
+          });
+        },
       });
       return yield* Effect.try({
         try: () =>

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-reader.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-reader.ts
@@ -209,6 +209,16 @@ export const createGithubPullRequestReviewReader = (): GithubPullRequestReviewRe
           });
         },
       });
+      const overviewComments = overview.comments.filter((comment) => {
+        if (comment.source !== "review") {
+          return true;
+        }
+        const isInlineOnlyReview =
+          comment.reviewOutcome === "commented" &&
+          comment.body.length === 0 &&
+          reviewThreads.reviewIdsWithComments.has(comment.id);
+        return !isInlineOnlyReview;
+      });
       return yield* Effect.try({
         try: () =>
           pullRequestReviewContextSchema.parse({
@@ -217,7 +227,7 @@ export const createGithubPullRequestReviewReader = (): GithubPullRequestReviewRe
             pullRequest: overview.pullRequest,
             aggregateStatus: aggregateChecks(checks),
             checks,
-            comments: [...overview.comments, ...reviewThreads.comments],
+            comments: [...overviewComments, ...reviewThreads.comments],
             reviewThreads: reviewThreads.summary,
             refreshedAt: new Date().toISOString(),
           }),

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-suggestions.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-suggestions.ts
@@ -1,4 +1,4 @@
-import { HostValidationError } from "../../effect/host-errors";
+import { HostValidationError } from "../../../effect/host-errors";
 
 type GithubReviewCommentContentInput = {
   body: string;

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-threads.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-threads.ts
@@ -26,12 +26,19 @@ export type ParsedReviewThreadsPage = {
   openThreadIds: string[];
   nextThreadsCursor: string | null;
   commentPageCursors: ReviewThreadCommentsCursor[];
+  reviewIdsWithComments: string[];
 };
 
 export type ParsedReviewThreadCommentsPage = {
   comments: PullRequestReviewActivity[];
   nextCommentsCursor: string | null;
+  reviewIdsWithComments: string[];
   threadId: string;
+};
+
+type ParsedReviewThreadComment = {
+  activity: PullRequestReviewActivity;
+  reviewId: string | null;
 };
 
 const REVIEW_THREAD_COMMENT_FIELDS = `
@@ -41,6 +48,9 @@ const REVIEW_THREAD_COMMENT_FIELDS = `
     avatarUrl(size: 64)
   }
   body
+  pullRequestReview {
+    id
+  }
   diffHunk
   url
   createdAt
@@ -113,7 +123,7 @@ const toReviewThreadComment = (
   field: string,
   threadId: string,
   isResolved: boolean,
-): PullRequestReviewActivity | null => {
+): ParsedReviewThreadComment | null => {
   const payload = requireGithubObject(payloadValue, field);
   const body = typeof payload.body === "string" ? payload.body : "";
   const patch = toNullableGithubString(payload.diffHunk);
@@ -130,21 +140,25 @@ const toReviewThreadComment = (
     return null;
   }
   const author = toNullableGithubObject(payload.author, `${field}.author`);
+  const review = toNullableGithubObject(payload.pullRequestReview, `${field}.pullRequestReview`);
   return {
-    id: requireGithubString(payload.id, `${field}.id`),
-    author: toNullableGithubString(author?.login),
-    authorAvatarUrl: toNullableGithubString(author?.avatarUrl),
-    body: content.body,
-    patch,
-    suggestionPatches: content.suggestionPatches,
-    url: toNullableGithubString(payload.url),
-    createdAt: toNullableGithubString(payload.createdAt),
-    updatedAt: toNullableGithubString(payload.updatedAt),
-    path: toNullableGithubString(payload.path),
-    line,
-    threadId,
-    isResolved,
-    source: "review_thread",
+    activity: {
+      id: requireGithubString(payload.id, `${field}.id`),
+      author: toNullableGithubString(author?.login),
+      authorAvatarUrl: toNullableGithubString(author?.avatarUrl),
+      body: content.body,
+      patch,
+      suggestionPatches: content.suggestionPatches,
+      url: toNullableGithubString(payload.url),
+      createdAt: toNullableGithubString(payload.createdAt),
+      updatedAt: toNullableGithubString(payload.updatedAt),
+      path: toNullableGithubString(payload.path),
+      line,
+      threadId,
+      isResolved,
+      source: "review_thread",
+    },
+    reviewId: review ? requireGithubString(review.id, `${field}.pullRequestReview.id`) : null,
   };
 };
 
@@ -160,6 +174,7 @@ const parseThread = (threadValue: unknown, field: string) => {
     });
   }
   const comments: PullRequestReviewActivity[] = [];
+  const reviewIdsWithComments: string[] = [];
   for (const [index, comment] of commentsConnection.nodes.entries()) {
     const normalized = toReviewThreadComment(
       comment,
@@ -168,7 +183,10 @@ const parseThread = (threadValue: unknown, field: string) => {
       isResolved,
     );
     if (normalized) {
-      comments.push(normalized);
+      comments.push(normalized.activity);
+      if (normalized.reviewId) {
+        reviewIdsWithComments.push(normalized.reviewId);
+      }
     }
   }
   return {
@@ -178,6 +196,7 @@ const parseThread = (threadValue: unknown, field: string) => {
       commentsConnection.pageInfo,
       `${field}.comments.pageInfo`,
     ),
+    reviewIdsWithComments,
     threadId,
   };
 };
@@ -198,9 +217,11 @@ const parseReviewThreadsPage = (payload: string): ParsedReviewThreadsPage => {
   const comments: PullRequestReviewActivity[] = [];
   const openThreadIds: string[] = [];
   const commentPageCursors: ReviewThreadCommentsCursor[] = [];
+  const reviewIdsWithComments: string[] = [];
   for (const [index, thread] of reviewThreads.nodes.entries()) {
     const parsedThread = parseThread(thread, `reviewThreads.nodes.${index}`);
     comments.push(...parsedThread.comments);
+    reviewIdsWithComments.push(...parsedThread.reviewIdsWithComments);
     if (!parsedThread.isResolved) {
       openThreadIds.push(parsedThread.threadId);
     }
@@ -216,6 +237,7 @@ const parseReviewThreadsPage = (payload: string): ParsedReviewThreadsPage => {
     openThreadIds,
     nextThreadsCursor: parseGithubNextPageCursor(reviewThreads.pageInfo, "reviewThreads.pageInfo"),
     commentPageCursors,
+    reviewIdsWithComments,
   };
 };
 
@@ -226,6 +248,7 @@ const parseReviewThreadCommentsPage = (payload: string): ParsedReviewThreadComme
   return {
     comments: thread.comments,
     nextCommentsCursor: thread.nextCommentsCursor,
+    reviewIdsWithComments: thread.reviewIdsWithComments,
     threadId: thread.threadId,
   };
 };
@@ -264,6 +287,7 @@ export const loadGithubReviewThreads = (input: GithubReviewThreadsReadInput) =>
   Effect.gen(function* () {
     const comments: PullRequestReviewActivity[] = [];
     const openThreadIds = new Set<string>();
+    const reviewIdsWithComments = new Set<string>();
     let threadsCursor: string | null = null;
 
     do {
@@ -290,6 +314,9 @@ export const loadGithubReviewThreads = (input: GithubReviewThreadsReadInput) =>
         },
       });
       comments.push(...page.comments);
+      for (const reviewId of page.reviewIdsWithComments) {
+        reviewIdsWithComments.add(reviewId);
+      }
       for (const threadId of page.openThreadIds) {
         openThreadIds.add(threadId);
       }
@@ -327,6 +354,9 @@ export const loadGithubReviewThreads = (input: GithubReviewThreadsReadInput) =>
             );
           }
           comments.push(...parsedCommentsPage.comments);
+          for (const reviewId of parsedCommentsPage.reviewIdsWithComments) {
+            reviewIdsWithComments.add(reviewId);
+          }
           commentsCursor = parsedCommentsPage.nextCommentsCursor;
         }
       }
@@ -336,6 +366,7 @@ export const loadGithubReviewThreads = (input: GithubReviewThreadsReadInput) =>
 
     return {
       comments,
+      reviewIdsWithComments,
       summary: { openCount: openThreadIds.size },
     };
   });

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-threads.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-threads.ts
@@ -7,6 +7,7 @@ import {
 import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 import {
   parseGithubJsonObject,
+  parseGithubNextPageCursor,
   requireGithubBoolean,
   requireGithubObject,
   requireGithubString,
@@ -107,12 +108,6 @@ query PullRequestReviewThreadComments($threadId: ID!, $commentsCursor: String) {
 const toNullableNumber = (value: unknown): number | null =>
   typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
 
-const parseNextCursor = (pageInfoValue: unknown, field: string): string | null => {
-  const pageInfo = requireGithubObject(pageInfoValue, field);
-  const hasNextPage = requireGithubBoolean(pageInfo.hasNextPage, `${field}.hasNextPage`);
-  return hasNextPage ? requireGithubString(pageInfo.endCursor, `${field}.endCursor`) : null;
-};
-
 const toReviewThreadComment = (
   payloadValue: unknown,
   field: string,
@@ -179,7 +174,10 @@ const parseThread = (threadValue: unknown, field: string) => {
   return {
     comments,
     isResolved,
-    nextCommentsCursor: parseNextCursor(commentsConnection.pageInfo, `${field}.comments.pageInfo`),
+    nextCommentsCursor: parseGithubNextPageCursor(
+      commentsConnection.pageInfo,
+      `${field}.comments.pageInfo`,
+    ),
     threadId,
   };
 };
@@ -216,7 +214,7 @@ const parseReviewThreadsPage = (payload: string): ParsedReviewThreadsPage => {
   return {
     comments,
     openThreadIds,
-    nextThreadsCursor: parseNextCursor(reviewThreads.pageInfo, "reviewThreads.pageInfo"),
+    nextThreadsCursor: parseGithubNextPageCursor(reviewThreads.pageInfo, "reviewThreads.pageInfo"),
     commentPageCursors,
   };
 };

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-threads.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-threads.ts
@@ -5,55 +5,15 @@ import {
   runGithubCommand,
 } from "../../../application/tasks/support/github-pull-requests";
 import { errorMessage, HostValidationError } from "../../../effect/host-errors";
+import {
+  parseGithubJsonObject,
+  requireGithubBoolean,
+  requireGithubObject,
+  requireGithubString,
+  toNullableGithubObject,
+  toNullableGithubString,
+} from "./github-pull-request-review-payload";
 import { parseGithubReviewCommentContent } from "./github-pull-request-review-suggestions";
-
-type GithubGraphqlPageInfoPayload = {
-  hasNextPage?: unknown;
-  endCursor?: unknown;
-};
-
-type GithubGraphqlReviewThreadCommentPayload = {
-  id?: unknown;
-  author?: { login?: unknown; avatarUrl?: unknown } | null;
-  body?: unknown;
-  diffHunk?: unknown;
-  createdAt?: unknown;
-  updatedAt?: unknown;
-  url?: unknown;
-  path?: unknown;
-  line?: unknown;
-  startLine?: unknown;
-  originalLine?: unknown;
-  originalStartLine?: unknown;
-};
-
-type GithubGraphqlReviewThreadPayload = {
-  id?: unknown;
-  isResolved?: unknown;
-  comments?: {
-    nodes?: unknown;
-    pageInfo?: GithubGraphqlPageInfoPayload | null;
-  } | null;
-};
-
-type GithubGraphqlReviewThreadsPayload = {
-  data?: {
-    repository?: {
-      pullRequest?: {
-        reviewThreads?: {
-          nodes?: unknown;
-          pageInfo?: GithubGraphqlPageInfoPayload | null;
-        } | null;
-      } | null;
-    } | null;
-  } | null;
-};
-
-type GithubGraphqlReviewThreadCommentsPayload = {
-  data?: {
-    node?: GithubGraphqlReviewThreadPayload | null;
-  } | null;
-};
 
 export type ReviewThreadCommentsCursor = {
   threadId: string;
@@ -144,66 +104,24 @@ query PullRequestReviewThreadComments($threadId: ID!, $commentsCursor: String) {
 }
 `;
 
-const toNullableString = (value: unknown): string | null =>
-  typeof value === "string" && value.trim().length > 0 ? value : null;
-
 const toNullableNumber = (value: unknown): number | null =>
   typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
 
-const requireString = (value: unknown, field: string): string => {
-  const parsed = toNullableString(value);
-  if (!parsed) {
-    throw new HostValidationError({
-      field,
-      message: `GitHub pull request review field '${field}' is missing or invalid.`,
-    });
-  }
-  return parsed;
-};
-
-const requireBoolean = (value: unknown, field: string): boolean => {
-  if (typeof value !== "boolean") {
-    throw new HostValidationError({
-      field,
-      message: `GitHub pull request review field '${field}' is missing or invalid.`,
-    });
-  }
-  return value;
-};
-
-const parseJson = (payload: string): unknown => {
-  try {
-    return JSON.parse(payload);
-  } catch (cause) {
-    throw new HostValidationError({
-      field: "payload",
-      message: `Failed to parse GitHub pull request review threads response: ${errorMessage(cause)}`,
-      cause,
-    });
-  }
-};
-
-const parseNextCursor = (
-  pageInfo: GithubGraphqlPageInfoPayload | null | undefined,
-  field: string,
-): string | null => {
-  if (!pageInfo) {
-    throw new HostValidationError({
-      field,
-      message: `GitHub pull request review field '${field}' is missing or invalid.`,
-    });
-  }
-  const hasNextPage = requireBoolean(pageInfo.hasNextPage, `${field}.hasNextPage`);
-  return hasNextPage ? requireString(pageInfo.endCursor, `${field}.endCursor`) : null;
+const parseNextCursor = (pageInfoValue: unknown, field: string): string | null => {
+  const pageInfo = requireGithubObject(pageInfoValue, field);
+  const hasNextPage = requireGithubBoolean(pageInfo.hasNextPage, `${field}.hasNextPage`);
+  return hasNextPage ? requireGithubString(pageInfo.endCursor, `${field}.endCursor`) : null;
 };
 
 const toReviewThreadComment = (
-  payload: GithubGraphqlReviewThreadCommentPayload,
+  payloadValue: unknown,
+  field: string,
   threadId: string,
   isResolved: boolean,
 ): PullRequestReviewActivity | null => {
+  const payload = requireGithubObject(payloadValue, field);
   const body = typeof payload.body === "string" ? payload.body : "";
-  const patch = toNullableString(payload.diffHunk);
+  const patch = toNullableGithubString(payload.diffHunk);
   const line = toNullableNumber(payload.line) ?? toNullableNumber(payload.originalLine);
   const startLine =
     toNullableNumber(payload.startLine) ?? toNullableNumber(payload.originalStartLine) ?? line;
@@ -216,17 +134,18 @@ const toReviewThreadComment = (
   if (!content.body && content.suggestionPatches.length === 0) {
     return null;
   }
+  const author = toNullableGithubObject(payload.author, `${field}.author`);
   return {
-    id: requireString(payload.id, "id"),
-    author: toNullableString(payload.author?.login),
-    authorAvatarUrl: toNullableString(payload.author?.avatarUrl),
+    id: requireGithubString(payload.id, `${field}.id`),
+    author: toNullableGithubString(author?.login),
+    authorAvatarUrl: toNullableGithubString(author?.avatarUrl),
     body: content.body,
     patch,
     suggestionPatches: content.suggestionPatches,
-    url: toNullableString(payload.url),
-    createdAt: toNullableString(payload.createdAt),
-    updatedAt: toNullableString(payload.updatedAt),
-    path: toNullableString(payload.path),
+    url: toNullableGithubString(payload.url),
+    createdAt: toNullableGithubString(payload.createdAt),
+    updatedAt: toNullableGithubString(payload.updatedAt),
+    path: toNullableGithubString(payload.path),
     line,
     threadId,
     isResolved,
@@ -234,19 +153,22 @@ const toReviewThreadComment = (
   };
 };
 
-const parseThread = (thread: GithubGraphqlReviewThreadPayload) => {
-  const threadId = requireString(thread.id, "thread.id");
-  const isResolved = requireBoolean(thread.isResolved, "thread.isResolved");
-  if (!Array.isArray(thread.comments?.nodes)) {
+const parseThread = (threadValue: unknown, field: string) => {
+  const thread = requireGithubObject(threadValue, field);
+  const threadId = requireGithubString(thread.id, `${field}.id`);
+  const isResolved = requireGithubBoolean(thread.isResolved, `${field}.isResolved`);
+  const commentsConnection = requireGithubObject(thread.comments, `${field}.comments`);
+  if (!Array.isArray(commentsConnection.nodes)) {
     throw new HostValidationError({
-      field: "thread.comments.nodes",
-      message: "GitHub pull request review field 'thread.comments.nodes' is missing or invalid.",
+      field: `${field}.comments.nodes`,
+      message: `GitHub pull request review field '${field}.comments.nodes' is missing or invalid.`,
     });
   }
   const comments: PullRequestReviewActivity[] = [];
-  for (const comment of thread.comments.nodes) {
+  for (const [index, comment] of commentsConnection.nodes.entries()) {
     const normalized = toReviewThreadComment(
-      comment as GithubGraphqlReviewThreadCommentPayload,
+      comment,
+      `${field}.comments.nodes.${index}`,
       threadId,
       isResolved,
     );
@@ -257,26 +179,18 @@ const parseThread = (thread: GithubGraphqlReviewThreadPayload) => {
   return {
     comments,
     isResolved,
-    nextCommentsCursor: parseNextCursor(thread.comments.pageInfo, "thread.comments.pageInfo"),
+    nextCommentsCursor: parseNextCursor(commentsConnection.pageInfo, `${field}.comments.pageInfo`),
     threadId,
   };
 };
 
-const requireObjectPayload = (payload: string): Record<string, unknown> => {
-  const parsed = parseJson(payload);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new HostValidationError({
-      field: "payload",
-      message: "Failed to parse GitHub pull request review threads response: expected an object.",
-    });
-  }
-  return parsed as Record<string, unknown>;
-};
-
 const parseReviewThreadsPage = (payload: string): ParsedReviewThreadsPage => {
-  const parsed = requireObjectPayload(payload) as GithubGraphqlReviewThreadsPayload;
-  const reviewThreads = parsed.data?.repository?.pullRequest?.reviewThreads;
-  if (!Array.isArray(reviewThreads?.nodes)) {
+  const parsed = parseGithubJsonObject(payload, "pull request review threads");
+  const data = requireGithubObject(parsed.data, "data");
+  const repository = requireGithubObject(data.repository, "repository");
+  const pullRequest = requireGithubObject(repository.pullRequest, "pullRequest");
+  const reviewThreads = requireGithubObject(pullRequest.reviewThreads, "reviewThreads");
+  if (!Array.isArray(reviewThreads.nodes)) {
     throw new HostValidationError({
       field: "reviewThreads.nodes",
       message:
@@ -286,8 +200,8 @@ const parseReviewThreadsPage = (payload: string): ParsedReviewThreadsPage => {
   const comments: PullRequestReviewActivity[] = [];
   const openThreadIds: string[] = [];
   const commentPageCursors: ReviewThreadCommentsCursor[] = [];
-  for (const thread of reviewThreads.nodes) {
-    const parsedThread = parseThread(thread as GithubGraphqlReviewThreadPayload);
+  for (const [index, thread] of reviewThreads.nodes.entries()) {
+    const parsedThread = parseThread(thread, `reviewThreads.nodes.${index}`);
     comments.push(...parsedThread.comments);
     if (!parsedThread.isResolved) {
       openThreadIds.push(parsedThread.threadId);
@@ -308,15 +222,9 @@ const parseReviewThreadsPage = (payload: string): ParsedReviewThreadsPage => {
 };
 
 const parseReviewThreadCommentsPage = (payload: string): ParsedReviewThreadCommentsPage => {
-  const parsed = requireObjectPayload(payload) as GithubGraphqlReviewThreadCommentsPayload;
-  if (!parsed.data?.node) {
-    throw new HostValidationError({
-      field: "node",
-      message:
-        "Failed to parse GitHub pull request review thread comments response: expected data.node.",
-    });
-  }
-  const thread = parseThread(parsed.data.node);
+  const parsed = parseGithubJsonObject(payload, "pull request review thread comments");
+  const data = requireGithubObject(parsed.data, "data");
+  const thread = parseThread(data.node, "node");
   return {
     comments: thread.comments,
     nextCommentsCursor: thread.nextCommentsCursor,
@@ -372,12 +280,16 @@ export const loadGithubReviewThreads = (input: GithubReviewThreadsReadInput) =>
       const payload = yield* runReviewGraphql(input, REVIEW_THREADS_QUERY, variables);
       const page = yield* Effect.try({
         try: () => parseReviewThreadsPage(payload),
-        catch: (cause) =>
-          new HostValidationError({
+        catch: (cause) => {
+          if (cause instanceof HostValidationError) {
+            return cause;
+          }
+          return new HostValidationError({
             field: "github.review_threads",
             message: errorMessage(cause),
             cause,
-          }),
+          });
+        },
       });
       comments.push(...page.comments);
       for (const threadId of page.openThreadIds) {
@@ -397,12 +309,16 @@ export const loadGithubReviewThreads = (input: GithubReviewThreadsReadInput) =>
           );
           const parsedCommentsPage: ParsedReviewThreadCommentsPage = yield* Effect.try({
             try: () => parseReviewThreadCommentsPage(commentsPayload),
-            catch: (cause) =>
-              new HostValidationError({
+            catch: (cause) => {
+              if (cause instanceof HostValidationError) {
+                return cause;
+              }
+              return new HostValidationError({
                 field: "github.review_threads",
                 message: errorMessage(cause),
                 cause,
-              }),
+              });
+            },
           });
           if (parsedCommentsPage.threadId !== commentPage.threadId) {
             return yield* Effect.fail(

--- a/packages/host/src/adapters/pull-requests/github/github-pull-request-review-threads.ts
+++ b/packages/host/src/adapters/pull-requests/github/github-pull-request-review-threads.ts
@@ -1,10 +1,10 @@
-import type { GitProviderRepository, PullRequestReviewComment } from "@openducktor/contracts";
+import type { GitProviderRepository, PullRequestReviewActivity } from "@openducktor/contracts";
 import { Effect } from "effect";
-import { errorMessage, HostValidationError } from "../../effect/host-errors";
 import {
   type GithubCommandDependencies,
   runGithubCommand,
-} from "../tasks/support/github-pull-requests";
+} from "../../../application/tasks/support/github-pull-requests";
+import { errorMessage, HostValidationError } from "../../../effect/host-errors";
 import { parseGithubReviewCommentContent } from "./github-pull-request-review-suggestions";
 
 type GithubGraphqlPageInfoPayload = {
@@ -61,14 +61,14 @@ export type ReviewThreadCommentsCursor = {
 };
 
 export type ParsedReviewThreadsPage = {
-  comments: PullRequestReviewComment[];
+  comments: PullRequestReviewActivity[];
   openThreadIds: string[];
   nextThreadsCursor: string | null;
   commentPageCursors: ReviewThreadCommentsCursor[];
 };
 
 export type ParsedReviewThreadCommentsPage = {
-  comments: PullRequestReviewComment[];
+  comments: PullRequestReviewActivity[];
   nextCommentsCursor: string | null;
   threadId: string;
 };
@@ -201,7 +201,7 @@ const toReviewThreadComment = (
   payload: GithubGraphqlReviewThreadCommentPayload,
   threadId: string,
   isResolved: boolean,
-): PullRequestReviewComment | null => {
+): PullRequestReviewActivity | null => {
   const body = typeof payload.body === "string" ? payload.body : "";
   const patch = toNullableString(payload.diffHunk);
   const line = toNullableNumber(payload.line) ?? toNullableNumber(payload.originalLine);
@@ -243,7 +243,7 @@ const parseThread = (thread: GithubGraphqlReviewThreadPayload) => {
       message: "GitHub pull request review field 'thread.comments.nodes' is missing or invalid.",
     });
   }
-  const comments: PullRequestReviewComment[] = [];
+  const comments: PullRequestReviewActivity[] = [];
   for (const comment of thread.comments.nodes) {
     const normalized = toReviewThreadComment(
       comment as GithubGraphqlReviewThreadCommentPayload,
@@ -283,7 +283,7 @@ const parseReviewThreadsPage = (payload: string): ParsedReviewThreadsPage => {
         "Failed to parse GitHub pull request review threads response: expected data.repository.pullRequest.reviewThreads.nodes.",
     });
   }
-  const comments: PullRequestReviewComment[] = [];
+  const comments: PullRequestReviewActivity[] = [];
   const openThreadIds: string[] = [];
   const commentPageCursors: ReviewThreadCommentsCursor[] = [];
   for (const thread of reviewThreads.nodes) {
@@ -356,7 +356,7 @@ const runReviewGraphql = (
 
 export const loadGithubReviewThreads = (input: GithubReviewThreadsReadInput) =>
   Effect.gen(function* () {
-    const comments: PullRequestReviewComment[] = [];
+    const comments: PullRequestReviewActivity[] = [];
     const openThreadIds = new Set<string>();
     let threadsCursor: string | null = null;
 

--- a/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
+++ b/packages/host/src/application/pull-requests/pull-request-review-service.test.ts
@@ -75,7 +75,25 @@ const makeLoadedContext = (providerId: GitProviderId): PullRequestReviewContext 
   },
   aggregateStatus: "success",
   checks: [],
-  comments: [],
+  comments: [
+    {
+      id: "review-1",
+      author: "reviewer",
+      authorAvatarUrl: null,
+      body: "",
+      patch: null,
+      suggestionPatches: [],
+      url: null,
+      createdAt: "2026-07-10T08:00:00.000Z",
+      updatedAt: null,
+      path: null,
+      line: null,
+      threadId: null,
+      isResolved: null,
+      source: "review",
+      reviewOutcome: "approved",
+    },
+  ],
   reviewThreads: { openCount: 0 },
   refreshedAt: "2026-07-10T08:00:00.000Z",
 });
@@ -109,12 +127,10 @@ describe("createPullRequestReviewService", () => {
       providers: [
         {
           providerId: "github",
-          isEnabled: () => true,
           readContext: githubReadContext,
         },
         {
           providerId: "gitlab",
-          isEnabled: () => true,
           readContext: gitlabReadContext,
         },
       ],
@@ -136,7 +152,6 @@ describe("createPullRequestReviewService", () => {
       providers: [
         {
           providerId: "github",
-          isEnabled: () => true,
           readContext: githubReadContext,
         },
       ],
@@ -160,7 +175,6 @@ describe("createPullRequestReviewService", () => {
       providers: [
         {
           providerId: "github",
-          isEnabled: () => true,
           readContext: githubReadContext,
         },
       ],

--- a/packages/host/src/composition/node/create-node-host-command-router.ts
+++ b/packages/host/src/composition/node/create-node-host-command-router.ts
@@ -11,7 +11,7 @@ import {
   resolveMcpBridgeDiscoveryPath,
 } from "../../adapters/mcp/mcp-host-bridge-server";
 import { createOpenCodeWorkspaceRuntimeStarter } from "../../adapters/opencode/opencode-workspace-runtime-starter";
-import { createGithubPullRequestReviewAdapter } from "../../adapters/pull-requests/github-pull-request-review-adapter";
+import { createGithubPullRequestReviewAdapter } from "../../adapters/pull-requests/github/github-pull-request-review-adapter";
 import { createRuntimeRegistry } from "../../adapters/runtimes/runtime-registry";
 import { createRuntimeTaskActivityGuard } from "../../adapters/runtimes/runtime-task-activity-guard";
 import { createSqliteTaskRepository } from "../../adapters/sqlite/sqlite-task-repository";

--- a/packages/host/src/ports/pull-request-review-provider-port.ts
+++ b/packages/host/src/ports/pull-request-review-provider-port.ts
@@ -14,7 +14,6 @@ export type PullRequestReviewProviderInput = {
 
 export type PullRequestReviewProviderPort = {
   providerId: GitProviderId;
-  isEnabled(repoConfig: RepoConfig): boolean;
   readContext(
     input: PullRequestReviewProviderInput,
   ): Effect.Effect<PullRequestReviewContext, HostValidationError>;


### PR DESCRIPTION
## Summary

- Show submitted pull request review outcomes in the CI activity feed, including reviews with no written body.
- Keep review activity provider-neutral while preserving existing comments, threads, checks, pagination, filtering, and links.
- Strengthen GitHub payload validation with precise typed field errors.

## Goal

GitHub approvals, change requests, comments, and dismissed reviews were either dropped or displayed as empty comments when the review body was blank. This made the CI activity feed hide the decision that mattered.

This pull request models the review decision separately from its optional text, so users can see each submitted outcome without fabricated comment content. It also keeps GitHub response details behind the adapter boundary so another Git provider can implement the same shared contract without changing the application service or UI meanings.

## Implementation

- Added a provider-neutral discriminated activity contract for ordinary comments, review summaries, and review-thread comments.
- Added normalized outcomes for approved, changes requested, commented, and dismissed reviews.
- Moved GitHub review parsing and state translation into the GitHub adapter boundary.
- Maps exact GitHub review states, omits PENDING reviews, and returns typed validation errors for malformed or unsupported submitted states.
- Preserves independent comment and review pagination, full review history, timestamps, authors, links, threads, and check aggregation.
- Renders accessible outcome labels in the CI activity card even when a review has no body.
- Renamed the adapter-local provider helper to reader and centralized GitHub payload validation to remove duplicated parsing and report exact malformed-node paths.

## Verification

- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/main...HEAD`
- Branch freshness after fetch: 0 behind, 4 ahead of `origin/main`
- Cargo checks are not applicable because this repository contains no `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request review data is now shown through a unified “review activity” model that covers comments, review summaries, and review-thread items.
  * Review outcomes (approved, changes requested, commented, dismissed) display as clear badges/status indicators, including bodyless reviews.
* **Bug Fixes**
  * Improved parsing/validation of GitHub review history and threads, with stricter handling of malformed or unsupported review states.
  * Review-thread disclosure behavior now resets correctly when resolution changes, and inline-only items are handled more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->