### PR TITLE
fix(electron): package node-pty prebuilds without rebuilding

### DIFF
--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -1,6 +1,7 @@
 appId: com.openducktor.app
 productName: OpenDucktor
 asar: true
+npmRebuild: false
 asarUnpack:
   - node_modules/node-pty/**/*
 


### PR DESCRIPTION
## Summary

Prevent local Electron packaging from rebuilding `node-pty` when the dependency already ships the required target prebuilds.

This removes the accidental Python/Visual Studio Spectre toolchain requirement from normal Windows packaging while preserving the existing `node-pty` inclusion and ASAR unpacking rules. The comparison note records why OpenDucktor follows T3 Code's prebuilt strategy instead of Orca's project-specific source rebuild flow.

## Technical choices

- Set Electron Builder's `npmRebuild` option to `false`.
- Keep the existing `node_modules/node-pty/**/*` packaging and `asarUnpack` configuration.
- Add no custom build hooks, rebuild scripts, fallbacks, or automated interactive terminal smoke tests.
- Keep packaged terminal interaction validation manual when Electron or `node-pty` changes.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test:scripts` (11 passed)
- `bun test apps/electron/scripts/package-build.test.ts` (14 passed)
- `bun electron:package` (Windows x64 NSIS installer produced; native rebuild skipped)
- Confirmed the packaged app contains `conpty.node`, `conpty_console_list.node`, `conpty.dll`, and `OpenConsole.exe`.

`bun run test` reaches eight unrelated host failures on this machine: seven Windows symlink tests fail with `EPERM`, and the Node SQLite adapter test requires a newer Node SQLite API than local Node 22.12 provides. All other workspaces report zero failures. Interactive packaged-terminal behavior remains a manual check by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app packaging process to streamline builds by skipping the automatic npm rebuild step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->