### PR TITLE
refactor(frontend): isolate review comments in Agent Studio

### DIFF
--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -33,7 +33,6 @@ const buildModel = () => ({
   isReadOnly: false,
   readOnlyReason: null,
   busySendBlockedReason: null,
-  pendingInlineCommentCount: 0,
   draftStateKey: "draft-1",
   draftPersistenceIdentity: null,
   onSend: SHARED_CALLBACKS.onSend,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
@@ -11,7 +11,6 @@ const buildModel = () => ({
   isReadOnly: false,
   readOnlyReason: null,
   busySendBlockedReason: null,
-  pendingInlineCommentCount: 0,
   draftStateKey: "draft-1",
   draftPersistenceIdentity: null,
   onSend: async () => true,
@@ -249,17 +248,21 @@ describe("AgentChatComposer", () => {
     expect(html).toContain('aria-label="Send message" disabled');
   });
 
-  test("shows a send badge and keeps send enabled when only inline comments are pending", () => {
+  test("shows caller-owned queued content and keeps send enabled when the draft is empty", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatComposer, {
         model: {
           ...buildModel(),
-          pendingInlineCommentCount: 3,
+          queuedSendContent: {
+            count: 3,
+            accessibleLabel: "3 queued review comments",
+          },
         },
       }),
     );
 
-    expect(html).toContain("agent-chat-send-comment-badge");
+    expect(html).toContain("agent-chat-send-queued-content-badge");
+    expect(html).toContain('aria-label="3 queued review comments"');
     expect(html).toContain(">3<");
     expect(html).not.toContain('aria-label="Send message" disabled');
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
@@ -248,21 +248,21 @@ describe("AgentChatComposer", () => {
     expect(html).toContain('aria-label="Send message" disabled');
   });
 
-  test("shows caller-owned queued content and keeps send enabled when the draft is empty", () => {
+  test("shows caller-owned pending send items and keeps send enabled when the draft is empty", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatComposer, {
         model: {
           ...buildModel(),
-          queuedSendContent: {
+          pendingSendItems: {
             count: 3,
-            accessibleLabel: "3 queued review comments",
+            accessibleLabel: "3 pending review comments",
           },
         },
       }),
     );
 
-    expect(html).toContain("agent-chat-send-queued-content-badge");
-    expect(html).toContain('aria-label="3 queued review comments"');
+    expect(html).toContain("agent-chat-send-pending-items-badge");
+    expect(html).toContain('aria-label="3 pending review comments"');
     expect(html).toContain(">3<");
     expect(html).not.toContain('aria-label="Send message" disabled');
   });

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -92,12 +92,12 @@ const renderUnsupportedAttachmentDescription = (name: string): ReactElement => {
 
 const hasComposerSendContent = (
   draft: AgentChatComposerDraft,
-  queuedSendContent: AgentChatComposerModel["queuedSendContent"],
+  pendingSendItems: AgentChatComposerModel["pendingSendItems"],
 ): boolean => {
-  return draftHasMeaningfulContent(draft) || (queuedSendContent?.count ?? 0) > 0;
+  return draftHasMeaningfulContent(draft) || (pendingSendItems?.count ?? 0) > 0;
 };
 
-const SEND_QUEUED_CONTENT_BADGE_CLASS_NAME =
+const SEND_PENDING_ITEMS_BADGE_CLASS_NAME =
   "pointer-events-none absolute -right-2 -top-2 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-amber-300 px-1 text-[10px] font-semibold leading-none text-neutral-950";
 
 const AgentChatComposerControls = memo(function AgentChatComposerControls({
@@ -119,7 +119,7 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
   onStopSession,
   showSubmittingState,
   sendDisabled,
-  queuedSendContent,
+  pendingSendItems,
 }: {
   onPickAttachments: () => void;
   attachmentIntakeDisabled: boolean;
@@ -139,7 +139,7 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
   onStopSession: AgentChatComposerModel["onStopSession"];
   showSubmittingState: boolean;
   sendDisabled: boolean;
-  queuedSendContent: AgentChatComposerModel["queuedSendContent"];
+  pendingSendItems: AgentChatComposerModel["pendingSendItems"];
 }): ReactElement {
   const hasVariantOptions = variantOptions.length > 0;
 
@@ -247,14 +247,14 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
               <SendHorizontal className="size-3.5" />
             )}
           </Button>
-          {queuedSendContent && queuedSendContent.count > 0 ? (
+          {pendingSendItems && pendingSendItems.count > 0 ? (
             <span
-              aria-label={queuedSendContent.accessibleLabel}
-              className={SEND_QUEUED_CONTENT_BADGE_CLASS_NAME}
-              data-testid="agent-chat-send-queued-content-badge"
+              aria-label={pendingSendItems.accessibleLabel}
+              className={SEND_PENDING_ITEMS_BADGE_CLASS_NAME}
+              data-testid="agent-chat-send-pending-items-badge"
               role="status"
             >
-              {queuedSendContent.count}
+              {pendingSendItems.count}
             </span>
           ) : null}
         </div>
@@ -284,7 +284,7 @@ function AgentChatComposerFormView({
   submitAction,
 }: AgentChatComposerFormViewProps): ReactElement {
   const {
-    queuedSendContent,
+    pendingSendItems,
     isSessionWorking,
     isWaitingInput,
     isSelectionCatalogLoading,
@@ -430,7 +430,7 @@ function AgentChatComposerFormView({
             onStopSession={onStopSession}
             showSubmittingState={isSubmitting}
             sendDisabled={sendDisabled}
-            queuedSendContent={queuedSendContent}
+            pendingSendItems={pendingSendItems}
           />
         </div>
       </div>
@@ -543,7 +543,7 @@ export function AgentChatComposer({
     isReadOnly,
     readOnlyReason,
     busySendBlockedReason,
-    queuedSendContent,
+    pendingSendItems,
     draftStateKey,
     draftPersistenceIdentity,
     onSend,
@@ -679,7 +679,7 @@ export function AgentChatComposer({
     hasBlockingAttachments ||
     hasSlashAttachmentConflict ||
     !taskId ||
-    !hasComposerSendContent(draft, queuedSendContent) ||
+    !hasComposerSendContent(draft, pendingSendItems) ||
     !isInteractionEnabled;
 
   useLayoutEffect(() => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -92,12 +92,12 @@ const renderUnsupportedAttachmentDescription = (name: string): ReactElement => {
 
 const hasComposerSendContent = (
   draft: AgentChatComposerDraft,
-  pendingInlineCommentCount: number,
+  queuedSendContent: AgentChatComposerModel["queuedSendContent"],
 ): boolean => {
-  return draftHasMeaningfulContent(draft) || pendingInlineCommentCount > 0;
+  return draftHasMeaningfulContent(draft) || (queuedSendContent?.count ?? 0) > 0;
 };
 
-const SEND_COMMENT_BADGE_CLASS_NAME =
+const SEND_QUEUED_CONTENT_BADGE_CLASS_NAME =
   "pointer-events-none absolute -right-2 -top-2 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-amber-300 px-1 text-[10px] font-semibold leading-none text-neutral-950";
 
 const AgentChatComposerControls = memo(function AgentChatComposerControls({
@@ -119,7 +119,7 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
   onStopSession,
   showSubmittingState,
   sendDisabled,
-  pendingInlineCommentCount,
+  queuedSendContent,
 }: {
   onPickAttachments: () => void;
   attachmentIntakeDisabled: boolean;
@@ -139,7 +139,7 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
   onStopSession: AgentChatComposerModel["onStopSession"];
   showSubmittingState: boolean;
   sendDisabled: boolean;
-  pendingInlineCommentCount: number;
+  queuedSendContent: AgentChatComposerModel["queuedSendContent"];
 }): ReactElement {
   const hasVariantOptions = variantOptions.length > 0;
 
@@ -247,12 +247,14 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
               <SendHorizontal className="size-3.5" />
             )}
           </Button>
-          {pendingInlineCommentCount > 0 ? (
+          {queuedSendContent && queuedSendContent.count > 0 ? (
             <span
-              className={SEND_COMMENT_BADGE_CLASS_NAME}
-              data-testid="agent-chat-send-comment-badge"
+              aria-label={queuedSendContent.accessibleLabel}
+              className={SEND_QUEUED_CONTENT_BADGE_CLASS_NAME}
+              data-testid="agent-chat-send-queued-content-badge"
+              role="status"
             >
-              {pendingInlineCommentCount}
+              {queuedSendContent.count}
             </span>
           ) : null}
         </div>
@@ -282,7 +284,7 @@ function AgentChatComposerFormView({
   submitAction,
 }: AgentChatComposerFormViewProps): ReactElement {
   const {
-    pendingInlineCommentCount,
+    queuedSendContent,
     isSessionWorking,
     isWaitingInput,
     isSelectionCatalogLoading,
@@ -428,7 +430,7 @@ function AgentChatComposerFormView({
             onStopSession={onStopSession}
             showSubmittingState={isSubmitting}
             sendDisabled={sendDisabled}
-            pendingInlineCommentCount={pendingInlineCommentCount}
+            queuedSendContent={queuedSendContent}
           />
         </div>
       </div>
@@ -541,7 +543,7 @@ export function AgentChatComposer({
     isReadOnly,
     readOnlyReason,
     busySendBlockedReason,
-    pendingInlineCommentCount,
+    queuedSendContent,
     draftStateKey,
     draftPersistenceIdentity,
     onSend,
@@ -677,7 +679,7 @@ export function AgentChatComposer({
     hasBlockingAttachments ||
     hasSlashAttachmentConflict ||
     !taskId ||
-    !hasComposerSendContent(draft, pendingInlineCommentCount) ||
+    !hasComposerSendContent(draft, queuedSendContent) ||
     !isInteractionEnabled;
 
   useLayoutEffect(() => {

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
@@ -50,7 +50,6 @@ const buildModel = () => ({
     isReadOnly: false,
     readOnlyReason: null,
     busySendBlockedReason: null,
-    pendingInlineCommentCount: 0,
     draftStateKey: "draft-1",
     draftPersistenceIdentity: null,
     onSend: async () => true,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -53,7 +53,6 @@ const buildModel = () => ({
     isReadOnly: false,
     readOnlyReason: null,
     busySendBlockedReason: null,
-    pendingInlineCommentCount: 0,
     draftStateKey: "draft-1",
     draftPersistenceIdentity: null,
     onSend: async () => true,

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -100,7 +100,7 @@ export type AgentChatThreadModel = {
   syncBottomAfterComposerLayoutRef: MutableRefObject<(() => void) | null>;
 };
 
-export type AgentChatQueuedSendContent = {
+export type AgentChatPendingSendItems = {
   count: number;
   accessibleLabel: string;
 };
@@ -112,7 +112,7 @@ export type AgentChatComposerModel = {
   isReadOnly: boolean;
   readOnlyReason: string | null;
   busySendBlockedReason: string | null;
-  queuedSendContent?: AgentChatQueuedSendContent;
+  pendingSendItems?: AgentChatPendingSendItems;
   draftStateKey: string;
   draftPersistenceIdentity: AgentChatDraftSessionIdentity | null;
   onSend: (draft: import("./agent-chat-composer-draft").AgentChatComposerDraft) => Promise<boolean>;

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -100,6 +100,11 @@ export type AgentChatThreadModel = {
   syncBottomAfterComposerLayoutRef: MutableRefObject<(() => void) | null>;
 };
 
+export type AgentChatQueuedSendContent = {
+  count: number;
+  accessibleLabel: string;
+};
+
 export type AgentChatComposerModel = {
   taskId: string;
   displayedSessionKey: string | null;
@@ -107,7 +112,7 @@ export type AgentChatComposerModel = {
   isReadOnly: boolean;
   readOnlyReason: string | null;
   busySendBlockedReason: string | null;
-  pendingInlineCommentCount: number;
+  queuedSendContent?: AgentChatQueuedSendContent;
   draftStateKey: string;
   draftPersistenceIdentity: AgentChatDraftSessionIdentity | null;
   onSend: (draft: import("./agent-chat-composer-draft").AgentChatComposerDraft) => Promise<boolean>;

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.test.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
+import { act, createRef } from "react";
+import { useInlineCommentDraftStore } from "@/state/use-inline-comment-draft-store";
+import { draftToSerializedText } from "./agent-chat-composer-draft";
+import { buildModelSelection, createComposerDraft } from "./agent-chat-test-fixtures";
+import {
+  type AgentChatComposerConfig,
+  useAgentChatComposerModel,
+} from "./use-agent-chat-composer-model";
+
+const buildComposerConfig = (
+  onSend: AgentChatComposerConfig["onSend"],
+): AgentChatComposerConfig => ({
+  taskId: "task-1",
+  displayedSessionKey: null,
+  selectedSession: null,
+  isSessionModelCatalogLoading: false,
+  isSessionWorking: false,
+  isWaitingInput: false,
+  waitingInputPlaceholder: null,
+  busySendBlockedReason: null,
+  canStopSession: false,
+  stopAgentSession: async () => {},
+  isReadOnly: false,
+  readOnlyReason: null,
+  draftStateKey: "task-1:build:new",
+  draftPersistenceIdentity: null,
+  onSend,
+  isSending: false,
+  isStarting: false,
+  contextUsage: null,
+  selectedModelSelection: buildModelSelection(),
+  isSelectionCatalogLoading: false,
+  supportsSlashCommands: false,
+  supportsFileSearch: false,
+  supportsSkillReferences: false,
+  supportsSubagentReferences: false,
+  slashCommandCatalog: null,
+  slashCommands: [],
+  slashCommandsError: null,
+  isSlashCommandsLoading: false,
+  skillCatalog: null,
+  skills: [],
+  skillsError: null,
+  isSkillsLoading: false,
+  subagentCatalog: null,
+  subagents: [],
+  subagentsError: null,
+  isSubagentsLoading: false,
+  searchFiles: async () => [],
+  agentOptions: [],
+  modelOptions: [],
+  modelGroups: [],
+  variantOptions: [],
+  onSelectAgent: () => {},
+  onSelectModel: () => {},
+  onSelectVariant: () => {},
+});
+
+describe("useAgentChatComposerModel", () => {
+  test("forwards only the caller draft when stale task review comments exist without an adapter", async () => {
+    const previousState = useInlineCommentDraftStore.getState();
+    const previousDrafts = previousState.drafts;
+    const previousDraftStateKey = previousState.draftStateKey;
+    useInlineCommentDraftStore.setState({
+      draftStateKey: "task-1:build:new",
+      drafts: [
+        {
+          id: "stale-review-comment",
+          filePath: "packages/frontend/src/stale.ts",
+          diffScope: "uncommitted",
+          startLine: 1,
+          endLine: 1,
+          side: "new",
+          text: "This must not join the shared chat send.",
+          codeContext: [{ lineNumber: 1, text: "const stale = true;", isSelected: true }],
+          language: "ts",
+          revision: 1,
+          submissionId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          status: "pending",
+        },
+      ],
+    });
+    const sentDraft = { text: null as string | null };
+    const callerDraft = createComposerDraft("Repository-only question");
+    const composerFormRef = createRef<HTMLFormElement>();
+    const composerEditorRef = createRef<HTMLDivElement>();
+    const scrollToBottomOnSendRef = { current: null as (() => void) | null };
+    const syncBottomAfterComposerLayoutRef = { current: null as (() => void) | null };
+    const rendered = renderHook(() =>
+      useAgentChatComposerModel({
+        composer: buildComposerConfig(async (draft) => {
+          sentDraft.text = draftToSerializedText(draft);
+          return true;
+        }),
+        runtimeReadiness: {
+          state: "ready",
+          message: null,
+          isLoadingChecks: false,
+          refreshChecks: async () => {},
+        },
+        sessionAgentColors: {},
+        composerFormRef,
+        composerEditorRef,
+        resizeComposerEditor: () => {},
+        scrollToBottomOnSendRef,
+        syncBottomAfterComposerLayoutRef,
+      }),
+    );
+
+    try {
+      await act(async () => {
+        const composerModel = rendered.result.current;
+        if (!composerModel) {
+          throw new Error("Expected a shared composer model.");
+        }
+        await composerModel.onSend(callerDraft);
+      });
+
+      expect(sentDraft.text).toBe("Repository-only question");
+      expect(useInlineCommentDraftStore.getState().drafts).toHaveLength(1);
+    } finally {
+      rendered.unmount();
+      useInlineCommentDraftStore.setState({
+        drafts: previousDrafts,
+        draftStateKey: previousDraftStateKey,
+      });
+    }
+  });
+});

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
@@ -40,7 +40,7 @@ export type AgentChatComposerConfig = {
   stopAgentSession: StopAgentSession;
   isReadOnly: boolean;
   readOnlyReason: string | null;
-  queuedSendContent?: AgentChatComposerModel["queuedSendContent"];
+  pendingSendItems?: AgentChatComposerModel["pendingSendItems"];
   draftStateKey: string;
   draftPersistenceIdentity: AgentChatDraftSessionIdentity | null;
   onSend: (draft: AgentChatComposerDraft) => Promise<boolean>;
@@ -140,7 +140,7 @@ export function useAgentChatComposerModel({
       isReadOnly: composer.isReadOnly,
       readOnlyReason: composer.readOnlyReason,
       busySendBlockedReason: composer.busySendBlockedReason,
-      ...(composer.queuedSendContent ? { queuedSendContent: composer.queuedSendContent } : {}),
+      ...(composer.pendingSendItems ? { pendingSendItems: composer.pendingSendItems } : {}),
       draftStateKey: composer.draftStateKey,
       draftPersistenceIdentity: composer.draftPersistenceIdentity,
       onSend: (draft) => submitComposerDraft(draft, composer.onSend),

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
@@ -3,25 +3,13 @@ import type {
   AgentModelCatalog,
   AgentModelSelection,
 } from "@openducktor/core";
-import {
-  type MutableRefObject,
-  type RefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from "react";
+import { type MutableRefObject, type RefObject, useCallback, useMemo } from "react";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { RepoRuntimeReadiness } from "@/lib/use-repo-runtime-readiness";
-import { useInlineCommentDraftStore } from "@/state/use-inline-comment-draft-store";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
 import type { AgentChatComposerModel } from "./agent-chat.types";
-import { type AgentChatComposerDraft, appendTextToDraft } from "./agent-chat-composer-draft";
+import type { AgentChatComposerDraft } from "./agent-chat-composer-draft";
 import { deriveAgentChatComposerModelState } from "./agent-chat-composer-model-state";
-import {
-  type AgentChatDraftScope,
-  didAgentChatDraftScopeSwitchSessionOnly,
-} from "./agent-chat-draft-scope";
 import type { AgentChatDraftSessionIdentity } from "./agent-chat-draft-storage";
 
 type StopAgentSession = (session: AgentSessionIdentity) => Promise<void>;
@@ -52,8 +40,8 @@ export type AgentChatComposerConfig = {
   stopAgentSession: StopAgentSession;
   isReadOnly: boolean;
   readOnlyReason: string | null;
+  queuedSendContent?: AgentChatComposerModel["queuedSendContent"];
   draftStateKey: string;
-  draftScope: AgentChatDraftScope;
   draftPersistenceIdentity: AgentChatDraftSessionIdentity | null;
   onSend: (draft: AgentChatComposerDraft) => Promise<boolean>;
   isSending: boolean;
@@ -114,71 +102,13 @@ export function useAgentChatComposerModel({
   scrollToBottomOnSendRef,
   syncBottomAfterComposerLayoutRef,
 }: UseAgentChatComposerModelArgs): AgentChatComposerModel | undefined {
-  const pendingInlineCommentCount = useInlineCommentDraftStore((store) => store.getDraftCount());
-  const previousDraftScopeRef = useRef<AgentChatDraftScope | null>(null);
-  const composerDraftStateKey = composer?.draftStateKey ?? null;
-  const composerDraftScope = composer?.draftScope ?? null;
-
-  useEffect(() => {
-    if (!composerDraftStateKey || !composerDraftScope) {
-      return;
-    }
-    const store = useInlineCommentDraftStore.getState();
-    const previousDraftScope = previousDraftScopeRef.current;
-    if (previousDraftScope === composerDraftScope) {
-      return;
-    }
-
-    if (
-      previousDraftScope != null &&
-      didAgentChatDraftScopeSwitchSessionOnly(previousDraftScope, composerDraftScope) &&
-      store.drafts.some((draft) => draft.status === "submitting")
-    ) {
-      store.setDraftStateKey(composerDraftStateKey);
-    } else {
-      store.resetForContext(composerDraftStateKey);
-    }
-
-    previousDraftScopeRef.current = composerDraftScope;
-  }, [composerDraftScope, composerDraftStateKey]);
-
   const submitComposerDraft = useCallback(
     async (
       draft: AgentChatComposerDraft,
       onSend: AgentChatComposerConfig["onSend"],
     ): Promise<boolean> => {
-      const pendingDrafts = useInlineCommentDraftStore.getState().getPendingDrafts();
-      const submittingDrafts = pendingDrafts.map((pendingDraft) => ({
-        id: pendingDraft.id,
-        revision: pendingDraft.revision,
-      }));
-      const commentAppendix = useInlineCommentDraftStore
-        .getState()
-        .formatBatchMessage(pendingDrafts);
-      const nextDraft =
-        commentAppendix.length > 0 ? appendTextToDraft(draft, commentAppendix) : draft;
       scrollToBottomOnSendRef.current?.();
-      const submissionId = useInlineCommentDraftStore
-        .getState()
-        .beginSubmittingDrafts(submittingDrafts);
-      try {
-        const didSend = await onSend(nextDraft);
-        if (!submissionId) {
-          return didSend;
-        }
-
-        if (didSend) {
-          useInlineCommentDraftStore.getState().completeSubmittingDrafts(submissionId);
-        } else {
-          useInlineCommentDraftStore.getState().restoreSubmittingDrafts(submissionId);
-        }
-        return didSend;
-      } catch (error) {
-        if (submissionId) {
-          useInlineCommentDraftStore.getState().restoreSubmittingDrafts(submissionId);
-        }
-        throw error;
-      }
+      return onSend(draft);
     },
     [scrollToBottomOnSendRef],
   );
@@ -210,7 +140,7 @@ export function useAgentChatComposerModel({
       isReadOnly: composer.isReadOnly,
       readOnlyReason: composer.readOnlyReason,
       busySendBlockedReason: composer.busySendBlockedReason,
-      pendingInlineCommentCount,
+      ...(composer.queuedSendContent ? { queuedSendContent: composer.queuedSendContent } : {}),
       draftStateKey: composer.draftStateKey,
       draftPersistenceIdentity: composer.draftPersistenceIdentity,
       onSend: (draft) => submitComposerDraft(draft, composer.onSend),
@@ -268,7 +198,6 @@ export function useAgentChatComposerModel({
     composerState,
     composerEditorRef,
     composerFormRef,
-    pendingInlineCommentCount,
     resizeComposerEditor,
     scrollToBottomOnSendRef,
     submitComposerDraft,

--- a/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/use-agent-chat-composer-model.ts
@@ -3,7 +3,7 @@ import type {
   AgentModelCatalog,
   AgentModelSelection,
 } from "@openducktor/core";
-import { type MutableRefObject, type RefObject, useCallback, useMemo } from "react";
+import { type MutableRefObject, type RefObject, useMemo } from "react";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { RepoRuntimeReadiness } from "@/lib/use-repo-runtime-readiness";
 import type { AgentSessionIdentity } from "@/types/agent-orchestrator";
@@ -102,17 +102,6 @@ export function useAgentChatComposerModel({
   scrollToBottomOnSendRef,
   syncBottomAfterComposerLayoutRef,
 }: UseAgentChatComposerModelArgs): AgentChatComposerModel | undefined {
-  const submitComposerDraft = useCallback(
-    async (
-      draft: AgentChatComposerDraft,
-      onSend: AgentChatComposerConfig["onSend"],
-    ): Promise<boolean> => {
-      scrollToBottomOnSendRef.current?.();
-      return onSend(draft);
-    },
-    [scrollToBottomOnSendRef],
-  );
-
   const isRuntimeReady = runtimeReadiness.state === "ready";
   const composerState = useMemo(
     () =>
@@ -143,7 +132,10 @@ export function useAgentChatComposerModel({
       ...(composer.pendingSendItems ? { pendingSendItems: composer.pendingSendItems } : {}),
       draftStateKey: composer.draftStateKey,
       draftPersistenceIdentity: composer.draftPersistenceIdentity,
-      onSend: (draft) => submitComposerDraft(draft, composer.onSend),
+      onSend: async (draft: AgentChatComposerDraft): Promise<boolean> => {
+        scrollToBottomOnSendRef.current?.();
+        return composer.onSend(draft);
+      },
       isSending: composer.isSending,
       isStarting: composer.isStarting,
       isSessionWorking: composer.isSessionWorking,
@@ -200,7 +192,6 @@ export function useAgentChatComposerModel({
     composerFormRef,
     resizeComposerEditor,
     scrollToBottomOnSendRef,
-    submitComposerDraft,
     syncBottomAfterComposerLayoutRef,
   ]);
 }

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -2,7 +2,10 @@ import type { ChatSettings } from "@openducktor/contracts";
 import type { AgentModelSelection } from "@openducktor/core";
 import { useMemo } from "react";
 import { resolveAgentSessionAccentColor } from "@/components/features/agents/agent-accent-color";
-import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
+import type {
+  AgentChatModel,
+  AgentChatPendingSendItems,
+} from "@/components/features/agents/agent-chat/agent-chat.types";
 import type { AgentChatComposerDraft } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
 import {
   type AgentChatDraftScope,
@@ -217,6 +220,18 @@ export function useAgentStudioChatModel({
     draftStateKey,
     onSend: sessionActions.onSend,
   });
+  const pendingSendItems = useMemo<AgentChatPendingSendItems | null>(() => {
+    const count = reviewCommentComposer.pendingInlineCommentCount;
+    if (count <= 0) {
+      return null;
+    }
+
+    const commentLabel = count === 1 ? "comment" : "comments";
+    return {
+      count,
+      accessibleLabel: `${count} pending review ${commentLabel}`,
+    };
+  }, [reviewCommentComposer.pendingInlineCommentCount]);
 
   const composerConfig = useMemo(
     () => ({
@@ -237,9 +252,7 @@ export function useAgentStudioChatModel({
       stopAgentSession: sessionActions.stopAgentSession,
       isReadOnly: surfaceState.composerReadOnly,
       readOnlyReason: surfaceState.composerReadOnlyReason,
-      ...(reviewCommentComposer.queuedSendContent
-        ? { queuedSendContent: reviewCommentComposer.queuedSendContent }
-        : {}),
+      ...(pendingSendItems ? { pendingSendItems } : {}),
       draftStateKey,
       draftPersistenceIdentity,
       onSend: reviewCommentComposer.onSend,
@@ -308,7 +321,7 @@ export function useAgentStudioChatModel({
       modelSelection.supportsSubagentReferences,
       modelSelection.variantOptions,
       reviewCommentComposer.onSend,
-      reviewCommentComposer.queuedSendContent,
+      pendingSendItems,
       selectedSession.pendingInput.waitingInputPlaceholder,
       selectedSessionIdentity,
       selectedSessionModel,

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -18,6 +18,7 @@ import type { AgentOperationsContextValue } from "@/types/state-slices";
 import { deriveAgentStudioChatSurfaceState } from "./agent-studio-chat-surface-state";
 import { toSelectedSessionThreadSession } from "./agent-studio-thread-session";
 import type { AgentStudioSelectedSessionContext } from "./selected-session/selected-session-context";
+import { useAgentStudioReviewCommentComposerAdapter } from "./use-agent-studio-review-comment-composer-adapter";
 
 export type AgentStudioChatSessionActionsContext = {
   isStarting: boolean;
@@ -210,6 +211,12 @@ export function useAgentStudioChatModel({
     selectedSessionTranscriptState.kind,
     sessionReadModelLoadState.kind,
   ]);
+  const draftStateKey = agentChatDraftScopeKey(composer.draftScope);
+  const reviewCommentComposer = useAgentStudioReviewCommentComposerAdapter({
+    draftScope: composer.draftScope,
+    draftStateKey,
+    onSend: sessionActions.onSend,
+  });
 
   const composerConfig = useMemo(
     () => ({
@@ -230,10 +237,12 @@ export function useAgentStudioChatModel({
       stopAgentSession: sessionActions.stopAgentSession,
       isReadOnly: surfaceState.composerReadOnly,
       readOnlyReason: surfaceState.composerReadOnlyReason,
-      draftStateKey: agentChatDraftScopeKey(composer.draftScope),
-      draftScope: composer.draftScope,
+      ...(reviewCommentComposer.queuedSendContent
+        ? { queuedSendContent: reviewCommentComposer.queuedSendContent }
+        : {}),
+      draftStateKey,
       draftPersistenceIdentity,
-      onSend: sessionActions.onSend,
+      onSend: reviewCommentComposer.onSend,
       isSending: sessionActions.isSending,
       isStarting: sessionActions.isStarting,
       contextUsage: chatContextUsage,
@@ -268,7 +277,7 @@ export function useAgentStudioChatModel({
     }),
     [
       chatContextUsage,
-      composer.draftScope,
+      draftStateKey,
       draftPersistenceIdentity,
       modelSelection.agentOptions,
       modelSelection.isSelectionCatalogLoading,
@@ -298,6 +307,8 @@ export function useAgentStudioChatModel({
       modelSelection.supportsSlashCommands,
       modelSelection.supportsSubagentReferences,
       modelSelection.variantOptions,
+      reviewCommentComposer.onSend,
+      reviewCommentComposer.queuedSendContent,
       selectedSession.pendingInput.waitingInputPlaceholder,
       selectedSessionIdentity,
       selectedSessionModel,
@@ -312,7 +323,6 @@ export function useAgentStudioChatModel({
       sessionActions.isSessionWorking,
       sessionActions.isStarting,
       sessionActions.isWaitingInput,
-      sessionActions.onSend,
       sessionActions.stopAgentSession,
     ],
   );

--- a/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.test.ts
@@ -159,7 +159,7 @@ const buildScope = (
 });
 
 describe("Agent Studio review comment composer adapter", () => {
-  test("formats queued comments and sends them when the typed draft is empty", async () => {
+  test("formats pending comments and sends them when the typed draft is empty", async () => {
     const fakeStore = createFakeReviewCommentStore([
       buildComment("first-comment", 1, "Keep this branch explicit."),
     ]);
@@ -177,7 +177,7 @@ describe("Agent Studio review comment composer adapter", () => {
     expect(fakeStore.getStore().drafts).toEqual([]);
   });
 
-  test("restores the exact queued comments when send returns false", async () => {
+  test("restores the exact pending comments when send returns false", async () => {
     const fakeStore = createFakeReviewCommentStore([
       buildComment("first-comment", 1, "Keep this branch explicit."),
     ]);
@@ -196,7 +196,7 @@ describe("Agent Studio review comment composer adapter", () => {
     ]);
   });
 
-  test("restores queued comments and propagates a thrown send failure", async () => {
+  test("restores pending comments and propagates a thrown send failure", async () => {
     const fakeStore = createFakeReviewCommentStore([
       buildComment("first-comment", 1, "Keep this branch explicit."),
     ]);

--- a/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createEmptyComposerDraft,
+  draftToSerializedText,
+} from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
+import type { AgentChatDraftScope } from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
+import type {
+  InlineCommentDraft,
+  InlineCommentDraftSnapshot,
+} from "@/state/use-inline-comment-draft-store";
+import {
+  type AgentStudioReviewCommentStore,
+  createAgentStudioReviewCommentComposerAdapter,
+} from "./use-agent-studio-review-comment-composer-adapter";
+
+type FakeReviewCommentStore = {
+  getStore: () => AgentStudioReviewCommentStore;
+  addDraft: (draft: InlineCommentDraft) => void;
+  updateDraft: (id: string, text: string, revision: number) => void;
+  setOnFormat: (onFormat: (() => void) | null) => void;
+  resetKeys: string[];
+  setKeys: string[];
+};
+
+const buildComment = (
+  id: string,
+  revision: number,
+  text: string,
+  status: InlineCommentDraft["status"] = "pending",
+): InlineCommentDraft => ({
+  id,
+  filePath: `packages/frontend/src/${id}.ts`,
+  diffScope: "uncommitted",
+  startLine: revision,
+  endLine: revision,
+  side: "new",
+  text,
+  codeContext: [{ lineNumber: revision, text: `const ${id} = true;`, isSelected: true }],
+  language: "ts",
+  revision,
+  submissionId: status === "submitting" ? `existing-${id}` : null,
+  createdAt: revision,
+  updatedAt: revision,
+  status,
+});
+
+const createFakeReviewCommentStore = (
+  initialDrafts: InlineCommentDraft[],
+  initialDraftStateKey = "task-1:build:new",
+): FakeReviewCommentStore => {
+  const drafts = initialDrafts.map((draft) => ({ ...draft }));
+  const resetKeys: string[] = [];
+  const setKeys: string[] = [];
+  let draftStateKey = initialDraftStateKey;
+  let nextSubmissionId = 0;
+  let onFormat: (() => void) | null = null;
+
+  const getPendingDrafts = (): InlineCommentDraft[] =>
+    drafts.filter((draft) => draft.status === "pending");
+
+  const beginSubmittingDrafts = (snapshots: InlineCommentDraftSnapshot[]): string | null => {
+    const submissionId = `submission-${++nextSubmissionId}`;
+    let didTransition = false;
+    for (const draft of drafts) {
+      if (
+        draft.status === "pending" &&
+        snapshots.some(
+          (snapshot) => snapshot.id === draft.id && snapshot.revision === draft.revision,
+        )
+      ) {
+        draft.status = "submitting";
+        draft.submissionId = submissionId;
+        didTransition = true;
+      }
+    }
+    return didTransition ? submissionId : null;
+  };
+
+  const store: AgentStudioReviewCommentStore = {
+    get drafts() {
+      return drafts;
+    },
+    getPendingDrafts,
+    formatBatchMessage: (pendingDrafts) => {
+      const message = [
+        "## Git Diff Comments",
+        ...pendingDrafts.map((draft) => `Instruction: ${draft.text}`),
+      ].join("\n\n");
+      onFormat?.();
+      return message;
+    },
+    beginSubmittingDrafts,
+    restoreSubmittingDrafts: (submissionId) => {
+      for (const draft of drafts) {
+        if (draft.status === "submitting" && draft.submissionId === submissionId) {
+          draft.status = "pending";
+          draft.submissionId = null;
+        }
+      }
+    },
+    completeSubmittingDrafts: (submissionId) => {
+      for (let index = drafts.length - 1; index >= 0; index -= 1) {
+        const draft = drafts[index];
+        if (draft?.status === "submitting" && draft.submissionId === submissionId) {
+          drafts.splice(index, 1);
+        }
+      }
+    },
+    setDraftStateKey: (nextDraftStateKey) => {
+      setKeys.push(nextDraftStateKey);
+      draftStateKey = nextDraftStateKey;
+    },
+    resetForContext: (nextDraftStateKey) => {
+      resetKeys.push(nextDraftStateKey);
+      if (draftStateKey === nextDraftStateKey) {
+        return;
+      }
+      drafts.splice(0, drafts.length);
+      draftStateKey = nextDraftStateKey;
+    },
+  };
+
+  return {
+    getStore: () => store,
+    addDraft: (draft) => {
+      drafts.push({ ...draft });
+    },
+    updateDraft: (id, text, revision) => {
+      const draft = drafts.find((candidate) => candidate.id === id);
+      if (!draft) {
+        throw new Error(`Missing ${id} comment fixture.`);
+      }
+      draft.text = text;
+      draft.revision = revision;
+    },
+    setOnFormat: (nextOnFormat) => {
+      onFormat = nextOnFormat;
+    },
+    resetKeys,
+    setKeys,
+  };
+};
+
+const buildScope = (
+  taskId: string,
+  role: AgentChatDraftScope["role"],
+  externalSessionId: string | null,
+): AgentChatDraftScope => ({
+  taskId,
+  role,
+  session:
+    externalSessionId === null
+      ? null
+      : {
+          externalSessionId,
+          runtimeKind: "opencode",
+          workingDirectory: "/repo",
+        },
+});
+
+describe("Agent Studio review comment composer adapter", () => {
+  test("formats queued comments and sends them when the typed draft is empty", async () => {
+    const fakeStore = createFakeReviewCommentStore([
+      buildComment("first-comment", 1, "Keep this branch explicit."),
+    ]);
+    const adapter = createAgentStudioReviewCommentComposerAdapter(fakeStore.getStore);
+    let sentText = "";
+
+    const didSend = await adapter.submitDraft(createEmptyComposerDraft(), async (draft) => {
+      sentText = draftToSerializedText(draft);
+      expect(fakeStore.getStore().drafts[0]?.status).toBe("submitting");
+      return true;
+    });
+
+    expect(didSend).toBe(true);
+    expect(sentText).toBe("## Git Diff Comments\n\nInstruction: Keep this branch explicit.");
+    expect(fakeStore.getStore().drafts).toEqual([]);
+  });
+
+  test("restores the exact queued comments when send returns false", async () => {
+    const fakeStore = createFakeReviewCommentStore([
+      buildComment("first-comment", 1, "Keep this branch explicit."),
+    ]);
+    const adapter = createAgentStudioReviewCommentComposerAdapter(fakeStore.getStore);
+
+    const didSend = await adapter.submitDraft(createEmptyComposerDraft(), async () => false);
+
+    expect(didSend).toBe(false);
+    expect(fakeStore.getStore().drafts).toMatchObject([
+      {
+        id: "first-comment",
+        revision: 1,
+        status: "pending",
+        submissionId: null,
+      },
+    ]);
+  });
+
+  test("restores queued comments and propagates a thrown send failure", async () => {
+    const fakeStore = createFakeReviewCommentStore([
+      buildComment("first-comment", 1, "Keep this branch explicit."),
+    ]);
+    const adapter = createAgentStudioReviewCommentComposerAdapter(fakeStore.getStore);
+
+    await expect(
+      adapter.submitDraft(createEmptyComposerDraft(), async () => {
+        throw new Error("Runtime send failed");
+      }),
+    ).rejects.toThrow("Runtime send failed");
+    expect(fakeStore.getStore().drafts).toMatchObject([
+      {
+        id: "first-comment",
+        revision: 1,
+        status: "pending",
+        submissionId: null,
+      },
+    ]);
+  });
+
+  test("does not complete an edited revision or a comment added during an older send", async () => {
+    const fakeStore = createFakeReviewCommentStore([
+      buildComment("edited-comment", 1, "Original instruction."),
+      buildComment("sent-comment", 2, "Send this instruction."),
+    ]);
+    fakeStore.setOnFormat(() => {
+      const editedDraft = fakeStore
+        .getStore()
+        .drafts.find((draft) => draft.id === "edited-comment");
+      if (!editedDraft) {
+        throw new Error("Missing edited comment fixture.");
+      }
+      editedDraft.text = "Updated instruction.";
+      editedDraft.revision = 3;
+    });
+    const adapter = createAgentStudioReviewCommentComposerAdapter(fakeStore.getStore);
+
+    await adapter.submitDraft(createEmptyComposerDraft(), async () => {
+      fakeStore.addDraft(buildComment("new-comment", 4, "Added during send."));
+      fakeStore.updateDraft("new-comment", "Edited during send.", 5);
+      return true;
+    });
+
+    expect(
+      fakeStore.getStore().drafts.map(({ id, revision, status }) => ({
+        id,
+        revision,
+        status,
+      })),
+    ).toEqual([
+      { id: "edited-comment", revision: 3, status: "pending" },
+      { id: "new-comment", revision: 5, status: "pending" },
+    ]);
+  });
+
+  test("preserves an in-flight transaction only for a session-only scope switch", () => {
+    const fakeStore = createFakeReviewCommentStore([
+      buildComment("submitting-comment", 1, "Already sending.", "submitting"),
+    ]);
+    const adapter = createAgentStudioReviewCommentComposerAdapter(fakeStore.getStore);
+    const initialScope = buildScope("task-1", "build", null);
+    const sessionScope = buildScope("task-1", "build", "session-1");
+
+    adapter.syncDraftScope(initialScope, "task-1:build:new");
+    adapter.syncDraftScope(sessionScope, "task-1:build:session-1");
+
+    expect(fakeStore.setKeys).toEqual(["task-1:build:session-1"]);
+    expect(fakeStore.getStore().drafts).toHaveLength(1);
+
+    const roleScope = buildScope("task-1", "qa", "session-1");
+    adapter.syncDraftScope(roleScope, "task-1:qa:session-1");
+    expect(fakeStore.resetKeys).toContain("task-1:qa:session-1");
+    expect(fakeStore.getStore().drafts).toEqual([]);
+
+    fakeStore.addDraft(buildComment("pending-comment", 2, "Not sending."));
+    const nextSessionScope = buildScope("task-1", "qa", "session-2");
+    adapter.syncDraftScope(nextSessionScope, "task-1:qa:session-2");
+    expect(fakeStore.getStore().drafts).toEqual([]);
+
+    fakeStore.addDraft(buildComment("next-task-comment", 3, "Different task."));
+    const taskScope = buildScope("task-2", "qa", "session-2");
+    adapter.syncDraftScope(taskScope, "task-2:qa:session-2");
+    expect(fakeStore.getStore().drafts).toEqual([]);
+  });
+});

--- a/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useMemo } from "react";
+import type {
+  AgentChatComposerModel,
+  AgentChatQueuedSendContent,
+} from "@/components/features/agents/agent-chat/agent-chat.types";
+import {
+  type AgentChatComposerDraft,
+  appendTextToDraft,
+} from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
+import {
+  type AgentChatDraftScope,
+  didAgentChatDraftScopeSwitchSessionOnly,
+} from "@/components/features/agents/agent-chat/agent-chat-draft-scope";
+import {
+  type InlineCommentDraftStore,
+  useInlineCommentDraftStore,
+} from "@/state/use-inline-comment-draft-store";
+
+export type AgentStudioReviewCommentStore = Pick<
+  InlineCommentDraftStore,
+  | "drafts"
+  | "getPendingDrafts"
+  | "formatBatchMessage"
+  | "beginSubmittingDrafts"
+  | "restoreSubmittingDrafts"
+  | "completeSubmittingDrafts"
+  | "setDraftStateKey"
+  | "resetForContext"
+>;
+
+type AgentStudioReviewCommentComposerAdapter = {
+  syncDraftScope: (draftScope: AgentChatDraftScope, draftStateKey: string) => void;
+  submitDraft: (
+    draft: AgentChatComposerDraft,
+    onSend: AgentChatComposerModel["onSend"],
+  ) => Promise<boolean>;
+};
+
+export const createAgentStudioReviewCommentComposerAdapter = (
+  getStore: () => AgentStudioReviewCommentStore,
+): AgentStudioReviewCommentComposerAdapter => {
+  let previousDraftScope: AgentChatDraftScope | null = null;
+
+  return {
+    syncDraftScope: (draftScope, draftStateKey) => {
+      if (previousDraftScope === draftScope) {
+        return;
+      }
+
+      const store = getStore();
+      if (
+        previousDraftScope !== null &&
+        didAgentChatDraftScopeSwitchSessionOnly(previousDraftScope, draftScope) &&
+        store.drafts.some((draft) => draft.status === "submitting")
+      ) {
+        store.setDraftStateKey(draftStateKey);
+      } else {
+        store.resetForContext(draftStateKey);
+      }
+
+      previousDraftScope = draftScope;
+    },
+    submitDraft: async (draft, onSend) => {
+      const store = getStore();
+      const pendingDrafts = store.getPendingDrafts();
+      const submittingDrafts = pendingDrafts.map((pendingDraft) => ({
+        id: pendingDraft.id,
+        revision: pendingDraft.revision,
+      }));
+      const commentAppendix = store.formatBatchMessage(pendingDrafts);
+      const nextDraft =
+        commentAppendix.length > 0 ? appendTextToDraft(draft, commentAppendix) : draft;
+      const submissionId = store.beginSubmittingDrafts(submittingDrafts);
+
+      try {
+        const didSend = await onSend(nextDraft);
+        if (!submissionId) {
+          return didSend;
+        }
+
+        if (didSend) {
+          getStore().completeSubmittingDrafts(submissionId);
+        } else {
+          getStore().restoreSubmittingDrafts(submissionId);
+        }
+        return didSend;
+      } catch (error) {
+        if (submissionId) {
+          getStore().restoreSubmittingDrafts(submissionId);
+        }
+        throw error;
+      }
+    },
+  };
+};
+
+type UseAgentStudioReviewCommentComposerAdapterArgs = {
+  draftScope: AgentChatDraftScope;
+  draftStateKey: string;
+  onSend: AgentChatComposerModel["onSend"];
+};
+
+type UseAgentStudioReviewCommentComposerAdapterResult = {
+  queuedSendContent: AgentChatQueuedSendContent | null;
+  onSend: AgentChatComposerModel["onSend"];
+};
+
+export function useAgentStudioReviewCommentComposerAdapter({
+  draftScope,
+  draftStateKey,
+  onSend,
+}: UseAgentStudioReviewCommentComposerAdapterArgs): UseAgentStudioReviewCommentComposerAdapterResult {
+  const queuedCommentCount = useInlineCommentDraftStore((store) => store.getDraftCount());
+  const adapter = useMemo(
+    () =>
+      createAgentStudioReviewCommentComposerAdapter(() => useInlineCommentDraftStore.getState()),
+    [],
+  );
+
+  useEffect(() => {
+    adapter.syncDraftScope(draftScope, draftStateKey);
+  }, [adapter, draftScope, draftStateKey]);
+
+  const submitDraft = useCallback(
+    (draft: AgentChatComposerDraft): Promise<boolean> => adapter.submitDraft(draft, onSend),
+    [adapter, onSend],
+  );
+  const queuedSendContent = useMemo<AgentChatQueuedSendContent | null>(() => {
+    if (queuedCommentCount <= 0) {
+      return null;
+    }
+
+    const commentLabel = queuedCommentCount === 1 ? "comment" : "comments";
+    return {
+      count: queuedCommentCount,
+      accessibleLabel: `${queuedCommentCount} queued review ${commentLabel}`,
+    };
+  }, [queuedCommentCount]);
+
+  return useMemo(
+    () => ({
+      queuedSendContent,
+      onSend: submitDraft,
+    }),
+    [queuedSendContent, submitDraft],
+  );
+}

--- a/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.ts
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useMemo } from "react";
-import type {
-  AgentChatComposerModel,
-  AgentChatQueuedSendContent,
-} from "@/components/features/agents/agent-chat/agent-chat.types";
+import type { AgentChatComposerModel } from "@/components/features/agents/agent-chat/agent-chat.types";
 import {
   type AgentChatComposerDraft,
   appendTextToDraft,
@@ -101,7 +98,7 @@ type UseAgentStudioReviewCommentComposerAdapterArgs = {
 };
 
 type UseAgentStudioReviewCommentComposerAdapterResult = {
-  queuedSendContent: AgentChatQueuedSendContent | null;
+  pendingInlineCommentCount: number;
   onSend: AgentChatComposerModel["onSend"];
 };
 
@@ -110,7 +107,7 @@ export function useAgentStudioReviewCommentComposerAdapter({
   draftStateKey,
   onSend,
 }: UseAgentStudioReviewCommentComposerAdapterArgs): UseAgentStudioReviewCommentComposerAdapterResult {
-  const queuedCommentCount = useInlineCommentDraftStore((store) => store.getDraftCount());
+  const pendingInlineCommentCount = useInlineCommentDraftStore((store) => store.getDraftCount());
   const adapter = useMemo(
     () =>
       createAgentStudioReviewCommentComposerAdapter(() => useInlineCommentDraftStore.getState()),
@@ -125,23 +122,12 @@ export function useAgentStudioReviewCommentComposerAdapter({
     (draft: AgentChatComposerDraft): Promise<boolean> => adapter.submitDraft(draft, onSend),
     [adapter, onSend],
   );
-  const queuedSendContent = useMemo<AgentChatQueuedSendContent | null>(() => {
-    if (queuedCommentCount <= 0) {
-      return null;
-    }
-
-    const commentLabel = queuedCommentCount === 1 ? "comment" : "comments";
-    return {
-      count: queuedCommentCount,
-      accessibleLabel: `${queuedCommentCount} queued review ${commentLabel}`,
-    };
-  }, [queuedCommentCount]);
 
   return useMemo(
     () => ({
-      queuedSendContent,
+      pendingInlineCommentCount,
       onSend: submitDraft,
     }),
-    [queuedSendContent, submitDraft],
+    [pendingInlineCommentCount, submitDraft],
   );
 }

--- a/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-review-comment-composer-adapter.ts
@@ -60,14 +60,14 @@ export const createAgentStudioReviewCommentComposerAdapter = (
     submitDraft: async (draft, onSend) => {
       const store = getStore();
       const pendingDrafts = store.getPendingDrafts();
-      const submittingDrafts = pendingDrafts.map((pendingDraft) => ({
+      const pendingDraftSnapshots = pendingDrafts.map((pendingDraft) => ({
         id: pendingDraft.id,
         revision: pendingDraft.revision,
       }));
       const commentAppendix = store.formatBatchMessage(pendingDrafts);
       const nextDraft =
         commentAppendix.length > 0 ? appendTextToDraft(draft, commentAppendix) : draft;
-      const submissionId = store.beginSubmittingDrafts(submittingDrafts);
+      const submissionId = store.beginSubmittingDrafts(pendingDraftSnapshots);
 
       try {
         const didSend = await onSend(nextDraft);


### PR DESCRIPTION
## Summary

- Moves inline task-review comment lookup, formatting, scope reset, and send transactions out of the shared AgentChat composer and into an Agent Studio-owned adapter.
- Keeps the shared composer generic through caller-owned pendingSendItems presentation metadata.
- Preserves empty-draft comment sends, exact revision completion, failure restoration, and session-only in-flight scope switching.

## Goal

Shared AgentChat consumers must not read or send review comments left in Agent Studio state. This refactor makes Agent Studio the only owner that can append those comments while preserving current review behavior.

## Implementation

- Added a focused Agent Studio review-comment composer adapter around the inline-comment store.
- Wrapped Agent Studio onSend at the page-model boundary and mapped pendingInlineCommentCount to generic pendingSendItems.
- Removed all inline-comment store imports and transaction calls from shared AgentChat production code.
- Added focused transaction, scope-switch, generic presentation, and stale-store isolation tests.
- Clarified pending-comment naming and simplified shared send delegation.

## Verification

- bun run lint
- bun run typecheck
- bun run test
- bun run build
- React Doctor: 100/100
- Thermos correctness and maintainability audits: no P0-P3 findings

Cargo checks are not applicable because this repository has no Cargo.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pending-items indicator to the agent chat composer, including an accessible label and item count.
  * Agent Studio review comments can now be submitted together with chat messages.
* **Bug Fixes**
  * Improved handling of review-comment drafts during submission failures, retries, scope changes, and concurrent edits.
  * Prevented stale drafts from being unintentionally included in new messages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->