### PR TITLE
feat(electron): integrate native window chrome

### DIFF
--- a/apps/electron/src/main/electron-window-chrome.test.ts
+++ b/apps/electron/src/main/electron-window-chrome.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { resolveElectronWindowChromeOptions } from "./electron-window-chrome";
+
+describe("resolveElectronWindowChromeOptions", () => {
+  test("keeps inset native traffic lights on macOS", () => {
+    expect(resolveElectronWindowChromeOptions("darwin")).toEqual({
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 14, y: 13 },
+    });
+  });
+
+  test.each(["win32", "linux"] as const)("uses native overlay controls on %s", (platform) => {
+    expect(resolveElectronWindowChromeOptions(platform)).toEqual({
+      titleBarStyle: "hidden",
+      titleBarOverlay: {
+        height: 40,
+      },
+    });
+  });
+});

--- a/apps/electron/src/main/electron-window-chrome.test.ts
+++ b/apps/electron/src/main/electron-window-chrome.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { ELECTRON_WINDOW_TITLE_BAR_HEIGHT } from "../shared/electron-bridge-contract";
 import { resolveElectronWindowChromeOptions } from "./electron-window-chrome";
 
 describe("resolveElectronWindowChromeOptions", () => {
@@ -13,7 +14,7 @@ describe("resolveElectronWindowChromeOptions", () => {
     expect(resolveElectronWindowChromeOptions(platform)).toEqual({
       titleBarStyle: "hidden",
       titleBarOverlay: {
-        height: 40,
+        height: ELECTRON_WINDOW_TITLE_BAR_HEIGHT,
       },
     });
   });

--- a/apps/electron/src/main/electron-window-chrome.ts
+++ b/apps/electron/src/main/electron-window-chrome.ts
@@ -1,0 +1,28 @@
+import type { AppPlatform } from "@openducktor/contracts";
+import type { BrowserWindowConstructorOptions } from "electron";
+import { ELECTRON_WINDOW_TITLE_BAR_HEIGHT } from "../shared/electron-bridge-contract";
+
+type ElectronWindowChromeOptions = Pick<
+  BrowserWindowConstructorOptions,
+  "titleBarOverlay" | "titleBarStyle" | "trafficLightPosition"
+>;
+
+export const resolveElectronWindowChromeOptions = (
+  platform: AppPlatform,
+): ElectronWindowChromeOptions => {
+  switch (platform) {
+    case "darwin":
+      return {
+        titleBarStyle: "hiddenInset",
+        trafficLightPosition: { x: 14, y: 13 },
+      };
+    case "linux":
+    case "win32":
+      return {
+        titleBarStyle: "hidden",
+        titleBarOverlay: {
+          height: ELECTRON_WINDOW_TITLE_BAR_HEIGHT,
+        },
+      };
+  }
+};

--- a/apps/electron/src/main/main.ts
+++ b/apps/electron/src/main/main.ts
@@ -4,6 +4,7 @@ import {
   type AppUpdateCommandResult,
   type AppUpdateOperation,
   type AppUpdateState,
+  appPlatformSchema,
   appUpdateCheckInputSchema,
   appUpdateCommandResultSchema,
   appUpdateStateSchema,
@@ -76,6 +77,7 @@ import { createElectronMainRuntimeBindings } from "./electron-main-runtime-bindi
 import { resolveElectronRuntimeDistribution } from "./electron-runtime-distribution";
 import { disableElectronKeychainStorage } from "./electron-storage-policy";
 import { registerElectronTaskStreamIpc } from "./electron-task-stream-ipc";
+import { resolveElectronWindowChromeOptions } from "./electron-window-chrome";
 import { installApplicationMenu, registerWindowContextMenu } from "./main-menu";
 import {
   createElectronTerminalIpcController,
@@ -89,6 +91,7 @@ const ELECTRON_RENDERER_SESSION_PARTITION = "persist:openducktor";
 const ELECTRON_RENDERER_START_PATH = "/kanban";
 const rendererDevUrl = app.isPackaged ? undefined : process.env.VITE_DEV_SERVER_URL;
 const isDevelopment = Boolean(rendererDevUrl);
+const electronAppPlatform = appPlatformSchema.parse(process.platform);
 const distDirectory = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(distDirectory, "../../..");
 
@@ -413,6 +416,7 @@ const createMainWindowEffect = (
           autoHideMenuBar: process.platform !== "darwin",
           title: "OpenDucktor",
           icon: resolveElectronWindowIcon(),
+          ...resolveElectronWindowChromeOptions(electronAppPlatform),
           webPreferences: {
             contextIsolation: true,
             devTools: isDevelopment,

--- a/apps/electron/src/preload/preload.ts
+++ b/apps/electron/src/preload/preload.ts
@@ -1,4 +1,8 @@
-import { appUpdateCommandResultSchema, appUpdateStateSchema } from "@openducktor/contracts";
+import {
+  appPlatformSchema,
+  appUpdateCommandResultSchema,
+  appUpdateStateSchema,
+} from "@openducktor/contracts";
 import electron from "electron";
 import {
   ELECTRON_APP_UPDATE_CHECK_CHANNEL,
@@ -87,6 +91,7 @@ const terminals: OpenDucktorElectronTerminalApi = {
 };
 
 const electronApi: OpenDucktorElectronApi = {
+  platform: appPlatformSchema.parse(process.platform),
   invoke: invokeHost,
   subscribe(channel, listener) {
     const handleEvent = (

--- a/apps/electron/src/renderer/electron-shell-bridge.test.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.test.ts
@@ -59,6 +59,7 @@ const createElectronApi = (): {
   const unsubscribeTaskStream = mock(() => {});
   return {
     electronApi: {
+      platform: "darwin",
       invoke: mock(async () => ({ ok: true as const, value: {} })),
       subscribe: mock(() => unsubscribe),
       appUpdates: {

--- a/apps/electron/src/renderer/electron-shell-bridge.ts
+++ b/apps/electron/src/renderer/electron-shell-bridge.ts
@@ -28,7 +28,7 @@ export class ElectronPreloadBridgeUnavailableError extends Error {
   }
 }
 
-const getElectronApi = (): OpenDucktorElectronApi => {
+export const getElectronApi = (): OpenDucktorElectronApi => {
   const electronApi = window.openducktorElectron;
   if (!electronApi) {
     throw new ElectronPreloadBridgeUnavailableError();

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -1,9 +1,18 @@
 import { bootstrapOpenDucktorShell } from "@openducktor/frontend";
 import "@openducktor/frontend/styles.css";
-import { createElectronShellBridge } from "./electron-shell-bridge";
+import { ELECTRON_WINDOW_TITLE_BAR_HEIGHT } from "../shared/electron-bridge-contract";
+import { createElectronShellBridge, getElectronApi } from "./electron-shell-bridge";
+
+const initializeElectronWindowChrome = (): void => {
+  const { platform } = getElectronApi();
+  const root = document.documentElement;
+  root.classList.add("electron-shell", `electron-platform-${platform}`);
+  root.style.setProperty("--electron-titlebar-height", `${ELECTRON_WINDOW_TITLE_BAR_HEIGHT}px`);
+};
 
 bootstrapOpenDucktorShell({
   createShellBridge: createElectronShellBridge,
+  prepare: initializeElectronWindowChrome,
   routerMode: "hash",
 }).catch((error: unknown) => {
   console.error("Critical Electron bootstrap failure", error);

--- a/apps/electron/src/shared/electron-bridge-contract.ts
+++ b/apps/electron/src/shared/electron-bridge-contract.ts
@@ -1,4 +1,5 @@
 import type {
+  AppPlatform,
   AppUpdateCheckInput,
   AppUpdateCommandResult,
   AppUpdateState,
@@ -35,6 +36,7 @@ export const ELECTRON_TASK_STREAM_TERMINAL_FAILURE_CHANNEL =
   "openducktor:task-stream:terminal-failure";
 export const ELECTRON_TASK_STREAM_ACKNOWLEDGE_CHANNEL = "openducktor:task-stream:acknowledge";
 export const ELECTRON_TASK_STREAM_UNSUBSCRIBE_CHANNEL = "openducktor:task-stream:unsubscribe";
+export const ELECTRON_WINDOW_TITLE_BAR_HEIGHT = 40;
 
 export type ElectronHostInvokeRequest = {
   command: string;
@@ -127,6 +129,7 @@ export type OpenDucktorElectronTaskStreamApi = {
 };
 
 export type OpenDucktorElectronApi = {
+  platform: AppPlatform;
   invoke(
     command: HostCommandName,
     args?: Record<string, unknown>,

--- a/packages/frontend/src/components/features/agents/agent-studio-header-workflow-rail.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-header-workflow-rail.tsx
@@ -164,7 +164,7 @@ function WorkflowStepButton({
       size="sm"
       variant="outline"
       className={cn(
-        "h-10 shrink-0 gap-2 rounded-lg border px-4 text-sm transition-none",
+        "h-9 shrink-0 gap-2 rounded-lg border px-4 text-sm transition-none",
         workflowStepClassName(step.state),
         workflowBorderStyleClassName(step.state),
         workflowSelectionClassName(isSelected, step.state),

--- a/packages/frontend/src/components/features/agents/agent-studio-header.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-studio-header.test.ts
@@ -168,7 +168,7 @@ const buildModel = () => ({
 });
 
 describe("AgentStudioHeader", () => {
-  test("renders workflow rail with browser layout and session controls", () => {
+  test("renders workflow rail and session controls", () => {
     const html = renderToStaticMarkup(
       createElement(AgentStudioHeader, {
         model: buildModel(),
@@ -181,9 +181,6 @@ describe("AgentStudioHeader", () => {
     expect(html).toMatch(/aria-label="Session history[^"]*"/);
     expect(html).toContain(">Open<");
     expect(html).toContain("Quick actions");
-    expect(html).toContain("truncate text-xl");
-    expect(html).toContain("mt-1 flex items-center gap-1.5");
-    expect(html).toContain("border-b border-border bg-card pb-4");
     const taskIdIndex = html.indexOf("fairnest-97f");
     const openButtonIndex = html.indexOf('aria-label="Open task details"');
     expect(taskIdIndex).toBeGreaterThan(-1);

--- a/packages/frontend/src/components/features/agents/agent-studio-header.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-studio-header.test.ts
@@ -181,8 +181,6 @@ describe("AgentStudioHeader", () => {
     expect(html).toMatch(/aria-label="Session history[^"]*"/);
     expect(html).toContain(">Open<");
     expect(html).toContain("Quick actions");
-    expect(html).not.toMatch(/flex-wrap/);
-    expect(html).toContain("mt-1 flex items-center gap-1.5");
     const taskIdIndex = html.indexOf("fairnest-97f");
     const openButtonIndex = html.indexOf('aria-label="Open task details"');
     expect(taskIdIndex).toBeGreaterThan(-1);

--- a/packages/frontend/src/components/features/agents/agent-studio-header.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-studio-header.test.ts
@@ -168,7 +168,7 @@ const buildModel = () => ({
 });
 
 describe("AgentStudioHeader", () => {
-  test("renders workflow rail with compact top-row session controls", () => {
+  test("renders workflow rail with browser layout and session controls", () => {
     const html = renderToStaticMarkup(
       createElement(AgentStudioHeader, {
         model: buildModel(),
@@ -181,6 +181,9 @@ describe("AgentStudioHeader", () => {
     expect(html).toMatch(/aria-label="Session history[^"]*"/);
     expect(html).toContain(">Open<");
     expect(html).toContain("Quick actions");
+    expect(html).toContain("truncate text-xl");
+    expect(html).toContain("mt-1 flex items-center gap-1.5");
+    expect(html).toContain("border-b border-border bg-card pb-4");
     const taskIdIndex = html.indexOf("fairnest-97f");
     const openButtonIndex = html.indexOf('aria-label="Open task details"');
     expect(taskIdIndex).toBeGreaterThan(-1);

--- a/packages/frontend/src/components/features/agents/agent-studio-header.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-header.tsx
@@ -28,20 +28,20 @@ function HeaderTitle({ taskTitle, taskId, onOpenTaskDetails }: HeaderTitleProps)
     <div className="min-w-0 flex-1">
       <div className="flex min-w-0 items-center gap-1.5">
         <CardTitle
-          className="truncate text-xl"
+          className="truncate text-lg leading-6"
           title={hasTaskTitle ? normalizedTaskTitle : undefined}
         >
           {hasTaskTitle ? normalizedTaskTitle : "Agent Studio"}
         </CardTitle>
       </div>
       {hasTaskId ? (
-        <div className="mt-1 flex items-center gap-1.5">
+        <div className="flex items-center gap-1.5">
           <TaskIdBadge taskId={normalizedTaskId} />
           {canOpenTaskDetails ? (
             <Button
               type="button"
               variant="ghost"
-              className="h-auto shrink-0 gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] font-normal text-muted-foreground transition hover:border-border hover:bg-muted hover:text-muted-foreground"
+              className="h-auto shrink-0 gap-1 rounded-md border border-transparent px-1.5 py-0 text-[11px] font-normal text-muted-foreground transition hover:border-border hover:bg-muted hover:text-muted-foreground"
               title="Open task details"
               aria-label="Open task details"
               onClick={() => onOpenTaskDetails?.()}
@@ -104,7 +104,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
     : "quick-actions-unavailable";
 
   return (
-    <CardHeader className="border-b border-border bg-card pb-4">
+    <CardHeader className="border-b border-border bg-card px-3 py-2">
       <div className="flex items-start justify-between gap-2">
         <HeaderTitle
           taskTitle={model.taskTitle}

--- a/packages/frontend/src/components/features/agents/agent-studio-header.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-header.tsx
@@ -28,14 +28,14 @@ function HeaderTitle({ taskTitle, taskId, onOpenTaskDetails }: HeaderTitleProps)
     <div className="min-w-0 flex-1">
       <div className="flex min-w-0 items-center gap-1.5">
         <CardTitle
-          className="truncate text-xl"
+          className="truncate text-lg leading-6"
           title={hasTaskTitle ? normalizedTaskTitle : undefined}
         >
           {hasTaskTitle ? normalizedTaskTitle : "Agent Studio"}
         </CardTitle>
       </div>
       {hasTaskId ? (
-        <div className="mt-1 flex items-center gap-1.5">
+        <div className="flex items-center gap-1.5">
           <TaskIdBadge taskId={normalizedTaskId} />
           {canOpenTaskDetails ? (
             <Button
@@ -104,7 +104,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
     : "quick-actions-unavailable";
 
   return (
-    <CardHeader className="border-b border-border bg-card pb-4">
+    <CardHeader className="border-b border-border bg-card py-3 px-3">
       <div className="flex items-start justify-between gap-2">
         <HeaderTitle
           taskTitle={model.taskTitle}

--- a/packages/frontend/src/components/features/agents/agent-studio-header.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-header.tsx
@@ -28,20 +28,20 @@ function HeaderTitle({ taskTitle, taskId, onOpenTaskDetails }: HeaderTitleProps)
     <div className="min-w-0 flex-1">
       <div className="flex min-w-0 items-center gap-1.5">
         <CardTitle
-          className="truncate text-lg leading-6"
+          className="truncate text-xl"
           title={hasTaskTitle ? normalizedTaskTitle : undefined}
         >
           {hasTaskTitle ? normalizedTaskTitle : "Agent Studio"}
         </CardTitle>
       </div>
       {hasTaskId ? (
-        <div className="flex items-center gap-1.5">
+        <div className="mt-1 flex items-center gap-1.5">
           <TaskIdBadge taskId={normalizedTaskId} />
           {canOpenTaskDetails ? (
             <Button
               type="button"
               variant="ghost"
-              className="h-auto shrink-0 gap-1 rounded-md border border-transparent px-1.5 py-0 text-[11px] font-normal text-muted-foreground transition hover:border-border hover:bg-muted hover:text-muted-foreground"
+              className="h-auto shrink-0 gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] font-normal text-muted-foreground transition hover:border-border hover:bg-muted hover:text-muted-foreground"
               title="Open task details"
               aria-label="Open task details"
               onClick={() => onOpenTaskDetails?.()}
@@ -104,7 +104,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
     : "quick-actions-unavailable";
 
   return (
-    <CardHeader className="border-b border-border bg-card px-3 py-2">
+    <CardHeader className="border-b border-border bg-card pb-4">
       <div className="flex items-start justify-between gap-2">
         <HeaderTitle
           taskTitle={model.taskTitle}

--- a/packages/frontend/src/components/features/agents/agent-studio-header.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-header.tsx
@@ -41,7 +41,7 @@ function HeaderTitle({ taskTitle, taskId, onOpenTaskDetails }: HeaderTitleProps)
             <Button
               type="button"
               variant="ghost"
-              className="h-auto shrink-0 gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] font-normal text-muted-foreground transition hover:border-border hover:bg-muted hover:text-muted-foreground"
+              className="h-auto shrink-0 gap-1 rounded-md border border-transparent px-1.5 py-0 text-[11px] font-normal text-muted-foreground transition hover:border-border hover:bg-muted hover:text-muted-foreground"
               title="Open task details"
               aria-label="Open task details"
               onClick={() => onOpenTaskDetails?.()}

--- a/packages/frontend/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -73,6 +73,12 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).not.toContain("rounded-full border");
     expect(html).not.toContain("bg-card/80");
     expect(html).toContain("bg-studio-chrome");
+    expect(html).toContain("agent-studio-titlebar-safe-area");
+    expect(html).toContain("pt-1.5");
+    expect(html).toContain("h-10");
+    expect(html).toContain("min-h-10");
+    expect(html).toContain("size-10");
+    expect(html).toContain("size-[1.4rem]");
     expect(html).toContain("cursor-pointer");
     expect(html).not.toContain("cursor-grab");
     expect(html).not.toContain("cursor-inherit");

--- a/packages/frontend/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -73,12 +73,6 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).not.toContain("rounded-full border");
     expect(html).not.toContain("bg-card/80");
     expect(html).toContain("bg-studio-chrome");
-    expect(html).toContain("agent-studio-titlebar-safe-area");
-    expect(html).toContain("pt-1.5");
-    expect(html).toContain("h-10");
-    expect(html).toContain("min-h-10");
-    expect(html).toContain("size-10");
-    expect(html).toContain("size-[1.4rem]");
     expect(html).toContain("cursor-pointer");
     expect(html).not.toContain("cursor-grab");
     expect(html).not.toContain("cursor-inherit");

--- a/packages/frontend/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -73,7 +73,6 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).not.toContain("rounded-full border");
     expect(html).not.toContain("bg-card/80");
     expect(html).toContain("bg-studio-chrome");
-    expect(html).toContain("size-[1.4rem]");
     expect(html).toContain("cursor-pointer");
     expect(html).not.toContain("cursor-grab");
     expect(html).not.toContain("cursor-inherit");

--- a/packages/frontend/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -55,11 +55,11 @@ export type TerminalPanelToggleModel = {
 };
 
 const taskTabLabelClassName =
-  "h-7 max-w-[19rem] cursor-pointer items-center justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none text-inherit";
+  "h-9 max-w-[19rem] cursor-pointer items-center justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none text-inherit";
 
 const taskTabShellClassName = (tab: AgentStudioTaskTab): string =>
   cn(
-    "group relative z-1 inline-flex h-8 shrink-0 cursor-pointer touch-none select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
+    "group relative z-1 inline-flex h-10 shrink-0 cursor-pointer touch-none select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
     tab.isActive
       ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
       : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
@@ -248,14 +248,11 @@ export function AgentStudioTaskTabs({
     : null;
 
   return (
-    <div className="electron-titlebar-safe-area bg-studio-chrome px-2 pb-0">
-      <div className="flex min-w-0 items-center gap-1 pt-1">
+    <div className="agent-studio-titlebar-safe-area electron-titlebar-safe-area bg-studio-chrome px-2 pt-1.5 pb-0">
+      <div className="flex min-w-0 items-center gap-1">
         <div className="flex min-w-0 flex-1 items-center gap-1">
-          <div
-            ref={scrollRegionRef}
-            className="hide-scrollbar min-w-0 max-w-full overflow-x-auto pt-0.5"
-          >
-            <div className="inline-flex h-8 min-w-max items-center gap-1 pl-1">
+          <div ref={scrollRegionRef} className="hide-scrollbar min-w-0 max-w-full overflow-x-auto">
+            <div className="inline-flex h-10 min-w-max items-center gap-1 pl-2">
               {hasAnyTab ? (
                 <DndContext
                   sensors={sensors}
@@ -269,7 +266,7 @@ export function AgentStudioTaskTabs({
                   <SortableContext items={tabTaskIds} strategy={horizontalListSortingStrategy}>
                     <TabsList
                       aria-label="Agent Studio task tabs"
-                      className="h-auto min-h-8 w-max justify-start gap-1 rounded-none bg-transparent p-0"
+                      className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
                     >
                       {tabs.map((tab) => (
                         <SortableAgentStudioTaskTab
@@ -300,14 +297,14 @@ export function AgentStudioTaskTabs({
             size="icon"
             variant="ghost"
             aria-label="Open new task tab"
-            className="size-8 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            className="size-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
             disabled={!canOpenCreateDialog}
             onClick={() => {
               setPendingTaskId(availableTabTasks[0]?.id ?? "");
               setIsCreateDialogOpen(true);
             }}
           >
-            <Plus className="size-5" />
+            <Plus className="size-[1.4rem]" />
             <span className="sr-only">New Tab</span>
           </Button>
         </div>

--- a/packages/frontend/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -55,11 +55,11 @@ export type TerminalPanelToggleModel = {
 };
 
 const taskTabLabelClassName =
-  "h-9 max-w-[19rem] cursor-pointer items-center justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none text-inherit";
+  "h-7 max-w-[19rem] cursor-pointer items-center justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none text-inherit";
 
 const taskTabShellClassName = (tab: AgentStudioTaskTab): string =>
   cn(
-    "group relative z-1 inline-flex h-10 shrink-0 cursor-pointer touch-none select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
+    "group relative z-1 inline-flex h-8 shrink-0 cursor-pointer touch-none select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
     tab.isActive
       ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
       : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
@@ -248,11 +248,14 @@ export function AgentStudioTaskTabs({
     : null;
 
   return (
-    <div className="bg-studio-chrome px-2 pt-1.5 pb-0">
-      <div className="flex min-w-0 items-center gap-1">
+    <div className="electron-titlebar-safe-area bg-studio-chrome px-2 pb-0">
+      <div className="flex min-w-0 items-center gap-1 pt-1">
         <div className="flex min-w-0 flex-1 items-center gap-1">
-          <div ref={scrollRegionRef} className="hide-scrollbar min-w-0 max-w-full overflow-x-auto">
-            <div className="inline-flex h-10 min-w-max items-center gap-1 pl-2">
+          <div
+            ref={scrollRegionRef}
+            className="hide-scrollbar min-w-0 max-w-full overflow-x-auto pt-0.5"
+          >
+            <div className="inline-flex h-8 min-w-max items-center gap-1 pl-1">
               {hasAnyTab ? (
                 <DndContext
                   sensors={sensors}
@@ -266,7 +269,7 @@ export function AgentStudioTaskTabs({
                   <SortableContext items={tabTaskIds} strategy={horizontalListSortingStrategy}>
                     <TabsList
                       aria-label="Agent Studio task tabs"
-                      className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
+                      className="h-auto min-h-8 w-max justify-start gap-1 rounded-none bg-transparent p-0"
                     >
                       {tabs.map((tab) => (
                         <SortableAgentStudioTaskTab
@@ -297,14 +300,14 @@ export function AgentStudioTaskTabs({
             size="icon"
             variant="ghost"
             aria-label="Open new task tab"
-            className="size-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            className="size-8 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
             disabled={!canOpenCreateDialog}
             onClick={() => {
               setPendingTaskId(availableTabTasks[0]?.id ?? "");
               setIsCreateDialogOpen(true);
             }}
           >
-            <Plus className="size-[1.4rem]" />
+            <Plus className="size-5" />
             <span className="sr-only">New Tab</span>
           </Button>
         </div>

--- a/packages/frontend/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/packages/frontend/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -55,11 +55,11 @@ export type TerminalPanelToggleModel = {
 };
 
 const taskTabLabelClassName =
-  "h-9 max-w-[19rem] cursor-pointer items-center justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none text-inherit";
+  "h-7 max-w-[19rem] cursor-pointer items-center justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none text-inherit";
 
 const taskTabShellClassName = (tab: AgentStudioTaskTab): string =>
   cn(
-    "group relative z-1 inline-flex h-10 shrink-0 cursor-pointer touch-none select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
+    "group relative z-1 inline-flex h-8 shrink-0 cursor-pointer touch-none select-none items-center gap-1 rounded-t-[10px] pl-2 pr-1",
     tab.isActive
       ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
       : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
@@ -248,11 +248,14 @@ export function AgentStudioTaskTabs({
     : null;
 
   return (
-    <div className="agent-studio-titlebar-safe-area electron-titlebar-safe-area bg-studio-chrome px-2 pt-1.5 pb-0">
-      <div className="flex min-w-0 items-center gap-1">
+    <div className="agent-studio-titlebar-safe-area electron-titlebar-safe-area bg-studio-chrome px-2 pb-0">
+      <div className="flex min-w-0 items-center gap-1 pt-1">
         <div className="flex min-w-0 flex-1 items-center gap-1">
-          <div ref={scrollRegionRef} className="hide-scrollbar min-w-0 max-w-full overflow-x-auto">
-            <div className="inline-flex h-10 min-w-max items-center gap-1 pl-2">
+          <div
+            ref={scrollRegionRef}
+            className="hide-scrollbar min-w-0 max-w-full overflow-x-auto pt-0.5"
+          >
+            <div className="inline-flex h-8 min-w-max items-center gap-1 pl-1">
               {hasAnyTab ? (
                 <DndContext
                   sensors={sensors}
@@ -266,7 +269,7 @@ export function AgentStudioTaskTabs({
                   <SortableContext items={tabTaskIds} strategy={horizontalListSortingStrategy}>
                     <TabsList
                       aria-label="Agent Studio task tabs"
-                      className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
+                      className="h-auto min-h-8 w-max justify-start gap-1 rounded-none bg-transparent p-0"
                     >
                       {tabs.map((tab) => (
                         <SortableAgentStudioTaskTab
@@ -297,14 +300,14 @@ export function AgentStudioTaskTabs({
             size="icon"
             variant="ghost"
             aria-label="Open new task tab"
-            className="size-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            className="size-8 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
             disabled={!canOpenCreateDialog}
             onClick={() => {
               setPendingTaskId(availableTabTasks[0]?.id ?? "");
               setIsCreateDialogOpen(true);
             }}
           >
-            <Plus className="size-[1.4rem]" />
+            <Plus className="size-5" />
             <span className="sr-only">New Tab</span>
           </Button>
         </div>

--- a/packages/frontend/src/components/features/agents/task-execution-panel.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-panel.tsx
@@ -283,7 +283,7 @@ export function TaskExecutionPanelToggleButton({
 }
 
 export const agentStudioPanelToggleButtonClassName =
-  "size-10 rounded-md border border-transparent bg-transparent text-studio-chrome-foreground hover:border-studio-chrome-foreground/30 hover:bg-studio-chrome-foreground/10";
+  "size-8 rounded-md border border-transparent bg-transparent text-studio-chrome-foreground hover:border-studio-chrome-foreground/30 hover:bg-studio-chrome-foreground/10";
 
 export function TaskExecutionPanel({ model }: { model: TaskExecutionPanelModel }): ReactElement {
   return <TaskExecutionPanelColumn model={model} />;

--- a/packages/frontend/src/components/features/agents/task-execution-panel.tsx
+++ b/packages/frontend/src/components/features/agents/task-execution-panel.tsx
@@ -283,7 +283,7 @@ export function TaskExecutionPanelToggleButton({
 }
 
 export const agentStudioPanelToggleButtonClassName =
-  "size-8 rounded-md border border-transparent bg-transparent text-studio-chrome-foreground hover:border-studio-chrome-foreground/30 hover:bg-studio-chrome-foreground/10";
+  "size-10 rounded-md border border-transparent bg-transparent text-studio-chrome-foreground hover:border-studio-chrome-foreground/30 hover:bg-studio-chrome-foreground/10";
 
 export function TaskExecutionPanel({ model }: { model: TaskExecutionPanelModel }): ReactElement {
   return <TaskExecutionPanelColumn model={model} />;

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.test.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.test.tsx
@@ -21,6 +21,5 @@ describe("KanbanCollapsedColumn", () => {
     expect(html).toContain('type="button"');
     expect(html).not.toContain('title="Backlog column is empty and collapsed"');
     expect(html).toContain("bg-muted-foreground/45");
-    expect(html).toContain("transition-[background-color,border-color,box-shadow]");
   });
 });

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.test.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.test.tsx
@@ -21,5 +21,6 @@ describe("KanbanCollapsedColumn", () => {
     expect(html).toContain('type="button"');
     expect(html).not.toContain('title="Backlog column is empty and collapsed"');
     expect(html).toContain("bg-muted-foreground/45");
+    expect(html).toContain("transition-[background-color,border-color,box-shadow]");
   });
 });

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
@@ -24,7 +24,7 @@ export function KanbanCollapsedColumn({ column }: KanbanCollapsedColumnProps): R
           type="button"
           aria-label={label}
           className={cn(
-            "group flex min-h-96 cursor-default flex-col overflow-hidden rounded-2xl border p-0 text-left shadow-sm transition-[background-color,border-color,box-shadow] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            "group flex min-h-96 cursor-default flex-col overflow-hidden rounded-2xl border p-0 text-left shadow-sm hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
             KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
             theme.boardSurfaceClass,
           )}

--- a/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
+++ b/packages/frontend/src/components/features/kanban/kanban-collapsed-column.tsx
@@ -24,7 +24,7 @@ export function KanbanCollapsedColumn({ column }: KanbanCollapsedColumnProps): R
           type="button"
           aria-label={label}
           className={cn(
-            "group flex min-h-96 cursor-default flex-col overflow-hidden rounded-2xl border p-0 text-left shadow-sm hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            "group flex min-h-96 cursor-default flex-col overflow-hidden rounded-2xl border p-0 text-left shadow-sm transition-[background-color,border-color,box-shadow] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
             KANBAN_COLLAPSED_LANE_WIDTH_CLASS,
             theme.boardSurfaceClass,
           )}

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -274,8 +274,10 @@ describe("AppShell", () => {
 
     const mainContent = document.querySelector('[data-main-scroll-container="true"]');
     const shellRoot = mainContent?.closest(".app-shell");
+    const nativeControlsSurface = shellRoot?.querySelector(".electron-native-controls-surface");
 
     expect(shellRoot?.getAttribute("data-sidebar-state")).toBe("open");
+    expect(nativeControlsSurface?.classList.contains("bg-sidebar")).toBe(true);
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
 

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -269,6 +269,19 @@ describe("AppShell", () => {
     expect(globalThis.localStorage.getItem(LEFT_SIDEBAR_STORAGE_KEY)).toBeNull();
   });
 
+  test("exposes the sidebar state to the shell layout", () => {
+    renderAppShellForTest();
+
+    const mainContent = document.querySelector('[data-main-scroll-container="true"]');
+    const shellRoot = mainContent?.closest(".app-shell");
+
+    expect(shellRoot?.getAttribute("data-sidebar-state")).toBe("open");
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+
+    expect(shellRoot?.getAttribute("data-sidebar-state")).toBe("collapsed");
+  });
+
   test("keeps the settings trigger available when the sidebar is collapsed", async () => {
     renderAppShellForTest();
 

--- a/packages/frontend/src/components/layout/app-shell.test.tsx
+++ b/packages/frontend/src/components/layout/app-shell.test.tsx
@@ -274,10 +274,8 @@ describe("AppShell", () => {
 
     const mainContent = document.querySelector('[data-main-scroll-container="true"]');
     const shellRoot = mainContent?.closest(".app-shell");
-    const nativeControlsSurface = shellRoot?.querySelector(".electron-native-controls-surface");
 
     expect(shellRoot?.getAttribute("data-sidebar-state")).toBe("open");
-    expect(nativeControlsSurface?.classList.contains("bg-sidebar")).toBe(true);
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
 

--- a/packages/frontend/src/components/layout/app-shell.tsx
+++ b/packages/frontend/src/components/layout/app-shell.tsx
@@ -112,7 +112,7 @@ export const AppShell = memo(function AppShell(): ReactElement {
         data-sidebar-state={isSidebarOpen ? "open" : "collapsed"}
       >
         <div
-          className="electron-native-controls-surface absolute left-0 top-0 z-10 w-[72px]"
+          className="electron-native-controls-surface absolute left-0 top-0 z-10 w-[72px] bg-sidebar"
           aria-hidden="true"
         />
         <div className="flex h-full min-h-0 w-full">

--- a/packages/frontend/src/components/layout/app-shell.tsx
+++ b/packages/frontend/src/components/layout/app-shell.tsx
@@ -112,7 +112,7 @@ export const AppShell = memo(function AppShell(): ReactElement {
         data-sidebar-state={isSidebarOpen ? "open" : "collapsed"}
       >
         <div
-          className="electron-native-controls-surface absolute left-0 top-0 z-10 w-[72px] bg-sidebar"
+          className="electron-native-controls-surface absolute left-0 top-0 z-10 w-[72px]"
           aria-hidden="true"
         />
         <div className="flex h-full min-h-0 w-full">

--- a/packages/frontend/src/components/layout/app-shell.tsx
+++ b/packages/frontend/src/components/layout/app-shell.tsx
@@ -107,21 +107,30 @@ export const AppShell = memo(function AppShell(): ReactElement {
 
   return (
     <>
-      <div className="h-screen min-h-screen w-full overflow-hidden">
+      <div
+        className="app-shell relative h-screen min-h-screen w-full overflow-hidden"
+        data-sidebar-state={isSidebarOpen ? "open" : "collapsed"}
+      >
+        <div
+          className="electron-native-controls-surface absolute left-0 top-0 z-10 w-[72px] bg-sidebar"
+          aria-hidden="true"
+        />
         <div className="flex h-full min-h-0 w-full">
           <WorkspaceRail onOpenRepositoryModal={openRepositoryModal} />
 
           <aside
             className={cn(
-              "flex h-full min-w-0 flex-col border-r border-sidebar-border bg-sidebar transition-[width] duration-200 ease-out",
+              "workspace-sidebar flex h-full min-w-0 flex-col border-r border-sidebar-border bg-sidebar transition-[width] duration-200 ease-out",
               isSidebarOpen ? "w-[248px]" : "w-14",
             )}
           >
             {isSidebarOpen ? (
               <>
-                <div className="flex-1 space-y-3 overflow-y-auto p-4">
-                  <div className="flex items-start justify-between gap-2">
-                    <AppBrand />
+                <div className="electron-sidebar-content-open flex-1 space-y-3 overflow-y-auto p-4">
+                  <div className="electron-sidebar-heading flex items-center justify-between gap-2">
+                    <div className="electron-sidebar-brand">
+                      <AppBrand />
+                    </div>
                     <Button
                       type="button"
                       size="icon"
@@ -171,18 +180,20 @@ export const AppShell = memo(function AppShell(): ReactElement {
                 </div>
               </>
             ) : (
-              <div className="flex h-full flex-col items-center gap-2 p-2">
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className="size-8 text-sidebar-muted-foreground hover:text-sidebar-foreground"
-                  onClick={handleShowSidebar}
-                  aria-label="Show sidebar"
-                  title="Show sidebar"
-                >
-                  <PanelLeftOpen className="size-4" />
-                </Button>
+              <div className="electron-sidebar-content-collapsed flex h-full flex-col items-center gap-2 p-2">
+                <div className="electron-sidebar-collapsed-title-row flex w-full items-center justify-center">
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="electron-sidebar-collapsed-toggle size-8 text-sidebar-muted-foreground hover:text-sidebar-foreground"
+                    onClick={handleShowSidebar}
+                    aria-label="Show sidebar"
+                    title="Show sidebar"
+                  >
+                    <PanelLeftOpen className="size-4" />
+                  </Button>
+                </div>
                 <div className="flex w-full justify-center border-t border-sidebar-border pt-2">
                   <DiagnosticsPanel
                     autoOpenedByRepo={diagnosticsAutoOpenedByRepo}

--- a/packages/frontend/src/components/layout/workspace-rail.tsx
+++ b/packages/frontend/src/components/layout/workspace-rail.tsx
@@ -286,7 +286,7 @@ export function WorkspaceRail({
   };
 
   return (
-    <aside className="flex h-full w-14 shrink-0 flex-col border-r border-border bg-background">
+    <aside className="workspace-rail flex h-full w-14 shrink-0 flex-col border-r border-border bg-background">
       <div className="hide-scrollbar flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
         {workspaces.length > 0 ? (
           <DndContext

--- a/packages/frontend/src/pages/kanban/kanban-page-header.tsx
+++ b/packages/frontend/src/pages/kanban/kanban-page-header.tsx
@@ -15,7 +15,7 @@ export function KanbanPageHeader({ model }: KanbanPageHeaderProps): ReactElement
   const isCreateTaskDisabled = isKanbanTaskCreationDisabled(activeWorkspace, taskStoreCheck);
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 pl-2 pr-4">
+    <div className="electron-titlebar-safe-area flex flex-wrap items-center justify-between gap-3 pl-2 pr-4">
       <h2 className="text-lg font-semibold tracking-tight text-foreground">Kanban Board</h2>
       <div className="flex items-center gap-2">
         <Button

--- a/packages/frontend/src/shell-bootstrap.test.tsx
+++ b/packages/frontend/src/shell-bootstrap.test.tsx
@@ -283,10 +283,9 @@ describe("shell entrypoints", () => {
     expect(source).toMatch(
       /import\s*\{\s*bootstrapOpenDucktorShell\s*\}\s*from\s*"@openducktor\/frontend"/u,
     );
-    expect(source).toContain("bootstrapOpenDucktorShell(");
-    expect(source).toContain("prepare: initializeElectronWindowChrome");
-    expect(source).toContain("createShellBridge: createElectronShellBridge");
-    expect(source).toContain('routerMode: "hash"');
+    expect(source).toMatch(
+      /bootstrapOpenDucktorShell\(\{\s*createShellBridge:\s*createElectronShellBridge,\s*prepare:\s*initializeElectronWindowChrome,\s*routerMode:\s*"hash",?\s*\}\)/u,
+    );
     expect(source).toContain('console.error("Critical Electron bootstrap failure", error);');
     expectNoManualShellBootstrapSteps(source);
   });

--- a/packages/frontend/src/shell-bootstrap.test.tsx
+++ b/packages/frontend/src/shell-bootstrap.test.tsx
@@ -283,9 +283,10 @@ describe("shell entrypoints", () => {
     expect(source).toMatch(
       /import\s*\{\s*bootstrapOpenDucktorShell\s*\}\s*from\s*"@openducktor\/frontend"/u,
     );
-    expect(source).toMatch(
-      /bootstrapOpenDucktorShell\(\{\s*createShellBridge:\s*createElectronShellBridge,\s*routerMode:\s*"hash",\s*\}\)/u,
-    );
+    expect(source).toContain("bootstrapOpenDucktorShell(");
+    expect(source).toContain("prepare: initializeElectronWindowChrome");
+    expect(source).toContain("createShellBridge: createElectronShellBridge");
+    expect(source).toContain('routerMode: "hash"');
     expect(source).toContain('console.error("Critical Electron bootstrap failure", error);');
     expectNoManualShellBootstrapSteps(source);
   });
@@ -312,18 +313,6 @@ describe("shell entrypoints", () => {
     );
     expect(source).toContain("<App routerMode={routerMode} />");
     expect(source).toContain("routerMode");
-  });
-
-  test("electron delegates shared startup to the frontend bootstrap", () => {
-    const source = readRepoFile("apps/electron/src/renderer/main.tsx");
-
-    expect(source).toMatch(
-      /import\s*\{\s*bootstrapOpenDucktorShell\s*\}\s*from\s*"@openducktor\/frontend"/u,
-    );
-    expect(source).toContain("createShellBridge: createElectronShellBridge");
-    expect(source).toContain('routerMode: "hash"');
-    expect(source).toContain('console.error("Critical Electron bootstrap failure", error);');
-    expectNoManualShellBootstrapSteps(source);
   });
 
   test("the frontend package root does not export bootstrap internals", () => {

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -373,6 +373,8 @@ body {
 
 .electron-platform-darwin .electron-native-controls-surface {
   display: block;
+  background: var(--background);
+  box-shadow: inset -1rem 0 0 var(--sidebar);
   -webkit-app-region: drag;
   user-select: none;
 }
@@ -429,6 +431,7 @@ body {
   transform: translateX(0.5rem);
 }
 
+/* Combined workspace rail and sidebar width used by titlebar safe areas. */
 .app-shell[data-sidebar-state="open"] {
   --electron-navigation-width: 19rem;
 }

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -373,8 +373,6 @@ body {
 
 .electron-platform-darwin .electron-native-controls-surface {
   display: block;
-  background: var(--background);
-  box-shadow: inset -1rem 0 0 var(--sidebar);
   -webkit-app-region: drag;
   user-select: none;
 }

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -469,6 +469,10 @@ body {
   user-select: none;
 }
 
+.electron-shell .agent-studio-titlebar-safe-area {
+  padding-top: 0;
+}
+
 .electron-shell .electron-titlebar-safe-area button {
   -webkit-app-region: no-drag;
 }

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -366,6 +366,112 @@ body {
   background: var(--background);
 }
 
+.electron-native-controls-surface {
+  display: none;
+  height: var(--electron-titlebar-height);
+}
+
+.electron-platform-darwin .electron-native-controls-surface {
+  display: block;
+  -webkit-app-region: drag;
+  user-select: none;
+}
+
+.electron-platform-darwin .workspace-rail {
+  height: calc(100% - var(--electron-titlebar-height));
+  margin-top: var(--electron-titlebar-height);
+}
+
+.electron-platform-darwin .electron-sidebar-content-open,
+.electron-platform-darwin .electron-sidebar-content-collapsed {
+  padding-top: 0;
+}
+
+.electron-shell .electron-sidebar-heading,
+.electron-shell .electron-sidebar-collapsed-title-row {
+  -webkit-app-region: drag;
+  user-select: none;
+}
+
+.electron-platform-darwin .electron-sidebar-heading {
+  display: grid;
+  gap: 0;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-rows: var(--electron-titlebar-height) auto;
+  margin-inline: -1rem;
+  padding-inline: 1rem;
+}
+
+.electron-platform-darwin .electron-sidebar-brand {
+  grid-column: 1 / -1;
+  grid-row: 2;
+}
+
+.electron-shell .electron-sidebar-heading > button,
+.electron-shell .electron-sidebar-collapsed-title-row button {
+  -webkit-app-region: no-drag;
+}
+
+.electron-shell .electron-sidebar-heading > button {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.electron-platform-darwin .electron-sidebar-collapsed-title-row {
+  height: var(--electron-titlebar-height);
+  flex-shrink: 0;
+  width: calc(100% + 1rem);
+  margin-inline: -0.5rem;
+  padding-inline: 0.5rem;
+}
+
+.electron-platform-darwin .electron-sidebar-collapsed-toggle {
+  transform: translateX(0.5rem);
+}
+
+.app-shell[data-sidebar-state="open"] {
+  --electron-navigation-width: 19rem;
+}
+
+.app-shell[data-sidebar-state="collapsed"] {
+  --electron-navigation-width: 7rem;
+}
+
+:is(.electron-platform-win32, .electron-platform-linux) .app-shell {
+  --electron-left-controls-height: clamp(
+    0px,
+    env(titlebar-area-x, 0px),
+    var(--electron-titlebar-height)
+  );
+  --electron-right-controls-width: max(
+    0px,
+    calc(100vw - env(titlebar-area-x, 0px) - env(titlebar-area-width, 100vw))
+  );
+}
+
+:is(.electron-platform-win32, .electron-platform-linux) .electron-titlebar-safe-area {
+  margin-left: max(0px, calc(env(titlebar-area-x, 0px) - var(--electron-navigation-width)));
+  margin-right: var(--electron-right-controls-width);
+}
+
+:is(.electron-platform-win32, .electron-platform-linux) .workspace-rail {
+  height: calc(100% - var(--electron-left-controls-height));
+  margin-top: var(--electron-left-controls-height);
+}
+
+:is(.electron-platform-win32, .electron-platform-linux) .workspace-sidebar {
+  padding-top: var(--electron-left-controls-height);
+}
+
+.electron-shell .electron-titlebar-safe-area {
+  -webkit-app-region: drag;
+  user-select: none;
+}
+
+.electron-shell .electron-titlebar-safe-area button {
+  -webkit-app-region: no-drag;
+}
+
 code,
 pre {
   font-family: "IBM Plex Mono", "SF Mono", Menlo, Monaco, Consolas, monospace;

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -469,8 +469,8 @@ body {
   user-select: none;
 }
 
-.electron-shell .agent-studio-titlebar-safe-area {
-  padding-top: 0;
+.electron-shell .agent-studio-titlebar-safe-area > div {
+  -webkit-app-region: no-drag;
 }
 
 .electron-shell .electron-titlebar-safe-area button {


### PR DESCRIPTION
## Résumé

- Utilise le chrome natif Electron sur macOS, Windows et Linux sans modifier le rendu du navigateur.
- Réserve les zones des contrôles système et conserve des zones de déplacement explicites.
- Ajuste le shell, Agent Studio et le bandeau Kanban pour utiliser cet espace réduit.

## Objectif

Supprimer le besoin de chrome global dessiné par application tout en gardant les contrôles de fenêtre natifs, les interactions existantes et une mise en page cohérente sur chaque système.

## Contexte

Le shell Electron partage le frontend du navigateur, mais doit aussi gérer les traffic lights macOS et le title bar overlay Windows/Linux. Les vues qui occupent le haut de la fenêtre doivent rester utilisables sans recouvrir ces contrôles.

## Choix techniques

- Valider `process.platform` avec le schéma partagé `appPlatformSchema` et exposer la plateforme par le preload typé.
- Centraliser les options `BrowserWindow` dans `resolveElectronWindowChromeOptions`.
- Utiliser `hiddenInset` avec des traffic lights natifs sur macOS.
- Utiliser `hidden` et `titleBarOverlay` sur Windows/Linux, sans imposer de couleurs aux contrôles système.
- Calculer les zones sûres avec les variables CSS `env(titlebar-area-*)` plutôt que maintenir un état JavaScript ou un listener de géométrie.
- Limiter les régions `drag` au chrome Electron et marquer les boutons interactifs en `no-drag`.

## Implémentation

- Configure les options de fenêtre natives selon la plateforme.
- Ajoute la plateforme au contrat preload Electron.
- Initialise les classes Electron et la hauteur de barre avant le bootstrap du frontend.
- Expose état et largeur de navigation dans `AppShell` pour calculer les marges sûres.
- Réserve une surface macOS autour des traffic lights et décale le rail de workspace.
- Compacte les contrôles supérieurs Agent Studio et aligne les actions Kanban avec les zones sûres.
- Ajoute des tests pour les options de fenêtre et état ouvert/replié de la sidebar.

## Vérification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `git diff --check`
- Analyse GitNexus du contenu staged: risque élevé, 25 symboles et 7 parcours concernés
- Aucun workspace Cargo détecté

## Validation manuelle

La validation visuelle native macOS, Windows et Linux reste à faire dans application Electron; aucun serveur ni application a été lancé pendant cette préparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-specific Electron titlebar styling for macOS, Windows, and Linux.
  * Improved draggable titlebar areas and safe spacing around the sidebar and workspace rail.
  * Added sidebar state tracking for expanded and collapsed layouts.

* **Style**
  * Refined Agent Studio headers, workflow controls, and task tab spacing for a more compact layout.

* **Tests**
  * Added coverage for platform-specific titlebar behavior and sidebar state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->