### PR TITLE
perf(frontend): defer cleanup impact reads until confirmation

### DIFF
--- a/packages/frontend/src/components/features/task-details/task-delete-confirm-dialog.test.tsx
+++ b/packages/frontend/src/components/features/task-details/task-delete-confirm-dialog.test.tsx
@@ -1,11 +1,55 @@
 import { describe, expect, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
 import {
   formatManagedSessionCleanupLoadingMessage,
   formatManagedSessionCleanupMessage,
   formatUnknownManagedSessionCleanupMessage,
 } from "./task-cleanup-impact-model";
+import { TaskDeleteConfirmDialog } from "./task-delete-confirm-dialog";
+
+const renderDialog = (terminalCount: number) =>
+  render(
+    <TaskDeleteConfirmDialog
+      open
+      onOpenChange={() => {}}
+      onCancel={() => {}}
+      onConfirm={() => {}}
+      taskId="task-1"
+      subtasksCount={0}
+      impact={{
+        hasSubtasks: false,
+        isLoading: false,
+        hasManagedSessionCleanup: false,
+        managedWorktreeCount: 0,
+        terminalCount,
+        error: null,
+      }}
+      deletion={{ isPending: false, error: null }}
+    />,
+  );
 
 describe("TaskDeleteConfirmDialog", () => {
+  test("uses standard spacing and hides terminal copy when no terminals will stop", () => {
+    const rendered = renderDialog(0);
+
+    expect(screen.queryByText(/running task terminals|associated terminal/i)).toBeNull();
+    const body = screen.getByText("This action permanently removes the task.").parentElement
+      ?.parentElement;
+    expect(body?.className).toContain("py-4");
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    expect(cancelButton.parentElement?.className).toContain("justify-between");
+
+    rendered.unmount();
+  });
+
+  test("warns when task terminals will be terminated", () => {
+    const rendered = renderDialog(2);
+
+    expect(screen.getByText(/2 associated terminals will be terminated/i)).toBeDefined();
+
+    rendered.unmount();
+  });
+
   test("mentions worktree and related branch cleanup when managed sessions exist", () => {
     const message = formatManagedSessionCleanupMessage(2);
 

--- a/packages/frontend/src/components/features/task-details/task-delete-confirm-dialog.tsx
+++ b/packages/frontend/src/components/features/task-details/task-delete-confirm-dialog.tsx
@@ -59,7 +59,7 @@ export function TaskDeleteConfirmDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="pt-4">
+        <DialogBody className="py-4">
           <div className="space-y-2 rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2 text-sm text-destructive-surface-foreground">
             <p className="font-medium">This action permanently removes the task.</p>
             {impact.hasSubtasks ? (
@@ -67,11 +67,12 @@ export function TaskDeleteConfirmDialog({
                 Direct subtasks will also be deleted to avoid orphaned children in the workflow.
               </p>
             ) : null}
-            <p>
-              {impact.terminalCount === 0
-                ? "No running task terminals will be stopped."
-                : `${impact.terminalCount} associated terminal${impact.terminalCount === 1 ? "" : "s"} will be terminated before deletion.`}
-            </p>
+            {impact.terminalCount === 0 ? null : (
+              <p>
+                {impact.terminalCount} associated terminal
+                {impact.terminalCount === 1 ? "" : "s"} will be terminated before deletion.
+              </p>
+            )}
             {impact.isLoading ? (
               <p>{formatManagedSessionCleanupLoadingMessage("delete")}</p>
             ) : impact.error ? (
@@ -84,7 +85,7 @@ export function TaskDeleteConfirmDialog({
           </div>
         </DialogBody>
 
-        <DialogFooter className="mt-0 flex flex-row justify-end gap-2 border-t border-border pt-5">
+        <DialogFooter className="mt-0 flex flex-row justify-between gap-2 border-t border-border pt-5">
           <Button
             type="button"
             variant="outline"

--- a/packages/frontend/src/components/features/task-details/task-details-sheet.test.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-sheet.test.tsx
@@ -55,6 +55,27 @@ const IsolatedProviders = ({ children }: PropsWithChildren) => (
   </QueryProvider>
 );
 
+const createTaskDocumentsHookMock = () =>
+  mock((_taskId: string | null, _open: boolean, _cacheScope = "") => ({
+    specDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
+    planDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
+    qaDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
+    ensureDocumentLoaded: () => false,
+    reloadDocument: () => false,
+    applyDocumentUpdate: () => {},
+  }));
+
+const createTaskCleanupImpactHookMock = () =>
+  mock((_taskIds: string[], _enabled: boolean) => ({
+    hasCanonicalWorktree: false,
+    hasManagedSessionCleanup: false,
+    managedWorktreeCount: 0,
+    legacyWorktreeCount: 0,
+    impactError: null,
+    isLoadingImpact: false,
+    terminalCount: 0,
+  }));
+
 describe("TaskDetailsSheet", () => {
   test("passes activeWorkspace into task details view model", async () => {
     const { useTaskDetailsSheetViewModel } = await import("./use-task-details-sheet-view-model");
@@ -80,25 +101,8 @@ describe("TaskDetailsSheet", () => {
       },
     });
 
-    const taskDocumentsHookMock = mock(
-      (_taskId: string | null, _open: boolean, _cacheScope = "") => ({
-        specDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-        planDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-        qaDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-        ensureDocumentLoaded: () => false,
-        reloadDocument: () => false,
-        applyDocumentUpdate: () => {},
-      }),
-    );
-    const taskCleanupImpactHookMock = mock((_taskIds: string[], _enabled: boolean) => ({
-      hasCanonicalWorktree: false,
-      hasManagedSessionCleanup: false,
-      managedWorktreeCount: 0,
-      legacyWorktreeCount: 0,
-      impactError: null,
-      isLoadingImpact: false,
-      terminalCount: 0,
-    }));
+    const taskDocumentsHookMock = createTaskDocumentsHookMock();
+    const taskCleanupImpactHookMock = createTaskCleanupImpactHookMock();
 
     const harness = createSharedHookHarness(useTaskDetailsSheetViewModel, {
       activeWorkspace: {
@@ -145,15 +149,7 @@ describe("TaskDetailsSheet", () => {
       issueType: "epic",
       subtaskIds: ["TASK-2"],
     });
-    const taskCleanupImpactHookMock = mock((_taskIds: string[], _enabled: boolean) => ({
-      hasCanonicalWorktree: false,
-      hasManagedSessionCleanup: false,
-      managedWorktreeCount: 0,
-      legacyWorktreeCount: 0,
-      impactError: null,
-      isLoadingImpact: false,
-      terminalCount: 0,
-    }));
+    const taskCleanupImpactHookMock = createTaskCleanupImpactHookMock();
     const harness = createSharedHookHarness(useTaskDetailsSheetViewModel, {
       activeWorkspace: {
         workspaceId: "workspace-a",
@@ -176,14 +172,7 @@ describe("TaskDetailsSheet", () => {
       onResetTask: mock(async () => {}),
       onCloseTask: mock(async () => {}),
       onDelete: mock(async () => {}),
-      taskDocumentsHook: () => ({
-        specDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-        planDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-        qaDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-        ensureDocumentLoaded: () => false,
-        reloadDocument: () => false,
-        applyDocumentUpdate: () => {},
-      }),
+      taskDocumentsHook: createTaskDocumentsHookMock(),
       taskCleanupImpactHook: taskCleanupImpactHookMock,
     });
     const latestImpactCalls = () => taskCleanupImpactHookMock.mock.calls.slice(-2);
@@ -228,23 +217,8 @@ describe("TaskDetailsSheet", () => {
     });
     const onCloseTask = mock(async () => {});
     const onOpenChange = mock(() => {});
-    const taskDocumentsHookMock = mock(() => ({
-      specDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-      planDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-      qaDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-      ensureDocumentLoaded: () => false,
-      reloadDocument: () => false,
-      applyDocumentUpdate: () => {},
-    }));
-    const taskCleanupImpactHookMock = mock((_taskIds: string[], _enabled: boolean) => ({
-      hasCanonicalWorktree: false,
-      hasManagedSessionCleanup: false,
-      managedWorktreeCount: 0,
-      legacyWorktreeCount: 0,
-      impactError: null,
-      isLoadingImpact: false,
-      terminalCount: 0,
-    }));
+    const taskDocumentsHookMock = createTaskDocumentsHookMock();
+    const taskCleanupImpactHookMock = createTaskCleanupImpactHookMock();
 
     const harness = createSharedHookHarness(useTaskDetailsSheetViewModel, {
       activeWorkspace: {
@@ -294,23 +268,8 @@ describe("TaskDetailsSheet", () => {
     const onCloseTask = mock(async () => {
       throw new Error("close failed");
     });
-    const taskDocumentsHookMock = mock(() => ({
-      specDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-      planDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-      qaDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
-      ensureDocumentLoaded: () => false,
-      reloadDocument: () => false,
-      applyDocumentUpdate: () => {},
-    }));
-    const taskCleanupImpactHookMock = mock((_taskIds: string[], _enabled: boolean) => ({
-      hasCanonicalWorktree: false,
-      hasManagedSessionCleanup: false,
-      managedWorktreeCount: 0,
-      legacyWorktreeCount: 0,
-      impactError: null,
-      isLoadingImpact: false,
-      terminalCount: 0,
-    }));
+    const taskDocumentsHookMock = createTaskDocumentsHookMock();
+    const taskCleanupImpactHookMock = createTaskCleanupImpactHookMock();
 
     const harness = createSharedHookHarness(useTaskDetailsSheetViewModel, {
       activeWorkspace: {

--- a/packages/frontend/src/components/features/task-details/task-details-sheet.test.tsx
+++ b/packages/frontend/src/components/features/task-details/task-details-sheet.test.tsx
@@ -90,7 +90,7 @@ describe("TaskDetailsSheet", () => {
         applyDocumentUpdate: () => {},
       }),
     );
-    const taskCleanupImpactHookMock = mock(() => ({
+    const taskCleanupImpactHookMock = mock((_taskIds: string[], _enabled: boolean) => ({
       hasCanonicalWorktree: false,
       hasManagedSessionCleanup: false,
       managedWorktreeCount: 0,
@@ -129,8 +129,91 @@ describe("TaskDetailsSheet", () => {
     try {
       await harness.mount();
       expect(taskDocumentsHookMock).toHaveBeenCalledWith("TASK-1", true, "/repo-a");
-      expect(taskCleanupImpactHookMock).toHaveBeenNthCalledWith(1, ["TASK-1", "TASK-2"], true);
-      expect(taskCleanupImpactHookMock).toHaveBeenNthCalledWith(2, ["TASK-1"], true);
+      expect(taskCleanupImpactHookMock).toHaveBeenNthCalledWith(1, ["TASK-1", "TASK-2"], false);
+      expect(taskCleanupImpactHookMock).toHaveBeenNthCalledWith(2, ["TASK-1"], false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("loads cleanup impact only for an available action's open confirmation", async () => {
+    const { useTaskDetailsSheetViewModel } = await import("./use-task-details-sheet-view-model");
+    const childTask = createTaskCardFixture({ id: "TASK-2", title: "Task 2" });
+    const task = createTaskCardFixture({
+      id: "TASK-1",
+      title: "Task 1",
+      issueType: "epic",
+      subtaskIds: ["TASK-2"],
+    });
+    const taskCleanupImpactHookMock = mock((_taskIds: string[], _enabled: boolean) => ({
+      hasCanonicalWorktree: false,
+      hasManagedSessionCleanup: false,
+      managedWorktreeCount: 0,
+      legacyWorktreeCount: 0,
+      impactError: null,
+      isLoadingImpact: false,
+      terminalCount: 0,
+    }));
+    const harness = createSharedHookHarness(useTaskDetailsSheetViewModel, {
+      activeWorkspace: {
+        workspaceId: "workspace-a",
+        workspaceName: "Workspace A",
+        repoPath: "/repo-a",
+      },
+      task,
+      allTasks: [task, childTask],
+      open: true,
+      onOpenChange: () => {},
+      onPlan: undefined,
+      onQaStart: undefined,
+      onQaOpen: undefined,
+      onBuild: undefined,
+      onOpenSession: undefined,
+      onDelegate: undefined,
+      onHumanApprove: undefined,
+      onHumanRequestChanges: undefined,
+      onResetImplementation: undefined,
+      onResetTask: mock(async () => {}),
+      onCloseTask: mock(async () => {}),
+      onDelete: mock(async () => {}),
+      taskDocumentsHook: () => ({
+        specDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
+        planDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
+        qaDoc: { markdown: "", updatedAt: null, isLoading: false, error: null, loaded: true },
+        ensureDocumentLoaded: () => false,
+        reloadDocument: () => false,
+        applyDocumentUpdate: () => {},
+      }),
+      taskCleanupImpactHook: taskCleanupImpactHookMock,
+    });
+    const latestImpactCalls = () => taskCleanupImpactHookMock.mock.calls.slice(-2);
+
+    try {
+      await harness.mount();
+      expect(latestImpactCalls()).toEqual([
+        [["TASK-1", "TASK-2"], false],
+        [["TASK-1"], false],
+      ]);
+
+      await harness.run((viewModel) => viewModel.openDeleteDialog());
+      expect(latestImpactCalls()).toEqual([
+        [["TASK-1", "TASK-2"], true],
+        [["TASK-1"], false],
+      ]);
+
+      await harness.run((viewModel) => viewModel.closeDeleteDialog());
+      await harness.run((viewModel) => viewModel.openResetDialog());
+      expect(latestImpactCalls()).toEqual([
+        [["TASK-1", "TASK-2"], false],
+        [["TASK-1"], true],
+      ]);
+
+      await harness.run((viewModel) => viewModel.closeResetDialog());
+      await harness.run((viewModel) => viewModel.openCloseDialog());
+      expect(latestImpactCalls()).toEqual([
+        [["TASK-1", "TASK-2"], false],
+        [["TASK-1"], true],
+      ]);
     } finally {
       await harness.unmount();
     }
@@ -153,7 +236,7 @@ describe("TaskDetailsSheet", () => {
       reloadDocument: () => false,
       applyDocumentUpdate: () => {},
     }));
-    const taskCleanupImpactHookMock = mock(() => ({
+    const taskCleanupImpactHookMock = mock((_taskIds: string[], _enabled: boolean) => ({
       hasCanonicalWorktree: false,
       hasManagedSessionCleanup: false,
       managedWorktreeCount: 0,
@@ -219,7 +302,7 @@ describe("TaskDetailsSheet", () => {
       reloadDocument: () => false,
       applyDocumentUpdate: () => {},
     }));
-    const taskCleanupImpactHookMock = mock(() => ({
+    const taskCleanupImpactHookMock = mock((_taskIds: string[], _enabled: boolean) => ({
       hasCanonicalWorktree: false,
       hasManagedSessionCleanup: false,
       managedWorktreeCount: 0,

--- a/packages/frontend/src/components/features/task-details/use-task-cleanup-impact-hook.test.tsx
+++ b/packages/frontend/src/components/features/task-details/use-task-cleanup-impact-hook.test.tsx
@@ -10,32 +10,39 @@ import { createHookHarness } from "@/test-utils/react-hook-harness";
 import type { WorkspaceStateContextValue } from "@/types/state-slices";
 import { useTaskCleanupImpact } from "./use-task-cleanup-impact";
 
-const workspaceState = {
-  activeWorkspace: {
-    workspaceId: "workspace-a",
-    workspaceName: "Workspace A",
-    repoPath: "/repo",
-  },
-} as WorkspaceStateContextValue;
+const createWorkspaceState = (): WorkspaceStateContextValue =>
+  ({
+    activeWorkspace: {
+      workspaceId: "workspace-a",
+      workspaceName: "Workspace A",
+      repoPath: "/repo",
+    },
+  }) as WorkspaceStateContextValue;
 
-const Wrapper = ({ children }: PropsWithChildren) => (
-  <QueryProvider useIsolatedClient>
-    <WorkspaceStateContext.Provider value={workspaceState}>
-      {children}
-    </WorkspaceStateContext.Provider>
-  </QueryProvider>
-);
+const createWrapper = () => {
+  const workspaceState = createWorkspaceState();
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryProvider useIsolatedClient>
+        <WorkspaceStateContext.Provider value={workspaceState}>
+          {children}
+        </WorkspaceStateContext.Provider>
+      </QueryProvider>
+    );
+  };
+};
 
-const sessionFixture: AgentSessionRecord = {
+const createSessionFixture = (): AgentSessionRecord => ({
   externalSessionId: "session-1",
   role: "build",
   runtimeKind: "opencode",
   workingDirectory: "/worktrees/task-1",
   startedAt: "2026-07-27T12:00:00.000Z",
   selectedModel: null,
-};
+});
 
 const createReadPorts = () => {
+  const sessionFixture = createSessionFixture();
   const agentSessionsList = mock(async () => [sessionFixture]);
   const agentSessionsListForTasks = mock(async (_repoPath: string, taskIds: string[]) =>
     taskIds.map((taskId) => ({
@@ -60,6 +67,7 @@ const createReadPorts = () => {
       taskWorktrees: { taskWorktreeGet },
       terminals: { terminalList },
     },
+    sessionFixture,
   };
 };
 
@@ -77,7 +85,7 @@ const createHarness = (initialProps: HarnessProps) =>
       return { impact, queryClient };
     },
     initialProps,
-    { wrapper: Wrapper },
+    { wrapper: createWrapper() },
   );
 
 describe("useTaskCleanupImpact", () => {
@@ -124,7 +132,7 @@ describe("useTaskCleanupImpact", () => {
   });
 
   test("reuses warm session and worktree cache entries", async () => {
-    const { calls, readPorts } = createReadPorts();
+    const { calls, readPorts, sessionFixture } = createReadPorts();
     const initialProps = { enabled: false, taskIds: ["task-1"], readPorts };
     const harness = createHarness(initialProps);
 
@@ -152,7 +160,7 @@ describe("useTaskCleanupImpact", () => {
   });
 
   test("refreshes an invalidated session entry through its canonical per-task query", async () => {
-    const { calls, readPorts } = createReadPorts();
+    const { calls, readPorts, sessionFixture } = createReadPorts();
     const initialProps = { enabled: false, taskIds: ["task-1"], readPorts };
     const harness = createHarness(initialProps);
 

--- a/packages/frontend/src/components/features/task-details/use-task-cleanup-impact-hook.test.tsx
+++ b/packages/frontend/src/components/features/task-details/use-task-cleanup-impact-hook.test.tsx
@@ -1,0 +1,200 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { QueryProvider } from "@/lib/query-provider";
+import { WorkspaceStateContext } from "@/state/app-state-contexts";
+import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
+import { taskWorktreeQueryKeys } from "@/state/queries/build-runtime";
+import { createHookHarness } from "@/test-utils/react-hook-harness";
+import type { WorkspaceStateContextValue } from "@/types/state-slices";
+import { useTaskCleanupImpact } from "./use-task-cleanup-impact";
+
+const workspaceState = {
+  activeWorkspace: {
+    workspaceId: "workspace-a",
+    workspaceName: "Workspace A",
+    repoPath: "/repo",
+  },
+} as WorkspaceStateContextValue;
+
+const Wrapper = ({ children }: PropsWithChildren) => (
+  <QueryProvider useIsolatedClient>
+    <WorkspaceStateContext.Provider value={workspaceState}>
+      {children}
+    </WorkspaceStateContext.Provider>
+  </QueryProvider>
+);
+
+const sessionFixture: AgentSessionRecord = {
+  externalSessionId: "session-1",
+  role: "build",
+  runtimeKind: "opencode",
+  workingDirectory: "/worktrees/task-1",
+  startedAt: "2026-07-27T12:00:00.000Z",
+  selectedModel: null,
+};
+
+const createReadPorts = () => {
+  const agentSessionsList = mock(async () => [sessionFixture]);
+  const agentSessionsListForTasks = mock(async (_repoPath: string, taskIds: string[]) =>
+    taskIds.map((taskId) => ({
+      taskId,
+      agentSessions: taskId === "task-1" ? [sessionFixture] : [],
+    })),
+  );
+  const taskWorktreeGet = mock(async (_repoPath: string, taskId: string) => ({
+    workingDirectory: `/worktrees/${taskId}`,
+  }));
+  const terminalList = mock(async () => ({ hostInstanceId: "host-1", terminals: [] }));
+
+  return {
+    calls: {
+      agentSessionsList,
+      agentSessionsListForTasks,
+      taskWorktreeGet,
+      terminalList,
+    },
+    readPorts: {
+      agentSessions: { agentSessionsList, agentSessionsListForTasks },
+      taskWorktrees: { taskWorktreeGet },
+      terminals: { terminalList },
+    },
+  };
+};
+
+type HarnessProps = {
+  enabled: boolean;
+  taskIds: string[];
+  readPorts: ReturnType<typeof createReadPorts>["readPorts"];
+};
+
+const createHarness = (initialProps: HarnessProps) =>
+  createHookHarness(
+    (props: HarnessProps) => {
+      const queryClient = useQueryClient();
+      const impact = useTaskCleanupImpact(props.taskIds, props.enabled, props.readPorts);
+      return { impact, queryClient };
+    },
+    initialProps,
+    { wrapper: Wrapper },
+  );
+
+describe("useTaskCleanupImpact", () => {
+  test("issues no cleanup commands while disabled", async () => {
+    const { calls, readPorts } = createReadPorts();
+    const harness = createHarness({ enabled: false, taskIds: ["task-1"], readPorts });
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().impact).toMatchObject({
+        impactError: null,
+        isLoadingImpact: false,
+        managedWorktreeCount: 0,
+        terminalCount: 0,
+      });
+      expect(calls.agentSessionsListForTasks).not.toHaveBeenCalled();
+      expect(calls.agentSessionsList).not.toHaveBeenCalled();
+      expect(calls.taskWorktreeGet).not.toHaveBeenCalled();
+      expect(calls.terminalList).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("uses one batch session command plus per-task worktree and terminal commands when cold", async () => {
+    const { calls, readPorts } = createReadPorts();
+    const harness = createHarness({
+      enabled: true,
+      taskIds: ["task-2", "task-1"],
+      readPorts,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(({ impact }) => !impact.isLoadingImpact);
+      expect(calls.agentSessionsListForTasks).toHaveBeenCalledTimes(1);
+      expect(calls.agentSessionsListForTasks).toHaveBeenCalledWith("/repo", ["task-1", "task-2"]);
+      expect(calls.agentSessionsList).not.toHaveBeenCalled();
+      expect(calls.taskWorktreeGet).toHaveBeenCalledTimes(2);
+      expect(calls.terminalList).toHaveBeenCalledTimes(2);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("reuses warm session and worktree cache entries", async () => {
+    const { calls, readPorts } = createReadPorts();
+    const initialProps = { enabled: false, taskIds: ["task-1"], readPorts };
+    const harness = createHarness(initialProps);
+
+    try {
+      await harness.mount();
+      const { queryClient } = harness.getLatest();
+      queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
+      queryClient.setQueryData(
+        taskWorktreeQueryKeys.taskWorktree({
+          repoPath: "/repo",
+          taskId: "task-1",
+        }),
+        { workingDirectory: "/worktrees/task-1" },
+      );
+
+      await harness.update({ ...initialProps, enabled: true });
+      await harness.waitFor(({ impact }) => !impact.isLoadingImpact);
+      expect(calls.agentSessionsListForTasks).not.toHaveBeenCalled();
+      expect(calls.agentSessionsList).not.toHaveBeenCalled();
+      expect(calls.taskWorktreeGet).not.toHaveBeenCalled();
+      expect(calls.terminalList).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("refreshes an invalidated session entry through its canonical per-task query", async () => {
+    const { calls, readPorts } = createReadPorts();
+    const initialProps = { enabled: false, taskIds: ["task-1"], readPorts };
+    const harness = createHarness(initialProps);
+
+    try {
+      await harness.mount();
+      const { queryClient } = harness.getLatest();
+      queryClient.setQueryData(agentSessionQueryKeys.list("/repo", "task-1"), [sessionFixture]);
+      await queryClient.invalidateQueries({
+        queryKey: agentSessionQueryKeys.list("/repo", "task-1"),
+        exact: true,
+        refetchType: "none",
+      });
+
+      await harness.update({ ...initialProps, enabled: true });
+      await harness.waitFor(() => calls.agentSessionsList.mock.calls.length === 1);
+      await harness.waitFor(({ impact }) => !impact.isLoadingImpact);
+      expect(calls.agentSessionsListForTasks).not.toHaveBeenCalled();
+      expect(calls.agentSessionsList).toHaveBeenCalledTimes(1);
+      expect(calls.agentSessionsList).toHaveBeenCalledWith("/repo", "task-1");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("surfaces batch session hydration failures", async () => {
+    const { calls, readPorts } = createReadPorts();
+    calls.agentSessionsListForTasks.mockImplementation(async () => {
+      throw new Error("batch session read failed");
+    });
+    const harness = createHarness({ enabled: true, taskIds: ["task-1"], readPorts });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(({ impact }) => impact.impactError !== null);
+      expect(harness.getLatest().impact).toMatchObject({
+        impactError: "Unable to load linked worktree cleanup impact.",
+        isLoadingImpact: false,
+      });
+      expect(calls.agentSessionsListForTasks).toHaveBeenCalledTimes(1);
+      expect(calls.agentSessionsList).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/packages/frontend/src/components/features/task-details/use-task-cleanup-impact-hook.test.tsx
+++ b/packages/frontend/src/components/features/task-details/use-task-cleanup-impact-hook.test.tsx
@@ -7,6 +7,7 @@ import { WorkspaceStateContext } from "@/state/app-state-contexts";
 import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
 import { taskWorktreeQueryKeys } from "@/state/queries/build-runtime";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
+import { createDeferred } from "@/test-utils/shared-test-fixtures";
 import type { WorkspaceStateContextValue } from "@/types/state-slices";
 import { useTaskCleanupImpact } from "./use-task-cleanup-impact";
 
@@ -161,6 +162,8 @@ describe("useTaskCleanupImpact", () => {
 
   test("refreshes an invalidated session entry through its canonical per-task query", async () => {
     const { calls, readPorts, sessionFixture } = createReadPorts();
+    const refresh = createDeferred<AgentSessionRecord[]>();
+    calls.agentSessionsList.mockImplementation(() => refresh.promise);
     const initialProps = { enabled: false, taskIds: ["task-1"], readPorts };
     const harness = createHarness(initialProps);
 
@@ -176,6 +179,8 @@ describe("useTaskCleanupImpact", () => {
 
       await harness.update({ ...initialProps, enabled: true });
       await harness.waitFor(() => calls.agentSessionsList.mock.calls.length === 1);
+      expect(harness.getLatest().impact.isLoadingImpact).toBe(true);
+      await harness.run(() => refresh.resolve([sessionFixture]));
       await harness.waitFor(({ impact }) => !impact.isLoadingImpact);
       expect(calls.agentSessionsListForTasks).not.toHaveBeenCalled();
       expect(calls.agentSessionsList).toHaveBeenCalledTimes(1);

--- a/packages/frontend/src/components/features/task-details/use-task-cleanup-impact.ts
+++ b/packages/frontend/src/components/features/task-details/use-task-cleanup-impact.ts
@@ -180,7 +180,8 @@ export function useTaskCleanupImpact(
     queryClient,
     ...(readPorts.agentSessions ? { readPort: readPorts.agentSessions } : {}),
   });
-  const taskSessionQueries = useQueries(
+  // Observe canonical per-task state without starting reads here; useAgentSessionLists owns session loading so cold gaps stay batched.
+  const taskSessionObservers = useQueries(
     {
       queries: taskIds.map((taskId) => ({
         ...agentSessionListQueryOptions(queryRepoPath, taskId, readPorts.agentSessions),
@@ -220,7 +221,7 @@ export function useTaskCleanupImpact(
     const sessionImpact = getTaskCleanupImpactFromSessionQueries(
       shouldLoadImpact ? workspaceRepoPath : null,
       taskIds,
-      taskSessionQueries.map((query) => ({
+      taskSessionObservers.map((query) => ({
         ...query,
         error: sessionLists.error ?? query.error,
         isLoading: sessionLists.isPending || query.isLoading,
@@ -253,7 +254,7 @@ export function useTaskCleanupImpact(
     taskIds,
     sessionLists.error,
     sessionLists.isPending,
-    taskSessionQueries,
+    taskSessionObservers,
     taskWorktreeQueries,
     terminalQueries,
   ]);

--- a/packages/frontend/src/components/features/task-details/use-task-cleanup-impact.ts
+++ b/packages/frontend/src/components/features/task-details/use-task-cleanup-impact.ts
@@ -1,11 +1,18 @@
 import type { AgentSessionRecord, TaskWorktreeSummary } from "@openducktor/contracts";
 import { normalizePathForComparison } from "@openducktor/path-support";
-import { useQueries } from "@tanstack/react-query";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useWorkspaceState } from "@/state/app-state-provider";
-import { agentSessionListQueryOptions } from "@/state/queries/agent-sessions";
-import { taskWorktreeQueryOptions } from "@/state/queries/build-runtime";
+import {
+  type AgentSessionReadPort,
+  agentSessionListQueryOptions,
+} from "@/state/queries/agent-sessions";
+import {
+  type TaskWorktreeQueryHost,
+  taskWorktreeQueryOptions,
+} from "@/state/queries/build-runtime";
 import { terminalListQueryOptions } from "@/state/queries/terminals";
+import { useAgentSessionLists } from "@/state/queries/use-agent-session-lists";
 
 type TaskCleanupImpact = {
   hasCanonicalWorktree: boolean;
@@ -29,6 +36,12 @@ type TaskWorktreeImpactQuerySnapshot = {
   error: unknown;
   isLoading: boolean;
   isFetching: boolean;
+};
+
+type TaskCleanupImpactReadPorts = {
+  agentSessions?: AgentSessionReadPort;
+  taskWorktrees?: TaskWorktreeQueryHost;
+  terminals?: NonNullable<Parameters<typeof terminalListQueryOptions>[0]["hostClient"]>;
 };
 
 const EMPTY_CLEANUP_IMPACT: TaskCleanupImpact = {
@@ -150,42 +163,71 @@ export const getTaskCleanupImpactFromSessionQueries = (
   };
 };
 
-export function useTaskCleanupImpact(taskIds: string[], open: boolean): TaskCleanupImpact {
+export function useTaskCleanupImpact(
+  taskIds: string[],
+  enabled: boolean,
+  readPorts: TaskCleanupImpactReadPorts = {},
+): TaskCleanupImpact {
   const { activeWorkspace } = useWorkspaceState();
+  const queryClient = useQueryClient();
   const workspaceRepoPath = activeWorkspace?.repoPath ?? null;
-  const taskSessionQueries = useQueries({
-    queries: taskIds.map((taskId) => ({
-      ...(workspaceRepoPath
-        ? agentSessionListQueryOptions(workspaceRepoPath, taskId)
-        : agentSessionListQueryOptions("", taskId)),
-      enabled: open && Boolean(workspaceRepoPath),
-    })),
+  const queryRepoPath = workspaceRepoPath ?? "";
+  const shouldLoadImpact = enabled && Boolean(workspaceRepoPath);
+  const sessionLists = useAgentSessionLists({
+    repoPath: workspaceRepoPath,
+    taskIds,
+    enabled: shouldLoadImpact,
+    queryClient,
+    ...(readPorts.agentSessions ? { readPort: readPorts.agentSessions } : {}),
   });
-  const taskWorktreeQueries = useQueries({
-    queries: taskIds.map((taskId) => ({
-      ...(workspaceRepoPath
-        ? taskWorktreeQueryOptions({ repoPath: workspaceRepoPath, taskId })
-        : taskWorktreeQueryOptions({ repoPath: "", taskId })),
-      enabled: open && Boolean(workspaceRepoPath),
-    })),
-  });
-  const terminalQueries = useQueries({
-    queries: taskIds.map((taskId) => ({
-      ...(workspaceRepoPath
-        ? terminalListQueryOptions({ repoPath: workspaceRepoPath, taskId })
-        : terminalListQueryOptions({ repoPath: "", taskId })),
-      enabled: open && Boolean(workspaceRepoPath),
-    })),
-  });
+  const taskSessionQueries = useQueries(
+    {
+      queries: taskIds.map((taskId) => ({
+        ...agentSessionListQueryOptions(queryRepoPath, taskId, readPorts.agentSessions),
+        enabled: false,
+      })),
+    },
+    queryClient,
+  );
+  const taskWorktreeQueries = useQueries(
+    {
+      queries: taskIds.map((taskId) => ({
+        ...taskWorktreeQueryOptions({
+          repoPath: queryRepoPath,
+          taskId,
+          ...(readPorts.taskWorktrees ? { hostClient: readPorts.taskWorktrees } : {}),
+        }),
+        enabled: shouldLoadImpact,
+      })),
+    },
+    queryClient,
+  );
+  const terminalQueries = useQueries(
+    {
+      queries: taskIds.map((taskId) => ({
+        ...terminalListQueryOptions({
+          repoPath: queryRepoPath,
+          taskId,
+          ...(readPorts.terminals ? { hostClient: readPorts.terminals } : {}),
+        }),
+        enabled: shouldLoadImpact,
+      })),
+    },
+    queryClient,
+  );
 
   return useMemo((): TaskCleanupImpact => {
     const sessionImpact = getTaskCleanupImpactFromSessionQueries(
-      open ? workspaceRepoPath : null,
+      shouldLoadImpact ? workspaceRepoPath : null,
       taskIds,
-      taskSessionQueries,
+      taskSessionQueries.map((query) => ({
+        ...query,
+        error: sessionLists.error ?? query.error,
+        isLoading: sessionLists.isPending || query.isLoading,
+      })),
       taskWorktreeQueries,
     );
-    if (!open || taskIds.length === 0 || !workspaceRepoPath) return sessionImpact;
+    if (!shouldLoadImpact || taskIds.length === 0 || !workspaceRepoPath) return sessionImpact;
     if (terminalQueries.some((query) => query.error != null)) {
       return {
         ...sessionImpact,
@@ -205,5 +247,14 @@ export function useTaskCleanupImpact(taskIds: string[], open: boolean): TaskClea
         0,
       ),
     };
-  }, [workspaceRepoPath, open, taskIds, taskSessionQueries, taskWorktreeQueries, terminalQueries]);
+  }, [
+    workspaceRepoPath,
+    shouldLoadImpact,
+    taskIds,
+    sessionLists.error,
+    sessionLists.isPending,
+    taskSessionQueries,
+    taskWorktreeQueries,
+    terminalQueries,
+  ]);
 }

--- a/packages/frontend/src/components/features/task-details/use-task-details-sheet-view-model.ts
+++ b/packages/frontend/src/components/features/task-details/use-task-details-sheet-view-model.ts
@@ -141,20 +141,6 @@ export function useTaskDetailsSheetViewModel({
     () => collectSingleTaskCleanupImpactTaskIds(task),
     [task],
   );
-  const {
-    hasManagedSessionCleanup: hasManagedDeleteSessionCleanup,
-    managedWorktreeCount: deleteManagedWorktreeCount,
-    impactError: deleteImpactError,
-    isLoadingImpact: isLoadingDeleteImpact,
-    terminalCount: deleteTerminalCount,
-  } = taskCleanupImpactHook(deleteImpactTaskIds, open);
-  const {
-    hasManagedSessionCleanup: hasManagedSingleTaskCleanup,
-    managedWorktreeCount: singleTaskCleanupWorktreeCount,
-    impactError: singleTaskCleanupImpactError,
-    isLoadingImpact: isLoadingSingleTaskCleanupImpact,
-    terminalCount: singleTaskTerminalCount,
-  } = taskCleanupImpactHook(singleTaskCleanupImpactTaskIds, open);
   const subtasks = useMemo(() => toSubtasks(task, taskById), [task, taskById]);
   const hasSubtasks = subtasks.length > 0;
   const shouldRenderSubtasks = task?.issueType === "epic";
@@ -203,6 +189,25 @@ export function useTaskDetailsSheetViewModel({
     onOpenChange,
     onCloseTask,
   });
+  const shouldLoadDeleteImpact = open && isDeleteDialogOpen && onDelete !== undefined;
+  const shouldLoadSingleTaskImpact =
+    open &&
+    ((isResetDialogOpen && onResetTask !== undefined) ||
+      (isCloseDialogOpen && onCloseTask !== undefined));
+  const {
+    hasManagedSessionCleanup: hasManagedDeleteSessionCleanup,
+    managedWorktreeCount: deleteManagedWorktreeCount,
+    impactError: deleteImpactError,
+    isLoadingImpact: isLoadingDeleteImpact,
+    terminalCount: deleteTerminalCount,
+  } = taskCleanupImpactHook(deleteImpactTaskIds, shouldLoadDeleteImpact);
+  const {
+    hasManagedSessionCleanup: hasManagedSingleTaskCleanup,
+    managedWorktreeCount: singleTaskCleanupWorktreeCount,
+    impactError: singleTaskCleanupImpactError,
+    isLoadingImpact: isLoadingSingleTaskCleanupImpact,
+    terminalCount: singleTaskTerminalCount,
+  } = taskCleanupImpactHook(singleTaskCleanupImpactTaskIds, shouldLoadSingleTaskImpact);
 
   const runWorkflowAction = useCallback(
     (action: TaskWorkflowAction): void => {


### PR DESCRIPTION
## Summary

- Load cleanup impact only while delete, reset, or close confirmation is open and its action is available.
- Reuse canonical session, worktree, and terminal query caches while batching cold session hydration.
- Add isolated coverage for disabled, cold, warm, invalidated-cache, and error paths.

## Goal

Opening ordinary task details previously started session, worktree, and terminal reads even though only cleanup confirmation dialogs use the result. Agent Studio has no cleanup actions but paid the same cost. This change removes those unused host commands while keeping cleanup previews accurate when users need them.

## Implementation

The task-details view model now derives cleanup-impact enablement from the active confirmation and matching handler. The cleanup hook delegates cold session gaps to useAgentSessionLists, observes canonical per-task query state for invalidation refreshes, and keeps the existing focused worktree and terminal queries. Tests inject narrow read ports to assert command counts without adding telemetry.

## Verification

- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
- bun run build

Cargo checks do not apply because this repository has no Cargo.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup-impact loading so it only triggers while the relevant delete/reset/close confirmation dialogs are active.
  * Improved cleanup-impact query behavior and messaging, including correct updates as dialogs open/close and better handling when session hydration fails.

* **UI**
  * Updated the task delete confirmation dialog’s terminal impact messaging and footer layout.

* **Tests**
  * Added/expanded hook and dialog rendering coverage for enabled/disabled, cached/refresh, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->