### PR TITLE
fix(codex): own item timestamps by runtime lifecycle

### DIFF
--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -820,7 +820,9 @@ describe("CodexAppServerAdapter streaming", () => {
     });
     const parentThreadId = "thread-saved";
     const childThreadId = "child-thread";
+    const grandchildThreadId = "grandchild-thread";
     const itemId = "reused-child-item";
+    const grandchildItemId = "grandchild-item";
     const internals = adapter as unknown as {
       subagents: CodexSubagentLinkState;
       runtimeEvents: {
@@ -834,6 +836,13 @@ describe("CodexAppServerAdapter streaming", () => {
       parentThreadId,
       childThreadId,
       itemId: "spawn-child",
+      status: "running",
+    });
+    internals.subagents.upsertLink({
+      runtimeId: "runtime-live",
+      parentThreadId: childThreadId,
+      childThreadId: grandchildThreadId,
+      itemId: "spawn-grandchild",
       status: "running",
     });
     emitNotification({
@@ -853,6 +862,23 @@ describe("CodexAppServerAdapter streaming", () => {
         },
       },
     });
+    emitNotification({
+      method: "item/started",
+      params: {
+        threadId: grandchildThreadId,
+        turnId: "grandchild-turn-before-release",
+        startedAtMs: 1_783_196_401_500,
+        item: {
+          type: "commandExecution",
+          id: grandchildItemId,
+          command: "true",
+          cwd: "/repo",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: "",
+        },
+      },
+    });
     await flushCodexAdapterWork();
 
     expect(
@@ -860,6 +886,11 @@ describe("CodexAppServerAdapter streaming", () => {
         .get("runtime-live")
         ?.get(childThreadId),
     ).toEqual(new Map([[itemId, 1_783_196_401_000]]));
+    expect(
+      internals.runtimeEvents.startedItemTimestampsByRuntimeId
+        .get("runtime-live")
+        ?.get(grandchildThreadId),
+    ).toEqual(new Map([[grandchildItemId, 1_783_196_401_500]]));
 
     await adapter.releaseSession(codexSessionRuntimeRef(parentThreadId));
 
@@ -867,6 +898,11 @@ describe("CodexAppServerAdapter streaming", () => {
       internals.runtimeEvents.startedItemTimestampsByRuntimeId
         .get("runtime-live")
         ?.has(childThreadId) ?? false,
+    ).toBe(false);
+    expect(
+      internals.runtimeEvents.startedItemTimestampsByRuntimeId
+        .get("runtime-live")
+        ?.has(grandchildThreadId) ?? false,
     ).toBe(false);
     expect(internals.subagents.routeForChild(childThreadId, "runtime-live")).toBeNull();
 
@@ -912,6 +948,79 @@ describe("CodexAppServerAdapter streaming", () => {
       .at(-1);
     expect(completedPart).toBeDefined();
     expect(completedPart).not.toHaveProperty("startedAtMs");
+  });
+
+  test("keeps routed item timing below a separately retained child lifecycle", async () => {
+    const { subscribeEvents, emitNotification } = createRuntimeStreamSubscription();
+    const { adapter } = createHarness({ subscribeEvents });
+    const parentThreadId = "thread-saved";
+    const childThreadId = "retained-child-thread";
+    const grandchildThreadId = "owned-grandchild-thread";
+    const internals = adapter as unknown as {
+      subagents: CodexSubagentLinkState;
+      runtimeEvents: {
+        startedItemTimestampsByRuntimeId: Map<string, Map<string, Map<string, number>>>;
+      };
+    };
+
+    await observeSessionState(adapter, parentThreadId);
+    await adapter.resumeSession(codexSessionRuntimeRef(childThreadId));
+    internals.subagents.upsertLink({
+      runtimeId: "runtime-live",
+      parentThreadId,
+      childThreadId,
+      itemId: "spawn-retained-child",
+      status: "running",
+    });
+    internals.subagents.upsertLink({
+      runtimeId: "runtime-live",
+      parentThreadId: childThreadId,
+      childThreadId: grandchildThreadId,
+      itemId: "spawn-owned-grandchild",
+      status: "running",
+    });
+    for (const [threadId, itemId, startedAtMs] of [
+      [childThreadId, "retained-child-item", 1_783_196_403_000],
+      [grandchildThreadId, "owned-grandchild-item", 1_783_196_404_000],
+    ] as const) {
+      emitNotification({
+        method: "item/started",
+        params: {
+          threadId,
+          turnId: `turn-${threadId}`,
+          startedAtMs,
+          item: {
+            type: "commandExecution",
+            id: itemId,
+            command: "true",
+            cwd: "/repo",
+            status: "inProgress",
+            commandActions: [],
+            aggregatedOutput: "",
+          },
+        },
+      });
+    }
+    await flushCodexAdapterWork();
+
+    await adapter.releaseSession(codexSessionRuntimeRef(parentThreadId));
+
+    expect(
+      internals.runtimeEvents.startedItemTimestampsByRuntimeId
+        .get("runtime-live")
+        ?.get(childThreadId),
+    ).toEqual(new Map([["retained-child-item", 1_783_196_403_000]]));
+    expect(
+      internals.runtimeEvents.startedItemTimestampsByRuntimeId
+        .get("runtime-live")
+        ?.get(grandchildThreadId),
+    ).toEqual(new Map([["owned-grandchild-item", 1_783_196_404_000]]));
+
+    await adapter.releaseSession(codexSessionRuntimeRef(childThreadId));
+
+    expect(internals.runtimeEvents.startedItemTimestampsByRuntimeId.has("runtime-live")).toBe(
+      false,
+    );
   });
 
   test("does not retain streamed events for a late renderer subscription", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.streaming.test.ts
@@ -8,7 +8,13 @@ import {
   createRuntimeStreamSubscription,
   flushCodexAdapterWork,
 } from "./codex-app-server-adapter.test-harness";
-import type { CodexAppServerAdapter, CodexJsonRpcRequest, CodexJsonRpcTransport } from "./index";
+import type { CodexSubagentLinkState } from "./codex-subagent-link-state";
+import type {
+  CodexAppServerAdapter,
+  CodexJsonRpcRequest,
+  CodexJsonRpcTransport,
+  CodexLiveSessionMutation,
+} from "./index";
 
 const observeSessionState = async (
   adapter: CodexAppServerAdapter,
@@ -801,6 +807,111 @@ describe("CodexAppServerAdapter streaming", () => {
       }),
     );
     unsubscribe();
+  });
+
+  test("clears unmatched routed-child item timing when its retained parent is released", async () => {
+    const { subscribeEvents, emitNotification } = createRuntimeStreamSubscription();
+    const liveMutations: CodexLiveSessionMutation[] = [];
+    const { adapter } = createHarness({
+      subscribeEvents,
+      onLiveSessionMutation: (mutation) => {
+        liveMutations.push(mutation);
+      },
+    });
+    const parentThreadId = "thread-saved";
+    const childThreadId = "child-thread";
+    const itemId = "reused-child-item";
+    const internals = adapter as unknown as {
+      subagents: CodexSubagentLinkState;
+      runtimeEvents: {
+        startedItemTimestampsByRuntimeId: Map<string, Map<string, Map<string, number>>>;
+      };
+    };
+
+    await observeSessionState(adapter, parentThreadId);
+    internals.subagents.upsertLink({
+      runtimeId: "runtime-live",
+      parentThreadId,
+      childThreadId,
+      itemId: "spawn-child",
+      status: "running",
+    });
+    emitNotification({
+      method: "item/started",
+      params: {
+        threadId: childThreadId,
+        turnId: "turn-before-release",
+        startedAtMs: 1_783_196_401_000,
+        item: {
+          type: "commandExecution",
+          id: itemId,
+          command: "true",
+          cwd: "/repo",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: "",
+        },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    expect(
+      internals.runtimeEvents.startedItemTimestampsByRuntimeId
+        .get("runtime-live")
+        ?.get(childThreadId),
+    ).toEqual(new Map([[itemId, 1_783_196_401_000]]));
+
+    await adapter.releaseSession(codexSessionRuntimeRef(parentThreadId));
+
+    expect(
+      internals.runtimeEvents.startedItemTimestampsByRuntimeId
+        .get("runtime-live")
+        ?.has(childThreadId) ?? false,
+    ).toBe(false);
+    expect(internals.subagents.routeForChild(childThreadId, "runtime-live")).toBeNull();
+
+    await observeSessionState(adapter, parentThreadId);
+    internals.subagents.upsertLink({
+      runtimeId: "runtime-live",
+      parentThreadId,
+      childThreadId,
+      itemId: "spawn-child-reused",
+      status: "running",
+    });
+    liveMutations.length = 0;
+    emitNotification({
+      method: "item/completed",
+      params: {
+        threadId: childThreadId,
+        turnId: "turn-after-release",
+        completedAtMs: 1_783_196_402_000,
+        item: {
+          type: "commandExecution",
+          id: itemId,
+          command: "true",
+          cwd: "/repo",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "",
+          exitCode: 0,
+        },
+      },
+    });
+    await flushCodexAdapterWork();
+
+    const completedPart = liveMutations
+      .flatMap((mutation) => mutation.transcriptEvents)
+      .flatMap((event) =>
+        event.type === "assistant_part" &&
+        event.part.kind === "tool" &&
+        event.part.callId === itemId &&
+        event.part.status === "completed"
+          ? [event.part]
+          : [],
+      )
+      .at(-1);
+    expect(completedPart).toBeDefined();
+    expect(completedPart).not.toHaveProperty("startedAtMs");
   });
 
   test("does not retain streamed events for a late renderer subscription", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-streaming.ts
@@ -60,13 +60,19 @@ export type CompletedAgentMessage = {
 
 export type CodexStreamingContext = {
   activeTurnsBySessionId: Map<string, ActiveCodexTurn>;
-  startedItemTimestampsByKey: Map<string, number>;
   syntheticUserMessageTextsByThreadId: Map<string, string[]>;
   completedAgentMessagesByTurnKey: Map<string, CompletedAgentMessage>;
   tokenUsageByTurnKey: Map<string, CodexTokenUsageTotals>;
   modelByTurnKey: Map<string, AgentModelSelection>;
   latestTodosBySessionId: Map<string, AgentSessionTodoItem[]>;
   eventMapperPipeline: CodexEventMapperPipeline;
+  recordStartedItemTimestamp(
+    runtimeId: string,
+    threadId: string,
+    itemId: string,
+    startedAtMs: number,
+  ): void;
+  takeStartedItemTimestamp(runtimeId: string, threadId: string, itemId: string): number | undefined;
   emitSessionEvent(externalSessionId: string, event: AgentEvent): void;
   bindActiveTurnId(activeTurn: ActiveCodexTurn, turnId: string, startedAtMs?: number): boolean;
   flushQueuedUserMessagesLater(activeTurn: ActiveCodexTurn): void;
@@ -182,27 +188,19 @@ const withLifecycleTimestamp = (
   return Number.isFinite(timestampMs) ? { ...item, [key]: timestampMs } : item;
 };
 
-const lifecycleItemKey = (
-  session: CodexSessionState,
-  item: Record<string, unknown>,
-): string | null => {
-  const itemId = extractStringField(item, ["id"]);
-  return itemId ? `${session.runtimeId}:${session.threadId}:${itemId}` : null;
-};
-
 const recordStartedItemTimestamp = (
   context: CodexStreamingContext,
   session: CodexSessionState,
   item: Record<string, unknown>,
   timestamp: string,
 ): void => {
-  const itemKey = lifecycleItemKey(session, item);
-  if (!itemKey) {
+  const itemId = extractStringField(item, ["id"]);
+  if (!itemId) {
     return;
   }
   const startedAtMs = Date.parse(timestamp);
   if (Number.isFinite(startedAtMs)) {
-    context.startedItemTimestampsByKey.set(itemKey, startedAtMs);
+    context.recordStartedItemTimestamp(session.runtimeId, session.threadId, itemId, startedAtMs);
   }
 };
 
@@ -211,12 +209,11 @@ const withRecordedStartedItemTimestamp = (
   session: CodexSessionState,
   item: Record<string, unknown>,
 ): Record<string, unknown> => {
-  const itemKey = lifecycleItemKey(session, item);
-  if (!itemKey) {
+  const itemId = extractStringField(item, ["id"]);
+  if (!itemId) {
     return item;
   }
-  const startedAtMs = context.startedItemTimestampsByKey.get(itemKey);
-  context.startedItemTimestampsByKey.delete(itemKey);
+  const startedAtMs = context.takeStartedItemTimestamp(session.runtimeId, session.threadId, itemId);
   if (
     typeof startedAtMs !== "number" ||
     Object.hasOwn(item, "startedAtMs") ||

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.test.ts
@@ -26,6 +26,7 @@ const createStore = () => {
   const clearedRuntimeEvents: Array<{ externalSessionId: string; runtimeId?: string }> = [];
   const clearedSubagents: Array<{ externalSessionId: string; runtimeId?: string }> = [];
   const clearedThreadStatusOverrides: Array<{ runtimeId: string; threadId: string }> = [];
+  const cleanupOrder: string[] = [];
   const activeTurnsBySessionId = new Map<string, unknown>();
   const store = new CodexLocalSessionState({
     sessionEvents: {
@@ -36,15 +37,19 @@ const createStore = () => {
       clearSession: (externalSessionId) => clearedPendingInput.push(externalSessionId),
     },
     subagents: {
-      clearSession: (externalSessionId, runtimeId) =>
-        clearedSubagents.push({ externalSessionId, runtimeId }),
+      clearSession: (externalSessionId, runtimeId) => {
+        cleanupOrder.push("subagents");
+        clearedSubagents.push({ externalSessionId, runtimeId });
+      },
     },
     threadStatusOverrides: {
       clear: (runtimeId, threadId) => clearedThreadStatusOverrides.push({ runtimeId, threadId }),
     },
     runtimeEvents: {
-      clearSession: (externalSessionId, runtimeId) =>
-        clearedRuntimeEvents.push({ externalSessionId, runtimeId }),
+      clearSession: (externalSessionId, runtimeId) => {
+        cleanupOrder.push("runtimeEvents");
+        clearedRuntimeEvents.push({ externalSessionId, runtimeId });
+      },
     },
   });
   return {
@@ -55,6 +60,7 @@ const createStore = () => {
     clearedRuntimeEvents,
     clearedSubagents,
     clearedThreadStatusOverrides,
+    cleanupOrder,
   };
 };
 
@@ -79,6 +85,7 @@ describe("CodexLocalSessionState", () => {
       clearedRuntimeEvents,
       clearedSubagents,
       clearedThreadStatusOverrides,
+      cleanupOrder,
     } = createStore();
     store.remember(session("thread-1"));
     store.remember(session("thread-2"));
@@ -101,6 +108,7 @@ describe("CodexLocalSessionState", () => {
     expect(clearedThreadStatusOverrides).toEqual([
       { runtimeId: "runtime-1", threadId: "thread-1" },
     ]);
+    expect(cleanupOrder).toEqual(["runtimeEvents", "subagents"]);
   });
 
   test("releases the last local session without runtime coordination", () => {

--- a/packages/adapters-codex-app-server/src/codex-local-session-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-local-session-state.ts
@@ -64,8 +64,8 @@ export class CodexLocalSessionState implements CodexSessionLookup {
     }
     this.deps.activeTurnsBySessionId.delete(externalSessionId);
     this.deps.pendingInput.clearSession(externalSessionId, session?.runtimeId);
-    this.deps.subagents.clearSession(externalSessionId, session?.runtimeId);
     this.deps.runtimeEvents.clearSession(externalSessionId, session?.runtimeId);
+    this.deps.subagents.clearSession(externalSessionId, session?.runtimeId);
     return session;
   }
 }

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.test.ts
@@ -64,6 +64,93 @@ const createRuntimeEvents = (
   });
 };
 
+type StartedItemTimestampState = Map<string, Map<string, Map<string, number>>>;
+
+const startedItemTimestampState = (
+  runtimeEvents: CodexRuntimeSessionEvents,
+): StartedItemTimestampState =>
+  (
+    runtimeEvents as unknown as {
+      startedItemTimestampsByRuntimeId: StartedItemTimestampState;
+    }
+  ).startedItemTimestampsByRuntimeId;
+
+type ItemLifecycleMethod = "item/started" | "item/completed";
+
+const createItemLifecycleHarness = (...initialSessions: CodexSessionState[]) => {
+  const listenersByRuntimeId = new Map<string, RuntimeListener>();
+  const sessions = new Map(initialSessions.map((session) => [session.threadId, session]));
+  const sessionEvents = new CodexSessionEventBus();
+  const emittedEvents: unknown[] = [];
+  const observedThreadIds = new Set<string>();
+  for (const session of initialSessions) {
+    if (observedThreadIds.has(session.threadId)) {
+      continue;
+    }
+    observedThreadIds.add(session.threadId);
+    sessionEvents.subscribe(codexSessionRef(session), (event) => emittedEvents.push(event));
+  }
+  const runtimeEvents = createRuntimeEvents({
+    subscribeEvents: (runtimeId, next) => {
+      listenersByRuntimeId.set(runtimeId, (event) => next(withRuntimeReceivedAt(event)));
+      return () => {
+        listenersByRuntimeId.delete(runtimeId);
+      };
+    },
+    sessions,
+    sessionEvents,
+  });
+
+  return {
+    emittedEvents,
+    runtimeEvents,
+    async subscribe(...runtimeIds: string[]): Promise<void> {
+      for (const runtimeId of runtimeIds) {
+        await runtimeEvents.ensureRuntimeEventSubscription(runtimeId);
+      }
+    },
+    emitItem(
+      session: CodexSessionState,
+      method: ItemLifecycleMethod,
+      timestampMs: number,
+      itemId: string,
+      itemOverrides: Record<string, unknown> = {},
+    ): void {
+      const listener = listenersByRuntimeId.get(session.runtimeId);
+      if (!listener) {
+        throw new Error(`Runtime '${session.runtimeId}' is not subscribed in the test harness.`);
+      }
+      const isStarted = method === "item/started";
+      const timing = isStarted ? { startedAtMs: timestampMs } : { completedAtMs: timestampMs };
+      const completionFields = isStarted ? {} : { exitCode: 0 };
+      sessions.set(session.threadId, session);
+      listener({
+        runtimeId: session.runtimeId,
+        kind: "notification",
+        message: {
+          method,
+          params: {
+            threadId: session.threadId,
+            turnId: `${session.runtimeId}-turn`,
+            ...timing,
+            item: {
+              type: "commandExecution",
+              id: itemId,
+              command: "true",
+              cwd: "/repo",
+              status: isStarted ? "inProgress" : "completed",
+              commandActions: [],
+              aggregatedOutput: "",
+              ...completionFields,
+              ...itemOverrides,
+            },
+          },
+        },
+      });
+    },
+  };
+};
+
 const model = { providerId: "openai", modelId: "gpt-5", variant: "medium" } as const;
 
 const createSession = (threadId: string): CodexSessionState => ({
@@ -864,6 +951,168 @@ describe("CodexRuntimeSessionEvents", () => {
       totalTokens: 200,
       contextWindow: 200_000,
     });
+  });
+
+  test("drops an unmatched item start when its session is released", async () => {
+    const session = createSession("thread/reused");
+    const harness = createItemLifecycleHarness(session);
+    await harness.subscribe(session.runtimeId);
+    harness.emitItem(session, "item/started", 1_783_109_994_000, "reused-item");
+    await flushRuntimeEvents();
+
+    harness.runtimeEvents.clearSession(session.threadId, session.runtimeId);
+    expect(startedItemTimestampState(harness.runtimeEvents).size).toBe(0);
+    harness.emittedEvents.length = 0;
+
+    harness.emitItem(session, "item/completed", 1_783_109_995_000, "reused-item");
+    await flushRuntimeEvents();
+
+    expect(harness.emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          callId: "reused-item",
+          endedAtMs: 1_783_109_995_000,
+        }),
+      }),
+    );
+    expect(harness.emittedEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          callId: "reused-item",
+          startedAtMs: 1_783_109_994_000,
+        }),
+      }),
+    );
+  });
+
+  test("takes matched item starts and prunes empty parent maps", async () => {
+    const session = createSession("thread/matched");
+    const harness = createItemLifecycleHarness(session);
+    await harness.subscribe(session.runtimeId);
+    harness.emitItem(session, "item/started", 1_783_109_996_000, "matched-item");
+    await flushRuntimeEvents();
+
+    expect(
+      startedItemTimestampState(harness.runtimeEvents)
+        .get(session.runtimeId)
+        ?.get(session.threadId),
+    ).toEqual(new Map([["matched-item", 1_783_109_996_000]]));
+
+    harness.emitItem(session, "item/completed", 1_783_109_997_000, "matched-item");
+    await flushRuntimeEvents();
+
+    expect(startedItemTimestampState(harness.runtimeEvents).size).toBe(0);
+    expect(harness.emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          callId: "matched-item",
+          startedAtMs: 1_783_109_996_000,
+          endedAtMs: 1_783_109_997_000,
+        }),
+      }),
+    );
+  });
+
+  test("isolates identical item IDs by runtime and clears runtime-owned state", async () => {
+    const threadId = "thread/shared";
+    const runtimeOneSession = createSessionForRuntime(threadId, "runtime-1");
+    const runtimeTwoSession = createSessionForRuntime(threadId, "runtime-2");
+    const harness = createItemLifecycleHarness(runtimeOneSession, runtimeTwoSession);
+    await harness.subscribe(runtimeOneSession.runtimeId, runtimeTwoSession.runtimeId);
+    for (const [session, startedAtMs] of [
+      [runtimeOneSession, 1_783_109_998_000],
+      [runtimeTwoSession, 1_783_109_999_000],
+    ] as const) {
+      harness.emitItem(session, "item/started", startedAtMs, "shared-item");
+      await flushRuntimeEvents();
+    }
+
+    expect(
+      startedItemTimestampState(harness.runtimeEvents).get("runtime-1")?.get(threadId),
+    ).toEqual(new Map([["shared-item", 1_783_109_998_000]]));
+    expect(
+      startedItemTimestampState(harness.runtimeEvents).get("runtime-2")?.get(threadId),
+    ).toEqual(new Map([["shared-item", 1_783_109_999_000]]));
+
+    harness.runtimeEvents.clearRuntime("runtime-1");
+    expect(startedItemTimestampState(harness.runtimeEvents).has("runtime-1")).toBe(false);
+    expect(
+      startedItemTimestampState(harness.runtimeEvents).get("runtime-2")?.get(threadId),
+    ).toEqual(new Map([["shared-item", 1_783_109_999_000]]));
+
+    harness.emitItem(runtimeTwoSession, "item/completed", 1_783_110_000_000, "shared-item");
+    await flushRuntimeEvents();
+
+    expect(harness.emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          callId: "shared-item",
+          startedAtMs: 1_783_109_999_000,
+          endedAtMs: 1_783_110_000_000,
+        }),
+      }),
+    );
+    expect(startedItemTimestampState(harness.runtimeEvents).size).toBe(0);
+
+    harness.emitItem(runtimeTwoSession, "item/started", 1_783_110_001_000, "orphaned-item");
+    await flushRuntimeEvents();
+    harness.runtimeEvents.clearRuntime("runtime-2");
+
+    expect(startedItemTimestampState(harness.runtimeEvents).size).toBe(0);
+  });
+
+  test("reuses item IDs and preserves runtime-supplied completion timing", async () => {
+    const session = createSession("thread/restarted-item");
+    const harness = createItemLifecycleHarness(session);
+    await harness.subscribe(session.runtimeId);
+    harness.emitItem(session, "item/started", 1_783_110_001_000, "restarted-item");
+    harness.emitItem(session, "item/completed", 1_783_110_002_000, "restarted-item");
+    await flushRuntimeEvents();
+
+    harness.emittedEvents.length = 0;
+    harness.emitItem(session, "item/started", 1_783_110_003_000, "restarted-item");
+    harness.emitItem(session, "item/completed", 1_783_110_004_000, "restarted-item");
+    await flushRuntimeEvents();
+
+    expect(harness.emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          callId: "restarted-item",
+          startedAtMs: 1_783_110_003_000,
+          endedAtMs: 1_783_110_004_000,
+        }),
+      }),
+    );
+
+    harness.emittedEvents.length = 0;
+    harness.emitItem(session, "item/started", 1_783_110_005_000, "restarted-item");
+    harness.emitItem(session, "item/completed", 1_783_110_006_000, "restarted-item", {
+      startedAtMs: 1_783_110_005_500,
+    });
+    await flushRuntimeEvents();
+
+    expect(harness.emittedEvents).toContainEqual(
+      expect.objectContaining({
+        type: "assistant_part",
+        part: expect.objectContaining({
+          kind: "tool",
+          callId: "restarted-item",
+          startedAtMs: 1_783_110_005_500,
+          endedAtMs: 1_783_110_006_000,
+        }),
+      }),
+    );
+    expect(startedItemTimestampState(harness.runtimeEvents).size).toBe(0);
   });
 
   test("returns null after a successful resume with no retained usage", async () => {

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -357,7 +357,14 @@ export class CodexRuntimeSessionEvents {
 
   clearSession(externalSessionId: string, runtimeId?: string): void {
     const routedDescendantThreadIds =
-      runtimeId === undefined ? [] : this.routedDescendantThreadIds(externalSessionId, runtimeId);
+      runtimeId === undefined
+        ? []
+        : this.deps.subagents
+            .descendantRoutesForParent(externalSessionId, runtimeId, (route) => {
+              const retainedChild = this.deps.sessions.get(route.childExternalSessionId);
+              return retainedChild?.runtimeId !== runtimeId;
+            })
+            .map((route) => route.childExternalSessionId);
     this.subagentLifecycle.clearSession(externalSessionId, runtimeId);
     if (runtimeId !== undefined) {
       this.clearStartedItemTimestampsForSession(runtimeId, externalSessionId);
@@ -902,32 +909,6 @@ export class CodexRuntimeSessionEvents {
 
   private clearStartedItemTimestampsForRuntime(runtimeId: string): void {
     this.startedItemTimestampsByRuntimeId.delete(runtimeId);
-  }
-
-  private routedDescendantThreadIds(parentThreadId: string, runtimeId: string): string[] {
-    const descendants: string[] = [];
-    const pendingParentThreadIds = [parentThreadId];
-    const visitedThreadIds = new Set(pendingParentThreadIds);
-    while (pendingParentThreadIds.length > 0) {
-      const currentParentThreadId = pendingParentThreadIds.pop();
-      if (!currentParentThreadId) {
-        continue;
-      }
-      for (const route of this.deps.subagents.routesForParent(currentParentThreadId, runtimeId)) {
-        const childThreadId = route.childExternalSessionId;
-        if (visitedThreadIds.has(childThreadId)) {
-          continue;
-        }
-        visitedThreadIds.add(childThreadId);
-        const retainedChild = this.deps.sessions.get(childThreadId);
-        if (retainedChild?.runtimeId === runtimeId) {
-          continue;
-        }
-        descendants.push(childThreadId);
-        pendingParentThreadIds.push(childThreadId);
-      }
-    }
-    return descendants;
   }
 
   private async handleServerRequest(

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -151,7 +151,10 @@ export class CodexRuntimeSessionEvents {
   private readonly completedAgentMessagesByTurnKey = new Map<string, CompletedAgentMessage>();
   private readonly tokenUsageByTurnKey = new Map<string, CodexTokenUsageTotals>();
   private readonly modelByTurnKey = new Map<string, AgentModelSelection>();
-  private readonly startedItemTimestampsByKey = new Map<string, number>();
+  private readonly startedItemTimestampsByRuntimeId = new Map<
+    string,
+    Map<string, Map<string, number>>
+  >();
   private readonly latestTodosBySessionId = new Map<string, AgentSessionTodoItem[]>();
   private readonly runtimeEventProcessingByRuntimeId = new Map<string, Promise<void>>();
   private readonly runtimeEventGenerationByRuntimeId = new Map<string, symbol>();
@@ -210,6 +213,7 @@ export class CodexRuntimeSessionEvents {
       this.stopRuntimeEventSubscription(runtimeId);
     } finally {
       this.subagentLifecycle.clearRuntime(runtimeId);
+      this.clearStartedItemTimestampsForRuntime(runtimeId);
       this.handledStreamRequestKeysByRuntimeId.delete(runtimeId);
       this.activeMutationByRuntimeId.delete(runtimeId);
     }
@@ -353,6 +357,9 @@ export class CodexRuntimeSessionEvents {
 
   clearSession(externalSessionId: string, runtimeId?: string): void {
     this.subagentLifecycle.clearSession(externalSessionId, runtimeId);
+    if (runtimeId !== undefined) {
+      this.clearStartedItemTimestampsForSession(runtimeId, externalSessionId);
+    }
     this.clearHandledStreamRequestKeys(externalSessionId, runtimeId);
     this.syntheticUserMessageTextsByThreadId.delete(externalSessionId);
     this.latestTodosBySessionId.delete(externalSessionId);
@@ -814,13 +821,16 @@ export class CodexRuntimeSessionEvents {
   private streamingContext(scopedSession?: CodexSessionState): CodexStreamingContext {
     return {
       activeTurnsBySessionId: this.deps.activeTurnsBySessionId,
-      startedItemTimestampsByKey: this.startedItemTimestampsByKey,
       syntheticUserMessageTextsByThreadId: this.syntheticUserMessageTextsByThreadId,
       completedAgentMessagesByTurnKey: this.completedAgentMessagesByTurnKey,
       tokenUsageByTurnKey: this.tokenUsageByTurnKey,
       modelByTurnKey: this.modelByTurnKey,
       latestTodosBySessionId: this.latestTodosBySessionId,
       eventMapperPipeline: this.eventMapperPipeline,
+      recordStartedItemTimestamp: (runtimeId, threadId, itemId, startedAtMs) =>
+        this.recordStartedItemTimestamp(runtimeId, threadId, itemId, startedAtMs),
+      takeStartedItemTimestamp: (runtimeId, threadId, itemId) =>
+        this.takeStartedItemTimestamp(runtimeId, threadId, itemId),
       emitSessionEvent: (externalSessionId, event) => {
         if (scopedSession?.threadId === externalSessionId) {
           this.emitSessionEventForSession(scopedSession, event);
@@ -836,6 +846,57 @@ export class CodexRuntimeSessionEvents {
       failUnlinkedSubagentSpawns: (parentThreadId, runtimeId, error) =>
         this.deps.subagents.failUnlinkedSpawnsForParent(parentThreadId, runtimeId, error),
     };
+  }
+
+  private recordStartedItemTimestamp(
+    runtimeId: string,
+    threadId: string,
+    itemId: string,
+    startedAtMs: number,
+  ): void {
+    let timestampsByThreadId = this.startedItemTimestampsByRuntimeId.get(runtimeId);
+    if (!timestampsByThreadId) {
+      timestampsByThreadId = new Map();
+      this.startedItemTimestampsByRuntimeId.set(runtimeId, timestampsByThreadId);
+    }
+    let timestampsByItemId = timestampsByThreadId.get(threadId);
+    if (!timestampsByItemId) {
+      timestampsByItemId = new Map();
+      timestampsByThreadId.set(threadId, timestampsByItemId);
+    }
+    timestampsByItemId.set(itemId, startedAtMs);
+  }
+
+  private takeStartedItemTimestamp(
+    runtimeId: string,
+    threadId: string,
+    itemId: string,
+  ): number | undefined {
+    const timestampsByThreadId = this.startedItemTimestampsByRuntimeId.get(runtimeId);
+    const timestampsByItemId = timestampsByThreadId?.get(threadId);
+    const startedAtMs = timestampsByItemId?.get(itemId);
+    if (!timestampsByItemId?.delete(itemId)) {
+      return undefined;
+    }
+    if (timestampsByItemId.size === 0) {
+      timestampsByThreadId?.delete(threadId);
+    }
+    if (timestampsByThreadId?.size === 0) {
+      this.startedItemTimestampsByRuntimeId.delete(runtimeId);
+    }
+    return startedAtMs;
+  }
+
+  private clearStartedItemTimestampsForSession(runtimeId: string, threadId: string): void {
+    const timestampsByThreadId = this.startedItemTimestampsByRuntimeId.get(runtimeId);
+    timestampsByThreadId?.delete(threadId);
+    if (timestampsByThreadId?.size === 0) {
+      this.startedItemTimestampsByRuntimeId.delete(runtimeId);
+    }
+  }
+
+  private clearStartedItemTimestampsForRuntime(runtimeId: string): void {
+    this.startedItemTimestampsByRuntimeId.delete(runtimeId);
   }
 
   private async handleServerRequest(

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -356,9 +356,14 @@ export class CodexRuntimeSessionEvents {
   }
 
   clearSession(externalSessionId: string, runtimeId?: string): void {
+    const routedDescendantThreadIds =
+      runtimeId === undefined ? [] : this.routedDescendantThreadIds(externalSessionId, runtimeId);
     this.subagentLifecycle.clearSession(externalSessionId, runtimeId);
     if (runtimeId !== undefined) {
       this.clearStartedItemTimestampsForSession(runtimeId, externalSessionId);
+      for (const threadId of routedDescendantThreadIds) {
+        this.clearStartedItemTimestampsForSession(runtimeId, threadId);
+      }
     }
     this.clearHandledStreamRequestKeys(externalSessionId, runtimeId);
     this.syntheticUserMessageTextsByThreadId.delete(externalSessionId);
@@ -897,6 +902,32 @@ export class CodexRuntimeSessionEvents {
 
   private clearStartedItemTimestampsForRuntime(runtimeId: string): void {
     this.startedItemTimestampsByRuntimeId.delete(runtimeId);
+  }
+
+  private routedDescendantThreadIds(parentThreadId: string, runtimeId: string): string[] {
+    const descendants: string[] = [];
+    const pendingParentThreadIds = [parentThreadId];
+    const visitedThreadIds = new Set(pendingParentThreadIds);
+    while (pendingParentThreadIds.length > 0) {
+      const currentParentThreadId = pendingParentThreadIds.pop();
+      if (!currentParentThreadId) {
+        continue;
+      }
+      for (const route of this.deps.subagents.routesForParent(currentParentThreadId, runtimeId)) {
+        const childThreadId = route.childExternalSessionId;
+        if (visitedThreadIds.has(childThreadId)) {
+          continue;
+        }
+        visitedThreadIds.add(childThreadId);
+        const retainedChild = this.deps.sessions.get(childThreadId);
+        if (retainedChild?.runtimeId === runtimeId) {
+          continue;
+        }
+        descendants.push(childThreadId);
+        pendingParentThreadIds.push(childThreadId);
+      }
+    }
+    return descendants;
   }
 
   private async handleServerRequest(

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.test.ts
@@ -327,6 +327,67 @@ describe("CodexSubagentLinkState", () => {
     ).toHaveLength(1);
   });
 
+  test("clears a displaced provisional correlation before its item id is reused", () => {
+    const subagents = new CodexSubagentLinkState();
+    subagents.upsertLink({
+      runtimeId: "runtime-1",
+      parentThreadId: "parent-thread",
+      itemId: "spawn-1",
+      status: "pending",
+    });
+    subagents.upsertLink({
+      runtimeId: "runtime-1",
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-1",
+      status: "running",
+    });
+    subagents.upsertLink({
+      runtimeId: "runtime-1",
+      parentThreadId: "parent-thread",
+      itemId: "spawn-2",
+      status: "running",
+      prompt: "stale prompt",
+    });
+    subagents.upsertLink({
+      runtimeId: "runtime-1",
+      parentThreadId: "parent-thread",
+      childThreadId: "child-thread",
+      itemId: "spawn-2",
+      status: "running",
+    });
+
+    subagents.clearSession("parent-thread", "runtime-1");
+
+    const indexes = subagents as unknown as {
+      linksByCorrelationKey: Map<string, unknown>;
+      linksByParentKey: Map<string, unknown>;
+      linksByChildThreadId: Map<string, unknown>;
+      provisionalByParentKey: Map<string, unknown>;
+    };
+    const clearedIndexSizes = {
+      correlations: indexes.linksByCorrelationKey.size,
+      parents: indexes.linksByParentKey.size,
+      children: indexes.linksByChildThreadId.size,
+      provisionals: indexes.provisionalByParentKey.size,
+    };
+    const reused = subagents.upsertLink({
+      runtimeId: "runtime-1",
+      parentThreadId: "parent-thread",
+      itemId: "spawn-2",
+      status: "pending",
+    });
+
+    expect(reused.status).toBe("pending");
+    expect(reused).not.toHaveProperty("prompt");
+    expect(clearedIndexSizes).toEqual({
+      correlations: 0,
+      parents: 0,
+      children: 0,
+      provisionals: 0,
+    });
+  });
+
   test("ignores an explicit restart older than the terminal lifecycle", () => {
     const subagents = new CodexSubagentLinkState();
     subagents.upsertLink({

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.test.ts
@@ -204,6 +204,84 @@ describe("CodexSubagentLinkState", () => {
     }
   });
 
+  test("walks only the requested runtime's routed descendant subtree", () => {
+    const subagents = new CodexSubagentLinkState();
+    for (const [runtimeId, parentThreadId, childThreadId] of [
+      ["runtime-1", "parent-thread", "child-thread"],
+      ["runtime-1", "child-thread", "grandchild-thread"],
+      ["runtime-1", "unrelated-parent", "unrelated-child"],
+      ["runtime-2", "parent-thread", "child-thread"],
+      ["runtime-2", "child-thread", "grandchild-thread"],
+    ] as const) {
+      subagents.upsertLink({
+        runtimeId,
+        parentThreadId,
+        childThreadId,
+        itemId: `spawn-${childThreadId}`,
+        status: "running",
+      });
+    }
+
+    const descendants = subagents.descendantRoutesForParent(
+      "parent-thread",
+      "runtime-1",
+      () => true,
+    );
+
+    expect(descendants.map((route) => route.childExternalSessionId)).toEqual([
+      "child-thread",
+      "grandchild-thread",
+    ]);
+  });
+
+  test("stops descendant traversal at a retained child boundary", () => {
+    const subagents = new CodexSubagentLinkState();
+    for (const [parentThreadId, childThreadId] of [
+      ["parent-thread", "retained-child"],
+      ["retained-child", "owned-grandchild"],
+    ] as const) {
+      subagents.upsertLink({
+        runtimeId: "runtime-1",
+        parentThreadId,
+        childThreadId,
+        itemId: `spawn-${childThreadId}`,
+        status: "running",
+      });
+    }
+
+    const descendants = subagents.descendantRoutesForParent(
+      "parent-thread",
+      "runtime-1",
+      (route) => route.childExternalSessionId !== "retained-child",
+    );
+
+    expect(descendants).toEqual([]);
+  });
+
+  test("terminates descendant traversal when routed links form a cycle", () => {
+    const subagents = new CodexSubagentLinkState();
+    for (const [parentThreadId, childThreadId] of [
+      ["parent-thread", "child-thread"],
+      ["child-thread", "parent-thread"],
+    ] as const) {
+      subagents.upsertLink({
+        runtimeId: "runtime-1",
+        parentThreadId,
+        childThreadId,
+        itemId: `spawn-${childThreadId}`,
+        status: "running",
+      });
+    }
+
+    const descendants = subagents.descendantRoutesForParent(
+      "parent-thread",
+      "runtime-1",
+      () => true,
+    );
+
+    expect(descendants.map((route) => route.childExternalSessionId)).toEqual(["child-thread"]);
+  });
+
   test("clears links for one runtime without deleting matching thread ids in another runtime", () => {
     const subagents = new CodexSubagentLinkState();
     subagents.upsertLink({

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -58,11 +58,8 @@ type CodexSubagentRouteListener = (route: CodexSubagentRoute) => void;
 const scopedKey = (runtimeId: string | undefined, ...parts: string[]): string =>
   [runtimeId ?? "", ...parts].join("\u0000");
 
-const subagentKey = (
-  runtimeId: string | undefined,
-  parentThreadId: string,
-  childThreadId: string,
-): string => scopedKey(runtimeId, parentThreadId, childThreadId);
+const parentThreadKey = (runtimeId: string | undefined, parentThreadId: string): string =>
+  scopedKey(runtimeId, parentThreadId);
 
 const childThreadKey = (runtimeId: string | undefined, childThreadId: string): string =>
   scopedKey(runtimeId, childThreadId);
@@ -173,10 +170,10 @@ const sameRoute = (previous: CodexSubagentRoute | null, next: CodexSubagentRoute
   previous?.subagentCorrelationKey === next?.subagentCorrelationKey;
 
 export class CodexSubagentLinkState {
-  private readonly linksByParentChildKey = new Map<string, CodexStoredSubagentLink>();
+  private readonly linksByParentKey = new Map<string, Map<string, CodexStoredSubagentLink>>();
   private readonly linksByChildThreadId = new Map<string, CodexStoredSubagentLink>();
   private readonly linksByCorrelationKey = new Map<string, CodexStoredSubagentLink>();
-  private readonly provisionalByParentItemKey = new Map<string, CodexStoredSubagentLink>();
+  private readonly provisionalByParentKey = new Map<string, Map<string, CodexStoredSubagentLink>>();
   private readonly routeListeners = new Set<CodexSubagentRouteListener>();
 
   onRouteLearned(listener: CodexSubagentRouteListener): () => void {
@@ -240,11 +237,9 @@ export class CodexSubagentLinkState {
     const previousRoute = input.childThreadId
       ? this.routeForChild(input.childThreadId, input.runtimeId)
       : null;
-    const parentItemKey = subagentKey(input.runtimeId, input.parentThreadId, input.itemId);
-    const existingProvisional = this.provisionalByParentItemKey.get(parentItemKey);
-    const parentChildKey = input.childThreadId
-      ? subagentKey(input.runtimeId, input.parentThreadId, input.childThreadId)
-      : null;
+    const parentKey = parentThreadKey(input.runtimeId, input.parentThreadId);
+    const parentItemKey = input.itemId;
+    const existingProvisional = this.provisionalByParentKey.get(parentKey)?.get(parentItemKey);
     const existingByChildThreadId = input.childThreadId
       ? this.linksByChildThreadId.get(childThreadKey(input.runtimeId, input.childThreadId))
       : undefined;
@@ -257,10 +252,9 @@ export class CodexSubagentLinkState {
         `Codex child thread '${input.childThreadId}' is already linked to parent '${existingByChildThreadId.parentThreadId}', not '${input.parentThreadId}'.`,
       );
     }
-    const existingLinked =
-      input.childThreadId && parentChildKey
-        ? (this.linksByParentChildKey.get(parentChildKey) ?? existingByChildThreadId)
-        : undefined;
+    const existingLinked = input.childThreadId
+      ? (this.linksByParentKey.get(parentKey)?.get(input.childThreadId) ?? existingByChildThreadId)
+      : undefined;
     const correlationKey =
       existingLinked?.correlationKey ??
       existingProvisional?.correlationKey ??
@@ -355,9 +349,14 @@ export class CodexSubagentLinkState {
     error: string,
   ): CodexSubagentPart[] {
     const failedParts: CodexSubagentPart[] = [];
-    for (const [parentItemKey, link] of this.provisionalByParentItemKey) {
+    const provisionalLinks = this.provisionalByParentKey.get(
+      parentThreadKey(runtimeId, parentThreadId),
+    );
+    if (!provisionalLinks) {
+      return failedParts;
+    }
+    for (const [parentItemKey, link] of provisionalLinks) {
       if (
-        link.parentThreadId !== parentThreadId ||
         link.runtimeId !== runtimeId ||
         link.childThreadId ||
         link.status === "cancelled" ||
@@ -370,7 +369,7 @@ export class CodexSubagentLinkState {
         status: "error",
         error,
       };
-      this.provisionalByParentItemKey.set(parentItemKey, failedLink);
+      provisionalLinks.set(parentItemKey, failedLink);
       this.linksByCorrelationKey.set(
         scopedKey(failedLink.runtimeId, failedLink.correlationKey),
         failedLink,
@@ -382,29 +381,91 @@ export class CodexSubagentLinkState {
 
   routesForParent(parentThreadId: string, runtimeId?: string): CodexSubagentRoute[] {
     const routes: CodexSubagentRoute[] = [];
-    for (const link of this.linksByChildThreadId.values()) {
-      if (link.parentThreadId !== parentThreadId) {
-        continue;
+    const linkBuckets: Array<Map<string, CodexStoredSubagentLink>> = [];
+    if (runtimeId !== undefined) {
+      const runtimeLinks = this.linksByParentKey.get(parentThreadKey(runtimeId, parentThreadId));
+      const unscopedLinks = this.linksByParentKey.get(parentThreadKey(undefined, parentThreadId));
+      if (runtimeLinks) {
+        linkBuckets.push(runtimeLinks);
       }
-      if (runtimeId && link.runtimeId && link.runtimeId !== runtimeId) {
-        continue;
+      if (unscopedLinks) {
+        linkBuckets.push(unscopedLinks);
       }
-      const route = routeFromLink(link);
-      if (route) {
-        routes.push(route);
+    } else {
+      for (const links of this.linksByParentKey.values()) {
+        const link = links.values().next().value;
+        if (link?.parentThreadId === parentThreadId) {
+          linkBuckets.push(links);
+        }
+      }
+    }
+    for (const links of linkBuckets) {
+      for (const link of links.values()) {
+        const route = routeFromLink(link);
+        if (route) {
+          routes.push(route);
+        }
       }
     }
     return routes;
   }
 
+  descendantRoutesForParent(
+    parentThreadId: string,
+    runtimeId: string,
+    shouldDescend: (route: CodexSubagentRoute) => boolean,
+  ): CodexSubagentRoute[] {
+    const descendants: CodexSubagentRoute[] = [];
+    const pendingParentThreadIds = [parentThreadId];
+    const visitedThreadIds = new Set(pendingParentThreadIds);
+    while (pendingParentThreadIds.length > 0) {
+      const currentParentThreadId = pendingParentThreadIds.pop();
+      if (!currentParentThreadId) {
+        continue;
+      }
+      for (const route of this.routesForParent(currentParentThreadId, runtimeId)) {
+        const childThreadId = route.childExternalSessionId;
+        if (visitedThreadIds.has(childThreadId)) {
+          continue;
+        }
+        visitedThreadIds.add(childThreadId);
+        if (!shouldDescend(route)) {
+          continue;
+        }
+        descendants.push(route);
+        pendingParentThreadIds.push(childThreadId);
+      }
+    }
+    return descendants;
+  }
+
   clearSession(externalSessionId: string, runtimeId?: string): void {
     const linksToClear = new Set<CodexStoredSubagentLink>();
-    for (const link of this.linksByCorrelationKey.values()) {
-      if (
-        (runtimeId === undefined || link.runtimeId === runtimeId) &&
-        (link.parentThreadId === externalSessionId || link.childThreadId === externalSessionId)
-      ) {
+    if (runtimeId !== undefined) {
+      for (const link of this.linksByParentKey
+        .get(parentThreadKey(runtimeId, externalSessionId))
+        ?.values() ?? []) {
         linksToClear.add(link);
+      }
+      for (const link of this.provisionalByParentKey
+        .get(parentThreadKey(runtimeId, externalSessionId))
+        ?.values() ?? []) {
+        linksToClear.add(link);
+      }
+      const childLink = this.linksByChildThreadId.get(childThreadKey(runtimeId, externalSessionId));
+      if (childLink) {
+        linksToClear.add(childLink);
+      }
+    } else {
+      for (const link of this.linksByCorrelationKey.values()) {
+        if (link.parentThreadId === externalSessionId) {
+          linksToClear.add(link);
+        }
+      }
+      for (const link of this.linksByChildThreadId.values()) {
+        if (link.childThreadId === externalSessionId) {
+          linksToClear.add(link);
+        }
       }
     }
     for (const link of linksToClear) {
@@ -431,36 +492,47 @@ export class CodexSubagentLinkState {
   }
 
   private storeLink(link: CodexStoredSubagentLink, parentItemKey: string): void {
-    const hadProvisionalBridge = this.provisionalByParentItemKey.has(parentItemKey);
+    const parentKey = parentThreadKey(link.runtimeId, link.parentThreadId);
+    const provisionalLinks =
+      this.provisionalByParentKey.get(parentKey) ?? new Map<string, CodexStoredSubagentLink>();
+    const hadProvisionalBridge = provisionalLinks.has(parentItemKey);
     this.linksByCorrelationKey.set(scopedKey(link.runtimeId, link.correlationKey), link);
     if (!link.childThreadId || hadProvisionalBridge) {
-      this.provisionalByParentItemKey.set(parentItemKey, link);
+      provisionalLinks.set(parentItemKey, link);
+      this.provisionalByParentKey.set(parentKey, provisionalLinks);
     }
     if (!link.childThreadId) {
       return;
     }
-    this.linksByParentChildKey.set(
-      subagentKey(link.runtimeId, link.parentThreadId, link.childThreadId),
-      link,
-    );
+    const linkedChildren =
+      this.linksByParentKey.get(parentKey) ?? new Map<string, CodexStoredSubagentLink>();
+    linkedChildren.set(link.childThreadId, link);
+    this.linksByParentKey.set(parentKey, linkedChildren);
     this.linksByChildThreadId.set(childThreadKey(link.runtimeId, link.childThreadId), link);
   }
 
   private deleteLink(link: CodexStoredSubagentLink): void {
+    const parentKey = parentThreadKey(link.runtimeId, link.parentThreadId);
     this.linksByCorrelationKey.delete(scopedKey(link.runtimeId, link.correlationKey));
     if (link.childThreadId) {
-      this.linksByParentChildKey.delete(
-        subagentKey(link.runtimeId, link.parentThreadId, link.childThreadId),
-      );
+      const linkedChildren = this.linksByParentKey.get(parentKey);
+      linkedChildren?.delete(link.childThreadId);
+      if (linkedChildren?.size === 0) {
+        this.linksByParentKey.delete(parentKey);
+      }
       this.linksByChildThreadId.delete(childThreadKey(link.runtimeId, link.childThreadId));
     }
-    for (const [key, provisional] of this.provisionalByParentItemKey) {
+    const provisionalLinks = this.provisionalByParentKey.get(parentKey);
+    for (const [key, provisional] of provisionalLinks ?? []) {
       if (
         provisional.runtimeId === link.runtimeId &&
         provisional.correlationKey === link.correlationKey
       ) {
-        this.provisionalByParentItemKey.delete(key);
+        provisionalLinks?.delete(key);
       }
+    }
+    if (provisionalLinks?.size === 0) {
+      this.provisionalByParentKey.delete(parentKey);
     }
   }
 

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -70,6 +70,13 @@ const linkedCorrelationKey = (parentThreadId: string, childThreadId: string): st
 const provisionalCorrelationKey = (parentThreadId: string, itemId: string): string =>
   `codex-subagent:${parentThreadId}:${itemId}`;
 
+const defaultCorrelationKey = (input: CodexSubagentLinkInput): string => {
+  if (!input.childThreadId || input.preferItemCorrelationKey) {
+    return provisionalCorrelationKey(input.parentThreadId, input.itemId);
+  }
+  return linkedCorrelationKey(input.parentThreadId, input.childThreadId);
+};
+
 const STATUS_PRECEDENCE: Record<AgentSubagentStatus, number> = {
   pending: 0,
   running: 1,
@@ -258,11 +265,7 @@ export class CodexSubagentLinkState {
     const correlationKey =
       existingLinked?.correlationKey ??
       existingProvisional?.correlationKey ??
-      (input.childThreadId
-        ? input.preferItemCorrelationKey
-          ? provisionalCorrelationKey(input.parentThreadId, input.itemId)
-          : linkedCorrelationKey(input.parentThreadId, input.childThreadId)
-        : provisionalCorrelationKey(input.parentThreadId, input.itemId));
+      defaultCorrelationKey(input);
     const existing =
       existingLinked ??
       existingProvisional ??

--- a/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
+++ b/packages/adapters-codex-app-server/src/codex-subagent-link-state.ts
@@ -495,9 +495,18 @@ export class CodexSubagentLinkState {
     const parentKey = parentThreadKey(link.runtimeId, link.parentThreadId);
     const provisionalLinks =
       this.provisionalByParentKey.get(parentKey) ?? new Map<string, CodexStoredSubagentLink>();
-    const hadProvisionalBridge = provisionalLinks.has(parentItemKey);
+    const displacedProvisional = provisionalLinks.get(parentItemKey);
+    if (displacedProvisional && displacedProvisional.correlationKey !== link.correlationKey) {
+      const displacedCorrelationKey = scopedKey(
+        displacedProvisional.runtimeId,
+        displacedProvisional.correlationKey,
+      );
+      if (this.linksByCorrelationKey.get(displacedCorrelationKey) === displacedProvisional) {
+        this.linksByCorrelationKey.delete(displacedCorrelationKey);
+      }
+    }
     this.linksByCorrelationKey.set(scopedKey(link.runtimeId, link.correlationKey), link);
-    if (!link.childThreadId || hadProvisionalBridge) {
+    if (!link.childThreadId || displacedProvisional) {
       provisionalLinks.set(parentItemKey, link);
       this.provisionalByParentKey.set(parentKey, provisionalLinks);
     }


### PR DESCRIPTION
## Summary

- Own Codex live item start timestamps by runtime, thread, and item lifecycle.
- Clear unmatched and routed item timing state during session and runtime teardown without scanning unrelated timestamps.
- Add lifecycle, routing, isolation, reuse, and index-cleanup regressions.
- Keep public runtime contracts, durable storage, and unrelated adapter cleanup out of scope.

## Goal

Codex can emit `item/started` without a matching `item/completed` event. The previous flat string-keyed timestamp map retained those unmatched starts for the process lifetime because session and runtime teardown could not remove owned entries directly.

This change gives timestamp state explicit lifecycle ownership so teardown removes all owned data while preserving matched completion behavior and runtime-supplied timestamps.

## Implementation

- Replace the flat timestamp map with nested runtime, thread, and item maps in `CodexRuntimeSessionEvents`.
- Expose narrow record, take-and-delete, session-clear, and runtime-clear operations. Taking a matched start prunes empty parent maps.
- Delete a known thread map directly during session release and the whole runtime map during runtime release. No prefix scan or duplicate timestamp ownership index is added.
- Capture unretained routed descendants before subagent link teardown, stop at separately retained child boundaries, and use parent-bucketed traversal so cleanup does not scan unrelated routes.
- Keep subagent correlation indexes coherent when provisional routes are displaced by deleting only records that still own their correlation entry.
- Preserve runtime-provided completion timing and fresh state when item identifiers are reused.

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run format:check`
- [x] `bun run test:scripts`

## Checklist

- [x] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [x] I linked related issues or context below

## Related Issues

- OpenDucktor task `openduckto-uxql`

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional Context

- No public workflow or runtime contract changed, so no user-facing docs needed an update.
- A queued runtime event cannot recreate released timestamp state: session release removes ownership and clears timestamps in one synchronous call stack, while queued event handling resolves ownership only when it starts. An already-started item notification records synchronously before its first yield, so release clears that timestamp afterward.
- Cargo checks do not apply because this repository has no `Cargo.toml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of session and routed-item state when sessions are released or resumed.
  * Prevented stale tool timing information from appearing in later assistant activity.
  * Improved handling of reused item identifiers and unmatched lifecycle events.
  * Ensured cleanup remains isolated across runtimes and retained child sessions.
  * Improved routed session tracking, including nested routes and cycle handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->