### PR TITLE
fix(codex): hydrate paginated transcript history

### DIFF
--- a/apps/electron/src/main/electron-host-invoke.test.ts
+++ b/apps/electron/src/main/electron-host-invoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { TerminalServiceError } from "@openducktor/host";
+import { CodexSessionHistoryError, TerminalServiceError } from "@openducktor/host";
 import { Effect } from "effect";
 import { runElectronHostInvoke } from "./electron-host-invoke";
 
@@ -24,6 +24,44 @@ describe("runElectronHostInvoke", () => {
           terminalFailure: {
             code: "unsupported_runtime",
             message: "Interactive terminals are unavailable in this runtime.",
+          },
+        },
+      },
+    });
+  });
+
+  test("serializes session history failures with diagnostics", async () => {
+    const response = await runElectronHostInvoke(
+      Effect.fail(
+        new CodexSessionHistoryError({
+          message: "Codex thread/turns/list response data[0] must be an object",
+          runtimeId: "runtime-1",
+          threadId: "thread-1",
+          failure: {
+            code: "invalid_runtime_response",
+            summary: "Codex returned invalid conversation history.",
+            detail: "Codex thread/turns/list response data[0] must be an object",
+            diagnosticId: "diagnostic-1",
+            method: "thread/turns/list",
+            pageCursor: null,
+          },
+        }),
+      ),
+    );
+
+    expect(response).toEqual({
+      ok: false,
+      error: {
+        message: "Codex thread/turns/list response data[0] must be an object",
+        failure: {
+          kind: "session_history",
+          sessionHistoryFailure: {
+            code: "invalid_runtime_response",
+            summary: "Codex returned invalid conversation history.",
+            detail: "Codex thread/turns/list response data[0] must be an object",
+            diagnosticId: "diagnostic-1",
+            method: "thread/turns/list",
+            pageCursor: null,
           },
         },
       },

--- a/apps/electron/src/main/electron-host-invoke.ts
+++ b/apps/electron/src/main/electron-host-invoke.ts
@@ -1,4 +1,4 @@
-import { TerminalServiceError, terminalServiceErrorToFailure } from "@openducktor/host";
+import { hostInvokeFailureFromError } from "@openducktor/host";
 import type { Effect } from "effect";
 import { runElectronEffect } from "../effect/electron-boundary";
 import { errorMessage } from "../effect/electron-errors";
@@ -11,18 +11,12 @@ export const runElectronHostInvoke = async <A, E extends Error>(
   try {
     return { ok: true, value: await execute(effect) };
   } catch (cause) {
+    const failure = hostInvokeFailureFromError(cause);
     return {
       ok: false,
       error: {
         message: errorMessage(cause),
-        ...(cause instanceof TerminalServiceError
-          ? {
-              failure: {
-                kind: "terminal" as const,
-                terminalFailure: terminalServiceErrorToFailure(cause),
-              },
-            }
-          : {}),
+        ...(failure ? { failure } : {}),
       },
     };
   }

--- a/apps/electron/src/main/electron-main-logger.ts
+++ b/apps/electron/src/main/electron-main-logger.ts
@@ -3,7 +3,7 @@ import {
   type OpenDucktorDailyLogWriter,
   type OpenDucktorLogPersistenceError,
 } from "@openducktor/host";
-import { Effect, Exit } from "effect";
+import { Effect, Exit, Inspectable } from "effect";
 import { causeToElectronBoundaryError } from "../effect/electron-errors";
 
 const ANSI_RESET = "\u001b[0m";
@@ -112,9 +112,12 @@ const colorMessage = (useAnsi: boolean, level: LogLevel, message: string): strin
 
 const formatError = (error: unknown): string => {
   if (error instanceof Error) {
-    return error.stack ?? error.message;
+    const stack = error.stack ?? error.message;
+    return Object.keys(error).length > 0
+      ? `${stack}\n${Inspectable.toStringUnknown(error)}`
+      : stack;
   }
-  return String(error);
+  return Inspectable.toStringUnknown(error);
 };
 
 export const createElectronMainLogger = ({

--- a/apps/electron/src/main/electron-main-runtime-bindings.test.ts
+++ b/apps/electron/src/main/electron-main-runtime-bindings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { CodexSessionHistoryError } from "@openducktor/host";
 import { Effect } from "effect";
 import { createElectronMainLogger, type ElectronMainLogger } from "./electron-main-logger";
 import { createElectronMainRuntimeBindings } from "./electron-main-runtime-bindings";
@@ -46,8 +47,20 @@ describe("createElectronMainRuntimeBindings", () => {
 
   test("persists rejected host commands before returning the original failure", async () => {
     const configDirectory = await mkdtemp(path.join(tmpdir(), "openducktor-host-command-log-"));
-    const command = "runtime.session.context-usage";
-    const failure = new Error("Codex session was released while context usage was loading");
+    const command = "agent.session.history";
+    const failure = new CodexSessionHistoryError({
+      message: "Codex returned invalid conversation history.",
+      failure: {
+        code: "invalid_runtime_response",
+        summary: "Codex returned invalid conversation history.",
+        detail: "Codex thread/turns/list response data[0] must be an object",
+        diagnosticId: "diagnostic-1",
+        method: "thread/turns/list",
+        pageCursor: null,
+      },
+      runtimeId: "runtime-1",
+      threadId: "thread-1",
+    });
     const expectedLogMessage = `ERROR Electron host command '${command}' failed`;
     let consoleOutput = "";
 
@@ -73,8 +86,10 @@ describe("createElectronMainRuntimeBindings", () => {
       );
       expect(consoleOutput).toContain(expectedLogMessage);
       expect(consoleOutput).toContain(failure.message);
+      expect(consoleOutput).toContain("diagnostic-1");
       expect(persisted).toContain(expectedLogMessage);
       expect(persisted).toContain(failure.message);
+      expect(persisted).toContain("diagnostic-1");
     } finally {
       await rm(configDirectory, { force: true, recursive: true });
     }

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   codexSessionRef,
+  codexSessionRuntimeRef,
   codexStartSessionInput,
   createDeferred,
   createHarness,
@@ -85,7 +86,7 @@ describe("CodexAppServerAdapter context loading", () => {
     const { adapter, transports } = createHarness({
       subscribeEvents: runtimeStream.subscribeEvents,
     });
-    await adapter.startSession(codexStartSessionInput());
+    await adapter.resumeSession(codexSessionRuntimeRef());
     const transport = transports.get("runtime-live");
     const request = transport?.request.bind(transport);
     const resumeStarted = createDeferred<void>();
@@ -112,7 +113,7 @@ describe("CodexAppServerAdapter context loading", () => {
   test("projects usage that arrives after a successful null resume", async () => {
     const runtimeStream = createRuntimeStreamSubscription();
     const { adapter } = createHarness({ subscribeEvents: runtimeStream.subscribeEvents });
-    await adapter.startSession(codexStartSessionInput());
+    await adapter.resumeSession(codexSessionRuntimeRef());
 
     await expect(adapter.loadSessionContextUsage(codexSessionRef())).resolves.toBeNull();
     runtimeStream.emitNotification(tokenUsageNotification(2_100));

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
@@ -168,7 +168,55 @@ describe("CodexAppServerAdapter history loading", () => {
     );
   });
 
-  test("marks hydrated item timestamps approximate when Codex only reports a turn boundary", async () => {
+  test("keeps stable paginated item ids while hydrating messages and tools", async () => {
+    const turns = [
+      {
+        id: "child-turn",
+        startedAt: 1_783_715_581,
+        completedAt: null,
+        durationMs: null,
+        status: "inProgress",
+        items: [
+          {
+            id: "child-user",
+            type: "userMessage",
+            content: [{ type: "text", text: "Inspect the repository" }],
+          },
+          {
+            id: "child-commentary",
+            type: "agentMessage",
+            phase: "commentary",
+            text: "I’m checking the repository now.",
+          },
+          {
+            id: "child-command",
+            type: "commandExecution",
+            command: "pwd",
+            cwd: "/repo",
+            processId: null,
+            source: "model",
+            status: "completed",
+            commandActions: [{ type: "unknown", command: "pwd" }],
+            aggregatedOutput: "/repo",
+            exitCode: 0,
+            durationMs: 12,
+          },
+          {
+            id: "child-tool",
+            type: "mcpToolCall",
+            server: "semble",
+            tool: "search",
+            status: "completed",
+            arguments: { query: "architecture" },
+            appContext: null,
+            pluginId: null,
+            result: { content: [{ type: "text", text: "result" }] },
+            error: null,
+            durationMs: 107,
+          },
+        ],
+      },
+    ];
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/read") {
@@ -178,59 +226,12 @@ describe("CodexAppServerAdapter history loading", () => {
               cwd: "/repo",
               createdAt: 1_783_715_580,
               status: { type: "idle" },
-              turns: [
-                {
-                  id: "child-turn",
-                  startedAt: 1_783_715_581,
-                  completedAt: null,
-                  durationMs: null,
-                  status: "inProgress",
-                  items: [
-                    {
-                      id: "child-user",
-                      type: "userMessage",
-                      content: [{ type: "text", text: "Inspect the repository" }],
-                    },
-                    {
-                      id: "child-commentary",
-                      type: "agentMessage",
-                      phase: "commentary",
-                      text: "I’m checking the repository now.",
-                    },
-                    {
-                      id: "child-command",
-                      type: "commandExecution",
-                      command: "pwd",
-                      cwd: "/repo",
-                      processId: null,
-                      source: "model",
-                      status: "completed",
-                      commandActions: [{ type: "unknown", command: "pwd" }],
-                      aggregatedOutput: "/repo",
-                      exitCode: 0,
-                      durationMs: 12,
-                    },
-                    {
-                      id: "child-tool",
-                      type: "mcpToolCall",
-                      server: "semble",
-                      tool: "search",
-                      status: "completed",
-                      arguments: { query: "architecture" },
-                      appContext: null,
-                      pluginId: null,
-                      result: { content: [{ type: "text", text: "result" }] },
-                      error: null,
-                      durationMs: 107,
-                    },
-                  ],
-                },
-              ],
+              turns: [],
             },
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return { data: turns, nextCursor: null } as Response;
         }
         throw new Error(`Unexpected method '${request.method}'.`);
       },
@@ -534,10 +535,6 @@ describe("CodexAppServerAdapter history loading", () => {
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-search", cwd: "/repo", createdAt: 1 } } as Response;
-        }
         return {
           thread: {
             id: "thread-search",
@@ -625,10 +622,6 @@ describe("CodexAppServerAdapter history loading", () => {
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
-        }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-skill", cwd: "/repo", createdAt: 1 } } as Response;
         }
         return {
           thread: {
@@ -888,10 +881,6 @@ describe("CodexAppServerAdapter history loading", () => {
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-contract", cwd: "/repo", createdAt: 1 } } as Response;
-        }
         return {
           thread: {
             id: "thread-contract",
@@ -1033,12 +1022,6 @@ describe("CodexAppServerAdapter history loading", () => {
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
-        }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return {
-            thread: { id: "thread-command-actions", cwd: "/repo", createdAt: 1 },
-          } as Response;
         }
         return {
           thread: {
@@ -1186,7 +1169,7 @@ describe("CodexAppServerAdapter history loading", () => {
     ).resolves.toEqual([]);
 
     expect(calls).toEqual([
-      { method: "thread/read", params: { threadId: "missing-thread", includeTurns: true } },
+      { method: "thread/read", params: { threadId: "missing-thread", includeTurns: false } },
     ]);
   });
 
@@ -1207,10 +1190,6 @@ describe("CodexAppServerAdapter history loading", () => {
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
-        }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-todos", cwd: "/repo", createdAt: 1 } } as Response;
         }
         return {
           thread: {
@@ -1542,10 +1521,6 @@ describe("CodexAppServerAdapter history loading", () => {
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-final-message", cwd: "/repo", createdAt: 1 } } as Response;
-        }
         return {
           thread: {
             id: "thread-final-message",
@@ -1605,10 +1580,6 @@ describe("CodexAppServerAdapter history loading", () => {
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
-        }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-plan-todos", cwd: "/repo", createdAt: 1 } } as Response;
         }
         return {
           thread: {
@@ -1675,12 +1646,6 @@ describe("CodexAppServerAdapter history loading", () => {
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
-        }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return {
-            thread: { id: "thread-plan-text-todos", cwd: "/repo", createdAt: 1 },
-          } as Response;
         }
         return {
           thread: {
@@ -1749,10 +1714,6 @@ describe("CodexAppServerAdapter history loading", () => {
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-named-todos", cwd: "/repo", createdAt: 1 } } as Response;
-        }
         return {
           thread: {
             id: "thread-named-todos",
@@ -1817,10 +1778,6 @@ describe("CodexAppServerAdapter history loading", () => {
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
-        }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-json-todos", cwd: "/repo", createdAt: 1 } } as Response;
         }
         return {
           thread: {
@@ -1888,10 +1845,6 @@ describe("CodexAppServerAdapter history loading", () => {
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
-        }
-        const includeTurns = (request.params as { includeTurns?: boolean }).includeTurns;
-        if (includeTurns === false) {
-          return { thread: { id: "thread-bad-todos", cwd: "/repo", createdAt: 1 } } as Response;
         }
         return {
           thread: {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.history.test.ts
@@ -8,61 +8,71 @@ import {
 } from "./codex-app-server-adapter.test-harness";
 import type { CodexJsonRpcRequest, CodexJsonRpcTransport } from "./index";
 
+type PaginatedThreadFixture = Record<string, unknown> & { turns: unknown[] };
+
+const paginatedThreadReadResponse = (thread: PaginatedThreadFixture): unknown => ({
+  thread: { ...thread, turns: [] },
+});
+
+const paginatedTurnsListResponse = (thread: PaginatedThreadFixture): unknown => ({
+  data: thread.turns,
+  nextCursor: null,
+});
+
 describe("CodexAppServerAdapter history loading", () => {
   test("keeps a hydrated subagent at its exact thread item position", async () => {
+    const thread = {
+      id: "parent-thread",
+      cwd: "/repo",
+      createdAt: 1_783_715_500,
+      status: { type: "idle" },
+      turns: [
+        {
+          id: "parent-turn",
+          startedAt: 1_783_715_500,
+          completedAt: 1_783_715_620,
+          status: "completed",
+          items: [
+            {
+              id: "parent-user",
+              type: "userMessage",
+              content: [{ type: "text", text: "Delegate this work" }],
+            },
+            {
+              id: "parent-delegating",
+              type: "agentMessage",
+              phase: "commentary",
+              text: "I am delegating this now.",
+            },
+            {
+              id: "parent-spawn",
+              type: "collabToolCall",
+              tool: "spawnAgent",
+              status: "completed",
+              senderThreadId: "parent-thread",
+              receiverThreadIds: ["child-thread"],
+              prompt: "Inspect the repository",
+              agentsStates: {
+                "child-thread": { status: "completed", message: "Done" },
+              },
+            },
+            {
+              id: "parent-waiting",
+              type: "agentMessage",
+              phase: "commentary",
+              text: "The subagent is running.",
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/read") {
-          return {
-            thread: {
-              id: "parent-thread",
-              cwd: "/repo",
-              createdAt: 1_783_715_500,
-              status: { type: "idle" },
-              turns: [
-                {
-                  id: "parent-turn",
-                  startedAt: 1_783_715_500,
-                  completedAt: 1_783_715_620,
-                  status: "completed",
-                  items: [
-                    {
-                      id: "parent-user",
-                      type: "userMessage",
-                      content: [{ type: "text", text: "Delegate this work" }],
-                    },
-                    {
-                      id: "parent-delegating",
-                      type: "agentMessage",
-                      phase: "commentary",
-                      text: "I am delegating this now.",
-                    },
-                    {
-                      id: "parent-spawn",
-                      type: "collabToolCall",
-                      tool: "spawnAgent",
-                      status: "completed",
-                      senderThreadId: "parent-thread",
-                      receiverThreadIds: ["child-thread"],
-                      prompt: "Inspect the repository",
-                      agentsStates: {
-                        "child-thread": { status: "completed", message: "Done" },
-                      },
-                    },
-                    {
-                      id: "parent-waiting",
-                      type: "agentMessage",
-                      phase: "commentary",
-                      text: "The subagent is running.",
-                    },
-                  ],
-                },
-              ],
-            },
-          } as Response;
+          return paginatedThreadReadResponse(thread) as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         throw new Error(`Unexpected method '${request.method}'.`);
       },
@@ -86,54 +96,53 @@ describe("CodexAppServerAdapter history loading", () => {
   });
 
   test("keeps inherited and child-owned subagent activity with their fork owners", async () => {
+    const thread = {
+      id: "child-thread",
+      cwd: "/repo",
+      createdAt: 10,
+      status: { type: "idle" },
+      forkedFromId: "root-thread",
+      parentThreadId: "root-thread",
+      turns: [
+        {
+          id: "root-turn",
+          startedAt: 5,
+          status: "completed",
+          items: [
+            {
+              id: "root-started-sibling",
+              type: "subAgentActivity",
+              agentThreadId: "sibling-thread",
+              kind: "started",
+            },
+          ],
+        },
+        {
+          id: "child-turn",
+          startedAt: 11,
+          status: "completed",
+          items: [
+            {
+              id: "child-started-grandchild",
+              type: "subAgentActivity",
+              agentThreadId: "grandchild-thread",
+              kind: "started",
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/read") {
-          return {
-            thread: {
-              id: "child-thread",
-              cwd: "/repo",
-              createdAt: 10,
-              status: { type: "idle" },
-              forkedFromId: "root-thread",
-              parentThreadId: "root-thread",
-              turns: [
-                {
-                  id: "root-turn",
-                  startedAt: 5,
-                  status: "completed",
-                  items: [
-                    {
-                      id: "root-started-sibling",
-                      type: "subAgentActivity",
-                      agentThreadId: "sibling-thread",
-                      kind: "started",
-                    },
-                  ],
-                },
-                {
-                  id: "child-turn",
-                  startedAt: 11,
-                  status: "completed",
-                  items: [
-                    {
-                      id: "child-started-grandchild",
-                      type: "subAgentActivity",
-                      agentThreadId: "grandchild-thread",
-                      kind: "started",
-                    },
-                  ],
-                },
-              ],
-            },
-          } as Response;
+          return paginatedThreadReadResponse(thread) as Response;
         }
         if (request.method === "thread/turns/list") {
           const { threadId } = request.params as { threadId: string };
           if (threadId === "root-thread") {
             return { data: [{ id: "root-turn" }], nextCursor: null } as Response;
           }
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         throw new Error(`Unexpected method '${request.method}'.`);
       },
@@ -284,14 +293,7 @@ describe("CodexAppServerAdapter history loading", () => {
               status: { type: "idle" },
               forkedFromId: "missing-parent",
               parentThreadId: "missing-parent",
-              turns: [
-                {
-                  id: "child-turn",
-                  startedAt: 2,
-                  status: "completed",
-                  items: [{ id: "child-answer", type: "agentMessage", text: "Child result" }],
-                },
-              ],
+              turns: [],
             },
           } as Response;
         }
@@ -351,20 +353,7 @@ describe("CodexAppServerAdapter history loading", () => {
               status: { type: "idle" },
               forkedFromId: "missing-parent",
               parentThreadId: "missing-parent",
-              turns: [
-                {
-                  id: "inherited-turn",
-                  startedAt: 5,
-                  status: "completed",
-                  items: [{ id: "parent-answer", type: "agentMessage", text: "Parent result" }],
-                },
-                {
-                  id: "child-turn",
-                  startedAt: 11,
-                  status: "completed",
-                  items: [{ id: "child-answer", type: "agentMessage", text: "Child result" }],
-                },
-              ],
+              turns: [],
             },
           } as Response;
         }
@@ -517,7 +506,42 @@ describe("CodexAppServerAdapter history loading", () => {
     );
   });
 
-  test("loads search command metadata and hides contextual user fragments from thread reads", async () => {
+  test("loads search command metadata and hides contextual user fragments from paginated history", async () => {
+    const thread = {
+      id: "thread-search",
+      cwd: "/repo",
+      createdAt: 1,
+      turns: [
+        {
+          id: "turn-search",
+          startedAt: 1,
+          completedAt: 2,
+          status: "completed",
+          items: [
+            {
+              id: "context-1",
+              type: "userMessage",
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "<environment_context>\nsecret repo context\n</environment_context>",
+                },
+              ],
+            },
+            {
+              id: "search-1",
+              type: "commandExecution",
+              command: "rg foo src",
+              cwd: "/repo",
+              status: "completed",
+              commandActions: [{ type: "search", command: "rg foo src" }],
+              aggregatedOutput: "src/app.ts:foo",
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -530,48 +554,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-search",
-            cwd: "/repo",
-            createdAt: 1,
-            turns: [
-              {
-                id: "turn-search",
-                startedAt: 1,
-                completedAt: 2,
-                status: "completed",
-                items: [
-                  {
-                    id: "context-1",
-                    type: "userMessage",
-                    role: "user",
-                    content: [
-                      {
-                        type: "text",
-                        text: "<environment_context>\nsecret repo context\n</environment_context>",
-                      },
-                    ],
-                  },
-                  {
-                    id: "search-1",
-                    type: "commandExecution",
-                    command: "rg foo src",
-                    cwd: "/repo",
-                    status: "completed",
-                    commandActions: [{ type: "search", command: "rg foo src" }],
-                    aggregatedOutput: "src/app.ts:foo",
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -605,6 +593,42 @@ describe("CodexAppServerAdapter history loading", () => {
 
   test("loads persisted Codex skill marker text into user display parts", async () => {
     const calls: CodexJsonRpcRequest[] = [];
+    const thread = {
+      id: "thread-skill",
+      cwd: "/repo",
+      createdAt: 1,
+      turns: [
+        {
+          id: "turn-skill",
+          startedAt: 1,
+          completedAt: 2,
+          status: "completed",
+          items: [
+            {
+              id: "skill-user-1",
+              type: "userMessage",
+              content: [
+                {
+                  type: "text",
+                  text: "Tell me the purpose of $create-pr please",
+                  text_elements: [
+                    {
+                      byteRange: { start: 23, end: 33 },
+                      placeholder: "$create-pr",
+                    },
+                  ],
+                },
+                {
+                  type: "skill",
+                  name: "create-pr",
+                  path: "/repo/.codex/skills/create-pr/SKILL.md",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         calls.push(request);
@@ -618,49 +642,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-skill",
-            cwd: "/repo",
-            createdAt: 1,
-            turns: [
-              {
-                id: "turn-skill",
-                startedAt: 1,
-                completedAt: 2,
-                status: "completed",
-                items: [
-                  {
-                    id: "skill-user-1",
-                    type: "userMessage",
-                    content: [
-                      {
-                        type: "text",
-                        text: "Tell me the purpose of $create-pr please",
-                        text_elements: [
-                          {
-                            byteRange: { start: 23, end: 33 },
-                            placeholder: "$create-pr",
-                          },
-                        ],
-                      },
-                      {
-                        type: "skill",
-                        name: "create-pr",
-                        path: "/repo/.codex/skills/create-pr/SKILL.md",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -703,34 +690,33 @@ describe("CodexAppServerAdapter history loading", () => {
 
   test("does not request context while reading unloaded idle history", async () => {
     const calls: CodexJsonRpcRequest[] = [];
+    const thread = {
+      id: "thread-unloaded-idle",
+      cwd: "/repo",
+      status: { type: "idle" },
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "msg-1",
+              type: "agentMessage",
+              phase: "final_answer",
+              text: "Hydrated from paginated history",
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         calls.push(request);
         if (request.method === "thread/read") {
-          return {
-            thread: {
-              id: "thread-unloaded-idle",
-              cwd: "/repo",
-              status: { type: "idle" },
-              turns: [
-                {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [
-                    {
-                      id: "msg-1",
-                      type: "agentMessage",
-                      phase: "final_answer",
-                      text: "Hydrated from thread/read",
-                    },
-                  ],
-                },
-              ],
-            },
-          } as Response;
+          return paginatedThreadReadResponse(thread) as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method === "thread/loaded/list") {
           return { data: [], nextCursor: null } as Response;
@@ -765,7 +751,7 @@ describe("CodexAppServerAdapter history loading", () => {
 
     expect(history.find((message) => message.messageId === "msg-1")).toEqual(
       expect.objectContaining({
-        text: "Hydrated from thread/read",
+        text: "Hydrated from paginated history",
       }),
     );
     await flushCodexAdapterWork();
@@ -797,20 +783,7 @@ describe("CodexAppServerAdapter history loading", () => {
               id: "thread-unloaded",
               cwd: "/repo",
               status: { type: "idle" },
-              turns: [
-                {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [
-                    {
-                      id: "msg-1",
-                      type: "agentMessage",
-                      phase: "final_answer",
-                      text: "Partial from thread/read",
-                    },
-                  ],
-                },
-              ],
+              turns: [],
             },
           } as Response;
         }
@@ -861,7 +834,57 @@ describe("CodexAppServerAdapter history loading", () => {
     expect(calls.some((call) => call.method === "thread/resume")).toBe(false);
   });
 
-  test("loads documented thread-read tool item shapes", async () => {
+  test("loads documented paginated tool item shapes", async () => {
+    const thread = {
+      id: "thread-contract",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          startedAt: 1,
+          completedAt: 2,
+          items: [
+            {
+              id: "cmd-array",
+              type: "commandExecution",
+              command: ["bun", "test"],
+              cwd: "/repo",
+              status: "completed",
+              aggregatedOutput: "70 pass",
+            },
+            {
+              id: "mcp-json-args",
+              type: "mcpToolCall",
+              server: "openducktor",
+              tool: "odt_read_task",
+              status: "completed",
+              arguments: JSON.stringify({ taskId: "task-1" }),
+              result: { content: [{ type: "text", text: "task ok" }] },
+            },
+            {
+              id: "dynamic-json-args",
+              type: "dynamicToolCall",
+              namespace: "functions",
+              tool: "request_user_input",
+              status: "completed",
+              success: true,
+              arguments: JSON.stringify({
+                requestId: "q1",
+                questions: [{ question: "Choose mode" }],
+              }),
+              contentItems: [{ type: "inputText", text: "selected" }],
+            },
+            {
+              id: "final-content-array",
+              type: "agentMessage",
+              phase: "final_answer",
+              content: [{ type: "output_text", text: "Final from content" }],
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -876,63 +899,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-contract",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                startedAt: 1,
-                completedAt: 2,
-                items: [
-                  {
-                    id: "cmd-array",
-                    type: "commandExecution",
-                    command: ["bun", "test"],
-                    cwd: "/repo",
-                    status: "completed",
-                    aggregatedOutput: "70 pass",
-                  },
-                  {
-                    id: "mcp-json-args",
-                    type: "mcpToolCall",
-                    server: "openducktor",
-                    tool: "odt_read_task",
-                    status: "completed",
-                    arguments: JSON.stringify({ taskId: "task-1" }),
-                    result: { content: [{ type: "text", text: "task ok" }] },
-                  },
-                  {
-                    id: "dynamic-json-args",
-                    type: "dynamicToolCall",
-                    namespace: "functions",
-                    tool: "request_user_input",
-                    status: "completed",
-                    success: true,
-                    arguments: JSON.stringify({
-                      requestId: "q1",
-                      questions: [{ question: "Choose mode" }],
-                    }),
-                    contentItems: [{ type: "inputText", text: "selected" }],
-                  },
-                  {
-                    id: "final-content-array",
-                    type: "agentMessage",
-                    phase: "final_answer",
-                    content: [{ type: "output_text", text: "Final from content" }],
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -998,7 +970,55 @@ describe("CodexAppServerAdapter history loading", () => {
     );
   });
 
-  test("loads command action read find and bash tools from thread reads", async () => {
+  test("loads command action read find and bash tools from paginated history", async () => {
+    const thread = {
+      id: "thread-command-actions",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          startedAt: 1,
+          completedAt: 4,
+          durationMs: 3000,
+          items: [
+            {
+              id: "cmd-read-action",
+              type: "commandExecution",
+              command: ["cat", "src/app.ts"],
+              cwd: "/repo",
+              status: "completed",
+              commandActions: [{ type: "Read", path: "src/app.ts" }],
+              aggregatedOutput: "const app = true;",
+            },
+            {
+              id: "cmd-find-action",
+              type: "commandExecution",
+              command: "find src -name '*.ts'",
+              cwd: "/repo",
+              status: "completed",
+              command_actions: [{ kind: "find", path: "src", pattern: "*.ts" }],
+              aggregated_output: "src/app.ts",
+            },
+            {
+              id: "cmd-bash-action",
+              type: "commandExecution",
+              command: "bun test",
+              cwd: "/repo",
+              status: "completed",
+              commandActions: [{ type: "exec", command: "bun test" }],
+              aggregatedOutput: "1 pass",
+            },
+            {
+              id: "final-action-turn",
+              type: "agentMessage",
+              phase: "final_answer",
+              text: "Done",
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -1018,61 +1038,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-command-actions",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                startedAt: 1,
-                completedAt: 4,
-                durationMs: 3000,
-                items: [
-                  {
-                    id: "cmd-read-action",
-                    type: "commandExecution",
-                    command: ["cat", "src/app.ts"],
-                    cwd: "/repo",
-                    status: "completed",
-                    commandActions: [{ type: "Read", path: "src/app.ts" }],
-                    aggregatedOutput: "const app = true;",
-                  },
-                  {
-                    id: "cmd-find-action",
-                    type: "commandExecution",
-                    command: "find src -name '*.ts'",
-                    cwd: "/repo",
-                    status: "completed",
-                    command_actions: [{ kind: "find", path: "src", pattern: "*.ts" }],
-                    aggregated_output: "src/app.ts",
-                  },
-                  {
-                    id: "cmd-bash-action",
-                    type: "commandExecution",
-                    command: "bun test",
-                    cwd: "/repo",
-                    status: "completed",
-                    commandActions: [{ type: "exec", command: "bun test" }],
-                    aggregatedOutput: "1 pass",
-                  },
-                  {
-                    id: "final-action-turn",
-                    type: "agentMessage",
-                    phase: "final_answer",
-                    text: "Done",
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -1173,7 +1144,31 @@ describe("CodexAppServerAdapter history loading", () => {
     ]);
   });
 
-  test("loads Codex session todos from thread-read update_plan tool calls", async () => {
+  test("loads Codex session todos from paginated update_plan tool calls", async () => {
+    const thread = {
+      id: "thread-todos",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "todo-call-1",
+              type: "dynamicToolCall",
+              namespace: "functions",
+              tool: "update_plan",
+              arguments: {
+                plan: [
+                  { step: "Inspect docs", status: "completed" },
+                  { step: "Wire todos", status: "inProgress" },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -1186,37 +1181,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-todos",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                items: [
-                  {
-                    id: "todo-call-1",
-                    type: "dynamicToolCall",
-                    namespace: "functions",
-                    tool: "update_plan",
-                    arguments: {
-                      plan: [
-                        { step: "Inspect docs", status: "completed" },
-                        { step: "Wire todos", status: "inProgress" },
-                      ],
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -1239,6 +1209,34 @@ describe("CodexAppServerAdapter history loading", () => {
   test("loads todos independently after loading Codex session history", async () => {
     const calls: CodexJsonRpcRequest[] = [];
     const completedAtMs = Date.parse("2026-05-20T10:00:02.000Z");
+    const thread = {
+      id: "thread-history-todos",
+      cwd: "/repo",
+      createdAt: 1,
+      status: { type: "idle" },
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "todo-call-1",
+              type: "dynamicToolCall",
+              namespace: "functions",
+              tool: "update_plan",
+              arguments: {
+                plan: [
+                  { step: "Load transcript once", status: "completed" },
+                  { step: "Reuse todos", status: "inProgress" },
+                ],
+              },
+              durationMs: 25,
+              completedAtMs,
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         calls.push(request);
@@ -1259,39 +1257,10 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/read") {
-          return {
-            thread: {
-              id: "thread-history-todos",
-              cwd: "/repo",
-              createdAt: 1,
-              status: { type: "idle" },
-              turns: [
-                {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [
-                    {
-                      id: "todo-call-1",
-                      type: "dynamicToolCall",
-                      namespace: "functions",
-                      tool: "update_plan",
-                      arguments: {
-                        plan: [
-                          { step: "Load transcript once", status: "completed" },
-                          { step: "Reuse todos", status: "inProgress" },
-                        ],
-                      },
-                      durationMs: 25,
-                      completedAtMs,
-                    },
-                  ],
-                },
-              ],
-            },
-          } as Response;
+          return paginatedThreadReadResponse(thread) as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         throw new Error(`Unexpected method '${request.method}'.`);
       },
@@ -1341,6 +1310,27 @@ describe("CodexAppServerAdapter history loading", () => {
 
   test("rejects Codex todo policy mismatches before returning cached todos", async () => {
     const calls: CodexJsonRpcRequest[] = [];
+    const thread = {
+      id: "thread-history-todos",
+      cwd: "/repo",
+      createdAt: 1,
+      status: { type: "idle" },
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "todo-call-1",
+              type: "dynamicToolCall",
+              namespace: "functions",
+              tool: "update_plan",
+              arguments: { plan: [{ step: "Cached todo", status: "completed" }] },
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         calls.push(request);
@@ -1361,32 +1351,10 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/read") {
-          return {
-            thread: {
-              id: "thread-history-todos",
-              cwd: "/repo",
-              createdAt: 1,
-              status: { type: "idle" },
-              turns: [
-                {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [
-                    {
-                      id: "todo-call-1",
-                      type: "dynamicToolCall",
-                      namespace: "functions",
-                      tool: "update_plan",
-                      arguments: { plan: [{ step: "Cached todo", status: "completed" }] },
-                    },
-                  ],
-                },
-              ],
-            },
-          } as Response;
+          return paginatedThreadReadResponse(thread) as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         throw new Error(`Unexpected method '${request.method}'.`);
       },
@@ -1420,6 +1388,17 @@ describe("CodexAppServerAdapter history loading", () => {
 
   test("loads empty todos independently after loading Codex session history", async () => {
     const calls: CodexJsonRpcRequest[] = [];
+    const thread = {
+      id: "thread-empty-todos",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         calls.push(request);
@@ -1451,24 +1430,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-empty-todos",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                items: [],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -1497,6 +1464,22 @@ describe("CodexAppServerAdapter history loading", () => {
   });
 
   test("loads only the selected final Codex agent message as finished", async () => {
+    const thread = {
+      id: "thread-final-message",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          startedAt: 1,
+          completedAt: 2,
+          items: [
+            { type: "agentMessage", phase: "commentary", text: "Working" },
+            { type: "agentMessage", phase: "final_answer", text: "Final answer" },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -1516,29 +1499,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-final-message",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                startedAt: 1,
-                completedAt: 2,
-                items: [
-                  { type: "agentMessage", phase: "commentary", text: "Working" },
-                  { type: "agentMessage", phase: "final_answer", text: "Final answer" },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -1561,7 +1527,27 @@ describe("CodexAppServerAdapter history loading", () => {
     ]);
   });
 
-  test("loads Codex session todos from thread-read plan items", async () => {
+  test("loads Codex session todos from paginated plan items", async () => {
+    const thread = {
+      id: "thread-plan-todos",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "plan-1",
+              type: "plan",
+              plan: [
+                { step: "Inspect", status: "completed" },
+                { step: "Fix hydration", status: "in_progress" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -1576,33 +1562,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-plan-todos",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                items: [
-                  {
-                    id: "plan-1",
-                    type: "plan",
-                    plan: [
-                      { step: "Inspect", status: "completed" },
-                      { step: "Fix hydration", status: "in_progress" },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -1622,7 +1587,30 @@ describe("CodexAppServerAdapter history loading", () => {
     ]);
   });
 
-  test("loads Codex session todos from thread-read plan text checklists", async () => {
+  test("loads Codex session todos from paginated plan text checklists", async () => {
+    const thread = {
+      id: "thread-plan-text-todos",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "plan-text-1",
+              type: "plan",
+              text: [
+                "- [x] First item",
+                "- [ ] Second item",
+                "- in progress: Third item",
+                "- pending: Fourth item",
+                "- pending: Fifth item",
+              ].join("\n"),
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -1642,36 +1630,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-plan-text-todos",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                items: [
-                  {
-                    id: "plan-text-1",
-                    type: "plan",
-                    text: [
-                      "- [x] First item",
-                      "- [ ] Second item",
-                      "- in progress: Third item",
-                      "- pending: Fourth item",
-                      "- pending: Fifth item",
-                    ].join("\n"),
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -1694,7 +1658,31 @@ describe("CodexAppServerAdapter history loading", () => {
     ]);
   });
 
-  test("loads Codex session todos from thread-read named todo tool inputs", async () => {
+  test("loads Codex session todos from paginated named todo tool inputs", async () => {
+    const thread = {
+      id: "thread-named-todos",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "todo-call-1",
+              type: "dynamicToolCall",
+              namespace: "functions",
+              name: "update_plan",
+              input: JSON.stringify({
+                plan: [
+                  { step: "Inspect", status: "completed" },
+                  { step: "Fix latest todo", status: "in_progress" },
+                ],
+              }),
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -1709,37 +1697,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-named-todos",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                items: [
-                  {
-                    id: "todo-call-1",
-                    type: "dynamicToolCall",
-                    namespace: "functions",
-                    name: "update_plan",
-                    input: JSON.stringify({
-                      plan: [
-                        { step: "Inspect", status: "completed" },
-                        { step: "Fix latest todo", status: "in_progress" },
-                      ],
-                    }),
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -1759,7 +1722,33 @@ describe("CodexAppServerAdapter history loading", () => {
     ]);
   });
 
-  test("loads Codex session todos from thread-read JSON arguments", async () => {
+  test("loads Codex session todos from paginated JSON arguments", async () => {
+    const thread = {
+      id: "thread-json-todos",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "todo-call-1",
+              type: "dynamicToolCall",
+              namespace: "functions",
+              tool: "update_plan",
+              status: "completed",
+              success: true,
+              arguments: JSON.stringify({
+                plan: [
+                  { step: "Map paginated history", status: "completed" },
+                  { step: "Hydrate todos", status: "in_progress" },
+                ],
+              }),
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -1774,39 +1763,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-json-todos",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                items: [
-                  {
-                    id: "todo-call-1",
-                    type: "dynamicToolCall",
-                    namespace: "functions",
-                    tool: "update_plan",
-                    status: "completed",
-                    success: true,
-                    arguments: JSON.stringify({
-                      plan: [
-                        { step: "Map thread/read", status: "completed" },
-                        { step: "Hydrate todos", status: "in_progress" },
-                      ],
-                    }),
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);
@@ -1821,12 +1783,41 @@ describe("CodexAppServerAdapter history loading", () => {
         runtimePolicy: { kind: "codex", policy: defaultCodexEffectivePolicy() },
       }),
     ).resolves.toEqual([
-      expect.objectContaining({ content: "Map thread/read", status: "completed" }),
+      expect.objectContaining({ content: "Map paginated history", status: "completed" }),
       expect.objectContaining({ content: "Hydrate todos", status: "in_progress" }),
     ]);
   });
 
-  test("ignores failed or incomplete Codex thread-read todo tool calls", async () => {
+  test("ignores failed or incomplete Codex paginated todo tool calls", async () => {
+    const thread = {
+      id: "thread-bad-todos",
+      cwd: "/repo",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              id: "todo-call-running",
+              type: "dynamicToolCall",
+              namespace: "functions",
+              tool: "update_plan",
+              status: "running",
+              arguments: { plan: [{ step: "Do not show", status: "in_progress" }] },
+            },
+            {
+              id: "todo-call-failed",
+              type: "dynamicToolCall",
+              namespace: "functions",
+              tool: "todo_write",
+              status: "completed",
+              success: false,
+              arguments: { todo: [{ step: "Also hidden", status: "pending" }] },
+            },
+          ],
+        },
+      ],
+    };
     const transport: CodexJsonRpcTransport = {
       async request<Response>(request: CodexJsonRpcRequest): Promise<Response> {
         if (request.method === "thread/loaded/list") {
@@ -1841,42 +1832,12 @@ describe("CodexAppServerAdapter history loading", () => {
           } as Response;
         }
         if (request.method === "thread/turns/list") {
-          return { data: [], nextCursor: null } as Response;
+          return paginatedTurnsListResponse(thread) as Response;
         }
         if (request.method !== "thread/read") {
           throw new Error(`Unexpected method '${request.method}'.`);
         }
-        return {
-          thread: {
-            id: "thread-bad-todos",
-            cwd: "/repo",
-            turns: [
-              {
-                id: "turn-1",
-                status: "completed",
-                items: [
-                  {
-                    id: "todo-call-running",
-                    type: "dynamicToolCall",
-                    namespace: "functions",
-                    tool: "update_plan",
-                    status: "running",
-                    arguments: { plan: [{ step: "Do not show", status: "in_progress" }] },
-                  },
-                  {
-                    id: "todo-call-failed",
-                    type: "dynamicToolCall",
-                    namespace: "functions",
-                    tool: "todo_write",
-                    status: "completed",
-                    success: false,
-                    arguments: { todo: [{ step: "Also hidden", status: "pending" }] },
-                  },
-                ],
-              },
-            ],
-          },
-        } as Response;
+        return paginatedThreadReadResponse(thread) as Response;
       },
     };
     const adapter = createAdapterWithTransport(transport);

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.lifecycle.test.ts
@@ -128,6 +128,7 @@ describe("CodexAppServerAdapter lifecycle", () => {
         ...expectedThreadPolicy,
         cwd: "/repo",
         developerInstructions: "Use the repo rules.",
+        historyMode: "paginated",
         model: "gpt-5",
         effort: "medium",
       },
@@ -242,6 +243,7 @@ describe("CodexAppServerAdapter lifecycle", () => {
       threadId: "thread-9",
       cwd: "/repo",
       developerInstructions: "Carry forward the plan.",
+      excludeTurns: true,
       model: "gpt-5",
       effort: "medium",
     });
@@ -250,6 +252,7 @@ describe("CodexAppServerAdapter lifecycle", () => {
       threadId: "thread-7",
       cwd: "/repo",
       developerInstructions: "Review the fork.",
+      excludeTurns: true,
       model: "gpt-5",
       effort: "medium",
     });
@@ -358,6 +361,7 @@ describe("CodexAppServerAdapter lifecycle", () => {
       sandbox: "workspace-write",
       cwd: "/repo",
       developerInstructions: "Use the repo rules.",
+      historyMode: "paginated",
       model: "gpt-5",
       effort: "medium",
     });
@@ -814,6 +818,7 @@ describe("CodexAppServerAdapter lifecycle", () => {
         ...expectedThreadPolicy,
         cwd: "/repo/worktree-task-1",
         developerInstructions: "Use the repo rules.",
+        historyMode: "paginated",
         model: "gpt-5",
         effort: "medium",
       },

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.runtime-snapshot.test.ts
@@ -600,6 +600,9 @@ describe("CodexAppServerAdapter runtime snapshots", () => {
     expect(resumeIndex).toBeGreaterThanOrEqual(0);
     expect(turnStartIndex).toBeGreaterThanOrEqual(0);
     expect(resumeIndex).toBeLessThan(turnStartIndex);
+    expect(transport.calls[resumeIndex]?.params).toEqual(
+      expect.objectContaining({ threadId: "thread-idle", excludeTurns: true }),
+    );
   });
 
   test("lists loaded Codex sessions from App Server", async () => {

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -323,26 +323,6 @@ export class RecordingTransport implements CodexJsonRpcTransport {
           method === "thread/resume"
             ? (params as { threadId: string }).threadId
             : `${method}-${this.runtimeId}`;
-        const turns =
-          method === "thread/resume" &&
-          (threadId === "thread-idle" || threadId === "thread/start-runtime-live")
-            ? [
-                {
-                  id: "turn-1",
-                  startedAt: 1_778_112_001,
-                  completedAt: 1_778_112_031,
-                  status: "completed",
-                  items: [
-                    {
-                      id: "msg-1",
-                      type: "agentMessage",
-                      phase: "final_answer",
-                      text: "Hello from history",
-                    },
-                  ],
-                },
-              ]
-            : [];
         return {
           thread: {
             id: threadId,
@@ -351,7 +331,7 @@ export class RecordingTransport implements CodexJsonRpcTransport {
             preview: "Live Codex session",
             status:
               threadId === "thread-idle" ? { type: "idle" } : { type: "active", activeFlags: [] },
-            turns,
+            turns: [],
           },
           startedAt: "2026-05-07T00:00:00.000Z",
         } as Response;

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.test-harness.ts
@@ -145,6 +145,134 @@ export const createRuntimeStreamSubscription = () => {
 
 export const createDeferred = <T>(): PromiseWithResolvers<T> => Promise.withResolvers<T>();
 
+const recordingTransportHistoryTurns = () => [
+  {
+    id: "turn-1",
+    startedAt: 1_778_112_001,
+    completedAt: 1_778_112_031,
+    status: "completed",
+    items: [
+      {
+        id: "user-history-1",
+        type: "userMessage",
+        content: [{ type: "text", text: "Hello Codex" }],
+      },
+      {
+        id: "reason-1",
+        type: "reasoning",
+        summary: ["Thinking"],
+        content: [],
+      },
+      {
+        id: "cmd-read-1",
+        type: "commandExecution",
+        command: "cat src/app.ts",
+        cwd: "/repo",
+        processId: "pty-1",
+        source: "model",
+        status: "completed",
+        commandActions: [
+          {
+            type: "read",
+            command: "cat src/app.ts",
+            name: "app.ts",
+            path: "/repo/src/app.ts",
+          },
+        ],
+        aggregatedOutput: "export const app = true;",
+        exitCode: 0,
+        durationMs: 12,
+      },
+      {
+        id: "cmd-bash-1",
+        type: "command_execution",
+        command: "bun test",
+        cwd: "/repo",
+        processId: "pty-2",
+        source: "model",
+        status: "completed",
+        command_actions: [{ type: "unknown", command: "bun test" }],
+        aggregated_output: "1 pass",
+        exitCode: 0,
+        durationMs: 34,
+      },
+      {
+        id: "file-change-1",
+        type: "fileChange",
+        status: "completed",
+        changes: [
+          {
+            path: "/repo/src/app.ts",
+            kind: "update",
+            diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new",
+          },
+        ],
+      },
+      {
+        id: "file-change-failed-1",
+        type: "fileChange",
+        status: "failed",
+        error: "patch failed",
+        changes: [
+          {
+            path: "/repo/src/broken.ts",
+            kind: "update",
+            diff: "--- a/src/broken.ts\n+++ b/src/broken.ts\n@@\n-old\n+broken",
+          },
+        ],
+      },
+      {
+        id: "dynamic-tool-1",
+        type: "dynamicToolCall",
+        namespace: "codex",
+        tool: "read",
+        arguments: { path: "/repo/README.md" },
+        status: "completed",
+        contentItems: [{ type: "inputText", text: "README" }],
+        success: true,
+        durationMs: 5,
+      },
+      {
+        id: "web-search-1",
+        type: "webSearch",
+        query: "OpenDucktor Codex runtime",
+        output: "search results",
+        action: null,
+      },
+      {
+        id: "tool-1",
+        type: "mcpToolCall",
+        server: "openducktor",
+        tool: "odt_read_task",
+        status: "completed",
+        arguments: { taskId: "task-1" },
+        result: { content: [{ type: "text", text: "ok" }] },
+      },
+      {
+        id: "tool-failed-1",
+        type: "mcpToolCall",
+        server: "openducktor",
+        tool: "odt_read_task",
+        status: "completed",
+        arguments: { taskId: "missing" },
+        result: { isError: true, message: "task missing" },
+      },
+      {
+        id: "msg-1",
+        type: "agentMessage",
+        phase: "final_answer",
+        text: "Hello from history",
+      },
+      {
+        id: "msg-commentary-1",
+        type: "agentMessage",
+        phase: "commentary",
+        text: "Later commentary",
+      },
+    ],
+  },
+];
+
 export class RecordingTransport implements CodexJsonRpcTransport {
   readonly calls: CodexJsonRpcRequest[] = [];
   readonly turnStartDeferred = createDeferred<unknown>();
@@ -274,133 +402,7 @@ export class RecordingTransport implements CodexJsonRpcTransport {
             createdAt: 1_778_112_000,
             preview: "Live Codex session",
             status: { type: "active", activeFlags: [] },
-            turns: [
-              {
-                id: "turn-1",
-                startedAt: 1_778_112_001,
-                completedAt: 1_778_112_031,
-                status: "completed",
-                items: [
-                  {
-                    id: "user-history-1",
-                    type: "userMessage",
-                    content: [{ type: "text", text: "Hello Codex" }],
-                  },
-                  {
-                    id: "reason-1",
-                    type: "reasoning",
-                    summary: ["Thinking"],
-                    content: [],
-                  },
-                  {
-                    id: "cmd-read-1",
-                    type: "commandExecution",
-                    command: "cat src/app.ts",
-                    cwd: "/repo",
-                    processId: "pty-1",
-                    source: "model",
-                    status: "completed",
-                    commandActions: [
-                      {
-                        type: "read",
-                        command: "cat src/app.ts",
-                        name: "app.ts",
-                        path: "/repo/src/app.ts",
-                      },
-                    ],
-                    aggregatedOutput: "export const app = true;",
-                    exitCode: 0,
-                    durationMs: 12,
-                  },
-                  {
-                    id: "cmd-bash-1",
-                    type: "command_execution",
-                    command: "bun test",
-                    cwd: "/repo",
-                    processId: "pty-2",
-                    source: "model",
-                    status: "completed",
-                    command_actions: [{ type: "unknown", command: "bun test" }],
-                    aggregated_output: "1 pass",
-                    exitCode: 0,
-                    durationMs: 34,
-                  },
-                  {
-                    id: "file-change-1",
-                    type: "fileChange",
-                    status: "completed",
-                    changes: [
-                      {
-                        path: "/repo/src/app.ts",
-                        kind: "update",
-                        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@\n-old\n+new",
-                      },
-                    ],
-                  },
-                  {
-                    id: "file-change-failed-1",
-                    type: "fileChange",
-                    status: "failed",
-                    error: "patch failed",
-                    changes: [
-                      {
-                        path: "/repo/src/broken.ts",
-                        kind: "update",
-                        diff: "--- a/src/broken.ts\n+++ b/src/broken.ts\n@@\n-old\n+broken",
-                      },
-                    ],
-                  },
-                  {
-                    id: "dynamic-tool-1",
-                    type: "dynamicToolCall",
-                    namespace: "codex",
-                    tool: "read",
-                    arguments: { path: "/repo/README.md" },
-                    status: "completed",
-                    contentItems: [{ type: "inputText", text: "README" }],
-                    success: true,
-                    durationMs: 5,
-                  },
-                  {
-                    id: "web-search-1",
-                    type: "webSearch",
-                    query: "OpenDucktor Codex runtime",
-                    output: "search results",
-                    action: null,
-                  },
-                  {
-                    id: "tool-1",
-                    type: "mcpToolCall",
-                    server: "openducktor",
-                    tool: "odt_read_task",
-                    status: "completed",
-                    arguments: { taskId: "task-1" },
-                    result: { content: [{ type: "text", text: "ok" }] },
-                  },
-                  {
-                    id: "tool-failed-1",
-                    type: "mcpToolCall",
-                    server: "openducktor",
-                    tool: "odt_read_task",
-                    status: "completed",
-                    arguments: { taskId: "missing" },
-                    result: { isError: true, message: "task missing" },
-                  },
-                  {
-                    id: "msg-1",
-                    type: "agentMessage",
-                    phase: "final_answer",
-                    text: "Hello from history",
-                  },
-                  {
-                    id: "msg-commentary-1",
-                    type: "agentMessage",
-                    phase: "commentary",
-                    text: "Later commentary",
-                  },
-                ],
-              },
-            ],
+            turns: [],
           },
         } as Response;
       case "thread/loaded/list":
@@ -434,7 +436,7 @@ export class RecordingTransport implements CodexJsonRpcTransport {
           backwardsCursor: null,
         } as Response;
       case "thread/turns/list":
-        return { data: [] } as Response;
+        return { data: recordingTransportHistoryTurns(), nextCursor: null } as Response;
       case "turn/diff":
         return {
           data: [

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -623,6 +623,7 @@ export class CodexAppServerAdapter
       ...("systemPrompt" in input && input.systemPrompt
         ? { developerInstructions: input.systemPrompt }
         : {}),
+      excludeTurns: true,
       ...(model ? { model: toTransportModelSelection(model).model } : {}),
       ...(model ? { effort: toTransportModelSelection(model).effort } : {}),
     });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -334,6 +334,7 @@ export class CodexAppServerAdapter
       ...codexTransportPolicy(policy),
       cwd: input.workingDirectory,
       developerInstructions: input.systemPrompt,
+      historyMode: "paginated",
       model: transportModel.model,
       effort: transportModel.effort,
     });
@@ -373,6 +374,7 @@ export class CodexAppServerAdapter
       threadId: input.externalSessionId,
       cwd: input.workingDirectory,
       ...(input.systemPrompt ? { developerInstructions: input.systemPrompt } : {}),
+      excludeTurns: true,
       model: toTransportModelSelection(model).model,
       effort: toTransportModelSelection(model).effort,
     });
@@ -406,6 +408,7 @@ export class CodexAppServerAdapter
       threadId: input.parentExternalSessionId,
       cwd: input.workingDirectory,
       developerInstructions: input.systemPrompt,
+      excludeTurns: true,
       model: toTransportModelSelection(model).model,
       effort: toTransportModelSelection(model).effort,
     });

--- a/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-adapter.ts
@@ -344,6 +344,7 @@ export class CodexAppServerAdapter
     const session = sessionStateFromThreadStart(input, runtimeId, model, response, title);
     const { summary } = session;
     this.localSessions.remember(session);
+    this.runtimeEvents.initializeFreshThreadContextUsage(runtimeId, session.threadId);
     await client.threadSetName({
       threadId: session.threadId,
       name: title,

--- a/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
+++ b/packages/adapters-codex-app-server/src/codex-app-server-shared.ts
@@ -60,10 +60,13 @@ export const extractText = (value: unknown): string | null => {
 
 export const isCodexUnmaterializedThreadError = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : String(error);
-  return (
+  const inlineTurnsUnavailable =
     message.includes("is not materialized yet") &&
-    message.includes("includeTurns is unavailable before first user message")
+    message.includes("includeTurns is unavailable before first user message");
+  const paginatedTurnsUnavailable = message.includes(
+    "thread/turns/list is unavailable before first user message",
   );
+  return inlineTurnsUnavailable || paginatedTurnsUnavailable;
 };
 
 export const isCodexThreadNotLoadedError = (error: unknown): boolean => {

--- a/packages/adapters-codex-app-server/src/codex-context-usage-loader.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-loader.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   codexSessionRef,
+  codexSessionRuntimeRef,
   codexStartSessionInput,
   createDeferred,
   createHarness,
@@ -30,6 +31,22 @@ const blockResume = (transport: RecordingTransport) => {
 };
 
 describe("CodexContextUsageLoader", () => {
+  test("returns zero context for a fresh session without resuming its new thread", async () => {
+    const { adapter, transports } = createHarness();
+    await adapter.startSession(codexStartSessionInput());
+
+    await expect(
+      adapter.loadLiveSessionContextUsage({
+        runtimeId: "runtime-live",
+        externalSessionId: "thread/start-runtime-live",
+      }),
+    ).resolves.toEqual({ totalTokens: 0 });
+
+    expect(transports.get("runtime-live")?.calls).not.toContainEqual(
+      expect.objectContaining({ method: "thread/resume" }),
+    );
+  });
+
   test("cancels cold loads for released sessions and runtimes without late retention", async () => {
     for (const release of ["session", "runtime"] as const) {
       const runtimeStream = createRuntimeStreamSubscription();
@@ -103,7 +120,7 @@ describe("CodexContextUsageLoader", () => {
     const { adapter, transports } = createHarness({
       subscribeEvents: runtimeStream.subscribeEvents,
     });
-    await adapter.startSession(codexStartSessionInput());
+    await adapter.resumeSession(codexSessionRuntimeRef());
     const transport = transports.get("runtime-live");
     if (!transport) {
       throw new Error("Expected Codex transport.");

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.test.ts
@@ -15,6 +15,20 @@ const usageNotification = (lastTotalTokens: number, totalTokens = lastTotalToken
 });
 
 describe("CodexContextUsageTracker", () => {
+  test("initializes fresh threads at zero without replacing observed usage", () => {
+    const tracker = new CodexContextUsageTracker();
+    tracker.initializeFreshThread("runtime-live", "thread-idle");
+    expect(tracker.latest("runtime-live", "thread-idle")).toEqual({ totalTokens: 0 });
+
+    tracker.observeNotification("runtime-live", usageNotification(42_000));
+    tracker.initializeFreshThread("runtime-live", "thread-idle");
+
+    expect(tracker.latest("runtime-live", "thread-idle")).toEqual({
+      totalTokens: 42_000,
+      contextWindow: 200_000,
+    });
+  });
+
   test("accepts zero current usage with a positive cumulative total", () => {
     const tracker = new CodexContextUsageTracker();
     tracker.observeNotification("runtime-live", usageNotification(42_000));

--- a/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
+++ b/packages/adapters-codex-app-server/src/codex-context-usage-tracker.ts
@@ -42,6 +42,13 @@ export class CodexContextUsageTracker {
   private readonly latestByKey = new Map<string, CodexSessionContextUsage>();
   private readonly inFlightLoadsByKey = new Map<string, Promise<CodexSessionContextUsage | null>>();
 
+  initializeFreshThread(runtimeId: string, threadId: string): void {
+    const key = contextUsageKey(runtimeId, threadId);
+    if (!this.latestByKey.has(key)) {
+      this.latestByKey.set(key, { totalTokens: 0 });
+    }
+  }
+
   latest(runtimeId: string, threadId: string): CodexSessionContextUsage | null {
     return this.latestByKey.get(contextUsageKey(runtimeId, threadId)) ?? null;
   }

--- a/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
+++ b/packages/adapters-codex-app-server/src/codex-runtime-session-events.ts
@@ -239,6 +239,10 @@ export class CodexRuntimeSessionEvents {
     return this.contextUsage.latest(runtimeId, threadId);
   }
 
+  initializeFreshThreadContextUsage(runtimeId: string, threadId: string): void {
+    this.contextUsage.initializeFreshThread(runtimeId, threadId);
+  }
+
   loadSessionContextUsage(
     runtimeId: string,
     threadId: string,

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
@@ -157,14 +157,14 @@ describe("CodexThreadInventoryReader", () => {
     ]);
   });
 
-  test("rejects malformed summary turn entries instead of returning an incomplete id set", async () => {
+  test("rejects malformed summary turn entries at the pagination boundary", async () => {
     const reader = new CodexThreadInventoryReader();
     const client = {
       threadTurnsList: async () => ({ data: [null], nextCursor: null }),
     } as unknown as CodexAppServerClient;
 
     await expect(reader.readThreadTurnIds(client, "parent-thread")).rejects.toThrow(
-      "returned a summary turn without an id",
+      "Codex thread/turns/list response data[0] must be an object.",
     );
   });
 
@@ -550,6 +550,21 @@ describe("CodexThreadInventoryReader", () => {
         workingDirectory: "/repo",
       }),
     ).rejects.toThrow("Codex thread/turns/list response data must be an array.");
+  });
+
+  test("rejects malformed turns in paginated history", async () => {
+    const reader = new CodexThreadInventoryReader();
+    const client = {
+      threadRead: async () => threadReadResponse("thread-idle"),
+      threadTurnsList: async () => ({ data: [null], nextCursor: null }),
+    } as unknown as CodexAppServerClient;
+
+    await expect(
+      reader.readThreadHistory(client, {
+        externalSessionId: "thread-idle",
+        workingDirectory: "/repo",
+      }),
+    ).rejects.toThrow("Codex thread/turns/list response data[0] must be an object.");
   });
 
   test("returns null when read-only history has no stored thread", async () => {

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
@@ -647,7 +647,11 @@ describe("CodexThreadInventoryReader", () => {
     threads.resolve(threadListResponse("thread-idle", "Idle inventory"));
 
     await expect(pendingRead).resolves.toMatchObject({ runtimeId: "runtime-1" });
-    await expect(pendingHistoryLoad).resolves.toEqual(threadReadResponse("thread-idle"));
+    await expect(pendingHistoryLoad).resolves.toEqual(
+      threadReadResponse("thread-idle", "/repo", { type: "idle" }, [
+        { id: "turn-1", status: "completed", items: [] },
+      ]),
+    );
     expect(calls).toEqual([
       "thread/loaded/list",
       "thread/list",

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
@@ -450,15 +450,35 @@ describe("CodexThreadInventoryReader", () => {
 
   test("reads stored threads for history without resuming them", async () => {
     const reader = new CodexThreadInventoryReader();
-    const calls: string[] = [];
-    const client = {
-      threadRead: async () => {
-        calls.push("thread/read");
-        return threadReadResponse("thread-idle");
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const pagedTurns = [
+      {
+        id: "turn-1",
+        status: "completed",
+        itemsView: "full",
+        items: [
+          {
+            type: "userMessage",
+            id: "user-live-id",
+            content: [{ type: "text", text: "Inspect the transcript." }],
+          },
+          {
+            type: "agentMessage",
+            id: "msg-live-id",
+            text: "The transcript is intact.",
+            phase: "final_answer",
+          },
+        ],
       },
-      threadTurnsList: async () => {
-        calls.push("thread/turns/list");
-        return { data: [] };
+    ];
+    const client = {
+      threadRead: async (params: unknown) => {
+        calls.push({ method: "thread/read", params });
+        return threadReadResponse("thread-idle", "/repo", { type: "idle" }, []);
+      },
+      threadTurnsList: async (params: unknown) => {
+        calls.push({ method: "thread/turns/list", params });
+        return { data: pagedTurns, nextCursor: null };
       },
     } as unknown as CodexAppServerClient;
 
@@ -467,8 +487,25 @@ describe("CodexThreadInventoryReader", () => {
       workingDirectory: "/repo",
     });
 
-    expect(historyLoad).toEqual(threadReadResponse("thread-idle"));
-    expect(calls).toEqual(["thread/read", "thread/turns/list"]);
+    expect(historyLoad).toEqual(
+      threadReadResponse("thread-idle", "/repo", { type: "idle" }, pagedTurns),
+    );
+    expect(calls).toEqual([
+      {
+        method: "thread/read",
+        params: { threadId: "thread-idle", includeTurns: false },
+      },
+      {
+        method: "thread/turns/list",
+        params: {
+          threadId: "thread-idle",
+          cursor: null,
+          limit: 100,
+          sortDirection: "asc",
+          itemsView: "full",
+        },
+      },
+    ]);
   });
 
   test("returns null when read-only history has no stored thread", async () => {

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
@@ -537,6 +537,21 @@ describe("CodexThreadInventoryReader", () => {
     expect(historyLoad).toEqual(threadReadResponse("thread-idle", "/repo", { type: "idle" }, []));
   });
 
+  test("rejects malformed paginated turn data", async () => {
+    const reader = new CodexThreadInventoryReader();
+    const client = {
+      threadRead: async () => threadReadResponse("thread-idle"),
+      threadTurnsList: async () => ({ data: {}, nextCursor: null }),
+    } as unknown as CodexAppServerClient;
+
+    await expect(
+      reader.readThreadHistory(client, {
+        externalSessionId: "thread-idle",
+        workingDirectory: "/repo",
+      }),
+    ).rejects.toThrow("Codex thread/turns/list response data must be an array.");
+  });
+
   test("returns null when read-only history has no stored thread", async () => {
     const reader = new CodexThreadInventoryReader();
     const calls: string[] = [];
@@ -563,6 +578,24 @@ describe("CodexThreadInventoryReader", () => {
         throw new Error(
           "thread is not materialized yet: includeTurns is unavailable before first user message",
         );
+      },
+    } as unknown as CodexAppServerClient;
+
+    await expect(
+      reader.readThreadHistory(client, {
+        externalSessionId: "thread-local",
+        workingDirectory: "/repo",
+        allowUnmaterialized: true,
+      }),
+    ).resolves.toEqual({ thread: { id: "thread-local", cwd: "/repo", turns: [] } });
+  });
+
+  test("preserves empty history when paginated turns are unavailable before the first message", async () => {
+    const reader = new CodexThreadInventoryReader();
+    const client = {
+      threadRead: async () => threadReadResponse("thread-local"),
+      threadTurnsList: async () => {
+        throw new Error("thread/turns/list is unavailable before first user message");
       },
     } as unknown as CodexAppServerClient;
 

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
@@ -508,6 +508,35 @@ describe("CodexThreadInventoryReader", () => {
     ]);
   });
 
+  test("uses an empty paginated history instead of stale thread metadata turns", async () => {
+    const reader = new CodexThreadInventoryReader();
+    const client = {
+      threadRead: async () =>
+        threadReadResponse("thread-idle", "/repo", { type: "idle" }, [
+          {
+            id: "stale-turn",
+            status: "completed",
+            items: [
+              {
+                id: "stale-message",
+                type: "agentMessage",
+                phase: "final_answer",
+                text: "Stale metadata history",
+              },
+            ],
+          },
+        ]),
+      threadTurnsList: async () => ({ data: [], nextCursor: null }),
+    } as unknown as CodexAppServerClient;
+
+    const historyLoad = await reader.readThreadHistory(client, {
+      externalSessionId: "thread-idle",
+      workingDirectory: "/repo",
+    });
+
+    expect(historyLoad).toEqual(threadReadResponse("thread-idle", "/repo", { type: "idle" }, []));
+  });
+
   test("returns null when read-only history has no stored thread", async () => {
     const reader = new CodexThreadInventoryReader();
     const calls: string[] = [];
@@ -601,11 +630,11 @@ describe("CodexThreadInventoryReader", () => {
       },
       threadRead: async () => {
         calls.push("thread/read");
-        return threadReadResponse("thread-idle");
+        return threadReadResponse("thread-idle", "/repo", { type: "idle" }, []);
       },
       threadTurnsList: async () => {
         calls.push("thread/turns/list");
-        return { data: [] };
+        return { data: [{ id: "turn-1", status: "completed", items: [] }] };
       },
     } as unknown as CodexAppServerClient;
 

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.test.ts
@@ -567,6 +567,24 @@ describe("CodexThreadInventoryReader", () => {
     ).rejects.toThrow("Codex thread/turns/list response data[0] must be an object.");
   });
 
+  test("rejects paginated history turns without full items", async () => {
+    const reader = new CodexThreadInventoryReader();
+    const client = {
+      threadRead: async () => threadReadResponse("thread-idle"),
+      threadTurnsList: async () => ({
+        data: [{ id: "turn-1", items: null }],
+        nextCursor: null,
+      }),
+    } as unknown as CodexAppServerClient;
+
+    await expect(
+      reader.readThreadHistory(client, {
+        externalSessionId: "thread-idle",
+        workingDirectory: "/repo",
+      }),
+    ).rejects.toThrow("Codex thread/turns/list response data[0].items must be an array.");
+  });
+
   test("returns null when read-only history has no stored thread", async () => {
     const reader = new CodexThreadInventoryReader();
     const calls: string[] = [];

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
@@ -1,5 +1,4 @@
 import {
-  arrayFromUnknown,
   extractStringField,
   isCodexThreadNotLoadedError,
   isCodexUnmaterializedThreadError,
@@ -248,8 +247,10 @@ export class CodexThreadInventoryReader {
     unmaterializedWorkingDirectory?: string,
   ): Promise<unknown> {
     let response: unknown;
+    let pagedTurns: Record<string, unknown>[];
     try {
       response = await client.threadRead({ threadId, includeTurns: false });
+      pagedTurns = (await this.fetchThreadTurns(client, threadId, "full")).filter(isPlainObject);
     } catch (error) {
       if (isCodexUnmaterializedThreadError(error)) {
         return {
@@ -262,9 +263,6 @@ export class CodexThreadInventoryReader {
       }
       throw error;
     }
-    const pagedTurns = (await this.fetchThreadTurns(client, threadId, "full")).filter(
-      isPlainObject,
-    );
     if (!isPlainObject(response) || !isPlainObject(response.thread)) {
       return { thread: { id: threadId, turns: pagedTurns } };
     }
@@ -374,10 +372,11 @@ export class CodexThreadInventoryReader {
         sortDirection: "asc",
         itemsView,
       });
-      turns.push(...arrayFromUnknown(isPlainObject(response) ? response.data : undefined));
-      cursor = isPlainObject(response)
-        ? (extractStringField(response, ["nextCursor", "next_cursor"]) ?? null)
-        : null;
+      if (!isPlainObject(response) || !Array.isArray(response.data)) {
+        throw new Error("Codex thread/turns/list response data must be an array.");
+      }
+      turns.push(...response.data);
+      cursor = extractStringField(response, ["nextCursor", "next_cursor"]) ?? null;
       if (cursor && seenCursors.has(cursor)) {
         throw new Error("Codex thread/turns/list returned a repeated pagination cursor.");
       }

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
@@ -249,7 +249,7 @@ export class CodexThreadInventoryReader {
   ): Promise<unknown> {
     let response: unknown;
     try {
-      response = await client.threadRead({ threadId, includeTurns: true });
+      response = await client.threadRead({ threadId, includeTurns: false });
     } catch (error) {
       if (isCodexUnmaterializedThreadError(error)) {
         return {

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
@@ -374,7 +374,7 @@ export class CodexThreadInventoryReader {
         sortDirection: "asc",
         itemsView,
       });
-      turns.push(...arrayFromUnknown(response));
+      turns.push(...arrayFromUnknown(isPlainObject(response) ? response.data : undefined));
       cursor = isPlainObject(response)
         ? (extractStringField(response, ["nextCursor", "next_cursor"]) ?? null)
         : null;

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
@@ -265,9 +265,6 @@ export class CodexThreadInventoryReader {
     const pagedTurns = (await this.fetchThreadTurns(client, threadId, "full")).filter(
       isPlainObject,
     );
-    if (pagedTurns.length === 0) {
-      return response;
-    }
     if (!isPlainObject(response) || !isPlainObject(response.thread)) {
       return { thread: { id: threadId, turns: pagedTurns } };
     }

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
@@ -250,7 +250,7 @@ export class CodexThreadInventoryReader {
     let pagedTurns: Record<string, unknown>[];
     try {
       response = await client.threadRead({ threadId, includeTurns: false });
-      pagedTurns = (await this.fetchThreadTurns(client, threadId, "full")).filter(isPlainObject);
+      pagedTurns = await this.fetchThreadTurns(client, threadId, "full");
     } catch (error) {
       if (isCodexUnmaterializedThreadError(error)) {
         return {
@@ -357,8 +357,8 @@ export class CodexThreadInventoryReader {
     client: CodexAppServerClient,
     threadId: string,
     itemsView: "full" | "summary",
-  ): Promise<unknown[]> {
-    const turns: unknown[] = [];
+  ): Promise<Record<string, unknown>[]> {
+    const turns: Record<string, unknown>[] = [];
     let cursor: string | null = null;
     const seenCursors = new Set<string>();
     do {
@@ -375,7 +375,12 @@ export class CodexThreadInventoryReader {
       if (!isPlainObject(response) || !Array.isArray(response.data)) {
         throw new Error("Codex thread/turns/list response data must be an array.");
       }
-      turns.push(...response.data);
+      for (const [turnIndex, turn] of response.data.entries()) {
+        if (!isPlainObject(turn)) {
+          throw new Error(`Codex thread/turns/list response data[${turnIndex}] must be an object.`);
+        }
+        turns.push(turn);
+      }
       cursor = extractStringField(response, ["nextCursor", "next_cursor"]) ?? null;
       if (cursor && seenCursors.has(cursor)) {
         throw new Error("Codex thread/turns/list returned a repeated pagination cursor.");

--- a/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
+++ b/packages/adapters-codex-app-server/src/codex-thread-inventory.ts
@@ -379,6 +379,11 @@ export class CodexThreadInventoryReader {
         if (!isPlainObject(turn)) {
           throw new Error(`Codex thread/turns/list response data[${turnIndex}] must be an object.`);
         }
+        if (itemsView === "full" && !Array.isArray(turn.items)) {
+          throw new Error(
+            `Codex thread/turns/list response data[${turnIndex}].items must be an array.`,
+          );
+        }
         turns.push(turn);
       }
       cursor = extractStringField(response, ["nextCursor", "next_cursor"]) ?? null;

--- a/packages/adapters-codex-app-server/src/types.ts
+++ b/packages/adapters-codex-app-server/src/types.ts
@@ -197,6 +197,7 @@ export type CodexThreadStartParams = {
   approvalsReviewer: CodexAppServerApprovalsReviewer | null;
   cwd: string;
   developerInstructions: string;
+  historyMode: "paginated";
   sandbox: CodexAppServerSandboxMode;
   model: string;
   effort: string;
@@ -220,6 +221,7 @@ export type CodexThreadForkParams = {
   threadId: string;
   cwd: string;
   developerInstructions: string;
+  excludeTurns: boolean;
   sandbox: CodexAppServerSandboxMode;
   model: string;
   effort: string;

--- a/packages/contracts/src/codex-app-server-protocol.ts
+++ b/packages/contracts/src/codex-app-server-protocol.ts
@@ -156,6 +156,7 @@ export type CodexAppServerThread = {
   ephemeral: boolean;
   forkedFromId: string | null;
   gitInfo: CodexAppServerJsonValue | null;
+  historyMode: CodexAppServerThreadHistoryMode;
   id: string;
   modelProvider: string;
   name: string | null;
@@ -169,6 +170,7 @@ export type CodexAppServerThread = {
   turns: CodexAppServerTurn[];
   updatedAt: number;
 };
+export type CodexAppServerThreadHistoryMode = "legacy" | "paginated";
 export type CodexAppServerTurn = {
   completedAt: number | null;
   durationMs: number | null;
@@ -188,6 +190,7 @@ export type CodexAppServerThreadStartParams = {
   cwd?: string | null;
   developerInstructions?: string | null;
   ephemeral?: boolean | null;
+  historyMode?: CodexAppServerThreadHistoryMode | null;
   model?: string | null;
   modelProvider?: string | null;
   personality?: CodexAppServerPersonality | null;
@@ -199,8 +202,9 @@ export type CodexAppServerThreadStartParams = {
 };
 export type CodexAppServerThreadResumeParams = Omit<
   CodexAppServerThreadStartParams,
-  "ephemeral" | "serviceName" | "sessionStartSource" | "threadSource"
+  "ephemeral" | "historyMode" | "serviceName" | "sessionStartSource" | "threadSource"
 > & {
+  excludeTurns?: boolean | null;
   threadId: string;
 };
 export type CodexAppServerThreadForkParams = CodexAppServerThreadResumeParams & {

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -637,6 +637,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "runtimeWorkingDirectoryRefSchema",
   "runtimeWorkflowCapabilitiesSchema",
   "searchTasksResultSchema",
+  "sessionHistoryFailureSchema",
   "SearchTasksInputSchema",
   "setPlanResultSchema",
   "SetPlanInputSchema",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -23,6 +23,7 @@ export * from "./prompt-schemas";
 export * from "./pull-request-review-schemas";
 export * from "./run-schemas";
 export * from "./runtime-descriptors";
+export * from "./session-history-failure-schemas";
 export * from "./session-schemas";
 export * from "./session-todo-parsing";
 export * from "./skill-schemas";

--- a/packages/contracts/src/session-history-failure-schemas.ts
+++ b/packages/contracts/src/session-history-failure-schemas.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const sessionHistoryFailureSchema = z
+  .object({
+    code: z.enum(["invalid_runtime_response", "request_failed"]),
+    summary: z.string().min(1),
+    detail: z.string().min(1),
+    diagnosticId: z.string().min(1).optional(),
+    method: z.string().min(1).optional(),
+    pageCursor: z.string().min(1).nullable().optional(),
+  })
+  .strict();
+
+export type SessionHistoryFailure = z.infer<typeof sessionHistoryFailureSchema>;

--- a/packages/contracts/src/terminal-schemas.ts
+++ b/packages/contracts/src/terminal-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { sessionHistoryFailureSchema } from "./session-history-failure-schemas";
 
 export const TERMINAL_ID_MAX_LENGTH = 128;
 export const terminalIdSchema = z.string().trim().min(1).max(TERMINAL_ID_MAX_LENGTH);
@@ -103,6 +104,12 @@ export const hostInvokeFailureSchema = z.discriminatedUnion("kind", [
     .object({
       kind: z.literal("terminal"),
       terminalFailure: terminalFailureSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("session_history"),
+      sessionHistoryFailure: sessionHistoryFailureSchema,
     })
     .strict(),
 ]);

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-test-fixtures.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-test-fixtures.ts
@@ -139,6 +139,9 @@ export const buildThreadTranscriptState = (
     ? {
         kind: "failed",
         message: transcriptState.message ?? "The selected conversation could not be loaded.",
+        ...("historyFailure" in transcriptState
+          ? { historyFailure: transcriptState.historyFailure }
+          : {}),
       }
     : transcriptState;
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread-state.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread-state.test.ts
@@ -18,6 +18,15 @@ const readyRuntimeReadiness = {
   refreshChecks: async () => {},
 };
 
+const historyFailure = {
+  code: "invalid_runtime_response" as const,
+  summary: "Codex returned invalid conversation history.",
+  detail: "Codex thread/turns/list response data[0] must be an object",
+  diagnosticId: "diagnostic-1",
+  method: "thread/turns/list",
+  pageCursor: null,
+};
+
 describe("projectAgentChatThreadState", () => {
   test("keeps the session renderable when the transcript is visible", () => {
     const session = buildSession({
@@ -128,15 +137,49 @@ describe("projectAgentChatThreadState", () => {
     const state = projectAgentChatThreadState({
       sessionKey: null,
       session: null,
-      transcriptState: buildThreadTranscriptState({ kind: "failed" }),
+      transcriptState: buildThreadTranscriptState({
+        kind: "failed",
+        message: historyFailure.summary,
+        historyFailure,
+      }),
       runtimeReadiness: readyRuntimeReadiness,
     });
 
     expect(state.transcriptNotice).toEqual({
       kind: "session_failed",
       severity: "error",
-      title: "Failed to load session",
-      description: "The selected conversation could not be loaded.",
+      title: "Couldn't load conversation history",
+      description: "Codex returned invalid conversation history.",
+      details: [
+        { label: "Error", value: historyFailure.detail },
+        { label: "Method", value: "thread/turns/list" },
+        { label: "Page cursor", value: "First page" },
+        { label: "Diagnostic ID", value: "diagnostic-1" },
+      ],
+    });
+  });
+
+  test("keeps an existing transcript visible with an incomplete-history warning", () => {
+    const session = buildSession();
+    const state = projectAgentChatThreadState({
+      sessionKey: agentSessionIdentityKey(session),
+      session,
+      transcriptState: buildThreadTranscriptState({ kind: "visible", historyFailure }),
+      runtimeReadiness: readyRuntimeReadiness,
+    });
+
+    expect(state.threadSession).toBe(session);
+    expect(state.transcriptNotice).toEqual({
+      kind: "session_history_warning",
+      severity: "error",
+      title: "History may be incomplete",
+      description: "Codex returned invalid conversation history.",
+      details: [
+        { label: "Error", value: historyFailure.detail },
+        { label: "Method", value: "thread/turns/list" },
+        { label: "Page cursor", value: "First page" },
+        { label: "Diagnostic ID", value: "diagnostic-1" },
+      ],
     });
   });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
@@ -1,3 +1,4 @@
+import type { SessionHistoryFailure } from "@openducktor/contracts";
 import type { RepoRuntimeReadiness } from "@/lib/use-repo-runtime-readiness";
 import {
   type AgentSessionTranscriptState,
@@ -23,6 +24,34 @@ type ProjectAgentChatThreadStateArgs = {
   runtimeReadiness: RepoRuntimeReadiness;
   failedTranscriptAction?: AgentChatTranscriptNoticeAction | null | undefined;
 };
+
+const sessionHistoryFailureDetails = (
+  failure: SessionHistoryFailure,
+): Array<{ label: string; value: string }> => [
+  { label: "Error", value: failure.detail },
+  ...(failure.method ? [{ label: "Method", value: failure.method }] : []),
+  ...(failure.pageCursor !== undefined
+    ? [{ label: "Page cursor", value: failure.pageCursor ?? "First page" }]
+    : []),
+  ...(failure.diagnosticId ? [{ label: "Diagnostic ID", value: failure.diagnosticId }] : []),
+];
+
+const sessionHistoryFailureNotice = ({
+  failure,
+  hasTranscript,
+  action,
+}: {
+  failure: SessionHistoryFailure;
+  hasTranscript: boolean;
+  action?: AgentChatTranscriptNoticeAction | null | undefined;
+}): AgentChatTranscriptNotice => ({
+  kind: hasTranscript ? "session_history_warning" : "session_failed",
+  severity: "error",
+  title: hasTranscript ? "History may be incomplete" : "Couldn't load conversation history",
+  description: failure.summary,
+  details: sessionHistoryFailureDetails(failure),
+  ...(action ? { action } : {}),
+});
 
 const deriveAgentChatTranscriptNotice = ({
   transcriptState,
@@ -69,7 +98,23 @@ const deriveAgentChatTranscriptNotice = ({
     };
   }
 
+  if (transcriptState.kind === "visible" && transcriptState.historyFailure) {
+    return sessionHistoryFailureNotice({
+      failure: transcriptState.historyFailure,
+      hasTranscript: true,
+      action: failedTranscriptAction,
+    });
+  }
+
   if (transcriptState.kind === "failed") {
+    if (transcriptState.historyFailure) {
+      return sessionHistoryFailureNotice({
+        failure: transcriptState.historyFailure,
+        hasTranscript: false,
+        action: failedTranscriptAction,
+      });
+    }
+
     return {
       kind: "session_failed",
       severity: "error",

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -378,19 +378,34 @@ describe("AgentChatThread", () => {
   });
 
   test("renders failed session loading state instead of a blank transcript", () => {
+    const failure = {
+      code: "invalid_runtime_response" as const,
+      summary: "Codex returned invalid conversation history.",
+      detail: "Codex thread/turns/list response data[0] must be an object",
+      diagnosticId: "diagnostic-1",
+      method: "thread/turns/list",
+      pageCursor: null,
+    };
     const html = renderToStaticMarkup(
       createElement(AgentChatThread, {
         model: {
           ...buildBaseModel(),
-          transcriptState: buildThreadTranscriptState({ kind: "failed" }),
+          transcriptState: buildThreadTranscriptState({
+            kind: "failed",
+            message: failure.summary,
+            historyFailure: failure,
+          }),
           isInteractionEnabled: false,
           session: null,
         },
       }),
     );
 
-    expect(html).toContain("Failed to load session");
-    expect(html).toContain("The selected conversation could not be loaded.");
+    expect(html).toContain("Couldn&#x27;t load conversation history");
+    expect(html).toContain("Codex returned invalid conversation history.");
+    expect(html).toContain("Show details");
+    expect(html).toContain("Codex thread/turns/list response data[0] must be an object");
+    expect(html).toContain("diagnostic-1");
     expect(html).not.toContain("Send a message to start a new session automatically.");
   });
 

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -83,6 +83,19 @@ const AgentChatTranscriptNotice = memo(function AgentChatTranscriptNotice({
             {notice.title}
           </p>
           <p className={isLoadingNotice ? "text-muted-foreground" : ""}>{notice.description}</p>
+          {notice.details && notice.details.length > 0 ? (
+            <details className="mt-2">
+              <summary className="cursor-pointer select-none font-medium">Show details</summary>
+              <dl className="mt-2 space-y-1 text-xs">
+                {notice.details.map((detail) => (
+                  <div key={detail.label} className="grid grid-cols-[auto_1fr] gap-2">
+                    <dt className="font-medium">{detail.label}</dt>
+                    <dd className="min-w-0 break-words font-mono">{detail.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </details>
+          ) : null}
         </div>
         {action ? (
           <Button

--- a/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/packages/frontend/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -58,10 +58,16 @@ export type AgentChatTranscriptNoticeAction = {
 };
 
 export type AgentChatTranscriptNotice = {
-  kind: "runtime_waiting" | "session_loading" | "session_failed" | "runtime_blocked";
+  kind:
+    | "runtime_waiting"
+    | "session_loading"
+    | "session_failed"
+    | "session_history_warning"
+    | "runtime_blocked";
   severity: "loading" | "error";
   title: string;
   description: string;
+  details?: Array<{ label: string; value: string }>;
   action?: AgentChatTranscriptNoticeAction;
 };
 

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-orchestration-shell-model.ts
@@ -28,6 +28,7 @@ type UseAgentsPageOrchestrationShellModelArgs = {
     ReturnType<typeof useAgentOperations>,
     | "sendAgentMessage"
     | "stopAgentSession"
+    | "loadAgentSessionHistory"
     | "updateAgentSessionModel"
     | "replyAgentApproval"
     | "answerAgentQuestion"
@@ -109,6 +110,7 @@ export function useAgentsPageOrchestrationShellModel({
       runSessionStartWorkflow,
       sendAgentMessage: agentOperations.sendAgentMessage,
       stopAgentSession: agentOperations.stopAgentSession,
+      loadAgentSessionHistory: agentOperations.loadAgentSessionHistory,
       updateAgentSessionModel: agentOperations.updateAgentSessionModel,
       humanRequestChangesTask,
       setTaskTargetBranch,

--- a/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/packages/frontend/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -77,6 +77,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     startAgentSession,
     sendAgentMessage,
     stopAgentSession,
+    loadAgentSessionHistory,
     updateAgentSessionModel,
     replyAgentApproval,
     answerAgentQuestion,
@@ -145,6 +146,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     agentOperations: {
       sendAgentMessage,
       stopAgentSession,
+      loadAgentSessionHistory,
       updateAgentSessionModel,
       replyAgentApproval,
       answerAgentQuestion,

--- a/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-chat-model.ts
@@ -38,6 +38,7 @@ export type AgentStudioChatSessionActionsContext = {
   startLaunchKickoff: () => Promise<void>;
   onSend: (draft: AgentChatComposerDraft) => Promise<boolean>;
   stopAgentSession: AgentOperationsContextValue["stopAgentSession"];
+  loadAgentSessionHistory: AgentOperationsContextValue["loadAgentSessionHistory"];
 };
 
 export type AgentStudioChatModelSelectionContext = {
@@ -197,6 +198,24 @@ export function useAgentStudioChatModel({
     ],
   );
   const failedTranscriptAction = useMemo(() => {
+    const historyLoadFailed =
+      (selectedSessionTranscriptState.kind === "failed" &&
+        selectedSessionTranscriptState.historyFailure != null) ||
+      (selectedSessionTranscriptState.kind === "visible" &&
+        selectedSessionTranscriptState.historyFailure != null);
+    if (
+      historyLoadFailed &&
+      selectedSessionIdentity !== null &&
+      selectedSessionState.loadedSession !== null
+    ) {
+      return {
+        label: "Retry",
+        onAction: () => {
+          void sessionActions.loadAgentSessionHistory(selectedSessionIdentity);
+        },
+      };
+    }
+
     if (
       selectedSessionTranscriptState.kind !== "failed" ||
       selectedSessionState.loadedSession !== null ||
@@ -211,9 +230,11 @@ export function useAgentStudioChatModel({
     };
   }, [
     reloadSessionReadModel,
+    selectedSessionIdentity,
     selectedSessionState.loadedSession,
     selectedSessionAuxiliaryError,
-    selectedSessionTranscriptState.kind,
+    selectedSessionTranscriptState,
+    sessionActions.loadAgentSessionHistory,
     sessionReadModelLoadState.kind,
   ]);
   const draftStateKey = agentStudioChatDraftScopeKey(composer.workspaceId, composer.draftScope);

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -73,6 +73,7 @@ const baseSessionActions = {
   approvalReplyErrorByRequestId: {},
   onReplyApproval: async () => {},
   stopAgentSession: async () => {},
+  loadAgentSessionHistory: async () => null,
 };
 const baseDocuments = {
   specDoc: taskDocument,

--- a/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/packages/frontend/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -41,6 +41,7 @@ type AgentStudioOrchestrationActionsContext = {
   runSessionStartWorkflow: RunSessionStartWorkflow;
   sendAgentMessage: AgentOperationsContextValue["sendAgentMessage"];
   stopAgentSession: AgentOperationsContextValue["stopAgentSession"];
+  loadAgentSessionHistory: AgentOperationsContextValue["loadAgentSessionHistory"];
   updateAgentSessionModel: AgentOperationsContextValue["updateAgentSessionModel"];
   humanRequestChangesTask: (taskId: string, note?: string) => Promise<void>;
   setTaskTargetBranch: (taskId: string, targetBranch: GitTargetBranch) => Promise<void>;
@@ -453,6 +454,7 @@ export function useAgentStudioOrchestrationController({
       handlePrepareMessageFirstSession,
       handleQuickAction,
       stopAgentSession,
+      loadAgentSessionHistory: actions.loadAgentSessionHistory,
     },
     modelSelection: {
       selectedModelSelection,

--- a/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/packages/frontend/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -243,6 +243,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     startLaunchKickoff: async () => {},
     onSend: async () => true,
     stopAgentSession: async () => {},
+    loadAgentSessionHistory: async () => null,
     ...overrides.sessionActions,
   };
   const selectedSessionActions: AgentStudioSelectedSessionContextInput["sessionActions"] = {
@@ -753,6 +754,49 @@ describe("useAgentStudioPageModels", () => {
     );
     expect(html).toContain("Cached transcript");
     expect(html).not.toContain("Loading session");
+
+    await harness.unmount();
+  });
+
+  test("offers a user-triggered retry when visible session history is incomplete", async () => {
+    const loadedSession = createSession("session-history-failed", "external-history-failed", {
+      messages: [
+        {
+          id: "assistant-cached",
+          role: "assistant",
+          content: "Cached transcript",
+          timestamp: "2026-02-22T08:00:05.000Z",
+        },
+      ],
+    });
+    const loadAgentSessionHistory = mock(async () => loadedSession);
+    const sessionActionsWithHistoryRetry = { loadAgentSessionHistory };
+    const historyFailure = {
+      code: "invalid_runtime_response" as const,
+      summary: "Codex returned invalid conversation history.",
+      detail: "Codex thread/turns/list response data[0] must be an object",
+    };
+    const harness = createHookHarness(
+      createHookArgs({
+        selectedSessionCore: {
+          loadedSession,
+          sessionsForTask: summarizeSessions([loadedSession]),
+          transcriptState: createSelectedSessionTranscriptStateFixture({
+            kind: "visible",
+            historyFailure,
+          }),
+        },
+        sessionActions: sessionActionsWithHistoryRetry,
+      }),
+    );
+
+    await harness.mount();
+
+    const notice = harness.getLatest().agentChatModel.thread.transcriptNotice;
+    expect(notice?.title).toBe("History may be incomplete");
+    expect(notice?.action?.label).toBe("Retry");
+    notice?.action?.onAction();
+    expect(loadAgentSessionHistory).toHaveBeenCalledWith(toAgentSessionIdentity(loadedSession));
 
     await harness.unmount();
   });

--- a/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-load-policy.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-load-policy.ts
@@ -1,3 +1,4 @@
+import type { SessionHistoryFailure } from "@openducktor/contracts";
 import type { AgentSessionHistoryMessage } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { applyLoadedSessionHistory } from "../support/session-history-chat-messages";
@@ -5,14 +6,14 @@ import { hasLoadedSessionHistory } from "../transcript/session-transcript-conten
 
 type SessionHistoryLoadPolicySession = Pick<
   AgentSessionState,
-  "externalSessionId" | "messages" | "historyLoadState"
+  "externalSessionId" | "messages" | "historyLoadState" | "historyLoadFailure"
 >;
 
 export type SessionHistoryLoadPolicy = {
   canClaimLoad(session: SessionHistoryLoadPolicySession): boolean;
   propagateFailure: boolean;
   abandonLoad(session: AgentSessionState): AgentSessionState;
-  failLoad(session: AgentSessionState): AgentSessionState;
+  failLoad(session: AgentSessionState, failure: SessionHistoryFailure): AgentSessionState;
   applyLoadedHistory(
     session: AgentSessionState,
     history: AgentSessionHistoryMessage[],
@@ -21,15 +22,30 @@ export type SessionHistoryLoadPolicy = {
 
 const abandonBaselineLoad = (session: AgentSessionState): AgentSessionState =>
   session.historyLoadState === "loading"
-    ? { ...session, historyLoadState: "not_requested" }
+    ? { ...session, historyLoadState: "not_requested", historyLoadFailure: null }
     : session;
 
-const failBaselineLoad = (session: AgentSessionState): AgentSessionState =>
-  session.historyLoadState === "loaded" ? session : { ...session, historyLoadState: "failed" };
+const failBaselineLoad = (
+  session: AgentSessionState,
+  failure: SessionHistoryFailure,
+): AgentSessionState =>
+  session.historyLoadState === "loaded"
+    ? session
+    : { ...session, historyLoadState: "failed", historyLoadFailure: failure };
 
 const restoreLoadedHistoryState = (session: AgentSessionState): AgentSessionState => ({
   ...session,
   historyLoadState: "loaded",
+  historyLoadFailure: null,
+});
+
+const markLoadedHistoryFailed = (
+  session: AgentSessionState,
+  failure: SessionHistoryFailure,
+): AgentSessionState => ({
+  ...session,
+  historyLoadState: "loaded",
+  historyLoadFailure: failure,
 });
 
 export const shouldRequestSelectedSessionBaselineHistory = (
@@ -37,7 +53,8 @@ export const shouldRequestSelectedSessionBaselineHistory = (
 ): boolean => session.historyLoadState === "not_requested";
 
 export const requestedSessionHistoryLoadPolicy: SessionHistoryLoadPolicy = {
-  canClaimLoad: (session) => !hasLoadedSessionHistory(session),
+  canClaimLoad: (session) =>
+    !hasLoadedSessionHistory(session) || session.historyLoadFailure != null,
   propagateFailure: false,
   abandonLoad: abandonBaselineLoad,
   failLoad: failBaselineLoad,
@@ -56,6 +73,6 @@ export const transcriptGapRecoveryHistoryLoadPolicy: SessionHistoryLoadPolicy = 
   canClaimLoad: hasLoadedSessionHistory,
   propagateFailure: true,
   abandonLoad: restoreLoadedHistoryState,
-  failLoad: restoreLoadedHistoryState,
+  failLoad: markLoadedHistoryFailed,
   applyLoadedHistory: applyLoadedSessionHistory,
 };

--- a/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-loader.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-loader.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
 import type { AgentSessionHistoryMessage } from "@openducktor/core";
+import { HostInvokeError } from "@openducktor/host-client";
 import {
   createAgentSessionCollection,
   getAgentSession,
@@ -152,6 +153,37 @@ describe("session history loader", () => {
     expect(harness.session.historyLoadState).toBe("failed");
   });
 
+  test("keeps structured session history diagnostics in transient session state", async () => {
+    const harness = createHistoryLoadHarness();
+    const failure = {
+      code: "invalid_runtime_response" as const,
+      summary: "Codex returned invalid conversation history.",
+      detail: "Codex thread/turns/list response data[0] must be an object",
+      diagnosticId: "diagnostic-1",
+      method: "thread/turns/list",
+      pageCursor: null,
+    };
+
+    await loadSessionHistoryIntoStore({
+      repoPath: "/repo",
+      adapter: {
+        loadSessionHistory: async () => {
+          throw new HostInvokeError("history unavailable", {
+            kind: "session_history",
+            sessionHistoryFailure: failure,
+          });
+        },
+      },
+      readSessionSnapshot: harness.readSessionSnapshot,
+      updateSession: harness.updateSession,
+      identity: sessionTarget,
+      isStaleRepoOperation: () => false,
+    });
+
+    expect(harness.session.historyLoadState).toBe("failed");
+    expect(harness.session.historyLoadFailure).toEqual(failure);
+  });
+
   test("allows caller-requested history loads to retry failed sessions", async () => {
     const loadSessionHistory = mock(async () => [
       {
@@ -180,6 +212,52 @@ describe("session history loader", () => {
     expect(harness.session.historyLoadState).toBe("loaded");
     expect(sessionMessagesToArray(harness.session).map((message) => message.content)).toEqual([
       "Loaded after retry",
+    ]);
+  });
+
+  test("allows caller-requested history loads to retry a failed refresh with visible messages", async () => {
+    const loadSessionHistory = mock(async () => [
+      {
+        messageId: "history-2",
+        role: "assistant" as const,
+        timestamp: "2026-06-12T08:00:02.000Z",
+        text: "Complete transcript",
+        parts: [],
+      },
+    ]);
+    const harness = createHistoryLoadHarness({
+      ...createSession(),
+      historyLoadState: "loaded",
+      historyLoadFailure: {
+        code: "invalid_runtime_response",
+        summary: "Codex returned invalid conversation history.",
+        detail: "Codex thread/turns/list response data[0] must be an object",
+      },
+      messages: createSessionMessagesState(sessionTarget.externalSessionId, [
+        {
+          id: "cached-1",
+          role: "assistant",
+          timestamp: "2026-06-12T08:00:01.000Z",
+          content: "Cached transcript",
+        },
+      ]),
+    });
+
+    await loadSessionHistoryIntoStore({
+      repoPath: "/repo",
+      adapter: { loadSessionHistory },
+      readSessionSnapshot: harness.readSessionSnapshot,
+      updateSession: harness.updateSession,
+      identity: sessionTarget,
+      isStaleRepoOperation: () => false,
+    });
+
+    expect(loadSessionHistory).toHaveBeenCalledTimes(1);
+    expect(harness.session.historyLoadState).toBe("loaded");
+    expect(harness.session.historyLoadFailure).toBeNull();
+    expect(sessionMessagesToArray(harness.session).map((message) => message.content)).toEqual([
+      "Cached transcript",
+      "Complete transcript",
     ]);
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-loader.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/history/session-history-loader.ts
@@ -1,5 +1,6 @@
-import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
+import type { RepoPromptOverrides, SessionHistoryFailure, TaskCard } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentSessionHistorySystemPromptContext } from "@openducktor/core";
+import { HostInvokeError } from "@openducktor/host-client";
 import type { MutableRefObject } from "react";
 import type { AgentSessionIdentity, AgentSessionState } from "@/types/agent-orchestrator";
 import type { UpdateSession } from "../events/session-event-types";
@@ -78,7 +79,7 @@ const markSessionHistoryLoading = ({
     }
 
     claimedLoad = true;
-    return { ...current, historyLoadState: "loading" };
+    return { ...current, historyLoadState: "loading", historyLoadFailure: null };
   });
 
   return { session: loadingSession, claimedLoad: loadingSession !== null && claimedLoad };
@@ -94,7 +95,20 @@ const failSessionHistoryLoad = (
   identity: AgentSessionIdentity,
   updateSession: UpdateSession,
   policy: SessionHistoryLoadPolicy,
-): AgentSessionState | null => updateSession(identity, policy.failLoad);
+  failure: SessionHistoryFailure,
+): AgentSessionState | null =>
+  updateSession(identity, (session) => policy.failLoad(session, failure));
+
+const sessionHistoryFailureFromError = (error: unknown): SessionHistoryFailure => {
+  if (error instanceof HostInvokeError && error.failure?.kind === "session_history") {
+    return error.failure.sessionHistoryFailure;
+  }
+  return {
+    code: "request_failed",
+    summary: "Conversation history could not be loaded.",
+    detail: error instanceof Error ? error.message : String(error),
+  };
+};
 
 const buildSessionHistorySystemPromptContext = async ({
   workspaceId,
@@ -221,7 +235,12 @@ const loadSessionHistoryIntoStoreWithPolicy = async ({
     if (isStaleRepoOperation()) {
       return finishStaleHistoryLoad();
     }
-    const failedSession = failSessionHistoryLoad(identity, updateSession, policy);
+    const failedSession = failSessionHistoryLoad(
+      identity,
+      updateSession,
+      policy,
+      sessionHistoryFailureFromError(error),
+    );
     if (policy.propagateFailure) {
       throw error;
     }

--- a/packages/frontend/src/state/operations/agent-orchestrator/support/session-history-chat-messages.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/support/session-history-chat-messages.ts
@@ -354,6 +354,7 @@ export const applyLoadedSessionHistory = (
   return {
     ...session,
     historyLoadState: "loaded",
+    historyLoadFailure: null,
     messages: mergeHistoryMessages(session.externalSessionId, loadedMessages, session.messages),
   };
 };

--- a/packages/frontend/src/state/operations/agent-orchestrator/transcript/session-transcript-state.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/transcript/session-transcript-state.test.ts
@@ -58,6 +58,15 @@ const deriveLoadedTranscriptStateForSession = ({
     repoReadinessState,
   });
 
+const historyFailure = {
+  code: "invalid_runtime_response" as const,
+  summary: "Codex returned invalid conversation history.",
+  detail: "Codex thread/turns/list response data[0] must be an object",
+  diagnosticId: "diagnostic-1",
+  method: "thread/turns/list",
+  pageCursor: null,
+};
+
 describe("deriveLoadedAgentSessionTranscriptState", () => {
   test("shows the history loader instead of a partial live tail before history is requested", () => {
     const transcriptState = deriveLoadedTranscriptStateForSession({
@@ -85,6 +94,7 @@ describe("deriveLoadedAgentSessionTranscriptState", () => {
     const transcriptState = deriveLoadedTranscriptStateForSession({
       session: createSession({
         historyLoadState: "failed",
+        historyLoadFailure: historyFailure,
         messages: [
           {
             id: "message-1",
@@ -97,13 +107,14 @@ describe("deriveLoadedAgentSessionTranscriptState", () => {
       repoReadinessState: "ready",
     });
 
-    expect(transcriptState).toEqual({ kind: "visible" });
+    expect(transcriptState).toEqual({ kind: "visible", historyFailure });
   });
 
   test("surfaces cold history failures when there is no transcript to render", () => {
     const transcriptState = deriveLoadedTranscriptStateForSession({
       session: createSession({
         historyLoadState: "failed",
+        historyLoadFailure: historyFailure,
         messages: [],
       }),
       repoReadinessState: "ready",
@@ -111,7 +122,8 @@ describe("deriveLoadedAgentSessionTranscriptState", () => {
 
     expect(transcriptState).toEqual({
       kind: "failed",
-      message: "The selected conversation could not be loaded.",
+      message: historyFailure.summary,
+      historyFailure,
     });
   });
 

--- a/packages/frontend/src/state/operations/agent-orchestrator/transcript/session-transcript-state.test.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/transcript/session-transcript-state.test.ts
@@ -110,6 +110,26 @@ describe("deriveLoadedAgentSessionTranscriptState", () => {
     expect(transcriptState).toEqual({ kind: "visible", historyFailure });
   });
 
+  test("keeps a loaded transcript visible with its gap recovery failure", () => {
+    const transcriptState = deriveLoadedTranscriptStateForSession({
+      session: createSession({
+        historyLoadState: "loaded",
+        historyLoadFailure: historyFailure,
+        messages: [
+          {
+            id: "message-1",
+            role: "assistant",
+            content: "still visible",
+            timestamp: "2026-02-22T08:00:03.000Z",
+          },
+        ],
+      }),
+      repoReadinessState: "ready",
+    });
+
+    expect(transcriptState).toEqual({ kind: "visible", historyFailure });
+  });
+
   test("surfaces cold history failures when there is no transcript to render", () => {
     const transcriptState = deriveLoadedTranscriptStateForSession({
       session: createSession({

--- a/packages/frontend/src/state/operations/agent-orchestrator/transcript/session-transcript-state.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/transcript/session-transcript-state.ts
@@ -68,7 +68,8 @@ export const deriveLoadedAgentSessionTranscriptState = ({
   }
 
   if (session.historyLoadState === "loaded") {
-    return { kind: "visible" };
+    const historyFailure = session.historyLoadFailure;
+    return historyFailure ? { kind: "visible", historyFailure } : { kind: "visible" };
   }
 
   return deriveRuntimeBoundTranscriptLoadingState({

--- a/packages/frontend/src/state/operations/agent-orchestrator/transcript/session-transcript-state.ts
+++ b/packages/frontend/src/state/operations/agent-orchestrator/transcript/session-transcript-state.ts
@@ -1,3 +1,4 @@
+import type { SessionHistoryFailure } from "@openducktor/contracts";
 import type { RepoRuntimeReadinessState } from "@/lib/repo-runtime-readiness";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentSessionReadModelLoadState } from "@/types/agent-session-read-model";
@@ -9,14 +10,14 @@ export type AgentSessionTranscriptLoadingReason = "preparing" | "history";
 type AgentSessionTranscriptNonEmptyState =
   | { kind: "runtime_waiting" }
   | { kind: "session_loading"; reason: AgentSessionTranscriptLoadingReason }
-  | { kind: "visible" }
-  | { kind: "failed"; message: string };
+  | { kind: "visible"; historyFailure?: SessionHistoryFailure }
+  | { kind: "failed"; message: string; historyFailure?: SessionHistoryFailure };
 
 export type AgentSessionTranscriptState =
   | { kind: "empty"; reason: AgentSessionTranscriptEmptyReason }
   | AgentSessionTranscriptNonEmptyState;
 
-const DEFAULT_TRANSCRIPT_FAILURE_MESSAGE = "The selected conversation could not be loaded.";
+const DEFAULT_TRANSCRIPT_FAILURE = "The selected conversation could not be loaded.";
 
 export const isAgentSessionTranscriptLoading = (
   transcriptState: AgentSessionTranscriptState,
@@ -55,11 +56,15 @@ export const deriveLoadedAgentSessionTranscriptState = ({
   repoReadinessState: RepoRuntimeReadinessState;
 }): AgentSessionTranscriptState => {
   if (session.historyLoadState === "failed") {
+    const historyFailure = session.historyLoadFailure;
+    const message = historyFailure?.summary ?? DEFAULT_TRANSCRIPT_FAILURE;
     if (hasRenderableSessionTranscript(session)) {
-      return { kind: "visible" };
+      return historyFailure ? { kind: "visible", historyFailure } : { kind: "visible" };
     }
 
-    return { kind: "failed", message: DEFAULT_TRANSCRIPT_FAILURE_MESSAGE };
+    return historyFailure
+      ? { kind: "failed", message, historyFailure }
+      : { kind: "failed", message };
   }
 
   if (session.historyLoadState === "loaded") {

--- a/packages/frontend/src/types/agent-orchestrator.ts
+++ b/packages/frontend/src/types/agent-orchestrator.ts
@@ -3,6 +3,7 @@ import type {
   FileContent,
   FileDiff,
   RuntimeKind,
+  SessionHistoryFailure,
 } from "@openducktor/contracts";
 import type {
   AgentModelSelection,
@@ -188,6 +189,7 @@ export type AgentSessionState = {
   /** Live-only parent link used to project descendant pending input to active ancestors. */
   liveParentExternalSessionId?: string | undefined;
   historyLoadState: AgentSessionHistoryLoadState;
+  historyLoadFailure?: SessionHistoryFailure | null;
   messages: AgentSessionMessages;
   contextUsage?: AgentSessionContextUsage | null;
   contextUsageError?: string | null;

--- a/packages/host/src/adapters/codex/codex-app-server-response-parsers.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-response-parsers.ts
@@ -119,7 +119,17 @@ export const parseThreadTurnsListResponse = (
     });
   }
   for (const [index, entry] of payload.data.entries()) {
-    requireRecord(entry, `Codex thread/turns/list response data[${index}]`);
+    const turn = requireRecord(entry, `Codex thread/turns/list response data[${index}]`);
+    const itemsContext = `Codex thread/turns/list response data[${index}].items`;
+    if (!Array.isArray(turn.items)) {
+      throw new HostValidationError({
+        message: `${itemsContext} must be an array`,
+        details: { context: itemsContext },
+      });
+    }
+    for (const [itemIndex, item] of turn.items.entries()) {
+      requireRecord(item, `${itemsContext}[${itemIndex}]`);
+    }
   }
   return {
     data: payload.data,

--- a/packages/host/src/adapters/codex/codex-app-server-response-parsers.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-response-parsers.ts
@@ -118,5 +118,15 @@ export const parseThreadTurnsListResponse = (
       details: { context: "Codex thread/turns/list response" },
     });
   }
-  return payload as unknown as CodexAppServerThreadTurnsListResponse;
+  for (const [index, entry] of payload.data.entries()) {
+    requireRecord(entry, `Codex thread/turns/list response data[${index}]`);
+  }
+  return {
+    data: payload.data,
+    nextCursor: parseCursor(payload.nextCursor, "Codex thread/turns/list nextCursor"),
+    backwardsCursor: parseCursor(
+      payload.backwardsCursor,
+      "Codex thread/turns/list backwardsCursor",
+    ),
+  } as CodexAppServerThreadTurnsListResponse;
 };

--- a/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
@@ -178,4 +178,47 @@ describe("createCodexAppServerTransportRegistry", () => {
       },
     });
   });
+
+  test("rejects malformed hydrated turn items with a structured session history failure", async () => {
+    const port = createCodexAppServerTransportRegistry();
+    port.registerTransport("runtime-1", {
+      request() {
+        return Effect.succeed(
+          parseCodexAppServerRequestResult("thread/turns/list", {
+            data: [{ items: [null] }],
+            nextCursor: null,
+            backwardsCursor: null,
+          }),
+        );
+      },
+      respond() {
+        return Effect.void;
+      },
+    });
+
+    await expect(
+      Effect.runPromise(
+        Effect.flip(
+          port.listThreadTurns({
+            runtimeId: "runtime-1",
+            threadId: "thread-1",
+            cursor: null,
+            limit: 100,
+            sortDirection: "asc",
+            itemsView: "full",
+          }),
+        ),
+      ),
+    ).resolves.toMatchObject({
+      _tag: "CodexSessionHistoryError",
+      message: "Codex thread/turns/list response data[0].items[0] must be an object",
+      failure: {
+        code: "invalid_runtime_response",
+        summary: "Codex returned invalid conversation history.",
+        detail: "Codex thread/turns/list response data[0].items[0] must be an object",
+        diagnosticId: expect.any(String),
+        method: "thread/turns/list",
+      },
+    });
+  });
 });

--- a/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
@@ -34,6 +34,7 @@ describe("createCodexAppServerTransportRegistry", () => {
                 gitInfo: null,
                 name: null,
                 status: { type: "active", activeFlags: [] },
+                historyMode: "paginated",
                 turns: [],
               },
             ],

--- a/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-registry.test.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { parseCodexAppServerRequestResult } from "../../ports/codex-app-server-protocol";
 import { createCodexAppServerTransportRegistry } from "./codex-app-server-transport-registry";
 
 describe("createCodexAppServerTransportRegistry", () => {
@@ -133,5 +134,48 @@ describe("createCodexAppServerTransportRegistry", () => {
     await expect(
       Effect.runPromise(port.request({ runtimeId: "runtime-1", method: "model/list", params: {} })),
     ).rejects.toThrow("Codex app-server transport not found for runtime runtime-1");
+  });
+
+  test("rejects malformed thread turns with a structured session history failure", async () => {
+    const port = createCodexAppServerTransportRegistry();
+    port.registerTransport("runtime-1", {
+      request() {
+        return Effect.succeed(
+          parseCodexAppServerRequestResult("thread/turns/list", {
+            data: [null],
+            nextCursor: null,
+            backwardsCursor: null,
+          }),
+        );
+      },
+      respond() {
+        return Effect.void;
+      },
+    });
+
+    await expect(
+      Effect.runPromise(
+        Effect.flip(
+          port.listThreadTurns({
+            runtimeId: "runtime-1",
+            threadId: "thread-1",
+            cursor: null,
+            limit: 100,
+            sortDirection: "asc",
+            itemsView: "full",
+          }),
+        ),
+      ),
+    ).resolves.toMatchObject({
+      _tag: "CodexSessionHistoryError",
+      message: "Codex thread/turns/list response data[0] must be an object",
+      failure: {
+        code: "invalid_runtime_response",
+        summary: "Codex returned invalid conversation history.",
+        detail: "Codex thread/turns/list response data[0] must be an object",
+        diagnosticId: expect.any(String),
+        method: "thread/turns/list",
+      },
+    });
   });
 });

--- a/packages/host/src/adapters/codex/codex-app-server-transport-registry.ts
+++ b/packages/host/src/adapters/codex/codex-app-server-transport-registry.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { Effect } from "effect";
 import {
   HostInvariantError,
@@ -11,9 +12,12 @@ import type {
   CodexAppServerRespondInput,
 } from "../../ports/codex-app-server-port";
 import type { CodexAppServerClientRequest } from "../../ports/codex-app-server-protocol";
+import { CodexSessionHistoryError } from "../../ports/codex-session-history-error";
+import type { CodexSessionHistoryPort } from "../../ports/codex-session-history-port";
 import {
   parseLoadedThreadListResponse,
   parseThreadListResponse,
+  parseThreadTurnsListResponse,
 } from "./codex-app-server-response-parsers";
 import type { CodexAppServerTransportError } from "./codex-app-server-transport-types";
 
@@ -28,10 +32,11 @@ export type CodexAppServerTransport = {
   ): Effect.Effect<void, CodexAppServerTransportError>;
 };
 
-export type CodexAppServerTransportRegistry = CodexAppServerPort & {
-  registerTransport(runtimeId: string, transport: CodexAppServerTransport): void;
-  unregisterTransport(runtimeId: string): void;
-};
+export type CodexAppServerTransportRegistry = CodexAppServerPort &
+  CodexSessionHistoryPort & {
+    registerTransport(runtimeId: string, transport: CodexAppServerTransport): void;
+    unregisterTransport(runtimeId: string): void;
+  };
 export const createCodexAppServerTransportRegistry = (): CodexAppServerTransportRegistry => {
   const transports = new Map<string, CodexAppServerTransport>();
   const requireTransport = (runtimeId: string) =>
@@ -117,6 +122,46 @@ export const createCodexAppServerTransportRegistry = (): CodexAppServerTransport
             }),
         });
       });
+    },
+    listThreadTurns({ runtimeId, threadId, cursor, limit, sortDirection, itemsView }) {
+      const method = "thread/turns/list";
+      const toFailure = (
+        code: "invalid_runtime_response" | "request_failed",
+        cause: unknown,
+      ): CodexSessionHistoryError => {
+        const detail = cause instanceof Error ? cause.message : String(cause);
+        return new CodexSessionHistoryError({
+          message: detail,
+          runtimeId,
+          threadId,
+          cause,
+          failure: {
+            code,
+            summary:
+              code === "invalid_runtime_response"
+                ? "Codex returned invalid conversation history."
+                : "Codex conversation history could not be loaded.",
+            detail,
+            diagnosticId: randomUUID(),
+            method,
+            pageCursor: cursor ?? null,
+          },
+        });
+      };
+
+      return requestJson({
+        runtimeId,
+        method,
+        params: { threadId, cursor, limit, sortDirection, itemsView },
+      }).pipe(
+        Effect.mapError((cause) => toFailure("request_failed", cause)),
+        Effect.flatMap((payload) =>
+          Effect.try({
+            try: () => parseThreadTurnsListResponse(payload),
+            catch: (cause) => toFailure("invalid_runtime_response", cause),
+          }),
+        ),
+      );
     },
     respond({ runtimeId, requestId, result, error }) {
       return Effect.gen(function* () {

--- a/packages/host/src/application/runtimes/codex-app-server-service.test.ts
+++ b/packages/host/src/application/runtimes/codex-app-server-service.test.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import type { CodexAppServerPort } from "../../ports/codex-app-server-port";
+import type { CodexSessionHistoryPort } from "../../ports/codex-session-history-port";
 import { createCodexAppServerService as createEffectCodexAppServerService } from "./codex-app-server-service";
 
 const createCodexAppServerService = (
@@ -7,7 +8,7 @@ const createCodexAppServerService = (
 ) => createEffectCodexAppServerService(...args);
 const createPort = (): {
   calls: unknown[];
-  port: CodexAppServerPort;
+  port: CodexAppServerPort & CodexSessionHistoryPort;
 } => {
   const calls: unknown[] = [];
   return {
@@ -28,6 +29,10 @@ const createPort = (): {
           nextCursor: null,
           backwardsCursor: null,
         });
+      },
+      listThreadTurns(input) {
+        calls.push({ method: "listThreadTurns", input });
+        return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
       },
       respond(input) {
         calls.push({ method: "respond", input });
@@ -61,6 +66,18 @@ describe("createCodexAppServerService", () => {
       nextCursor: null,
       backwardsCursor: null,
     });
+    await expect(
+      Effect.runPromise(
+        service.listThreadTurns({
+          runtimeId: "runtime-1",
+          threadId: "session-1",
+          cursor: null,
+          limit: 100,
+          sortDirection: "asc",
+          itemsView: "full",
+        }),
+      ),
+    ).resolves.toEqual({ data: [], nextCursor: null, backwardsCursor: null });
     expect(calls).toEqual([
       {
         method: "request",
@@ -77,6 +94,17 @@ describe("createCodexAppServerService", () => {
       {
         method: "listThreads",
         input: { runtimeId: "runtime-1", cursor: null, limit: 100 },
+      },
+      {
+        method: "listThreadTurns",
+        input: {
+          runtimeId: "runtime-1",
+          threadId: "session-1",
+          cursor: null,
+          limit: 100,
+          sortDirection: "asc",
+          itemsView: "full",
+        },
       },
     ]);
   });

--- a/packages/host/src/application/runtimes/codex-app-server-service.ts
+++ b/packages/host/src/application/runtimes/codex-app-server-service.ts
@@ -9,8 +9,14 @@ import type {
   CodexAppServerThreadListInput,
   CodexAppServerThreadListResponse,
 } from "../../ports/codex-app-server-port";
+import type { CodexAppServerThreadTurnsListResponse } from "../../ports/codex-app-server-protocol";
+import type { CodexSessionHistoryError } from "../../ports/codex-session-history-error";
+import type {
+  CodexSessionHistoryPageInput,
+  CodexSessionHistoryPort,
+} from "../../ports/codex-session-history-port";
 
-export type CodexAppServerServiceError = CodexAppServerError;
+export type CodexAppServerServiceError = CodexAppServerError | CodexSessionHistoryError;
 
 export type CodexAppServerService = {
   request(
@@ -22,11 +28,15 @@ export type CodexAppServerService = {
   listThreads(
     input: CodexAppServerThreadListInput,
   ): Effect.Effect<CodexAppServerThreadListResponse, CodexAppServerServiceError>;
+  listThreadTurns(
+    input: CodexSessionHistoryPageInput,
+  ): Effect.Effect<CodexAppServerThreadTurnsListResponse, CodexAppServerServiceError>;
 };
 export const createCodexAppServerService = (
-  codexAppServerPort: CodexAppServerPort,
+  codexAppServerPort: CodexAppServerPort & CodexSessionHistoryPort,
 ): CodexAppServerService => ({
   request: (input) => codexAppServerPort.request(input),
   listLoadedThreads: (input) => codexAppServerPort.listLoadedThreads(input),
   listThreads: (input) => codexAppServerPort.listThreads(input),
+  listThreadTurns: (input) => codexAppServerPort.listThreadTurns(input),
 });

--- a/packages/host/src/composition/node/node-host-default-ports.ts
+++ b/packages/host/src/composition/node/node-host-default-ports.ts
@@ -17,6 +17,7 @@ import { createToolDiscoveryAdapter } from "../../adapters/system/tool-discovery
 import { toHostOperationError } from "../../effect/host-errors";
 import { createProcessEnvironment } from "../../infrastructure/process/process-environment";
 import { type CodexAppServerPort, CodexAppServerPortTag } from "../../ports/codex-app-server-port";
+import type { CodexSessionHistoryPort } from "../../ports/codex-session-history-port";
 import {
   type DevServerProcessPort,
   DevServerProcessPortTag,
@@ -40,7 +41,7 @@ import {
 import { type WorktreeFilePort, WorktreeFilePortTag } from "../../ports/worktree-file-port";
 
 export type NodeHostDefaultPorts = {
-  codexAppServer: CodexAppServerPort;
+  codexAppServer: CodexAppServerPort & CodexSessionHistoryPort;
   codexTransportRegistry: CodexAppServerTransportRegistry;
   devServerProcesses: DevServerProcessPort;
   filesystem: FilesystemPort;
@@ -61,7 +62,7 @@ export type CreateNodeHostDefaultPortsInput = {
   runtimeDistribution: HostRuntimeDistribution;
   terminalPty: TerminalPtyPort;
 } & Partial<{
-  codexAppServer: CodexAppServerPort;
+  codexAppServer: CodexAppServerPort & CodexSessionHistoryPort;
   codexAppServerTransportRegistry: CodexAppServerTransportRegistry;
   devServerProcesses: DevServerProcessPort;
   filesystem: FilesystemPort;

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -86,6 +86,7 @@ export type {
   EffectHostCommandRouter,
   HostCommandRouter,
 } from "./interface/router/host-command-router";
+export { hostInvokeFailureFromError } from "./interface/router/host-invoke-failure";
 export type {
   AgentSessionLiveAdapterBinding,
   AgentSessionLiveAdapterChange,
@@ -95,6 +96,7 @@ export type {
   AgentSessionRuntimeAdapterPort,
 } from "./ports/agent-session-live-adapter-port";
 export type { CodexAppServerPort } from "./ports/codex-app-server-port";
+export { CodexSessionHistoryError } from "./ports/codex-session-history-error";
 export type { DevServerProcessPort } from "./ports/dev-server-process-port";
 export type { FilesystemPort } from "./ports/filesystem-port";
 export type { GitPort } from "./ports/git-port";

--- a/packages/host/src/interface/commands/codex-app-server-command-handlers.test.ts
+++ b/packages/host/src/interface/commands/codex-app-server-command-handlers.test.ts
@@ -27,6 +27,7 @@ describe("createCodexAppServerCommandHandlers", () => {
       listThreads() {
         return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
       },
+      listThreadTurns: () => Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null }),
     };
     const router = createHostCommandRouter({
       handlers: createCodexAppServerCommandHandlers(service),
@@ -100,6 +101,7 @@ describe("createCodexAppServerCommandHandlers", () => {
       listThreads() {
         return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
       },
+      listThreadTurns: () => Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null }),
     };
     const router = createHostCommandRouter({
       handlers: createCodexAppServerCommandHandlers(service, {
@@ -180,6 +182,7 @@ describe("createCodexAppServerCommandHandlers", () => {
       request: () => Effect.succeed(committedResult),
       listLoadedThreads: () => Effect.succeed({ data: [], nextCursor: null }),
       listThreads: () => Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null }),
+      listThreadTurns: () => Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null }),
     };
     const router = createHostCommandRouter({
       handlers: createCodexAppServerCommandHandlers(service, {
@@ -232,6 +235,7 @@ describe("createCodexAppServerCommandHandlers", () => {
         calls.push({ method: "listThreads", input });
         return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
       },
+      listThreadTurns: () => Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null }),
     };
     const router = createHostCommandRouter({
       handlers: createCodexAppServerCommandHandlers(service),
@@ -310,6 +314,77 @@ describe("createCodexAppServerCommandHandlers", () => {
       },
     ]);
   });
+
+  test("routes thread turn pages through the validated history operation", async () => {
+    const calls: Array<{ method: string; input: unknown }> = [];
+    const service: CodexAppServerService = {
+      request(input) {
+        calls.push({ method: "request", input });
+        return Effect.succeed({ data: [], nextCursor: null });
+      },
+      listLoadedThreads: () => Effect.succeed({ data: [], nextCursor: null }),
+      listThreads: () => Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null }),
+      listThreadTurns(input) {
+        calls.push({ method: "listThreadTurns", input });
+        return Effect.succeed({ data: [], nextCursor: null, backwardsCursor: null });
+      },
+    };
+    const router = createHostCommandRouter({
+      handlers: createCodexAppServerCommandHandlers(service),
+    });
+
+    await expect(
+      router.invoke("codex_app_server_request", {
+        runtimeId: "runtime-1",
+        method: "thread/turns/list",
+        params: {
+          threadId: "thread-1",
+          cursor: "cursor-1",
+          limit: 100,
+          sortDirection: "asc",
+          itemsView: "full",
+        },
+      }),
+    ).resolves.toEqual({ data: [], nextCursor: null, backwardsCursor: null });
+    await expect(
+      router.invoke("codex_app_server_request", {
+        runtimeId: "runtime-1",
+        method: "thread/turns/list",
+        params: {
+          threadId: "thread-1",
+          cursor: null,
+          limit: null,
+          sortDirection: null,
+          itemsView: null,
+        },
+      }),
+    ).resolves.toEqual({ data: [], nextCursor: null, backwardsCursor: null });
+    expect(calls).toEqual([
+      {
+        method: "listThreadTurns",
+        input: {
+          runtimeId: "runtime-1",
+          threadId: "thread-1",
+          cursor: "cursor-1",
+          limit: 100,
+          sortDirection: "asc",
+          itemsView: "full",
+        },
+      },
+      {
+        method: "listThreadTurns",
+        input: {
+          runtimeId: "runtime-1",
+          threadId: "thread-1",
+          cursor: null,
+          limit: null,
+          sortDirection: null,
+          itemsView: null,
+        },
+      },
+    ]);
+  });
+
   test("rejects malformed command inputs before calling the service", async () => {
     const calls: unknown[] = [];
     const unexpectedCall = (input: unknown) =>
@@ -345,6 +420,7 @@ describe("createCodexAppServerCommandHandlers", () => {
           }),
         );
       },
+      listThreadTurns: () => Effect.dieMessage("unexpected call"),
     };
     const router = createHostCommandRouter({
       handlers: createCodexAppServerCommandHandlers(service),

--- a/packages/host/src/interface/commands/codex-app-server-command-handlers.ts
+++ b/packages/host/src/interface/commands/codex-app-server-command-handlers.ts
@@ -1,5 +1,8 @@
 import { Effect } from "effect";
-import type { CodexAppServerService } from "../../application/runtimes/codex-app-server-service";
+import type {
+  CodexAppServerService,
+  CodexAppServerServiceError,
+} from "../../application/runtimes/codex-app-server-service";
 import { type HostLifecycleLogger, writeHostLifecycleLog } from "../../composition/host-lifecycle";
 import { type HostOperationError, HostValidationError } from "../../effect/host-errors";
 import type {
@@ -191,24 +194,94 @@ const parseRequestInput = (
   };
 };
 
+const optionalNullableString = (value: unknown, field: string): string | null | undefined => {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  return requireString(value, field);
+};
+
+const optionalNullablePositiveInteger = (
+  value: unknown,
+  field: string,
+): number | null | undefined => {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new HostValidationError({
+      message: `${field} must be a positive integer.`,
+      field,
+    });
+  }
+  return value;
+};
+
+const optionalNullableLiteral = <Value extends string>(
+  value: unknown,
+  field: string,
+  allowed: readonly Value[],
+): Value | null | undefined => {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  const parsed = requireString(value, field);
+  const match = allowed.find((candidate) => candidate === parsed);
+  if (!match) {
+    throw new HostValidationError({
+      message: `${field} must be one of: ${allowed.join(", ")}.`,
+      field,
+    });
+  }
+  return match;
+};
+
+const requestCodexAppServer = (
+  service: CodexAppServerService,
+  input: CodexAppServerRequestInput,
+): Effect.Effect<CodexAppServerRequestResult, CodexAppServerServiceError> => {
+  if (input.method !== "thread/turns/list") {
+    return service.request(input);
+  }
+
+  const params = recordFromValue(input.params);
+  const cursor = optionalNullableString(params.cursor, "cursor");
+  const limit = optionalNullablePositiveInteger(params.limit, "limit");
+  const sortDirection = optionalNullableLiteral(params.sortDirection, "sortDirection", [
+    "asc",
+    "desc",
+  ]);
+  const itemsView = optionalNullableLiteral(params.itemsView, "itemsView", [
+    "notLoaded",
+    "summary",
+    "full",
+  ]);
+  return service.listThreadTurns({
+    runtimeId: input.runtimeId,
+    threadId: requireString(params.threadId, "threadId"),
+    ...(cursor !== undefined ? { cursor } : {}),
+    ...(limit !== undefined ? { limit } : {}),
+    ...(sortDirection !== undefined ? { sortDirection } : {}),
+    ...(itemsView !== undefined ? { itemsView } : {}),
+  });
+};
+
 export const createCodexAppServerCommandHandlers = (
   codexAppServerService: CodexAppServerService,
   options: CodexAppServerCommandHandlerOptions = defaultCodexAppServerCommandHandlerOptions,
 ): HostCommandHandlers => ({
   codex_app_server_request: (args) => {
     const input = parseRequestInput(args);
-    return codexAppServerService
-      .request(input)
-      .pipe(
-        Effect.tap((result) =>
-          Effect.either(logCodexPolicyRequest(options.logger, input, result)).pipe(
-            Effect.flatMap((loggingResult) =>
-              loggingResult._tag === "Left"
-                ? options.onBackgroundFailure(loggingResult.left)
-                : Effect.void,
-            ),
+    return requestCodexAppServer(codexAppServerService, input).pipe(
+      Effect.tap((result) =>
+        Effect.either(logCodexPolicyRequest(options.logger, input, result)).pipe(
+          Effect.flatMap((loggingResult) =>
+            loggingResult._tag === "Left"
+              ? options.onBackgroundFailure(loggingResult.left)
+              : Effect.void,
           ),
         ),
-      );
+      ),
+    );
   },
 });

--- a/packages/host/src/interface/router/host-command-router.ts
+++ b/packages/host/src/interface/router/host-command-router.ts
@@ -9,6 +9,7 @@ import {
   HostResourceError,
   isHostError,
 } from "../../effect/host-errors";
+import type { CodexSessionHistoryError } from "../../ports/codex-session-history-error";
 import type { DevServerProcessStartExitError } from "../../ports/dev-server-process-port";
 import { type HostCommandName, parseHostCommandName } from "../commands/host-command-registry";
 export type HostCommandArgs = Record<string, unknown> | undefined;
@@ -17,6 +18,7 @@ export type HostCommandContext = {
   args: HostCommandArgs;
 };
 export type HostCommandHandlerError =
+  | CodexSessionHistoryError
   | DevServerProcessStartExitError
   | FilesystemListDirectoryError
   | HostError

--- a/packages/host/src/interface/router/host-invoke-failure.ts
+++ b/packages/host/src/interface/router/host-invoke-failure.ts
@@ -1,0 +1,22 @@
+import type { HostInvokeFailure } from "@openducktor/contracts";
+import {
+  TerminalServiceError,
+  terminalServiceErrorToFailure,
+} from "../../application/terminals/terminal-service";
+import { CodexSessionHistoryError } from "../../ports/codex-session-history-error";
+
+export const hostInvokeFailureFromError = (cause: unknown): HostInvokeFailure | undefined => {
+  if (cause instanceof TerminalServiceError) {
+    return {
+      kind: "terminal",
+      terminalFailure: terminalServiceErrorToFailure(cause),
+    };
+  }
+  if (cause instanceof CodexSessionHistoryError) {
+    return {
+      kind: "session_history",
+      sessionHistoryFailure: cause.failure,
+    };
+  }
+  return undefined;
+};

--- a/packages/host/src/ports/codex-app-server-protocol.ts
+++ b/packages/host/src/ports/codex-app-server-protocol.ts
@@ -24,6 +24,8 @@ export type {
   CodexAppServerServerNotificationMethod,
   CodexAppServerServerRequest,
   CodexAppServerServerRequestMethod,
+  CodexAppServerThreadTurnsListParams,
+  CodexAppServerThreadTurnsListResponse,
 } from "@openducktor/contracts";
 export {
   CODEX_APP_SERVER_SERVER_REQUEST_METHODS,

--- a/packages/host/src/ports/codex-session-history-error.ts
+++ b/packages/host/src/ports/codex-session-history-error.ts
@@ -1,0 +1,10 @@
+import type { SessionHistoryFailure } from "@openducktor/contracts";
+import { Data } from "effect";
+
+export class CodexSessionHistoryError extends Data.TaggedError("CodexSessionHistoryError")<{
+  readonly message: string;
+  readonly failure: SessionHistoryFailure;
+  readonly runtimeId: string;
+  readonly threadId: string;
+  readonly cause?: unknown | undefined;
+}> {}

--- a/packages/host/src/ports/codex-session-history-port.ts
+++ b/packages/host/src/ports/codex-session-history-port.ts
@@ -1,0 +1,16 @@
+import type { Effect } from "effect";
+import type {
+  CodexAppServerThreadTurnsListParams,
+  CodexAppServerThreadTurnsListResponse,
+} from "./codex-app-server-protocol";
+import type { CodexSessionHistoryError } from "./codex-session-history-error";
+
+export type CodexSessionHistoryPageInput = {
+  runtimeId: string;
+} & CodexAppServerThreadTurnsListParams;
+
+export type CodexSessionHistoryPort = {
+  listThreadTurns(
+    input: CodexSessionHistoryPageInput,
+  ): Effect.Effect<CodexAppServerThreadTurnsListResponse, CodexSessionHistoryError>;
+};

--- a/packages/openducktor-web/src/typescript-host-backend.test.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.test.ts
@@ -9,6 +9,7 @@ import {
   TERMINAL_PROTOCOL_VERSION,
 } from "@openducktor/contracts";
 import {
+  CodexSessionHistoryError,
   createLocalAttachmentAdapter,
   createSourceRuntimeDistribution,
   type EffectHostCommandRouter,
@@ -524,6 +525,59 @@ describe("TypeScript web host backend", () => {
           code: "unsupported_runtime",
           message: "Interactive terminals are unavailable in this runtime.",
           workingDir: "/repo/worktree",
+        },
+      },
+    });
+  });
+
+  test("preserves structured session history failures in invoke error responses", async () => {
+    const hostCommandRouter = createTestHostCommandRouter(() =>
+      Effect.fail(
+        new CodexSessionHistoryError({
+          message: "Codex thread/turns/list response data[0] must be an object",
+          runtimeId: "runtime-1",
+          threadId: "thread-1",
+          failure: {
+            code: "invalid_runtime_response",
+            summary: "Codex returned invalid conversation history.",
+            detail: "Codex thread/turns/list response data[0] must be an object",
+            diagnosticId: "diagnostic-1",
+            method: "thread/turns/list",
+            pageCursor: null,
+          },
+        }),
+      ),
+    );
+
+    const response = await handleTestRequest(
+      new Request("http://127.0.0.1/invoke/codex_app_server_request", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openducktor-app-token": APP_TOKEN,
+        },
+        body: JSON.stringify({
+          runtimeId: "runtime-1",
+          method: "thread/turns/list",
+          params: { threadId: "thread-1" },
+        }),
+      }),
+      { hostCommandRouter },
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "Codex thread/turns/list response data[0] must be an object",
+      message: "Codex thread/turns/list response data[0] must be an object",
+      failure: {
+        kind: "session_history",
+        sessionHistoryFailure: {
+          code: "invalid_runtime_response",
+          summary: "Codex returned invalid conversation history.",
+          detail: "Codex thread/turns/list response data[0] must be an object",
+          diagnosticId: "diagnostic-1",
+          method: "thread/turns/list",
+          pageCursor: null,
         },
       },
     });

--- a/packages/openducktor-web/src/typescript-host-backend.ts
+++ b/packages/openducktor-web/src/typescript-host-backend.ts
@@ -13,10 +13,9 @@ import {
   type EffectHostCommandRouter,
   type EffectNodeHostCommandRouter,
   type HostRuntimeDistribution,
+  hostInvokeFailureFromError,
   type McpBridgeDiscoveryMode,
-  TerminalServiceError,
   type ToolDiscoveryId,
-  terminalServiceErrorToFailure,
 } from "@openducktor/host";
 import { Cause, Effect } from "effect";
 import {
@@ -282,13 +281,7 @@ const extractHostCommandFailureKind = (
 const hostCommandFailureToWebError = (command: string, error: unknown): WebHostRequestError => {
   const failureKind = extractHostCommandFailureKind(error);
   const details = readStructuredDetails(error);
-  const hostInvokeFailure =
-    error instanceof TerminalServiceError
-      ? {
-          kind: "terminal" as const,
-          terminalFailure: terminalServiceErrorToFailure(error),
-        }
-      : undefined;
+  const hostInvokeFailure = hostInvokeFailureFromError(error);
   return new WebHostRequestError({
     message: errorMessage(error),
     status: 500,


### PR DESCRIPTION
## Summary

- Fix duplicate and misplaced Codex transcript items by using paginated turns as the sole history source.
- Load every `thread/turns/list` page with full items while lifecycle requests stay metadata-only.
- Avoid `thread/resume` against a just-created empty rollout by recording the true initial zero-token context state.
- Keep Codex version gating out of scope; OpenDucktor targets Codex 0.147.0+.

## Related Issues

- Codex session `019faff7-647f-7332-bc92-60c51a2ea4d4` exposed the live transcript regression.
- Codex 0.146 session `019fb52d-9630-7031-a602-85ff348a4ae4` exposed a separate upstream paginated projection failure and the fresh-thread resume race.


## Additional Context

- New sessions keep `historyMode: "paginated"`; resume, fork, and stored-session activation use `excludeTurns: true`.
- History reads request metadata with `includeTurns: false`, then fetch all turn pages in ascending order with `itemsView: "full"`.
- Empty paginated history remains authoritative, so stale inline metadata turns cannot reappear.
- Fresh root threads start with zero tracked context and do not resume merely to discover usage. Runtime token notifications replace that initial value.
- Codex 0.147.0 includes the upstream SQLite projection fixes required for reliable paginated history. This PR does not add a legacy mode or parse Codex rollout files.
- The earlier macOS failure passed on rerun without a code change; 100 focused local repetitions and the full local suite passed the PTY cleanup test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated history support for Codex sessions, improving loading of long conversations.
  * Preserved message, tool, todo, and fork history when navigating or restoring sessions.
  * Added initial context-usage tracking for newly started sessions.

* **Bug Fixes**
  * Improved restoration of sessions with missing, incomplete, stale, or unavailable history.
  * Improved handling of forked and resumed sessions while avoiding unnecessary history loading.
  * Ensured context usage remains accurate across fresh and existing sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->