### PR TITLE
fix(opencode): normalize sync lineage routing

### DIFF
--- a/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.subagents.test.ts
@@ -811,8 +811,8 @@ describe("event-stream subagent correlation", () => {
     );
   });
 
-  test("binds child session creation when the parent id is on event properties", async () => {
-    const { emitted, sessionRecord } = await runEventStreamWithSession([
+  test("reports child session creation when info.parentID is missing", async () => {
+    const { emitted } = await runEventStreamWithSession([
       assistantRoleEvent("assistant-subagent-top-level-parent"),
       makeAssistantSubtaskPartUpdatedEvent({
         messageId: "assistant-subagent-top-level-parent",
@@ -825,18 +825,11 @@ describe("event-stream subagent correlation", () => {
       }),
     ]);
 
-    const subagentParts = readSubagentParts(emitted);
-    expect(subagentParts).toHaveLength(2);
-    expect(subagentParts.map((part) => part.externalSessionId)).toEqual([
-      undefined,
-      "external-child-session",
-    ]);
-    expect(subagentParts[1]).toMatchObject({
-      correlationKey: "part:assistant-subagent-top-level-parent:subtask-a",
-      status: "running",
-    });
-    expect(sessionRecord.subagentPartIdByExternalSessionId.get("external-child-session")).toBe(
-      "subtask-a",
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("info.parentID"),
+      }),
     );
   });
 

--- a/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
@@ -1,4 +1,4 @@
-import type { Event, OpencodeClient, Session } from "@opencode-ai/sdk/v2/client";
+import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import { workflowAgentSessionScope } from "@openducktor/core";
 import { subscribeSessionToRuntimeEvents } from "./session-registry";
@@ -11,15 +11,9 @@ import type {
 
 type RunEventStreamOptions = {
   logEvent?: OpencodeEventLogger;
-  childrenBySessionId?: Record<string, Session[]>;
 };
 
-export const makeClientWithEvents = (
-  events: Event[],
-  options?: {
-    childrenBySessionId?: Record<string, Session[]>;
-  },
-): OpencodeClient => {
+export const makeClientWithEvents = (events: Event[]): OpencodeClient => {
   return {
     global: {
       event: async () => {
@@ -34,15 +28,6 @@ export const makeClientWithEvents = (
         return { stream: iterator() };
       },
     },
-    ...(options?.childrenBySessionId
-      ? {
-          session: {
-            children: async ({ sessionID }: { sessionID: string }) => ({
-              data: options.childrenBySessionId?.[sessionID] ?? [],
-            }),
-          },
-        }
-      : {}),
   } as unknown as OpencodeClient;
 };
 
@@ -99,9 +84,7 @@ export const runEventStreamWithSession = async (
   configureSession?: (sessionRecord: SessionRecord) => void,
   options: RunEventStreamOptions = {},
 ): Promise<{ emitted: AgentEvent[]; sessionRecord: SessionRecord }> => {
-  const client = makeClientWithEvents(events, {
-    ...(options.childrenBySessionId ? { childrenBySessionId: options.childrenBySessionId } : {}),
-  });
+  const client = makeClientWithEvents(events);
   const emitted: AgentEvent[] = [];
   const sessionRecord = makeSessionRecord(client);
   configureSession?.(sessionRecord);

--- a/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
@@ -1,4 +1,4 @@
-import type { Event, GlobalEvent, OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import type { GlobalEvent, OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import { workflowAgentSessionScope } from "@openducktor/core";
 import { subscribeSessionToRuntimeEvents } from "./session-registry";
@@ -14,16 +14,24 @@ type RunEventStreamOptions = {
 };
 
 type GlobalEventPayload = GlobalEvent["payload"];
+type WithoutOuterSyncId<T> = T extends { type: "sync" } ? Omit<T, "id"> : never;
 
-export const makeClientWithEvents = (events: GlobalEventPayload[]): OpencodeClient => {
+export type TestGlobalEventPayload = GlobalEventPayload | WithoutOuterSyncId<GlobalEventPayload>;
+
+type TestGlobalEvent = Omit<GlobalEvent, "payload"> & {
+  payload: TestGlobalEventPayload;
+};
+
+export const makeClientWithEvents = (events: TestGlobalEventPayload[]): OpencodeClient => {
   return {
     global: {
       event: async () => {
-        async function* iterator(): AsyncGenerator<GlobalEvent> {
+        async function* iterator(): AsyncGenerator<TestGlobalEvent> {
           for (const event of events) {
-            const directory =
-              (event as Event & { properties?: { directory?: string } }).properties?.directory ??
-              "/repo";
+            const properties = "properties" in event ? event.properties : undefined;
+            const directoryValue =
+              properties && "directory" in properties ? properties.directory : undefined;
+            const directory = typeof directoryValue === "string" ? directoryValue : "/repo";
             yield { directory, payload: event };
           }
         }
@@ -82,7 +90,7 @@ export const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
 });
 
 export const runEventStreamWithSession = async (
-  events: GlobalEventPayload[],
+  events: TestGlobalEventPayload[],
   configureSession?: (sessionRecord: SessionRecord) => void,
   options: RunEventStreamOptions = {},
 ): Promise<{ emitted: AgentEvent[]; sessionRecord: SessionRecord }> => {
@@ -116,6 +124,6 @@ export const runEventStreamWithSession = async (
   return { emitted, sessionRecord };
 };
 
-export const runEventStream = async (events: GlobalEventPayload[]): Promise<AgentEvent[]> => {
+export const runEventStream = async (events: TestGlobalEventPayload[]): Promise<AgentEvent[]> => {
   return (await runEventStreamWithSession(events)).emitted;
 };

--- a/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
@@ -1,4 +1,10 @@
-import type { GlobalEvent, OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import type {
+  EventSessionCreated,
+  GlobalEvent,
+  OpencodeClient,
+  Session,
+  SyncEventSessionCreated,
+} from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import { workflowAgentSessionScope } from "@openducktor/core";
 import { subscribeSessionToRuntimeEvents } from "./session-registry";
@@ -15,11 +21,136 @@ type RunEventStreamOptions = {
 
 type GlobalEventPayload = GlobalEvent["payload"];
 type WithoutOuterSyncId<T> = T extends { type: "sync" } ? Omit<T, "id"> : never;
+type ParentAlias = "parentId" | "parent_id";
+type ParentAliasSessionInfo = Session & Partial<Record<ParentAlias, string>>;
 
 export type TestGlobalEventPayload = GlobalEventPayload | WithoutOuterSyncId<GlobalEventPayload>;
+export type RuntimeSourceSyncEventSessionCreated = Omit<SyncEventSessionCreated, "id">;
+export type UnsupportedParentAliasSessionCreatedEvent = Omit<EventSessionCreated, "properties"> & {
+  properties: Omit<EventSessionCreated["properties"], "info"> & {
+    info: ParentAliasSessionInfo;
+  };
+};
+export type UnsupportedRuntimeSourceSyncSessionCreatedEvent = Omit<
+  RuntimeSourceSyncEventSessionCreated,
+  "syncEvent"
+> & {
+  syncEvent: Omit<RuntimeSourceSyncEventSessionCreated["syncEvent"], "data"> & {
+    data: Omit<RuntimeSourceSyncEventSessionCreated["syncEvent"]["data"], "info"> & {
+      info: ParentAliasSessionInfo;
+    };
+  };
+};
 
 type TestGlobalEvent = Omit<GlobalEvent, "payload"> & {
   payload: TestGlobalEventPayload;
+};
+
+export const childSessionInfo = (childSessionId: string, parentID?: string): Session => ({
+  id: childSessionId,
+  slug: childSessionId,
+  projectID: "project-1",
+  directory: "/repo",
+  ...(parentID ? { parentID } : {}),
+  title: "Subagent",
+  version: "1.0.0",
+  time: {
+    created: Date.parse("2026-02-22T12:00:10.000Z"),
+    updated: Date.parse("2026-02-22T12:00:10.000Z"),
+  },
+});
+
+export const childSessionCreatedEvent = (
+  childSessionId: string,
+  parentID = "external-session-1",
+): EventSessionCreated =>
+  ({
+    id: `event-created-${childSessionId}`,
+    type: "session.created",
+    properties: {
+      sessionID: childSessionId,
+      info: childSessionInfo(childSessionId, parentID),
+    },
+  }) satisfies EventSessionCreated;
+
+export const childSessionCreatedEventWithParentAlias = (
+  childSessionId: string,
+  parentAlias: ParentAlias,
+  parentExternalSessionId = "external-session-1",
+): UnsupportedParentAliasSessionCreatedEvent => {
+  const info = {
+    ...childSessionInfo(childSessionId),
+    [parentAlias]: parentExternalSessionId,
+  };
+  return {
+    id: `event-created-${childSessionId}-${parentAlias}`,
+    type: "session.created",
+    properties: {
+      sessionID: childSessionId,
+      info,
+    },
+  } satisfies UnsupportedParentAliasSessionCreatedEvent;
+};
+
+export const syncChildSessionCreatedEvent = (
+  childSessionId: string,
+  parentID = "external-session-1",
+): SyncEventSessionCreated =>
+  ({
+    type: "sync",
+    id: `sync-${childSessionId}`,
+    syncEvent: {
+      type: "session.created.1",
+      id: `sync-event-${childSessionId}`,
+      seq: 2,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        info: childSessionInfo(childSessionId, parentID),
+      },
+    },
+  }) satisfies SyncEventSessionCreated;
+
+export const runtimeSourceSyncChildSessionCreatedEvent = (
+  childSessionId: string,
+  parentID = "external-session-1",
+): RuntimeSourceSyncEventSessionCreated =>
+  ({
+    type: "sync",
+    syncEvent: {
+      type: "session.created.1",
+      id: `sync-event-runtime-source-${childSessionId}`,
+      seq: 2,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        info: childSessionInfo(childSessionId, parentID),
+      },
+    },
+  }) satisfies RuntimeSourceSyncEventSessionCreated;
+
+export const runtimeSourceSyncChildSessionCreatedEventWithParentAlias = (
+  childSessionId: string,
+  parentAlias: ParentAlias,
+  parentExternalSessionId = "external-session-1",
+): UnsupportedRuntimeSourceSyncSessionCreatedEvent => {
+  const info = {
+    ...childSessionInfo(childSessionId),
+    [parentAlias]: parentExternalSessionId,
+  };
+  return {
+    type: "sync",
+    syncEvent: {
+      type: "session.created.1",
+      id: `sync-event-runtime-source-${childSessionId}-${parentAlias}`,
+      seq: 2,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        info,
+      },
+    },
+  } satisfies UnsupportedRuntimeSourceSyncSessionCreatedEvent;
 };
 
 export const makeClientWithEvents = (events: TestGlobalEventPayload[]): OpencodeClient => {

--- a/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test-support.ts
@@ -1,4 +1,4 @@
-import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import type { Event, GlobalEvent, OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import { workflowAgentSessionScope } from "@openducktor/core";
 import { subscribeSessionToRuntimeEvents } from "./session-registry";
@@ -13,11 +13,13 @@ type RunEventStreamOptions = {
   logEvent?: OpencodeEventLogger;
 };
 
-export const makeClientWithEvents = (events: Event[]): OpencodeClient => {
+type GlobalEventPayload = GlobalEvent["payload"];
+
+export const makeClientWithEvents = (events: GlobalEventPayload[]): OpencodeClient => {
   return {
     global: {
       event: async () => {
-        async function* iterator(): AsyncGenerator<{ directory: string; payload: Event }> {
+        async function* iterator(): AsyncGenerator<GlobalEvent> {
           for (const event of events) {
             const directory =
               (event as Event & { properties?: { directory?: string } }).properties?.directory ??
@@ -80,7 +82,7 @@ export const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
 });
 
 export const runEventStreamWithSession = async (
-  events: Event[],
+  events: GlobalEventPayload[],
   configureSession?: (sessionRecord: SessionRecord) => void,
   options: RunEventStreamOptions = {},
 ): Promise<{ emitted: AgentEvent[]; sessionRecord: SessionRecord }> => {
@@ -114,6 +116,6 @@ export const runEventStreamWithSession = async (
   return { emitted, sessionRecord };
 };
 
-export const runEventStream = async (events: Event[]): Promise<AgentEvent[]> => {
+export const runEventStream = async (events: GlobalEventPayload[]): Promise<AgentEvent[]> => {
   return (await runEventStreamWithSession(events)).emitted;
 };

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type {
-  Event,
-  EventSessionCreated,
-  EventSessionUpdated,
-  Session,
-} from "@opencode-ai/sdk/v2/client";
+import type { Event, EventSessionUpdated } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent, AgentModelSelection, AgentUserMessagePart } from "@openducktor/core";
 import {
   isRelevantSubscriberEvent,
@@ -16,8 +11,12 @@ import {
   flushPendingSubagentInputEventsForSession,
   readEventParentExternalSessionId,
   readEventSessionId,
+  readSessionLifecycleEvent,
 } from "./event-stream/shared";
 import {
+  childSessionCreatedEvent,
+  childSessionCreatedEventWithParentAlias,
+  childSessionInfo,
   makeClientWithEvents,
   makeSessionInput,
   makeSessionRecord,
@@ -98,30 +97,6 @@ const buildQueuedSignature = (message: string, model?: AgentModelSelection | nul
   return buildQueuedRequestSignature(parts, model ?? undefined);
 };
 
-const childSessionInfo = (parentID: string | null = "external-session-1"): Session => ({
-  id: "external-child-session",
-  slug: "external-child-session",
-  projectID: "project-1",
-  directory: "/repo",
-  ...(parentID ? { parentID } : {}),
-  title: "Subagent",
-  version: "1.0.0",
-  time: {
-    created: Date.parse("2026-02-22T12:00:10.000Z"),
-    updated: Date.parse("2026-02-22T12:00:10.000Z"),
-  },
-});
-
-const childSessionLifecycleEvent = (): EventSessionCreated =>
-  ({
-    id: "event-child-session-created",
-    type: "session.created",
-    properties: {
-      sessionID: "external-child-session",
-      info: childSessionInfo(),
-    },
-  }) satisfies EventSessionCreated;
-
 test("readEventParentExternalSessionId accepts OpenCode parent id spellings", () => {
   for (const key of ["parentID", "parentId", "parent_id"] as const) {
     expect(readEventParentExternalSessionId({ [key]: "external-parent-session" })).toBe(
@@ -162,6 +137,31 @@ test("readEventSessionId accepts info.id only for session lifecycle events", () 
       properties: {
         info: { id: "message-1" },
       },
+    } as unknown as Event),
+  ).toBeUndefined();
+});
+
+test("readSessionLifecycleEvent reads exact lifecycle lineage", () => {
+  const event = childSessionCreatedEvent("external-child-session");
+
+  expect(readSessionLifecycleEvent(event)).toEqual({
+    type: "session.created",
+    properties: event.properties,
+    info: event.properties.info,
+    externalSessionId: "external-child-session",
+    parentExternalSessionId: "external-session-1",
+  });
+});
+
+test("readSessionLifecycleEvent ignores parent aliases and non-lifecycle events", () => {
+  const event = childSessionCreatedEvent("external-child-session");
+  const aliasEvent = childSessionCreatedEventWithParentAlias("external-child-session", "parentId");
+
+  expect(readSessionLifecycleEvent(aliasEvent)?.parentExternalSessionId).toBeUndefined();
+  expect(
+    readSessionLifecycleEvent({
+      type: "message.updated",
+      properties: event.properties,
     } as unknown as Event),
   ).toBeUndefined();
 });
@@ -2166,18 +2166,11 @@ describe("event-stream", () => {
     };
 
     for (const parentAlias of ["parentId", "parent_id"] as const) {
-      const info = {
-        ...childSessionInfo(null),
-        [parentAlias]: parentSubscriber.externalSessionId,
-      };
-      const lifecycleEvent = {
-        id: `event-child-session-created-${parentAlias}`,
-        type: "session.created",
-        properties: {
-          sessionID: "external-child-session",
-          info,
-        },
-      } satisfies EventSessionCreated;
+      const lifecycleEvent = childSessionCreatedEventWithParentAlias(
+        "external-child-session",
+        parentAlias,
+        parentSubscriber.externalSessionId,
+      );
 
       expect(isRelevantSubscriberEvent(parentSubscriber, lifecycleEvent)).toBe(false);
     }
@@ -2187,18 +2180,11 @@ describe("event-stream", () => {
     for (const parentAlias of ["parentId", "parent_id"] as const) {
       const sessionRecord = makeSessionRecord(makeClientWithEvents([]));
       sessionRecord.pendingSubagentCorrelationKeys.push("part:assistant-1:subtask-1");
-      const info = {
-        ...childSessionInfo(null),
-        [parentAlias]: sessionRecord.externalSessionId,
-      };
-      const lifecycleEvent = {
-        id: `event-child-session-created-${parentAlias}`,
-        type: "session.created",
-        properties: {
-          sessionID: "external-child-session",
-          info,
-        },
-      } satisfies EventSessionCreated;
+      const lifecycleEvent = childSessionCreatedEventWithParentAlias(
+        "external-child-session",
+        parentAlias,
+        sessionRecord.externalSessionId,
+      );
 
       processOpencodeEvent({
         context: {
@@ -2602,7 +2588,7 @@ describe("event-stream", () => {
   test("runtime event transport forwards known child question events to parent subscribers", async () => {
     const { emitted } = await runEventStreamWithSession(
       [
-        childSessionLifecycleEvent(),
+        childSessionCreatedEvent("external-child-session"),
         {
           type: "question.asked",
           properties: {
@@ -2697,7 +2683,7 @@ describe("event-stream", () => {
           type: "session.updated",
           properties: {
             sessionID: "external-child-session",
-            info: childSessionInfo(),
+            info: childSessionInfo("external-child-session", "external-session-1"),
           },
         } satisfies EventSessionUpdated,
       ],
@@ -2831,7 +2817,7 @@ describe("event-stream", () => {
   test("runtime event transport forwards known child permission events to parent subscribers", async () => {
     const { emitted } = await runEventStreamWithSession(
       [
-        childSessionLifecycleEvent(),
+        childSessionCreatedEvent("external-child-session"),
         {
           type: "permission.asked",
           properties: {
@@ -2865,7 +2851,7 @@ describe("event-stream", () => {
   test("runtime event transport forwards known child permission v2 events to parent subscribers", async () => {
     const { emitted } = await runEventStreamWithSession(
       [
-        childSessionLifecycleEvent(),
+        childSessionCreatedEvent("external-child-session"),
         {
           type: "permission.v2.asked",
           properties: {
@@ -2899,7 +2885,7 @@ describe("event-stream", () => {
   test("runtime event transport forwards known child permission resolved events to parent subscribers", async () => {
     const { emitted } = await runEventStreamWithSession(
       [
-        childSessionLifecycleEvent(),
+        childSessionCreatedEvent("external-child-session"),
         {
           type: "permission.replied",
           properties: {

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -93,6 +93,21 @@ const buildQueuedSignature = (message: string, model?: AgentModelSelection | nul
   return buildQueuedRequestSignature(parts, model ?? undefined);
 };
 
+const childSessionLifecycleEvent = (): Event =>
+  ({
+    type: "session.created",
+    properties: {
+      sessionID: "external-child-session",
+      info: {
+        id: "external-child-session",
+        parentID: "external-session-1",
+        time: {
+          created: Date.parse("2026-02-22T12:00:10.000Z"),
+        },
+      },
+    },
+  }) as unknown as Event;
+
 test("readEventParentExternalSessionId accepts OpenCode parent id spellings", () => {
   for (const key of ["parentID", "parentId", "parent_id"] as const) {
     expect(readEventParentExternalSessionId({ [key]: "external-parent-session" })).toBe(
@@ -2091,19 +2106,23 @@ describe("event-stream", () => {
     expect(isRelevantSubscriberEvent(parentSubscriber, childPermissionEvent)).toBe(false);
     expect(
       isRelevantSubscriberEvent(parentSubscriber, childPermissionEvent, {
-        isKnownChildExternalSessionId: (externalSessionId) =>
-          externalSessionId === "external-child-session",
+        resolveParentExternalSessionId: (externalSessionId) =>
+          externalSessionId === "external-child-session"
+            ? parentSubscriber.externalSessionId
+            : undefined,
       }),
     ).toBe(true);
     expect(
       isRelevantSubscriberEvent(parentSubscriber, childMessageEvent, {
-        isKnownChildExternalSessionId: (externalSessionId) =>
-          externalSessionId === "external-child-session",
+        resolveParentExternalSessionId: (externalSessionId) =>
+          externalSessionId === "external-child-session"
+            ? parentSubscriber.externalSessionId
+            : undefined,
       }),
     ).toBe(false);
   });
 
-  test("treats child session creation with top-level parent id as relevant to the parent subscriber", () => {
+  test("does not treat a top-level lifecycle parent id as authoritative", () => {
     const childSessionCreatedEvent = {
       type: "session.created",
       properties: {
@@ -2122,7 +2141,7 @@ describe("event-stream", () => {
       input: makeSessionInput(),
     };
 
-    expect(isRelevantSubscriberEvent(parentSubscriber, childSessionCreatedEvent)).toBe(true);
+    expect(isRelevantSubscriberEvent(parentSubscriber, childSessionCreatedEvent)).toBe(false);
     expect(isRelevantSubscriberEvent(otherSubscriber, childSessionCreatedEvent)).toBe(false);
   });
 
@@ -2508,6 +2527,7 @@ describe("event-stream", () => {
   test("runtime event transport forwards known child question events to parent subscribers", async () => {
     const { emitted } = await runEventStreamWithSession(
       [
+        childSessionLifecycleEvent(),
         {
           type: "question.asked",
           properties: {
@@ -2740,6 +2760,7 @@ describe("event-stream", () => {
   test("runtime event transport forwards known child permission events to parent subscribers", async () => {
     const { emitted } = await runEventStreamWithSession(
       [
+        childSessionLifecycleEvent(),
         {
           type: "permission.asked",
           properties: {
@@ -2773,6 +2794,7 @@ describe("event-stream", () => {
   test("runtime event transport forwards known child permission v2 events to parent subscribers", async () => {
     const { emitted } = await runEventStreamWithSession(
       [
+        childSessionLifecycleEvent(),
         {
           type: "permission.v2.asked",
           properties: {
@@ -2806,6 +2828,7 @@ describe("event-stream", () => {
   test("runtime event transport forwards known child permission resolved events to parent subscribers", async () => {
     const { emitted } = await runEventStreamWithSession(
       [
+        childSessionLifecycleEvent(),
         {
           type: "permission.replied",
           properties: {

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { Event } from "@opencode-ai/sdk/v2/client";
+import type {
+  Event,
+  EventSessionCreated,
+  EventSessionUpdated,
+  Session,
+} from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent, AgentModelSelection, AgentUserMessagePart } from "@openducktor/core";
 import {
   isRelevantSubscriberEvent,
@@ -93,20 +98,29 @@ const buildQueuedSignature = (message: string, model?: AgentModelSelection | nul
   return buildQueuedRequestSignature(parts, model ?? undefined);
 };
 
-const childSessionLifecycleEvent = (): Event =>
+const childSessionInfo = (parentID: string | null = "external-session-1"): Session => ({
+  id: "external-child-session",
+  slug: "external-child-session",
+  projectID: "project-1",
+  directory: "/repo",
+  ...(parentID ? { parentID } : {}),
+  title: "Subagent",
+  version: "1.0.0",
+  time: {
+    created: Date.parse("2026-02-22T12:00:10.000Z"),
+    updated: Date.parse("2026-02-22T12:00:10.000Z"),
+  },
+});
+
+const childSessionLifecycleEvent = (): EventSessionCreated =>
   ({
+    id: "event-child-session-created",
     type: "session.created",
     properties: {
       sessionID: "external-child-session",
-      info: {
-        id: "external-child-session",
-        parentID: "external-session-1",
-        time: {
-          created: Date.parse("2026-02-22T12:00:10.000Z"),
-        },
-      },
+      info: childSessionInfo(),
     },
-  }) as unknown as Event;
+  }) satisfies EventSessionCreated;
 
 test("readEventParentExternalSessionId accepts OpenCode parent id spellings", () => {
   for (const key of ["parentID", "parentId", "parent_id"] as const) {
@@ -2145,6 +2159,67 @@ describe("event-stream", () => {
     expect(isRelevantSubscriberEvent(otherSubscriber, childSessionCreatedEvent)).toBe(false);
   });
 
+  test("does not treat lifecycle parent aliases as authoritative", () => {
+    const parentSubscriber = {
+      externalSessionId: "external-parent-session",
+      input: makeSessionInput(),
+    };
+
+    for (const parentAlias of ["parentId", "parent_id"] as const) {
+      const info = {
+        ...childSessionInfo(null),
+        [parentAlias]: parentSubscriber.externalSessionId,
+      };
+      const lifecycleEvent = {
+        id: `event-child-session-created-${parentAlias}`,
+        type: "session.created",
+        properties: {
+          sessionID: "external-child-session",
+          info,
+        },
+      } satisfies EventSessionCreated;
+
+      expect(isRelevantSubscriberEvent(parentSubscriber, lifecycleEvent)).toBe(false);
+    }
+  });
+
+  test("does not bind child correlation from lifecycle parent aliases", () => {
+    for (const parentAlias of ["parentId", "parent_id"] as const) {
+      const sessionRecord = makeSessionRecord(makeClientWithEvents([]));
+      sessionRecord.pendingSubagentCorrelationKeys.push("part:assistant-1:subtask-1");
+      const info = {
+        ...childSessionInfo(null),
+        [parentAlias]: sessionRecord.externalSessionId,
+      };
+      const lifecycleEvent = {
+        id: `event-child-session-created-${parentAlias}`,
+        type: "session.created",
+        properties: {
+          sessionID: "external-child-session",
+          info,
+        },
+      } satisfies EventSessionCreated;
+
+      processOpencodeEvent({
+        context: {
+          externalSessionId: sessionRecord.externalSessionId,
+          input: sessionRecord.input,
+        },
+        event: lifecycleEvent,
+        now: () => "2026-02-22T12:00:00.000Z",
+        emit: () => undefined,
+        getSession: () => sessionRecord,
+      });
+
+      expect(
+        sessionRecord.pendingSubagentSessionsByExternalSessionId.has("external-child-session"),
+      ).toBe(false);
+      expect(
+        sessionRecord.subagentCorrelationKeyByExternalSessionId.has("external-child-session"),
+      ).toBe(false);
+    }
+  });
+
   test("does not treat same-directory child input events as parent-owned without a child link", () => {
     const parentSubscriber = {
       externalSessionId: "external-parent-session",
@@ -2618,17 +2693,13 @@ describe("event-stream", () => {
           },
         } as unknown as Event,
         {
+          id: "event-child-session-updated",
           type: "session.updated",
           properties: {
-            info: {
-              id: "external-child-session",
-              parentID: "external-session-1",
-              time: {
-                created: Date.parse("2026-02-22T12:00:11.000Z"),
-              },
-            },
+            sessionID: "external-child-session",
+            info: childSessionInfo(),
           },
-        } as unknown as Event,
+        } satisfies EventSessionUpdated,
       ],
       (session) => {
         session.pendingSubagentCorrelationKeys.push("part:assistant-1:subtask-1");

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -2136,6 +2136,48 @@ describe("event-stream", () => {
     ).toBe(false);
   });
 
+  test("prefers explicit pending-input parents over conflicting confirmed lineage", () => {
+    const confirmedParentSubscriber = {
+      externalSessionId: "external-confirmed-parent",
+      input: makeSessionInput(),
+    };
+    const explicitParentSubscriber = {
+      externalSessionId: "external-explicit-parent",
+      input: makeSessionInput(),
+    };
+    const resolveConfirmedParent = (externalSessionId: string) =>
+      externalSessionId === "external-child-session"
+        ? confirmedParentSubscriber.externalSessionId
+        : undefined;
+
+    for (const eventType of [
+      "permission.asked",
+      "permission.v2.asked",
+      "permission.replied",
+      "question.asked",
+      "question.replied",
+    ] as const) {
+      const event = {
+        type: eventType,
+        properties: {
+          sessionID: "external-child-session",
+          parentID: explicitParentSubscriber.externalSessionId,
+        },
+      } as unknown as Event;
+
+      expect(
+        isRelevantSubscriberEvent(confirmedParentSubscriber, event, {
+          resolveParentExternalSessionId: resolveConfirmedParent,
+        }),
+      ).toBe(false);
+      expect(
+        isRelevantSubscriberEvent(explicitParentSubscriber, event, {
+          resolveParentExternalSessionId: resolveConfirmedParent,
+        }),
+      ).toBe(true);
+    }
+  });
+
   test("does not treat a top-level lifecycle parent id as authoritative", () => {
     const childSessionCreatedEvent = {
       type: "session.created",

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -22,6 +22,7 @@ import {
   makeSessionRecord,
   runEventStream,
   runEventStreamWithSession,
+  runtimeSourceSyncChildSessionCreatedEvent,
 } from "./event-stream.test-support";
 import {
   buildQueuedRequestAttachmentIdentitySignature,
@@ -90,6 +91,33 @@ test("global event observation becomes ready only after the lazy SSE stream conn
   connect?.();
   await observation;
   expect(order).toEqual(["server.connected", "ready"]);
+});
+
+test("global event observation drops the raw envelope after normalizing sync events", async () => {
+  const client = makeClientWithEvents([
+    runtimeSourceSyncChildSessionCreatedEvent("external-child-session"),
+  ]);
+  const events: Event[] = [];
+
+  await subscribeGlobalEvents({
+    client,
+    controller: new AbortController(),
+    onEvent: (event) => {
+      events.push(event);
+    },
+  });
+
+  expect(events).toHaveLength(1);
+  expect(events[0]).not.toHaveProperty("syncEvent");
+  expect(events[0]).toEqual({
+    id: "sync-event-runtime-source-external-child-session",
+    type: "session.created",
+    properties: {
+      sessionID: "external-child-session",
+      info: childSessionInfo("external-child-session", "external-session-1"),
+      directory: "/repo",
+    },
+  });
 });
 
 const buildQueuedSignature = (message: string, model?: AgentModelSelection | null): string => {

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -62,7 +62,7 @@ type GlobalEventApi = {
   event: (options?: { signal?: AbortSignal }) => Promise<GlobalEventStream> | GlobalEventStream;
 };
 
-const SYNC_EVENT_TYPE_BY_NAME = {
+const NORMALIZED_EVENT_TYPE_BY_SYNC_TYPE = {
   "message.updated.1": "message.updated",
   "message.part.updated.1": "message.part.updated",
   "message.part.removed.1": "message.part.removed",
@@ -117,7 +117,10 @@ const normalizeGlobalEventPayload = (payload: GlobalEventPayload): Event => {
     );
   }
 
-  const eventType = SYNC_EVENT_TYPE_BY_NAME[syncEventType as keyof typeof SYNC_EVENT_TYPE_BY_NAME];
+  const eventType =
+    NORMALIZED_EVENT_TYPE_BY_SYNC_TYPE[
+      syncEventType as keyof typeof NORMALIZED_EVENT_TYPE_BY_SYNC_TYPE
+    ];
   if (!eventType) {
     return payload as unknown as Event;
   }
@@ -264,12 +267,8 @@ export const isRelevantSubscriberEvent = (
       ? lifecycleEvent.parentExternalSessionId
       : readEventParentExternalSessionId(properties);
 
-    if (eventType === "question.asked" && parentExternalSessionId) {
+    if (parentExternalSessionId) {
       return parentExternalSessionId === subscriber.externalSessionId;
-    }
-
-    if (parentExternalSessionId === subscriber.externalSessionId) {
-      return true;
     }
 
     if (

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -48,7 +48,7 @@ type LogEventInput = {
 };
 
 type RelevantSubscriberEventOptions = {
-  isKnownChildExternalSessionId?: (externalSessionId: string) => boolean;
+  resolveParentExternalSessionId?: (childExternalSessionId: string) => string | undefined;
 };
 
 type GlobalEventStream = {
@@ -65,6 +65,7 @@ const SYNC_EVENT_TYPE_BY_NAME = {
   "message.part.removed.1": "message.part.removed",
   "session.created.1": "session.created",
   "session.updated.1": "session.updated",
+  "session.deleted.1": "session.deleted",
 } as const;
 
 const getGlobalEventApi = (client: OpencodeClient): GlobalEventApi => {
@@ -100,19 +101,24 @@ const normalizeGlobalEventPayload = (payload: Event): Event => {
     return payload;
   }
 
-  const name = payloadRecord.name;
-  if (typeof name !== "string") {
+  const syncEvent = asUnknownRecord(payloadRecord.syncEvent);
+  if (!syncEvent) {
+    return payload;
+  }
+  const syncEventType = syncEvent.type;
+  if (typeof syncEventType !== "string") {
     return payload;
   }
 
-  const eventType = SYNC_EVENT_TYPE_BY_NAME[name as keyof typeof SYNC_EVENT_TYPE_BY_NAME];
-  const data = asUnknownRecord(payloadRecord.data);
+  const eventType = SYNC_EVENT_TYPE_BY_NAME[syncEventType as keyof typeof SYNC_EVENT_TYPE_BY_NAME];
+  const data = asUnknownRecord(syncEvent.data);
   if (!eventType || !data) {
     return payload;
   }
 
   return {
     ...payloadRecord,
+    ...(typeof syncEvent.id === "string" ? { id: syncEvent.id } : {}),
     type: eventType,
     properties: data,
   } as unknown as Event;
@@ -239,7 +245,14 @@ export const isRelevantSubscriberEvent = (
   if (eventExternalSessionId) {
     const eventType = String(event.type);
     const properties = "properties" in event ? event.properties : undefined;
-    const parentExternalSessionId = readEventParentExternalSessionId(properties);
+    const propertiesRecord = asUnknownRecord(properties);
+    const parentSource =
+      eventType === "session.created" ||
+      eventType === "session.updated" ||
+      eventType === "session.deleted"
+        ? propertiesRecord?.info
+        : properties;
+    const parentExternalSessionId = readEventParentExternalSessionId(parentSource);
 
     if (eventType === "question.asked" && parentExternalSessionId) {
       return parentExternalSessionId === subscriber.externalSessionId;
@@ -255,7 +268,8 @@ export const isRelevantSubscriberEvent = (
         eventType === "permission.replied" ||
         eventType === "question.asked" ||
         eventType === "question.replied") &&
-      options?.isKnownChildExternalSessionId?.(eventExternalSessionId)
+      options?.resolveParentExternalSessionId?.(eventExternalSessionId) ===
+        subscriber.externalSessionId
     ) {
       return true;
     }

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -9,7 +9,7 @@ import {
   readEventDirectory,
   readEventParentExternalSessionId,
   readEventSessionId,
-  readLifecycleParentExternalSessionId,
+  readSessionLifecycleEvent,
 } from "./event-stream/shared";
 import { asUnknownRecord } from "./guards";
 import type {
@@ -253,19 +253,16 @@ export const isRelevantSubscriberEvent = (
     return true;
   }
 
-  const eventExternalSessionId = readEventSessionId(event);
+  const lifecycleEvent = readSessionLifecycleEvent(event);
+  const eventExternalSessionId = lifecycleEvent
+    ? lifecycleEvent.externalSessionId
+    : readEventSessionId(event);
   if (eventExternalSessionId) {
-    const eventType = String(event.type);
+    const eventType = lifecycleEvent?.type ?? String(event.type);
     const properties = "properties" in event ? event.properties : undefined;
-    const propertiesRecord = asUnknownRecord(properties);
-    const isLifecycleEvent =
-      eventType === "session.created" ||
-      eventType === "session.updated" ||
-      eventType === "session.deleted";
-    const parentSource = isLifecycleEvent ? propertiesRecord?.info : properties;
-    const parentExternalSessionId = isLifecycleEvent
-      ? readLifecycleParentExternalSessionId(parentSource)
-      : readEventParentExternalSessionId(parentSource);
+    const parentExternalSessionId = lifecycleEvent
+      ? lifecycleEvent.parentExternalSessionId
+      : readEventParentExternalSessionId(properties);
 
     if (eventType === "question.asked" && parentExternalSessionId) {
       return parentExternalSessionId === subscriber.externalSessionId;

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -9,6 +9,7 @@ import {
   readEventDirectory,
   readEventParentExternalSessionId,
   readEventSessionId,
+  readLifecycleParentExternalSessionId,
 } from "./event-stream/shared";
 import { asUnknownRecord } from "./guards";
 import type {
@@ -257,13 +258,14 @@ export const isRelevantSubscriberEvent = (
     const eventType = String(event.type);
     const properties = "properties" in event ? event.properties : undefined;
     const propertiesRecord = asUnknownRecord(properties);
-    const parentSource =
+    const isLifecycleEvent =
       eventType === "session.created" ||
       eventType === "session.updated" ||
-      eventType === "session.deleted"
-        ? propertiesRecord?.info
-        : properties;
-    const parentExternalSessionId = readEventParentExternalSessionId(parentSource);
+      eventType === "session.deleted";
+    const parentSource = isLifecycleEvent ? propertiesRecord?.info : properties;
+    const parentExternalSessionId = isLifecycleEvent
+      ? readLifecycleParentExternalSessionId(parentSource)
+      : readEventParentExternalSessionId(parentSource);
 
     if (eventType === "question.asked" && parentExternalSessionId) {
       return parentExternalSessionId === subscriber.externalSessionId;

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -132,7 +132,6 @@ const normalizeGlobalEventPayload = (payload: GlobalEventPayload): Event => {
   }
 
   return {
-    ...payloadRecord,
     ...(typeof syncEvent.id === "string" ? { id: syncEvent.id } : {}),
     type: eventType,
     properties: data,

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -55,6 +55,8 @@ type GlobalEventStream = {
   stream: AsyncIterable<GlobalEvent>;
 };
 
+type GlobalEventPayload = GlobalEvent["payload"];
+
 type GlobalEventApi = {
   event: (options?: { signal?: AbortSignal }) => Promise<GlobalEventStream> | GlobalEventStream;
 };
@@ -95,25 +97,34 @@ const resolveGlobalEventStream = async (
   throw new Error("OpenCode SDK global event stream must expose a stream async iterator.");
 };
 
-const normalizeGlobalEventPayload = (payload: Event): Event => {
+const normalizeGlobalEventPayload = (payload: GlobalEventPayload): Event => {
   const payloadRecord = asUnknownRecord(payload);
   if (payloadRecord?.type !== "sync") {
-    return payload;
+    return payload as Event;
   }
 
   const syncEvent = asUnknownRecord(payloadRecord.syncEvent);
   if (!syncEvent) {
-    return payload;
+    throw new Error(
+      "OpenCode sync event is missing its syncEvent envelope; update the runtime or adapter to a supported event contract.",
+    );
   }
   const syncEventType = syncEvent.type;
   if (typeof syncEventType !== "string") {
-    return payload;
+    throw new Error(
+      "OpenCode sync event is missing syncEvent.type; update the runtime or adapter to a supported event contract.",
+    );
   }
 
   const eventType = SYNC_EVENT_TYPE_BY_NAME[syncEventType as keyof typeof SYNC_EVENT_TYPE_BY_NAME];
+  if (!eventType) {
+    return payload as unknown as Event;
+  }
   const data = asUnknownRecord(syncEvent.data);
-  if (!eventType || !data) {
-    return payload;
+  if (!data) {
+    throw new Error(
+      `OpenCode ${syncEventType} event is missing object syncEvent.data; update the runtime or adapter to a supported event contract.`,
+    );
   }
 
   return {
@@ -125,7 +136,7 @@ const normalizeGlobalEventPayload = (payload: Event): Event => {
 };
 
 const toDirectoryScopedEvent = (event: GlobalEvent): Event => {
-  const payload = normalizeGlobalEventPayload(event.payload as Event) as Event & {
+  const payload = normalizeGlobalEventPayload(event.payload) as Event & {
     properties?: Record<string, unknown>;
   };
   return {

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -9,7 +9,6 @@ import {
   parsePermissionAsked,
   parseQuestionAsked,
   parseSessionStatus,
-  readEventInfo,
   readEventProperties,
   readSessionErrorMessage,
   readTodoPayload,
@@ -25,7 +24,7 @@ import {
   readEventDirectory,
   readEventParentExternalSessionId,
   readEventSessionId,
-  readLifecycleParentExternalSessionId,
+  readSessionLifecycleEvent,
   removePendingSubagentCorrelationKey,
 } from "./shared";
 
@@ -405,14 +404,16 @@ const handleTodoUpdatedEvent = (event: Event, runtime: EventStreamRuntime): bool
 };
 
 const bindChildSessionCorrelation = (event: Event, runtime: EventStreamRuntime): boolean => {
-  if (event.type !== "session.created" && event.type !== "session.updated") {
+  const lifecycleEvent = readSessionLifecycleEvent(event);
+  if (!lifecycleEvent || lifecycleEvent.type === "session.deleted") {
     return false;
   }
 
-  const properties = readEventProperties(event);
-  const info = readEventInfo(properties);
-  const childExternalSessionId = readEventSessionId(event);
-  const parentExternalSessionId = readLifecycleParentExternalSessionId(info);
+  const {
+    info,
+    externalSessionId: childExternalSessionId,
+    parentExternalSessionId,
+  } = lifecycleEvent;
 
   if (
     !childExternalSessionId ||

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -25,6 +25,7 @@ import {
   readEventDirectory,
   readEventParentExternalSessionId,
   readEventSessionId,
+  readLifecycleParentExternalSessionId,
   removePendingSubagentCorrelationKey,
 } from "./shared";
 
@@ -411,7 +412,7 @@ const bindChildSessionCorrelation = (event: Event, runtime: EventStreamRuntime):
   const properties = readEventProperties(event);
   const info = readEventInfo(properties);
   const childExternalSessionId = readEventSessionId(event);
-  const parentExternalSessionId = readEventParentExternalSessionId(properties);
+  const parentExternalSessionId = readLifecycleParentExternalSessionId(info);
 
   if (
     !childExternalSessionId ||

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -105,9 +105,8 @@ export const readEventParentExternalSessionId = (properties: unknown): string | 
   );
 };
 
-export const readLifecycleParentExternalSessionId = (info: unknown): string | undefined => {
-  const parentID = readStringProp(info, ["parentID"]);
-  return parentID && parentID.trim().length > 0 ? parentID : undefined;
+const readLifecycleParentExternalSessionId = (info: unknown): string | undefined => {
+  return readStringProp(info, ["parentID"]);
 };
 
 export const flushPendingSubagentInputEventsForSession = (

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -97,6 +97,11 @@ export const readEventParentExternalSessionId = (properties: unknown): string | 
   );
 };
 
+export const readLifecycleParentExternalSessionId = (info: unknown): string | undefined => {
+  const parentID = readStringProp(info, ["parentID"]);
+  return parentID && parentID.trim().length > 0 ? parentID : undefined;
+};
+
 export const flushPendingSubagentInputEventsForSession = (
   runtime: EventStreamRuntime,
   childExternalSessionId: string,

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -106,7 +106,16 @@ export const readEventParentExternalSessionId = (properties: unknown): string | 
 };
 
 const readLifecycleParentExternalSessionId = (info: unknown): string | undefined => {
-  return readStringProp(info, ["parentID"]);
+  const parentExternalSessionId = readStringProp(info, ["parentID"]);
+  if (parentExternalSessionId?.trim()) {
+    return parentExternalSessionId;
+  }
+  if (typeof asUnknownRecord(info)?.parentID === "string") {
+    throw new Error(
+      "OpenCode session lifecycle event has malformed info.parentID lineage; expected a non-blank string.",
+    );
+  }
+  return undefined;
 };
 
 export const flushPendingSubagentInputEventsForSession = (

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -1,6 +1,6 @@
 import type { Event, Part } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent, AgentStreamPart } from "@openducktor/core";
-import { asUnknownRecord, readRecordProp, readStringProp } from "../guards";
+import { asUnknownRecord, readRecordProp, readStringProp, type UnknownRecord } from "../guards";
 import {
   clearAwaitingRuntimeTurnStart,
   isAwaitingRuntimeTurnStart,
@@ -9,7 +9,7 @@ import {
   markStreamTurnIdle,
 } from "../session-activity";
 import type { SessionInput, SessionRecord } from "../types";
-import { readEventProperties } from "./schemas";
+import { readEventInfo, readEventProperties } from "./schemas";
 
 export type PendingPartDelta = {
   field: string;
@@ -34,6 +34,14 @@ export type PendingBackgroundTaskResult = {
 export type PendingSubagentSessionBinding = {
   createdAtMs?: number;
   arrivalOrder: number;
+};
+
+type SessionLifecycleEvent = {
+  type: "session.created" | "session.updated" | "session.deleted";
+  properties: UnknownRecord | undefined;
+  info: UnknownRecord | undefined;
+  externalSessionId: string | undefined;
+  parentExternalSessionId: string | undefined;
 };
 
 export type EventStreamContext = {
@@ -308,6 +316,27 @@ export const readEventSessionId = (event: Event): string | undefined => {
   }
 
   return undefined;
+};
+
+export const readSessionLifecycleEvent = (event: Event): SessionLifecycleEvent | undefined => {
+  const eventType = String(event.type);
+  if (
+    eventType !== "session.created" &&
+    eventType !== "session.updated" &&
+    eventType !== "session.deleted"
+  ) {
+    return undefined;
+  }
+
+  const properties = readEventProperties(event);
+  const info = readEventInfo(properties);
+  return {
+    type: eventType,
+    properties,
+    info,
+    externalSessionId: readEventSessionId(event),
+    parentExternalSessionId: readLifecycleParentExternalSessionId(info),
+  };
 };
 
 export const readEventDirectory = (event: Event): string | undefined => {

--- a/packages/adapters-opencode-sdk/src/session-registry.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.test.ts
@@ -427,6 +427,50 @@ describe("session registry runtime event transport", () => {
     );
   });
 
+  test("rejects whitespace-only direct child lineage without recording it", async () => {
+    let transport: RuntimeEventTransportRecord | undefined;
+    const emitted = await runRuntimeEventTransport(
+      [childSessionCreatedEvent("external-child-session", "   ")],
+      {
+        onTransport: (record) => {
+          transport = record;
+        },
+      },
+    );
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("info.parentID"),
+      }),
+    );
+    expect(
+      transport?.parentExternalSessionIdByChildExternalSessionId.has("external-child-session"),
+    ).toBe(false);
+  });
+
+  test("rejects whitespace-only nested sync child lineage without recording it", async () => {
+    let transport: RuntimeEventTransportRecord | undefined;
+    const emitted = await runRuntimeEventTransport(
+      [runtimeSourceSyncChildSessionCreatedEvent("external-child-session", "   ")],
+      {
+        onTransport: (record) => {
+          transport = record;
+        },
+      },
+    );
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("info.parentID"),
+      }),
+    );
+    expect(
+      transport?.parentExternalSessionIdByChildExternalSessionId.has("external-child-session"),
+    ).toBe(false);
+  });
+
   test("rejects direct child lifecycle parentId aliases without recording lineage", async () => {
     let transport: RuntimeEventTransportRecord | undefined;
     const emitted = await runRuntimeEventTransport(

--- a/packages/adapters-opencode-sdk/src/session-registry.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.test.ts
@@ -1,12 +1,36 @@
 import { describe, expect, test } from "bun:test";
-import type { Event } from "@opencode-ai/sdk/v2/client";
+import type {
+  Event,
+  GlobalEvent,
+  OpencodeClient,
+  Session,
+  SyncEventMessagePartUpdated,
+  SyncEventSessionCreated,
+  SyncEventSessionDeleted,
+  SyncEventSessionUpdated,
+} from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import { makeClientWithEvents, makeSessionInput } from "./event-stream.test-support";
-import { registerSession } from "./session-registry";
+import { observeRuntimeEvents, registerSession } from "./session-registry";
 import type { RuntimeEventTransportRecord, SessionRecord } from "./types";
 
+type GlobalEventPayload = GlobalEvent["payload"];
 type AssistantPartEvent = Extract<AgentEvent, { type: "assistant_part" }>;
 type SubagentPart = Extract<AssistantPartEvent["part"], { kind: "subagent" }>;
+
+const childSessionInfo = (childSessionId: string, parentID?: string): Session => ({
+  id: childSessionId,
+  slug: childSessionId,
+  projectID: "project-1",
+  directory: "/repo",
+  ...(parentID ? { parentID } : {}),
+  title: "Subagent",
+  version: "1.0.0",
+  time: {
+    created: Date.parse("2026-02-22T12:00:10.000Z"),
+    updated: Date.parse("2026-02-22T12:00:10.000Z"),
+  },
+});
 
 const readSubagentParts = (events: AgentEvent[]): SubagentPart[] =>
   events
@@ -109,7 +133,7 @@ const syncAssistantSubtaskEvent = (input: {
   messageId: string;
   partId: string;
   description: string;
-}): Event =>
+}): SyncEventMessagePartUpdated =>
   ({
     type: "sync",
     id: `sync-${input.partId}`,
@@ -132,30 +156,18 @@ const syncAssistantSubtaskEvent = (input: {
         },
       },
     },
-  }) as unknown as Event;
+  }) satisfies SyncEventMessagePartUpdated;
 
 const childSessionCreatedEvent = (childSessionId: string): Event =>
   ({
     type: "session.created",
     properties: {
       sessionID: childSessionId,
-      info: {
-        id: childSessionId,
-        slug: childSessionId,
-        projectID: "project-1",
-        directory: "/repo",
-        parentID: "external-session-1",
-        title: "Subagent",
-        version: "1.0.0",
-        time: {
-          created: Date.parse("2026-02-22T12:00:10.000Z"),
-          updated: Date.parse("2026-02-22T12:00:10.000Z"),
-        },
-      },
+      info: childSessionInfo(childSessionId, "external-session-1"),
     },
   }) as unknown as Event;
 
-const syncChildSessionCreatedEvent = (childSessionId: string): Event =>
+const syncChildSessionCreatedEvent = (childSessionId: string): SyncEventSessionCreated =>
   ({
     type: "sync",
     id: `sync-${childSessionId}`,
@@ -166,25 +178,13 @@ const syncChildSessionCreatedEvent = (childSessionId: string): Event =>
       aggregateID: childSessionId,
       data: {
         sessionID: childSessionId,
-        info: {
-          id: childSessionId,
-          slug: childSessionId,
-          projectID: "project-1",
-          parentID: "external-session-1",
-          directory: "/repo",
-          title: "Subagent",
-          version: "1.0.0",
-          time: {
-            created: Date.parse("2026-02-22T12:00:10.000Z"),
-            updated: Date.parse("2026-02-22T12:00:10.000Z"),
-          },
-        },
+        info: childSessionInfo(childSessionId, "external-session-1"),
       },
     },
-  }) as unknown as Event;
+  }) satisfies SyncEventSessionCreated;
 
-const syncChildSessionCreatedEventWithoutParent = (childSessionId: string): Event =>
-  ({
+const syncChildSessionCreatedEventWithoutParent = (childSessionId: string): GlobalEventPayload => {
+  return {
     type: "sync",
     id: `sync-${childSessionId}`,
     syncEvent: {
@@ -209,31 +209,105 @@ const syncChildSessionCreatedEventWithoutParent = (childSessionId: string): Even
         },
       },
     },
-  }) as unknown as Event;
+  } as unknown as GlobalEventPayload;
+};
+
+const syncChildSessionUpdatedEvent = (childSessionId: string): SyncEventSessionUpdated =>
+  ({
+    type: "sync",
+    id: `sync-updated-${childSessionId}`,
+    syncEvent: {
+      type: "session.updated.1",
+      id: `sync-event-updated-${childSessionId}`,
+      seq: 3,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        info: childSessionInfo(childSessionId, "external-session-1"),
+      },
+    },
+  }) satisfies SyncEventSessionUpdated;
+
+const syncChildSessionDeletedEvent = (
+  childSessionId: string,
+  parentID?: string,
+): SyncEventSessionDeleted =>
+  ({
+    type: "sync",
+    id: `sync-deleted-${childSessionId}`,
+    syncEvent: {
+      type: "session.deleted.1",
+      id: `sync-event-deleted-${childSessionId}`,
+      seq: 4,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        info: childSessionInfo(childSessionId, parentID),
+      },
+    },
+  }) satisfies SyncEventSessionDeleted;
+
+const malformedSyncLifecycleDataEvent = (): GlobalEventPayload =>
+  ({
+    type: "sync",
+    id: "sync-malformed-session-created",
+    syncEvent: {
+      type: "session.created.1",
+      id: "sync-event-malformed-session-created",
+      seq: 1,
+      aggregateID: "external-child-session",
+      data: null,
+    },
+  }) as unknown as GlobalEventPayload;
 
 const childSessionDeletedEvent = (childSessionId: string): Event =>
   ({
     type: "session.deleted",
     properties: {
       sessionID: childSessionId,
-      info: {
-        id: childSessionId,
-        slug: childSessionId,
-        projectID: "project-1",
-        directory: "/repo",
-        parentID: "external-session-1",
-        title: "Subagent",
-        version: "1.0.0",
-        time: {
-          created: Date.parse("2026-02-22T12:00:10.000Z"),
-          updated: Date.parse("2026-02-22T12:00:11.000Z"),
-        },
-      },
+      info: childSessionInfo(childSessionId, "external-session-1"),
     },
   }) as unknown as Event;
 
+const childSessionDeletedEventWithoutParent = (sessionId: string): Event =>
+  ({
+    type: "session.deleted",
+    properties: {
+      sessionID: sessionId,
+      info: childSessionInfo(sessionId),
+    },
+  }) as unknown as Event;
+
+const makeLiveClient = (): OpencodeClient => {
+  const connectedPayload = {
+    id: "event-server-connected",
+    type: "server.connected",
+    properties: {},
+  } satisfies Extract<GlobalEventPayload, { type: "server.connected" }>;
+
+  return {
+    global: {
+      event: async (options?: { signal?: AbortSignal }) => {
+        async function* iterator(): AsyncGenerator<GlobalEvent> {
+          yield {
+            directory: "/repo",
+            payload: connectedPayload,
+          };
+          if (options?.signal?.aborted) {
+            return;
+          }
+          await new Promise<void>((resolve) => {
+            options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+        }
+        return { stream: iterator() };
+      },
+    },
+  } as unknown as OpencodeClient;
+};
+
 const runRuntimeEventTransport = async (
-  events: Event[],
+  events: GlobalEventPayload[],
   options?: {
     onTransport?: (transport: RuntimeEventTransportRecord) => void;
   },
@@ -341,6 +415,26 @@ describe("session registry runtime event transport", () => {
     });
   });
 
+  test("routes parentless child input after a sync session update confirms lineage", async () => {
+    const emitted = await runRuntimeEventTransport([
+      assistantRoleEvent("assistant-sync-subagent-session-updated"),
+      syncAssistantSubtaskEvent({
+        messageId: "assistant-sync-subagent-session-updated",
+        partId: "subtask-a",
+        description: "Read omp.json file",
+      }),
+      syncChildSessionUpdatedEvent("external-child-session"),
+      childPermissionEvent("external-child-session"),
+    ]);
+
+    expect(emitted.filter((event) => event.type === "approval_required")).toContainEqual(
+      expect.objectContaining({
+        childExternalSessionId: "external-child-session",
+        parentExternalSessionId: "external-session-1",
+      }),
+    );
+  });
+
   test("reports sync child lifecycle events that omit info.parentID", async () => {
     const emitted = await runRuntimeEventTransport([
       assistantRoleEvent("assistant-sync-subagent-session-created"),
@@ -356,6 +450,17 @@ describe("session registry runtime event transport", () => {
       expect.objectContaining({
         type: "session_error",
         message: expect.stringContaining("info.parentID"),
+      }),
+    );
+  });
+
+  test("reports recognized sync lifecycle events with malformed data", async () => {
+    const emitted = await runRuntimeEventTransport([malformedSyncLifecycleDataEvent()]);
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("syncEvent.data"),
       }),
     );
   });
@@ -427,6 +532,52 @@ describe("session registry runtime event transport", () => {
     expect(emitted.filter((event) => event.type === "approval_required")).toHaveLength(0);
   });
 
+  test("reports confirmed child deletion when info.parentID is missing", async () => {
+    const emitted = await runRuntimeEventTransport([
+      childSessionCreatedEvent("external-child-session"),
+      childSessionDeletedEventWithoutParent("external-child-session"),
+    ]);
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("info.parentID"),
+      }),
+    );
+  });
+
+  test("accepts root session deletion without parent lineage", async () => {
+    const emitted = await runRuntimeEventTransport([
+      childSessionDeletedEventWithoutParent("external-root-session"),
+    ]);
+
+    expect(emitted.filter((event) => event.type === "session_error")).toHaveLength(0);
+  });
+
+  test("clears confirmed lineage after nested session deletion", async () => {
+    const emitted = await runRuntimeEventTransport([
+      syncChildSessionCreatedEvent("external-child-session"),
+      syncChildSessionDeletedEvent("external-child-session", "external-session-1"),
+      childPermissionEvent("external-child-session"),
+    ]);
+
+    expect(emitted.filter((event) => event.type === "approval_required")).toHaveLength(0);
+  });
+
+  test("reports nested confirmed child deletion when info.parentID is missing", async () => {
+    const emitted = await runRuntimeEventTransport([
+      syncChildSessionCreatedEvent("external-child-session"),
+      syncChildSessionDeletedEvent("external-child-session"),
+    ]);
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("info.parentID"),
+      }),
+    );
+  });
+
   test("clears confirmed child lineage when the runtime transport ends", async () => {
     let transport: RuntimeEventTransportRecord | undefined;
     await runRuntimeEventTransport([childSessionCreatedEvent("external-child-session")], {
@@ -441,5 +592,53 @@ describe("session registry runtime event transport", () => {
       }
     ).parentExternalSessionIdByChildExternalSessionId;
     expect(lineage.size).toBe(0);
+  });
+
+  test("explicit release clears, aborts, detaches, and permits same-runtime reuse", async () => {
+    const runtimeEventTransports = new Map<string, RuntimeEventTransportRecord>();
+    const sessions = new Map<string, SessionRecord>();
+    let clientCount = 0;
+    const observe = () =>
+      observeRuntimeEvents({
+        runtimeEventTransports,
+        createClient: () => {
+          clientCount += 1;
+          return makeLiveClient();
+        },
+        runtimeId: "runtime-opencode-1",
+        runtimeEndpoint: "http://127.0.0.1:12345",
+        sessions,
+        now: () => "2026-02-22T12:00:00.000Z",
+        emit: () => undefined,
+        observer: () => undefined,
+        terminalObserver: () => undefined,
+      });
+
+    const firstObservation = await observe();
+    const firstTransport = runtimeEventTransports.get("runtime-opencode-1");
+    if (!firstTransport) {
+      throw new Error("Expected first OpenCode runtime event transport.");
+    }
+    await firstObservation.dispatch(childSessionCreatedEvent("external-child-session"));
+    expect(
+      firstTransport.parentExternalSessionIdByChildExternalSessionId.get("external-child-session"),
+    ).toBe("external-session-1");
+
+    await firstObservation.release();
+    await firstTransport.streamDone;
+    expect(firstTransport.controller.signal.aborted).toBe(true);
+    expect(firstTransport.parentExternalSessionIdByChildExternalSessionId.size).toBe(0);
+    expect(runtimeEventTransports.has("runtime-opencode-1")).toBe(false);
+
+    const secondObservation = await observe();
+    const secondTransport = runtimeEventTransports.get("runtime-opencode-1");
+    if (!secondTransport) {
+      throw new Error("Expected replacement OpenCode runtime event transport.");
+    }
+    expect(secondTransport).not.toBe(firstTransport);
+    expect(clientCount).toBe(2);
+
+    await secondObservation.release();
+    await secondTransport.streamDone;
   });
 });

--- a/packages/adapters-opencode-sdk/src/session-registry.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.test.ts
@@ -427,7 +427,7 @@ describe("session registry runtime event transport", () => {
     );
   });
 
-  test("rejects direct child lifecycle parentId aliases without routing later input", async () => {
+  test("rejects direct child lifecycle parentId aliases without recording lineage", async () => {
     let transport: RuntimeEventTransportRecord | undefined;
     const emitted = await runRuntimeEventTransport(
       [
@@ -447,13 +447,12 @@ describe("session registry runtime event transport", () => {
         message: expect.stringContaining("info.parentID"),
       }),
     );
-    expect(emitted.filter((event) => event.type === "approval_required")).toHaveLength(0);
     expect(
       transport?.parentExternalSessionIdByChildExternalSessionId.has("external-child-session"),
     ).toBe(false);
   });
 
-  test("rejects runtime-source nested parent_id aliases without routing later input", async () => {
+  test("rejects runtime-source nested parent_id aliases without recording lineage", async () => {
     let transport: RuntimeEventTransportRecord | undefined;
     const emitted = await runRuntimeEventTransport(
       [
@@ -476,7 +475,6 @@ describe("session registry runtime event transport", () => {
         message: expect.stringContaining("info.parentID"),
       }),
     );
-    expect(emitted.filter((event) => event.type === "approval_required")).toHaveLength(0);
     expect(
       transport?.parentExternalSessionIdByChildExternalSessionId.has("external-child-session"),
     ).toBe(false);
@@ -633,12 +631,7 @@ describe("session registry runtime event transport", () => {
       },
     });
 
-    const lineage = (
-      transport as RuntimeEventTransportRecord & {
-        parentExternalSessionIdByChildExternalSessionId: Map<string, string>;
-      }
-    ).parentExternalSessionIdByChildExternalSessionId;
-    expect(lineage.size).toBe(0);
+    expect(transport?.parentExternalSessionIdByChildExternalSessionId.size).toBe(0);
   });
 
   test("explicit release clears, aborts, detaches, and permits same-runtime reuse", async () => {

--- a/packages/adapters-opencode-sdk/src/session-registry.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.test.ts
@@ -1,43 +1,31 @@
 import { describe, expect, test } from "bun:test";
 import type {
   Event,
-  EventSessionCreated,
   EventSessionDeleted,
   GlobalEvent,
   OpencodeClient,
-  Session,
   SyncEventMessagePartUpdated,
-  SyncEventSessionCreated,
   SyncEventSessionDeleted,
   SyncEventSessionUpdated,
 } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import {
+  childSessionCreatedEvent,
+  childSessionCreatedEventWithParentAlias,
+  childSessionInfo,
   makeClientWithEvents,
   makeSessionInput,
+  runtimeSourceSyncChildSessionCreatedEvent,
+  runtimeSourceSyncChildSessionCreatedEventWithParentAlias,
+  syncChildSessionCreatedEvent,
   type TestGlobalEventPayload,
 } from "./event-stream.test-support";
 import { observeRuntimeEvents, registerSession } from "./session-registry";
 import type { RuntimeEventTransportRecord, SessionRecord } from "./types";
 
 type GlobalEventPayload = TestGlobalEventPayload;
-type RuntimeSourceSyncEventSessionCreated = Omit<SyncEventSessionCreated, "id">;
 type AssistantPartEvent = Extract<AgentEvent, { type: "assistant_part" }>;
 type SubagentPart = Extract<AssistantPartEvent["part"], { kind: "subagent" }>;
-
-const childSessionInfo = (childSessionId: string, parentID?: string): Session => ({
-  id: childSessionId,
-  slug: childSessionId,
-  projectID: "project-1",
-  directory: "/repo",
-  ...(parentID ? { parentID } : {}),
-  title: "Subagent",
-  version: "1.0.0",
-  time: {
-    created: Date.parse("2026-02-22T12:00:10.000Z"),
-    updated: Date.parse("2026-02-22T12:00:10.000Z"),
-  },
-});
 
 const readSubagentParts = (events: AgentEvent[]): SubagentPart[] =>
   events
@@ -164,90 +152,6 @@ const syncAssistantSubtaskEvent = (input: {
       },
     },
   }) satisfies SyncEventMessagePartUpdated;
-
-const childSessionCreatedEvent = (childSessionId: string): EventSessionCreated =>
-  ({
-    id: `event-created-${childSessionId}`,
-    type: "session.created",
-    properties: {
-      sessionID: childSessionId,
-      info: childSessionInfo(childSessionId, "external-session-1"),
-    },
-  }) satisfies EventSessionCreated;
-
-const childSessionCreatedEventWithParentAlias = (
-  childSessionId: string,
-  parentAlias: "parentId" | "parent_id",
-): EventSessionCreated => {
-  const info = {
-    ...childSessionInfo(childSessionId),
-    [parentAlias]: "external-session-1",
-  };
-  return {
-    id: `event-created-${childSessionId}-${parentAlias}`,
-    type: "session.created",
-    properties: {
-      sessionID: childSessionId,
-      info,
-    },
-  } satisfies EventSessionCreated;
-};
-
-const syncChildSessionCreatedEvent = (childSessionId: string): SyncEventSessionCreated =>
-  ({
-    type: "sync",
-    id: `sync-${childSessionId}`,
-    syncEvent: {
-      type: "session.created.1",
-      id: `sync-event-${childSessionId}`,
-      seq: 2,
-      aggregateID: childSessionId,
-      data: {
-        sessionID: childSessionId,
-        info: childSessionInfo(childSessionId, "external-session-1"),
-      },
-    },
-  }) satisfies SyncEventSessionCreated;
-
-const runtimeSourceSyncChildSessionCreatedEvent = (
-  childSessionId: string,
-): RuntimeSourceSyncEventSessionCreated =>
-  ({
-    type: "sync",
-    syncEvent: {
-      type: "session.created.1",
-      id: `sync-event-runtime-source-${childSessionId}`,
-      seq: 2,
-      aggregateID: childSessionId,
-      data: {
-        sessionID: childSessionId,
-        info: childSessionInfo(childSessionId, "external-session-1"),
-      },
-    },
-  }) satisfies RuntimeSourceSyncEventSessionCreated;
-
-const runtimeSourceSyncChildSessionCreatedEventWithParentAlias = (
-  childSessionId: string,
-  parentAlias: "parentId" | "parent_id",
-): RuntimeSourceSyncEventSessionCreated => {
-  const info = {
-    ...childSessionInfo(childSessionId),
-    [parentAlias]: "external-session-1",
-  };
-  return {
-    type: "sync",
-    syncEvent: {
-      type: "session.created.1",
-      id: `sync-event-runtime-source-${childSessionId}-${parentAlias}`,
-      seq: 2,
-      aggregateID: childSessionId,
-      data: {
-        sessionID: childSessionId,
-        info,
-      },
-    },
-  } satisfies RuntimeSourceSyncEventSessionCreated;
-};
 
 const syncChildSessionCreatedEventWithoutParent = (childSessionId: string): GlobalEventPayload => {
   return {

--- a/packages/adapters-opencode-sdk/src/session-registry.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type {
   Event,
+  EventSessionCreated,
+  EventSessionDeleted,
   GlobalEvent,
   OpencodeClient,
   Session,
@@ -10,11 +12,16 @@ import type {
   SyncEventSessionUpdated,
 } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
-import { makeClientWithEvents, makeSessionInput } from "./event-stream.test-support";
+import {
+  makeClientWithEvents,
+  makeSessionInput,
+  type TestGlobalEventPayload,
+} from "./event-stream.test-support";
 import { observeRuntimeEvents, registerSession } from "./session-registry";
 import type { RuntimeEventTransportRecord, SessionRecord } from "./types";
 
-type GlobalEventPayload = GlobalEvent["payload"];
+type GlobalEventPayload = TestGlobalEventPayload;
+type RuntimeSourceSyncEventSessionCreated = Omit<SyncEventSessionCreated, "id">;
 type AssistantPartEvent = Extract<AgentEvent, { type: "assistant_part" }>;
 type SubagentPart = Extract<AssistantPartEvent["part"], { kind: "subagent" }>;
 
@@ -158,14 +165,33 @@ const syncAssistantSubtaskEvent = (input: {
     },
   }) satisfies SyncEventMessagePartUpdated;
 
-const childSessionCreatedEvent = (childSessionId: string): Event =>
+const childSessionCreatedEvent = (childSessionId: string): EventSessionCreated =>
   ({
+    id: `event-created-${childSessionId}`,
     type: "session.created",
     properties: {
       sessionID: childSessionId,
       info: childSessionInfo(childSessionId, "external-session-1"),
     },
-  }) as unknown as Event;
+  }) satisfies EventSessionCreated;
+
+const childSessionCreatedEventWithParentAlias = (
+  childSessionId: string,
+  parentAlias: "parentId" | "parent_id",
+): EventSessionCreated => {
+  const info = {
+    ...childSessionInfo(childSessionId),
+    [parentAlias]: "external-session-1",
+  };
+  return {
+    id: `event-created-${childSessionId}-${parentAlias}`,
+    type: "session.created",
+    properties: {
+      sessionID: childSessionId,
+      info,
+    },
+  } satisfies EventSessionCreated;
+};
 
 const syncChildSessionCreatedEvent = (childSessionId: string): SyncEventSessionCreated =>
   ({
@@ -182,6 +208,46 @@ const syncChildSessionCreatedEvent = (childSessionId: string): SyncEventSessionC
       },
     },
   }) satisfies SyncEventSessionCreated;
+
+const runtimeSourceSyncChildSessionCreatedEvent = (
+  childSessionId: string,
+): RuntimeSourceSyncEventSessionCreated =>
+  ({
+    type: "sync",
+    syncEvent: {
+      type: "session.created.1",
+      id: `sync-event-runtime-source-${childSessionId}`,
+      seq: 2,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        info: childSessionInfo(childSessionId, "external-session-1"),
+      },
+    },
+  }) satisfies RuntimeSourceSyncEventSessionCreated;
+
+const runtimeSourceSyncChildSessionCreatedEventWithParentAlias = (
+  childSessionId: string,
+  parentAlias: "parentId" | "parent_id",
+): RuntimeSourceSyncEventSessionCreated => {
+  const info = {
+    ...childSessionInfo(childSessionId),
+    [parentAlias]: "external-session-1",
+  };
+  return {
+    type: "sync",
+    syncEvent: {
+      type: "session.created.1",
+      id: `sync-event-runtime-source-${childSessionId}-${parentAlias}`,
+      seq: 2,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        info,
+      },
+    },
+  } satisfies RuntimeSourceSyncEventSessionCreated;
+};
 
 const syncChildSessionCreatedEventWithoutParent = (childSessionId: string): GlobalEventPayload => {
   return {
@@ -260,23 +326,25 @@ const malformedSyncLifecycleDataEvent = (): GlobalEventPayload =>
     },
   }) as unknown as GlobalEventPayload;
 
-const childSessionDeletedEvent = (childSessionId: string): Event =>
+const childSessionDeletedEvent = (childSessionId: string): EventSessionDeleted =>
   ({
+    id: `event-deleted-${childSessionId}`,
     type: "session.deleted",
     properties: {
       sessionID: childSessionId,
       info: childSessionInfo(childSessionId, "external-session-1"),
     },
-  }) as unknown as Event;
+  }) satisfies EventSessionDeleted;
 
-const childSessionDeletedEventWithoutParent = (sessionId: string): Event =>
+const childSessionDeletedEventWithoutParent = (sessionId: string): EventSessionDeleted =>
   ({
+    id: `event-deleted-${sessionId}-without-parent`,
     type: "session.deleted",
     properties: {
       sessionID: sessionId,
       info: childSessionInfo(sessionId),
     },
-  }) as unknown as Event;
+  }) satisfies EventSessionDeleted;
 
 const makeLiveClient = (): OpencodeClient => {
   const connectedPayload = {
@@ -415,6 +483,26 @@ describe("session registry runtime event transport", () => {
     });
   });
 
+  test("routes the runtime-source nested sync shape without an outer id", async () => {
+    const emitted = await runRuntimeEventTransport([
+      assistantRoleEvent("assistant-runtime-source-sync-session-created"),
+      syncAssistantSubtaskEvent({
+        messageId: "assistant-runtime-source-sync-session-created",
+        partId: "subtask-a",
+        description: "Read omp.json file",
+      }),
+      runtimeSourceSyncChildSessionCreatedEvent("external-child-session"),
+      childPermissionEvent("external-child-session"),
+    ]);
+
+    expect(emitted.filter((event) => event.type === "approval_required")).toContainEqual(
+      expect.objectContaining({
+        childExternalSessionId: "external-child-session",
+        parentExternalSessionId: "external-session-1",
+      }),
+    );
+  });
+
   test("routes parentless child input after a sync session update confirms lineage", async () => {
     const emitted = await runRuntimeEventTransport([
       assistantRoleEvent("assistant-sync-subagent-session-updated"),
@@ -433,6 +521,61 @@ describe("session registry runtime event transport", () => {
         parentExternalSessionId: "external-session-1",
       }),
     );
+  });
+
+  test("rejects direct child lifecycle parentId aliases without routing later input", async () => {
+    let transport: RuntimeEventTransportRecord | undefined;
+    const emitted = await runRuntimeEventTransport(
+      [
+        childSessionCreatedEventWithParentAlias("external-child-session", "parentId"),
+        childPermissionEvent("external-child-session"),
+      ],
+      {
+        onTransport: (record) => {
+          transport = record;
+        },
+      },
+    );
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("info.parentID"),
+      }),
+    );
+    expect(emitted.filter((event) => event.type === "approval_required")).toHaveLength(0);
+    expect(
+      transport?.parentExternalSessionIdByChildExternalSessionId.has("external-child-session"),
+    ).toBe(false);
+  });
+
+  test("rejects runtime-source nested parent_id aliases without routing later input", async () => {
+    let transport: RuntimeEventTransportRecord | undefined;
+    const emitted = await runRuntimeEventTransport(
+      [
+        runtimeSourceSyncChildSessionCreatedEventWithParentAlias(
+          "external-child-session",
+          "parent_id",
+        ),
+        childPermissionEvent("external-child-session"),
+      ],
+      {
+        onTransport: (record) => {
+          transport = record;
+        },
+      },
+    );
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("info.parentID"),
+      }),
+    );
+    expect(emitted.filter((event) => event.type === "approval_required")).toHaveLength(0);
+    expect(
+      transport?.parentExternalSessionIdByChildExternalSessionId.has("external-child-session"),
+    ).toBe(false);
   });
 
   test("reports sync child lifecycle events that omit info.parentID", async () => {

--- a/packages/adapters-opencode-sdk/src/session-registry.test.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Event, Session } from "@opencode-ai/sdk/v2/client";
+import type { Event } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
 import { makeClientWithEvents, makeSessionInput } from "./event-stream.test-support";
 import { registerSession } from "./session-registry";
@@ -89,6 +89,22 @@ const childPermissionEvent = (childSessionId: string): Event =>
     },
   }) as unknown as Event;
 
+const childQuestionEvent = (childSessionId: string): Event =>
+  ({
+    type: "question.asked",
+    properties: {
+      sessionID: childSessionId,
+      id: "question-child-1",
+      questions: [
+        {
+          header: "Scope",
+          question: "Pick target",
+          options: [{ label: "Current file", description: "Inspect only the requested file" }],
+        },
+      ],
+    },
+  }) as unknown as Event;
+
 const syncAssistantSubtaskEvent = (input: {
   messageId: string;
   partId: string;
@@ -96,21 +112,24 @@ const syncAssistantSubtaskEvent = (input: {
 }): Event =>
   ({
     type: "sync",
-    name: "message.part.updated.1",
     id: `sync-${input.partId}`,
-    seq: 1,
-    aggregateID: "sessionID",
-    data: {
-      sessionID: "external-session-1",
-      time: Date.parse("2026-02-22T12:00:09.000Z"),
-      part: {
-        id: input.partId,
+    syncEvent: {
+      type: "message.part.updated.1",
+      id: `sync-event-${input.partId}`,
+      seq: 1,
+      aggregateID: "external-session-1",
+      data: {
         sessionID: "external-session-1",
-        messageID: input.messageId,
-        type: "subtask",
-        agent: "build",
-        prompt: "Inspect repo",
-        description: input.description,
+        time: Date.parse("2026-02-22T12:00:09.000Z"),
+        part: {
+          id: input.partId,
+          sessionID: "external-session-1",
+          messageID: input.messageId,
+          type: "subtask",
+          agent: "build",
+          prompt: "Inspect repo",
+          description: input.description,
+        },
       },
     },
   }) as unknown as Event;
@@ -119,11 +138,18 @@ const childSessionCreatedEvent = (childSessionId: string): Event =>
   ({
     type: "session.created",
     properties: {
-      parentID: "external-session-1",
+      sessionID: childSessionId,
       info: {
         id: childSessionId,
+        slug: childSessionId,
+        projectID: "project-1",
+        directory: "/repo",
+        parentID: "external-session-1",
+        title: "Subagent",
+        version: "1.0.0",
         time: {
           created: Date.parse("2026-02-22T12:00:10.000Z"),
+          updated: Date.parse("2026-02-22T12:00:10.000Z"),
         },
       },
     },
@@ -132,21 +158,26 @@ const childSessionCreatedEvent = (childSessionId: string): Event =>
 const syncChildSessionCreatedEvent = (childSessionId: string): Event =>
   ({
     type: "sync",
-    name: "session.created.1",
     id: `sync-${childSessionId}`,
-    seq: 2,
-    aggregateID: "sessionID",
-    data: {
-      sessionID: childSessionId,
-      info: {
-        id: childSessionId,
-        parentID: "external-session-1",
-        directory: "/repo",
-        title: "Subagent",
-        version: "1.0.0",
-        time: {
-          created: Date.parse("2026-02-22T12:00:10.000Z"),
-          updated: Date.parse("2026-02-22T12:00:10.000Z"),
+    syncEvent: {
+      type: "session.created.1",
+      id: `sync-event-${childSessionId}`,
+      seq: 2,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        info: {
+          id: childSessionId,
+          slug: childSessionId,
+          projectID: "project-1",
+          parentID: "external-session-1",
+          directory: "/repo",
+          title: "Subagent",
+          version: "1.0.0",
+          time: {
+            created: Date.parse("2026-02-22T12:00:10.000Z"),
+            updated: Date.parse("2026-02-22T12:00:10.000Z"),
+          },
         },
       },
     },
@@ -155,62 +186,59 @@ const syncChildSessionCreatedEvent = (childSessionId: string): Event =>
 const syncChildSessionCreatedEventWithoutParent = (childSessionId: string): Event =>
   ({
     type: "sync",
-    name: "session.created.1",
     id: `sync-${childSessionId}`,
-    seq: 2,
-    aggregateID: "sessionID",
-    data: {
-      sessionID: childSessionId,
-      info: {
-        id: childSessionId,
-        directory: "/repo",
-        title: "Subagent",
-        version: "1.0.0",
-        time: {
-          created: Date.parse("2026-02-22T12:00:10.000Z"),
-          updated: Date.parse("2026-02-22T12:00:10.000Z"),
+    syncEvent: {
+      type: "session.created.1",
+      id: `sync-event-${childSessionId}`,
+      seq: 2,
+      aggregateID: childSessionId,
+      data: {
+        sessionID: childSessionId,
+        parentID: "external-session-1",
+        info: {
+          id: childSessionId,
+          slug: childSessionId,
+          projectID: "project-1",
+          directory: "/repo",
+          title: "Subagent",
+          version: "1.0.0",
+          time: {
+            created: Date.parse("2026-02-22T12:00:10.000Z"),
+            updated: Date.parse("2026-02-22T12:00:10.000Z"),
+          },
         },
       },
     },
   }) as unknown as Event;
 
-const makeSessionChild = (id: string, parentID: string): Session =>
+const childSessionDeletedEvent = (childSessionId: string): Event =>
   ({
-    id,
-    slug: id,
-    projectID: "project-1",
-    directory: "/repo",
-    parentID,
-    title: "Subagent",
-    version: "1.0.0",
-    time: {
-      created: Date.parse("2026-02-22T12:00:10.000Z"),
-      updated: Date.parse("2026-02-22T12:00:10.000Z"),
+    type: "session.deleted",
+    properties: {
+      sessionID: childSessionId,
+      info: {
+        id: childSessionId,
+        slug: childSessionId,
+        projectID: "project-1",
+        directory: "/repo",
+        parentID: "external-session-1",
+        title: "Subagent",
+        version: "1.0.0",
+        time: {
+          created: Date.parse("2026-02-22T12:00:10.000Z"),
+          updated: Date.parse("2026-02-22T12:00:11.000Z"),
+        },
+      },
     },
-  }) as Session;
-
-const makeSessionChildWithParentId = (id: string, parentId: string): Session =>
-  ({
-    id,
-    slug: id,
-    projectID: "project-1",
-    directory: "/repo",
-    parentId,
-    title: "Subagent",
-    version: "1.0.0",
-    time: {
-      created: Date.parse("2026-02-22T12:00:10.000Z"),
-      updated: Date.parse("2026-02-22T12:00:10.000Z"),
-    },
-  }) as unknown as Session;
+  }) as unknown as Event;
 
 const runRuntimeEventTransport = async (
   events: Event[],
   options?: {
-    childrenBySessionId?: Record<string, Session[]>;
+    onTransport?: (transport: RuntimeEventTransportRecord) => void;
   },
 ): Promise<AgentEvent[]> => {
-  const client = makeClientWithEvents(events, options);
+  const client = makeClientWithEvents(events);
   const sessions = new Map<string, SessionRecord>();
   const runtimeEventTransports = new Map<string, RuntimeEventTransportRecord>();
   const emitted: AgentEvent[] = [];
@@ -233,12 +261,17 @@ const runRuntimeEventTransport = async (
     },
   });
 
-  await runtimeEventTransports.get("runtime-opencode-1")?.streamDone;
+  const transport = runtimeEventTransports.get("runtime-opencode-1");
+  if (!transport) {
+    throw new Error("Expected OpenCode runtime event transport.");
+  }
+  options?.onTransport?.(transport);
+  await transport.streamDone;
   return emitted;
 };
 
 describe("session registry runtime event transport", () => {
-  test("routes top-level parent child session creation to the single pending subagent card", async () => {
+  test("routes direct child session creation to the single pending subagent card", async () => {
     const emitted = await runRuntimeEventTransport([
       assistantRoleEvent("assistant-subagent-session-created"),
       assistantSubtaskEvent({
@@ -308,80 +341,23 @@ describe("session registry runtime event transport", () => {
     });
   });
 
-  test("routes parentless sync child session creation through session children lookup", async () => {
-    const emitted = await runRuntimeEventTransport(
-      [
-        assistantRoleEvent("assistant-sync-subagent-session-created"),
-        syncAssistantSubtaskEvent({
-          messageId: "assistant-sync-subagent-session-created",
-          partId: "subtask-a",
-          description: "Read omp.json file",
-        }),
-        syncChildSessionCreatedEventWithoutParent("external-child-session"),
-        childPermissionEvent("external-child-session"),
-      ],
-      {
-        childrenBySessionId: {
-          "external-session-1": [makeSessionChild("external-child-session", "external-session-1")],
-        },
-      },
+  test("reports sync child lifecycle events that omit info.parentID", async () => {
+    const emitted = await runRuntimeEventTransport([
+      assistantRoleEvent("assistant-sync-subagent-session-created"),
+      syncAssistantSubtaskEvent({
+        messageId: "assistant-sync-subagent-session-created",
+        partId: "subtask-a",
+        description: "Read omp.json file",
+      }),
+      syncChildSessionCreatedEventWithoutParent("external-child-session"),
+    ]);
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "session_error",
+        message: expect.stringContaining("info.parentID"),
+      }),
     );
-
-    const subagentParts = readSubagentParts(emitted);
-    expect(subagentParts).toHaveLength(2);
-    expect(subagentParts[1]).toMatchObject({
-      correlationKey: "part:assistant-sync-subagent-session-created:subtask-a",
-      externalSessionId: "external-child-session",
-      status: "running",
-    });
-
-    const approvalEvents = emitted.filter((event) => event.type === "approval_required");
-    expect(approvalEvents).toHaveLength(1);
-    expect(approvalEvents[0]).toMatchObject({
-      requestId: "permission-child-1",
-      childExternalSessionId: "external-child-session",
-      parentExternalSessionId: "external-session-1",
-      subagentCorrelationKey: "part:assistant-sync-subagent-session-created:subtask-a",
-    });
-  });
-
-  test("resolves parentless child session events when session children use parentId", async () => {
-    const emitted = await runRuntimeEventTransport(
-      [
-        assistantRoleEvent("assistant-sync-subagent-session-created"),
-        syncAssistantSubtaskEvent({
-          messageId: "assistant-sync-subagent-session-created",
-          partId: "subtask-a",
-          description: "Read omp.json file",
-        }),
-        syncChildSessionCreatedEventWithoutParent("external-child-session"),
-        childPermissionEvent("external-child-session"),
-      ],
-      {
-        childrenBySessionId: {
-          "external-session-1": [
-            makeSessionChildWithParentId("external-child-session", "external-session-1"),
-          ],
-        },
-      },
-    );
-
-    const subagentParts = readSubagentParts(emitted);
-    expect(subagentParts).toHaveLength(2);
-    expect(subagentParts[1]).toMatchObject({
-      correlationKey: "part:assistant-sync-subagent-session-created:subtask-a",
-      externalSessionId: "external-child-session",
-      status: "running",
-    });
-
-    const approvalEvents = emitted.filter((event) => event.type === "approval_required");
-    expect(approvalEvents).toHaveLength(1);
-    expect(approvalEvents[0]).toMatchObject({
-      requestId: "permission-child-1",
-      childExternalSessionId: "external-child-session",
-      parentExternalSessionId: "external-session-1",
-      subagentCorrelationKey: "part:assistant-sync-subagent-session-created:subtask-a",
-    });
   });
 
   test("routes known child permission events after the child session link is established", async () => {
@@ -411,5 +387,59 @@ describe("session registry runtime event transport", () => {
       parentExternalSessionId: "external-session-1",
       subagentCorrelationKey: "part:assistant-subagent-permission:subtask-a",
     });
+  });
+
+  test("routes later parentless child question events from confirmed lifecycle lineage", async () => {
+    const emitted = await runRuntimeEventTransport([
+      assistantRoleEvent("assistant-subagent-question"),
+      assistantSubtaskEvent({
+        messageId: "assistant-subagent-question",
+        partId: "subtask-a",
+        description: "Ask for scope",
+      }),
+      childSessionCreatedEvent("external-child-session"),
+      childQuestionEvent("external-child-session"),
+    ]);
+
+    const questionEvents = emitted.filter((event) => event.type === "question_required");
+    expect(questionEvents).toHaveLength(1);
+    expect(questionEvents[0]).toMatchObject({
+      requestId: "question-child-1",
+      childExternalSessionId: "external-child-session",
+      parentExternalSessionId: "external-session-1",
+      subagentCorrelationKey: "part:assistant-subagent-question:subtask-a",
+    });
+  });
+
+  test("stops routing a child after session deletion clears confirmed lineage", async () => {
+    const emitted = await runRuntimeEventTransport([
+      assistantRoleEvent("assistant-subagent-deleted"),
+      assistantSubtaskEvent({
+        messageId: "assistant-subagent-deleted",
+        partId: "subtask-a",
+        description: "Read omp.json file",
+      }),
+      childSessionCreatedEvent("external-child-session"),
+      childSessionDeletedEvent("external-child-session"),
+      childPermissionEvent("external-child-session"),
+    ]);
+
+    expect(emitted.filter((event) => event.type === "approval_required")).toHaveLength(0);
+  });
+
+  test("clears confirmed child lineage when the runtime transport ends", async () => {
+    let transport: RuntimeEventTransportRecord | undefined;
+    await runRuntimeEventTransport([childSessionCreatedEvent("external-child-session")], {
+      onTransport: (record) => {
+        transport = record;
+      },
+    });
+
+    const lineage = (
+      transport as RuntimeEventTransportRecord & {
+        parentExternalSessionIdByChildExternalSessionId: Map<string, string>;
+      }
+    ).parentExternalSessionIdByChildExternalSessionId;
+    expect(lineage.size).toBe(0);
   });
 });

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -1,7 +1,6 @@
-import type { Event, OpencodeClient, Session } from "@opencode-ai/sdk/v2/client";
+import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent, AgentSessionSummary } from "@openducktor/core";
 import { formatWorkflowAgentSessionTitle } from "@openducktor/core";
-import { unwrapData } from "./data-utils";
 import {
   assertGlobalEventSupport,
   isRelevantSubscriberEvent,
@@ -9,15 +8,14 @@ import {
   processOpencodeEvent,
   subscribeGlobalEvents,
 } from "./event-stream";
+import { readEventInfo, readEventProperties } from "./event-stream/schemas";
 import {
-  readEventDirectory,
   readEventParentExternalSessionId,
   readEventSessionId,
   type SubagentSessionLink,
 } from "./event-stream/shared";
 import type {
   ClientFactory,
-  EventStreamSubscriber,
   OpencodeEventLogger,
   RuntimeEventTransportRecord,
   SessionInput,
@@ -67,111 +65,56 @@ const resolveSubagentSessionLink = (
   return matches.length === 1 ? matches[0] : undefined;
 };
 
-const PARENT_CHILD_LOOKUP_EVENT_TYPES = new Set([
-  "session.created",
-  "session.updated",
-  "permission.asked",
-  "permission.v2.asked",
-  "permission.replied",
-  "question.asked",
-  "question.replied",
-]);
-
-const shouldResolveParentlessChildEvent = (
-  subscriber: EventStreamSubscriber,
+const processRuntimeSessionLineage = (
+  eventTransport: RuntimeEventTransportRecord,
   event: Event,
-): string | null => {
-  if (!PARENT_CHILD_LOOKUP_EVENT_TYPES.has(event.type)) {
-    return null;
+): void => {
+  const eventType = String(event.type);
+  if (eventType === "session.deleted") {
+    const deletedExternalSessionId = readEventSessionId(event);
+    if (deletedExternalSessionId) {
+      eventTransport.parentExternalSessionIdByChildExternalSessionId.delete(
+        deletedExternalSessionId,
+      );
+    }
+    return;
   }
 
+  if (eventType !== "session.created" && eventType !== "session.updated") {
+    return;
+  }
+
+  const properties = readEventProperties(event);
+  const info = readEventInfo(properties);
   const childExternalSessionId = readEventSessionId(event);
-  if (
-    !childExternalSessionId ||
-    childExternalSessionId === subscriber.externalSessionId ||
-    readEventParentExternalSessionId("properties" in event ? event.properties : undefined)
-  ) {
-    return null;
-  }
-
-  const eventDirectory = readEventDirectory(event);
-  if (eventDirectory && eventDirectory !== subscriber.input.workingDirectory) {
-    return null;
-  }
-
-  return childExternalSessionId;
-};
-
-const listChildSessions = async (
-  client: OpencodeClient,
-  subscriber: EventStreamSubscriber,
-): Promise<Session[]> => {
-  const childrenApi = (client as OpencodeClient & { session?: { children?: unknown } }).session
-    ?.children;
-  if (typeof childrenApi !== "function") {
+  if (!childExternalSessionId || !info) {
     throw new Error(
-      "OpenCode SDK does not expose session.children(); cannot resolve parentless child session events.",
+      `OpenCode ${eventType} event is missing its session id or info payload; update the runtime or adapter to a supported event contract.`,
     );
   }
 
-  const response = await client.session.children({
-    directory: subscriber.input.workingDirectory,
-    sessionID: subscriber.externalSessionId,
-  });
-  return unwrapData(response, `list child sessions for ${subscriber.externalSessionId}`);
-};
+  const parentExternalSessionId = readEventParentExternalSessionId(info);
+  if (!parentExternalSessionId) {
+    const hasNonAuthoritativeParent = Boolean(readEventParentExternalSessionId(properties));
+    const isConfirmedChild =
+      eventTransport.parentExternalSessionIdByChildExternalSessionId.has(childExternalSessionId);
+    if (!hasNonAuthoritativeParent && !isConfirmedChild) {
+      return;
+    }
+    throw new Error(
+      `OpenCode ${eventType} event for child session '${childExternalSessionId}' is missing authoritative info.parentID lineage; update the runtime or adapter to a supported event contract.`,
+    );
+  }
 
-const hasConfirmedChildSession = (
-  children: Session[],
-  subscriber: EventStreamSubscriber,
-  childExternalSessionId: string,
-): boolean => {
-  return children.some(
-    (child) =>
-      child.id === childExternalSessionId &&
-      readEventParentExternalSessionId(child) === subscriber.externalSessionId,
+  eventTransport.parentExternalSessionIdByChildExternalSessionId.set(
+    childExternalSessionId,
+    parentExternalSessionId,
   );
 };
 
-const withParentExternalSessionId = (event: Event, parentExternalSessionId: string): Event => {
-  const properties =
-    "properties" in event && event.properties && typeof event.properties === "object"
-      ? (event.properties as Record<string, unknown>)
-      : {};
-  const info =
-    properties.info && typeof properties.info === "object"
-      ? (properties.info as Record<string, unknown>)
-      : {};
-
-  return {
-    ...event,
-    properties: {
-      ...properties,
-      parentID: parentExternalSessionId,
-      info: {
-        ...info,
-        parentID: parentExternalSessionId,
-      },
-    },
-  } as Event;
-};
-
-const resolveParentlessChildEvent = async (input: {
-  client: OpencodeClient;
-  subscriber: EventStreamSubscriber;
-  event: Event;
-}): Promise<Event | null> => {
-  const childExternalSessionId = shouldResolveParentlessChildEvent(input.subscriber, input.event);
-  if (!childExternalSessionId) {
-    return null;
-  }
-
-  const children = await listChildSessions(input.client, input.subscriber);
-  if (!hasConfirmedChildSession(children, input.subscriber, childExternalSessionId)) {
-    return null;
-  }
-
-  return withParentExternalSessionId(input.event, input.subscriber.externalSessionId);
+const abortRuntimeEventTransport = (eventTransport: RuntimeEventTransportRecord): void => {
+  eventTransport.parentExternalSessionIdByChildExternalSessionId.clear();
+  eventTransport.controller.abort();
 };
 
 const ensureRuntimeEventTransport = (input: {
@@ -211,29 +154,14 @@ const ensureRuntimeEventTransport = (input: {
     runtimeEndpoint: input.runtimeEndpoint,
     controller,
     dispatch: async (event) => {
+      processRuntimeSessionLineage(streamRecord, event);
       for (const subscriber of streamRecord.subscribers.values()) {
-        let eventForSubscriber = event;
-        let relevant = isRelevantSubscriberEvent(subscriber, event, {
-          isKnownChildExternalSessionId: (externalSessionId) => {
-            const session = input.sessions.get(subscriber.externalSessionId);
-            return (
-              (session?.subagentCorrelationKeyByExternalSessionId.has(externalSessionId) ??
-                false) ||
-              (session?.pendingSubagentSessionsByExternalSessionId.has(externalSessionId) ?? false)
-            );
-          },
+        const relevant = isRelevantSubscriberEvent(subscriber, event, {
+          resolveParentExternalSessionId: (childExternalSessionId) =>
+            streamRecord.parentExternalSessionIdByChildExternalSessionId.get(
+              childExternalSessionId,
+            ),
         });
-        if (!relevant) {
-          const parentLinkedEvent = await resolveParentlessChildEvent({
-            client: streamClient,
-            subscriber,
-            event,
-          });
-          if (parentLinkedEvent) {
-            eventForSubscriber = parentLinkedEvent;
-            relevant = true;
-          }
-        }
         logStreamEvent({
           subscriber,
           event,
@@ -248,7 +176,7 @@ const ensureRuntimeEventTransport = (input: {
             externalSessionId: subscriber.externalSessionId,
             input: subscriber.input,
           },
-          event: eventForSubscriber,
+          event,
           now: input.now,
           emit: input.emit,
           getSession: (sessionId) => input.sessions.get(sessionId),
@@ -262,6 +190,7 @@ const ensureRuntimeEventTransport = (input: {
     subscribers: new Map(),
     observers: new Set(),
     terminalObservers: new Set(),
+    parentExternalSessionIdByChildExternalSessionId: new Map(),
   };
   streamRecord.streamDone = subscribeGlobalEvents({
     client: streamClient,
@@ -301,6 +230,7 @@ const ensureRuntimeEventTransport = (input: {
       }
     })
     .finally(() => {
+      streamRecord.parentExternalSessionIdByChildExternalSessionId.clear();
       if (input.runtimeEventTransports.get(input.runtimeId) === streamRecord) {
         input.runtimeEventTransports.delete(input.runtimeId);
       }
@@ -320,7 +250,7 @@ const releaseRuntimeEventTransportIfUnused = async (
   ) {
     return;
   }
-  eventTransport.controller.abort();
+  abortRuntimeEventTransport(eventTransport);
   await eventTransport.streamDone.catch(() => undefined);
 };
 
@@ -383,7 +313,7 @@ export const observeRuntimeEvents = async (input: {
         if (input.runtimeEventTransports.get(input.runtimeId) === eventTransport) {
           input.runtimeEventTransports.delete(input.runtimeId);
         }
-        eventTransport.controller.abort();
+        abortRuntimeEventTransport(eventTransport);
       }
     },
   };

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -70,17 +70,8 @@ const processRuntimeSessionLineage = (
   event: Event,
 ): void => {
   const eventType = String(event.type);
-  if (eventType === "session.deleted") {
-    const deletedExternalSessionId = readEventSessionId(event);
-    if (deletedExternalSessionId) {
-      eventTransport.parentExternalSessionIdByChildExternalSessionId.delete(
-        deletedExternalSessionId,
-      );
-    }
-    return;
-  }
-
-  if (eventType !== "session.created" && eventType !== "session.updated") {
+  const isDeleted = eventType === "session.deleted";
+  if (eventType !== "session.created" && eventType !== "session.updated" && !isDeleted) {
     return;
   }
 
@@ -104,6 +95,11 @@ const processRuntimeSessionLineage = (
     throw new Error(
       `OpenCode ${eventType} event for child session '${childExternalSessionId}' is missing authoritative info.parentID lineage; update the runtime or adapter to a supported event contract.`,
     );
+  }
+
+  if (isDeleted) {
+    eventTransport.parentExternalSessionIdByChildExternalSessionId.delete(childExternalSessionId);
+    return;
   }
 
   eventTransport.parentExternalSessionIdByChildExternalSessionId.set(

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -8,11 +8,9 @@ import {
   processOpencodeEvent,
   subscribeGlobalEvents,
 } from "./event-stream";
-import { readEventInfo, readEventProperties } from "./event-stream/schemas";
 import {
   readEventParentExternalSessionId,
-  readEventSessionId,
-  readLifecycleParentExternalSessionId,
+  readSessionLifecycleEvent,
   type SubagentSessionLink,
 } from "./event-stream/shared";
 import type {
@@ -70,22 +68,24 @@ const processRuntimeSessionLineage = (
   eventTransport: RuntimeEventTransportRecord,
   event: Event,
 ): void => {
-  const eventType = String(event.type);
-  const isDeleted = eventType === "session.deleted";
-  if (eventType !== "session.created" && eventType !== "session.updated" && !isDeleted) {
+  const lifecycleEvent = readSessionLifecycleEvent(event);
+  if (!lifecycleEvent) {
     return;
   }
 
-  const properties = readEventProperties(event);
-  const info = readEventInfo(properties);
-  const childExternalSessionId = readEventSessionId(event);
+  const {
+    type: eventType,
+    properties,
+    info,
+    externalSessionId: childExternalSessionId,
+    parentExternalSessionId,
+  } = lifecycleEvent;
   if (!childExternalSessionId || !info) {
     throw new Error(
       `OpenCode ${eventType} event is missing its session id or info payload; update the runtime or adapter to a supported event contract.`,
     );
   }
 
-  const parentExternalSessionId = readLifecycleParentExternalSessionId(info);
   if (!parentExternalSessionId) {
     const hasNonAuthoritativeParent = Boolean(readEventParentExternalSessionId(properties));
     const isConfirmedChild =
@@ -98,7 +98,7 @@ const processRuntimeSessionLineage = (
     );
   }
 
-  if (isDeleted) {
+  if (eventType === "session.deleted") {
     eventTransport.parentExternalSessionIdByChildExternalSessionId.delete(childExternalSessionId);
     return;
   }

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -12,6 +12,7 @@ import { readEventInfo, readEventProperties } from "./event-stream/schemas";
 import {
   readEventParentExternalSessionId,
   readEventSessionId,
+  readLifecycleParentExternalSessionId,
   type SubagentSessionLink,
 } from "./event-stream/shared";
 import type {
@@ -84,7 +85,7 @@ const processRuntimeSessionLineage = (
     );
   }
 
-  const parentExternalSessionId = readEventParentExternalSessionId(info);
+  const parentExternalSessionId = readLifecycleParentExternalSessionId(info);
   if (!parentExternalSessionId) {
     const hasNonAuthoritativeParent = Boolean(readEventParentExternalSessionId(properties));
     const isConfirmedChild =

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -99,6 +99,7 @@ export type RuntimeEventTransportRecord = {
   subscribers: Map<string, EventStreamSubscriber>;
   observers: Set<(event: Event) => void | Promise<void>>;
   terminalObservers: Set<(error: Error) => void | Promise<void>>;
+  parentExternalSessionIdByChildExternalSessionId: Map<string, string>;
 };
 
 export type ClientFactory = (input: {


### PR DESCRIPTION
## Summary
- Normalize OpenCode SDK v1.18.4 nested sync envelopes.
- Route child pending input from transport-scoped lifecycle lineage without hot-path RPCs.
- Make explicit parent metadata authoritative and clear lineage on deletion and transport release.

## Goal and context
OpenCode emits nested sync events through syncEvent.type and syncEvent.data, while lifecycle info.parentID is the authoritative child-parent link. The old adapter lost that lineage and compensated with serialized session.children() calls in the event path. This change aligns the adapter with the installed SDK and runtime contract and removes that network wait from normal subscriber dispatch.

## Technical choices
- Normalize recognized nested sync lifecycle and message events at the SDK boundary without retaining the raw sync envelope.
- Decode lifecycle fields once and update a runtime-transport child-to-parent map before subscriber fan-out.
- Use cached lineage only for parentless permission and question events; explicit parent metadata always wins.
- Clear lineage on session.deleted, natural stream end, abort, release, and same-runtime reuse.
- Reject malformed child lifecycle events with an actionable diagnostic instead of guessing.
- Cover generated SDK fixtures, runtime-source fixtures, cleanup, serial ordering, malformed lineage, conflicting explicit-parent cases, and normalized envelope cleanup.

## Testing
- bun run format:check
- bun run --filter @openducktor/adapters-opencode-sdk lint
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/adapters-opencode-sdk test: 427 passed
- bun run --filter @openducktor/adapters-opencode-sdk build
- bun run deps:unused:deps
- bun run deps:unused:exports
- git diff --check
- GitNexus compare with main: low risk and no affected execution flows

## Checklist
- [x] Added or updated tests for changed behavior.
- [x] Ran formatting, lint, typecheck, tests, build, and direct Knip scans.
- [x] Kept the change within the approved adapter scope.
- [x] No database or persisted record changes.
- [ ] All required CI checks pass. Dependency Hygiene stops before Knip on GHSA-mh99-v99m-4gvg in transitive Electron build dependencies.

## Related Issues
- OpenDucktor task openduckto-lqdf

## Breaking Changes
None.

## Additional Context
The direct Knip dependency and export scans pass. The Dependency Hygiene job fails first in deps:audit:high because brace-expansion versions used by transitive Electron packaging dependencies are covered by a newly published high-severity advisory. The patched v5 release is not compatible with the older minimatch consumers that still require v1 and v2, so this PR does not weaken the audit gate or force an unsafe global override.

Cargo checks do not apply because this repository has no Cargo workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session lineage correlation for child events using session lifecycle details, including external session IDs.
  * Normalized incoming sync events consistently and prevented incorrect projection of sync envelopes.
  * Added stricter validation and clearer `session_error` messages when parent linkage data is missing, malformed, or uses unsupported parent aliases.
  * Fixed routing and correlation cleanup after session deletion and runtime transport shutdown, including transport reuse.
* **Tests**
  * Expanded coverage for nested sessions, event relevance/routing rules, and error handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->